### PR TITLE
Linearization algorithm based on max flow/min cut

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8538,6 +8538,83 @@ int main_test(int argc, char** argv){
     return vg::unittest::run_unit_tests(argc, argv);
 }
 
+void help_sort(char** argv){
+    cerr << "usage: " << argv[0] << " sort [options] -i input_file -r reference_name > sorted.vg " << endl
+         << "options: " << endl
+         << "           -g, --gfa           input in GFA format" << endl
+         << "           -i, --in            input file" << endl
+         << "           -r, --ref            reference name" << endl
+         << endl;
+}
+
+int main_sort(int argc, char *argv[]) {
+
+    //default input format is vg
+    bool gfa_input = false;
+    string file_name = "";
+    string reference_name = "";
+    
+    int c;
+    while (true) {
+        static struct option long_options[] =
+            {
+                {"gfa", no_argument, 0, 'g'},
+                {"in", required_argument, 0, 'i'},
+                {"ref", required_argument, 0, 'r'},
+                {0, 0, 0, 0}
+            };
+
+        int option_index = 0;
+        c = getopt_long (argc, argv, "i:r:g",
+                         long_options, &option_index);
+
+        /* Detect the end of the options. */
+        if (c == -1)
+            break;
+
+        switch (c)
+        {
+        case 'g':
+            gfa_input = true;
+            break;
+        case 'r':
+            reference_name = optarg;
+            break;
+        case 'i':
+            file_name = optarg;
+            break;
+        case 'h':
+        case '?':
+            /* getopt_long already printed an error message. */
+            help_sort(argv);
+            exit(1);
+            break;
+        default:
+            abort ();
+        }
+    }
+  
+    if (reference_name.empty() || file_name.empty()) {
+        help_sort(argv);
+        exit(1);
+    }
+    
+    ifstream in;
+    in.open(file_name.c_str());        
+    VG* graph = nullptr; 
+    if (gfa_input) {
+        graph = new VG;
+        graph->from_gfa(in);
+    } else {
+        graph = new VG(in);
+    }
+        
+    graph->max_flow(reference_name);    
+    graph->serialize_to_ostream(std::cout);
+    delete graph;  
+    return 0;
+}
+
 void vg_help(char** argv) {
     cerr << "vg: variation graph tool, version " << VG_GIT_VERSION << endl
          << endl
@@ -8571,7 +8648,8 @@ void vg_help(char** argv) {
          << "  -- translate     project alignments and paths through a graph translation" << endl
          << "  -- validate      validate the semantics of a graph" << endl
          << "  -- test          run unit tests" << endl
-         << "  -- version       version information" << endl;
+         << "  -- version       version information" << endl
+  	 << "  -- sort          sort variant graph using max flow algorithm" << endl;
 }
 
 int main(int argc, char *argv[])
@@ -8643,6 +8721,8 @@ int main(int argc, char *argv[])
         return main_version(argc, argv);
     } else if (command == "test") {
         return main_test(argc, argv);
+    } else if (command == "sort") {
+        return main_sort(argc, argv);
     }else {
         cerr << "error:[vg] command " << command << " not found" << endl;
         vg_help(argv);

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -14,6 +14,12 @@ typedef size_t off_t;
 // position type: id, direction, offset
 typedef std::tuple<id_t, bool, off_t> pos_t;
 
+// node to path mapping
+typedef std::map<std::string, std::set<Mapping*>> NodeMapping;
+
+//node to edges mapping
+typedef std::map<id_t, std::vector<Edge*>> EdgeMapping;
+
 }
 
 #endif

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <set>
 #include <vector>
+#include "vg.pb.h"
 
 namespace vg {
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -2,6 +2,10 @@
 #define VG_TYPES_H
 
 #include <tuple>
+#include <map>
+#include <string>
+#include <set>
+#include <vector>
 
 namespace vg {
 

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -10233,4 +10233,443 @@ void VG::orient_nodes_forward(set<id_t>& nodes_flipped) {
 
 }
 
+void VG::max_flow(const string& ref_name) {
+    if (size() <= 1) return;
+    // Topologically sort, which orders and orients all the nodes.
+    deque<NodeTraversal> sorted_nodes;
+    max_flow_sort(sorted_nodes, ref_name);
+    deque<NodeTraversal>::iterator n = sorted_nodes.begin();
+    int i = 0;
+    for ( ; i < graph.node_size() && n != sorted_nodes.end();
+          ++i, ++n) {
+        // Put the nodes in the order we got
+        swap_nodes(graph.mutable_node(i), (*n).node);
+    }
+}
+
+void VG::max_flow_sort(deque<NodeTraversal>& sorted_nodes, const string& ref_name) {
+        
+    typedef hash_map<id_t, vector < Edge*>> EdgeMapping;
+    typedef map<string, set < Mapping*>> NodeMapping;
+    hash_map<Edge*, int> edge_weight;
+
+    int ref_weight = 5;
+   
+    set<Edge*> reversing;
+    EdgeMapping edges_out_nodes;
+    EdgeMapping edges_in_nodes;
+
+    //assign weight to edges
+    //edge is determined as number of paths, going throw the edge
+    for (auto const &edge : edge_index) {
+        //skip any reversing edges
+        if (edge.first->from_start() || edge.first->to_end()) {
+            continue;
+        }
+        Node* nodeFrom = node_by_id[edge.first->from()];
+        Node* nodeTo = node_by_id[edge.first->to()];
+        edges_out_nodes[edge.first->from()].push_back(edge.first);
+        edges_in_nodes[edge.first->to()].push_back(edge.first);
+
+        //assign weight to the minimum number of paths of the adjacent nodes
+        NodeMapping from_node_mapping = paths.get_node_mapping(edge.first->from());
+        NodeMapping to_node_mapping = paths.get_node_mapping(edge.first->to());
+        int weight = 0;
+
+        //if this is a reference edge, increase the weight
+        if (from_node_mapping.count(ref_name) &&
+                to_node_mapping.count(ref_name)) {
+            weight += ref_weight;
+        }
+
+        for (auto const &path_mapping : from_node_mapping) {
+            string path_name = path_mapping.first;
+            if (to_node_mapping.count(path_name)) {
+                for (auto const &mapping : to_node_mapping[path_name]) {
+                    if (mapping->position().node_id() == nodeTo->id()) {
+                        weight++;
+                    }
+                }
+
+            }
+        }
+
+        //we do not allow zero weight
+        if (!weight) {
+            weight = 1;
+        }
+
+        edge_weight[edge.first] = weight;
+    }
+
+    list<Mapping>& ref_path = paths.get_path(ref_name);
+    ref_path.reverse();
+    set<id_t> backbone;
+    list<id_t> reference;
+    for(auto const &mapping : ref_path) {
+        backbone.insert(mapping.position().node_id());
+        reference.push_back(mapping.position().node_id());
+    }
+    set<id_t> nodes;
+    for (auto const &entry : node_by_id) {
+        nodes.insert(entry.first);
+    }
+    
+    find_in_out_web(sorted_nodes, backbone, nodes, reference, edges_out_nodes, 
+                    edges_in_nodes, edge_weight);
+    
+    cerr << "sorted nodes" << endl;
+    for (auto node : sorted_nodes) {
+        cerr << node.node->id()  << " ";
+    }
+    cerr << endl;           
+}
+
+void VG::find_in_out_web(deque<NodeTraversal>& sorted_nodes, set<id_t> backbone,
+                            set<id_t> nodes, 
+                            list<id_t> ref_path,
+                            hash_map<id_t, vector < Edge*>> edges_out_nodes,
+                            hash_map<id_t, vector < Edge*>> edges_in_nodes,
+                            hash_map<Edge*, int> edge_weight) {
+     
+    //for efficiency if size of the backbone == size of the nodes
+    //we just add all backbone to sorted nodes and quit
+    if (nodes.size() == backbone.size()) {
+        for (auto const &id: ref_path) {
+            NodeTraversal node = NodeTraversal(graph.mutable_node(id - 1), false);
+            sorted_nodes.push_back(node);
+        }
+        return;
+    }
+    
+    
+    //determine max outgoing weight
+    int max_weight = 0;
+    
+    //add source and sink nodes
+    id_t source = graph.node_size() + 1;
+    id_t sink = graph.node_size() + 2;
+    id_t graph_size = sink + 1;
+    
+     //for simple test implementation we represent the graph as a matrix
+    unique_ptr<int[]> graph_matrix(new int[graph_size * graph_size]); 
+    for (id_t i = 0; i < graph_size; i++) {
+        for (id_t j = 0; j < graph_size; j++) {
+            graph_matrix[i * graph_size + j] = 0;
+        }
+    }
+    
+    set<Edge*> out_joins;
+    set<Edge*> in_joins;
+    
+    for(auto const &node : nodes) {
+        int current_weight = 0;
+        for (auto const &edge : edges_out_nodes[node]) {
+            if (!nodes.count(edge->to())) {
+                continue;
+            }
+            current_weight += edge_weight[edge];
+            if (backbone.count(node) && !backbone.count(edge->to())) {
+                out_joins.insert(edge);
+            }
+
+            if (!backbone.count(node) && backbone.count(edge->to())) {
+                in_joins.insert(edge);
+                continue;
+            } 
+            graph_matrix[edge->from() * graph_size + edge->to()] = edge_weight[edge];
+        }
+        
+        if (current_weight > max_weight) {
+            max_weight = current_weight;
+        }
+    }
+
+    cerr << "max outgoing flow " << max_weight << endl;
+    
+    //set weight for source edges
+    for (auto const &edge : out_joins) {
+        graph_matrix[source * graph_size + edge->from()] = max_weight + 1;
+          
+    }
+
+    //set weight for sink edges
+    for (auto const &edge : in_joins) {
+        graph_matrix[edge->from() * graph_size + sink] = edge_weight[edge];;
+    }
+
+//        cerr << "Edge weight" << endl;
+//        for (id_t i = 0; i < sink + 1; i++) {
+//            for (int j = 0; j < sink + 1; j++) {
+//                cerr << graph_matrix[i * graph_size + j] << " ";
+//            }
+//            cerr << endl;
+//        }
+
+//        cerr << "Out joins" << endl;
+//        for (auto const &edge : out_joins) {
+//            cerr << "from " << edge->from() << " to " << edge->to() << endl;
+//        }
+//        cerr << "In joins" << endl;
+//        for (auto const &edge : in_joins) {
+//            cerr << "from " << edge->from() << " to " << edge->to() << endl;
+//        }
+
+    vector<pair<id_t,id_t>> cut = min_cut(graph_matrix.get(), source, 
+                                                    sink, graph_size, edges_out_nodes, edges_in_nodes);
+    //remove min cut edges
+    for(auto const &edge : cut) {
+            id_t to = edge.second;
+            if (to == sink) {
+                for (auto const &in_join : in_joins) {
+                    if (in_join->from() == edge.first) {
+                        to = in_join->to();
+                    }
+                }
+            }
+            if (edges_out_nodes.count(edge.first)) {
+                auto& out_edges = edges_out_nodes[edge.first];
+                auto it = begin(out_edges);
+                while (it != end(out_edges)) {
+                    if ((*it)->to() == to) {
+                        out_edges.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+            }
+            if (edges_in_nodes.count(to)) {
+                auto& in_edges = edges_in_nodes[to];
+                auto it = begin(in_edges);
+                while (it != end(in_edges)) {
+                    if ((*it)->from() == edge.first) {
+                        in_edges.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+            }
+        }
+            
+    vector<bool> visited(graph_size, false);
+    for (auto &current_id: ref_path) {
+        cerr << current_id << endl; 
+        NodeTraversal node = NodeTraversal(graph.mutable_node(current_id - 1), false);
+            
+        //out growth
+        if (edges_out_nodes.count(current_id)) {    
+            for (auto &edge : edges_out_nodes[current_id]) {
+                if (nodes.count(edge->to()) && !backbone.count(edge->to())) {
+                    //out going edge
+                    cerr << "out web " << edge->from() << " " << edge->to() << endl;      
+                    id_t start_node = edge->to();
+                    set<id_t> new_backbone;
+                    list<id_t> new_ref_path;
+                    while (true) {
+                        if (new_backbone.count(start_node) 
+                                || !edges_out_nodes.count(start_node) 
+                                || backbone.count(start_node)
+                                || visited[start_node]) {
+                            break;
+                        }
+                        new_backbone.insert(start_node);
+                        new_ref_path.push_back(start_node);
+                        int weight = 0;
+                        Edge* next_edge;
+                        for (auto const &out_edge : edges_out_nodes[start_node]) {
+                            if (edge_weight[out_edge] > weight) {
+                                weight = edge_weight[out_edge];
+                                next_edge = out_edge;
+                            }
+                        }
+                        start_node = next_edge->to();  
+                    }  
+                    set<id_t> out_web;
+                    mark_dfs_out(edges_out_nodes, edge->to(), out_web, visited);
+                    new_ref_path.reverse();
+                    find_in_out_web(sorted_nodes, new_backbone, out_web, new_ref_path, edges_out_nodes, edges_in_nodes, edge_weight);
+                }
+            }
+        }
+        //add backbone node to the result
+        sorted_nodes.push_back(node);
+        //in growth
+        if (edges_in_nodes.count(current_id)) {
+            for (auto &edge : edges_in_nodes[current_id]) {
+                if (nodes.count(edge->from()) && !backbone.count(edge->from())) {
+                    //in going edge
+                    cerr << "in web " << edge->from() << " " << edge->to() << endl;                
+         
+                    id_t start_node = edge->from();
+                    set<id_t> new_backbone;
+                    list<id_t> new_ref_path;
+                    while (true) {
+                        if (new_backbone.count(start_node)  
+                                || backbone.count(start_node)
+                                || visited[start_node]) {
+                            break;
+                        }
+                        new_backbone.insert(start_node);
+                        new_ref_path.push_back(start_node);                       
+                        int weight = 0;
+                        Edge* next_edge;
+                        for (auto const &in_edge : edges_in_nodes[start_node]) {
+                            if (edge_weight[in_edge] > weight) {
+                                weight = edge_weight[in_edge];
+                                next_edge = in_edge;
+                                start_node = next_edge->from();  
+                            }
+                        }
+                    }  
+                    set<id_t> in_web;
+                    mark_dfs_in(edges_in_nodes, edge->from(), in_web, visited);
+                    find_in_out_web(sorted_nodes, new_backbone, in_web, new_ref_path, edges_out_nodes, edges_in_nodes, edge_weight);
+                }
+            }
+        }
+    }
+}
+
+void VG::mark_dfs_out(hash_map<id_t, vector < Edge*>> edges_out_nodes, id_t s,
+            set<id_t>& sorted_nodes, vector<bool>& visited) {
+    visited[s] = true;
+    cerr << "node " << s << endl;
+    sorted_nodes.insert(s);
+    if (edges_out_nodes.count(s)) {
+        for (auto edge: edges_out_nodes[s]) {
+            if (!visited[edge->to()]) {
+                mark_dfs_out(edges_out_nodes, edge->to(), sorted_nodes, visited);
+            }
+        }
+    }
+
+}
+    
+void VG::mark_dfs_in(hash_map<id_t, vector < Edge*>> edges_in_nodes, id_t s,
+            set<id_t>& sorted_nodes, vector<bool>& visited) {
+    visited[s] = true;
+    cerr << "node " << s << endl;
+    sorted_nodes.insert(s);
+    if (edges_in_nodes.count(s)) {
+        for (auto edge: edges_in_nodes[s]) {
+            if (!visited[edge->from()]) {
+                mark_dfs_in(edges_in_nodes, edge->from(), sorted_nodes, visited);
+            }
+        }
+    }
+
+}
+
+/* Returns true if there is a path from source 's' to sink 't' in
+   residual graph. Also fills parent[] to store the path */
+bool VG::bfs(int* rGraph, id_t s, id_t t, vector<id_t>& parent, id_t graph_size) {
+    // Create a visited array and mark all vertices as not visited
+    vector<bool> visited(graph_size, false);
+
+    // Create a queue, enqueue source vertex and mark source vertex
+    // as visited
+    std::queue<id_t> q({ s }); 
+    visited[s] = true;
+    parent[s] = -1;
+
+    // Standard BFS Loop
+    while (!q.empty()) {
+        id_t u = q.front();
+        q.pop();
+
+        for (id_t v = 0; v < graph_size; v++) {
+            if (visited[v] == false && rGraph[u * graph_size + v] > 0) {
+                q.push(v);
+                parent[v] = u;
+                visited[v] = true;
+            }
+        }
+    }
+
+    // If we reached sink in BFS starting from source, then return
+    // true, else false
+    return (visited[t] == true);
+
+}
+
+// A DFS based function to find all reachable vertices from s.  The function
+// marks visited[i] as true if i is reachable from s.  The initial values in
+// visited[] must be false. We can also use BFS to find reachable vertices
+
+void VG::dfs(int* rGraph, id_t s, vector<bool>& visited, id_t graph_size) {
+    visited[s] = true;
+    for (id_t i = 0; i < graph_size; i++)
+        if (rGraph[s * graph_size + i] && !visited[i])
+            dfs(rGraph, i, visited, graph_size);
+}
+
+// Returns the minimum s-t cut
+
+vector<pair<id_t,id_t>> VG::min_cut(int* graph, id_t s, id_t t, id_t graph_size, 
+                hash_map<id_t, vector < Edge*>>& edges_out_nodes,
+                hash_map<id_t, vector < Edge*>>& edges_in_nodes) {
+    id_t u, v;
+
+    // Create a residual graph and fill the residual graph with
+    // given capacities in the original graph as residual capacities
+    // in residual graph
+    // rGraph[i][j] indicates residual capacity of edge i-j
+   
+    unique_ptr<int[]> rGraph(new int[graph_size * graph_size]); 
+    for (id_t i = 0; i < graph_size; i++) {
+        for (id_t j = 0; j < graph_size; j++) {
+            rGraph[i * graph_size + j] = 0;
+        }
+    }
+    
+    for (u = 0; u < graph_size; u++)
+        for (v = 0; v < graph_size; v++)
+            rGraph[u * graph_size + v] = graph[u * graph_size + v];
+    // This array is filled by BFS and to store path
+    vector<id_t> parent(graph_size);
+    memset(parent.data(), 0, parent.size() * sizeof(id_t));
+
+    // Augment the flow while there is path from source to sink
+    while (bfs(rGraph.get(), s, t, parent, graph_size)) {
+        // Find minimum residual capacity of the edges along the
+        // path filled by BFS. Or we can say find the maximum flow
+        // through the path found.
+        int path_flow = numeric_limits<int>::max();;
+        for (v = t; v != s; v = parent[v]) {
+            u = parent[v];
+            path_flow = min(path_flow, rGraph[u *graph_size + v]);
+        }
+
+        // update residual capacities of the edges and reverse edges
+        // along the path
+        for (v = t; v != s; v = parent[v]) {v
+            u = parent[v];
+            rGraph[u * graph_size + v] -= path_flow;
+            rGraph[v * graph_size + u] += path_flow;
+        }
+    }
+
+    // Flow is maximum now, find vertices reachable from s
+
+    vector<bool> visited(graph_size, false);
+
+    dfs(rGraph.get(), s, visited, graph_size);
+    vector<pair<id_t,id_t>> min_cut;
+
+    // Print all edges that are from a reachable vertex to
+    // non-reachable vertex in the original graph
+    for (id_t i = 0; i < graph_size; i++) {
+        for (id_t j = 0; j < graph_size; j++) {
+            if (visited[i] && !visited[j] && graph[i * graph_size + j]) {
+                cout << i << " - " << j << endl;
+                    //remove min cut edges
+                min_cut.push_back(pair<id_t, id_t>(i, j));
+                rGraph[i * graph_size + j] = 0;
+            }
+        }
+    }
+    return min_cut;
+}
+
+
 } // end namespace

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -712,12 +712,14 @@ public:
     void dfs(int* rGraph, id_t s, vector<bool>& visited, id_t graph_size);
     void find_in_out_web(deque<NodeTraversal>& sorted_nodes, set<id_t> backbone,
                             set<id_t> nodes, list<id_t> ref_path,
-                            hash_map<id_t, vector <Edge*>> edges_out_nodes,
-                            hash_map<id_t, vector <Edge*>> edges_in_nodes,
+                            EdgeMapping edges_out_nodes,
+                            EdgeMapping edges_in_nodes,
                             hash_map<Edge*, int> edge_weight);
-    void mark_dfs_in(hash_map<id_t, vector <Edge*>> graph_matrix, id_t s, set<id_t>& sorted_nodes, vector<bool>& visited);
-    void mark_dfs_out(hash_map<id_t, vector <Edge*>> graph_matrix, id_t s, set<id_t>& sorted_nodes, vector<bool>& visited);
-    vector<pair<id_t,id_t>> min_cut(int* graph, id_t s, id_t t, id_t graph_size, hash_map<id_t, vector < Edge*>>& edges_out_nodes, hash_map<id_t, vector < Edge*>>& edges_in_nodes);
+    void mark_dfs(EdgeMapping graph_matrix, id_t s, set<id_t>& sorted_nodes, 
+                vector<bool>& visited, bool reverse);
+    vector<pair<id_t,id_t>> min_cut(int* graph, id_t s, id_t t, id_t graph_size,
+                EdgeMapping& edges_out_nodes, EdgeMapping& edges_in_nodes);
+    void remove_edge(EdgeMapping& nodes_to_edges, id_t node, id_t to, bool reverse);
     
 
     // Use a topological sort to order and orient the nodes, and then flip some

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -708,20 +708,51 @@ public:
     //sorts graph using max-flow algorithm	
     void max_flow(const string& ref_name);
     void max_flow_sort(deque<NodeTraversal>& sorted_nodes, const string& ref_name);
+    //Structure for holding weighted edges of the graph
+    struct WeightedGraph {
+        EdgeMapping edges_out_nodes;
+        EdgeMapping edges_in_nodes;
+        map<Edge*, int> edge_weight;
+      
+        WeightedGraph(EdgeMapping& edges_out_nodes,
+            EdgeMapping& edges_in_nodes,
+            map<Edge*, int>& edge_weight)
+            : edges_out_nodes(std::move(edges_out_nodes)),
+            edges_in_nodes(std::move(edges_in_nodes)),
+            edge_weight(std::move(edge_weight))
+            { };
+    };
+    WeightedGraph get_weighted_graph(const string& ref_name);
+    struct InOutGrowth {
+        set<id_t> nodes;
+        set<id_t> backbone;
+        list<id_t> ref_path;
+      
+        InOutGrowth(set<id_t> nodes,
+            set<id_t> backbone,
+            list<id_t> ref_path)
+            : nodes(std::move(nodes)),
+            backbone(std::move(backbone)),
+            ref_path(std::move(ref_path))
+            { };
+    };    
     bool bfs(int* rGraph, id_t s, id_t t, vector<id_t>& parent, id_t graph_size);
     void dfs(int* rGraph, id_t s, vector<bool>& visited, id_t graph_size);
-    void find_in_out_web(deque<NodeTraversal>& sorted_nodes, set<id_t> backbone,
-                            set<id_t> nodes, list<id_t> ref_path,
-                            EdgeMapping edges_out_nodes,
-                            EdgeMapping edges_in_nodes,
-                            hash_map<Edge*, int> edge_weight);
+    void find_in_out_web(   deque<NodeTraversal>& sorted_nodes, 
+                            InOutGrowth in_out_growth,
+                            WeightedGraph weighted_graph);
+    void process_in_out_growth( EdgeMapping edges_out_nodes, id_t current_id,
+                                InOutGrowth in_out_growth,
+                                WeightedGraph weighted_graph,
+                                vector<bool>& visited,
+                                deque<NodeTraversal>& sorted_nodes, 
+                                bool reverse);
     void mark_dfs(EdgeMapping graph_matrix, id_t s, set<id_t>& sorted_nodes, 
                 vector<bool>& visited, bool reverse);
     vector<pair<id_t,id_t>> min_cut(int* graph, id_t s, id_t t, id_t graph_size,
                 EdgeMapping& edges_out_nodes, EdgeMapping& edges_in_nodes);
     void remove_edge(EdgeMapping& nodes_to_edges, id_t node, id_t to, bool reverse);
     
-
     // Use a topological sort to order and orient the nodes, and then flip some
     // nodes around so that they are oriented the way they are in the sort.
     // Populates nodes_flipped with the ids of the nodes that have had their

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -705,6 +705,21 @@ public:
     void topological_sort(deque<NodeTraversal>& l);
     void swap_nodes(Node* a, Node* b);
 
+    //sorts graph using max-flow algorithm	
+    void max_flow(const string& ref_name);
+    void max_flow_sort(deque<NodeTraversal>& sorted_nodes, const string& ref_name);
+    bool bfs(int* rGraph, id_t s, id_t t, vector<id_t>& parent, id_t graph_size);
+    void dfs(int* rGraph, id_t s, vector<bool>& visited, id_t graph_size);
+    void find_in_out_web(deque<NodeTraversal>& sorted_nodes, set<id_t> backbone,
+                            set<id_t> nodes, list<id_t> ref_path,
+                            hash_map<id_t, vector <Edge*>> edges_out_nodes,
+                            hash_map<id_t, vector <Edge*>> edges_in_nodes,
+                            hash_map<Edge*, int> edge_weight);
+    void mark_dfs_in(hash_map<id_t, vector <Edge*>> graph_matrix, id_t s, set<id_t>& sorted_nodes, vector<bool>& visited);
+    void mark_dfs_out(hash_map<id_t, vector <Edge*>> graph_matrix, id_t s, set<id_t>& sorted_nodes, vector<bool>& visited);
+    vector<pair<id_t,id_t>> min_cut(int* graph, id_t s, id_t t, id_t graph_size, hash_map<id_t, vector < Edge*>>& edges_out_nodes, hash_map<id_t, vector < Edge*>>& edges_in_nodes);
+    
+
     // Use a topological sort to order and orient the nodes, and then flip some
     // nodes around so that they are oriented the way they are in the sort.
     // Populates nodes_flipped with the ids of the nodes that have had their

--- a/test/sort/test_sort.gfa
+++ b/test/sort/test_sort.gfa
@@ -1,0 +1,71 @@
+H	VN:Z:1.0
+S	1	C
+P	1	ref	1	+	1M
+P	1	alt2	1	+	1M
+P	1	alt3	1	+	1M
+P	1	alt4	1	+	1M
+P	1	alt5	1	+	1M
+P	1	alt6	1	+	1M
+S	2	G
+P	2	ref	2	+	1M
+P	2	alt1	2	+	1M
+P	2	alt2	2	+	1M
+P	2	alt3	2	+	1M
+P	2	alt5	2	+	1M
+L	1	+	2	+	1M
+S	3	C
+P	3	alt1	4	+	1M
+P	3	alt2	4	+	1M
+S	4	G
+P	4	alt2	5	+	1M
+S	5	C
+P	5	alt1	5	+	1M
+P	5	alt2	6	+	1M
+S	6	T
+P	6	alt4	2	+	1M
+P	6	alt6	2	+	1M
+S	7	C
+P	7	alt6	3	+	1M
+S	8	A
+P	8	alt4	3	+	1M
+P	8	alt6	4	+	1M
+S	9	C
+P	9	alt4	5	+	1M
+P	9	alt6	5	+	1M
+S	10	G
+P	10	alt3	3	+	1M
+P	10	alt5	3	+	1M
+S	11	A
+L	2	+	10	+	1M
+L	2	+	11	+	1M
+P	11	ref	3	+	1M
+P	11	alt1	3	+	1M
+P	11	alt2	3	+	1M
+P	11	alt1	6	+	1M
+S	12	T
+L	11	+	12	+	1M
+P	12	ref	4	+	1M
+P	12	alt4	4	+	1M
+P	12	alt5	5	+	1M
+P	12	alt6	6	+	1M
+P	12	alt1	7	+	1M
+P	12	alt2	8	+	1M
+S	13	C
+L	12	+	13	+	1M
+P	13	ref	5	+	1M
+P	13	alt4	6	+	1M
+L	10	+	12	+	1M
+L	10	+	12	+	1M
+L	1	+	6	+	1M
+L	6	+	8	+	1M
+L	10	+	9	+	1M
+L	6	+	7	+	1M
+L	7	+	7	+	1M
+L	7	+	8	+	1M
+L	8	+	9	+	1M
+L	11	+	3	+	1M
+L	3	+	5	+	1M
+L	3	+	4	+	1M
+L	4	+	5	+	1M
+L	5	+	11	+	1M
+L	12	-	9	-	1M

--- a/test/t/28_sort.t
+++ b/test/t/28_sort.t
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+
+plan tests 2
+
+vg sort -r ref -g -i sort/test_sort.gfa > sorted.vg
+
+is $(vg view -g sorted.vg | grep "^S" | wc -l) 13 "sorted graph contains expected number of nodes"
+is $(vg view -d sorted.vg | grep label | tr '\n' ' ' | grep -E '1:C(.*)6:T(.*)7:C(.*)8:A(.*)2:G(.*)10:G(.*)9:C(.*)3:C(.*)4:G(.*)5:C(.*)11:A(.*)12:T(.*)13:C' | wc -l) 1 "nodes appear in the expected order"
+
+rm -f sorted.vg


### PR DESCRIPTION
Hello!
This is implementation of vg sorting using max flow/min cut algorithm from the paper.
Sorting now is implemented as a separate tool "vg sort".
For first implementation I've used a simple Ford–Fulkerson algorithm for finding min cut in the graph and a matrix representation of a graph for it. Surely we'll change it, when we figure out which max flow algorithm implementation is the best for this task.
I have some questions on the sorting algorithm, it would be great to discuss them and make some changes to the code:
1. As we have discussed earlier, we need to determine the approach for assigning weights to edges (joins). Now it is implemented as a number of paths, that go through the edge (path goes through edge, if both adjacent nodes are mapped to that path). This approach is relatively fast, but it needs several paths in vg file. This was considered as “OK for now”. How do you see the further development of this approach?
2. We have implemented the backbone determining in the following way:
   a. for the whole graph we use a path from the “-ref” parameter as a backbone;
   b. we use a greedy algorithm for recursive calls for in- and out-growths; we start from the backbone and go in depth always selecting the edge with the maximum weight.
   This is not always optimal, but it is fast. What would you say? Can you suggest any other approach?
3. We have used cactus and brca1 graphs for testing. Can we use some extra data for this to be more sure that testing is sufficient? 
4. For comparing various approaches we probably need to add some graph metrics – like weighted feedback, cutwidth, etc. Do you have any ideas for such metrics?

For now there is only one unit test, it is based on example, described in the paper. It checks, that order of the nodes after sorting the same as expected. I think we need more small graphs with some "corner cases" to make testing sufficient.

Looking forward to your answers and review!  
