### PR TITLE
Fix Cactus memory leak, document option

### DIFF
--- a/src/bubbles.cpp
+++ b/src/bubbles.cpp
@@ -147,7 +147,24 @@ struct CactusSide {
 };
 
 void* mergeNodeObjects(void* a, void* b) {
-    return *(id_t*)a < *(id_t*)b ? a : b; 
+    // One of the objects is going to get returned, and the other one is going
+    // to get freed (since the graph is supposed to won them all).
+    id_t* to_return;
+    id_t* to_free;
+    
+    if(*(id_t*)a < *(id_t*)b) {
+        to_return = (id_t*)a;
+        to_free = (id_t*)b;
+    } else {
+        to_free = (id_t*)a;
+        to_return = (id_t*)b;
+    }
+    
+    // Free the thing we aren't keeping
+    free(to_free);
+    
+    // Return the one we are
+    return (void*)to_return;
 }
 
 // Step 2) Make a Cactus Graph

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1584,6 +1584,7 @@ void help_genotype(char** argv) {
          << "    -o, --offset INT        offset variant positions by this amount" << std::endl
          << "    -l, --length INT        override total sequence length" << std::endl
          << "    -a, --augmented FILE    dump augmented graph to FILE" << std::endl
+         << "    -C, --cactus            use cactus for site finding" << std::endl
          << "    -p, --progress          show progress" << endl
          << "    -t, --threads N         number of threads to use" << endl;
 }
@@ -1713,7 +1714,7 @@ int main_genotype(int argc, char** argv) {
         return 1;
     }
     if (show_progress) {
-        cerr << "Reading input graph" << endl;
+        cerr << "Reading input graph..." << endl;
     }
     VG* graph;
     string graph_file_name = argv[optind++];
@@ -1739,6 +1740,10 @@ int main_genotype(int argc, char** argv) {
         }
     }
     
+    if(output_vcf && show_progress) {
+        cerr << "Calling against path " << ref_path_name << endl;
+    }
+    
     if(sample_name.empty()) {
         // Set a default sample name
         sample_name = "SAMPLE";
@@ -1749,6 +1754,11 @@ int main_genotype(int argc, char** argv) {
         help_call(argv);
         return 1;
     }
+    
+    if(show_progress) {
+        cerr << "Loading reads..." << endl;
+    }
+    
     string reads_index_name = argv[optind];
     // This holds the RocksDB index that has all our reads, indexed by the nodes they visit.
     Index index;


### PR DESCRIPTION
Cactus superbubble finding was leaking allocated node IDs when things were merged.

Also, the -C option for vg genotype wasn't in the help text.