### PR TITLE
copy the stream::for_each_parallel into batched and not-batched versions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1911,7 +1911,7 @@ int main_pileup(int argc, char** argv) {
             int tid = omp_get_thread_num();
             pileups[tid].compute_from_alignment(aln);
         };
-        stream::for_each_parallel(alignment_stream, lambda);
+        stream::for_each_parallel_batched(alignment_stream, lambda);
     });
 
     // single-threaded (!) merge
@@ -4256,7 +4256,7 @@ int main_stats(int argc, char** argv) {
         };
 
         // Actually go through all the reads and count stuff up.
-        stream::for_each_parallel(alignment_stream, lambda);
+        stream::for_each_parallel_batched(alignment_stream, lambda);
 
         // Calculate stats about the reads per allele data
         for(auto& site_and_alleles : reads_on_allele) {


### PR DESCRIPTION
The current for_each_parallel on master appears to hurt performance when the runtime of the lambda is long relative to the parsing time. This is in contrast to the issue that @mlin and @glennhickey resolved where performance was very bad in the old version when processing time in the lambda was short.

This PR proposes to split the solutions into two functions and select the one appropriate for the current task depending on the expected runtime of the lambda. @mlin's improved version is now called `stream::for_each_parallel_batched`.