### PR TITLE
A couple of bugfixes

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -4744,7 +4744,9 @@ Alignment Mapper::smooth_alignment(const Alignment& aln) {
                 } else {
                     ++count_fwd;
                 }
-                graph.add_node(xindex->node(mapping.position().node_id()));
+                if (mapping.position().node_id()) {
+                    graph.add_node(xindex->node(mapping.position().node_id()));
+                }
             }
         }
         xindex->expand_context(graph.graph, 1, false);

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -138,7 +138,7 @@ int main_index(int argc, char** argv) {
             {"rename", required_argument, 0, 'r'},
             {"verify-index", no_argument, 0, 'V'},
             {"forward-only", no_argument, 0, 'F'},
-            {"size-limit", no_argument, 0, 'Z'},
+            {"size-limit", required_argument, 0, 'Z'},
             {"path-only", no_argument, 0, 'O'},
             {"store-threads", no_argument, 0, 'T'},
             {"node-alignments", no_argument, 0, 'N'},


### PR DESCRIPTION
Don't try and add node 0 to a context graph when alignments have empty mapping positions.

Make sure the argument on `--size-limit` in `vg index` is properly expected.