### PR TITLE
Genotyper Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ $(OBJ_DIR)/vg_set.o: $(SRC_DIR)/vg_set.cpp $(SRC_DIR)/vg_set.hpp $(SRC_DIR)/vg.h
 $(OBJ_DIR)/mapper.o: $(SRC_DIR)/mapper.cpp $(SRC_DIR)/mapper.hpp $(CPP_DIR)/vg.pb.h $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libxg.a
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
-$(OBJ_DIR)/main.o: $(SRC_DIR)/main.cpp $(INC_DIR)/vg_git_version.hpp $(LIB_DIR)/libvcflib.a $(OBJ_DIR)/Fasta.o $(LIB_DIR)/libgssw.a $(INC_DIR)/stream.hpp $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(LIB_DIR)/librocksdb.a $(CPP_DIR)/vg.pb.h $(LIB_DIR)/libxg.a $(INC_DIR)/gcsa.h $(LIB_DIR)/libhts.a $(INC_DIR)/sha1.hpp $(OBJ_DIR)/progress_bar.o $(INC_DIR)/lru_cache.h $(LIB_DIR)/libvcfh.a $(LIB_DIR)/libgfakluge.a $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libpinchesandcacti.a $(LIB_DIR)/libsonlib.a $(INC_DIR)/globalDefs.hpp $(SRC_DIR)/bubbles.hpp
+$(OBJ_DIR)/main.o: $(SRC_DIR)/main.cpp $(INC_DIR)/vg_git_version.hpp $(LIB_DIR)/libvcflib.a $(OBJ_DIR)/Fasta.o $(LIB_DIR)/libgssw.a $(INC_DIR)/stream.hpp $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(LIB_DIR)/librocksdb.a $(CPP_DIR)/vg.pb.h $(LIB_DIR)/libxg.a $(INC_DIR)/gcsa.h $(LIB_DIR)/libhts.a $(INC_DIR)/sha1.hpp $(OBJ_DIR)/progress_bar.o $(INC_DIR)/lru_cache.h $(LIB_DIR)/libvcfh.a $(LIB_DIR)/libgfakluge.a $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libpinchesandcacti.a $(LIB_DIR)/libsonlib.a $(INC_DIR)/globalDefs.hpp $(SRC_DIR)/bubbles.hpp $(SRC_DIR)/genotyper.hpp
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
 $(OBJ_DIR)/region.o: $(SRC_DIR)/region.cpp $(SRC_DIR)/region.hpp $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -380,6 +380,11 @@ void Genotyper::run(VG& graph,
         #pragma omp critical (cerr)
         cerr << "Computed " << total_affinities << " affinities" << endl;
     }
+    
+    if(output_vcf) {
+        delete vcf;
+        delete reference_index;
+    }
 
 }
 

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -69,12 +69,15 @@ public:
         double affinity = 0;
         // Is the read on the forward strand (false) or reverse strand (true)
         bool is_reverse = false;
+        // What's the actual raw score (not necessarily normalized out of 1)?
+        double raw_score = 0;        
         
         // Have a default constructor
         Affinity() = default;
         
         // Have a useful constructor
-        Affinity(double affinity, bool is_reverse) : consistent(affinity == 1), affinity(affinity), is_reverse(is_reverse) {
+        Affinity(double affinity, bool is_reverse) : consistent(affinity == 1), 
+            affinity(affinity), is_reverse(is_reverse), raw_score(affinity) {
             // Nothing to do
         }
         

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -69,15 +69,16 @@ public:
         double affinity = 0;
         // Is the read on the forward strand (false) or reverse strand (true)
         bool is_reverse = false;
-        // What's the actual raw score (not necessarily normalized out of 1)?
-        double raw_score = 0;        
+        // What's the actual score (not necessarily normalized out of 1)?
+        // We'll probably put per-base alignment score here
+        double score = 0;        
         
         // Have a default constructor
         Affinity() = default;
         
         // Have a useful constructor
         Affinity(double affinity, bool is_reverse) : consistent(affinity == 1), 
-            affinity(affinity), is_reverse(is_reverse), raw_score(affinity) {
+            affinity(affinity), is_reverse(is_reverse), score(affinity) {
             // Nothing to do
         }
         
@@ -116,6 +117,10 @@ public:
     
     // How much support must an alt have on each strand before we can call it?
     int min_consistent_per_strand = 2;
+    
+    // When we realign reads, what's the minimum per-base score for a read in
+    // order to actually use it as supporting the thing we just aligned it to?
+    double min_score_per_base = 0.90;
     
     // What should our prior on being heterozygous at a site be?
     double het_prior_logprob = prob_to_logprob(0.001);

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -177,9 +177,13 @@ public:
     
     /**
      * For the given site, emit all subpaths with unique sequences that run from
-     * start to end, out of the paths in the graph.
+     * start to end, out of the paths in the graph. Uses the map of reads by
+     * name to determine if a path is a read or a real named path. Paths through
+     * the site supported only by reads are subject to a min recurrence count,
+     * while those supported by actual embedded named paths are not.
      */
-    vector<list<NodeTraversal>> get_paths_through_site(VG& graph, const Site& site);
+    vector<list<NodeTraversal>> get_paths_through_site(VG& graph, const Site& site,
+        const map<string, Alignment*>& reads_by_name);
     
     /**
      * Get all the quality values in the alignment between the start and end nodes

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1826,6 +1826,8 @@ int main_genotype(int argc, char** argv) {
                   output_json,
                   length_override,
                   variant_offset);
+                  
+    delete graph;
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1799,15 +1799,7 @@ int main_genotype(int argc, char** argv) {
         
         if(contained) {
             // This alignment completely falls within the graph
-            
-            // Correct its quality scores from phred+33, as in GAM or an index,
-            // to phred, as used within vg for math.
-            // TODO: just keep them like this all the time
-            auto alignment_copy = alignment;
-            
-            alignment_copy.set_quality(string_quality_char_to_short(alignment_copy.quality()));
-            
-            alignments.push_back(alignment_copy);
+            alignments.push_back(alignment);
         }
     });
         
@@ -7515,7 +7507,6 @@ int main_view(int argc, char** argv) {
             if (output_type == "json") {
                 // convert values to printable ones
                 function<void(Alignment&)> lambda = [](Alignment& a) {
-                    alignment_quality_short_to_char(a);
                     if(std::isnan(a.identity())) {
                         // Fix up NAN identities that can't be serialized in
                         // JSON. We shouldn't generate these any more, and they

--- a/test/t/03_vg_view.t
+++ b/test/t/03_vg_view.t
@@ -5,13 +5,15 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 12
+plan tests 13
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg view -d - | wc -l) 505 "view produces the expected number of lines of dot output"
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg view -g - | wc -l) 641 "view produces the expected number of lines of GFA output"
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg view - | head | vg view -Fv - | vg view - | wc -l) 10 "view converts back and forth between GFA and vg format"
 
 is $(samtools view -u minigiab/NA12878.chr22.tiny.bam | vg view -bG - | vg view -a - | wc -l) $(samtools view -u minigiab/NA12878.chr22.tiny.bam | samtools view - | wc -l) "view can convert BAM to GAM"
+
+is "$(samtools view -u minigiab/NA12878.chr22.tiny.bam | vg view -bG - | vg view -aj - | jq -c --sort-keys . | sort | md5sum)" "$(samtools view -u minigiab/NA12878.chr22.tiny.bam | vg view -bG - | vg view -aj - | vg view -JGa - | vg view -aj - | jq -c --sort-keys . | sort | md5sum)" "view can round-trip JSON and GAM"
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg view -j x.vg | jq . | vg view -Jv - | diff x.vg -


### PR DESCRIPTION
This has a couple of improvements to the genotyper.

I no longer throw out the allele supported by the reference (or any real named path), even if it's not sufficiently recurrent. This prevents us from having weird-looking/undefined PLs for genotypes involving the reference allele when we make a VCF.

I trim variants down to just the differing bases, which helps keep things from wandering into high-confidence regions when we do the VCF comparison.

I mark reads as not being consistent with indel alleles if, when realigned to the indel, they score below a certain threshold score per base.

I also no longer hardcode GQs for calls of 0/0 with no alt alleles.

I also added deletes for some per-run data structures in the genotyper, which I had forgotten. It shouldn't improve memory usage when running, but it makes valgrind happier.

Finally, I have a fix for #419 in here. Qualities should stay as just plain phred (and not phred+33) in GAM format, and the genotyper should interpret them as such.