### PR TITLE
Sim good

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/srpe_filter.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/phase_duplicator.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/feature_set.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/mapping.o
+UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/alignment.o
 
 
 # These aren;t put into libvg, but they provide subcommand implementations for the vg bianry
@@ -442,6 +443,8 @@ $(UNITTEST_OBJ_DIR)/phase_duplicator.o: $(UNITTEST_SRC_DIR)/phase_duplicator.cpp
 $(UNITTEST_OBJ_DIR)/feature_set.o: $(UNITTEST_SRC_DIR)/feature_set.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/feature_set.hpp $(DEPS)
 
 $(UNITTEST_OBJ_DIR)/mapping.o: $(UNITTEST_SRC_DIR)/mapping.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/path.hpp $(DEPS)
+
+$(UNITTEST_OBJ_DIR)/alignment.o: $(UNITTEST_SRC_DIR)/alignment.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/alignment.hpp $(DEPS)
 
 ###################################
 ## VG subcommand compilation begins here

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/flow_sort_test.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/srpe_filter.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/phase_duplicator.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/feature_set.o
+UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/mapping.o
 
 
 # These aren;t put into libvg, but they provide subcommand implementations for the vg bianry
@@ -371,7 +372,7 @@ $(OBJ_DIR)/deconstructor.o: $(SRC_DIR)/deconstructor.cpp $(SRC_DIR)/deconstructo
 
 $(OBJ_DIR)/vectorizer.o: $(SRC_DIR)/vectorizer.cpp $(SRC_DIR)/vectorizer.hpp $(DEPS)
 
-$(OBJ_DIR)/sampler.o: $(SRC_DIR)/sampler.cpp $(SRC_DIR)/sampler.hpp $(DEPS)
+$(OBJ_DIR)/sampler.o: $(SRC_DIR)/sampler.cpp $(SRC_DIR)/sampler.hpp $(SRC_DIR)/path.hpp $(DEPS)
 
 $(OBJ_DIR)/filter.o: $(SRC_DIR)/filter.cpp $(SRC_DIR)/filter.hpp $(DEPS)
 
@@ -439,6 +440,8 @@ $(UNITTEST_OBJ_DIR)/flow_sort_test.o: $(UNITTEST_SRC_DIR)/flow_sort_test.cpp $(U
 $(UNITTEST_OBJ_DIR)/phase_duplicator.o: $(UNITTEST_SRC_DIR)/phase_duplicator.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/phase_duplicator.hpp $(DEPS)
 
 $(UNITTEST_OBJ_DIR)/feature_set.o: $(UNITTEST_SRC_DIR)/feature_set.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/feature_set.hpp $(DEPS)
+
+$(UNITTEST_OBJ_DIR)/mapping.o: $(UNITTEST_SRC_DIR)/mapping.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/path.hpp $(DEPS)
 
 ###################################
 ## VG subcommand compilation begins here

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -110,7 +110,9 @@ void translate_nodes(Alignment& a, const map<id_t, pair<id_t, bool> >& ids, cons
 // listed. It needs a callback to ask the length of any given node.
 void flip_nodes(Alignment& a, const set<int64_t>& ids, const std::function<size_t(int64_t)>& node_length);
 
-// simplifies the path in the alignment
+/// Simplifies the Path in the Alignment. Note that this removes deletions at
+/// the start and end of Mappings, so code that handles simplified Alignments
+/// needs to handle offsets on internal Mappings.
 Alignment simplify(const Alignment& a);
 void write_alignment_to_file(const Alignment& aln, const string& filename);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5258,7 +5258,7 @@ void help_map(char** argv) {
          << "    -W, --fragment-max N      maximum fragment size to be used for estimating the fragment length distribution (default: 1e4)" << endl
          << "    -2, --fragment-sigma N    calculate fragment size as mean(buf)+sd(buf)*N where buf is the buffer of perfect pairs we use (default: 10)" << endl
          << "    -p, --pair-window N       maximum distance between properly paired reads in node ID space" << endl
-         << "    -u, --extra-multimaps N   examine N extra mappings looking for a consistent read pairing (default: 2)" << endl
+         << "    -u, --extra-multimaps N   examine N extra mappings looking for a consistent read pairing (default: 1)" << endl
          << "    -U, --always-rescue       rescue each imperfectly-mapped read in a pair off the other" << endl
          << "    -O, --top-pairs-only      only produce paired alignments if both sides of the pair are top-scoring individually" << endl
          << "generic mapping parameters:" << endl

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -226,13 +226,20 @@ Mapping reverse_complement_mapping(const Mapping& m,
 // from the other ends of their nodes.
 Path reverse_complement_path(const Path& path,
                              const function<int64_t(id_t)>& node_length);
-// Simplify the path for addition as new material in the graph. Remove any
-// mappings that are merely single deletions, merge adjacent edis of the same
-// type, strip leading and trailing deletion edits on mappings, and make sure no
-// mappings have missing positions.
+/// Simplify the path for addition as new material in the graph. Remove any
+/// mappings that are merely single deletions, merge adjacent edits of the same
+/// type, strip leading and trailing deletion edits on mappings, and make sure no
+/// mappings have missing positions.
 Path simplify(const Path& p);
-// does the same for a single mapping element
+/// Merge adjacent edits of the same type, strip leading and trailing deletion
+/// edits (while updating positions if necessary), and makes sure position is
+/// actually set.
 Mapping simplify(const Mapping& m);
+
+/// Merge adjacent edits of the same type
+Path merge_adjacent_edits(const Path& m);
+/// Merge adjacent edits of the same type
+Mapping merge_adjacent_edits(const Mapping& m);
 // trim path so it starts and begins with a match (or is empty)
 Path trim_hanging_ends(const Path& p);
 // make a new mapping that concatenates the mappings

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -17,6 +17,10 @@ namespace vg {
 
 using namespace std;
 
+/**
+ * Generate Alignments (with or without mutations, and in pairs or alone) from
+ * an XG index.
+ */
 class Sampler {
 
 public:
@@ -56,6 +60,11 @@ public:
                      double base_error,
                      double indel_error);
 
+    /**
+     * Mutate the given edit, producing a vector of edits that should replace
+     * it. Position is the position of the start of the edit, and is updated to
+     * point to the next base after the mutated edit.
+     */
     vector<Edit> mutate_edit(const Edit& edit,
                              const pos_t& position,
                              double base_error,
@@ -65,6 +74,13 @@ public:
                              uniform_int_distribution<int>& rbase);
 
     string alignment_seq(const Alignment& aln);
+    
+    /// Return true if the alignment is semantically valid against the XG index
+    /// we wrap, and false otherwise. Checks from_lengths on mappings to make
+    /// sure all node bases are accounted for. Won't accept alignments with
+    /// internal jumps between graph locations or regions; all skipped bases
+    /// need to be accounted for by deletions.
+    bool is_valid(const Alignment& aln);
 
 };
 

--- a/src/unittest/alignment.cpp
+++ b/src/unittest/alignment.cpp
@@ -1,0 +1,53 @@
+/// \file alignment.cpp
+///  
+/// unit tests for Alignments and their utility functions
+///
+
+#include <iostream>
+#include <string>
+#include "../json2pb.h"
+#include "../vg.pb.h"
+#include "../alignment.hpp"
+#include "catch.hpp"
+
+namespace vg {
+namespace unittest {
+using namespace std;
+
+TEST_CASE("Alignment simplification removes deletions on the edges of Mappings", "[alignment]") {
+    
+    string alignment_string = R"(
+        {
+            "sequence": "A",
+            "path": {"mapping": [
+                {
+                    "position": {"node_id": 1},
+                    "edit": [
+                        {"from_length": 1, "to_length": 1},
+                        {"from_length": 1}
+                    ]
+                },
+                {
+                    "position": {"node_id": 2},
+                    "edit": [
+                        {"from_length": 1, "to_length": 1}
+                    ]
+                }
+            ]}
+        }
+    )";
+    
+    Alignment a;
+    json2pb(a, alignment_string.c_str(), alignment_string.size());
+    
+    cerr << pb2json(a) << endl;
+    
+    auto simple = simplify(a);
+    REQUIRE(simple.path().mapping_size() == 2);
+    REQUIRE(simple.path().mapping(0).edit_size() == 1);
+    
+}
+   
+}
+}
+        

--- a/src/unittest/mapping.cpp
+++ b/src/unittest/mapping.cpp
@@ -1,0 +1,32 @@
+/// \file mapping.cpp
+///  
+/// unit tests for Mappings and their utility functions
+///
+
+#include <iostream>
+#include <string>
+#include "../json2pb.h"
+#include "../vg.pb.h"
+#include "../path.hpp"
+#include "catch.hpp"
+
+namespace vg {
+namespace unittest {
+using namespace std;
+
+TEST_CASE("Mapping simplification keeps pure deletion edits", "[mapping]") {
+    
+    string mapping_string = R"({"edit": [{"from_length": 1, "to_length": 1}, {"from_length": 1}]})";
+    
+    Mapping m;
+    json2pb(m, mapping_string.c_str(), mapping_string.size());
+    
+    auto simple = simplify(m);
+    
+    REQUIRE(simple.edit_size() == m.edit_size());
+    
+}
+   
+}
+}
+        

--- a/src/unittest/mapping.cpp
+++ b/src/unittest/mapping.cpp
@@ -14,16 +14,41 @@ namespace vg {
 namespace unittest {
 using namespace std;
 
-TEST_CASE("Mapping simplification keeps pure deletion edits", "[mapping]") {
+TEST_CASE("Mapping simplification fails when mapping position is not set", "[mapping]") {
+    
+    // We can't remove leading deletions if there's no position to update
+    string mapping_string = R"({"edit": [{"from_length": 1}, {"from_length": 1, "to_length": 1}]})";
+    
+    Mapping m;
+    json2pb(m, mapping_string.c_str(), mapping_string.size());
+    
+    REQUIRE_THROWS(simplify(m));
+    
+}
+
+TEST_CASE("Mapping adjacent edit merging keeps leading deletions", "[mapping]") {
+    
+    string mapping_string = R"({"edit": [{"from_length": 1}, {"from_length": 1, "to_length": 1}]})";
+    
+    Mapping m;
+    json2pb(m, mapping_string.c_str(), mapping_string.size());
+    
+    auto merged = merge_adjacent_edits(m);
+    
+    REQUIRE(merged.edit_size() == 2);
+    
+}
+
+TEST_CASE("Mapping adjacent edit merging keeps trailing deletions", "[mapping]") {
     
     string mapping_string = R"({"edit": [{"from_length": 1, "to_length": 1}, {"from_length": 1}]})";
     
     Mapping m;
     json2pb(m, mapping_string.c_str(), mapping_string.size());
     
-    auto simple = simplify(m);
+    auto merged = merge_adjacent_edits(m);
     
-    REQUIRE(simple.edit_size() == m.edit_size());
+    REQUIRE(merged.edit_size() == 2);
     
 }
    

--- a/src/unittest/multipath_alignment.cpp
+++ b/src/unittest/multipath_alignment.cpp
@@ -1,8 +1,7 @@
-//
-//  multipath_alignment.cpp
-//  
-// unit tests for multipath alignment construction and utility functions
-//
+/// \file multipath_alignment.cpp
+///  
+/// unit tests for multipath alignment construction and utility functions
+///
 
 #include <stdio.h>
 #include <iostream>

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -5016,7 +5016,6 @@ void VG::add_nodes_and_edges(const Path& path,
                 if (right_node != nullptr) dangling = NodeSide(right_node->id(), !m.position().is_reverse());
             } else {
                 // We don't need to deal with deletions since we'll deal with the actual match/insert edits on either side
-                // Also, simplify() simplifies them out.
 #ifdef debug_edit
                 cerr << "Skipping other edit relative to " << node_id << endl;
 #endif

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -406,8 +406,9 @@ public:
     /// Given a path on nodes that may or may not exist, and a map from node ID
     /// in the path's node ID space to a table of offset and actual node, add in
     /// all the new sequence and edges required by the path. The given path must
-    /// not contain adjacent perfect match edits in the same mapping (the removal
-    /// of which can be accomplished with the Path::simplify() function).
+    /// not contain adjacent perfect match edits in the same mapping, or any
+    /// deletions on the start or end of mappings (the removal of which can be
+    /// accomplished with the Path::simplify() function).
     void add_nodes_and_edges(const Path& path,
                              const map<pos_t, Node*>& node_translation,
                              map<pair<pos_t, string>, Node*>& added_seqs,

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -114,7 +114,7 @@ vg index -x x.xg -g x.gcsa -k 16 x.vg
 vg sim -s 1337 -n 100 -e 0.01 -i 0.005 -x x.xg -a >x.sim
 vg map -x x.xg -g x.gcsa -G x.sim -t 1 >x.gam
 vg mod -Z x.trans -i x.gam x.vg >x.mod.vg
-is $(vg view -Z x.trans | wc -l) 1332 "the expected graph translation is exported when the graph is edited"
+is $(vg view -Z x.trans | wc -l) 1276 "the expected graph translation is exported when the graph is edited"
 rm -rf x.vg x.xg x.gcsa x.reads x.gam x.mod.vg x.trans
 
 vg construct -r tiny/tiny.fa >flat.vg


### PR DESCRIPTION
`vg sim` was producing some reads that had extra deletions in them that shouldn't have been present, and also was not including deletions at the ends of nodes in the alignments it articulated.

I've redone the mutation generation logic to be correct about how it moves through both graph and read space (even if fed a read that already has non-perfect-match edits). I've also added validation logic that should throw an error if it gets too out of sync with itself.

I am also now outputting all the deletion edits, instead of getting rid of some like `simplify(Alignment&)` does. When looking at simulated reads, it makes more sense for the "truth" to show a deletion than a skip to the next node.

Overall I think we ought to think about whether the `simplify()` functions should be deleting these deletions and relying on the position of the next mapping to let you know there's a deletion. On the one hand it will exercise out jump-handling code. (Some code I think currently isn't even looking at positions on internal mappings in an alignment, and that's bad and we need to catch it and fix it.) But on the other hand it means there's no way to look at the alignment alone and find out how long a deletion is (and there's not necessarily an efficient way to do it looking at the alignment and the graph together). This makes things like verifying alignment scores hard.