### PR TITLE
Workarounds for a couple more vg call issues

### DIFF
--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -30,7 +30,8 @@ Caller::Caller(VG* graph,
                bool leave_uncalled,
                int default_quality,
                double max_strand_bias,
-               ostream* text_calls):
+               ostream* text_calls,
+               bool bridge_alts):
     _graph(graph),
     _het_log_prior(safe_log(het_prior)),
     _hom_log_prior(safe_log(.5 * (1. - het_prior))),
@@ -42,7 +43,8 @@ Caller::Caller(VG* graph,
     _leave_uncalled(leave_uncalled),
     _default_quality(default_quality),
     _max_strand_bias(max_strand_bias),
-    _text_calls(text_calls) {
+    _text_calls(text_calls),
+    _bridge_alts(bridge_alts) {
     _max_id = _graph->max_node_id();
     _node_divider._max_id = &_max_id;
 }
@@ -322,16 +324,29 @@ void Caller::create_augmented_edge(Node* node1, int from_offset, bool left_side1
     for (int i = 0; i < (int)NodeDivider::EntryCat::Last; ++i) {
         for (int j = 0; j < (int)NodeDivider::EntryCat::Last; ++j) {
             if (call_sides1[i] != NULL && call_sides2[j] != NULL) {
-                NodeSide side1(call_sides1[i]->id(), !left_side1);
-                NodeSide side2(call_sides2[j]->id(), !left_side2);
-                if (!_call_graph.has_edge(side1, side2)) {
-                    Edge* edge = _call_graph.create_edge(call_sides1[i], call_sides2[j],
-                                                         left_side1, !left_side2);
-                    // can edges be written more than once with different cats?
-                    // if so, first one will prevail. should check if this
-                    // can impact vcf converter...
-                    if (_text_calls != NULL) {
-                        write_edge_tsv(edge, cat);
+                // always make an edge if the bridge flag is set
+                // otherwise, only make links between alts and reference
+                // (be more strict on deletion edges, only linking two reference)
+                // there is a possibility of disconnecting the graph in
+                // certain cases here, maybe it should be relaxed to make
+                // at least one edge in all cases? 
+                if (_bridge_alts ||
+                    (i == (int)NodeDivider::EntryCat::Ref &&
+                     j == (int)NodeDivider::EntryCat::Ref) ||
+                    ((i == (int)NodeDivider::EntryCat::Ref || 
+                      j == (int)NodeDivider::EntryCat::Ref) &&
+                     cat != 'L')) {                    
+                    NodeSide side1(call_sides1[i]->id(), !left_side1);
+                    NodeSide side2(call_sides2[j]->id(), !left_side2);
+                    if (!_call_graph.has_edge(side1, side2)) {
+                        Edge* edge = _call_graph.create_edge(call_sides1[i], call_sides2[j],
+                                                             left_side1, !left_side2);
+                        // can edges be written more than once with different cats?
+                        // if so, first one will prevail. should check if this
+                        // can impact vcf converter...
+                        if (_text_calls != NULL) {
+                            write_edge_tsv(edge, cat);
+                        }
                     }
                 }
             }

--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -16,7 +16,7 @@ const int Caller::Default_min_depth = 10;
 const int Caller::Default_max_depth = 200;
 const int Caller::Default_min_support = 1;
 const double Caller::Default_min_frac = 0.25;
-const double Caller::Default_min_likelihood = 1e-50;
+const double Caller::Default_min_log_likelihood = -5000.0;
 const char Caller::Default_default_quality = 30;
 const double Caller::Default_max_strand_bias = 0.5;
 
@@ -26,7 +26,7 @@ Caller::Caller(VG* graph,
                int max_depth,
                int min_support,
                double min_frac,
-               double min_likelihood, 
+               double min_log_likelihood, 
                bool leave_uncalled,
                int default_quality,
                double max_strand_bias,
@@ -38,7 +38,7 @@ Caller::Caller(VG* graph,
     _max_depth(max_depth),
     _min_support(min_support),
     _min_frac(min_frac),
-    _min_log_likelihood(safe_log(min_likelihood)),
+    _min_log_likelihood(min_log_likelihood),
     _leave_uncalled(leave_uncalled),
     _default_quality(default_quality),
     _max_strand_bias(max_strand_bias),

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -103,7 +103,8 @@ public:
            bool leave_uncalled = false,
            int default_quality = Default_default_quality,
            double max_strand_bias = Default_max_strand_bias,
-           ostream* text_calls = NULL);
+           ostream* text_calls = NULL,
+           bool bridge_alts = false);
     ~Caller();
     void clear();
 
@@ -165,6 +166,13 @@ public:
     char _default_quality;
     // min deviation from .5 in proportion of negative strand reads
     double _max_strand_bias;
+    // the base-by-base calling is very limited, and adjacent
+    // variants are not properly phased according to the reads.
+    // so we choose either to add all edges between neighboring
+    // positions (true) or none except via reference (false)
+    // (default to latter as most haplotypes rarely contain
+    // pairs of consecutive alts). 
+    bool _bridge_alts;
 
     // write the call graph
     void write_call_graph(ostream& out, bool json);

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -87,7 +87,7 @@ public:
     // same as min_support, but as fraction of total depth
     static const double Default_min_frac;
     // minimum likelihood to call a snp
-    static const double Default_min_likelihood;
+    static const double Default_min_log_likelihood;
     // use this score when pileup is missing quality
     static const char Default_default_quality;
     // use to balance alignments to forward and reverse strand
@@ -99,7 +99,7 @@ public:
            int max_depth = Default_max_depth,
            int min_support = Default_min_support,
            double min_frac = Default_min_frac,
-           double min_likelihood = Default_min_likelihood, 
+           double min_log_likelihood = Default_min_log_likelihood, 
            bool leave_uncalled = false,
            int default_quality = Default_default_quality,
            double max_strand_bias = Default_max_strand_bias,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1196,7 +1196,7 @@ int main_call(int argc, char** argv) {
     }
     Caller caller(graph,
                   het_prior, min_depth, max_depth, min_support,
-                  min_frac, Caller::Default_min_likelihood,
+                  min_frac, Caller::Default_min_log_likelihood,
                   leave_uncalled, default_read_qual, max_strand_bias,
                   text_file_stream);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1028,6 +1028,7 @@ void help_call(char** argv) {
          << "    -b, --max_strand_bias N limit to absolute difference between 0.5 and proportion of supporting reads on reverse strand. (default=" << Caller::Default_max_strand_bias << ")" << endl
          << "    -l, --leave_uncalled    leave un-called graph regions in output, producing augmented graph" << endl
          << "    -c, --calls TSV         write extra call information in TSV (must use with -l)" << endl
+         << "    -a, --link-alts         add all possible edges between adjacent alts" << endl       
          << "    -j, --json              output in JSON" << endl
          << "    -p, --progress          show progress" << endl
          << "    -t, --threads N         number of threads to use" << endl;
@@ -1049,6 +1050,7 @@ int main_call(int argc, char** argv) {
     double max_strand_bias = Caller::Default_max_strand_bias;
     bool leave_uncalled = false;
     string calls_file;
+    bool bridge_alts = false;
     bool output_json = false;
     bool show_progress = false;
     int thread_count = 1;
@@ -1066,6 +1068,7 @@ int main_call(int argc, char** argv) {
                 {"max_strand_bias", required_argument, 0, 'b'},
                 {"leave_uncalled", no_argument, 0, 'l'},
                 {"calls", required_argument, 0, 'c'},
+                {"link-alts", no_argument, 0, 'a'},
                 {"json", no_argument, 0, 'j'},
                 {"progress", no_argument, 0, 'p'},
                 {"het_prior", required_argument, 0, 'r'},
@@ -1074,7 +1077,7 @@ int main_call(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "d:e:s:f:q:b:lc:jpr:t:",
+        c = getopt_long (argc, argv, "d:e:s:f:q:b:lc:ajpr:t:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -1119,6 +1122,9 @@ int main_call(int argc, char** argv) {
         case 't':
             thread_count = atoi(optarg);
             break;
+        case 'a':
+            bridge_alts = true;
+            break;            
         case 'h':
         case '?':
             /* getopt_long already printed an error message. */
@@ -1198,7 +1204,7 @@ int main_call(int argc, char** argv) {
                   het_prior, min_depth, max_depth, min_support,
                   min_frac, Caller::Default_min_log_likelihood,
                   leave_uncalled, default_read_qual, max_strand_bias,
-                  text_file_stream);
+                  text_file_stream, bridge_alts);
 
     function<void(Pileup&)> lambda = [&caller](Pileup& pileup) {
         for (int i = 0; i < pileup.node_pileups_size(); ++i) {


### PR DESCRIPTION
that involve overlapping deletions or deletions adjacent to snps.  There's a little more to be done for deletion consistency but it's getting to the point where time is better spent on a proper haplotype-aware design... 