### PR TITLE
Call improvements and nesting prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,13 +374,13 @@ $(OBJ_DIR)/entropy.o: $(SRC_DIR)/entropy.cpp $(SRC_DIR)/entropy.hpp $(DEPS)
 
 $(OBJ_DIR)/pileup.o: $(SRC_DIR)/pileup.cpp $(SRC_DIR)/pileup.hpp $(INC_DIR)/stream.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/json2pb.h $(DEPS)
 
-$(OBJ_DIR)/caller.o: $(SRC_DIR)/caller.cpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(INC_DIR)/stream.hpp $(SRC_DIR)/json2pb.h $(SRC_DIR)/pileup.hpp $(DEPS)
+$(OBJ_DIR)/caller.o: $(SRC_DIR)/caller.cpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(INC_DIR)/stream.hpp $(SRC_DIR)/json2pb.h $(SRC_DIR)/pileup.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
 
-$(OBJ_DIR)/call2vcf.o: $(SRC_DIR)/call2vcf.cpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/nodeside.hpp $(SRC_DIR)/nodetraversal.hpp $(SRC_DIR)/snarls.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/genotypekit.hpp $(DEPS)
+$(OBJ_DIR)/call2vcf.o: $(SRC_DIR)/call2vcf.cpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/nodeside.hpp $(SRC_DIR)/nodetraversal.hpp $(SRC_DIR)/snarls.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/genotypekit.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
 
 $(OBJ_DIR)/genotyper.o: $(SRC_DIR)/genotyper.cpp $(SRC_DIR)/genotyper.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/json2pb.h $(DEPS) $(INC_DIR)/sparsehash/sparse_hash_map $(SRC_DIR)/bubbles.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/utility.hpp
 
-$(OBJ_DIR)/genotypekit.o: $(SRC_DIR)/genotypekit.cpp $(SRC_DIR)/genotypekit.hpp $(DEPS) $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/utility.hpp $(SRC_DIR)/distributions.hpp $(DEPS)
+$(OBJ_DIR)/genotypekit.o: $(SRC_DIR)/genotypekit.cpp $(SRC_DIR)/genotypekit.hpp $(DEPS) $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/utility.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
 
 $(OBJ_DIR)/position.o: $(SRC_DIR)/position.cpp $(SRC_DIR)/position.hpp $(CPP_DIR)/vg.pb.h $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/json2pb.h $(DEPS)
 
@@ -443,11 +443,12 @@ $(OBJ_DIR)/feature_set.o: $(SRC_DIR)/feature_set.cpp $(SRC_DIR)/feature_set.hpp 
 
 $(OBJ_DIR)/simplifier.o: $(SRC_DIR)/simplifier.cpp $(SRC_DIR)/simplifier.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/utility.hpp $(SRC_DIR)/feature_set.hpp $(SRC_DIR)/path.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/distributions.hpp $(DEPS)
 
-$(OBJ_DIR)/nested_traversal_finder.o: $(SRC_DIR)/nested_traversal_finder.cpp $(SRC_DIR)/nested_traversal_finder.hpp $(SRC_DIR)/genotypekit.hpp $(DEPS)
+$(OBJ_DIR)/nested_traversal_finder.o: $(SRC_DIR)/nested_traversal_finder.cpp $(SRC_DIR)/nested_traversal_finder.hpp $(SRC_DIR)/genotypekit.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
 
 ### Algorithms ###
 
 $(OBJ_DIR)/vg_algorithms.o: $(ALGORITHMS_SRC_DIR)/vg_algorithms.cpp $(ALGORITHMS_SRC_DIR)/vg_algorithms.hpp $(DEPS)
+	. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
 ###################################
 ## VG unit test compilation begins here

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ OBJ += $(OBJ_DIR)/variant_adder.o
 OBJ += $(OBJ_DIR)/name_mapper.o
 OBJ += $(OBJ_DIR)/graph_synchronizer.o
 OBJ += $(OBJ_DIR)/vg_algorithms.o
+OBJ += $(OBJ_DIR)/nested_traversal_finder.o
 
 # These aren't put into libvg. But they do go into the main vg binary to power its self-test.
 UNITTEST_OBJ =
@@ -442,8 +443,11 @@ $(OBJ_DIR)/feature_set.o: $(SRC_DIR)/feature_set.cpp $(SRC_DIR)/feature_set.hpp 
 
 $(OBJ_DIR)/simplifier.o: $(SRC_DIR)/simplifier.cpp $(SRC_DIR)/simplifier.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/utility.hpp $(SRC_DIR)/feature_set.hpp $(SRC_DIR)/path.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/distributions.hpp $(DEPS)
 
-$(OBJ_DIR)/vg_algorithms.o: $(ALGORITHMS_SRC_DIR)/vg_algorithms.cpp $(ALGORITHMS_SRC_DIR)/vg_algorithms.hpp
-	. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
+$(OBJ_DIR)/nested_traversal_finder.o: $(SRC_DIR)/nested_traversal_finder.cpp $(SRC_DIR)/genotypekit.hpp $(DEPS)
+
+### Algorithms ###
+
+$(OBJ_DIR)/vg_algorithms.o: $(ALGORITHMS_SRC_DIR)/vg_algorithms.cpp $(ALGORITHMS_SRC_DIR)/vg_algorithms.hpp $(DEPS)
 
 ###################################
 ## VG unit test compilation begins here

--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ $(OBJ_DIR)/feature_set.o: $(SRC_DIR)/feature_set.cpp $(SRC_DIR)/feature_set.hpp 
 
 $(OBJ_DIR)/simplifier.o: $(SRC_DIR)/simplifier.cpp $(SRC_DIR)/simplifier.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/utility.hpp $(SRC_DIR)/feature_set.hpp $(SRC_DIR)/path.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/distributions.hpp $(DEPS)
 
-$(OBJ_DIR)/nested_traversal_finder.o: $(SRC_DIR)/nested_traversal_finder.cpp $(SRC_DIR)/genotypekit.hpp $(DEPS)
+$(OBJ_DIR)/nested_traversal_finder.o: $(SRC_DIR)/nested_traversal_finder.cpp $(SRC_DIR)/nested_traversal_finder.hpp $(SRC_DIR)/genotypekit.hpp $(DEPS)
 
 ### Algorithms ###
 

--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -19,6 +19,7 @@
 #include "path_index.hpp"
 #include "caller.hpp"
 #include "stream.hpp"
+#include "nested_traversal_finder.hpp"
 
 //#define debug
 
@@ -477,7 +478,7 @@ void Call2Vcf::call(
         
         // Get the traversals. The ref traversal is the first one. They are all
         // in site orientation, which may oppose primary path orientation.
-        auto traversals = traversal_finder.find_traversals(*site);
+        vector<SnarlTraversal> traversals = traversal_finder.find_traversals(*site);
         
         // Make a Locus to represent this site, with all the Paths of the
         // different alleles.

--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -486,9 +486,6 @@ void Call2Vcf::call(
         // And keep around a vector of is_reference statuses for all the alleles
         vector<bool> is_ref;
         
-        // We turn them all back into NodeTraversal vectors
-        vector<pair<vector<NodeTraversal>, bool>> ordered_paths;
-        
         for (auto& traversal : traversals) {
             // Convert each traversal to a path
             Path* path = locus.add_allele();
@@ -504,38 +501,6 @@ void Call2Vcf::call(
             
             // Save the traversal's reference status
             is_ref.push_back(is_reference(traversal, augmented, index));
-            
-            // TODO: Also, save the data the old way that powers the VCF output
-            // currently
-            
-            // Make each traversal into a vector of NodeTraversals
-            vector<NodeTraversal> traversal_vector;
-            // Start at the start of the site
-            traversal_vector.push_back(to_node_traversal(site->start(), augmented.graph));
-            for (size_t i = 0; i < traversal.visits_size(); i++) {
-                // Then visit each node in turn
-                traversal_vector.push_back(to_node_traversal(traversal.visits(i), augmented.graph));
-            }
-            // Finish up with the site's end
-            traversal_vector.push_back(to_node_traversal(site->end(), augmented.graph));
-            
-            if (index.by_id.count(site->start().node_id()) && index.by_id.count(site->end().node_id())) {
-                // This site is on the primary path
-                if (index.by_id.at(site->start().node_id()).first > index.by_id.at(site->end().node_id()).first) {
-                    // This site is backward relative to the primary path.
-                    
-                    // Turn the traversal around to primary path orientation.
-                    reverse(traversal_vector.begin(), traversal_vector.end());
-                    for (auto& trav : traversal_vector) {
-                        // Flip every traversal in it
-                        trav = trav.reverse();
-                    }
-                }
-            }
-            
-            // Put it in the list, with an annotation saying whether it's a
-            // previously-known traversal or not.
-            ordered_paths.push_back(make_pair(traversal_vector, is_ref.back()));
         }
         
         // Collect sequences for all the paths

--- a/src/nested_traversal_finder.cpp
+++ b/src/nested_traversal_finder.cpp
@@ -1,0 +1,212 @@
+/// \file nested_traversal_finder.cpp: Contains implementation for a TraversalFinder that works on non-leaf Snarls.
+
+#include "genotypekit.hpp"
+
+namespace vg {
+
+using namespace std;
+
+/**
+ * This TraversalFinder emits at least one traversal representing every node,
+ * edge, or child Snarl. Only works on ultrabubbles, and so does not handle
+ * cycles.
+ */
+class NestedTraversalFinder : public TraversalFinder {
+
+protected:
+    /// The annotated, augmented graph we're finding traversals in
+    AugmentedGraph& augmented;
+    /// The SnarlManager managiung the snarls we use
+    SnarlManager& snarl_manager;
+    
+    /**
+     * Given an edge or node or child snarl in the augmented graph, look out
+     * from the edge or node or child in both directions to find a shortest
+     * bubble connecting the start and end of the given site.
+     *
+     * Exactly one of edge and node and child must be non-null.
+     *
+     * Return the found traversal as a vector of Visits, including anchoring
+     * Visits to the site's start and end nodes. Also return the minimum support
+     * found on any edge or node in the bubble that is not contained within a
+     * child.
+     */
+    pair<Support, vector<Visit>> find_bubble(Node* node, Edge* edge, Snarl* child, const Snarl& site);
+        
+    /**
+     * Get the minimum support of all nodes and edges used in the given path
+     * that are not inside child snarls.
+     */
+    Support min_support_in_path(const vector<Visit>& path);
+        
+    /**
+     * Do a breadth-first search left from the given node traversal, and return
+     * lengths (in visits) and paths starting at the given node and ending on
+     * the given indexed path. Refuses to visit nodes with no support.
+     *
+     * Lengths are included so that shorter paths sort first.
+     */
+    set<pair<size_t, list<Visit>>> search_left(Visit root, const Snarl& site,
+        const map<NodeTraversal, const Snarl*>& child_boundary_index);
+        
+    /**
+     * Do a breadth-first search right from the given node traversal, and return
+     * lengths (in visits) and paths starting at the given node and ending on
+     * the given indexed path.
+     *
+     * Lengths are included so that shorter paths sort first.
+     */
+    set<pair<size_t, list<Visit>>> search_right(Visit root, const Snarl& site,
+        const map<NodeTraversal, const Snarl*>& child_boundary_index);
+        
+    /**
+     * Get the length of a path through nodes and child sites, in base pairs.
+     * Ignores any bases inside child sites.
+     */
+    size_t bp_length(const list<Visit>& path);
+    
+public:
+
+    NestedTraversalFinder(AugmentedGraph& augmented, SnarlManager& snarl_manager);
+    
+    /// Should we emit verbose debugging info?
+    bool verbose = false;
+    
+    virtual ~NestedTraversalFinder() = default;
+    
+    /**
+     * Find traversals to cover the nodes, edges, and children of the snarl.
+     * Always emits the primary path traversal first, if applicable.
+     */
+    virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
+    
+};
+
+
+NestedTraversalFinder::NestedTraversalFinder(AugmentedGraph& augmented,
+    SnarlManager& snarl_manager) : augmented(augmented), snarl_manager(snarl_manager) {
+    
+    // Nothing to do!
+
+}
+
+vector<SnarlTraversal> NestedTraversalFinder::find_traversals(const Snarl& site) {
+    
+    // TODO: implement
+}
+
+pair<Support, vector<Visit>> NestedTraversalFinder::find_bubble(Node* node, Edge* edge, Snarl* child, const Snarl& site) {
+
+    // TODO: implement
+    
+}
+
+Support NestedTraversalFinder::min_support_in_path(const vector<Visit>& path) {
+    
+    // TODO: implement
+}
+
+set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_left(Visit root, const Snarl& site,
+    const map<NodeTraversal, const Snarl*>& child_boundary_index) {
+    
+    // Find paths left from the given visit to the start or end of the given
+    // ultrabubble.
+    
+    // Right now just finds the shortest path in nodes.
+
+    // Holds partial paths we want to return, with their lengths in visits.
+    set<pair<size_t, list<Visit>>> to_return;
+    
+    // Do a BFS
+    
+    // This holds the parent of each Visit in the queue, back to the initial
+    // rooting visit.
+    map<Visit, Visit> parents;
+    
+    // This holds all the visits we need to look at.
+    list<Visit> queue {root};
+    
+    while(!queue.empty()) {
+        // Keep going until we've emptied the queue
+        
+        // Dequeue a visit to continue from.
+        Visit to_extend_from = queue.front();
+        queue.pop_front();
+        
+        if (to_extend_from == site.start() || to_extend_from == site.end()) {
+            // We're done! Do a trace back.
+            
+            // Fill in this path
+            list<visit> path;           
+            
+            // With this cursor
+            Visit v = to_extend_from;
+            
+            while (v != root) {
+                // Until we get to the root, put this node on the path and get
+                // its parent.
+                path.push_back(v);
+                v = parents.at(v);
+            }
+            // We hit the root so add it to the path too.
+            path.push_back(v);
+            
+            // Add the path and its length to the list to return
+            to_return.push_back(make_pair(path.size(), path));
+            
+            // And go ahead and return it right now (since it's maximally short)
+            return to_return;
+        } else {
+            // We haven't reached a boundary, so just keep searching left from
+            // this visit.
+            vector<Visit> neighbors = visits_left(to_extend_from, augmented.graph, child_boundary_index);
+            
+            
+            // TODO: implement
+            // For each thing off the left
+            
+            // Check the edge to it to make sure it has coverage
+            
+            // If the next thing is a node, check it to make sure it has coverage
+            
+            // If the next thing is a snarl, maybe check its attached boundary node to make sure it has coverage?
+            
+            // If it checks out, queue each neighbor with this visit as its parent
+            
+        }
+        
+    }
+    
+    // We should never get here becuase we should eventually reach the end of
+    // the site we're searching.
+    throw runtime_error("Got lost in site in bfs_left!");
+}
+
+set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_right(Visit root, const Snarl& site,
+    const map<NodeTraversal, const Snarl*>& child_boundary_index) {
+
+    // Make a backwards version of the root
+    Visit root_rev = root;
+    root_rev.set_backward(!root_rev.backward());
+
+    // Look left from the backward version of the root
+    auto toConvert = bfs_left(rev_root, site, child_boundary_index);
+    
+    // Since we can't modify set records in place, we need to do a copy
+    set<pair<size_t, list<Visit>>> to_return;
+    
+    for(auto length_and_path : toConvert) {
+        // Flip every path to run the other way
+        length_and_path.second.reverse();
+        for(auto& visit : length_and_path.second) {
+            // And invert the orientation of every visit in the path in place.
+            visit.set_backward(!visit.backward());
+        }
+        // Stick it in the new set
+        to_return.emplace(move(length_and_path));
+    }
+    
+    return to_return;
+}
+
+}

--- a/src/nested_traversal_finder.cpp
+++ b/src/nested_traversal_finder.cpp
@@ -121,7 +121,7 @@ pair<Support, vector<Visit>> NestedTraversalFinder::find_bubble(Node* node, Edge
     // What are we going to find our left and right path halves based on?
     Visit left_visit;
     Visit right_visit;
-
+    
     if(edge != nullptr) {
         // Be edge-based
         

--- a/src/nested_traversal_finder.cpp
+++ b/src/nested_traversal_finder.cpp
@@ -30,8 +30,12 @@ protected:
      * Visits to the site's start and end nodes. Also return the minimum support
      * found on any edge or node in the bubble that is not contained within a
      * child.
+     *
+     * If there is no path with any support, returns a zero Support and an empty
+     * vector.
      */
-    pair<Support, vector<Visit>> find_bubble(Node* node, Edge* edge, Snarl* child, const Snarl& site);
+    pair<Support, vector<Visit>> find_bubble(Node* node, Edge* edge, Snarl* child,
+        const Snarl& site, const map<NodeTraversal, const Snarl*>& child_boundary_index);
         
     /**
      * Get the minimum support of all nodes and edges used in the given path
@@ -46,7 +50,7 @@ protected:
      *
      * Lengths are included so that shorter paths sort first.
      */
-    set<pair<size_t, list<Visit>>> search_left(Visit root, const Snarl& site,
+    set<pair<size_t, list<Visit>>> search_left(const Visit& root, const Snarl& site,
         const map<NodeTraversal, const Snarl*>& child_boundary_index);
         
     /**
@@ -56,7 +60,7 @@ protected:
      *
      * Lengths are included so that shorter paths sort first.
      */
-    set<pair<size_t, list<Visit>>> search_right(Visit root, const Snarl& site,
+    set<pair<size_t, list<Visit>>> search_right(const Visit& root, const Snarl& site,
         const map<NodeTraversal, const Snarl*>& child_boundary_index);
         
     /**
@@ -92,21 +96,124 @@ NestedTraversalFinder::NestedTraversalFinder(AugmentedGraph& augmented,
 
 vector<SnarlTraversal> NestedTraversalFinder::find_traversals(const Snarl& site) {
     
-    // TODO: implement
+    // For each node, edge, and child snarl, try and find a traversal that visits it
 }
 
-pair<Support, vector<Visit>> NestedTraversalFinder::find_bubble(Node* node, Edge* edge, Snarl* child, const Snarl& site) {
+pair<Support, vector<Visit>> NestedTraversalFinder::find_bubble(Node* node, Edge* edge, Snarl* child, const Snarl& site, const map<NodeTraversal, const Snarl*>& child_boundary_index) {
 
-    // TODO: implement
+    // What are we going to find our left and right path halves based on?
+    Visit left_visit;
+    Visit right_visit;
+
+    if(edge != nullptr) {
+        // Be edge-based
+        
+        // TODO: if the edge has no support, don't go looking for a path
+        
+        // Find the nodes at the ends of the edges. Look at them traversed in the
+        // edge's local orientation.
+        left_visit.set_node_id(edge->from());
+        left_visit.set_backward(edge->from_start());
+        
+        right_visit.set_node_id(edge->to());
+        right_visit.set_backward(edge->to_end());
+    } else if (node != nullptr) {
+        // Be node-based. Both roots are the same visit
+        left_visit.set_node_id(node->id());
+        right_visit = left_visit;
+    } else {
+        // We must be child-based
+        assert(child != nullptr);
+        
+        // Both roots are the same child snarl visit
+        transfer_boundary_info(*child, *left_visit.mutable_snarl());
+        right_visit = left_visit;
+    }
+    
+    // Find paths on both sides, anchored into the outside of our snarl. Returns
+    // path lengths (in visits) and paths in pairs in a set.
+    auto left_paths = search_left(left_visit, site, child_boundary_index);
+    auto right_paths = search_right(right_visit, site, child_boundary_index);
+    
+    // Now splice the paths together to get max support.
+    
+    // TODO: implement that. For now just get any path with nonzero support.
+    
+    for (auto& left : left_paths) {
+        for (auto& right : right_paths) {
+            // Splice together the first path from each set
+            
+            // Start witht he whole left path
+            vector<Visit> spliced_path {left.second.begin(), left.second.end()};
+            
+            auto it = right.second.begin();
+            if (it != right.second.end() && !spliced_path.empty() && *it == spliced_path.back()) {
+                // If the right path starts with the same visit the left path ended with, skip it.
+                ++it;
+            }
+            
+            // Copy over the rest of the right side path
+            copy(it, right.second.end(), back_inserter(spliced_path));
+            
+            // Return this spliced-together path with its support
+            return make_pair(min_support_in_path(spliced_path), spliced_path);
+            
+        }
+    }
+    
+    // If we get here there's no pair of paths to combine. Return the zero value.
+    return pair<Support, vector<Visit>>();
     
 }
 
 Support NestedTraversalFinder::min_support_in_path(const vector<Visit>& path) {
     
-    // TODO: implement
+    if (path.empty()) {
+        return Support();
+    }
+    // We look at the current visit and the next visit so we can think about
+    // edges.
+    auto cur = path.begin();
+    auto next = path.begin();
+    ++next;
+    
+    // We have a function to get the support for a visit
+    function<Support(const Visit&)> support_for_visit = [&](const Visit& v) { 
+        if (v.node_id()) {
+            // This is a node visit
+            Node* node = augmented.graph.get_node(v.node_id());
+            
+            // Return the support for it, or 0 if it's not in the map.
+            return augmented.node_supports.count(node) ? augmented.node_supports.at(node) : Support();
+        } else {
+            // It's a snarl visit. We assume it goes in one side and out the
+            // other.
+            
+            // We don't inspect the whole snarl, but we know you have to visit
+            // the start and end nodes, so we look at them.
+            return support_min(support_for_visit(v.snarl().start()), support_for_visit(v.snarl().end()));
+        }
+    }; 
+    
+    // Start out with the support for the current visit.
+    Support min_support = support_for_visit(*cur);
+    for (; next != path.end(); ++cur, ++next) {
+        // For each subsequent node next
+    
+        // check the node support
+        min_support = support_min(min_support, support_for_visit(*next));
+        
+        // check the edge support
+        Edge* edge = augmented.graph.get_edge(to_left_side(*cur), to_right_side(*next));
+        assert(edge != NULL);
+        Support edge_support = augmented.edge_supports.count(edge) ? augmented.edge_supports.at(edge) : Support();
+        min_support = support_min(min_support, edge_support);
+    }
+
+    return min_support;
 }
 
-set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_left(Visit root, const Snarl& site,
+set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_left(const Visit& root, const Snarl& site,
     const map<NodeTraversal, const Snarl*>& child_boundary_index) {
     
     // Find paths left from the given visit to the start or end of the given
@@ -161,28 +268,46 @@ set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_left(Visit root, co
             // this visit.
             vector<Visit> neighbors = visits_left(to_extend_from, augmented.graph, child_boundary_index);
             
-            
-            // TODO: implement
-            // For each thing off the left
-            
-            // Check the edge to it to make sure it has coverage
-            
-            // If the next thing is a node, check it to make sure it has coverage
-            
-            // If the next thing is a snarl, maybe check its attached boundary node to make sure it has coverage?
-            
-            // If it checks out, queue each neighbor with this visit as its parent
+            for (auto& extension : neighbors) {
+                // For each thing off the left
+                
+                if (parents.count(extension)) {
+                    // This next node is already reachable by a path this short or shorter.
+                    continue;
+                }
+                
+                // Check the edge to it to make sure it has coverage
+                Edge* edge = augmented.graph.get_edge(to_right_side(extension), to_left_side(to_extend_from));
+                
+                if (!augmented.edge_supports.count(edge) || total(augmented.edge_supports.at(edge)) == 0) {
+                    // This edge is not supported, so don't explore this extension.
+                    continue;
+                }
+
+                // Look up the node we're entering (either the snarl boundary or
+                // just the node we're going to visit), so we can check to make
+                // sure it has coverage.
+                Node* node = augmented.graph.get_node(to_right_side(extension).node);
+                
+                if (!augmented.node_supports.count(node) || total(augmented.node_supports.at(node)) == 0) {
+                    // This node is not supported, so don't explore this extension.
+                    continue;
+                }
+                
+                // If it checks out, queue the neighbor with this visit as its parent
+                parents[extension] = to_extend_from;
+                queue.push_back(extension);
+            }
             
         }
         
     }
     
-    // We should never get here becuase we should eventually reach the end of
-    // the site we're searching.
-    throw runtime_error("Got lost in site in search_left!");
+    // If we get here, no path with any support was found. Return our still-empty set.
+    return to_return;
 }
 
-set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_right(Visit root, const Snarl& site,
+set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_right(const Visit& root, const Snarl& site,
     const map<NodeTraversal, const Snarl*>& child_boundary_index) {
 
     // Make a backwards version of the root

--- a/src/nested_traversal_finder.cpp
+++ b/src/nested_traversal_finder.cpp
@@ -137,7 +137,7 @@ set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_left(Visit root, co
             // We're done! Do a trace back.
             
             // Fill in this path
-            list<visit> path;           
+            list<Visit> path;           
             
             // With this cursor
             Visit v = to_extend_from;
@@ -152,7 +152,7 @@ set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_left(Visit root, co
             path.push_back(v);
             
             // Add the path and its length to the list to return
-            to_return.push_back(make_pair(path.size(), path));
+            to_return.insert(make_pair(path.size(), path));
             
             // And go ahead and return it right now (since it's maximally short)
             return to_return;
@@ -179,7 +179,7 @@ set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_left(Visit root, co
     
     // We should never get here becuase we should eventually reach the end of
     // the site we're searching.
-    throw runtime_error("Got lost in site in bfs_left!");
+    throw runtime_error("Got lost in site in search_left!");
 }
 
 set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_right(Visit root, const Snarl& site,
@@ -190,12 +190,12 @@ set<pair<size_t, list<Visit>>> NestedTraversalFinder::search_right(Visit root, c
     root_rev.set_backward(!root_rev.backward());
 
     // Look left from the backward version of the root
-    auto toConvert = bfs_left(rev_root, site, child_boundary_index);
+    auto to_convert = search_left(root_rev, site, child_boundary_index);
     
     // Since we can't modify set records in place, we need to do a copy
     set<pair<size_t, list<Visit>>> to_return;
     
-    for(auto length_and_path : toConvert) {
+    for(auto length_and_path : to_convert) {
         // Flip every path to run the other way
         length_and_path.second.reverse();
         for(auto& visit : length_and_path.second) {

--- a/src/nested_traversal_finder.cpp
+++ b/src/nested_traversal_finder.cpp
@@ -1,90 +1,11 @@
-/// \file nested_traversal_finder.cpp: Contains implementation for a TraversalFinder that works on non-leaf Snarls.
+/// \file nested_traversal_finder.cpp: Contains implementation for a
+/// TraversalFinder that works on non-leaf Snarls and produces covering paths.
 
-#include "genotypekit.hpp"
+#include "nested_traversal_finder.hpp"
 
 namespace vg {
 
 using namespace std;
-
-/**
- * This TraversalFinder emits at least one traversal representing every node,
- * edge, or child Snarl. Only works on ultrabubbles, and so does not handle
- * cycles.
- */
-class NestedTraversalFinder : public TraversalFinder {
-
-protected:
-    /// The annotated, augmented graph we're finding traversals in
-    AugmentedGraph& augmented;
-    /// The SnarlManager managiung the snarls we use
-    SnarlManager& snarl_manager;
-    
-    /**
-     * Given an edge or node or child snarl in the augmented graph, look out
-     * from the edge or node or child in both directions to find a shortest
-     * bubble connecting the start and end of the given site.
-     *
-     * Exactly one of edge and node and child must be non-null.
-     *
-     * Return the found traversal as a vector of Visits, including anchoring
-     * Visits to the site's start and end nodes. Also return the minimum support
-     * found on any edge or node in the bubble that is not contained within a
-     * child.
-     *
-     * If there is no path with any support, returns a zero Support and a
-     * possibly empty Path.
-     */
-    pair<Support, vector<Visit>> find_bubble(Node* node, Edge* edge, const Snarl* child,
-        const Snarl& site, const map<NodeTraversal, const Snarl*>& child_boundary_index);
-        
-    /**
-     * Get the minimum support of all nodes and edges used in the given path
-     * that are not inside child snarls.
-     */
-    Support min_support_in_path(const vector<Visit>& path);
-        
-    /**
-     * Do a breadth-first search left from the given node traversal, and return
-     * lengths (in visits) and paths starting at the given node and ending on
-     * the given indexed path. Refuses to visit nodes with no support.
-     *
-     * Lengths are included so that shorter paths sort first.
-     */
-    set<pair<size_t, list<Visit>>> search_left(const Visit& root, const Snarl& site,
-        const map<NodeTraversal, const Snarl*>& child_boundary_index);
-        
-    /**
-     * Do a breadth-first search right from the given node traversal, and return
-     * lengths (in visits) and paths starting at the given node and ending on
-     * the given indexed path.
-     *
-     * Lengths are included so that shorter paths sort first.
-     */
-    set<pair<size_t, list<Visit>>> search_right(const Visit& root, const Snarl& site,
-        const map<NodeTraversal, const Snarl*>& child_boundary_index);
-        
-    /**
-     * Get the length of a path through nodes and child sites, in base pairs.
-     * Ignores any bases inside child sites.
-     */
-    size_t bp_length(const list<Visit>& path);
-    
-public:
-
-    NestedTraversalFinder(AugmentedGraph& augmented, SnarlManager& snarl_manager);
-    
-    /// Should we emit verbose debugging info?
-    bool verbose = false;
-    
-    virtual ~NestedTraversalFinder() = default;
-    
-    /**
-     * Find traversals to cover the nodes, edges, and children of the snarl.
-     * Always emits the primary path traversal first, if applicable.
-     */
-    virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
-    
-};
 
 
 NestedTraversalFinder::NestedTraversalFinder(AugmentedGraph& augmented,

--- a/src/nested_traversal_finder.hpp
+++ b/src/nested_traversal_finder.hpp
@@ -1,0 +1,95 @@
+#ifndef VG_NESTED_TRAVERSAL_FINDER_H
+#define VG_NESTED_TRAVERSAL_FINDER_H
+
+/// \file nested_traversal_finder.hpp: Defines a TraversalFinder that produces
+/// covering paths, with an awareness of nested Snarls.
+
+#include "genotypekit.hpp"
+
+namespace vg {
+
+using namespace std;
+
+/**
+ * This TraversalFinder emits at least one traversal representing every node,
+ * edge, or child Snarl. Only works on ultrabubbles, and so does not handle
+ * cycles.
+ */
+class NestedTraversalFinder : public TraversalFinder {
+
+protected:
+    /// The annotated, augmented graph we're finding traversals in
+    AugmentedGraph& augmented;
+    /// The SnarlManager managiung the snarls we use
+    SnarlManager& snarl_manager;
+    
+    /**
+     * Given an edge or node or child snarl in the augmented graph, look out
+     * from the edge or node or child in both directions to find a shortest
+     * bubble connecting the start and end of the given site.
+     *
+     * Exactly one of edge and node and child must be non-null.
+     *
+     * Return the found traversal as a vector of Visits, including anchoring
+     * Visits to the site's start and end nodes. Also return the minimum support
+     * found on any edge or node in the bubble that is not contained within a
+     * child.
+     *
+     * If there is no path with any support, returns a zero Support and a
+     * possibly empty Path.
+     */
+    pair<Support, vector<Visit>> find_bubble(Node* node, Edge* edge, const Snarl* child,
+        const Snarl& site, const map<NodeTraversal, const Snarl*>& child_boundary_index);
+        
+    /**
+     * Get the minimum support of all nodes and edges used in the given path
+     * that are not inside child snarls.
+     */
+    Support min_support_in_path(const vector<Visit>& path);
+        
+    /**
+     * Do a breadth-first search left from the given node traversal, and return
+     * lengths (in visits) and paths starting at the given node and ending on
+     * the given indexed path. Refuses to visit nodes with no support.
+     *
+     * Lengths are included so that shorter paths sort first.
+     */
+    set<pair<size_t, list<Visit>>> search_left(const Visit& root, const Snarl& site,
+        const map<NodeTraversal, const Snarl*>& child_boundary_index);
+        
+    /**
+     * Do a breadth-first search right from the given node traversal, and return
+     * lengths (in visits) and paths starting at the given node and ending on
+     * the given indexed path.
+     *
+     * Lengths are included so that shorter paths sort first.
+     */
+    set<pair<size_t, list<Visit>>> search_right(const Visit& root, const Snarl& site,
+        const map<NodeTraversal, const Snarl*>& child_boundary_index);
+        
+    /**
+     * Get the length of a path through nodes and child sites, in base pairs.
+     * Ignores any bases inside child sites.
+     */
+    size_t bp_length(const list<Visit>& path);
+    
+public:
+
+    NestedTraversalFinder(AugmentedGraph& augmented, SnarlManager& snarl_manager);
+    
+    /// Should we emit verbose debugging info?
+    bool verbose = false;
+    
+    virtual ~NestedTraversalFinder() = default;
+    
+    /**
+     * Find traversals to cover the nodes, edges, and children of the snarl.
+     * Always emits the primary path traversal first, if applicable.
+     */
+    virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
+    
+};
+
+}
+
+#endif

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -492,6 +492,8 @@ namespace vg {
             }
         }
         
+        return to_return;
+        
     }
     
     vector<Visit> visits_left(const Visit& visit, VG& graph,

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -505,6 +505,103 @@ namespace vg {
         return visits_right(reversed, graph, child_boundary_index);
         
     }
+    
+    bool operator==(const Visit& a, const Visit& b) {
+        // IDs and orientations have to match, and nobody has a snarl or the
+        // snarls match.
+        return a.node_id() == b.node_id() &&
+            a.backward() == b.backward() &&
+            ((!a.has_snarl() && !b.has_snarl()) ||
+            a.snarl() == b.snarl());
+    }
+    
+    bool operator!=(const Visit& a, const Visit& b) {
+        return !(a == b);
+    }
+    
+    bool operator<(const Visit& a, const Visit& b) {
+        if (!a.has_snarl() && !b.has_snarl()) {
+            // Compare everything but the snarl
+            return make_tuple(a.node_id(), a.backward()) < make_tuple(b.node_id(), b.backward());
+        } else {
+            // Compare including the snarl
+            return make_tuple(a.node_id(), a.snarl(), a.backward()) < make_tuple(b.node_id(), b.snarl(), b.backward());
+        }        
+    }
+    
+    bool operator==(const SnarlTraversal& a, const SnarlTraversal& b) {
+        if (a.snarl() != b.snarl()) {
+            return false;
+        }
+        if (a.visits_size() != b.visits_size()) {
+            return false;
+        }
+        for (size_t i = 0; i < a.visits_size(); i++) {
+            if (a.visits(i) != b.visits(i)) {
+                return false;
+            }
+        }
+        // Otherwise everything we can think of matches
+        return true;
+    }
+    
+    bool operator!=(const SnarlTraversal& a, const SnarlTraversal& b) {
+        return !(a == b);
+    }
+    
+    bool operator<(const SnarlTraversal& a, const SnarlTraversal& b) {
+        if (a.snarl() < b.snarl()) {
+            return true;
+        } else if (b.snarl() < a.snarl()) {
+            return false;
+        }
+        for (size_t i = 0; i < b.visits_size(); i++) {
+            if (i >= a.visits_size()) {
+                // A has run out and B is still going
+                return true;
+            }
+            
+            if (a.visits(i) < b.visits(i)) {
+                return true;
+            } else if (b.visits(i) < a.visits(i)) {
+                return false;
+            }
+        }
+        
+        // If we get here either they're equal or A has more visits than B
+        return false;
+    }
+    
+    bool operator==(const Snarl& a, const Snarl& b) {
+        if (a.type() != b.type()) {
+            return false;
+        }
+        if (a.start() != b.start()) {
+            return false;
+        }
+        if (a.end() != b.end()) {
+            return false;
+        }
+        if (a.has_parent() || b.has_parent()) {
+            // Someone has a parent so we must compare them.
+            return a.parent() == b.parent();
+        }
+        return true;
+    }
+    
+    bool operator!=(const Snarl& a, const Snarl& b) {
+        return !(a == b);
+    }
+    
+    bool operator<(const Snarl& a, const Snarl& b) {
+        if (!a.has_parent() && !b.has_parent()) {
+            // Compare without parent
+            return make_tuple(a.type(), a.start(), a.end()) < make_tuple(b.type(), b.start(), b.end());
+        } else {
+            // Compare with parent
+            return make_tuple(a.type(), a.start(), a.end(), a.parent()) < make_tuple(b.type(), b.start(), b.end(), b.parent());
+        }
+    }
 }
 
 

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -441,6 +441,70 @@ namespace vg {
         
         return to_return;
     }
+    
+    vector<Visit> visits_right(const Visit& visit, VG& graph,
+        const map<NodeTraversal, const Snarl*>& child_boundary_index) {
+        
+        // We'll populate this
+        vector<Visit> to_return;
+        
+        // Find the right side of the visit we're on
+        NodeSide right_side = to_right_side(visit);
+        
+        for (auto attached : graph.sides_of(right_side)) {
+            // For every NodeSide attached to the right side of this visit
+            
+            // Make it a NodeTraversal reading away from that side
+            NodeTraversal attached_traversal(graph.get_node(attached.node), attached.is_end);
+            
+            if (child_boundary_index.count(attached_traversal)) {
+                // We're reading into a child
+                
+                // Which child is it?
+                const Snarl* child = child_boundary_index.at(attached_traversal);
+                
+                if (attached.node == child->start().node_id()) {
+                    // We're reading into the start of the child
+                    
+                    // Make a visit to the child snarl
+                    Visit child_visit;
+                    transfer_boundary_info(*child, *child_visit.mutable_snarl());
+                    
+                    // Put it in in the forward orientation
+                    to_return.push_back(child_visit);
+                } else if (attached.node == child->end().node_id()) {
+                    // We're reading into the end of the child
+                    
+                    // Make a visit to the child snarl
+                    Visit child_visit;
+                    transfer_boundary_info(*child, *child_visit.mutable_snarl());
+                    child_visit.set_backward(true);
+                    
+                    // Put it in in the reverse orientation
+                    to_return.push_back(child_visit);
+                } else {
+                    // Should never happen
+                    throw runtime_error("Read into child " + pb2json(*child) + " with non-matching traversal");
+                }
+            } else {
+                // We just go into a normal node
+                to_return.push_back(to_visit(attached_traversal));
+            }
+        }
+        
+    }
+    
+    vector<Visit> visits_left(const Visit& visit, VG& graph,
+        const map<NodeTraversal, const Snarl*>& child_boundary_index) {
+        
+        // Reverse the visit
+        Visit reversed = visit;
+        reversed.set_backward(!reversed.backward());
+        
+        // Return everything right of the reversed version
+        return visits_right(reversed, graph, child_boundary_index);
+        
+    }
 }
 
 

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -229,6 +229,7 @@ namespace vg {
     }
     
     inline NodeSide to_left_side(const Visit& visit) {
+        assert(visit.node_id() || (visit.snarl().start().node_id() && visit.snarl().end().node_id()));
         if (visit.node_id()) {
             // Just report the left side of this node
             return NodeSide(visit.node_id(), visit.backward());
@@ -246,6 +247,7 @@ namespace vg {
     }
     
     inline NodeSide to_right_side(const Visit& visit) {
+        assert(visit.node_id() || (visit.snarl().start().node_id() && visit.snarl().end().node_id()));
         if (visit.node_id()) {
             // Just report the right side of this node
             return NodeSide(visit.node_id(), !visit.backward());

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -150,14 +150,59 @@ namespace vg {
     inline void transfer_boundary_info(const Snarl& from, Snarl& to);
     
     // We need some Visit operators
+    
+    /**
+     * Two Visits are equal if they represent the same traversal of the same
+     * Node or Snarl.
+     */
     bool operator==(const Visit& a, const Visit& b);
+    /**
+     * Two Visits are unequal if they are not equal.
+     */
     bool operator!=(const Visit& a, const Visit& b);
+    /**
+     * A Visit is less than another Visit if it represents a traversal of a
+     * smaller node, or it represents a traversal of a smaller snarl, or it
+     * represents a traversal of the same node or snarl forward instead of
+     * backward.
+     */
     bool operator<(const Visit& a, const Visit& b);
     
     // And some operators for SnarlTraversals
+    
+    /**
+     * Two SnarlTraversals are equal if their snarls are equal and they have the
+     * same number of visits and all their visits are equal.
+     */
     bool operator==(const SnarlTraversal& a, const SnarlTraversal& b);
+    /**
+     * Two SnarlTraversals are unequal if they are not equal.
+     */
     bool operator!=(const SnarlTraversal& a, const SnarlTraversal& b);
+    /**
+     * A SnalTraversal is less than another if it is a traversal of a smaller
+     * Snarl, or if its list of Visits has a smaller Visit first, or if its list
+     * of Visits is shorter.
+     */
     bool operator<(const SnarlTraversal& a, const SnarlTraversal& b);
+    
+    // And some operators for Snarls
+    
+    /**
+     * Two Snarls are equal if their types are equal and their bounding Visits
+     * are equal and their parents are equal.
+     */
+    bool operator==(const Snarl& a, const Snarl& b);
+    /**
+     * Two Snarls are unequal if they are not equal.
+     */
+    bool operator!=(const Snarl& a, const Snarl& b);
+    /**
+     * A Snarl is less than another Snarl if its type is smaller, or its start
+     * Visit is smaller, or its end Visit is smaller, or its parent is smaller.
+     */
+    bool operator<(const Snarl& a, const Snarl& b);
+    
     
     /****
      * Template and Inlines:

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -154,6 +154,11 @@ namespace vg {
     bool operator!=(const Visit& a, const Visit& b);
     bool operator<(const Visit& a, const Visit& b);
     
+    // And some operators for SnarlTraversals
+    bool operator==(const SnarlTraversal& a, const SnarlTraversal& b);
+    bool operator!=(const SnarlTraversal& a, const SnarlTraversal& b);
+    bool operator<(const SnarlTraversal& a, const SnarlTraversal& b);
+    
     /****
      * Template and Inlines:
      ****/

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -151,6 +151,7 @@ namespace vg {
     
     // We need some Visit operators
     bool operator==(const Visit& a, const Visit& b);
+    bool operator!=(const Visit& a, const Visit& b);
     bool operator<(const Visit& a, const Visit& b);
     
     /****

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -75,6 +75,7 @@ void help_mod(char** argv) {
          << "    -B, --bluntify          bluntify the graph, making nodes for duplicated sequences in overlaps" << endl
          << "    -a, --cactus            convert to cactus graph representation" << endl
          << "    -v, --sample-vcf FILE   for a graph with allele paths, compute the sample graph from the given VCF" << endl
+         << "    -G, --sample-graph FILE subset an augmented graph to a sample graph using a Locus file" << endl
          << "    -t, --threads N         for tasks that can be done in parallel, use this many threads" << endl;
 }
 
@@ -126,6 +127,7 @@ int main_mod(int argc, char** argv) {
     bool flip_doubly_reversed_edges = false;
     bool cactus = false;
     string vcf_filename;
+    string loci_filename;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -176,11 +178,12 @@ int main_mod(int argc, char** argv) {
             {"unreverse-edges", required_argument, 0, 'E'},
             {"cactus", no_argument, 0, 'a'},
             {"sample-vcf", required_argument, 0, 'v'},
+            {"sample-fraph", required_argument, 0, 'G'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hk:oi:q:Q:cpl:e:mt:SX:KPsunzNf:CDFr:Ig:x:RTU:Bbd:Ow:L:y:Z:Eav:",
+        c = getopt_long (argc, argv, "hk:oi:q:Q:cpl:e:mt:SX:KPsunzNf:CDFr:Ig:x:RTU:Bbd:Ow:L:y:Z:Eav:G:",
                 long_options, &option_index);
 
 
@@ -359,6 +362,10 @@ int main_mod(int argc, char** argv) {
         case 'v':
             vcf_filename = optarg;
             break;
+            
+        case 'G':
+            loci_filename = optarg;
+            break;
 
         case 'h':
         case '?':
@@ -530,6 +537,81 @@ int main_mod(int argc, char** argv) {
             graph->destroy_node(node_id);
         }
 
+    }
+    
+    if (!loci_filename.empty()) {
+        // Open the file
+        ifstream loci_file(loci_filename);
+        assert(loci_file.is_open());
+    
+        // What nodes and edges are called as present by the loci?
+        set<Node*> called_nodes;
+        set<Edge*> called_edges;
+    
+        function<void(Locus&)> lambda = [&](Locus& locus) {
+            // For each locus
+            
+            if (locus.genotype_size() == 0) {
+                // No call made here. Just remove all the nodes/edges. TODO:
+                // should we keep them all if we don't know if they're there or
+                // not? Or should the caller call ref with some low confidence?
+                return;
+            }
+            
+            const Genotype& gt = locus.genotype(0);
+            
+            for (size_t j = 0; j < gt.allele_size(); j++) {
+                // For every allele called as present
+                int allele_number = gt.allele(j);
+                const Path& allele = locus.allele(allele_number);
+                
+                for (size_t i = 0; i < allele.mapping_size(); i++) {
+                    // For every Mapping in the allele
+                    const Mapping& m = allele.mapping(i);
+                    
+                    // Remember to keep this node
+                    called_nodes.insert(graph->get_node(m.position().node_id()));
+                    
+                    if (i + 1 < allele.mapping_size()) {
+                        // Look at the next mapping, which exists
+                        const Mapping& m2 = allele.mapping(i + 1);
+                        
+                        // Find the edge from the last Mapping's node to this one and mark it as used
+                        called_edges.insert(graph->get_edge(NodeSide(m.position().node_id(), !m.position().is_reverse()),
+                            NodeSide(m2.position().node_id(), m2.position().is_reverse())));
+                    }
+                }
+            }
+        };
+        stream::for_each(loci_file, lambda);
+        
+        // Collect all the unused nodes and edges (so we don't try to delete
+        // while iterating...)
+        set<Node*> unused_nodes;
+        set<Edge*> unused_edges;
+        
+        graph->for_each_node([&](Node* n) {
+            if (!called_nodes.count(n)) {
+                unused_nodes.insert(n);
+            }
+        });
+        
+        graph->for_each_edge([&](Edge* e) {
+            if (!called_edges.count(e)) {
+                unused_edges.insert(e);
+            }
+        });
+        
+        
+        
+        // Destroy all the extra edges (in case they use extra nodes)
+        for (auto* e : unused_edges) {
+            graph->destroy_edge(e);
+        }
+        
+        for (auto* n : unused_nodes) {
+            graph->destroy_node(n);
+        }
     }
 
     if (bluntify) {


### PR DESCRIPTION
Add an (untested) TraversalFinder that finds some representative traversals of sites with children.

Also adds calling of edges (and their nodes) outside of any called ultrabubble, and some code to subset an augmented graph to a sample graph using loci.