### PR TITLE
Add snarls subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/index_main.o
 SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/mod_main.o
 SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/annotate_main.o
 SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/chunk_main.o
+SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/snarls_main.o
 
 RAPTOR_DIR:=deps/raptor
 PROTOBUF_DIR:=deps/protobuf
@@ -496,6 +497,8 @@ $(SUBCOMMAND_OBJ_DIR)/annotate_main.o: $(SUBCOMMAND_SRC_DIR)/annotate_main.cpp $
 $(SUBCOMMAND_OBJ_DIR)/chunk_main.o: $(SUBCOMMAND_SRC_DIR)/chunk_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/utility.hpp $(DEPS)
 
 $(SUBCOMMAND_OBJ_DIR)/add_main.o: $(SUBCOMMAND_SRC_DIR)/add_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vcf_buffer.hpp $(SRC_DIR)/variant_adder.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/utility.hpp $(DEPS)
+
+$(SUBCOMMAND_OBJ_DIR)/snarls_main.o: $(SUBCOMMAND_SRC_DIR)/snarls_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/utility.hpp $(DEPS)
 
 
 ########################

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -226,7 +226,11 @@ vector<SnarlTraversal> ExhaustiveTraversalFinder::find_traversals(const Snarl& s
             stack.push_back(to_rev_node_traversal(child_site->start(), graph));
         }
         else {
-            // add all of the node traversals we can reach through valid walks
+            // make a visit out of the node traversal
+            visit.set_node_id(node_traversal.node->id());
+            visit.set_backward(node_traversal.backward);
+            
+            // add all of the node traversals we can reach through valid walks to stack
             stack_up_valid_walks(node_traversal, stack);
         }
         

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -58,8 +58,8 @@ SnarlManager CactusUltrabubbleFinder::find_snarls() {
             snarl.mutable_end()->set_node_id(bubble.end.node);
             snarl.mutable_end()->set_backward(bubble.end.is_end);
             
-            // Mark snarl as an ultrabubble
-            snarl.set_type(ULTRABUBBLE);
+            // Mark snarl as an ultrabubble if it's acyclic
+            snarl.set_type(bubble.acyclic ? ULTRABUBBLE : UNCLASSIFIED);
             
             // If not a top level site, add parent info
             if (node->parent != bubble_tree->root) {

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -184,7 +184,7 @@ public:
     
 };
     
-class ExhaustiveTraversalFinder : TraversalFinder {
+class ExhaustiveTraversalFinder : public TraversalFinder {
     
     VG& graph;
     SnarlManager& snarl_manager;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3532,8 +3532,6 @@ void help_stats(char** argv) {
          << "    -H, --heads           list the head nodes of the graph" << endl
          << "    -T, --tails           list the tail nodes of the graph" << endl
          << "    -S, --siblings        describe the siblings of each node" << endl
-         << "    -b, --superbubbles    describe the superbubbles of the graph" << endl
-         << "    -u, --ultrabubbles    describe the ultrabubbles of the graph" << endl
          << "    -c, --components      print the strongly connected components of the graph" << endl
          << "    -A, --is-acyclic      print if the graph is acyclic or not" << endl
          << "    -n, --node ID         consider node with the given id" << endl
@@ -3561,8 +3559,6 @@ int main_stats(int argc, char** argv) {
     bool distance_to_tail = false;
     bool node_count = false;
     bool edge_count = false;
-    bool superbubbles = false;
-    bool ultrabubbles = false;
     bool verbose = false;
     bool is_acyclic = false;
     set<vg::id_t> ids;
@@ -3588,8 +3584,6 @@ int main_stats(int argc, char** argv) {
             {"to-head", no_argument, 0, 'd'},
             {"to-tail", no_argument, 0, 't'},
             {"node", required_argument, 0, 'n'},
-            {"superbubbles", no_argument, 0, 'b'},
-            {"ultrabubbles", no_argument, 0, 'u'},
             {"alignments", required_argument, 0, 'a'},
             {"is-acyclic", no_argument, 0, 'A'},
             {"verbose", no_argument, 0, 'v'},
@@ -3652,14 +3646,6 @@ int main_stats(int argc, char** argv) {
 
         case 'n':
             ids.insert(atoi(optarg));
-            break;
-
-        case 'b':
-            superbubbles = true;
-            break;
-
-        case 'u':
-            ultrabubbles = true;
             break;
 
         case 'A':
@@ -3740,21 +3726,6 @@ int main_stats(int argc, char** argv) {
                 cout << (h==heads.begin()?"":",") << (*h)->id();
             }
             cout << "\t" << length << endl;
-        }
-    }
-
-    if (superbubbles || ultrabubbles) {
-        auto bubbles = superbubbles ? vg::superbubbles(*graph) : vg::ultrabubbles(*graph);
-        for (auto& i : bubbles) {
-            auto b = i.first;
-            auto v = i.second;
-            // sort output for now, to help do diffs in testing
-            sort(v.begin(), v.end());
-            cout << b.first << "\t" << b.second << "\t";
-            for (auto& n : v) {
-                cout << n << ",";
-            }
-            cout << endl;
         }
     }
 

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -1,0 +1,187 @@
+// snarl_main.cpp: define the "vg snarls" subcommand, which outputs snarls and bubbles
+
+#include <omp.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <list>
+#include <fstream>
+
+#include "subcommand.hpp"
+
+#include "../vg.hpp"
+#include "../genotypekit.hpp"
+
+
+using namespace std;
+using namespace vg;
+using namespace vg::subcommand;
+
+void help_snarl(char** argv) {
+    cerr << "usage: " << argv[0] << " snarls [options] graph.vg > snarls.pb" << endl
+         << "options:" << endl
+         << "traversals:" << endl
+         << "    -r, --traversals FILE output SnarlTraversals for ultrabubbles." << endl
+         << "    -l, --leaf-only       restrict traversals to leaf ultrabubbles." << endl
+         << "    -o, --top-level       restrict traversals to top level ultrabubbles" << endl
+         << "    -i, --include-ends    include snarl endpoints as first and last nodes in traversal" << endl
+         << "    -m, --max-nodes N     only compute traversals for snarls with <= N nodes [10]" << endl;    
+}
+
+int main_snarl(int argc, char** argv) {
+
+    if (argc == 2) {
+        help_snarl(argv);
+        return 1;
+    }
+
+    static const int buffer_size = 100;
+    
+    string traversal_file;
+    bool leaf_only = false;
+    bool top_level_only = false;
+    bool include_endpoints = false;
+    int max_nodes = 100;
+
+    int c;
+    optind = 2; // force optind past command positional argument
+    while (true) {
+        static struct option long_options[] =
+            {
+                {"traversals", required_argument, 0, 'r'},
+                {"leaf-only", no_argument, 0, 'l'},
+                {"top-level", no_argument, 0, 'o'},
+                {"include-endpoints", no_argument, 0, 'i'},
+                {"max-nodes", required_argument, 0, 'm'},
+                {0, 0, 0, 0}
+            };
+
+        int option_index = 0;
+        c = getopt_long (argc, argv, "r:loim:h?",
+                         long_options, &option_index);
+
+        /* Detect the end of the options. */
+        if (c == -1)
+            break;
+
+        switch (c)
+        {
+
+        case 'r':
+            traversal_file = optarg;
+            break;
+
+        case 'l':
+            leaf_only = true;
+            break;
+
+        case 'o':
+            top_level_only = true;
+            break;
+
+        case 'i':
+            include_endpoints = true;
+            break;
+
+        case 'm':
+            max_nodes = atoi(optarg);
+            break;            
+            
+        case 'h':
+        case '?':
+            /* getopt_long already printed an error message. */
+            help_snarl(argv);
+            exit(1);
+            break;
+
+        default:
+            abort ();
+
+        }
+    }
+
+    // Prepare traversal output stream
+    ofstream trav_stream;
+    if (!traversal_file.empty()) {
+        trav_stream.open(traversal_file);
+        if (!trav_stream) {
+            cerr << "error:[vg snarl]: Could not open \"" << traversal_file
+                 << "\" for writing" << endl;
+        }
+    }
+
+    // Read the graph
+    VG* graph;
+    get_input_file(optind, argc, argv, [&](istream& in) {
+            graph = new VG(in);
+        });
+    
+    if (graph == nullptr) {
+        cerr << "error:[vg snarl]: Could not load graph" << endl;
+        exit(1);
+    }
+    
+    // The only implemnted snarl finder:
+    SnarlFinder* snarl_finder = new CactusUltrabubbleFinder(*graph);
+    
+    // Load up all the snarls
+    SnarlManager snarl_manager = snarl_finder->find_snarls();
+    const vector<const Snarl*>& snarl_roots = snarl_manager.top_level_snarls();
+
+    // The only implemented traversal finder
+    TraversalFinder* trav_finder = new ExhaustiveTraversalFinder(*graph, snarl_manager);
+
+    // Protobuf output buffers
+    vector<Snarl> snarl_buffer;
+    vector<SnarlTraversal> traversal_buffer;
+
+    for (const Snarl* snarl : snarl_roots) {
+
+        // Write our snarl tree
+        snarl_buffer.push_back(*snarl);
+        stream::write_buffered(cout, snarl_buffer, buffer_size);
+
+        // Optionally write our traversals
+        if (!traversal_file.empty() && snarl->type() == ULTRABUBBLE &&
+            (!leaf_only || snarl_manager.is_leaf(snarl)) &&
+            (!top_level_only || snarl_manager.is_root(snarl)) &&
+            (snarl_manager.deep_contents(snarl, *graph, true).first.size() < max_nodes)) {
+
+            vector<SnarlTraversal> travs = trav_finder->find_traversals(*snarl);
+                
+            // Optionally add endpoints into traversals
+            if (include_endpoints) {
+                for (auto& trav : travs) {
+                    SnarlTraversal new_trav;
+                    Visit* start_visit = new_trav.add_visits();
+                    *start_visit = snarl->start();
+                    for (int i = 0; i < trav.visits_size(); ++i) {
+                        Visit* visit = new_trav.add_visits();
+                        *visit = trav.visits(i);
+                    }
+                    Visit* end_visit = new_trav.add_visits();
+                    *end_visit = snarl->end();
+                    swap(trav, new_trav);
+                }
+            }
+
+            traversal_buffer.insert(traversal_buffer.end(), travs.begin(), travs.end());
+            stream::write_buffered(trav_stream, traversal_buffer, buffer_size);
+        }
+    }
+    // flush
+    stream::write_buffered(cout, snarl_buffer, 0);
+    if (!traversal_file.empty()) {
+        stream::write_buffered(trav_stream, traversal_buffer, 0);
+    }
+    
+    delete snarl_finder;
+    delete trav_finder;
+    delete graph;
+
+    return 0;
+}
+
+// Register subcommand
+static Subcommand vg_snarl("snarls", "compute snarls and their traversals", main_snarl);
+

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 15
+plan tests 9
 
 vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 #is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
@@ -33,25 +33,6 @@ is $(vg view -Fv msgas/q_redundant.gfa | vg stats -S - | md5sum | cut -f 1 -d\ )
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg
 is $(vg stats -n 13 -d t.vg | cut -f 2) 38 "distance to head is correct"
 is $(vg stats -n 13 -t t.vg | cut -f 2) 11 "distance to tail is correct"
-
-is $(vg stats -b t.vg | head -1 | cut -f 3) 1,2,3,4,5,6, "a superbubble's internal nodes are correctly reported"
-is $(vg stats -u t.vg | head -1 | cut -f 3) 1,2,3,4,5,6, "a ultrabubble's internal nodes are correctly reported"
-rm -f t.vg
-
-is $(cat graphs/missed_bubble.gfa | vg view -Fv - | vg stats -b - | grep 79,80,81,299, | wc -l) 1 "superbubbles are detected even when the graph initially has reversing edges"
-is $(cat graphs/missed_bubble.gfa | vg view -Fv - | vg stats -u - | grep 79,80,81,299, | wc -l) 1 "ultrabubbles are detected even when the graph initially has reversing edges"
-
-vg stats z.vg -b > sb.txt
-vg stats z.vg -u > cb.txt
-is $(diff sb.txt cb.txt | wc -l) 0 "superbubbles and cactus bubbles identical for 1mb1kgp"
-rm -f z.vg sb.txt cb.txt
-
-vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg mod -X 1 - > tiny.vg
-vg stats tiny.vg -b > sb.txt
-vg stats tiny.vg -u > cb.txt
-is $(diff sb.txt cb.txt | wc -l) 0 "superbubbles and cactus bubbles identical for atomized tiny"
-
-rm sb.txt cb.txt tiny.vg
 
 vg construct -r small/x.fa -a -f -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 16 x.vg

--- a/test/t/32_vg_snarls.t
+++ b/test/t/32_vg_snarls.t
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 8
+
+vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg
+
+is $(vg snarls -b t.vg | head -1 | cut -f 3) 1,2,3,4,5,6, "a superbubble's internal nodes are correctly reported"
+is $(vg snarls -u t.vg | head -1 | cut -f 3) 1,2,3,4,5,6, "a ultrabubble's internal nodes are correctly reported"
+rm -f t.vg
+
+is $(cat graphs/missed_bubble.gfa | vg view -Fv - | vg snarls -b - | grep 79,80,81,299, | wc -l) 1 "superbubbles are detected even when the graph initially has reversing edges"
+is $(cat graphs/missed_bubble.gfa | vg view -Fv - | vg snarls -u - | grep 79,80,81,299, | wc -l) 1 "ultrabubbles are detected even when the graph initially has reversing edges"
+
+vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
+
+vg snarls z.vg -b > sb.txt
+vg snarls z.vg -u > cb.txt
+is $(diff sb.txt cb.txt | wc -l) 0 "superbubbles and cactus bubbles identical for 1mb1kgp"
+
+is $(vg snarls z.vg -r st.pb | vg view -R - | wc -l) 27303 "vg snarls made right number of protobuf Snarls"
+is $(vg view -E st.pb | wc -l) 57570 "vg snarls made right number of protobug SnarlTraversals"
+
+rm -f z.vg sb.txt cb.txt st.pb 
+
+vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg mod -X 1 - > tiny.vg
+
+vg snarls tiny.vg -b > sb.txt
+vg snarls tiny.vg -u > cb.txt
+is $(diff sb.txt cb.txt | wc -l) 0 "superbubbles and cactus bubbles identical for atomized tiny"
+
+rm sb.txt cb.txt tiny.vg


### PR DESCRIPTION
(beginnings) of command interface for snarls.hpp

@jeizenga I can't get ExhaustiveTraversalFinder to work at all.  On tiny.vg, the traversals are returned with empty visits:

 {"visits": [{}, {}]}
 
On larger tests it gets hung up for ever on very simple looking snarls that don't seem at all cyclic. 


