### PR TITLE
Stricter ultrabubble definition

### DIFF
--- a/src/bubbles.hpp
+++ b/src/bubbles.hpp
@@ -48,7 +48,7 @@ struct Bubble {
     // of children in chain i.  existing code that doesn't use
     // chains will be unaffected. 
     vector<int> chain_offsets;
-    bool acyclic;
+    bool dag;
 };
 
 typedef Tree<Bubble> BubbleTree;

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -59,7 +59,7 @@ SnarlManager CactusUltrabubbleFinder::find_snarls() {
             snarl.mutable_end()->set_backward(bubble.end.is_end);
             
             // Mark snarl as an ultrabubble if it's acyclic
-            snarl.set_type(bubble.acyclic ? ULTRABUBBLE : UNCLASSIFIED);
+            snarl.set_type(bubble.dag ? ULTRABUBBLE : UNCLASSIFIED);
             
             // If not a top level site, add parent info
             if (node->parent != bubble_tree->root) {

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -361,5 +361,106 @@ TEST_CASE("ExhaustiveTraversalFinder finds all paths on a bubble with an inverte
     REQUIRE(found_trav_2);
 }
 
+TEST_CASE("SiteFinder can differntiate ultrabubbles from snarls", "[genotype]") {
+
+    SECTION("Directed cycle does not count as ultrabubble") {
+    
+        // Build a toy graph
+        const string graph_json = R"(
+    
+        {
+        "node": [
+            {"id": 1, "sequence": "G"},
+            {"id": 2, "sequence": "A"},
+            {"id": 3, "sequence": "T"},
+            {"id": 4, "sequence": "GGG"},
+            {"id": 5, "sequence": "GT"}
+        ],
+        "edge": [
+            {"from": 1, "to": 2},
+            {"from": 2, "to": 3},
+            {"from": 3, "to": 4},
+            {"from": 1, "to": 4, "to_end": true},
+            {"from": 4, "to": 5}
+        ]
+        }
+        )";
+    
+        // Make an actual graph
+        VG graph;
+        Graph chunk;
+        json2pb(chunk, graph_json.c_str(), graph_json.size());
+        graph.merge(chunk);
+
+        // Find the snarls
+        CactusUltrabubbleFinder cubs(graph);
+        SnarlManager snarl_manager = cubs.find_snarls();
+        const vector<const Snarl*>& snarl_roots = snarl_manager.top_level_snarls();
+
+        // Make sure we have one non-ultrabubble start at 1-5
+        REQUIRE(snarl_roots.size() == 1);
+        const Snarl* snarl = snarl_roots[0];
+        int64_t start = snarl->start().node_id();
+        int64_t end = snarl->end().node_id();
+        if (start > end) {
+            swap(start, end);
+        }
+        REQUIRE((start == 1 && end == 5) == true);
+        REQUIRE(snarl->type() != ULTRABUBBLE);
+    }
+
+    SECTION("Ultrabubble flagged as ultrabubble") {
+    
+        // Build a toy graph
+        const string graph_json = R"(
+    
+        {
+        "node": [
+            {"id": 1, "sequence": "G"},
+            {"id": 2, "sequence": "A"},
+            {"id": 3, "sequence": "T"},
+            {"id": 4, "sequence": "GGG"},
+            {"id": 5, "sequence": "GT"},
+            {"id": 6, "sequence": "GT"}
+        ],
+        "edge": [
+            {"from": 1, "to": 2, "to_end": true},
+            {"from": 2, "to": 4, "from_start": true},
+            {"from": 2, "to": 5, "from_start": true},
+            {"from": 4, "to": 6, "to_end": true},
+            {"from": 3, "to": 1, "from_start": true, "to_end": true},
+            {"from": 4, "to": 3, "from_start": true, "to_end": true},
+            {"from": 5, "to": 3, "from_start": true, "to_end": true},
+            {"from": 6, "to": 5, "to_end": true},
+            {"from": 1, "to": 6, "from_start": true}
+        ]
+        }
+        )";
+    
+        // Make an actual graph
+        VG graph;
+        Graph chunk;
+        json2pb(chunk, graph_json.c_str(), graph_json.size());
+        graph.merge(chunk);
+
+        // Find the snarls
+        CactusUltrabubbleFinder cubs(graph);
+        SnarlManager snarl_manager = cubs.find_snarls();
+        const vector<const Snarl*>& snarl_roots = snarl_manager.top_level_snarls();
+
+        // Make sure we have one non-ultrabubble start at 1-5
+        REQUIRE(snarl_roots.size() == 1);
+        const Snarl* snarl = snarl_roots[0];
+        int64_t start = snarl->start().node_id();
+        int64_t end = snarl->end().node_id();
+        if (start > end) {
+            swap(start, end);
+        }
+        REQUIRE((start == 1 && end == 6) == true);
+        REQUIRE(snarl->type() == ULTRABUBBLE);
+    }
+
+}
+
 }
 }


### PR DESCRIPTION
Before, a snarl was flagged as an ultrabubble if it contained no bidirected cycles.  This was confusing and against the intent (if not the letter) of the paper (See #672).

So here we may the definition more strict:  if we can loop back to a node in any direction it's not a bubble. 