### PR TITLE
Make cactus bubbles more robust to dangling nodes

### DIFF
--- a/source_me.sh
+++ b/source_me.sh
@@ -8,8 +8,12 @@ export PATH=`pwd`/bin:`pwd`/scripts:$PATH
 export CC=$(which gcc)
 export CXX=$(which g++)
 
+#
+#  disable until file arguments work as in normal bash :(
+#
 # add bash autocompletion
-if test -n "$BASH_VERSION"
-then
-	 . ./autocomp.bash
-fi
+#if test -n "$BASH_VERSION"
+#then
+#
+#	 . ./autocomp.bash
+#fi

--- a/src/bubbles.hpp
+++ b/src/bubbles.hpp
@@ -59,7 +59,7 @@ pair<stCactusGraph*, stCactusNode*> vg_to_cactus(VG& graph, id_t source_id, id_t
 pair<id_t, id_t> get_cactus_source_sink(VG& graph);
 
 // Get source and sink nodes from path endpoints
-pair<id_t, id_t> get_cactus_source_sink(VG& graph, const string& path_name);
+pair<id_t, id_t> get_cactus_source_sink(VG& graph, const string& path_name, int steps = 5);
 
 // Return the hierchical cactus decomposition
 // Input graph must be sorted!

--- a/src/bubbles.hpp
+++ b/src/bubbles.hpp
@@ -55,11 +55,15 @@ typedef Tree<Bubble> BubbleTree;
 //  - returns "root" node as well as graph
 pair<stCactusGraph*, stCactusNode*> vg_to_cactus(VG& graph, id_t source_id, id_t sink_id);
 
-// Get source and sink nodes
+// Get source and sink nodes, relying on node ranks of sorted graph
 pair<id_t, id_t> get_cactus_source_sink(VG& graph);
 
+// Get source and sink nodes from path endpoints
+pair<id_t, id_t> get_cactus_source_sink(VG& graph, const string& path_name);
+
 // Return the hierchical cactus decomposition
-BubbleTree cactusbubble_tree(VG& graph);
+// Input graph must be sorted!
+BubbleTree cactusbubble_tree(VG& graph, pair<id_t, id_t> source_sink);
 
 // By default, bubble X's contents array doesn't have all the nodes
 // in its children's contents (ie each node only stored in lowest bubble
@@ -70,6 +74,7 @@ void bubble_up_bubbles(BubbleTree& bubble_tree);
 
 // Enumerate Cactus bubbles.  Interface (and output on DAGs)
 // identical to superbubbles()
+// Note: input graph will be sorted (as done for superbubbles())
 map<pair<id_t, id_t>, vector<id_t> > cactusbubbles(VG& graph);
 
 // Convert back from Cactus to VG
@@ -78,6 +83,7 @@ map<pair<id_t, id_t>, vector<id_t> > cactusbubbles(VG& graph);
 VG cactus_to_vg(stCactusGraph* cactus_graph);
 
 // Convert vg into vg formatted cactus representation
+// Input graph must be sorted!
 VG cactusify(VG& graph);
 
 }

--- a/src/bubbles.hpp
+++ b/src/bubbles.hpp
@@ -72,6 +72,13 @@ void bubble_up_bubbles(BubbleTree& bubble_tree);
 // identical to superbubbles()
 map<pair<id_t, id_t>, vector<id_t> > cactusbubbles(VG& graph);
 
+// Convert back from Cactus to VG
+// (to, for example, display using vg view)
+// todo: also provide mapping info to get nodes embedded in cactus components
+VG cactus_to_vg(stCactusGraph* cactus_graph);
+
+// Convert vg into vg formatted cactus representation
+VG cactusify(VG& graph);
 
 }
 

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -107,7 +107,7 @@ vector<Genotyper::Site> Genotyper::find_sites(VG& graph) {
     
 }
 
-vector<Genotyper::Site> Genotyper::find_sites_with_cactus(VG& graph) {
+vector<Genotyper::Site> Genotyper::find_sites_with_cactus(VG& graph, const string& ref_path_name) {
 
     // Set up our output vector
     vector<Site> to_return;
@@ -116,7 +116,7 @@ vector<Genotyper::Site> Genotyper::find_sites_with_cactus(VG& graph) {
     graph.sort();
     
     // get endpoints using node ranks
-    pair<id_t, id_t> source_sink = get_cactus_source_sink(graph);
+    pair<id_t, id_t> source_sink = get_cactus_source_sink(graph, ref_path_name);
 
     // todo: use deomposition instead of converting tree into flat structure
     BubbleTree bubble_tree = cactusbubble_tree(graph, source_sink);

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -112,8 +112,14 @@ vector<Genotyper::Site> Genotyper::find_sites_with_cactus(VG& graph) {
     // Set up our output vector
     vector<Site> to_return;
 
+    // cactus needs the nodes to be sorted in order to find a source and sink
+    graph.sort();
+    
+    // get endpoints using node ranks
+    pair<id_t, id_t> source_sink = get_cactus_source_sink(graph);
+
     // todo: use deomposition instead of converting tree into flat structure
-    BubbleTree bubble_tree = cactusbubble_tree(graph);
+    BubbleTree bubble_tree = cactusbubble_tree(graph, source_sink);
 
     // copy nodes up to bubbles that contain their bubble
     bubble_up_bubbles(bubble_tree);

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -132,7 +132,7 @@ public:
      * This is more general and doesn't require DAGifcation etc., but we keep
      * both versions around for now for debugging and comparison
      */
-    vector<Site> find_sites_with_cactus(VG& graph);
+    vector<Site> find_sites_with_cactus(VG& graph, const string& ref_path_name);
     
     /**
      * Given a path (which may run either direction through a site, or not touch

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1841,7 +1841,7 @@ int main_genotype(int argc, char** argv) {
     // Note that in os_x, iostream ends up pulling in headers that define a ::id_t type.
     
     // Unfold/unroll, find the superbubbles, and translate back.
-    vector<Genotyper::Site> sites = use_cactus ? genotyper.find_sites_with_cactus(augmented_graph) : genotyper.find_sites(augmented_graph);
+    vector<Genotyper::Site> sites = use_cactus ? genotyper.find_sites_with_cactus(augmented_graph, ref_path_name) : genotyper.find_sites(augmented_graph);
     
     if(show_progress) {
         cerr << "Found " << sites.size() << " superbubbles" << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3752,6 +3752,8 @@ int main_mod(int argc, char** argv) {
     }
 
     if (cactus) {
+        // ensure we're sorted
+        graph->sort();
         *graph = cactusify(*graph);
         // no paths survive, make sure they are erased
         graph->paths = Paths();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3296,6 +3296,7 @@ void help_mod(char** argv) {
          << "    -F, --force-path-match  sets path edits explicitly equal to the nodes they traverse" << endl
          << "    -y, --destroy-node ID   remove node with given id" << endl
          << "    -B, --bluntify          bluntify the graph, making nodes for duplicated sequences in overlaps" << endl
+         << "    -a, --cactus            convert to cactus graph representation" << endl
          << "    -t, --threads N         for tasks that can be done in parallel, use this many threads" << endl;
 }
 
@@ -3342,6 +3343,7 @@ int main_mod(int argc, char** argv) {
     int until_normal_iter = 0;
     string translation_file;
     bool flip_doubly_reversed_edges = false;
+    bool cactus = false;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -3388,11 +3390,12 @@ int main_mod(int argc, char** argv) {
             {"destroy-node", required_argument, 0, 'y'},
             {"translation", required_argument, 0, 'Z'},
             {"unreverse-edges", required_argument, 0, 'E'},
+            {"cactus", no_argument, 0, 'a'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hk:oi:cpl:e:mt:SX:KPsunzNf:CDFr:g:x:RTU:Bbd:Ow:L:y:Z:E",
+        c = getopt_long (argc, argv, "hk:oi:cpl:e:mt:SX:KPsunzNf:CDFr:g:x:RTU:Bbd:Ow:L:y:Z:Ea",
                 long_options, &option_index);
 
 
@@ -3519,7 +3522,6 @@ int main_mod(int argc, char** argv) {
             dagify_to = atoi(optarg);
             break;
 
-
         case 'L':
             dagify_component_length_max = atoi(optarg);
             break;
@@ -3550,6 +3552,10 @@ int main_mod(int argc, char** argv) {
 
         case 'y':
             destroy_node_id = atoi(optarg);
+            break;
+            
+        case 'a':
+            cactus = true;
             break;
 
         case 'h':
@@ -3743,6 +3749,12 @@ int main_mod(int argc, char** argv) {
 
     if (destroy_node_id > 0) {
         graph->destroy_node(destroy_node_id);
+    }
+
+    if (cactus) {
+        *graph = cactusify(*graph);
+        // no paths survive, make sure they are erased
+        graph->paths = Paths();
     }
 
     graph->serialize_to_ostream(std::cout);


### PR DESCRIPTION
Dangling nodes can cause cactus bubbles to be wrong, or crash (#396).  Try to fix this by choosing better source and sink (Still testing)