### PR TITLE
vg index: change RocksDB key schema for mappings & alignments

### DIFF
--- a/src/index.hpp
+++ b/src/index.hpp
@@ -112,8 +112,7 @@ public:
     rocksdb::WriteOptions write_options;
     rocksdb::ColumnFamilyOptions column_family_options;
     bool bulk_load;
-    size_t block_cache_size;
-    mt19937 rng;
+    std::atomic<uint64_t> next_nonce;
 
     void load_graph(VG& graph);
     void dump(std::ostream& out);
@@ -196,8 +195,8 @@ public:
                          int64_t& node_id, int64_t& path_id, int64_t& path_pos, bool& backward, Mapping& mapping);
     void parse_path_position(const string& key, const string& value,
                              int64_t& path_id, int64_t& path_pos, bool& backward, int64_t& node_id, Mapping& mapping);
-    void parse_mapping(const string& key, const string& value, int64_t& node_id, string& hash, Mapping& mapping);
-    void parse_alignment(const string& key, const string& value, int64_t& node_id, string& hash, Alignment& alignment);
+    void parse_mapping(const string& key, const string& value, int64_t& node_id, uint64_t& nonce, Mapping& mapping);
+    void parse_alignment(const string& key, const string& value, int64_t& node_id, uint64_t& nonce, Alignment& alignment);
     void parse_base(const string& key, const string& value, int64_t& aln_id, Alignment& alignment);
     void parse_traversal(const string& key, const string& value, int64_t& node_id, int16_t& rank, bool& backward, int64_t& aln_id);
 

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="en_US.utf8" # force ekg's favorite sort order 
 
-plan tests 44
+plan tests 45
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 
@@ -49,22 +49,30 @@ rm -f x.gcsa x.gcsa.lcp x.graph
 vg index -s -k 11 -d x.idx x.vg
 num_records=$(vg index -D -d x.idx | wc -l)
 is $? 0 "dumping graph index"
-is $num_records 3207 "correct number of records in graph index"
+is $num_records 3208 "correct number of records in graph index"
 
 vg index -x x.xg x.vg
-vg map -r <(vg sim -s 1337 -n 100 -x x.xg) -d x.idx | vg index -a - -d x.vg.aln
-is $(vg index -D -d x.vg.aln | wc -l) 100 "index can store alignments"
+vg map -r <(vg sim -s 1337 -n 100 -x x.xg) -d x.idx > x1337.gam
+vg index -a x1337.gam -d x.vg.aln
+is $(vg index -D -d x.vg.aln | wc -l) 101 "index can store alignments"
 is $(vg index -A -d x.vg.aln | vg view -a - | wc -l) 100 "index can dump alignments"
 
 # repeat with an unmapped read (sequence from phiX)
 rm -rf x.vg.aln
-(vg map -s "CTGATGAGGCCGCCCCTAGTTTTGTTTCTGGTGCTATGGCTAAAGCTGGTAAAGGACTTC" -d x.idx; vg map -r <(vg sim -s 1337 -n 100 -x x.xg) -d x.idx) | vg index -a - -d x.vg.aln
-is $(vg index -D -d x.vg.aln | wc -l) 100 "FIXME: alignment index does NOT store unmapped reads!"
+(vg map -s "CTGATGAGGCCGCCCCTAGTTTTGTTTCTGGTGCTATGGCTAAAGCTGGTAAAGGACTTC" -d x.idx; cat x1337.gam) | vg index -a - -d x.vg.aln
+is $(vg index -D -d x.vg.aln | wc -l) 101 "FIXME: alignment index does NOT store unmapped reads!"
+
+# load the same data again & see that the records are duplicated.
+# that's not really a wise use-case, but it tests that we don't
+# overwrite anything in an existing alignment index, by virtue
+# of keying each entry with a unqiue nonce.
+vg index -a x1337.gam -d x.vg.aln
+is $(vg index -D -d x.vg.aln | wc -l) 201 "alignment index can be loaded using sequential invocations; next_nonce persistence"
 
 vg map -r <(vg sim -s 1337 -n 100 -x x.xg) -d x.idx | vg index -m - -d x.vg.map
-is $(vg index -D -d x.vg.map | wc -l) 1476 "index stores all mappings"
+is $(vg index -D -d x.vg.map | wc -l) 1477 "index stores all mappings"
 
-rm -rf x.idx x.vg.map x.vg.aln
+rm -rf x.idx x.vg.map x.vg.aln x1337.gam
 
 vg construct -r small/x.fa -v small/x.vcf.gz -a >x.vg
 vg index -x x.xg -v small/x.vcf.gz x.vg
@@ -87,8 +95,8 @@ vg index -s -d x.idx x.vg
 single=$(vg index -D -d x.idx | wc -l)
 triple=$(vg index -D -d q.idx | wc -l)
 
-# subtract two for metadata lines about paths that aren't duplicated in the merged
-is $triple $(echo "$single * 3 - 2" | bc) "storage of multiple graphs in an index succeeds"
+# subtract four for metadata lines about paths that aren't duplicated in the merged
+is $triple $(echo "$single * 3 - 4" | bc) "storage of multiple graphs in an index succeeds"
 
 vg ids -j x.vg q.vg
 vg index -k 2 -g qx.vg.gcsa q.vg x.vg
@@ -131,7 +139,7 @@ is $(vg index -D -d r.idx | grep '"from": 55' | grep '"from_start": true' | wc -
 is $(vg index -D -d r.idx | grep '"to": 55' | grep '"to_end": true' | wc -l) 2 "to_end edges in index"
 
 vg map -r <(vg sim -s 1338 -n 100 -x r.xg) -d r.idx | vg index -a - -d r.aln.idx
-is $(vg index -D -d r.aln.idx | wc -l) 100 "index can store alignments to backward nodes"
+is $(vg index -D -d r.aln.idx | wc -l) 101 "index can store alignments to backward nodes"
 
 rm -rf r.idx r.aln.idx r.xg
 
@@ -140,7 +148,7 @@ is $? 0 "index can store a cyclic graph"
 
 vg index -x c.xg cyclic/all.vg
 vg map -r <(vg sim -s 1337 -n 100 -x c.xg) -d c.idx | vg index -a - -d all.vg.aln
-is $(vg index -D -d all.vg.aln | wc -l) 100 "index can store alignments to cyclic graphs"
+is $(vg index -D -d all.vg.aln | wc -l) 101 "index can store alignments to cyclic graphs"
 
 rm -rf c.idx all.vg.aln c.xg
 


### PR DESCRIPTION
These were formerly keyed by node ID & the first 8 characters of the hex SHA1 of the alignment. This was not sufficient to ensure uniqueness for high-depth (birthday problem), leading to a little bit of lost data loading the index.

This diff instead keys by node ID and a unique nonce, with the nonce state persisted in the database. **Existing RocksDB mapping/alignment indexes would be invalidated by this diff.**

Also ensures that if we crash or something while building a RocksDB index, it will not be usable thereafter; and tightens error handling in some existing RocksDB calls.