### PR TITLE
Attempt to fix ssw build on Mac

### DIFF
--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -2815,7 +2815,7 @@ void VG::from_gfa(istream& in, bool showp) {
     map<string, sequence_elem>::iterator it;
     id_t curr_id = 1;
     map<string, id_t> id_names;
-    std::function<id_t(const string&)> get_add_id = [&](const string& name) {
+    std::function<id_t(const string&)> get_add_id = [&](const string& name) -> id_t { 
         if (is_number(name)) {
             return std::stol(name);
         } else {


### PR DESCRIPTION
Why do we even have ssw and gssw in the same project? Can't gssw do whatever it is we want ssw for?

Anyway, this uses ssw with -rdynamic pulled out, which the Mac build on Travis didn't like.