### PR TITLE
src/utility.hpp - adds include to build with gcc (GCC) 6.1.1 20160802

### DIFF
--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <algorithm>
 #include <numeric>
+#include <cmath>
 #include <unistd.h>
 #include "vg.pb.h"
 #include "sha1.hpp"

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -7,6 +7,7 @@
 #include <omp.h>
 #include <cstring>
 #include <algorithm>
+#include <numeric>
 #include <unistd.h>
 #include "vg.pb.h"
 #include "sha1.hpp"


### PR DESCRIPTION
This include seems to be necessary to compile vg on Arch linux. xref: http://stackoverflow.com/questions/28028949/gcc-cannot-resolve-proper-stdaccumulate
http://stackoverflow.com/questions/16518210/sqrt-is-not-a-member-of-std