### PR TITLE
Phase Duplicator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/phased_genome.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/constructor.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/flow_sort_test.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/srpe_filter.o
+UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/phase_duplicator.o
 
 
 # These aren;t put into libvg, but they provide subcommand implementations for the vg bianry
@@ -426,6 +427,8 @@ $(UNITTEST_OBJ_DIR)/vg.o: $(UNITTEST_SRC_DIR)/vg.cpp $(UNITTEST_SRC_DIR)/catch.h
 $(UNITTEST_OBJ_DIR)/constructor.o: $(UNITTEST_SRC_DIR)/constructor.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/constructor.hpp $(DEPS)
 
 $(UNITTEST_OBJ_DIR)/flow_sort_test.o: $(UNITTEST_SRC_DIR)/flow_sort_test.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(DEPS)
+
+$(UNITTEST_OBJ_DIR)/phase_duplicator.o: $(UNITTEST_SRC_DIR)/phase_duplicator.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/phase_duplicator.hpp $(DEPS)
 
 ###################################
 ## VG subcommand compilation begins here

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ OBJ += $(OBJ_DIR)/progressive.o
 OBJ += $(OBJ_DIR)/flow_sort.o
 OBJ += $(OBJ_DIR)/homogenizer.o
 OBJ += $(OBJ_DIR)/path_index.o
+OBJ += $(OBJ_DIR)/phase_duplicator.o
 
 # These aren't put into libvg. But they do go into the main vg binary to power its self-test.
 UNITTEST_OBJ =
@@ -392,13 +393,14 @@ $(OBJ_DIR)/multipath_alignment.o: $(SRC_DIR)/multipath_alignment.cpp $(SRC_DIR)/
 $(OBJ_DIR)/flow_sort.o: $(SRC_DIR)/flow_sort.cpp $(SRC_DIR)/flow_sort.hpp $(SRC_DIR)/vg.hpp $(DEPS)
 
 $(OBJ_DIR)/srpe.o: $(SRC_DIR)/srpe.cpp $(SRC_DIR)/srpe.hpp $(OBJ_DIR)/filter.o $(DEPS)
-	+$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS)
 
-$(OBJ_DIR)/pathindex.o: $(SRC_DIR)/pathindex.cpp $(SRC_DIR)/pathindex.hpp $(DEPS)
-	+. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
-	###################################
-	## VG unit test compilation begins here
-	####################################
+$(OBJ_DIR)/path_index.o: $(SRC_DIR)/path_index.cpp $(SRC_DIR)/path_index.hpp $(DEPS)
+
+$(OBJ_DIR)/phase_duplicator.o: $(SRC_DIR)/phase_duplicator.cpp $(SRC_DIR)/phase_duplicator.hpp $(SRC_DIR)/types.hpp $(DEPS)
+
+###################################
+## VG unit test compilation begins here
+####################################
 
 $(UNITTEST_OBJ_DIR)/driver.o: $(UNITTEST_SRC_DIR)/driver.cpp $(UNITTEST_SRC_DIR)/driver.hpp $(UNITTEST_SRC_DIR)/catch.hpp $(DEPS)
 

--- a/src/phase_duplicator.cpp
+++ b/src/phase_duplicator.cpp
@@ -8,7 +8,7 @@ PhaseDuplicator::PhaseDuplicator(const xg::XG& index) : index(index) {
     // Nothing to do!
 }
 
-pair<Graph, vector<Translation>>&& PhaseDuplicator::duplicate(set<id_t> subgraph, id_t& next_id) const {
+pair<Graph, vector<Translation>> PhaseDuplicator::duplicate(set<id_t> subgraph, id_t& next_id) const {
 
     // Allocate space for the result
     pair<Graph, vector<Translation>> to_return;
@@ -19,7 +19,7 @@ pair<Graph, vector<Translation>>&& PhaseDuplicator::duplicate(set<id_t> subgraph
     // TODO: actually do the duplication
     
     // Ship out the result
-    return move(to_return);
+    return to_return;
 }
 
 }

--- a/src/phase_duplicator.cpp
+++ b/src/phase_duplicator.cpp
@@ -1,0 +1,25 @@
+#include "phase_duplicator.hpp"
+
+namespace vg {
+
+using namespace std;
+
+PhaseDuplicator::PhaseDuplicator(const xg::XG& index) : index(index) {
+    // Nothing to do!
+}
+
+pair<Graph, vector<Translation>>&& PhaseDuplicator::duplicate(set<id_t> subgraph, id_t& next_id) const {
+
+    // Allocate space for the result
+    pair<Graph, vector<Translation>> to_return;
+    // Name the pair members
+    Graph& duplicated = to_return.first;
+    vector<Translation>& translations = to_return.second;
+    
+    // TODO: actually do the duplication
+    
+    // Ship out the result
+    return move(to_return);
+}
+
+}

--- a/src/phase_duplicator.cpp
+++ b/src/phase_duplicator.cpp
@@ -22,4 +22,92 @@ pair<Graph, vector<Translation>> PhaseDuplicator::duplicate(set<id_t> subgraph, 
     return to_return;
 }
 
+vector<pair<xg::thread_t, int>> PhaseDuplicator::list_haplotypes(const xg::XG& index, set<id_t> subgraph) const {
+    // Adapted from Yohei's "haplotype_extracter"
+    
+    // This holds extracted sub-haplotypes and the search states for looking right off their ends.
+    vector<pair<thread_t, xg::XG::ThreadSearchState>> search_intermediates;
+    // This holds the results we will return, as pairs of extracted haplotypes and haplotype counts
+    vector<pair<thread_t, int>> search_results;
+    
+    // Start a search at the first node traversal
+    thread_t first_thread = {start_node};
+    xg::XG::ThreadSearchState first_state;
+    index.extend_search(first_state, first_thread);
+    
+    // Grab the edges out of that node traversal
+    vector<Edge> edges = start_node.is_reverse ? index.edges_on_start(start_node.node_id) : index.edges_on_end(start_node.node_id);
+    for (int i = 0; i < edges.size(); i++) {
+        // Consider following each edge
+        
+        // Where would we go?
+        xg::XG::ThreadMapping next_node;
+        next_node.node_id = edges[i].to();
+        next_node.is_reverse = edges[i].to_end();
+        
+        // How many haplotypes also go there?
+        xg::XG::ThreadSearchState new_state = first_state;
+        thread_t t = {next_node};
+        index.extend_search(new_state, t);
+        
+        // If any do, remember there as a search state
+        thread_t new_thread = first_thread;
+        new_thread.push_back(next_node);
+        if (!new_state.is_empty()) {
+            search_intermediates.push_back(make_pair(new_thread,new_state));
+        }
+    }
+    
+    while (search_intermediates.size() > 0) {
+        // Until we've finished all our intermediates...
+        // Pop one off
+        pair<thread_t,xg::XG::ThreadSearchState> last = search_intermediates.back();
+        search_intermediates.pop_back();
+        
+        // Remember how many we had besides thsi one, so we can see if we added
+        // any descendants of this one, or if this one is a dead end.
+        int check_size = search_intermediates.size();
+        
+        // Grab the edges out of the last thing in the partial haplotype
+        vector<Edge> edges = last.first.back().is_reverse ? index.edges_on_start(last.first.back().node_id) : index.edges_on_end(last.first.back().node_id);
+        if (edges.size() == 0) {
+            // If there's nowhere to go, we're a dead end, so finish the haplotype here.
+            search_results.push_back(make_pair(last.first,last.second.count()));
+        } else {
+            // There are edges to trace
+            for (int i = 0; i < edges.size(); i++) {
+                // Follow each of them
+                xg::XG::ThreadMapping next_node;
+                next_node.node_id = edges[i].to();
+                next_node.is_reverse = edges[i].to_end();
+                
+                // Try searching with where the edge goes
+                xg::XG::ThreadSearchState new_state = last.second;
+                thread_t next_thread = {next_node};
+                index.extend_search(new_state,next_thread);
+                
+                // If there's anything there...
+                thread_t new_thread = last.first;
+                new_thread.push_back(next_node);
+                if (!new_state.is_empty()) {
+                    if (new_thread.size() >= extend_distance) {
+                        // We found something but it's too far away. Stop here.
+                        search_results.push_back(make_pair(new_thread,new_state.count()));
+                    } else {
+                        // We found something and it's close enough to explore. Go explore it.
+                        search_intermediates.push_back(make_pair(new_thread,new_state));
+                    }
+                }
+            }
+            if (check_size == search_intermediates.size() && last.first.size() < extend_distance - 1) {
+                // If we didn't hit a dead end or our extension limit but no
+                // haplotypes actually went anywhere, then we need to count what
+                // we have so far as a haplotype.
+                search_results.push_back(make_pair(last.first,last.second.count()));
+            }
+        }
+    }
+    return search_results;
+}
+
 }

--- a/src/phase_duplicator.cpp
+++ b/src/phase_duplicator.cpp
@@ -8,7 +8,7 @@ PhaseDuplicator::PhaseDuplicator(const xg::XG& index) : index(index) {
     // Nothing to do!
 }
 
-pair<Graph, vector<Translation>> PhaseDuplicator::duplicate(set<id_t> subgraph, id_t& next_id) const {
+pair<Graph, vector<Translation>> PhaseDuplicator::duplicate(const set<id_t>& subgraph, id_t& next_id) const {
 
     // Allocate space for the result
     pair<Graph, vector<Translation>> to_return;
@@ -16,98 +16,366 @@ pair<Graph, vector<Translation>> PhaseDuplicator::duplicate(set<id_t> subgraph, 
     Graph& duplicated = to_return.first;
     vector<Translation>& translations = to_return.second;
     
-    // TODO: actually do the duplication
+    // The duplicated graph is produced assuming the original nodes and their edges are all deleted.
+    
+    // Find all the traversals
+    vector<pair<xg::XG::thread_t, int>> observed_threads = list_haplotypes(subgraph);
+    
+    for (auto& thread_and_count : observed_threads) {
+        // For every unique haplotype in the subgraph
+        
+        // Grab it
+        auto& thread = thread_and_count.first;
+        
+        // We want a translation
+        translations.emplace_back();
+        Translation& translation = translations.back();
+        
+        // As we scan along this thread, what was the last node we created?
+        Node* last_node = nullptr;
+        // Were we visiting that node in reverse?
+        bool last_is_reverse = false;
+        
+        for (size_t i = 0; i < thread.size(); i++) {
+            // For every visit in the thread...
+            auto& visit = thread[i];
+        
+            // We'll duplicate the original node in its original orientation for
+            // each visit.
+            
+            // Grab a new ID
+            id_t new_id = ++next_id;
+            
+            // Make the node
+            Node* node = duplicated.add_node();
+            node->set_sequence(index.node_sequence(visit.node_id));
+            node->set_id(new_id);
+            
+            if (last_node != nullptr) {
+                // Add a connecting edge to the previous node
+                Edge* edge = duplicated.add_edge();
+                edge->set_from(last_node->id());
+                edge->set_from_start(last_is_reverse);
+                edge->set_to(node->id());
+                edge->set_to_end(visit.is_reverse);
+            }
+            last_node = node;
+            last_is_reverse = visit.is_reverse;
+            
+            
+            if (i == 0 || i + 1 == thread.size()) {
+                // We're at the start or end of a traversal, so we might be at a
+                // border where we want to enter or leave the subgraph.
+                
+                // Get the edges on the outside ends of this node that cross borders
+                vector<Edge> border_edges;
+                
+                if (i == 0) {
+                    // If we're on the left edge of the thread, look at border-crossing edges on our left edge
+                    auto off_left = find_border_edges(visit, true, subgraph);
+                    copy(off_left.begin(), off_left.end(), back_inserter(border_edges));
+                }
+                
+                if (i + 1 == thread.size()) {
+                    // If we're on the right edge of the thread, look at border-crossing edges on our right edge
+                    auto off_right = find_border_edges(visit, false, subgraph);
+                    copy(off_right.begin(), off_right.end(), back_inserter(border_edges));
+                }
+
+                for (auto& border_edge : border_edges) {
+                    // Make a new duplicate of each edge
+                    Edge* new_edge = duplicated.add_edge();
+                    *new_edge = border_edge;
+                    
+                    if (new_edge->from() == visit.node_id) {
+                        // Update the from if necessary
+                        new_edge->set_from(node->id());
+                    }
+                    
+                    if (new_edge->to() == visit.node_id) {
+                        // Update the to if necessary
+                        new_edge->set_to(node->id());
+                    }
+                    
+                }
+            }
+            
+            // Add the pair of Mappings to the translation paths
+            // We go "from" the original graph "to" the duplicated graph.
+            Mapping* to_mapping = translation.mutable_to()->add_mapping();
+            to_mapping->mutable_position()->set_node_id(new_id);
+            to_mapping->mutable_position()->set_is_reverse(visit.is_reverse);
+            Edit* to_edit = to_mapping->add_edit();
+            to_edit->set_from_length(node->sequence().size());
+            to_edit->set_to_length(node->sequence().size());
+            
+            Mapping* from_mapping = translation.mutable_from()->add_mapping();
+            from_mapping->mutable_position()->set_node_id(visit.node_id);
+            from_mapping->mutable_position()->set_is_reverse(visit.is_reverse);
+            // Just copy the edit data because it's the same in both paths
+            *(from_mapping->add_edit()) = *to_edit;
+        }
+    }
     
     // Ship out the result
     return to_return;
 }
 
-vector<pair<xg::thread_t, int>> PhaseDuplicator::list_haplotypes(const xg::XG& index, set<id_t> subgraph) const {
+vector<pair<xg::XG::thread_t, int>> PhaseDuplicator::list_haplotypes(const set<id_t>& subgraph) const {
+    // We need to look at all the nodes in the subgraph and extract all the
+    // unique traversals not contained in another traversal.
+    
+    // What we need to do is look at all the threads coming in through border
+    // nodes, and all the threads starting at interior nodes, and then orient
+    // and deduplicate.
+    
+    // Get all the border traversals
+    vector<xg::XG::ThreadMapping> borders = find_borders(subgraph);
+    
+    // This holds all the traversals observed (full and partial) in their canonical orientations, with their total counts
+    map<xg::XG::thread_t, int> observed_traversals;
+    
+    for (auto& start : borders) {
+        // For every incoming traversal of a node, get the haplotypes that go through it.
+        vector<pair<xg::XG::thread_t, int>> threads_and_counts = list_haplotypes_through(start, subgraph);
+        
+        for (auto& found : threads_and_counts) {
+            // Add each found traversal to the set in its canonical orientation
+            observed_traversals[canonicalize(found.first)] += found.second;
+        }
+    }
+    
+    // TODO: Add in the traversals that start in the middle
+    
+    // TODO: deduplicate prefixes/suffixes of existing traversals
+    
+    // Vectorize the map
+    // TODO: skip this copy somehow (maybe use sets throughout?)
+    vector<pair<xg::XG::thread_t, int>> flat_traversals;
+    for (auto& kv : observed_traversals) {
+        // Blit all the pairs over
+        flat_traversals.push_back(kv);
+    }
+    
+    return flat_traversals;
+}
+
+vector<pair<xg::XG::thread_t, int>> PhaseDuplicator::list_haplotypes_through(xg::XG::ThreadMapping start_node,
+    const set<id_t>& subgraph) const {
+    
+    // We want all haplotypes that start with a traversal through the given
+    // node.
+    
+    // Start a search at the first node traversal
+    xg::XG::ThreadSearchState start_state;
+    index.extend_search(start_state, start_node);
+    
+    // Call the search starting from a state selecting everything on the side
+    return list_haplotypes(start_node, start_state, subgraph);
+}
+
+vector<pair<xg::XG::thread_t, int>> PhaseDuplicator::list_haplotypes_from(xg::XG::ThreadMapping start_node,
+    const set<id_t>& subgraph) const {
+    
+    // We want all haplotypes that start their threads actually at this side of this node.
+    xg::XG::ThreadSearchState start_state = index.select_starting(start_node);
+    
+    // Call the search starting with only the threads that begin here selected.
+    return list_haplotypes(start_node, start_state, subgraph);
+}
+    
+
+vector<pair<xg::XG::thread_t, int>> PhaseDuplicator::list_haplotypes(xg::XG::ThreadMapping start_node,
+    xg::XG::ThreadSearchState start_state, const set<id_t>& subgraph) const {
     // Adapted from Yohei's "haplotype_extracter"
     
     // This holds extracted sub-haplotypes and the search states for looking right off their ends.
-    vector<pair<thread_t, xg::XG::ThreadSearchState>> search_intermediates;
+    vector<pair<xg::XG::thread_t, xg::XG::ThreadSearchState>> search_intermediates;
     // This holds the results we will return, as pairs of extracted haplotypes and haplotype counts
-    vector<pair<thread_t, int>> search_results;
+    vector<pair<xg::XG::thread_t, int>> search_results;
     
-    // Start a search at the first node traversal
-    thread_t first_thread = {start_node};
-    xg::XG::ThreadSearchState first_state;
-    index.extend_search(first_state, first_thread);
-    
-    // Grab the edges out of that node traversal
-    vector<Edge> edges = start_node.is_reverse ? index.edges_on_start(start_node.node_id) : index.edges_on_end(start_node.node_id);
-    for (int i = 0; i < edges.size(); i++) {
-        // Consider following each edge
-        
-        // Where would we go?
-        xg::XG::ThreadMapping next_node;
-        next_node.node_id = edges[i].to();
-        next_node.is_reverse = edges[i].to_end();
-        
-        // How many haplotypes also go there?
-        xg::XG::ThreadSearchState new_state = first_state;
-        thread_t t = {next_node};
-        index.extend_search(new_state, t);
-        
-        // If any do, remember there as a search state
-        thread_t new_thread = first_thread;
-        new_thread.push_back(next_node);
-        if (!new_state.is_empty()) {
-            search_intermediates.push_back(make_pair(new_thread,new_state));
-        }
+    if (start_state.is_empty()) {
+        // Nothing visits the first node in the right direction
+        return search_results;
     }
+    // Otherwise, start with this as the first intermediate result
+    search_intermediates.push_back(make_pair(xg::XG::thread_t{start_node}, start_state));
     
     while (search_intermediates.size() > 0) {
         // Until we've finished all our intermediates...
         // Pop one off
-        pair<thread_t,xg::XG::ThreadSearchState> last = search_intermediates.back();
+        pair<xg::XG::thread_t, xg::XG::ThreadSearchState> last(move(search_intermediates.back()));
         search_intermediates.pop_back();
         
-        // Remember how many we had besides thsi one, so we can see if we added
+        // Break out contents
+        auto& last_thread = last.first;
+        auto& last_node = last_thread.back();
+        auto& last_state = last.second;
+        
+        // Remember how many we had besides this one, so we can see if we added
         // any descendants of this one, or if this one is a dead end.
-        int check_size = search_intermediates.size();
+        auto check_size = search_intermediates.size();
         
         // Grab the edges out of the last thing in the partial haplotype
-        vector<Edge> edges = last.first.back().is_reverse ? index.edges_on_start(last.first.back().node_id) : index.edges_on_end(last.first.back().node_id);
-        if (edges.size() == 0) {
-            // If there's nowhere to go, we're a dead end, so finish the haplotype here.
-            search_results.push_back(make_pair(last.first,last.second.count()));
+        vector<Edge> edges = last_node.is_reverse ?
+            index.edges_on_start(last_node.node_id) :
+            index.edges_on_end(last_node.node_id);
+            
+        // Keep track of all the successful extensions
+        vector<pair<xg::XG::ThreadMapping, xg::XG::ThreadSearchState>> extensions;
+            
+        for (int i = 0; i < edges.size(); i++) {
+            // Follow each of them
+            xg::XG::ThreadMapping next_node = traverse_edge(edges[i], last_node);
+            
+            if (!subgraph.count(next_node.node_id)) {
+                // Skip edges that leave the subgraph
+                continue;
+            }
+            
+            // Try searching with where the edge goes
+            xg::XG::ThreadSearchState new_state = last_state;
+            xg::XG::thread_t next_thread = {next_node};
+            index.extend_search(new_state, next_thread);
+            
+            if (!new_state.is_empty()) {
+                // We found something. Remember it
+                extensions.push_back(make_pair(next_node, new_state));                
+            }
+        }
+        
+        while (extensions.size() > 1) {
+            // Handle all but one extension by copying the thread
+            xg::XG::thread_t new_thread(last_thread);
+            // Stick the new ThreadMapping onto the end of the copy
+            new_thread.push_back(extensions.back().first);
+            // Move the longer thread and the new search state into the intermediates
+            search_intermediates.emplace_back(move(new_thread), extensions.back().second);
+            
+            // We finished this extension
+            extensions.pop_back();
+        }
+        if (extensions.size() == 1) {
+            // Only one remaining successful extension, so we can just use the old thread
+            last_thread.push_back(extensions.back().first);
+            search_intermediates.emplace_back(move(last_thread), extensions.back().second);
         } else {
-            // There are edges to trace
-            for (int i = 0; i < edges.size(); i++) {
-                // Follow each of them
-                xg::XG::ThreadMapping next_node;
-                next_node.node_id = edges[i].to();
-                next_node.is_reverse = edges[i].to_end();
-                
-                // Try searching with where the edge goes
-                xg::XG::ThreadSearchState new_state = last.second;
-                thread_t next_thread = {next_node};
-                index.extend_search(new_state,next_thread);
-                
-                // If there's anything there...
-                thread_t new_thread = last.first;
-                new_thread.push_back(next_node);
-                if (!new_state.is_empty()) {
-                    if (new_thread.size() >= extend_distance) {
-                        // We found something but it's too far away. Stop here.
-                        search_results.push_back(make_pair(new_thread,new_state.count()));
-                    } else {
-                        // We found something and it's close enough to explore. Go explore it.
-                        search_intermediates.push_back(make_pair(new_thread,new_state));
-                    }
-                }
-            }
-            if (check_size == search_intermediates.size() && last.first.size() < extend_distance - 1) {
-                // If we didn't hit a dead end or our extension limit but no
-                // haplotypes actually went anywhere, then we need to count what
-                // we have so far as a haplotype.
-                search_results.push_back(make_pair(last.first,last.second.count()));
-            }
+            // We couldn't find anywhere inside the subgraph that anyone
+            // actually goes. So we have to end this traversal here. Send the
+            // last thread out as the search result, together with its count.
+            search_results.emplace_back(move(last_thread), last_state.count());
         }
     }
     return search_results;
 }
 
+vector<xg::XG::ThreadMapping> PhaseDuplicator::find_borders(const set<id_t> subgraph) const {
+    // We want all the traversals along which we can enter the subgraph.
+    
+    // We'll put them all in here
+    vector<xg::XG::ThreadMapping> borders;
+    
+    for (auto& node_id : subgraph) {
+        // For every node
+        for (auto is_reverse : {false, true}) {
+            // In every direction
+            
+            // Get the *previous* edges that we could have read through to hit
+            // this node in this orientation.
+            vector<Edge> edges = is_reverse ?
+                index.edges_on_end(node_id) :
+                index.edges_on_start(node_id);
+                
+            // We set this to true if a predecessor edge escapes from the subgraph.
+            bool is_border = false;
+            for (auto& edge : edges) {
+                // Look at each edge
+                if (!subgraph.count(edge.from()) || !subgraph.count(edge.to())) {
+                    // As soon as we find one that escapes the subgraph, we know we have a border here
+                    is_border = true;
+                    break;
+                }
+            }
+            
+            if (is_border) {
+                // We can read into the subgraph and hit this traversal.
+                xg::XG::ThreadMapping mapping;
+                mapping.node_id = node_id;
+                mapping.is_reverse = is_reverse;
+                borders.push_back(mapping);
+            }
+        }
+    }
+    
+    return borders;
 }
+
+vector<Edge> PhaseDuplicator::find_border_edges(xg::XG::ThreadMapping mapping, bool on_start, const set<id_t>& subgraph) const {
+        
+    // We'll fill this in with the border edges
+    vector<Edge> border_edges;
+        
+    // Get the edges on the start or end of the given ThreadMapping, as
+    // appropriate.
+    vector<Edge> edges = on_start != mapping.is_reverse ?
+        index.edges_on_start(mapping.node_id) :
+        index.edges_on_end(mapping.node_id);
+        
+    for (auto& edge : edges) {
+        // Look at each edge
+        if (!subgraph.count(edge.from()) || !subgraph.count(edge.to())) {
+            // If either end escapes the subgraph, it's a border edge
+            border_edges.push_back(edge);
+        }
+    }
+    
+    return border_edges;
+    
+}
+
+xg::XG::ThreadMapping PhaseDuplicator::traverse_edge(const Edge& e, const xg::XG::ThreadMapping& prev) {
+    // We're going to traverse this edge. We need to know if we take it forward
+    // or backward. This is true if, reading through the prev node in the given
+    // orientation, we could traverse the edge forwards. We may also be able to
+    // traverse it backwards, but in that case it's a single-side self loop, so
+    // direction doesn't really matter.
+    bool traverse_forward = (prev.node_id == e.from() && prev.is_reverse == e.from_start());
+    
+    // We'll fill this in with where we land
+    xg::XG::ThreadMapping next;
+    
+    if (traverse_forward) {
+        // Land at the end of the edge
+        next.node_id = e.to();
+        next.is_reverse = e.to_end();
+    } else {
+        // Land at the start of the edge
+        next.node_id = e.from();
+        next.is_reverse = !e.from_start();
+    }
+    
+    return next;
+}
+
+xg::XG::thread_t PhaseDuplicator::canonicalize(const xg::XG::thread_t& thread) {
+    xg::XG::thread_t reversed;
+    
+    for (auto i = thread.rbegin(); i != thread.rend(); ++i) {
+        // Reverse every mapping in the original thread
+        xg::XG::ThreadMapping reversed_mapping = *i;
+        reversed_mapping.is_reverse = !reversed_mapping.is_reverse;
+        
+        // And put it in the new one
+        reversed.push_back(reversed_mapping);
+    }
+    
+    if (reversed < thread) {
+        // The reversed version compares smaller and is thus canonical.
+        return reversed;
+    } else {
+        // The original compares smaller and is thus canonical.
+        return thread;
+    }
+}
+
+} 

--- a/src/phase_duplicator.hpp
+++ b/src/phase_duplicator.hpp
@@ -80,7 +80,7 @@ public:
      * Get the traversals that represent the borders of the subgraph, through
      * which we can enter the subgraph.
      */
-    vector<xg::XG::ThreadMapping> find_borders(const set<id_t> subgraph) const;
+    set<xg::XG::ThreadMapping> find_borders(const set<id_t> subgraph) const;
     
     /**
      * Find the edges on the given side of the given oriented ThreadMapping that

--- a/src/phase_duplicator.hpp
+++ b/src/phase_duplicator.hpp
@@ -46,7 +46,62 @@ public:
      * TODO: invent some kind of thread safe ID allocator so we can do multiple
      * subgraphs in parallel without renumbering later.
      */
-    pair<Graph, vector<Translation>> duplicate(set<id_t> subgraph, id_t& next_id) const;
+    pair<Graph, vector<Translation>> duplicate(const set<id_t>& subgraph, id_t& next_id) const;
+    
+    /**
+     * List all the distinct haplotypes within a subgraph and their counts.
+     * Reports each haplotype in only one direction.
+     */
+    vector<pair<xg::XG::thread_t, int>> list_haplotypes(const set<id_t>& subgraph) const;
+    
+    /**
+     * List all the distinct haplotypes going through the given node in the given
+     * orientation, and staying within the given subgraph, along with their
+     * counts. Some may be suffixes of others.
+     */
+    vector<pair<xg::XG::thread_t, int>> list_haplotypes_through(xg::XG::ThreadMapping start_node, const set<id_t>& subgraph) const;
+    
+    /**
+     * List all the distinct haplotypes actually beginning at the given node in
+     * the given orientation, and staying within the given subgraph, along with
+     * their counts. Haplotypes that begin and end at the same side may or may
+     * not be reported multiple times, in differing orientations.
+     */
+    vector<pair<xg::XG::thread_t, int>> list_haplotypes_from(xg::XG::ThreadMapping start_node, const set<id_t>& subgraph) const;
+    
+    /**
+     * List all the distinct haplotypes beginning at the given node, using the
+     * given starting search state, that traverse through the subgraph.
+     */
+    vector<pair<xg::XG::thread_t, int>> list_haplotypes(xg::XG::ThreadMapping start_node,
+        xg::XG::ThreadSearchState start_state, const set<id_t>& subgraph) const;
+        
+    /**
+     * Get the traversals that represent the borders of the subgraph, through
+     * which we can enter the subgraph.
+     */
+    vector<xg::XG::ThreadMapping> find_borders(const set<id_t> subgraph) const;
+    
+    /**
+     * Find the edges on the given side of the given oriented ThreadMapping that
+     * cross the border of the given subgraph.
+     */
+    vector<Edge> find_border_edges(xg::XG::ThreadMapping mapping, bool on_start, const set<id_t>& subgraph) const;
+    
+    /**
+     * Follow the given edge from the given node visited in the given
+     * orientation, and return the node and orientation we land in.
+     *
+     * TODO: I think I may have written this logic already with one of the other
+     * two oriented node types (NodeTraversal and NodeSide).
+     */
+    static xg::XG::ThreadMapping traverse_edge(const Edge& e, const xg::XG::ThreadMapping& prev);
+    
+    /**
+     * Return a copy of the given thread in a canonical orientation (either
+     * forward or reverse, whichever compares smaller).
+     */
+    static xg::XG::thread_t canonicalize(const xg::XG::thread_t& thread);
     
 private:
     /// What XG index describes the graph we operate on?

--- a/src/phase_duplicator.hpp
+++ b/src/phase_duplicator.hpp
@@ -1,0 +1,58 @@
+#ifndef VG_PHASE_DUPLICATOR_H
+#define VG_PHASE_DUPLICATOR_H
+
+/** \file
+ *
+ * This file contains the PhaseDuplicator, which duplicates and un-crosslinks
+ * complex regions of a graph using information about phased traversals.
+ */
+
+#include <utility> 
+#include <vector>
+
+#include <xg.hpp>
+
+#include "vg.pb.h"
+#include "types.hpp"
+
+namespace vg {
+
+using namespace std;
+
+/**
+ * Transforms complex subregions of a graph into collections of disconnected
+ * distinct traversal haplotypes. Requires an xg index with a gPBWT in order to
+ * work.
+ */
+class PhaseDuplicator {
+public:
+    /// Make a new PhaseDuplicator backed by the gievn index with gPBWT
+    PhaseDuplicator(const xg::XG& index);
+    
+    /**
+     * Duplicate out the subgraph induced by the given set of node IDs. Border
+     * nodes of the subgraph, which edges out to the rest of the graph will be
+     * identified, and all unique traversals from one border node to another
+     * will be generated as new nodes, with edges connecting them to material
+     * outside the graph and Translations embedding them in the original graph.
+     *
+     * TODO: also generate one-end-anchored traversals and internal not-
+     * attached-to-a-border traversals, because there may be phase breaks in the
+     * region.
+     *
+     * New IDs will be generated startign with next_id, and next_id will be
+     * updated to the next ID after the IDs of all generated material.
+     * 
+     * TODO: invent some kind of thread safe ID allocator so we can do multiple
+     * subgraphs in parallel without renumbering later.
+     */
+    pair<Graph, vector<Translation>>&& duplicate(set<id_t> subgraph, id_t& next_id) const;
+    
+private:
+    /// What XG index describes the graph we operate on?
+    const xg::XG& index;
+};
+
+}
+
+#endif 

--- a/src/phase_duplicator.hpp
+++ b/src/phase_duplicator.hpp
@@ -46,7 +46,7 @@ public:
      * TODO: invent some kind of thread safe ID allocator so we can do multiple
      * subgraphs in parallel without renumbering later.
      */
-    pair<Graph, vector<Translation>>&& duplicate(set<id_t> subgraph, id_t& next_id) const;
+    pair<Graph, vector<Translation>> duplicate(set<id_t> subgraph, id_t& next_id) const;
     
 private:
     /// What XG index describes the graph we operate on?

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -115,6 +115,7 @@ int main_index(int argc, char** argv) {
             //{"verbose", no_argument,       &verbose_flag, 1},
             {"db-name", required_argument, 0, 'd'},
             {"kmer-size", required_argument, 0, 'k'},
+            {"doubling-steps", required_argument, 0, 'X'},
             {"edge-max", required_argument, 0, 'e'},
             {"kmer-stride", required_argument, 0, 'j'},
             {"store-graph", no_argument, 0, 's'},

--- a/src/unittest/phase_duplicator.cpp
+++ b/src/unittest/phase_duplicator.cpp
@@ -12,52 +12,53 @@
 
 namespace vg {
 namespace unittest {
+
+// Build a toy graph
+const string duplicator_graph_1 = R"(
+    {
+        "node": [
+            {"id": 1, "sequence": "G"},
+            {"id": 2, "sequence": "A"},
+            {"id": 3, "sequence": "T"},
+            {"id": 4, "sequence": "GGG"},
+            {"id": 5, "sequence": "T"},
+            {"id": 6, "sequence": "A"},
+            {"id": 7, "sequence": "C"},
+            {"id": 8, "sequence": "A"},
+            {"id": 9, "sequence": "A"}
+        ],
+        "edge": [
+            {"from": 1, "to": 2},
+            {"from": 1, "to": 6},
+            {"from": 2, "to": 3},
+            {"from": 2, "to": 4},
+            {"from": 3, "to": 5},
+            {"from": 4, "to": 5},
+            {"from": 5, "to": 6},
+            {"from": 6, "to": 7},
+            {"from": 6, "to": 8},
+            {"from": 7, "to": 9},
+            {"from": 8, "to": 9}
+            
+        ],
+        "path": [
+            {"name": "hint", "mapping": [
+                {"position": {"node_id": 1}},
+                {"position": {"node_id": 6}},
+                {"position": {"node_id": 8}},
+                {"position": {"node_id": 9}}
+            ]}
+        ]
+    }
+    )";
         
 TEST_CASE("PhaseDuplicator can emit a single traversal", "[phaseduplicator][indexing]") {
         
     // Make a graph
-    // Build a toy graph
-    const string graph_json = R"(
-        {
-            "node": [
-                {"id": 1, "sequence": "G"},
-                {"id": 2, "sequence": "A"},
-                {"id": 3, "sequence": "T"},
-                {"id": 4, "sequence": "GGG"},
-                {"id": 5, "sequence": "T"},
-                {"id": 6, "sequence": "A"},
-                {"id": 7, "sequence": "C"},
-                {"id": 8, "sequence": "A"},
-                {"id": 9, "sequence": "A"}
-            ],
-            "edge": [
-                {"from": 1, "to": 2},
-                {"from": 1, "to": 6},
-                {"from": 2, "to": 3},
-                {"from": 2, "to": 4},
-                {"from": 3, "to": 5},
-                {"from": 4, "to": 5},
-                {"from": 5, "to": 6},
-                {"from": 6, "to": 7},
-                {"from": 6, "to": 8},
-                {"from": 7, "to": 9},
-                {"from": 8, "to": 9}
-                
-            ],
-            "path": [
-                {"name": "hint", "mapping": [
-                    {"position": {"node_id": 1}},
-                    {"position": {"node_id": 6}},
-                    {"position": {"node_id": 8}},
-                    {"position": {"node_id": 9}}
-                ]}
-            ]
-        }
-        )";
     
     // Make an actual graph
     Graph graph;
-    json2pb(graph, graph_json.c_str(), graph_json.size());
+    json2pb(graph, duplicator_graph_1.c_str(), duplicator_graph_1.size());
             
     // Make an XG index of the graph
     xg::XG index(graph);
@@ -114,7 +115,207 @@ TEST_CASE("PhaseDuplicator can emit a single traversal", "[phaseduplicator][inde
         REQUIRE(duped.edge_size() == 4);
     }
     
+    SECTION("there should be 1 translation") {
+        REQUIRE(translations.size() == 1);
+        
+        auto& translation = translations.front();
+        
+        SECTION("the translation should have 3 mappings in each path") {
+            REQUIRE(translation.from().mapping_size() == 3);
+            REQUIRE(translation.to().mapping_size() == 3);
             
+            SECTION("the from mappings should trace the original path") {
+                REQUIRE(translation.from().mapping(0).position().node_id() == 2);
+                REQUIRE(translation.from().mapping(0).position().is_reverse() == false);
+                REQUIRE(translation.from().mapping(1).position().node_id() == 3);
+                REQUIRE(translation.from().mapping(1).position().is_reverse() == false);
+                REQUIRE(translation.from().mapping(2).position().node_id() == 5);
+                REQUIRE(translation.from().mapping(2).position().is_reverse() == false);
+            }
+            
+            SECTION("the to mappings should also spell out ATT") {
+                // We need to index the duplicated nodes
+                map<id_t, Node> id_to_node;
+                for (size_t i = 0; i < duped.node_size(); i++) {
+                    id_to_node[duped.node(i).id()] = duped.node(i);
+                }
+                
+                for (size_t i = 0; i < translation.to().mapping_size(); i++) {
+                    // All the mappings have to be to forward copies of these nodes.
+                    auto& mapping = translation.to().mapping(i);
+                    REQUIRE(id_to_node.count(mapping.position().node_id()));
+                    REQUIRE(mapping.position().is_reverse() == false);
+                }
+                
+                // And when we look at the nodes they need the right sequences
+                REQUIRE(id_to_node[translation.to().mapping(0).position().node_id()].sequence() == "A");
+                REQUIRE(id_to_node[translation.to().mapping(1).position().node_id()].sequence() == "T");
+                REQUIRE(id_to_node[translation.to().mapping(2).position().node_id()].sequence() == "T");
+            }
+        }
+        
+    }
+    
+            
+}
+
+TEST_CASE("PhaseDuplicator can deduplicate identical traversals", "[phaseduplicator][indexing]") {
+        
+    // Make a graph
+    
+    // Make an actual graph
+    Graph graph;
+    json2pb(graph, duplicator_graph_1.c_str(), duplicator_graph_1.size());
+            
+    // Make an XG index of the graph
+    xg::XG index(graph);
+    
+    // Add in a thread
+    vector<xg::XG::thread_t> threads {{
+        {1, false},
+        {2, false},
+        {3, false},
+        {5, false},
+        {6, false},
+        {7, false},
+        {9, false}
+    }, {
+        {1, false},
+        {2, false},
+        {3, false},
+        {5, false},
+        {6, false},
+        {7, false},
+        {9, false}
+    }, {
+        {9, true},
+        {7, true},
+        {6, true},
+        {5, true},
+        {3, true},
+        {2, true},
+        {1, true}
+    }};
+    index.insert_threads_into_dag(threads);
+    
+    // Make a duplicator
+    PhaseDuplicator duplicator(index);
+    
+    // Define a subgraph to duplicate out
+    set<id_t> to_duplicate {2, 3, 4, 5};
+    // And the next ID to use
+    id_t next_id = 10;
+    
+    // Do the duplication
+    pair<Graph, vector<Translation>> result(duplicator.duplicate(to_duplicate, next_id));
+    Graph& duped = result.first;
+    vector<Translation>& translations = result.second;
+    
+#ifdef debug
+    cerr << pb2json(duped) << endl;
+#endif
+    
+    // Check the result
+    SECTION("the duplicated graph should have 3 nodes") {
+        REQUIRE(duped.node_size() == 3);
+        
+        SECTION("the nodes should be A, T, and T") {
+            bool a_found = false;
+            for (size_t i = 0; i < duped.node_size(); i++) {
+                auto& node = duped.node(i);
+                if (node.sequence() == "A") {
+                    REQUIRE(!a_found);
+                    a_found = true;
+                } else {
+                    REQUIRE(node.sequence() == "T");
+                }
+            }
+            REQUIRE(a_found);
+        }
+    }
+    
+    SECTION("the duplicated graph should have 4 edges") {
+        REQUIRE(duped.edge_size() == 4);
+    }
+}
+
+TEST_CASE("PhaseDuplicator can produce internal traversals", "[phaseduplicator][indexing]") {
+        
+    // Make a graph
+    
+    // Make an actual graph
+    Graph graph;
+    json2pb(graph, duplicator_graph_1.c_str(), duplicator_graph_1.size());
+            
+    // Make an XG index of the graph
+    xg::XG index(graph);
+    
+    // Add in a thread
+    vector<xg::XG::thread_t> threads {{
+        {1, false},
+        {2, false},
+        {3, false},
+        {5, false},
+        {6, false},
+        {7, false},
+        {9, false}
+    }, {
+        {1, false},
+        {2, false},
+        {3, false},
+        {5, false},
+        {6, false},
+        {7, false},
+        {9, false}
+    }, {
+        {4, true},
+    }};
+    index.insert_threads_into_dag(threads);
+    
+    // Make a duplicator
+    PhaseDuplicator duplicator(index);
+    
+    // Define a subgraph to duplicate out
+    set<id_t> to_duplicate {2, 3, 4, 5};
+    // And the next ID to use
+    id_t next_id = 10;
+    
+    // Do the duplication
+    pair<Graph, vector<Translation>> result(duplicator.duplicate(to_duplicate, next_id));
+    Graph& duped = result.first;
+    vector<Translation>& translations = result.second;
+    
+#ifdef debug
+    cerr << pb2json(duped) << endl;
+#endif
+    
+    // Check the result
+    SECTION("the duplicated graph should have 4 nodes") {
+        REQUIRE(duped.node_size() == 3);
+        
+        SECTION("the nodes should be A, T, T, and GGG") {
+            bool a_found = false;
+            bool ggg_found = false;
+            for (size_t i = 0; i < duped.node_size(); i++) {
+                auto& node = duped.node(i);
+                if (node.sequence() == "A") {
+                    REQUIRE(!a_found);
+                    a_found = true;
+                } else if (node.sequence() == "GGG") {
+                    REQUIRE(!ggg_found);
+                    ggg_found = true;
+                } else {
+                    REQUIRE(node.sequence() == "T");
+                }
+            }
+            REQUIRE(a_found);
+            REQUIRE(ggg_found);
+        }
+    }
+    
+    SECTION("the duplicated graph should have 4 edges") {
+        REQUIRE(duped.edge_size() == 4);
+    }
 }
     
 }

--- a/src/unittest/phase_duplicator.cpp
+++ b/src/unittest/phase_duplicator.cpp
@@ -51,7 +51,7 @@ const string duplicator_graph_1 = R"(
         ]
     }
     )";
-        
+
 TEST_CASE("PhaseDuplicator can emit a single traversal", "[phaseduplicator][indexing]") {
         
     // Make a graph
@@ -268,7 +268,7 @@ TEST_CASE("PhaseDuplicator can produce internal traversals", "[phaseduplicator][
         {7, false},
         {9, false}
     }, {
-        {4, true},
+        {4, true}
     }};
     index.insert_threads_into_dag(threads);
     
@@ -291,7 +291,7 @@ TEST_CASE("PhaseDuplicator can produce internal traversals", "[phaseduplicator][
     
     // Check the result
     SECTION("the duplicated graph should have 4 nodes") {
-        REQUIRE(duped.node_size() == 3);
+        REQUIRE(duped.node_size() == 4);
         
         SECTION("the nodes should be A, T, T, and GGG") {
             bool a_found = false;

--- a/src/unittest/phase_duplicator.cpp
+++ b/src/unittest/phase_duplicator.cpp
@@ -1,0 +1,121 @@
+/** \file
+ *
+ * Unit tests for the PhaseDuplicator, which replaces complex subgraphs with
+ * observed traversals.
+ */
+
+#include <iostream>
+#include "../phase_duplicator.hpp"
+#include "../json2pb.h"
+
+#include "catch.hpp"
+
+namespace vg {
+namespace unittest {
+        
+TEST_CASE("PhaseDuplicator can emit a single traversal", "[phaseduplicator][indexing]") {
+        
+    // Make a graph
+    // Build a toy graph
+    const string graph_json = R"(
+        {
+            "node": [
+                {"id": 1, "sequence": "G"},
+                {"id": 2, "sequence": "A"},
+                {"id": 3, "sequence": "T"},
+                {"id": 4, "sequence": "GGG"},
+                {"id": 5, "sequence": "T"},
+                {"id": 6, "sequence": "A"},
+                {"id": 7, "sequence": "C"},
+                {"id": 8, "sequence": "A"},
+                {"id": 9, "sequence": "A"}
+            ],
+            "edge": [
+                {"from": 1, "to": 2},
+                {"from": 1, "to": 6},
+                {"from": 2, "to": 3},
+                {"from": 2, "to": 4},
+                {"from": 3, "to": 5},
+                {"from": 4, "to": 5},
+                {"from": 5, "to": 6},
+                {"from": 6, "to": 7},
+                {"from": 6, "to": 8},
+                {"from": 7, "to": 9},
+                {"from": 8, "to": 9}
+                
+            ],
+            "path": [
+                {"name": "hint", "mapping": [
+                    {"position": {"node_id": 1}},
+                    {"position": {"node_id": 6}},
+                    {"position": {"node_id": 8}},
+                    {"position": {"node_id": 9}}
+                ]}
+            ]
+        }
+        )";
+    
+    // Make an actual graph
+    Graph graph;
+    json2pb(graph, graph_json.c_str(), graph_json.size());
+            
+    // Make an XG index of the graph
+    xg::XG index(graph);
+    
+    // Add in a thread
+    vector<xg::XG::thread_t> threads {{
+        {1, false},
+        {2, false},
+        {3, false},
+        {5, false},
+        {6, false},
+        {7, false},
+        {9, false}
+    }};
+    index.insert_threads_into_dag(threads);
+    
+    // Make a duplicator
+    PhaseDuplicator duplicator(index);
+    
+    // Define a subgraph to duplicate out
+    set<id_t> to_duplicate {2, 3, 4, 5};
+    // And the next ID to use
+    id_t next_id = 10;
+    
+    // Do the duplication
+    pair<Graph, vector<Translation>> result(duplicator.duplicate(to_duplicate, next_id));
+    Graph& duped = result.first;
+    vector<Translation>& translations = result.second;
+    
+#ifdef debug
+    cerr << pb2json(duped) << endl;
+#endif
+    
+    // Check the result
+    SECTION("the duplicated graph should have 3 nodes") {
+        REQUIRE(duped.node_size() == 3);
+        
+        SECTION("the nodes should be A, T, and T") {
+            bool a_found = false;
+            for (size_t i = 0; i < duped.node_size(); i++) {
+                auto& node = duped.node(i);
+                if (node.sequence() == "A") {
+                    REQUIRE(!a_found);
+                    a_found = true;
+                } else {
+                    REQUIRE(node.sequence() == "T");
+                }
+            }
+            REQUIRE(a_found);
+        }
+    }
+    
+    SECTION("the duplicated graph should have 4 edges") {
+        REQUIRE(duped.edge_size() == 4);
+    }
+    
+            
+}
+    
+}
+}


### PR DESCRIPTION
This is my initial implementation of a `PhaseDuplicator`. You can give it an xg index, and then give it subgraphs, and it will duplicate out those subgraphs to represent all the distinct haplotypes observed crossing the subgraph in the gPBWT.

The plan is to use this to replace the current pruning of complex regions when constructing the GCSA2 index.