### PR TITLE
Remove redundant barrier; it was actually the variable move

### DIFF
--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -229,9 +229,6 @@ void for_each_parallel(std::istream& in,
         delete gzip_in;
         delete raw_in;
     }
-
-    // Don't clean up function locals before tasks finish using them
-    #pragma omp taskwait
 }
 
 template <typename T>


### PR DESCRIPTION
@mlin is right about implicit task barriers at the end of `#pragma omp parallel` blocks.