### PR TITLE
Locus output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8637,11 +8637,12 @@ void help_deconstruct(char** argv){
 
 void help_locify(char** argv){
     cerr << "usage: " << argv[0] << " locify [options] " << endl
-         << "    -l, --loci FILE     input loci over which to locify the alignments" << endl
-         << "    -a, --aln-idx DIR   use this rocksdb alignment index (from vg index -N)" << endl
-         << "    -x, --xg-idx FILE   use this xg index" << endl
-         << "    -n, --name-alleles  generate names for each allele rather than using full Paths" << endl
-         << "    -f, --forwardize    flip alignments on the reverse strand to the forward" << endl;
+         << "    -l, --loci FILE      input loci over which to locify the alignments" << endl
+         << "    -a, --aln-idx DIR    use this rocksdb alignment index (from vg index -N)" << endl
+         << "    -x, --xg-idx FILE    use this xg index" << endl
+         << "    -n, --name-alleles   generate names for each allele rather than using full Paths" << endl
+         << "    -f, --forwardize     flip alignments on the reverse strand to the forward" << endl
+         << "    -o, --loci-out FILE  write the non-nested loci out in their sorted order" << endl;
         // TODO -- add some basic filters that are useful downstream in whatshap
 }
 
@@ -8652,6 +8653,7 @@ int main_locify(int argc, char** argv){
     string xg_idx_name;
     bool name_alleles = false;
     bool forwardize = false;
+    string loci_out;
 
     if (argc <= 2){
         help_locify(argv);
@@ -8669,11 +8671,12 @@ int main_locify(int argc, char** argv){
             {"xg-idx", required_argument, 0, 'x'},
             {"name-alleles", no_argument, 0, 'n'},
             {"forwardize", no_argument, 0, 'f'},
+            {"loci-out", required_argument, 0, 'o'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hl:x:g:nf",
+        c = getopt_long (argc, argv, "hl:x:g:nfo:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -8700,6 +8703,10 @@ int main_locify(int argc, char** argv){
 
         case 'f':
             forwardize = true;
+            break;
+
+        case 'o':
+            loci_out = optarg;
             break;
 
         case 'h':
@@ -8736,16 +8743,29 @@ int main_locify(int argc, char** argv){
 
     };
 
+    vector<string> locus_names;
     map<string, map<string, int > > locus_allele_names;
     map<string, Alignment> alignments_with_loci;
+    map<pos_t, set<string> > pos_to_loci;
+    map<string, set<pos_t> > locus_to_pos;
     int count = 0;
     std::function<void(Locus&)> lambda = [&](Locus& l){
+        locus_names.push_back(l.name());
         set<vg::id_t> nodes_in_locus;
         for (int i = 0; i < l.allele_size(); ++i) {
             auto& allele = l.allele(i);
             for (int j = 0; j < allele.mapping_size(); ++j) {
                 auto& position = allele.mapping(j).position();
                 nodes_in_locus.insert(position.node_id());
+            }
+            // for position in mapping
+            map<pos_t, int> ref_positions;
+            map<int, Edit> edits;
+            decompose(allele, ref_positions, edits);
+            // warning: uses only reference positions!!!
+            for (auto& pos : ref_positions) {
+                pos_to_loci[pos.first].insert(l.name());
+                locus_to_pos[l.name()].insert(pos.first);
             }
         }
         // void for_alignment_in_range(int64_t id1, int64_t id2, std::function<void(const Alignment&)> lambda);
@@ -8800,13 +8820,43 @@ int main_locify(int argc, char** argv){
     if (!loci_file.empty()){
         ifstream ifi(loci_file);
         stream::for_each(ifi, lambda);
+    } else {
+        cerr << "[vg locify] Warning: empty locus file given, could not annotate alignments with loci." << endl;
     }
 
-    // barf PB structures {Alignment : list(Locus)} as JSON objects
-    //
+    // find the non-nested loci
+    vector<string> non_nested_loci;
+    for (auto& name : locus_names) {
+        // is it nested?
+        auto& positions = locus_to_pos[name];
+        int min_loci = 0;
+        for (auto& pos : positions) {
+            auto& loci = pos_to_loci[pos];
+            min_loci = (min_loci == 0 ? (int)loci.size() : min(min_loci, (int)loci.size()));
+        }
+        if (min_loci == 1) {
+            // not fully contained in any other locus
+            non_nested_loci.push_back(name);
+        }
+    }
+
+    // sort them using... ? ids?
+    sort(non_nested_loci.begin(), non_nested_loci.end(),
+         [&locus_to_pos](const string& s1, const string& s2) {
+             return *locus_to_pos[s1].begin() < *locus_to_pos[s2].begin();
+         });
+
+    if (!loci_out.empty()) {
+        ofstream outloci(loci_out);
+        for (auto& name : non_nested_loci) {
+            outloci << name << endl;
+        }
+        outloci.close();
+    }
+
     vector<Alignment> output_buf;
     for (auto& aln : alignments_with_loci) {
-        // TODO order the loci by their order in the alignment
+        // TODO order the loci by their order in the alignments
         if (forwardize) {
             if (aln.second.path().mapping_size() && aln.second.path().mapping(0).position().is_reverse()) {
                 output_buf.push_back(reverse_complement_alignment(aln.second,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8640,7 +8640,8 @@ void help_locify(char** argv){
          << "    -l, --loci FILE     input loci over which to locify the alignments" << endl
          << "    -a, --aln-idx DIR   use this rocksdb alignment index (from vg index -N)" << endl
          << "    -x, --xg-idx FILE   use this xg index" << endl
-         << "    -n, --name-alleles  generate names for each allele rather than using full Paths" << endl;
+         << "    -n, --name-alleles  generate names for each allele rather than using full Paths" << endl
+         << "    -f, --forwardize    flip alignments on the reverse strand to the forward" << endl;
         // TODO -- add some basic filters that are useful downstream in whatshap
 }
 
@@ -8650,6 +8651,7 @@ int main_locify(int argc, char** argv){
     Index gam_idx;
     string xg_idx_name;
     bool name_alleles = false;
+    bool forwardize = false;
 
     if (argc <= 2){
         help_locify(argv);
@@ -8666,11 +8668,12 @@ int main_locify(int argc, char** argv){
             {"loci", required_argument, 0, 'l'},
             {"xg-idx", required_argument, 0, 'x'},
             {"name-alleles", no_argument, 0, 'n'},
+            {"forwardize", no_argument, 0, 'f'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hl:x:g:n",
+        c = getopt_long (argc, argv, "hl:x:g:nf",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -8695,6 +8698,10 @@ int main_locify(int argc, char** argv){
             name_alleles = true;
             break;
 
+        case 'f':
+            forwardize = true;
+            break;
+
         case 'h':
         case '?':
             help_locify(argv);
@@ -8709,6 +8716,13 @@ int main_locify(int argc, char** argv){
     if (!gam_idx_name.empty()) {
         gam_idx.open_read_only(gam_idx_name);
     }
+
+    if (xg_idx_name.empty()) {
+        cerr << "[vg locify] Error: no xg index provided" << endl;
+        return 1;
+    }
+    ifstream xgstream(xg_idx_name);
+    xg::XG xgidx(xgstream);
 
     std::function<vector<string>(string, char)> strsplit = [&](string x, char delim){
 
@@ -8793,7 +8807,16 @@ int main_locify(int argc, char** argv){
     vector<Alignment> output_buf;
     for (auto& aln : alignments_with_loci) {
         // TODO order the loci by their order in the alignment
-        output_buf.push_back(aln.second);
+        if (forwardize) {
+            if (aln.second.path().mapping_size() && aln.second.path().mapping(0).position().is_reverse()) {
+                output_buf.push_back(reverse_complement_alignment(aln.second,
+                                                                  [&xgidx](int64_t id) { return xgidx.node_length(id); }));
+            } else {
+                output_buf.push_back(aln.second);
+            }
+        } else {
+            output_buf.push_back(aln.second);
+        }
         stream::write_buffered(cout, output_buf, 100);
     }
     stream::write_buffered(cout, output_buf, 0);        

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1215,7 +1215,7 @@ set<MaximalExactMatch*> Mapper::resolve_paired_mems(vector<MaximalExactMatch>& m
 int64_t Mapper::get_node_length(int64_t node_id) {
     if(xindex) {
         // Grab the node sequence only from the XG index and get its size.
-        return xindex->node_sequence(node_id).size();
+        return xindex->node_length(node_id);
     } else if(index) {
         // Get a 1-element range from the index and then use that.
         VG one_node_graph;

--- a/test/t/29_vg_locify.t
+++ b/test/t/29_vg_locify.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 5
+
+vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa > tiny.vg
+vg index -x tiny.vg.xg tiny.vg
+vg sim -a -s 1337 -n 100 -x tiny.vg.xg -l 30 > reads.gam
+vg map -G reads.gam -k 8 -V tiny.vg > tiny.gam
+vg index -d tiny.gam.index -N tiny.gam
+vg genotype tiny.vg tiny.gam.index >tiny.loci
+is $(vg locify -g tiny.gam.index -x tiny.vg.xg -l tiny.loci -f -n -o loci.sorted | vg view -a - | wc -l) 100 "locify produces output for each input alignment"
+is $(cat loci.sorted | wc -l) 6 "the sorted list of loci is the right length"
+is $(head -1 loci.sorted) "1+0_1+0" "the first locus is as expected"
+is $(head -4 loci.sorted | tail -1) "9+18_12+0" "a middle locus is as expected"
+is $(tail -1 loci.sorted) "15+9_15+9" "the last locus is as expected"
+
+rm -rf tiny.vg tiny.vg.xg tiny.vg reads.gam tiny.gam tiny.gam.index tiny.loci loci.sorted


### PR DESCRIPTION
More updates to the locus output script.

Here's how to use:

```
vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa > tiny.vg
vg index -x tiny.vg.xg tiny.vg
vg sim -a -s 1337 -n 100 -x tiny.vg.xg -l 30 > reads.gam
vg map -G reads.gam -k 8 -V tiny.vg > tiny.gam
vg index -d tiny.gam.index -N tiny.gam
vg genotype tiny.vg tiny.gam.index >tiny.loci
vg locify -g tiny.gam.index -x tiny.vg.xg -l tiny.loci -f -n -o loci.sorted >tagged_aln.gam
```