### PR TITLE
Revamped VG graph manipulation algorithms

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -848,7 +848,7 @@ Alignment merge_alignments(const Alignment& a1, const Alignment& a2, bool debug)
     return a3;
 }
 
-void translate_nodes(Alignment& a, const map<id_t, pair<id_t, bool> >& ids, const std::function<size_t(int64_t)>& node_length) {
+void translate_nodes(Alignment& a, const unordered_map<id_t, pair<id_t, bool> >& ids, const std::function<size_t(int64_t)>& node_length) {
     Path* path = a.mutable_path();
     for(size_t i = 0; i < path->mapping_size(); i++) {
         // Grab each mapping (includes its position)

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -105,7 +105,7 @@ size_t to_length_before_pos(const Alignment& aln, const Position& pos);
 size_t from_length_before_pos(const Alignment& aln, const Position& pos);
 
 // project the alignment's path back into a different ID space
-void translate_nodes(Alignment& a, const map<id_t, pair<id_t, bool> >& ids, const std::function<size_t(int64_t)>& node_length);
+void translate_nodes(Alignment& a, const unordered_map<id_t, pair<id_t, bool> >& ids, const std::function<size_t(int64_t)>& node_length);
 
 // Invert the orientation in the alignment of all the nodes whose IDs are
 // listed. It needs a callback to ask the length of any given node.

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -67,9 +67,9 @@ namespace vg{
 		  VG* my_vg;
           xg::XG* my_xg;
           map<pair<id_t, id_t>, vector<id_t> > my_sbs;
-          map<id_t, pair<id_t, bool> > my_translation;
-          map<id_t, pair<id_t, bool> > my_unroll_translation;
-          map<id_t, pair<id_t, bool> > my_dagify_translation;
+          unordered_map<id_t, pair<id_t, bool> > my_translation;
+          unordered_map<id_t, pair<id_t, bool> > my_unroll_translation;
+          unordered_map<id_t, pair<id_t, bool> > my_dagify_translation;
           map<id_t, SuperBubble> id_to_bub; 
 
           vector<id_t> reverse_topo_order;

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -651,7 +651,7 @@ vector<Genotyper::Site> Genotyper::find_sites_with_supbub(VG& graph) {
     // Unfold the graph
     // Copy the graph and unfold the copy. We need to hold this translation
     // table from new node ID to old node and relative orientation.
-    map<vg::id_t, pair<vg::id_t, bool>> unfold_translation;
+    unordered_map<vg::id_t, pair<vg::id_t, bool>> unfold_translation;
     auto transformed = graph.unfold(unfold_max_length, unfold_translation);
     
     // Fix up any doubly reversed edges
@@ -659,11 +659,11 @@ vector<Genotyper::Site> Genotyper::find_sites_with_supbub(VG& graph) {
 
     // Now dagify the graph. We need to hold this translation table from new
     // node ID to old node and relative orientation.
-    map<vg::id_t, pair<vg::id_t, bool>> dag_translation;
+    unordered_map<vg::id_t, pair<vg::id_t, bool>> dag_translation;
     transformed = transformed.dagify(dagify_steps, dag_translation);
     
     // Compose the complete translation
-    map<vg::id_t, pair<vg::id_t, bool>> overall_translation = transformed.overlay_node_translations(dag_translation, unfold_translation);
+    unordered_map<vg::id_t, pair<vg::id_t, bool>> overall_translation = transformed.overlay_node_translations(dag_translation, unfold_translation);
     dag_translation.clear();
     unfold_translation.clear();
     

--- a/src/nodetraversal.hpp
+++ b/src/nodetraversal.hpp
@@ -2,7 +2,7 @@
 #define VG_NODETRAVERSAL_HPP
 
 #include "vg.pb.h"
-
+#include "hash_map.hpp"
 
 
 namespace vg {
@@ -79,9 +79,9 @@ inline ostream& operator<<(ostream& out, const NodeTraversal& nodetraversal) {
 namespace std {
     /// hash function for NodeTraversals
     template<>
-    struct hash<const vg::NodeTraversal> {
+    struct hash<vg::NodeTraversal> {
         size_t operator()(const vg::NodeTraversal& trav) const {
-            return hash<pair<Node*, bool > >(trav.node, trav.backward);
+            return hash<pair<vg::Node*, bool > >()(make_pair(trav.node, trav.backward));
         }
     };
 }

--- a/src/nodetraversal.hpp
+++ b/src/nodetraversal.hpp
@@ -76,5 +76,15 @@ inline ostream& operator<<(ostream& out, const NodeTraversal& nodetraversal) {
 
 }
 
+namespace std {
+    /// hash function for NodeTraversals
+    template<>
+    struct hash<const vg::NodeTraversal> {
+        size_t operator()(const vg::NodeTraversal& trav) const {
+            return hash<pair<Node*, bool > >(trav.node, trav.backward);
+        }
+    };
+}
+
 
 #endif

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -672,18 +672,18 @@ int main_mod(int argc, char** argv) {
     }
 
     if (dagify_steps) {
-        map<int64_t, pair<int64_t, bool> > node_translation;
+        unordered_map<int64_t, pair<int64_t, bool> > node_translation;
         *graph = graph->dagify(dagify_steps, node_translation, 0, dagify_component_length_max);
     }
 
     if (dagify_to) {
-        map<int64_t, pair<int64_t, bool> > node_translation;
+        unordered_map<int64_t, pair<int64_t, bool> > node_translation;
         // use the walk as our maximum number of steps; it's the worst case
         *graph = graph->dagify(dagify_to, node_translation, dagify_to, dagify_component_length_max);
     }
 
     if (unfold_to) {
-        map<int64_t, pair<int64_t, bool> > node_translation;
+        unordered_map<int64_t, pair<int64_t, bool> > node_translation;
         *graph = graph->unfold(unfold_to, node_translation);
     }
 

--- a/src/unittest/vg.cpp
+++ b/src/unittest/vg.cpp
@@ -4,6 +4,7 @@
 
 #include "catch.hpp"
 #include "vg.hpp"
+#include "utility.hpp"
 
 namespace vg {
 namespace unittest {
@@ -146,52 +147,765 @@ TEST_CASE("is_acyclic() should return whether the graph is acyclic", "[vg][cycle
 
 TEST_CASE("unfold() should properly unfold a graph out to the requested length", "[vg][unfold]") {
 
-    SECTION("unfolding across a single reversing edge should double the entire graph") {
-
+    SECTION("Unfolding a graph with no reversing edges should create an isomorphic graph") {
         const string graph_json = R"(
         {
-          "node": [
-            {"sequence": "CACACACACACTGAGATACCATCTCCCGTCGGTCAGAATGGCCATTTGTCCAAAGT","id": 1},
-            {"sequence": "CCAACATTTACATGCTGACAAGGCAGCGGAGGAAAGCAAACACTG","id": 2},
-            {"sequence": "C","id": 3},
-            {"sequence": "T","id": 4},
-            {"sequence": "TACACTCTTGGAGGGAA","id": 5},
-            {"sequence": "T","id": 6},
-            {"sequence": "C","id": 7},
-            {"sequence": "AAAAACTAG","id": 8},
-            {"sequence": "AGTTGCAT","id": 9},
-            {"sequence": "TTCTCTGATGATGAG","id": 10},
-            {"sequence": "TGATGTTGAGGGTTTTTTTTGTCT","id": 11},
-            {"sequence": "ATTGGTCACTTGTACATCTTATTTTTACAA","id": 12},
-            {"sequence":"GAACGTCTTCATGTCTTTTACCCATTGTTTGATTGGCTTATTTGTCTTTCTGCCTCTTGATTTTTTTAAGGTCACGTTAGAGTCTGGCTATTAGGTCTTGGTCAGAAGCATAGTTTGGGAACATTTTCTCCCATCCTGTAGGCTATGTTTTTACTGTGCTGGTGATTTATTTTGCTGTCTGGCAGTGTTTTAGTTTCTTAGGCCCAACTTGTCCATTTTGGTTTTTCTTGCCGTTGCTCTTAGGGACTAAGTTATTTAAATTCTTTACCAAAGCCCATGTTGAGAAAGGTATTTCCTAGTTTTTCTTGTAGGACTTGTATAGTTTGTAGTCTTCTGCTGAAATCTTTCATTCACCTTGAGTTAGTTTTTGCATCTTGTGAGAGGTAAGGCTGTAGTGCTGTTCATCTGCAAGTGGCTAGACACTATCCCAGTGCCATTCATTGCACAGTGAGCCCTTTCCACATCTGAATTTTGGTGTTTCAAAGGTCAGATGGTTGTGGGTATGTGGGGTTGCTTCTGGGTTTCCTATTCTGTCTAGGTGGAGGTGGGTCTGTAGCTTTTCTGTGAAATTTGAAATTGGAGAGTGTGGTCCATCTGACATCGTCTGAATCTCCCAGCCTGGCTTTGGAGTTTCAGAGCATTTTGTGGTCCCATGGGAATTTTAGCATTCATTGTTTCTTCACATTGCTTTCAAAAAACAAAATCGACCCCATCCTAAAGGTGTACAGGTAGGGGGTAGAGTGGAATATTTGGATCCATGC","id": 13}
-          ],
-          "edge": [
-            {"from": 1,"to": 9,"from_start": true},
-            {"from": 1,"to": 2},
-            {"from": 2,"to": 3},
-            {"from": 2,"to": 4},
-            {"from": 3, "to": 5},
-            {"from": 4,"to": 5},
-            {"from": 5,"to": 6},
-            {"from": 5,"to": 7},
-            {"from": 6,"to": 8},
-            {"from": 7,"to": 8},
-            {"from": 9,"to": 10},
-            {"from": 10,"to": 11},
-            {"from": 11,"to": 12},
-            {"from": 12,"to": 13}
-          ]
+            "node": [
+                     {"sequence": "ATA","id": 1},
+                     {"sequence": "CT","id": 2},
+                     {"sequence": "TGA","id": 3},
+                     {"sequence": "GGC","id": 4}
+                     ],
+            "edge": [
+                     {"from": 1,"to": 2},
+                     {"from": 1,"to": 3},
+                     {"from": 2,"to": 4},
+                     {"from": 3,"to": 4}
+                     ]
         }
         )";
         
         VG graph = string_to_graph(graph_json);
         
-        map<id_t, pair<id_t, bool> > node_translation;
-        VG completely_unfolded = graph.unfold(10000, node_translation);
+        unordered_map<id_t, pair<id_t, bool> > node_translation;
+        VG unfolded = graph.unfold(10000, node_translation);
         
-        REQUIRE(completely_unfolded.size() == graph.size() * 2);
+        Graph& g = unfolded.graph;
+        
+        REQUIRE(g.node_size() == 4);
+        REQUIRE(g.edge_size() == 4);
+        
+        bool found_node_1 = false;
+        bool found_node_2 = false;
+        bool found_node_3 = false;
+        bool found_node_4 = false;
+        
+        for (int i = 0; i < g.node_size(); i++) {
+            const Node& n = g.node(i);
+            int64_t orig_id = node_translation[n.id()].first;
+            if (orig_id == 1) {
+                found_node_1 = true;
+            }
+            else if (orig_id == 2) {
+                found_node_2 = true;
+            }
+            else if (orig_id == 3) {
+                found_node_3 = true;
+            }
+            else if (orig_id == 4) {
+                found_node_4 = true;
+            }
+        }
+        
+        REQUIRE(found_node_1);
+        REQUIRE(found_node_2);
+        REQUIRE(found_node_3);
+        REQUIRE(found_node_4);
+        
+        bool found_edge_1 = false;
+        bool found_edge_2 = false;
+        bool found_edge_3 = false;
+        bool found_edge_4 = false;
+        
+        for (int i = 0; i < g.edge_size(); i++) {
+            const Edge& e = g.edge(i);
+            int64_t from = node_translation[e.from()].first;
+            int64_t to = node_translation[e.to()].first;
+            Node& orig_from_node = *graph.get_node(from);
+            Node& orig_to_node = *graph.get_node(to);
+            Node& unfold_from_node = *unfolded.get_node(e.from());
+            Node& unfold_to_node = *unfolded.get_node(e.to());
+            if ((from == 1 && to == 2 && unfold_from_node.sequence() == orig_from_node.sequence()
+                 && orig_to_node.sequence() == unfold_to_node.sequence()
+                 && (!e.from_start() && !e.to_end())) ||
+                (from == 2 && to == 1 && unfold_from_node.sequence() == orig_from_node.sequence()
+                 && orig_to_node.sequence() == unfold_to_node.sequence()
+                 && (e.from_start() && e.to_end())) ||
+                (from == 2 && to == 1 && unfold_from_node.sequence() == reverse_complement(orig_from_node.sequence())
+                 && orig_to_node.sequence() == reverse_complement(unfold_to_node.sequence())
+                 && (!e.from_start() && !e.to_end())) ||
+                (from == 1 && to == 2 && unfold_from_node.sequence() == reverse_complement(orig_from_node.sequence())
+                 && orig_to_node.sequence() == reverse_complement(unfold_to_node.sequence())
+                 && (e.from_start() && e.to_end()))) {
+                found_edge_1 = true;
+            }
+            else if ((from == 1 && to == 3 && unfold_from_node.sequence() == orig_from_node.sequence()
+                      && orig_to_node.sequence() == unfold_to_node.sequence()
+                      && (!e.from_start() && !e.to_end())) ||
+                     (from == 3 && to == 1 && unfold_from_node.sequence() == orig_from_node.sequence()
+                      && orig_to_node.sequence() == unfold_to_node.sequence()
+                      && (e.from_start() && e.to_end())) ||
+                     (from == 3 && to == 1 && unfold_from_node.sequence() == reverse_complement(orig_from_node.sequence())
+                      && orig_to_node.sequence() == reverse_complement(unfold_to_node.sequence())
+                      && (!e.from_start() && !e.to_end())) ||
+                     (from == 1 && to == 3 && unfold_from_node.sequence() == reverse_complement(orig_from_node.sequence())
+                      && orig_to_node.sequence() == reverse_complement(unfold_to_node.sequence())
+                      && (e.from_start() && e.to_end()))) {
+                found_edge_2 = true;
+            }
+            else if ((from == 2 && to == 4 && unfold_from_node.sequence() == orig_from_node.sequence()
+                      && orig_to_node.sequence() == unfold_to_node.sequence()
+                      && (!e.from_start() && !e.to_end())) ||
+                     (from == 4 && to == 2 && unfold_from_node.sequence() == orig_from_node.sequence()
+                      && orig_to_node.sequence() == unfold_to_node.sequence()
+                      && (e.from_start() && e.to_end())) ||
+                     (from == 4 && to == 2 && unfold_from_node.sequence() == reverse_complement(orig_from_node.sequence())
+                      && orig_to_node.sequence() == reverse_complement(unfold_to_node.sequence())
+                      && (!e.from_start() && !e.to_end())) ||
+                     (from == 2 && to == 4 && unfold_from_node.sequence() == reverse_complement(orig_from_node.sequence())
+                      && orig_to_node.sequence() == reverse_complement(unfold_to_node.sequence())
+                      && (e.from_start() && e.to_end()))) {
+                found_edge_3 = true;
+            }
+            else if ((from == 3 && to == 4 && unfold_from_node.sequence() == orig_from_node.sequence()
+                      && orig_to_node.sequence() == unfold_to_node.sequence()
+                      && (!e.from_start() && !e.to_end())) ||
+                     (from == 4 && to == 3 && unfold_from_node.sequence() == orig_from_node.sequence()
+                      && orig_to_node.sequence() == unfold_to_node.sequence()
+                      && (e.from_start() && e.to_end())) ||
+                     (from == 4 && to == 3 && unfold_from_node.sequence() == reverse_complement(orig_from_node.sequence())
+                      && orig_to_node.sequence() == reverse_complement(unfold_to_node.sequence())
+                      && (!e.from_start() && !e.to_end())) ||
+                     (from == 3 && to == 4 && unfold_from_node.sequence() == reverse_complement(orig_from_node.sequence())
+                      && orig_to_node.sequence() == reverse_complement(unfold_to_node.sequence())
+                      && (e.from_start() && e.to_end()))) {
+                found_edge_4 = true;
+            }
+        }
+        
+        REQUIRE(found_edge_1);
+        REQUIRE(found_edge_2);
+        REQUIRE(found_edge_3);
+        REQUIRE(found_edge_4);
     }
-
+    
+    SECTION("Unfolding can flip the reversed portion of a non-branching path with reversing edges") {
+        const string graph_json = R"(
+        {
+            "node": [
+                     {"sequence": "ATA","id": 1},
+                     {"sequence": "CT","id": 2},
+                     {"sequence": "TGA","id": 3}
+                     ],
+            "edge": [
+                     {"from": 1,"to": 2,"to_end": true},
+                     {"from": 2,"to": 3,"from_start": true}
+                     ]
+        }
+        )";
+        
+        VG graph = string_to_graph(graph_json);
+        
+        unordered_map<id_t, pair<id_t, bool> > node_translation;
+        VG unfolded = graph.unfold(10000, node_translation);
+        
+        Graph& g = unfolded.graph;
+        
+        REQUIRE(g.node_size() == 3);
+        REQUIRE(g.edge_size() == 2);
+        
+        bool in_orientation_1 = true;
+        bool in_orientation_2 = true;
+        for (auto record : node_translation) {
+            if (record.second.first == 1) {
+                in_orientation_1 = in_orientation_1 && !record.second.second;
+                in_orientation_2 = in_orientation_2 && record.second.second;
+            }
+            else if (record.second.first == 2) {
+                in_orientation_1 = in_orientation_1 && record.second.second;
+                in_orientation_2 = in_orientation_2 && !record.second.second;
+            }
+            else if (record.second.first == 3) {
+                in_orientation_1 = in_orientation_1 && !record.second.second;
+                in_orientation_2 = in_orientation_2 && record.second.second;
+            }
+        }
+        REQUIRE(in_orientation_1 != in_orientation_2);
+        
+        if (in_orientation_1) {
+            for (int i = 0; i < g.node_size(); i++) {
+                const Node& unfold_node = g.node(i);
+                const Node& orig_node = *graph.get_node(node_translation[unfold_node.id()].first);
+                if (orig_node.id() == 1) {
+                    REQUIRE(unfold_node.sequence() == orig_node.sequence());
+                }
+                else if (orig_node.id() == 2) {
+                    REQUIRE(unfold_node.sequence() == reverse_complement(orig_node.sequence()));
+                }
+                else if (orig_node.id() == 3) {
+                    REQUIRE(unfold_node.sequence() == orig_node.sequence());
+                }
+            }
+        }
+        else {
+            for (int i = 0; i < g.node_size(); i++) {
+                const Node& unfold_node = g.node(i);
+                const Node& orig_node = *graph.get_node(node_translation[unfold_node.id()].first);
+                if (orig_node.id() == 1) {
+                    REQUIRE(unfold_node.sequence() == reverse_complement(orig_node.sequence()));
+                }
+                else if (orig_node.id() == 2) {
+                    REQUIRE(unfold_node.sequence() == orig_node.sequence());
+                }
+                else if (orig_node.id() == 3) {
+                    REQUIRE(unfold_node.sequence() == reverse_complement(orig_node.sequence()));
+                }
+            }
+        }
+    }
+    
+    SECTION("Unfolding can turn a reversing cycle into a directed cycle") {
+        const string graph_json = R"(
+        {
+            "node": [
+                     {"sequence": "ATA","id": 1},
+                     {"sequence": "CT","id": 2}
+                     ],
+            "edge": [
+                     {"from": 1,"to": 2},
+                     {"from": 2,"to": 2,"to_end": true},
+                     {"from": 1,"to": 1,"from_start": true}
+                     ]
+        }
+        )";
+        
+        VG graph = string_to_graph(graph_json);
+        
+        unordered_map<id_t, pair<id_t, bool> > node_translation;
+        VG unfolded = graph.unfold(10000, node_translation);
+        
+        Graph& g = unfolded.graph;
+        
+        REQUIRE(g.node_size() == 4);
+        REQUIRE(g.edge_size() == 4);
+        
+        int64_t node_1 = 0;
+        int64_t node_2 = 0;
+        int64_t node_3 = 0;
+        int64_t node_4 = 0;
+        
+        for (int i = 0; i < g.node_size(); i++) {
+            const Node& n = g.node(i);
+            int64_t orig_id = node_translation[n.id()].first;
+            bool flipped =  node_translation[n.id()].second;
+            if (orig_id == 1 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_1 = n.id();
+            }
+            else if (orig_id == 1 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_2 = n.id();
+            }
+            else if (orig_id == 2 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_3 = n.id();
+            }
+            else if (orig_id == 2 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_4 = n.id();
+            }
+        }
+        
+        REQUIRE(node_1 != 0);
+        REQUIRE(node_2 != 0);
+        REQUIRE(node_3 != 0);
+        REQUIRE(node_4 != 0);
+        
+        bool found_edge_1 = false;
+        bool found_edge_2 = false;
+        bool found_edge_3 = false;
+        bool found_edge_4 = false;
+        
+        for (int i = 0; i < g.edge_size(); i++) {
+            const Edge& e = g.edge(i);
+            if ((e.from() == node_1 && e.to() == node_3 && !e.from_start() && !e.to_end()) ||
+                (e.from() == node_3 && e.to() == node_1 && e.from_start() && e.to_end())) {
+                    found_edge_1 = true;
+                }
+            else if ((e.from() == node_3 && e.to() == node_4 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_4 && e.to() == node_3 && e.from_start() && e.to_end())) {
+                         found_edge_2 = true;
+                     }
+            else if ((e.from() == node_4 && e.to() == node_2 && !e.from_start() && !e.to_end()) ||
+                    (e.from() == node_2 && e.to() == node_4 && e.from_start() && e.to_end())) {
+                         found_edge_3 = true;
+                     }
+            else if ((e.from() == node_2 && e.to() == node_1 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_1 && e.to() == node_2 && e.from_start() && e.to_end())) {
+                found_edge_4 = true;
+            }
+        }
+        
+        REQUIRE(found_edge_1);
+        REQUIRE(found_edge_2);
+        REQUIRE(found_edge_3);
+        REQUIRE(found_edge_4);
+    }
+    
+    SECTION("Unfolding can find reverse strand nodes that require traversing the same node in opposite directions") {
+        const string graph_json = R"(
+        {
+            "node": [
+                     {"sequence": "ATA","id": 1},
+                     {"sequence": "CT","id": 2},
+                     {"sequence": "GG","id": 3},
+                     {"sequence": "TGC","id": 4},
+                     {"sequence": "T","id": 5}
+                     ],
+            "edge": [
+                     {"from": 1,"to": 3},
+                     {"from": 2,"to": 3},
+                     {"from": 3,"to": 4},
+                     {"from": 3,"to": 5},
+                     {"from": 2,"to": 2, "from_start": true},
+                     {"from": 4,"to": 4, "to_end": true}
+                     ]
+        }
+        )";
+        
+        VG graph = string_to_graph(graph_json);
+        
+        unordered_map<id_t, pair<id_t, bool> > node_translation;
+        VG unfolded = graph.unfold(10000, node_translation);
+        
+        Graph& g = unfolded.graph;
+        
+        REQUIRE(g.node_size() == 10);
+        REQUIRE(g.edge_size() == 10);
+        
+        int64_t node_1 = 0;
+        int64_t node_2 = 0;
+        int64_t node_3 = 0;
+        int64_t node_4 = 0;
+        int64_t node_5 = 0;
+        int64_t node_6 = 0;
+        int64_t node_7 = 0;
+        int64_t node_8 = 0;
+        int64_t node_9 = 0;
+        int64_t node_10 = 0;
+        
+        for (int i = 0; i < g.node_size(); i++) {
+            const Node& n = g.node(i);
+            int64_t orig_id = node_translation[n.id()].first;
+            bool flipped =  node_translation[n.id()].second;
+            if (orig_id == 1 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_1 = n.id();
+            }
+            else if (orig_id == 1 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_2 = n.id();
+            }
+            else if (orig_id == 2 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_3 = n.id();
+            }
+            else if (orig_id == 2 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_4 = n.id();
+            }
+            else if (orig_id == 3 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_5 = n.id();
+            }
+            else if (orig_id == 3 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_6 = n.id();
+            }
+            else if (orig_id == 4 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_7 = n.id();
+            }
+            else if (orig_id == 4 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_8 = n.id();
+            }
+            else if (orig_id == 5 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_9 = n.id();
+            }
+            else if (orig_id == 5 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_10 = n.id();
+            }
+        }
+        
+        REQUIRE(node_1 != 0);
+        REQUIRE(node_2 != 0);
+        REQUIRE(node_3 != 0);
+        REQUIRE(node_4 != 0);
+        REQUIRE(node_5 != 0);
+        REQUIRE(node_6 != 0);
+        REQUIRE(node_7 != 0);
+        REQUIRE(node_8 != 0);
+        REQUIRE(node_9 != 0);
+        REQUIRE(node_10 != 0);
+        
+        
+        bool found_edge_1 = false;
+        bool found_edge_2 = false;
+        bool found_edge_3 = false;
+        bool found_edge_4 = false;
+        bool found_edge_5 = false;
+        bool found_edge_6 = false;
+        bool found_edge_7 = false;
+        bool found_edge_8 = false;
+        bool found_edge_9 = false;
+        bool found_edge_10 = false;
+        
+        for (int i = 0; i < g.edge_size(); i++) {
+            const Edge& e = g.edge(i);
+            if ((e.from() == node_1 && e.to() == node_5 && !e.from_start() && !e.to_end()) ||
+                (e.from() == node_5 && e.to() == node_1 && e.from_start() && e.to_end())) {
+                found_edge_1 = true;
+            }
+            else if ((e.from() == node_3 && e.to() == node_5 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_5 && e.to() == node_3 && e.from_start() && e.to_end())) {
+                found_edge_2 = true;
+            }
+            else if ((e.from() == node_5 && e.to() == node_7 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_7 && e.to() == node_5 && e.from_start() && e.to_end())) {
+                found_edge_3 = true;
+            }
+            else if ((e.from() == node_5 && e.to() == node_9 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_9 && e.to() == node_5 && e.from_start() && e.to_end())) {
+                found_edge_4 = true;
+            }
+            else if ((e.from() == node_7 && e.to() == node_8 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_8 && e.to() == node_7 && e.from_start() && e.to_end())) {
+                found_edge_5 = true;
+            }
+            else if ((e.from() == node_8 && e.to() == node_6 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_6 && e.to() == node_8 && e.from_start() && e.to_end())) {
+                found_edge_6 = true;
+            }
+            else if ((e.from() == node_10 && e.to() == node_6 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_6 && e.to() == node_10 && e.from_start() && e.to_end())) {
+                found_edge_7 = true;
+            }
+            else if ((e.from() == node_6 && e.to() == node_2 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_2 && e.to() == node_6 && e.from_start() && e.to_end())) {
+                found_edge_8 = true;
+            }
+            else if ((e.from() == node_6 && e.to() == node_4 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_4 && e.to() == node_6 && e.from_start() && e.to_end())) {
+                found_edge_9 = true;
+            }
+            else if ((e.from() == node_4 && e.to() == node_3 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_3 && e.to() == node_4 && e.from_start() && e.to_end())) {
+                found_edge_10 = true;
+            }
+        }
+        
+        REQUIRE(found_edge_1);
+        REQUIRE(found_edge_2);
+        REQUIRE(found_edge_3);
+        REQUIRE(found_edge_4);
+        REQUIRE(found_edge_5);
+        REQUIRE(found_edge_6);
+        REQUIRE(found_edge_7);
+        REQUIRE(found_edge_8);
+        REQUIRE(found_edge_9);
+        REQUIRE(found_edge_10);
+    }
+    
+    SECTION("Unfolding correctly handles a reversing path along a reverse-oriented path") {
+        const string graph_json = R"(
+        {
+            "node": [
+                     {"sequence": "ATA","id": 1},
+                     {"sequence": "CT","id": 2},
+                     {"sequence": "GG","id": 3},
+                     {"sequence": "TGC","id": 4},
+                     {"sequence": "T","id": 5}
+                     ],
+            "edge": [
+                     {"from": 1,"to": 2, "to_end": true},
+                     {"from": 2,"to": 3, "from_start": true, "to_end": true},
+                     {"from": 3,"to": 4, "from_start": true, "to_end": true},
+                     {"from": 4,"to": 5, "from_start": true},
+                     {"from": 3,"to": 2, "from_start": true},
+                     {"from": 4,"to": 3, "to_end": true}
+                     ]
+        }
+        )";
+        
+        VG graph = string_to_graph(graph_json);
+        
+        unordered_map<id_t, pair<id_t, bool> > node_translation;
+        VG unfolded = graph.unfold(10000, node_translation);
+        
+        Graph& g = unfolded.graph;
+        
+        REQUIRE(g.node_size() == 10);
+        REQUIRE(g.edge_size() == 12);
+        
+        int64_t node_1 = 0;
+        int64_t node_2 = 0;
+        int64_t node_3 = 0;
+        int64_t node_4 = 0;
+        int64_t node_5 = 0;
+        int64_t node_6 = 0;
+        int64_t node_7 = 0;
+        int64_t node_8 = 0;
+        int64_t node_9 = 0;
+        int64_t node_10 = 0;
+        
+        for (int i = 0; i < g.node_size(); i++) {
+            const Node& n = g.node(i);
+            int64_t orig_id = node_translation[n.id()].first;
+            bool flipped =  node_translation[n.id()].second;
+            if (orig_id == 1 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_1 = n.id();
+            }
+            else if (orig_id == 1 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_2 = n.id();
+            }
+            else if (orig_id == 2 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_3 = n.id();
+            }
+            else if (orig_id == 2 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_4 = n.id();
+            }
+            else if (orig_id == 3 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_5 = n.id();
+            }
+            else if (orig_id == 3 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_10 = n.id();
+            }
+            else if (orig_id == 4 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_6 = n.id();
+            }
+            else if (orig_id == 4 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_7 = n.id();
+            }
+            else if (orig_id == 5 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_8 = n.id();
+            }
+            else if (orig_id == 5 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_9 = n.id();
+            }
+        }
+        
+        REQUIRE(node_1 != 0);
+        REQUIRE(node_2 != 0);
+        REQUIRE(node_3 != 0);
+        REQUIRE(node_4 != 0);
+        REQUIRE(node_5 != 0);
+        REQUIRE(node_6 != 0);
+        REQUIRE(node_7 != 0);
+        REQUIRE(node_8 != 0);
+        REQUIRE(node_9 != 0);
+        REQUIRE(node_10 != 0);
+        
+        bool found_edge_1 = false;
+        bool found_edge_2 = false;
+        bool found_edge_3 = false;
+        bool found_edge_4 = false;
+        bool found_edge_5 = false;
+        bool found_edge_6 = false;
+        bool found_edge_7 = false;
+        bool found_edge_8 = false;
+        bool found_edge_9 = false;
+        bool found_edge_10 = false;
+        bool found_edge_11 = false;
+        bool found_edge_12 = false;
+        
+        for (int i = 0; i < g.edge_size(); i++) {
+            const Edge& e = g.edge(i);
+            if ((e.from() == node_1 && e.to() == node_4 && !e.from_start() && !e.to_end()) ||
+                (e.from() == node_4 && e.to() == node_1 && e.from_start() && e.to_end())) {
+                found_edge_1 = true;
+            }
+            else if ((e.from() == node_4 && e.to() == node_5 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_5 && e.to() == node_4 && e.from_start() && e.to_end())) {
+                found_edge_2 = true;
+            }
+            else if ((e.from() == node_9 && e.to() == node_6 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_6 && e.to() == node_9 && e.from_start() && e.to_end())) {
+                found_edge_3 = true;
+            }
+            else if ((e.from() == node_6 && e.to() == node_5 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_5 && e.to() == node_6 && e.from_start() && e.to_end())) {
+                found_edge_4 = true;
+            }
+            else if ((e.from() == node_5 && e.to() == node_3 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_3 && e.to() == node_5 && e.from_start() && e.to_end())) {
+                found_edge_5 = true;
+            }
+            else if ((e.from() == node_3 && e.to() == node_2 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_2 && e.to() == node_3 && e.from_start() && e.to_end())) {
+                found_edge_6 = true;
+            }
+            else if ((e.from() == node_5 && e.to() == node_7 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_7 && e.to() == node_5 && e.from_start() && e.to_end())) {
+                found_edge_7 = true;
+            }
+            else if ((e.from() == node_7 && e.to() == node_8 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_8 && e.to() == node_7 && e.from_start() && e.to_end())) {
+                found_edge_8 = true;
+            }
+            else if ((e.from() == node_4 && e.to() == node_10 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_10 && e.to() == node_4 && e.from_start() && e.to_end())) {
+                found_edge_9 = true;
+            }
+            else if ((e.from() == node_6 && e.to() == node_10 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_10 && e.to() == node_6 && e.from_start() && e.to_end())) {
+                found_edge_10 = true;
+            }
+            else if ((e.from() == node_10 && e.to() == node_7 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_7 && e.to() == node_10 && e.from_start() && e.to_end())) {
+                found_edge_11 = true;
+            }
+            else if ((e.from() == node_10 && e.to() == node_3 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_3 && e.to() == node_10 && e.from_start() && e.to_end())) {
+                found_edge_12 = true;
+            }
+        }
+        
+        REQUIRE(found_edge_1);
+        REQUIRE(found_edge_2);
+        REQUIRE(found_edge_3);
+        REQUIRE(found_edge_4);
+        REQUIRE(found_edge_5);
+        REQUIRE(found_edge_6);
+        REQUIRE(found_edge_7);
+        REQUIRE(found_edge_8);
+        REQUIRE(found_edge_9);
+        REQUIRE(found_edge_10);
+        REQUIRE(found_edge_11);
+        REQUIRE(found_edge_12);
+    }
+    
+    SECTION("Unfolding does not duplicate past the length limit") {
+        const string graph_json = R"(
+        {
+            "node": [
+                     {"sequence": "ATA","id": 1},
+                     {"sequence": "CT","id": 2},
+                     {"sequence": "GG","id": 3},
+                     {"sequence": "TA","id": 4},
+                     {"sequence": "ACT","id": 5}
+                     ],
+            "edge": [
+                     {"from": 1,"to": 2},
+                     {"from": 2,"to": 3},
+                     {"from": 2,"to": 3, "to_end": true},
+                     {"from": 3,"to": 4},
+                     {"from": 3,"to": 4, "from_start": true},
+                     {"from": 4,"to": 5}
+                     ]
+        }
+        )";
+        
+        VG graph = string_to_graph(graph_json);
+        
+        unordered_map<id_t, pair<id_t, bool> > node_translation;
+        VG unfolded = graph.unfold(2, node_translation);
+        
+        Graph& g = unfolded.graph;
+                
+        REQUIRE(g.node_size() == 8);
+        REQUIRE(g.edge_size() == 8);
+        
+        int64_t node_1 = 0;
+        int64_t node_2 = 0;
+        int64_t node_3 = 0;
+        int64_t node_4 = 0;
+        int64_t node_5 = 0;
+        int64_t node_6 = 0;
+        int64_t node_7 = 0;
+        int64_t node_8 = 0;
+        
+        for (int i = 0; i < g.node_size(); i++) {
+            const Node& n = g.node(i);
+            int64_t orig_id = node_translation[n.id()].first;
+            bool flipped =  node_translation[n.id()].second;
+            if (orig_id == 1 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_1 = n.id();
+            }
+            else if (orig_id == 2 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_2 = n.id();
+            }
+            else if (orig_id == 2 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_3 = n.id();
+            }
+            else if (orig_id == 3 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_4 = n.id();
+            }
+            else if (orig_id == 3 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_5 = n.id();
+            }
+            else if (orig_id == 4 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_6 = n.id();
+            }
+            else if (orig_id == 4 && flipped && n.sequence() == reverse_complement(graph.get_node(orig_id)->sequence())) {
+                node_7 = n.id();
+            }
+            else if (orig_id == 5 && !flipped && n.sequence() == graph.get_node(orig_id)->sequence()) {
+                node_8 = n.id();
+            }
+        }
+        
+        REQUIRE(node_1 != 0);
+        REQUIRE(node_2 != 0);
+        REQUIRE(node_3 != 0);
+        REQUIRE(node_4 != 0);
+        REQUIRE(node_5 != 0);
+        REQUIRE(node_6 != 0);
+        REQUIRE(node_7 != 0);
+        REQUIRE(node_8 != 0);
+        
+        bool found_edge_1 = false;
+        bool found_edge_2 = false;
+        bool found_edge_3 = false;
+        bool found_edge_4 = false;
+        bool found_edge_5 = false;
+        bool found_edge_6 = false;
+        bool found_edge_7 = false;
+        bool found_edge_8 = false;
+        bool found_edge_9 = false;
+        bool found_edge_10 = false;
+        
+        for (int i = 0; i < g.edge_size(); i++) {
+            const Edge& e = g.edge(i);
+            if ((e.from() == node_1 && e.to() == node_2 && !e.from_start() && !e.to_end()) ||
+                (e.from() == node_2 && e.to() == node_1 && e.from_start() && e.to_end())) {
+                found_edge_1 = true;
+            }
+            else if ((e.from() == node_2 && e.to() == node_4 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_4 && e.to() == node_2 && e.from_start() && e.to_end())) {
+                found_edge_2 = true;
+            }
+            else if ((e.from() == node_4 && e.to() == node_6 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_6 && e.to() == node_4 && e.from_start() && e.to_end())) {
+                found_edge_3 = true;
+            }
+            else if ((e.from() == node_6 && e.to() == node_8 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_8 && e.to() == node_6 && e.from_start() && e.to_end())) {
+                found_edge_4 = true;
+            }
+            else if ((e.from() == node_2 && e.to() == node_5 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_5 && e.to() == node_2 && e.from_start() && e.to_end())) {
+                found_edge_5 = true;
+            }
+            else if ((e.from() == node_4 && e.to() == node_3 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_3 && e.to() == node_4 && e.from_start() && e.to_end())) {
+                found_edge_6 = true;
+            }
+            else if ((e.from() == node_7 && e.to() == node_4 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_4 && e.to() == node_7 && e.from_start() && e.to_end())) {
+                found_edge_7 = true;
+            }
+            else if ((e.from() == node_5 && e.to() == node_6 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_6 && e.to() == node_5 && e.from_start() && e.to_end())) {
+                found_edge_8 = true;
+            }
+            else if ((e.from() == node_7 && e.to() == node_5 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_5 && e.to() == node_7 && e.from_start() && e.to_end())) {
+                found_edge_9 = true;
+            }
+            else if ((e.from() == node_5 && e.to() == node_3 && !e.from_start() && !e.to_end()) ||
+                     (e.from() == node_3 && e.to() == node_5 && e.from_start() && e.to_end())) {
+                found_edge_10 = true;
+            }
+        }
+        
+        REQUIRE(found_edge_1);
+        REQUIRE(found_edge_2 != found_edge_9);
+        REQUIRE(found_edge_3 != found_edge_10);
+        REQUIRE(found_edge_4);
+        REQUIRE(found_edge_5);
+        REQUIRE(found_edge_6);
+        REQUIRE(found_edge_7);
+        REQUIRE(found_edge_8);
+    }
 }
 
 TEST_CASE("expand_context_by_length() should respect barriers", "[vg][context]") {

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -8625,162 +8625,426 @@ void VG::fill_empty_path_mappings(void) {
         });
 }
 
+VG VG::unfold(uint32_t max_length,
+              map<id_t, pair<id_t, bool> >& node_translation) {
+    
+    // graph we will build
+    VG unfolded;
+    
+    // records the induced forward orientation of each node
+    unordered_map<id_t, pair<id_t, bool>> main_orientation;
+    // edges we have traversed in the forward direction
+    unordered_set<Edge*> forward_edges;
+    // edges that we find in the traversal that flip onto the reverse strand
+    unordered_set<pair<Edge*, NodeTraversal>> reversing_edges;
+    
+    // initially traverse the entire graph with DFS to induce an orientation
+    for (int64_t i = 0; i < graph.node_size(); i++) {
+        // iterate along starting nodes in case there are disconnected components
+        
+        Node* node = graph->mutable_node(i);
+        if (main_orientation.count(node->id())) {
+            continue;
+        }
+        
+        // let this node greedily induce an orientation on the entire component
+        Node* inducing_node = unfolded.add_node(node->sequence());
+        main_orientation[node->id()] = make_pair(inducing_node->id(), false);
+        
+        // DFS
+        list<NodeTraversal> stack;
+        stack.push_back(NodeTraversal(node, false));
+        while (!stack.empty()) {
+            NodeTraversal trav = stack.back();
+            stack.pop_back();
+            
+            auto oriented_trav = main_orientation[trav.node->id()]
+            
+            // check in the forward direction from this node
+            for (NodeTraversal next : travs_from(trav)) {
+                if (main_orientation.count(next.node->id())) {
+                    // we have seen this node before
+                    auto oriented_next = main_orientation[next.node->id()];
+                    Edge* trav_edge = get_edge(trav, next);
+                    
+                    if (next.backward != oriented_next.second) {
+                        // we've encountered this node in the opposite direction, so the edge
+                        // must have reversed the traversal relative to the induce orientation
+                        reversing_edges.emplace(edge, next);
+                    }
+                    else if (!forward_edges.count(trav_edge)) {
+                        // we've never traversed this edge to this node, so add the edge and move on
+                        forward_edges.insert(trav_edge);
+                        
+                        Edge edge;
+                        edge.set_from(oriented_trav.first);
+                        edge.set_to(oriented_next.first);
+                        unfolded.add_edge(edge);
+                    }
+                }
+                else {
+                    // we've never seen this node before, so we induce the current orientation on it
+                    Node* new_node = unfolded.add_node(next.backward ? reverse_complement(next.node->sequence())
+                                                       : next.node->sequence());
+                    main_orientation[next.node->id()] = make_pair(new_node->id(), next.backward);
+                    
+                    // also copy the edge
+                    forward_edges.insert(get_edge(trav, next));
+                    
+                    Edge edge;
+                    edge.set_from(oriented_trav.first);
+                    edge.set_to(new_node->id());
+                    unfolded.add_edge(edge);
+                    
+                    // add to stack to continue traversal
+                    stack.push_back(next);
+                }
+            }
+            
+            // check in the reverse direction from this node
+            for (NodeTraversal prev : travs_to(trav)) {
+                if (orientation.count(prev.node->id())) {
+                    // we have seen this node before
+                    auto oriented_prev = main_orientation[prev.node->id()];
+                    Edge* trav_edge = get_edge(prev, trav);
+                    
+                    if (prev.backward != oriented_prev.second) {
+                        // we've encountered this node in the opposite direction, so the edge
+                        // must have reversed the traversal relative to the induce orientation
+                        reversing_edges.emplace(get_edge(prev, trav), NodeTraversal(prev.node, !prev.backward));
+                    }
+                    else if (!forward_edges.count(trav_edge)) {
+                        // we've never traversed this edge to this node, so add the edge and move on
+                        forward_edges.insert(trav_edge);
+                        
+                        Edge edge;
+                        edge.set_from(oriented_prev.first);
+                        edge.set_to(oriented_trav.first);
+                        unfolded.add_edge(edge);
+                    }
+                }
+                else {
+                    // we've never seen this node before, so we induce the current orientation on it
+                    Node* new_node = unfolded.add_node(prev.backward ? reverse_complement(prev.node->sequence())
+                                                       : prev.node->sequence());
+                    
+                    main_orientation[prev.node->id()] = make_pair(new_node->id(), next.backward);
+                    
+                    // also copy the edge
+                    forward_edges.insert(get_edge(prev, trav));
+                    
+                    Edge edge;
+                    edge.set_from(new_node->id());
+                    edge.set_to(oriented_trav.first);
+                    unfolded.add_edge(edge);
+                    
+                    // add to stack to continue traversal
+                    stack.push_back(prev);
+                }
+            }
+        }
+    }
+    
+    // as an edge case, skip traversing the reverse strand if the search length is 0
+    if (!max_length) {
+        return unfolded;
+    }
+    
+    struct DistTraversal {
+        DistTraversal(NodeTraversal trav, int64_t dist) : trav(trav), dist(dist) {}
+        NodeTraversal trav;
+        int64_t dist;
+        inline bool operator<(const DistTraversal& other) const {
+            return dist > other.dist; // opposite order so priority queue selects minimum
+        }
+    };
+    
+    // the IDs of nodes that we have duplicated in the reverse of the main orientation
+    unordered_map<id_t, id_t> reversed_nodes;
+    // edges that we have already added onto, from, or within the copy of the reverse strand
+    unordered_set<Edge*> reversed_edges;
+    
+    // function to add in an edge that involves a reversed node
+    auto add_rev_path_edge = [&](NodeTraversal next, Edge* forward_edge, bool tail_forward, bool head_forward) {
+        id_t trans_from_id, trans_to_id;
+        if (next.node->id() == forward_edge->to() && (next.backward == forward_edge->to_end())) {
+            if (tail_forward) {
+                trans_from_id = main_orientation[forward_edge->from()].first;
+            }
+            else {
+                trans_from_id = reversed_nodes[forward_edge->from()];
+            }
+            
+            if (head_forward) {
+                trans_to_id = main_orientation[forward_edge->to()].first;
+            }
+            else {
+                trans_from_id = reversed_nodes[forward_edge->to()];
+            }
+        }
+        else {
+            if (tail_forward) {
+                trans_from_id = main_orientation[forward_edge->to()].first;
+            }
+            else {
+                trans_from_id = reversed_nodes[forward_edge->to()];
+            }
+            
+            if (head_forward) {
+                trans_to_id = main_orientation[forward_edge->from()].first;
+            }
+            else {
+                trans_from_id = reversed_nodes[forward_edge->from()];
+            }
+        }
+        
+        Edge edge;
+        edge.set_from(trans_from_id);
+        edge.set_to(trans_to_id);
+        unfolded.add_edge(edge);
+        
+        reversed_edges.insert(forward_edge);
+    }
+    
+    // initialize the queue with the traversals along all of the reversing edges we found
+    // during the orientation-inducing DFS
+    unordered_set<pair<id_t, bool>> queued;
+    priority_queue<DistTraversal> queue;
+    for (auto search_init : reversing_edges) {
+        Edge* init_edge = init.first;
+        NodeTraversal init_trav = init.second;
+        
+        if (!reversed_edges.count(init_edge)) {
+            // we have not added this reverse edge yet, do it
+            add_rev_edge(init_trav, init_edge, true, false);
+        }
+        
+        if (!reversed_nodes.count(init_trav.node->id())) {
+            // we have not added this reverse node yet, so do it
+            Node* rev_init_node = unfolded.add_node(main_orientation[init_trav.node->id()].second ? init_trav.node->sequence()
+                                                    : reverse_complement(init_trav.node->sequence()));
+            reversed_nodes[init_trav.node->id()] = rev_init_node->id();
+        }
+        
+        if (!queued.count(make_pair(init_trav.node->id(), init_trav.backward))) {
+            // we have not starting a traversal along this node in this direction, so add it to the queue
+            queue.emplace(init_trav, 0);
+            queued.emplace(init_trav.node->id(), init_trav.backward);
+        }
+    }
+    
+    while (!queue.empty()) {
+        DistTraversal dist_trav = queue.top();
+        queue.pop();
+        
+        int64_t dist_thru = dist_trav.dist + dist_trav.trav.node->sequence().size();
+        if (dist_thru >= max_length) {
+            continue;
+        }
+        
+        for (NodeTraversal next : travs_from(dist_trav.trav)) {
+            
+            Edge* edge = get_edge(dist_trav.trav, next);
+            
+            if (reversed_edges.count(edge)) {
+                // this edge has already been added, don't search through it
+                continue;
+            }
+            if (next.backward != dist_trav.trav.backward) {
+                // this edge reverses back onto the forward strand, so we don't need to keep searching
+                add_rev_edge(next, edge, false, true);
+            }
+            else {
+                // we haven't traversed this edge and it stays on the reverse strand
+                add_rev_edge(next, edge, false, false);
+                
+                if (!reversed_nodes.count(next.node->id())) {
+                    // this is the first time we've encountered this node in any direction on the reverse strand
+                    // so add the reverse node
+                    Node* rev_node = unfolded.add_node(main_orientation[next.node->id()].second ? next.node->sequence()
+                                                       : reverse_complement(next.node->sequence()));
+                    reversed_nodes[next.node->id()] = rev_node->id();
+                }
+                
+                if (!queued.count(make_pair(next.node->id(), next.backward))) {
+                    // this is the first time we've encountered this node in this direction on the reverse strand
+                    // so queue it up for the search through
+                    queue.emplace(next, 0);
+                    queued.emplace(next.node->id(), next.backward);
+                }
+            }
+        }
+    }
+    
+    // construct the backward node translators
+    for (auto orient_record : main_orientation) {
+        node_translation[orient_record.second.first] = make_pair(orient_record.first,
+                                                                 orient_record.second.second);
+    }
+    for (auto rev_orient_record : reversed_nodes) {
+        node_translation[rev_orient_record.second] = make_pair(rev_orient_record.first,
+                                                               !main_orientation[rev_orient_record.first].second);
+    }
+    
+    return unfolded;
+}
+
 // for each inverting edge
 // we walk up to max_length across the inversion
 // adding the forward complement of nodes we reach
 // stopping if we reach an inversion back to the forward graph
 // so as to ensure that sequences up to length max_length that cross the inversion
 // would align to the forward component of the resulting graph
-VG VG::unfold(uint32_t max_length,
-              map<id_t, pair<id_t, bool> >& node_translation) {
-    VG unfolded = *this;
-    unfolded.flip_doubly_reversed_edges();
-    if (!unfolded.has_inverting_edges()) return unfolded;
-    
-    // This is the set of oriented nodes that we want to include in a reverse orientation.
-    set<NodeTraversal> travs_to_flip;
-    // These are the edges we need to fix up
-    set<pair<NodeTraversal, NodeTraversal> > edges_to_flip;
-    // These are edges from the reverse world to the forward world
-    set<pair<NodeTraversal, NodeTraversal> > edges_to_forward;
-    // And these are edges from the forward world to the reverse worls
-    set<pair<NodeTraversal, NodeTraversal> > edges_from_forward;
-
-    // collect the set to invert
-    // and we'll copy them over
-    // then link back in according to how the inbound links work
-    // so as to eliminate the reversing edges
-    
-    // This stores how much length we had left when we visited each node in the
-    // original graph in each orientation.
-    map<NodeTraversal, int32_t> seen;
-    function<void(NodeTraversal,int32_t)> walk = [&](NodeTraversal curr,
-                                                     int32_t length) {
-
-#ifdef debug
-        cerr << "Visit " << curr << " with " << length << " bases remaining" << endl;
-#endif
-        
-        set<NodeTraversal> next;
-        travs_to_flip.insert(curr);
-
-        // check if we've passed our length limit
-        // or if we've seen this node before at an earlier step
-        // (in which case we're done b/c we will traverse the rest of the graph up to max_length)
-        if (length <= 0 || (seen.find(curr) != seen.end() && seen[curr] >= length)) {
-#ifdef debug
-            cerr << "\tDon't explore further" << endl;
-            if (seen.find(curr) != seen.end()) {
-                cerr << "\t\tBecause we already saw " << curr << " with " << seen[curr] << " remaining" << endl;
-            } else {
-                cerr << "\t\tBecuase " << length << " <= 0" << endl;
-            }
-#endif
-            return;
-        }
-        
-        // We can reach this node with this much length left.
-        seen[curr] = length;
-        for (auto& trav : travs_from(curr)) {
-            // Look at all the oriented nodes we can go to next
-            if (trav.backward) {
-                // We can get to this node backward from a node that's already
-                // backward, so remember to make a reverse-world version of the
-                // edge.
-                edges_to_flip.insert(make_pair(curr, trav));
-                // Flip and continue from that node with the remaining length
-                walk(trav, length-trav.node->sequence().size());
-            } else {
-                // we would not continue, but we should retain this edge because it brings
-                // us back into the forward strand
-                edges_to_forward.insert(make_pair(curr, trav));
-            }
-        }
-        for (auto& trav : travs_to(curr)) {
-            // Look at all the oriented nodes we could have come from
-            if (trav.backward) {
-                // We can get to this node backward from a node that's already
-                // backward, so remember to make a reverse-world version of the
-                // edge.
-                edges_to_flip.insert(make_pair(trav, curr));
-                // Keep looking off of that node.
-                walk(trav, length-trav.node->sequence().size());
-            } else {
-                // we would not continue, but we should retain this edge because it brings
-                // us back into the forward strand
-                edges_from_forward.insert(make_pair(trav, curr));
-            }
-        }
-    };
-
-    // run over the inverting edges
-    for_each_node([&](Node* node) {
-            // For each node
-            for (auto& trav : travs_of(NodeTraversal(node, false))) {
-                // For everything connecte dto this node in the forward orientation
-                if (trav.backward) {
-                    // If it's in the reverse orientation, look outwards from it
-#ifdef debug
-                    cerr << "Start walk out from " << trav << " which is reverse and attached to "
-                        << node->id() << " forward" << endl;
-#endif
-                    walk(trav,  max_length);
-                }
-            }
-        });
-    // now build out the component of the graph that's reversed
-
-    // This map is sort of the reverse of map<id_t, pair<id_t, bool> >& node_translation
-    // It maps from original NodeTranslation to the new node ID that represents it on the forward strand.
-    map<NodeTraversal, id_t> inv_translation;
-
-    // first adding nodes that we've flipped
-    for (auto t : travs_to_flip) {
-        // make a new node, add it to the flattened version
-        // record it in the translation
-        string seq = reverse_complement(t.node->sequence());
-        id_t i = unfolded.create_node(seq)->id();
-        // Remember the old node ID and orientation as where this new node came from
-        node_translation[i] = make_pair(t.node->id(), t.backward);
-        // Remember the new ID for the forward version of this NodeTraversal.
-        inv_translation[t] = i;
-        
-#ifdef debug
-        cerr << "Transform " << t << " into new node " << i << endl;
-#endif
-        
-    }
-
-    // then edges that we should translate into the reversed component
-    for (auto e : edges_to_flip) {
-        // both of the edges are now in nodes that have been flipped
-        // we need to find the new nodes and add the natural edge
-        // the edge will also be reversed
-        Edge f;
-        f.set_from(inv_translation[e.first]);
-        f.set_to(inv_translation[e.second]);
-        unfolded.add_edge(f);
-    }
-
-    // finally the edges that take us from the reversed component back to the original graph
-    for (auto e : edges_to_forward) {
-        Edge f;
-        f.set_from(inv_translation[e.first]);
-        f.set_to(e.second.node->id());
-        unfolded.add_edge(f);
-    }
-    for (auto e : edges_from_forward) {
-        Edge f;
-        f.set_from(e.first.node->id());
-        f.set_to(inv_translation[e.second]);
-        unfolded.add_edge(f);
-    }
-
-    // now remove all inverting edges, so we have no more folds in the graph
-    unfolded.remove_inverting_edges();
-
-    return unfolded;
-}
+//VG VG::unfold(uint32_t max_length,
+//              map<id_t, pair<id_t, bool> >& node_translation) {
+//    VG unfolded = *this;
+//    unfolded.flip_doubly_reversed_edges();
+//    if (!unfolded.has_inverting_edges()) return unfolded;
+//    
+//    // This is the set of oriented nodes that we want to include in a reverse orientation.
+//    set<NodeTraversal> travs_to_flip;
+//    // These are the edges we need to fix up
+//    set<pair<NodeTraversal, NodeTraversal> > edges_to_flip;
+//    // These are edges from the reverse world to the forward world
+//    set<pair<NodeTraversal, NodeTraversal> > edges_to_forward;
+//    // And these are edges from the forward world to the reverse worls
+//    set<pair<NodeTraversal, NodeTraversal> > edges_from_forward;
+//
+//    // collect the set to invert
+//    // and we'll copy them over
+//    // then link back in according to how the inbound links work
+//    // so as to eliminate the reversing edges
+//    
+//    // This stores how much length we had left when we visited each node in the
+//    // original graph in each orientation.
+//    map<NodeTraversal, int32_t> seen;
+//    function<void(NodeTraversal,int32_t)> walk = [&](NodeTraversal curr,
+//                                                     int32_t length) {
+//
+//#ifdef debug
+//        cerr << "Visit " << curr << " with " << length << " bases remaining" << endl;
+//#endif
+//        
+//        set<NodeTraversal> next;
+//        travs_to_flip.insert(curr);
+//
+//        // check if we've passed our length limit
+//        // or if we've seen this node before at an earlier step
+//        // (in which case we're done b/c we will traverse the rest of the graph up to max_length)
+//        if (length <= 0 || (seen.find(curr) != seen.end() && seen[curr] >= length)) {
+//#ifdef debug
+//            cerr << "\tDon't explore further" << endl;
+//            if (seen.find(curr) != seen.end()) {
+//                cerr << "\t\tBecause we already saw " << curr << " with " << seen[curr] << " remaining" << endl;
+//            } else {
+//                cerr << "\t\tBecuase " << length << " <= 0" << endl;
+//            }
+//#endif
+//            return;
+//        }
+//        
+//        // We can reach this node with this much length left.
+//        seen[curr] = length;
+//        for (auto& trav : travs_from(curr)) {
+//            // Look at all the oriented nodes we can go to next
+//            if (trav.backward) {
+//                // We can get to this node backward from a node that's already
+//                // backward, so remember to make a reverse-world version of the
+//                // edge.
+//                edges_to_flip.insert(make_pair(curr, trav));
+//                // Flip and continue from that node with the remaining length
+//                walk(trav, length-trav.node->sequence().size());
+//            } else {
+//                // we would not continue, but we should retain this edge because it brings
+//                // us back into the forward strand
+//                edges_to_forward.insert(make_pair(curr, trav));
+//            }
+//        }
+//        for (auto& trav : travs_to(curr)) {
+//            // Look at all the oriented nodes we could have come from
+//            if (trav.backward) {
+//                // We can get to this node backward from a node that's already
+//                // backward, so remember to make a reverse-world version of the
+//                // edge.
+//                edges_to_flip.insert(make_pair(trav, curr));
+//                // Keep looking off of that node.
+//                walk(trav, length-trav.node->sequence().size());
+//            } else {
+//                // we would not continue, but we should retain this edge because it brings
+//                // us back into the forward strand
+//                edges_from_forward.insert(make_pair(trav, curr));
+//            }
+//        }
+//    };
+//
+//    // run over the inverting edges
+//    for_each_node([&](Node* node) {
+//            // For each node
+//            for (auto& trav : travs_of(NodeTraversal(node, false))) {
+//                // For everything connecte dto this node in the forward orientation
+//                if (trav.backward) {
+//                    // If it's in the reverse orientation, look outwards from it
+//#ifdef debug
+//                    cerr << "Start walk out from " << trav << " which is reverse and attached to "
+//                        << node->id() << " forward" << endl;
+//#endif
+//                    walk(trav,  max_length);
+//                }
+//            }
+//        });
+//    // now build out the component of the graph that's reversed
+//
+//    // This map is sort of the reverse of map<id_t, pair<id_t, bool> >& node_translation
+//    // It maps from original NodeTranslation to the new node ID that represents it on the forward strand.
+//    map<NodeTraversal, id_t> inv_translation;
+//
+//    // first adding nodes that we've flipped
+//    for (auto t : travs_to_flip) {
+//        // make a new node, add it to the flattened version
+//        // record it in the translation
+//        string seq = reverse_complement(t.node->sequence());
+//        id_t i = unfolded.create_node(seq)->id();
+//        // Remember the old node ID and orientation as where this new node came from
+//        node_translation[i] = make_pair(t.node->id(), t.backward);
+//        // Remember the new ID for the forward version of this NodeTraversal.
+//        inv_translation[t] = i;
+//        
+//#ifdef debug
+//        cerr << "Transform " << t << " into new node " << i << endl;
+//#endif
+//        
+//    }
+//
+//    // then edges that we should translate into the reversed component
+//    for (auto e : edges_to_flip) {
+//        // both of the edges are now in nodes that have been flipped
+//        // we need to find the new nodes and add the natural edge
+//        // the edge will also be reversed
+//        Edge f;
+//        f.set_from(inv_translation[e.first]);
+//        f.set_to(inv_translation[e.second]);
+//        unfolded.add_edge(f);
+//    }
+//
+//    // finally the edges that take us from the reversed component back to the original graph
+//    for (auto e : edges_to_forward) {
+//        Edge f;
+//        f.set_from(inv_translation[e.first]);
+//        f.set_to(e.second.node->id());
+//        unfolded.add_edge(f);
+//    }
+//    for (auto e : edges_from_forward) {
+//        Edge f;
+//        f.set_from(e.first.node->id());
+//        f.set_to(inv_translation[e.second]);
+//        unfolded.add_edge(f);
+//    }
+//
+//    // now remove all inverting edges, so we have no more folds in the graph
+//    unfolded.remove_inverting_edges();
+//
+//    return unfolded;
+//}
 
 bool VG::has_inverting_edges(void) {
     for (id_t i = 0; i < graph.edge_size(); ++i) {

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -232,9 +232,16 @@ public:
     /// Generate a new graph that unrolls the current one using backtracking. Caution: exponential in branching.
     VG backtracking_unroll(uint32_t max_length, uint32_t max_depth,
                            unordered_map<id_t, pair<id_t, bool> >& node_translation);
-    /// Represent the whole graph up to max_length across an inversion on the forward strand.
+    /// Ensure that all traversals up to max_length are represented as a path on one strand or the other
+    /// without taking an inverting edge. All inverting edges are converted to non-inverting edges to
+    /// reverse complement nodes. If no inverting edges are present, the strandedness of all nodes is
+    /// the same as the input graph. If inverting edges are present, node strandedness is arbitrary.
     VG unfold(uint32_t max_length,
               unordered_map<id_t, pair<id_t, bool> >& node_translation);
+    /// Create reverse complement nodes and edges for the entire graph. Doubles the size. Converts all inverting
+    /// edges into non-inverting edges.
+    VG split_strands(unordered_map<id_t, pair<id_t, bool> >& node_translation);
+    
     /// Assume two node translations, the over is based on the under; merge them.
     unordered_map<id_t, pair<id_t, bool> > overlay_node_translations(const unordered_map<id_t, pair<id_t, bool> >& over,
                                                                      const unordered_map<id_t, pair<id_t, bool> >& under);

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -226,18 +226,18 @@ public:
     /// Turn the graph into a dag by copying strongly connected components expand_scc_steps times
     /// and translating the edges in the component to flow through the copies in one direction.
     VG dagify(uint32_t expand_scc_steps,
-              map<id_t, pair<id_t, bool> >& node_translation,
+              unordered_map<id_t, pair<id_t, bool> >& node_translation,
               size_t target_min_walk_length = 0,
               size_t component_length_max = 0);
     /// Generate a new graph that unrolls the current one using backtracking. Caution: exponential in branching.
     VG backtracking_unroll(uint32_t max_length, uint32_t max_depth,
-                           map<id_t, pair<id_t, bool> >& node_translation);
+                           unordered_map<id_t, pair<id_t, bool> >& node_translation);
     /// Represent the whole graph up to max_length across an inversion on the forward strand.
     VG unfold(uint32_t max_length,
-              map<id_t, pair<id_t, bool> >& node_translation);
+              unordered_map<id_t, pair<id_t, bool> >& node_translation);
     /// Assume two node translations, the over is based on the under; merge them.
-    map<id_t, pair<id_t, bool> > overlay_node_translations(const map<id_t, pair<id_t, bool> >& over,
-                                                           const map<id_t, pair<id_t, bool> >& under);
+    unordered_map<id_t, pair<id_t, bool> > overlay_node_translations(const unordered_map<id_t, pair<id_t, bool> >& over,
+                                                                     const unordered_map<id_t, pair<id_t, bool> >& under);
     /// Use our topological sort to quickly break cycles in the graph, return the edges which are removed.
     /// Very non-optimal, but fast.
     vector<Edge> break_cycles(void);


### PR DESCRIPTION
- Rewrote `VG::unfold` to have more consistent semantics. No longer has artifacts resulting from arbitrarily preferring the forward strand around inversions. Providing extremely long unfold distances near an inverting edge does not always produce the equivalent unidirected graph anymore.
- Added a new `VG::split_strands` algorithm that converts to the equivalent unidirected sequence graph.
- Added tests for both algorithms.
- Switched all node translators to unordered maps, which are better.