### PR TITLE
Clean up extra nodes

### DIFF
--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -143,8 +143,11 @@ bool ReadFilter::trim_ambiguous_end(xg::XG* index, Alignment& alignment, int k) 
                 from_length += mapping.edit(j).from_length();
             }
             
-            // Non-leading mappings can't have offsets.
-            assert(mapping.position().offset() == 0);
+            if(mapping.position().offset() != 0) {
+                // Non-leading mappings can't have offsets. That implies
+                // skipping over some ref sequence without an appropriate edit.
+                throw runtime_error("Non leading mapping has offset in alignment: " + pb2json(alignment));
+            }
             
             // Put in the sequence that the mapping visits
             target_sequence_stream << sequence.substr(0, from_length);

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -7486,6 +7486,10 @@ Alignment VG::align(const Alignment& alignment,
         sort();
         // run the alignment
         do_align(this->graph);
+        
+        // Clean up the node we added. This is important because this graph will
+        // later be extended with more material for softclip handling, and we
+        // might need that node ID.
         destroy_node(root);
 
     } else {
@@ -7544,6 +7548,11 @@ Alignment VG::align(const Alignment& alignment,
                 return get_node(node_id)->sequence().size();
             });
         //check_aln(*this, aln);
+        
+        // Clean up the node we added. This is important because this graph will
+        // later be extended with more material for softclip handling, and we
+        // might need that node ID.
+        destroy_node(root);
 
     }
 

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -729,6 +729,7 @@ public:
     // Will modify the graph by re-ordering the nodes.
     
     // align without base quality adjusted scores
+    // May add nodes to the graph, but cleans them up afterward
     Alignment align(const string& sequence,
                     Aligner& aligner,
                     size_t max_query_graph_ratio = 0,
@@ -739,6 +740,7 @@ public:
                     bool print_score_matrices = false);
     
     // align with default Aligner
+    // May add nodes to the graph, but cleans them up afterward
     Alignment align(const Alignment& alignment,
                     size_t max_query_graph_ratio = 0,
                     bool print_score_matrices = false);


### PR DESCRIPTION
It looks like @ekg partly fixed this already, but this just makes sure that in all cases extra nodes added vg VG::align() are deleted before the softclip code can try to re-use the graph.