### PR TITLE
Add splitting option to vg filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ $(LIB_DIR)/libxg.a: $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libprotobuf.a $(CPP_DIR)/vg.
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c $(XG_DIR)/src/xg.cpp -o $(CWD)/$(OBJ_DIR)/xg.o $(LD_INCLUDE_FLAGS) -I$(INC_DIR)/dynamic && ar rs $(CWD)/$(LIB_DIR)/libxg.a $(CWD)/$(OBJ_DIR)/xg.o $(CWD)/$(CPP_DIR)/vg.pb.o && cp $(XG_DIR)/src/*.hpp $(CWD)/$(INC_DIR)/
 
 $(LIB_DIR)/libvcflib.a: .pre-build
-	+. ./source_me.sh && cd $(VCFLIB_DIR) && $(MAKE) libvcflib.a && cp lib/* $(CWD)/$(LIB_DIR)/ && cp include/* $(CWD)/$(INC_DIR)/ && cp src/*.h* $(CWD)/$(INC_DIR)/
+	+. ./source_me.sh && cd $(VCFLIB_DIR) && $(MAKE) libvcflib.a && cp lib/* $(CWD)/$(LIB_DIR)/ && cp include/* intervaltree/*.h $(CWD)/$(INC_DIR)/ && cp src/*.h* $(CWD)/$(INC_DIR)/
 
 $(LIB_DIR)/libgssw.a: .pre-build $(GSSW_DIR)/src/gssw.c $(GSSW_DIR)/src/gssw.h
 	+cd $(GSSW_DIR) && $(MAKE) && cp lib/* $(CWD)/$(LIB_DIR)/ && cp obj/* $(CWD)/$(OBJ_DIR) && cp src/*.h $(CWD)/$(INC_DIR)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ void help_filter(char** argv) {
          << "    -f, --frac-score        normalize score based on length" << endl
          << "    -a, --frac-delta        use (secondary / primary) for delta comparisons" << endl
          << "    -u, --substitutions     use substitution count instead of score" << endl
-         << "    -o, --max-overhang N    filter reads whose alignments begin or end with an insert > N [default=100]" << endl
+         << "    -o, --max-overhang N    filter reads whose alignments begin or end with an insert > N [default=99999]" << endl
          << "    -x, --xg-name FILE      use this xg index (required for -R)" << endl
          << "    -R, --regions-file      only output alignments that intersect regions (BED file with 0-based coordinates expected)" << endl
          << "    -B, --output-basename   output to file(s) (required for -R).  The ith file will correspond to the ith BED region" << endl;
@@ -56,7 +56,7 @@ void help_filter(char** argv) {
 
 int main_filter(int argc, char** argv) {
 
-    if (argc <= 3) {
+    if (argc <= 2) {
         help_filter(argv);
         return 1;
     }
@@ -68,7 +68,7 @@ int main_filter(int argc, char** argv) {
     bool frac_score = false;
     bool frac_delta = false;
     bool sub_score = false;
-    int max_overhang = 100;
+    int max_overhang = 99999;
     string xg_name;
     string regions_file;
     string outbase;
@@ -287,11 +287,11 @@ int main_filter(int argc, char** argv) {
     function<void()> flush_buffer = [&buffer, &cur_buffer, &write_buffer, &chunk_names, &chunk_append]() {
         ofstream outfile;
         auto& outbuf = chunk_names[cur_buffer] == "-" ? cout : outfile;
-        if (&outbuf == &outfile) {
+        if (chunk_names[cur_buffer] != "-") {
             outfile.open(chunk_names[cur_buffer], chunk_append[cur_buffer] ? ios::app : ios_base::out);
             chunk_append[cur_buffer] = true;
         }
-        stream::write(outfile, buffer[cur_buffer].size(), write_buffer);
+        stream::write(outbuf, buffer[cur_buffer].size(), write_buffer);
         buffer[cur_buffer].clear();
     };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,6 +147,10 @@ int main_filter(int argc, char** argv) {
         }
     }
 
+    if (optind >= argc) {
+        help_filter(argv);
+        return 1;
+    }
     string graph_file_name = argv[optind++];
 
     // name helper for output
@@ -232,6 +236,10 @@ int main_filter(int argc, char** argv) {
     }
     
     // setup alignment stream
+    if (optind >= argc) {
+        help_filter(argv);
+        return 1;
+    }
     string alignments_file_name = argv[optind++];
     istream* alignment_stream = NULL;
     ifstream in;

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -1,3 +1,6 @@
+#include <iostream>
+#include <fstream>
+#include <cassert>
 #include "region.hpp"
 
 namespace vg {
@@ -40,5 +43,38 @@ void parse_region(
         }
     }
 }
+
+void parse_bed_regions(const string& bed_path,
+                       vector<Region>& out_regions) {
+    out_regions.clear();
+    ifstream bedstream(bed_path);
+    if (!bedstream) {
+        cerr << "Unable to open bed file: " << bed_path << endl;
+        return;
+    }
+    string row;
+    string sbuf;
+    string ebuf;
+    while (getline(bedstream, row)) {
+        Region region;
+        istringstream ss(row);
+        if (!getline(ss, region.seq, '\t') ||
+            !getline(ss, sbuf, '\t') ||
+            !getline(ss, ebuf, '\t')) {
+            cerr << "Error parsing bed line: " << row << endl;
+            out_regions.clear();
+            return;
+        }
+        region.start = std::stoi(sbuf);
+        region.end = std::stoi(ebuf);
+        assert(region.end > region.start);
+        
+        // convert from BED-style to VCF-style coordinates
+        region.start += 1;
+
+        out_regions.push_back(region);
+    }
+}
+
 
 }

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -55,24 +55,26 @@ void parse_bed_regions(const string& bed_path,
     string row;
     string sbuf;
     string ebuf;
-    while (getline(bedstream, row)) {
+    for (int line = 1; getline(bedstream, row); ++line) {
         Region region;
+        if (row.size() < 2 || row[0] == '#') {
+            continue;
+        }
         istringstream ss(row);
         if (!getline(ss, region.seq, '\t') ||
             !getline(ss, sbuf, '\t') ||
             !getline(ss, ebuf, '\t')) {
-            cerr << "Error parsing bed line: " << row << endl;
-            out_regions.clear();
-            return;
-        }
-        region.start = std::stoi(sbuf);
-        region.end = std::stoi(ebuf);
-        assert(region.end > region.start);
-        
-        // convert from BED-style to VCF-style coordinates
-        region.start += 1;
+            cerr << "Error parsing bed line " << line << ": " << row << endl;
+        } else {
+            region.start = std::stoi(sbuf);
+            region.end = std::stoi(ebuf);
+            assert(region.end > region.start);
+            
+            // convert from BED-style to VCF-style coordinates
+            region.start += 1;
 
-        out_regions.push_back(region);
+            out_regions.push_back(region);
+        }
     }
 }
 

--- a/src/region.hpp
+++ b/src/region.hpp
@@ -2,17 +2,44 @@
 #define VG_UTILITY_H
 
 #include <string>
+#include <vector>
+#include <sstream>
 
 namespace vg {
 
 using namespace std;
 
+// wrap up region parse output
+struct Region {
+    string seq;
+    int start;
+    int end;
+};
+
+// parse a region in the form: chrom:start-stop
+// (if only chrom given, start, stop will be set to 0,-1)
 void parse_region(
     string& region,
     string& startSeq,
     int& startPos,
     int& stopPos);
 
+
+inline void parse_region(string& region,
+                         Region& out_region) {
+    parse_region(region,
+                 out_region.seq,
+                 out_region.start,
+                 out_region.end);
 }
+    
+// parse a bed file and return a list of regions (like above)
+// IMPORTANT: expects usual 0-based BED format.
+// So bedline "chr1   5   10" will return start=6 stop=10
+void parse_bed_regions(
+    const string& bed_path,
+    vector<Region>& out_regions);
+    
+}    
 
 #endif

--- a/test/t/21_vg_filter.t
+++ b/test/t/21_vg_filter.t
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 5
+
+vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
+vg index -x x.xg  x.vg
+vg sim x.vg -l 100 -n 1000 -s 0 -e 0.01 -i 0.001 -a > x.gam
+vg view -a x.gam > x.gam.json
+
+# sanity check: does passing no options preserve input
+is $(vg filter x.gam | vg view -a - | jq . | grep mapping | wc -l) 1000 "vg filter with no options preserves input."
+
+# basic chunking tests
+printf "x\t2\t8\nx\t8\t20\ny\t0\t1\nx\t150\t500\nx\t0\t100000000\n" > chunks.bed
+vg filter -x x.xg -R chunks.bed -B filter_chunk x.gam
+
+# right number of chunks
+is $(ls -l filter_chunk-*.gam | wc -l) 4 "vg filter makes right number of chunks."
+
+# is chunk 0 (2-3) comprised of nodes 1,2,4? 
+is $(vg view -a filter_chunk-0.gam | jq -c '.path.mapping[].position' | jq 'select ((.node_id == 1) or (.node_id == 2) or (.node_id == 4))' | wc -l) 65 "vg filter left chunk has all left nodes"
+
+# check that chunk 4 is off to the right a bit
+is $(vg view -a filter_chunk-3.gam | jq -c '.path.mapping[].position' | jq 'select ((.node_id < 4))' | wc -l) 0 "vg filter right chunk has no left nodes"
+
+# check that chunk 5 is everything
+is $(vg view -a filter_chunk-4.gam | jq . | grep mapping | wc -l) 1000 "vg filter big chunk has everything"
+
+rm -f x.vg x.xg x.gam x.gam.json filter_chunk*.gam chunks.bed


### PR DESCRIPTION
Takes a bed file as input, and uses the xg index to find all node ranges in each region.  The gam is chunked out accordingly, where an alignment gets put into the chunk corresponding to a node range if it contains at least one node in that range.