### PR TITLE
Solves hanging behaviour when running only 'vg construct -a'

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8935,11 +8935,11 @@ int main_construct(int argc, char** argv) {
         return 1;
     }
 
-    FastaReference reference;
     if (fasta_file_name.empty()) {
         cerr << "error:[vg construct] a reference is required for graph construction" << endl;
         return 1;
     }
+    FastaReference reference;
     reference.open(fasta_file_name);
 
     // store our reference sequence paths


### PR DESCRIPTION
Dear vg team,

When I run just the command `vg construct -a` it appears that vg gets stuck waiting for input instead of terminating properly. I think I have solved the issue by lowering the initiation of the FastaReference object until after the error message is returned. 

I hope this helps. All best,

Youri

