### PR TITLE
Tidy up a few calling related things

### DIFF
--- a/scripts/chunked_call
+++ b/scripts/chunked_call
@@ -179,7 +179,7 @@ def sort_vcf(vcf_path, sorted_vcf_path):
     run("grep -v \"^#\" {} | sort -k1,1d -k2,2n >> {}".format(
         vcf_path, sorted_vcf_path))
     
-def call_chunk(xg_path, path_name, out_dir, chunks, chunk_i, overlap,
+def call_chunk(xg_path, path_name, out_dir, chunks, chunk_i, path_size, overlap,
                pileup_opts, call_options, sample_name, threads, overwrite):
     """ create VCF from a given chunk """
     # make the graph chunk
@@ -213,8 +213,8 @@ def call_chunk(xg_path, path_name, out_dir, chunks, chunk_i, overlap,
     vcf_path = chunk_base_name(path_name, out_dir, chunk_i, ".vcf")
     if overwrite or not os.path.isfile(vcf_path + ".gz"):
         offset = xg_path_node_offset(xg_path, chunk[0], chunk[1])
-        run("glenn2vcf {} {} -o {} -c {} -s {} > {} 2> {}".format(
-            ag_path, tsv_path, offset, chunk[0], sample_name,
+        run("glenn2vcf {} {} -o {} -c {} -s {} -l {} > {} 2> {}".format(
+            ag_path, tsv_path, offset, chunk[0], sample_name, path_size,
             vcf_path + ".us", vcf_path + ".log"))
         sort_vcf(vcf_path + ".us", vcf_path)
         run("rm {}".format(vcf_path + ".us"))
@@ -241,38 +241,17 @@ def merge_vcf_chunks(out_dir, path_name, path_size, chunks, overwrite):
             clip_path = chunk_base_name(path_name, out_dir, chunk_i, "_clip.vcf")
             if os.path.isfile(clip_path):
                 if first is True:
-                    # start a new header with the full path size in it
-                    create_vcf_header(clip_path, path_name, path_size, vcf_path)
+                    # copy everything including the header
+                    run("cat {} > {}".format(clip_path, vcf_path))
                     first = False
-                # add on everythin but header
-                run("grep -v \"^#\" {} >> {}".format(clip_path, vcf_path), check=False)
+                else:
+                    # add on everythin but header
+                    run("grep -v \"^#\" {} >> {}".format(clip_path, vcf_path), check=False)
                 
     # add a compressed indexed version
     if overwrite or not os.path.isfile(vcf_path + ".gz"):
         run("bgzip -c {} > {}".format(vcf_path, vcf_path + ".gz"))
         run("tabix -f -p vcf {}".format(vcf_path + ".gz"))
-
-def create_vcf_header(clip_path, path_name, path_size, vcf_path):
-    """ copy header from clip_path, changing only the path size.
-    probably more elegant way to do this... """
-
-    # we are assuming that glenn2vcf created something that looks 
-    # like: ##contig=<ID=21,length=9994011>
-    with open(clip_path) as in_file, open(vcf_path, "w") as out_file:
-        contig = False
-        for line in in_file:
-            if len(line) > 0 and line[0] == "#":
-                if line.find("##contig=<ID={},length=".format(path_name)) == 0:
-                    assert contig == False
-                    out_file.write("##contig=<ID={},length={}>\n".format(
-                        path_name, path_size))
-                    contig = True
-                else:
-                    out_file.write(line)
-            else:
-                # end of header
-                break
-        assert contig is True    
 
 def main(args):
     
@@ -298,7 +277,7 @@ def main(args):
     for chunk_i, chunk in enumerate(chunks):
         call_chunk(options.xg_path, options.path_name,
                    options.out_dir, chunks, chunk_i,
-                   options.overlap,
+                   options.path_size, options.overlap,
                    options.pileup_opts, options.call_opts,
                    options.sample_name, options.threads,
                    options.overwrite)

--- a/src/pileup.hpp
+++ b/src/pileup.hpp
@@ -23,12 +23,11 @@ class Pileups {
 public:
     
     Pileups(VG* graph, int min_quality = 0, int max_mismatches = 1, int window_size = 0,
-            double max_insert_frac_read_end = 0.1, int max_depth = 500) :
+            int max_depth = 1000) :
         _graph(graph),
         _min_quality(min_quality),
         _max_mismatches(max_mismatches),
         _window_size(window_size),
-        _max_insert_frac_read_end(max_insert_frac_read_end),
         _max_depth(max_depth){}
     
     // copy constructor
@@ -41,7 +40,6 @@ public:
             _min_quality = other._min_quality;
             _max_mismatches = other._max_mismatches;
             _window_size = other._window_size;
-            _max_insert_frac_read_end = other._max_insert_frac_read_end;
             _max_depth = other._max_depth;
         }
     }
@@ -54,7 +52,6 @@ public:
         _min_quality = other._min_quality;
         _max_mismatches = other._max_mismatches;
         _window_size = other._window_size;
-        _max_insert_frac_read_end = other._max_insert_frac_read_end;
         _max_depth = other._max_depth;
     }
 
@@ -73,7 +70,6 @@ public:
         _min_quality = other._min_quality;
         _max_mismatches = other._max_mismatches;
         _window_size = other._window_size;
-        _max_insert_frac_read_end = other._max_insert_frac_read_end;
         _max_depth = other._max_depth;
         return *this;
     }
@@ -99,8 +95,6 @@ public:
     int _max_mismatches;
     // number of bases to scan in each direction for mismatches
     int _window_size;
-    // to work around clipping issues, we skip last read bases if there too many inserts
-    double _max_insert_frac_read_end;
     // prevent giant protobufs
     int _max_depth;
 
@@ -180,13 +174,13 @@ public:
     Pileups& merge(Pileups& other);
 
     // merge p2 into p1 and return 1. p2 is left an empty husk
-    static BasePileup& merge_base_pileups(BasePileup& p1, BasePileup& p2);
+    BasePileup& merge_base_pileups(BasePileup& p1, BasePileup& p2);
 
     // merge p2 into p1 and return 1. p2 is lef an empty husk
-    static NodePileup& merge_node_pileups(NodePileup& p1, NodePileup& p2, int max_depth);
+    NodePileup& merge_node_pileups(NodePileup& p1, NodePileup& p2);
     
     // merge p2 into p1 and return 1. p2 is lef an empty husk
-    static EdgePileup& merge_edge_pileups(EdgePileup& p1, EdgePileup& p2);
+    EdgePileup& merge_edge_pileups(EdgePileup& p1, EdgePileup& p2);
 
     // get ith BasePileup record
     static BasePileup* get_base_pileup(NodePileup& np, int64_t offset) {

--- a/test/t/17_vg_pileup.t
+++ b/test/t/17_vg_pileup.t
@@ -15,5 +15,5 @@ vg view -J -a -G pileup/alignment.json > alignment.gam
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
 vg pileup tiny.vg alignment.gam > tiny.gpu
 vg view tiny.gpu -l -j | jq . > tiny.gpu.json
-is $(jq --argfile a tiny.gpu.json --argfile b pileup/truth.json -n '($a | (.. | arrays) |= sort) as $a | ($b | (.. | arrays) |= sort) as $b | $a == $b') true "vg pileup produces the expected output for test case on tiny graph."
+is $(jq --argfile a tiny.gpu.json --argfile b pileup/truth.json -n '($a == $b)') true "vg pileup produces the expected output for test case on tiny graph."
 rm -f alignment.gam tiny.vg tiny.gpu tiny.gpu.json


### PR DESCRIPTION
that got messed up in the rush for the Precision FDA deadline. 

* merge in Adam's clean up for glenn2vcf -l
* get pileup test passing again
* clean up pileup depth cutoff option (which is used to avoid protobuf message size errors)