### PR TITLE
Scaling params

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4928,7 +4928,7 @@ void help_map(char** argv) {
          << "                              max, mean, stdev, orientation (1=same, 0=flip), direction (1=forward, 0=backward)" << endl
          << "    -2, --fragment-sigma N    calculate fragment size as mean(buf)+sd(buf)*N where buf is the buffer of perfect pairs we use (default: 10e)" << endl
          << "    -p, --pair-window N       maximum distance between properly paired reads in node ID space" << endl
-         << "    -u, --extra-multimaps N   examine N extra mappings looking for a consistent read pairing (default: 32)" << endl
+         << "    -u, --extra-multimaps N   examine N extra mappings looking for a consistent read pairing (default: 100)" << endl
          << "    -U, --always-rescue       rescue each imperfectly-mapped read in a pair off the other" << endl
          << "    -O, --top-pairs-only      only produce paired alignments if both sides of the pair are top-scoring individually" << endl
          << "generic mapping parameters:" << endl
@@ -4937,7 +4937,7 @@ void help_map(char** argv) {
          << "    -n, --context-depth N     follow this many edges out from each thread for alignment (default: 7)" << endl
          << "    -M, --max-multimaps N     produce up to N alignments for each read (default: 1)" << endl
          << "    -3, --softclip-trig N     trigger graph extension and realignment when either end has softclips (default: 0)" << endl
-         << "    -m, --hit-max N           ignore kmers or MEMs who have >N hits in our index (default: 100)" << endl
+         << "    -m, --hit-max N           ignore kmers or MEMs who have >N hits in our index (default: 10000)" << endl
          << "    -c, --clusters N          use at most the largest N ordered clusters of the kmer graph for alignment (default: all)" << endl
          << "    -C, --cluster-min N       require at least this many kmer hits in a cluster to attempt alignment (default: 1)" << endl
          << "    -H, --max-target-x N      skip cluster subgraphs with length > N*read_length (default: 100; unset: 0)" << endl
@@ -4988,7 +4988,7 @@ int main_map(int argc, char** argv) {
     string read_file;
     string hts_file;
     bool keep_secondary = false;
-    int hit_max = 100;
+    int hit_max = 10000;
     int max_multimaps = 1;
     int thread_count = 1;
     int thread_ex = 10;
@@ -5024,7 +5024,7 @@ int main_map(int argc, char** argv) {
     int gap_extend = 1;
     int full_length_bonus = 5;
     bool qual_adjust_alignments = false;
-    int extra_multimaps = 32;
+    int extra_multimaps = 100;
     int max_mapping_quality = 60;
     int method_code = 1;
     string gam_input;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1355,7 +1355,8 @@ void help_msga(char** argv) {
          << "    -M, --max-attempts N    only attempt the N best subgraphs ranked by SMEM support (default: 10)" << endl
          << "    -q, --max-target-x N    skip cluster subgraphs with length > N*read_length (default: 100; 0=unset)" << endl
          << "    -I, --max-multimaps N   if N>1, keep N best mappings of each band, resolve alignment by DP (default: 1)" << endl
-         << "    -V, --mem-reseed N       reseed SMEMs longer than this length to find non-supermaximal MEMs inside them (default: 2x min-mem)" << endl
+         << "    -V, --mem-reseed N      reseed SMEMs longer than this length to find non-supermaximal MEMs inside them" << endl
+         << "                            set to -1 to estimate as 2x min mem length (default: 0/unset)" << endl
          << "index generation:" << endl
          << "    -K, --idx-kmer-size N   use kmers of this size for building the GCSA indexes (default: 16)" << endl
          << "    -O, --idx-no-recomb     index only embedded paths, not recombinations of them" << endl
@@ -1800,7 +1801,8 @@ int main_msga(int argc, char** argv) {
             mapper->min_mem_length = (min_mem_length > 0 ? min_mem_length
                                       : mapper->random_match_length(chance_match));
             mapper->mem_reseed_length = (mem_reseed_length > 0 ? mem_reseed_length
-                                         : 2 * mapper->min_mem_length);
+                                         : (mem_reseed_length == 0 ? 0
+                                            : 2 * mapper->min_mem_length));
             mapper->hit_max = hit_max;
             mapper->greedy_accept = greedy_accept;
             mapper->max_target_factor = max_target_factor;
@@ -4951,7 +4953,8 @@ void help_map(char** argv) {
          << "    -L, --min-mem-length N   ignore MEMs shorter than this length (default: estimated minimum where [-F] of hits are by chance)" << endl
          << "    -F, --chance-match N     set the minimum MEM length so ~ this fraction of min-length hits will by by chance (default: 0.05)" << endl
          << "    -Y, --max-mem-length N   ignore MEMs longer than this length by stopping backward search (default: 0/unset)" << endl
-         << "    -V, --mem-reseed N       reseed SMEMs longer than this length to find non-supermaximal MEMs inside them (default: 32)" << endl
+         << "    -V, --mem-reseed N       reseed SMEMs longer than this length to find non-supermaximal MEMs inside them" << endl
+         << "                             set to -1 to estimate as 2x min mem length (default: 0/unset)" << endl
          << "    -6, --fast-reseed        use fast SMEM reseeding" << endl
          << "    -a, --id-clustering      use id clustering to drive the mapper, rather than MEM-threading" << endl
          << "    -5, --unsmoothly         don't smooth alignments after patching" << endl
@@ -5543,7 +5546,8 @@ int main_map(int argc, char** argv) {
         m->min_mem_length = (min_mem_length > 0 ? min_mem_length
                              : m->random_match_length(chance_match));
         m->mem_reseed_length = (mem_reseed_length > 0 ? mem_reseed_length
-                                : 2 * m->min_mem_length);
+                                : (mem_reseed_length == 0 ? 0
+                                   : 2 * m->min_mem_length));
         if (debug && i == 0) {
             cerr << "[vg map] : min_mem_length = " << m->min_mem_length
                  << ", mem_reseed_length = " << m->mem_reseed_length << endl;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -56,7 +56,7 @@ Mapper::Mapper(Index* idex,
     , full_length_alignment_bonus(5)
     , max_mapping_quality(60)
     , max_cluster_mapping_quality(1024)
-    , mem_reseed_length(32)
+    , mem_reseed_length(0)
     , use_cluster_mq(false)
     , smooth_alignments(true)
     , simultaneous_pair_alignment(false)

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -38,7 +38,7 @@ Mapper::Mapper(Index* idex,
     , fast_reseed(false)
     , max_target_factor(128)
     , max_query_graph_ratio(128)
-    , extra_multimaps(16)
+    , extra_multimaps(100)
     , always_rescue(false)
     , fragment_size(0)
     , fragment_max(1e5)

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -109,7 +109,7 @@ is $(printf "%s\t%s\n" $paired_score $independent_score | awk '{if ($1 < $2) pri
 paired_range=$(jq -r ".path.mapping[0].position.node_id" <  temp_paired_alignment.json| sort | rs -T | awk '{print ($2 - $1)}')
 independent_range=$(jq -r ".path.mapping[0].position.node_id" <  temp_independent_alignment.json| sort | rs -T | awk '{print ($2 - $1)}')
 is $(printf "%s\t%s\n" $paired_range $independent_range | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be consistent are closer together in node id space than unrestricted alignments"
-is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -J -M 10 | jq -r ".mapping_quality" | grep -v null | wc -l) 2 "only primary alignments have mapping quality scores"
+is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -J -M 10 | jq -r ".mapping_quality" | grep -v null | wc -l) 1 "only primary alignments have mapping quality scores"
 is $(vg map -r x.reads -x x.xg -g x.gcsa -k 22 -J | jq -r ".mapping_quality" | wc -l) 1000 "unpaired reads produce mapping quality scores"
 
 rm temp_paired_alignment.json temp_independent_alignment.json


### PR DESCRIPTION
These are tweaks to the default parameters that are designed to improve our performance in large genomes. Of course, we need to maintain performance in small ones as well.

The major change here is to set much higher limits for the hit max and number of extra multimap attempts. Also, we disable MEM reseeding, as this seemed to only be throwing up noise, at least the simple method I've implemented.