### PR TITLE
Banded global alignment update

### DIFF
--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -1696,7 +1696,7 @@ BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g
     // find the shortest sequence leading to each node so we can infer the length
     // of lead deletions
     vector<int64_t> shortest_seqs;
-    shortest_seq_paths(node_edges_out, source_nodes, band_ends, shortest_seqs);
+    shortest_seq_paths(node_edges_out, source_nodes, shortest_seqs);
     
 #ifdef debug_banded_aligner_objects
     cerr << "[BandedGlobalAligner]: constructing banded matrix objects" << endl;
@@ -2024,7 +2024,6 @@ void BandedGlobalAligner<IntType>::find_banded_paths(const string& read, bool pe
 template <class IntType>
 void BandedGlobalAligner<IntType>::shortest_seq_paths(vector<vector<int64_t>>& node_edges_out,
                                                       unordered_set<Node*>& source_nodes,
-                                                      vector<pair<int64_t, int64_t>>& band_ends,
                                                       vector<int64_t>& seq_lens_out) {
     
     // initialize vector with min identity to store sequence lengths

--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -35,9 +35,10 @@ BandedGlobalAligner<IntType>::BABuilder::~BABuilder() {
 
 template<class IntType>
 void BandedGlobalAligner<IntType>::BABuilder::update_state(matrix_t matrix, Node* node,
-                                                           int64_t read_idx, int64_t node_idx) {
+                                                           int64_t read_idx, int64_t node_idx,
+                                                           bool empty_node_seq) {
 #ifdef debug_banded_aligner_traceback
-    cerr << "[BABuilder::update_state] beginning state update for read index " << read_idx << ", node seq index " << node_idx << endl;
+    cerr << "[BABuilder::update_state] beginning " << (empty_node_seq ? "" : "non-") << "empty state update for read index " << read_idx << ", node seq index " << node_idx << endl;
 #endif
     if (node != current_node) {
 #ifdef debug_banded_aligner_traceback
@@ -50,7 +51,7 @@ void BandedGlobalAligner<IntType>::BABuilder::update_state(matrix_t matrix, Node
         if (matrix_state == Match) {
             matching = (alignment.sequence()[read_idx] == current_node->sequence()[node_idx]);
         }
-        edit_length = 1;
+        edit_length = !empty_node_seq;
         edit_read_end_idx = read_idx;
     }
     else if (matrix != matrix_state) {
@@ -155,7 +156,7 @@ void BandedGlobalAligner<IntType>::BABuilder::finish_current_node() {
 }
 
 template <class IntType>
-void BandedGlobalAligner<IntType>::BABuilder::finalize_alignment() {
+void BandedGlobalAligner<IntType>::BABuilder::finalize_alignment(const list<int64_t>& empty_prefix) {
     
     finish_current_node();
     
@@ -170,6 +171,15 @@ void BandedGlobalAligner<IntType>::BABuilder::finalize_alignment() {
     for (Mapping& mapping : node_mappings) {
         mapping.set_rank(mapping_rank);
         *(path->add_mapping()) = mapping;
+        mapping_rank++;
+    }
+    
+    // if there were any empty nodes traversed before the traceback began, add those to the end
+    for (int64_t empty_id : empty_prefix) {
+        Mapping* mapping = path->add_mapping();
+        mapping->add_edit();
+        mapping->mutable_position()->set_node_id(empty_id);
+        mapping->set_rank(mapping_rank);
         mapping_rank++;
     }
     
@@ -265,15 +275,213 @@ void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(int8_t* score_mat, int8
     
     int64_t idx, up_idx, diag_idx, left_idx;
     
+    // rows in the rectangularized band corresponding to diagonals
+    int64_t iter_start = top_diag < 0 ? -top_diag : 0;
+    int64_t iter_stop = bottom_diag >= (int64_t) read.length() ? band_height + (int64_t) read.length() - bottom_diag - 1 : band_height;
+    
+    // initialize with min infs (identity of max function)
+    for (int64_t i = iter_start; i < iter_stop; i++) {
+        idx = i * ncols;
+        match[idx] = min_inf;
+        insert_col[idx] = min_inf;
+        // can skip insert row since it doesn't cross node boundaries
+    }
+    
+    // make sure this one insert row value is there so we can use it for checking band boundaries
+    // later
+    insert_row[iter_start * ncols] = min_inf;
+    
+    // we will allow the alignment to treat this node as a source if it has no seeds or if it
+    // is connected to a source node by a length 0 path (which we will check later)
+    bool treat_as_source = (num_seeds == 0);
+    
+    list<BAMatrix*> seed_queue;
+    for (int64_t seed_num = 0; seed_num < num_seeds; seed_num++) {
+        seed_queue.push_back(seeds[seed_num]);
+    }
+    
+    while (!seed_queue.empty()) {
+        BAMatrix* seed = seed_queue.front();
+        seed_queue.pop_front();
+        
+        if (seed == nullptr) {
+#ifdef debug_banded_aligner_fill_matrix
+            cerr << "[BAMatrix::fill_matrix]: seed is masked, skipping" << endl;
+#endif
+            continue;
+        }
+        
+#ifdef debug_banded_aligner_fill_matrix
+        cerr << "[BAMatrix::fill_matrix]: doing POA across boundary from seed node " << seed->node->id() << " to node " << node->id() << endl;
+#endif
+        
+        int64_t seed_node_seq_len = seed->node->sequence().length();
+        
+        if (seed_node_seq_len == 0) {
+#ifdef debug_banded_aligner_fill_matrix
+            cerr << "[BAMatrix::fill_matrix]: seed node " << seed->node->id() << " has no sequence, adding its predecessors as seed nodes" << endl;
+#endif
+            // this is a length 0 node, so let this seed's predecessors seed into this one or
+            // identify this node as a "source"
+            treat_as_source = treat_as_source || (seed->num_seeds == 0);
+            for (int64_t seed_num = 0; seed_num < seed->num_seeds; seed_num++) {
+                seed_queue.push_back(seed->seeds[seed_num]);
+            }
+            continue;
+        }
+        
+        // compute the interval of diagonals that this seed reaches
+        int64_t seed_next_top_diag = seed->top_diag + seed_node_seq_len;
+        int64_t seed_next_bottom_diag = seed->bottom_diag + seed_node_seq_len;
+        
+        // characterize the this interval
+        bool beyond_top_of_matrix = seed_next_top_diag < 0;
+        bool abutting_top_of_matrix = seed_next_top_diag == 0;
+        bool beyond_bottom_of_matrix = seed_next_bottom_diag >= (int64_t) read.length();
+        int64_t seed_next_top_diag_iter = beyond_top_of_matrix ? 0 : seed_next_top_diag;
+        int64_t seed_next_bottom_diag_iter = beyond_bottom_of_matrix ? (int64_t) read.length() - 1 : seed_next_bottom_diag;
+        
+        // the shortest sequence path to any source that goes through this seed
+        int64_t extended_cumulative_seq_len = seed->cumulative_seq_len + seed_node_seq_len;
+        
+#ifdef debug_banded_aligner_fill_matrix
+        cerr << "[BAMatrix::fill_matrix]: this seed reaches diagonals " << seed_next_top_diag << " to " << seed_next_bottom_diag << " out of matrix range " << top_diag << " to " << bottom_diag << endl;
+#endif
+        // special logic for first row
+        idx = (seed_next_top_diag_iter - top_diag) * ncols;
+        
+        IntType match_score;
+        if (qual_adjusted) {
+            match_score = score_mat[25 * base_quality[seed_next_top_diag_iter] + 5 * nt_table[node_seq[0]] + nt_table[read[seed_next_top_diag_iter]]];
+        }
+        else {
+            match_score = score_mat[5 * nt_table[node_seq[0]] + nt_table[read[seed_next_top_diag_iter]]];
+        }
+        
+        if (beyond_top_of_matrix) {
+            // the implied cell above this cell is within the extended band form this seed, so we can extend from
+            // paths through this node into both the match and insert row from a lead gap
+            
+            // match after implied gap along top edge
+            match[idx] = max<IntType>(match_score - gap_open - (extended_cumulative_seq_len - 1) * gap_extend, match[idx]);
+            // gap open after implied gap along top edge
+            insert_row[idx] = max<IntType>(-2 * gap_open - extended_cumulative_seq_len * gap_extend, insert_row[idx]);
+        }
+        else if (abutting_top_of_matrix) {
+            // the implied cell above this cell is not in the extended band, but the one diagonal is, so we can extend
+            // into match from a lead gap but not insert row
+            
+            // match after implied gap along top edge
+            match[idx] = max<IntType>(match_score - gap_open - (extended_cumulative_seq_len - 1) * gap_extend, match[idx]);
+            
+        }
+        else {
+#ifdef debug_banded_aligner_fill_matrix
+            cerr << "[BAMatrix::fill_matrix]: top cell in match matrix is reachable without a lead gap" << endl;
+#endif
+            diag_idx = (seed_next_top_diag_iter - seed_next_top_diag) * seed_node_seq_len + seed_node_seq_len - 1;
+            
+            match[idx] = max<IntType>(match_score + max<IntType>(max<IntType>(seed->match[diag_idx],
+                                                                              seed->insert_row[diag_idx]),
+                                                                 seed->insert_col[diag_idx]), match[idx]);
+        }
+        
+        if (seed_next_top_diag < seed_next_bottom_diag) {
+#ifdef debug_banded_aligner_fill_matrix
+            cerr << "[BAMatrix::fill_matrix]: seed band is greater than height 1, can extend column gap into first row" << endl;
+#endif
+            left_idx = (seed_next_top_diag_iter - seed_next_top_diag + 2) * seed_node_seq_len - 1;
+            insert_col[idx] = max<IntType>(max<IntType>(max<IntType>(seed->match[left_idx] - gap_open,
+                                                                     seed->insert_row[left_idx] - gap_open),
+                                                        seed->insert_col[left_idx] - gap_extend), insert_col[idx]);
+        }
+        
+        
+        for (int64_t diag = seed_next_top_diag_iter + 1; diag < seed_next_bottom_diag_iter; diag++) {
+            idx = (diag - top_diag) * ncols;
+            
+#ifdef debug_banded_aligner_fill_matrix
+            cerr << "[BAMatrix::fill_matrix]: extending a match and column gap into matrix coord (" << diag << ", 0)" << ", rectangular coord coord (" << diag - top_diag << ", 0)" << endl;
+#endif
+            
+            // extend a match
+            diag_idx = (diag - seed_next_top_diag) * seed_node_seq_len + seed_node_seq_len - 1;
+            if (qual_adjusted) {
+                match_score = score_mat[25 * base_quality[diag] + 5 * nt_table[node_seq[0]] + nt_table[read[diag]]];
+            }
+            else {
+                match_score = score_mat[5 * nt_table[node_seq[0]] + nt_table[read[diag]]];
+            }
+            
+#ifdef debug_banded_aligner_fill_matrix
+            cerr << "[BAMatrix::fill_matrix]: extending match from rectangular coord (" << diag - seed_next_top_diag << ", " << seed_node_seq_len - 1 << ")" << " with match score " << (int) match_score << ", scores are " << (int) seed->match[diag_idx] << " (M), " << (int) seed->insert_row[diag_idx] << " (Ir), and " << (int) seed->insert_col[diag_idx] << " (Ic), current score is " << (int) match[idx] << endl;
+#endif
+            
+            match[idx] = max<IntType>(match_score + max<IntType>(max<IntType>(seed->match[diag_idx],
+                                                                              seed->insert_row[diag_idx]),
+                                                                 seed->insert_col[diag_idx]), match[idx]);
+            
+            // extend a column gap
+            left_idx = (diag - seed_next_top_diag + 2) * seed_node_seq_len - 1;
+            
+#ifdef debug_banded_aligner_fill_matrix
+            cerr << "[BAMatrix::fill_matrix]: extending match from rectangular coord (" << diag - seed_next_top_diag + 1 << ", " << seed_node_seq_len - 1 << ")" << ", scores are " << (int) seed->match[left_idx] << " (M), " << (int) seed->insert_row[left_idx] << " (Ir), and " << (int) seed->insert_col[left_idx] << " (Ic), current score is " << (int) insert_col[idx] << endl;
+#endif
+            insert_col[idx] = max<IntType>(max<IntType>(max<IntType>(seed->match[left_idx] - gap_open,
+                                                                     seed->insert_row[left_idx] - gap_open),
+                                                        seed->insert_col[left_idx] - gap_extend), insert_col[idx]);
+            
+#ifdef debug_banded_aligner_fill_matrix
+            cerr << "[BAMatrix::fill_matrix]: score is now " << (int) insert_col[idx] << endl;
+#endif
+        }
+        
+        // don't handle final row edge case if we actually got it with the first row edge case
+        if (seed_next_bottom_diag_iter != seed_next_top_diag_iter) {
+#ifdef debug_banded_aligner_fill_matrix
+            cerr << "[BAMatrix::fill_matrix]: edge case for final cell in column" << endl;
+            cerr << "[BAMatrix::fill_matrix]: extending a match and column gap into matrix coord (" << seed_next_bottom_diag_iter << ", 0)" << ", rectangular coord coord (" << seed_next_bottom_diag_iter - top_diag << ", 0)" << endl;
+#endif
+            
+            // may only be able to extend a match on last iteration
+            idx = (seed_next_bottom_diag_iter - top_diag) * ncols;
+            diag_idx = (seed_next_bottom_diag_iter - seed_next_top_diag) * seed_node_seq_len + seed_node_seq_len - 1;
+            if (qual_adjusted) {
+                match_score = score_mat[25 * base_quality[seed_next_bottom_diag_iter] + 5 * nt_table[node_seq[0]] + nt_table[read[seed_next_bottom_diag_iter]]];
+            }
+            else {
+                match_score = score_mat[5 * nt_table[node_seq[0]] + nt_table[read[seed_next_bottom_diag_iter]]];
+            }
+            
+#ifdef debug_banded_aligner_fill_matrix
+            cerr << "[BAMatrix::fill_matrix]: extending match from rectangular coord (" << seed_next_bottom_diag_iter - seed_next_top_diag << ", " << seed_node_seq_len - 1 << ")" << " with match score " << (int) match_score << ", scores are " << (int) seed->match[diag_idx] << " (M), " << (int) seed->insert_row[diag_idx] << " (Ir), and " << (int) seed->insert_col[diag_idx] << " (Ic), current score is " << (int) match[idx] << endl;
+#endif
+            match[idx] = max<IntType>(match_score + max<IntType>(max<IntType>(seed->match[diag_idx],
+                                                                              seed->insert_row[diag_idx]),
+                                                                 seed->insert_col[diag_idx]), match[idx]);
+            
+            // can only extend column gap if the bottom of the matrix was hit in the last seed
+            if (beyond_bottom_of_matrix) {
+#ifdef debug_banded_aligner_fill_matrix
+                cerr << "[BAMatrix::fill_matrix]: can also extend a column gap since already reached edge of matrix" << endl;
+#endif
+                left_idx = (seed_next_bottom_diag_iter - seed_next_top_diag + 2) * seed_node_seq_len - 1;
+                insert_col[idx] = max<IntType>(max<IntType>(max<IntType>(seed->match[left_idx] - gap_open,
+                                                                         seed->insert_row[left_idx] - gap_open),
+                                                            seed->insert_col[left_idx] - gap_extend), insert_col[idx]);
+            }
+        }
+    }
+    
     // POA into left hand column from the seeds
-    if (seeds == nullptr) {
+    if (treat_as_source && node->sequence().length() != 0) {
         if (cumulative_seq_len != 0) {
             cerr << "error:[BandedGlobalAligner] banded alignment has no node predecessor for node in middle of path" << endl;
             assert(0);
         }
         
 #ifdef debug_banded_aligner_fill_matrix
-        cerr << "[BAMatrix::fill_matrix]: no previous seeds, computing implied edge conditions" << endl;
+        cerr << "[BAMatrix::fill_matrix]: this is a source node, computing implied edge conditions" << endl;
 #endif
         
         // first node in alignment, fill out initial column based on implied lead gaps
@@ -285,28 +493,25 @@ void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(int8_t* score_mat, int8
         // cap stop index if last diagonal is below bottom of matrix
         int64_t iter_stop = bottom_diag > (int64_t) read.length() ? band_height + (int64_t) read.length() - bottom_diag - 1 : band_height;
         
-
-        
         // match of first nucleotides
         if (qual_adjusted) {
-            match[idx] = score_mat[25 * base_quality[0] + 5 * nt_table[node_seq[0]] + nt_table[read[0]]];
+            match[idx] = max<IntType>(score_mat[25 * base_quality[0] + 5 * nt_table[node_seq[0]] + nt_table[read[0]]], match[idx]);
+            
 #ifdef debug_banded_aligner_fill_matrix
             cerr << "[BAMatrix::fill_matrix]: set quality adjusted initial match cell to " << (int) match[idx] << " from node char " << node_seq[0] << ", read char " << read[0] << ", base qual " << (int) base_quality[0] << " for adjusted matrix index " << 25 * base_quality[0] + 5 * nt_table[node_seq[0]] + nt_table[read[0]] << " and score " << (int) score_mat[25 * base_quality[0] + 5 * nt_table[node_seq[0]] + nt_table[read[0]]] << endl;
 #endif
         }
         else {
-            match[idx] = score_mat[5 * nt_table[node_seq[0]] + nt_table[read[0]]];
+             match[idx] = max<IntType>(match[idx] = score_mat[5 * nt_table[node_seq[0]] + nt_table[read[0]]], match[idx]);
         }
         
-
-        
         // only way to end an alignment in a gap here is to row and column gap
-        insert_col[idx] = -2 * gap_open;
-        insert_row[idx] = -2 * gap_open;
+        insert_row[idx] = max<IntType>(-2 * gap_open, insert_row[idx]);
+        insert_col[idx] = max<IntType>(-2 * gap_open, insert_col[idx]);
         
         for (int64_t i = iter_start + 1; i < iter_stop; i++) {
             idx = i * ncols;
-            up_idx = (i - 1) * ncols;
+            up_idx = idx - ncols;
             // score of a match in this cell
             IntType match_score;
             if (qual_adjusted) {
@@ -316,12 +521,12 @@ void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(int8_t* score_mat, int8
                 match_score = score_mat[5 * nt_table[node_seq[0]] + nt_table[read[top_diag + i]]];
             }
             // must take one lead gap to get into first column
-            match[idx] = match_score - gap_open - (top_diag + i - 1) * gap_extend;
+            match[idx] = max<IntType>(match_score - gap_open - (top_diag + i - 1) * gap_extend, match[idx]);
             // normal iteration along column
-            insert_row[idx] = max(max(match[up_idx] - gap_open, insert_row[up_idx] - gap_extend),
-                                  insert_col[up_idx] - gap_open);
+            insert_row[idx] = max<IntType>(max<IntType>(match[up_idx] - gap_open, insert_row[up_idx] - gap_extend),
+                                           insert_col[up_idx] - gap_open);
             // must take two gaps to get into first column
-            insert_col[idx] = -2 * gap_open - (top_diag + i) * gap_extend;
+            insert_col[idx] = max<IntType>(-2 * gap_open - (top_diag + i) * gap_extend, insert_col[idx]);
 
 #ifdef debug_banded_aligner_fill_matrix
             cerr << "[BAMatrix::fill_matrix]: on left edge of matrix at rectangle coords (" << i << ", " << 0 << "), match score of node char " << 0 << " (" << node_seq[0] << ") and read char " << i + top_diag << " (" << read[i + top_diag] << ") is " << (int) match_score << ", leading gap length is " << top_diag + i << " for total match matrix score of " << (int) match[idx] << endl;
@@ -332,243 +537,14 @@ void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(int8_t* score_mat, int8
         insert_col[idx] = min_inf;
     }
     else {
-        
-#ifdef debug_banded_aligner_fill_matrix
-        cerr << "[BAMatrix::fill_matrix] seed nodes are present, preparing to do POA" << endl;;
-#endif
-        
-        // are we clipping any diagonals because they are outside the range of the matrix in this column?
-        bool bottom_diag_outside = bottom_diag >= (int64_t) read.length();
-        bool top_diag_outside = top_diag < 0;
-//        bool top_diag_abutting = top_diag == 0;
-        
-        // rows in the rectangularized band corresponding to diagonals
-        int64_t iter_start = top_diag_outside ? -top_diag : 0;
-        int64_t iter_stop = bottom_diag_outside ? band_height + (int64_t) read.length() - bottom_diag - 1 : band_height;
-        
-        IntType match_score;
-        if (qual_adjusted) {
-            match_score = score_mat[25 * base_quality[iter_start + top_diag] + 5 * nt_table[node_seq[0]] + nt_table[read[iter_start + top_diag]]];
-        }
-        else {
-            match_score = score_mat[5 * nt_table[node_seq[0]] + nt_table[read[iter_start + top_diag]]];
-        }
-        
-//        // handle special logic for lead column insertions
-//        idx = iter_start * ncols;
-//        if (top_diag_outside || top_diag_abutting) {
-//#ifdef debug_banded_aligner_fill_matrix
-//            cerr << "[BAMatrix::fill_matrix]: node still at top of matrix, adding implied gap to match of length " << cumulative_seq_len << " with a match score of " << (int) match_score << " for a total score of " << match_score - gap_open - (cumulative_seq_len - 1) * gap_extend << " and initializing rest of column to -inf" << endl;
-//#endif
-//            // match after implied gap along top edge
-//            match[idx] = match_score - gap_open - (cumulative_seq_len - 1) * gap_extend;
-//        }
-//        else {
-//#ifdef debug_banded_aligner_fill_matrix
-//            cerr << "[BAMatrix::fill_matrix]: no lead gap possible, initializing first column to all -inf" << endl;
-//#endif
-//            // no lead gaps possible so seed with identity of max function to prepare for POA
-//            match[idx] = min_inf;
-//        }
-//        
-//        if (top_diag_outside) {
-//            // gap open after implied gap along top edge
-//            insert_row[idx] = -2 * gap_open - cumulative_seq_len * gap_extend;
-//        }
-//        else {
-//            // no lead gaps possible so seed with identity of max function to prepare for POA
-//            insert_row[idx] = min_inf;
-//        }
-//        
-//        insert_col[idx] = min_inf;
-//        
-//        // start with each cell in the leftmost column as identity of max function to prepare for POA
-//        for (int64_t i = iter_start + 1; i < iter_stop; i++) {
-        for (int64_t i = iter_start; i < iter_stop; i++) {
-            idx = i * ncols;
-            match[idx] = min_inf;
-            insert_col[idx] = min_inf;
-            // since insert row does not cross node boundary can put it off until after computing
-            // match and insert col
-        }
-        
-        // initalize the first cell in insert row so we can use it when looking for lead column gaps
-        insert_row[iter_start * ncols] = min_inf;
-        
-        // the band size selection algorithm should guarantee that the band extension of each seed
-        // is present in the current matrix, but not that every cell in the current matrix has a
-        // predecessor from every seed
-        
-        // iterate through each seed and carry forward its subset of the current band
-        for (int64_t seed_num = 0; seed_num < num_seeds; seed_num++) {
-            BAMatrix* seed = seeds[seed_num];
-            
-            if (seed == nullptr) {
-#ifdef debug_banded_aligner_fill_matrix
-                cerr << "[BAMatrix::fill_matrix]: seed is masked, skipping" << endl;
-#endif
-                continue;
-            }
-            
-#ifdef debug_banded_aligner_fill_matrix
-            cerr << "[BAMatrix::fill_matrix]: doing POA across boundary from " << seed_num << "-th seed node " << seed->node->id() << " to node " << node->id() << endl;
-#endif
-            
-            // compute the interval of diagonals that this seed reaches
-            int64_t seed_node_seq_len = seed->node->sequence().length();
-            int64_t seed_next_top_diag = seed->top_diag + seed_node_seq_len;
-            int64_t seed_next_bottom_diag = seed->bottom_diag + seed_node_seq_len;
-            
-            // characterize the this interval
-            bool beyond_top_of_matrix = seed_next_top_diag < 0;
-            bool abutting_top_of_matrix = seed_next_top_diag == 0;
-            bool beyond_bottom_of_matrix = seed_next_bottom_diag >= (int64_t) read.length();
-            int64_t seed_next_top_diag_iter = beyond_top_of_matrix ? 0 : seed_next_top_diag;
-            int64_t seed_next_bottom_diag_iter = beyond_bottom_of_matrix ? (int64_t) read.length() - 1 : seed_next_bottom_diag;
-            
-            // the shortest sequence path to any source that goes through this seed
-            int64_t extended_cumulative_seq_len = seed->cumulative_seq_len + seed_node_seq_len;
-            
-#ifdef debug_banded_aligner_fill_matrix
-            cerr << "[BAMatrix::fill_matrix]: this seed reaches diagonals " << seed_next_top_diag << " to " << seed_next_bottom_diag << " out of matrix range " << top_diag << " to " << bottom_diag << endl;
-#endif
-            // special logic for first row
-            idx = (seed_next_top_diag_iter - top_diag) * ncols;
-            
-            if (qual_adjusted) {
-                match_score = score_mat[25 * base_quality[seed_next_top_diag_iter] + 5 * nt_table[node_seq[0]] + nt_table[read[seed_next_top_diag_iter]]];
-            }
-            else {
-                match_score = score_mat[5 * nt_table[node_seq[0]] + nt_table[read[seed_next_top_diag_iter]]];
-            }
-            
-            if (beyond_top_of_matrix) {
-                // the implied cell above this cell is within the extended band form this seed, so we can extend from
-                // paths through this node into both the match and insert row from a lead gap
-                
-                // match after implied gap along top edge
-                match[idx] = max<IntType>(match_score - gap_open - (extended_cumulative_seq_len - 1) * gap_extend, match[idx]);
-                // gap open after implied gap along top edge
-                insert_row[idx] = max<IntType>(-2 * gap_open - extended_cumulative_seq_len * gap_extend, insert_row[idx]);
-            }
-            else if (abutting_top_of_matrix) {
-                // the implied cell above this cell is not in the extended band, but the one diagonal is, so we can extend
-                // into match from a lead gap but not insert row
-                
-                // match after implied gap along top edge
-                match[idx] = max<IntType>(match_score - gap_open - (extended_cumulative_seq_len - 1) * gap_extend, match[idx]);
-                
-            }
-            else {
-#ifdef debug_banded_aligner_fill_matrix
-                cerr << "[BAMatrix::fill_matrix]: top cell in match matrix is reachable without a lead gap" << endl;
-#endif
-                diag_idx = (seed_next_top_diag_iter - seed_next_top_diag) * seed_node_seq_len + seed_node_seq_len - 1;
-                
-                match[idx] = max<IntType>(match_score + max<IntType>(max<IntType>(seed->match[diag_idx],
-                                                                               seed->insert_row[diag_idx]),
-                                                                   seed->insert_col[diag_idx]), match[idx]);
-            }
-            
-            if (seed_next_top_diag < seed_next_bottom_diag) {
-#ifdef debug_banded_aligner_fill_matrix
-                cerr << "[BAMatrix::fill_matrix]: seed band is greater than height 1, can extend column gap into first row" << endl;
-#endif
-                left_idx = (seed_next_top_diag_iter - seed_next_top_diag + 2) * seed_node_seq_len - 1;
-                insert_col[idx] = max<IntType>(max<IntType>(max<IntType>(seed->match[left_idx] - gap_open,
-                                                                      seed->insert_row[left_idx] - gap_open),
-                                                          seed->insert_col[left_idx] - gap_extend), insert_col[idx]);
-            }
-            
-            
-            for (int64_t diag = seed_next_top_diag_iter + 1; diag < seed_next_bottom_diag_iter; diag++) {
-                idx = (diag - top_diag) * ncols;
-                
-#ifdef debug_banded_aligner_fill_matrix
-                cerr << "[BAMatrix::fill_matrix]: extending a match and column gap into matrix coord (" << diag << ", 0)" << ", rectangular coord coord (" << diag - top_diag << ", 0)" << endl;
-#endif
-                
-                // extend a match
-                diag_idx = (diag - seed_next_top_diag) * seed_node_seq_len + seed_node_seq_len - 1;
-                IntType match_score;
-                if (qual_adjusted) {
-                    match_score = score_mat[25 * base_quality[diag] + 5 * nt_table[node_seq[0]] + nt_table[read[diag]]];
-                }
-                else {
-                    match_score = score_mat[5 * nt_table[node_seq[0]] + nt_table[read[diag]]];
-                }
-                
-#ifdef debug_banded_aligner_fill_matrix
-                cerr << "[BAMatrix::fill_matrix]: extending match from rectangular coord (" << diag - seed_next_top_diag << ", " << seed_node_seq_len - 1 << ")" << " with match score " << (int) match_score << ", scores are " << (int) seed->match[diag_idx] << " (M), " << (int) seed->insert_row[diag_idx] << " (Ir), and " << (int) seed->insert_col[diag_idx] << " (Ic), current score is " << (int) match[idx] << endl;
-#endif
-                
-                match[idx] = max<IntType>(match_score + max<IntType>(max<IntType>(seed->match[diag_idx],
-                                                                               seed->insert_row[diag_idx]),
-                                                                   seed->insert_col[diag_idx]), match[idx]);
-                
-                // extend a column gap
-                left_idx = (diag - seed_next_top_diag + 2) * seed_node_seq_len - 1;
-                
-#ifdef debug_banded_aligner_fill_matrix
-                cerr << "[BAMatrix::fill_matrix]: extending match from rectangular coord (" << diag - seed_next_top_diag + 1 << ", " << seed_node_seq_len - 1 << ")" << ", scores are " << (int) seed->match[left_idx] << " (M), " << (int) seed->insert_row[left_idx] << " (Ir), and " << (int) seed->insert_col[left_idx] << " (Ic), current score is " << (int) insert_col[idx] << endl;
-#endif
-                insert_col[idx] = max<IntType>(max<IntType>(max<IntType>(seed->match[left_idx] - gap_open,
-                                                                      seed->insert_row[left_idx] - gap_open),
-                                                          seed->insert_col[left_idx] - gap_extend), insert_col[idx]);
-                
-#ifdef debug_banded_aligner_fill_matrix
-                cerr << "[BAMatrix::fill_matrix]: score is now " << (int) insert_col[idx] << endl;
-#endif
-            }
-            
-            // don't handle final row edge case if we actually got it with the first row edge case
-            if (seed_next_bottom_diag_iter != seed_next_top_diag_iter) {
-#ifdef debug_banded_aligner_fill_matrix
-                cerr << "[BAMatrix::fill_matrix]: edge case for final cell in column" << endl;
-                cerr << "[BAMatrix::fill_matrix]: extending a match and column gap into matrix coord (" << seed_next_bottom_diag_iter << ", 0)" << ", rectangular coord coord (" << seed_next_bottom_diag_iter - top_diag << ", 0)" << endl;
-#endif
-                
-                // may only be able to extend a match on last iteration
-                idx = (seed_next_bottom_diag_iter - top_diag) * ncols;
-                diag_idx = (seed_next_bottom_diag_iter - seed_next_top_diag) * seed_node_seq_len + seed_node_seq_len - 1;
-                if (qual_adjusted) {
-                    match_score = score_mat[25 * base_quality[seed_next_bottom_diag_iter] + 5 * nt_table[node_seq[0]] + nt_table[read[seed_next_bottom_diag_iter]]];
-                }
-                else {
-                    match_score = score_mat[5 * nt_table[node_seq[0]] + nt_table[read[seed_next_bottom_diag_iter]]];
-                }
-                
-#ifdef debug_banded_aligner_fill_matrix
-                cerr << "[BAMatrix::fill_matrix]: extending match from rectangular coord (" << seed_next_bottom_diag_iter - seed_next_top_diag << ", " << seed_node_seq_len - 1 << ")" << " with match score " << (int) match_score << ", scores are " << (int) seed->match[diag_idx] << " (M), " << (int) seed->insert_row[diag_idx] << " (Ir), and " << (int) seed->insert_col[diag_idx] << " (Ic), current score is " << (int) match[idx] << endl;
-#endif
-                match[idx] = max<IntType>(match_score + max<IntType>(max<IntType>(seed->match[diag_idx],
-                                                                               seed->insert_row[diag_idx]),
-                                                                   seed->insert_col[diag_idx]), match[idx]);
-                
-                // can only extend column gap if the bottom of the matrix was hit in the last seed
-                if (beyond_bottom_of_matrix) {
-#ifdef debug_banded_aligner_fill_matrix
-                    cerr << "[BAMatrix::fill_matrix]: can also extend a column gap since already reached edge of matrix" << endl;
-#endif
-                    left_idx = (seed_next_bottom_diag_iter - seed_next_top_diag + 2) * seed_node_seq_len - 1;
-                    insert_col[idx] = max<IntType>(max<IntType>(max<IntType>(seed->match[left_idx] - gap_open,
-                                                                          seed->insert_row[left_idx] - gap_open),
-                                                              seed->insert_col[left_idx] - gap_extend), insert_col[idx]);
-                }
-            }
-
-        }
-#ifdef debug_banded_aligner_fill_matrix
-        cerr << "[BAMatrix::fill_matrix]: filling out initial column of insert row matrix" << endl;
-#endif
-        // compute the insert row scores (they can be computed after the POA iterations since they do not
-        // cross node boundaries)
+        // compute the insert row scores without any cases for lead gaps (these can be safely computed after
+        // the POA iterations since they do not cross node boundaries)
         for (int64_t i = iter_start + 1; i < iter_stop; i++) {
             idx = i * ncols;
             up_idx = (i - 1) * ncols;
             
-            insert_row[idx] = max(max(match[up_idx] - gap_open, insert_row[up_idx] - gap_extend),
-                                  insert_col[up_idx] - gap_open);
+            insert_row[idx] = max<IntType>(max<IntType>(match[up_idx] - gap_open, insert_row[up_idx] - gap_extend),
+                                           insert_col[up_idx] - gap_open);
         }
     }
     
@@ -807,6 +783,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
                     cerr << "[BAMatrix::traceback_internal] next cell is outside matrix, opening implied lead gap" << endl;
 #endif
                     // at top of matrix, move into implied lead gap along top edge
+                    curr_mat = InsertCol;
                     j--;
                     in_lead_gap = true;
                     // no where else to go, so break out of switch statement without checking alts
@@ -1029,106 +1006,460 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
         }
     }
     
-    // are there are predecessor nodes?
-    if (num_seeds > 0) {
-        
-        BAMatrix* traceback_seed;
-        int64_t traceback_seed_row;
-        int64_t traceback_seed_col;
-        matrix_t traceback_mat;
-        
-        if (in_lead_gap) {
+    // begin POA across the boundary
+    
+    bool treat_as_source = false;
+    unordered_set<int64_t> traceback_source_nodes;
+    if (num_seeds == 0) {
+        treat_as_source = true;
+        traceback_source_nodes.insert(node->id());
+    }
+    
+    BAMatrix* traceback_seed = nullptr;
+    int64_t traceback_seed_row;
+    int64_t traceback_seed_col;
+    matrix_t traceback_mat;
+    
+    int64_t curr_diag = top_diag + i;
+    
+    if (traceback_stack.at_next_deflection(node_id, i, j)) {
 #ifdef debug_banded_aligner_traceback
-            cerr << "[BAMatrix::traceback_internal] at boundary, following seed backward from a lead gap" << endl;
+        cerr << "[BAMatrix::traceback_internal] at boundary, taking a deflection" << endl;
 #endif
-            // we are in the implied lead gap along the top of the matrix
-            // take the shortest path back to the origin of the global alignment
+        
+        builder.update_state(curr_mat, node, curr_diag, 0);
+        
+        // where to deflect to?
+        int64_t deflect_node_id;
+        matrix_t deflect_matrix = traceback_stack.deflect_to_matrix(deflect_node_id);
+        
+        // find which seed matrix to deflect to (don't have a better way of looking this up right now)
+        list<BAMatrix*> seed_path;
+        for (int64_t k = 0; k < num_seeds; k++) {
             
-            // add final read deletion of node
-            builder.update_state(curr_mat, node, -1, j);
+            list<BAMatrix*> seed_stack{seeds[k]};
             
-            int64_t shortest_seq_len = numeric_limits<int64_t>::max();
-            for (int64_t k = 0; k < num_seeds; k++) {
-                BAMatrix* seed = seeds[k];
-                // is seed masked?
-                if (seed == nullptr) {
-                    continue;
+            while (!seed_stack.empty()) {
+                BAMatrix* seed = seed_stack.back();
+                seed_stack.pop_back();
+                
+                if (!seed) {
+                    // pop off the path if we hit the stack marker
+                    seed_path.pop_back();
                 }
-                // does a shorter path to origin go through this seed?
-                if (seed->cumulative_seq_len < shortest_seq_len) {
-                    traceback_seed = seed;
-                    shortest_seq_len = seed->cumulative_seq_len;
+                else if (seed->node->id() == deflect_node_id) {
+                    // we found the traceback node
+                    seed_path.push_back(seed);
+                    break;
+                }
+                else if (seed->node->sequence().length() == 0) {
+                    // this is not the traceback node, but it is an empty node so the traceback
+                    // might be on the other side of it
+                    seed_path.push_back(seed);
+                    seed_stack.push_back(nullptr);
+                    for (int64_t l = 0; l < seed->num_seeds; l++) {
+                        seed_stack.push_back(seed->seeds[l]);
+                    }
                 }
             }
             
+            // stop looking if we found a path to the traceback seed
+            if (!seed_path.empty()) {
+                break;
+            }
+        }
+        
+        if (seed_path.empty()) {
+            cerr << "error:[BandedGlobalAligner] traceback node boundary could not find node to deflect to" << endl;
+            assert(0);
+        }
+        
+        // if we traversed empty nodes on the way to the traceback node, add empty mapping for those
+        if (seed_path.size() > 1) {
+            auto end = seed_path.end();
+            end--;
+            for (auto iter = seed_path.begin(); iter != end; iter++) {
+                builder.update_state(curr_mat, (*iter)->node, i, 0, true);
+            }
+        }
+        
+        BAMatrix* seed = seed_path.back();
+        
+        int64_t seed_ncols = seed->node->sequence().length();
+        traceback_seed_row = curr_diag - seed->top_diag - seed_ncols + (curr_mat == InsertCol);
+        traceback_seed_col = seed_ncols - 1;
+        
+#ifdef debug_banded_aligner_traceback
+        cerr << "[BAMatrix::traceback_internal] taking node boundary deflection to " << (deflect_matrix == Match ? "match" : (deflect_matrix == InsertCol ? "insert column" : "insert row")) << " in node " << deflect_node_id << ", will start at coordinates (" << traceback_seed_row << ", " << traceback_seed_col << ")" << endl;
+#endif
+        
+        // continue traceback in the next node
+        seed->traceback_internal(builder, traceback_stack, traceback_seed_row, traceback_seed_col, deflect_matrix,
+                                 in_lead_gap, score_mat, nt_table, gap_open, gap_extend, qual_adjusted, min_inf);
+        return;
+    }
+    
+    bool found_trace = false;
+    vector<BAMatrix*> empty_intermediate_nodes;
+    
+    // a queue of seeds and their empty predecessors
+    list<pair<BAMatrix*, vector<BAMatrix*>>> seed_queue;
+    for (int64_t k = 0; k < num_seeds; k++) {
+        seed_queue.push_back(make_pair(seeds[k], vector<BAMatrix*>()));
+    }
+    
+    if (in_lead_gap) {
+#ifdef debug_banded_aligner_traceback
+        cerr << "[BAMatrix::traceback_internal] at boundary, following seed backward from a lead gap" << endl;
+#endif
+        // we are in the implied lead gap along the top of the matrix
+        // take the shortest path back to the origin of the global alignment
+        
+        found_trace = true;
+        
+        // add final read deletion of node
+        builder.update_state(curr_mat, node, -1, j);
+        
+        int64_t shortest_seq_len = numeric_limits<int64_t>::max();
+        while (!seed_queue.empty()) {
+            
+            auto seed_record = seed_queue.front();
+            BAMatrix* seed = seed_record.first;
+            seed_queue.pop_front();
+            
+            // is seed masked?
+            if (seed == nullptr) {
+                continue;
+            }
+            
+#ifdef debug_banded_aligner_traceback
+            cerr << "[BAMatrix::traceback_internal] checking seed node " << seed->node->id() << endl;
+#endif
+            
+            // if this node is empty, add its predecessors to the queue
+            if (seed->node->sequence().length() == 0) {
+#ifdef debug_banded_aligner_traceback
+                cerr << "[BAMatrix::traceback_internal] seed node " << seed->node->id() << " is empty, checking predecessors" << endl;
+#endif
+                if (seed->num_seeds == 0) {
+#ifdef debug_banded_aligner_traceback
+                    cerr << "[BAMatrix::traceback_internal] empty seed node " << seed->node->id() << " is a source" << endl;
+#endif
+                    treat_as_source = true;
+                    traceback_source_nodes.insert(seed->node->id());
+                    empty_intermediate_nodes = seed_record.second;
+                    empty_intermediate_nodes.push_back(seed);
+                }
+                
+                for (int64_t seed_num = 0; seed_num < seed->num_seeds; seed_num++) {
+                    seed_queue.push_back(make_pair(seed->seeds[seed_num], seed_record.second));
+                    // record that this seed comes before its predecessors in the traceback
+                    seed_queue.back().second.push_back(seed);
+                }
+                continue;
+            }
+            
+            // does a shorter path to origin go through this seed?
+            if (seed->cumulative_seq_len < shortest_seq_len) {
+                traceback_seed = seed;
+                shortest_seq_len = seed->cumulative_seq_len;
+            }
+        }
+        
+        if (traceback_seed) {
             // where in the matrix is this?
             int64_t seed_ncols = traceback_seed->node->sequence().length();
             int64_t seed_extended_top_diag = traceback_seed->top_diag + seed_ncols;
             traceback_seed_row = top_diag - seed_extended_top_diag + i + 1;
             traceback_seed_col = seed_ncols - 1;
+            found_trace = true;
         }
-        else {
-            
-            int64_t curr_diag = top_diag + i;
-            builder.update_state(curr_mat, node, curr_diag, 0);
-            
-            if (traceback_stack.at_next_deflection(node_id, i, j)) {
-#ifdef debug_banded_aligner_traceback
-                cerr << "[BAMatrix::traceback_internal] at boundary, taking a deflection" << endl;
-#endif
-                
-                // where to deflect to?
-                int64_t deflect_node_id;
-                matrix_t deflect_matrix = traceback_stack.deflect_to_matrix(deflect_node_id);
-                
-
-                
-                // find which seed matrix to deflect to (don't have a better way of looking this up right now)
-                BAMatrix* seed;
-                for (int64_t k = 0; k < num_seeds; k++) {
-                    seed = seeds[k];
-                    if (seed->node->id() == deflect_node_id) {
-                        break;
-                    }
+    }
+    else {
+        
+        builder.update_state(curr_mat, node, curr_diag, 0);
+        
+        IntType match_score;
+        switch (curr_mat) {
+            case Match:
+            {
+                curr_score = match[i * ncols];
+                if (qual_adjusted) {
+                    match_score = score_mat[25 * base_quality[i + top_diag] + 5 * nt_table[node_seq[j]] + nt_table[read[i + top_diag]]];
                 }
+                else {
+                    match_score = score_mat[5 * nt_table[node_seq[j]] + nt_table[read[i + top_diag]]];
+                }
+                break;
+            }
                 
-                int64_t seed_ncols = seed->node->sequence().length();
-                traceback_seed_row = curr_diag - seed->top_diag - seed_ncols + (curr_mat == InsertCol);
-                traceback_seed_col = seed_ncols - 1;
+            case InsertCol:
+            {
+                curr_score = insert_col[i * ncols];
+                break;
+            }
                 
+            case InsertRow:
+            {
+                cerr << "error:[BandedGlobalAligner] traceback attempted to open row gap over node boundary" << endl;
+                assert(0);
+                break;
+            }
+                
+            default:
+            {
+                cerr << "error:[BandedGlobalAligner] unrecognized matrix type given to traceback" << endl;
+                assert(0);
+                break;
+            }
+        }
+        
 #ifdef debug_banded_aligner_traceback
-                cerr << "[BAMatrix::traceback_internal] taking node boundary deflection to " << (deflect_matrix == Match ? "match" : (deflect_matrix == InsertCol ? "insert column" : "insert row")) << " in node " << deflect_node_id << ", will start at coordinates (" << traceback_seed_row << ", " << traceback_seed_col << ")" << endl;
+        cerr << "[BAMatrix::traceback_internal] at boundary, in node " << node->id() << " following seed backward from " << (curr_mat == Match ? "match" : "insert column") << " matrix with score " << (int) curr_score << endl;
 #endif
-                
-                // continue traceback in the next node
-                seed->traceback_internal(builder, traceback_stack, traceback_seed_row, traceback_seed_col, deflect_matrix,
-                                         in_lead_gap, score_mat, nt_table, gap_open, gap_extend, qual_adjusted, min_inf);
-                return;
+        
+        // matches stay on same diagonal, column insertions move over one diagonal
+        // note that the indexing is relative to THIS matrix, not the seed
+        
+        // check traceback goes to each seed matrix
+        while (!seed_queue.empty()) {
+            auto seed_record = seed_queue.front();
+            BAMatrix* seed = seed_record.first;
+            seed_queue.pop_front();
+            
+            // is the matrix masked?
+            if (seed == nullptr) {
+#ifdef debug_banded_aligner_traceback
+                cerr << "[BAMatrix::traceback_internal] seed is masked" << endl;
+#endif
+                continue;
             }
             
-            IntType match_score;
+            if (seed->node->sequence().length() == 0) {
+                
+                for (int64_t seed_num = 0; seed_num < seed->num_seeds; seed_num++) {
+                    seed_queue.push_back(make_pair(seed->seeds[seed_num], seed_record.second));
+                    seed_queue.back().second.push_back(seed);
+                }
+                
+                if (seed->num_seeds == 0) {
+                    treat_as_source = true;
+                    // keep track of the path through empty nodes to a source (this will be overwritten
+                    // if we find a a trace)
+                    if (!found_trace) {
+                        empty_intermediate_nodes = seed_record.second;
+                        empty_intermediate_nodes.push_back(seed);
+                    }
+                }
+                continue;
+            }
+            
+            
+#ifdef debug_banded_aligner_traceback
+            cerr << "[BAMatrix::traceback_internal] checking seed node " << seed->node->id() << endl;
+#endif
+            
+            int64_t seed_node_id = seed->node->id();
+            int64_t seed_ncols = seed->node->sequence().length();
+            
+            // the diagonals in the current matrix that this seed extends to
+            int64_t seed_extended_top_diag = seed->top_diag + seed_ncols;
+            int64_t seed_extended_bottom_diag = seed->bottom_diag + seed_ncols;
+            
+            // does the traceback diagonal extend backward to this matrix?
+            if (curr_diag > seed_extended_bottom_diag - (curr_mat == InsertCol) // col inserts hit 1 less of band
+                || curr_diag < seed_extended_top_diag) {
+#ifdef debug_banded_aligner_traceback
+                cerr << "[BAMatrix::traceback_internal] seed extended diags are top: " << seed_extended_top_diag << ", bottom: " << seed_extended_bottom_diag << " and curr mat is " << (curr_mat == InsertCol ? "" : "not") << " insert column, so we cannot extend from this seed to the current diag " << curr_diag << endl;
+#endif
+                continue;
+            }
+            
+            int64_t seed_col = seed_ncols - 1;
+            int64_t seed_row = -(seed_extended_top_diag - top_diag) + i + (curr_mat == InsertCol);
+            next_idx = seed_row * seed_ncols + seed_col;
+            
+#ifdef debug_banded_aligner_traceback
+            cerr << "[BAMatrix::traceback_internal] checking seed rectangular coordinates (" << seed_row << ", " << seed_col << "), with indices calculated from current diagonal " << curr_diag << " (top diag " << top_diag << " + offset " << i << "), seed top diagonal " << seed->top_diag << ", seed seq length " << seed_ncols << " with insert column offset " << (curr_mat == InsertCol) << endl;
+#endif
+            
             switch (curr_mat) {
                 case Match:
                 {
-                    curr_score = match[i * ncols];
-                    if (qual_adjusted) {
-                        match_score = score_mat[25 * base_quality[i + top_diag] + 5 * nt_table[node_seq[j]] + nt_table[read[i + top_diag]]];
+#ifdef debug_banded_aligner_traceback
+                    cerr << "[BAMatrix::traceback_internal] poa backwards from match, seed extended top diag " << seed_extended_top_diag << endl;
+#endif
+                    // does match lead into a lead row gap?
+                    if (seed->top_diag + seed_row + seed_col == -1) {
+#ifdef debug_banded_aligner_traceback
+                        cerr << "[BAMatrix::traceback_internal] traceback points to a lead column gap of length " << seed->cumulative_seq_len + seed_ncols << " with score " << (int) -gap_open - (seed->cumulative_seq_len + seed_ncols - 1) * gap_extend << " extending to score here of " << (int) curr_score << " with match score " << (int) match_score << endl;
+#endif
+                        // score of implied column gap
+                        source_score = -gap_open - (seed->cumulative_seq_len + seed_ncols - 1) * gap_extend;
+                        score_diff = curr_score - (source_score + match_score);
+                        if (score_diff == 0 && !found_trace) {
+                            traceback_mat = InsertCol;
+                            traceback_seed = seed;
+                            traceback_seed_row = seed_row;
+                            traceback_seed_col = seed_col;
+                            in_lead_gap = true;
+                            found_trace = true;
+                            empty_intermediate_nodes = seed_record.second;
+#ifdef debug_banded_aligner_traceback
+                            cerr << "[BAMatrix::traceback_internal] hit found in lead gap with score " << -gap_open - (seed->cumulative_seq_len + seed_ncols - 1) * gap_extend << endl;
+#endif
+                        }
+                        else {
+                            alt_score = curr_traceback_score - score_diff;
+                            traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, Match);
+                        }
+                        
+                        // don't check any of the matrices because they will have garbage values in this position or seg fault
+                        break;
+                    }
+                    
+                    source_score = seed->match[next_idx];
+                    // don't need to check edge condition because match does not have min inf
+                    score_diff = curr_score - (source_score + match_score);
+                    if (score_diff == 0 && !found_trace) {
+                        traceback_mat = Match;
+                        traceback_seed = seed;
+                        traceback_seed_row = seed_row;
+                        traceback_seed_col = seed_col;
+                        found_trace = true;
+                        empty_intermediate_nodes = seed_record.second;
+#ifdef debug_banded_aligner_traceback
+                        cerr << "[BAMatrix::traceback_internal] hit found in match matrix with score " << (int) seed->match[next_idx] << endl;
+#endif
                     }
                     else {
-                        match_score = score_mat[5 * nt_table[node_seq[j]] + nt_table[read[i + top_diag]]];
+                        alt_score = curr_traceback_score - score_diff;
+                        traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, Match);
                     }
+                    
+                    source_score = seed->insert_col[next_idx];
+                    // check edge condition
+                    if (source_score > min_inf) {
+                        score_diff = curr_score - (source_score + match_score);
+                        if (score_diff == 0 && !found_trace) {
+#ifdef debug_banded_aligner_traceback
+                            cerr << "[BAMatrix::traceback_internal] hit found in insert column matrix  with score " << (int) seed->insert_col[next_idx] << endl;
+#endif
+                            traceback_mat = InsertCol;
+                            traceback_seed = seed;
+                            traceback_seed_row = seed_row;
+                            traceback_seed_col = seed_col;
+                            found_trace = true;
+                            empty_intermediate_nodes = seed_record.second;
+                        }
+                        else {
+                            alt_score = curr_traceback_score - score_diff;
+                            traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, InsertCol);
+                        }
+                    }
+                    
+                    source_score = seed->insert_row[next_idx];
+                    // check edge condition
+                    if (source_score > min_inf) {
+                        score_diff = curr_score - (source_score + match_score);
+                        if (score_diff == 0 && !found_trace) {
+#ifdef debug_banded_aligner_traceback
+                            cerr << "[BAMatrix::traceback_internal] hit found in insert row matrix  with score " << (int) seed->insert_row[next_idx] << endl;
+#endif
+                            traceback_mat = InsertRow;
+                            traceback_seed = seed;
+                            traceback_seed_row = seed_row;
+                            traceback_seed_col = seed_col;
+                            found_trace = true;
+                            empty_intermediate_nodes = seed_record.second;
+                        }
+                        else {
+                            alt_score = curr_traceback_score - score_diff;
+                            traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, InsertRow);
+                        }
+                    }
+                    
                     break;
                 }
                     
                 case InsertCol:
                 {
-                    curr_score = insert_col[i * ncols];
+                    source_score = seed->match[next_idx];
+                    // don't need to check edge condition because match does not have min inf
+                    score_diff = curr_score - (source_score - gap_open);
+                    if (score_diff == 0 && !found_trace) {
+#ifdef debug_banded_aligner_traceback
+                        cerr << "[BAMatrix::traceback_internal] hit found in match matrix with score " << (int) seed->match[next_idx] << endl;
+#endif
+                        traceback_mat = Match;
+                        traceback_seed = seed;
+                        traceback_seed_row = seed_row;
+                        traceback_seed_col = seed_col;
+                        found_trace = true;
+                        empty_intermediate_nodes = seed_record.second;
+                    }
+                    else {
+                        alt_score = curr_traceback_score - score_diff;
+#ifdef debug_banded_aligner_traceback
+                        cerr << "[BAMatrix::traceback_internal] no hit in match matrix, proposing deflection with alt score " << (int) alt_score << " from current traceback score " << curr_traceback_score << " and score diff " << score_diff << endl;
+#endif
+                        traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, Match);
+                    }
+                    
+                    source_score = seed->insert_col[next_idx];
+                    // check edge condition
+                    if (source_score > min_inf) {
+                        score_diff = curr_score - (source_score - gap_extend);
+                        if (score_diff == 0 && !found_trace) {
+#ifdef debug_banded_aligner_traceback
+                            cerr << "[BAMatrix::traceback_internal] hit found in insert column matrix with score " << (int) seed->match[next_idx] << endl;
+#endif
+                            traceback_mat = InsertCol;
+                            traceback_seed = seed;
+                            traceback_seed_row = seed_row;
+                            traceback_seed_col = seed_col;
+                            found_trace = true;
+                            empty_intermediate_nodes = seed_record.second;
+                        }
+                        else {
+                            alt_score = curr_traceback_score - score_diff;
+#ifdef debug_banded_aligner_traceback
+                            cerr << "[BAMatrix::traceback_internal] no hit in insert row matrix, proposing deflection with alt score " << (int) alt_score << " from current traceback score " << curr_traceback_score << " and score diff " << score_diff << endl;
+#endif
+                            traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, InsertCol);
+                        }
+                    }
+                    
+                    source_score = seed->insert_row[next_idx];
+                    // check edge condition
+                    if (source_score > min_inf) {
+                        score_diff = curr_score - (source_score - gap_open);
+                        if (score_diff == 0 && !found_trace) {
+#ifdef debug_banded_aligner_traceback
+                            cerr << "[BAMatrix::traceback_internal] hit found in insert row matrix with score " << (int) seed->match[next_idx] << endl;
+#endif
+                            traceback_mat = InsertRow;
+                            traceback_seed = seed;
+                            traceback_seed_row = seed_row;
+                            traceback_seed_col = seed_col;
+                            found_trace = true;
+                            empty_intermediate_nodes = seed_record.second;
+                        }
+                        else {
+                            alt_score = curr_traceback_score - score_diff;
+#ifdef debug_banded_aligner_traceback
+                            cerr << "[BAMatrix::traceback_internal] no hit in insert column matrix, proposing deflection with alt score " << (int) alt_score << " from current traceback score " << curr_traceback_score << " and score diff " << score_diff << endl;
+#endif
+                            traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, InsertRow);
+                        }
+                    }
+                    
                     break;
                 }
                     
                 case InsertRow:
                 {
-                    cerr << "error:[BandedGlobalAligner] traceback attempted to open row gap over node boundary" << endl;
+                    cerr << "error:[BandedGlobalAligner] illegal matrix type for moving across node boundary" << endl;
                     assert(0);
                     break;
                 }
@@ -1140,279 +1471,74 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
                     break;
                 }
             }
-            
-#ifdef debug_banded_aligner_traceback
-            cerr << "[BAMatrix::traceback_internal] at boundary, in node " << node->id() << " following seed backward from " << (curr_mat == Match ? "match" : "insert column") << " matrix with score " << (int) curr_score << endl;
-#endif
-            
-            // matches stay on same diagonal, column insertions move over one diagonal
-            // note that the indexing is relative to THIS matrix, not the seed
-            
-            bool found_trace = false;
-            // check traceback goes to each seed matrix
-            for (int64_t k = 0; k < num_seeds; k++) {
-                BAMatrix* seed = seeds[k];
-
-                // is the matrix masked?
-                if (seed == nullptr) {
-#ifdef debug_banded_aligner_traceback
-                    cerr << "[BAMatrix::traceback_internal] seed " << k << " is masked" << endl;
-#endif
-                    continue;
-                }
-                
-#ifdef debug_banded_aligner_traceback
-                cerr << "[BAMatrix::traceback_internal] checking seed number " << k << " which corresponds to node " << seed->node->id() << endl;
-#endif
-                
-                int64_t seed_node_id = seed->node->id();
-                int64_t seed_ncols = seed->node->sequence().length();
-                
-                // the diagonals in the current matrix that this seed extends to
-                int64_t seed_extended_top_diag = seed->top_diag + seed_ncols;
-                int64_t seed_extended_bottom_diag = seed->bottom_diag + seed_ncols;
-                
-                // does the traceback diagonal extend backward to this matrix?
-                if (curr_diag > seed_extended_bottom_diag - (curr_mat == InsertCol) // col inserts hit 1 less of band
-                    || curr_diag < seed_extended_top_diag) {
-#ifdef debug_banded_aligner_traceback
-                    cerr << "[BAMatrix::traceback_internal] seed extended diags are top: " << seed_extended_top_diag << ", bottom: " << seed_extended_bottom_diag << " and curr mat is " << (curr_mat == InsertCol ? "" : "not") << " insert column, so we cannot extend from this seed to the current diag " << curr_diag << endl;
-#endif
-                    continue;
-                }
-                
-                int64_t seed_col = seed_ncols - 1;
-                int64_t seed_row = -(seed_extended_top_diag - top_diag) + i + (curr_mat == InsertCol);
-                next_idx = seed_row * seed_ncols + seed_col;
-                
-#ifdef debug_banded_aligner_traceback
-                cerr << "[BAMatrix::traceback_internal] checking seed rectangular coordinates (" << seed_row << ", " << seed_col << "), with indices calculated from current diagonal " << curr_diag << " (top diag " << top_diag << " + offset " << i << "), seed top diagonal " << seed->top_diag << ", seed seq length " << seed_ncols << " with insert column offset " << (curr_mat == InsertCol) << endl;
-#endif
-                
-                switch (curr_mat) {
-                    case Match:
-                    {
-#ifdef debug_banded_aligner_traceback
-                        cerr << "[BAMatrix::traceback_internal] poa backwards from match, seed extended top diag " << seed_extended_top_diag << endl;
-#endif
-                        // does match lead into a lead row gap?
-                        if (seed->top_diag + seed_row + seed_col == -1) {
-#ifdef debug_banded_aligner_traceback
-                            cerr << "[BAMatrix::traceback_internal] traceback points to a lead column gap of length " << seed->cumulative_seq_len + seed_ncols << " with score " << (int) -gap_open - (seed->cumulative_seq_len + seed_ncols - 1) * gap_extend << " extending to score here of " << (int) curr_score << " with match score " << (int) match_score << endl;
-#endif
-                            // score of implied column gap
-                            source_score = -gap_open - (seed->cumulative_seq_len + seed_ncols - 1) * gap_extend;
-                            score_diff = curr_score - (source_score + match_score);
-                            if (score_diff == 0 && !found_trace) {
-                                traceback_seed = seed;
-                                traceback_seed_row = seed_row;
-                                traceback_seed_col = seed_col;
-                                in_lead_gap = true;
-                                found_trace = true;
-#ifdef debug_banded_aligner_traceback
-                                cerr << "[BAMatrix::traceback_internal] hit found in lead gap with score " << -gap_open - (seed->cumulative_seq_len + seed_ncols - 1) * gap_extend << endl;
-#endif
-                            }
-                            else {
-                                alt_score = curr_traceback_score - score_diff;
-                                traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, Match);
-                            }
-                            
-                            // don't check any of the matrices because they will have garbage values in this position or seg fault
-                            break;
-                        }
-                        
-                        source_score = seed->match[next_idx];
-                        // don't need to check edge condition because match does not have min inf
-                        score_diff = curr_score - (source_score + match_score);
-                        if (score_diff == 0 && !found_trace) {
-                            traceback_mat = Match;
-                            traceback_seed = seed;
-                            traceback_seed_row = seed_row;
-                            traceback_seed_col = seed_col;
-                            found_trace = true;
-#ifdef debug_banded_aligner_traceback
-                            cerr << "[BAMatrix::traceback_internal] hit found in match matrix with score " << (int) seed->match[next_idx] << endl;
-#endif
-                        }
-                        else {
-                            alt_score = curr_traceback_score - score_diff;
-                            traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, Match);
-                        }
-                        
-                        source_score = seed->insert_col[next_idx];
-                        // check edge condition
-                        if (source_score > min_inf) {
-                            score_diff = curr_score - (source_score + match_score);
-                            if (score_diff == 0 && !found_trace) {
-#ifdef debug_banded_aligner_traceback
-                                cerr << "[BAMatrix::traceback_internal] hit found in insert column matrix  with score " << (int) seed->insert_col[next_idx] << endl;
-#endif
-                                traceback_mat = InsertCol;
-                                traceback_seed = seed;
-                                traceback_seed_row = seed_row;
-                                traceback_seed_col = seed_col;
-                                found_trace = true;
-                            }
-                            else {
-                                alt_score = curr_traceback_score - score_diff;
-                                traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, InsertCol);
-                            }
-                        }
-                        
-                        source_score = seed->insert_row[next_idx];
-                        // check edge condition
-                        if (source_score > min_inf) {
-                            score_diff = curr_score - (source_score + match_score);
-                            if (score_diff == 0 && !found_trace) {
-#ifdef debug_banded_aligner_traceback
-                                cerr << "[BAMatrix::traceback_internal] hit found in insert row matrix  with score " << (int) seed->insert_row[next_idx] << endl;
-#endif
-                                traceback_mat = InsertRow;
-                                traceback_seed = seed;
-                                traceback_seed_row = seed_row;
-                                traceback_seed_col = seed_col;
-                                found_trace = true;
-                            }
-                            else {
-                                alt_score = curr_traceback_score - score_diff;
-                                traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, InsertRow);
-                            }
-                        }
-                        
-                        break;
-                    }
-                        
-                    case InsertCol:
-                    {
-                        source_score = seed->match[next_idx];
-                        // don't need to check edge condition because match does not have min inf
-                        score_diff = curr_score - (source_score - gap_open);
-                        if (score_diff == 0 && !found_trace) {
-#ifdef debug_banded_aligner_traceback
-                            cerr << "[BAMatrix::traceback_internal] hit found in match matrix with score " << (int) seed->match[next_idx] << endl;
-#endif
-                            traceback_mat = Match;
-                            traceback_seed = seed;
-                            traceback_seed_row = seed_row;
-                            traceback_seed_col = seed_col;
-                            found_trace = true;
-                        }
-                        else {
-                            alt_score = curr_traceback_score - score_diff;
-#ifdef debug_banded_aligner_traceback
-                            cerr << "[BAMatrix::traceback_internal] no hit in match matrix, proposing deflection with alt score " << (int) alt_score << " from current traceback score " << curr_traceback_score << " and score diff " << score_diff << endl;
-#endif
-                            traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, Match);
-                        }
-                        
-                        source_score = seed->insert_col[next_idx];
-                        // check edge condition
-                        if (source_score > min_inf) {
-                            score_diff = curr_score - (source_score - gap_extend);
-                            if (score_diff == 0 && !found_trace) {
-#ifdef debug_banded_aligner_traceback
-                                cerr << "[BAMatrix::traceback_internal] hit found in insert column matrix with score " << (int) seed->match[next_idx] << endl;
-#endif
-                                traceback_mat = InsertCol;
-                                traceback_seed = seed;
-                                traceback_seed_row = seed_row;
-                                traceback_seed_col = seed_col;
-                                found_trace = true;
-                            }
-                            else {
-                                alt_score = curr_traceback_score - score_diff;
-#ifdef debug_banded_aligner_traceback
-                                cerr << "[BAMatrix::traceback_internal] no hit in insert row matrix, proposing deflection with alt score " << (int) alt_score << " from current traceback score " << curr_traceback_score << " and score diff " << score_diff << endl;
-#endif
-                                traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, InsertCol);
-                            }
-                        }
-                        
-                        source_score = seed->insert_row[next_idx];
-                        // check edge condition
-                        if (source_score > min_inf) {
-                            score_diff = curr_score - (source_score - gap_open);
-                            if (score_diff == 0 && !found_trace) {
-#ifdef debug_banded_aligner_traceback
-                                cerr << "[BAMatrix::traceback_internal] hit found in insert row matrix with score " << (int) seed->match[next_idx] << endl;
-#endif
-                                traceback_mat = InsertRow;
-                                traceback_seed = seed;
-                                traceback_seed_row = seed_row;
-                                traceback_seed_col = seed_col;
-                                found_trace = true;
-                            }
-                            else {
-                                alt_score = curr_traceback_score - score_diff;
-#ifdef debug_banded_aligner_traceback
-                                cerr << "[BAMatrix::traceback_internal] no hit in insert column matrix, proposing deflection with alt score " << (int) alt_score << " from current traceback score " << curr_traceback_score << " and score diff " << score_diff << endl;
-#endif
-                                traceback_stack.propose_deflection(alt_score, node_id, i, j, seed_node_id, InsertRow);
-                            }
-                        }
-                        
-                        break;
-                    }
-                        
-                    case InsertRow:
-                    {
-                        cerr << "error:[BandedGlobalAligner] illegal matrix type for moving across node boundary" << endl;
-                        assert(0);
-                        break;
-                    }
-                        
-                    default:
-                    {
-                        cerr << "error:[BandedGlobalAligner] unrecognized matrix type given to traceback" << endl;
-                        assert(0);
-                        break;
-                    }
-                }
-            }
-            
-            if (!found_trace) {
-                cerr << "error:[BandedGlobalAligner] traceback stuck at node boundary" << endl;
-                assert(0);
-            }
         }
-        
-        // continue traceback in the next node
-        traceback_seed->traceback_internal(builder, traceback_stack, traceback_seed_row, traceback_seed_col, traceback_mat,
-                                           in_lead_gap, score_mat, nt_table, gap_open, gap_extend, qual_adjusted, min_inf);
     }
-    else {
-        // this is the first node in the alignment, finish off the alignment and return
+    
+    bool found_source_trace = false;
+    
+    if (treat_as_source) {
+        // this is the first node in the alignment
 #ifdef debug_banded_aligner_traceback
         cerr << "[BAMatrix::traceback_internal] at beginning of first node in alignment" << endl;
 #endif
         if (in_lead_gap) {
-            builder.update_state(curr_mat, node, -1, 0);
+            found_source_trace = true;
+            j--;
+            i++;
         }
         else {
-            
-            builder.update_state(curr_mat, node, i + top_diag, 0);
-            
             switch (curr_mat) {
                 case Match:
                 {
+                    IntType match_score;
+                    if (qual_adjusted) {
+                        match_score = score_mat[25 * base_quality[i + top_diag + j] + 5 * nt_table[node_seq[j]] + nt_table[read[i + top_diag + j]]];
+                    }
+                    else {
+                        match_score = score_mat[5 * nt_table[node_seq[j]] + nt_table[read[i + top_diag + j]]];
+                    }
+                    
+                    source_score = curr_diag > 0 ? -gap_open - (curr_diag - 1) * gap_extend : 0;
+                    score_diff = curr_score - (source_score + match_score);
+                    if (score_diff == 0 && !found_trace) {
 #ifdef debug_banded_aligner_traceback
-                    cerr << "[BAMatrix::traceback_internal] alignment starts with match, adding read char " << top_diag + i << ": " << read[top_diag + i] << endl;
+                        cerr << "[BAMatrix::traceback_internal] alignment starts with match, adding read char " << top_diag + i << ": " << read[top_diag + i] << endl;
 #endif
+                        curr_mat = InsertRow;
+                        found_source_trace = true;
+                    }
+                    else {
+                        alt_score = curr_traceback_score - score_diff;
+                        for (int64_t source_node_id : traceback_source_nodes) {
+                            traceback_stack.propose_deflection(alt_score, node_id, i, j, source_node_id, InsertRow);
+                        }
+                    }
                     j--;
                     break;
                 }
                     
                 case InsertCol:
                 {
+                    source_score = -gap_open - (i + top_diag) * gap_extend;
+                    score_diff = curr_score - (source_score - gap_open);
+                    if (score_diff == 0 && !found_trace) {
 #ifdef debug_banded_aligner_traceback
-                    cerr << "[BAMatrix::traceback_internal] alignment starts with column gap" << endl;
+                        cerr << "[BAMatrix::traceback_internal] alignment starts with column gap" << endl;
 #endif
+                        curr_mat = InsertRow;
+                        found_source_trace = true;
+                    }
+                    else {
+                        alt_score = curr_traceback_score - score_diff;
+                        for (int64_t source_node_id : traceback_source_nodes) {
+                            traceback_stack.propose_deflection(alt_score, node_id, i, j, source_node_id, InsertRow);
+                        }
+                    }
                     j--;
                     i++;
                     break;
                 }
-                
+                    
                 default:
                 {
                     cerr << "error:[BandedGlobalAligner] invalid matrix type for final traceback column" << endl;
@@ -1420,18 +1546,34 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
                     break;
                 }
             }
-            
-            // add any lead row gaps necessary
-            curr_mat = InsertRow;
-            while (top_diag + i > 0) {
-#ifdef debug_banded_aligner_traceback
-                cerr << "[BAMatrix::traceback_internal] initial row gaps are present, adding read char " << top_diag + i - 1 << ": " << (char) tolower(read[top_diag + i - 1]) << " (lowercase of " << read[top_diag + i - 1]     << ")" << endl;
-#endif
-                builder.update_state(curr_mat, node, i + top_diag - 1, -1);
-                i--;
-            }
         }
     }
+    
+    // if we traversed any empty nodes before finding the traceback, add empty updates for them
+    for (BAMatrix* intermediate_node : empty_intermediate_nodes) {
+        builder.update_state(curr_mat, intermediate_node->node, i + top_diag, 0, true);
+    }
+    
+    if (found_source_trace) {
+        // add any lead row gaps necessary
+        while (top_diag + i > 0) {
+#ifdef debug_banded_aligner_traceback
+            cerr << "[BAMatrix::traceback_internal] initial row gaps are present, adding read char " << top_diag + i - 1 << ": " << (char) tolower(read[top_diag + i - 1]) << " (lowercase of " << read[top_diag + i - 1]     << ")" << endl;
+#endif
+            builder.update_state(curr_mat, node, i + top_diag - 1, -1);
+            i--;
+        }
+        return;
+    }
+    
+    if (!found_trace) {
+        cerr << "error:[BandedGlobalAligner] traceback stuck at node boundary" << endl;
+        assert(0);
+    }
+    
+    // continue traceback in the next node
+    traceback_seed->traceback_internal(builder, traceback_stack, traceback_seed_row, traceback_seed_col, traceback_mat,
+                                       in_lead_gap, score_mat, nt_table, gap_open, gap_extend, qual_adjusted, min_inf);
 }
 
 template <class IntType>
@@ -1597,6 +1739,7 @@ BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g
                                                   BandedGlobalAligner(alignment, g,
                                                                       &alt_alignments,
                                                                       max_multi_alns,
+                                                                      band_padding,
                                                                       permissive_banding,
                                                                       adjust_for_base_quality)
 {
@@ -1620,7 +1763,7 @@ BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g
                                                   adjust_for_base_quality(adjust_for_base_quality)
 {
 #ifdef debug_banded_aligner_objects
-    cerr << "[BandedGlobalAligner]: constructing BandedBlobalAligner with " << band_padding << " padding and " << permissive_banding << " permissive" << endl;
+    cerr << "[BandedGlobalAligner]: constructing BandedBlobalAligner with " << band_padding << " padding, " << permissive_banding << " permissive, " << adjust_for_base_quality << " quality adjusted" << endl;
 #endif
     if (adjust_for_base_quality) {
         if (alignment.quality().empty()) {
@@ -2089,25 +2232,27 @@ void BandedGlobalAligner<IntType>::align(int8_t* score_mat, int8_t* nt_table, in
 template <class IntType>
 void BandedGlobalAligner<IntType>::traceback(int8_t* score_mat, int8_t* nt_table, int8_t gap_open, int8_t gap_extend, IntType min_inf) {
     
-    // get the sink node matrices for alignment stack
-    vector<BAMatrix*> sink_node_matrices;
-    sink_node_matrices.reserve(sink_nodes.size());
+    // get the sink and source node matrices for alignment stack
+    unordered_set<BAMatrix*> sink_node_matrices;
+    unordered_set<BAMatrix*> source_node_matrices;
     for (Node* node : sink_nodes) {
-        sink_node_matrices.push_back(banded_matrices[node_id_to_idx[node->id()]]);
+        sink_node_matrices.insert(banded_matrices[node_id_to_idx[node->id()]]);
+    }
+    for (Node* node : source_nodes) {
+        source_node_matrices.insert(banded_matrices[node_id_to_idx[node->id()]]);
     }
     
-    // find the optimal alignment(s) and initialize stack
-    AltTracebackStack traceback_stack(max_multi_alns, sink_node_matrices);
+    int64_t read_length = alignment.sequence().length();
+    int32_t empty_score = read_length > 0 ? -gap_open - (read_length - 1) * gap_extend : 0;
     
-    for (; traceback_stack.has_next(); traceback_stack.next()) {
+    // find the optimal alignment(s) and initialize stack
+    AltTracebackStack traceback_stack(max_multi_alns, empty_score, source_node_matrices, sink_node_matrices);
+    
+    while (traceback_stack.has_next()) {
         int64_t end_node_id;
         matrix_t end_matrix;
         traceback_stack.get_alignment_start(end_node_id, end_matrix);
         int64_t end_node_idx = node_id_to_idx[end_node_id];
-        
-#ifdef debug_banded_aligner_traceback
-        cerr << "[BandedGlobalAligner::traceback] beginning traceback ending at node " << end_node_id << " in matrix " << (end_matrix == Match ? "match" : (end_matrix == InsertCol ? "insert column" : "insert row")) << endl;
-#endif
         
         Alignment* next_alignment;
         if (!alt_alignments) {
@@ -2125,16 +2270,30 @@ void BandedGlobalAligner<IntType>::traceback(int8_t* score_mat, int8_t* nt_table
             next_alignment->set_quality(alignment.quality());
         }
         
-        // add score to alignment
-        next_alignment->set_score(traceback_stack.current_traceback_score());
-        
-        // do traceback
-        BABuilder builder(*next_alignment);
-        banded_matrices[end_node_idx]->traceback(builder, traceback_stack, end_matrix, score_mat, nt_table,
-                                                 gap_open, gap_extend, adjust_for_base_quality, min_inf);
-        
-        // construct the alignment path
-        builder.finalize_alignment();
+        if (traceback_stack.next_is_empty()) {
+#ifdef debug_banded_aligner_traceback
+            cerr << "[BandedGlobalAligner::traceback] taking the next full empty alignment" << endl;
+#endif
+            traceback_stack.next_empty_alignment(*next_alignment);
+        }
+        else {
+            
+#ifdef debug_banded_aligner_traceback
+            cerr << "[BandedGlobalAligner::traceback] beginning traceback ending at node " << end_node_id << " in matrix " << (end_matrix == Match ? "match" : (end_matrix == InsertCol ? "insert column" : "insert row")) << endl;
+#endif
+            // add score to alignment
+            next_alignment->set_score(traceback_stack.current_traceback_score());
+            
+            // do traceback
+            BABuilder builder(*next_alignment);
+            banded_matrices[end_node_idx]->traceback(builder, traceback_stack, end_matrix, score_mat, nt_table,
+                                                     gap_open, gap_extend, adjust_for_base_quality, min_inf);
+            
+            // construct the alignment path
+            builder.finalize_alignment(traceback_stack.current_empty_prefix());
+            
+            traceback_stack.next_traceback_alignment();
+        }
         
         if (alt_alignments) {
             if (alt_alignments->empty()) {
@@ -2147,50 +2306,84 @@ void BandedGlobalAligner<IntType>::traceback(int8_t* score_mat, int8_t* nt_table
 
 template <class IntType>
 BandedGlobalAligner<IntType>::AltTracebackStack::AltTracebackStack(int64_t max_multi_alns,
-                                                                   vector<BAMatrix*>& sink_node_matrices) :
+                                                                   int32_t empty_score,
+                                                                   unordered_set<BAMatrix*>& source_node_matrices,
+                                                                   unordered_set<BAMatrix*>& sink_node_matrices) :
+                                                                   empty_score(empty_score),
                                                                    max_multi_alns(max_multi_alns)
 {
-    
     // an empty trace back prefix for the initial tracebacks
     vector<Deflection> null_prefix;
     
     // check tracebacks for alignments ending in all sink nodes
-    for (BAMatrix* band_matrix : sink_node_matrices) {
-        if (band_matrix == nullptr) {
+    for (BAMatrix* sink_matrix : sink_node_matrices) {
+        if (sink_matrix == nullptr) {
             // This is a masked sink node. Skip it.
             continue;
         }
     
-        if (band_matrix->match == nullptr) {
+        if (sink_matrix->match == nullptr) {
             cerr << "error:[BandedGlobalAligner] must fill dynamic programming matrices before finding optimal score" << endl;
             assert(0);
         }
         
-
-        // get the coordinates of the bottom right corner
-        Node* node = band_matrix->node;
-        int64_t node_id = node->id();
-        
-        const string& read = band_matrix->alignment.sequence();
-        int64_t ncols = node->sequence().length();
-        
-        int64_t final_col = ncols - 1;
-        int64_t final_row = band_matrix->bottom_diag + ncols > (int64_t) read.length() ? (int64_t) read.length() - band_matrix->top_diag - ncols : band_matrix->bottom_diag - band_matrix->top_diag;
-        
-        int64_t final_idx = final_row * ncols + final_col;
-        
-        // let the insert routine figure out which one is the best and which ones to keep in the stack
-        insert_traceback(null_prefix, band_matrix->match[final_idx],
-                         node_id, final_row, final_col, node_id, Match);
-        insert_traceback(null_prefix, band_matrix->insert_row[final_idx],
-                         node_id, final_row, final_col, node_id, InsertRow);
-        insert_traceback(null_prefix, band_matrix->insert_col[final_idx],
-                         node_id, final_row, final_col, node_id, InsertCol);
+        list<BAMatrix*> band_stack{sink_matrix};
+        list<int64_t> path;
+        while (!band_stack.empty()) {
+            BAMatrix* band_matrix = band_stack.back();
+            band_stack.pop_back();
+            
+            if (!band_matrix) {
+                path.pop_front();
+                continue;
+            }
+            
+            if (band_matrix->node->sequence().length() == 0) {
+                path.push_front(band_matrix->node->id());
+                band_stack.push_back(nullptr);
+                
+                // we went all the way from a source to a sink using only nodes with
+                // no sequence, keep track of these later so we can decide later
+                // whether they are sufficiently high scoring alignments to yield
+                if (source_node_matrices.count(band_matrix)) {
+                    empty_full_paths.push_back(path);
+                    continue;
+                }
+                
+                for (int64_t i = 0; i < band_matrix->num_seeds; i++) {
+                    BAMatrix* seed = band_matrix->seeds[i];
+                    if (seed) {
+                        band_stack.push_back(seed);
+                    }
+                }
+            }
+            else {
+                // get the coordinates of the bottom right corner
+                Node* node = band_matrix->node;
+                int64_t node_id = node->id();
+                
+                int64_t read_length = band_matrix->alignment.sequence().length();
+                int64_t ncols = node->sequence().length();
+                
+                int64_t final_col = ncols - 1;
+                int64_t final_row = band_matrix->bottom_diag + ncols > read_length ? read_length - band_matrix->top_diag - ncols : band_matrix->bottom_diag - band_matrix->top_diag;
+                
+                int64_t final_idx = final_row * ncols + final_col;
+                
+                // let the insert routine figure out which one is the best and which ones to keep in the stack
+                insert_traceback(null_prefix, band_matrix->match[final_idx],
+                                 node_id, final_row, final_col, node_id, Match, path);
+                insert_traceback(null_prefix, band_matrix->insert_row[final_idx],
+                                 node_id, final_row, final_col, node_id, InsertRow, path);
+                insert_traceback(null_prefix, band_matrix->insert_col[final_idx],
+                                 node_id, final_row, final_col, node_id, InsertCol, path);
+            }
+        }
     }
     
     // initialize the traceback trackers for the optimal traceback
     curr_traceback = alt_tracebacks.begin();
-    curr_deflxn = (*curr_traceback).first.begin();
+    curr_deflxn = get<0>(*curr_traceback).begin();
 }
 
 template <class IntType>
@@ -2201,11 +2394,10 @@ BandedGlobalAligner<IntType>::AltTracebackStack::~AltTracebackStack() {
 template <class IntType>
 inline void BandedGlobalAligner<IntType>::AltTracebackStack::get_alignment_start(int64_t& node_id, matrix_t& matrix) {
     
-    
     // move to next traceback
     if (curr_traceback != alt_tracebacks.end()) {
         // get the start node the first deflection
-        curr_deflxn = (*curr_traceback).first.begin();
+        curr_deflxn = get<0>(*curr_traceback).begin();
         node_id = (*curr_deflxn).from_node_id;
         // get the matrix and advance to the next deflection
         matrix = (*curr_deflxn).to_matrix;
@@ -2219,16 +2411,81 @@ inline void BandedGlobalAligner<IntType>::AltTracebackStack::get_alignment_start
 }
 
 template <class IntType>
-inline void BandedGlobalAligner<IntType>::AltTracebackStack::next() {
-    if (curr_deflxn != (*curr_traceback).first.end()) {
-        cerr << "warning:[BandedGlobalAligner] moving on to next alternate alignment without taking all deflections" << endl;
-    }
-    curr_traceback++;
+inline bool BandedGlobalAligner<IntType>::AltTracebackStack::has_next() {
+    return curr_traceback != alt_tracebacks.end() || !empty_full_paths.empty();
 }
 
 template <class IntType>
-inline bool BandedGlobalAligner<IntType>::AltTracebackStack::has_next() {
-    return (curr_traceback != alt_tracebacks.end());
+inline void BandedGlobalAligner<IntType>::AltTracebackStack::next_traceback_alignment() {
+    if (curr_deflxn != get<0>(*curr_traceback).end()) {
+        cerr << "warning:[BandedGlobalAligner] moving on to next alternate alignment without taking all deflections" << endl;
+    }
+    curr_traceback++;
+    // the alt tracebacks list keeps track of how many alternates are left, so if we've
+    // used them all up, dump the empty alignments list
+    if (curr_traceback == alt_tracebacks.end()) {
+        empty_full_paths.clear();
+    }
+}
+
+template <class IntType>
+inline bool BandedGlobalAligner<IntType>::AltTracebackStack::next_is_empty()  {
+    return empty_score >= get<1>(*curr_traceback) && !empty_full_paths.empty();
+}
+
+template <class IntType>
+inline void BandedGlobalAligner<IntType>::AltTracebackStack::next_empty_alignment(Alignment& alignment) {
+#ifdef debug_banded_aligner_traceback
+    cerr << "[BandedGlobalAligner::next_empty_alignment] creating empty alignment" << endl;
+#endif
+    
+    // score to a full insertion
+    alignment.set_score(empty_score);
+    
+    // add all the nodes in the path with empty edits
+    Path* path = alignment.mutable_path();
+    list<int64_t>& node_id_path = empty_full_paths.front();
+    int32_t rank = 1;
+    for (int64_t node_id : node_id_path) {
+        Mapping* mapping = path->add_mapping();
+        mapping->mutable_position()->set_node_id(node_id);
+        mapping->set_rank(rank);
+        mapping->add_edit();
+        rank++;
+    }
+    
+    // add the insertion onto the first mapping
+    Edit* first_edit = path->mutable_mapping(0)->mutable_edit(0);
+    first_edit->set_to_length(alignment.sequence().length());
+    first_edit->set_sequence(alignment.sequence());
+    
+#ifdef debug_banded_aligner_traceback
+    cerr << "[BandedGlobalAligner::next_empty_alignment] dequeueing empty alignment" << endl;
+#endif
+    
+    // remove the empty path we just added
+    empty_full_paths.pop_front();
+    
+    // we used up one of the alloted multi alignments on an empty path, so reduce
+    // the max size of the stack and if necessary remove one from the back
+    max_multi_alns--;
+    if (alt_tracebacks.size() > max_multi_alns) {
+#ifdef debug_banded_aligner_traceback
+        cerr << "[BandedGlobalAligner::next_empty_alignment] removing alternate traceback alignments from stack after taking empty alignment" << endl;
+#endif
+        auto back = alt_tracebacks.end();
+        back--;
+        if (curr_traceback == back) {
+            // we're moving the back of the stack past the current alternate traceback,
+            // so we're done, dump the rest of the empty paths
+            alt_tracebacks.pop_back();
+            curr_traceback = alt_tracebacks.end();
+            empty_full_paths.clear();
+        }
+        else {
+            alt_tracebacks.pop_back();
+        }
+    }
 }
 
 template <class IntType>
@@ -2236,30 +2493,31 @@ inline void BandedGlobalAligner<IntType>::AltTracebackStack::propose_deflection(
                                                                                 const int64_t row_idx, const int64_t col_idx,
                                                                                 const int64_t to_node_id, const matrix_t to_matrix) {
     // only propose deflections if we're going through a new untraversed section of the traceback
-    if (curr_deflxn != (*curr_traceback).first.end()) {
+    if (curr_deflxn != get<0>(*curr_traceback).end()) {
         return;
     }
     
     // is the score good enough to be put on the stack?
-    if (score <= alt_tracebacks.back().second && alt_tracebacks.size() >= max_multi_alns) {
+    if (score <= get<1>(alt_tracebacks.back()) && alt_tracebacks.size() >= max_multi_alns) {
         return;
     }
     
-    insert_traceback((*curr_traceback).first, score, from_node_id, row_idx, col_idx, to_node_id, to_matrix);
+    insert_traceback(get<0>(*curr_traceback), score, from_node_id, row_idx, col_idx, to_node_id, to_matrix, list<int64_t>());
 }
 
 template <class IntType>
 inline void BandedGlobalAligner<IntType>::AltTracebackStack::insert_traceback(const vector<Deflection>& traceback_prefix,
                                                                               const IntType score, const int64_t from_node_id,
                                                                               const int64_t row_idx, const int64_t col_idx,
-                                                                              const int64_t to_node_id, const matrix_t to_matrix) {
+                                                                              const int64_t to_node_id, const matrix_t to_matrix,
+                                                                              const list<int64_t>& empty_node_prefix) {
 #ifdef debug_banded_aligner_traceback
     cerr << "[AltTracebackStack::insert_traceback] adding traceback with score " << (int) score << ", new deflection at (" << row_idx << ", " << col_idx << ") on node " << from_node_id << " to " << (to_matrix == Match ? "match" : (to_matrix == InsertRow ? "insert row" : "insert column")) << " matrix on node " << to_node_id << endl;
 #endif
     
     // find position in stack where this should go
     auto insert_after = alt_tracebacks.rbegin();
-    while (score > (*insert_after).second) {
+    while (score > get<1>(*insert_after)) {
         insert_after++;
         if (insert_after == alt_tracebacks.rend()) {
             break;
@@ -2270,9 +2528,9 @@ inline void BandedGlobalAligner<IntType>::AltTracebackStack::insert_traceback(co
     if (insert_after != alt_tracebacks.rbegin() || alt_tracebacks.size() < max_multi_alns) {
         
         // create a new traceback here
-        auto new_traceback = alt_tracebacks.emplace(insert_after.base(), vector<Deflection>(), score);
+        auto new_traceback = alt_tracebacks.emplace(insert_after.base(), vector<Deflection>(), score, empty_node_prefix);
         
-        vector<Deflection>& deflections = (*new_traceback).first;
+        vector<Deflection>& deflections = get<0>(*new_traceback);
         
         // add the deflections from the prefix
         deflections.reserve(traceback_prefix.size() + 1);
@@ -2291,8 +2549,8 @@ inline void BandedGlobalAligner<IntType>::AltTracebackStack::insert_traceback(co
     
 #ifdef debug_banded_aligner_traceback
     cerr << "[AltTracebackStack::insert_traceback] scores in alt traceback stack currently ";
-    for (pair<vector<Deflection>, IntType> trace : alt_tracebacks) {
-        cerr << (int) trace.second << " -> ";
+    for (auto trace : alt_tracebacks) {
+        cerr << (int) get<1>(trace) << " -> ";
     }
     cerr << endl;
 #endif
@@ -2300,27 +2558,26 @@ inline void BandedGlobalAligner<IntType>::AltTracebackStack::insert_traceback(co
 
 template <class IntType>
 inline IntType BandedGlobalAligner<IntType>::AltTracebackStack::current_traceback_score() {
-    return (*curr_traceback).second;
+    return get<1>(*curr_traceback);
+}
+
+template <class IntType>
+inline const list<int64_t>& BandedGlobalAligner<IntType>::AltTracebackStack::current_empty_prefix() {
+    return get<2>(*curr_traceback);
 }
 
 template <class IntType>
 inline bool BandedGlobalAligner<IntType>::AltTracebackStack::at_next_deflection(int64_t node_id, int64_t row_idx,
-                                                                       int64_t col_idx) {
+                                                                                int64_t col_idx) {
     // taken all deflections already?
-    if (curr_deflxn == (*curr_traceback).first.end()) {
+    if (curr_deflxn == get<0>(*curr_traceback).end()) {
         return false;
     }
-    // correct coordinates?
-    if (node_id != (*curr_deflxn).from_node_id) {
-        return false;
-    }
-    if (row_idx != (*curr_deflxn).row_idx) {
-        return false;
-    }
-    if (col_idx != (*curr_deflxn).col_idx) {
-        return false;
-    }
-    return true;
+    
+    // at the correct coordinates?
+    return node_id == (*curr_deflxn).from_node_id &&
+           row_idx == (*curr_deflxn).row_idx &&
+           col_idx == (*curr_deflxn).col_idx;
 }
 
 template <class IntType>

--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -1101,6 +1101,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
     }
     
     bool found_trace = false;
+    // if we traverse through nodes with no sequence, we need to keep track of which ones
     vector<BAMatrix*> empty_intermediate_nodes;
     
     // a queue of seeds and their empty predecessors
@@ -1478,7 +1479,8 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
     bool found_source_trace = false;
     
     if (treat_as_source) {
-        // this is the first node in the alignment
+        // this is a source node, or it is connected to one by a zero-length path
+        
 #ifdef debug_banded_aligner_traceback
         cerr << "[BAMatrix::traceback_internal] at beginning of first node in alignment" << endl;
 #endif
@@ -1562,8 +1564,8 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
 #ifdef debug_banded_aligner_traceback
             cerr << "[BAMatrix::traceback_internal] initial row gaps are present, adding read char " << top_diag + i - 1 << ": " << (char) tolower(read[top_diag + i - 1]) << " (lowercase of " << read[top_diag + i - 1]     << ")" << endl;
 #endif
-            builder.update_state(curr_mat, node, i + top_diag - 1, -1);
             i--;
+            builder.update_state(curr_mat, node, i + top_diag, -1);
         }
         return;
     }

--- a/src/banded_global_aligner.hpp
+++ b/src/banded_global_aligner.hpp
@@ -144,7 +144,7 @@ namespace vg {
                                vector<bool>& node_masked, vector<pair<int64_t, int64_t>>& band_ends);
         /// Constructor helper function: compute the shortest path from a source to each node
         void shortest_seq_paths(vector<vector<int64_t>>& node_edges_out, unordered_set<Node*>& source_nodes,
-                                vector<pair<int64_t, int64_t>>& band_ends, vector<int64_t>& seq_lens_out);
+                                vector<int64_t>& seq_lens_out);
     };
 
     /**

--- a/src/banded_global_aligner.hpp
+++ b/src/banded_global_aligner.hpp
@@ -46,7 +46,7 @@ namespace vg {
         /// Initializes banded alignment
         ///
         /// Args:
-        /// alignment                   empty alignment with a sequence (and possibly base qualities)
+        ///  alignment                   empty alignment with a sequence (and possibly base qualities)
         ///  g                           graph to align to
         ///  band_padding                width to expand band by
         ///  permissive_banding          expand band, not necessarily symmetrically, to allow all node paths
@@ -143,8 +143,8 @@ namespace vg {
                                vector<vector<int64_t>>& node_edges_out, int64_t band_padding,
                                vector<bool>& node_masked, vector<pair<int64_t, int64_t>>& band_ends);
         /// Constructor helper function: compute the shortest path from a source to each node
-        void shortest_seq_paths(vector<vector<int64_t>>& node_edges_out, vector<int64_t>& seq_lens_out,
-                                unordered_set<Node*> source_nodes);
+        void shortest_seq_paths(vector<vector<int64_t>>& node_edges_out, unordered_set<Node*>& source_nodes,
+                                vector<pair<int64_t, int64_t>>& band_ends, vector<int64_t>& seq_lens_out);
     };
 
     /**
@@ -218,7 +218,7 @@ namespace vg {
     template <class IntType>
     class BandedGlobalAligner<IntType>::AltTracebackStack {
     public:
-        AltTracebackStack(int64_t max_multi_alns, vector<BAMatrix*> sink_node_matrices);
+        AltTracebackStack(int64_t max_multi_alns, vector<BAMatrix*>& sink_node_matrices);
         ~AltTracebackStack();
         
         /// Get the start position of the current alignment and advance deflection pointer to the first deflection

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -31,11 +31,6 @@ void Genotyper::run(VG& graph,
                     int length_override,
                     int variant_offset) {
     
-    // TODO: this maybe should be in a constructor? Or the base Aligner's
-    // constructor?
-    // Set up the mapping quality on our aligner.
-    normal_aligner.init_mapping_quality(default_gc_content);
-    
     if(ref_path_name.empty()) {
         // Guess the ref path name
         if(graph.paths.size() == 1) {

--- a/src/gssw_aligner.cpp
+++ b/src/gssw_aligner.cpp
@@ -8,38 +8,12 @@ static const double exp_overflow_limit = log(std::numeric_limits<double>::max())
 using namespace vg;
 using namespace std;
 
-double add_log(double log_x, double log_y) {
-    if (log_x > log_y) {
-        return log_x + log(1.0 + exp(log_y - log_x));
-    }
-    else {
-        return log_y + log(1.0 + exp(log_x - log_y));
-    }
-}
-
-Aligner::~Aligner(void) {
+BaseAligner::~BaseAligner(void) {
     free(nt_table);
     free(score_matrix);
 }
 
-Aligner::Aligner(int32_t _match,
-                 int32_t _mismatch,
-                 int32_t _gap_open,
-                 int32_t _gap_extension)
-{
-    match = _match;
-    mismatch = _mismatch;
-    gap_open = _gap_open;
-    gap_extension = _gap_extension;
-    
-    // these are used when setting up the nodes
-    nt_table = gssw_create_nt_table();
-    score_matrix = gssw_create_score_matrix(match, mismatch);
-    log_base = 0.0;
-}
-
-
-gssw_graph* Aligner::create_gssw_graph(Graph& g, bool add_pinning_node, gssw_node** gssw_pinned_node_out) {
+gssw_graph* BaseAligner::create_gssw_graph(Graph& g, bool add_pinning_node, gssw_node** gssw_pinned_node_out) {
     
     // add a dummy sink node if we're pinning
     gssw_graph* graph = gssw_graph_create(g.node_size() + add_pinning_node);
@@ -58,7 +32,7 @@ gssw_graph* Aligner::create_gssw_graph(Graph& g, bool add_pinning_node, gssw_nod
     }
     
     unordered_set<int64_t> non_sink_nodes;
-
+    
     for (int i = 0; i < g.edge_size(); ++i) {
         // Convert all the edges
         Edge* e = g.mutable_edge(i);
@@ -68,7 +42,7 @@ gssw_graph* Aligner::create_gssw_graph(Graph& g, bool add_pinning_node, gssw_nod
             non_sink_nodes.insert(e->from());
         } else if(e->from_start() && e->to_end()) {
             // This is a start to end edge, but isn't reversing and can be converted to a normal end to start edge.
-
+            
             // Flip the start and end
             gssw_nodes_add_edge(nodes[e->to()], nodes[e->from()]);
             non_sink_nodes.insert(e->to());
@@ -85,7 +59,7 @@ gssw_graph* Aligner::create_gssw_graph(Graph& g, bool add_pinning_node, gssw_nod
                 // to run termiante in parallel. This doesn't make it safe, just
                 // slightly safer.
                 cerr << "Can't gssw over reversing edge " <<e->from() << (e->from_start() ? " start" : " end") << " -> "
-                     << e->to() << (e->to_end() ? " end" : " start")  << endl;
+                << e->to() << (e->to_end() ? " end" : " start")  << endl;
                 // TODO: there's no safe way to kill the program without a way
                 // to signal the master to do it, via a shared variable in the
                 // clause that made us parallel.
@@ -104,7 +78,7 @@ gssw_graph* Aligner::create_gssw_graph(Graph& g, bool add_pinning_node, gssw_nod
         
         *gssw_pinned_node_out = pinned_node;
         
-
+        
         
         // connect all sink nodes to the dummy node
         for (int i = 0; i < g.node_size(); i++) {
@@ -115,8 +89,683 @@ gssw_graph* Aligner::create_gssw_graph(Graph& g, bool add_pinning_node, gssw_nod
     }
     
     return graph;
-
+    
 }
+
+
+
+void BaseAligner::gssw_mapping_to_alignment(gssw_graph* graph,
+                                            gssw_graph_mapping* gm,
+                                            Alignment& alignment,
+                                            bool pinned,
+                                            bool pin_left,
+                                            bool print_score_matrices) {
+    alignment.clear_path();
+    alignment.set_score(gm->score);
+    alignment.set_query_position(0);
+    Path* path = alignment.mutable_path();
+    //alignment.set_cigar(graph_cigar(gm));
+    
+    gssw_graph_cigar* gc = &gm->cigar;
+    gssw_node_cigar* ncs = gc->elements;
+    //cerr << "gm->position " << gm->position << endl;
+    string& to_seq = *alignment.mutable_sequence();
+    //cerr << "-------------" << endl;
+    
+    if (print_score_matrices) {
+        gssw_graph_print_score_matrices(graph, to_seq.c_str(), to_seq.size(), stderr);
+        //cerr << alignment.DebugString() << endl;
+    }
+    
+    int graph_cigar_length = gc->length;
+    int graph_cigar_start = 0;
+    
+    // TODO: moving these inserts/deletions can create repeat pinned alignments for multialignments
+    // and also artificially lower their score if we take a I/D to get rid of the N rather than an N match
+    
+    if (pinned) {
+        // if the alignment is pinned the final mapping will be to the dummy node, so ignore it
+        if (pin_left) {
+            graph_cigar_start++;
+        }
+        else {
+            graph_cigar_length--;
+        }
+        // need to detect insertions or deletions that have been recorded on the dummy node and move them onto real nodes
+        if (pin_left) {
+            gssw_cigar* dummy_node_cigar = ncs[0].cigar;
+            
+            // was the dummy node's "N" sequence deleted?
+            if (dummy_node_cigar->elements[dummy_node_cigar->length - 1].type == 'D') {
+                if (dummy_node_cigar->elements[0].type == 'I') {
+                    // there is also insert, which must include the dummy N sequence, so remove one
+                    dummy_node_cigar->elements[0].length--;
+                }
+                else {
+                    // need to move the deletion to where the dummy N match occurred
+                    bool deletion_swapped = false;
+                    for (int i = graph_cigar_start; i < graph_cigar_length && !deletion_swapped; i++) {
+                        gssw_cigar* cigar = ncs[i].cigar;
+                        for (int j = 0; j < cigar->length && !deletion_swapped; j++) {
+                            if (cigar->elements[j].type == 'N' || cigar->elements[j].type == 'I') {
+                                // we found the dummy N match or insert
+                                
+                                if (j > 0) {
+                                    // there is a deletion preceding it (asssertion below guarantees it's a deletion)
+                                    
+                                    // increase the length of the deletion
+                                    cigar->elements[j - 1].length++;
+                                    
+                                    if (cigar->elements[j].length > 1) {
+                                        // the N-match/insertion is in a run, decrease its length
+                                        cigar->elements[j].length--;
+                                    }
+                                    else {
+                                        // overwrite the N match/insertion and move all of the subsequent elements down one position
+                                        for (int k = j + 1; k < cigar->length; k++) {
+                                            cigar->elements[k - 1] = cigar->elements[k];
+                                        }
+                                        // adjust the length of the element array
+                                        cigar->length--;
+                                    }
+                                }
+                                else if (cigar->elements[j].length == 1 && cigar->elements[j].type == 'N') {
+                                    // only one N match, can swap in the single deletion
+                                    cigar->elements[j].type = 'D';
+                                }
+                                else if (cigar->elements[j].length == 1 && cigar->elements[j].type == 'I') {
+                                    // one deletion and one insertion cancel each other out, remove this edit
+                                    for (int k = j + 1; k < cigar->length; k++) {
+                                        cigar->elements[k - 1] = cigar->elements[k];
+                                    }
+                                    // adjust the length of the element array
+                                    cigar->length--;
+                                }
+                                else {
+                                    // more than one N-match/insert, remove one and add the deletion onto the front
+                                    cigar->elements[j].length--;
+                                    gssw_cigar_push_front(cigar, 'D', 1);
+                                }
+                                
+                                deletion_swapped = true;
+                            }
+                            else if (cigar->elements[j].type != 'D') {
+                                cerr << "error:[Aligner] pinned alignment took a true match before the dummy pinning N-match" << endl;
+                                assert(false);
+                            }
+                        }
+                    }
+                    
+                    assert(deletion_swapped);
+                }
+            }
+            
+            // was there an insertion on the dummy node?
+            if (dummy_node_cigar->elements[0].type == 'I') {
+                // need to move the inserted sequence onto the next node
+                if (graph_cigar_start < graph_cigar_length) {
+                    // the graph is non-empty
+                    gssw_cigar_push_front(ncs[graph_cigar_start].cigar, 'I', dummy_node_cigar->elements[0].length);
+                }
+            }
+        }
+        else {
+            // repeat the whole routine except with indices reversed for right-pinning
+            // TODO: is there a less repetitious way to do this?
+            gssw_cigar* dummy_node_cigar = ncs[graph_cigar_length].cigar;
+            
+            // was the dummy node's "N" sequence deleted?
+            if (dummy_node_cigar->elements[0].type == 'D') {
+                if (dummy_node_cigar->elements[dummy_node_cigar->length - 1].type == 'I') {
+                    // there is also insert, which must include the dummy N sequence, so remove one
+                    dummy_node_cigar->elements[dummy_node_cigar->length - 1].length--;
+                }
+                else {
+                    // need to move the deletion to where the dummy N match occurred
+                    bool deletion_swapped = false;
+                    for (int i = graph_cigar_length - 1; i >= graph_cigar_start && !deletion_swapped; i--) {
+                        gssw_cigar* cigar = ncs[i].cigar;
+                        for (int j = cigar->length - 1; j >= 0 && !deletion_swapped; j--) {
+                            if (cigar->elements[j].type == 'N' || cigar->elements[j].type == 'I') {
+                                // we found the dummy N match/insert
+                                
+                                if (j < cigar->length - 1) {
+                                    // there is a deletion preceding this N match/insert (asssertion below guarantees it's a deletion)
+                                    
+                                    // increase the length of the deletion
+                                    cigar->elements[j + 1].length++;
+                                    
+                                    if (cigar->elements[j].length > 1) {
+                                        // the N-match/insert is in a run, decrease its length
+                                        cigar->elements[j].length--;
+                                    }
+                                    else {
+                                        // overwrite the N-match/insert and move all of the subsequent elements down one position
+                                        for (int k = j + 1; k < cigar->length; k++) {
+                                            cigar->elements[k - 1] = cigar->elements[k];
+                                        }
+                                        // adjust the length of the element array
+                                        cigar->length--;
+                                    }
+                                }
+                                else if (cigar->elements[j].length == 1 && cigar->elements[j].type == 'N') {
+                                    // only one N match, can swap in the single deletion
+                                    cigar->elements[j].type = 'D';
+                                }
+                                else if (cigar->elements[j].length == 1 && cigar->elements[j].type == 'I') {
+                                    // one deletion and one insertion cancel each other out, remove this edit
+                                    for (int k = j + 1; k < cigar->length; k++) {
+                                        cigar->elements[k - 1] = cigar->elements[k];
+                                    }
+                                    // adjust the length of the element array
+                                    cigar->length--;
+                                }
+                                else {
+                                    // more than one N-match/insert, remove one and add the deletion onto the front
+                                    cigar->elements[j].length--;
+                                    gssw_cigar_push_back(cigar, 'D', 1);
+                                }
+                                
+                                deletion_swapped = true;
+                            }
+                            else if (cigar->elements[j].type != 'D') {
+                                cerr << "error:[Aligner] pinned alignment took a true match before the dummy N-match" << endl;
+                                assert(false);
+                            }
+                        }
+                    }
+                    
+                    assert(deletion_swapped);
+                }
+            }
+            
+            // was there an insertion on the dummy node?
+            if (dummy_node_cigar->elements[dummy_node_cigar->length - 1].type == 'I') {
+                // need to move the inserted sequence onto the next node
+                if (graph_cigar_start < graph_cigar_length) {
+                    // the graph is non-empty
+                    gssw_cigar_push_back(ncs[graph_cigar_length - 1].cigar, 'I', dummy_node_cigar->elements[dummy_node_cigar->length - 1].length);
+                }
+            }
+        }
+    }
+    
+    int to_pos = 0;
+    int from_pos = gm->position;
+    
+    for (int i = graph_cigar_start; i < graph_cigar_length; ++i) {
+        // check that the current alignment has a non-zero length
+        gssw_cigar* c = ncs[i].cigar;
+        int l = c->length;
+        if (l == 0) continue;
+        gssw_cigar_element* e = c->elements;
+        
+        Node* from_node = (Node*) ncs[i].node->data;
+        string& from_seq = *from_node->mutable_sequence();
+        Mapping* mapping = path->add_mapping();
+        
+        if (i > graph_cigar_start){
+            // reset for each node after the first
+            from_pos = 0;
+        }
+        
+        mapping->mutable_position()->set_node_id(ncs[i].node->id);
+        mapping->mutable_position()->set_offset(from_pos);
+        mapping->set_rank(path->mapping_size());
+        
+        //cerr << from_node->id() << ":" << endl;
+        
+        for (int j=0; j < l; ++j, ++e) {
+            int32_t length = e->length;
+            //cerr << e->length << e->type << endl;
+            
+            Edit* edit;
+            switch (e->type) {
+                case 'M':
+                case 'X':
+                case 'N': {
+                    // do the sequences match?
+                    // emit a stream of "SNPs" and matches
+                    int h = from_pos;
+                    int last_start = from_pos;
+                    int k = to_pos;
+                    for ( ; h < from_pos + length; ++h, ++k) {
+                        //cerr << h << ":" << k << " " << from_seq[h] << " " << to_seq[k] << endl;
+                        if (from_seq[h] != to_seq[k]) {
+                            // emit the last "match" region
+                            if (h - last_start > 0) {
+                                edit = mapping->add_edit();
+                                edit->set_from_length(h-last_start);
+                                edit->set_to_length(h-last_start);
+                            }
+                            // set up the SNP
+                            edit = mapping->add_edit();
+                            edit->set_from_length(1);
+                            edit->set_to_length(1);
+                            edit->set_sequence(to_seq.substr(k,1));
+                            last_start = h+1;
+                        }
+                    }
+                    // handles the match at the end or the case of no SNP
+                    if (h - last_start > 0) {
+                        edit = mapping->add_edit();
+                        edit->set_from_length(h-last_start);
+                        edit->set_to_length(h-last_start);
+                    }
+                    to_pos += length;
+                    from_pos += length;
+                } break;
+                case 'D':
+                    edit = mapping->add_edit();
+                    edit->set_from_length(length);
+                    edit->set_to_length(0);
+                    from_pos += length;
+                    break;
+                case 'I':
+                    edit = mapping->add_edit();
+                    edit->set_from_length(0);
+                    edit->set_to_length(length);
+                    edit->set_sequence(to_seq.substr(to_pos, length));
+                    to_pos += length;
+                    break;
+                case 'S':
+                    // note that soft clips and insertions are semantically equivalent
+                    // and can only be differentiated by their position in the read
+                    // with soft clips coming at the start or end
+                    edit = mapping->add_edit();
+                    edit->set_from_length(0);
+                    edit->set_to_length(length);
+                    edit->set_sequence(to_seq.substr(to_pos, length));
+                    to_pos += length;
+                    break;
+                default:
+                    cerr << "error:[Aligner::gssw_mapping_to_alignment] "
+                    << "unsupported cigar op type " << e->type << endl;
+                    exit(1);
+                    break;
+                    
+            }
+        }
+    }
+    
+    // compute and set identity
+    alignment.set_identity(identity(alignment.path()));
+}
+
+void BaseAligner::reverse_graph(Graph& g, Graph& reversed_graph_out) {
+    if (reversed_graph_out.node_size()) {
+        cerr << "error:[Aligner::reverse_graph] output graph is not empty" << endl;
+        exit(EXIT_FAILURE);
+    }
+    
+    // add reversed nodes in reverse order (Graphs come in topologically sorted and gssw
+    // depends on this fact)
+    for (int64_t i = g.node_size() - 1; i >= 0; i--) {
+        const Node& original_node = g.node(i);
+        
+        Node* reversed_node = reversed_graph_out.add_node();
+        
+        // reverse the sequence
+        string* reversed_node_seq = reversed_node->mutable_sequence();
+        reversed_node_seq->resize(original_node.sequence().length());
+        reverse_copy(original_node.sequence().begin(), original_node.sequence().end(), reversed_node_seq->begin());
+        
+        // preserve ids for easier translation
+        reversed_node->set_id(original_node.id());
+    }
+    
+    // add reversed edges
+    for (int64_t i = 0; i < g.edge_size(); i++) {
+        const Edge& original_edge = g.edge(i);
+        
+        Edge* reversed_edge = reversed_graph_out.add_edge();
+        
+        // reverse edge orientation
+        reversed_edge->set_from(original_edge.to());
+        reversed_edge->set_to(original_edge.from());
+        
+        // we will swap the 5'/3' labels of the node ends after reversing the sequence so that
+        // an edge leaving an end now enters a beginning and an edge entering a beginning now
+        // leaves an end
+        reversed_edge->set_from_start(original_edge.to_end());
+        reversed_edge->set_to_end(original_edge.from_start());
+    }
+    
+}
+
+void BaseAligner::unreverse_graph(Graph& graph) {
+    // this is only for getting correct reference-relative edits, so we can get away with only
+    // reversing the sequences and not paying attention to the edges
+    for (int64_t i = 0; i < graph.node_size(); i++) {
+        Node* node = graph.mutable_node(i);
+        string* node_seq = node->mutable_sequence();
+        reverse(node_seq->begin(), node_seq->end());
+    }
+}
+
+void BaseAligner::unreverse_graph_mapping(gssw_graph_mapping* gm) {
+    
+    gssw_graph_cigar* graph_cigar = &(gm->cigar);
+    gssw_node_cigar* node_cigars = graph_cigar->elements;
+    
+    // reverse the order of the node cigars
+    int32_t num_switching_nodes = graph_cigar->length / 2;
+    int32_t last_idx = graph_cigar->length - 1;
+    for (int32_t i = 0; i < num_switching_nodes; i++) {
+        swap(node_cigars[i], node_cigars[last_idx - i]);
+    }
+    
+    // reverse the actual cigar string for each node cigar
+    for (int32_t i = 0; i < graph_cigar->length; i++) {
+        gssw_cigar* node_cigar = node_cigars[i].cigar;
+        gssw_cigar_element* elements = node_cigar->elements;
+        
+        int32_t num_switching_elements = node_cigar->length / 2;
+        last_idx = node_cigar->length - 1;
+        for (int32_t j = 0; j < num_switching_elements; j++) {
+            swap(elements[j], elements[last_idx - j]);
+        }
+    }
+    
+    // compute the position in the first node
+    if (graph_cigar->length > 0) {
+        gssw_cigar_element* first_node_elements = node_cigars[0].cigar->elements;
+        int32_t num_first_node_elements = node_cigars[0].cigar->length;
+        uint32_t num_ref_aligned = 0; // the number of characters on the node sequence that are aligned
+        for (int32_t i = 0; i < num_first_node_elements; i++) {
+            switch (first_node_elements[i].type) {
+                case 'M':
+                case 'X':
+                case 'N':
+                case 'D':
+                    num_ref_aligned += first_node_elements[i].length;
+                    break;
+                    
+            }
+        }
+        gm->position = node_cigars[0].node->len - num_ref_aligned;
+    }
+    else {
+        gm->position = 0;
+    }
+}
+
+string BaseAligner::graph_cigar(gssw_graph_mapping* gm) {
+    stringstream s;
+    gssw_graph_cigar* gc = &gm->cigar;
+    gssw_node_cigar* nc = gc->elements;
+    int to_pos = 0;
+    int from_pos = gm->position;
+    //string& to_seq = *alignment.mutable_sequence();
+    s << from_pos << '@';
+    for (int i = 0; i < gc->length; ++i, ++nc) {
+        if (i > 0) from_pos = 0; // reset for each node after the first
+        Node* from_node = (Node*) nc->node->data;
+        s << from_node->id() << ':';
+        gssw_cigar* c = nc->cigar;
+        int l = c->length;
+        gssw_cigar_element* e = c->elements;
+        for (int j=0; j < l; ++j, ++e) {
+            s << e->length << e->type;
+        }
+        if (i + 1 < gc->length) {
+            s << ",";
+        }
+    }
+    return s.str();
+}
+
+void BaseAligner::init_mapping_quality(double gc_content) {
+    log_base = gssw_dna_recover_log_base(match, mismatch, gc_content, 1e-12);
+}
+
+double BaseAligner::maximum_mapping_quality_exact(vector<double>& scaled_scores, size_t* max_idx_out) {
+    size_t size = scaled_scores.size();
+    
+    // if necessary, assume a null alignment of 0.0 for comparison since this is local
+    if (size == 1) {
+        scaled_scores.push_back(0.0);
+    }
+    
+    double max_score = scaled_scores[0];
+    size_t max_idx = 0;
+    for (size_t i = 1; i < size; i++) {
+        if (scaled_scores[i] > max_score) {
+            max_score = scaled_scores[i];
+            max_idx = i;
+        }
+    }
+    
+    *max_idx_out = max_idx;
+    
+    if (max_score * size < exp_overflow_limit) {
+        // no risk of double overflow, sum exp directly (half as many transcendental function evals)
+        double numer = 0.0;
+        for (size_t i = 0; i < size; i++) {
+            if (i == max_idx) {
+                continue;
+            }
+            numer += exp(scaled_scores[i]);
+        }
+        return -10.0 * log10(numer / (numer + exp(scaled_scores[max_idx])));
+    }
+    else {
+        // work in log transformed valued to avoid risk of overflow
+        double log_sum_exp = scaled_scores[0];
+        for (size_t i = 1; i < size; i++) {
+            log_sum_exp = add_log(log_sum_exp, scaled_scores[i]);
+        }
+        return -10.0 * log10(1.0 - exp(scaled_scores[max_idx] - log_sum_exp));
+    }
+}
+
+// TODO: this algorithm has numerical problems that would be difficult to solve without increasing the
+// time complexity: adding the probability of the maximum likelihood tends to erase the contribution
+// of the other terms so that when you subtract them off you get scores of 0 or infinity
+
+//vector<double> Aligner::all_mapping_qualities_exact(vector<double>& scaled_scores) {
+//
+//    double max_score = *max_element(scaled_scores.begin(), scaled_scores.end());
+//    size_t size = scaled_scores.size();
+//
+//    vector<double> mapping_qualities(size);
+//
+//    if (max_score * size < exp_overflow_limit) {
+//        // no risk of double overflow, sum exp directly (half as many transcendental function evals)
+//        vector<double> exp_scaled_scores(size);
+//        for (size_t i = 0; i < size; i++) {
+//            exp_scaled_scores[i] = exp(scaled_scores[i]);
+//        }
+//        double denom = std::accumulate(exp_scaled_scores.begin(), exp_scaled_scores.end(), 0.0);
+//        for (size_t i = 0; i < size; i++) {
+//            mapping_qualities[i] = -10.0 * log10((denom - exp_scaled_scores[i]) / denom);
+//        }
+//    }
+//    else {
+//        // work in log transformed valued to avoid risk of overflow
+//        double log_sum_exp = scaled_scores[0];
+//        for (size_t i = 1; i < size; i++) {
+//            log_sum_exp = add_log(log_sum_exp, scaled_scores[i]);
+//        }
+//        for (size_t i = 0; i < size; i++) {
+//            mapping_qualities[i] = -10.0 * log10(1.0 - exp(scaled_scores[i] - log_sum_exp));
+//        }
+//    }
+//    return mapping_qualities;
+//}
+
+double BaseAligner::maximum_mapping_quality_approx(vector<double>& scaled_scores, size_t* max_idx_out) {
+    
+    // if necessary, assume a null alignment of 0.0 for comparison since this is local
+    if (scaled_scores.size() == 1) {
+        scaled_scores.push_back(0.0);
+    }
+    
+    double max_score = scaled_scores[0];
+    size_t max_idx = 0;
+    
+    double next_score = -std::numeric_limits<double>::max();
+    int32_t next_count = 0;
+    
+    for (int32_t i = 1; i < scaled_scores.size(); i++) {
+        double score = scaled_scores[i];
+        if (score > max_score) {
+            if (next_score == max_score) {
+                next_count++;
+            }
+            else {
+                next_score = max_score;
+                next_count = 1;
+            }
+            max_score = score;
+            max_idx = i;
+        }
+        else if (score > next_score) {
+            next_score = score;
+            next_count = 1;
+        }
+        else if (score == next_score) {
+            next_count++;
+        }
+    }
+    
+    *max_idx_out = max_idx;
+    
+    return max(0.0, quality_scale_factor * (max_score - next_score - (next_count > 1 ? log(next_count) : 0.0)));
+}
+
+void BaseAligner::compute_mapping_quality(vector<Alignment>& alignments,
+                                          int max_mapping_quality,
+                                          bool fast_approximation,
+                                          double cluster_mq,
+                                          bool use_cluster_mq) {
+    
+    if (log_base <= 0.0) {
+        cerr << "error:[Aligner] must call init_mapping_quality before computing mapping qualities" << endl;
+        exit(EXIT_FAILURE);
+    }
+    
+    size_t size = alignments.size();
+    
+    if (size == 0) {
+        return;
+    }
+    
+    vector<double> scaled_scores(size);
+    for (size_t i = 0; i < size; i++) {
+        scaled_scores[i] = log_base * alignments[i].score();
+    }
+    
+    double mapping_quality;
+    size_t max_idx;
+    if (!fast_approximation) {
+        mapping_quality = maximum_mapping_quality_exact(scaled_scores, &max_idx);
+    }
+    else {
+        mapping_quality = maximum_mapping_quality_approx(scaled_scores, &max_idx);
+    }
+    
+    double max_weight = scaled_scores[max_idx];
+    int max_count = 0;
+    for (auto& score : scaled_scores) if (score == max_weight) ++max_count;
+    if (max_count > 1) {
+        double best_chance = prob_to_phred(1.0-(1.0/max_count));
+        mapping_quality = max(best_chance, mapping_quality);
+    }
+    
+    if (use_cluster_mq) {
+        mapping_quality = prob_to_phred(sqrt(phred_to_prob(cluster_mq + mapping_quality)));
+    }
+    
+    if (mapping_quality > max_mapping_quality) {
+        mapping_quality = max_mapping_quality;
+    }
+    
+    alignments[max_idx].set_mapping_quality((int32_t) round(mapping_quality));
+}
+
+void BaseAligner::compute_paired_mapping_quality(pair<vector<Alignment>, vector<Alignment>>& alignment_pairs,
+                                                 int max_mapping_quality,
+                                                 bool fast_approximation,
+                                                 double cluster_mq,
+                                                 bool use_cluster_mq) {
+    
+    if (log_base <= 0.0) {
+        cerr << "error:[Aligner] must call init_mapping_quality before computing mapping qualities" << endl;
+        exit(EXIT_FAILURE);
+    }
+    
+    size_t size = min(
+                      alignment_pairs.first.size(),
+                      alignment_pairs.second.size());
+    
+    if (size == 0) {
+        return;
+    }
+    
+    vector<double> scaled_scores(size);
+    
+    for (size_t i = 0; i < size; i++) {
+        scaled_scores[i] = log_base * (alignment_pairs.first[i].score() + alignment_pairs.second[i].score());
+    }
+    
+    size_t max_idx;
+    double mapping_quality;
+    if (!fast_approximation) {
+        mapping_quality = maximum_mapping_quality_exact(scaled_scores, &max_idx);
+    }
+    else {
+        mapping_quality = maximum_mapping_quality_approx(scaled_scores, &max_idx);
+    }
+    
+    double max_weight = scaled_scores[max_idx];
+    int max_count = 0;
+    for (auto& score : scaled_scores) if (score == max_weight) ++max_count;
+    if (max_count > 1) {
+        double best_chance = prob_to_phred(1.0-(1.0/max_count));
+        mapping_quality = max(best_chance, mapping_quality);
+    }
+    
+    if (use_cluster_mq) {
+        mapping_quality = prob_to_phred(sqrt(phred_to_prob(cluster_mq + mapping_quality)));
+    }
+    
+    // scale mapping quality by half to match bwa mem
+    mapping_quality /= 2;
+    
+    if (mapping_quality > max_mapping_quality) {
+        mapping_quality = max_mapping_quality;
+    }
+    
+    alignment_pairs.first[max_idx].set_mapping_quality((int32_t) round(mapping_quality));
+    alignment_pairs.second[max_idx].set_mapping_quality((int32_t) round(mapping_quality));
+}
+
+double BaseAligner::score_to_unnormalized_likelihood_ln(double score) {
+    // Log base needs to be set, or this can't work. It's set by default in
+    // QualAdjAligner but needs to be set up manually in the normal Aligner.
+    assert(log_base != 0);
+    // Likelihood is proportional to e^(lambda * score), so ln is just the exponent.
+    return log_base * score;
+}
+
+Aligner::Aligner(int8_t _match,
+                 int8_t _mismatch,
+                 int8_t _gap_open,
+                 int8_t _gap_extension,
+                 double gc_content)
+{
+    match = _match;
+    mismatch = _mismatch;
+    gap_open = _gap_open;
+    gap_extension = _gap_extension;
+    
+    // these are used when setting up the nodes
+    nt_table = gssw_create_nt_table();
+    score_matrix = gssw_create_score_matrix(match, mismatch);
+    init_mapping_quality(gc_content);
+}
+
 
 void Aligner::align_internal(Alignment& alignment, vector<Alignment>* multi_alignments, Graph& g,
                              bool pinned, bool pin_left, int32_t max_alt_alns, int8_t full_length_bonus,
@@ -419,667 +1068,8 @@ void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>&
     }
 }
 
-void Aligner::gssw_mapping_to_alignment(gssw_graph* graph,
-                                        gssw_graph_mapping* gm,
-                                        Alignment& alignment,
-                                        bool pinned,
-                                        bool pin_left,
-                                        bool print_score_matrices) {
-    alignment.clear_path();
-    alignment.set_score(gm->score);
-    alignment.set_query_position(0);
-    Path* path = alignment.mutable_path();
-    //alignment.set_cigar(graph_cigar(gm));
-
-    gssw_graph_cigar* gc = &gm->cigar;
-    gssw_node_cigar* ncs = gc->elements;
-    //cerr << "gm->position " << gm->position << endl;
-    string& to_seq = *alignment.mutable_sequence();
-    //cerr << "-------------" << endl;
-
-    if (print_score_matrices) {
-        gssw_graph_print_score_matrices(graph, to_seq.c_str(), to_seq.size(), stderr);
-        //cerr << alignment.DebugString() << endl;
-    }
-   
-    int graph_cigar_length = gc->length;
-    int graph_cigar_start = 0;
-    
-    // TODO: moving these inserts/deletions can create repeat pinned alignments for multialignments
-    // and also artificially lower their score if we take a I/D to get rid of the N rather than an N match
-    
-    if (pinned) {
-         // if the alignment is pinned the final mapping will be to the dummy node, so ignore it
-        if (pin_left) {
-            graph_cigar_start++;
-        }
-        else {
-            graph_cigar_length--;
-        }
-        // need to detect insertions or deletions that have been recorded on the dummy node and move them onto real nodes
-        if (pin_left) {
-            gssw_cigar* dummy_node_cigar = ncs[0].cigar;
-            
-            // was the dummy node's "N" sequence deleted?
-            if (dummy_node_cigar->elements[dummy_node_cigar->length - 1].type == 'D') {
-                if (dummy_node_cigar->elements[0].type == 'I') {
-                    // there is also insert, which must include the dummy N sequence, so remove one
-                    dummy_node_cigar->elements[0].length--;
-                }
-                else {
-                    // need to move the deletion to where the dummy N match occurred
-                    bool deletion_swapped = false;
-                    for (int i = graph_cigar_start; i < graph_cigar_length && !deletion_swapped; i++) {
-                        gssw_cigar* cigar = ncs[i].cigar;
-                        for (int j = 0; j < cigar->length && !deletion_swapped; j++) {
-                            if (cigar->elements[j].type == 'N' || cigar->elements[j].type == 'I') {
-                                // we found the dummy N match or insert
-                                
-                                if (j > 0) {
-                                    // there is a deletion preceding it (asssertion below guarantees it's a deletion)
-                                    
-                                    // increase the length of the deletion
-                                    cigar->elements[j - 1].length++;
-                                    
-                                    if (cigar->elements[j].length > 1) {
-                                        // the N-match/insertion is in a run, decrease its length
-                                        cigar->elements[j].length--;
-                                    }
-                                    else {
-                                        // overwrite the N match/insertion and move all of the subsequent elements down one position
-                                        for (int k = j + 1; k < cigar->length; k++) {
-                                            cigar->elements[k - 1] = cigar->elements[k];
-                                        }
-                                        // adjust the length of the element array
-                                        cigar->length--;
-                                    }
-                                }
-                                else if (cigar->elements[j].length == 1 && cigar->elements[j].type == 'N') {
-                                    // only one N match, can swap in the single deletion
-                                    cigar->elements[j].type = 'D';
-                                }
-                                else if (cigar->elements[j].length == 1 && cigar->elements[j].type == 'I') {
-                                    // one deletion and one insertion cancel each other out, remove this edit
-                                    for (int k = j + 1; k < cigar->length; k++) {
-                                        cigar->elements[k - 1] = cigar->elements[k];
-                                    }
-                                    // adjust the length of the element array
-                                    cigar->length--;
-                                }
-                                else {
-                                    // more than one N-match/insert, remove one and add the deletion onto the front
-                                    cigar->elements[j].length--;
-                                    gssw_cigar_push_front(cigar, 'D', 1);
-                                }
-                                
-                                deletion_swapped = true;
-                            }
-                            else if (cigar->elements[j].type != 'D') {
-                                cerr << "error:[Aligner] pinned alignment took a true match before the dummy pinning N-match" << endl;
-                                assert(false);
-                            }
-                        }
-                    }
-                    
-                    assert(deletion_swapped);
-                }
-            }
-            
-            // was there an insertion on the dummy node?
-            if (dummy_node_cigar->elements[0].type == 'I') {
-                // need to move the inserted sequence onto the next node
-                if (graph_cigar_start < graph_cigar_length) {
-                    // the graph is non-empty
-                    gssw_cigar_push_front(ncs[graph_cigar_start].cigar, 'I', dummy_node_cigar->elements[0].length);
-                }
-            }
-        }
-        else {
-            // repeat the whole routine except with indices reversed for right-pinning
-            // TODO: is there a less repetitious way to do this?
-            gssw_cigar* dummy_node_cigar = ncs[graph_cigar_length].cigar;
-            
-            // was the dummy node's "N" sequence deleted?
-            if (dummy_node_cigar->elements[0].type == 'D') {
-                if (dummy_node_cigar->elements[dummy_node_cigar->length - 1].type == 'I') {
-                    // there is also insert, which must include the dummy N sequence, so remove one
-                    dummy_node_cigar->elements[dummy_node_cigar->length - 1].length--;
-                }
-                else {
-                    // need to move the deletion to where the dummy N match occurred
-                    bool deletion_swapped = false;
-                    for (int i = graph_cigar_length - 1; i >= graph_cigar_start && !deletion_swapped; i--) {
-                        gssw_cigar* cigar = ncs[i].cigar;
-                        for (int j = cigar->length - 1; j >= 0 && !deletion_swapped; j--) {
-                            if (cigar->elements[j].type == 'N' || cigar->elements[j].type == 'I') {
-                                // we found the dummy N match/insert
-                                
-                                if (j < cigar->length - 1) {
-                                    // there is a deletion preceding this N match/insert (asssertion below guarantees it's a deletion)
-                                    
-                                    // increase the length of the deletion
-                                    cigar->elements[j + 1].length++;
-                                    
-                                    if (cigar->elements[j].length > 1) {
-                                        // the N-match/insert is in a run, decrease its length
-                                        cigar->elements[j].length--;
-                                    }
-                                    else {
-                                        // overwrite the N-match/insert and move all of the subsequent elements down one position
-                                        for (int k = j + 1; k < cigar->length; k++) {
-                                            cigar->elements[k - 1] = cigar->elements[k];
-                                        }
-                                        // adjust the length of the element array
-                                        cigar->length--;
-                                    }
-                                }
-                                else if (cigar->elements[j].length == 1 && cigar->elements[j].type == 'N') {
-                                    // only one N match, can swap in the single deletion
-                                    cigar->elements[j].type = 'D';
-                                }
-                                else if (cigar->elements[j].length == 1 && cigar->elements[j].type == 'I') {
-                                    // one deletion and one insertion cancel each other out, remove this edit
-                                    for (int k = j + 1; k < cigar->length; k++) {
-                                        cigar->elements[k - 1] = cigar->elements[k];
-                                    }
-                                    // adjust the length of the element array
-                                    cigar->length--;
-                                }
-                                else {
-                                    // more than one N-match/insert, remove one and add the deletion onto the front
-                                    cigar->elements[j].length--;
-                                    gssw_cigar_push_back(cigar, 'D', 1);
-                                }
-                                
-                                deletion_swapped = true;
-                            }
-                            else if (cigar->elements[j].type != 'D') {
-                                cerr << "error:[Aligner] pinned alignment took a true match before the dummy N-match" << endl;
-                                assert(false);
-                            }
-                        }
-                    }
-                    
-                    assert(deletion_swapped);
-                }
-            }
-            
-            // was there an insertion on the dummy node?
-            if (dummy_node_cigar->elements[dummy_node_cigar->length - 1].type == 'I') {
-                // need to move the inserted sequence onto the next node
-                if (graph_cigar_start < graph_cigar_length) {
-                    // the graph is non-empty
-                    gssw_cigar_push_back(ncs[graph_cigar_length - 1].cigar, 'I', dummy_node_cigar->elements[dummy_node_cigar->length - 1].length);
-                }
-            }
-        }
-    }
-    
-    int to_pos = 0;
-    int from_pos = gm->position;
-    
-    for (int i = graph_cigar_start; i < graph_cigar_length; ++i) {
-        // check that the current alignment has a non-zero length
-        gssw_cigar* c = ncs[i].cigar;
-        int l = c->length;
-        if (l == 0) continue;
-        gssw_cigar_element* e = c->elements;
-
-        Node* from_node = (Node*) ncs[i].node->data;
-        string& from_seq = *from_node->mutable_sequence();
-        Mapping* mapping = path->add_mapping();
-        
-        if (i > graph_cigar_start){
-             // reset for each node after the first
-            from_pos = 0;
-        }
-        
-        mapping->mutable_position()->set_node_id(ncs[i].node->id);
-        mapping->mutable_position()->set_offset(from_pos);
-        mapping->set_rank(path->mapping_size());
-
-        //cerr << from_node->id() << ":" << endl;
-
-        for (int j=0; j < l; ++j, ++e) {
-            int32_t length = e->length;
-            //cerr << e->length << e->type << endl;
-            
-            Edit* edit;
-            switch (e->type) {
-            case 'M':
-            case 'X':
-            case 'N': {
-                // do the sequences match?
-                // emit a stream of "SNPs" and matches
-                int h = from_pos;
-                int last_start = from_pos;
-                int k = to_pos;
-                for ( ; h < from_pos + length; ++h, ++k) {
-                    //cerr << h << ":" << k << " " << from_seq[h] << " " << to_seq[k] << endl;
-                    if (from_seq[h] != to_seq[k]) {
-                        // emit the last "match" region
-                        if (h - last_start > 0) {
-                            edit = mapping->add_edit();
-                            edit->set_from_length(h-last_start);
-                            edit->set_to_length(h-last_start);
-                        }
-                        // set up the SNP
-                        edit = mapping->add_edit();
-                        edit->set_from_length(1);
-                        edit->set_to_length(1);
-                        edit->set_sequence(to_seq.substr(k,1));
-                        last_start = h+1;
-                    }
-                }
-                // handles the match at the end or the case of no SNP
-                if (h - last_start > 0) {
-                    edit = mapping->add_edit();
-                    edit->set_from_length(h-last_start);
-                    edit->set_to_length(h-last_start);
-                }
-                to_pos += length;
-                from_pos += length;
-            } break;
-            case 'D':
-                edit = mapping->add_edit();
-                edit->set_from_length(length);
-                edit->set_to_length(0);
-                from_pos += length;
-                break;
-            case 'I':
-                edit = mapping->add_edit();
-                edit->set_from_length(0);
-                edit->set_to_length(length);
-                edit->set_sequence(to_seq.substr(to_pos, length));
-                to_pos += length;
-                break;
-            case 'S':
-                // note that soft clips and insertions are semantically equivalent
-                // and can only be differentiated by their position in the read
-                // with soft clips coming at the start or end
-                edit = mapping->add_edit();
-                edit->set_from_length(0);
-                edit->set_to_length(length);
-                edit->set_sequence(to_seq.substr(to_pos, length));
-                to_pos += length;
-                break;
-            default:
-                cerr << "error:[Aligner::gssw_mapping_to_alignment] "
-                     << "unsupported cigar op type " << e->type << endl;
-                exit(1);
-                break;
-                 
-            }
-        }
-    }
-
-    // compute and set identity
-    alignment.set_identity(identity(alignment.path()));
-}
-
-void Aligner::reverse_graph(Graph& g, Graph& reversed_graph_out) {
-    if (reversed_graph_out.node_size()) {
-        cerr << "error:[Aligner::reverse_graph] output graph is not empty" << endl;
-        exit(EXIT_FAILURE);
-    }
-    
-    // add reversed nodes in reverse order (Graphs come in topologically sorted and gssw
-    // depends on this fact)
-    for (int64_t i = g.node_size() - 1; i >= 0; i--) {
-        const Node& original_node = g.node(i);
-        
-        Node* reversed_node = reversed_graph_out.add_node();
-        
-        // reverse the sequence
-        string* reversed_node_seq = reversed_node->mutable_sequence();
-        reversed_node_seq->resize(original_node.sequence().length());
-        reverse_copy(original_node.sequence().begin(), original_node.sequence().end(), reversed_node_seq->begin());
-        
-        // preserve ids for easier translation
-        reversed_node->set_id(original_node.id());
-    }
-    
-    // add reversed edges
-    for (int64_t i = 0; i < g.edge_size(); i++) {
-        const Edge& original_edge = g.edge(i);
-        
-        Edge* reversed_edge = reversed_graph_out.add_edge();
-        
-        // reverse edge orientation
-        reversed_edge->set_from(original_edge.to());
-        reversed_edge->set_to(original_edge.from());
-        
-        // we will swap the 5'/3' labels of the node ends after reversing the sequence so that
-        // an edge leaving an end now enters a beginning and an edge entering a beginning now
-        // leaves an end
-        reversed_edge->set_from_start(original_edge.to_end());
-        reversed_edge->set_to_end(original_edge.from_start());
-    }
-
-}
-
-void Aligner::unreverse_graph(Graph& graph) {
-    // this is only for getting correct reference-relative edits, so we can get away with only
-    // reversing the sequences and not paying attention to the edges
-    for (int64_t i = 0; i < graph.node_size(); i++) {
-        Node* node = graph.mutable_node(i);
-        string* node_seq = node->mutable_sequence();
-        reverse(node_seq->begin(), node_seq->end());
-    }
-}
-
-void Aligner::unreverse_graph_mapping(gssw_graph_mapping* gm) {
-    
-    gssw_graph_cigar* graph_cigar = &(gm->cigar);
-    gssw_node_cigar* node_cigars = graph_cigar->elements;
-    
-    // reverse the order of the node cigars
-    int32_t num_switching_nodes = graph_cigar->length / 2;
-    int32_t last_idx = graph_cigar->length - 1;
-    for (int32_t i = 0; i < num_switching_nodes; i++) {
-        swap(node_cigars[i], node_cigars[last_idx - i]);
-    }
-    
-    // reverse the actual cigar string for each node cigar
-    for (int32_t i = 0; i < graph_cigar->length; i++) {
-        gssw_cigar* node_cigar = node_cigars[i].cigar;
-        gssw_cigar_element* elements = node_cigar->elements;
-        
-        int32_t num_switching_elements = node_cigar->length / 2;
-        last_idx = node_cigar->length - 1;
-        for (int32_t j = 0; j < num_switching_elements; j++) {
-            swap(elements[j], elements[last_idx - j]);
-        }
-    }
-    
-    // compute the position in the first node
-    if (graph_cigar->length > 0) {
-        gssw_cigar_element* first_node_elements = node_cigars[0].cigar->elements;
-        int32_t num_first_node_elements = node_cigars[0].cigar->length;
-        uint32_t num_ref_aligned = 0; // the number of characters on the node sequence that are aligned
-        for (int32_t i = 0; i < num_first_node_elements; i++) {
-            switch (first_node_elements[i].type) {
-                case 'M':
-                case 'X':
-                case 'N':
-                case 'D':
-                    num_ref_aligned += first_node_elements[i].length;
-                    break;
-                    
-            }
-        }
-        gm->position = node_cigars[0].node->len - num_ref_aligned;
-    }
-    else {
-        gm->position = 0;
-    }
-}
-
-string Aligner::graph_cigar(gssw_graph_mapping* gm) {
-    stringstream s;
-    gssw_graph_cigar* gc = &gm->cigar;
-    gssw_node_cigar* nc = gc->elements;
-    int to_pos = 0;
-    int from_pos = gm->position;
-    //string& to_seq = *alignment.mutable_sequence();
-    s << from_pos << '@';
-    for (int i = 0; i < gc->length; ++i, ++nc) {
-        if (i > 0) from_pos = 0; // reset for each node after the first
-        Node* from_node = (Node*) nc->node->data;
-        s << from_node->id() << ':';
-        gssw_cigar* c = nc->cigar;
-        int l = c->length;
-        gssw_cigar_element* e = c->elements;
-        for (int j=0; j < l; ++j, ++e) {
-            s << e->length << e->type;
-        }
-        if (i + 1 < gc->length) {
-            s << ",";
-        }
-    }
-    return s.str();
-}
-
-void Aligner::init_mapping_quality(double gc_content) {
-    log_base = gssw_dna_recover_log_base(match, mismatch, gc_content, 1e-12);
-}
-
-bool Aligner::is_mapping_quality_initialized() {
-    return (log_base <= 0.0);
-}
-
-double Aligner::maximum_mapping_quality_exact(vector<double>& scaled_scores, size_t* max_idx_out) {
-    size_t size = scaled_scores.size();
-        
-    // if necessary, assume a null alignment of 0.0 for comparison since this is local
-    if (size == 1) {
-        scaled_scores.push_back(0.0);
-    }
-    
-    double max_score = scaled_scores[0];
-    size_t max_idx = 0;
-    for (size_t i = 1; i < size; i++) {
-        if (scaled_scores[i] > max_score) {
-            max_score = scaled_scores[i];
-            max_idx = i;
-        }
-    }
-    
-    *max_idx_out = max_idx;
-    
-    if (max_score * size < exp_overflow_limit) {
-        // no risk of double overflow, sum exp directly (half as many transcendental function evals)
-        double numer = 0.0;
-        for (size_t i = 0; i < size; i++) {
-            if (i == max_idx) {
-                continue;
-            }
-            numer += exp(scaled_scores[i]);
-        }
-        return -10.0 * log10(numer / (numer + exp(scaled_scores[max_idx])));
-    }
-    else {
-        // work in log transformed valued to avoid risk of overflow
-        double log_sum_exp = scaled_scores[0];
-        for (size_t i = 1; i < size; i++) {
-            log_sum_exp = add_log(log_sum_exp, scaled_scores[i]);
-        }
-        return -10.0 * log10(1.0 - exp(scaled_scores[max_idx] - log_sum_exp));
-    }
-}
-
-// TODO: this algorithm has numerical problems that would be difficult to solve without increasing the
-// time complexity: adding the probability of the maximum likelihood tends to erase the contribution
-// of the other terms so that when you subtract them off you get scores of 0 or infinity
-
-//vector<double> Aligner::all_mapping_qualities_exact(vector<double>& scaled_scores) {
-//    
-//    double max_score = *max_element(scaled_scores.begin(), scaled_scores.end());
-//    size_t size = scaled_scores.size();
-//    
-//    vector<double> mapping_qualities(size);
-//    
-//    if (max_score * size < exp_overflow_limit) {
-//        // no risk of double overflow, sum exp directly (half as many transcendental function evals)
-//        vector<double> exp_scaled_scores(size);
-//        for (size_t i = 0; i < size; i++) {
-//            exp_scaled_scores[i] = exp(scaled_scores[i]);
-//        }
-//        double denom = std::accumulate(exp_scaled_scores.begin(), exp_scaled_scores.end(), 0.0);
-//        for (size_t i = 0; i < size; i++) {
-//            mapping_qualities[i] = -10.0 * log10((denom - exp_scaled_scores[i]) / denom);
-//        }
-//    }
-//    else {
-//        // work in log transformed valued to avoid risk of overflow
-//        double log_sum_exp = scaled_scores[0];
-//        for (size_t i = 1; i < size; i++) {
-//            log_sum_exp = add_log(log_sum_exp, scaled_scores[i]);
-//        }
-//        for (size_t i = 0; i < size; i++) {
-//            mapping_qualities[i] = -10.0 * log10(1.0 - exp(scaled_scores[i] - log_sum_exp));
-//        }
-//    }
-//    return mapping_qualities;
-//}
-
-double Aligner::maximum_mapping_quality_approx(vector<double>& scaled_scores, size_t* max_idx_out) {
-
-    // if necessary, assume a null alignment of 0.0 for comparison since this is local
-    if (scaled_scores.size() == 1) {
-        scaled_scores.push_back(0.0);
-    }
-
-    double max_score = scaled_scores[0];
-    size_t max_idx = 0;
-
-    double next_score = -std::numeric_limits<double>::max();
-    int32_t next_count = 0;
-
-    for (int32_t i = 1; i < scaled_scores.size(); i++) {
-        double score = scaled_scores[i];
-        if (score > max_score) {
-            if (next_score == max_score) {
-                next_count++;
-            }
-            else {
-                next_score = max_score;
-                next_count = 1;
-            }
-            max_score = score;
-            max_idx = i;
-        }
-        else if (score > next_score) {
-            next_score = score;
-            next_count = 1;
-        }
-        else if (score == next_score) {
-            next_count++;
-        }
-    }
-
-    *max_idx_out = max_idx;
-
-    return max(0.0, quality_scale_factor * (max_score - next_score - (next_count > 1 ? log(next_count) : 0.0)));
-}
-
-void Aligner::compute_mapping_quality(vector<Alignment>& alignments,
-                                      int max_mapping_quality,
-                                      bool fast_approximation,
-                                      double cluster_mq,
-                                      bool use_cluster_mq) {
-
-    if (log_base <= 0.0) {
-        cerr << "error:[Aligner] must call init_mapping_quality before computing mapping qualities" << endl;
-        exit(EXIT_FAILURE);
-    }
-    
-    size_t size = alignments.size();
-    
-    if (size == 0) {
-        return;
-    }
-
-    vector<double> scaled_scores(size);
-    for (size_t i = 0; i < size; i++) {
-        scaled_scores[i] = log_base * alignments[i].score();
-    }
-    
-    double mapping_quality;
-    size_t max_idx;
-    if (!fast_approximation) {
-        mapping_quality = maximum_mapping_quality_exact(scaled_scores, &max_idx);
-    }
-    else {
-        mapping_quality = maximum_mapping_quality_approx(scaled_scores, &max_idx);
-    }
-
-    double max_weight = scaled_scores[max_idx];
-    int max_count = 0;
-    for (auto& score : scaled_scores) if (score == max_weight) ++max_count;
-    if (max_count > 1) {
-        double best_chance = prob_to_phred(1.0-(1.0/max_count));
-        mapping_quality = max(best_chance, mapping_quality);
-    }
-
-    if (use_cluster_mq) {
-        mapping_quality = prob_to_phred(sqrt(phred_to_prob(cluster_mq + mapping_quality)));
-    }
-
-    if (mapping_quality > max_mapping_quality) {
-        mapping_quality = max_mapping_quality;
-    }
-
-    alignments[max_idx].set_mapping_quality((int32_t) round(mapping_quality));
-}
-
-void Aligner::compute_paired_mapping_quality(pair<vector<Alignment>, vector<Alignment>>& alignment_pairs,
-                                             int max_mapping_quality,
-                                             bool fast_approximation,
-                                             double cluster_mq,
-                                             bool use_cluster_mq) {
-
-    if (log_base <= 0.0) {
-        cerr << "error:[Aligner] must call init_mapping_quality before computing mapping qualities" << endl;
-        exit(EXIT_FAILURE);
-    }
-    
-    size_t size = min(
-        alignment_pairs.first.size(),
-        alignment_pairs.second.size());
-    
-    if (size == 0) {
-        return;
-    }
-    
-    vector<double> scaled_scores(size);
-
-    for (size_t i = 0; i < size; i++) {
-        scaled_scores[i] = log_base * (alignment_pairs.first[i].score() + alignment_pairs.second[i].score());
-    }
-    
-    size_t max_idx;
-    double mapping_quality;
-    if (!fast_approximation) {
-        mapping_quality = maximum_mapping_quality_exact(scaled_scores, &max_idx);
-    }
-    else {
-        mapping_quality = maximum_mapping_quality_approx(scaled_scores, &max_idx);
-    }
-
-    double max_weight = scaled_scores[max_idx];
-    int max_count = 0;
-    for (auto& score : scaled_scores) if (score == max_weight) ++max_count;
-    if (max_count > 1) {
-        double best_chance = prob_to_phred(1.0-(1.0/max_count));
-        mapping_quality = max(best_chance, mapping_quality);
-    }
-
-    if (use_cluster_mq) {
-        mapping_quality = prob_to_phred(sqrt(phred_to_prob(cluster_mq + mapping_quality)));
-    }
-
-    // scale mapping quality by half to match bwa mem
-    mapping_quality /= 2;
-
-    if (mapping_quality > max_mapping_quality) {
-        mapping_quality = max_mapping_quality;
-    }
-
-    alignment_pairs.first[max_idx].set_mapping_quality((int32_t) round(mapping_quality));
-    alignment_pairs.second[max_idx].set_mapping_quality((int32_t) round(mapping_quality));
-}
-
 int32_t Aligner::score_exact_match(const string& sequence) {
     return match * sequence.length();
-}
-
-double Aligner::score_to_unnormalized_likelihood_ln(double score) {
-    // Log base needs to be set, or this can't work. It's set by default in
-    // QualAdjAligner but needs to be set up manually in the normal Aligner.
-    assert(log_base != 0);
-    // Likelihood is proportional to e^(lambda * score), so ln is just the exponent.
-    return log_base * score; 
 }
 
 QualAdjAligner::QualAdjAligner(int8_t _match,
@@ -1088,32 +1078,26 @@ QualAdjAligner::QualAdjAligner(int8_t _match,
                                int8_t _gap_extension,
                                int8_t _max_scaled_score,
                                uint8_t _max_qual_score,
-                               double gc_content) : Aligner(_match, _mismatch, _gap_open, _gap_extension) {
+                               double gc_content)
+{
     
-    init_quality_adjusted_scores(_max_scaled_score, _max_qual_score, gc_content);
-}
-
-void QualAdjAligner::init_quality_adjusted_scores(int8_t _max_scaled_score,
-                                                  uint8_t _max_qual_score,
-                                                  double gc_content) {
     max_qual_score = _max_qual_score;
-    scaled_gap_open = gap_open;
-    scaled_gap_extension = gap_extension;
+    match = _match;
+    mismatch = _mismatch;
+    gap_open = _gap_open;
+    gap_extension = _gap_extension;
     
-    adjusted_score_matrix = gssw_dna_scaled_adjusted_qual_matrix(_max_scaled_score, max_qual_score, &scaled_gap_open,
-                                                                 &scaled_gap_extension, match, mismatch,
-                                                                 gc_content, 1e-12);
+    int8_t original_gap_open = gap_open;
+    
+    nt_table = gssw_create_nt_table();
+    score_matrix = gssw_dna_scaled_adjusted_qual_matrix(_max_scaled_score, max_qual_score, &gap_open,
+                                                        &gap_extension, match, mismatch,
+                                                        gc_content, 1e-12);
+    scale_factor = gap_open / original_gap_open;
+    match *= scale_factor;
+    mismatch *= scale_factor;
+    
     init_mapping_quality(gc_content);
-}
-
-void QualAdjAligner::init_mapping_quality(double gc_content) {
-    log_base = gssw_dna_recover_log_base(match, mismatch, gc_content, 1e-12);
-    // adjust to scaled matrix (a bit hacky but correct)
-    log_base /= (scaled_gap_open / gap_open);
-}
-
-QualAdjAligner::~QualAdjAligner(void) {
-    free(adjusted_score_matrix);
 }
 
 void QualAdjAligner::align_internal(Alignment& alignment, vector<Alignment>* multi_alignments, Graph& g,
@@ -1135,7 +1119,7 @@ void QualAdjAligner::align_internal(Alignment& alignment, vector<Alignment>* mul
     }
     
     // scale up the full length bonus
-    full_length_bonus *= (scaled_gap_open / gap_open);
+    full_length_bonus *= scale_factor;
     
     // alignment pinning algorithm is based on pinning in bottom right corner, if pinning in top
     // left we need to reverse all the sequences first and translate the alignment back later
@@ -1179,8 +1163,8 @@ void QualAdjAligner::align_internal(Alignment& alignment, vector<Alignment>* mul
     // perform dynamic programming
     // offer a full length bonus on each end, or only on the left if the right end is pinned.
     gssw_graph_fill_pinned_qual_adj(graph, align_sequence.c_str(), align_quality.c_str(),
-                                    nt_table, adjusted_score_matrix,
-                                    scaled_gap_open, scaled_gap_extension,
+                                    nt_table, score_matrix,
+                                    gap_open, gap_extension,
                                     full_length_bonus, pinned ? 0 : full_length_bonus, 15, 2);
     
     // traceback either from pinned position or optimal local alignment
@@ -1193,9 +1177,9 @@ void QualAdjAligner::align_internal(Alignment& alignment, vector<Alignment>* mul
                                                                                 align_quality.c_str(),
                                                                                 align_sequence.size(),
                                                                                 nt_table,
-                                                                                adjusted_score_matrix,
-                                                                                scaled_gap_open,
-                                                                                scaled_gap_extension,
+                                                                                score_matrix,
+                                                                                gap_open,
+                                                                                gap_extension,
                                                                                 full_length_bonus,
                                                                                 0);
         
@@ -1284,9 +1268,9 @@ void QualAdjAligner::align_internal(Alignment& alignment, vector<Alignment>* mul
                                                                  align_quality.c_str(),
                                                                  align_sequence.size(),
                                                                  nt_table,
-                                                                 adjusted_score_matrix,
-                                                                 scaled_gap_open,
-                                                                 scaled_gap_extension,
+                                                                 score_matrix,
+                                                                 gap_open,
+                                                                 gap_extension,
                                                                  full_length_bonus,
                                                                  full_length_bonus);
         
@@ -1325,7 +1309,7 @@ void QualAdjAligner::align_global_banded(Alignment& alignment, Graph& g,
                                                                            permissive_banding,
                                                                            true);
     
-    band_graph.align(adjusted_score_matrix, nt_table, scaled_gap_open, scaled_gap_extension);
+    band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     
 }
 
@@ -1340,7 +1324,7 @@ void QualAdjAligner::align_global_banded_multi(Alignment& alignment, vector<Alig
                                                                            permissive_banding,
                                                                            true);
     
-    band_graph.align(adjusted_score_matrix, nt_table, scaled_gap_open, scaled_gap_extension);
+    band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     
 }
 
@@ -1349,7 +1333,7 @@ int32_t QualAdjAligner::score_exact_match(const string& sequence, const string& 
     for (int32_t i = 0; i < sequence.length(); i++) {
         // index 5 x 5 score matrices (ACGTN)
         // always have match so that row and column index are same and can combine algebraically
-        score += adjusted_score_matrix[25 * base_quality[i] + 6 * nt_table[sequence[i]]];
+        score += score_matrix[25 * base_quality[i] + 6 * nt_table[sequence[i]]];
     }
     return score;
 }

--- a/src/gssw_aligner.hpp
+++ b/src/gssw_aligner.hpp
@@ -1,7 +1,6 @@
 #ifndef GSSW_ALIGNER_H
 #define GSSW_ALIGNER_H
 
-#include <cmath>
 #include <algorithm>
 #include <vector>
 #include <set>
@@ -13,6 +12,7 @@
 #include "Variant.h"
 #include "Fasta.h"
 #include "path.hpp"
+#include "utility.hpp"
 #include "banded_global_aligner.hpp"
 
 namespace vg {
@@ -25,8 +25,10 @@ namespace vg {
     static const uint8_t default_max_qual_score = 255;
     static const double default_gc_content = 0.5;
 
-    class Aligner {
+    class BaseAligner {
     protected:
+        BaseAligner() = default;
+        ~BaseAligner();
         
         // for construction
         // needed when constructing an alignable graph from the nodes
@@ -53,27 +55,105 @@ namespace vg {
                                        bool print_score_matrices = false);
         string graph_cigar(gssw_graph_mapping* gm);
         
-        // internal function interacting with gssw for pinned and local alignment
-        void align_internal(Alignment& alignment, vector<Alignment>* multi_alignments, Graph& g,
-                            bool pinned, bool pin_left, int32_t max_alt_alns, int8_t full_length_bonus,
-                            bool print_score_matrices = false);
-        
         double maximum_mapping_quality_exact(vector<double>& scaled_scores, size_t* max_idx_out);
         double maximum_mapping_quality_approx(vector<double>& scaled_scores, size_t* max_idx_out);
+        
+        // must be called before querying mapping_quality
+        void init_mapping_quality(double gc_content);
         
         // TODO: this algorithm has numerical problems, just removing it for now
         //vector<double> all_mapping_qualities_exact(vector<double> scaled_scores);
         
         // log of the base of the logarithm underlying the log-odds interpretation of the scores
-        double log_base;
+        double log_base = 0.0;
         
     public:
         
-        Aligner(int32_t _match = default_match,
-                int32_t _mismatch = default_mismatch,
-                int32_t _gap_open = default_gap_open,
-                int32_t _gap_extension = default_gap_extension);
-        ~Aligner(void);
+        /// Store optimal local alignment against a graph in the Alignment object.
+        /// Gives the full length bonus separately on each end of the alignment.
+        /// Assumes that graph is topologically sorted by node index.
+        virtual void align(Alignment& alignment, Graph& g, int8_t full_length_bonus, bool print_score_matrices = false) = 0;
+        
+        // store optimal alignment against a graph in the Alignment object with one end of the sequence
+        // guaranteed to align to a source/sink node
+        //
+        // pinning left means that that the alignment starts with the first base of the read sequence and
+        // the first base of a source node sequence, pinning right means that the alignment starts with
+        // the final base of the read sequence and the final base of a sink node sequence
+        //
+        // Gives the full length bonus only on the non-pinned end of the alignment.
+        //
+        // assumes that graph is topologically sorted by node index
+        virtual void align_pinned(Alignment& alignment, Graph& g, bool pin_left, int8_t full_length_bonus = 0) = 0;
+        
+        // store the top scoring pinned alignments in the vector in descending score order up to a maximum
+        // number of alignments (including the optimal one). if there are fewer than the maximum number in
+        // the return value, then it includes all alignments with a positive score. the optimal alignment
+        // will be stored in both the vector and in the main alignment object
+        //
+        // assumes that graph is topologically sorted by node index
+        virtual void align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, Graph& g,
+                                        bool pin_left, int32_t max_alt_alns, int8_t full_length_bonus = 0) = 0;
+        
+        // store optimal global alignment against a graph within a specified band in the Alignment object
+        // permissive banding auto detects the width of band needed so that paths can travel
+        // through every node in the graph
+        virtual void align_global_banded(Alignment& alignment, Graph& g,
+                                         int32_t band_padding = 0, bool permissive_banding = true) = 0;
+        
+        // store top scoring global alignments in the vector in descending score order up to a maximum number
+        // of alternate alignments (including the optimal alignment). if there are fewer than the maximum
+        // number of alignments in the return value, then the vector contains all possible alignments. the
+        // optimal alignment will be stored in both the vector and the original alignment object
+        virtual void align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments,
+                                               Graph& g, int32_t max_alt_alns, int32_t band_padding = 0,
+                                               bool permissive_banding = true) = 0;
+        
+        // stores -10 * log_10(P_err) in alignment mapping_quality field where P_err is the
+        // probability that the alignment is not the correct one (assuming that one of the alignments
+        // in the vector is correct). alignments must have been created with this Aligner for quality
+        // score to be valid
+        void compute_mapping_quality(vector<Alignment>& alignments,
+                                     int max_mapping_quality,
+                                     bool fast_approximation,
+                                     double cluster_mq,
+                                     bool use_cluster_mq);
+        // same function for paired reads, mapping qualities are stored in both alignments in the pair
+        void compute_paired_mapping_quality(pair<vector<Alignment>, vector<Alignment>>& alignment_pairs,
+                                            int max_mapping_quality,
+                                            bool fast_approximation,
+                                            double cluster_mq,
+                                            bool use_cluster_mq);
+        
+        // Convert a score to an unnormalized log likelihood for the sequence.
+        // Requires log_base to have been set.
+        double score_to_unnormalized_likelihood_ln(double score);
+        
+        // members
+        int8_t* nt_table = nullptr;
+        int8_t* score_matrix = nullptr;
+        int8_t match;
+        int8_t mismatch;
+        int8_t gap_open;
+        int8_t gap_extension;
+        
+    };
+    
+    class Aligner : public BaseAligner {
+    private:
+        
+        // internal function interacting with gssw for pinned and local alignment
+        void align_internal(Alignment& alignment, vector<Alignment>* multi_alignments, Graph& g,
+                            bool pinned, bool pin_left, int32_t max_alt_alns, int8_t full_length_bonus,
+                            bool print_score_matrices = false);
+    public:
+        
+        Aligner(int8_t _match = default_match,
+                int8_t _mismatch = default_mismatch,
+                int8_t _gap_open = default_gap_open,
+                int8_t _gap_extension = default_gap_extension,
+                double _gc_content = default_gc_content);
+        ~Aligner(void) = default;
         
         /// Store optimal local alignment against a graph in the Alignment object.
         /// Gives the full length bonus separately on each end of the alignment.
@@ -114,44 +194,12 @@ namespace vg {
         void align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, Graph& g,
                                        int32_t max_alt_alns, int32_t band_padding = 0, bool permissive_banding = true);
         
-        // must be called before querying mapping_quality
-        void init_mapping_quality(double gc_content);
-        
-        bool is_mapping_quality_initialized();
-        
-        // stores -10 * log_10(P_err) in alignment mapping_quality field where P_err is the
-        // probability that the alignment is not the correct one (assuming that one of the alignments
-        // in the vector is correct). alignments must have been created with this Aligner for quality
-        // score to be valid
-        void compute_mapping_quality(vector<Alignment>& alignments,
-                                     int max_mapping_quality,
-                                     bool fast_approximation,
-                                     double cluster_mq,
-                                     bool use_cluster_mq);
-        // same function for paired reads, mapping qualities are stored in both alignments in the pair
-        void compute_paired_mapping_quality(pair<vector<Alignment>, vector<Alignment>>& alignment_pairs,
-                                            int max_mapping_quality,
-                                            bool fast_approximation,
-                                            double cluster_mq,
-                                            bool use_cluster_mq);
-                                            
-        // Convert a score to an unnormalized log likelihood for the sequence.
-        // Requires log_base to have been set.
-        double score_to_unnormalized_likelihood_ln(double score);
         
         int32_t score_exact_match(const string& sequence);
-        
-        // members
-        int8_t* nt_table;
-        int8_t* score_matrix;
-        int32_t match;
-        int32_t mismatch;
-        int32_t gap_open;
-        int32_t gap_extension;
-        
+
     };
 
-    class QualAdjAligner : public Aligner {
+    class QualAdjAligner : public BaseAligner {
     public:
         
         QualAdjAligner(int8_t _match = default_match,
@@ -162,7 +210,7 @@ namespace vg {
                        uint8_t _max_qual_score = default_max_qual_score,
                        double gc_content = default_gc_content);
 
-        ~QualAdjAligner(void);
+        ~QualAdjAligner(void) = default;
 
         // base quality adjusted counterparts to functions of same name from Aligner
         void align(Alignment& alignment, Graph& g, int8_t full_length_bonus = 0, bool print_score_matrices = false);
@@ -175,21 +223,13 @@ namespace vg {
                                 bool pin_left, int32_t max_alt_alns, int8_t full_length_bonus = 0);
         
         
-        void init_mapping_quality(double gc_content);
-
-        uint8_t max_qual_score;
-        int8_t scaled_gap_open;
-        int8_t scaled_gap_extension;
-        int8_t* adjusted_score_matrix;
-        
-        
         int32_t score_exact_match(const string& sequence, const string& base_quality);
         
-    protected:
-        void init_quality_adjusted_scores(int8_t _max_scaled_score,
-                                          uint8_t _max_qual_score,
-                                          double gc_content);
+        uint8_t max_qual_score;
+        int8_t scale_factor;
         
+    private:
+
         void align_internal(Alignment& alignment, vector<Alignment>* multi_alignments, Graph& g,
                             bool pinned, bool pin_left, int32_t max_alt_alns, int8_t full_length_bonus,
                             bool print_score_matrices = false);

--- a/src/unittest/banded_global_aligner.cpp
+++ b/src/unittest/banded_global_aligner.cpp
@@ -24,7 +24,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AGTG");
                 Node* n1 = graph.create_node("C");
@@ -41,13 +41,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -78,7 +73,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AGTG");
                 Node* n1 = graph.create_node("C");
@@ -95,13 +90,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -132,7 +122,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("CCCAGTT");
                 Node* n1 = graph.create_node("C");
@@ -149,13 +139,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = true;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                                 
                 const Path& path = aln.path();
                 
@@ -190,7 +175,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("CCCAGATG");
                 Node* n1 = graph.create_node("C");
@@ -207,13 +192,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 2;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -252,7 +232,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AACCCAGATG");
                 Node* n1 = graph.create_node("C");
@@ -269,13 +249,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 2;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);;
                 
                 const Path& path = aln.path();
                 
@@ -314,7 +289,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AACCCAGG");
                 Node* n1 = graph.create_node("C");
@@ -331,13 +306,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 2;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -376,7 +346,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AACCCAGG");
                 Node* n1 = graph.create_node("C");
@@ -393,13 +363,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 2;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -438,7 +403,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AACCCAGG");
                 Node* n1 = graph.create_node("CA");
@@ -455,13 +420,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 2;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -501,7 +461,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AACCCAGG");
                 Node* n1 = graph.create_node("CA");
@@ -518,13 +478,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 2;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -561,7 +516,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AACCCAGG");
                 Node* n1 = graph.create_node("CA");
@@ -578,13 +533,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 2;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -619,7 +569,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AACCCAGG");
                 Node* n1 = graph.create_node("CA");
@@ -636,13 +586,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 2;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);;
                 
                 const Path& path = aln.path();
                 
@@ -677,7 +622,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AACCCAGG");
                 Node* n1 = graph.create_node("CA");
@@ -694,13 +639,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 2;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);;
                 
                 const Path& path = aln.path();
                 
@@ -735,7 +675,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AA");
                 Node* n1 = graph.create_node("CCCAGGCA");
@@ -752,13 +692,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 3;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -879,7 +814,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("TG");
                 Node* n1 = graph.create_node("TGGC");
@@ -896,13 +831,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1015,7 +945,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("TG");
                 Node* n1 = graph.create_node("TGGC");
@@ -1032,13 +962,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1069,7 +994,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AGTG");
                 Node* n1 = graph.create_node("CGCC");
@@ -1083,13 +1008,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1115,7 +1035,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AGTG");
                 Node* n1 = graph.create_node("C");
@@ -1129,13 +1049,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1161,7 +1076,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AGTG");
                 Node* n1 = graph.create_node("CGCC");
@@ -1179,13 +1094,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1216,7 +1126,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AGTG");
                 Node* n1 = graph.create_node("CGCC");
@@ -1231,13 +1141,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1268,7 +1173,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("CAGGA");
                 Node* n1 = graph.create_node("AA");
@@ -1285,13 +1190,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 20;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1322,7 +1222,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AGTG");
                 Node* n1 = graph.create_node("C");
@@ -1339,13 +1239,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 0;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = false;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1419,7 +1314,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner = Aligner();
                 
                 Node* n0 = graph.create_node("AGTG");
                 Node* n1 = graph.create_node("C");
@@ -1436,14 +1331,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width,
-                                                                                         true);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = true;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1474,7 +1363,7 @@ namespace vg {
                 
                 VG graph;
                 
-                QualAdjAligner aligner = QualAdjAligner();
+                Aligner aligner;
                 
                 Node* n0 = graph.create_node("AGTG");
                 Node* n1 = graph.create_node("CTGGTGTAGTA");
@@ -1491,14 +1380,8 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_width = 0;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width,
-                                                                                         true);
-                
-                
-                banded_aligner.align(aligner.score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = true;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1561,15 +1444,8 @@ namespace vg {
                 alignment_quality_char_to_short(aln);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width,
-                                                                                         true,
-                                                                                         true);
-                
-                
-                banded_aligner.align(aligner.adjusted_score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = true;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1620,15 +1496,8 @@ namespace vg {
                 alignment_quality_char_to_short(aln);
                 
                 int band_width = 1;
-                BandedGlobalAligner<int8_t> banded_aligner = BandedGlobalAligner<int8_t>(aln,
-                                                                                         graph.graph,
-                                                                                         band_width,
-                                                                                         true,
-                                                                                         true);
-                
-                
-                banded_aligner.align(aligner.adjusted_score_matrix, aligner.nt_table, aligner.gap_open,
-                                     aligner.gap_extension);
+                bool permissive_banding = true;
+                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1678,27 +1547,9 @@ namespace vg {
                 alignment_quality_char_to_short(aln_reduced);
                 
                 int band_width = 1;
-                
-                BandedGlobalAligner<int8_t> banded_aligner_full = BandedGlobalAligner<int8_t>(aln_full,
-                                                                                              graph.graph,
-                                                                                              band_width,
-                                                                                              true,
-                                                                                              true);
-                
-                BandedGlobalAligner<int8_t> banded_aligner_reduced = BandedGlobalAligner<int8_t>(aln_reduced,
-                                                                                                 graph.graph,
-                                                                                                 band_width,
-                                                                                                 true,
-                                                                                                 true);
-                
-                
-                banded_aligner_full.align(aligner.adjusted_score_matrix, aligner.nt_table, aligner.scaled_gap_open,
-                                          aligner.scaled_gap_extension);
-                
-                banded_aligner_reduced.align(aligner.adjusted_score_matrix, aligner.nt_table, aligner.scaled_gap_open,
-                                             aligner.scaled_gap_extension);
-                
-                
+                bool permissive_banding = true;
+                aligner.align_global_banded(aln_full, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln_reduced, graph.graph, band_width, permissive_banding);
                 
                 const Path& path_full = aln_full.path();
                 const Path& path_reduced = aln_reduced.path();
@@ -2249,6 +2100,742 @@ namespace vg {
                     REQUIRE(alns_seen.count(aln_string) == 0);
                     alns_seen.insert(aln_string);
                 }
+            }
+        }
+        
+        TEST_CASE( "Banded global aligner can align to graphs with empty sources and sinks",
+                  "[alignment][banded][mapping]" ) {
+            
+            SECTION( "Banded global aligner can align to a graph with an empty source node") {
+                
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("");
+                Node* n1 = graph.create_node("CT");
+                Node* n2 = graph.create_node("TA");
+                Node* n3 = graph.create_node("GA");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n0, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n3);
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                
+                string read = "CTGA";
+                string qual = "HHHH";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n1->id());
+                REQUIRE(aln.path().mapping(2).position().node_id() == n3->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(1).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(1).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(1).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(2).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(2).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(2).edit(0).sequence().empty());
+                
+                aln.Clear();
+                read = "TGA";
+                qual = "HHH";
+                
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n1->id());
+                REQUIRE(aln.path().mapping(2).position().node_id() == n3->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(1).edit(0).from_length() == 1);
+                REQUIRE(aln.path().mapping(1).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(1).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(1).edit(1).from_length() == 1);
+                REQUIRE(aln.path().mapping(1).edit(1).to_length() == 1);
+                REQUIRE(aln.path().mapping(1).edit(1).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(2).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(2).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(2).edit(0).sequence().empty());
+                
+            }
+            
+            SECTION( "Banded global aligner can align to a graph with an empty sink node") {
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("GA");
+                Node* n1 = graph.create_node("CT");
+                Node* n2 = graph.create_node("TA");
+                Node* n3 = graph.create_node("");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n0, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n3);
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                
+                string read = "GACT";
+                string qual = "HHHH";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n1->id());
+                REQUIRE(aln.path().mapping(2).position().node_id() == n3->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(1).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(1).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(1).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(2).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(2).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(2).edit(0).sequence().empty());
+            }
+            
+            SECTION( "Banded global aligner can align to a graph with an empty source and sink node") {
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("");
+                Node* n1 = graph.create_node("CT");
+                Node* n2 = graph.create_node("TA");
+                Node* n3 = graph.create_node("");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n0, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n3);
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                
+                string read = "CT";
+                string qual = "HH";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n1->id());
+                REQUIRE(aln.path().mapping(2).position().node_id() == n3->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(1).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(1).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(1).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(2).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(2).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(2).edit(0).sequence().empty());
+            }
+            
+            SECTION( "Banded global aligner can align to a graph with a chained empty source and sink nodes") {
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("");
+                Node* n1 = graph.create_node("");
+                Node* n2 = graph.create_node("CT");
+                Node* n3 = graph.create_node("TA");
+                Node* n4 = graph.create_node("");
+                Node* n5 = graph.create_node("");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n1, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n4);
+                graph.create_edge(n3, n4);
+                graph.create_edge(n4, n5);
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                
+                string read = "CT";
+                string qual = "HH";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n1->id());
+                REQUIRE(aln.path().mapping(2).position().node_id() == n2->id());
+                REQUIRE(aln.path().mapping(3).position().node_id() == n4->id());
+                REQUIRE(aln.path().mapping(4).position().node_id() == n5->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(1).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(1).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(1).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(2).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(2).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(2).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(3).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(3).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(3).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(4).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(4).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(4).edit(0).sequence().empty());
+            }
+            
+            SECTION( "Banded global aligner can align to a graph with an empty nodes that is both a source and sink") {
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("");
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                
+                string read = "CT";
+                string qual = "HH";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence() == read);
+            }
+            
+            SECTION( "Banded global aligner can align to a graph with both empty and non-empty sources and sinks") {
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("");
+                Node* n1 = graph.create_node("GA");
+                Node* n2 = graph.create_node("CT");
+                Node* n3 = graph.create_node("GA");
+                Node* n4 = graph.create_node("");
+                
+                graph.create_edge(n0, n2);
+                graph.create_edge(n1, n2);
+                graph.create_edge(n2, n3);
+                graph.create_edge(n2, n4);
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                
+                string read = "CTGA";
+                string qual = "HHHH";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n2->id());
+                REQUIRE(aln.path().mapping(2).position().node_id() == n3->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(1).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(1).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(1).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(2).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(2).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(2).edit(0).sequence().empty());
+                
+                
+                aln.Clear();
+                read = "GACT";
+                qual = "HHHH";
+                
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n1->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n2->id());
+                REQUIRE(aln.path().mapping(2).position().node_id() == n4->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(1).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(1).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(1).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(2).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(2).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(2).edit(0).sequence().empty());
+            }
+            
+            SECTION( "Banded global aligner can align to a graph with empty interior nodes") {
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("GA");
+                Node* n1 = graph.create_node("");
+                Node* n2 = graph.create_node("");
+                Node* n3 = graph.create_node("CT");
+                Node* n4 = graph.create_node("TA");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n0, n3);
+                graph.create_edge(n1, n2);
+                graph.create_edge(n2, n4);
+                graph.create_edge(n3, n4);
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                
+                string read = "GATA";
+                string qual = "HHHH";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n1->id());
+                REQUIRE(aln.path().mapping(2).position().node_id() == n2->id());
+                REQUIRE(aln.path().mapping(3).position().node_id() == n4->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(1).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(1).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(1).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(2).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(2).edit(0).to_length() == 0);
+                REQUIRE(aln.path().mapping(2).edit(0).sequence().empty());
+                
+                REQUIRE(aln.path().mapping(3).edit(0).from_length() == 2);
+                REQUIRE(aln.path().mapping(3).edit(0).to_length() == 2);
+                REQUIRE(aln.path().mapping(3).edit(0).sequence().empty());
+            }
+            
+            SECTION( "Banded global aligner can align to an empty graph" ) {
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("");
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                
+                string read = "G";
+                string qual = "H";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 1);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence() == read);
+            }
+            
+            
+            SECTION( "Banded global aligner can align to an empty graph of more than one node" ) {
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("");
+                Node* n1 = graph.create_node("");
+                
+                graph.create_edge(n0, n1);
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                
+                string read = "G";
+                string qual = "H";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n1->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(1).edit(0).from_length() == 0);
+                
+                REQUIRE((aln.path().mapping(0).edit(0).to_length() == 1) != (aln.path().mapping(1).edit(0).to_length() == 1));
+                REQUIRE((aln.path().mapping(0).edit(0).to_length() == 0) != (aln.path().mapping(1).edit(0).to_length() == 0));
+                
+                REQUIRE((aln.path().mapping(0).edit(0).sequence() == read) != (aln.path().mapping(1).edit(0).sequence() == read));
+                REQUIRE((aln.path().mapping(0).edit(0).sequence().empty()) != (aln.path().mapping(1).edit(0).sequence().empty()));
+            }
+            
+            SECTION( "Banded global aligner can align to a graph with empty and non-empty paths" ) {
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("");
+                Node* n1 = graph.create_node("");
+                Node* n2 = graph.create_node("TCA");
+                
+                graph.create_edge(n0, n1);
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                
+                string read = "G";
+                string qual = "H";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n1->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 0);
+                REQUIRE(aln.path().mapping(1).edit(0).from_length() == 0);
+                
+                REQUIRE((aln.path().mapping(0).edit(0).to_length() == 1) != (aln.path().mapping(1).edit(0).to_length() == 1));
+                REQUIRE((aln.path().mapping(0).edit(0).to_length() == 0) != (aln.path().mapping(1).edit(0).to_length() == 0));
+                
+                REQUIRE((aln.path().mapping(0).edit(0).sequence() == read) != (aln.path().mapping(1).edit(0).sequence() == read));
+                REQUIRE((aln.path().mapping(0).edit(0).sequence().empty()) != (aln.path().mapping(1).edit(0).sequence().empty()));
+                
+                
+                aln.Clear();
+                read = "TCA";
+                qual = "HHH";
+                
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                
+                // is a global alignment
+                REQUIRE(aln.path().mapping(0).position().offset() == 0);
+                REQUIRE(mapping_from_length(aln.path().mapping(aln.path().mapping_size() - 1)) == graph.graph.node(aln.path().mapping(aln.path().mapping_size() - 1).position().node_id() - 1).sequence().length());
+                
+                // follows correct path
+                REQUIRE(aln.path().mapping(0).position().node_id() == n2->id());
+                
+                // has corrects edits
+                REQUIRE(aln.path().mapping(0).edit(0).from_length() == 3);
+                REQUIRE(aln.path().mapping(0).edit(0).to_length() == 3);
+                REQUIRE(aln.path().mapping(0).edit(0).sequence().empty());
+            }
+            
+            SECTION( "Banded global aligner can find multi-alignments over empty sink nodes" ) {
+                
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("GA");
+                Node* n1 = graph.create_node("");
+                Node* n2 = graph.create_node("");
+                
+                graph.create_edge(n0, n1);
+                graph.create_edge(n0, n2);
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                int max_multi_alns = 2;
+                vector<Alignment> multi_alns;
+                
+                string read = "GA";
+                string qual = "HH";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                                                  band_padding, permissive_banding);
+                
+                bool found_first_opt = false;
+                bool found_second_opt = false;
+                for (Alignment& alt_aln : multi_alns) {
+                    const Path& path = alt_aln.path();
+                    
+                    bool is_first_opt = true;
+                    bool is_second_opt = true;
+                    
+                    // is a global alignment
+                    REQUIRE(path.mapping(0).position().offset() == 0);
+                    REQUIRE(mapping_from_length(path.mapping(path.mapping_size() - 1)) == graph.graph.node(path.mapping(path.mapping_size() - 1).position().node_id() - 1).sequence().length());
+                    
+                    // follows correct path
+                    is_first_opt = is_first_opt && (path.mapping(0).position().node_id() == n0->id());
+                    is_first_opt = is_first_opt && (path.mapping(1).position().node_id() == n1->id());
+                    
+                    // has corrects edits
+                    is_first_opt = is_first_opt && (path.mapping(0).edit(0).from_length() == 2);
+                    is_first_opt = is_first_opt && (path.mapping(0).edit(0).to_length() == 2);
+                    is_first_opt = is_first_opt && (path.mapping(0).edit(0).sequence().empty());
+                    
+                    is_first_opt = is_first_opt && (path.mapping(1).edit(0).from_length() == 0);
+                    is_first_opt = is_first_opt && (path.mapping(1).edit(0).to_length() == 0);
+                    is_first_opt = is_first_opt && (path.mapping(1).edit(0).sequence().empty());
+                    
+                    // follows correct path
+                    is_second_opt = is_second_opt && (path.mapping(0).position().node_id() == n0->id());
+                    is_second_opt = is_second_opt && (path.mapping(1).position().node_id() == n2->id());
+                    
+                    // has corrects edits
+                    is_second_opt = is_second_opt && (path.mapping(0).edit(0).from_length() == 2);
+                    is_second_opt = is_second_opt && (path.mapping(0).edit(0).to_length() == 2);
+                    is_second_opt = is_second_opt && (path.mapping(0).edit(0).sequence().empty());
+                    
+                    is_second_opt = is_second_opt && (path.mapping(1).edit(0).from_length() == 0);
+                    is_second_opt = is_second_opt && (path.mapping(1).edit(0).to_length() == 0);
+                    is_second_opt = is_second_opt && (path.mapping(1).edit(0).sequence().empty());
+                    
+                    found_first_opt = found_first_opt || is_first_opt;
+                    found_second_opt = found_second_opt || is_second_opt;
+                }
+                
+                REQUIRE(found_first_opt);
+                REQUIRE(found_second_opt);
+                
+            }
+            
+            // note: alternate alignments over different paths of empty nodes from the same non-empty node
+            // to either the same non-empty node or a source are not supported
+            
+            SECTION( "Banded global aligner can find multi-alignments over empty and non-empty separated components" ) {
+                
+                VG graph;
+                
+                QualAdjAligner aligner(1, 4, 6, 1, 6);
+                
+                Node* n0 = graph.create_node("C");
+                Node* n1 = graph.create_node("TT");
+                Node* n2 = graph.create_node("");
+                
+                bool permissive_banding = true;
+                int band_padding = 1;
+                int max_multi_alns = 3;
+                vector<Alignment> multi_alns;
+                
+                string read = "C";
+                string qual = "H";
+                
+                Alignment aln;
+                aln.set_sequence(read);
+                aln.set_quality(qual);
+                alignment_quality_char_to_short(aln);
+                
+                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                                                  band_padding, permissive_banding);
+                
+                REQUIRE(multi_alns.size() <= 3);
+                
+                bool found_first_opt = false;
+                bool found_second_opt = false;
+                bool found_third_opt = false;
+                for (Alignment& alt_aln : multi_alns) {
+                    
+                    const Path& path = alt_aln.path();
+                    
+                    bool is_first_opt = true;
+                    bool is_second_opt = true;
+                    bool is_third_opt = true;
+                    
+                    // is a global alignment
+                    REQUIRE(path.mapping(0).position().offset() == 0);
+                    REQUIRE(mapping_from_length(path.mapping(path.mapping_size() - 1)) == graph.graph.node(path.mapping(path.mapping_size() - 1).position().node_id() - 1).sequence().length());
+                    
+                    // follows correct path
+                    is_first_opt = is_first_opt && (path.mapping(0).position().node_id() == n0->id());
+                    
+                    // has corrects edits
+                    is_first_opt = is_first_opt && (path.mapping(0).edit(0).from_length() == 1);
+                    is_first_opt = is_first_opt && (path.mapping(0).edit(0).to_length() == 1);
+                    is_first_opt = is_first_opt && (path.mapping(0).edit(0).sequence().empty());
+                    
+                    // follows correct path
+                    is_second_opt = is_second_opt && (path.mapping(0).position().node_id() == n2->id());
+                    
+                    // has corrects edits
+                    is_second_opt = is_second_opt && (path.mapping(0).edit(0).from_length() == 0);
+                    is_second_opt = is_second_opt && (path.mapping(0).edit(0).to_length() == 1);
+                    is_second_opt = is_second_opt && (path.mapping(0).edit(0).sequence() == read);
+                    
+                    // follows correct path
+                    is_third_opt = is_third_opt && (path.mapping(0).position().node_id() == n1->id());
+                    
+                    // has corrects edits
+                    is_third_opt = is_third_opt && (path.mapping(0).edit(0).from_length() == 1);
+                    is_third_opt = is_third_opt && (path.mapping(0).edit(1).from_length() == 1);
+                    is_third_opt = is_third_opt && (path.mapping(0).edit(0).to_length() == 0 || path.mapping(0).edit(0).to_length() == 1);
+                    is_third_opt = is_third_opt && (path.mapping(0).edit(1).to_length() == 0 || path.mapping(0).edit(1).to_length() == 1);
+                    is_third_opt = is_third_opt && (path.mapping(0).edit(0).to_length() == 0 != path.mapping(0).edit(1).to_length() == 0);
+                    
+                    found_first_opt = found_first_opt || is_first_opt;
+                    found_second_opt = found_second_opt || is_second_opt;
+                    found_third_opt = found_third_opt || is_third_opt;
+                }
+                
+                REQUIRE(found_first_opt);
+                REQUIRE(found_second_opt);
+                REQUIRE(found_third_opt);
             }
         }
     }

--- a/src/unittest/banded_global_aligner.cpp
+++ b/src/unittest/banded_global_aligner.cpp
@@ -2093,7 +2093,7 @@ namespace vg {
                 bool found_second_opt = false;
                 for (Alignment& alt_aln : multi_alns) {
                     const Path& path = alt_aln.path();
-                                        
+                    
                     bool is_first_opt = true;
                     bool is_second_opt = true;
                     

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -50,6 +50,11 @@ double stdev(const T& v) {
 // https://en.wikipedia.org/wiki/Cumulative_distribution_function
 double phi(double x1, double x2);
 
+inline double add_log(double log_x, double log_y) {
+    return log_x > log_y ? log_x + log(1.0 + exp(log_y - log_x)) : log_y + log(1.0 + exp(log_x - log_y));
+
+}
+    
 // Convert a probability to a natural log probability.
 inline double prob_to_logprob(double prob) {
     return log(prob);


### PR DESCRIPTION
Several small-to-moderate size updates:
- Fixes the DP bug in the banded global aligner referenced in https://github.com/vgteam/vg/issues/678
- Adds support for empty nodes (i.e. with no sequence) in the banded global aligner. This is important for use with my new subgraph extraction algorithm, which sometimes makes them. 
- Edits the banded global aligner's alternate traceback algorithm, which could miss some high scoring alternates in rare scenarios.
- Adds unit tests for new banded global alignment features.
- Refactors the Aligner and QualAdjAligner to both inherit from one base class with an interface rather than having the QualAdjAligner inherit from the Aligner.