### PR TITLE
Fix NaNs preventing JSON GAM serialization

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5815,6 +5815,14 @@ int main_view(int argc, char** argv) {
                 // convert values to printable ones
                 function<void(Alignment&)> lambda = [](Alignment& a) {
                     alignment_quality_short_to_char(a);
+                    
+                    if(std::isnan(a.identity())) {
+                        // Fix up NAN identities that can't be serialized in
+                        // JSON. We shouldn't generate these any more, and they
+                        // are out of spec, but they can be in files.
+                        a.set_identity(0);
+                    }
+                    
                     cout << pb2json(a) << "\n";
                 };
                 if (file_name == "-") {

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1623,7 +1623,7 @@ double identity(const Path& path) {
             }
         }
     }
-    return (double) matched_length / (double) total_length;
+    return total_length == 0 ? 0.0 : (double) matched_length / (double) total_length;
 }
 
 }

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -233,6 +233,8 @@ bool adjacent_mappings(const Mapping& m1, const Mapping& m2);
 // Return true if a mapping is a perfect match (i.e. contains no non-match edits)
 bool mapping_is_match(const Mapping& m);
 double divergence(const Mapping& m);
+// Return the identity for the path: perfect matches over total length.
+// For zero-length paths, returns 0.
 double identity(const Path& path);
 
 }

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -104,7 +104,7 @@ message Alignment {
     Alignment fragment_prev = 11; // e.g. contains an alignment with only a name, or only a graph mapping position
     Alignment fragment_next = 12; // same thing for next in fragment
     bool is_secondary = 15; // All but one maximal-scoring alignment of a given read in a GAM file must be secondary.
-    double identity = 16;
+    double identity = 16; // Portion of aligned bases that are perfect matches, or 0 if no bases are aligned.
 }
 
 // Fragments represent the library fragments that yield pairs of alignments


### PR DESCRIPTION
JSON doesn't have a numerical NaN, and json2pb can't convert to/from any string representations for them.

We also probably don't want NaN identity values anyway. I think we're getting them when the path is empty. This sets them to 0 (i.e. unset).