### PR TITLE
No read constraint

### DIFF
--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -6485,7 +6485,7 @@ void VG::to_dot(ostream& out, vector<Alignment> alignments,
             if (i > 0) {
                 out << "    "
                     << alnid-1 << " -> "
-                    << alnid << "[dir=none,color=\"black\"];" << endl;
+                    << alnid << "[dir=none,color=\"black\",constraint=false];" << endl;
             }
             out << "    "
                 << alnid << " -> " << m.position().node_id()


### PR DESCRIPTION
Don't use edges with constraint on when plotting reads on a graph. This lets the underlying graph dictate the layout, and doesn't confuse graphviz quite so badly when the read aligns to the reverse strand and is articulated in right-to-left order.