### PR TITLE
fixed breaking of haplotypes in index due to improper handling of alts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,7 +318,7 @@ int main_filter(int argc, char** argv) {
             break;
         case 'D':
             filter.defray_length = atoi(optarg);
-            break;          
+            break;
 
         case 'h':
         case '?':
@@ -337,7 +337,7 @@ int main_filter(int argc, char** argv) {
         help_filter(argv);
         return 1;
     }
-    
+
     // If the user gave us an XG index, we probably ought to load it up.
     // TODO: make sure if we add any other error exits from this function we
     // remember to delete this!
@@ -351,7 +351,7 @@ int main_filter(int argc, char** argv) {
         }
         xindex = new xg::XG(xg_stream);
     }
-    
+
     string alignments_file_name = argv[optind++];
     istream* alignment_stream = NULL;
     ifstream in;
@@ -361,22 +361,22 @@ int main_filter(int argc, char** argv) {
         in.open(alignments_file_name);
         if (!in) {
             cerr << "error: input file " << alignments_file_name << " not found." << endl;
-            
+
             if(xindex != nullptr) {
                 delete xindex;
             }
             return 1;
-            
+
         }
         alignment_stream = &in;
     }
 
     auto to_return = filter.filter(alignment_stream, xindex);
-    
+
     if(xindex != nullptr) {
         delete xindex;
     }
-    
+
     return to_return;
 }
 
@@ -1005,7 +1005,7 @@ int main_vectorize(int argc, char** argv){
             stream::for_each(in, lambda);
         }
     }
-    
+
     string mapping_str = vz.output_wabbit_map();
     if (output_wabbit){
         if (!wabbit_mapping_file.empty()){
@@ -1019,7 +1019,7 @@ int main_vectorize(int argc, char** argv){
             ofi.close();
         }
         else{
-        
+
             cerr << mapping_str;
         }
     }
@@ -1223,7 +1223,7 @@ int main_call(int argc, char** argv) {
     // primary path? Keep in mind we need to look at all valid paths (and all
     // combinations thereof) until we find a valid pair.
     int64_t maxDepth = 10;
-    // Should we write pileup information to the VCF for debugging? 
+    // Should we write pileup information to the VCF for debugging?
     bool pileupAnnotate = false;
     // What should the total sequence length reported in the VCF header be?
     int64_t lengthOverride = -1;
@@ -1304,7 +1304,7 @@ int main_call(int argc, char** argv) {
                 {"no_overlap", no_argument, 0, 'O'},
                 {"use_avg_support", no_argument, 0, 'u'},
                 {"singleallelic", no_argument, 0, 'I'},
-                {"min_mad", required_argument, 0, 'E'},                
+                {"min_mad", required_argument, 0, 'E'},
                 {"help", no_argument, 0, 'h'},
                 {0, 0, 0, 0}
             };
@@ -1417,13 +1417,13 @@ int main_call(int argc, char** argv) {
         case 'E':
             // Minimum min-allele-depth required to give Filter column a PASS
             min_mad_for_filter = std::stoi(optarg);
-            break;                                
+            break;
         case 'p':
             show_progress = true;
             break;
         case 'v':
             verbose = true;
-            break;            
+            break;
         case 't':
             thread_count = atoi(optarg);
             break;
@@ -1561,7 +1561,7 @@ int main_call(int argc, char** argv) {
                         max_bubble_paths,
                         min_mad_for_filter,
                         verbose);
-    
+
     return 0;
 }
 
@@ -1602,7 +1602,7 @@ int main_genotype(int argc, char** argv) {
     bool show_progress = false;
     // How many threads should we use?
     int thread_count = 0;
-    
+
     // What reference path should we use
     string ref_path_name;
     // What sample name should we use for output
@@ -1613,15 +1613,15 @@ int main_genotype(int argc, char** argv) {
     int64_t variant_offset = 0;
     // What length override should we use
     int64_t length_override = 0;
-    
+
     // Should we use mapping qualities?
     bool use_mapq = false;
     // Should we do indel realignment?
     bool realign_indels = false;
-    
+
     // Should we dump the augmented graph to a file?
     string augmented_file_name;
-    
+
     // Should we do superbubbles/sites with Cactus (true) or supbub (false)
     bool use_cactus = false;
     // Should we find superbubbles on the supported subset (true) or the whole graph (false)?
@@ -1767,7 +1767,7 @@ int main_genotype(int argc, char** argv) {
         help_genotype(argv);
         return 1;
     }
-    
+
     string reads_index_name = argv[optind];
     // This holds the RocksDB index that has all our reads, indexed by the nodes they visit.
     Index index;
@@ -1789,7 +1789,7 @@ int main_genotype(int argc, char** argv) {
 
     index.for_alignment_to_nodes(graph_ids, [&](const Alignment& alignment) {
         // Extract all the alignments
-        
+
         // Only take alignments that don't visit nodes not in the graph
         bool contained = true;
         for(size_t i = 0; i < alignment.path().mapping_size(); i++) {
@@ -1798,17 +1798,17 @@ int main_genotype(int argc, char** argv) {
                 contained = false;
             }
         }
-        
+
         if(contained) {
             // This alignment completely falls within the graph
             alignments.push_back(alignment);
         }
     });
-        
+
     if(show_progress) {
         cerr << "Loaded " << alignments.size() << " alignments" << endl;
     }
-    
+
     // Make a Genotyper to do the genotyping
     Genotyper genotyper;
     // Configure it
@@ -1832,7 +1832,7 @@ int main_genotype(int argc, char** argv) {
                   output_json,
                   length_override,
                   variant_offset);
-                  
+
     delete graph;
 
     return 0;
@@ -2431,7 +2431,7 @@ int main_msga(int argc, char** argv) {
         if (debug) cerr << "building GCSA2 index" << endl;
         // Configure GCSA2 verbosity so it doesn't spit out loads of extra info
         if(!debug) gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
-        
+
         if (edge_max) {
             VG gcsa_graph = *graph; // copy the graph
             // remove complex components
@@ -2997,8 +2997,8 @@ int main_surject(int argc, char** argv) {
                     handle_buffer(buffer[tid]);
 
                 };
-            
-            
+
+
             // now apply the alignment processor to the stream
             if (file_name == "-") {
                 stream::for_each_parallel(std::cin, lambda);
@@ -3220,7 +3220,7 @@ void help_mod(char** argv) {
          << "    -y, --destroy-node ID   remove node with given id" << endl
          << "    -B, --bluntify          bluntify the graph, making nodes for duplicated sequences in overlaps" << endl
          << "    -a, --cactus            convert to cactus graph representation" << endl
-         << "    -v, --sample-vcf FILE   for a graph with allele paths, compute the sample graph from the given VCF" << endl 
+         << "    -v, --sample-vcf FILE   for a graph with allele paths, compute the sample graph from the given VCF" << endl
          << "    -t, --threads N         for tasks that can be done in parallel, use this many threads" << endl;
 }
 
@@ -3492,11 +3492,11 @@ int main_mod(int argc, char** argv) {
         case 'y':
             destroy_node_id = atoi(optarg);
             break;
-            
+
         case 'a':
             cactus = true;
             break;
-            
+
         case 'v':
             vcf_filename = optarg;
             break;
@@ -3525,7 +3525,7 @@ int main_mod(int argc, char** argv) {
     if (!vcf_filename.empty()) {
         // We need to throw out the parts of the graph that are on alt paths,
         // but not on alt paths for alts used by the first sample in the VCF.
-        
+
         // This is matched against the entire path name string to detect alt
         // paths.
         regex is_alt("_alt_.+_[0-9]+");
@@ -3538,7 +3538,7 @@ int main_mod(int argc, char** argv) {
             cerr << "error:[vg mod] could not open" << vcf_filename << endl;
             return 1;
         }
-        
+
         // Now go through and prune down the varaints.
 
         // How many phases are there?
@@ -3551,18 +3551,18 @@ int main_mod(int argc, char** argv) {
 
         graph->paths.for_each_name([&](const string& alt_path_name) {
             // For every path name in the graph
-            
+
             if(regex_match(alt_path_name, is_alt)) {
                 // If it's an alt path
-                
+
                 for(auto& mapping : graph->paths.get_path(alt_path_name)) {
                     // Mark all nodes that are part of it as on alt paths
                     alt_path_ids.insert(mapping.position().node_id());
                 }
-            
+
             }
         });
-        
+
         // We also have a function to handle each variant as it comes in.
         auto handle_variant = [&](vcflib::Variant& variant) {
             // So we have a variant
@@ -3574,7 +3574,7 @@ int main_mod(int argc, char** argv) {
 
             // Grab its id, or make one by hashing stuff if it doesn't
             // have an ID.
-            string var_name = get_or_make_variant_id(variant);
+            string var_name = make_variant_id(variant);
 
             if(!graph->paths.has_path("_alt_" + var_name + "_0")) {
                 // There isn't a reference alt path for this variant. Someone messed up.
@@ -3607,12 +3607,12 @@ int main_mod(int argc, char** argv) {
                     // Parse the allele number
                     allele_number = stoi(it->str());
                 }
-                
-                
-                
+
+
+
                 // Make the name for its alt path
                 string alt_path_name = "_alt_" + var_name + "_" + to_string(allele_number);
-                
+
                 for(auto& mapping : graph->paths.get_path(alt_path_name)) {
                     // Un-mark all nodes that are on this alt path, since it is used by the sample.
                     alt_path_ids.erase(mapping.position().node_id());
@@ -3641,12 +3641,12 @@ int main_mod(int argc, char** argv) {
             // Handle the variant
             handle_variant(var);
         }
-        
-        
+
+
         for(auto& node_id : alt_path_ids) {
             // And delete all the nodes that were used by alt paths that weren't
             // in the genotype of the first sample.
-            
+
             for(auto& path_name : graph->paths.of_node(node_id)) {
                 // For every path that touches the node we're destroying,
                 // destroy the path. We can't leave it because it won't be the
@@ -3656,11 +3656,11 @@ int main_mod(int argc, char** argv) {
                 cerr << "Node " << node_id << " was on path " << path_name << endl;
 #endif
             }
-            
+
             // Actually get rid of the node once its paths are gone.
             graph->destroy_node(node_id);
         }
-        
+
     }
 
     if (bluntify) {
@@ -4684,11 +4684,11 @@ int main_stats(int argc, char** argv) {
         case 'A':
             is_acyclic = true;
             break;
-            
+
         case 'a':
             alignments_filename = optarg;
             break;
-            
+
         case 'v':
             verbose = true;
             break;
@@ -4823,66 +4823,66 @@ int main_stats(int argc, char** argv) {
                 << graph->distance_to_tail(NodeTraversal(graph->get_node(id), false)) << endl;
         }
     }
-    
+
     if (!alignments_filename.empty()) {
         // Read in the given GAM
         ifstream alignment_stream(alignments_filename);
-        
+
         // We need some allele parsing functions
-        
+
         // This one decided if a path is really an allele path
         auto path_name_is_allele = [](const string path_name) -> bool {
             string prefix = "_alt_";
             // It needs to start with "_alt_" and have another separating
             // underscore between site name and allele number
             return(prefix.size() < path_name.size() &&
-                count(path_name.begin(), path_name.end(), '_') >= 3 && 
+                count(path_name.begin(), path_name.end(), '_') >= 3 &&
                 equal(prefix.begin(), prefix.end(), path_name.begin()));
         };
-        
+
         // This one gets the site name from an allele path name
         auto path_name_to_site = [](const string& path_name) -> string {
             auto last_underscore = path_name.rfind('_');
             assert(last_underscore != string::npos);
             return path_name.substr(0, last_underscore);
         };
-        
+
         // This one gets the allele name from an allele path name
         auto path_name_to_allele = [](const string& path_name) -> string {
             auto last_underscore = path_name.rfind('_');
             assert(last_underscore != string::npos);
             return path_name.substr(last_underscore + 1);
         };
-        
+
         // Before we go over the reads, we need to make a map that tells us what
         // nodes are unique to what allele paths. Stores site and allele parts
         // separately.
         map<vg::id_t, pair<string, string>> allele_path_for_node;
-        
+
         // This is what we really care about: for each pair of allele paths in
         // the graph, we need to find out whether the coverage imbalance between
         // them among primary alignments is statistically significant. For this,
         // we need to track how many reads overlap the distinct parts of allele
         // paths.
-        
+
         // This is going to be indexed by site
         // ("_alt_f6d951572f9c664d5d388375aa8b018492224533") and then by allele
         // ("0"). A read only counts if it visits a node that's on one allele
         // and not any others in that site.
-        
+
         // We need to pre-populate it with 0s so we know which sites actually
         // have 2 alleles and which only have 1 in the graph.
         map<string, map<string, size_t>> reads_on_allele;
-        
+
         graph->for_each_node_parallel([&](Node* node) {
             // For every node
-            
+
             if(!graph->paths.has_node_mapping(node)) {
                 // No paths to go over. If we try and get them we'll be
                 // modifying the paths in parallel, which will explode.
                 return;
             }
-            
+
             // We want an allele path on it
             string allele_path;
             for(auto& name_and_mappings : graph->paths.get_node_mapping(node)) {
@@ -4899,40 +4899,40 @@ int main_stats(int argc, char** argv) {
                     }
                 }
             }
-            
+
             if(!allele_path.empty()) {
                 // We found an allele path for this node
-                
+
                 // Get its site and allele so we can count it as a biallelic
                 // site. Note that sites where an allele has no unique nodes
                 // (pure indels, for example) can't be handled and will be
                 // ignored.
                 auto site = path_name_to_site(allele_path);
                 auto allele = path_name_to_allele(allele_path);
-                
-                
+
+
                 #pragma omp critical (allele_path_for_node)
                 allele_path_for_node[node->id()] = make_pair(site, allele);
-                
+
                 #pragma omp critical (reads_on_allele)
                 reads_on_allele[site][allele] = 0;
             }
         });
-        
-        
+
+
         // These are the general stats we will compute.
         size_t total_alignments = 0;
         size_t total_aligned = 0;
         size_t total_primary = 0;
         size_t total_secondary = 0;
-        
+
         // These are for counting significantly allele-biased hets
         size_t total_hets = 0;
         size_t significantly_biased_hets = 0;
-        
+
         // These are for tracking which nodes are covered and which are not
         map<vg::id_t, size_t> node_visit_counts;
-        
+
         // And for counting indels
         // Inserted bases also counts softclips
         size_t total_insertions = 0;
@@ -4945,19 +4945,19 @@ int main_stats(int argc, char** argv) {
         // And softclips
         size_t total_softclips = 0;
         size_t total_softclipped_bases = 0;
-        
+
         // In verbose mode we want to report details of insertions, deletions,
         // and substitutions, and soft clips.
         vector<pair<vg::id_t, Edit>> insertions;
         vector<pair<vg::id_t, Edit>> deletions;
         vector<pair<vg::id_t, Edit>> substitutions;
         vector<pair<vg::id_t, Edit>> softclips;
-        
+
         function<void(Alignment&)> lambda = [&](Alignment& aln) {
             int tid = omp_get_thread_num();
-            
+
             // We ought to be able to do many stats on the alignments.
-            
+
             // Now do all the non-mapping stats
             #pragma omp critical (total_alignments)
             total_alignments++;
@@ -4974,33 +4974,33 @@ int main_stats(int argc, char** argv) {
                     #pragma omp critical (total_aligned)
                     total_aligned++;
                 }
-                
+
                 // Which sites and alleles does this read support. TODO: if we hit
                 // unique nodes from multiple alleles of the same site, we should...
                 // do something. Discard the read? Not just count it on both sides
                 // like we do now.
                 set<pair<string, string>> alleles_supported;
-                
+
                 for(size_t i = 0; i < aln.path().mapping_size(); i++) {
                     // For every mapping...
                     auto& mapping = aln.path().mapping(i);
                     vg::id_t node_id = mapping.position().node_id();
-                    
+
                     if(allele_path_for_node.count(node_id)) {
                         // We hit a unique node for this allele. Add it to the set,
                         // in case we hit another unique node for it later in the
                         // read.
                         alleles_supported.insert(allele_path_for_node.at(node_id));
                     }
-                    
+
                     // Record that there was a visit to this node.
                     #pragma omp critical (node_visit_counts)
                     node_visit_counts[node_id]++;
-                    
+
                     for(size_t j = 0; j < mapping.edit_size(); j++) {
                         // Go through edits and look for each type.
                         auto& edit = mapping.edit(j);
-                        
+
                         if(edit.to_length() > edit.from_length()) {
                             if((j == 0 && i == 0) || (j == mapping.edit_size() - 1 && i == aln.path().mapping_size() - 1)) {
                                 // We're at the very end of the path, so this is a soft clip.
@@ -5025,7 +5025,7 @@ int main_stats(int argc, char** argv) {
                                     insertions.push_back(make_pair(node_id, edit));
                                 }
                             }
-                            
+
                         } else if(edit.from_length() > edit.to_length()) {
                             // Record this deletion
                             #pragma omp critical (total_deleted_bases)
@@ -5050,10 +5050,10 @@ int main_stats(int argc, char** argv) {
                                 substitutions.push_back(make_pair(node_id, edit));
                             }
                         }
-                        
+
                     }
                 }
-                
+
                 for(auto& site_and_allele : alleles_supported) {
                     // This read is informative for an allele of a site.
                     // Up the reads on that allele of that site.
@@ -5061,52 +5061,52 @@ int main_stats(int argc, char** argv) {
                     reads_on_allele[site_and_allele.first][site_and_allele.second]++;
                 }
             }
-            
+
         };
-        
+
         // Actually go through all the reads and count stuff up.
         stream::for_each_parallel(alignment_stream, lambda);
-        
+
         // Calculate stats about the reads per allele data
         for(auto& site_and_alleles : reads_on_allele) {
             // For every site
             if(site_and_alleles.second.size() == 2) {
                 // If it actually has 2 alleles with unique nodes in the
                 // graph (so we can use the binomial)
-                
+
                 // We'll fill this with the counts for the two present alleles.
                 vector<size_t> counts;
-                
+
                 for(auto& allele_and_count : site_and_alleles.second) {
                     // Collect all the counts
                     counts.push_back(allele_and_count.second);
                 }
-                
+
                 if(counts[0] > counts[1]) {
                     // We have a 50% underlying probability so we can just put
                     // the rarer allele first.
                     swap(counts[0], counts[1]);
                 }
-                
+
                 // What's the log prob for the smaller tail?
                 auto tail_logprob = binomial_cmf_ln(prob_to_logprob(0.5),  counts[1] + counts[0], counts[0]);
-                
+
                 // Double it to get the two-tailed test
                 tail_logprob += prob_to_logprob(2);
-                
+
 #ifdef debug
                 cerr << "Site " << site_and_alleles.first << " has " << counts[0]
                     << " and " << counts[1] << " p=" << logprob_to_prob(tail_logprob) << endl;
 #endif
-                
+
                 if(tail_logprob < prob_to_logprob(0.05)) {
                     significantly_biased_hets++;
                 }
                 total_hets++;
-                
+
             }
         }
-        
+
         // Go through all the nodes again and sum up unvisited nodes
         size_t unvisited_nodes = 0;
         // And unvisited base count
@@ -5148,12 +5148,12 @@ int main_stats(int argc, char** argv) {
                 }
             }
         });
-        
+
         cout << "Total alignments: " << total_alignments << endl;
         cout << "Total primary: " << total_primary << endl;
         cout << "Total secondary: " << total_secondary << endl;
         cout << "Total aligned: " << total_aligned << endl;
-        
+
         cout << "Insertions: " << total_inserted_bases << " bp in " << total_insertions << " read events" << endl;
         if(verbose) {
             for(auto& id_and_edit : insertions) {
@@ -5182,7 +5182,7 @@ int main_stats(int argc, char** argv) {
                     << " on " << id_and_edit.first << endl;
             }
         }
-        
+
         cout << "Unvisited nodes: " << unvisited_nodes << "/" << graph->node_count()
             << " (" << unvisited_node_bases << " bp)" << endl;
         if(verbose) {
@@ -5190,22 +5190,22 @@ int main_stats(int argc, char** argv) {
                 cout << "\t" << id << endl;
             }
         }
-        
+
         cout << "Single-visited nodes: " << single_visited_nodes << "/" << graph->node_count()
             << " (" << single_visited_node_bases << " bp)" << endl;
         if(verbose) {
             for(auto& id : single_visited_ids) {
                 cout << "\t" << id << endl;
             }
-        }     
-        
+        }
+
         cout << "Significantly biased heterozygous sites: " << significantly_biased_hets << "/" << total_hets;
         if(total_hets > 0) {
             cout << " (" << (double)significantly_biased_hets / total_hets * 100 << "%)";
         }
         cout << endl;
-        
-        
+
+
     }
 
     delete graph;
@@ -5571,7 +5571,7 @@ int main_find(int argc, char** argv) {
         case 'D':
             pairwise_distance = true;
             break;
-            
+
         case 'H':
             haplotype_alignments = optarg;
             break;
@@ -5765,7 +5765,7 @@ int main_find(int argc, char** argv) {
                 // Count the amtches to the path. The path might be empty, in
                 // which case it will yield the biggest size_t you can have.
                 size_t matches = xindex.count_matches(aln.path());
-                
+
                 // We do this single-threaded, at least for now, so we don't
                 // need to worry about coordinating output, and we can just
                 // spit out the counts as bare numbers.
@@ -5782,7 +5782,7 @@ int main_find(int argc, char** argv) {
                 }
                 stream::for_each(in, lambda);
             }
-            
+
         }
         if (!gam_file.empty()) {
             set<vg::id_t> nodes;
@@ -5919,10 +5919,10 @@ int main_find(int argc, char** argv) {
             }
         } else {
             // let's use the GCSA index
-            
+
             // Configure GCSA2 verbosity so it doesn't spit out loads of extra info
             gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
-            
+
             // Open it
             ifstream in_gcsa(gcsa_in.c_str());
             gcsa::GCSA gcsa_index;
@@ -5956,7 +5956,7 @@ int main_find(int argc, char** argv) {
                 for (auto& mem : mems) mem.fill_nodes(&gcsa_index);
                 // dump them to stdout
                 cout << mems_to_json(mems) << endl;
-                
+
             }
         }
     }
@@ -5996,7 +5996,7 @@ int main_find(int argc, char** argv) {
             result_graph.serialize_to_ostream(cout);
         }
     }
-    
+
     if (vindex) delete vindex;
 
     return 0;
@@ -6043,7 +6043,8 @@ void help_index(char** argv) {
          << "    -S, --set-kmer         assert that the kmer size (-k) is in the db" << endl
         //<< "    -b, --tmp-db-base S    use this base name for temporary indexes" << endl
          << "    -C, --compact          compact the index into a single level (improves performance)" << endl
-         << "    -Q, --use-snappy       use snappy compression (faster, larger) rather than zlib" << endl;
+         << "    -Q, --use-snappy       use snappy compression (faster, larger) rather than zlib" << endl
+         << "    -o, --discard-overlaps if phasing vcf calls alts at overlapping variants, call all but the first one as ref" << endl;
 
 }
 
@@ -6083,6 +6084,7 @@ int main_index(int argc, char** argv) {
     bool forward_only = false;
     size_t size_limit = 200; // in gigabytes
     bool store_threads = false; // use gPBWT to store paths
+    bool discard_overlaps = false;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -6118,11 +6120,12 @@ int main_index(int argc, char** argv) {
             {"store-threads", no_argument, 0, 'T'},
             {"node-alignments", no_argument, 0, 'N'},
             {"dbg-in", required_argument, 0, 'i'},
+            {"discard-overlaps", no_argument, 0, 'o'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "d:k:j:pDshMt:b:e:SP:LmaCnAQg:X:x:v:VFZ:Oi:TN",
+        c = getopt_long (argc, argv, "d:k:j:pDshMt:b:e:SP:LmaCnAQg:X:x:v:VFZ:Oi:TNo",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -6317,13 +6320,13 @@ int main_index(int argc, char** argv) {
         VGset graphs(file_names);
         // Turn into an XG index, except for the alt paths which we pull out and load into RAM instead.
         xg::XG index = graphs.to_xg(store_threads, is_alt, alt_paths);
-        
+
         // We're going to collect all the phase threads as XG threads (which
         // aren't huge like Protobuf Paths), and then insert them all into xg in
         // a batch, for speed. This will take a lot of memory (although not as
         // much as a real vg::Paths index or vector<Path> would)
         vector<xg::XG::thread_t> all_phase_threads;
-        
+
         if(variant_file.is_open()) {
             // Now go through and add the varaints.
 
@@ -6346,7 +6349,7 @@ int main_index(int argc, char** argv) {
 
                 // How many bases is it?
                 size_t path_length = index.path_length(path_name);
-                
+
                 // Allocate some threads to store phase threads
                 vector<xg::XG::thread_t> active_phase_threads{num_phases};
                 // We need to remember how many paths of a particular phase have
@@ -6354,7 +6357,7 @@ int main_index(int argc, char** argv) {
                 vector<int> saved_phase_paths(num_phases, 0);
 
                 // What's the first reference position after the last variant?
-                size_t nonvariant_start = 0;
+                vector<size_t> nonvariant_starts(num_phases, 0);
 
                 // Completed ones just get dumped into the index
                 auto finish_phase = [&](size_t phase_number) {
@@ -6364,21 +6367,21 @@ int main_index(int argc, char** argv) {
 
                     // Find where this path is in our vector
                     xg::XG::thread_t& to_save = active_phase_threads[phase_number];
-                    
+
                     if(to_save.size() > 0) {
                         // Only actually do anything if we put in some mappings.
-                        
+
                         // Count this thread from this phase as being saved.
                         saved_phase_paths[phase_number]++;
-                        
+
                         // We don't tie threads from a pahse together in the
                         // index yet.
-                            
+
                         // Copy the thread over to our batch that we GPBWT all
                         // at once, exploiting the fact that VCF-derived graphs
                         // are DAGs.
                         all_phase_threads.push_back(to_save);
-                        
+
                         // Clear it out for re-use
                         to_save.clear();
                     }
@@ -6390,16 +6393,16 @@ int main_index(int argc, char** argv) {
                 auto append_mapping = [&](size_t phase_number, const Mapping& mapping) {
                     // Find the path to add to
                     xg::XG::thread_t& to_extend = active_phase_threads[phase_number];
-                    
+
                     // See if the edge we need to follow exists
                     if(to_extend.size() > 0) {
                         // If there's a previous mapping, go find it
                         const xg::XG::ThreadMapping& previous = to_extend[to_extend.size() - 1];
-                        
+
                         // Break out the IDs and flags we need to check for the edge
                         int64_t last_node = previous.node_id;
                         bool last_from_start = previous.is_reverse;
-                        
+
                         int64_t new_node = mapping.position().node_id();
                         bool new_to_end = mapping.position().is_reverse();
 
@@ -6411,11 +6414,11 @@ int main_index(int argc, char** argv) {
                                 << last_node << (last_from_start ? "L" : "R") << " - "
                                 << new_node << (new_to_end ? "R" : "L")
                                 << " which does not exist. Splitting!" << endl;
-#endif                    
+#endif
                             finish_phase(phase_number);
                         }
                     }
-                    
+
                     // Add a new ThreadMapping for the mapping
                     xg::XG::ThreadMapping tm = {mapping.position().node_id(), mapping.position().is_reverse()};
                     active_phase_threads[phase_number].push_back(tm);
@@ -6429,7 +6432,7 @@ int main_index(int argc, char** argv) {
                     // intervening reference nodes from the last variant, if
                     // any. For which we need access to the last variant's past-
                     // the-end reference position.
-                    size_t ref_pos = nonvariant_start;
+                    size_t ref_pos = nonvariant_starts[phase_number];
                     while(ref_pos < end) {
                         // While there is intervening reference
                         // sequence, add it to our phase.
@@ -6443,6 +6446,7 @@ int main_index(int argc, char** argv) {
                         // Advance to what's after that mapping
                         ref_pos += index.node_length(ref_mapping.position().node_id());
                     }
+                    nonvariant_starts[phase_number] = ref_pos;
                 };
 
                 // We also have another function to handle each variant as it comes in.
@@ -6451,7 +6455,7 @@ int main_index(int argc, char** argv) {
 
                     // Grab its id, or make one by hashing stuff if it doesn't
                     // have an ID.
-                    string var_name = get_or_make_variant_id(variant);
+                    string var_name = make_variant_id(variant);
 
                     if(alt_paths.count("_alt_" + var_name + "_0") == 0) {
                         // There isn't a reference alt path for this variant.
@@ -6474,18 +6478,6 @@ int main_index(int argc, char** argv) {
                         // Find the phasing bar
                         auto bar_pos = genotype.find('|');
 
-                        for(int phase_offset = 0; phase_offset < 2; phase_offset++) {
-                            // For both the phases for the sample, add mappings
-                            // through all the fixed reference nodes between the
-                            // last variant and here.
-                            append_reference_mappings_until(sample_number * 2 + phase_offset, variant.position);
-
-                            // If this variant isn't phased, this will just be a
-                            // reference-matching piece of thread after the last
-                            // variant. If that wasn't phased either, it's just
-                            // a floating perfect reference match.
-                        }
-
                         if(bar_pos == string::npos || bar_pos == 0 || bar_pos + 1 >= genotype.size()) {
                             // If it isn't phased, or we otherwise don't like
                             // it, we need to break phasing paths.
@@ -6504,19 +6496,28 @@ int main_index(int argc, char** argv) {
                             // Handle each phase and its alt
                             int& alt_index = alt_indices[phase_offset];
 
-                            // We need to find the path for this alt of this
-                            // variant. We can pull out the whole thing since it
-                            // should be short.
-                            Path alt_path = alt_paths.at("_alt_" + var_name + "_" + to_string(alt_index));
-                            // TODO: if we can't find this path, it probaby
-                            // means we mismatched the vg file and the vcf file.
-                            // Maybe we should complain to the user instead of
-                            // just failing an assert in at()?
+                            // If this sample doesn't take the reference path at this
+                            // variant
+                            if(alt_index != 0) {
 
+                              // We need to find the path for this alt of this
+                              // variant. We can pull out the whole thing since it
+                              // should be short.
+                              Path alt_path = alt_paths.at("_alt_" + var_name + "_" + to_string(alt_index));
+                              // TODO: if we can't find this path, it probaby
+                              // means we mismatched the vg file and the vcf file.
+                              // Maybe we should complain to the user instead of
+                              // just failing an assert in at()?
 
-                            for(size_t i = 0; i < alt_path.mapping_size(); i++) {
-                                // Then blit mappings from the alt over to the phase thread
-                                append_mapping(sample_number * 2 + phase_offset, alt_path.mapping(i));
+                              if(nonvariant_starts[sample_number * 2 + phase_offset] <= variant.position || !discard_overlaps) {
+
+                                for(size_t i = 0; i < alt_path.mapping_size(); i++) {
+                                    // Then blit mappings from the alt over to the phase thread
+                                    append_mapping(sample_number * 2 + phase_offset, alt_path.mapping(i));
+                                }
+
+                                nonvariant_starts[sample_number * 2 + phase_offset] = variant.position + variant.ref.size();
+                              }
                             }
 
                             // TODO: We can't really land anywhere on the other
@@ -6529,10 +6530,6 @@ int main_index(int argc, char** argv) {
 
                         // Now we have processed both phasinbgs for this sample.
                     }
-
-                    // Update the past-the-last-variant position, globally,
-                    // after we do all the samples.
-                    nonvariant_start = variant.position + variant.ref.size();
                 };
 
                 // Look for variants only on this path
@@ -6593,22 +6590,22 @@ int main_index(int argc, char** argv) {
                 }
 
             }
-            
+
             if(show_progress) {
                 cerr << "Inserting all phase threads into DAG..." << endl;
             }
-            
+
             // Now insert all the threads in a batch into the known-DAG VCF-
             // derived graph.
             index.insert_threads_into_dag(all_phase_threads);
             all_phase_threads.clear();
-            
+
         }
-        
+
         if(show_progress) {
             cerr << "Saving index to disk..." << endl;
         }
-        
+
         // save the xg version to the file name we've been given
         ofstream db_out(xg_name);
         index.serialize(db_out);
@@ -7029,7 +7026,7 @@ void help_map(char** argv) {
          << "    -1, --qual-adjust     perform base quality adjusted alignments (requires base quality input)" << endl
          << "paired end alignment parameters:" << endl
          << "    -W, --fragment-max N       maximum fragment size to be used for estimating the fragment length distribution (default: 1e5)" << endl
-         << "    -2, --fragment-sigma N     calculate fragment size as mean(buf)+sd(buf)*N where buf is the buffer of perfect pairs we use (default: 10)" << endl 
+         << "    -2, --fragment-sigma N     calculate fragment size as mean(buf)+sd(buf)*N where buf is the buffer of perfect pairs we use (default: 10)" << endl
          << "    -p, --pair-window N        maximum distance between properly paired reads in node ID space" << endl
          << "    -u, --pairing-multimaps N  examine N extra mappings looking for a consistent read pairing (default: 4)" << endl
          << "    -U, --always-rescue        rescue each imperfectly-mapped read in a pair off the other" << endl
@@ -7204,7 +7201,7 @@ int main_map(int argc, char** argv) {
         case 's':
             seq = optarg;
             break;
-            
+
         case 'I':
             qual = string_quality_char_to_short(string(optarg));
                 break;
@@ -7390,15 +7387,15 @@ int main_map(int argc, char** argv) {
         case 'y':
             gap_extend = atoi(optarg);
             break;
-            
+
         case '1':
             qual_adjust_alignments = true;
             break;
-            
+
         case 'u':
             extra_pairing_multimaps = atoi(optarg);
             break;
-                
+
         case 'v':
             method_code = atoi(optarg);
             break;
@@ -7438,7 +7435,7 @@ int main_map(int argc, char** argv) {
         cerr << "error:[vg map] sequence and base quality string must be the same length" << endl;
         return 1;
     }
-    
+
     if (qual_adjust_alignments && ((fastq1.empty() && hts_file.empty() && qual.empty()) // must have some quality input
                                    || (!seq.empty() && qual.empty())                    // can't provide sequence without quality
                                    || !read_file.empty()))                              // can't provide sequence list without qualities
@@ -7447,7 +7444,7 @@ int main_map(int argc, char** argv) {
         return 1;
     }
     // note: still possible that hts file types don't have quality, but have to check the file to know
-    
+
     MappingQualityMethod mapping_quality_method;
     if (method_code == 0) {
         mapping_quality_method = None;
@@ -7462,7 +7459,7 @@ int main_map(int argc, char** argv) {
         cerr << "error:[vg map] unrecognized mapping quality method command line arg '" << method_code << "'" << endl;
         return 1;
     }
-    
+
 
     // should probably disable this
     string file_name;
@@ -7581,7 +7578,7 @@ int main_map(int argc, char** argv) {
             stream::write_buffered(cout, output_buf, buffer_size);
         }
     };
-    
+
     for (int i = 0; i < thread_count; ++i) {
         Mapper* m;
         if(xindex && gcsa && lcp) {
@@ -7625,7 +7622,7 @@ int main_map(int argc, char** argv) {
 
         Alignment unaligned;
         unaligned.set_sequence(seq);
-        
+
         if (!qual.empty()) {
             unaligned.set_quality(qual);
         }
@@ -7635,14 +7632,14 @@ int main_map(int argc, char** argv) {
             // If we didn't have any alignments, report the unaligned alignment
             alignments.push_back(unaligned);
         }
-        
+
 
         for(auto& alignment : alignments) {
             if (!sample_name.empty()) alignment.set_sample_name(sample_name);
             if (!read_group.empty()) alignment.set_read_group(read_group);
             if (!seq_name.empty()) alignment.set_name(seq_name);
         }
-        
+
         // Output the alignments in JSON or protobuf as appropriate.
         output_alignments(alignments);
     }
@@ -8601,13 +8598,13 @@ int main_view(int argc, char** argv) {
     } else if (output_type == "vg") {
         graph->serialize_to_ostream(cout);
     } else if (output_type == "locus") {
-        
+
     } else {
         // We somehow got here with a bad output format.
         cerr << "[vg view] error: cannot save a graph in " << output_type << " format" << endl;
         return 1;
     }
-    
+
     // We made it to the end and nothing broke.
     return 0;
 }
@@ -8724,10 +8721,10 @@ int main_deconstruct(int argc, char** argv){
 
     Deconstructor decon = Deconstructor(graph);
     if (!xg_name.empty()){
-        ifstream xg_stream(xg_name);                                                                                                                                             
-        if(!xg_stream) {                                                                                                                                                         
-            cerr << "Unable to open xg index: " << xg_name << endl;                                                                                                              
-            exit(1);                                                                                                                                                             
+        ifstream xg_stream(xg_name);
+        if(!xg_stream) {
+            cerr << "Unable to open xg index: " << xg_name << endl;
+            exit(1);
         }
 
         xg::XG* xindex = new  xg::XG(xg_stream);
@@ -8747,7 +8744,7 @@ int main_deconstruct(int argc, char** argv){
             cerr << "Done." << endl;
         }
 
-    
+
 
     // At this point, we can detect the superbubbles
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6246,6 +6246,10 @@ int main_index(int argc, char** argv) {
             store_threads = true;
             break;
 
+        case 'o':
+            discard_overlaps = true;
+            break;
+
         case 'N':
             store_node_alignments = true;
             break;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -34,7 +34,7 @@ static const char complement[256] = {'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 
                                      'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 240
                                      'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 248
                                      'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N'};// 256
-    
+
 char reverse_complement(const char& c) {
     return complement[c];
 }
@@ -152,21 +152,38 @@ string get_or_make_variant_id(vcflib::Variant variant) {
         return variant.id;
     } else {
         // Synthesize a name for the variant
-        
+
         // Let's just hash
         SHA1 hasher;
-        
+
         // Turn the variant back into a string line and hash it.
         // Note that this keeps the modified 0-based position.
         std::stringstream variant_stringer;
         variant_stringer << variant;
         hasher.update(variant_stringer.str());
-        
+
         // Name the variant with the hex hash. Will be unique unless two
         // identical variant lines are in the file.
         return hasher.final();
-        
+
     }
+}
+
+string make_variant_id(vcflib::Variant variant) {
+    // Synthesize a name for the variant
+
+    // Let's just hash
+    SHA1 hasher;
+
+    // Turn the variant back into a string line and hash it.
+    // Note that this keeps the modified 0-based position.
+    std::stringstream variant_stringer;
+    variant_stringer << variant;
+    hasher.update(variant_stringer.str());
+
+    // Name the variant with the hex hash. Will be unique unless two
+    // identical variant lines are in the file.
+    return hasher.final();
 }
 
 double median(std::vector<int> &v) {

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -125,18 +125,18 @@ vector<T> vpmax(const std::vector<std::vector<T>>& vv) {
  */
 template<typename Collection>
 typename Collection::value_type sum(const Collection& collection) {
-    
+
     // Set up an alias
     using Item = typename Collection::value_type;
-    
+
     // Make a new zero-valued item to hold the sum
     auto total = Item();
     for(auto& to_sum : collection) {
         total += to_sum;
     }
-    
+
     return total;
-    
+
 }
 
 /**
@@ -146,18 +146,18 @@ typename Collection::value_type sum(const Collection& collection) {
  */
 template<typename Collection>
 typename Collection::value_type logprob_sum(const Collection& collection) {
-    
+
     // Set up an alias
     using Item = typename Collection::value_type;
-    
+
     // Pull out the minimum value
     auto min_iterator = min_element(begin(collection), end(collection));
-    
+
     if(min_iterator == end(collection)) {
         // Nothing there, p = 0
         return Item(prob_to_logprob(0));
     }
-    
+
     auto check_iterator = begin(collection);
     ++check_iterator;
     if(check_iterator == end(collection)) {
@@ -165,22 +165,22 @@ typename Collection::value_type logprob_sum(const Collection& collection) {
         // out because we'll get 0s.
         return *min_iterator;
     }
-    
+
     // Pull this much out of every logprob.
     Item pulled_out = *min_iterator;
-    
+
     if(logprob_to_prob(pulled_out) == 0) {
         // Can't divide by 0!
         // TODO: fix this in selection
         pulled_out = prob_to_logprob(1);
     }
-    
+
     Item total(0);
     for(auto& to_add : collection) {
         // Sum up all the scaled probabilities.
         total += logprob_to_prob(to_add - pulled_out);
     }
-    
+
     // Re-log and re-scale
     return pulled_out + prob_to_logprob(total);
 }
@@ -190,6 +190,7 @@ string tmpfilename(const string& base);
 // Code to detect if a variant lacks an ID and give it a unique but repeatable
 // one.
 string get_or_make_variant_id(vcflib::Variant variant);
+string make_variant_id(vcflib::Variant variant);
 
 // Simple little tree
 template<typename T>

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -183,7 +183,7 @@ SB_Input VG::vg_to_sb_input(){
 
     id_t VG::get_node_at_nucleotide(string pathname, int nuc){
         Path p = paths.path(pathname);
-        
+
         int nt_start = 0;
         int nt_end = 0;
         for (int i = 0; i < p.mapping_size(); i++){
@@ -202,7 +202,7 @@ SB_Input VG::vg_to_sb_input(){
         }
 
     }
- 
+
  map<id_t, vcflib::Variant> VG::get_node_id_to_variant(vcflib::VariantCallFile vfile){
     map<id_t, vcflib::Variant> ret;
     vcflib::Variant var;
@@ -2119,7 +2119,7 @@ void VG::vcf_records_to_alleles(vector<vcflib::Variant>& records,
         // unique, even if there are multiple variant records at the same
         // position in the VCF. Also, we don't necessarily have every variant in
         // the VCF in our records vector.
-        string var_name = get_or_make_variant_id(var);
+        string var_name = make_variant_id(var);
 
         // decompose to alts
         // This holds a map from alt or ref allele sequence to a series of VariantAlleles describing an alignment.
@@ -2913,7 +2913,7 @@ void VG::from_gfa(istream& in, bool showp) {
     map<string, sequence_elem>::iterator it;
     id_t curr_id = 1;
     map<string, id_t> id_names;
-    std::function<id_t(const string&)> get_add_id = [&](const string& name) -> id_t { 
+    std::function<id_t(const string&)> get_add_id = [&](const string& name) -> id_t {
         if (is_number(name)) {
             return std::stol(name);
         } else {
@@ -2988,7 +2988,7 @@ void VG::bluntify(void) {
                 //cerr << "claimed overlap " << edge->overlap() << endl;
                 // derive and check the overlap seqs
                 auto from_seq = trav_sequence(NodeTraversal(get_node(edge->from()), edge->from_start()));
-                //string from_overlap = 
+                //string from_overlap =
                 //from_overlap = from_overlap.substr(from_overlap.size() - edge->overlap());
                 auto to_seq = trav_sequence(NodeTraversal(get_node(edge->to()), edge->to_end()));
 
@@ -3029,7 +3029,7 @@ void VG::bluntify(void) {
                         edge->set_overlap(0);
                         // we should axe the edge so as to not generate spurious sequences in the graph
                     }
-                    
+
                 } else {
                     //cerr << "overlap as expected" << endl;
                     //overlap_node[edge] = create_node(to_seq);
@@ -3212,10 +3212,10 @@ void VG::bluntify(void) {
             edges_to_create.insert(make_pair(prev_trav, node_trav));
         }
 
-        // if we matched 
+        // if we matched
         // walk forward until we reach a bifurcation
         // or we are no longer matching sequence
-        
+
         // we reattach the overlap node to that point
         // later, normalization will remove the superfluous parts
     }
@@ -3277,7 +3277,7 @@ void VG::bluntify(void) {
     for (auto& id : nodes_to_destroy) {
         destroy_node(id);
     }
-    
+
 }
 
 static
@@ -3495,7 +3495,7 @@ VG::VG(vcflib::VariantCallFile& variantCallFile,
     // our chunk size isn't going to reach into the range where we'll have issues (>several megs)
     // so we'll run this for regions of moderate size, scaling up in the case that we run into a big deletion
     //
-    
+
     for (vector<string>::iterator t = targets.begin(); t != targets.end(); ++t) {
 
         //string& seq_name = *t;
@@ -3594,7 +3594,7 @@ VG::VG(vcflib::VariantCallFile& variantCallFile,
                 var.position -= 1; // convert to 0-based
                 if (allowed_variants == nullptr
                     || allowed_variants->count(vrepr)) {
-                    records.push_back(var);                    
+                    records.push_back(var);
                 }
             }
             if (++i % 1000 == 0) update_progress(var.position-start_pos);
@@ -3942,7 +3942,7 @@ VG::VG(vcflib::VariantCallFile& variantCallFile,
         }
         return true;
     };
-    
+
     for_each_node([&](Node* node) {
             if (!all_upper(node->sequence())){
                 cerr << "WARNING: Lower case letters found during construction" << endl;
@@ -4000,16 +4000,16 @@ void VG::dfs(
     // attempt the search rooted at all NodeTraversals
     for (id_t i = 0; i < graph.node_size(); ++i) {
         Node* root_node = graph.mutable_node(i);
-        
+
         for(int orientation = 0; orientation < 2; orientation++) {
             // Try both orientations
             NodeTraversal root(root_node, (bool)orientation);
-        
+
             // to store the stack frames
             deque<Frame> todo;
             if (state[root] == SearchState::PRE) {
                 state[root] = SearchState::CURR;
-                
+
                 // Collect all the edges attached to the outgoing side of the
                 // traversal.
                 auto& es = edges[root];
@@ -4020,7 +4020,7 @@ void VG::dfs(
                     assert(edge != nullptr);
                     es.push_back(edge);
                 }
-                
+
                 todo.push_back(Frame(root, es.begin(), es.end()));
                 // run our discovery-time callback
                 node_begin_fn(root);
@@ -4043,7 +4043,7 @@ void VG::dfs(
                     auto edge = *edges_begin;
                     // run the edge callback
                     edge_fn(edge);
-                    
+
                     // what's the traversal we'd get to following this edge
                     NodeTraversal target;
                     if(edge->from() == trav.node->id() && edge->to() != trav.node->id()) {
@@ -4060,7 +4060,7 @@ void VG::dfs(
                     // When we follow this edge, do we reverse traversal orientation?
                     bool is_reversing = (edge->from_start() != edge->to_end());
                     target.backward = trav.backward != is_reversing;
-                    
+
                     auto search_state = state[target];
                     // if we've not seen it, follow it
                     if (search_state == SearchState::PRE) {
@@ -4072,7 +4072,7 @@ void VG::dfs(
                         // and store it on the stack
                         state[trav] = SearchState::CURR;
                         auto& es = edges[trav];
-                    
+
                         for(auto& next : travs_from(trav)) {
                             // Every NodeTraversal following on from this one has an
                             // edge we take to get to it.
@@ -4080,7 +4080,7 @@ void VG::dfs(
                             assert(edge != nullptr);
                             es.push_back(edge);
                         }
-                    
+
                         edges_begin = es.begin();
                         edges_end = es.end();
                         // run our discovery-time callback
@@ -4263,7 +4263,7 @@ bool VG::is_acyclic(void) {
         },
         [&](NodeTraversal trav) {
             // When we leave a node orientation
-            
+
             // Remove it from the seen array. We may later start from a
             // different root and see a way into this node in this orientation,
             // but it's only a cycle if there's a way into this node in this
@@ -6658,7 +6658,7 @@ void VG::to_dot(ostream& out,
             out << "    " << n->id() << " [label=\"" << nlabel.str() << "\",penwidth=2,shape=circle,";
         } else if (superbubble_labeling || cactusbubble_labeling) {
             //out << "    " << n->id() << " [label=" << nlabel.str() << ",shape=box,penwidth=2,";
-            out << "    " << n->id() << " [label=" << nlabel.str() << ",shape=none,width=0,height=0,margin=0,";      
+            out << "    " << n->id() << " [label=" << nlabel.str() << ",shape=none,width=0,height=0,margin=0,";
         } else {
             out << "    " << n->id() << " [label=" << nlabel.str() << ",shape=none,width=0,height=0,margin=0,";
         }
@@ -6846,13 +6846,13 @@ void VG::to_dot(ostream& out,
         alnid++;
         for (int i = 0; i < aln.path().mapping_size(); ++i) {
             const Mapping& m = aln.path().mapping(i);
-            
+
             if(!has_node(m.position().node_id()) && skip_missing_nodes) {
                 // We don't have the node this is aligned to. We probably are
                 // looking at a subset graph, and the user asked us to skip it.
                 continue;
             }
-            
+
             //void mapping_cigar(const Mapping& mapping, vector<pair<int, char> >& cigar);
             //string cigar_string(vector<pair<int, char> >& cigar);
             //mapid << alnid << ":" << m.position().node_id() << ":" << cigar_string(cigar);
@@ -6986,7 +6986,7 @@ void VG::to_dot(ostream& out,
                         out << "    " << pathid-1 << " -> " << path_starts[path.name()]
                             << " [dir=none,color=\"" << color << "\",constraint=false];" << endl;
                     }
-                    
+
                 }
             }
             if (walk_paths) {
@@ -7475,7 +7475,7 @@ Alignment VG::align(const Alignment& alignment,
                     QualAdjAligner* qual_adj_aligner,
                     size_t max_query_graph_ratio,
                     bool print_score_matrices) {
-    
+
     auto aln = alignment;
 
     /*
@@ -7504,7 +7504,7 @@ Alignment VG::align(const Alignment& alignment,
         sort();
         // run the alignment
         do_align(this->graph);
-        
+
         // Clean up the node we added. This is important because this graph will
         // later be extended with more material for softclip handling, and we
         // might need that node ID.
@@ -7566,7 +7566,7 @@ Alignment VG::align(const Alignment& alignment,
                 return get_node(node_id)->sequence().size();
             });
         //check_aln(*this, aln);
-        
+
         // Clean up the node we added. This is important because this graph will
         // later be extended with more material for softclip handling, and we
         // might need that node ID.
@@ -7595,7 +7595,7 @@ Alignment VG::align(const string& sequence,
     alignment.set_sequence(sequence);
     return align(alignment, aligner, max_query_graph_ratio, print_score_matrices);
 }
-    
+
 Alignment VG::align(const Alignment& alignment,
                     size_t max_query_graph_ratio,
                     bool print_score_matrices) {


### PR DESCRIPTION
Previously indexing would break paths needlessly for two reasons:

1. If there were multiple alts at a single position, in cases where they were not called, the ref sequence corresponding to each would be "filled in" without checking if you actually were taking a different alt at the same position since ref sequence was "filled in" in tandem for all samples >>>> fixed by maintaining a "filled in ref up to here" vector with separate entries for all samples and not filling in ref sequence until you were sure that no alts at any position were taken by the sample
2. If there were multiple alts at a single position, the corresponding alt mapping would be concatenated since alts are named according to their position >>>> fixed by making all alts be named by the hash of their variant -> string conversion

Furthermore

3. If a vcf specified multiple alts with overlapping reference sequence, we would try to take them both, which would imply a path which is not present in the graph. Vcfs probably shouldn't do this, but some do. >>> Added an option "-o" to drop the right overlapping alt(s) and consider them to be ref