### PR TITLE
vg add improvements and alignment error checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,7 +413,7 @@ $(OBJ_DIR)/variant_adder.o: $(SRC_DIR)/variant_adder.cpp $(SRC_DIR)/variant_adde
 
 $(OBJ_DIR)/name_mapper.o: $(SRC_DIR)/name_mapper.cpp $(DEPS)
 
-$(OBJ_DIR)/graph_synchronizer.o: $(SRC_DIR)/graph_synchronizer.cpp $(SRC_DIR)/graph_synchronizer.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/vg.hpp $(DEPS)
+$(OBJ_DIR)/graph_synchronizer.o: $(SRC_DIR)/graph_synchronizer.cpp $(SRC_DIR)/graph_synchronizer.hpp $(SRC_DIR)/algorithms/vg_algorithms.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/vg.hpp $(DEPS)
 
 # We also build the main file from xg, so we can offer it as a command
 # TODO: wrap it as a vg subcommand?

--- a/src/graph_synchronizer.cpp
+++ b/src/graph_synchronizer.cpp
@@ -1,4 +1,5 @@
 #include "graph_synchronizer.hpp"
+#include "algorithms/vg_algorithms.hpp"
 
 #include <iterator>
 
@@ -88,61 +89,45 @@ void GraphSynchronizer::Lock::lock() {
         if (start != 0 || past_end != 0) {
             // We want to extract a range
             
+            // Make a Graph to fill in
+            Graph context_graph;
+            
             // Find the outer ends of this range
             NodeSide start_left = synchronizer.get_path_index(path_name).at_position(start);
             NodeSide end_right = synchronizer.get_path_index(path_name).at_position(past_end == 0 ? 0 : past_end - 1).flip();
             
-            // Save the endpoints, so the user can know the ends of their
-            // subgraph that they got.
+            // Fill in the endpoints pair
             endpoints = make_pair(start_left, end_right);
             
-            // Copy over only the bounding nodes, and the edge between them on
-            // the non-barrier side, if any.
-            context.add_node(*synchronizer.graph.get_node(start_left.node));
-            context.add_node(*synchronizer.graph.get_node(end_right.node));
-            if (synchronizer.graph.has_edge(start_left.flip(), end_right.flip())) {
-                // The seed nodes are connected on the non-barrier side. Copy
-                // that edge, because context expansion only adds edges between
-                // newly found nodes.
-                context.add_edge(*synchronizer.graph.get_edge(start_left.flip(), end_right.flip()));
+            // Make them into pos_ts that point left to right, the way Jordan thinks.
+            pos_t left_pos = make_pos_t(start_left.node, start_left.is_end, 0);
+            pos_t right_pos = make_pos_t(end_right.node, !end_right.is_end,
+                synchronizer.graph.get_node(end_right.node)->sequence().size() - 1);
+            
+            // Since these are already at node ends, we don't need to worry about node cuts.
+            
+            // Extract paths out to the length we need to connect the ends, or a bit further.
+            // TODO: be sure to extract really big indels somehow...
+            auto duplications = algorithms::extract_connecting_graph(synchronizer.graph,
+                context_graph,
+                (past_end - start) * 2,
+                left_pos,
+                right_pos,
+                true, // Keep the specified positions in the graph
+                false, // Disallow terminal node cycles, so we don't duplicate nodes
+                true, // Remove other tipe
+                false, // We don't care about being on a path
+                false); // Or being strictly less than the specified length
+                
+            // Any duplication is going to mess things up, since we need
+            // operations on the new graph to make sense in the original graph.
+            // We need all the entries in this duplication map to be no-ops.
+            for (auto& kv : duplications) {
+                assert(kv.first == kv.second);
             }
             
-            // Go do a normal context expansion, but not going through those sides.
-            synchronizer.graph.expand_context_by_length(context, (past_end - start) * 2, false, true, {start_left, end_right});
-            
-            // Now we have to address the problem where long inserts will take
-            // any longer path and match terribly, rather than fit on the
-            // shorter chromosome path, when there are other available tips in
-            // the graph.
-            
-            // TODO: Jordan's fancy extractor will do this.
-            
-            // For now, just prune back any tips that aren't the designated
-            // nodes.
-            
-            // Keep going until we don't find any nodes to kill
-            bool removed = true;
-            while (removed) {
-                // Find the heads and tails
-                auto head_nodes = context.head_nodes();
-                auto tail_nodes = context.tail_nodes();
-                
-                // Make a set of all nodes that are heads or tails
-                set<Node*> tip_nodes{head_nodes.begin(), head_nodes.end()};
-                copy(tail_nodes.begin(), tail_nodes.end(), inserter(tip_nodes, tip_nodes.end()));
-                
-                removed = false;
-                for (Node* tip : tip_nodes) {
-                    // Look at all of them
-                    if (tip->id() != start_left.node && tip->id() != end_right.node) {
-                        // If any of them aren't the nodes we are supposed to
-                        // havem drop them (and their edges)
-                        context.destroy_node(tip);
-                        removed = true;
-                    }
-                }
-            }
-            // TODO: this loop is like n^2 for dropping long sticks we don't want.
+            // Dump nodes and edges into the context VG object.
+            context.extend(context_graph);
             
         } else {
             // We want to extract a radius

--- a/src/graph_synchronizer.hpp
+++ b/src/graph_synchronizer.hpp
@@ -150,13 +150,13 @@ public:
         string path_name;
         
         // These can be set
-        size_t path_offset;
-        size_t context_bases;
-        bool reflect; // Should we bounce off node ends?
+        size_t path_offset = 0;
+        size_t context_bases = 0;
+        bool reflect = false; // Should we bounce off node ends?
         
         // Or these can be set
-        size_t start;
-        size_t past_end;
+        size_t start = 0;
+        size_t past_end = 0;
         
         /// This is the subgraph that got extracted during the locking procedure.
         VG subgraph;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5455,7 +5455,7 @@ int main_map(int argc, char** argv) {
                 {"output-json", no_argument, 0, 'J'},
                 {"hts-input", required_argument, 0, 'b'},
                 {"keep-secondary", no_argument, 0, 'K'},
-                {"fastq", no_argument, 0, 'f'},
+                {"fastq", required_argument, 0, 'f'},
                 {"interleaved", no_argument, 0, 'i'},
                 {"pair-window", required_argument, 0, 'p'},
                 {"band-width", required_argument, 0, 'B'},

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2719,6 +2719,22 @@ vector<Alignment> Mapper::align_multi_internal(bool compute_unpaired_quality,
         filter_and_process_multimaps(alignments, additional_multimaps);
     }
     
+    for (auto& aln : alignments) {
+        // Make sure no alignments are wandering out of the graph
+        for (size_t i = 0; i < aln.path().mapping_size(); i++) {
+            // Look at each mapping
+            auto& mapping = aln.path().mapping(i);
+            
+            if (mapping.position().node_id()) {
+                // Get the size of its node
+                size_t node_size = xindex->node_length(mapping.position().node_id());
+                
+                // Make sure the mapping fits in the node
+                assert(mapping.position().offset() + mapping_from_length(mapping) <= node_size);
+            }
+        }
+    }
+    
     return alignments;
 }
 

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2113,13 +2113,12 @@ set<MaximalExactMatch*> Mapper::resolve_paired_mems(vector<MaximalExactMatch>& m
 }
 
 // We need a function to get the lengths of nodes, in case we need to
-// reverse an Alignment, including all its Mappings and Positions. TODO:
-// make this cache the node lengths for the nodes used in the actual
-// alignments somehow?
+// reverse an Alignment, including all its Mappings and Positions.
 int64_t Mapper::get_node_length(int64_t node_id) {
     if(xindex) {
         // Grab the node sequence only from the XG index and get its size.
-        return xindex->node_length(node_id);
+        // Make sure to use the cache
+        return xg_cached_node_length(node_id, xindex, get_node_cache());
     } else if(index) {
         // Get a 1-element range from the index and then use that.
         VG one_node_graph;
@@ -2726,8 +2725,8 @@ vector<Alignment> Mapper::align_multi_internal(bool compute_unpaired_quality,
             auto& mapping = aln.path().mapping(i);
             
             if (mapping.position().node_id()) {
-                // Get the size of its node
-                size_t node_size = xindex->node_length(mapping.position().node_id());
+                // Get the size of its node from whatever index we have
+                size_t node_size = get_node_length(mapping.position().node_id());
                 
                 // Make sure the mapping fits in the node
                 assert(mapping.position().offset() + mapping_from_length(mapping) <= node_size);

--- a/src/pileup.cpp
+++ b/src/pileup.cpp
@@ -273,6 +273,8 @@ void Pileups::compute_from_edit(NodePileup& pileup, int64_t& node_offset,
         int64_t delta = map_reverse ? -1 : 1;
         for (int64_t i = 0; i < edit.from_length(); ++i) {
             if (pass_filter(alignment, read_offset, 1, mismatch_counts)) {
+                // Don't go outside the node
+                assert(node_offset < _graph->get_node(pileup.node_id())->sequence().size());
                 BasePileup* base_pileup = get_create_base_pileup(pileup, node_offset);
                 if (base_pileup->num_bases() < _max_depth) {
                     // reference_base if empty
@@ -309,6 +311,8 @@ void Pileups::compute_from_edit(NodePileup& pileup, int64_t& node_offset,
                         dp_node_offset = open_del.second;
                     }
                     Node* dp_node = _graph->get_node(dp_node_id);
+                    // Don't go outside the node
+                    assert(dp_node_offset < dp_node->sequence().size());
                     NodePileup* dp_node_pileup = get_create_node_pileup(dp_node);
                     BasePileup* dp_base_pileup = get_create_base_pileup(*dp_node_pileup, dp_node_offset);
                     if (dp_base_pileup->num_bases() < _max_depth) {
@@ -349,7 +353,9 @@ void Pileups::compute_from_edit(NodePileup& pileup, int64_t& node_offset,
             if (insert_offset >= 0 &&
                 // make sure we have a match before and after the insert to take it seriously
                 next_edit != NULL && last_match.first != NULL &&
-                next_edit->from_length() == next_edit->to_length()) {        
+                next_edit->from_length() == next_edit->to_length()) { 
+                // Don't go outside the node
+                assert(insert_offset < _graph->get_node(pileup.node_id())->sequence().size());       
                 BasePileup* base_pileup = get_create_base_pileup(pileup, insert_offset);
                 if (base_pileup->num_bases() < _max_depth) {
                     // reference_base if empty
@@ -586,6 +592,9 @@ BasePileup& Pileups::merge_base_pileups(BasePileup& p1, BasePileup& p2) {
 
 NodePileup& Pileups::merge_node_pileups(NodePileup& p1, NodePileup& p2) {
     assert(p1.node_id() == p2.node_id());
+    // Don't go outside the node
+    assert(p1.base_pileup_size() <= _graph->get_node(p1.node_id())->sequence().size());
+    assert(p2.base_pileup_size() <= _graph->get_node(p2.node_id())->sequence().size());
     for (int i = 0; i < p2.base_pileup_size(); ++i) {
         BasePileup* bp1 = get_create_base_pileup(p1, i);
         BasePileup* bp2 = get_base_pileup(p2, i);

--- a/src/pileup.hpp
+++ b/src/pileup.hpp
@@ -13,12 +13,12 @@ namespace vg {
 
 using namespace std;
 
-// This is a collection of protobuf NodePileup records that are indexed
-// on their position, as well as EdgePileup records.
-// Pileups can be merged and streamed, and computed
-// from Alignments.  The pileup records themselves are essentially
-// protobuf versions of lines in Samtools pileup format, with deletions
-// represented using a graph-based notation. 
+/// This is a collection of protobuf NodePileup records that are indexed
+/// on their position, as well as EdgePileup records.
+/// Pileups can be merged and streamed, and computed
+/// from Alignments.  The pileup records themselves are essentially
+/// protobuf versions of lines in Samtools pileup format, with deletions
+/// represented using a graph-based notation. 
 class Pileups {
 public:
     
@@ -35,7 +35,7 @@ public:
         _use_mapq(use_mapq)
 {}
     
-    // copy constructor
+    /// copy constructor
     Pileups(const Pileups& other) {
         if (this != &other) {
             _graph = other._graph;
@@ -53,7 +53,7 @@ public:
         }
     }
 
-    // move constructor
+    /// move constructor
     Pileups(Pileups&& other) noexcept {
         _graph = other._graph;
         _node_pileups = other._node_pileups;
@@ -68,14 +68,14 @@ public:
         _use_mapq = other._use_mapq;
     }
 
-    // copy assignment operator
+    /// copy assignment operator
     Pileups& operator=(const Pileups& other) {
         Pileups tmp(other);
         *this = move(tmp);
         return *this;
     }
 
-    // move assignment operator
+    /// move assignment operator
     Pileups& operator=(Pileups&& other) noexcept {
         _graph = other._graph;
         swap(_node_pileups, other._node_pileups);
@@ -91,7 +91,7 @@ public:
         return *this;
     }
 
-    // delete contents of table
+    /// delete contents of table
     ~Pileups() {
         clear();
     }
@@ -102,44 +102,44 @@ public:
 
     VG* _graph;
     
-    // This maps from Position to Pileup.
+    /// This maps from Position to Pileup.
     NodePileupHash _node_pileups;
     EdgePileupHash _edge_pileups;
 
-    // Ignore bases with quality less than this
+    /// Ignore bases with quality less than this
     int _min_quality;
-    // max mismatches within window_size
+    /// max mismatches within window_size
     int _max_mismatches;
-    // number of bases to scan in each direction for mismatches
+    /// number of bases to scan in each direction for mismatches
     int _window_size;
-    // prevent giant protobufs
+    /// prevent giant protobufs
     int _max_depth;
-    // toggle whether we incorporate Alignment.mapping_quality
+    /// toggle whether we incorporate Alignment.mapping_quality
     bool _use_mapq;
-    // Keep count of bases filtered by quality
+    /// Keep count of bases filtered by quality
     mutable uint64_t _min_quality_count;
-    // keep count of bases filtered by mismatches
+    /// keep count of bases filtered by mismatches
     mutable uint64_t _max_mismatch_count;
-    // overall count for perspective on above
+    /// overall count for perspective on above
     mutable uint64_t _bases_count;
 
-    // write to JSON
+    /// write to JSON
     void to_json(ostream& out);
-    // read from protobuf
+    /// read from protobuf
     void load(istream& in);
-    // write to protobuf
+    /// write to protobuf
     void write(ostream& out, uint64_t buffer_size = 5);
 
-    // apply function to each pileup in table
+    /// apply function to each pileup in table
     void for_each_node_pileup(const function<void(NodePileup&)>& lambda);
 
-    // search hash table for node id
+    /// search hash table for node id
     NodePileup* get_node_pileup(int64_t node_id) {
         auto p = _node_pileups.find(node_id);
         return p != _node_pileups.end() ? p->second : NULL;
     }
         
-    // get a pileup.  if it's null, create a new one and insert it.
+    /// get a pileup.  if it's null, create a new one and insert it.
     NodePileup* get_create_node_pileup(const Node* node) {
       NodePileup* p = get_node_pileup(node->id());
         if (p == NULL) {
@@ -157,24 +157,24 @@ public:
 
     void for_each_edge_pileup(const function<void(EdgePileup&)>& lambda);
 
-    // search hash table for edge id
+    /// search hash table for edge id
     EdgePileup* get_edge_pileup(pair<NodeSide, NodeSide> sides);
             
-    // get a pileup.  if it's null, create a new one and insert it.
+    /// get a pileup.  if it's null, create a new one and insert it.
     EdgePileup* get_create_edge_pileup(pair<NodeSide, NodeSide> sides);
     
     void extend(Pileup& pileup);
 
-    // insert a pileup into the table. it will be deleted by ~Pileups()!!!
-    // return true if new pileup inserted, false if merged into existing one
+    /// insert a pileup into the table. it will be deleted by ~Pileups()!!!
+    /// return true if new pileup inserted, false if merged into existing one
     bool insert_node_pileup(NodePileup* pileup);
     bool insert_edge_pileup(EdgePileup* edge_pileup);
     
-    // create / update all pileups from a single alignment
+    /// create / update all pileups from a single alignment
     void compute_from_alignment(Alignment& alignment);
 
-    // create / update all pileups from an edit (called by above).
-    // query stores the current position (and nothing else).  
+    /// create / update all pileups from an edit (called by above).
+    /// query stores the current position (and nothing else).  
     void compute_from_edit(NodePileup& pileup, int64_t& node_offset, int64_t& read_offset,
                            const Node& node, const Alignment& alignment,
                            const Mapping& mapping, const Edit& edit,
@@ -184,32 +184,32 @@ public:
                            pair<const Mapping*, int64_t>& last_del,
                            pair<const Mapping*, int64_t>& open_del);
 
-    // do one pass to count all mismatches in read, so we can do
-    // mismatch filter efficiently in 2nd path.
-    // mismatches[i] stores number of mismatches in range (0, i)
+    /// do one pass to count all mismatches in read, so we can do
+    /// mismatch filter efficiently in 2nd path.
+    /// mismatches[i] stores number of mismatches in range (0, i)
     static void count_mismatches(VG& graph, const Path& path, vector<int>& mismatches,
                                  bool skipIndels = false);
 
-    // check base quality as well as miss match filter
+    /// check base quality as well as miss match filter
     bool pass_filter(const Alignment& alignment, int64_t read_offset,
                      int64_t length,
                      const vector<int>& mismatches) const;
             
-    // move all entries in other object into this one.
-    // if two positions collide, they are merged.
-    // other will be left empty. this is returned
+    /// move all entries in other object into this one.
+    /// if two positions collide, they are merged.
+    /// other will be left empty. this is returned
     Pileups& merge(Pileups& other);
 
-    // merge p2 into p1 and return 1. p2 is left an empty husk
+    /// merge p2 into p1 and return 1. p2 is left an empty husk
     BasePileup& merge_base_pileups(BasePileup& p1, BasePileup& p2);
 
-    // merge p2 into p1 and return 1. p2 is lef an empty husk
+    /// merge p2 into p1 and return 1. p2 is lef an empty husk
     NodePileup& merge_node_pileups(NodePileup& p1, NodePileup& p2);
     
-    // merge p2 into p1 and return 1. p2 is lef an empty husk
+    /// merge p2 into p1 and return 1. p2 is lef an empty husk
     EdgePileup& merge_edge_pileups(EdgePileup& p1, EdgePileup& p2);
 
-    // create combine map quality (optionally) with base quality
+    /// create combine map quality (optionally) with base quality
     char combined_quality(char base_quality, int map_quality) const {
         if (!_use_mapq) {
             return base_quality;
@@ -224,7 +224,7 @@ public:
         }
     }        
 
-    // get ith BasePileup record
+    /// get ith BasePileup record
     static BasePileup* get_base_pileup(NodePileup& np, int64_t offset) {
         assert(offset < np.base_pileup_size() && offset >= 0);
         return np.mutable_base_pileup(offset);
@@ -234,7 +234,7 @@ public:
         return &np.base_pileup(offset);
     }
 
-    // get ith BasePileup record, create if doesn't exist
+    /// get ith BasePileup record, create if doesn't exist
     static BasePileup* get_create_base_pileup(NodePileup& np, int64_t offset) {
         for (int64_t i = np.base_pileup_size(); i <= offset; ++i) {
             np.add_base_pileup();
@@ -242,16 +242,16 @@ public:
         return get_base_pileup(np, offset);
     }
 
-    // the bases string in BasePileup doesn't allow random access.  This function
-    // will parse out all the offsets of snps, insertions, and deletions
-    // into one array, each offset is a pair of indexes in the bases and qualities arrays
+    /// the bases string in BasePileup doesn't allow random access.  This function
+    /// will parse out all the offsets of snps, insertions, and deletions
+    /// into one array, each offset is a pair of indexes in the bases and qualities arrays
     static void parse_base_offsets(const BasePileup& bp,
                                    vector<pair<int64_t, int64_t> >& offsets);
 
-    // transform case of every character in string
+    /// transform case of every character in string
     static void casify(string& seq, bool is_reverse);
 
-    // make the sam pileup style token
+    /// make the sam pileup style token
     static void make_match(string& seq, int64_t from_length, bool is_reverse);
     static void make_insert(string& seq, bool is_reverse);
     static void make_delete(string& seq, bool is_reverse,
@@ -268,10 +268,10 @@ public:
 
     static bool base_equal(char c1, char c2, bool is_reverse);
     
-    // get a pileup value on forward strand
+    /// get a pileup value on forward strand
     static char extract_match(const BasePileup& bp, int64_t offset);
 
-    // get arbitrary value from offset on forward strand
+    /// get arbitrary value from offset on forward strand
     static string extract(const BasePileup& bp, int64_t offset);
 };
 


### PR DESCRIPTION
This improves vg add to not use uninitialized memory, adopts Jordan's subgraph extraction to speed up getting large regions without extra heads/tails, and adds some asserts to make sure that alignment and pileup steps explode if invalid alignments past the ends of nodes get generated.