### PR TITLE
Change over to the scoring parameters used in BWA-MEM

### DIFF
--- a/src/gssw_aligner.cpp
+++ b/src/gssw_aligner.cpp
@@ -91,6 +91,7 @@ void GSSWAligner::align(Alignment& alignment, bool print_score_matrices) {
                                                     gap_open,
                                                     gap_extension);
 
+    //gssw_graph_print_score_matrices(graph, sequence.c_str(), sequence.size(), stderr);
 
     gssw_mapping_to_alignment(gm, alignment, print_score_matrices);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -986,6 +986,11 @@ void help_msga(char** argv) {
          << "    -b, --base NAME         use this sequence as the graph basis if graph is empty" << endl
          << "    -s, --seq SEQUENCE      literally include this sequence" << endl
          << "    -g, --graph FILE        include this graph" << endl
+         << "local alignment parameters:" << endl
+         << "    -a, --match N         use this match score (default: 1)" << endl
+         << "    -i, --mismatch N      use this mismatch penalty (default: 4)" << endl
+         << "    -o, --gap-open N      use this gap open penalty (default: 6)" << endl
+         << "    -e, --gap-extend N    use this gap extension penalty (default: 1)" << endl
          << "mem mapping:" << endl
          << "    -L, --min-mem-length N  ignore SMEMs shorter than this length (default: 0/unset)" << endl
          << "    -Y, --max-mem-length N  ignore SMEMs longer than this length by stopping backward search (default: 0/unset)" << endl
@@ -1061,6 +1066,10 @@ int main_msga(int argc, char** argv) {
     float accept_identity = 0;
     int max_target_factor = 100;
     bool idx_path_only = false;
+    int match = 1;
+    int mismatch = 4;
+    int gap_open = 6;
+    int gap_extend = 1;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -1097,11 +1106,15 @@ int main_msga(int argc, char** argv) {
                 {"thread-ex", required_argument, 0, 'T'},
                 {"max-target-x", required_argument, 0, 'q'},
                 {"max-multimaps", required_argument, 0, 'I'},
+                {"match", required_argument, 0, 'a'},
+                {"mismatch", required_argument, 0, 'i'},
+                {"gap-open", required_argument, 0, 'o'},
+                {"gap-extend", required_argument, 0, 'e'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:B:DAc:P:E:Q:NzI:L:Y:H:t:m:GS:M:T:q:OI:",
+        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:B:DAc:P:E:Q:NzI:L:Y:H:t:m:GS:M:T:q:OI:a:i:o:e:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -1151,7 +1164,6 @@ int main_msga(int argc, char** argv) {
         case 'c':
             context_depth = atoi(optarg);
             break;
-
 
         case 'f':
             fasta_files.push_back(optarg);
@@ -1231,6 +1243,22 @@ int main_msga(int argc, char** argv) {
 
             case 'z':
                 allow_nonpath = true;
+                break;
+                
+            case 'a':
+                match = atoi(optarg);
+                break;
+
+            case 'i':
+                mismatch = atoi(optarg);
+                break;
+
+            case 'o':
+                gap_open = atoi(optarg);
+                break;
+
+            case 'e':
+                gap_extend = atoi(optarg);
                 break;
 
             case 'h':
@@ -1356,6 +1384,10 @@ int main_msga(int argc, char** argv) {
             mapper->max_target_factor = max_target_factor;
             mapper->max_multimaps = max_multimaps;
             mapper->accept_identity = accept_identity;
+            mapper->match = match;
+            mapper->mismatch = mismatch;
+            mapper->gap_open = gap_open;
+            mapper->gap_extend = gap_extend;
         }
     };
 
@@ -4585,11 +4617,15 @@ void help_align(char** argv) {
          << "    -s, --sequence STR    align a string to the graph in graph.vg using partial order alignment" << endl
          << "    -Q, --seq-name STR    name the sequence using this value" << endl
          << "    -j, --json            output alignments in JSON format (default GAM)" << endl
-         << "    -m, --match N         use this match score (default: 2)" << endl
-         << "    -M, --mismatch N      use this mismatch penalty (default: 2)" << endl
-         << "    -g, --gap-open N      use this gap open penalty (default: 3)" << endl
+         << "    -m, --match N         use this match score (default: 1)" << endl
+         << "    -M, --mismatch N      use this mismatch penalty (default: 4)" << endl
+         << "    -g, --gap-open N      use this gap open penalty (default: 6)" << endl
          << "    -e, --gap-extend N    use this gap extension penalty (default: 1)" << endl
-         << "    -D, --debug           print out score matrices and other debugging info" << endl;
+         << "    -D, --debug           print out score matrices and other debugging info" << endl
+         << "options:" << endl
+         << "    -s, --sequence STR    align a string to the graph in graph.vg using partial order alignment" << endl
+         << "    -Q, --seq-name STR    name the sequence using this value" << endl
+         << "    -j, --json            output alignments in JSON format (default GAM)" << endl;
 }
 
 int main_align(int argc, char** argv) {
@@ -4604,9 +4640,9 @@ int main_align(int argc, char** argv) {
 
     bool print_cigar = false;
     bool output_json = false;
-    int match = 2;
-    int mismatch = 2;
-    int gap_open = 3;
+    int match = 1;
+    int mismatch = 4;
+    int gap_open = 6;
     int gap_extend = 1;
     bool debug = false;
 
@@ -4738,9 +4774,9 @@ void help_map(char** argv) {
          << "    -Z, --buffer-size N   buffer this many alignments together before outputting in GAM (default: 100)" << endl
          << "    -D, --debug           print debugging information about alignment to stderr" << endl
          << "local alignment parameters:" << endl
-         << "    -q, --match N         use this match score (default: 2)" << endl
-         << "    -z, --mismatch N      use this mismatch penalty (default: 2)" << endl
-         << "    -o, --gap-open N      use this gap open penalty (default: 3)" << endl
+         << "    -q, --match N         use this match score (default: 1)" << endl
+         << "    -z, --mismatch N      use this mismatch penalty (default: 4)" << endl
+         << "    -o, --gap-open N      use this gap open penalty (default: 6)" << endl
          << "    -y, --gap-extend N    use this gap extension penalty (default: 1)" << endl
          << "generic mapping parameters:" << endl
          << "    -B, --band-width N    for very long sequences, align in chunks then merge paths (default 1000bp)" << endl
@@ -4819,9 +4855,9 @@ int main_map(int argc, char** argv) {
     int max_target_factor = 100;
     bool in_mem_path_only = false;
     int buffer_size = 100;
-    int match = 2;
-    int mismatch = 2;
-    int gap_open = 3;
+    int match = 1;
+    int mismatch = 4;
+    int gap_open = 6;
     int gap_extend = 1;
 
     int c;
@@ -4945,7 +4981,7 @@ int main_map(int argc, char** argv) {
         case 'm':
             hit_max = atoi(optarg);
             break;
-
+            
         case 'M':
             max_multimaps = atoi(optarg);
             break;
@@ -5178,7 +5214,7 @@ int main_map(int argc, char** argv) {
     // Make sure to flush the buffer at the end of the program!
     auto output_alignments = [&output_buffer, &output_json, &buffer_size](vector<Alignment>& alignments) {
         // for(auto& alignment : alignments){
-        // 		cerr << "This is in output_alignments" << alignment.DebugString() << endl;
+        //     cerr << "This is in output_alignments" << alignment.DebugString() << endl;
         // }
 
         if (output_json) {
@@ -5765,7 +5801,7 @@ int main_view(int argc, char** argv) {
              graph->from_turtle("/dev/stdin", rdf_base_uri);
         } else {
              graph->from_turtle(file_name, rdf_base_uri);
-	}
+        }
     } else if (input_type == "gam") {
         if (input_json == false) {
             if (output_type == "json") {

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -32,9 +32,9 @@ Mapper::Mapper(Index* idex,
     , max_mem_length(0)
     , min_mem_length(0)
     , max_target_factor(128)
-    , match(2)
-    , mismatch(2)
-    , gap_open(3)
+    , match(1)
+    , mismatch(4)
+    , gap_open(6)
     , gap_extend(1)
     , max_query_graph_ratio(128)
 {

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -790,16 +790,16 @@ public:
     // Align to the graph. The graph must be acyclic and contain only end-to-start edges.
     // Will modify the graph by re-ordering the nodes.
     Alignment align(const Alignment& alignment,
-                    int32_t match = 2,
-                    int32_t mismatch = 2,
-                    int32_t gap_open = 3,
+                    int32_t match = 1,
+                    int32_t mismatch = 4,
+                    int32_t gap_open = 6,
                     int32_t gap_extension = 1,
                     size_t max_query_graph_ratio = 0,
                     bool print_score_matrices = false);
     Alignment align(const string& sequence,
-                    int32_t match = 2,
-                    int32_t mismatch = 2,
-                    int32_t gap_open = 3,
+                    int32_t match = 1,
+                    int32_t mismatch = 4,
+                    int32_t gap_open = 6,
                     int32_t gap_extension = 1,
                     size_t max_query_graph_ratio = 0,
                     bool print_score_matrices = false);

--- a/test/t/04_vg_align.t
+++ b/test/t/04_vg_align.t
@@ -5,15 +5,17 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 12
+plan tests 13
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg align -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -j - | tr ',' '\n' | grep node_id | grep "72\|74\|75\|77" | wc -l) 4 "alignment traverses the correct path"
 
-is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg align -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -j - | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 96 "alignment score is as expected"
+is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg align -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -j - | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 48 "alignment score is as expected"
 
-is $(vg align -js $(cat mapsoftclip/70211809-70211845.seq) mapsoftclip/70211809-70211845.vg | jq -c '.path .mapping[0] .position .node_id') 70211814 "alignment does not contain excessive soft clips"
+is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg align --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -j - | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 96 "scoring parameters are respected"
 
-is $(vg align -js $(cat mapsoftclip/113968116:113968146.seq ) mapsoftclip/113968116:113968146.vg | jq -c ".score") 274 "alignment does not overflow when using 8x16bit vectors"
+is $(vg align -js $(cat mapsoftclip/70211809-70211845.seq) --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 mapsoftclip/70211809-70211845.vg | jq -c '.path .mapping[0] .position .node_id') 70211814 "alignment does not contain excessive soft clips under lenient scoring"
+
+is $(vg align -js $(cat mapsoftclip/113968116:113968146.seq ) --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 mapsoftclip/113968116:113968146.vg | jq -c ".score") 274 "alignment score does not overflow at 255 when using 8x16bit vectors"
 
 is $(vg align -js $(cat mapsoftclip/280136066-280136088.seq) mapsoftclip/280136066-280136088.vg | jq -c '.path .mapping[0] .position .node_id') 280136076 "Ns do not cause excessive soft clipping"
 

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -12,7 +12,7 @@ vg construct -r small/x.fa >j.vg
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -s -k 11 -d x.idx x.vg
 
-is $(vg map -r <(vg sim -s 1337 -n 100 j.vg) -d x.idx | vg surject -p x -d x.idx -t 1 - | vg view -a - | jq .score | grep 200 | wc -l) \
+is $(vg map -r <(vg sim -s 1337 -n 100 j.vg) -d x.idx | vg surject -p x -d x.idx -t 1 - | vg view -a - | jq .score | grep 100 | wc -l) \
     100 "vg surject works perfectly for perfect reads derived from the reference"
     
 is $(vg map -r <(vg sim -s 1337 -n 100 j.vg) -d x.idx | vg surject -p x -d x.idx -t 1 -s - | grep -v "@" | cut -f3 | grep x | wc -l) \

--- a/test/t/16_vg_msga.t
+++ b/test/t/16_vg_msga.t
@@ -8,9 +8,9 @@ PATH=../bin:$PATH # for vg
 
 plan tests 16
 
-is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 | vg mod -n - | vg mod -n - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) 16e56f0090b310d2b1479d49cf790324 "MSGA produces the expected graph for GRCh38 HLA-V"
+is $(vg msga -a 2 -i 2 -o 3 -e 1 -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 | vg mod -n - | vg mod -n - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) 16e56f0090b310d2b1479d49cf790324 "MSGA produces the expected graph for GRCh38 HLA-V"
 
-is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 4 | vg mod -n - | vg mod -n - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) 16e56f0090b310d2b1479d49cf790324 "graph for GRCh38 HLA-V is unaffected by the number of alignment threads"
+is $(vg msga -a 2 -i 2 -o 3 -e 1 -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 4 | vg mod -n - | vg mod -n - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) 16e56f0090b310d2b1479d49cf790324 "graph for GRCh38 HLA-V is unaffected by the number of alignment threads"
 
 is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -n 'gi|568815592:29791752-29792749' -n 'gi|568815454:1057585-1058559' -b 'gi|568815454:1057585-1058559' -B 10000 -N | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -n 'gi|568815592:29791752-29792749' -n 'gi|568815454:1057585-1058559' -b 'gi|568815454:1057585-1058559' -B 300 -N | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ )  "varying alignment bandwidth does not affect output graph"
 


### PR DESCRIPTION
The current scoring parameters of match = +2, mismatch = -2, gap open = -3, gap extend = -1 have a bit of a problem: if you can replace 2 mismatches with 2 indels and create an extra match, it's free (and the aligner seems to tend to do it).

These scoring parameters don't seem to have that problem.

Unfortunately, changing the default scoring parameters seems to have confused a large number of tests. Some of them just need to be adjusted to assume a perfect score is 1 point per base instead of 2 (or we could double the score values), but some of them (like the problem with vg mod) seem to indicate that these mapping parameters produce different mappings that aren't what the tests are expecting.

Do we actually want to change over to these parameters as the defaults, or should I just make them configurable and use them in my mapping runs?