### PR TITLE
Limit node size by default.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6782,8 +6782,9 @@ int main_view(int argc, char** argv) {
             << "    -C, --region-is-chrom don't attempt to parse the region (use when the reference" << endl
             << "                          sequence name could be inadvertently parsed as a region)" << endl
             << "    -z, --region-size N   variants per region to parallelize" << endl
-            << "    -m, --node-max N      limit the maximum allowable node sequence size" << endl
+            << "    -m, --node-max N      limit the maximum allowable node sequence size (defaults to 1000)" << endl
             << "                          nodes greater than this threshold will be divided" << endl
+            << "                          Note: nodes larger than ~1024 bp can't be GCSA2-indexed" << endl
             << "    -p, --progress        show progress" << endl
             << "    -t, --threads N       use N threads to construct graph (defaults to numCPUs)" << endl
             << "    -f, --flat-alts N     don't chop up alternate alleles from input vcf" << endl;
@@ -6802,7 +6803,7 @@ int main_view(int argc, char** argv) {
         string output_type = "VG";
         bool progress = false;
         int vars_per_region = 25000;
-        int max_node_size = 0;
+        int max_node_size = 1000;
         string ref_paths_file;
         bool flat_alts = false;
         // Should we make paths out of phasing blocks in the called samples?

--- a/test/t/02_vg_construct.t
+++ b/test/t/02_vg_construct.t
@@ -17,10 +17,10 @@ vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
 
 nodes=$(vg stats -z z.vg | head -1 | cut -f 2)
-is $nodes 84553 "the 1mb graph has the expected number of nodes"
+is $nodes 84557 "the 1mb graph has the expected number of nodes"
 
 edges=$(vg stats -z z.vg | tail -1 | cut -f 2)
-is $edges 115357 "the 1mb graph has the expected number of edges"
+is $edges 115361 "the 1mb graph has the expected number of edges"
 
 rm -f z.vg
 

--- a/test/t/02_vg_construct.t
+++ b/test/t/02_vg_construct.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order 
 
-plan tests 21
+plan tests 22
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg stats -z - | grep nodes | cut -f 2) 210 "construction produces the right number of nodes"
 
@@ -23,6 +23,8 @@ edges=$(vg stats -z z.vg | tail -1 | cut -f 2)
 is $edges 115357 "the 1mb graph has the expected number of edges"
 
 rm -f z.vg
+
+is $(vg construct -r 1mb1kgp/z.fa | vg view -j - | jq -c '.node[] | select((.sequence | length) >= 1024)' | wc -l) 0 "node size is manageable by default"
 
 vg construct -r complex/c.fa -v complex/c.vcf.gz >c.vg
 is $? 0 "construction of a very complex region succeeds"

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -11,10 +11,10 @@ vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 #is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
 
 nodes=$(vg stats -z z.vg | head -1 | cut -f 2)
-is $nodes 84553 "vg stats reports the expected number of nodes"
+is $nodes 84557 "vg stats reports the expected number of nodes"
 
 edges=$(vg stats -z z.vg | tail -1 | cut -f 2)
-is $edges 115357 "vg stats reports the expected number of edges"
+is $edges 115361 "vg stats reports the expected number of edges"
 
 graph_length=$(vg stats -l z.vg | tail -1 | cut -f 2)
 is $graph_length 1029257 "vg stats reports the expected graph length"


### PR DESCRIPTION
Now `vg construct` with default options should not produce nodes too big
for `vg index` to GCSA2-index.

Closes #250. Closes #337.