### PR TITLE
Added an algorithm to extract the subgraph surrounding a set of positions

### DIFF
--- a/src/algorithms/vg_algorithms.cpp
+++ b/src/algorithms/vg_algorithms.cpp
@@ -1496,6 +1496,294 @@ namespace algorithms {
                                                      [&](id_t id) {return xg_index.node_sequence(id);});
         }
     }
+    
+    void extract_containing_graph_internal(Graph& g, const vector<pos_t>& positions,
+                                           const vector<size_t>& forward_search_lengths,
+                                           const vector<size_t>& backward_search_lengths,
+                                           function<vector<Edge>(id_t)> edges_on_start,
+                                           function<vector<Edge>(id_t)> edges_on_end,
+                                           function<string(id_t)> node_sequence) {
+        
+        if (forward_search_lengths.size() != backward_search_lengths.size()
+            || forward_search_lengths.size() != positions.size()) {
+            cerr << "error:[extract_containing_graph] subgraph extraction search lengths do not match seed positions" << endl;
+            assert(false);
+        }
+        
+        if (g.node_size() || g.edge_size()) {
+            cerr << "error:[extract_containing_graph] must extract into an empty graph" << endl;
+            assert(false);
+        }
+        
+        // TODO: these structs are duplicative with extract_connecting_graph
+        
+        // a local struct that packages a node traversal with its distance from the first position
+        // note: we don't use NodeTraversals because we may be using an XG, in which case we don't
+        // have Node*'s
+        struct Traversal {
+            Traversal(id_t id, bool rev, int64_t dist) : id(id), rev(rev), dist(dist) {}
+            int64_t dist; // distance from pos_1 to the right side of this node
+            id_t id;      // node ID
+            bool rev;     // strand
+            inline bool operator<(const Traversal& other) const {
+                return dist > other.dist; // opposite order so priority queue selects minimum
+            }
+        };
+        
+        // represent an edge in a canonical ((from, from_start), (to, to_end)) format so that a hash can
+        // identify edges as the same or different
+        auto canonical_form_edge = [](const id_t& id, const bool& left_side, const id_t& to_id, const bool& reversing) {
+            if (id < to_id) {
+                return make_pair(make_pair(id, left_side), make_pair(to_id, left_side != reversing));
+            }
+            else if (to_id < id) {
+                return make_pair(make_pair(to_id, left_side == reversing), make_pair(id, !left_side));
+            }
+            else {
+                return make_pair(make_pair(id, reversing && left_side), make_pair(id, reversing && !left_side));
+            }
+        };
+        
+        // a graph index that we will maintain as we extract the subgraph
+        unordered_map<id_t, Node*> graph;
+        
+        size_t max_search_length = max(*std::max_element(forward_search_lengths.begin(), forward_search_lengths.end()),
+                                       *std::max_element(backward_search_lengths.begin(), backward_search_lengths.end()));
+        
+        
+        // initialize the queue
+        priority_queue<Traversal> queue;
+        for (size_t i = 0; i < positions.size(); i++) {
+            const pos_t& pos = positions[i];
+            // add all of the initial nodes to the graph
+            if (!graph.count(id(pos))) {
+                Node* node = g.add_node();
+                node->set_sequence(node_sequence(id(pos)));
+                node->set_id(id(pos));
+                graph[id(pos)] = node;
+            }
+            
+            // adding this extra distance allows us to keep the searches from all of the seed nodes in
+            // the same priority queue so that we only need to do one Dijkstra traversal
+            
+            // add a traversal for each direction
+            size_t dist_forward = graph[id(pos)]->sequence().size() - offset(pos) + max_search_length - forward_search_lengths[i];
+            size_t dist_backward = offset(pos) + max_search_length - backward_search_lengths[i];
+            if (dist_forward < max_search_length) {
+                queue.emplace(id(pos), is_rev(pos), dist_forward);
+            }
+            if (dist_backward < max_search_length) {
+                queue.emplace(id(pos), !is_rev(pos), dist_backward);
+            }
+        }
+        
+        unordered_set<pair<id_t, bool>> traversed;
+        unordered_set<pair<pair<id_t, bool>, pair<id_t, bool>>> observed_edges;
+        
+        while (!queue.empty()) {
+            // get the next shortest distance traversal from either the init
+            Traversal trav = queue.top();
+            queue.pop();
+            
+            // make sure we haven't traversed this node already
+            if (traversed.count(make_pair(trav.id, trav.rev))) {
+                continue;
+            }
+            // mark the node as traversed
+            traversed.emplace(trav.id, trav.rev);
+            
+            // which side are we traversing out of?
+            for (Edge& edge : (trav.rev ? edges_on_start(trav.id) : edges_on_end(trav.id))) {
+                
+                // get the orientation and id of the other side of the edge
+                id_t next_id;
+                bool next_rev;
+                if (edge.from() == trav.id && edge.from_start() == trav.rev) {
+                    next_id = edge.to();
+                    next_rev = edge.to_end();
+                }
+                else {
+                    next_id = edge.from();
+                    next_rev = !edge.from_start();
+                }
+                
+                // record the edge
+                observed_edges.insert(canonical_form_edge(trav.id, trav.rev, next_id, next_rev != trav.rev));
+                
+                // make sure the node is in the graph
+                if (!graph.count(next_id)) {
+                    Node* node = g.add_node();
+                    node->set_sequence(node_sequence(next_id));
+                    node->set_id(next_id);
+                    graph[next_id] = node;
+                }
+                
+                // distance to the end of this node
+                int64_t dist_thru = trav.dist + graph[next_id]->sequence().size();
+                if (!traversed.count(make_pair(next_id, next_rev)) && dist_thru < max_search_length) {
+                    // we can add more nodes along same path without going over the max length
+                    queue.emplace(next_id, next_rev, dist_thru);
+                }
+            }
+        }
+        
+        // add the edges to the graph
+        for (const pair<pair<id_t, bool>, pair<id_t, bool>>& edge : observed_edges) {
+            Edge* e = g.add_edge();
+            e->set_from(edge.first.first);
+            e->set_to(edge.second.first);
+            e->set_from_start(edge.first.second);
+            e->set_to_end(edge.second.second);
+        }
+    }
+    
+    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions, size_t max_dist) {
+        
+        // make a dummy vector for all positions at the same distance
+        vector<size_t> dists(positions.size(), max_dist);
+        return extract_containing_graph_internal(g, positions, dists, dists,
+                                                 [&](id_t id) {
+                                                     vector<Edge> to_return;
+                                                     for (Edge* edge : vg.edges_of(vg.get_node(id))) {
+                                                         if ((edge->from() == id && edge->from_start())
+                                                             || (edge->to() == id && !edge->to_end())) {
+                                                             to_return.push_back(*edge);
+                                                         }
+                                                     }
+                                                     return to_return;
+                                                 },
+                                                 [&](id_t id) {
+                                                     vector<Edge> to_return;
+                                                     for (Edge* edge : vg.edges_of(vg.get_node(id))) {
+                                                         if ((edge->from() == id && !edge->from_start())
+                                                             || (edge->to() == id && edge->to_end())) {
+                                                             to_return.push_back(*edge);
+                                                         }
+                                                     }
+                                                     return to_return;
+                                                 },
+                                                 [&](id_t id) {
+                                                     return vg.get_node(id)->sequence();
+                                                 });
+    }
+    
+    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions,
+                                  const vector<size_t>& position_max_dist) {
+        
+        return extract_containing_graph_internal(g, positions, position_max_dist, position_max_dist,
+                                                 [&](id_t id) {
+                                                     vector<Edge> to_return;
+                                                     for (Edge* edge : vg.edges_of(vg.get_node(id))) {
+                                                         if ((edge->from() == id && edge->from_start())
+                                                             || (edge->to() == id && !edge->to_end())) {
+                                                             to_return.push_back(*edge);
+                                                         }
+                                                     }
+                                                     return to_return;
+                                                 },
+                                                 [&](id_t id) {
+                                                     vector<Edge> to_return;
+                                                     for (Edge* edge : vg.edges_of(vg.get_node(id))) {
+                                                         if ((edge->from() == id && !edge->from_start())
+                                                             || (edge->to() == id && edge->to_end())) {
+                                                             to_return.push_back(*edge);
+                                                         }
+                                                     }
+                                                     return to_return;
+                                                 },
+                                                 [&](id_t id) {
+                                                     return vg.get_node(id)->sequence();
+                                                 });
+    }
+    
+    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions,
+                                  const vector<size_t>& position_forward_max_dist,
+                                  const vector<size_t>& position_backward_max_dist) {
+        
+        return extract_containing_graph_internal(g, positions, position_forward_max_dist, position_backward_max_dist,
+                                                 [&](id_t id) {
+                                                     vector<Edge> to_return;
+                                                     for (Edge* edge : vg.edges_of(vg.get_node(id))) {
+                                                         if ((edge->from() == id && edge->from_start())
+                                                             || (edge->to() == id && !edge->to_end())) {
+                                                             to_return.push_back(*edge);
+                                                         }
+                                                     }
+                                                     return to_return;
+                                                 },
+                                                 [&](id_t id) {
+                                                     vector<Edge> to_return;
+                                                     for (Edge* edge : vg.edges_of(vg.get_node(id))) {
+                                                         if ((edge->from() == id && !edge->from_start())
+                                                             || (edge->to() == id && edge->to_end())) {
+                                                             to_return.push_back(*edge);
+                                                         }
+                                                     }
+                                                     return to_return;
+                                                 },
+                                                 [&](id_t id) {
+                                                     return vg.get_node(id)->sequence();
+                                                 });
+    }
+    
+    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions, size_t max_dist,
+                                  LRUCache<id_t, Node>* node_cache) {
+        
+        // make a dummy vector for all positions at the same distance
+        vector<size_t> dists(positions.size(), max_dist);
+        if (node_cache) {
+            return extract_containing_graph_internal(g, positions, dists, dists,
+                                                     [&](id_t id) {return xg_index.edges_on_start(id);},
+                                                     [&](id_t id) {return xg_index.edges_on_end(id);},
+                                                     [&](id_t id) {return xg_cached_node_sequence(id, &xg_index,
+                                                                                                  *node_cache);});
+        }
+        else {
+            return extract_containing_graph_internal(g, positions, dists, dists,
+                                                     [&](id_t id) {return xg_index.edges_on_start(id);},
+                                                     [&](id_t id) {return xg_index.edges_on_end(id);},
+                                                     [&](id_t id) {return xg_index.node_sequence(id);});
+        }
+    }
+    
+    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions,
+                                  const vector<size_t>& position_max_dist,
+                                  LRUCache<id_t, Node>* node_cache) {
+        
+        if (node_cache) {
+            return extract_containing_graph_internal(g, positions, position_max_dist, position_max_dist,
+                                                     [&](id_t id) {return xg_index.edges_on_start(id);},
+                                                     [&](id_t id) {return xg_index.edges_on_end(id);},
+                                                     [&](id_t id) {return xg_cached_node_sequence(id, &xg_index,
+                                                                                                  *node_cache);});
+        }
+        else {
+            return extract_containing_graph_internal(g, positions, position_max_dist, position_max_dist,
+                                                     [&](id_t id) {return xg_index.edges_on_start(id);},
+                                                     [&](id_t id) {return xg_index.edges_on_end(id);},
+                                                     [&](id_t id) {return xg_index.node_sequence(id);});
+        }
+    }
+    
+    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions,
+                                  const vector<size_t>& position_forward_max_dist,
+                                  const vector<size_t>& position_backward_max_dist,
+                                  LRUCache<id_t, Node>* node_cache) {
+        
+        if (node_cache) {
+            return extract_containing_graph_internal(g, positions, position_forward_max_dist, position_backward_max_dist,
+                                                     [&](id_t id) {return xg_index.edges_on_start(id);},
+                                                     [&](id_t id) {return xg_index.edges_on_end(id);},
+                                                     [&](id_t id) {return xg_cached_node_sequence(id, &xg_index,
+                                                                                                  *node_cache);});
+        }
+        else {
+            return extract_containing_graph_internal(g, positions, position_forward_max_dist, position_backward_max_dist,
+                                                     [&](id_t id) {return xg_index.edges_on_start(id);},
+                                                     [&](id_t id) {return xg_index.edges_on_end(id);},
+                                                     [&](id_t id) {return xg_index.node_sequence(id);});
+        }
+    }
 }
 }
 

--- a/src/algorithms/vg_algorithms.hpp
+++ b/src/algorithms/vg_algorithms.hpp
@@ -68,6 +68,51 @@ namespace algorithms {
                                                        bool strict_max_len = false,
                                                        LRUCache<id_t, Node>* node_cache = nullptr);
     
+    
+    /// Fills graph g with the subgraph of the VG graph vg that contains all of the positions in
+    /// the positions vector and all other nodes and edges that can be reached within a maximum
+    /// distance from any of these positions.
+    ///
+    /// Args:
+    ///  vg                         graph to extract subgraph from
+    ///  g                          graph to extract into
+    ///  positions                  search outward from these positions
+    ///  max_dist                   include all nodes and edges that can be reached in at most this distance
+    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions, size_t max_dist);
+    
+    /// Same semantics as previous, but accesses graph through an XG instead of a VG. Optionally uses
+    /// an LRUCache to speed up Node queries.
+    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions, size_t max_dist,
+                                  LRUCache<id_t, Node>* node_cache = nullptr);
+    
+    /// Same semantics as previous except that there is a separate maximum distance for different
+    /// positions in the graph. Each distance is associated with the position with the same index. Throws
+    /// an error if the position and distance vectors are not the same length.
+    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions,
+                                  const vector<size_t>& position_max_dist);
+    
+    /// Same semantics as previous, but accesses graph through an XG instead of a VG. Optionally uses
+    /// an LRUCache to speed up Node queries.
+    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions,
+                                  const vector<size_t>& position_max_dist,
+                                  LRUCache<id_t, Node>* node_cache = nullptr);
+    
+    /// Same semantics as previous except that there is a separate maximum distance for different
+    /// positions in the graph and for each search direction. Each distance is associated with the
+    /// position with the same index. The forward distance is in the same orientation as the position,
+    /// and the backward distance is in the reverse orientation of the position. Throws an error if
+    /// the position and distance vectors are not the same length.
+    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions,
+                                  const vector<size_t>& position_forward_max_dist,
+                                  const vector<size_t>& position_backward_max_dist);
+    
+    /// Same semantics as previous, but accesses graph through an XG instead of a VG. Optionally uses
+    /// an LRUCache to speed up Node queries.
+    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions,
+                                  const vector<size_t>& position_forward_max_dist,
+                                  const vector<size_t>& position_backward_max_dist,
+                                  LRUCache<id_t, Node>* node_cache = nullptr);
+    
 }
 }
 


### PR DESCRIPTION
Added an algorithm that can extract the subgraph surrounding a set of positions. The implementation is VG/XG flexible. It also has some options that I want, like the ability to assign different search distances to different positions or to different directions from each position. Some tests are included.