### PR TITLE
Change how vg add handles Ns

### DIFF
--- a/src/path_index.cpp
+++ b/src/path_index.cpp
@@ -323,6 +323,9 @@ PathIndex::iterator PathIndex::find_position(size_t position) const {
 #ifdef debug
     cerr << "At " << position << " we have " << starts_next->second << endl;
 #endif
+
+    // Make sure we didn't fall off the ends
+    assert(position - starts_next->first < node_length(starts_next));
     
     // Return that
     return starts_next;

--- a/src/unittest/aligner.cpp
+++ b/src/unittest/aligner.cpp
@@ -172,6 +172,120 @@ TEST_CASE("Full-length bonus can hold down the right end", "[aligner][alignment]
         REQUIRE(aln2.path().mapping(0).edit(2).sequence() == "");
     }
 }
+
+TEST_CASE("Full-length bonus can attach Ns", "[aligner][alignment][mapping]") {
+    
+    VG graph;
+    
+    Aligner aligner;
+    
+    Node* n0 = graph.create_node("AGTG");
+    Node* n1 = graph.create_node("C");
+    Node* n2 = graph.create_node("A");
+    Node* n3 = graph.create_node("TGAAGT");
+    
+    graph.create_edge(n0, n1);
+    graph.create_edge(n0, n2);
+    graph.create_edge(n1, n3);
+    graph.create_edge(n2, n3);
+    
+    string read = string("NNNNCTGANNN");
+    Alignment aln1, aln2;
+    aln1.set_sequence(read);
+    aln2.set_sequence(read);
+    
+    aligner.align(aln1, graph.graph, 0);
+    aligner.align(aln2, graph.graph, 10);
+    
+    SECTION("bonused alignment ends in full-length match/mismatches") {
+        REQUIRE(aln2.path().mapping_size() == 3);
+        REQUIRE(mapping_from_length(aln2.path().mapping(0)) == 4);
+        REQUIRE(mapping_to_length(aln2.path().mapping(0)) == 4);
+        REQUIRE(mapping_from_length(aln2.path().mapping(2)) == 6);
+        REQUIRE(mapping_to_length(aln2.path().mapping(2)) == 6);
+    }
+    
+    SECTION("bonus is collected at both ends") {
+        REQUIRE(aln2.score() == aln1.score() + 20);
+    }
+    
+}
+
+TEST_CASE("Full-length bonus can attach to Ns", "[aligner][alignment][mapping]") {
+    
+    VG graph;
+    
+    Aligner aligner;
+    
+    Node* n0 = graph.create_node("NNNG");
+    Node* n1 = graph.create_node("C");
+    Node* n2 = graph.create_node("A");
+    Node* n3 = graph.create_node("TGANNN");
+    
+    graph.create_edge(n0, n1);
+    graph.create_edge(n0, n2);
+    graph.create_edge(n1, n3);
+    graph.create_edge(n2, n3);
+    
+    string read = string("AGTGCTGAAGT");
+    Alignment aln1, aln2;
+    aln1.set_sequence(read);
+    aln2.set_sequence(read);
+    
+    aligner.align(aln1, graph.graph, 0);
+    aligner.align(aln2, graph.graph, 10);
+    
+    SECTION("bonused alignment ends in full-length match/mismatches") {
+        REQUIRE(aln2.path().mapping_size() == 3);
+        REQUIRE(mapping_from_length(aln2.path().mapping(0)) == 4);
+        REQUIRE(mapping_to_length(aln2.path().mapping(0)) == 4);
+        REQUIRE(mapping_from_length(aln2.path().mapping(2)) == 6);
+        REQUIRE(mapping_to_length(aln2.path().mapping(2)) == 6);
+    }
+    
+    SECTION("bonus is collected at both ends") {
+        REQUIRE(aln2.score() == aln1.score() + 20);
+    }
+    
+}
+
+TEST_CASE("Full-length bonus can attach Ns to Ns", "[aligner][alignment][mapping]") {
+    
+    VG graph;
+    
+    Aligner aligner;
+    
+    Node* n0 = graph.create_node("NNNG");
+    Node* n1 = graph.create_node("C");
+    Node* n2 = graph.create_node("A");
+    Node* n3 = graph.create_node("TGANNN");
+    
+    graph.create_edge(n0, n1);
+    graph.create_edge(n0, n2);
+    graph.create_edge(n1, n3);
+    graph.create_edge(n2, n3);
+    
+    string read = string("NNNGCTGANNN");
+    Alignment aln1, aln2;
+    aln1.set_sequence(read);
+    aln2.set_sequence(read);
+    
+    aligner.align(aln1, graph.graph, 0);
+    aligner.align(aln2, graph.graph, 10);
+    
+    SECTION("bonused alignment ends in full-length match/mismatches") {
+        REQUIRE(aln2.path().mapping_size() == 3);
+        REQUIRE(mapping_from_length(aln2.path().mapping(0)) == 4);
+        REQUIRE(mapping_to_length(aln2.path().mapping(0)) == 4);
+        REQUIRE(mapping_from_length(aln2.path().mapping(2)) == 6);
+        REQUIRE(mapping_to_length(aln2.path().mapping(2)) == 6);
+    }
+    
+    SECTION("bonus is collected at both ends") {
+        REQUIRE(aln2.score() == aln1.score() + 20);
+    }
+    
+}
    
 }
 }

--- a/src/unittest/banded_global_aligner.cpp
+++ b/src/unittest/banded_global_aligner.cpp
@@ -2251,6 +2251,130 @@ namespace vg {
                 }
             }
         }
+        
+        TEST_CASE( "Banded global aligner works with Ns",
+                  "[alignment][banded][mapping]" ) {
+                  
+            SECTION( "Banded global aligner can align Ns to letters" ) {
+                VG graph;
+                
+                QualAdjAligner aligner = QualAdjAligner();
+                
+                Node* n0 = graph.create_node("AGTG");
+                Node* n1 = graph.create_node("C");
+                Node* n2 = graph.create_node("A");
+                Node* n3 = graph.create_node("TGAAGT");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n0, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n3);
+                
+                string read = string("NNNGCTGANNN");
+                Alignment aln;
+                aln.set_sequence(read);
+                
+                int band_width = 1;
+                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
+                                                                                         graph.graph,
+                                                                                         band_width,
+                                                                                         true);
+                
+                
+                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
+                                     aligner.gap_extension);
+                
+                SECTION("alignment ends in full-length matches/mismatches") {
+                    REQUIRE(aln.path().mapping_size() == 3);
+                    REQUIRE(mapping_from_length(aln.path().mapping(0)) == 4);
+                    REQUIRE(mapping_to_length(aln.path().mapping(0)) == 4);
+                    REQUIRE(mapping_from_length(aln.path().mapping(2)) == 6);
+                    REQUIRE(mapping_to_length(aln.path().mapping(2)) == 6);
+                }
+                
+                  
+            }
+        
+            SECTION( "Banded global aligner can align letters to Ns" ) {
+                VG graph;
+                
+                QualAdjAligner aligner = QualAdjAligner();
+                
+                Node* n0 = graph.create_node("AGTG");
+                Node* n1 = graph.create_node("C");
+                Node* n2 = graph.create_node("A");
+                Node* n3 = graph.create_node("TGAAGT");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n0, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n3);
+                
+                string read = string("AGTGCTGAAGT");
+                Alignment aln;
+                aln.set_sequence(read);
+                
+                int band_width = 1;
+                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
+                                                                                         graph.graph,
+                                                                                         band_width,
+                                                                                         true);
+                
+                
+                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
+                                     aligner.gap_extension);
+                
+                SECTION("alignment ends in full-length matches/mismatches") {
+                    REQUIRE(aln.path().mapping_size() == 3);
+                    REQUIRE(mapping_from_length(aln.path().mapping(0)) == 4);
+                    REQUIRE(mapping_to_length(aln.path().mapping(0)) == 4);
+                    REQUIRE(mapping_from_length(aln.path().mapping(2)) == 6);
+                    REQUIRE(mapping_to_length(aln.path().mapping(2)) == 6);
+                }
+                
+                  
+            }
+        
+            SECTION( "Banded global aligner can align Ns to Ns" ) {
+                VG graph;
+                
+                QualAdjAligner aligner = QualAdjAligner();
+                
+                Node* n0 = graph.create_node("NNNG");
+                Node* n1 = graph.create_node("C");
+                Node* n2 = graph.create_node("A");
+                Node* n3 = graph.create_node("TGANNN");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n0, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n3);
+                
+                string read = string("NNNGCTGANNN");
+                Alignment aln;
+                aln.set_sequence(read);
+                
+                int band_width = 1;
+                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
+                                                                                         graph.graph,
+                                                                                         band_width,
+                                                                                         true);
+                
+                
+                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
+                                     aligner.gap_extension);
+                
+                SECTION("alignment ends in full-length matches/mismatches") {
+                    REQUIRE(aln.path().mapping_size() == 3);
+                    REQUIRE(mapping_from_length(aln.path().mapping(0)) == 4);
+                    REQUIRE(mapping_to_length(aln.path().mapping(0)) == 4);
+                    REQUIRE(mapping_from_length(aln.path().mapping(2)) == 6);
+                    REQUIRE(mapping_to_length(aln.path().mapping(2)) == 6);
+                }
+                
+                  
+            }
+        }
     }
 }
 

--- a/src/unittest/pinned_alignment.cpp
+++ b/src/unittest/pinned_alignment.cpp
@@ -374,6 +374,115 @@ namespace vg {
                 REQUIRE(path.mapping(2).edit(0).sequence().empty());
             }
             
+            SECTION( "Right-pinned alignment accepts a match of N to N on the right end") {
+                
+                VG graph;
+                
+                Aligner aligner;
+                
+                Node* n0 = graph.create_node("CGTG");
+                Node* n1 = graph.create_node("C");
+                Node* n2 = graph.create_node("A");
+                Node* n3 = graph.create_node("TGANNN");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n0, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n3);
+                
+                string read = string("CGTGCTGANNN");
+                Alignment aln;
+                aln.set_sequence(read);
+                
+                Node* pinned_node = n3;
+                bool pin_left = false;
+                
+                aligner.align_pinned(aln, graph.graph, pin_left);
+                
+                const Path& path = aln.path();
+                
+                // is a pinned alignment
+                if (pin_left) {
+                    REQUIRE(path.mapping(0).position().offset() == 0);
+                    REQUIRE(path.mapping(0).position().node_id() == pinned_node->id());
+                }
+                else {
+                    REQUIRE(mapping_from_length(path.mapping(path.mapping_size() - 1)) == pinned_node->sequence().length());
+                    REQUIRE(path.mapping(path.mapping_size() - 1).position().node_id() == pinned_node->id());
+                }
+                
+                // follows correct path
+                REQUIRE(path.mapping(0).position().node_id() == 1);
+                REQUIRE(path.mapping(1).position().node_id() == 2);
+                REQUIRE(path.mapping(2).position().node_id() == 4);
+                
+                // has correct mapping characteristics
+                // TODO: the N-N matches are produced as separate edits from the normal matches.
+                REQUIRE(mapping_from_length(path.mapping(0)) == 4);
+                REQUIRE(mapping_from_length(path.mapping(0)) == 4);
+                
+                REQUIRE(path.mapping(1).edit(0).from_length() == 1);
+                REQUIRE(path.mapping(1).edit(0).to_length() == 1);
+                REQUIRE(path.mapping(1).edit(0).sequence().empty());
+                
+                REQUIRE(mapping_from_length(path.mapping(2)) == 6);
+                REQUIRE(mapping_from_length(path.mapping(2)) == 6);
+            }
+            
+            SECTION( "Left-pinned alignment accepts a match of N to N on the left end") {
+                
+                VG graph;
+                
+                Aligner aligner;
+                
+                Node* n0 = graph.create_node("NNNG");
+                Node* n1 = graph.create_node("C");
+                Node* n2 = graph.create_node("A");
+                Node* n3 = graph.create_node("TGAAGT");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n0, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n3);
+                
+                string read = string("NNNGCTGAAGT");
+                Alignment aln;
+                aln.set_sequence(read);
+                
+                Node* pinned_node = n0;
+                bool pin_left = true;
+                
+                aligner.align_pinned(aln, graph.graph, pin_left);
+                
+                const Path& path = aln.path();
+                
+                // is a pinned alignment
+                if (pin_left) {
+                    REQUIRE(path.mapping(0).position().offset() == 0);
+                    REQUIRE(path.mapping(0).position().node_id() == pinned_node->id());
+                }
+                else {
+                    REQUIRE(mapping_from_length(path.mapping(path.mapping_size() - 1)) == pinned_node->sequence().length());
+                    REQUIRE(path.mapping(path.mapping_size() - 1).position().node_id() == pinned_node->id());
+                }
+                
+                // follows correct path
+                REQUIRE(path.mapping(0).position().node_id() == 1);
+                REQUIRE(path.mapping(1).position().node_id() == 2);
+                REQUIRE(path.mapping(2).position().node_id() == 4);
+                
+                // has correct mapping characteristics
+                REQUIRE(mapping_from_length(path.mapping(0)) == 4);
+                REQUIRE(mapping_from_length(path.mapping(0)) == 4);
+                
+                REQUIRE(path.mapping(1).edit(0).from_length() == 1);
+                REQUIRE(path.mapping(1).edit(0).to_length() == 1);
+                REQUIRE(path.mapping(1).edit(0).sequence().empty());
+                
+                REQUIRE(mapping_from_length(path.mapping(2)) == 6);
+                REQUIRE(mapping_from_length(path.mapping(2)) == 6);
+            }
+            
             SECTION( "Pinned alignment produces correct alignment when there is a mismatch" ) {
                 
                 VG graph;

--- a/src/variant_adder.cpp
+++ b/src/variant_adder.cpp
@@ -189,7 +189,8 @@ void VariantAdder::add_variants(vcflib::VariantCallFile* vcf) {
                 // shifted an indel to the border of our context.
             
                 
-                // We need to move the bounds out so that we aren;t trying to anchor our alignment with Ns
+                // We need to move the bounds out so that we aren't trying to
+                // anchor our alignment with Ns, if that's possible not to do
                 char left_anchor_character;
                 char right_anchor_character;
                 do {
@@ -205,21 +206,19 @@ void VariantAdder::add_variants(vcflib::VariantCallFile* vcf) {
                     left_anchor_character = ref_sequence.at(left_context_start);
                     right_anchor_character = ref_sequence.at(right_context_past_end - 1);
                     
-                    if (left_anchor_character == 'N') {
+                    if (left_anchor_character == 'N' && left_context_start > 0) {
                         // Try moving left.
-                        // TODO: somehow solve the problem of being at the end of the graph with an N.
-                        assert(left_context_start > 0);
                         left_context_start--;
                     }
                     
-                    if (right_anchor_character == 'N') {
-                        // Try moving left.
-                        // TODO: somehow solve the problem of being at the end of the graph with an N.
-                        assert(right_context_past_end <= ref_sequence.size());
+                    if (right_anchor_character == 'N' && right_context_past_end <= ref_sequence.size()) {
+                        // Try moving right.
                         right_context_past_end++;
                     }
                     
-                } while (left_anchor_character == 'N' || right_anchor_character == 'N');
+                } while ((left_anchor_character == 'N' && left_context_start > 0) || 
+                    (right_anchor_character == 'N' && right_context_past_end <= ref_sequence.size()));
+                // Keep looping until we haven't landed on N (or we hit the contig ends)
                 
 #ifdef debug
                 cerr << "New context bounds: " << left_context_start << " - " << right_context_past_end << endl;


### PR DESCRIPTION
It's now allowed to anchor an alignment with Ns in vg add if it bumps up against the end of a contig.

I'm also adding some unit tests to make explicit that the various aligner end-pinning-down modes are willing to match stuff against Ns.

I noticed that matches or mismatches against Ns will be placed in their own edits, separate from matches or mismatches against other bases. My tests don't treat that as a failure right now.