### PR TITLE
Restore surject

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -620,7 +620,7 @@ vector<Alignment> reverse_complement_alignments(const vector<Alignment>& alns, c
 }
 
 Alignment reverse_complement_alignment(const Alignment& aln,
-                                       const function<int64_t(int64_t)>& node_length) {
+                                       const function<int64_t(id_t)>& node_length) {
     // We're going to reverse the alignment and all its mappings.
     // TODO: should we/can we do this in place?
     

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -85,7 +85,7 @@ const string hash_alignment(const Alignment& aln);
 // Mappings to match. A function to get node lengths is needed because the
 // Mappings in the alignment will need to give their positions from the opposite
 // ends of their nodes.
-Alignment reverse_complement_alignment(const Alignment& aln, const function<int64_t(int64_t)>& node_length);
+Alignment reverse_complement_alignment(const Alignment& aln, const function<int64_t(id_t)>& node_length);
 vector<Alignment> reverse_complement_alignments(const vector<Alignment>& alns, const function<int64_t(int64_t)>& node_length);
 int softclip_start(Alignment& alignment);
 int softclip_end(Alignment& alignment);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1222,7 +1222,7 @@ const string mapping_sequence(const Mapping& mp, const Node& n) {
     auto& node_seq = n.sequence();
     string seq;
     // todo reverse the mapping
-    function<id_t(id_t)> lambda = [&node_seq](id_t i){return node_seq.size();};
+    function<int64_t(id_t)> lambda = [&node_seq](id_t i){return node_seq.size();};
     Mapping m = (mp.position().is_reverse()
                  ? reverse_complement_mapping(mp, lambda) : mp);
     // then edit in the forward direction (easier)
@@ -1254,7 +1254,7 @@ const string mapping_sequence(const Mapping& mp, const Node& n) {
 }
 
 Mapping reverse_complement_mapping(const Mapping& m,
-                                   const function<id_t(id_t)>& node_length) {
+                                   const function<int64_t(id_t)>& node_length) {
     // Make a new reversed mapping
     Mapping reversed = m;
 
@@ -1282,7 +1282,7 @@ Mapping reverse_complement_mapping(const Mapping& m,
 }
 
 Path reverse_complement_path(const Path& path,
-                             const function<id_t(id_t)>& node_length) {
+                             const function<int64_t(id_t)>& node_length) {
     // Make a new reversed path
     Path reversed = path;
 

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -198,12 +198,12 @@ const string mapping_sequence(const Mapping& m, const Node& n);
 // lengths is needed, because the mapping will need to count its position from
 // the other end of the node.
 Mapping reverse_complement_mapping(const Mapping& m,
-                                   const function<id_t(id_t)>& node_length);
+                                   const function<int64_t(id_t)>& node_length);
 // Reverse-complement a Path and all the Mappings in it. A function to get node
 // lengths is needed, because the mappings will need to count their positions
 // from the other ends of their nodes.
 Path reverse_complement_path(const Path& path,
-                             const function<id_t(id_t)>& node_length);
+                             const function<int64_t(id_t)>& node_length);
 // Simplify the path for addition as new material in the graph. Remove any
 // mappings that are merely single deletions, merge adjacent edits of the same
 // type, strip leading and trailing deletion edits on mappings, and make sure no

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 8
+plan tests 9
 
 vg construct -r small/x.fa >j.vg
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
@@ -14,6 +14,9 @@ vg index -s -k 11 -d x.idx x.vg
 
 is $(vg map -r <(vg sim -s 1337 -n 100 j.vg) -d x.idx | vg surject -p x -d x.idx -t 1 - | vg view -a - | jq .score | grep 200 | wc -l) \
     100 "vg surject works perfectly for perfect reads derived from the reference"
+    
+is $(vg map -r <(vg sim -s 1337 -n 100 j.vg) -d x.idx | vg surject -p x -d x.idx -t 1 -s - | grep -v "@" | cut -f3 | grep x | wc -l) \
+    100 "vg surject actually places reads on the correct path"
 
 is $(vg map -r <(vg sim -s 1337 -n 100 x.vg) -d x.idx | vg surject -p x -d x.idx -t 1 - | vg view -a - | wc -l) \
     100 "vg surject works for every read simulated from a dense graph"


### PR DESCRIPTION
Surject is currently completely broken. This fixes it to actually include mappings in the surjected alignments, and to work on both strands.