### PR TITLE
Make MEM threader optional in MSGA

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1731,6 +1731,7 @@ void help_msga(char** argv) {
          << "    -o, --gap-open N      use this gap open penalty (default: 6)" << endl
          << "    -e, --gap-extend N    use this gap extension penalty (default: 1)" << endl
          << "mem mapping:" << endl
+         << "    -l, --no-mem-threader   do not use the mem-threader-based aligner" << endl
          << "    -L, --min-mem-length N  ignore SMEMs shorter than this length (default: 0/unset)" << endl
          << "    -Y, --max-mem-length N  ignore SMEMs longer than this length by stopping backward search (default: 0/unset)" << endl
          << "    -H, --hit-max N         SMEMs which have >N hits in our index (default: 100)" << endl
@@ -1800,6 +1801,7 @@ int main_msga(int argc, char** argv) {
     bool normalize = false;
     bool allow_nonpath = false;
     int iter_max = 1;
+    bool use_mem_threader = true;
     int max_mem_length = 0;
     int min_mem_length = 8;
     bool greedy_accept = false;
@@ -1837,6 +1839,7 @@ int main_msga(int argc, char** argv) {
                 {"idx-prune-subs", required_argument, 0, 'Q'},
                 {"normalize", no_argument, 0, 'N'},
                 {"allow-nonpath", no_argument, 0, 'z'},
+                {"no-mem-threader", no_argument, 0, 'l'},
                 {"min-mem-length", required_argument, 0, 'L'},
                 {"max-mem-length", required_argument, 0, 'Y'},
                 {"hit-max", required_argument, 0, 'H'},
@@ -1857,7 +1860,7 @@ int main_msga(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:B:DAc:P:E:Q:NzI:L:Y:H:t:m:GS:M:T:q:OI:a:i:o:e:C",
+        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:B:DAc:P:E:Q:NzI:lL:Y:H:t:m:GS:M:T:q:OI:a:i:o:e:C",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -1866,6 +1869,10 @@ int main_msga(int argc, char** argv) {
 
         switch (c)
         {
+
+        case 'l':
+            use_mem_threader = false;
+            break;
 
         case 'L':
             min_mem_length = atoi(optarg);
@@ -2166,7 +2173,7 @@ int main_msga(int argc, char** argv) {
             mapper->max_target_factor = max_target_factor;
             mapper->max_multimaps = max_multimaps;
             mapper->accept_identity = accept_identity;
-            mapper->mem_threading = true;
+            mapper->mem_threading = use_mem_threader;
 
             // set up the multi-threaded alignment interface
             // TODO abstract this into a single call!!
@@ -2176,7 +2183,6 @@ int main_msga(int argc, char** argv) {
             mapper->set_alignment_scores(match, mismatch, gap_open, gap_extend);
             mapper->init_node_cache();
             mapper->init_node_pos_cache();
-            mapper->mem_threading = true;
         }
     };
 

--- a/test/t/16_vg_msga.t
+++ b/test/t/16_vg_msga.t
@@ -6,11 +6,13 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 14
+plan tests 15
 
 is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 | vg mod -U 10 - | vg mod -c - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) 16e56f0090b310d2b1479d49cf790324 "MSGA produces the expected graph for GRCh38 HLA-V"
 
 is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 4 | vg mod -U 10 - | vg mod -c - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) 16e56f0090b310d2b1479d49cf790324 "graph for GRCh38 HLA-V is unaffected by the number of alignment threads"
+
+is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 --no-mem-threader| vg mod -U 10 - | vg mod -c - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) 5456c2fb7c9a9c80f6a4cfd4dcc8d4ec "MSGA produces the expected graph for GRCh38 HLA-V with the MEM threader off"
 
 is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -n 'gi|568815592:29791752-29792749' -n 'gi|568815454:1057585-1058559' -b 'gi|568815454:1057585-1058559' -B 10000 -N | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -n 'gi|568815592:29791752-29792749' -n 'gi|568815454:1057585-1058559' -b 'gi|568815454:1057585-1058559' -B 300 -N | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ )  "varying alignment bandwidth does not affect output graph"
 


### PR DESCRIPTION
I was having some trouble getting a set of sequences to MSGA correctly, because the paths that got added to the graph didn't actually trace out the sequences. I fixed this by disabling the MEM threader.

I can provide the offending file upon request, and I have a bunch of debugging code that tries to dig into the problem in my debug-msga branch.