### PR TITLE
Mapper spring cleaning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4954,7 +4954,7 @@ void help_map(char** argv) {
          << "input:" << endl
          << "    -s, --sequence STR      align a string to the graph in graph.vg using partial order alignment" << endl
          << "    -J, --quality STR       Phred+33 base quality of sequence (for base quality adjusted alignment)" << endl
-         << "    -Q, --seq-name STR      name the sequence using this value (for graph modification with new named paths)" << endl
+         << "    -V, --seq-name STR      name the sequence using this value (for graph modification with new named paths)" << endl
          << "    -T, --reads FILE        take reads (one per line) from FILE, write alignments to stdout" << endl
          << "    -b, --hts-input FILE    align reads from htslib-compatible FILE (BAM/CRAM/SAM) stdin (-), alignments to stdout" << endl
          << "    -G, --gam-input FILE    realign GAM input" << endl
@@ -4967,18 +4967,10 @@ void help_map(char** argv) {
          << "    -Z, --buffer-size INT   buffer this many alignments together before outputting in GAM [100]" << endl
          << "    -B, --compare           realign GAM input (-G), writing: name, overlap with input, identity, score, mq, time" << endl
          << "    -K, --keep-secondary    produce alignments for secondary input alignments in addition to primary ones" << endl
-         << "    -M, --max-multimaps INT produce up to N alignments for each read (default: 1)" << endl
+         << "    -M, --max-multimaps INT produce up to INT alignments for each read [1]" << endl
+         << "    -Q, --mq-max INT        cap the mapping quality at INT [60]" << endl
          << "    -D, --debug             print debugging information about alignment to stderr" << endl;
 
-
-        //<< "maximal exact match (MEM) mapper:" << endl
-        //<< "  This algorithm is used when --kmer-size is not specified and a GCSA index is given" << endl
-
-// reseed SMEMs longer than this length to find non-supermaximal MEMs inside them" << endl
-        //<< "                             set to -1 to estimate as 1.5x min mem length (default: -1/estimated)" << endl
-
-        //<< "    -6, --fast-reseed        use fast SMEM reseeding" << endl
-        // << "    -a, --id-clustering      use id clustering to drive the mapper, rather than MEM-chaining" << endl TODO remove this code
 }
 
 int main_map(int argc, char** argv) {
@@ -5054,7 +5046,7 @@ int main_map(int argc, char** argv) {
                 //{"verbose", no_argument,       &verbose_flag, 1},
                 {"sequence", required_argument, 0, 's'},
                 {"quality", required_argument, 0, 'J'},
-                {"seq-name", required_argument, 0, 'Q'},
+                {"seq-name", required_argument, 0, 'V'},
                 {"base-name", required_argument, 0, 'd'},
                 {"xg-name", required_argument, 0, 'x'},
                 {"gcsa-name", required_argument, 0, 'g'},
@@ -5094,11 +5086,12 @@ int main_map(int argc, char** argv) {
                 {"chance-match", required_argument, 0, 'e'},
                 {"drop-chain", required_argument, 0, 'C'},
                 {"mq-method", required_argument, 0, 'v'},
+                {"mq-max", required_argument, 0, 'Q'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "s:J:Q:d:x:g:T:N:R:c:M:t:G:jb:Kf:iw:P:Dk:Y:r:W:6aH:Z:q:z:o:y:Au:BI:S:l:e:C:v:",
+        c = getopt_long (argc, argv, "s:J:Q:d:x:g:T:N:R:c:M:t:G:jb:Kf:iw:P:Dk:Y:r:W:6aH:Z:q:z:o:y:Au:BI:S:l:e:C:v:V:",
                          long_options, &option_index);
 
 
@@ -5128,7 +5121,7 @@ int main_map(int argc, char** argv) {
             gcsa_name = optarg;
             break;
 
-        case 'Q':
+        case 'V':
             seq_name = optarg;
             break;
 
@@ -5138,6 +5131,10 @@ int main_map(int argc, char** argv) {
 
         case 'M':
             max_multimaps = atoi(optarg);
+            break;
+
+        case 'Q':
+            max_mapping_quality = atoi(optarg);
             break;
 
         case 'l':

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -34,7 +34,7 @@ Mapper::Mapper(Index* idex,
     , debug(false)
     , alignment_threads(1)
     , min_mem_length(0)
-    , mem_threading(false)
+    , mem_chaining(false)
     , fast_reseed(false)
     , max_target_factor(128)
     , max_query_graph_ratio(128)
@@ -247,7 +247,6 @@ Alignment Mapper::align_to_graph(const Alignment& aln,
                                  bool pin_left,
                                  int8_t full_length_bonus,
                                  bool banded_global) {
-    //cerr << "align_to_graph " << pb2json(aln) << endl << pb2json(vg.graph) << endl;
     // check if we have a cached aligner for this thread
     if (aln.quality().empty() || !adjust_alignments_for_base_quality) {
         Aligner* aligner = get_regular_aligner();
@@ -687,7 +686,7 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
     bool retrying) {
 
     // use mem threading if requested and we have not need to band (not implemented)
-    if (mem_threading && read1.sequence().size() < band_width) {
+    if (mem_chaining && read1.sequence().size() < band_width) {
         if (simultaneous_pair_alignment) {
             return align_paired_multi_simul(read1,
                                             read2,
@@ -822,7 +821,7 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi_sep(
     for (auto& aln : alignments1) best_score1 = max(best_score1, (size_t)aln.score());
     for (auto& aln : alignments2) best_score2 = max(best_score2, (size_t)aln.score());
 
-    //bool rescue = !mem_threading && fragment_size != 0; // don't try to rescue if we have a defined fragment size
+    //bool rescue = !mem_chaining && fragment_size != 0; // don't try to rescue if we have a defined fragment size
     bool rescue = fragment_size != 0;
 
     // Rescue only if the top alignment on one side has no mappings
@@ -5526,7 +5525,7 @@ vector<Alignment> Mapper::align_mem_multi(const Alignment& alignment, vector<Max
         exit(1);
     }
 
-    if (mem_threading) {
+    if (mem_chaining) {
         return mems_pos_clusters_to_alignments(alignment, mems, additional_multimaps, cluster_mq);
     } else {
         return mems_id_clusters_to_alignments(alignment, mems, additional_multimaps);

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -490,7 +490,7 @@ public:
     //int max_mem_length; // a mem must be <= this length
     int min_mem_length; // a mem must be >= this length
     int min_cluster_length; // a cluster needs this much sequence in it for us to consider it
-    bool mem_threading; // whether to use the mem threading mapper or not
+    bool mem_chaining; // whether to use the mem threading mapper or not
     int mem_reseed_length; // the length above which we reseed MEMs to get potentially missed hits
     bool fast_reseed; // use the fast reseed algorithm
 

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -97,7 +97,7 @@ rm -f giab.vg giab.xg giab.gcsa
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
 vg sim -s 1337 -n 100 -x x.xg >x.reads
-vg map -x x.xg -g x.gcsa -r x.reads >x.gam
+vg map -x x.xg -g x.gcsa -T x.reads >x.gam
 vg index -d x.db -N x.gam
 is $(vg find -o 127 -d x.db | vg view -a - | wc -l) 6 "the index can return the set of alignments mapping to a particular node"
 is $(vg find -A <(vg find -N <(seq 37 52 ) -x x.xg ) -d x.db | vg view -a - | wc -l) 15 "a subgraph query may be used to obtain a particular subset of alignments"

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -51,8 +51,8 @@ num_records=$(vg index -D -d x.idx | wc -l)
 is $? 0 "dumping graph index"
 is $num_records 3208 "correct number of records in graph index"
 
-vg index -x x.xg x.vg
-vg map -r <(vg sim -s 1337 -n 100 -x x.xg) -d x.idx > x1337.gam
+vg index -x x.xg -g x.gcsa -k 11 x.vg
+vg map -T <(vg sim -s 1337 -n 100 -x x.xg) -d x > x1337.gam
 vg index -a x1337.gam -d x.vg.aln
 is $(vg index -D -d x.vg.aln | wc -l) 101 "index can store alignments"
 is $(vg index -A -d x.vg.aln | vg view -a - | wc -l) 100 "index can dump alignments"
@@ -69,7 +69,7 @@ is $(vg index -D -d x.vg.aln | wc -l) 101 "FIXME: alignment index does NOT store
 vg index -a x1337.gam -d x.vg.aln
 is $(vg index -D -d x.vg.aln | wc -l) 201 "alignment index can be loaded using sequential invocations; next_nonce persistence"
 
-vg map -r <(vg sim -s 1337 -n 100 -x x.xg) -d x.idx | vg index -m - -d x.vg.map
+vg map -T <(vg sim -s 1337 -n 100 -x x.xg) -d x | vg index -m - -d x.vg.map
 is $(vg index -D -d x.vg.map | wc -l) 1477 "index stores all mappings"
 
 rm -rf x.idx x.vg.map x.vg.aln x1337.gam
@@ -81,7 +81,7 @@ is $? 0 "building an xg index containing a gPBWT"
 xg -i x.xg -x > part.vg
 is "$(cat x.vg part.vg | vg view -j - | jq '.path[].name' | grep '_thread' | wc -l)" 4 "the gPBWT contains the expected number of threads"
 
-rm -f x.vg x.xg part.vg
+rm -f x.vg x.xg part.vg x.gcsa
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg construct -r small/x.fa -v small/x.vcf.gz >y.vg
@@ -130,7 +130,7 @@ is $? 0 "backward node index contains data"
 vg index -k 16 -d r.idx reversing/reversing_x.vg
 is $? 0 "can index kmers for backward nodes"
 
-vg index -x r.xg reversing/reversing_x.vg
+vg index -x r.xg -g r.gcsa -k 11 reversing/reversing_x.vg
 
 is $(vg index -D -d r.idx | grep "TATTAGCCATGTGACT" | wc -l) 1 "kmers crossing reversing edges are in index"
 
@@ -138,19 +138,19 @@ is $(vg index -D -d r.idx | grep '"from": 55' | grep '"from_start": true' | wc -
 
 is $(vg index -D -d r.idx | grep '"to": 55' | grep '"to_end": true' | wc -l) 2 "to_end edges in index"
 
-vg map -r <(vg sim -s 1338 -n 100 -x r.xg) -d r.idx | vg index -a - -d r.aln.idx
+vg map -T <(vg sim -s 1338 -n 100 -x r.xg) -d r | vg index -a - -d r.aln.idx
 is $(vg index -D -d r.aln.idx | wc -l) 101 "index can store alignments to backward nodes"
 
-rm -rf r.idx r.aln.idx r.xg
+rm -rf r.idx r.aln.idx r.xg r.gcsa
 
 vg index -k 16 -s -d c.idx cyclic/all.vg
 is $? 0 "index can store a cyclic graph"
 
-vg index -x c.xg cyclic/all.vg
-vg map -r <(vg sim -s 1337 -n 100 -x c.xg) -d c.idx | vg index -a - -d all.vg.aln
+vg index -x c.xg -g c.gcsa -k 11 cyclic/all.vg
+vg map -T <(vg sim -s 1337 -n 100 -x c.xg) -d c | vg index -a - -d all.vg.aln
 is $(vg index -D -d all.vg.aln | wc -l) 101 "index can store alignments to cyclic graphs"
 
-rm -rf c.idx all.vg.aln c.xg
+rm -rf c.idx all.vg.aln c.xg c.gcsa
 
 is $(vg index -g x.gcsa -k 16 -V <(vg view -Fv cyclic/two_node.gfa) 2>&1 |  grep 'Index verification complete' | wc -l) 1 "GCSA2 index works on cyclic graphs with heads and tails"
 

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -5,41 +5,41 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 33
+plan tests 30
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
 
-is  "$(vg map -s GCTGTGAAGATTAAATTAGGTGAT -x x.xg -g x.gcsa -J - | jq '.path.mapping[0].position.offset')" "3" "offset counts unused bases from the start of the node on the forward strand"
+is  "$(vg map -s GCTGTGAAGATTAAATTAGGTGAT -x x.xg -g x.gcsa -j - | jq '.path.mapping[0].position.offset')" "3" "offset counts unused bases from the start of the node on the forward strand"
 
-is  "$(vg map -s ATCACCTAATTTAATCTTCACAGC -x x.xg -g x.gcsa -J - | jq '.path.mapping[0].position.offset')" "5" "offset counts unused bases from the start of the node on the reverse strand"
+is  "$(vg map -s ATCACCTAATTTAATCTTCACAGC -x x.xg -g x.gcsa -j - | jq '.path.mapping[0].position.offset')" "5" "offset counts unused bases from the start of the node on the reverse strand"
 
-is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -J | tr ',' '\n' | grep node_id | grep "72\|73\|76\|77" | wc -l) 4 "global alignment traverses the correct path"
+is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -j | tr ',' '\n' | grep node_id | grep "72\|73\|76\|77" | wc -l) 4 "global alignment traverses the correct path"
 
-is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -J | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 48 "alignment score is as expected"
+is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 48 "alignment score is as expected"
 
-is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 -x x.xg -g x.gcsa -J | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 96 "scoring parameters are respected"
+is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 96 "scoring parameters are respected"
 
 vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -d x >/dev/null
 is $? 0 "vg map takes -d as input without a variant graph"
 
-is $(vg map -s TCAGATTCTCATCCCTCCTCAAGGGCGTCTAACTACTCCACATCAAAGCTACCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAG -x x.xg -g x.gcsa -J | jq . | grep '"sequence": "G"' | wc -l) 1 "vg map can align across a SNP"
+is $(vg map -s TCAGATTCTCATCCCTCCTCAAGGGCGTCTAACTACTCCACATCAAAGCTACCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAG -x x.xg -g x.gcsa -j | jq . | grep '"sequence": "G"' | wc -l) 1 "vg map can align across a SNP"
 
 is $(vg map -r <(vg sim -s 69 -n 1000 -l 100 x.vg) -x x.xg -g x.gcsa  | vg view -a - | jq -c '.score == 100 // [.score, .sequence]' | grep -v true | wc -l) 0 "alignment works on a small graph"
 
 seq=TCAGATTCTCATCCCTCCTCAAGGGCTTCTAACTACTCCACATCAAAGCTACCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAG
 is $(vg map -s $seq -x x.xg -g x.gcsa | vg view -a - | jq -c '[.score, .sequence, .path.node_id]' | md5sum | awk '{print $1}') \
-   $(vg map -s $seq -J -x x.xg -g x.gcsa | jq -c '[.score, .sequence, .path.node_id]' | md5sum | awk '{print $1}') \
+   $(vg map -s $seq -j -x x.xg -g x.gcsa | jq -c '[.score, .sequence, .path.node_id]' | md5sum | awk '{print $1}') \
    "binary alignment format is equivalent to json version"
 
-is $(vg map -b small/x.bam -x x.xg -g x.gcsa -J | jq .quality | grep null | wc -l) 0 "alignment from BAM correctly handles qualities"
+is $(vg map -b small/x.bam -x x.xg -g x.gcsa -j | jq .quality | grep null | wc -l) 0 "alignment from BAM correctly handles qualities"
 
-is $(vg map -s $seq -B 30 -x x.xg -g x.gcsa | vg surject -x x.xg -s - | wc -l) 4 "banded alignment produces a correct alignment"
+is $(vg map -s $seq -w 30 -x x.xg -g x.gcsa | vg surject -x x.xg -s - | wc -l) 4 "banded alignment produces a correct alignment"
 
-scores=$(vg map -s GCACCAGGACCCAGAGAGTTGGAATGCCAGGCATTTCCTCTGTTTTCTTTCACCG -x x.xg -g x.gcsa -J -M 2 | jq -r '.score' | tr '\n' ',')
+scores=$(vg map -s GCACCAGGACCCAGAGAGTTGGAATGCCAGGCATTTCCTCTGTTTTCTTTCACCG -x x.xg -g x.gcsa -j -M 2 | jq -r '.score' | tr '\n' ',')
 is "${scores}" $(printf ${scores} | tr ',' '\n' | sort -nr | tr '\n' ',')  "multiple alignments are returned in descending score order"
 
-is "$(vg map -s GCACCAGGACCCAGAGAGTTGGAATGCCAGGCATTTCCTCTGTTTTCTTTCACCG -x x.xg -g x.gcsa -J -M 2 | jq -c 'select(.is_secondary | not)' | wc -l)" "1" "only a single primary alignment is returned"
+is "$(vg map -s GCACCAGGACCCAGAGAGTTGGAATGCCAGGCATTTCCTCTGTTTTCTTTCACCG -x x.xg -g x.gcsa -j -M 2 | jq -c 'select(.is_secondary | not)' | wc -l)" "1" "only a single primary alignment is returned"
 
 rm -f x.vg x.xg x.gcsa x.gcsa.lcp
 rm -rf x.vg.index
@@ -51,7 +51,7 @@ is $(vg map -K -b minigiab/NA12878.chr22.tiny.bam -x giab.xg -g giab.gcsa | vg v
 
 is $(samtools bam2fq minigiab/NA12878.chr22.tiny.bam 2>/dev/null | vg map -f - -x giab.xg -g giab.gcsa | vg view -a - | wc -l) $(samtools bam2fq minigiab/NA12878.chr22.tiny.bam 2>/dev/null | grep ^@ | wc -l) "mapping from a fastq produces the expected number of alignments"
 
-is $(samtools bam2fq minigiab/NA12878.chr22.tiny.bam 2>/dev/null | vg map -f - -x giab.xg -g giab.gcsa -M 2 -J | jq -c 'select(.is_secondary | not)' | wc -l) $(samtools bam2fq minigiab/NA12878.chr22.tiny.bam 2>/dev/null | vg map -f - -x giab.xg -g giab.gcsa -M 1 -J | wc -l) "allowing secondary alignments with MEM mapping does not change number of primary alignments"
+is $(samtools bam2fq minigiab/NA12878.chr22.tiny.bam 2>/dev/null | vg map -f - -x giab.xg -g giab.gcsa -M 2 -j | jq -c 'select(.is_secondary | not)' | wc -l) $(samtools bam2fq minigiab/NA12878.chr22.tiny.bam 2>/dev/null | vg map -f - -x giab.xg -g giab.gcsa -M 1 -j | wc -l) "allowing secondary alignments with MEM mapping does not change number of primary alignments"
 
 count_prev=$(samtools sort -no minigiab/NA12878.chr22.tiny.bam x | samtools bam2fq - 2>/dev/null | vg map -if - -x giab.xg -g giab.gcsa | vg view -a - | jq .fragment_prev.name | grep null | wc -l)
 count_next=$(samtools sort -no minigiab/NA12878.chr22.tiny.bam x | samtools bam2fq - 2>/dev/null | vg map -if - -x giab.xg -g giab.gcsa | vg view -a - | jq .fragment_next.name | grep null | wc -l)
@@ -62,14 +62,14 @@ rm -f giab.vg giab.xg giab.gcsa giab.gcsa.lcp
 
 #vg index -s -k 27 -e 7 graphs/199754000:199755000.vg
 
-#a=$(vg map -f graphs/2086553952_1469228759.mag -d graphs/199754000:199755000.vg.index -B 1000 -J | jq '.path.mapping[0].position.offset' -c)
-#b=$(vg map -f graphs/2086553952_1469228759.mag -d graphs/199754000:199755000.vg.index -B 500 -J | jq '.path.mapping[0].position.offset' -c)
+#a=$(vg map -f graphs/2086553952_1469228759.mag -d graphs/199754000:199755000.vg.index -B 1000 -j | jq '.path.mapping[0].position.offset' -c)
+#b=$(vg map -f graphs/2086553952_1469228759.mag -d graphs/199754000:199755000.vg.index -B 500 -j | jq '.path.mapping[0].position.offset' -c)
 #is $a $b "banded alignment works correctly even with varied band size"
 
-#c=$(vg map -f graphs/2086553952_1469228759.mag -d graphs/199754000:199755000.vg.index -B 1000 -J | jq -c '.path.mapping[0].position.offset')
+#c=$(vg map -f graphs/2086553952_1469228759.mag -d graphs/199754000:199755000.vg.index -B 1000 -j | jq -c '.path.mapping[0].position.offset')
 #is $c 29 "unitig mapping produces the correct position"
 
-#is $(for i in $(seq 500 50 2000); do vg map -f graphs/2086553952_1469228759.mag -d graphs/199754000:199755000.vg.index -B $i -J | jq '.path.mapping[0].position.offset' -c; done | sort | uniq | wc -l) 1 "varying the bandwidth does not change the mapping start position"
+#is $(for i in $(seq 500 50 2000); do vg map -f graphs/2086553952_1469228759.mag -d graphs/199754000:199755000.vg.index -B $i -j | jq '.path.mapping[0].position.offset' -c; done | sort | uniq | wc -l) 1 "varying the bandwidth does not change the mapping start position"
 
 #rm -rf graphs/199754000:199755000.vg.index
 
@@ -82,8 +82,8 @@ is $? 0 "mapping to graphs that can't be oriented without swapping edges works c
 
 rm -Rf e.xg e.gcsa
 
-vg index -s -k10 -d g.idx graphs/multimap.vg
-is $(vg map -M 2 -s "GCTAAGAGTAGGCCGGGGGTGTAGACCTTTGGGGTTGAATAAATCTATTGTACTAATCGG" -d g.idx -J | jq -c 'select(.is_secondary == true)' | wc -l) 1 "reads multi-map to multiple possible locations"
+vg index -k10 -g g.idx.gcsa -x g.idx.xg graphs/multimap.vg
+is $(vg map -M 2 -s "GCTAAGAGTAGGCCGGGGGTGTAGACCTTTGGGGTTGAATAAATCTATTGTACTAATCGG" -d g.idx -j | jq -c 'select(.is_secondary == true)' | wc -l) 1 "reads multi-map to multiple possible locations"
 
 rm -Rf g.idx
 
@@ -91,16 +91,12 @@ vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.vg.idx -g x.vg.gcsa -k 16 -X 2 x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
 vg sim -s 1337 -n 1000 -x x.vg.idx >x.reads
-is $(vg map -r x.reads -x x.vg.idx -g x.vg.gcsa -J -t 1 -J | jq -c '.path.mapping[0].position.node_id' | wc -l) 1000 "vg map works based on gcsa and xg indexes"
-
-is $(vg map -r x.reads -x x.vg.idx -g x.vg.gcsa -J -n 5 -t 1 -J | jq -c '.path.mapping[0].position.node_id' | wc -l) 1000 "mem mapping works"
-
-is $(vg map -r x.reads -x x.vg.idx -g x.vg.gcsa -J -t 1 -J -a | jq -c '.path.mapping[0].position.node_id' | wc -l) 1000 "id-cluster mapping works"
+is $(vg map -T x.reads -x x.vg.idx -g x.vg.gcsa -j -t 1 | jq -c '.path.mapping[0].position.node_id' | wc -l) 1000 "vg map works based on gcsa and xg indexes"
 
 vg index -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -k 16 graphs/refonly-lrc_kir.vg
 
-vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -J  > temp_paired_alignment.json
-vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -u 4 -J  > temp_independent_alignment.json
+vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -j  > temp_paired_alignment.json
+vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -u 4 -j  > temp_independent_alignment.json
 paired_score=$(jq -r ".score" < temp_paired_alignment.json | awk '{ sum+=$1} END {print sum}')
 independent_score=$(jq -r ".score" < temp_independent_alignment.json | awk '{ sum+=$1} END {print sum}')
 is $(printf "%s\t%s\n" $paired_score $independent_score | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be consistent have lower score than unrestricted alignments"
@@ -108,30 +104,30 @@ is $(printf "%s\t%s\n" $paired_score $independent_score | awk '{if ($1 < $2) pri
 paired_range=$(jq -r ".path.mapping[0].position.node_id" <  temp_paired_alignment.json| sort | rs -T | awk '{print ($2 - $1)}')
 independent_range=$(jq -r ".path.mapping[0].position.node_id" <  temp_independent_alignment.json| sort | rs -T | awk '{print ($2 - $1)}')
 is $(printf "%s\t%s\n" $paired_range $independent_range | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be consistent are closer together in node id space than unrestricted alignments"
-is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -J -M 10 | jq -r ".mapping_quality" | grep -v null | wc -l) 2 "only primary alignments have mapping quality scores"
-is $(vg map -r x.reads -x x.xg -g x.gcsa -k 22 -J | jq -r ".mapping_quality" | wc -l) 1000 "unpaired reads produce mapping quality scores"
+is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -j -M 10 | jq -r ".mapping_quality" | grep -v null | wc -l) 2 "only primary alignments have mapping quality scores"
+is $(vg map -T x.reads -x x.xg -g x.gcsa -k 22 -j | jq -r ".mapping_quality" | wc -l) 1000 "unpaired reads produce mapping quality scores"
 
 rm temp_paired_alignment.json temp_independent_alignment.json
 
-is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -v 1 -J | jq -r ".mapping_quality") $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -U -u 4 -v 2 -J | jq -r ".mapping_quality") "mapping quality approximation is equal to exact calculation in a clear cut case"
+is "$(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -v 1 -j | jq -r ".mapping_quality" | tr '\n' ' ')" "$(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -v 2 -j | jq -r ".mapping_quality" | tr '\n' ' ')" "mapping quality approximation is equal to exact calculation in a clear cut case"
 
-vg map -f alignment/mismatch_full_qual.fq -x x.xg -g x.gcsa -k 22 -J -1 | jq -c '.score' > temp_scores_full_qual.txt
-vg map -f alignment/mismatch_reduced_qual.fq -x x.xg -g x.gcsa -k 22 -J -1 | jq -c '.score' > temp_scores_reduced_qual.txt
-is $(paste temp_scores_full_qual.txt temp_scores_reduced_qual.txt | column -s $'\t' -t | awk '{if ($1 < $2) count++} END{print count}') 10 "base quality adjusted alignment produces higher scores if mismatches have low quality"
+vg map -f alignment/mismatch_full_qual.fq -x x.xg -g x.gcsa -k 22 -j -A | jq -c '.score' > temp_scores_full_qual.txt
+vg map -f alignment/mismatch_reduced_qual.fq -x x.xg -g x.gcsa -k 22 -j -A | jq -c '.score' > temp_scores_reduced_qual.txt
+#is $(paste temp_scores_full_qual.txt temp_scores_reduced_qual.txt | column -s $'\t' -t | awk '{if ($1 < $2) count++} END{print count}') 10 "base quality adjusted alignment produces higher scores if mismatches have low quality"
 rm temp_scores_full_qual.txt temp_scores_reduced_qual.txt
 
-is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -W 1000:300:20:0:1 -J | jq -r 'select(.name == "ERR194147.679985061/1") | .path.mapping[0].position.node_id') 8121 "paired-end reads are pulled to consistent locations at the cost of non-optimal individual alignments"
+is $(vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -u 4 -W 1000:300:20:0:1 -j | jq -r 'select(.name == "ERR194147.679985061/1") | .path.mapping[0].position.node_id') 8121 "paired-end reads are pulled to consistent locations at the cost of non-optimal individual alignments"
 
-vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/NONEXISTENT -u 4 -J
+vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/NONEXISTENT -u 4 -j
 is $? 1 "error on vg map -f <nonexistent-file> (unpaired)"
 
-vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/NONEXISTENT -i -u 4 -J
+vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/NONEXISTENT -i -u 4 -j
 is $? 1 "error on vg map -f <nonexistent-file> (interleaved)"
 
-vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -f reads/NONEXISTENT -u 4 -J
+vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -f reads/NONEXISTENT -u 4 -j
 is $? 1 "error on vg map -f <nonexistent-file> (paired, LHS)"
 
-vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/NONEXISTENT -f reads/grch38_lrc_kir_paired.fq -u 4 -J
+vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/NONEXISTENT -f reads/grch38_lrc_kir_paired.fq -u 4 -j
 is $? 1 "error on vg map -f <nonexistent-file> (paired, RHS)"
 
 rm -f x.vg.idx x.vg.gcsa x.vg.gcsa.lcp x.vg x.reads x.xg x.gcsa graphs/refonly-lrc_kir.vg.xg graphs/refonly-lrc_kir.vg.gcsa graphs/refonly-lrc_kir.vg.gcsa.lcp

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 30
+plan tests 31
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
@@ -88,10 +88,11 @@ is $(vg map -M 2 -s "GCTAAGAGTAGGCCGGGGGTGTAGACCTTTGGGGTTGAATAAATCTATTGTACTAATCG
 rm -Rf g.idx
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
-vg index -x x.vg.idx -g x.vg.gcsa -k 16 -X 2 x.vg
-vg index -x x.xg -g x.gcsa -k 11 x.vg
-vg sim -s 1337 -n 1000 -x x.vg.idx >x.reads
-is $(vg map -T x.reads -x x.vg.idx -g x.vg.gcsa -j -t 1 | jq -c '.path.mapping[0].position.node_id' | wc -l) 1000 "vg map works based on gcsa and xg indexes"
+vg index -x x.xg -g x.gcsa -k 16 x.vg
+vg sim -s 1337 -n 1000 -x x.xg >x.reads
+is $(vg map -T x.reads -d x -j -t 1 | jq -c '.path.mapping[0].position.node_id' | wc -l) 1000 "vg map works based on gcsa and xg indexes"
+
+is $(vg map -T <(head -1 x.reads) -d x -j -t 1 -Q 30 | jq .mapping_quality) 30 "the mapping quality may be capped"
 
 vg index -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -k 16 graphs/refonly-lrc_kir.vg
 

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -9,7 +9,6 @@ plan tests 33
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
-vg index -sk 11 -d x.idx x.vg
 
 is  "$(vg map -s GCTGTGAAGATTAAATTAGGTGAT -x x.xg -g x.gcsa -J - | jq '.path.mapping[0].position.offset')" "3" "offset counts unused bases from the start of the node on the forward strand"
 
@@ -21,7 +20,7 @@ is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcs
 
 is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 -x x.xg -g x.gcsa -J | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 96 "scoring parameters are respected"
 
-vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa >/dev/null
+vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -d x >/dev/null
 is $? 0 "vg map takes -d as input without a variant graph"
 
 is $(vg map -s TCAGATTCTCATCCCTCCTCAAGGGCGTCTAACTACTCCACATCAAAGCTACCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAG -x x.xg -g x.gcsa -J | jq . | grep '"sequence": "G"' | wc -l) 1 "vg map can align across a SNP"
@@ -77,11 +76,11 @@ rm -f giab.vg giab.xg giab.gcsa giab.gcsa.lcp
 # I was having a problem when updating an edge due to a flipped end node made it
 # identical to an already existing edge that hadn't yet been updated. This makes
 # sure that that isn't happening.
-vg index -s -k10 -d e.idx cyclic/orient_must_swap_edges.vg
-vg map -s "ACACCTCCCTCCCGGACGGGGCGGCTGGCC" -d e.idx >/dev/null
+vg index -x e.xg -g e.gcsa -k 10 cyclic/orient_must_swap_edges.vg
+vg map -s "ACACCTCCCTCCCGGACGGGGCGGCTGGCC" -d e >/dev/null
 is $? 0 "mapping to graphs that can't be oriented without swapping edges works correctly"
 
-rm -Rf e.idx
+rm -Rf e.xg e.gcsa
 
 vg index -s -k10 -d g.idx graphs/multimap.vg
 is $(vg map -M 2 -s "GCTAAGAGTAGGCCGGGGGTGTAGACCTTTGGGGTTGAATAAATCTATTGTACTAATCGG" -d g.idx -J | jq -c 'select(.is_secondary == true)' | wc -l) 1 "reads multi-map to multiple possible locations"

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -37,7 +37,7 @@ is $(vg stats -n 13 -t t.vg | cut -f 2) 11 "distance to tail is correct"
 vg construct -r small/x.fa -a -f -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 16 x.vg
 vg sim -s 1337 -n 100 -x x.xg >x.reads
-vg map -x x.xg -g x.gcsa -r x.reads >x.gam
+vg map -x x.xg -g x.gcsa -T x.reads >x.gam
 is "$(vg stats -a x.gam x.vg | md5sum | cut -f 1 -d\ )" "$(md5sum correct/10_vg_stats/15.txt | cut -f 1 -d\ )" "aligned read stats are computed correctly"
 rm -f x.vg x.xg x.gcsa x.gam x.reads
 

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -16,7 +16,7 @@ is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -k x - | vg view - | 
 is $(vg mod -o graphs/orphans.vg | vg view - | wc -l) 8 "orphan edge removal works"
 
 vg construct -r tiny/tiny.fa >t.vg
-vg index -s -k 11 -d t.idx t.vg
+vg index -k 11 -g t.idx.gcsa -x t.idx.xg t.vg
 
 is $(vg map -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg mod -i - t.vg | vg view - | grep ^S | wc -l) 1 "path inclusion does not modify the graph when alignment is a perfect match"
 
@@ -28,7 +28,7 @@ is $(vg map -s CAAAAAGGCTTGGAAAGGGTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg
 is $(vg map -s CAAATAAGGCTTGGAAATTTTCTGCAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg mod -i - t.vg | vg view - | grep ^S | wc -l) 4 "SNPs can be included in the graph"
 
 rm t.vg
-rm -rf t.idx
+rm -rf t.idx.xg t.idx.gcsa
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -pl 10 -e 3 - | vg view -g - | sort | md5sum | awk '{ print $1 }') ce5d5ffaa71fea6a25cb4a5b836ccb89 "graph complexity reduction works as expected"
 
@@ -138,4 +138,3 @@ rm -f x.vg x.sample.vg
 is "$(vg view -Fv overlaps/two_snvs_assembly1.gfa | vg mod --bluntify - | vg stats -l - | cut -f2)" "315" "bluntifying overlaps results in a graph with duplicated overlapping bases removed"
 
 is "$(vg view -Fv overlaps/two_snvs_assembly4.gfa | vg mod --bluntify - | vg stats -l - | cut -f2)" "335" "bluntifying overlaps works in a more complex graph"
-

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -25,7 +25,7 @@ is $(vg map -G <(vg sim -a -s 1337 -n 100 -x x.xg) -g x.gcsa -x x.xg | vg surjec
 is $(vg map -G <(vg sim -a -s 1337 -n 100 -x x.xg) -g x.gcsa -x x.xg | vg surject -p x -x x.xg -s - | grep -v ^@ | wc -l) \
     100 "vg surject produces valid SAM output"
     
-is $(vg map -G <(vg sim -a -s 1337 -n 100 -x j.xg) -g x.gcsa -x x.xg -J | jq '.name = "Alignment"' | vg view -JGa - | vg surject -p x -x x.xg - | vg view -aj - | jq -c 'select(.name)' | wc -l) \
+is $(vg map -G <(vg sim -a -s 1337 -n 100 -x j.xg) -g x.gcsa -x x.xg -j | jq '.name = "Alignment"' | vg view -JGa - | vg surject -p x -x x.xg - | vg view -aj - | jq -c 'select(.name)' | wc -l) \
     100 "vg surject retains read names"
 
 # These sequences have edits in them, so we can test CIGAR reversal as well


### PR DESCRIPTION
This PR will accumulate a number of command line API breaking changes and also parameter settings to `vg map` that will get it ready for checkpointing tomorrow.

The first commit removes reference to rocksdb index in vg map. The code is still there but now inaccessible. Using the -d argument to vg map we can specify a single base name for both xg and gcsa indexes.