### PR TITLE
RocksDB whispering

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -9,12 +9,10 @@ Index::Index(void) {
     start_sep = '\x00';
     end_sep = '\xff';
     write_options = rocksdb::WriteOptions();
-    mem_env = false;
-    use_snappy = false;
-    // We haven't opened the index yet. We don't get false by default on all platforms.
-    is_open = false;
+    // disable write-ahead logging when writing to RocksDB. This is for write durability
+    // in the event of power failure etc. which is not really relevant to our use case.
+    write_options.disableWAL = true;
     db = nullptr;
-    //block_cache_size = 1024 * 1024 * 10; // 10MB
     rng.seed(time(NULL));
 
     threads = 1;
@@ -26,53 +24,76 @@ Index::Index(void) {
 
 }
 
-rocksdb::Options Index::GetOptions(void) {
+rocksdb::Options Index::GetOptions(bool read_only) {
+    // TODO: make the following configurable
+    const size_t block_cache_bytes = 1<<30;
+    const size_t memtable_bytes = 4 * size_t(1<<30);
 
     rocksdb::Options options;
 
-    if (mem_env) {
-        options.env = rocksdb::NewMemEnv(options.env);
+    options.create_if_missing = !read_only;
+    // TODO: error_if_exists by default, with override for user who really wishes
+    // to add into an existing index.
+    // options.error_if_exists = true;
+    if (read_only) {
+        // dump RocksDB's debug log into /tmp instead of db dir, to avoid
+        // touching the latter in read-only mode
+        options.db_log_dir = "/tmp";
     }
-
-    options.create_if_missing = true;
     options.max_open_files = -1;
-    options.compression = rocksdb::kSnappyCompression;
-    options.compaction_style = rocksdb::kCompactionStyleLevel;
-    // we are unlikely to reach either of these limits
-    options.IncreaseParallelism(threads);
-    options.max_background_flushes = threads;
-    options.max_background_compactions = threads;
-
-    options.num_levels = 2;
-    options.target_file_size_base = (long) 1024 * 1024 * 512; // ~512MB (bigger in practice)
-    options.write_buffer_size = 1024 * 1024 * 256; // ~256MB
-
-    // doesn't work this way
-    rocksdb::BlockBasedTableOptions topt;
-    topt.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, true));
-    topt.block_cache = rocksdb::NewLRUCache(512 * 1024 * 1024, 7);
-    topt.no_block_cache = true;
-    options.table_factory.reset(NewBlockBasedTableFactory(topt));
-    options.table_cache_numshardbits = 7;
     options.allow_mmap_reads = true;
-    options.allow_mmap_writes = false;
+    options.disableDataSync = true; // like disableWAL above
+
+    // set up table format
+    rocksdb::BlockBasedTableOptions topt;
+    topt.format_version = 2;
+    topt.block_size = 4 << 20;
+    topt.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, true));
+    topt.block_cache = rocksdb::NewLRUCache(block_cache_bytes);
+    options.table_factory.reset(NewBlockBasedTableFactory(topt));
+
+    // set up concurrency
+    options.IncreaseParallelism(threads);
+    options.max_background_flushes = 3; // overrides IncreaseParallelism
+
+    // set up universal compaction
+    options.OptimizeUniversalStyleCompaction(memtable_bytes);
+    options.max_write_buffer_number = 4;             // overrides OptimizeUniversalStyleCompaction
+    options.write_buffer_size = (memtable_bytes/4);  // overrides OptimizeUniversalStyleCompaction
+    options.min_write_buffer_number_to_merge = 1;    // overrides OptimizeUniversalStyleCompaction
+
+    // 3 Snappy-compressed levels [0-2]. Using background compactions, try to
+    // keep fewer than 5 files in L0 (each file being a sorted "sub-level").
+    // L1 & L2 are each fully sorted, but split into disjoint 16GB chunks.
+    // See https://github.com/facebook/rocksdb/wiki/Universal-Compaction for
+    // explanation of multi-level universal compaction.
+    // TODO: switch to zstd compression
+    options.num_levels = 3;
+    options.compression_per_level.clear();
+    options.compression = rocksdb::kSnappyCompression;
+    options.level0_file_num_compaction_trigger = 5;
+    options.target_file_size_base = 16 * size_t(1<<30);
+    options.access_hint_on_compaction_start = rocksdb::Options::AccessHint::SEQUENTIAL;
+    options.compaction_readahead_size = 16 << 20;
 
     if (bulk_load) {
-        options.PrepareForBulkLoad();
-        options.max_write_buffer_number = threads;
-        options.max_background_flushes = threads;
-        options.max_background_compactions = threads;
-        options.compaction_style = rocksdb::kCompactionStyleNone;
+        // vector memtable provides much faster loading provided there's no
+        // concurrent reading happening
         options.memtable_factory.reset(new rocksdb::VectorRepFactory(1000));
-    }
 
-    options.compression_per_level.resize(options.num_levels);
-    for (int i = 0; i < options.num_levels; ++i) {
-        if (i == 0 || use_snappy == true) {
-            options.compression_per_level[i] = rocksdb::kSnappyCompression;
-        } else {
-            options.compression_per_level[i] = rocksdb::kZlibCompression;
-        }
+        // disable write throttling because we'll have other logic to let
+        // background compactions converge.
+        options.level0_slowdown_writes_trigger = (1<<30);
+        options.level0_stop_writes_trigger = (1<<30);
+        options.compaction_options_universal.compression_size_percent = -1;
+        // size amplification is not a facttor for our write-once use case
+        options.compaction_options_universal.max_size_amplification_percent = (1<<30);
+        options.compaction_options_universal.size_ratio = 10;
+        options.compaction_options_universal.min_merge_width = 2;
+        options.compaction_options_universal.max_merge_width = 10;
+    } else {
+        options.allow_concurrent_memtable_write = true;
+        options.enable_write_thread_adaptive_yield = true;
     }
 
     return options;
@@ -81,7 +102,7 @@ rocksdb::Options Index::GetOptions(void) {
 void Index::open(const std::string& dir, bool read_only) {
 
     name = dir;
-    db_options = GetOptions();
+    db_options = GetOptions(read_only);
 
     rocksdb::Status s;
     if (read_only) {
@@ -91,15 +112,17 @@ void Index::open(const std::string& dir, bool read_only) {
         s = rocksdb::DB::Open(db_options, name, &db);
     }
     if (!s.ok()) {
+        if (db) {
+            delete db;
+        }
+        db = nullptr;
         throw indexOpenException("can't open " + dir);
     }
-    is_open = true;
 
 }
 
 void Index::open_read_only(string& dir) {
     bulk_load = false;
-    //mem_env = true;
     open(dir, true);
 }
 
@@ -114,7 +137,7 @@ void Index::open_for_bulk_load(string& dir) {
 }
 
 Index::~Index(void) {
-    if (is_open) {
+    if (db) {
         close();
     }
 }
@@ -122,15 +145,33 @@ Index::~Index(void) {
 void Index::close(void) {
     flush();
     delete db;
-    is_open = false;
+    db = nullptr;
 }
 
 void Index::flush(void) {
     db->Flush(rocksdb::FlushOptions());
+
+    if (bulk_load) {
+        // Wait for compactions to converge. Specifically, wait until
+        // there's no more than one background compaction running.
+        // Argument: once that's the case, the number of L0 files isn't
+        // too much greater than level0_file_num_compaction_trigger,
+        // or else a second background compaction would start.
+        uint64_t num_running_compactions = 0;
+        while(true) {
+            num_running_compactions = 0;
+            db->GetIntProperty(rocksdb::DB::Properties::kNumRunningCompactions,
+                            &num_running_compactions);
+            if (num_running_compactions<=1) {
+                break;
+            }
+            usleep(10000);
+        }
+    }
 }
 
 void Index::compact(void) {
-    db->CompactRange(NULL, NULL);
+    db->CompactRange(rocksdb::CompactRangeOptions(), NULL, NULL);
 }
 
 // todo: replace with union / struct
@@ -821,6 +862,13 @@ void Index::put_mapping(const Mapping& mapping) {
 }
 
 void Index::put_alignment(const Alignment& alignment) {
+    static std::atomic<bool> warned_unmapped(false);
+    if (!alignment.has_path()) {
+        if (!warned_unmapped.exchange(true)) {
+            std::cerr << "[vg index] WARNING: not storing unmapped reads in alignment index. (FIXME)" << std::endl;
+        }
+        return;
+    }
     string data;
     alignment.SerializeToString(&data);
     db->Put(write_options, key_for_alignment(alignment), data);

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -90,7 +90,7 @@ public:
     Index(string& name);
     ~Index(void);
 
-    rocksdb::Options GetOptions(void);
+    rocksdb::Options GetOptions(bool read_only);
     void open(const std::string& dir, bool read_only = false);
     void open_read_only(string& dir);
     void open_for_write(string& dir);
@@ -108,13 +108,10 @@ public:
     int threads;
 
     rocksdb::DB* db;
-    bool is_open;
-    bool use_snappy;
     rocksdb::Options db_options;
     rocksdb::WriteOptions write_options;
     rocksdb::ColumnFamilyOptions column_family_options;
     bool bulk_load;
-    bool mem_env;
     size_t block_cache_size;
     mt19937 rng;
 

--- a/src/subcommand/index.cpp
+++ b/src/subcommand/index.cpp
@@ -62,9 +62,7 @@ void help_index(char** argv) {
          << "    -S, --set-kmer         assert that the kmer size (-k) is in the db" << endl
         //<< "    -b, --tmp-db-base S    use this base name for temporary indexes" << endl
          << "    -C, --compact          compact the index into a single level (improves performance)" << endl
-         << "    -Q, --use-snappy       use snappy compression (faster, larger) rather than zlib" << endl
          << "    -o, --discard-overlaps if phasing vcf calls alts at overlapping variants, call all but the first one as ref" << endl;
-
 }
 
 int main_index(int argc, char** argv) {
@@ -97,7 +95,6 @@ int main_index(int argc, char** argv) {
     bool allow_negs = false;
     bool compact = false;
     bool dump_alignments = false;
-    bool use_snappy = false;
     int doubling_steps = 3;
     bool verify_index = false;
     bool forward_only = false;
@@ -128,7 +125,6 @@ int main_index(int argc, char** argv) {
             {"path-layout", no_argument, 0, 'L'},
             {"compact", no_argument, 0, 'C'},
             {"allow-negs", no_argument, 0, 'n'},
-            {"use-snappy", no_argument, 0, 'Q'},
             {"gcsa-name", required_argument, 0, 'g'},
             {"xg-name", required_argument, 0, 'x'},
             {"vcf-phasing", required_argument, 0, 'v'},
@@ -144,7 +140,7 @@ int main_index(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "d:k:j:pDshMt:b:e:SP:LmaCnAQg:X:x:v:VFZ:Oi:TNo",
+        c = getopt_long (argc, argv, "d:k:j:pDshMt:b:e:SP:LmaCnAg:X:x:v:VFZ:Oi:TNo",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -229,10 +225,6 @@ int main_index(int argc, char** argv) {
 
         case 'C':
             compact = true;
-            break;
-
-        case 'Q':
-            use_snappy = true;
             break;
 
         case 't':
@@ -705,7 +697,6 @@ int main_index(int argc, char** argv) {
     if (!rocksdb_name.empty()) {
 
         Index index;
-        index.use_snappy = use_snappy;
 
         if (compact) {
             index.open_for_write(rocksdb_name);
@@ -734,7 +725,7 @@ int main_index(int argc, char** argv) {
         }
 
         if (store_node_alignments && file_names.size() > 0) {
-            index.open_for_write(rocksdb_name);
+            index.open_for_bulk_load(rocksdb_name);
             int64_t aln_idx = 0;
             function<void(Alignment&)> lambda = [&index,&aln_idx](Alignment& aln) {
                 index.cross_alignment(aln_idx++, aln);
@@ -749,13 +740,13 @@ int main_index(int argc, char** argv) {
         }
 
         if (store_alignments && file_names.size() > 0) {
-            index.open_for_write(rocksdb_name);
+            index.open_for_bulk_load(rocksdb_name);
             function<void(Alignment&)> lambda = [&index](Alignment& aln) {
                 index.put_alignment(aln);
             };
             for (auto& file_name : file_names) {
                 get_input_file(file_name, [&](istream& in) {
-                    stream::for_each(in, lambda);
+                    stream::for_each_parallel(in, lambda);
                 });
             }
             index.flush();
@@ -775,7 +766,7 @@ int main_index(int argc, char** argv) {
         }
 
         if (store_mappings && file_names.size() > 0) {
-            index.open_for_write(rocksdb_name);
+            index.open_for_bulk_load(rocksdb_name);
             function<void(Alignment&)> lambda = [&index](Alignment& aln) {
                 const Path& path = aln.path();
                 for (int i = 0; i < path.mapping_size(); ++i) {
@@ -784,7 +775,7 @@ int main_index(int argc, char** argv) {
             };
             for (auto& file_name : file_names) {
                 get_input_file(file_name, [&](istream& in) {
-                    stream::for_each(in, lambda);
+                    stream::for_each_parallel(in, lambda);
                 });
             }
             index.flush();

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="en_US.utf8" # force ekg's favorite sort order 
 
-plan tests 41
+plan tests 42
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 
@@ -55,6 +55,11 @@ vg index -x x.xg x.vg
 vg map -r <(vg sim -s 1337 -n 100 -x x.xg) -d x.idx | vg index -a - -d x.vg.aln
 is $(vg index -D -d x.vg.aln | wc -l) 100 "index can store alignments"
 is $(vg index -A -d x.vg.aln | vg view -a - | wc -l) 100 "index can dump alignments"
+
+# repeat with an unmapped read (sequence from phiX)
+rm -rf x.vg.aln
+(vg map -s "CTGATGAGGCCGCCCCTAGTTTTGTTTCTGGTGCTATGGCTAAAGCTGGTAAAGGACTTC" -d x.idx; vg map -r <(vg sim -s 1337 -n 100 -x x.xg) -d x.idx) | vg index -a - -d x.vg.aln
+is $(vg index -D -d x.vg.aln | wc -l) 100 "FIXME: alignment index does NOT store unmapped reads!"
 
 vg map -r <(vg sim -s 1337 -n 100 -x x.xg) -d x.idx | vg index -m - -d x.vg.map
 is $(vg index -D -d x.vg.map | wc -l) 1476 "index stores all mappings"


### PR DESCRIPTION
* Make `vg index --store-alignments` efficient enough for WGS GAMs by wandering through the [RocksDB options jungle](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide) to tune buffer sizes, concurrency, and write amplification.
* We no longer perform a total compaction of the RocksDB database upon initial completion of the load. The tradeoff is more work to do during subsequent reads from the index, as RocksDB needs to search within a number of sorted tables instead of just one. We do however keep this number small using background compactions while the load is running, so the practical impact should be minimal compared to the frustration of waiting for the single-threaded total compaction (which can still be done using `vg index --compact`).
* `vg index --store-alignments` would crash on any 'unmapped' read. For now I've avoided the crash by making it ignore/discard such reads and printing a warning (as a temporary FIXME measure). As a next step, we should decide how these should be keyed in the database.

This is a start- lots more to do!