### PR TITLE
Combi alignments for pairs

### DIFF
--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -210,6 +210,11 @@ public:
     LRUCache<id_t, Node>& get_node_cache(void);
     void init_node_cache(void);
 
+    // node start cache for fast approximate position estimates
+    vector<LRUCache<id_t, size_t>* > node_start_cache;
+    LRUCache<id_t, size_t>& get_node_start_cache(void);
+    void init_node_start_cache(void);
+
     // match node traversals to path positions
     vector<LRUCache<gcsa::node_type, map<string, vector<size_t> > >* > node_pos_cache;
     LRUCache<gcsa::node_type, map<string, vector<size_t> > >& get_node_pos_cache(void);

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -255,6 +255,10 @@ public:
                                const map<string, double>& pos2,
                                int fragment_size_bound);
 
+    // use the fragment length annotations to assess if the pair is consistent or not
+    bool pair_consistent(const Alignment& aln1,
+                         const Alignment& aln2);
+
     // Align read2 to the subgraph near the alignment of read1.
     // TODO: support banded alignment and intelligently use orientation heuristics
     void align_mate_in_window(const Alignment& read1, Alignment& read2, int pair_window);

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -355,6 +355,18 @@ public:
                                bool only_top_scoring_pair = false,
                                bool retrying = false);
 
+    // align the pair's ends singly, then take the cross of possible pairs based on the fragment distribution
+    pair<vector<Alignment>, vector<Alignment>>
+        align_paired_multi_combi(const Alignment& read1,
+                                 const Alignment& read2,
+                                 bool& queued_resolve_later,
+                                 int kmer_size = 0,
+                                 int stride = 0,
+                                 int max_mem_length = 0,
+                                 int band_width = 1000,
+                                 bool only_top_scoring_pair = false,
+                                 bool retrying = false);
+
     // align the pair as a single component using MEM threading and patching on the pair simultaneously
     pair<vector<Alignment>, vector<Alignment>> 
         align_paired_multi_simul(const Alignment& read1,
@@ -498,6 +510,7 @@ public:
     int fragment_length_cache_size;
     float perfect_pair_identity_threshold;
     int8_t full_length_alignment_bonus;
+    bool simultaneous_pair_alignment;
 
 };
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -106,6 +106,15 @@ size_t xg_cached_node_length(id_t id, xg::XG* xgidx, LRUCache<id_t, Node>& node_
     return node.sequence().size();
 }
 
+size_t xg_cached_node_start(id_t id, xg::XG* xgidx, LRUCache<id_t, size_t>& node_start_cache) {
+    pair<size_t, bool> cached = node_start_cache.retrieve(id);
+    if(!cached.second) {
+        cached.first = xgidx->node_start(id(pos));
+        node_start_cache.put(id, cached.first);
+    }
+    return cached.first;
+}
+
 char xg_cached_pos_char(pos_t pos, xg::XG* xgidx, LRUCache<id_t, Node>& node_cache) {
     pair<Node, bool> cached = node_cache.retrieve(id(pos));
     if(!cached.second) {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -109,7 +109,7 @@ size_t xg_cached_node_length(id_t id, xg::XG* xgidx, LRUCache<id_t, Node>& node_
 size_t xg_cached_node_start(id_t id, xg::XG* xgidx, LRUCache<id_t, size_t>& node_start_cache) {
     pair<size_t, bool> cached = node_start_cache.retrieve(id);
     if(!cached.second) {
-        cached.first = xgidx->node_start(id(pos));
+        cached.first = xgidx->node_start(id);
         node_start_cache.put(id, cached.first);
     }
     return cached.first;

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -56,6 +56,8 @@ Position make_position(gcsa::node_type node);
 string xg_cached_node_sequence(id_t id, xg::XG* xgidx, LRUCache<id_t, Node>& node_cache);
 /// Get the length of a Node from an xg::XG index, with cacheing of deserialized nodes.
 size_t xg_cached_node_length(id_t id, xg::XG* xgidx, LRUCache<id_t, Node>& node_cache);
+/// Get the node start position in the sequence vector
+size_t xg_cached_node_start(id_t id, xg::XG* xgidx, LRUCache<id_t, size_t>& node_start_cache);
 /// Get the character at a position in an xg::XG index, with cacheing of deserialized nodes.
 char xg_cached_pos_char(pos_t pos, xg::XG* xgidx, LRUCache<id_t, Node>& node_cache);
 /// Get the characters at positions after the given position from an xg::XG index, with cacheing of deserialized nodes.

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -100,8 +100,8 @@ is $(vg map -r x.reads -x x.vg.idx -g x.vg.gcsa -J -t 1 -J -a | jq -c '.path.map
 
 vg index -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -k 16 graphs/refonly-lrc_kir.vg
 
-vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -J  > temp_paired_alignment.json
-vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -u 4 -J  > temp_independent_alignment.json
+vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -J -a  > temp_paired_alignment.json
+vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -u 4 -J -a  > temp_independent_alignment.json
 paired_score=$(jq -r ".score" < temp_paired_alignment.json | awk '{ sum+=$1} END {print sum}')
 independent_score=$(jq -r ".score" < temp_independent_alignment.json | awk '{ sum+=$1} END {print sum}')
 is $(printf "%s\t%s\n" $paired_score $independent_score | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be consistent have lower score than unrestricted alignments"
@@ -114,14 +114,14 @@ is $(vg map -r x.reads -x x.xg -g x.gcsa -k 22 -J | jq -r ".mapping_quality" | w
 
 rm temp_paired_alignment.json temp_independent_alignment.json
 
-is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -v 1 -J | jq -r ".mapping_quality") $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -U -u 4 -v 2 -J | jq -r ".mapping_quality") "mapping quality approximation is equal to exact calculation in a clear cut case"
+is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -v 1 -J -a | jq -r ".mapping_quality") $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -U -u 4 -v 2 -J -a | jq -r ".mapping_quality") "mapping quality approximation is equal to exact calculation in a clear cut case"
 
 vg map -f alignment/mismatch_full_qual.fq -x x.xg -g x.gcsa -k 22 -J -1 | jq -c '.score' > temp_scores_full_qual.txt
 vg map -f alignment/mismatch_reduced_qual.fq -x x.xg -g x.gcsa -k 22 -J -1 | jq -c '.score' > temp_scores_reduced_qual.txt
 is $(paste temp_scores_full_qual.txt temp_scores_reduced_qual.txt | column -s $'\t' -t | awk '{if ($1 < $2) count++} END{print count}') 10 "base quality adjusted alignment produces higher scores if mismatches have low quality"
 rm temp_scores_full_qual.txt temp_scores_reduced_qual.txt
 
-is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -W 1000:300:20:0:1 -J | jq -r 'select(.name == "ERR194147.679985061/1") | .path.mapping[0].position.node_id') 8121 "paired-end reads are pulled to consistent locations at the cost of non-optimal individual alignments"
+is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -W 1000:300:20:0:1 -J -a | jq -r 'select(.name == "ERR194147.679985061/1") | .path.mapping[0].position.node_id') 8121 "paired-end reads are pulled to consistent locations at the cost of non-optimal individual alignments"
 
 vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/NONEXISTENT -u 4 -J
 is $? 1 "error on vg map -f <nonexistent-file> (unpaired)"


### PR DESCRIPTION
Add another alignment function for pairs which aligns each read independently with the single ended aligner, then crosses all pairs, scoring them based on their individual scores plus a bonus for alignments that fit into the fragment length distribution that we've observed or set.

This alignment function align_paired_multi_combi implements this model. A flag is added to the Mapper to allow configuring this dynamically but it is not hooked up to the command line interface.