### PR TITLE
Add alignment ambiguity trimming to vg filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 STATIC_FLAGS=-static -static-libstdc++ -static-libgcc
 
 # These are put into libvg.
-OBJ:=$(OBJ_DIR)/gssw_aligner.o $(OBJ_DIR)/vg.o cpp/vg.pb.o $(OBJ_DIR)/index.o $(OBJ_DIR)/mapper.o $(OBJ_DIR)/region.o $(OBJ_DIR)/progress_bar.o $(OBJ_DIR)/vg_set.o $(OBJ_DIR)/utility.o $(OBJ_DIR)/path.o $(OBJ_DIR)/alignment.o $(OBJ_DIR)/edit.o $(OBJ_DIR)/sha1.o $(OBJ_DIR)/json2pb.o $(OBJ_DIR)/entropy.o $(OBJ_DIR)/pileup.o $(OBJ_DIR)/caller.o $(OBJ_DIR)/call2vcf.o $(OBJ_DIR)/genotyper.o $(OBJ_DIR)/genotypekit.o $(OBJ_DIR)/position.o $(OBJ_DIR)/deconstructor.o $(OBJ_DIR)/vectorizer.o $(OBJ_DIR)/sampler.o $(OBJ_DIR)/filter.o $(OBJ_DIR)/ssw_aligner.o $(OBJ_DIR)/bubbles.o $(OBJ_DIR)/translator.o $(OBJ_DIR)/version.o
+OBJ:=$(OBJ_DIR)/gssw_aligner.o $(OBJ_DIR)/vg.o cpp/vg.pb.o $(OBJ_DIR)/index.o $(OBJ_DIR)/mapper.o $(OBJ_DIR)/region.o $(OBJ_DIR)/progress_bar.o $(OBJ_DIR)/vg_set.o $(OBJ_DIR)/utility.o $(OBJ_DIR)/path.o $(OBJ_DIR)/alignment.o $(OBJ_DIR)/edit.o $(OBJ_DIR)/sha1.o $(OBJ_DIR)/json2pb.o $(OBJ_DIR)/entropy.o $(OBJ_DIR)/pileup.o $(OBJ_DIR)/caller.o $(OBJ_DIR)/call2vcf.o $(OBJ_DIR)/genotyper.o $(OBJ_DIR)/genotypekit.o $(OBJ_DIR)/position.o $(OBJ_DIR)/deconstructor.o $(OBJ_DIR)/vectorizer.o $(OBJ_DIR)/sampler.o $(OBJ_DIR)/filter.o $(OBJ_DIR)/readfilter.o $(OBJ_DIR)/ssw_aligner.o $(OBJ_DIR)/bubbles.o $(OBJ_DIR)/translator.o $(OBJ_DIR)/version.o
 
 # These aren't put into libvg. But they do go into the main vg binary to power its self-test.
 UNITTEST_OBJ:=$(UNITTEST_OBJ_DIR)/driver.o $(UNITTEST_OBJ_DIR)/distributions.o $(UNITTEST_OBJ_DIR)/genotypekit.o
@@ -204,7 +204,7 @@ $(OBJ_DIR)/vg_set.o: $(SRC_DIR)/vg_set.cpp $(SRC_DIR)/vg_set.hpp $(SRC_DIR)/vg.h
 $(OBJ_DIR)/mapper.o: $(SRC_DIR)/mapper.cpp $(SRC_DIR)/mapper.hpp $(CPP_DIR)/vg.pb.h $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libxg.a
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
-$(OBJ_DIR)/main.o: $(SRC_DIR)/main.cpp $(LIB_DIR)/libvcflib.a $(OBJ_DIR)/Fasta.o $(LIB_DIR)/libgssw.a $(INC_DIR)/stream.hpp $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(LIB_DIR)/librocksdb.a $(CPP_DIR)/vg.pb.h $(LIB_DIR)/libxg.a $(INC_DIR)/gcsa.h $(LIB_DIR)/libhts.a $(INC_DIR)/sha1.hpp $(OBJ_DIR)/progress_bar.o $(INC_DIR)/lru_cache.h $(LIB_DIR)/libvcfh.a $(LIB_DIR)/libgfakluge.a $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libpinchesandcacti.a $(LIB_DIR)/libsonlib.a $(INC_DIR)/globalDefs.hpp $(SRC_DIR)/bubbles.hpp $(SRC_DIR)/genotyper.hpp $(SRC_DIR)/distributions.hpp
+$(OBJ_DIR)/main.o: $(SRC_DIR)/main.cpp $(LIB_DIR)/libvcflib.a $(OBJ_DIR)/Fasta.o $(LIB_DIR)/libgssw.a $(INC_DIR)/stream.hpp $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map $(LIB_DIR)/librocksdb.a $(CPP_DIR)/vg.pb.h $(LIB_DIR)/libxg.a $(INC_DIR)/gcsa.h $(LIB_DIR)/libhts.a $(INC_DIR)/sha1.hpp $(OBJ_DIR)/progress_bar.o $(INC_DIR)/lru_cache.h $(LIB_DIR)/libvcfh.a $(LIB_DIR)/libgfakluge.a $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libpinchesandcacti.a $(LIB_DIR)/libsonlib.a $(INC_DIR)/globalDefs.hpp $(SRC_DIR)/bubbles.hpp $(SRC_DIR)/genotyper.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/readfilter.hpp
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
 $(OBJ_DIR)/region.o: $(SRC_DIR)/region.cpp $(SRC_DIR)/region.hpp $(LIB_DIR)/libprotobuf.a $(INC_DIR)/sparsehash/sparse_hash_map
@@ -263,6 +263,9 @@ $(OBJ_DIR)/sampler.o: $(SRC_DIR)/sampler.cpp $(SRC_DIR)/sampler.hpp $(LIB_DIR)/l
 	+$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
 $(OBJ_DIR)/filter.o: $(SRC_DIR)/filter.cpp $(SRC_DIR)/filter.hpp $(LIB_DIR)/libprotobuf.a $(LIB_DIR)/libxg.a $(CPP_DIR)/vg.pb.h
+	+$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
+	
+$(OBJ_DIR)/readfilter.o: $(SRC_DIR)/readfilter.cpp $(SRC_DIR)/readfilter.hpp $(SRC_DIR)/vg.hpp $(LIB_DIR)/libprotobuf.a $(LIB_DIR)/libxg.a $(CPP_DIR)/vg.pb.h
 	+$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
 $(OBJ_DIR)/bubbles.o: $(SRC_DIR)/bubbles.cpp $(SRC_DIR)/bubbles.hpp $(LIB_DIR)/libprotobuf.a $(LIB_DIR)/libxg.a $(CPP_DIR)/vg.pb.h $(LIB_DIR)/libpinchesandcacti.a $(LIB_DIR)/libsonlib.a

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ STATIC_FLAGS=-static -static-libstdc++ -static-libgcc
 OBJ:=$(OBJ_DIR)/gssw_aligner.o $(OBJ_DIR)/vg.o cpp/vg.pb.o $(OBJ_DIR)/index.o $(OBJ_DIR)/mapper.o $(OBJ_DIR)/region.o $(OBJ_DIR)/progress_bar.o $(OBJ_DIR)/vg_set.o $(OBJ_DIR)/utility.o $(OBJ_DIR)/path.o $(OBJ_DIR)/alignment.o $(OBJ_DIR)/edit.o $(OBJ_DIR)/sha1.o $(OBJ_DIR)/json2pb.o $(OBJ_DIR)/entropy.o $(OBJ_DIR)/pileup.o $(OBJ_DIR)/caller.o $(OBJ_DIR)/call2vcf.o $(OBJ_DIR)/genotyper.o $(OBJ_DIR)/genotypekit.o $(OBJ_DIR)/position.o $(OBJ_DIR)/deconstructor.o $(OBJ_DIR)/vectorizer.o $(OBJ_DIR)/sampler.o $(OBJ_DIR)/filter.o $(OBJ_DIR)/readfilter.o $(OBJ_DIR)/ssw_aligner.o $(OBJ_DIR)/bubbles.o $(OBJ_DIR)/translator.o $(OBJ_DIR)/version.o
 
 # These aren't put into libvg. But they do go into the main vg binary to power its self-test.
-UNITTEST_OBJ:=$(UNITTEST_OBJ_DIR)/driver.o $(UNITTEST_OBJ_DIR)/distributions.o $(UNITTEST_OBJ_DIR)/genotypekit.o
+UNITTEST_OBJ:=$(UNITTEST_OBJ_DIR)/driver.o $(UNITTEST_OBJ_DIR)/distributions.o $(UNITTEST_OBJ_DIR)/genotypekit.o $(UNITTEST_OBJ_DIR)/readfilter.o
 
 RAPTOR_DIR:=deps/raptor
 PROTOBUF_DIR:=deps/protobuf
@@ -285,6 +285,9 @@ $(UNITTEST_OBJ_DIR)/distributions.o: $(UNITTEST_SRC_DIR)/distributions.cpp $(UNI
 	 +$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 	 
 $(UNITTEST_OBJ_DIR)/genotypekit.o: $(UNITTEST_SRC_DIR)/genotypekit.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/genotypekit.hpp
+	 +$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
+	 
+$(UNITTEST_OBJ_DIR)/readfilter.o: $(UNITTEST_SRC_DIR)/readfilter.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/readfilter.hpp
 	 +$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
 ###################################

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -661,9 +661,9 @@ Alignment reverse_complement_alignment(const Alignment& aln,
     
     if(aln.has_path()) {
         // Now invert the order of the mappings, and for each mapping, flip the
-        // is_reverse flag. The edits within mappings also get put in reverse
-        // order, get their positions corrected, and get their sequences get
-        // reverse complemented.
+        // is_reverse flag, and adjust offsets to count from the other end. The
+        // edits within mappings also get put in reverse order, and get their
+        // sequences reverse complemented.
         *reversed.mutable_path() = reverse_complement_path(aln.path(), node_length);
     }
     

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -87,7 +87,8 @@ const string hash_alignment(const Alignment& aln);
 // Flip the alignment's sequence and is_reverse flag, and flip and re-order its
 // Mappings to match. A function to get node lengths is needed because the
 // Mappings in the alignment will need to give their positions from the opposite
-// ends of their nodes.
+// ends of their nodes. Offsets will be updated to count unused bases from node
+// start when considering the node in its new orientation.
 Alignment reverse_complement_alignment(const Alignment& aln, const function<int64_t(id_t)>& node_length);
 vector<Alignment> reverse_complement_alignments(const vector<Alignment>& alns, const function<int64_t(int64_t)>& node_length);
 int softclip_start(Alignment& alignment);

--- a/src/filter.hpp
+++ b/src/filter.hpp
@@ -1,3 +1,6 @@
+#ifndef VG_FILTER_HPP
+#define VG_FILTER_HPP
+
 #include <vector>
 #include <cstdlib>
 #include <iostream>
@@ -92,3 +95,4 @@ class Filter{
         double min_avg_qual = 0.0;
         };
 }
+#endif

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -1159,10 +1159,11 @@ map<Alignment*, vector<Genotyper::Affinity>>
                 // If the first difference is the past-the-rend of the suffix, then it's a suffix
                 affinity.consistent = (difference.first == seq.rend());
             } else {
-                // This read doesn't touch either end. Just assume it's
-                // consistent and let scoring work it out.
+                // This read doesn't touch either end. This might happen if the
+                // site is very large. Just assume it's consistent and let
+                // scoring work it out.
                 #pragma omp critical (cerr)
-                cerr << "Warning: realigned read doesn't touch either end of its site!" << endl;
+                cerr << "Warning: realigned read " << aligned.sequence() << " doesn't touch either end of its site!" << endl;
                 affinity.consistent = true;
             }
             

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -976,7 +976,9 @@ map<Alignment*, vector<Genotyper::Affinity>>
     for(auto id : relevant_ids) {
         // For all the IDs in the surrounding material
         
-        if(!graph.paths.has_node_mapping(id) || graph.paths.get_node_mapping(id).size() < min_recurrence) {
+        if(min_recurrence != 0 && 
+            (!graph.paths.has_node_mapping(id) || 
+            graph.paths.get_node_mapping(id).size() < min_recurrence)) {
             // Skip nodes in the graph that have too little support. In practice
             // this means we'll restrict ourselves to supported, known nodes.
             // TODO: somehow do the same for edges.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,10 +27,10 @@
 #include "google/protobuf/stubs/common.h"
 #include "progress_bar.hpp"
 #include "version.hpp"
-#include "IntervalTree.h"
 #include "genotyper.hpp"
 #include "bubbles.hpp"
 #include "translator.hpp"
+#include "readfilter.hpp"
 #include "distributions.hpp"
 #include "unittest/driver.hpp"
 
@@ -223,21 +223,11 @@ int main_filter(int argc, char** argv) {
         return 1;
     }
 
-    double min_secondary = 0.;
-    double min_primary = 0.;
-    double min_sec_delta = 0.;
-    double min_pri_delta = 0.;
-    bool frac_score = false;
-    bool frac_delta = false;
-    bool sub_score = false;
-    int max_overhang = 99999;
-    string xg_name;
-    string regions_file;
-    string outbase;
-    int context_size = 0;
-    bool verbose = false;
-    double min_mapq = 0.;
-    int repeat_size = 0;
+    // This is the better design for a subcommand: we have a class that
+    // implements it and encapsulates all the default parameters, and then we
+    // just feed in overrides in the option parsing code. Thsi way we don't have
+    // multiple defaults all over the place.
+    ReadFilter filter;
 
     int c;
     optind = 2; // force optind past command positional arguments
@@ -273,49 +263,49 @@ int main_filter(int argc, char** argv) {
         switch (c)
         {
         case 's':
-            min_secondary = atof(optarg);
+            filter.min_secondary = atof(optarg);
             break;
         case 'r':
-            min_primary = atof(optarg);
+            filter.min_primary = atof(optarg);
             break;
         case 'd':
-            min_sec_delta = atof(optarg);
+            filter.min_sec_delta = atof(optarg);
             break;
         case 'e':
-            min_pri_delta = atof(optarg);
+            filter.min_pri_delta = atof(optarg);
             break;
         case 'f':
-            frac_score = true;
+            filter.frac_score = true;
             break;
         case 'a':
-            frac_delta = true;
+            filter.frac_delta = true;
             break;
         case 'u':
-            sub_score = true;
+            filter.sub_score = true;
             break;
         case 'o':
-            max_overhang = atoi(optarg);
+            filter.max_overhang = atoi(optarg);
             break;
         case 'x':
-            xg_name = optarg;
+            filter.xg_name = optarg;
             break;
         case 'R':
-            regions_file = optarg;
+            filter.regions_file = optarg;
             break;
         case 'B':
-            outbase = optarg;
+            filter.outbase = optarg;
             break;
         case 'c':
-            context_size = atoi(optarg);
+            filter.context_size = atoi(optarg);
             break;
         case 'q':
-            min_mapq = atof(optarg);
+            filter.min_mapq = atof(optarg);
             break;
         case 'v':
-            verbose = true;
+            filter.verbose = true;
             break;
         case 'E':
-            repeat_size = atoi(optarg);
+            filter.repeat_size = atoi(optarg);
             break;            
 
         case 'h':
@@ -329,96 +319,6 @@ int main_filter(int argc, char** argv) {
             abort ();
         }
     }
-
-    // name helper for output
-    function<string(int)> chunk_name = [&outbase](int num) -> string {
-        stringstream ss;
-        ss << outbase << "-" << num << ".gam";
-        return ss.str();
-    };
-
-    // index regions by their inclusive ranges
-    vector<Interval<int, int64_t> > interval_list;
-    vector<Region> regions;
-    // use strings instead of ofstreams because worried about too many handles
-    vector<string> chunk_names;
-    vector<bool> chunk_new; // flag if write or append
-
-    // parse a bed, for now this is only way to do regions.  note
-    // this operation converts from 0-based BED to 1-based inclusive VCF
-    if (!regions_file.empty()) {
-        if (outbase.empty()) {
-            cerr << "-B option required with -R" << endl;
-            exit(1);
-        }
-        parse_bed_regions(regions_file, regions);
-        if (regions.empty()) {
-            cerr << "No regions read from BED file, doing whole graph" << endl;
-        }
-    }
-
-    // empty region, do everything
-    if (regions.empty()) {
-        // we handle empty intervals as special case when looking up, otherwise,
-        // need to insert giant interval here.
-        chunk_names.push_back(outbase.empty() ? "-" : chunk_name(0));
-    }
-
-    // otherwise, need to extract regions with xg
-    else {
-        if (xg_name.empty()) {
-            cerr << "xg index required for -R option" << endl;
-            exit(1);
-        }
-        // read the xg index
-        ifstream xg_stream(xg_name);
-        if(!xg_stream) {
-            cerr << "Unable to open xg index: " << xg_name << endl;
-            exit(1);
-        }
-        xg::XG xindex(xg_stream);
-
-        // fill in the map using xg index
-        // relies entirely on the assumption that are path chunks
-        // are perfectly spanned by an id range
-        for (int i = 0; i < regions.size(); ++i) {
-            Graph graph;
-            int rank = xindex.path_rank(regions[i].seq);
-            int path_size = rank == 0 ? 0 : xindex.path_length(regions[i].seq);
-
-            if (regions[i].start >= path_size) {
-                cerr << "Unable to find region in index: " << regions[i].seq << ":" << regions[i].start
-                     << "-" << regions[i].end << endl;
-            } else {
-                // clip region on end of path
-                regions[i].end = min(path_size - 1, regions[i].end);
-                // do path node query
-                // convert to 0-based coordinates as this seems to be what xg wants
-                xindex.get_path_range(regions[i].seq, regions[i].start - 1, regions[i].end - 1, graph);
-                if (context_size > 0) {
-                    xindex.expand_context(graph, context_size);
-                }
-            }
-            // find node range of graph, without bothering to build vg indices..
-            int64_t min_id = numeric_limits<int64_t>::max();
-            int64_t max_id = 0;
-            for (int j = 0; j < graph.node_size(); ++j) {
-                min_id = min(min_id, (int64_t)graph.node(j).id());
-                max_id = max(max_id, (int64_t)graph.node(j).id());
-            }
-            // map the chunk id to a name
-            chunk_names.push_back(chunk_name(i));
-
-            // map the node range to the chunk id.
-            if (graph.node_size() > 0) {
-                interval_list.push_back(Interval<int, int64_t>(min_id, max_id, i));
-                assert(chunk_names.size() == i + 1);
-            }
-        }
-    }
-
-    // index chunk regions
-    IntervalTree<int, int64_t> region_map(interval_list);
 
     // setup alignment stream
     if (optind >= argc) {
@@ -439,273 +339,7 @@ int main_filter(int argc, char** argv) {
         alignment_stream = &in;
     }
 
-    // which chunk(s) does a gam belong to?
-    function<void(Alignment&, vector<int>&)> get_chunks = [&region_map, &regions](Alignment& aln, vector<int>& chunks) {
-        // speed up case where no chunking
-        if (regions.empty()) {
-            chunks.push_back(0);
-        } else {
-            int64_t min_aln_id = numeric_limits<int64_t>::max();
-            int64_t max_aln_id = -1;
-            for (int i = 0; i < aln.path().mapping_size(); ++i) {
-                const Mapping& mapping = aln.path().mapping(i);
-                min_aln_id = min(min_aln_id, (int64_t)mapping.position().node_id());
-                max_aln_id = max(max_aln_id, (int64_t)mapping.position().node_id());
-            }
-            vector<Interval<int, int64_t> > found_ranges;
-            region_map.findOverlapping(min_aln_id, max_aln_id, found_ranges);
-            for (auto& interval : found_ranges) {
-                chunks.push_back(interval.value);
-            }
-        }
-    };
-
-    // buffered output (one buffer per chunk)
-    vector<vector<Alignment> > buffer(chunk_names.size());
-    int cur_buffer = -1;
-    static const int buffer_size = 1000; // we let this be off by 1
-    function<Alignment&(uint64_t)> write_buffer = [&buffer, &cur_buffer](uint64_t i) -> Alignment& {
-        return buffer[cur_buffer][i];
-    };
-    // remember if write or append
-    vector<bool> chunk_append(chunk_names.size(), false);
-
-    // flush a buffer specified by cur_buffer to target in chunk_names, and clear it
-    function<void()> flush_buffer = [&buffer, &cur_buffer, &write_buffer, &chunk_names, &chunk_append]() {
-        ofstream outfile;
-        auto& outbuf = chunk_names[cur_buffer] == "-" ? cout : outfile;
-        if (chunk_names[cur_buffer] != "-") {
-            outfile.open(chunk_names[cur_buffer], chunk_append[cur_buffer] ? ios::app : ios_base::out);
-            chunk_append[cur_buffer] = true;
-        }
-        stream::write(outbuf, buffer[cur_buffer].size(), write_buffer);
-        buffer[cur_buffer].clear();
-    };
-
-    // add alignment to all appropriate buffers, flushing as necessary
-    // (note cur_buffer variable used here as a hack to specify which buffer is written to)
-    function<void(Alignment&)> update_buffers = [&buffer, &cur_buffer, &region_map,
-                                                 &write_buffer, &get_chunks, &flush_buffer](Alignment& aln) {
-        vector<int> aln_chunks;
-        get_chunks(aln, aln_chunks);
-        for (auto chunk : aln_chunks) {
-            buffer[chunk].push_back(aln);
-            if (buffer[chunk].size() >= buffer_size) {
-                // flush buffer
-                cur_buffer = chunk;
-                flush_buffer();
-            }
-        }
-    };
-
-    // keep track of how many reads were dropped by which option
-    size_t pri_read_count = 0;
-    size_t sec_read_count = 0;
-    size_t sec_filtered_count = 0;
-    size_t pri_filtered_count = 0;
-    size_t min_sec_count = 0;
-    size_t min_pri_count = 0;
-    size_t min_sec_delta_count = 0;
-    size_t min_pri_delta_count = 0;
-    size_t max_sec_overhang_count = 0;
-    size_t max_pri_overhang_count = 0;
-    size_t min_sec_mapq_count = 0;
-    size_t min_pri_mapq_count = 0;
-    size_t repeat_sec_count = 0;
-    size_t repeat_pri_count = 0;
-
-    // for deltas, we keep track of last primary
-    Alignment prev;
-    bool prev_primary = false;
-    bool keep_prev = true;
-    double prev_score;
-
-    // quick and dirty filter to see if removing reads that can slip around
-    // and still map perfectly helps vg call.  returns true if at either
-    // end of read sequence, at least k bases are repetitive, checking repeats
-    // of up to size 2k
-    function<bool(Alignment&, int k)> has_repeat = [](Alignment& aln, int k) {
-        if (k == 0) {
-            return false;
-        }
-        const string& s = aln.sequence();
-        for (int i = 1; i <= 2 * k; ++i) {
-            int covered = 0;
-            bool ffound = true;
-            bool bfound = true;
-            for (int j = 1; (ffound || bfound) && (j + 1) * i < s.length(); ++j) {
-                ffound = ffound && s.substr(0, i) == s.substr(j * i, i);
-                bfound = bfound && s.substr(s.length() - i, i) == s.substr(s.length() - i - j * i, i);
-                if (ffound || bfound) {
-                    covered += i;
-                }
-            }
-            if (covered >= k) {
-                return true;
-            }
-        }
-        return false;
-    };
-        
-    // we assume that every primary alignment has 0 or 1 secondary alignment
-    // immediately following in the stream
-    function<void(Alignment&)> lambda = [&](Alignment& aln) {
-        bool keep = true;
-        double score = (double)aln.score();
-        double denom = 2. * aln.sequence().length();
-        // toggle substitution score
-        if (sub_score == true) {
-            // hack in ident to replace old counting logic.
-            score = aln.identity() * aln.sequence().length();
-            denom = aln.sequence().length();
-            assert(score <= denom);
-        }
-        // toggle absolute or fractional score
-        if (frac_score == true) {
-            if (denom > 0.) {
-                score /= denom;
-            }
-            else {
-                assert(score == 0.);
-            }
-        }
-        // compute overhang
-        int overhang = 0;
-        if (aln.path().mapping_size() > 0) {
-            const auto& left_mapping = aln.path().mapping(0);
-            if (left_mapping.edit_size() > 0) {
-                overhang = left_mapping.edit(0).to_length() - left_mapping.edit(0).from_length();
-            }
-            const auto& right_mapping = aln.path().mapping(aln.path().mapping_size() - 1);
-            if (right_mapping.edit_size() > 0) {
-                const auto& edit = right_mapping.edit(right_mapping.edit_size() - 1);
-                overhang = max(overhang, edit.to_length() - edit.from_length());
-            }
-        } else {
-            overhang = aln.sequence().length();
-        }
-
-        if (aln.is_secondary()) {
-            ++sec_read_count;
-            assert(prev_primary && aln.name() == prev.name());
-            double delta = prev_score - score;
-            if (frac_delta == true) {
-                delta = prev_score > 0 ? score / prev_score : 0.;
-            }
-
-            // filter (current) secondary
-            keep = true;
-            if (score < min_secondary) {
-                ++min_sec_count;
-                keep = false;
-            }
-            if ((keep || verbose) && delta < min_sec_delta) {
-                ++min_sec_delta_count;
-                keep = false;
-            }
-            if ((keep || verbose) && overhang > max_overhang) {
-                ++max_sec_overhang_count;
-                keep = false;
-            }
-            if ((keep || verbose) && aln.mapping_quality() < min_mapq) {
-                ++min_sec_mapq_count;
-                keep = false;
-            }
-            if ((keep || verbose) && has_repeat(aln, repeat_size)) {
-                ++repeat_sec_count;
-                keep = false;
-            }
-            if (!keep) {
-                ++sec_filtered_count;
-            }
-
-            // filter unfiltered previous primary
-            if (keep_prev && delta < min_pri_delta) {
-                ++min_pri_delta_count;
-                ++pri_filtered_count;
-                keep_prev = false;
-            }
-            // add to write buffer
-            if (keep) {
-                update_buffers(aln);
-            }
-            if (keep_prev) {
-                update_buffers(prev);
-            }
-
-            // forget last primary
-            prev_primary = false;
-            prev_score = -1;
-            keep_prev = false;
-
-        } else {
-            // this awkward logic where we keep the primary and write in the secondary
-            // is because we can only stream one at a time with for_each, but we need
-            // to look at pairs (if secondary exists)...
-            ++pri_read_count;
-            if (keep_prev) {
-                update_buffers(prev);
-            }
-
-            prev_primary = true;
-            prev_score = score;
-            prev = aln;
-            keep_prev = true;
-            if (score < min_primary) {
-                ++min_pri_count;
-                keep_prev = false;
-            }
-            if ((keep_prev || verbose) && overhang > max_overhang) {
-                ++max_pri_overhang_count;
-                keep_prev = false;
-            }
-            if ((keep_prev || verbose) && aln.mapping_quality() < min_mapq) {
-                ++min_pri_mapq_count;
-                keep_prev = false;
-            }
-            if ((keep_prev || verbose) && has_repeat(aln, repeat_size)) {
-                ++repeat_pri_count;
-                keep_prev = false;
-            }
-            if (!keep_prev) {
-                ++pri_filtered_count;
-            }
-        }
-    };
-    stream::for_each(*alignment_stream, lambda);
-
-    // flush buffer if trailing primary to keep
-    if (keep_prev) {
-        update_buffers(prev);
-    }
-
-    for (int i = 0; i < buffer.size(); ++i) {
-        if (buffer[i].size() > 0) {
-            cur_buffer = i;
-            flush_buffer();
-        }
-    }
-
-    if (verbose) {
-        size_t tot_reads = pri_read_count + sec_read_count;
-        size_t tot_filtered = pri_filtered_count + sec_filtered_count;
-        cerr << "Total Filtered (primary):          " << pri_filtered_count << " / "
-             << pri_read_count << endl
-             << "Total Filtered (secondary):        " << sec_filtered_count << " / "
-             << sec_read_count << endl
-             << "Min Identity Filter (primary):     " << min_pri_count << endl
-             << "Min Identity Filter (secondary):   " << min_sec_count << endl
-             << "Min Delta Filter (primary):        " << min_pri_delta_count << endl
-             << "Min Delta Filter (secondary):      " << min_sec_delta_count << endl
-             << "Max Overhang Filter (primary):     " << max_pri_overhang_count << endl
-             << "Max Overhang Filter (secondary):   " << max_sec_overhang_count << endl
-             << "Repeat Ends Filter (primary):     " << repeat_pri_count << endl
-             << "Repeat Ends Filter (secondary):   " << repeat_sec_count << endl
-
-             << endl;
-    }
-
-    return 0;
+    return filter.filter(alignment_stream);
 }
 
 void help_validate(char** argv) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,7 +213,8 @@ void help_filter(char** argv) {
          << "    -c, --context STEPS     expand the context of the subgraph this many steps when looking up chunks" << endl
          << "    -v, --verbose           print out statistics on numbers of reads filtered by what." << endl
          << "    -q, --min-mapq N        filter alignments with mapping quality < N" << endl
-         << "    -E, --repeat-ends N     filter reads with tandem repeat (motif size <= 2N, spanning >= N bases) at either end" << endl;
+         << "    -E, --repeat-ends N     filter reads with tandem repeat (motif size <= 2N, spanning >= N bases) at either end" << endl
+         << "    -D, --defray-ends N     clip back the ends of reads that are ambiguously aligned, up to N bases" << endl;
 }
 
 int main_filter(int argc, char** argv) {
@@ -249,11 +250,12 @@ int main_filter(int argc, char** argv) {
                 {"verbose",  no_argument, 0, 'v'},
                 {"min-mapq", required_argument, 0, 'q'},
                 {"repeat-ends", required_argument, 0, 'E'},
+                {"defray-ends", required_argument, 0, 'D'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "s:r:d:e:fauo:x:R:B:c:vq:E:",
+        c = getopt_long (argc, argv, "s:r:d:e:fauo:x:R:B:c:vq:E:D:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -306,7 +308,10 @@ int main_filter(int argc, char** argv) {
             break;
         case 'E':
             filter.repeat_size = atoi(optarg);
-            break;            
+            break;
+        case 'D':
+            filter.defray_length = atoi(optarg);
+            break;          
 
         case 'h':
         case '?':

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1308,11 +1308,22 @@ Mapping reverse_complement_mapping(const Mapping& m,
         
         if(m.edit_size() == 0) {
             // This is an old-style perfect match mapping with no edits.
-            // We can't deal with a nonzeor offset; that's weird.
-            assert(p->offset() == 0);
             
-            // All we need to do is flip the flag.
-             p->set_is_reverse(!p->is_reverse());
+            // The offset becomes unused bases after the mapping
+            size_t unused_bases_after = p->offset();
+            size_t used_bases = node_length(p->node_id()) - unused_bases_after;
+            
+            // There are now no unused bases before
+            p->set_offset(0);
+            // And we are on the other strand
+            p->set_is_reverse(!p->is_reverse());
+            
+            // But we have to have a mapping in there in order to actually
+            // specify that we're ending at the not-at-the-end position where we
+            // used to start.
+            Edit* edit = reversed.add_edit();
+            edit->set_from_length(used_bases);
+            edit->set_to_length(used_bases);
         } else {
             // We have edits; we may not be a full-length perfect match.
         

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1318,9 +1318,15 @@ Mapping reverse_complement_mapping(const Mapping& m,
         // The remainder ought to be taken up by the offset on this strand.
         size_t unused_bases_before = node_length(p->node_id()) - used_bases - unused_bases_after;
         
-        cerr << "Node " << p->node_id() << " breakdown: " << unused_bases_before << ", " << used_bases << ", " << unused_bases_after << endl;
+#ifdef debug
+        cerr << "Node " << p->node_id() << " breakdown: " << unused_bases_before << ", "
+            << used_bases << ", " << unused_bases_after << endl;
+#endif
         
+        // Adopt the new offset
         p->set_offset(unused_bases_before);
+        // Toggle the reversed-ness flag
+        p->set_is_reverse(!p->is_reverse());
     }
 
     // Clear out all the edits. TODO: we wasted time copying them

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1306,6 +1306,11 @@ Mapping reverse_complement_mapping(const Mapping& m,
     if(m.has_position() && m.position().node_id() != 0) {
         Position* p = reversed.mutable_position();
         
+        // We can't work on old-style implicit perfect match mappings. We need
+        // to have new-style explicit-perfect-match mappings. Empty mappings are
+        // also nonsense.
+        assert(m.edit_size() > 0);
+        
         // How many node bases are used by the mapping?
         size_t used_bases = mapping_from_length(m);
         // How many are taken up by the offset on the other strand?

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -54,7 +54,7 @@ bool ReadFilter::has_repeat(Alignment& aln, int k) {
     return false;
 }
 
-int ReadFilter::filter(istream* alignment_stream) {
+int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
 
     // name helper for output
     function<string(int)> chunk_name = [this](int num) -> string {
@@ -83,20 +83,6 @@ int ReadFilter::filter(istream* alignment_stream) {
         }
     }
 
-    // If the user gave us an XG index, we probably ought to load it up.
-    // TODO: make sure if we add any other error exits from this function we
-    // remember to delete this!
-    xg::XG* xindex = nullptr;
-    if (!xg_name.empty()) {
-        // read the xg index
-        ifstream xg_stream(xg_name);
-        if(!xg_stream) {
-            cerr << "Unable to open xg index: " << xg_name << endl;
-            return 1;
-        }
-        xindex = new xg::XG(xg_stream);
-    }
-    
     if(defray_length > 0 && xindex == nullptr) {
         cerr << "xg index required for end de-fraying" << endl;
         return 1;

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -726,11 +726,6 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
              << endl;
     }
     
-    if (xindex != nullptr) {
-        // Clean up any XG index we loaded.
-        delete xindex;
-    }
-
     return 0;
 
 }

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -23,7 +23,12 @@ bool ReadFilter::trim_ambiguous_ends(xg::XG* index, Alignment& alignment, int k)
     // Trim the end
     bool end_changed = trim_ambiguous_end(index, alignment, k);
     // Flip and trim the start
+    
+    cerr << "Forward: " << pb2json(alignment) << endl;
+    
     Alignment flipped = reverse_complement_alignment(alignment, get_node_length);
+    
+    cerr << "Reverse: " << pb2json(flipped) << endl;
     
     if(trim_ambiguous_end(index, flipped, k)) {
         // The start needed trimming

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -137,10 +137,29 @@ bool ReadFilter::trim_ambiguous_end(xg::XG* index, Alignment& alignment, int k) 
     // bases of the target sequence.
     
     // Return the total number of leaves in all subtrees that match the full
-    // target sequence, and the shortest nonzero length of target sequence
-    // matched within multiple subtrees under the specified node.
+    // target sequence, and the depth in bases of the shallowest point at which
+    // multiple subtrees with full lenght matches are unified.
     auto do_dfs = [&](id_t node_id, bool is_reverse, size_t matched) -> pair<size_t, size_t> {
-        // TODO: implement!
+        // Grab the node sequence and match more of the target sequence. If we
+        // finish the target sequence, return one match and unification at full
+        // length (i.e. nothing can be discarded). If we mismatch, return 0
+        // matches and unification at full length.
+    
+        // If we get through the whole node sequence without mismatching or
+        // running out of target sequence, keep going.
+    
+        // Get all the places we can go to off of the right side of this
+        // oriented node.
+        
+        // Recurse on all of them and collect the results.
+        
+        // Sum up the total leaf matches, which will be our leaf match count.
+        
+        // If multiple children have nonzero leaf match counts, report
+        // unification at the end of this node. Otherwise, report unification at
+        // the min unification depth of any subtree (and there will only be one
+        // that isn't at full length).
+        
         return make_pair(0, 0);
     };
     

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -8,6 +8,29 @@ namespace vg {
 
 using namespace std;
 
+bool ReadFilter::has_repeat(Alignment& aln, int k) {
+    if (k == 0) {
+        return false;
+    }
+    const string& s = aln.sequence();
+    for (int i = 1; i <= 2 * k; ++i) {
+        int covered = 0;
+        bool ffound = true;
+        bool bfound = true;
+        for (int j = 1; (ffound || bfound) && (j + 1) * i < s.length(); ++j) {
+            ffound = ffound && s.substr(0, i) == s.substr(j * i, i);
+            bfound = bfound && s.substr(s.length() - i, i) == s.substr(s.length() - i - j * i, i);
+            if (ffound || bfound) {
+                covered += i;
+            }
+        }
+        if (covered >= k) {
+            return true;
+        }
+    }
+    return false;
+}
+
 int ReadFilter::filter(istream* alignment_stream) {
 
     // name helper for output
@@ -185,28 +208,7 @@ int ReadFilter::filter(istream* alignment_stream) {
     // and still map perfectly helps vg call.  returns true if at either
     // end of read sequence, at least k bases are repetitive, checking repeats
     // of up to size 2k
-    function<bool(Alignment&, int k)> has_repeat = [](Alignment& aln, int k) {
-        if (k == 0) {
-            return false;
-        }
-        const string& s = aln.sequence();
-        for (int i = 1; i <= 2 * k; ++i) {
-            int covered = 0;
-            bool ffound = true;
-            bool bfound = true;
-            for (int j = 1; (ffound || bfound) && (j + 1) * i < s.length(); ++j) {
-                ffound = ffound && s.substr(0, i) == s.substr(j * i, i);
-                bfound = bfound && s.substr(s.length() - i, i) == s.substr(s.length() - i - j * i, i);
-                if (ffound || bfound) {
-                    covered += i;
-                }
-            }
-            if (covered >= k) {
-                return true;
-            }
-        }
-        return false;
-    };
+    
         
     // we assume that every primary alignment has 0 or 1 secondary alignment
     // immediately following in the stream

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -1,0 +1,373 @@
+#include "readfilter.hpp"
+#include "IntervalTree.h"
+
+#include <fstream>
+#include <sstream>
+
+namespace vg {
+
+using namespace std;
+
+int ReadFilter::filter(istream* alignment_stream) {
+
+    // name helper for output
+    function<string(int)> chunk_name = [this](int num) -> string {
+        stringstream ss;
+        ss << outbase << "-" << num << ".gam";
+        return ss.str();
+    };
+
+    // index regions by their inclusive ranges
+    vector<Interval<int, int64_t> > interval_list;
+    vector<Region> regions;
+    // use strings instead of ofstreams because worried about too many handles
+    vector<string> chunk_names;
+    vector<bool> chunk_new; // flag if write or append
+
+    // parse a bed, for now this is only way to do regions.  note
+    // this operation converts from 0-based BED to 1-based inclusive VCF
+    if (!regions_file.empty()) {
+        if (outbase.empty()) {
+            cerr << "-B option required with -R" << endl;
+            exit(1);
+        }
+        parse_bed_regions(regions_file, regions);
+        if (regions.empty()) {
+            cerr << "No regions read from BED file, doing whole graph" << endl;
+        }
+    }
+
+    // empty region, do everything
+    if (regions.empty()) {
+        // we handle empty intervals as special case when looking up, otherwise,
+        // need to insert giant interval here.
+        chunk_names.push_back(outbase.empty() ? "-" : chunk_name(0));
+    }
+
+    // otherwise, need to extract regions with xg
+    else {
+        if (xg_name.empty()) {
+            cerr << "xg index required for -R option" << endl;
+            exit(1);
+        }
+        // read the xg index
+        ifstream xg_stream(xg_name);
+        if(!xg_stream) {
+            cerr << "Unable to open xg index: " << xg_name << endl;
+            exit(1);
+        }
+        xg::XG xindex(xg_stream);
+
+        // fill in the map using xg index
+        // relies entirely on the assumption that are path chunks
+        // are perfectly spanned by an id range
+        for (int i = 0; i < regions.size(); ++i) {
+            Graph graph;
+            int rank = xindex.path_rank(regions[i].seq);
+            int path_size = rank == 0 ? 0 : xindex.path_length(regions[i].seq);
+
+            if (regions[i].start >= path_size) {
+                cerr << "Unable to find region in index: " << regions[i].seq << ":" << regions[i].start
+                     << "-" << regions[i].end << endl;
+            } else {
+                // clip region on end of path
+                regions[i].end = min(path_size - 1, regions[i].end);
+                // do path node query
+                // convert to 0-based coordinates as this seems to be what xg wants
+                xindex.get_path_range(regions[i].seq, regions[i].start - 1, regions[i].end - 1, graph);
+                if (context_size > 0) {
+                    xindex.expand_context(graph, context_size);
+                }
+            }
+            // find node range of graph, without bothering to build vg indices..
+            int64_t min_id = numeric_limits<int64_t>::max();
+            int64_t max_id = 0;
+            for (int j = 0; j < graph.node_size(); ++j) {
+                min_id = min(min_id, (int64_t)graph.node(j).id());
+                max_id = max(max_id, (int64_t)graph.node(j).id());
+            }
+            // map the chunk id to a name
+            chunk_names.push_back(chunk_name(i));
+
+            // map the node range to the chunk id.
+            if (graph.node_size() > 0) {
+                interval_list.push_back(Interval<int, int64_t>(min_id, max_id, i));
+                assert(chunk_names.size() == i + 1);
+            }
+        }
+    }
+
+    // index chunk regions
+    IntervalTree<int, int64_t> region_map(interval_list);
+
+    // which chunk(s) does a gam belong to?
+    function<void(Alignment&, vector<int>&)> get_chunks = [&region_map, &regions](Alignment& aln, vector<int>& chunks) {
+        // speed up case where no chunking
+        if (regions.empty()) {
+            chunks.push_back(0);
+        } else {
+            int64_t min_aln_id = numeric_limits<int64_t>::max();
+            int64_t max_aln_id = -1;
+            for (int i = 0; i < aln.path().mapping_size(); ++i) {
+                const Mapping& mapping = aln.path().mapping(i);
+                min_aln_id = min(min_aln_id, (int64_t)mapping.position().node_id());
+                max_aln_id = max(max_aln_id, (int64_t)mapping.position().node_id());
+            }
+            vector<Interval<int, int64_t> > found_ranges;
+            region_map.findOverlapping(min_aln_id, max_aln_id, found_ranges);
+            for (auto& interval : found_ranges) {
+                chunks.push_back(interval.value);
+            }
+        }
+    };
+
+    // buffered output (one buffer per chunk)
+    vector<vector<Alignment> > buffer(chunk_names.size());
+    int cur_buffer = -1;
+    static const int buffer_size = 1000; // we let this be off by 1
+    function<Alignment&(uint64_t)> write_buffer = [&buffer, &cur_buffer](uint64_t i) -> Alignment& {
+        return buffer[cur_buffer][i];
+    };
+    // remember if write or append
+    vector<bool> chunk_append(chunk_names.size(), false);
+
+    // flush a buffer specified by cur_buffer to target in chunk_names, and clear it
+    function<void()> flush_buffer = [&buffer, &cur_buffer, &write_buffer, &chunk_names, &chunk_append]() {
+        ofstream outfile;
+        auto& outbuf = chunk_names[cur_buffer] == "-" ? cout : outfile;
+        if (chunk_names[cur_buffer] != "-") {
+            outfile.open(chunk_names[cur_buffer], chunk_append[cur_buffer] ? ios::app : ios_base::out);
+            chunk_append[cur_buffer] = true;
+        }
+        stream::write(outbuf, buffer[cur_buffer].size(), write_buffer);
+        buffer[cur_buffer].clear();
+    };
+
+    // add alignment to all appropriate buffers, flushing as necessary
+    // (note cur_buffer variable used here as a hack to specify which buffer is written to)
+    function<void(Alignment&)> update_buffers = [&buffer, &cur_buffer, &region_map,
+                                                 &write_buffer, &get_chunks, &flush_buffer](Alignment& aln) {
+        vector<int> aln_chunks;
+        get_chunks(aln, aln_chunks);
+        for (auto chunk : aln_chunks) {
+            buffer[chunk].push_back(aln);
+            if (buffer[chunk].size() >= buffer_size) {
+                // flush buffer
+                cur_buffer = chunk;
+                flush_buffer();
+            }
+        }
+    };
+
+    // keep track of how many reads were dropped by which option
+    size_t pri_read_count = 0;
+    size_t sec_read_count = 0;
+    size_t sec_filtered_count = 0;
+    size_t pri_filtered_count = 0;
+    size_t min_sec_count = 0;
+    size_t min_pri_count = 0;
+    size_t min_sec_delta_count = 0;
+    size_t min_pri_delta_count = 0;
+    size_t max_sec_overhang_count = 0;
+    size_t max_pri_overhang_count = 0;
+    size_t min_sec_mapq_count = 0;
+    size_t min_pri_mapq_count = 0;
+    size_t repeat_sec_count = 0;
+    size_t repeat_pri_count = 0;
+
+    // for deltas, we keep track of last primary
+    Alignment prev;
+    bool prev_primary = false;
+    bool keep_prev = true;
+    double prev_score;
+
+    // quick and dirty filter to see if removing reads that can slip around
+    // and still map perfectly helps vg call.  returns true if at either
+    // end of read sequence, at least k bases are repetitive, checking repeats
+    // of up to size 2k
+    function<bool(Alignment&, int k)> has_repeat = [](Alignment& aln, int k) {
+        if (k == 0) {
+            return false;
+        }
+        const string& s = aln.sequence();
+        for (int i = 1; i <= 2 * k; ++i) {
+            int covered = 0;
+            bool ffound = true;
+            bool bfound = true;
+            for (int j = 1; (ffound || bfound) && (j + 1) * i < s.length(); ++j) {
+                ffound = ffound && s.substr(0, i) == s.substr(j * i, i);
+                bfound = bfound && s.substr(s.length() - i, i) == s.substr(s.length() - i - j * i, i);
+                if (ffound || bfound) {
+                    covered += i;
+                }
+            }
+            if (covered >= k) {
+                return true;
+            }
+        }
+        return false;
+    };
+        
+    // we assume that every primary alignment has 0 or 1 secondary alignment
+    // immediately following in the stream
+    function<void(Alignment&)> lambda = [&](Alignment& aln) {
+        bool keep = true;
+        double score = (double)aln.score();
+        double denom = 2. * aln.sequence().length();
+        // toggle substitution score
+        if (sub_score == true) {
+            // hack in ident to replace old counting logic.
+            score = aln.identity() * aln.sequence().length();
+            denom = aln.sequence().length();
+            assert(score <= denom);
+        }
+        // toggle absolute or fractional score
+        if (frac_score == true) {
+            if (denom > 0.) {
+                score /= denom;
+            }
+            else {
+                assert(score == 0.);
+            }
+        }
+        // compute overhang
+        int overhang = 0;
+        if (aln.path().mapping_size() > 0) {
+            const auto& left_mapping = aln.path().mapping(0);
+            if (left_mapping.edit_size() > 0) {
+                overhang = left_mapping.edit(0).to_length() - left_mapping.edit(0).from_length();
+            }
+            const auto& right_mapping = aln.path().mapping(aln.path().mapping_size() - 1);
+            if (right_mapping.edit_size() > 0) {
+                const auto& edit = right_mapping.edit(right_mapping.edit_size() - 1);
+                overhang = max(overhang, edit.to_length() - edit.from_length());
+            }
+        } else {
+            overhang = aln.sequence().length();
+        }
+
+        if (aln.is_secondary()) {
+            ++sec_read_count;
+            assert(prev_primary && aln.name() == prev.name());
+            double delta = prev_score - score;
+            if (frac_delta == true) {
+                delta = prev_score > 0 ? score / prev_score : 0.;
+            }
+
+            // filter (current) secondary
+            keep = true;
+            if (score < min_secondary) {
+                ++min_sec_count;
+                keep = false;
+            }
+            if ((keep || verbose) && delta < min_sec_delta) {
+                ++min_sec_delta_count;
+                keep = false;
+            }
+            if ((keep || verbose) && overhang > max_overhang) {
+                ++max_sec_overhang_count;
+                keep = false;
+            }
+            if ((keep || verbose) && aln.mapping_quality() < min_mapq) {
+                ++min_sec_mapq_count;
+                keep = false;
+            }
+            if ((keep || verbose) && has_repeat(aln, repeat_size)) {
+                ++repeat_sec_count;
+                keep = false;
+            }
+            if (!keep) {
+                ++sec_filtered_count;
+            }
+
+            // filter unfiltered previous primary
+            if (keep_prev && delta < min_pri_delta) {
+                ++min_pri_delta_count;
+                ++pri_filtered_count;
+                keep_prev = false;
+            }
+            // add to write buffer
+            if (keep) {
+                update_buffers(aln);
+            }
+            if (keep_prev) {
+                update_buffers(prev);
+            }
+
+            // forget last primary
+            prev_primary = false;
+            prev_score = -1;
+            keep_prev = false;
+
+        } else {
+            // this awkward logic where we keep the primary and write in the secondary
+            // is because we can only stream one at a time with for_each, but we need
+            // to look at pairs (if secondary exists)...
+            ++pri_read_count;
+            if (keep_prev) {
+                update_buffers(prev);
+            }
+
+            prev_primary = true;
+            prev_score = score;
+            prev = aln;
+            keep_prev = true;
+            if (score < min_primary) {
+                ++min_pri_count;
+                keep_prev = false;
+            }
+            if ((keep_prev || verbose) && overhang > max_overhang) {
+                ++max_pri_overhang_count;
+                keep_prev = false;
+            }
+            if ((keep_prev || verbose) && aln.mapping_quality() < min_mapq) {
+                ++min_pri_mapq_count;
+                keep_prev = false;
+            }
+            if ((keep_prev || verbose) && has_repeat(aln, repeat_size)) {
+                ++repeat_pri_count;
+                keep_prev = false;
+            }
+            if (!keep_prev) {
+                ++pri_filtered_count;
+            }
+        }
+    };
+    stream::for_each(*alignment_stream, lambda);
+
+    // flush buffer if trailing primary to keep
+    if (keep_prev) {
+        update_buffers(prev);
+    }
+
+    for (int i = 0; i < buffer.size(); ++i) {
+        if (buffer[i].size() > 0) {
+            cur_buffer = i;
+            flush_buffer();
+        }
+    }
+
+    if (verbose) {
+        size_t tot_reads = pri_read_count + sec_read_count;
+        size_t tot_filtered = pri_filtered_count + sec_filtered_count;
+        cerr << "Total Filtered (primary):          " << pri_filtered_count << " / "
+             << pri_read_count << endl
+             << "Total Filtered (secondary):        " << sec_filtered_count << " / "
+             << sec_read_count << endl
+             << "Min Identity Filter (primary):     " << min_pri_count << endl
+             << "Min Identity Filter (secondary):   " << min_sec_count << endl
+             << "Min Delta Filter (primary):        " << min_pri_delta_count << endl
+             << "Min Delta Filter (secondary):      " << min_sec_delta_count << endl
+             << "Max Overhang Filter (primary):     " << max_pri_overhang_count << endl
+             << "Max Overhang Filter (secondary):   " << max_sec_overhang_count << endl
+             << "Repeat Ends Filter (primary):     " << repeat_pri_count << endl
+             << "Repeat Ends Filter (secondary):   " << repeat_sec_count << endl
+
+             << endl;
+    }
+
+    return 0;
+
+}
+
+}

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -55,16 +55,6 @@ public:
      */
     int filter(istream* alignment_stream, xg::XG* xindex = nullptr);
     
-private:
-
-    /**
-     * quick and dirty filter to see if removing reads that can slip around
-     * and still map perfectly helps vg call.  returns true if at either
-     * end of read sequence, at least k bases are repetitive, checking repeats
-     * of up to size 2k
-     */
-    bool has_repeat(Alignment& aln, int k);
-    
     /**
      * Look at either end of the given alignment, up to k bases in from the end.
      * See if that tail of the alignment is mapped such that another embedding
@@ -79,7 +69,17 @@ private:
      * MUST NOT be called with a null index.
      */
     bool trim_ambiguous_ends(xg::XG* index, Alignment& alignment, int k);
+    
+private:
 
+    /**
+     * quick and dirty filter to see if removing reads that can slip around
+     * and still map perfectly helps vg call.  returns true if at either
+     * end of read sequence, at least k bases are repetitive, checking repeats
+     * of up to size 2k
+     */
+    bool has_repeat(Alignment& aln, int k);
+    
 };
 }
 

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -49,6 +49,16 @@ public:
      * TODO: Refactor to be less CLI-aware and more modular-y.
      */
     int filter(istream* alignment_stream);
+    
+private:
+
+    /**
+     * quick and dirty filter to see if removing reads that can slip around
+     * and still map perfectly helps vg call.  returns true if at either
+     * end of read sequence, at least k bases are repetitive, checking repeats
+     * of up to size 2k
+     */
+    bool has_repeat(Alignment& aln, int k);
 
 };
 }

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -1,0 +1,56 @@
+#ifndef VG_READFILTER_HPP
+#define VG_READFILTER_HPP
+
+#include <vector>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include "vg.hpp"
+#include "xg.hpp"
+#include "vg.pb.h"
+
+/**
+ * Provides a way to filter and transform reads, implementing the bulk of the
+ * `vg filter` command.
+ *
+ */
+namespace vg{
+
+using namespace std;
+
+class ReadFilter{
+public:
+    
+    // Filtering parameters
+    double min_secondary = 0.;
+    double min_primary = 0.;
+    double min_sec_delta = 0.;
+    double min_pri_delta = 0.;
+    bool frac_score = false;
+    bool frac_delta = false;
+    bool sub_score = false;
+    int max_overhang = 99999;
+    int context_size = 0;
+    bool verbose = false;
+    double min_mapq = 0.;
+    int repeat_size = 0;
+    
+    // Extra filename things we need for chunking. TODO: refactor that somehow
+    // to maybe be a different class?
+    string xg_name;
+    string regions_file;
+    string outbase;
+    
+    /**
+     * Filter the alignments available from the given stream, placing them on
+     * standard output or in the appropriate file. Returns 0 on success, exit
+     * code to use on error.
+     *
+     * TODO: Refactor to be less CLI-aware and more modular-y.
+     */
+    int filter(istream* alignment_stream);
+
+};
+}
+
+#endif

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -34,6 +34,9 @@ public:
     bool verbose = false;
     double min_mapq = 0.;
     int repeat_size = 0;
+    // How far in from the end should we look for ambiguous end alignment to
+    // clip off?
+    int defray_length = 0;
     
     // Extra filename things we need for chunking. TODO: refactor that somehow
     // to maybe be a different class?
@@ -59,6 +62,21 @@ private:
      * of up to size 2k
      */
     bool has_repeat(Alignment& aln, int k);
+    
+    /**
+     * Look at either end of the given alignment, up to k bases in from the end.
+     * See if that tail of the alignment is mapped such that another embedding
+     * in the given graph can produce the same sequence as the sequence along
+     * the embedding that the read actually has, and if so trim back the read.
+     *
+     * In the case of softclips, the aligned portion of the read is considered,
+     * and if trimmign is required, the softclips are hard-clipped off.
+     *
+     * Returns true if the read had to be modified, and false otherwise.
+     *
+     * MUST NOT be called with a null index.
+     */
+    bool trim_ambiguous_ends(xg::XG* index, Alignment& alignment, int k);
 
 };
 }

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -40,7 +40,6 @@ public:
     
     // Extra filename things we need for chunking. TODO: refactor that somehow
     // to maybe be a different class?
-    string xg_name;
     string regions_file;
     string outbase;
     
@@ -49,9 +48,12 @@ public:
      * standard output or in the appropriate file. Returns 0 on success, exit
      * code to use on error.
      *
+     * If an XG index is required, use the specified one. If one is required and
+     * not provided, the function will complain and return nonzero.
+     *
      * TODO: Refactor to be less CLI-aware and more modular-y.
      */
-    int filter(istream* alignment_stream);
+    int filter(istream* alignment_stream, xg::XG* xindex = nullptr);
     
 private:
 

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -80,6 +80,12 @@ private:
      */
     bool has_repeat(Alignment& aln, int k);
     
+    /**
+     * Trim only the end of the given alignment, leaving the start alone. Two
+     * calls of this implement trim_ambiguous_ends above.
+     */
+    bool trim_ambiguous_end(xg::XG* index, Alignment& alignment, int k);
+    
 };
 }
 

--- a/src/unittest/readfilter.cpp
+++ b/src/unittest/readfilter.cpp
@@ -10,7 +10,67 @@ namespace unittest {
 
 using namespace std;
 
+TEST_CASE("reads with ambiguous ends can be trimmed", "[filter]") {
+    
+    // Build a toy graph
+    const string graph_json = R"(
+    
+    {
+        "node": [
+            {"id": 1, "sequence": "GATTAC"},
+            {"id": 2, "sequence": "A"},
+            {"id": 3, "sequence": "AAAAA"},
+            {"id": 4, "sequence": "CATTAG"}
+        ],
+        "edge": [
+            {"from": 1, "to": 2},
+            {"from": 2, "to": 3},
+            {"from": 1, "to": 3},
+            {"from": 3, "to": 4}            
+        ]
+    }
+    
+    )";
+    
+    // Load it into Protobuf
+    Graph chunk;
+    json2pb(chunk, graph_json.c_str(), graph_json.size());
+    
+    // Pass it over to XG
+    xg::XG index(chunk);
+    
+    // Make a ReadFilter;
+    ReadFilter filter;
+    
+    // Configure it for end trimming
+    filter.defray_length = 3;
+    
+    SECTION("A read with an ambiguous end should be trimmed") {
+        // Build the read
+        const string read_json = R"(
+        
+        {
+            "sequence": "GATTACAA",
+            "quality": "ICAgICAgICA=",
+            "path": {
+                "mapping": [
+                    {"position": {"node_id": 1}, "edit": [{"from_length": 6, "to_length": 6}]},
+                    {"position": {"node_id": 2}, "edit": [{"from_length": 1, "to_length": 1}]},
+                    {"position": {"node_id": 3}, "edit": [{"from_length": 1, "to_length": 1}]}
+                ]
+            }
+        }
+        
+        )";
+        
+        // Fluff it up into a real read
+        Alignment ambiguous;
+        json2pb(ambiguous, read_json.c_str(), read_json.size());
+        
+        
+    }
 
+}
 
 
 }

--- a/src/unittest/readfilter.cpp
+++ b/src/unittest/readfilter.cpp
@@ -1,0 +1,17 @@
+/**
+ * unittest/readfilter.cpp: test cases for the read filtering/transforming logic
+ */
+
+#include "catch.hpp"
+#include "readfilter.hpp"
+
+namespace vg {
+namespace unittest {
+
+using namespace std;
+
+
+
+
+}
+}

--- a/src/unittest/readfilter.cpp
+++ b/src/unittest/readfilter.cpp
@@ -200,7 +200,7 @@ TEST_CASE("reads with ambiguous ends can be trimmed", "[filter]") {
         
     }
     
-    SECTION("A read with no edits in its mappings is interpreted as having perfect matches") {
+    SECTION("A read with no edits in its mappings is rejected") {
         // Build the read
         const string read_json = R"(
         
@@ -223,15 +223,9 @@ TEST_CASE("reads with ambiguous ends can be trimmed", "[filter]") {
         Alignment ambiguous;
         json2pb(ambiguous, read_json.c_str(), read_json.size());
         
-        // It has to say it trimmed it
-        REQUIRE(filter.trim_ambiguous_ends(&index, ambiguous, 10) == true);
-        // And it has to trim it to the right thing
-        REQUIRE(ambiguous.sequence() == "AGATA");
-        REQUIRE(ambiguous.quality() == "00000");
-        REQUIRE(ambiguous.path().mapping_size() == 1);
-        REQUIRE(ambiguous.path().mapping(0).position().node_id() == 7);
-        REQUIRE(ambiguous.path().mapping(0).position().is_reverse() == false);
-        // Ignore the edits; they may get normalized or not.
+        // It has to explode instead of trimming it. Mappings are always
+        // required to be specified now.
+        REQUIRE_THROWS(filter.trim_ambiguous_ends(&index, ambiguous, 10));
         
     }
     

--- a/src/unittest/readfilter.cpp
+++ b/src/unittest/readfilter.cpp
@@ -20,13 +20,24 @@ TEST_CASE("reads with ambiguous ends can be trimmed", "[filter]") {
             {"id": 1, "sequence": "GATTAC"},
             {"id": 2, "sequence": "A"},
             {"id": 3, "sequence": "AAAAA"},
-            {"id": 4, "sequence": "CATTAG"}
+            {"id": 4, "sequence": "CATTAG"},
+            {"id": 5, "sequence": "TAGTAG"},
+            {"id": 6, "sequence": "TAG"},
+            {"id": 7, "sequence": "AGATA"},
+            {"id": 8, "sequence": "TTT"},
+            {"id": 9, "sequence": "AAA"}
         ],
         "edge": [
             {"from": 1, "to": 2},
             {"from": 2, "to": 3},
             {"from": 1, "to": 3},
-            {"from": 3, "to": 4}            
+            {"from": 3, "to": 4},
+            {"from": 4, "to": 5},
+            {"from": 6, "to": 4, "from_start": true, "to_end": true},
+            {"from": 5, "to": 7},
+            {"from": 6, "to": 7},
+            {"from": 7, "to": 8, "to_end": true},
+            {"from": 7, "to": 9}       
         ]
     }
     
@@ -42,16 +53,49 @@ TEST_CASE("reads with ambiguous ends can be trimmed", "[filter]") {
     // Make a ReadFilter;
     ReadFilter filter;
     
-    // Configure it for end trimming
-    filter.defray_length = 3;
+    SECTION("A read that is not ambiguous is not trimmed") {
+        // Build the read
+        const string read_json = R"(
+        
+        {
+            "sequence": "GATTACAAAAAA",
+            "quality": "MDAwMDAwMDAwMDAw",
+            "path": {
+                "mapping": [
+                    {"position": {"node_id": 1}, "edit": [{"from_length": 6, "to_length": 6}]},
+                    {"position": {"node_id": 2}, "edit": [{"from_length": 1, "to_length": 1}]},
+                    {"position": {"node_id": 3}, "edit": [{"from_length": 5, "to_length": 5}]}
+                ]
+            }
+        }
+        
+        )";
+        
+        // Fluff it up into a real read
+        Alignment ambiguous;
+        json2pb(ambiguous, read_json.c_str(), read_json.size());
+        
+        // It has to say it didn't trim it
+        REQUIRE(filter.trim_ambiguous_ends(&index, ambiguous, 10) == false);
+        // And it has to not mess it up
+        REQUIRE(ambiguous.sequence() == "GATTACAAAAAA");
+        REQUIRE(ambiguous.quality() == "000000000000");
+        REQUIRE(ambiguous.path().mapping_size() == 3);
+        REQUIRE(ambiguous.path().mapping(2).position().node_id() == 3);
+        REQUIRE(ambiguous.path().mapping(2).edit_size() == 1);
+        REQUIRE(ambiguous.path().mapping(2).edit(0).from_length() == 5);
+        REQUIRE(ambiguous.path().mapping(2).edit(0).to_length() == 5);
+        
+        
+    }
     
-    SECTION("A read with an ambiguous end should be trimmed") {
+    SECTION("A read with an ambiguous end should be trimmed to the unambiguous part") {
         // Build the read
         const string read_json = R"(
         
         {
             "sequence": "GATTACAA",
-            "quality": "ICAgICAgICA=",
+            "quality": "MTIzNDU2Nzg=",
             "path": {
                 "mapping": [
                     {"position": {"node_id": 1}, "edit": [{"from_length": 6, "to_length": 6}]},
@@ -66,6 +110,92 @@ TEST_CASE("reads with ambiguous ends can be trimmed", "[filter]") {
         // Fluff it up into a real read
         Alignment ambiguous;
         json2pb(ambiguous, read_json.c_str(), read_json.size());
+        
+        // It has to say it trimmed it
+        REQUIRE(filter.trim_ambiguous_ends(&index, ambiguous, 10) == true);
+        // And it has to trim it to the right thing
+        REQUIRE(ambiguous.sequence() == "GATTAC");
+        REQUIRE(ambiguous.quality() == "123456");
+        REQUIRE(ambiguous.path().mapping_size() == 1);
+        REQUIRE(ambiguous.path().mapping(0).position().node_id() == 1);
+        REQUIRE(ambiguous.path().mapping(0).edit_size() == 1);
+        REQUIRE(ambiguous.path().mapping(0).edit(0).from_length() == 6);
+        REQUIRE(ambiguous.path().mapping(0).edit(0).to_length() == 6);
+        
+        
+    }
+    
+    SECTION("A read with an ambiguous start should be trimmed to the unambiguous part") {
+        // Build the read
+        const string read_json = R"(
+        
+        {
+            "sequence": "TTGTAATC",
+            "quality": "MTIzNDU2Nzg=",
+            "path": {
+                "mapping": [
+                    {"position": {"node_id": 3, "is_reverse": true, "offset": 4}, "edit": [{"from_length": 1, "to_length": 1}]},
+                    {"position": {"node_id": 2, "is_reverse": true}, "edit": [{"from_length": 1, "to_length": 1}]},
+                    {"position": {"node_id": 1, "is_reverse": true}, "edit": [{"from_length": 6, "to_length": 6}]}
+                ]
+            }
+        }
+        
+        )";
+        
+        // Fluff it up into a real read
+        Alignment ambiguous;
+        json2pb(ambiguous, read_json.c_str(), read_json.size());
+        
+        // It has to say it trimmed it
+        REQUIRE(filter.trim_ambiguous_ends(&index, ambiguous, 10) == true);
+        // And it has to trim it to the right thing
+        REQUIRE(ambiguous.sequence() == "GTAATC");
+        REQUIRE(ambiguous.quality() == "345678");
+        REQUIRE(ambiguous.path().mapping_size() == 1);
+        REQUIRE(ambiguous.path().mapping(0).position().node_id() == 1);
+        REQUIRE(ambiguous.path().mapping(0).position().is_reverse() == true);
+        REQUIRE(ambiguous.path().mapping(0).edit_size() == 1);
+        REQUIRE(ambiguous.path().mapping(0).edit(0).from_length() == 6);
+        REQUIRE(ambiguous.path().mapping(0).edit(0).to_length() == 6);
+        
+        
+    }
+    
+    SECTION("A read with both an ambiguous start and an ambiguous end should be trimmed to the unambiguous part") {
+        // Build the read
+        const string read_json = R"(
+        
+        {
+            "sequence": "TAGTAGAGATAAAA",
+            "quality": "QkxBQkxBMDAwMDBMT0w=",
+            "path": {
+                "mapping": [
+                    {"position": {"node_id": 4, "offset": 3}, "edit": [{"from_length": 3, "to_length": 3}]},
+                    {"position": {"node_id": 6}, "edit": [{"from_length": 3, "to_length": 3}]},
+                    {"position": {"node_id": 7}, "edit": [{"from_length": 5, "to_length": 5}]},
+                    {"position": {"node_id": 8, "is_reverse": true}, "edit": [{"from_length": 3, "to_length": 3}]}
+                ]
+            }
+        }
+        
+        )";
+        
+        // Fluff it up into a real read
+        Alignment ambiguous;
+        json2pb(ambiguous, read_json.c_str(), read_json.size());
+        
+        // It has to say it trimmed it
+        REQUIRE(filter.trim_ambiguous_ends(&index, ambiguous, 10) == true);
+        // And it has to trim it to the right thing
+        REQUIRE(ambiguous.sequence() == "AGATA");
+        REQUIRE(ambiguous.quality() == "00000");
+        REQUIRE(ambiguous.path().mapping_size() == 1);
+        REQUIRE(ambiguous.path().mapping(0).position().node_id() == 7);
+        REQUIRE(ambiguous.path().mapping(0).position().is_reverse() == false);
+        REQUIRE(ambiguous.path().mapping(0).edit_size() == 1);
+        REQUIRE(ambiguous.path().mapping(0).edit(0).from_length() == 5);
+        REQUIRE(ambiguous.path().mapping(0).edit(0).to_length() == 5);
         
         
     }

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -72,8 +72,14 @@ message Mapping {
 // offset+  → 0 1 2 3 4 5 6 7
 //
 // seq-        C T A A T G T
-// offset-    7 6 5 4 3 2 1 0 ←
+// offset+  → 0 1 2 3 4 5 6 7
 //
+// Or both at once:
+//
+// offset-    7 6 5 4 3 2 1 0 ←
+// seq+        G A T T A C A
+// offset+  → 0 1 2 3 4 5 6 7
+
 message Position {
     int64 node_id = 1;
     int64 offset = 2;

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -5,11 +5,15 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 28
+plan tests 30
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
 vg index -sk 11 -d x.idx x.vg
+
+is  "$(vg map -s GCTGTGAAGATTAAATTAGGTGAT -x x.xg -g x.gcsa -J - | jq '.path.mapping[0].position.offset')" "3" "offset counts unused bases from the start of the node on the forward strand"
+
+is  "$(vg map -s ATCACCTAATTTAATCTTCACAGC -x x.xg -g x.gcsa -J - | jq '.path.mapping[0].position.offset')" "5" "offset counts unused bases from the start of the node on the reverse strand"
 
 is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -J | tr ',' '\n' | grep node_id | grep "72\|74\|75\|77" | wc -l) 4 "global alignment traverses the correct path"
 


### PR DESCRIPTION
This adds a `-D` or `--defray-ends` option to `vg filter` that should let you find and clip off instances where the end of a read has been arbitrarily assigned to one path out of many sequence-identical paths available in the graph.

This commit also addresses #127 by updating the comments in `vg.proto`, and fixing `reverse_complement_alignment()` to use offsets just like `vg map`'s output has been using them. This might confuse other uses of `reverse_complement_alignment()`, so we ought to keep an eye on the test results.