### PR TITLE
Construct multiple contigs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -434,7 +434,7 @@ $(UNITTEST_OBJ_DIR)/phased_genome.o: $(UNITTEST_SRC_DIR)/phased_genome.cpp $(UNI
 
 $(UNITTEST_OBJ_DIR)/vg.o: $(UNITTEST_SRC_DIR)/vg.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(DEPS)
 
-$(UNITTEST_OBJ_DIR)/constructor.o: $(UNITTEST_SRC_DIR)/constructor.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/constructor.hpp $(DEPS)
+$(UNITTEST_OBJ_DIR)/constructor.o: $(UNITTEST_SRC_DIR)/constructor.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/constructor.hpp $(SRC_DIR)/utility.hpp $(DEPS)
 
 $(UNITTEST_OBJ_DIR)/flow_sort_test.o: $(UNITTEST_SRC_DIR)/flow_sort_test.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(DEPS)
 

--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1038,10 +1038,6 @@ namespace vg {
         // previous chunk.
         set<id_t> exposed_nodes;
 
-        // We'll also need to bump chunk IDs out of the way. What's the max ID used
-        // in previous chunks?
-        id_t max_id = 0;
-
         // And we need to do the same for ranks on the reference path? What's the
         // max rank used?
         size_t max_ref_rank = 0;
@@ -1489,6 +1485,8 @@ namespace vg {
 
         // All the chunks have been wired and emitted. Now emit the very last node, if any
         emit_reference_node(last_node_buffer);
+        // Update the max ID with that last node, so the next call starts at the next ID
+        max_id = max(max_id, (id_t) last_node_buffer.id());
 
         destroy_progress();
 

--- a/src/constructor.hpp
+++ b/src/constructor.hpp
@@ -280,6 +280,14 @@ protected:
     /// Remembers which unusable symbolic alleles we've already emitted a warning
     /// about during construction.
     set<string> symbolic_allele_warnings;
+    
+    /// All chunks are generated with IDs starting at 1, but graphs emitted from
+    /// construct_graph need to have the IDs rewritten so they don't overlap.
+    /// Moreover, multiple calls to construct_graph need to not have conflicting
+    /// IDs, because some construct_graph implementations call other ones. What
+    /// we do for now is globally track the max ID already used, so all calls to
+    /// construct_graph follow a single ID ordering.
+    id_t max_id = 0;
 
 private:
 

--- a/src/unittest/constructor.cpp
+++ b/src/unittest/constructor.cpp
@@ -5,6 +5,7 @@
 #include "catch.hpp"
 #include "../constructor.hpp"
 
+#include "../utility.hpp"
 #include "../path.hpp"
 #include "../json2pb.h"
 
@@ -178,7 +179,7 @@ TEST_CASE( "Max node length is respected", "[constructor]" ) {
 }
 
 /**
- * Testing wrapper to build a graph from a VCF string. Adds alt paths by default.
+ * Testing wrapper to build a graph chunk from a VCF string. Adds alt paths by default.
  */
 ConstructedChunk construct_test_chunk(string ref_sequence, string ref_name, string vcf_data) {
     
@@ -205,6 +206,62 @@ ConstructedChunk construct_test_chunk(string ref_sequence, string ref_name, stri
 
     // Construct the graph    
     return constructor.construct_chunk(ref_sequence, ref_name, variants, 0);
+}
+
+/**
+ * Testing wrapper to build a whole graph from a VCF string. Adds alt paths by default.
+ */
+Graph construct_test_graph(string fasta_data, string vcf_data) {
+    
+    // Merge all the graphs we get into this graph
+    Graph built;
+    
+    // Make a stream out of the VCF data
+    std::stringstream vcf_stream(vcf_data);
+    
+    // Load it up in vcflib
+    vcflib::VariantCallFile vcf;
+    vcf.open(vcf_stream);
+    
+    // Put it in a vector
+    vector<vcflib::VariantCallFile*> vcf_pointers {&vcf};
+    
+    // We have to write the FASTA to a file
+    string fasta_filename = tmpfilename();
+    ofstream fasta_stream(fasta_filename);
+    fasta_stream << fasta_data;
+    fasta_stream.close(); 
+    
+    // Make a FastaReference out of it
+    FastaReference reference;
+    reference.open(fasta_filename);
+    
+    // Put it in a vector
+    vector<FastaReference*> fasta_pointers {&reference};
+    
+    // Make an empty vector of insertion files
+    vector<FastaReference*> ins_pointers;
+    
+    // Make a callback to handle the output
+    auto callback = [&](Graph& constructed) {
+        // Merge everything that comes out into one graph in memory.
+        #pragma omp critical
+        built.MergeFrom(constructed);
+    };
+    
+    Constructor constructor;
+    constructor.alt_paths = true;
+    // Make sure we can test the node splitting behavior at reasonable sizes
+    constructor.max_node_size = 50;
+
+    // Construct the graph    
+    constructor.construct_graph(fasta_pointers, vcf_pointers, ins_pointers, callback);
+    
+    // Delete our temporary file
+    remove(fasta_filename.c_str());
+    
+    // Return the aggregated result
+    return built;
 }
 
 TEST_CASE( "A SNP can be constructed", "[constructor]" ) {
@@ -1139,6 +1196,53 @@ ref	11	.	TAG	T	29	PASS	.	GT
     // TODO: the center ought to look like this:
     // (A)TT A-+->C-+->ACAT(T)
     //       T-+----/
+
+}
+
+#define debug
+TEST_CASE( "A VCF and FASTA on two contigs make a graph with a consistent ID space", "[constructor][broken]" ) {
+
+    auto vcf_data = R"(##fileformat=VCFv4.0
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=1000GenomesPilot-NCBI36
+##phasing=partial
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
+ref1	1	.	GA	A	29	PASS	.	GT
+ref1	5	rs1337	AC	A	29	PASS	.	GT
+ref2	5	.	A	T	29	PASS	.	GT
+ref2	6	rs1338	C	G	29	PASS	.	GT
+ref2	11	.	TAG	T	29	PASS	.	GT
+)";
+
+    auto fasta_data = R"(>ref1
+GATTACACATTAG
+>ref2
+GATTACACATTAG
+)";
+
+    // Build the graph
+    auto result = construct_test_graph(fasta_data, vcf_data);
+    
+#ifdef debug
+    std::cerr << pb2json(result) << std::endl;
+#endif
+
+    SECTION("node IDs are not repeated") {
+        set<id_t> seen_ids;
+        
+        for (size_t i = 0; i < result.node_size(); i++) {
+            // Look at each node
+            auto& node = result.node(i);
+            
+            // Make sure its ID hasn't been seen before
+            REQUIRE(!seen_ids.count(node.id()));
+            seen_ids.insert(node.id());
+        }
+    }
 
 }
 

--- a/src/unittest/constructor.cpp
+++ b/src/unittest/constructor.cpp
@@ -1199,8 +1199,7 @@ ref	11	.	TAG	T	29	PASS	.	GT
 
 }
 
-#define debug
-TEST_CASE( "A VCF and FASTA on two contigs make a graph with a consistent ID space", "[constructor][broken]" ) {
+TEST_CASE( "A VCF and FASTA on two contigs make a graph with a consistent ID space", "[constructor]" ) {
 
     auto vcf_data = R"(##fileformat=VCFv4.0
 ##fileDate=20090805

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -145,6 +145,25 @@ string tmpfilename(const string& base) {
     return tmpname;
 }
 
+string tmpfilename() {
+    // We need to find the system temp directory.
+    const char* system_temp_dir = nullptr;
+    
+    for(const char* var_name : {"TMPDIR", "TMP", "TEMP", "TEMPDIR", "USERPROFILE"}) {
+        // Try all these env vars in order
+        if (system_temp_dir == nullptr) {
+            system_temp_dir = getenv(var_name);
+        }
+    }
+    if (system_temp_dir == nullptr) {
+        // Then if none were set default to /tmp
+        system_temp_dir = "/tmp";
+    }
+    
+    // Make a temp file in there.
+    return tmpfilename(string(system_temp_dir) + "/vg");
+}
+
 string get_or_make_variant_id(const vcflib::Variant& variant) {
 
      if(!variant.id.empty() && variant.id != ".") {

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -209,7 +209,11 @@ typename Collection::value_type logprob_sum(const Collection& collection) {
     return pulled_out + prob_to_logprob(total);
 }
 
+/// Create a temporary file starting with the given base name
 string tmpfilename(const string& base);
+
+/// Create a temporary file in the appropriate system temporary directory
+string tmpfilename();
 
 // Code to detect if a variant lacks an ID and give it a unique but repeatable
 // one.


### PR DESCRIPTION
This ought to fix the bug @edawson found in #620 where construct just doesn't think about multiple calls to `construct_graph` needing to be in the same ID space. Now all the graphs produced by a `Constructor` should be in a shared ID space.