### PR TITLE
attempt to use chars instead of integeters, and to use switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ vg
 *.fa.fai
 test/build_graph
 test/.*
+test/*.lcp
+test/*/*.lcp
 test/**/*.index/
 trash
 # Ignore a bunch of files people might dump in the root when testing

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ This model is similar to a number of sequence graphs that have been used in asse
 
 ### building
 
-Before you begin, you'll need to install some basic tools if they are not already installed. You'll need the protobuf and jansson development libraries installed on your server. Additionally, to run the tests, you will need jq and bc.
+Before you begin, you'll need to install some basic tools if they are not already installed. You'll need the protobuf and jansson development libraries installed on your server. Additionally, to run the tests, you will need `jq`, `bc` and `rs`.
 
     sudo apt-get install build-essential git cmake pkg-config libncurses-dev libbz2-dev  \
                          protobuf-compiler libprotoc-dev libjansson-dev automake libtool \
-                         jq bc curl unzip redland-utils librdf-dev bison flex
+                         jq bc rs curl unzip redland-utils librdf-dev bison flex
 
 You can also run `make get-deps`.
 

--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -513,45 +513,51 @@ void Caller::compute_top_frequencies(const BasePileup& bp,
             // base == '' -> Uncalled: 0 Points
             return 0;
         }
-        else if(n == 1)
+        else
         {
             char cbase = base[0];
             
-            switch(cbase) {
-                case '.':// Ref: 6 Points
-                    return 6;
-                break;
-                case '-': // Uncalled: 0 Points
-                    return 0;
-                break;
-                
-                // Transition: 5 points.  Transversion: 4 points 
-                case 'A':
-                case 't':
-                    return cbase == 'G' ? 5 : 4;
-                break;
-                
-                case 'C':
-                case 'g':
-                    return cbase == 'T' ? 5 : 4;
-                break;
-                
-                case 'G':
-                case 'c':
-                    return cbase == 'A' ? 5 : 4;
-                break;
-                
-                case 'T':
-                case 'a':
-                    return cbase == 'C' ? 5 : 4;
-                break;
+             if(n == 1)
+             {
+                switch(cbase) {
+                    case '.':// Ref: 6 Points
+                        return 6;
+                    break;
+                    case '-': // Uncalled: 0 Points
+                        return 0;
+                    break;
+                    
+                    // Transition: 5 points.  Transversion: 4 points 
+                    case 'A':
+                    case 't':
+                        return cbase == 'G' ? 5 : 4;
+                    break;
+                    
+                    case 'C':
+                    case 'g':
+                        return cbase == 'T' ? 5 : 4;
+                    break;
+                    
+                    case 'G':
+                    case 'c':
+                        return cbase == 'A' ? 5 : 4;
+                    break;
+                    
+                    case 'T':
+                    case 'a':
+                        return cbase == 'C' ? 5 : 4;
+                    break;
+                }
             }
-        }
-        else { // n > 1
-            if (base[0] == '-') {
-                return 3; // Deletion: 3 Points
-            } else if (base[0] == '+') {
-                return 2; // Insertion: 2 Points
+            
+            // need to happen in any other case - i.e. also for n > 1
+            switch(cbase) {
+                case '-':
+                    return 3; // Deletion: 3 Points
+                break;
+                case '+':
+                    return 2; // Insertion: 2 Points
+                break;
             }
         }
         return 1;

--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -507,7 +507,7 @@ void Caller::compute_top_frequencies(const BasePileup& bp,
 
     // tie-breaker heuristic:
     // reference > transition > transversion > delete > insert > N
-    function<unsigned char(const string&)> base_priority = [&ref_base](const string& base) {
+    function<int(const string&)> base_priority = [&ref_base](const string& base) {
         size_t n = base.length();
         if(n == 0) {
             // base == '' -> Uncalled: 0 Points
@@ -515,7 +515,7 @@ void Caller::compute_top_frequencies(const BasePileup& bp,
         }
         else
         {
-            char cbase = base[0];
+             char cbase = base[0];
             
              if(n == 1)
              {
@@ -568,8 +568,8 @@ void Caller::compute_top_frequencies(const BasePileup& bp,
     function<bool(const string&, int, const string&, int)> base_greater = [&base_priority] (
         const string& base1, int count1, const string& base2, int count2) {
         if (count1 == count2) {
-            unsigned char p1 = base_priority(base1);
-            unsigned char p2 = base_priority(base2);
+            int p1 = base_priority(base1);
+            int p2 = base_priority(base2);
             if (p1 == p2) {
                 return base1 > base2;
             } else {


### PR DESCRIPTION
Hi there,

This PR should be a small optimization to the callers subfunction `base_priority` by avoiding a few string comparisons, replacing them with a switch and using `unsigned char` over `int`.

I hope you like it. Thanks,

Youri
