### PR TITLE
Fix up site finding and skipping

### DIFF
--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -148,6 +148,37 @@ void Genotyper::run(VG& graph,
                     vector<list<NodeTraversal>> paths = get_paths_through_site(graph, site);
                     cerr << "got " << paths.size() << " paths through site" << endl;
                     
+                    if(reference_index->byId.count(site.start.node->id()) && 
+                        reference_index->byId.count(site.end.node->id())) {
+                        // This site is on the reference
+                        
+                        // Where do the start and end nodes fall in the reference?
+                        auto start_ref_appearance = reference_index->byId.at(site.start.node->id());
+                        auto end_ref_appearance = reference_index->byId.at(site.end.node->id());
+                        
+                        
+                        // Are the ends running with the reference (false) or against it (true)
+                        auto start_rel_orientation = (site.start.backward != start_ref_appearance.second);
+                        auto end_rel_orientation = (site.end.backward != end_ref_appearance.second);
+                        
+                        if(show_progress) {
+                            // Determine where the site starts and ends along the reference path
+                            #pragma omp critical (cerr)
+                            cerr << "Site " << site.start << " - " << site.end << " runs reference " << 
+                                start_ref_appearance.first << " to " << 
+                                end_ref_appearance.first << endl;
+                                
+                            if(!start_rel_orientation && !end_rel_orientation &&
+                                end_ref_appearance.first < start_ref_appearance.first) {
+                                // The site runs backward in the reference (but somewhat sensibly).
+                                #pragma omp critical (cerr)
+                                cerr << "Warning! Site runs backwards!" << endl;
+                            } 
+                                
+                        }
+                            
+                    }
+                    
                     if(skip_reference && paths.size() == 1 && paths[0].size() == 2) {
                         // Skip boring guaranteed ref only sites where the only path is just the 2 anchoring nodes.
                         // TODO: can't continue out of task

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -145,7 +145,6 @@ void Genotyper::run(VG& graph,
                     
                     // Get all the paths through the site
                     vector<list<NodeTraversal>> paths = get_paths_through_site(graph, site);
-                    cerr << "got " << paths.size() << " paths through site" << endl;
                     
                     if(paths.size() == 0) {
                         // TODO: this compensates for inside-out sites from
@@ -166,9 +165,10 @@ void Genotyper::run(VG& graph,
                         }
                     }
                     
-                    if(reference_index->byId.count(site.start.node->id()) && 
+                    if(reference_index != nullptr &&
+                        reference_index->byId.count(site.start.node->id()) && 
                         reference_index->byId.count(site.end.node->id())) {
-                        // This site is on the reference
+                        // This site is on the reference (and we are indexing a reference because we are going to vcf)
                         
                         // Where do the start and end nodes fall in the reference?
                         auto start_ref_appearance = reference_index->byId.at(site.start.node->id());

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -151,12 +151,27 @@ void Genotyper::run(VG& graph,
                     if(skip_reference && paths.size() == 1 && paths[0].size() == 2) {
                         // Skip boring guaranteed ref only sites where the only path is just the 2 anchoring nodes.
                         // TODO: can't continue out of task
+                        if(show_progress) {
+                            #pragma omp critical (cerr)
+                            cerr << "Site " << site.start << " - " << site.end << " has " << paths.size() <<
+                                " alleles: skipped for being trivial" << endl;
+                        }
                     } else if(skip_reference && paths.size() == 1 && output_vcf) {
                         // Skip boring guaranteed ref only sites where there is just 1 path.
                         // If it were the reference path, it'd be a noop, and if it's not the reference path, there's no way to express it as VCF.
                         // TODO: can't continue out of task
+                        if(show_progress) {
+                            #pragma omp critical (cerr)
+                            cerr << "Site " << site.start << " - " << site.end << " has " << paths.size() <<
+                                " alleles: skipped for being fixed reference" << endl;
+                        }
                     } else if(paths.empty()) {
                         // Don't do anything for superbubbles with no routes through
+                        if(show_progress) {
+                            #pragma omp critical (cerr)
+                            cerr << "Site " << site.start << " - " << site.end << " has " << paths.size() <<
+                                " alleles: skipped for having no alleles" << endl;
+                        }
                     } else {
                     
                         if(show_progress) {
@@ -168,7 +183,7 @@ void Genotyper::run(VG& graph,
                                 cerr << "\t" << traversals_to_string(path) << endl;
                             }
                         }
-
+                        
                         // Get the affinities for all the paths
                         map<Alignment*, vector<Genotyper::Affinity>> affinities = get_affinities_fast(graph, reads_by_name, site, paths);
                         
@@ -179,8 +194,7 @@ void Genotyper::run(VG& graph,
                         
                         // Get a genotyped locus in the original frame
                         Locus genotyped = genotype_site(graph, site, paths, affinities);
-                        //translator.translate(
-
+                        
                         if(output_json) {
                             // Dump in JSON
                             #pragma omp critical (cout)

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -119,7 +119,6 @@ public:
              bool show_progress = false,
              bool output_vcf = false,
              bool output_json = false,
-             bool skip_reference = false,
              int length_override = 0,
              int variant_offset = 0);
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1615,9 +1615,6 @@ int main_genotype(int argc, char** argv) {
     // What length override should we use
     int64_t length_override = 0;
     
-    // Don't bother genotyping ref only superbubbles
-    bool skip_reference = true;
-
     // Should we dump the augmented graph to a file?
     string augmented_file_name;
     
@@ -1790,7 +1787,6 @@ int main_genotype(int argc, char** argv) {
                   show_progress,
                   output_vcf,
                   output_json,
-                  skip_reference,
                   length_override,
                   variant_offset);
 
@@ -4398,7 +4394,9 @@ int main_stats(int argc, char** argv) {
         for (auto& i : vg::superbubbles(*graph)) {
             auto b = i.first;
             auto v = i.second;
-            // sort output for now, to be consistent with cactus
+            // sort output for now, to be consistent with cactus. We don't have
+            // any orientations involved here, so we're free to re-order as we
+            // wish.
             b = minmax(b.first, b.second);
             sort(v.begin(), v.end());
             cout << b.first << "\t" << b.second << "\t";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1757,7 +1757,20 @@ int main_genotype(int argc, char** argv) {
 
     index.for_alignment_to_nodes(graph_ids, [&](const Alignment& alignment) {
         // Extract all the alignments
-        alignments.push_back(alignment);
+        
+        // Only take alignments that don't visit nodes not in the graph
+        bool contained = true;
+        for(size_t i = 0; i < alignment.path().mapping_size(); i++) {
+            if(!graph->has_node(alignment.path().mapping(i).position().node_id())) {
+                // Throw out the read
+                contained = false;
+            }
+        }
+        
+        if(contained) {
+            // This alignment completely falls within the graph
+            alignments.push_back(alignment);
+        }
     });
         
     if(show_progress) {

--- a/src/nodetraversal.hpp
+++ b/src/nodetraversal.hpp
@@ -34,8 +34,22 @@ public:
         return node != other.node || backward != other.backward;
     }
 
+    // Make sure to sort by node ID and not pointer value, because people will expect that.
     inline bool operator<(const NodeTraversal& other) const {
-        return node < other.node || (node == other.node && backward < other.backward);
+        if(node == nullptr && other.node != nullptr) {
+            // We might have a null node when they don't.
+            return true;
+        }
+        if(other.node == nullptr && node != nullptr) {
+            // They might have a null node when we don't.
+            return false;
+        }
+        if(other.node == nullptr && node == nullptr) {
+            // We bith might have null nodes.
+            return backward < other.backward;
+        }
+        // Now we know none of the nodes are null. Sort by actual ID.
+        return node->id() < other.node->id() || (node == other.node && backward < other.backward);
     }
 
     // reverse complement the node traversal


### PR DESCRIPTION
We should now look at sites from Cactus in the correct orientation all of the time.

We also shouldn't skip sites where all the reads supported an alt and the non-recurrent ref path was dropped. Previously we would look at them and assume the single path through was the ref allele and not bother to call them.

It would be nice to skip homozygous ref sites with no alts proposed, though. We just need to do it correctly, perhaps by determining the reference allele string from the site boundaries before doing the affinities, when in VCF mode.