### PR TITLE
Make surject work on the reverse strand

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -407,13 +407,14 @@ bam1_t* alignment_to_bam(const string& sam_header,
                          const Alignment& alignment,
                          const string& refseq,
                          const int32_t refpos,
+                         const bool refrev,
                          const string& cigar,
                          const string& mateseq,
                          const int32_t matepos,
                          const int32_t tlen) {
 
     assert(!sam_header.empty());
-    string sam_file = "data:" + sam_header + alignment_to_sam(alignment, refseq, refpos, cigar, mateseq, matepos, tlen);
+    string sam_file = "data:" + sam_header + alignment_to_sam(alignment, refseq, refpos, refrev, cigar, mateseq, matepos, tlen);
     const char* sam = sam_file.c_str();
     samFile *in = sam_open(sam, "r");
     bam_hdr_t *header = sam_hdr_read(in);
@@ -432,14 +433,19 @@ bam1_t* alignment_to_bam(const string& sam_header,
 string alignment_to_sam(const Alignment& alignment,
                         const string& refseq,
                         const int32_t refpos,
+                        const bool refrev,
                         const string& cigar,
                         const string& mateseq,
                         const int32_t matepos,
                         const int32_t tlen) {
+                        
+    // Determine flags, using orientation.
+    int32_t flags = sam_flag(alignment, refrev);
+    
     stringstream sam;
 
     sam << (!alignment.name().empty() ? alignment.name() : "*") << "\t"
-        << sam_flag(alignment) << "\t"
+        << flags << "\t"
         << (refseq.empty() ? "*" : refseq) << "\t"
         << refpos + 1 << "\t"
         //<< (alignment.path().mapping_size() ? refpos + 1 : 0) << "\t" // positions are 1-based in SAM, 0 means unmapped
@@ -448,7 +454,8 @@ string alignment_to_sam(const Alignment& alignment,
         << (mateseq == refseq ? "=" : mateseq) << "\t"
         << matepos + 1 << "\t"
         << tlen << "\t"
-        << (!alignment.sequence().empty() ? alignment.sequence() : "*") << "\t";
+        // Make sure sequence always comes out in reference forward orientation by looking at the flags.
+        << (!alignment.sequence().empty() ? (refrev ? reverse_complement(alignment.sequence()) : alignment.sequence()) : "*") << "\t";
     // hack much?
     if (!alignment.quality().empty()) {
         const string& quality = alignment.quality();
@@ -467,7 +474,8 @@ string alignment_to_sam(const Alignment& alignment,
 
 // act like the path this is against is the reference
 // and generate an equivalent cigar
-string cigar_against_path(const Alignment& alignment) {
+// Produces CIGAR in forward strand space of the reference sequence.
+string cigar_against_path(const Alignment& alignment, bool on_reverse_strand) {
     vector<pair<int, char> > cigar;
     if (!alignment.has_path()) return "";
     const Path& path = alignment.path();
@@ -475,10 +483,16 @@ string cigar_against_path(const Alignment& alignment) {
     for (const auto& mapping : path.mapping()) {
         mapping_cigar(mapping, cigar);
     }
+    
+    if(on_reverse_strand) {
+        // Flip CIGAR ops into forward strand ordering
+        reverse(cigar.begin(), cigar.end());
+    }
+    
     return cigar_string(cigar);
 }
 
-int32_t sam_flag(const Alignment& alignment) {
+int32_t sam_flag(const Alignment& alignment, bool on_reverse_strand) {
     int16_t flag = 0;
 
     if (alignment.score() == 0) {
@@ -488,10 +502,7 @@ int32_t sam_flag(const Alignment& alignment) {
         // correctly aligned
         flag |= BAM_FPROPER_PAIR;
     }
-    // HACKZ -- you can't determine orientation from a single part of the mapping
-    // unless the graph is a DAG
-    if (alignment.has_path()
-        && alignment.path().mapping(0).position().is_reverse()) {
+    if (on_reverse_strand) {
         flag |= BAM_FREVERSE;
     }
     if (alignment.is_secondary()) {

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -46,6 +46,7 @@ bam1_t* alignment_to_bam(const string& sam_header,
                          const Alignment& alignment,
                          const string& refseq,
                          const int32_t refpos,
+                         const bool refrev,
                          const string& cigar,
                          const string& mateseq,
                          const int32_t matepos,
@@ -54,14 +55,15 @@ bam1_t* alignment_to_bam(const string& sam_header,
 string alignment_to_sam(const Alignment& alignment,
                         const string& refseq,
                         const int32_t refpos,
+                        const bool refrev,
                         const string& cigar,
                         const string& mateseq,
                         const int32_t matepos,
                         const int32_t tlen);
 
-string cigar_against_path(const Alignment& alignment);
+string cigar_against_path(const Alignment& alignment, bool on_reverse_strand);
 
-int32_t sam_flag(const Alignment& alignment);
+int32_t sam_flag(const Alignment& alignment, bool on_reverse_strand);
 short quality_char_to_short(char c);
 char quality_short_to_char(short i);
 string string_quality_char_to_short(const string& quality);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1259,6 +1259,7 @@ bool Index::surject_alignment(const Alignment& source,
                               Alignment& surjection,
                               string& path_name,
                               int64_t& path_pos,
+                              bool& path_reverse,
                               int window) {
     VG graph;
     // get start and end nodes in path
@@ -1303,7 +1304,8 @@ bool Index::surject_alignment(const Alignment& source,
     // What is our alignment to surject spelled the other way around? We can't
     // just use the normal alignment RC function because the mappings reference
     // nonexistent nodes.
-    Alignment source_rc;
+    // Make sure to copy all the things about the alignment (name, etc.)
+    Alignment source_rc = source;
     source_rc.set_sequence(reverse_complement(source.sequence()));
     
     // Align the old alignment to the graph in both orientations. Apparently
@@ -1338,7 +1340,7 @@ bool Index::surject_alignment(const Alignment& source,
 
     if (surjection.path().mapping_size() > 0 && kept_paths.size() == 1) {
         // determine the paths of the node we mapped into
-        //  ... get the id of the first node, get the pahs of it
+        //  ... get the id of the first node, get the paths of it
         assert(kept_paths.size() == 1);
         path_name = *kept_paths.begin();
 
@@ -1357,6 +1359,33 @@ bool Index::surject_alignment(const Alignment& source,
         // as a surjection this node must be in the path
         // the nearest place we map should be the head of this node
         assert(path_prev.size()==1 && hit_id == path_prev.front().first && hit_backward == path_prev.front().second);
+        
+        if(prev_orientation) {
+            // We really are running backward along the path.
+            // Get a version for which the path runs forward
+            Alignment path_oriented_surjection = reverse_complement_alignment(surjection, node_length);
+            
+            // Use that instead
+            hit_id = path_oriented_surjection.path().mapping(0).position().node_id();
+            get_node(hit_id, hit_node);
+            hit_backward = path_oriented_surjection.path().mapping(0).position().is_reverse();
+            pos = path_oriented_surjection.path().mapping(0).position().offset();
+            get_node_path_relative_position(hit_id, hit_backward, path_id, path_prev, prev_pos, prev_orientation,
+                                            path_next, next_pos, next_orientation);
+                                            
+            assert(path_prev.size()==1 && hit_id == path_prev.front().first && hit_backward == path_prev.front().second);
+            assert(!prev_orientation);
+            
+            path_reverse = true;
+        } else {
+            // The orientation of the best alignment runs forward along the path.
+            path_reverse = false;
+        }
+        
+        // Make sure we're landing in the right direction.
+        assert(next_pos >= prev_pos);
+        assert(prev_orientation == next_orientation);
+        
         // we then add the position of this node against the path to our offset in the node (from the left side)
         // to get the final chrom+position for the surjection
         path_pos = prev_pos + (hit_backward ? hit_node.sequence().size() - pos - 1 : pos);

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -255,11 +255,16 @@ public:
                                   list<pair<int64_t, bool>>& path_prev, int64_t& prev_pos, bool& prev_orientation,
                                   list<pair<int64_t, bool>>& path_next, int64_t& next_pos, bool& next_orientation);
 
+    // Surject an alignment. Fills in path_name with the path surjected onto,
+    // path_pos with the leftmost position along that path that is used, and
+    // path_reverse with whether the alignemnt lands on the path in a reverse
+    // orientation.
     bool surject_alignment(const Alignment& source,
                            set<string>& path_names,
                            Alignment& surjection,
                            string& path_name,
                            int64_t& path_pos,
+                           bool& path_reverse,
                            int window = 5);
     // Populates layout with path start and end nodes (and orientations),
     // indexed by path names, and lengths with path lengths indexed by path


### PR DESCRIPTION
Turns out surject wasn't working for the reverse strand. This should fix (and test) that.