### PR TITLE
Sim pairs ok

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -157,7 +157,8 @@ string Sampler::alignment_seq(const Alignment& aln) {
 vector<Alignment> Sampler::alignment_pair(size_t read_length, size_t fragment_length, double fragment_std_dev, double base_error, double indel_error) {
     // simulate forward/reverse pair by first simulating a long read
     normal_distribution<> norm_dist(fragment_length, fragment_std_dev);
-    int frag_len = round(norm_dist(rng));
+    // bound at read length so we always get enough sequence
+    int frag_len = max((int)read_length, (int)round(norm_dist(rng)));
     auto fragment = alignment_with_error(frag_len, base_error, indel_error);
     // then taking the ends
     auto fragments = alignment_ends(fragment, read_length, read_length);

--- a/test/t/13_vg_sim.t
+++ b/test/t/13_vg_sim.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 5
+plan tests 6
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
@@ -22,6 +22,8 @@ is $(vg sim -s 33232 -l 100 -n 100 -J -x x.xg | grep is_reverse | wc -l) 50 "ali
 is $(vg sim -s 1337 -l 100 -n 100 -e 0.1 -i 0.1 -J -x x.xg | jq .sequence | wc -c) 10300 "high simulated error rates do not change the number of bases generated"
 
 is $(vg sim -l 100 -n 100 -x x.xg -aJ | jq 'select(.path.mapping[0].is_reverse)' | wc -l) 0 \
-    "vg sim creates forward-strand reads when asked"
+   "vg sim creates forward-strand reads when asked"
+
+is $(vg sim -n 10 -i 0.005 -l 10 -p 50 -v 50 -s 42 -x x.xg -J | wc -l) 20 "pairs simulated even when fragments overlap"
 
 rm -f x.vg x.xg


### PR DESCRIPTION
Fixes problem where not enough sequence remained in the simulated fragment to generate the read pair.