### PR TITLE
don't simulate reads from N-containing parts of the graph

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2559,6 +2559,7 @@ int main_sim(int argc, char** argv) {
     bool json_out = false;
     int fragment_length = 0;
     double fragment_std_dev = 0;
+    bool reads_may_contain_Ns = false;
     string xg_name;
 
     int c;
@@ -2666,7 +2667,7 @@ int main_sim(int argc, char** argv) {
         return 1;
     }
 
-    Sampler sampler(xgidx, seed_val, forward_only);
+    Sampler sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns);
     size_t max_iter = 1000;
     int nonce = 1;
     for (int i = 0; i < num_reads; ++i) {

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -303,6 +303,9 @@ Alignment Sampler::alignment(size_t length) {
     // we do something wildly inefficient but conceptually clean
     // for each position in the mapping we add a mapping
     // at the end we will simplify the alignment, merging redundant mappings
+    auto allowed_seq = [&](const string& seq) {
+        return !(seq.size() < length || (no_Ns && seq.find('N') != string::npos));
+    };
     do {
         // add in the char for the current position
         seq += c;
@@ -324,7 +327,7 @@ Alignment Sampler::alignment(size_t length) {
         pos = nextp.at(next_dist(rng));
         // update our char
         c = nextc[pos];
-    } while (seq.size() < length);
+    } while (!allowed_seq(seq));
     // save our sequence in the alignment
     aln.set_sequence(seq);
     // Simplify the alignment to merge redundant mappings. There are no deletions to get removed.

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -34,7 +34,17 @@ public:
     // If set, only sample positions/start reads on the forward strands of their
     // nodes.
     bool forward_only;
-    Sampler(xg::XG* x, int seed = 0, bool forward_only = false) : xgidx(x), node_cache(100), forward_only(forward_only), nonce(0) {
+    // A flag that we set if we don't want to generate sequences with Ns (on by dfault)
+    bool no_Ns;
+    Sampler(xg::XG* x,
+            int seed = 0,
+            bool forward_only = false,
+            bool allow_Ns = false)
+        : xgidx(x),
+          node_cache(100),
+          forward_only(forward_only),
+          no_Ns(!allow_Ns),
+          nonce(0) {
         if (!seed) {
             seed = time(NULL);
         }


### PR DESCRIPTION
This improves the Markov model that we sample our candidate chains out of by "banding" based on approximate positions in the graph (as given by the node offset in the xg index).