### PR TITLE
fix typos in vg snarls

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3600,7 +3600,7 @@ int main_stats(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hzlsHTScdtn:NEbua:vA",
+        c = getopt_long (argc, argv, "hzlsHTScdtn:NEa:vA",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -44,7 +44,7 @@ int main_snarl(int argc, char** argv) {
     bool leaf_only = false;
     bool top_level_only = false;
     bool include_endpoints = false;
-    int max_nodes = 100;
+    int max_nodes = 10;
     bool legacy_superbubbles = false;
     bool legacy_ultrabubbles = false;
 
@@ -147,7 +147,7 @@ int main_snarl(int argc, char** argv) {
 
     // old code from vg stats
     if (legacy_superbubbles || legacy_ultrabubbles) {
-        auto bubbles = superbubbles ? vg::superbubbles(*graph) : vg::ultrabubbles(*graph);
+        auto bubbles = legacy_superbubbles ? vg::superbubbles(*graph) : vg::ultrabubbles(*graph);
         for (auto& i : bubbles) {
             auto b = i.first;
             auto v = i.second;

--- a/test/t/32_vg_snarls.t
+++ b/test/t/32_vg_snarls.t
@@ -22,7 +22,7 @@ vg snarls z.vg -b > sb.txt
 vg snarls z.vg -u > cb.txt
 is $(diff sb.txt cb.txt | wc -l) 0 "superbubbles and cactus bubbles identical for 1mb1kgp"
 
-is $(vg snarls z.vg -r st.pb | vg view -R - | wc -l) 27303 "vg snarls made right number of protobuf Snarls"
+is $(vg snarls z.vg -r st.pb -m 100 | vg view -R - | wc -l) 27303 "vg snarls made right number of protobuf Snarls"
 is $(vg view -E st.pb | wc -l) 57570 "vg snarls made right number of protobug SnarlTraversals"
 
 rm -f z.vg sb.txt cb.txt st.pb 


### PR DESCRIPTION
* default bubble size for traversals misrepresented in help
* -u activated superbubbles instead of ultrabubbles (#653)
* -u -b traces still left in vg stats. 