### PR TITLE
Add vg version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,11 @@ $(LIB_DIR)/libraptor2.a: .pre-build
 $(INC_DIR)/sha1.hpp: $(OBJ_DIR)/sha1.o
 $(OBJ_DIR)/sha1.o: $(SHA1_DIR)/sha1.cpp $(SHA1_DIR)/sha1.hpp .pre-build
 	+$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) && cp $(SHA1_DIR)/*.h* $(CWD)/$(INC_DIR)/
+	
+# Auto-versioning
+$(INC_DIR)/vg_git_version.hpp: .pre-build .git/HEAD .git/index
+	echo "#define VG_GIT_VERSION \"$(shell git describe --always --tags || echo unknown)\"" > $@
+	
 
 ###################################
 ## VG source code compilation begins here
@@ -183,7 +188,7 @@ $(OBJ_DIR)/vg_set.o: $(SRC_DIR)/vg_set.cpp $(SRC_DIR)/vg_set.hpp $(SRC_DIR)/vg.h
 $(OBJ_DIR)/mapper.o: $(SRC_DIR)/mapper.cpp $(SRC_DIR)/mapper.hpp $(CPP_DIR)/vg.pb.h $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libxg.a
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
-$(OBJ_DIR)/main.o: $(SRC_DIR)/main.cpp $(LIB_DIR)/libvcflib.a $(OBJ_DIR)/Fasta.o $(LIB_DIR)/libgssw.a $(INC_DIR)/stream.hpp $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(LIB_DIR)/librocksdb.a $(CPP_DIR)/vg.pb.h $(LIB_DIR)/libxg.a $(INC_DIR)/gcsa.h $(LIB_DIR)/libhts.a $(INC_DIR)/sha1.hpp $(OBJ_DIR)/progress_bar.o $(INC_DIR)/lru_cache.h $(LIB_DIR)/libvcfh.a $(LIB_DIR)/libgfakluge.a $(LIB_DIR)/libsdsl.a
+$(OBJ_DIR)/main.o: $(SRC_DIR)/main.cpp $(INC_DIR)/vg_git_version.hpp $(LIB_DIR)/libvcflib.a $(OBJ_DIR)/Fasta.o $(LIB_DIR)/libgssw.a $(INC_DIR)/stream.hpp $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(LIB_DIR)/librocksdb.a $(CPP_DIR)/vg.pb.h $(LIB_DIR)/libxg.a $(INC_DIR)/gcsa.h $(LIB_DIR)/libhts.a $(INC_DIR)/sha1.hpp $(OBJ_DIR)/progress_bar.o $(INC_DIR)/lru_cache.h $(LIB_DIR)/libvcfh.a $(LIB_DIR)/libgfakluge.a $(LIB_DIR)/libsdsl.a
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
 $(OBJ_DIR)/region.o: $(SRC_DIR)/region.cpp $(SRC_DIR)/region.hpp $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,12 @@
 #include "vectorizer.hpp"
 #include "google/protobuf/stubs/common.h"
 #include "progress_bar.hpp"
+#include "vg_git_version.hpp"
+
+// Make sure the version macro is a thing
+#ifndef VG_GIT_VERSION
+    #define VG_GIT_VERSION "missing"
+#endif
 
 using namespace std;
 using namespace google::protobuf;
@@ -5994,7 +6000,7 @@ int main_view(int argc, char** argv) {
             << "options: " << endl
             << endl;
     }
-int main_deconstruct(int argc, char** argv){
+    int main_deconstruct(int argc, char** argv){
         cerr << "WARNING: EXPERIMENTAL" << endl;
             if (argc <= 2) {
             help_deconstruct(argv);
@@ -6241,15 +6247,33 @@ int main_deconstruct(int argc, char** argv){
 
         return 0;
     }
+    
+    void help_version(char** argv){
+        cerr << "usage: " << argv[0] << " version" << endl
+            << "options: " << endl
+            << endl;
+    }
+    int main_version(int argc, char** argv){
+    
+        if (argc != 2) {
+            help_version(argv);
+            return 1;
+        }
+    
+        cout << VG_GIT_VERSION << endl;
+        return 0;
+    }
 
     void vg_help(char** argv) {
-        cerr << "usage: " << argv[0] << " <command> [options]" << endl
+        cerr << "vg: variation graph tool, version " << VG_GIT_VERSION << endl
+             << endl
+             << "usage: " << argv[0] << " <command> [options]" << endl
              << endl
              << "commands:" << endl
              << "  -- construct     graph construction" << endl
              << "  -- deconstruct   convert a graph into VCF relative to a reference." << endl
              << "  -- view          format conversions for graphs and alignments" << endl
-             << "  -- vectorize     Transform alignments to one-hot vectors." << endl
+             << "  -- vectorize     transform alignments to one-hot vectors" << endl
              << "  -- index         index features of the graph in a disk-backed key/value store" << endl
              << "  -- find          use an index to find nodes, edges, kmers, or positions" << endl
              << "  -- paths         traverse paths in the graph" << endl
@@ -6267,7 +6291,8 @@ int main_deconstruct(int argc, char** argv){
              << "  -- pileup        build a pileup from a set of alignments" << endl
              << "  -- call          prune the graph by genotyping a pileup" << endl
              << "  -- compare       compare the kmer space of two graphs" << endl
-             << "  -- validate      validate the semantics of a graph" << endl;
+             << "  -- validate      validate the semantics of a graph" << endl
+             << "  -- version       version information" << endl;
     }
 
     int main(int argc, char *argv[])
@@ -6327,6 +6352,8 @@ int main_deconstruct(int argc, char** argv){
             return main_filter(argc, argv);
         } else if (command == "vectorize") {
             return main_vectorize(argc, argv);
+        } else if (command == "version") {
+            return main_version(argc, argv);
         }else {
             cerr << "error:[vg] command " << command << " not found" << endl;
             vg_help(argv);


### PR DESCRIPTION
Closes #283.

This implements a `vg version` which will return the git version used to build VG.

It comes out looking like `v1.4.0-422-gfd37dd3`, which is the most recent tag, then the number of commits since the tag, and then "g" and the short git commit hash. This is what `git describe --always --tags` gives you.

The version also appears in the main vg help.

The downside of the implementation approach taken here is that it forces main.cpp to rebuild whenever you make a commit. I think it's fine for now, but we definitely want to break up that file soon.