### PR TITLE
update GCSA2 to v0.6

### DIFF
--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -185,4 +185,19 @@ string cigar_string(vector<pair<int, char> >& cigar) {
     return cigarss.str();
 }
 
+string tmpfilename(const string& base) {
+    string tmpname = base + "XXXXXXXX";
+    // hack to use mkstemp to get us a safe temporary file name
+    int fd = mkstemp(&tmpname[0]);
+    if(fd != -1) {
+        // we don't leave it open; we are assumed to open it again externally
+        close(fd);
+    } else {
+        cerr << "[vg utility.cpp]: couldn't create temp file on base "
+             << base << " : " << tmpname << endl;
+        exit(1);
+    }
+    return tmpname;
+}
+
 }

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -7,6 +7,7 @@
 #include <omp.h>
 #include <cstring>
 #include <algorithm>
+#include <unistd.h>
 #include "vg.pb.h"
 #include "sha1.hpp"
 
@@ -63,6 +64,8 @@ vector<T> vpmax(const std::vector<std::vector<T>>& vv) {
     }
     return c;
 }
+
+string tmpfilename(const string& base);
 
 }
 

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -944,9 +944,22 @@ public:
                         vector<gcsa::KMer>& kmers_out,
                         id_t& head_id, id_t& tail_id);
 
+    void write_gcsa_kmers(int kmer_size, int edge_max, int stride,
+                          bool forward_only,
+                          ostream& out,
+                          id_t& head_id, id_t& tail_id);
+
+    // write the kmers to a tmp file with the given base, return the name of the file
+    string write_gcsa_kmers_to_tmpfile(int kmer_size, bool forward_only,
+                                       size_t doubling_steps = 2,
+                                       size_t size_limit = 200,
+                                       const string& base_file_name = ".vg-kmers-tmp-");
+
+    // construct the GCSA index for this graph
     gcsa::GCSA* build_gcsa_index(int kmer_size, bool forward_only,
                                  size_t doubling_steps = 2,
-                                 size_t size_limit = 200);
+                                 size_t size_limit = 200,
+                                 const string& base_file_name = ".vg-kmers-tmp-");
 
     // for pruning graph prior to indexing with gcsa2
     // takes all nodes that would introduce paths of > edge_max edge crossings, removes them, and links their neighbors to

--- a/src/vg_set.hpp
+++ b/src/vg_set.hpp
@@ -49,21 +49,30 @@ public:
         bool allow_dups, bool allow_negatives = false);
     
     // Write out kmer lines to GCSA2
-    void write_gcsa_out(ostream& out, int kmer_size, int edge_max, int stride,
+    void write_gcsa_out(ostream& out, int kmer_size,
                         bool forward_only,
                         int64_t head_id=0, int64_t tail_id=0);
-    
+
+    void write_gcsa_kmers_binary(ostream& out,
+                                 int kmer_size,
+                                 bool forward_only,
+                                 int64_t head_id=0, int64_t tail_id=0);
+
     // gets all the kmers in GCSA's internal format.
-    void get_gcsa_kmers(int kmer_size, int edge_max, int stride,
+    void get_gcsa_kmers(int kmer_size,
                         bool forward_only,
                         vector<gcsa::KMer>& kmers_out,
                         int64_t head_id=0, int64_t tail_id=0);
+
+    vector<string> write_gcsa_kmers_binary(int kmer_size,
+                                           bool forward_only,
+                                           int64_t head_id=0, int64_t tail_id=0);
 
     bool show_progress;
 
 private:
 
-    void for_each_gcsa_kmer_position_parallel(int kmer_size, int edge_max, int stride,
+    void for_each_gcsa_kmer_position_parallel(int kmer_size,
                                               bool forward_only,
                                               int64_t& head_id, int64_t& tail_id,
                                               function<void(KmerPosition&)> lambda);

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -130,32 +130,28 @@ is $(vg index -D -d all.vg.aln | wc -l) ${NUM_UNIQUE_READS} "index can store ali
 
 rm -rf cyclic/all.vg.index all.vg.aln
 
-is $(vg index -g x.gcsa -k 16 -V <(vg view -Fv cyclic/two_node.gfa) 2>&1 |  grep 'Index verification complete.' | wc -l) 1 "GCSA2 index works on cyclic graphs with heads and tails"
+is $(vg index -g x.gcsa -k 16 -V <(vg view -Fv cyclic/two_node.gfa) 2>&1 |  grep 'Index verification complete' | wc -l) 1 "GCSA2 index works on cyclic graphs with heads and tails"
 
-is $(vg index -g x.gcsa -k 16 -V cyclic/no_heads.vg 2>&1 |  grep 'Index verification complete.' | wc -l) 1 "GCSA2 index works on cyclic graphs with no heads or tails"
+is $(vg index -g x.gcsa -k 16 -V cyclic/no_heads.vg 2>&1 |  grep 'Index verification complete' | wc -l) 1 "GCSA2 index works on cyclic graphs with no heads or tails"
 
-is $(vg index -g x.gcsa -k 16 -V cyclic/self_loops.vg 2>&1 |  grep 'Index verification complete.' | wc -l) 1 "GCSA2 index works on cyclic graphs with self loops"
+is $(vg index -g x.gcsa -k 16 -V cyclic/self_loops.vg 2>&1 |  grep 'Index verification complete' | wc -l) 1 "GCSA2 index works on cyclic graphs with self loops"
 
-is $(vg index -g x.gcsa -k 16 -V cyclic/all.vg 2>&1 |  grep 'Index verification complete.' | wc -l) 1 "GCSA2 index works on general cyclic graphs"
+is $(vg index -g x.gcsa -k 16 -V cyclic/all.vg 2>&1 |  grep 'Index verification complete' | wc -l) 1 "GCSA2 index works on general cyclic graphs"
 
-is $(vg index -g x.gcsa -k 16 -V -F cyclic/no_heads.vg 2>&1 |  grep 'Index verification complete.' | wc -l) 1 "GCSA2 forward-only indexing works on cyclic graphs with no heads or tails"
-
-#is $(vg index -g -k 16 -V -F cyclic/self_loops.vg | 2>&1 |  grep 'Index verification complete.' | wc -l) 1 "GCSA2 forward-only indexing works on cyclic graphs with self loops"
-
-#is $(vg index -g -k 16 -V -F cyclic/all.vg 2>&1 | grep 'Index verification complete.' | wc -l) 1 "GCSA2 forward-only indexing works on general cyclic graphs"
+is $(vg index -g x.gcsa -k 16 -V -F cyclic/no_heads.vg 2>&1 |  grep 'Index verification complete' | wc -l) 1 "GCSA2 forward-only indexing works on cyclic graphs with no heads or tails"
 
 rm -f x.gcsa
 
-is $(vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg index -g t.idx -k 16 -V - 2>&1 |  grep 'Index verification complete.' | wc -l) 1 "GCSA2 indexing of a tiny graph works"
+is $(vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg index -g t.idx -k 16 -V - 2>&1 |  grep 'Index verification complete' | wc -l) 1 "GCSA2 indexing of a tiny graph works"
 
-is $(vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg index -g t.idx -k 16 -V - 2>&1 | grep 'Index verification complete.' | wc -l) 1 "GCSA2 forward-only indexing of a tiny graph works"
+is $(vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg index -g t.idx -k 16 -V - 2>&1 | grep 'Index verification complete' | wc -l) 1 "GCSA2 forward-only indexing of a tiny graph works"
 
-is $(vg construct -r tiny/tiny.fa | vg index -g t.idx -k 16 -V - 2>&1 | grep 'Index verification complete.' | wc -l) 1 "GCSA2 indexing succeeds on a single-node graph"
+is $(vg construct -r tiny/tiny.fa | vg index -g t.idx -k 16 -V - 2>&1 | grep 'Index verification complete' | wc -l) 1 "GCSA2 indexing succeeds on a single-node graph"
 
-is $(vg construct -r tiny/tiny.fa | vg index -g t.idx -k 16 -V -F - 2>&1 | grep 'Index verification complete.' | wc -l) 1 "GCSA2 forward-only indexing succeeds on a single-node graph"
+is $(vg construct -r tiny/tiny.fa | vg index -g t.idx -k 16 -V -F - 2>&1 | grep 'Index verification complete' | wc -l) 1 "GCSA2 forward-only indexing succeeds on a single-node graph"
 
-is $(vg index -g t.idx reversing/cactus.vg -k 16 -V 2>&1 | grep 'Index verification complete.' | wc -l) 1 "GCSA2 indexing succeeds on graph with heads but no tails"
+is $(vg index -g t.idx reversing/cactus.vg -k 16 -V 2>&1 | grep 'Index verification complete' | wc -l) 1 "GCSA2 indexing succeeds on graph with heads but no tails"
 
-is $(vg index -g t.idx reversing/cactus.vg -k 16 -V -F 2>&1 | grep 'Index verification complete.' | wc -l) 0 "GCSA2 forward-only indexing fails due to impossibility on graph with heads but no tails"
+is $(vg index -g t.idx reversing/cactus.vg -k 16 -V -F 2>&1 | grep 'Index verification complete' | wc -l) 0 "GCSA2 forward-only indexing fails due to impossibility on graph with heads but no tails"
 
 rm t.idx


### PR DESCRIPTION
We need the updates in GCSA2 for counting queries (efficiently determining how many matches there are to a given sequence without actually looking them up) and for implementing true MEM/SMEM queries (the `parent()` function on the suffix array).