### PR TITLE
Improve gPBWT construction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ $(OBJ_DIR)/caller.o: $(SRC_DIR)/caller.cpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/vg.h
 $(OBJ_DIR)/call2vcf.o: $(SRC_DIR)/call2vcf.cpp $(SRC_DIR)/caller.hpp $(DEPS)
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
-$(OBJ_DIR)/genotyper.o: $(SRC_DIR)/genotyper.cpp $(SRC_DIR)/genotyper.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(INC_DIR)/stream.hpp $(SRC_DIR)/json2pb.h $(DEPS) $(INC_DIR)/sparsehash/sparse_hash_map $(SRC_DIR)/bubbles.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/utility.hpp
+$(OBJ_DIR)/genotyper.o: $(SRC_DIR)/genotyper.cpp $(SRC_DIR)/genotyper.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/pathindex.hpp $(SRC_DIR)/json2pb.h $(DEPS) $(INC_DIR)/sparsehash/sparse_hash_map $(SRC_DIR)/bubbles.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/utility.hpp
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $(SRC_DIR)/genotyper.cpp $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
 $(OBJ_DIR)/genotypekit.o: $(SRC_DIR)/genotypekit.cpp $(SRC_DIR)/genotypekit.hpp $(DEPS) $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/utility.hpp

--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ $(OBJ_DIR)/bubbles.o: $(SRC_DIR)/bubbles.cpp $(SRC_DIR)/bubbles.hpp $(DEPS)
 $(OBJ_DIR)/translator.o: $(SRC_DIR)/translator.cpp $(SRC_DIR)/translator.hpp $(DEPS)
 	+$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
-$(OBJ_DIR)/constructor.o: $(SRC_DIR)/constructor.cpp $(SRC_DIR)/constructor.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(DEPS)
+$(OBJ_DIR)/constructor.o: $(SRC_DIR)/constructor.cpp $(SRC_DIR)/constructor.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/utility.hpp $(DEPS)
 	+$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
 # We also build the main file from xg, so we can offer it as a command

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ROCKSDB_LDFLAGS = $(shell grep PLATFORM_LDFLAGS deps/rocksdb/make_config.mk | cu
 STATIC_FLAGS=-static -static-libstdc++ -static-libgcc
 
 # These are put into libvg.
-OBJ:=$(OBJ_DIR)/gssw_aligner.o $(OBJ_DIR)/vg.o cpp/vg.pb.o $(OBJ_DIR)/index.o $(OBJ_DIR)/mapper.o $(OBJ_DIR)/region.o $(OBJ_DIR)/progress_bar.o $(OBJ_DIR)/vg_set.o $(OBJ_DIR)/utility.o $(OBJ_DIR)/path.o $(OBJ_DIR)/alignment.o $(OBJ_DIR)/edit.o $(OBJ_DIR)/sha1.o $(OBJ_DIR)/json2pb.o $(OBJ_DIR)/entropy.o $(OBJ_DIR)/pileup.o $(OBJ_DIR)/caller.o $(OBJ_DIR)/call2vcf.o $(OBJ_DIR)/genotyper.o $(OBJ_DIR)/genotypekit.o $(OBJ_DIR)/position.o $(OBJ_DIR)/deconstructor.o $(OBJ_DIR)/vectorizer.o $(OBJ_DIR)/sampler.o $(OBJ_DIR)/filter.o $(OBJ_DIR)/readfilter.o $(OBJ_DIR)/ssw_aligner.o $(OBJ_DIR)/bubbles.o $(OBJ_DIR)/translator.o $(OBJ_DIR)/version.o $(OBJ_DIR)/banded_global_aligner.o $(OBJ_DIR)/multipath_alignment.o $(OBJ_DIR)/phased_genome.o  $(OBJ_DIR)/constructor.o $(OBJ_DIR)/progressive.o $(OBJ_DIR)/flow_sort.o
+OBJ:=$(OBJ_DIR)/gssw_aligner.o $(OBJ_DIR)/vg.o cpp/vg.pb.o $(OBJ_DIR)/index.o $(OBJ_DIR)/mapper.o $(OBJ_DIR)/region.o $(OBJ_DIR)/progress_bar.o $(OBJ_DIR)/vg_set.o $(OBJ_DIR)/utility.o $(OBJ_DIR)/path.o $(OBJ_DIR)/alignment.o $(OBJ_DIR)/edit.o $(OBJ_DIR)/sha1.o $(OBJ_DIR)/json2pb.o $(OBJ_DIR)/entropy.o $(OBJ_DIR)/pileup.o $(OBJ_DIR)/caller.o $(OBJ_DIR)/call2vcf.o $(OBJ_DIR)/genotyper.o $(OBJ_DIR)/genotypekit.o $(OBJ_DIR)/position.o $(OBJ_DIR)/deconstructor.o $(OBJ_DIR)/vectorizer.o $(OBJ_DIR)/sampler.o $(OBJ_DIR)/filter.o $(OBJ_DIR)/readfilter.o $(OBJ_DIR)/ssw_aligner.o $(OBJ_DIR)/bubbles.o $(OBJ_DIR)/translator.o $(OBJ_DIR)/version.o $(OBJ_DIR)/banded_global_aligner.o $(OBJ_DIR)/multipath_alignment.o $(OBJ_DIR)/phased_genome.o  $(OBJ_DIR)/constructor.o $(OBJ_DIR)/progressive.o $(OBJ_DIR)/flow_sort.o $(OBJ_DIR)/pathindex.o
 
 # These aren't put into libvg. But they do go into the main vg binary to power its self-test.
 UNITTEST_OBJ:=$(UNITTEST_OBJ_DIR)/driver.o $(UNITTEST_OBJ_DIR)/distributions.o $(UNITTEST_OBJ_DIR)/genotypekit.o $(UNITTEST_OBJ_DIR)/readfilter.o $(UNITTEST_OBJ_DIR)/banded_global_aligner.o $(UNITTEST_OBJ_DIR)/pinned_alignment.o $(UNITTEST_OBJ_DIR)/vg.o $(UNITTEST_OBJ_DIR)/multipath_alignment.o $(UNITTEST_OBJ_DIR)/phased_genome.o $(UNITTEST_OBJ_DIR)/constructor.o $(UNITTEST_OBJ_DIR)/flow_sort_test.o
@@ -158,7 +158,7 @@ $(OBJ_DIR)/Fasta.o:
 $(LIB_DIR)/libhts.a:
 	+cd $(HTSLIB_DIR) && $(MAKE) lib-static && mv libhts.a $(CWD)/$(LIB_DIR) && cp *.h $(CWD)/$(INC_DIR) && cp -r htslib $(CWD)/$(INC_DIR)/
 
-$(LIB_DIR)/libxg.a: $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libprotobuf.a $(CPP_DIR)/vg.pb.o $(INC_DIR)/dynamic.hpp $(XG_DIR)/src/xg.cpp $(INC_DIR)/sparsehash/sparse_hash_map
+$(LIB_DIR)/libxg.a: $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libprotobuf.a $(CPP_DIR)/vg.pb.o $(INC_DIR)/dynamic.hpp $(XG_DIR)/src/xg.cpp $(XG_DIR)/src/xg.hpp $(INC_DIR)/sparsehash/sparse_hash_map
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c $(XG_DIR)/src/xg.cpp -o $(CWD)/$(OBJ_DIR)/xg.o $(LD_INCLUDE_FLAGS) -I$(INC_DIR)/dynamic && ar rs $(CWD)/$(LIB_DIR)/libxg.a $(CWD)/$(OBJ_DIR)/xg.o $(CWD)/$(CPP_DIR)/vg.pb.o && cp $(XG_DIR)/src/*.hpp $(CWD)/$(INC_DIR)/
 
 $(LIB_DIR)/libvcflib.a: $(VCFLIB_DIR)/src/*.cpp $(VCFLIB_DIR)/src/*.hpp $(VCFLIB_DIR)/intervaltree/*.cpp $(VCFLIB_DIR)/intervaltree/*.h
@@ -295,6 +295,9 @@ $(OBJ_DIR)/version.o: $(SRC_DIR)/version.cpp $(SRC_DIR)/version.hpp $(INC_DIR)/v
 
 $(OBJ_DIR)/progressive.o: $(SRC_DIR)/progressive.cpp $(SRC_DIR)/progressive.hpp $(DEPS)
 	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
+	
+$(OBJ_DIR)/pathindex.o: $(SRC_DIR)/pathindex.cpp $(SRC_DIR)/pathindex.hpp $(DEPS)
+	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
 ## TODO vcflib build loses variant.h
 $(OBJ_DIR)/deconstructor.o: $(SRC_DIR)/deconstructor.cpp $(SRC_DIR)/deconstructor.hpp $(LIB_DIR)/libvcfh.a $(SRC_DIR)/bubbles.hpp $(DEPS)
@@ -386,7 +389,7 @@ $(SUBCOMMAND_OBJ_DIR)/construct.o: $(SUBCOMMAND_SRC_DIR)/construct.cpp $(SUBCOMM
 $(SUBCOMMAND_OBJ_DIR)/simplify.o: $(SUBCOMMAND_SRC_DIR)/simplify.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/utility.hpp $(DEPS)
 	 +$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
-$(SUBCOMMAND_OBJ_DIR)/index.o: $(SUBCOMMAND_SRC_DIR)/index.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/index.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/vg_set.hpp $(SRC_DIR)/utility.hpp $(DEPS)
+$(SUBCOMMAND_OBJ_DIR)/index.o: $(SUBCOMMAND_SRC_DIR)/index.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/index.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/vg_set.hpp $(SRC_DIR)/utility.hpp $(SRC_DIR)/pathindex.hpp $(DEPS)
 	 +$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 	 
 $(SUBCOMMAND_OBJ_DIR)/mod.o: $(SUBCOMMAND_SRC_DIR)/mod.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/utility.hpp $(DEPS)

--- a/src/constructor.hpp
+++ b/src/constructor.hpp
@@ -250,14 +250,33 @@ public:
     
 protected:
     
-    // This map maps from VCF sequence names to FASTA sequence names. If a
-    // VCF sequence name doesn't appear in here, it gets passed through
-    // unchanged. Note that the primary path for each contig will be named after
-    // the FASTA sequence name and not the VCF sequence name.
+    /// This map maps from VCF sequence names to FASTA sequence names. If a
+    /// VCF sequence name doesn't appear in here, it gets passed through
+    /// unchanged. Note that the primary path for each contig will be named after
+    /// the FASTA sequence name and not the VCF sequence name.
     map<string, string> vcf_to_fasta_renames;
     
-    // This is the reverse map from FASTA sequence name to VCF sequence name.
+    /// This is the reverse map from FASTA sequence name to VCF sequence name.
     map<string, string> fasta_to_vcf_renames;
+    
+private:
+
+    /**
+     * Given a list of VariantAllele edits, trim in from the left and right,
+     * leaving a core of edits bounded by edits that actually change the
+     * reference.
+     */
+    static void trim_to_variable(list<vcflib::VariantAllele>& parsed_allele); 
+
+    /**
+     * Given a vector of lists of VariantAllele edits that have been trimmed
+     * with trim_to_variable() above, one per non-reference alt for a variant,
+     * return the position of the first varaible base, and the position of the
+     * last variable base. If there's no variable-region, the result is max
+     * int64_t and -1, and if there's a 0-length variable region, the result is
+     * the base after it and the base before it.
+     */
+    static pair<int64_t, int64_t> get_bounds(const vector<list<vcflib::VariantAllele>>& trimmed_variant);
     
 
 };

--- a/src/constructor.hpp
+++ b/src/constructor.hpp
@@ -262,11 +262,20 @@ protected:
 private:
 
     /**
-     * Given a list of VariantAllele edits, trim in from the left and right,
-     * leaving a core of edits bounded by edits that actually change the
-     * reference.
+     * Given a vector of lists of VariantAllele edits, trim in from the left and
+     * right, leaving a core of edits bounded by edits that actually change the
+     * reference in at least one allele.
+     *
+     * Postcondition: either all lists of VariantAlleles are empty, or at least
+     * one begins with a non-match and at least one ends with a non-match.
      */
-    static void trim_to_variable(list<vcflib::VariantAllele>& parsed_allele); 
+    static void trim_to_variable(vector<list<vcflib::VariantAllele>>& parsed_alleles);
+    
+    /**
+     * Given a list of VariantAllele edits, condense adjacent perfect match
+     * edits to be maximally long.
+     */
+    static void condense_edits(list<vcflib::VariantAllele>& parsed_allele); 
 
     /**
      * Given a vector of lists of VariantAllele edits that have been trimmed

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -17,32 +17,11 @@
 #include "utility.hpp"
 #include "types.hpp"
 #include "genotypekit.hpp"
+#include "pathindex.hpp"
 
 namespace vg {
 
 using namespace std;
-
-/**
- * Holds indexes of the reference in a graph: position to node, node to position
- * and orientation, and the full reference string.
- */
-struct ReferenceIndex {
-    // Index from node ID to first position on the reference string and
-    // orientation it occurs there.
-    std::map<int64_t, std::pair<size_t, bool>> byId;
-    
-    // Index from start position on the reference to the oriented node that
-    // begins there.  Some nodes may be backward (orientation true) at their
-    // canonical reference positions. In this case, the last base of the node
-    // occurs at the given position.
-    std::map<size_t, vg::NodeTraversal> byStart;
-    
-    // The actual sequence of the reference.
-    std::string sequence;
-    
-    // Make a ReferenceIndex from a path in a graph
-    ReferenceIndex(VG& vg, string refPathName);
-};
 
 /**
  * Class to hold on to genotyping parameters and genotyping functions.
@@ -293,7 +272,7 @@ public:
      * Sometimes if we can't make a variant for the superbubble against the
      * reference path, we'll emit 0 variants.
      */
-    vector<vcflib::Variant> locus_to_variant(VG& graph, const Site& site, const ReferenceIndex& index, vcflib::VariantCallFile& vcf, const Locus& locus,
+    vector<vcflib::Variant> locus_to_variant(VG& graph, const Site& site, const PathIndex& index, vcflib::VariantCallFile& vcf, const Locus& locus,
         const string& sample_name = "SAMPLE");
     
     /**
@@ -304,7 +283,7 @@ public:
     /**
      * Start VCF output to a stream. Returns a VCFlib VariantCallFile that needs to be deleted.
      */
-    vcflib::VariantCallFile* start_vcf(std::ostream& stream, const ReferenceIndex& index, const string& sample_name, const string& contig_name, size_t contig_size);
+    vcflib::VariantCallFile* start_vcf(std::ostream& stream, const PathIndex& index, const string& sample_name, const string& contig_name, size_t contig_size);
     
     /**
      * Utility function for getting the reference bounds (start and past-end) of
@@ -313,14 +292,14 @@ public:
      * returns whether the reference path goes through the site forwards (false)
      * or backwards (true).
      */
-    pair<pair<int64_t, int64_t>, bool> get_site_reference_bounds(const Site& site, const ReferenceIndex& index);
+    pair<pair<int64_t, int64_t>, bool> get_site_reference_bounds(const Site& site, const PathIndex& index);
     
     /**
      * Tell the statistics tracking code that a site exists. We can do things
      * like count up the site length in the reference and so on. Called only
      * once per site, but may be called on multiple threads simultaneously.
      */
-    void report_site(const Site& site, const ReferenceIndex* index = nullptr);
+    void report_site(const Site& site, const PathIndex* index = nullptr);
     
     /**
      * Tell the statistics tracking code that a read traverses a site

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2340,7 +2340,9 @@ int main_msga(int argc, char** argv) {
         build_graph(strings[base_seq_name], base_seq_name);
     }
 
-    //cerr << "path going in " << pb2json(graph->graph.path(0)) << endl;
+#ifdef debug
+    cerr << "path going in " << pb2json(graph->graph.path(0)) << endl;
+#endif
 
     // questions:
     // should we preferentially use sequences from fasta files in the order they were given?
@@ -2353,18 +2355,19 @@ int main_msga(int argc, char** argv) {
     size_t iter = 0;
 
     auto rebuild = [&](VG* graph) {
-        //stringstream s; s << iter++ << ".vg";
-        graph->sort();
-        graph->sync_paths();
-        graph->rebuild_indexes();
         if (mapper) delete mapper;
         if (xgidx) delete xgidx;
         if (gcsaidx) delete gcsaidx;
         if (lcpidx) delete lcpidx;
+    
+        //stringstream s; s << iter++ << ".vg";
+        graph->sort();
+        graph->sync_paths();
+        graph->graph.clear_path();
+        graph->paths.to_graph(graph->graph);
+        graph->rebuild_indexes();
 
         if (debug) cerr << "building xg index" << endl;
-        graph->sync_paths();
-        graph->paths.to_graph(graph->graph);
         xgidx = new xg::XG(graph->graph);
 
         if (debug) cerr << "building GCSA2 index" << endl;

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -65,6 +65,7 @@ public:
     // (which can then be used to get the list its iterator belongs to).
     map<Mapping*, string> mapping_path;
     void sort_by_mapping_rank(void);
+    /// Reassign ranks and rebuild indexes, treating the mapping lists in _paths as the truth.
     void rebuild_mapping_aux(void);
     // We need this in order to make sure we aren't adding duplicate mappings
     // with the same rank in the same path. Maps from path name and rank to
@@ -84,7 +85,6 @@ public:
     void make_linear(const string& name);
     
     void rebuild_node_mapping(void);
-    //void sync_paths_with_mapping_lists(void);
     
     // Find the given mapping in its path, so mappings can be inserted before
     // it.
@@ -162,6 +162,7 @@ public:
     //void add_node_mapping(Node* n);
     void load(istream& in);
     void write(ostream& out);
+    /// Add all paths into the given Protobuf graph. Creates a new path for every path.
     void to_graph(Graph& g);
     // get a path
     Path path(const string& name);

--- a/src/pathindex.cpp
+++ b/src/pathindex.cpp
@@ -1,0 +1,288 @@
+#include "pathindex.hpp"
+
+namespace vg {
+
+PathIndex::PathIndex(const Path& path) {
+    // Just trace the path, which we assume has mapping lengths filled in.
+    
+    // What base are we at in the path?
+    size_t path_base = 0;
+    
+    // What was the last rank? Ranks must always go up.
+    int64_t last_rank = -1;
+    
+    for (size_t i = 0; i < path.mapping_size(); i++) {
+        // For every mapping
+        auto& mapping = path.mapping(i);
+    
+        if (!by_id.count(mapping.position().node_id())) {
+            // This is the first time we have visited this node in the path.
+            
+            // Add in a mapping.
+            by_id[mapping.position().node_id()] = 
+                std::make_pair(path_base, mapping.position().is_reverse());
+        }
+        
+        // Say that this node appears here along the reference in this
+        // orientation.
+        by_start[path_base] = NodeSide(mapping.position().node_id(), mapping.position().is_reverse());
+        
+        // Just advance and don't grab sequence.
+        path_base +=mapping_from_length(mapping);
+    }
+
+#ifdef debug    
+    // Announce progress.
+    #pragma omp critical (cerr)
+    std::cerr << "Traced " << path_base << " bp path of " << path.mapping_size() << " mappings." << std::endl;
+#endif
+    
+}
+
+PathIndex::PathIndex(const Path& path, VG& vg) {
+    // Trace the given path in the given VG graph, collecting sequence
+    
+    // We're going to build the sequence string
+    std::stringstream seq_stream;
+    
+    // What base are we at in the path?
+    size_t path_base = 0;
+    
+    // What was the last rank? Ranks must always go up.
+    int64_t last_rank = -1;
+    
+    for (size_t i = 0; i < path.mapping_size(); i++) {
+        auto& mapping = path.mapping(i);
+    
+        if (!by_id.count(mapping.position().node_id())) {
+            // This is the first time we have visited this node in the path.
+            
+            // Add in a mapping.
+            by_id[mapping.position().node_id()] = 
+                std::make_pair(path_base, mapping.position().is_reverse());
+#ifdef debug
+            #pragma omp critical (cerr)
+            std::cerr << "Node " << mapping.position().node_id() << " rank " << mapping.rank()
+                << " starts at base " << path_base << " with "
+                << vg.get_node(mapping.position().node_id())->sequence() << std::endl;
+#endif
+            
+            // Make sure ranks are monotonically increasing along the path.
+            assert(mapping.rank() > last_rank);
+            last_rank = mapping.rank();
+        }
+        
+        // Say that this node appears here along the reference in this
+        // orientation.
+        by_start[path_base] = NodeSide(mapping.position().node_id(), mapping.position().is_reverse());
+    
+    
+        // Find the node's sequence
+        std::string node_sequence = vg.get_node(mapping.position().node_id())->sequence();
+    
+        while(path_base == 0 && node_sequence.size() > 0 &&
+            (node_sequence[0] != 'A' && node_sequence[0] != 'T' && node_sequence[0] != 'C' &&
+            node_sequence[0] != 'G' && node_sequence[0] != 'N')) {
+            
+            // If the path leads with invalid characters (like "X"), throw them
+            // out when computing path positions.
+            
+            // TODO: this is a hack to deal with the debruijn-brca1-k63 graph,
+            // which leads with an X.
+            #pragma omp critical (cerr)
+            std::cerr << "Warning: dropping invalid leading character "
+                << node_sequence[0] << " from node " << mapping.position().node_id()
+                << std::endl;
+                
+            node_sequence.erase(node_sequence.begin());
+        }
+        
+        if (mapping.position().is_reverse()) {
+            // Put the reverse sequence in the path
+            seq_stream << reverse_complement(node_sequence);
+        } else {
+            // Put the forward sequence in the path
+            seq_stream << node_sequence;
+        }
+        
+        // Whether we found the right place for this node in the reference or
+        // not, we still need to advance along the reference path. We assume the
+        // whole node (except any leading bogus characters) is included in the
+        // path (since it sort of has to be, syntactically, unless it's the
+        // first or last node).
+        path_base += node_sequence.size();
+        
+        // TODO: handle leading bogus characters in calls on the first node.
+    }
+    
+    // Create the actual reference sequence we will use
+    sequence = seq_stream.str();
+    
+#ifdef debug
+    // Announce progress.
+    #pragma omp critical (cerr)
+    std::cerr << "Traced " << path_base << " bp path." << std::endl;
+    
+    if (sequence.size() < 100) {
+        #pragma omp critical (cerr)
+        std::cerr << "Sequence: " << sequence << std::endl;
+    }
+#endif
+    
+}
+
+PathIndex::PathIndex(const Path& path, const xg::XG& index) {
+    // Trace the given path in the given XG graph, collecting sequence
+    
+    // We're going to build the sequence string
+    std::stringstream seq_stream;
+    
+    // What base are we at in the path?
+    size_t path_base = 0;
+    
+    // What was the last rank? Ranks must always go up.
+    int64_t last_rank = -1;
+    
+    for (size_t i = 0; i < path.mapping_size(); i++) {
+        auto& mapping = path.mapping(i);
+    
+        if (!by_id.count(mapping.position().node_id())) {
+            // This is the first time we have visited this node in the path.
+            
+            // Add in a mapping.
+            by_id[mapping.position().node_id()] = 
+                std::make_pair(path_base, mapping.position().is_reverse());
+#ifdef debug
+            #pragma omp critical (cerr)
+            std::cerr << "Node " << mapping.position().node_id() << " rank " << mapping.rank()
+                << " starts at base " << path_base << " with "
+                << index.node_sequence(mapping.position().node_id()) << std::endl;
+#endif
+            
+            // Make sure ranks are monotonically increasing along the path.
+            assert(mapping.rank() > last_rank);
+            last_rank = mapping.rank();
+        }
+        
+        // Say that this node appears here along the reference in this
+        // orientation.
+        by_start[path_base] = NodeSide(mapping.position().node_id(), mapping.position().is_reverse());
+    
+    
+        // Find the node's sequence
+        std::string node_sequence = index.node_sequence(mapping.position().node_id());
+    
+        while(path_base == 0 && node_sequence.size() > 0 &&
+            (node_sequence[0] != 'A' && node_sequence[0] != 'T' && node_sequence[0] != 'C' &&
+            node_sequence[0] != 'G' && node_sequence[0] != 'N')) {
+            
+            // If the path leads with invalid characters (like "X"), throw them
+            // out when computing path positions.
+            
+            // TODO: this is a hack to deal with the debruijn-brca1-k63 graph,
+            // which leads with an X.
+            #pragma omp critical (cerr)
+            std::cerr << "Warning: dropping invalid leading character "
+                << node_sequence[0] << " from node " << mapping.position().node_id()
+                << std::endl;
+                
+            node_sequence.erase(node_sequence.begin());
+        }
+        
+        if (mapping.position().is_reverse()) {
+            // Put the reverse sequence in the path
+            seq_stream << reverse_complement(node_sequence);
+        } else {
+            // Put the forward sequence in the path
+            seq_stream << node_sequence;
+        }
+        
+        // Whether we found the right place for this node in the reference or
+        // not, we still need to advance along the reference path. We assume the
+        // whole node (except any leading bogus characters) is included in the
+        // path (since it sort of has to be, syntactically, unless it's the
+        // first or last node).
+        path_base += node_sequence.size();
+        
+        // TODO: handle leading bogus characters in calls on the first node.
+    }
+    
+    // Create the actual reference sequence we will use
+    sequence = seq_stream.str();
+    
+#ifdef debug
+    // Announce progress.
+    #pragma omp critical (cerr)
+    std::cerr << "Traced " << path_base << " bp path." << std::endl;
+    
+    if (sequence.size() < 100) {
+        #pragma omp critical (cerr)
+        std::cerr << "Sequence: " << sequence << std::endl;
+    }
+#endif
+
+}
+
+PathIndex::PathIndex(VG& vg, const string& path_name, bool extract_sequence) {
+    // Make sure the path is present
+    assert(vg.paths.has_path(path_name));
+    
+    if (extract_sequence) {
+        // Constructor dispatch hack
+        *this = PathIndex(vg.paths.path(path_name), vg);
+    } else {
+        *this = PathIndex(vg.paths.path(path_name));
+    }
+}
+
+PathIndex::PathIndex(const xg::XG& index, const string& path_name, bool extract_sequence) {
+    // Make sure the path is present
+    assert(index.path_rank(path_name) != 0);
+    
+    if (extract_sequence) {
+        // Constructor dispatch hack
+        *this = PathIndex(index.path(path_name), index);
+    } else {
+        *this = PathIndex(index.path(path_name));
+    }
+}
+
+NodeSide PathIndex::at_position(size_t position) {
+    assert(!by_start.empty());
+    
+    // Look up the iterator to whatever starts after here
+    auto starts_next = by_start.upper_bound(position);
+    
+    // This can't work if we try to look before the first node.
+    assert(starts_next != by_start.begin());
+    
+    // Walk one back, to the node that has to own the position we asked about.
+    starts_next--;
+    
+#ifdef debug
+    cerr << "At " << position << " we have " << starts_next->second << endl;
+#endif
+    
+    // Return that
+    return starts_next->second;
+}
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/pathindex.hpp
+++ b/src/pathindex.hpp
@@ -20,7 +20,8 @@ namespace vg {
 
 /**
  * Holds indexes of the reference in a graph: position to node, node to position
- * and orientation, and the full reference string.
+ * and orientation, and the full reference string. Also knows about the lengths
+ * of nodes on the path, and lets you iterate back and forth over it.
  */
 struct PathIndex {
     /// Index from node ID to first position on the reference string and
@@ -31,6 +32,10 @@ struct PathIndex {
     /// begins there. If it is a right side, the node occurs on the path in a
     /// reverse orientation.
     std::map<size_t, vg::NodeSide> by_start;
+    
+    /// This, combined with by_start, gets us the length of every node on the
+    /// indexed path.
+    size_t last_node_length;
     
     /// The actual sequence of the path, if desired.
     std::string sequence;
@@ -50,8 +55,25 @@ struct PathIndex {
     /// Make a PathIndex from a path in an indexed graph
     PathIndex(const xg::XG& index, const string& ref_path_name, bool extract_sequence = false);
     
-    // Find what node and orientation covers a position
-    NodeSide at_position(size_t position);
+    /// Find what node and orientation covers a position. The position must not
+    /// be greater than the path length.
+    NodeSide at_position(size_t position) const;
+    
+    /// We keep iterators to node occurrences along the ref path.
+    using iterator = std::map<size_t, vg::NodeSide>::const_iterator;
+    
+    /// Get the iterator to the first node occurrence on the indexed path.
+    iterator begin() const;
+    /// Get the iterator to the last node occurrence on the indexed path.
+    iterator end() const;
+    
+    /// Find the iterator at the given position along the ref path. The position
+    /// must not be greater than the path length.
+    iterator find_position(size_t position) const;
+    
+    /// Get the length of the node occurrence on the path represented by this
+    /// iterator.
+    size_t node_length(const iterator& here) const;
 };
 
 }

--- a/src/pathindex.hpp
+++ b/src/pathindex.hpp
@@ -1,0 +1,59 @@
+#ifndef VG_PATHINDEX_H
+#define VG_PATHINDEX_H
+
+/** \file
+ *
+ * Provides an index for indexing an individual path for fast random access.
+ * Stores all the mappings uncompressed in memory.
+ *
+ * Used for the reference path during VCF creation and interpretation.
+ */
+ 
+#include <map>
+#include <utility>
+#include <string>
+
+#include "vg.hpp"
+#include "xg.hpp"
+
+namespace vg {
+
+/**
+ * Holds indexes of the reference in a graph: position to node, node to position
+ * and orientation, and the full reference string.
+ */
+struct PathIndex {
+    /// Index from node ID to first position on the reference string and
+    /// orientation it occurs there.
+    std::map<int64_t, std::pair<size_t, bool>> by_id;
+    
+    /// Index from start position on the reference to the side of the node that
+    /// begins there. If it is a right side, the node occurs on the path in a
+    /// reverse orientation.
+    std::map<size_t, vg::NodeSide> by_start;
+    
+    /// The actual sequence of the path, if desired.
+    std::string sequence;
+    
+    /// Index just a path
+    PathIndex(const Path& path);
+    
+    /// Index a path and pull sequence from a VG graph.
+    PathIndex(const Path& path, VG& vg);
+    
+    /// Index a path and pull sequence from an XG index.
+    PathIndex(const Path& path, const xg::XG& vg);
+    
+    /// Make a PathIndex from a path in a graph
+    PathIndex(VG& vg, const string& ref_path_name, bool extract_sequence = false);
+    
+    /// Make a PathIndex from a path in an indexed graph
+    PathIndex(const xg::XG& index, const string& ref_path_name, bool extract_sequence = false);
+    
+    // Find what node and orientation covers a position
+    NodeSide at_position(size_t position);
+};
+
+}
+ 
+#endif

--- a/src/subcommand/index.cpp
+++ b/src/subcommand/index.cpp
@@ -500,7 +500,6 @@ int main_index(int argc, char** argv) {
                                 << " which does not exist. Splitting!" << endl;
 #endif
                             finish_phase(phase_number);
-                            assert(false);
                         }
                     }
 

--- a/src/subcommand/index.cpp
+++ b/src/subcommand/index.cpp
@@ -487,19 +487,27 @@ int main_index(int argc, char** argv) {
                     // any. For which we need access to the last variant's past-
                     // the-end reference position.
                     size_t ref_pos = nonvariant_starts[phase_number];
-                    while(ref_pos < end) {
+                    
+                    // Get an iterator to the next node visit to add
+                    PathIndex::iterator next_to_add = path_index.find_position(ref_pos);
+                    
+                    while(ref_pos < end && next_to_add != path_index.end()) {
                         // While there is intervening reference
                         // sequence, add it to our phase.
 
                         // What node side is the node that covers here?
-                        auto ref_side = path_index.at_position(ref_pos);
+                        NodeSide ref_side = next_to_add->second;
 
                         // Stick it in the phase path
                         append_mapping(phase_number, node_side_to_thread_mapping(ref_side));
 
-                        // Advance to what's after that mapping
-                        // TODO: maybe node lengths should be cached?                   
-                        ref_pos += index.node_length(ref_side.node);
+                        // Advance to what's after that mapping, pulling node
+                        // length from the path index
+                        ref_pos += path_index.node_length(next_to_add);
+                        
+                        // Budge the iterator over so we don't need to do
+                        // another tree query.
+                        next_to_add++;
                     }
                     nonvariant_starts[phase_number] = ref_pos;
                 };

--- a/src/subcommand/index.cpp
+++ b/src/subcommand/index.cpp
@@ -321,6 +321,8 @@ int main_index(int argc, char** argv) {
             if (!variant_file.is_open()) {
                 cerr << "error:[vg index] could not open" << vcf_name << endl;
                 return 1;
+            } else if (show_progress) {
+                cerr << "Opened variant file " << vcf_name << endl;
             }
 
         }
@@ -342,8 +344,17 @@ int main_index(int argc, char** argv) {
         // store the graphs
         VGset graphs(file_names);
         // Turn into an XG index, except for the alt paths which we pull out and load into RAM instead.
+<<<<<<< HEAD
         xg::XG index;
         graphs.to_xg(index, store_threads, is_alt, alt_paths);
+=======
+        unique_ptr<xg::XG> index_ptr(graphs.to_xg(store_threads, is_alt, alt_paths));
+        xg::XG& index = *index_ptr;
+
+        if (show_progress) {
+            cerr << "Built base XG index" << endl;
+        }
+>>>>>>> 95c9ca4... Use new xg
 
         // We're going to collect all the phase threads as XG threads (which
         // aren't huge like Protobuf Paths), and then insert them all into xg in

--- a/src/subcommand/index.cpp
+++ b/src/subcommand/index.cpp
@@ -365,17 +365,12 @@ int main_index(int argc, char** argv) {
         // store the graphs
         VGset graphs(file_names);
         // Turn into an XG index, except for the alt paths which we pull out and load into RAM instead.
-<<<<<<< HEAD
         xg::XG index;
         graphs.to_xg(index, store_threads, is_alt, alt_paths);
-=======
-        unique_ptr<xg::XG> index_ptr(graphs.to_xg(store_threads, is_alt, alt_paths));
-        xg::XG& index = *index_ptr;
 
         if (show_progress) {
             cerr << "Built base XG index" << endl;
         }
->>>>>>> 95c9ca4... Use new xg
 
         // We're going to collect all the phase threads as XG threads (which
         // aren't huge like Protobuf Paths), and then insert them all into xg in

--- a/src/unittest/constructor.cpp
+++ b/src/unittest/constructor.cpp
@@ -1063,6 +1063,43 @@ ref	2	rs554978012;rs201121256	GTA	GTATA,G	.	GT
 
 }
 
+TEST_CASE( "An insert with adjacent SNP can be constructed", "[constructor]" ) {
+
+    auto vcf_data = R"(##fileformat=VCFv4.0
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=1000GenomesPilot-NCBI36
+##phasing=partial
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
+ref	2	rs572383716	T	TA	100	PASS	.	GT    
+ref	3	rs76837267	A	T	100	PASS	.	GT
+)";
+
+    auto ref = "CTATAC";
+
+    // Build the graph
+    auto result = construct_test_chunk(ref, "ref", vcf_data);
+    
+    // It should be like
+    // CT,A/-,A/T,AC
+    
+    
+#ifdef debug
+    std::cerr << pb2json(result.graph) << std::endl;
+#endif
+    
+    SECTION("the graph should have 5 nodes") {
+        REQUIRE(result.graph.node_size() == 5);
+    }
+    
+    SECTION("the graph should have 7 edges") {
+        REQUIRE(result.graph.edge_size() == 7);
+    }
+}
+
 
 TEST_CASE( "A VCF with multiple clumps can be constructed", "[constructor]" ) {
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -145,7 +145,7 @@ string tmpfilename(const string& base) {
     return tmpname;
 }
 
-string get_or_make_variant_id(vcflib::Variant variant) {
+string get_or_make_variant_id(const vcflib::Variant& variant) {
 
      if(!variant.id.empty() && variant.id != ".") {
         // We assume all the actually filled in ID fields in a VCF are unique.
@@ -153,36 +153,30 @@ string get_or_make_variant_id(vcflib::Variant variant) {
     } else {
         // Synthesize a name for the variant
 
-        // Let's just hash
-        SHA1 hasher;
-
-        // Turn the variant back into a string line and hash it.
-        // Note that this keeps the modified 0-based position.
-        std::stringstream variant_stringer;
-        variant_stringer << variant;
-        hasher.update(variant_stringer.str());
-
-        // Name the variant with the hex hash. Will be unique unless two
-        // identical variant lines are in the file.
-        return hasher.final();
+        return make_variant_id(variant);
 
     }
 }
 
-string make_variant_id(vcflib::Variant variant) {
+string make_variant_id(const vcflib::Variant& variant) {
     // Synthesize a name for the variant
 
     // Let's just hash
     SHA1 hasher;
 
-    // Turn the variant back into a string line and hash it.
-    // Note that this keeps the modified 0-based position.
+    // Turn the variant into a string, leaving out the actual calls and any
+    // assigned ID. Note that this keeps the modified 0-based position.
     std::stringstream variant_stringer;
-    variant_stringer << variant;
+    variant_stringer << variant.sequenceName << '\n';
+    variant_stringer << variant.position << '\n';
+    variant_stringer << variant.ref << '\n';
+    for (auto& alt : variant.alt) {
+        variant_stringer << alt << '\n';
+    }
     hasher.update(variant_stringer.str());
 
     // Name the variant with the hex hash. Will be unique unless two
-    // identical variant lines are in the file.
+    // identical variants are in the file.
     return hasher.final();
 }
 

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -189,8 +189,8 @@ string tmpfilename(const string& base);
 
 // Code to detect if a variant lacks an ID and give it a unique but repeatable
 // one.
-string get_or_make_variant_id(vcflib::Variant variant);
-string make_variant_id(vcflib::Variant variant);
+string get_or_make_variant_id(const vcflib::Variant& variant);
+string make_variant_id(const vcflib::Variant& variant);
 
 // Simple little tree
 template<typename T>

--- a/src/vg_set.hpp
+++ b/src/vg_set.hpp
@@ -31,10 +31,10 @@ public:
     // necessary when storing many graphs in the same index
     int64_t merge_id_space(void);
 
-    // Transforms to a succinct, queryable representation
+    /// Transforms to a succinct, queryable representation
     void to_xg(xg::XG& index, bool store_threads = false);
-    // As above, except paths with names matching the given regex are removed
-    // and returned separately by inserting them into the provided map.
+    /// As above, except paths with names matching the given regex are removed
+    /// and returned separately by inserting them into the provided map.
     void to_xg(xg::XG& index, bool store_threads, const regex& paths_to_take, map<string, Path>& removed_paths);
 
     // stores the nodes in the VGs identified by the filenames into the index

--- a/test/t/02_vg_construct.t
+++ b/test/t/02_vg_construct.t
@@ -19,10 +19,10 @@ vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
 
 nodes=$(vg stats -z z.vg | head -1 | cut -f 2)
-is $nodes 84555 "the 1mb graph has the expected number of nodes"
+is $nodes 84559 "the 1mb graph has the expected number of nodes"
 
 edges=$(vg stats -z z.vg | tail -1 | cut -f 2)
-is $edges 115361 "the 1mb graph has the expected number of edges"
+is $edges 115375 "the 1mb graph has the expected number of edges"
 
 rm -f z.vg
 

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -11,13 +11,16 @@ vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 #is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
 
 nodes=$(vg stats -z z.vg | head -1 | cut -f 2)
-is $nodes 84555 "vg stats reports the expected number of nodes"
+real_nodes=$(vg view -j z.vg | jq -c '.node[]' | wc -l)
+is $nodes $real_nodes "vg stats reports the expected number of nodes"
 
 edges=$(vg stats -z z.vg | tail -1 | cut -f 2)
-is $edges 115361 "vg stats reports the expected number of edges"
+real_edges=$(vg view -j z.vg | jq -c '.edge[]' | wc -l)
+is $edges $real_edges "vg stats reports the expected number of edges"
 
 graph_length=$(vg stats -l z.vg | tail -1 | cut -f 2)
-is $graph_length 1029257 "vg stats reports the expected graph length"
+real_length=$(vg view -j z.vg | jq -r '.node[].sequence' | tr -d '\n' | wc -c)
+is $graph_length $real_length "vg stats reports the expected graph length"
 
 subgraph_count=$(vg stats -s z.vg | wc -l)
 is $subgraph_count 1 "vg stats reports the correct number of subgraphs"


### PR DESCRIPTION
The xg changes that enable compression have already been merged, but these changes fix some issues with graph construction that were coming up when encoding the gPBWT, and fixes some oversights in the phase thread construction algorithm for the gPBWT.

I've also refactored out a PathIndex that can be used to efficiently find nodes and positions in a reference path, which we now use in the gPBWT construction as well as the genotyper.