### PR TITLE
Allow multiple FASTAs and VCF files, and allow contig renaming

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -777,6 +777,9 @@ void Constructor::add_name_mapping(const string& vcf_name, const string& fasta_n
     // TODO: C++ doesn't have a 2-way map right?
     vcf_to_fasta_renames[vcf_name] = fasta_name;
     fasta_to_vcf_renames[fasta_name] = vcf_name;
+#ifdef debug
+    cerr << "Added rename of " << vcf_name << " to " << fasta_name << endl;
+#endif
 }
 
 string Constructor::vcf_to_fasta(const string& vcf_name) const {
@@ -1160,12 +1163,16 @@ void Constructor::construct_graph(const vector<FastaReference*>& references,
 
     // Make a map from contig name to fasta reference containing it.
     map<string, FastaReference*> reference_for;
-    for (auto* reference : references) {
+    for (size_t i = 0; i < references.size(); i++) {
         // For every FASTA reference, make sure it has an index
+        auto* reference = references[i];
         assert(reference->index);
         for (auto& kv : *(reference->index)) {
             // For every sequence name and index entry, point to this reference
             reference_for[kv.first] = reference;
+#ifdef debug
+            cerr << "Contig " << kv.first << " is in reference " << i << endl;
+#endif
         }
     }
     
@@ -1189,6 +1196,11 @@ void Constructor::construct_graph(const vector<FastaReference*>& references,
         for (string vcf_name : allowed_vcf_names) {
             // For each VCF contig, get the FASTA name
             string fasta_name = vcf_to_fasta(vcf_name);
+            
+#ifdef debug
+            cerr << "Make graph for " << vcf_name << " = " << fasta_name << endl;
+#endif
+            
             // Also the FASTA reference that has that sequence
             assert(reference_for.count(fasta_name));
             FastaReference* reference = reference_for[fasta_name];

--- a/src/subcommand/construct.cpp
+++ b/src/subcommand/construct.cpp
@@ -3,6 +3,7 @@
 #include <omp.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <memory>
 
 #include "subcommand.hpp"
 
@@ -17,8 +18,9 @@ using namespace vg::subcommand;
 void help_construct(char** argv) {
     cerr << "usage: " << argv[0] << " construct [options] >new.vg" << endl
          << "options:" << endl
-         << "    -v, --vcf FILE        input VCF" << endl
-         << "    -r, --reference FILE  input FASTA reference" << endl
+         << "    -v, --vcf FILE        input VCF (may repeat)" << endl
+         << "    -r, --reference FILE  input FASTA reference (may repeat)" << endl
+         << "    -n, --rename V=F      rename contig V in the VCFs to contig F in the FASTAs (may repeat)" << endl
          << "    -a, --alt-paths       save paths for alts of variants by variant ID" << endl
          << "    -R, --region REGION   specify a particular chromosome or 1-based inclusive region" << endl
          << "    -C, --region-is-chrom don't attempt to parse the region (use when the reference" << endl
@@ -43,7 +45,8 @@ int main_construct(int argc, char** argv) {
     Constructor constructor;
 
     // We also parse some arguments separately.
-    string fasta_file_name, vcf_file_name, json_filename;
+    vector<string> fasta_filenames;
+    vector<string> vcf_filenames;
     string region;
     bool region_is_chrom = false;
 
@@ -56,6 +59,7 @@ int main_construct(int argc, char** argv) {
                 //{"verbose", no_argument,       &verbose_flag, 1},
                 {"vcf", required_argument, 0, 'v'},
                 {"reference", required_argument, 0, 'r'},
+                {"rename", required_argument, 0, 'n'},
                 {"alt-paths", no_argument, 0, 'a'},
                 {"progress",  no_argument, 0, 'p'},
                 {"region-size", required_argument, 0, 'z'},
@@ -68,7 +72,7 @@ int main_construct(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "v:r:ph?z:t:R:m:as:Cf",
+        c = getopt_long (argc, argv, "v:r:n:ph?z:t:R:m:as:Cf",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -78,11 +82,28 @@ int main_construct(int argc, char** argv) {
         switch (c)
         {
         case 'v':
-            vcf_file_name = optarg;
+            vcf_filenames.push_back(optarg);
             break;
 
         case 'r':
-            fasta_file_name = optarg;
+            fasta_filenames.push_back(optarg);
+            break;
+            
+        case 'n':
+            {
+                // Parse the rename old=new
+                string key_value(optarg);
+                auto found = key_value.find('=');
+                if (found == string::npos || found == 0 || found + 1 == key_value.size()) {
+                    cerr << "error:[vg construct] could not parse rename " << key_value << endl;
+                    exit(1);
+                }
+                // Parse out the two parts
+                string vcf_contig = key_value.substr(0, found - 1);
+                string fasta_contig = key_value.substr(found + 1);
+                // Add the name mapping
+                constructor.add_name_mapping(vcf_contig, fasta_contig);
+            }
             break;
 
         case 'a':
@@ -172,31 +193,39 @@ int main_construct(int argc, char** argv) {
          }
     }
 
-    vcflib::VariantCallFile variant_file;
-    if (!vcf_file_name.empty()) {
-        // Make sure the file exists. Otherwise Tabix++ may exit with a non-
+    // This will own all the VCF files
+    vector<unique_ptr<vcflib::VariantCallFile>> variant_files;
+    for (auto& vcf_filename : vcf_filenames) {
+        // Make sure each VCF file exists. Otherwise Tabix++ may exit with a non-
         // helpful message.
 
         // We can't invoke stat woithout a place for it to write. But all we
         // really want is its return value.
         struct stat temp;
-        if(stat(vcf_file_name.c_str(), &temp)) {
-            cerr << "error:[vg construct] file \"" << vcf_file_name << "\" not found" << endl;
+        if(stat(vcf_filename.c_str(), &temp)) {
+            cerr << "error:[vg construct] file \"" << vcf_filename << "\" not found" << endl;
             return 1;
         }
-        variant_file.open(vcf_file_name);
-        if (!variant_file.is_open()) {
-            cerr << "error:[vg construct] could not open" << vcf_file_name << endl;
+        vcflib::VariantCallFile* variant_file = new vcflib::VariantCallFile();
+        variant_files.emplace_back(variant_file);
+        variant_file->open(vcf_filename);
+        if (!variant_file->is_open()) {
+            cerr << "error:[vg construct] could not open" << vcf_filename << endl;
             return 1;
         }
     }
 
-    if (fasta_file_name.empty()) {
+    if (fasta_filenames.empty()) {
         cerr << "error:[vg construct] a reference is required for graph construction" << endl;
         return 1;
     }
-    FastaReference reference;
-    reference.open(fasta_file_name);
+    vector<unique_ptr<FastaReference>> references;
+    for (auto& fasta_filename : fasta_filenames) {
+        // Open each FASTA file
+        FastaReference* reference = new FastaReference();
+        references.emplace_back(reference);
+        reference->open(fasta_filename);
+    }
 
     // We need a callback to handle pieces of graph as they are produced.
     auto callback = [&](Graph& big_chunk) {
@@ -210,8 +239,18 @@ int main_construct(int argc, char** argv) {
         }));
     };
 
-    // Construct the graph. Make sure to make our FASTA and VCF into vectors.
-    constructor.construct_graph({&reference}, {&variant_file}, callback);
+    // Make vectors of just bare pointers
+    vector<vcflib::VariantCallFile*> vcf_pointers;
+    for(auto& vcf : variant_files) {
+        vcf_pointers.push_back(vcf.get());
+    }
+    vector<FastaReference*> fasta_pointers;
+    for(auto& fasta : references) {
+        fasta_pointers.push_back(fasta.get());
+    }
+
+    // Construct the graph.
+    constructor.construct_graph(fasta_pointers, vcf_pointers, callback);
 
     // NB: If you worry about "still reachable but possibly lost" warnings in valgrind,
     // this would free all the memory used by protobuf:

--- a/src/subcommand/construct.cpp
+++ b/src/subcommand/construct.cpp
@@ -99,7 +99,7 @@ int main_construct(int argc, char** argv) {
                     exit(1);
                 }
                 // Parse out the two parts
-                string vcf_contig = key_value.substr(0, found - 1);
+                string vcf_contig = key_value.substr(0, found);
                 string fasta_contig = key_value.substr(found + 1);
                 // Add the name mapping
                 constructor.add_name_mapping(vcf_contig, fasta_contig);

--- a/test/t/02_vg_construct.t
+++ b/test/t/02_vg_construct.t
@@ -7,11 +7,13 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order 
 
-plan tests 22
+plan tests 23
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg stats -z - | grep nodes | cut -f 2) 210 "construction produces the right number of nodes"
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg stats -z - | grep edges | cut -f 2) 291 "construction produces the right number of edges"
+
+is $(vg construct -r small/x.fa --rename chrX=x -R chrX:1-2 | vg stats -l - | cut -f 2 ) 2 "construction obeys rename and region options"
 
 vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"


### PR DESCRIPTION
This implements the UI for the new features of the new streaming construct implementation. You can now have multiple VCFs and FASTAs in one vg construct operation, and you can specify a mapping from VCF to FASTA sequence names, so you don't have to rewrite your input files.