### PR TITLE
add wrapper script to call vcf chunk by chunk

### DIFF
--- a/scripts/chunked_call
+++ b/scripts/chunked_call
@@ -1,0 +1,272 @@
+#!/usr/bin/env python2.7
+"""
+Generate a VCF from a GAM and XG by splitting into GAM/VG chunks.
+Chunks are then called in series, and the VCFs stitched together.
+Any step whose expected output exists is skipped unles --overwrite 
+specified.  
+"""
+
+import argparse, sys, os, os.path, random, subprocess, shutil, itertools, glob
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser(description=__doc__, 
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+        
+    # General options
+    parser.add_argument("xg_path", type=str,
+                        help="input xg file")
+    parser.add_argument("gam_path", type=str,
+                        help="input alignment")
+    parser.add_argument("path_name", type=str,
+                        help="name of reference path in graph (ex chr21)")
+    parser.add_argument("path_size", type=int,
+                        help="size of the reference path in graph")
+    parser.add_argument("sample_name", type=str,
+                        help="sample name (ex NA12878)")
+    parser.add_argument("out_dir", type=str,
+                        help="directory where all output will be written")    
+    parser.add_argument("--chunk", type=int, default=10000000,
+                        help="chunk size")
+    parser.add_argument("--overlap", type=int, default=2000,
+                        help="amount of overlap between chunks")
+    parser.add_argument("--filter_opts", type=str,
+                        default="-r 0.9 -d 0.05 -e 0.05 -afu -s 1000 -o 10",
+                        help="options to pass to vg filter. wrap in \"\"")
+    parser.add_argument("--pileup_opts", type=str,
+                        default="-w 40 -m 10 -q 10",
+                        help="options to pass to vg pileup. wrap in \"\"")
+    parser.add_argument("--call_opts", type=str,
+                        default="-r 0.0001 -b 0.4 -f 0.25 -d 10",
+                        help="options to pass to vg call. wrap in \"\"")
+    parser.add_argument("--threads", type=int, default=20,
+                        help="number of threads to use in vg call and vg pileup")
+    parser.add_argument("--overwrite", action="store_true",
+                        help="always overwrite existing files")
+                        
+    args = args[1:]
+        
+    return parser.parse_args(args)
+
+def run(cmd, proc_stdout = sys.stdout, proc_stderr = sys.stderr,
+        check = True):
+    """ run command in shell and throw exception if it doesn't work 
+    """
+    proc = subprocess.Popen(cmd, shell=True, bufsize=-1,
+                            stdout=proc_stdout, stderr=proc_stderr)
+    sys.stdout.write("{}\n".format(cmd))
+    output, errors = proc.communicate()
+    sts = proc.wait()
+    if check is True and sts != 0:
+        raise RuntimeError("Command: %s exited with non-zero status %i" % (cmd, sts))
+    return output, errors
+
+def make_chunks(path_name, path_size, chunk_size, overlap):
+    """ compute chunks as BED (0-based) 3-tuples: ie
+    (chr1, 0, 10) is the range from 0-9 inclusive of chr1
+    """
+    assert chunk_size > overlap
+    covered = 0
+    chunks = []
+    while covered < path_size:
+        start = max(0, covered - overlap)
+        end = min(path_size, start + chunk_size)
+        chunks.append((path_name, start, end))
+        covered = end
+    return chunks
+
+def chunk_base_name(path_name, out_dir, chunk_i = None, tag= ""):
+    """ centralize naming of output chunk-related files """
+    bn = os.path.join(out_dir, "{}-chunk".format(path_name))
+    if chunk_i is not None:
+        bn += "-{}".format(chunk_i)
+    return "{}{}".format(bn, tag)
+
+def chunk_gam(gam_path, xg_path, path_name, out_dir, chunks, filter_opts, overwrite):
+    """ use vg filter to chunk up the gam """
+    # make bed chunks
+    chunk_path = os.path.join(out_dir, path_name + "_chunks.bed")
+    with open(chunk_path, "w") as f:
+        for chunk in chunks:
+            f.write("{}\t{}\t{}\n".format(chunk[0], chunk[1], chunk[2]))
+    # run vg filter on the gam
+    if overwrite or not any(
+            os.path.isfile(chunk_base_name(path_name, out_dir, i, ".gam")) \
+               for i in range(len(chunks))):
+        run("vg filter {} -x {} -R {} -B {} {}".format(
+            gam_path, xg_path, chunk_path,
+            os.path.join(out_dir, path_name + "-chunk"), filter_opts))
+
+                    
+def chunk_vg(xg_path, out_dir, chunks, chunk_i, overwrite):
+    """ use vg find to make one chunk of the graph """
+    chunk = chunks[chunk_i]
+    vg_chunk_path = chunk_base_name(chunk[0], out_dir, chunk_i, ".vg")
+    if overwrite or not os.path.isfile(vg_chunk_path):
+        run("vg find -x {} -p {}:{}-{} | vg mod -o - > {}".format(
+            xg_path, chunk[0], int(chunk[1]) + 1, chunk[2], vg_chunk_path))
+
+def xg_path_node_offset(xg_path, path_name, offset):
+    """ get the offset of the node containing the given position of a path
+    """
+    # first we find the node
+    stdout, stderr = run("vg find -x {} -p {}:{}-{} | vg view -j - | jq .node[0].id".format(
+        xg_path, path_name, offset, offset),
+                         proc_stdout=subprocess.PIPE)
+    node_id = int(stdout)
+
+    # now we find the offset of the beginning of the node
+    stdout, stderr = run("vg find -x {} -P {} -n {}".format(
+        xg_path, path_name, node_id),
+                         proc_stdout=subprocess.PIPE)
+    toks = stdout.split()
+    # if len > 2 then we have a cyclic path, which we're assuming we don't
+    assert len(toks) == 2
+    assert toks[0] == str(node_id)
+    node_offset = int(toks[1])
+    # node_offset must be before
+    assert node_offset <= offset
+    # sanity check (should really use node size instead of 1000 here)
+    assert offset - node_offset < 1000
+
+    return node_offset
+    
+def sort_vcf(vcf_path, sorted_vcf_path):
+    """ from vcflib """
+    run("head -10000 {} | grep \"^#\" > {}".format(
+        vcf_path, sorted_vcf_path))
+    run("grep -v \"^#\" {} | sort -k1,1d -k2,2n >> {}".format(
+        vcf_path, sorted_vcf_path))
+    
+def call_chunk(xg_path, out_dir, chunks, chunk_i, overlap, pileup_opts,
+               call_options, sample_name, threads, overwrite):
+    """ create VCF from a given chunk """
+    # make the graph chunk
+    chunk_vg(xg_path, out_dir, chunks, chunk_i, overwrite)
+
+    chunk = chunks[chunk_i]
+    path_name = chunk[0]
+    vg_path = chunk_base_name(path_name, out_dir, chunk_i, ".vg")
+    gam_path = chunk_base_name(path_name, out_dir, chunk_i, ".gam")
+
+    # a chunk can be empty if nothing aligns there.
+    if not os.path.isfile(gam_path):
+        sys.stderr.write("Warning: chunk not found: {}\n".format(gam_path))
+        return
+    
+    # do the pileup.  this is the most resource intensive step,
+    # especially in terms of mermory used.
+    pu_path = chunk_base_name(path_name, out_dir, chunk_i, ".pu")
+    if overwrite or not os.path.isfile(pu_path):
+        run("vg pileup {} {} -t {} {} > {}".format(
+            vg_path, gam_path, threads, pileup_opts, pu_path))
+
+    # do the calling.
+    tsv_path = chunk_base_name(path_name, out_dir, chunk_i, "_call.tsv")
+    ag_path = chunk_base_name(path_name, out_dir, chunk_i, "_call.vg")
+    if overwrite or not os.path.isfile(tsv_path) or not os.path.isfile(ag_path):
+        run("vg call {} {} -t {} {} -l -c {} > {}".format(
+            vg_path, pu_path, threads, call_options, tsv_path, ag_path))
+
+    # do the vcf export.
+    vcf_path = chunk_base_name(path_name, out_dir, chunk_i, ".vcf")
+    if overwrite or not os.path.isfile(vcf_path + ".gz"):
+        offset = xg_path_node_offset(xg_path, chunk[0], chunk[1] + 1)
+        run("glenn2vcf {} {} -o {} -c {} -s {} > {} 2> {}".format(
+            ag_path, tsv_path, offset, chunk[0], sample_name,
+            vcf_path + ".us", vcf_path + ".log"))
+        sort_vcf(vcf_path + ".us", vcf_path)
+        run("rm {}".format(vcf_path + ".us"))
+        run("bgzip {}".format(vcf_path))
+        run("tabix -f -p vcf {}".format(vcf_path + ".gz"))
+
+    # do the vcf clip
+    left_clip = 0 if chunk_i == 0 else overlap / 2
+    right_clip = 0 if chunk_i == len(chunks) - 1 else overlap / 2
+    clip_path = chunk_base_name(path_name, out_dir, chunk_i, "_clip.vcf")
+    if overwrite or not os.path.isfile(clip_path):
+        run("bcftools view -r {}:{}-{} {} > {}".format(
+            path_name, chunk[1] + left_clip + 1,
+            chunk[2] - right_clip, vcf_path + ".gz", clip_path))
+
+            
+def merge_vcf_chunks(out_dir, path_name, path_size, chunks, overwrite):
+    """ merge a bunch of clipped vcfs created above, taking care to 
+    fix up the headers.  everything expected to be sorted already """
+    vcf_path = os.path.join(out_dir, path_name + ".vcf")
+    if overwrite or not os.path.isfile(vcf_path):
+        first = True
+        for chunk_i, chunk in enumerate(chunks):
+            clip_path = chunk_base_name(path_name, out_dir, chunk_i, "_clip.vcf")
+            if os.path.isfile(clip_path):
+                if first is True:
+                    # start a new header with the full path size in it
+                    create_vcf_header(clip_path, path_name, path_size, vcf_path)
+                    first = False
+                # add on everythin but header
+                run("grep -v \"^#\" {} >> {}".format(clip_path, vcf_path), check=False)
+                
+    # add a compressed indexed version
+    if overwrite or not os.path.isfile(vcf_path + ".gz"):
+        run("bgzip -c {} > {}".format(vcf_path, vcf_path + ".gz"))
+        run("tabix -f -p vcf {}".format(vcf_path + ".gz"))
+
+def create_vcf_header(clip_path, path_name, path_size, vcf_path):
+    """ copy header from clip_path, changing only the path size.
+    probably more elegant way to do this... """
+
+    # we are assuming that glenn2vcf created something that looks 
+    # like: ##contig=<ID=21,length=9994011>
+    with open(clip_path) as in_file, open(vcf_path, "w") as out_file:
+        contig = False
+        for line in in_file:
+            if len(line) > 0 and line[0] == "#":
+                if line.find("##contig=<ID={},length=".format(path_name)) == 0:
+                    assert contig == False
+                    out_file.write("##contig=<ID={},length={}>\n".format(
+                        path_name, path_size))
+                    contig = True
+                else:
+                    out_file.write(line)
+            else:
+                # end of header
+                break
+        assert contig is True    
+
+def main(args):
+    
+    options = parse_args(args)
+
+    if not os.path.isdir(options.out_dir):
+        os.makedirs(options.out_dir)
+
+    # make things slightly simpler as we split overlap
+    # between adjacent chunks
+    assert options.overlap % 2 == 0
+
+    # compute overlapping chunks
+    chunks = make_chunks(options.path_name, options.path_size,
+                options.chunk, options.overlap)
+
+    # split the gam in one go
+    chunk_gam(options.gam_path, options.xg_path,
+              options.path_name, options.out_dir,
+              chunks, options.filter_opts, options.overwrite)
+
+    # call every chunk in series
+    for chunk_i, chunk in enumerate(chunks):
+        call_chunk(options.xg_path, options.out_dir, chunks, chunk_i,
+                   options.overlap,
+                   options.pileup_opts, options.call_opts,
+                   options.sample_name, options.threads,
+                   options.overwrite)
+    
+    # stitch together the vcf
+    merge_vcf_chunks(options.out_dir, options.path_name,
+                     options.path_size,
+                     chunks, options.overwrite)
+    
+if __name__ == "__main__" :
+    sys.exit(main(sys.argv))
+        
+        

--- a/source_me.sh
+++ b/source_me.sh
@@ -4,6 +4,6 @@ export LD_INCLUDE_PATH=`pwd`/include:$LD_INCLUDE_PATH
 export C_INCLUDE_PATH=`pwd`/include:$C_INCLUDE_PATH
 export CPLUS_INCLUDE_PATH=`pwd`/include:$CPLUS_INCLUDE_PATH
 export INCLUDE_PATH=`pwd`/include:$INCLUDE_PATH
-export PATH=`pwd`/bin:$PATH
+export PATH=`pwd`/bin:`pwd`/scripts:$PATH
 export CC=$(which gcc)
 export CXX=$(which g++)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4156,6 +4156,18 @@ int main_find(int argc, char** argv) {
                 cout << (e.from_start() ? -1 : 1) * e.from() << "\t" <<  (e.to_end() ? -1 : 1) * e.to() << endl;
             }
         }
+        if (!node_ids.empty() && !path_name.empty()) {
+            // Note: this isn't at all consistent with -P option with rocksdb, which couts a range
+            // and then mapping, but need this info right now for scripts/chunked_call
+            for (auto node_id : node_ids) {
+                cout << node_id;
+                vector<size_t> positions = xindex.node_positions_in_path(node_id, path_name);
+                for (auto pos : positions) {
+                    cout << "\t" << pos;
+                }
+                cout << endl;
+            }
+        }
         if (!target.empty()) {
             string name;
             int64_t start, end;

--- a/src/pileup.cpp
+++ b/src/pileup.cpp
@@ -207,7 +207,7 @@ void Pileups::compute_from_alignment(Alignment& alignment) {
     for (int i = 2; i < ranks.size(); ++i) {
         int rank1_idx = ranks[i-1];
         int rank2_idx = ranks[i];
-        if (rank1_idx > 0 || rank2_idx > 0 && (rank1_idx >= 0 && rank2_idx >= 0)) {
+        if ((rank1_idx > 0 || rank2_idx > 0) && (rank1_idx >= 0 && rank2_idx >= 0)) {
             auto& m1 = path.mapping(rank1_idx);
             auto& m2 = path.mapping(rank2_idx);
             auto s1 = NodeSide(m1.position().node_id(), (m1.position().is_reverse() ? false : true));

--- a/src/pileup.cpp
+++ b/src/pileup.cpp
@@ -166,6 +166,7 @@ void Pileups::compute_from_alignment(Alignment& alignment) {
     pair<const Mapping*, int64_t> open_del(NULL, -1);
     for (int i = 0; i < path.mapping_size(); ++i) {
         const Mapping& mapping = path.mapping(i);
+        int rank = mapping.rank() <= 0 ? i + 1 : mapping.rank(); 
         if (_graph->has_node(mapping.position().node_id())) {
             const Node* node = _graph->get_node(mapping.position().node_id());
             NodePileup* pileup = get_create_node_pileup(node);
@@ -184,14 +185,21 @@ void Pileups::compute_from_alignment(Alignment& alignment) {
                                   alignment, mapping, edit, mismatch_counts, last_match, last_del, open_del);
             }
             out_read_offsets[i] = read_offset - 1;
-        }
-        int rank = mapping.rank() <= 0 ? i + 1 : mapping.rank();
-        if (rank <= 0 || rank >= ranks.size() || ranks[rank] != -1) {
+
+            if (rank <= 0 || rank >= ranks.size() || ranks[rank] != -1) {
             cerr << "Error determining rank of mapping " << i << " in path " << path.name() << ": "
                  << pb2json(mapping) << endl;
-        }
-        else {
-            ranks[rank] = i;
+            }
+            else {
+                ranks[rank] = i;
+            }
+        } else {
+            // node not in graph. that's okay, we do nothing but update the read_offset to
+            // not trigger assert at end of this function
+            for (int j = 0; j < mapping.edit_size(); ++j) {
+                read_offset += mapping.edit(j).to_length();
+            }
+            ranks[rank] = -1;
         }
     }
     // loop again over all the edges crossed by the mapping alignment, using
@@ -199,7 +207,7 @@ void Pileups::compute_from_alignment(Alignment& alignment) {
     for (int i = 2; i < ranks.size(); ++i) {
         int rank1_idx = ranks[i-1];
         int rank2_idx = ranks[i];
-        if (rank1_idx > 0 || rank2_idx > 0) {
+        if (rank1_idx > 0 && rank2_idx > 0) {
             auto& m1 = path.mapping(rank1_idx);
             auto& m2 = path.mapping(rank2_idx);
             auto s1 = NodeSide(m1.position().node_id(), (m1.position().is_reverse() ? false : true));
@@ -444,6 +452,14 @@ void Pileups::count_mismatches(VG& graph, const Path& path,
                     int64_t delta = is_reverse ? -edit.from_length() : edit.from_length();
                     // stay put on read, move left/right depending on strand on reference
                     node_offset += delta;
+                }
+            }
+        } else {
+            // node not in graph: count 0 mismatches for each absent position
+            for (int j = 0; j < mapping.edit_size(); ++j) {
+                read_offset += mapping.edit(j).to_length();
+                for (int k = 0; k < mapping.edit(j).to_length(); ++k) {
+                    mismatches.push_back(0);
                 }
             }
         }

--- a/src/pileup.cpp
+++ b/src/pileup.cpp
@@ -207,7 +207,7 @@ void Pileups::compute_from_alignment(Alignment& alignment) {
     for (int i = 2; i < ranks.size(); ++i) {
         int rank1_idx = ranks[i-1];
         int rank2_idx = ranks[i];
-        if (rank1_idx > 0 && rank2_idx > 0) {
+        if (rank1_idx > 0 || rank2_idx > 0 && (rank1_idx >= 0 && rank2_idx >= 0)) {
             auto& m1 = path.mapping(rank1_idx);
             auto& m2 = path.mapping(rank2_idx);
             auto s1 = NodeSide(m1.position().node_id(), (m1.position().is_reverse() ? false : true));

--- a/src/pileup.hpp
+++ b/src/pileup.hpp
@@ -103,7 +103,7 @@ public:
     // read from protobuf
     void load(istream& in);
     // write to protobuf
-    void write(ostream& out, uint64_t buffer_size = 1000);
+    void write(ostream& out, uint64_t buffer_size = 20);
 
     // apply function to each pileup in table
     void for_each_node_pileup(const function<void(NodePileup&)>& lambda);


### PR DESCRIPTION
vg pileup is a memory hog.  Add script, scripts/chunked_call, to automatically split a sequence into overlapping GAM chunks, call each chunk, then merge back together into single VCF.

apart from the script, vg find -P is implemented for xg indexes and vg pileup fixed to handle alignments that aren't completely contained in graph.  

I'm still looking into a protobuf record size issue, which prevents this from working on chromosome 1 (but this would be a problem without chunking as well...)