### PR TITLE
Added warning to vg.cpp if input fasta is lower case

### DIFF
--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -3006,7 +3006,8 @@ VG::VG(vcflib::VariantCallFile& variantCallFile,
     //
     
     std::function<bool(string)> all_upper = [](string s){
-        for (int i = 0; i < s.size(); i++){
+        //GO until [size() - 1 ] to avoid the newline char
+        for (int i = 0; i < s.size() - 1; i++){
             if (!isupper(s[i])){
                 return false;
             }

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -3004,12 +3004,25 @@ VG::VG(vcflib::VariantCallFile& variantCallFile,
     // so we'll run this for regions of moderate size, scaling up in the case that we run into a big deletion
     //
     //
+    
+    std::function<bool(string)> all_upper = [](string s){
+        for (int i = 0; i < s.size(); i++){
+            if (!isupper(s[i])){
+                return false;
+            }
+        }
+        return true;
+    };
 
     for (vector<string>::iterator t = targets.begin(); t != targets.end(); ++t) {
 
         //string& seq_name = *t;
         string seq_name;
         string target = *t;
+        if (!all_upper(target)){
+            cerr << "WARNING: Lower case letters found during construction" << endl;
+            cerr << "Sequences may not map to this reference." << endl;
+        }
         int start_pos = 0, stop_pos = 0;
         // nasty hack for handling single regions
         if (!target_is_chrom) {


### PR DESCRIPTION
Ran into this on #294. This doesn't fix it per se, but it will toss a simple two line warning. It's one short lambda applied during construction.