### PR TITLE
Add a return to main_view

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8440,6 +8440,9 @@ int main_view(int argc, char** argv) {
         cerr << "[vg view] error: cannot save a graph in " << output_type << " format" << endl;
         return 1;
     }
+    
+    // We made it to the end and nothing broke.
+    return 0;
 }
 
     void help_sv(char** argv){


### PR DESCRIPTION
If you don't hit a return on the way out of the function, the program ends up returning nonzero exit codes when everything worked, which confuses any pipelines trying to run it.