### PR TITLE
Add vg map option to be stricter about alignment pairs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6057,11 +6057,11 @@ int main_map(int argc, char** argv) {
                  &max_mem_length,
                  &band_width,
                  &pair_window,
-                 &only_top_pairs,
+                 &top_pairs_only,
                  &output_func](Alignment& aln1, Alignment& aln2) {
                 auto our_mapper = mapper[omp_get_thread_num()];
                 bool queued_resolve_later = false;
-                auto alnp = our_mapper->align_paired_multi(aln1, aln2, queued_resolve_later, kmer_size, kmer_stride, max_mem_length, band_width, pair_window, only_top_pairs);
+                auto alnp = our_mapper->align_paired_multi(aln1, aln2, queued_resolve_later, kmer_size, kmer_stride, max_mem_length, band_width, pair_window, top_pairs_only);
                 if (!queued_resolve_later) {
                     output_func(aln1, aln2, alnp);
                     // check if we should try to align the queued alignments
@@ -6073,7 +6073,7 @@ int main_map(int argc, char** argv) {
                                                                        queued_resolve_later, kmer_size,
                                                                        kmer_stride, max_mem_length,
                                                                        band_width, pair_window,
-                                                                       only_top_pairs);
+                                                                       top_pairs_only);
                             output_func(p.first, p.second, alnp);
                         }
                         our_mapper->imperfect_pairs_to_retry.clear();
@@ -6092,7 +6092,7 @@ int main_map(int argc, char** argv) {
                                                                queued_resolve_later, kmer_size,
                                                                kmer_stride, max_mem_length,
                                                                band_width, pair_window,
-                                                               only_top_pairs);
+                                                               top_pairs_only);
                     output_func(p.first, p.second, alnp);
                 }
                 our_mapper->imperfect_pairs_to_retry.clear();
@@ -6140,11 +6140,11 @@ int main_map(int argc, char** argv) {
                  &max_mem_length,
                  &band_width,
                  &pair_window,
-                 &only_top_pairs,
+                 &top_pairs_only,
                  &output_func](Alignment& aln1, Alignment& aln2) {
                 auto our_mapper = mapper[omp_get_thread_num()];
                 bool queued_resolve_later = false;
-                auto alnp = our_mapper->align_paired_multi(aln1, aln2, queued_resolve_later, kmer_size, kmer_stride, max_mem_length, band_width, pair_window, only_top_pairs);
+                auto alnp = our_mapper->align_paired_multi(aln1, aln2, queued_resolve_later, kmer_size, kmer_stride, max_mem_length, band_width, pair_window, top_pairs_only);
                 if (!queued_resolve_later) {
                     output_func(aln1, aln2, alnp);
                     // check if we should try to align the queued alignments
@@ -6156,7 +6156,7 @@ int main_map(int argc, char** argv) {
                                                                        queued_resolve_later, kmer_size,
                                                                        kmer_stride, max_mem_length,
                                                                        band_width, pair_window,
-                                                                       only_top_pairs);
+                                                                       top_pairs_only);
                             output_func(p.first, p.second, alnp);
                         }
                         our_mapper->imperfect_pairs_to_retry.clear();
@@ -6174,7 +6174,7 @@ int main_map(int argc, char** argv) {
                                                                queued_resolve_later, kmer_size,
                                                                kmer_stride, max_mem_length,
                                                                band_width, pair_window,
-                                                               only_top_pairs);
+                                                               top_pairs_only);
                     output_func(p.first, p.second, alnp);
                 }
                 our_mapper->imperfect_pairs_to_retry.clear();
@@ -6212,11 +6212,11 @@ int main_map(int argc, char** argv) {
                  &band_width,
                  &compare_gam,
                  &pair_window,
-                 &only_top_pairs,
+                 &top_pairs_only,
                  &output_func](Alignment& aln1, Alignment& aln2) {
                 auto our_mapper = mapper[omp_get_thread_num()];
                 bool queued_resolve_later = false;
-                auto alnp = our_mapper->align_paired_multi(aln1, aln2, queued_resolve_later, kmer_size, kmer_stride, max_mem_length, band_width, pair_window, only_top_pairs);
+                auto alnp = our_mapper->align_paired_multi(aln1, aln2, queued_resolve_later, kmer_size, kmer_stride, max_mem_length, band_width, pair_window, top_pairs_only);
                 if (!queued_resolve_later) {
                     output_func(aln1, aln2, alnp);
                     // check if we should try to align the queued alignments
@@ -6228,7 +6228,7 @@ int main_map(int argc, char** argv) {
                                                                        queued_resolve_later, kmer_size,
                                                                        kmer_stride, max_mem_length,
                                                                        band_width, pair_window,
-                                                                       only_top_pairs);
+                                                                       top_pairs_only);
                             output_func(p.first, p.second, alnp);
                         }
                         our_mapper->imperfect_pairs_to_retry.clear();
@@ -6246,7 +6246,7 @@ int main_map(int argc, char** argv) {
                                                                queued_resolve_later, kmer_size,
                                                                kmer_stride, max_mem_length,
                                                                band_width, pair_window,
-                                                               only_top_pairs);
+                                                               top_pairs_only);
                     output_func(p.first, p.second, alnp);
                 }
                 our_mapper->imperfect_pairs_to_retry.clear();

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -373,7 +373,8 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
     int stride,
     int max_mem_length,
     int band_width,
-    int pair_window) {
+    int pair_window,
+    bool only_top_scoring_pair) {
 
     // We have some logic around align_mate_in_window to handle orientation
     // Since we now support reversing edges, we have to at least try opposing orientations for the reads.
@@ -698,6 +699,14 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
             consistent_pairs.second[i].mutable_fragment_prev()->set_name(read1.name());
             consistent_pairs.second[i].set_is_secondary(i > 0);
         }
+
+        // zap everything unless the primary alignments are individually top-scoring
+        if (only_top_scoring_pair && consistent_pairs.first.size() && 
+            (consistent_pairs.first[0].score() < alignments1[0].score() ||
+             consistent_pairs.second[0].score() < alignments2[0].score())) {
+            consistent_pairs.first.clear();
+            consistent_pairs.second.clear();
+        }        
 
         if (!consistent_pairs.first.empty()) {
             results = consistent_pairs;

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -266,6 +266,8 @@ public:
     // Alignments at corresponding positions in the two vectors may or may not
     // be corresponding paired alignments. If a read does not map, its vector
     // will be empty.
+    // If only_top_scoring_pair is set, then the vectors will be empty unless
+    // the primary pair of alignments each have top scores individually as well. 
     pair<vector<Alignment>, vector<Alignment>> 
         align_paired_multi(const Alignment& read1,
                            const Alignment& read2,
@@ -274,7 +276,8 @@ public:
                            int stride = 0,
                            int max_mem_length = 0,
                            int band_width = 1000,
-                           int pair_window = 64);
+                           int pair_window = 64,
+                           bool only_top_scoring_pair = false);
     
     // Paired-end alignment ignoring multi-mapping. Returns either the two
     // highest-scoring reads if no rescue was required, or the highest-scoring


### PR DESCRIPTION
Specifically, this new option (-O), will only report a paired alignment if both read-alignments of the primary pair are also individually top-scoring for their respective reads.  

vg filter (pre-parallelization) used to do something similar by filtering any primary mapping with a higher-scoring secondary mapping.  This logic noticeably helped whole-genome calling results.  The new option here makes a bit more sense in that it treats both fragments together when filtering, so hopefully it helps at least as much.     

@mlin I added this (but using -a instead of -O) to my freeze-with-parallel-filter branch here https://github.com/glennhickey/vg/commit/70200fab8d69c960eff05367df86389588fecd82