### PR TITLE
Perfect confusion

### DIFF
--- a/scripts/map-sim
+++ b/scripts/map-sim
@@ -1,56 +1,75 @@
 #!/bin/bash
 
+if [ $# -ne 5 ];
+then
+    echo "usage: "$(basename $0) "[output-dir] [fasta-ref] [vg-ref] [vg-pan] [num-reads]"
+    exit
+fi
+
+output=$1
+fasta=$2
+ref=$3
+pan=$4
+num_reads=$5
+
+pan_xg=$pan.xg
+pan_gcsa=$pan.gcsa
+ref_xg=$ref.xg
+ref_gcsa=$ref.gcsa
+
+mkdir -p $output
+
 # Get the vg id
-cd ~/vg && id=$(git log | head -1 | cut -f 2 -d\ | head -c 8) && cd -
+id=$(vg version | cut -f 3 -d- | tail -c 8 | head -c 7)
 echo testing vg-$id
 
 # Generate 500k read pairs (1M reads) and their "true" positions from the vg graph:
 echo generating simulated reads
-time vg sim -s 271 -n 500000 -l 150 -p 500 -v 50 -x ~/pan/vg/index.xg -a | tee sim.gam | vg annotate -p -x ~/pan/vg/index.xg -a - | vg view -a - | jq -c -r '[ .name, .refpos[0].name, .refpos[0].offset ] | @tsv' | pv -l | sort >true.pos
+time vg sim -s 271 -n $num_reads -l 150 -p 500 -v 50 -x $pan_xg -a | tee $output/sim.gam | vg annotate -p -x $pan_xg -a - | vg view -a - | jq -c -r '[ .name, .refpos[0].name, .refpos[0].offset ] | @tsv' | pv -l | sort >$output/true.pos
 
 # This can then be mapped six ways.
 
 # By bwa:
 # first split the file into the mates
-vg view -a sim.gam | jq -cr 'select(.name | test("_1$"))' | pv -l | vg view -JaG - | vg view -X - | sed s/_1$// | gzip >sim_1.fq.gz
-vg view -a sim.gam | jq -cr 'select(.name | test("_2$"))' | pv -l | vg view -JaG - | vg view -X - | sed s/_2$// | gzip >sim_2.fq.gz
+vg view -a $output/sim.gam | jq -cr 'select(.name | test("_1$"))' | pv -l | vg view -JaG - | vg view -X - | sed s/_1$// | gzip >$output/sim_1.fq.gz
+vg view -a $output/sim.gam | jq -cr 'select(.name | test("_2$"))' | pv -l | vg view -JaG - | vg view -X - | sed s/_2$// | gzip >$output/sim_2.fq.gz
 # then map, correcting the names so they match vg's
 echo bwa mem paired mapping
-time bwa mem -t 32 ~/hs37d5/hs37d5.fa sim_1.fq.gz sim_2.fq.gz | grep -v ^@ | perl -ne '@val = split("\t", $_); print @val[0] . "_" . (@val[1] & 64 ? "1" : @val[1] & 128 ? "2" : "?"), "\t" . @val[2] . "\t" . @val[3] . "\t" . @val[4] . "\n";' | pv -l | sort >bwa_mem-pe.pos
-join true.pos bwa_mem-pe.pos | ~/vg/scripts/pos_compare.py >bwa-pe.compare
+time bwa mem -t 32 $fasta $output/sim_1.fq.gz $output/sim_2.fq.gz | grep -v ^@ | perl -ne '@val = split("\t", $_); print @val[0] . "_" . (@val[1] & 64 ? "1" : @val[1] & 128 ? "2" : "?"), "\t" . @val[2] . "\t" . @val[3] . "\t" . @val[4] . "\n";' | pv -l | sort >$output/bwa_mem-pe.pos
+join $output/true.pos $output/bwa_mem-pe.pos | ~/vg/scripts/pos_compare.py >$output/bwa-pe.compare
 # map single end
 echo bwa mem single mapping
-time bwa mem -t 32 ~/hs37d5/hs37d5.fa <(vg view -X sim.gam) | grep -v ^@ | pv -l | cut -f 1,3,4,5 | sort >bwa_mem-se.pos
-join true.pos bwa_mem-se.pos | ~/vg/scripts/pos_compare.py >bwa-se.compare
+time bwa mem -t 32 $fasta <(vg view -X $output/sim.gam) | grep -v ^@ | pv -l | cut -f 1,3,4,5 | sort >$output/bwa_mem-se.pos
+join $output/true.pos $output/bwa_mem-se.pos | ~/vg/scripts/pos_compare.py >$output/bwa-se.compare
 
 # By vg-ref:
 echo vg ref paired mapping
-time vg map -iG sim.gam -x ~/ref/vg/index.xg -g ~/ref/vg/index.gcsa -t 32 | vg annotate -x ~/ref/vg/index.xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >vg-ref-pe.pos
-join true.pos vg-ref-pe.pos | ~/vg/scripts/pos_compare.py >vg-ref-pe.compare
+time vg map -iG $output/sim.gam -x $ref_xg -g $ref_gcsa -t 32 | vg annotate -x $ref_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-ref-pe.pos
+join $output/true.pos $output/vg-ref-pe.pos | ~/vg/scripts/pos_compare.py >$output/vg-ref-pe.compare
 echo vg ref single mapping
-time vg map -G sim.gam -x ~/ref/vg/index.xg -g ~/ref/vg/index.gcsa -t 32 | vg annotate -x ~/ref/vg/index.xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >vg-ref-se.pos
-join true.pos vg-ref-se.pos | ~/vg/scripts/pos_compare.py >vg-ref-se.compare
+time vg map -G $output/sim.gam -x $ref_xg -g $ref_gcsa -t 32 | vg annotate -x $ref_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-ref-se.pos
+join $output/true.pos $output/vg-ref-se.pos | ~/vg/scripts/pos_compare.py >$output/vg-ref-se.compare
 
 # By vg-pan:
 echo vg pan paired mappping
-time vg map -iG sim.gam -x ~/pan/vg/index.xg -g ~/pan/vg/index.gcsa -t 32 | vg annotate -x ~/pan/vg/index.xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >vg-pan-pe.pos
-join true.pos vg-pan-pe.pos | ~/vg/scripts/pos_compare.py >vg-pan-pe.compare
+time vg map -iG $output/sim.gam -x $pan_xg -g $pan_gcsa -t 32 | vg annotate -x $pan_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-pan-pe.pos
+join $output/true.pos $output/vg-pan-pe.pos | ~/vg/scripts/pos_compare.py >$output/vg-pan-pe.compare
 echo vg pan single mappping
-time vg map -G sim.gam -x ~/pan/vg/index.xg -g ~/pan/vg/index.gcsa -t 32 | vg annotate -x ~/pan/vg/index.xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >vg-pan-se.pos
-join true.pos vg-pan-se.pos | ~/vg/scripts/pos_compare.py >vg-pan-se.compare
+time vg map -G $output/sim.gam -x $pan_xg -g $pan_gcsa -t 32 | vg annotate -x $pan_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-pan-se.pos
+join $output/true.pos $output/vg-pan-se.pos | ~/vg/scripts/pos_compare.py >$output/vg-pan-se.compare
 
 # Now we combine the various positions into one table
 
 echo combining results
-( cat bwa-pe.compare    | awk 'BEGIN { OFS="\t"; print "correct", "mq", "aligner"; } { print $2, $3, "bwa.mem.pe" }' ;
-  cat bwa-se.compare | awk 'BEGIN { OFS="\t"} { print $2, $3, "bwa.mem.se" }' ;
-  cat vg-ref-pe.compare | awk 'BEGIN { OFS="\t"} { print $2, $3, "vg.ref.pe" }' ;
-  cat vg-ref-se.compare | awk 'BEGIN { OFS="\t"} { print $2, $3, "vg.ref.se" }' ;
-  cat vg-pan-pe.compare | awk 'BEGIN { OFS="\t"} { print $2, $3, "vg.pan.pe" }' ;
-  cat vg-pan-se.compare | awk 'BEGIN { OFS="\t"} { print $2, $3, "vg.pan.se" }') >results-$id.tsv
+( cat $output/bwa-pe.compare | awk 'BEGIN { OFS="\t"; print "correct", "mq", "aligner"; } { print $2, $3, "bwa.mem.pe" }' ;
+  cat $output/bwa-se.compare | awk 'BEGIN { OFS="\t"} { print $2, $3, "bwa.mem.se" }' ;
+  cat $output/vg-ref-pe.compare | awk 'BEGIN { OFS="\t"} { print $2, $3, "vg.ref.pe" }' ;
+  cat $output/vg-ref-se.compare | awk 'BEGIN { OFS="\t"} { print $2, $3, "vg.ref.se" }' ;
+  cat $output/vg-pan-pe.compare | awk 'BEGIN { OFS="\t"} { print $2, $3, "vg.pan.pe" }' ;
+  cat $output/vg-pan-se.compare | awk 'BEGIN { OFS="\t"} { print $2, $3, "vg.pan.se" }') >$output/results-$id.tsv
 
 # This can then be rendered using scripts in the vg repo
 echo rendering ROC
-~/vg/scripts/roc.R results-$id.tsv roc-$id.pdf
+~/vg/scripts/roc.R $output/results-$id.tsv $output/roc-$id.pdf
 echo rendering QQ
-~/vg/scripts/qq.R results-$id.tsv qq-$id.pdf
+~/vg/scripts/qq.R $output/results-$id.tsv $output/qq-$id.pdf

--- a/scripts/map-sim
+++ b/scripts/map-sim
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-if [ $# -ne 5 ];
+if [ $# -ne 6 ];
 then
-    echo "usage: "$(basename $0) "[output-dir] [fasta-ref] [vg-ref] [vg-pan] [num-reads]"
+    echo "usage: "$(basename $0) "[output-dir] [fasta-ref] [vg-ref] [vg-pan] [threads] [sim-read-spec]"
+    echo "example: "$(basename $0) 'SGRP2/SGD_2010.fasta SGRP2/SGRP2-cerevisiae.pathonly SGRP2/SGRP2-cerevisiae 4 "-s 271 -n 50000 -e 0.01 -i 0.002 -l 100 -p 500 -v 50"'
     exit
 fi
 
@@ -10,7 +11,8 @@ output=$1
 fasta=$2
 ref=$3
 pan=$4
-num_reads=$5
+threads=$5
+read_spec=$6
 
 pan_xg=$pan.xg
 pan_gcsa=$pan.gcsa
@@ -25,7 +27,8 @@ echo testing vg-$id
 
 # Generate 500k read pairs (1M reads) and their "true" positions from the vg graph:
 echo generating simulated reads
-time vg sim -s 271 -n $num_reads -e 0.01 -i 0.002 -l 150 -p 500 -v 50 -x $pan_xg -a | tee $output/sim.gam | vg annotate -p -x $pan_xg -a - | vg view -a - | jq -c -r '[ .name, .refpos[0].name, .refpos[0].offset ] | @tsv' | pv -l | sort >$output/true.pos
+# -s 271 -n $num_reads -e 0.01 -i 0.002 -l 150 -p 500 -v 50
+time vg sim $read_spec -x $pan_xg -a | tee $output/sim.gam | vg annotate -p -x $pan_xg -a - | vg view -a - | jq -c -r '[ .name, .refpos[0].name, .refpos[0].offset ] | @tsv' | pv -l | sort >$output/true.pos
 
 # This can then be mapped six ways.
 
@@ -35,27 +38,27 @@ vg view -a $output/sim.gam | jq -cr 'select(.name | test("_1$"))' | pv -l | vg v
 vg view -a $output/sim.gam | jq -cr 'select(.name | test("_2$"))' | pv -l | vg view -JaG - | vg view -X - | sed s/_2$// | gzip >$output/sim_2.fq.gz
 # then map, correcting the names so they match vg's
 echo bwa mem paired mapping
-time bwa mem -t 32 $fasta $output/sim_1.fq.gz $output/sim_2.fq.gz | grep -v ^@ | perl -ne '@val = split("\t", $_); print @val[0] . "_" . (@val[1] & 64 ? "1" : @val[1] & 128 ? "2" : "?"), "\t" . @val[2] . "\t" . @val[3] . "\t" . @val[4] . "\n";' | pv -l | sort >$output/bwa_mem-pe.pos
+time bwa mem -t $threads $fasta $output/sim_1.fq.gz $output/sim_2.fq.gz | grep -v ^@ | perl -ne '@val = split("\t", $_); print @val[0] . "_" . (@val[1] & 64 ? "1" : @val[1] & 128 ? "2" : "?"), "\t" . @val[2] . "\t" . @val[3] . "\t" . @val[4] . "\n";' | pv -l | sort >$output/bwa_mem-pe.pos
 join $output/true.pos $output/bwa_mem-pe.pos | ~/vg/scripts/pos_compare.py >$output/bwa-pe.compare
 # map single end
 echo bwa mem single mapping
-time bwa mem -t 32 $fasta <(vg view -X $output/sim.gam) | grep -v ^@ | pv -l | cut -f 1,3,4,5 | sort >$output/bwa_mem-se.pos
+time bwa mem -t $threads $fasta <(vg view -X $output/sim.gam) | grep -v ^@ | pv -l | cut -f 1,3,4,5 | sort >$output/bwa_mem-se.pos
 join $output/true.pos $output/bwa_mem-se.pos | ~/vg/scripts/pos_compare.py >$output/bwa-se.compare
 
 # By vg-ref:
 echo vg ref paired mapping
-time vg map -iG $output/sim.gam -x $ref_xg -g $ref_gcsa -t 32 | vg annotate -x $ref_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-ref-pe.pos
+time vg map -iG $output/sim.gam -x $ref_xg -g $ref_gcsa -t $threads | vg annotate -x $ref_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-ref-pe.pos
 join $output/true.pos $output/vg-ref-pe.pos | ~/vg/scripts/pos_compare.py >$output/vg-ref-pe.compare
 echo vg ref single mapping
-time vg map -G $output/sim.gam -x $ref_xg -g $ref_gcsa -t 32 | vg annotate -x $ref_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-ref-se.pos
+time vg map -G $output/sim.gam -x $ref_xg -g $ref_gcsa -t $threads | vg annotate -x $ref_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-ref-se.pos
 join $output/true.pos $output/vg-ref-se.pos | ~/vg/scripts/pos_compare.py >$output/vg-ref-se.compare
 
 # By vg-pan:
 echo vg pan paired mappping
-time vg map -iG $output/sim.gam -x $pan_xg -g $pan_gcsa -t 32 | vg annotate -x $pan_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-pan-pe.pos
+time vg map -iG $output/sim.gam -x $pan_xg -g $pan_gcsa -t $threads | vg annotate -x $pan_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-pan-pe.pos
 join $output/true.pos $output/vg-pan-pe.pos | ~/vg/scripts/pos_compare.py >$output/vg-pan-pe.compare
 echo vg pan single mappping
-time vg map -G $output/sim.gam -x $pan_xg -g $pan_gcsa -t 32 | vg annotate -x $pan_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-pan-se.pos
+time vg map -G $output/sim.gam -x $pan_xg -g $pan_gcsa -t $threads | vg annotate -x $pan_xg -p -a - | vg view -a - | pv -l | jq -c -r '[.name, .refpos[0].name, .refpos[0].offset, if .mapping_quality == null then 0 else .mapping_quality end ] | @tsv'  | sed s/null/0/g | sort >$output/vg-pan-se.pos
 join $output/true.pos $output/vg-pan-se.pos | ~/vg/scripts/pos_compare.py >$output/vg-pan-se.compare
 
 # Now we combine the various positions into one table

--- a/scripts/map-sim
+++ b/scripts/map-sim
@@ -25,7 +25,7 @@ echo testing vg-$id
 
 # Generate 500k read pairs (1M reads) and their "true" positions from the vg graph:
 echo generating simulated reads
-time vg sim -s 271 -n $num_reads -l 150 -p 500 -v 50 -x $pan_xg -a | tee $output/sim.gam | vg annotate -p -x $pan_xg -a - | vg view -a - | jq -c -r '[ .name, .refpos[0].name, .refpos[0].offset ] | @tsv' | pv -l | sort >$output/true.pos
+time vg sim -s 271 -n $num_reads -e 0.01 -i 0.002 -l 150 -p 500 -v 50 -x $pan_xg -a | tee $output/sim.gam | vg annotate -p -x $pan_xg -a - | vg view -a - | jq -c -r '[ .name, .refpos[0].name, .refpos[0].offset ] | @tsv' | pv -l | sort >$output/true.pos
 
 # This can then be mapped six ways.
 

--- a/scripts/qq.R
+++ b/scripts/qq.R
@@ -3,6 +3,8 @@
 list.of.packages <- c("tidyverse", "ggrepel")
 new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
 if(length(new.packages)) install.packages(new.packages)
+require("tidyverse")
+require("ggrepel")
 
 dat <- read.table(commandArgs(TRUE)[1], header=T)
 dat$bin <- cut(dat$mq, c(-Inf,seq(0,60,1),Inf))

--- a/scripts/qq.R
+++ b/scripts/qq.R
@@ -9,6 +9,6 @@ require("ggrepel")
 dat <- read.table(commandArgs(TRUE)[1], header=T)
 dat$bin <- cut(dat$mq, c(-Inf,seq(0,60,1),Inf))
 x <- as.data.frame(summarize(group_by(dat, bin, aligner), N=n(), mapq=mean(mq), mapprob=mean(1-10^(-mapq/10)), observed=mean(correct)))
-gplot(x, aes(1-mapprob+1e-9, 1-observed+1e-9, color=aligner, size=N, weight=N, label=round(mapq,2))) + scale_y_log10("measured error", limits=c(5e-7,2), breaks=c(1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e0)) + scale_x_log10("error estimate", limits=c(5e-7,2), breaks=c(1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e0)) + geom_point() + geom_smooth() + geom_abline(intercept=0, slope=1, linetype=2) + theme_bw()
+ggplot(x, aes(1-mapprob+1e-9, 1-observed+1e-9, color=aligner, size=N, weight=N, label=round(mapq,2))) + scale_y_log10("measured error", limits=c(5e-7,2), breaks=c(1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e0)) + scale_x_log10("error estimate", limits=c(5e-7,2), breaks=c(1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e0)) + geom_point() + geom_smooth() + geom_abline(intercept=0, slope=1, linetype=2) + theme_bw()
 filename <- commandArgs(TRUE)[2]
 ggsave(filename, height=7, width=10)

--- a/scripts/roc.R
+++ b/scripts/roc.R
@@ -3,6 +3,8 @@
 list.of.packages <- c("tidyverse", "ggrepel")
 new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
 if(length(new.packages)) install.packages(new.packages)
+require("tidyverse")
+require("ggrepel")
 
 dat <- read.table(commandArgs(TRUE)[1], header=T)
 dat$bin <- cut(dat$mq, c(-Inf,seq(0,60,1),Inf))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1356,7 +1356,7 @@ void help_msga(char** argv) {
          << "    -q, --max-target-x N    skip cluster subgraphs with length > N*read_length (default: 100; 0=unset)" << endl
          << "    -I, --max-multimaps N   if N>1, keep N best mappings of each band, resolve alignment by DP (default: 1)" << endl
          << "    -V, --mem-reseed N      reseed SMEMs longer than this length to find non-supermaximal MEMs inside them" << endl
-         << "                            set to -1 to estimate as 2x min mem length (default: 0/unset)" << endl
+         << "                            set to -1 to estimate as 2x min mem length (default: -1/estimated)" << endl
          << "index generation:" << endl
          << "    -K, --idx-kmer-size N   use kmers of this size for building the GCSA indexes (default: 16)" << endl
          << "    -O, --idx-no-recomb     index only embedded paths, not recombinations of them" << endl
@@ -1428,7 +1428,7 @@ int main_msga(int argc, char** argv) {
     bool circularize = false;
     int sens_step = 5;
     float chance_match = 0.05;
-    int mem_reseed_length = 0;
+    int mem_reseed_length = -1;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -1802,7 +1802,7 @@ int main_msga(int argc, char** argv) {
                                       : mapper->random_match_length(chance_match));
             mapper->mem_reseed_length = (mem_reseed_length > 0 ? mem_reseed_length
                                          : (mem_reseed_length == 0 ? 0
-                                            : 2 * mapper->min_mem_length));
+                                            : round(2 * mapper->min_mem_length)));
             mapper->hit_max = hit_max;
             mapper->greedy_accept = greedy_accept;
             mapper->max_target_factor = max_target_factor;
@@ -4954,7 +4954,7 @@ void help_map(char** argv) {
          << "    -F, --chance-match N     set the minimum MEM length so ~ this fraction of min-length hits will by by chance (default: 0.05)" << endl
          << "    -Y, --max-mem-length N   ignore MEMs longer than this length by stopping backward search (default: 0/unset)" << endl
          << "    -V, --mem-reseed N       reseed SMEMs longer than this length to find non-supermaximal MEMs inside them" << endl
-         << "                             set to -1 to estimate as 2x min mem length (default: 0/unset)" << endl
+         << "                             set to -1 to estimate as 2x min mem length (default: -1/estimated)" << endl
          << "    -6, --fast-reseed        use fast SMEM reseeding" << endl
          << "    -a, --id-clustering      use id clustering to drive the mapper, rather than MEM-threading" << endl
          << "    -5, --unsmoothly         don't smooth alignments after patching" << endl
@@ -4988,7 +4988,7 @@ int main_map(int argc, char** argv) {
     string read_file;
     string hts_file;
     bool keep_secondary = false;
-    int hit_max = 10000;
+    int hit_max = 100;
     int max_multimaps = 1;
     int thread_count = 1;
     int thread_ex = 10;
@@ -5014,7 +5014,7 @@ int main_map(int argc, char** argv) {
     int max_mem_length = 0;
     int min_mem_length = 0;
     float random_match_chance = 0.05;
-    int mem_reseed_length = 0;
+    int mem_reseed_length = -1;
     bool mem_threading = true;
     int max_target_factor = 100;
     int buffer_size = 100;
@@ -5024,7 +5024,7 @@ int main_map(int argc, char** argv) {
     int gap_extend = 1;
     int full_length_bonus = 5;
     bool qual_adjust_alignments = false;
-    int extra_multimaps = 100;
+    int extra_multimaps = 32;
     int max_mapping_quality = 60;
     int method_code = 1;
     string gam_input;
@@ -5547,7 +5547,7 @@ int main_map(int argc, char** argv) {
                              : m->random_match_length(chance_match));
         m->mem_reseed_length = (mem_reseed_length > 0 ? mem_reseed_length
                                 : (mem_reseed_length == 0 ? 0
-                                   : 2 * m->min_mem_length));
+                                   : round(2 * m->min_mem_length)));
         if (debug && i == 0) {
             cerr << "[vg map] : min_mem_length = " << m->min_mem_length
                  << ", mem_reseed_length = " << m->mem_reseed_length << endl;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1736,7 +1736,7 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi_simul(
 
     // build the paired-read MEM markov model
     MEMMarkovModel markov_model({ read1.sequence().size(), read2.sequence().size() }, { mems1, mems2 }, this, transition_weight, 32);
-    vector<vector<MaximalExactMatch> > clusters = markov_model.traceback(total_multimaps, true, debug);
+    vector<vector<MaximalExactMatch> > clusters = markov_model.traceback(total_multimaps, false, debug);
 
     // now reconstruct the paired fragments from the threads
     // for each thread we accept either both pairs or one fragment or the other

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -476,6 +476,7 @@ public:
     //
     //int max_mem_length; // a mem must be <= this length
     int min_mem_length; // a mem must be >= this length
+    int min_cluster_length; // a cluster needs this much sequence in it for us to consider it
     bool mem_threading; // whether to use the mem threading mapper or not
     int mem_reseed_length; // the length above which we reseed MEMs to get potentially missed hits
     bool fast_reseed; // use the fast reseed algorithm

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -100,8 +100,8 @@ is $(vg map -r x.reads -x x.vg.idx -g x.vg.gcsa -J -t 1 -J -a | jq -c '.path.map
 
 vg index -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -k 16 graphs/refonly-lrc_kir.vg
 
-vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -J -a  > temp_paired_alignment.json
-vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -u 4 -J -a  > temp_independent_alignment.json
+vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -J  > temp_paired_alignment.json
+vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -u 4 -J  > temp_independent_alignment.json
 paired_score=$(jq -r ".score" < temp_paired_alignment.json | awk '{ sum+=$1} END {print sum}')
 independent_score=$(jq -r ".score" < temp_independent_alignment.json | awk '{ sum+=$1} END {print sum}')
 is $(printf "%s\t%s\n" $paired_score $independent_score | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be consistent have lower score than unrestricted alignments"
@@ -109,19 +109,19 @@ is $(printf "%s\t%s\n" $paired_score $independent_score | awk '{if ($1 < $2) pri
 paired_range=$(jq -r ".path.mapping[0].position.node_id" <  temp_paired_alignment.json| sort | rs -T | awk '{print ($2 - $1)}')
 independent_range=$(jq -r ".path.mapping[0].position.node_id" <  temp_independent_alignment.json| sort | rs -T | awk '{print ($2 - $1)}')
 is $(printf "%s\t%s\n" $paired_range $independent_range | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be consistent are closer together in node id space than unrestricted alignments"
-is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -J -M 10 | jq -r ".mapping_quality" | grep -v null | wc -l) 1 "only primary alignments have mapping quality scores"
+is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -J -M 10 | jq -r ".mapping_quality" | grep -v null | wc -l) 2 "only primary alignments have mapping quality scores"
 is $(vg map -r x.reads -x x.xg -g x.gcsa -k 22 -J | jq -r ".mapping_quality" | wc -l) 1000 "unpaired reads produce mapping quality scores"
 
 rm temp_paired_alignment.json temp_independent_alignment.json
 
-is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -v 1 -J -a | jq -r ".mapping_quality") $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -U -u 4 -v 2 -J -a | jq -r ".mapping_quality") "mapping quality approximation is equal to exact calculation in a clear cut case"
+is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -v 1 -J | jq -r ".mapping_quality") $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -U -u 4 -v 2 -J | jq -r ".mapping_quality") "mapping quality approximation is equal to exact calculation in a clear cut case"
 
 vg map -f alignment/mismatch_full_qual.fq -x x.xg -g x.gcsa -k 22 -J -1 | jq -c '.score' > temp_scores_full_qual.txt
 vg map -f alignment/mismatch_reduced_qual.fq -x x.xg -g x.gcsa -k 22 -J -1 | jq -c '.score' > temp_scores_reduced_qual.txt
 is $(paste temp_scores_full_qual.txt temp_scores_reduced_qual.txt | column -s $'\t' -t | awk '{if ($1 < $2) count++} END{print count}') 10 "base quality adjusted alignment produces higher scores if mismatches have low quality"
 rm temp_scores_full_qual.txt temp_scores_reduced_qual.txt
 
-is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -W 1000:300:20:0:1 -J -a | jq -r 'select(.name == "ERR194147.679985061/1") | .path.mapping[0].position.node_id') 8121 "paired-end reads are pulled to consistent locations at the cost of non-optimal individual alignments"
+is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -W 1000:300:20:0:1 -J | jq -r 'select(.name == "ERR194147.679985061/1") | .path.mapping[0].position.node_id') 8121 "paired-end reads are pulled to consistent locations at the cost of non-optimal individual alignments"
 
 vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/NONEXISTENT -u 4 -J
 is $? 1 "error on vg map -f <nonexistent-file> (unpaired)"


### PR DESCRIPTION
Undo a series of changes I implemented that led to severe degradation of performance when reads contained any kind of error. I discovered the issue when building up the reproducible test for yeast. I had optimized vg to work best in the case where the read was a perfect match to the genome, which resulted in a lot of problems when any errors were introduced.

Results that I've circulated in the past week are affected by this. Anything I've done with human has this problem as it looks like the map-sim script has failed to include errors in the simulated reads since its creation.