### PR TITLE
Call and Simplify bugfixes

### DIFF
--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -380,8 +380,10 @@ void Call2Vcf::call(
         const Snarl* site = move(site_queue.front());
         site_queue.pop_front();
         
-        if (index.by_id.count(site->start().node_id()) && index.by_id.count(site->end().node_id())) {
-            // This site is on the primary path
+        if (site->type() == ULTRABUBBLE &&
+            index.by_id.count(site->start().node_id()) &&
+            index.by_id.count(site->end().node_id())) {
+            // This site is an ultrabubble on the primary path
         
             // Where does the variable region start and end on the reference?
             size_t ref_start = index.by_id.at(site->start().node_id()).first +
@@ -433,15 +435,16 @@ void Call2Vcf::call(
                 // Throw it in the final vector of sites we're going to process.
                 sites.push_back(site);
             }        
-        } else if (!convert_to_vcf) {
-            // The site is not on the primary path, but we can handle it anyway.
+        } else if (site->type() == ULTRABUBBLE && !convert_to_vcf) {
+            // This site is an ultrabubble and we can handle things off the
+            // primary path.
             
             // TODO: enforce a max size or something?
             sites.push_back(site);
             
         } else {
-            // The site is not on the primary path, but maybe the primary path
-            // is inside it somewhere and one of its children might be on it.
+            // The site is not on the primary path or isn't an ultrabubble, but
+            // maybe one of its children will meet our requirements.
             
             size_t child_count = site_manager.children_of(site).size();
             

--- a/src/subcommand/add_main.cpp
+++ b/src/subcommand/add_main.cpp
@@ -28,8 +28,8 @@ void help_add(char** argv) {
          << "    -v, --vcf FILE         add in variants from the given VCF file (may repeat)" << endl
          << "    -n, --rename V=G       rename contig V in the VCFs to contig G in the graph (may repeat)" << endl
          << "    -i, --ignore-missing   ignore contigs in the VCF not found in the graph" << endl
-         << "    -r, --variant-range    range in which to look for nearby variants to make a haplotype" << endl
-         << "    -f, --flank-range      extra flanking sequence to use outside of found variants" << endl
+         << "    -r, --variant-range N  range in which to look for nearby variants to make a haplotype" << endl
+         << "    -f, --flank-range N    extra flanking sequence to use outside of found variants" << endl
          << "    -p, --progress         show progress" << endl
          << "    -t, --threads N        use N threads (defaults to numCPUs)" << endl;
 }

--- a/src/subcommand/explode_main.cpp
+++ b/src/subcommand/explode_main.cpp
@@ -126,7 +126,11 @@ int main_explode(int argc, char** argv) {
                 }
             });
             
-            component.sync_paths();
+            // We inserted mappings into the component in more or less arbitrary
+            // order, so sort them by rank.
+            component.paths.sort_by_mapping_rank();
+            // Then rebuild the other path indexes
+            component.paths.rebuild_mapping_aux();
             
             // Save the component
             string filename = output_dir + "/component" + to_string(component_index) + ".vg";


### PR DESCRIPTION
This fixes vg call to not try and call non-ultrabubbles, and fixes vg simplify to not try and use a SnarlManager after modifying its graph.