### PR TITLE
Improve genotyper statistics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ $(OBJ_DIR)/pileup.o: $(SRC_DIR)/pileup.cpp $(SRC_DIR)/pileup.hpp $(CPP_DIR)/vg.p
 $(OBJ_DIR)/caller.o: $(SRC_DIR)/caller.cpp $(SRC_DIR)/caller.hpp $(CPP_DIR)/vg.pb.h $(SRC_DIR)/vg.hpp $(INC_DIR)/stream.hpp $(SRC_DIR)/json2pb.h $(SRC_DIR)/pileup.hpp $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $(OBJ_DIR)/caller.o $(SRC_DIR)/caller.cpp $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
-$(OBJ_DIR)/genotyper.o: $(SRC_DIR)/genotyper.cpp $(SRC_DIR)/genotyper.hpp $(CPP_DIR)/vg.pb.h $(SRC_DIR)/vg.hpp $(INC_DIR)/stream.hpp $(SRC_DIR)/json2pb.h $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(SRC_DIR)/bubbles.hpp
+$(OBJ_DIR)/genotyper.o: $(SRC_DIR)/genotyper.cpp $(SRC_DIR)/genotyper.hpp $(CPP_DIR)/vg.pb.h $(SRC_DIR)/vg.hpp $(INC_DIR)/stream.hpp $(SRC_DIR)/json2pb.h $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(SRC_DIR)/bubbles.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/utility.hpp
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $(OBJ_DIR)/genotyper.o $(SRC_DIR)/genotyper.cpp $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
 $(OBJ_DIR)/position.o: $(SRC_DIR)/position.cpp $(SRC_DIR)/position.hpp $(CPP_DIR)/vg.pb.h $(SRC_DIR)/vg.hpp $(SRC_DIR)/json2pb.h $(LIB_DIR)/libprotobuf.a

--- a/src/distributions.hpp
+++ b/src/distributions.hpp
@@ -1,0 +1,91 @@
+#ifndef VG_DISTRIBUTIONS_H
+#define VG_DISTRIBUTIONS_H
+
+// distributions.hpp: contains functions for probability distributions used in genotyping.
+// Also includes a fancy cacheing factorial system from Freebayes
+
+
+#include <map>
+#include <cmath>
+
+#include "utility.hpp"
+
+namespace vg {
+
+using namespace std;
+
+// We use this slightly nonstandard type for our math. We wrap it so it's easy
+// to change later.
+using real_t = long double;
+
+/**
+ * Calculate the natural log of the gamma function of the given argument.
+ */
+inline real_t gamma_ln(real_t x) {
+
+    real_t cofactors[] = {76.18009173, 
+        -86.50532033,
+        24.01409822,
+        -1.231739516,
+        0.120858003E-2,
+        -0.536382E-5};    
+
+    real_t x1 = x - 1.0;
+    real_t tmp = x1 + 5.5;
+    tmp -= (x1 + 0.5) * log(tmp);
+    real_t ser = 1.0;
+    for (int j=0; j<=5; j++) {
+        x1 += 1.0;
+        ser += cofactors[j]/x1;
+    }
+    real_t y =  (-1.0 * tmp + log(2.50662827465 * ser));
+
+    return y;
+}
+
+/**
+ * Calculate the natural log of the factorial of the given integer. TODO:
+ * replace with a cache or giant lookup table from Freebayes.
+ */
+inline real_t factorial_ln(int n) {
+    if (n < 0) {
+        return (long double)-1.0;
+    }
+    else if (n == 0) {
+        return (long double)0.0;
+    }
+    else {
+        return gamma_ln(n + 1.0);
+    }
+}
+
+/**
+ * Raise a log probability to a power
+ */
+real_t powln(real_t m, int n) {
+    return m * n;
+}
+
+/**
+ * Get the probability for sampling the counts in obs from a set of categories
+ * weighted by the probabilities in probs. Works for both double and real_t probabilities.
+ */
+template <typename ProbIn>
+real_t multinomial_sampling_prob_ln(const vector<ProbIn>& probs, const vector<int>& obs) {
+    vector<real_t> factorials;
+    vector<real_t> probsPowObs;
+    factorials.resize(obs.size());
+    transform(obs.begin(), obs.end(), factorials.begin(), factorial_ln);
+    typename vector<ProbIn>::const_iterator p = probs.begin();
+    vector<int>::const_iterator o = obs.begin();
+    for (; p != probs.end() && o != obs.end(); ++p, ++o) {
+        probsPowObs.push_back(powln(log(*p), *o));
+    }
+    // Use the collection sum defined in utility.hpp
+    return factorial_ln(sum(obs)) - sum(factorials) + sum(probsPowObs);
+}
+
+
+}
+
+#endif

--- a/src/distributions.hpp
+++ b/src/distributions.hpp
@@ -62,8 +62,17 @@ inline real_t factorial_ln(int n) {
 /**
  * Raise a log probability to a power
  */
-real_t powln(real_t m, int n) {
+inline real_t pow_ln(real_t m, int n) {
     return m * n;
+}
+
+/**
+ * Compute the number of ways to select k items from a collection of n
+ * distinguishable items, ignoring order. Returns the natural log of the
+ * (integer) result.
+ */
+inline real_t choose_ln(int n, int k) {
+    return factorial_ln(n) - (factorial_ln(k) + factorial_ln(n - k));
 }
 
 /**
@@ -79,7 +88,7 @@ real_t multinomial_sampling_prob_ln(const vector<ProbIn>& probs, const vector<in
     typename vector<ProbIn>::const_iterator p = probs.begin();
     vector<int>::const_iterator o = obs.begin();
     for (; p != probs.end() && o != obs.end(); ++p, ++o) {
-        probsPowObs.push_back(powln(log(*p), *o));
+        probsPowObs.push_back(pow_ln(log(*p), *o));
     }
     // Use the collection sum defined in utility.hpp
     return factorial_ln(sum(obs)) - sum(factorials) + sum(probsPowObs);

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -767,7 +767,6 @@ string Genotyper::traversals_to_string(const list<NodeTraversal>& path) {
     return seq.str();
 }
 
-#define debug
 map<Alignment*, vector<Genotyper::Affinity> >
 Genotyper::get_affinities_fast(VG& graph,
                                const map<string, Alignment*>& reads_by_name,
@@ -983,9 +982,6 @@ double Genotyper::get_genotype_log_likelihood(const vector<int>& genotype, const
                 logprob_wrong = phred_to_logprob(read_qual);
             }
             
-            // TODO: don't override
-            logprob_wrong = prob_to_logprob(0.001);
-            
 #ifdef debug
             cerr << "P(wrong) = " << logprob_to_prob(logprob_wrong) << endl;
 #endif
@@ -1128,7 +1124,6 @@ double Genotyper::get_genotype_log_likelihood(const vector<int>& genotype, const
 
     
 }
-#undef debug
 
 double Genotyper::get_genotype_log_prior(const vector<int>& genotype) {
     assert(genotype.size() == 2);
@@ -1210,7 +1205,6 @@ string Genotyper::get_qualities_in_site(VG& graph, const Site& site, const Align
     
 }
 
-#define debug
 Locus Genotyper::genotype_site(VG& graph,
                                const Site& site,
                                const vector<list<NodeTraversal>>& superbubble_paths,
@@ -1396,7 +1390,6 @@ Locus Genotyper::genotype_site(VG& graph,
     // Now we've populated the genotype so return it.
     return to_return;
 }
-#undef debug
 
 /**
  * Create the reference allele for an empty vcflib Variant, since apaprently

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -105,7 +105,7 @@ public:
     int min_recurrence = 2;
     
     // How much support must an alt have on each strand before we can call it?
-    int min_consistent_per_strand = 1;
+    int min_consistent_per_strand = 2;
     
     // What should our prior on being heterozygous at a site be?
     double het_prior_logprob = prob_to_logprob(0.001);

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -96,6 +96,10 @@ public:
     // Should we use mapping quality when computing P(reads | genotype)?
     bool use_mapq = false;
     
+    // Whould we do indel realignment, or should we use fast substring
+    // affinities for everything?
+    bool realign_indels = false;
+    
     // If base qualities aren't available, what is the Phred-scale qualtiy of a
     // piece of sequence being correct?
     int default_sequence_quality = 15;

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -104,6 +104,9 @@ public:
     // Note that the primary path counts as a recurrence.
     int min_recurrence = 2;
     
+    // How much support must an alt have on each strand before we can call it?
+    int min_consistent_per_strand = 1;
+    
     // What should our prior on being heterozygous at a site be?
     double het_prior_logprob = prob_to_logprob(0.001);
 

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -215,7 +215,7 @@ public:
      * Alignments should have had their quality values trimmed down to just the
      * part covering the superbubble.
      *
-     * Returns a log base 2 likelihood.
+     * Returns a natural log likelihood.
      */
     double get_genotype_log_likelihood(const vector<int>& genotype, const vector<pair<Alignment, vector<Affinity>>> alignment_consistency);
     
@@ -225,7 +225,7 @@ public:
      * Takes a genotype as a vector of allele numbers. It is not guaranteed that
      * allele 0 corresponds to any notion of primary reference-ness.
      *
-     * Returns a log base 2 prior probability.
+     * Returns a natural log prior probability.
      *
      * TODO: add in strand bias
      */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1782,7 +1782,15 @@ int main_genotype(int argc, char** argv) {
         
         if(contained) {
             // This alignment completely falls within the graph
-            alignments.push_back(alignment);
+            
+            // Correct its quality scores from phred+33, as in GAM or an index,
+            // to phred, as used within vg for math.
+            // TODO: just keep them like this all the time
+            auto alignment_copy = alignment;
+            
+            alignment_copy.set_quality(string_quality_char_to_short(alignment_copy.quality()));
+            
+            alignments.push_back(alignment_copy);
         }
     });
         

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1602,6 +1602,7 @@ void help_genotype(char** argv) {
          << "    -a, --augmented FILE    dump augmented graph to FILE" << std::endl
          << "    -q, --use_mapq          use mapping qualities" << std::endl
          << "    -C, --cactus            use cactus for site finding" << std::endl
+         << "    -i, --realign_indels    realign at indels" << std::endl
          << "    -p, --progress          show progress" << endl
          << "    -t, --threads N         number of threads to use" << endl;
 }
@@ -1634,6 +1635,8 @@ int main_genotype(int argc, char** argv) {
     
     // Should we use mapping qualities?
     bool use_mapq = false;
+    // Should we do indel realignment?
+    bool realign_indels = false;
     
     // Should we dump the augmented graph to a file?
     string augmented_file_name;
@@ -1656,13 +1659,14 @@ int main_genotype(int argc, char** argv) {
                 {"augmented", required_argument, 0, 'a'},
                 {"use_mapq", no_argument, 0, 'q'},
                 {"cactus", no_argument, 0, 'C'},
+                {"realign_indels", no_argument, 0, 'i'},
                 {"progress", no_argument, 0, 'p'},
                 {"threads", required_argument, 0, 't'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hjvr:c:s:o:l:a:qCpt:",
+        c = getopt_long (argc, argv, "hjvr:c:s:o:l:a:qCipt:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -1708,6 +1712,10 @@ int main_genotype(int argc, char** argv) {
         case 'C':
             // Use Cactus to find sites
             use_cactus = true;
+            break;
+        case 'i':
+            // Do indel realignment
+            realign_indels = true;
             break;
         case 'p':
             show_progress = true;
@@ -1811,6 +1819,7 @@ int main_genotype(int argc, char** argv) {
     Genotyper genotyper;
     // Configure it
     genotyper.use_mapq = use_mapq;
+    genotyper.realign_indels = realign_indels;
     // TODO: move arguments below up into configuration
     genotyper.run(*graph,
                   alignments,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1600,6 +1600,7 @@ void help_genotype(char** argv) {
          << "    -o, --offset INT        offset variant positions by this amount" << std::endl
          << "    -l, --length INT        override total sequence length" << std::endl
          << "    -a, --augmented FILE    dump augmented graph to FILE" << std::endl
+         << "    -q, --use_mapq          use mapping qualities" << std::endl
          << "    -C, --cactus            use cactus for site finding" << std::endl
          << "    -p, --progress          show progress" << endl
          << "    -t, --threads N         number of threads to use" << endl;
@@ -1631,6 +1632,9 @@ int main_genotype(int argc, char** argv) {
     // What length override should we use
     int64_t length_override = 0;
     
+    // Should we use mapping qualities?
+    bool use_mapq = false;
+    
     // Should we dump the augmented graph to a file?
     string augmented_file_name;
     
@@ -1650,6 +1654,7 @@ int main_genotype(int argc, char** argv) {
                 {"offset", required_argument, 0, 'o'},
                 {"length", required_argument, 0, 'l'},
                 {"augmented", required_argument, 0, 'a'},
+                {"use_mapq", no_argument, 0, 'q'},
                 {"cactus", no_argument, 0, 'C'},
                 {"progress", no_argument, 0, 'p'},
                 {"threads", required_argument, 0, 't'},
@@ -1657,7 +1662,7 @@ int main_genotype(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hjvr:c:s:o:l:a:Cpt:",
+        c = getopt_long (argc, argv, "hjvr:c:s:o:l:a:qCpt:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -1695,6 +1700,10 @@ int main_genotype(int argc, char** argv) {
         case 'a':
             // Dump augmented graph
             augmented_file_name = optarg;
+            break;
+        case 'q':
+            // Use mapping qualities
+            use_mapq = true;
             break;
         case 'C':
             // Use Cactus to find sites
@@ -1800,6 +1809,9 @@ int main_genotype(int argc, char** argv) {
     
     // Make a Genotyper to do the genotyping
     Genotyper genotyper;
+    // Configure it
+    genotyper.use_mapq = use_mapq;
+    // TODO: move arguments below up into configuration
     genotyper.run(*graph,
                   alignments,
                   cout,

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -110,6 +110,26 @@ vector<T> vpmax(const std::vector<std::vector<T>>& vv) {
     return c;
 }
 
+/**
+ * Compute the sum of the values in a collection. Values must be default-
+ * constructable (like numbers are).
+ */
+template<typename Collection>
+typename Collection::value_type sum(const Collection& collection) {
+    
+    // Set up an alias
+    using Item = typename Collection::value_type;
+    
+    // Make a new zero-valued item to hold the sum
+    auto total = Item();
+    for(auto& to_sum : collection) {
+        total += to_sum;
+    }
+    
+    return total;
+    
+}
+
 string tmpfilename(const string& base);
 
 // Code to detect if a variant lacks an ID and give it a unique but repeatable

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -36,13 +36,13 @@ string cigar_string(vector<pair<int, char> >& cigar);
 string mapping_string(const string& source, const Mapping& mapping);
 double median(std::vector<int> &v);
 
-// Convert a probability to a base-2 log probability.
+// Convert a probability to a natural log probability.
 inline double prob_to_logprob(double prob) {
-    return log2(prob);
+    return log(prob);
 }
-// Convert a base-2 log probability to a probability
+// Convert natural log probability to a probability
 inline double logprob_to_prob(double logprob) {
-    return pow(2, logprob);
+    return exp(logprob);
 }
 // Add two probabilities (expressed as logprobs) together and return the result
 // as a logprob.
@@ -67,14 +67,14 @@ inline int prob_to_phred(double prob) {
     return round(-10.0 * log10(prob));
 }
 
-// Convert a Phred quality score directly to a base-2 log probability of wrongness.
+// Convert a Phred quality score directly to a natural log probability of wrongness.
 inline double phred_to_logprob(int phred) {
-    return (-((double)phred) / 10) / log10(2.0);
+    return (-((double)phred) / 10) / log10(exp(1.0));
 }
 
-// Convert a base-2 log probability of wrongness directly to a Phred quality score.
+// Convert a natural log probability of wrongness directly to a Phred quality score.
 inline int logprob_to_phred(double logprob ) {
-    return round(-10.0 * logprob * log10(2.0));
+    return round(-10.0 * logprob * log10(exp(1.0)));
 }
 
 template<typename T, typename V>

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -178,9 +178,9 @@ message Genotype {
     repeated int32 allele = 1;
     bool is_phased = 2;
     double likelihood = 3;
-    double log_likelihood = 4; // Likelihood logged base 2
-    double log_prior = 5; // Prior logged base 2
-    double log_posterior = 6; // Posterior logged base 2 (unnormalized)
+    double log_likelihood = 4; // Likelihood natural logged
+    double log_prior = 5; // Prior natural logged
+    double log_posterior = 6; // Posterior natural logged (unnormalized)
 }
 
 // Aggregates information about the reads supporting an allele


### PR DESCRIPTION
This add strand bias and allele bias (for diploids) into the `vg genotype` likelihood calculations. I'm also allowing the use of MAPQs (with -q) and realignment of reads when working on indels (-i).

This also included a genotype quality, estimated from posterior distribution peakedness, which really seems to help.