### PR TITLE
Fix ExhuastiveTraversalFinder bug

### DIFF
--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -226,7 +226,11 @@ vector<SnarlTraversal> ExhaustiveTraversalFinder::find_traversals(const Snarl& s
             stack.push_back(to_rev_node_traversal(child_site->start(), graph));
         }
         else {
-            // add all of the node traversals we can reach through valid walks
+            // make a visit out of the node traversal
+            visit.set_node_id(node_traversal.node->id());
+            visit.set_backward(node_traversal.backward);
+            
+            // add all of the node traversals we can reach through valid walks to stack
             stack_up_valid_walks(node_traversal, stack);
         }
         


### PR DESCRIPTION
Fixes bug mentioned in https://github.com/vgteam/vg/pull/644 where SnarlTraversals are returned without filled Visits