### PR TITLE
Allow multiple primary path contigs in vg call

### DIFF
--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -351,32 +351,87 @@ public:
     /**
      * We use this to represent a contig in the primary path, with its index and coverage info.
      */
-    struct PrimaryPath {
-    
+    class PrimaryPath {
+    public:
         /**
          * Index the given path in the given augmented graph, and compute all
-         * the coverage bin information.
+         * the coverage bin information with the given bin size.
          */
-        PrimaryPath(AugmentedGraph& augmented, const string& ref_path_name); 
+        PrimaryPath(AugmentedGraph& augmented, const string& ref_path_name, size_t ref_bin_size); 
     
-        /// This holds the index for this path
-        PathIndex index;
+        /**
+         * Get the support at the bin appropriate for the given primary path
+         * offset.
+         */
+        const Support& get_support_at(size_t primary_path_offset);
         
+        /**
+         * Get the index of the bin that the given path position falls in.
+         */
+        size_t get_bin_index(size_t primary_path_offset);
+    
+        /**
+         * Get the bin with minimal coverage.
+         */
+        size_t get_min_bin();
+    
+        /**
+         * Get the bin with maximal coverage.
+         */
+        size_t get_max_bin();
+    
+        /**
+         * Get the support in the given bin.
+         */
+        const Support& get_bin(size_t bin);
+        
+        /**
+         * Get the total number of bins that the path is divided into.
+         */
+        size_t get_total_bins();
+        
+        /**
+         * Get the average support over the path.
+         */
+        const Support get_average_support();
+        
+        /**
+         * Get the total support for the path.
+         */
+        const Support get_total_support();
+    
+        /**
+         * Get the PathIndex for this primary path.
+         */
+        PathIndex& get_index();
+    
+    protected:
         /// How wide is each coverage bin along the path?
         size_t ref_bin_size;
+        
+        /// This holds the index for this path
+        PathIndex index;
         
         /// What's the expected in each bin along the path? Coverage gets split
         /// evenly over both strands.
         vector<Support> binned_support;
+        
+        /// Which bin has min support?
+        size_t min_bin;
+        /// Which bin has max support?
+        size_t max_bin;
+        
+        /// What's the total Support over every bin?
+        Support total_support;
     };
     
     
     /**
      * Produce calls for the given annotated augmented graph. If a
-     * pileupFilename is provided, the pileup is loaded again and used to add
+     * pileup_filename is provided, the pileup is loaded again and used to add
      * comments describing variants
      */
-    void call(AugmentedGraph& augmented, string pileupFilename = "");
+    void call(AugmentedGraph& augmented, string pileup_filename = "");
     
     /**
      * Decide if the given SnarlTraversal is included in the original base graph
@@ -437,7 +492,7 @@ public:
     size_t ref_bin_size = 250;
     // On some graphs, we can't get the coverage because it's split over
     // parallel paths.  Allow overriding here
-    size_t expCoverage = 0;
+    double expCoverage = 0.0;
     // Should we drop variants that would overlap old ones? TODO: we really need
     // a proper system for accounting for usage of graph material.
     bool suppress_overlaps = false;

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -363,54 +363,72 @@ public:
          * Get the support at the bin appropriate for the given primary path
          * offset.
          */
-        const Support& get_support_at(size_t primary_path_offset);
+        const Support& get_support_at(size_t primary_path_offset) const;
         
         /**
          * Get the index of the bin that the given path position falls in.
          */
-        size_t get_bin_index(size_t primary_path_offset);
+        size_t get_bin_index(size_t primary_path_offset) const;
     
         /**
          * Get the bin with minimal coverage.
          */
-        size_t get_min_bin();
+        size_t get_min_bin() const;
     
         /**
          * Get the bin with maximal coverage.
          */
-        size_t get_max_bin();
+        size_t get_max_bin() const;
     
         /**
          * Get the support in the given bin.
          */
-        const Support& get_bin(size_t bin);
+        const Support& get_bin(size_t bin) const;
         
         /**
          * Get the total number of bins that the path is divided into.
          */
-        size_t get_total_bins();
+        size_t get_total_bins() const;
         
         /**
          * Get the average support over the path.
          */
-        const Support get_average_support();
+        Support get_average_support() const;
+        
+        /**
+         * Get the average support over a collection of paths.
+         */
+        static Support get_average_support(const map<string, PrimaryPath>& paths);
         
         /**
          * Get the total support for the path.
          */
-        const Support get_total_support();
+        Support get_total_support() const;
     
         /**
          * Get the PathIndex for this primary path.
          */
         PathIndex& get_index();
-    
+        
+        /**
+         * Get the PathIndex for this primary path.
+         */
+        const PathIndex& get_index() const;
+        
+        /**
+         * Gets the path name we are representing.
+         */
+        const string& get_name() const;
+        
     protected:
         /// How wide is each coverage bin along the path?
         size_t ref_bin_size;
         
         /// This holds the index for this path
         PathIndex index;
+        
+        /// This holds the name of the path
+        string name;
         
         /// What's the expected in each bin along the path? Coverage gets split
         /// evenly over both strands.
@@ -437,8 +455,8 @@ public:
      * Decide if the given SnarlTraversal is included in the original base graph
      * (true), or if it represents a novel variant (false).
      *
-     * Looks at the nodes in the traversal that aren't along the primary path,
-     * and sees if their calls are CALL_REFERENCE or not.
+     * Looks at the nodes in the traversal, and sees if their calls are
+     * CALL_REFERENCE or not.
      *
      * Specially handles single-edge traversals.
      *
@@ -446,7 +464,14 @@ public:
      * reference, because it assumes the caller will never pass it the all-
      * primary-path reference traversal.
      */
-    bool is_reference(const SnarlTraversal& trav, AugmentedGraph& augmented, const PathIndex& primary_path);
+    bool is_reference(const SnarlTraversal& trav, AugmentedGraph& augmented);
+    
+    /**
+     * Find the primary path, if any, that the given site is threaded onto.
+     *
+     * TODO: can only work by brute-force search.
+     */
+    map<string, PrimaryPath>::iterator find_path(const Snarl& site, map<string, PrimaryPath>& primary_paths);
     
     // Option variables
     
@@ -455,20 +480,23 @@ public:
     // How big should our output buffer be?
     size_t locus_buffer_size = 1000;
     
-    // What's the name of the reference path in the graph?
-    string ref_path_name = "";
-    // What name should we give the contig in the VCF file?
-    string contigName = "";
+    // What are the names of the reference paths, if any, in the graph?
+    vector<string> ref_path_names;
+    // What name should we give each contig in the VCF file? Autodetected from
+    // path names if empty or too short.
+    vector<string> contig_name_overrides;
+    // What should the total sequence length reported in the VCF header be for
+    // each contig? Autodetected from path lengths if empty or too short.
+    vector<size_t> length_overrides;
     // What name should we use for the sample in the VCF file?
-    string sampleName = "SAMPLE";
+    string sample_name = "SAMPLE";
     // How far should we offset positions of variants?
     int64_t variantOffset = 0;
     // How many nodes should we be willing to look at on our path back to the
     // primary path? Keep in mind we need to look at all valid paths (and all
     // combinations thereof) until we find a valid pair.
     int64_t maxDepth = 10;
-    // What should the total sequence length reported in the VCF header be?
-    int64_t lengthOverride = -1;
+    
     
     // What fraction of average coverage should be the minimum to call a variant (or a single copy)?
     // Default to 0 because vg call is still applying depth thresholding

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -349,6 +349,29 @@ public:
     Call2Vcf() = default;
     
     /**
+     * We use this to represent a contig in the primary path, with its index and coverage info.
+     */
+    struct PrimaryPath {
+    
+        /**
+         * Index the given path in the given augmented graph, and compute all
+         * the coverage bin information.
+         */
+        PrimaryPath(AugmentedGraph& augmented, const string& ref_path_name); 
+    
+        /// This holds the index for this path
+        PathIndex index;
+        
+        /// How wide is each coverage bin along the path?
+        size_t ref_bin_size;
+        
+        /// What's the expected in each bin along the path? Coverage gets split
+        /// evenly over both strands.
+        vector<Support> binned_support;
+    };
+    
+    
+    /**
      * Produce calls for the given annotated augmented graph. If a
      * pileupFilename is provided, the pileup is loaded again and used to add
      * comments describing variants
@@ -378,7 +401,7 @@ public:
     size_t locus_buffer_size = 1000;
     
     // What's the name of the reference path in the graph?
-    string refPathName = "";
+    string ref_path_name = "";
     // What name should we give the contig in the VCF file?
     string contigName = "";
     // What name should we use for the sample in the VCF file?
@@ -411,7 +434,7 @@ public:
     // Bin size used for counting coverage along the reference path.  The
     // bin coverage is used for computing the probability of an allele
     // of a certain depth
-    size_t refBinSize = 250;
+    size_t ref_bin_size = 250;
     // On some graphs, we can't get the coverage because it's split over
     // parallel paths.  Allow overriding here
     size_t expCoverage = 0;

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -620,9 +620,9 @@ vector<SnarlTraversal> TrivialTraversalFinder::find_traversals(const Snarl& site
 }
 
 RepresentativeTraversalFinder::RepresentativeTraversalFinder(AugmentedGraph& augmented,
-    SnarlManager& snarl_manager, PathIndex& primary_path_index, size_t max_depth,
-    size_t max_bubble_paths) : augmented(augmented), snarl_manager(snarl_manager),
-    primary_path_index(primary_path_index), max_depth(max_depth), max_bubble_paths(max_bubble_paths) {
+    SnarlManager& snarl_manager, size_t max_depth, size_t max_bubble_paths,
+    function<PathIndex*(const Snarl&)> get_index) : augmented(augmented), snarl_manager(snarl_manager),
+    max_depth(max_depth), max_bubble_paths(max_bubble_paths), get_index(get_index) {
     
     // Nothing to do!
 
@@ -662,7 +662,13 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
     // on the primary path.
     unique_ptr<PathIndex> backbone_index;
     
-    if (!primary_path_index.by_id.count(site.start().node_id()) || !primary_path_index.by_id.count(site.end().node_id())) {
+    // See what the index for the appropriate primary path, if any, is. If we
+    // get something non-null the site must be threaded on it.
+    PathIndex* primary_path_index = get_index(site);
+    
+    if (primary_path_index == nullptr ||
+        !primary_path_index->by_id.count(site.start().node_id()) ||
+        !primary_path_index->by_id.count(site.end().node_id())) {
         // This site is not strung along the primary path, so we will need to
         // generate a backbone traversal of it to structure our search for
         // representative traversals (because they always want to come back to
@@ -678,7 +684,7 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
     
     // Determnine what path will be the path we use to scaffold the traversals:
     // the primary path index by default, or the backbone index if we needed one.
-    PathIndex& index = (backbone_index.get() != nullptr ? *backbone_index : primary_path_index);
+    PathIndex& index = (backbone_index.get() != nullptr ? *backbone_index : *primary_path_index);
     
     // Get the site's nodes and edges (including all child sites)
     pair<unordered_set<Node*>, unordered_set<Edge*>> contents = snarl_manager.deep_contents(&site, augmented.graph, true);

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -319,9 +319,11 @@ protected:
     AugmentedGraph& augmented;
     /// The SnarlManager managiung the snarls we use
     SnarlManager& snarl_manager;
-    /// An index of the primary path in the graph, to scaffold the produced
-    /// traversals when sites are on the primary path.
-    PathIndex& primary_path_index;
+    
+    /// We keep around a function that can be used to get an index for the
+    /// appropriate path to use to scaffold a given site, or null if no
+    /// appropriate index exists.
+    function<PathIndex*(const Snarl&)> get_index;
     
     /// What DFS depth should we search to?
     size_t max_depth;
@@ -380,7 +382,8 @@ protected:
 public:
 
     RepresentativeTraversalFinder(AugmentedGraph& augmented, SnarlManager& snarl_manager,
-        PathIndex& index, size_t max_depth, size_t max_bubble_paths);
+        size_t max_depth, size_t max_bubble_paths,
+        function<PathIndex*(const Snarl&)> get_index = [](const Snarl& s) { return nullptr; });
     
     /// Should we emit verbose debugging info?
     bool verbose = false;

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -171,7 +171,7 @@ int main_call(int argc, char** argv) {
         // old glenn2vcf opts start here
         case 'r':
             // Set the reference path name
-            call2vcf.refPathName = optarg;
+            call2vcf.ref_path_name = optarg;
             break;
         case 'c':
             // Set the contig name
@@ -224,7 +224,7 @@ int main_call(int argc, char** argv) {
             break;
         case 'B':
             // Set the reference bin size
-            call2vcf.refBinSize = std::stoll(optarg);
+            call2vcf.ref_bin_size = std::stoll(optarg);
             break;
         case 'C':
             // Override expected coverage

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -36,11 +36,11 @@ void help_call(char** argv) {
          << "    -b, --max-strand-bias FLOAT limit to absolute difference between 0.5 and proportion of supporting reads on reverse strand. [" << Caller::Default_max_strand_bias << "]" << endl
          << "    -a, --link-alts            add all possible edges between adjacent alts" << endl
          << "    -A, --aug-graph FILE       write out the agumented graph in vg format" << endl
-         << "    -r, --ref PATH             use the given path name as the reference path" << endl
-         << "    -c, --contig NAME          use the given name as the VCF contig name" << endl
+         << "    -r, --ref PATH             use the path with the given name as a reference path (can repeat)" << endl
+         << "    -c, --contig NAME          use the given name as the VCF name for the corresponding reference path" << endl
          << "    -S, --sample NAME          name the sample in the VCF with the given name [SAMPLE]" << endl
          << "    -o, --offset INT           offset variant positions by this amount in VCF [0]" << endl
-         << "    -l, --length INT           override total sequence length in VCF" << endl
+         << "    -l, --length INT           override total sequence length in VCF for the corresponding reference path" << endl
          << "    -U, --subgraph             expect a subgraph and ignore extra pileup entries outside it" << endl
          << "    -P, --pileup               write pileup under VCF lines (for debugging, output not valid VCF)" << endl
          << "    -D, --depth INT            maximum depth for path search [default 10 nodes]" << endl
@@ -170,16 +170,16 @@ int main_call(int argc, char** argv) {
             break;
         // old glenn2vcf opts start here
         case 'r':
-            // Set the reference path name
-            call2vcf.ref_path_name = optarg;
+            // Remember each reference path name
+            call2vcf.ref_path_names.push_back(optarg);
             break;
         case 'c':
-            // Set the contig name
-            call2vcf.contigName = optarg;
+            // Remember each contig name
+            call2vcf.contig_name_overrides.push_back(optarg);
             break;
         case 'S':
             // Set the sample name
-            call2vcf.sampleName = optarg;
+            call2vcf.sample_name = optarg;
             break;
         case 'o':
             // Offset variants
@@ -190,8 +190,8 @@ int main_call(int argc, char** argv) {
             call2vcf.maxDepth = std::stoll(optarg);
             break;
         case 'l':
-            // Set a length override
-            call2vcf.lengthOverride = std::stoll(optarg);
+            // Remember a length override for the correspondig contig
+            call2vcf.length_overrides.push_back(std::stoll(optarg));
             break;
         case 'U':
             expectSubgraph = true;


### PR DESCRIPTION
Now you can run vg call and have multiple paths denoted as constituting the primary path.

Each path will have independent coverage binning, and cases where the average primary path coverage is used (like off-primary-path sites) will get their expected coverage from a weighted average of all the primary path contigs.

This is necessary for deploying vg call on big multi-part HGVM graphs larger than a single chromosome, when you may not have a good way to break up the graph into chunks to call independently.