### PR TITLE
Fast sub-MEM algorithm

### DIFF
--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -160,6 +160,14 @@ private:
                        int min_mem_length,
                        vector<pair<MaximalExactMatch, vector<size_t>>>& sub_mems_out);
     
+    // Provides same semantics as find_sub_mems but with a different algorithm. This algorithm uses the
+    // min_mem_length as a pruning tool instead of the LCP index. It can be expected to be faster when both
+    // the min_mem_length reasonably large relative to the reseed_length (e.g. 1/2 of SMEM size or similar).
+    void find_sub_mems_fast(vector<MaximalExactMatch>& mems,
+                            string::const_iterator next_mem_end,
+                            int min_sub_mem_length,
+                            vector<pair<MaximalExactMatch, vector<size_t>>>& sub_mems_out);
+    
     // finds the nodes of sub MEMs that do not occur inside parent MEMs, each sub MEM should be associated
     // with a vector of the indices of the SMEMs that contain it in the parent MEMs vector
     void fill_nonredundant_sub_mem_nodes(vector<MaximalExactMatch>& parent_mems,
@@ -411,6 +419,7 @@ public:
     int min_mem_length; // a mem must be >= this length
     bool mem_threading; // whether to use the mem threading mapper or not
     int mem_reseed_length; // the length above which we reseed MEMs to get potentially missed hits
+    bool fast_reseed; // use the fast reseed algorithm
 
     // general parameters, applying to both types of mapping
     //

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 37
+plan tests 39
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 is $? 0 "construction"
@@ -86,11 +86,13 @@ rm -f giab.vg giab.xg giab.gcsa
 vg construct -r mem/r.fa > r.vg
 vg index -x r.xg -g r.gcsa -k 16 r.vg
 is $(vg find -M GAGGCAGTGAAGAGATCGTGGGAGGGAC -R 10 -Z 10 -g r.gcsa -x r.xg) '[["GAGGCAGTGAAGAGATCGTGGGAG",["1:20"]],["GCAGTGAAGAGATCGTGGGAGGGAC",["1:43"]],["CAGTGAAGAGATCGTGGGAGG",["1:0"]]]' "we can find sub-MEMs and only return hits that are not within containing MEMs"
+is $(vg find -M GAGGCAGTGAAGAGATCGTGGGAGGGAC -R 10 -Z 10 -f -g r.gcsa -x r.xg) '[["GAGGCAGTGAAGAGATCGTGGGAG",["1:20"]],["GCAGTGAAGAGATCGTGGGAGGGAC",["1:43"]],["CAGTGAAGAGATCGTGGGAGG",["1:0"]]]' "we get the same (sufficiently long) MEMs with the fast sub-MEM option"
 rm -rf r.vg r.xg r.gcsa* mem/r.fa.fai
 
 vg view -J mem/s.json -v > s.vg
 vg index -x s.xg -g s.gcsa -k 16 s.vg
 is $(vg find -M ACGTGCCGTTAGCCAGTGGGTTAG -R 10 -Z 10 -x s.xg -g s.gcsa) '[["ACGTGCCGTTAGCCAGTGGGTTAG",["3:11"]],["AGCCAGTGGGTTA",["1:0","2:0"]]]' "we can find sub-MEMs in a hard case of de-duplication"
+is $(vg find -M ACGTGCCGTTAGCCAGTGGGTTAG -R 10 -Z 10 -f -x s.xg -g s.gcsa) '[["ACGTGCCGTTAGCCAGTGGGTTAG",["3:11"]],["AGCCAGTGGGTTA",["1:0","2:0"]]]' "we can find the same (sufficiently long) sub-MEMs the hard de-duplication case with the fast sub-MEM option"
 rm -rf s.vg s.xg s.gcsa*
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg


### PR DESCRIPTION
I went ahead and implemented the other sub-MEM algorithm I mentioned in https://github.com/vgteam/vg/pull/628 and included it has a command line option. Right now it needs to be turned on, but I think it's worth considering making it the default. We would probably want to do speed tests on real data first.

The main difference between the two algorithms is that the new one doesn't make any calls to the LCP index, which are O(log(|graph|)). That's not as huge a deal when you only need to make a few calls to it for a read because you're looking at mostly true, long SMEMs. In contrast, when you're looking for sub-MEMs most of the MEMs are short false MEMs, which means you have to make a bunch of LCP queries (say, something like |SMEM| / 4 of them).

Instead, the new algorithm looks for "probe matches" with length equal to the minimum MEM length and then tries to extend them into MEMs. If the minimum MEM length is substantially longer than the expected length of a match to random sequence (10-16 bps in most genomes), this leads to an effective pruning strategy. To help ensure this criterion, I boost the minimum MEM length up to |SMEM| / 2 when reseeding. 

I think this PR will still fail the one test in mod that https://github.com/vgteam/vg/pull/628 failed. If I understand it correctly, that's another test where changing the mapping algorithm will pretty much always cause it to fail. Really, it's enforcing that none of the underlying processes change from when the test was introduced, which I don't think is a good way to design tests when we're working with approximations. If nobody objects, I'd like to replace it with something less stringent and add that to this PR.