### PR TITLE
Improve vg call VCF output and options system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ OBJ += $(OBJ_DIR)/name_mapper.o
 OBJ += $(OBJ_DIR)/graph_synchronizer.o
 OBJ += $(OBJ_DIR)/vg_algorithms.o
 OBJ += $(OBJ_DIR)/nested_traversal_finder.o
+OBJ += $(OBJ_DIR)/option.o
 
 # These aren't put into libvg. But they do go into the main vg binary to power its self-test.
 UNITTEST_OBJ =
@@ -377,9 +378,9 @@ $(OBJ_DIR)/entropy.o: $(SRC_DIR)/entropy.cpp $(SRC_DIR)/entropy.hpp $(DEPS)
 
 $(OBJ_DIR)/pileup.o: $(SRC_DIR)/pileup.cpp $(SRC_DIR)/pileup.hpp $(INC_DIR)/stream.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/json2pb.h $(DEPS)
 
-$(OBJ_DIR)/caller.o: $(SRC_DIR)/caller.cpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(INC_DIR)/stream.hpp $(SRC_DIR)/json2pb.h $(SRC_DIR)/pileup.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
+$(OBJ_DIR)/caller.o: $(SRC_DIR)/caller.cpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/option.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(INC_DIR)/stream.hpp $(SRC_DIR)/json2pb.h $(SRC_DIR)/pileup.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
 
-$(OBJ_DIR)/call2vcf.o: $(SRC_DIR)/call2vcf.cpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/nodeside.hpp $(SRC_DIR)/nodetraversal.hpp $(SRC_DIR)/snarls.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/genotypekit.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
+$(OBJ_DIR)/call2vcf.o: $(SRC_DIR)/call2vcf.cpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/option.hpp $(SRC_DIR)/nodeside.hpp $(SRC_DIR)/nodetraversal.hpp $(SRC_DIR)/snarls.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/genotypekit.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
 
 $(OBJ_DIR)/genotyper.o: $(SRC_DIR)/genotyper.cpp $(SRC_DIR)/genotyper.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/json2pb.h $(DEPS) $(INC_DIR)/sparsehash/sparse_hash_map $(SRC_DIR)/bubbles.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/utility.hpp
 
@@ -447,6 +448,8 @@ $(OBJ_DIR)/feature_set.o: $(SRC_DIR)/feature_set.cpp $(SRC_DIR)/feature_set.hpp 
 $(OBJ_DIR)/simplifier.o: $(SRC_DIR)/simplifier.cpp $(SRC_DIR)/simplifier.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/utility.hpp $(SRC_DIR)/feature_set.hpp $(SRC_DIR)/path.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/distributions.hpp $(DEPS)
 
 $(OBJ_DIR)/nested_traversal_finder.o: $(SRC_DIR)/nested_traversal_finder.cpp $(SRC_DIR)/nested_traversal_finder.hpp $(SRC_DIR)/genotypekit.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
+
+$(OBJ_DIR)/option.o: $(SRC_DIR)/option.cpp $(SRC_DIR)/option.hpp $(DEPS)
 
 ### Algorithms ###
 
@@ -535,7 +538,7 @@ $(SUBCOMMAND_OBJ_DIR)/snarls_main.o: $(SUBCOMMAND_SRC_DIR)/snarls_main.cpp $(SUB
 
 $(SUBCOMMAND_OBJ_DIR)/explode_main.o: $(SUBCOMMAND_SRC_DIR)/explode_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/utility.hpp $(DEPS)
 
-$(SUBCOMMAND_OBJ_DIR)/call_main.o: $(SUBCOMMAND_SRC_DIR)/call_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/utility.hpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/nodeside.hpp $(SRC_DIR)/nodetraversal.hpp $(SRC_DIR)/snarls.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/json2pb.h $(SRC_DIR)/pileup.hpp $(DEPS)
+$(SUBCOMMAND_OBJ_DIR)/call_main.o: $(SUBCOMMAND_SRC_DIR)/call_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/option.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/utility.hpp $(SRC_DIR)/caller.hpp $(SRC_DIR)/nodeside.hpp $(SRC_DIR)/nodetraversal.hpp $(SRC_DIR)/snarls.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/distributions.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/json2pb.h $(SRC_DIR)/pileup.hpp $(DEPS)
 
 
 ########################

--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -616,7 +616,7 @@ void Call2Vcf::call(
     }
     
     // Now start looking for traversals of the sites.
-    RepresentativeTraversalFinder traversal_finder(augmented, site_manager, maxDepth, max_bubble_paths,
+    RepresentativeTraversalFinder traversal_finder(augmented, site_manager, max_search_depth, max_bubble_paths,
         [&] (const Snarl& site) -> PathIndex* {
         
         // When the TraversalFinder needs an index for a site, it can look it up with this function.
@@ -1068,7 +1068,7 @@ void Call2Vcf::call(
             variant.setVariantCallFile(vcf);
             variant.quality = 0;
             // Position should be 1-based and offset with our offset option.
-            variant.position = variation_start + 1 + variantOffset;
+            variant.position = variation_start + 1 + variant_offset;
             
             // Set the ID based on the IDs of the involved nodes. Note that the best
             // allele may have no nodes (because it's a pure edge)

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -477,26 +477,33 @@ public:
     // Option variables
     
     // Should we output in VCF (true) or Protobuf Locus (false) format?
-    bool convert_to_vcf = true;
+    Option<bool> convert_to_vcf{this, "no-vcf", "V", true,
+        "output variants in binary Loci format instead of text VCF format"};
     // How big should our output buffer be?
     size_t locus_buffer_size = 1000;
     
     // What are the names of the reference paths, if any, in the graph?
-    vector<string> ref_path_names;
+    Option<vector<string>> ref_path_names{this, "ref", "r", {},
+        "use the path with the given name as a reference path (can repeat)"};
     // What name should we give each contig in the VCF file? Autodetected from
     // path names if empty or too short.
-    vector<string> contig_name_overrides;
+    Option<vector<string>> contig_name_overrides{this, "contig", "c", {},
+        "use the given name as the VCF name for the corresponding reference path"};
     // What should the total sequence length reported in the VCF header be for
     // each contig? Autodetected from path lengths if empty or too short.
-    vector<size_t> length_overrides;
+    Option<vector<size_t>> length_overrides{this, "length", "l", {},
+        "override total sequence length in VCF for the corresponding reference path"};
     // What name should we use for the sample in the VCF file?
-    string sample_name = "SAMPLE";
+    Option<string> sample_name{this, "sample", "S", "SAMPLE",
+        "name the sample in the VCF with the given name"};
     // How far should we offset positions of variants?
-    int64_t variantOffset = 0;
+    Option<int64_t> variant_offset{this, "offset", "o", 0,
+        "offset variant positions by this amount in VCF"};
     // How many nodes should we be willing to look at on our path back to the
     // primary path? Keep in mind we need to look at all valid paths (and all
     // combinations thereof) until we find a valid pair.
-    int64_t maxDepth = 10;
+    Option<int64_t> max_search_depth{this, "max-search-depth", "D", 10,
+        "maximum depth for path search"};
     
     
     // What fraction of average coverage should be the minimum to call a variant (or a single copy)?

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -15,6 +15,7 @@
 #include "pileup.hpp"
 #include "path_index.hpp"
 #include "genotypekit.hpp"
+#include "option.hpp"
 
 namespace vg {
 
@@ -339,7 +340,7 @@ ostream& operator<<(ostream& os, const Caller::NodeOffSide& no);
  * Call2Vcf: take an augmented graph from a Caller and produce actual calls in a
  * VCF.
  */
-class Call2Vcf {
+class Call2Vcf : public Configurable {
 
 public:
 
@@ -528,7 +529,9 @@ public:
     bool useAverageSupport = false;
     // What's the max ref length of a site that we genotype as a whole instead
     // of splitting?
-    size_t max_ref_length = 100;
+    Option<size_t> max_ref_length{this, "max-ref-length", "mMrRlL", 100,
+        "max length of a site to genotype as a whole instead of splitting"};
+    
     // What's the maximum number of bubble path combinations we can explore
     // while finding one with maximum support?
     size_t max_bubble_paths = 100;

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -508,32 +508,41 @@ public:
     
     // What fraction of average coverage should be the minimum to call a variant (or a single copy)?
     // Default to 0 because vg call is still applying depth thresholding
-    double minFractionForCall = 0;
+    Option<double> min_fraction_for_call{this, "min-cov-frac", "F", 0,
+        "min fraction of average coverage at which to call"};
     // What fraction of the reads supporting an alt are we willing to discount?
     // At 2, if twice the reads support one allele as the other, we'll call
     // homozygous instead of heterozygous. At infinity, every call will be
     // heterozygous if even one read supports each allele.
-    double maxHetBias = 3;
+    Option<double> max_het_bias{this, "max-het-bias", "H", 3,
+        "max imbalance factor between alts to call heterozygous"};
     // Like above, but applied to ref / alt ratio (instead of alt / ref)
-    double maxRefHetBias = 4;
+    Option<double> max_ref_het_bias{this, "max-ref-bias", "R", 4,
+        "max imbalance factor between ref and alts to call heterozygous ref"};
     // How much should we multiply the bias limits for indels?
-    double indelBiasMultiple = 1;
+    Option<double> indel_bias_multiple{this, "bias-mult", "M", 1,
+        "multiplier for bias limits for indels as opposed to substitutions"};
     // What's the minimum integer number of reads that must support a call? We
     // don't necessarily want to call a SNP as het because we have a single
     // supporting read, even if there are only 10 reads on the site.
-    size_t minTotalSupportForCall = 1;
+    Option<size_t> min_total_support_for_call{this, "min-count", "n", 1, 
+        "min total supporting read count to call a variant"};
     // Bin size used for counting coverage along the reference path.  The
     // bin coverage is used for computing the probability of an allele
     // of a certain depth
-    size_t ref_bin_size = 250;
+    Option<size_t> ref_bin_size{this, "bin-size", "B", 250,
+        "bin size used for counting coverage"};
     // On some graphs, we can't get the coverage because it's split over
     // parallel paths.  Allow overriding here
-    double expCoverage = 0.0;
+    Option<double> expected_coverage{this, "avg-coverage", "C", 0.0,
+        "specify expected coverage (instead of computing on reference)"};
     // Should we drop variants that would overlap old ones? TODO: we really need
     // a proper system for accounting for usage of graph material.
-    bool suppress_overlaps = false;
+    Option<bool> suppress_overlaps{this, "no-overlap", "O", false,
+        "don't emit new variants that overlap old ones"};
     // Should we use average support instead of minimum support for our calculations?
-    bool useAverageSupport = false;
+    Option<bool> use_average_support{this, "use-avg-support", "u", false,
+        "use average instead of minimum support"};
     // What's the max ref length of a site that we genotype as a whole instead
     // of splitting?
     Option<size_t> max_ref_length{this, "max-ref-length", "mMrRlL", 100,
@@ -544,7 +553,8 @@ public:
     size_t max_bubble_paths = 100;
     // what's the minimum minimum allele depth to give a PASS in the filter column
     // (anything below gets FAIL)    
-    size_t min_mad_for_filter = 5;
+    Option<size_t> min_mad_for_filter{this, "min-mad", "E", 5,
+        "min. minimum allele depth required to PASS filter"};
     // print warnings etc. to stderr
     bool verbose = false;
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5435,10 +5435,13 @@ int main_map(int argc, char** argv) {
     };
 
     for (int i = 0; i < thread_count; ++i) {
-        Mapper* m;
+        Mapper* m = nullptr;
         if(xindex && gcsa && lcp) {
             // We have the xg and GCSA indexes, so use them
             m = new Mapper(xindex, gcsa, lcp);
+        } else {
+            // Can't continue with null
+            throw runtime_error("Need XG, GCSA, and LCP to create a Mapper");
         }
         m->hit_max = hit_max;
         m->max_multimaps = max_multimaps;

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -7,18 +7,18 @@ namespace vg {
 
 using namespace std;
 
-void Configurable::register_option(BaseOption* option) {
+void Configurable::register_option(OptionInterface* option) {
     // Turn into an offset from this
     ptrdiff_t offset = (ptrdiff_t) option - (ptrdiff_t) this;
     option_offsets.push_back(offset);
 }
 
-vector<BaseOption*> Configurable::get_options() {
-    vector<BaseOption*> reconstructed;
+vector<OptionInterface*> Configurable::get_options() {
+    vector<OptionInterface*> reconstructed;
     
     for (ptrdiff_t offset : option_offsets) {
         // Convert each offset back to a pointer
-        BaseOption* option = (BaseOption*)((ptrdiff_t) this + offset);
+        OptionInterface* option = (OptionInterface*)((ptrdiff_t) this + offset);
         reconstructed.push_back(option);
     }
     
@@ -82,7 +82,7 @@ void ConfigurableParser::register_configurable(Configurable* configurable) {
     // Remember that we have options for this thing.
     configurables.push_back(configurable);
 
-    for (BaseOption* option : configurable->get_options()) {
+    for (OptionInterface* option : configurable->get_options()) {
         // For each option...
         
         // Try and assign it a short option character.
@@ -134,7 +134,7 @@ void ConfigurableParser::print_help(ostream& out) const {
         // Give it a header
         out << "configurable component options:" << endl;
         
-        for (BaseOption* option : component->get_options()) {
+        for (OptionInterface* option : component->get_options()) {
             // For each option, find its code.
             // TODO: we assume each option actually gets assigned a code.
             auto& code = codes_by_option.at(option);
@@ -193,7 +193,7 @@ void ConfigurableParser::parse(int argc, char** argv) {
         // Otherwise, see if the code is associated with an option object.
         if (options_by_code.count(c)) {
             // If so, dispatch to that option
-            BaseOption* option = options_by_code.at(c);
+            OptionInterface* option = options_by_code.at(c);
             
             if (option->has_argument()) {
                 // Parse with the option's argument

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -1,0 +1,223 @@
+#include "option.hpp"
+
+/// \file option.cpp: Definitions for our thing-doer-class-attached option
+/// system
+
+namespace vg {
+
+using namespace std;
+
+void Configurable::register_option(BaseOption* option) {
+    // Turn into an offset from this
+    ptrdiff_t offset = (ptrdiff_t) option - (ptrdiff_t) this;
+    option_offsets.push_back(offset);
+}
+
+vector<BaseOption*> Configurable::get_options() {
+    vector<BaseOption*> reconstructed;
+    
+    for (ptrdiff_t offset : option_offsets) {
+        // Convert each offset back to a pointer
+        BaseOption* option = (BaseOption*)((ptrdiff_t) this + offset);
+        reconstructed.push_back(option);
+    }
+    
+    return reconstructed;
+}
+
+ConfigurableParser::ConfigurableParser(const char* base_short_options, const struct option* base_long_options,
+    function<void(int)> handle_base_option): handle_base_option(handle_base_option) {
+    
+    // Initialize the set of unused option characters.
+    for (char i = 'a'; i <= 'z'; i++) {
+        available_short_options.insert(i);
+    }
+    for (char i = 'A'; i <= 'Z'; i++) {
+        available_short_options.insert(i);
+    }
+    for (char i = '0'; i <= '9'; i++) {
+        available_short_options.insert(i);
+    }
+    
+    if (base_short_options != nullptr) {
+        // Use these base short options
+        short_options = string(base_short_options);
+        
+        for (auto c : short_options) {
+            // Look at each base short option
+            if (c == ':') {
+                // Ignore the colons marking things as needing arguments
+                continue;
+            }
+            
+            if (available_short_options.count(c)) {
+                // We would want to assign this, but it's used already.
+                available_short_options.erase(c);
+            }
+        }
+    }
+    
+    if (base_long_options != nullptr) {
+        // Use these base long options
+        const struct option* long_option = base_long_options;
+        while (long_option->name != nullptr || long_option->has_arg != 0 ||
+            long_option->flag != nullptr || long_option->val != 0) {
+            // This long option isn't the null terminator, so keep it
+            long_options.push_back(*long_option);
+            
+            if (long_option->flag == nullptr && available_short_options.count(long_option->val)) {
+                // This long option uses a short option character we might want
+                // to assign to something later. Don't re-assign it.
+                available_short_options.erase(long_option->val);
+            }
+            
+            // Check the next long option
+            long_option++;
+        }
+    }
+}
+
+void ConfigurableParser::register_configurable(Configurable* configurable) {
+
+    // Remember that we have options for this thing.
+    configurables.push_back(configurable);
+
+    for (BaseOption* option : configurable->get_options()) {
+        // For each option...
+        
+        // Try and assign it a short option character.
+        char assigned = 0;
+        for (char wanted : option->get_short_options()) {
+            // First try the ones it wants
+            if (available_short_options.count(wanted)) {
+                assigned = wanted;
+                break;
+            }
+        }
+        if (assigned == 0 && !available_short_options.empty()) {
+            // Then fall back to any available
+            assigned = (char) *available_short_options.begin();
+        }
+        if (assigned == 0) {
+            // Die because we ran out of room
+            throw runtime_error("Unable to assign short option to " + option->get_long_option());
+        }
+        // Mark the character as used
+        available_short_options.erase(assigned);
+        // Remember the option for the code
+        options_by_code[assigned] = option;
+        // And the code for the option
+        codes_by_option[option] = assigned;
+        
+        // Add it to the short options config string
+        short_options.push_back(assigned);
+        if (option->has_argument()) {
+            short_options.push_back(':');
+        }
+        
+        // Add it to the long options struct list
+        long_options.push_back({
+            option->get_long_option().c_str(),
+            option->has_argument() ? required_argument : no_argument,
+            nullptr,
+            assigned
+        });
+    }
+}
+
+void ConfigurableParser::print_help(ostream& out) const {
+    // Print help for all our registered options.
+    
+    for (Configurable* component : configurables) {
+        // For each thing that has options
+        
+        // Give it a header
+        out << "configurable component options:" << endl;
+        
+        for (BaseOption* option : component->get_options()) {
+            // For each option, find its code.
+            // TODO: we assume each option actually gets assigned a code.
+            auto& code = codes_by_option.at(option);
+        
+            // First indent
+            out << "    "; 
+            
+            // Then the short option
+            out << "-" << (char) code;
+            
+            // Then the separator
+            out << ", ";
+            
+            // Then the long option
+            out << "--" << option->get_long_option();
+            
+            if (option->has_argument()) {
+                // Then the argument placeholder if needed
+                out << " ARG";
+            }
+            
+            // Then some spaces.
+            // TODO: how many?
+            for (size_t i = 0; i < 4; i++) {
+                out << " ";
+            }
+            
+            // Then the description
+            out << option->get_description();
+            
+            // Finish up with the default value
+            out << " [" << option->get_default_value() << "]" << endl;
+        }
+        
+    }
+    
+    
+}
+
+void ConfigurableParser::parse(int argc, char** argv) {
+    
+    // Stick the null terminator on the long options
+    long_options.push_back({0, 0, 0, 0});
+    
+    while (true) {
+        // For each option we get, save its index
+        int option_index = 0;
+        // And its code
+        int c = getopt_long (argc, argv, short_options.c_str(), &long_options[0], &option_index);
+
+        // A code of -1 indicates there are no more options.
+        if (c == -1) {
+            break;
+        }
+
+        // Otherwise, see if the code is associated with an option object.
+        if (options_by_code.count(c)) {
+            // If so, dispatch to that option
+            BaseOption* option = options_by_code.at(c);
+            
+            if (option->has_argument()) {
+                // Parse with the option's argument
+                option->parse(optarg);
+            } else {
+                // Parse without an argument (i.e. set a bool)
+                option->parse();
+            }
+        } else {
+            // This option is to be handled manually, or is unrecognized
+            handle_base_option(c);
+        }
+    }
+
+    // Pop the null terminator again
+    long_options.pop_back();
+}
+
+
+
+
+
+
+
+
+    
+}

--- a/src/option.hpp
+++ b/src/option.hpp
@@ -88,6 +88,11 @@ public:
      */
     virtual vector<OptionInterface*> get_options();
     
+    /**
+     * Get the name of the thing being configured, for titling the help section.
+     */
+    virtual string get_name();
+    
 private:
     /// We really should be using something like CRTP and pointer-to-members on
     /// the actual class that's configurable, but for now we'll just exploit
@@ -155,6 +160,9 @@ private:
     /// And a reverse map for when we look up assigned codes for printing.
     /// TODO: No forgery!
     map<OptionInterface*, int> codes_by_option;
+    
+    /// And a set of long options used so we can detect collisions
+    set<string> long_options_used;
     
     /// And a vector of Configurables in the order registered so we can
     /// interrogate them and group their options when printing help.
@@ -224,11 +232,23 @@ inline void OptionValueParser<bool>::parse_default(const bool& default_value, bo
 }
 
 /**
- * If someone gives an option to a bool, explode.
+ * If someone gives a value to a bool, explode.
  */
 template<>
 inline void OptionValueParser<bool>::parse(const string& arg, bool& value) {
     throw runtime_error("Boolean options should not take arguments.");
+}
+
+/**
+ * Represent default values for bools as true and false.
+ */
+template<>
+inline string OptionValueParser<bool>::unparse(const bool& value) {
+    if (value) {
+        return "TRUE";
+    } else {
+        return "FALSE";
+    }
 }
 
 /**

--- a/src/option.hpp
+++ b/src/option.hpp
@@ -1,0 +1,387 @@
+#ifndef VG_OPTION_H
+#define VG_OPTION_H
+
+/**
+ * \file option.hpp: Command-line options that can be attached to configurable thing-doer calsses (variant callers, mappers, etc.)
+ *
+ * To use: make your configurable object inherit from Configurable, and make all your command-line-option fields into Option<whatever type>.
+ */
+
+#include <string>
+#include <vector>
+#include <set>
+#include <map>
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <getopt.h>
+ 
+namespace vg {
+
+using namespace std;
+
+/**
+ * All of the option templates inherit from this base class, which the command-
+ * line parser uses to feed them strings.
+ */
+class BaseOption {
+public:
+    /**
+     * Get the long oiption text without --, like "foos-to-bar".
+     */
+    virtual const string& get_long_option() const = 0;
+    
+    /**
+     * Gets a list of short option characters that the option wants, in priority
+     * order. If none of these are available, the option will be automatically
+     * assigned some other free character.
+     */
+    virtual const string& get_short_options() const = 0;
+
+    /**
+     * Get the description, like "number of foos to bar per frobnitz".
+     */
+    virtual const string& get_description() const = 0;
+    
+    /**
+     * Get the default value as a string. May be generated on the fly.
+     */
+    virtual string get_default_value() const = 0;
+    
+    /**
+     * Returns true if the option takes an argument, and false otherwise.
+     */
+    virtual bool has_argument() const = 0;
+    
+    /**
+     * Called for no-argument options when the parser encounters them.
+     */
+    virtual void parse() = 0;
+    
+    /**
+     * Called for argument-having options when the parser encounters them. The
+     * passed reference is only valid during the function call, so the option
+     * should make a copy.
+     */
+    virtual void parse(const string& arg) = 0;
+    
+    /**
+     * Everyone needs a virtual destructor!
+     */
+    virtual ~BaseOption() = default;
+};
+
+/**
+ * Represents a thing-doing class that has options. You construct the class,
+ * configure its options, and then set it going.
+ */
+class Configurable {
+public:
+    /**
+     * Each option will call this on construction and register with its owner.
+     */
+    virtual void register_option(BaseOption* option);
+    
+    /**
+     * Get all the options for this class. These pointers are only valid unless
+     * or until the underlying Configurable object moves or is assigned to.
+     */
+    virtual vector<BaseOption*> get_options();
+    
+private:
+    /// We really should be using something like CRTP and pointer-to-members on
+    /// the actual class that's configurable, but for now we'll just exploit
+    /// int<->pointer conversion and store the offset from us in memory to the
+    /// location of the option in memory. If the option is correctly a mamber of
+    /// a class derived from this one, it will work correctly because all
+    /// instances share the same memory layout for members.
+    vector<ptrdiff_t> option_offsets;
+};
+
+/**
+ * Actual implementation class that connects a bunch of Configurable things to
+ * getopt.
+ *
+ * TODO: right now every option must have a long option and a char short option.
+ * In theory we can use any int as an ID for a long option. We should support
+ * long options with untypable or non-char option IDs.
+ */
+class ConfigurableParser {
+public:
+
+    /**
+     * Constructor that sets up our magic option assigning code. Makes a parser
+     * that will parse the given base Getopt null-terminated long and short
+     * options with Getopt and call the given function with each.
+     *
+     * The base option handler, if specified, should error on unrecognized
+     * options.
+     */
+    ConfigurableParser(const char* base_short_options = nullptr,
+        const struct option* base_long_options = nullptr,
+        function<void(int)> handle_base_option = [](int c) { throw runtime_error("Invalid option: " + string(1, (char) c)); });
+        
+    /**
+     * Register a Configurable thing and allocate characters for all its
+     * options. The Configurable is not allowed to move after registration.
+     */
+    void register_configurable(Configurable* configurable);
+    
+    /**
+     * Print option descriptions for registered Configurables to the given
+     * stream.
+     */
+    void print_help(ostream& out) const;
+    
+    /**
+     * Parse the options with getopt. Uses the existing value of the global
+     * optind, and updates the global optind, just as getopt would.
+     */
+    void parse(int argc, char** argv);
+
+private:
+    /// Holds all the long option structs for options we have
+    vector<struct option> long_options;
+    /// Holds all the available short option characters that have not been
+    /// assigned. Stored as ints so we can check ints against it safely.
+    set<int> available_short_options;
+    /// Holds the short options string (with colons) for the short options we
+    /// have.
+    string short_options;
+    
+    /// Keep a map from assigned character to actual option.
+    map<int, BaseOption*> options_by_code;
+    
+    /// And a reverse map for when we look up assigned codes for printing.
+    /// TODO: No forgery!
+    map<BaseOption*, int> codes_by_option;
+    
+    /// And a vector of Configurables in the order registered so we can
+    /// interrogate them and group their options when printing help.
+    vector<Configurable*> configurables;
+    
+    /// Handle an option not assigned to an Option object.
+    function<void(int)> handle_base_option;
+};
+
+/**
+ * This class holds static methods explaining how to parse a type.
+ */
+template <typename Value>
+class OptionValueParser {
+public:
+    // In general, try using << and >>.
+    
+    /**
+     * Return true if we need an argument and false otherwise.
+     */
+    static bool has_argument() {
+        return true;
+    }
+    
+    /**
+     * Parse from no argument, but a default value.
+     */
+    static Value parse_default(const Value& default_value) {
+        throw runtime_error("Argument required for option!");
+    }
+    
+    /**
+     * Parse from an argument.
+     */
+    static Value parse(const string& arg) {
+        stringstream s(arg);
+        Value v;
+        s >> v;
+        return v;
+    }
+    
+    /**
+     * Stringify a default value.
+     */
+    static string unparse(const Value& v) {
+        stringstream s;
+        s << v;
+        return s.str();
+    }
+};
+
+// For bools we override some things in the basic OptionValueParser.
+// If these weren't inline we'd have to put the code in the .cpp file.
+
+/**
+ * Bool options don't need arguments.
+ */
+template<>
+inline bool OptionValueParser<bool>::has_argument() {
+    return false;
+}
+
+/**
+ * When someone gives a bool option they mean to invert it.
+ */
+template<>
+inline bool OptionValueParser<bool>::parse_default(const bool& default_value) {
+    return !default_value;
+}
+
+/**
+ * If someone gives an option to a bool, explode.
+ */
+template<>
+inline bool OptionValueParser<bool>::parse(const string& arg) {
+    throw runtime_error("Boolean options should not take arguments.");
+}
+
+
+/**
+ * Represents a configurable parameter for a class that we might want to expose
+ * on the command line.
+ *
+ * We need to allow these to be defined with default values in the class's
+ * header, but be overridable by simple assignment of a value of the right type.
+ * But we also need to be able to interrogate an instance of the class to get
+ * all its options that need to be filled in and their help text, and ideally to
+ * choose short options to assign to them that don't conflict.
+ *
+ * So our approach is to have the class keep track of all its option objects,
+ * and to have the options register themselves at construction time with a
+ * passed this pointer (since this is in scope in the class body in the header).
+ *
+ * Option instances MUST exist as MEMBERS of classes that inherit from
+ * Configurable! They can't live in vectors or anything, or the magic code that
+ * tracks them as the enclosing object moves won't work!
+ *
+ * We'll have an assignment operator from the wrapped type to make setting
+ * options manually easy.
+ *
+ * We also have magical conversion to the wrapped type.
+ *
+ * We wrap all the type-specific parsing into a parser template. You could
+ * specify your own if you want custom parsing logic for like a map or
+ * something...
+ */
+template<typename Value, typename Parser = OptionValueParser<Value>>
+class Option : public BaseOption {
+
+public:
+
+    /**
+     * No default constructor.
+     */
+    Option() = delete;
+    
+    /**
+     * Default destructor.
+     */
+    virtual ~Option() = default;
+
+    /**
+     * Make a new Option that lives in a class, with the given name, short
+     * option characters, and default value.
+     */
+    Option(Configurable* owner, const string& long_opt, const string& short_opts, const Value& default_value,
+        const string& description) : long_opt(long_opt), short_opts(short_opts), description(description),
+        default_value(default_value), value(default_value) {
+        
+        // Register with the owner
+        owner->register_option(this);
+    }
+    
+    /**
+     * Assignment from an Option of the correct type.
+     */
+    Option<Value, Parser>& operator=(const Option<Value, Parser>& other) = default;
+    
+    /**
+     * Assignment from an unwrapped value.
+     */
+    Option<Value, Parser>& operator=(const Value& other) {
+        // Just use the value type's assignment operator.
+        value = other;
+        return *this;
+    }
+    
+    /**
+     * Conversion to the wrapped type.
+     */
+    operator Value&() {
+        return value;
+    }
+    
+    // Implementation for the option interface follows
+    
+    /**
+     * Get the long oiption text without --, like "foos-to-bar".
+     */
+    virtual const string& get_long_option() const {
+        return long_opt;
+    }
+    
+    /**
+     * Gets a list of short option characters that the option wants, in priority
+     * order. If none of these are available, the option will be automatically
+     * assigned some other free character.
+     */
+    virtual const string& get_short_options() const {
+        return short_opts;
+    }
+
+    /**
+     * Get the description, like "number of foos to bar per frobnitz".
+     */
+    virtual const string& get_description() const {
+        return description;
+    }
+    
+    /**
+     * Get the default value as a string.
+     */
+    virtual string get_default_value() const {
+        return Parser::unparse(default_value);
+    };
+    
+    /**
+     * Returns true if the option takes an argument, and false otherwise.
+     */
+    virtual bool has_argument() const {
+        return Parser::has_argument();
+    }
+    
+    /**
+     * Called for no-argument options when the parser encounters them.
+     */
+    virtual void parse() {
+        value = Parser::parse_default(default_value);
+    }
+    
+    /**
+     * Called for argument-having options when the parser encounters them. The
+     * passed reference is only valid during the function call, so the option
+     * should make a copy.
+     */
+    virtual void parse(const string& arg) {
+        value = Parser::parse(arg);
+    }
+    
+private:
+    /// What is the options's long option name
+    string long_opt;
+    /// What is the option's short option name
+    string short_opts;
+    /// How is this option described to the user?
+    string description;
+    /// We keep a value of our chosen type. It just has to be copyable and
+    /// assignable.
+    Value value;
+    /// We also keep the default value around, in case we somehow get assigned
+    /// and then get asked to report our metadata.
+    /// TODO: do this as a string instead?
+    Value default_value;
+    
+
+};
+
+}
+
+#endif

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -28,7 +28,6 @@ void help_call(char** argv, ConfigurableParser& parser) {
          << "Output variant calls in VCF or Loci format given a graph and pileup" << endl
          << endl
          << "options:" << endl
-         << "    -V, --no-vcf               output variants in binary Loci format instead of text VCF format" << endl
          << "    -d, --min-depth INT        minimum depth of pileup [" << Caller::Default_min_depth <<"]" << endl
          << "    -e, --max-depth INT        maximum depth of pileup [" << Caller::Default_max_depth <<"]" << endl
          << "    -s, --min-support INT      minimum number of reads required to support snp [" << Caller::Default_min_support <<"]" << endl
@@ -38,14 +37,8 @@ void help_call(char** argv, ConfigurableParser& parser) {
          << "    -b, --max-strand-bias FLOAT limit to absolute difference between 0.5 and proportion of supporting reads on reverse strand. [" << Caller::Default_max_strand_bias << "]" << endl
          << "    -a, --link-alts            add all possible edges between adjacent alts" << endl
          << "    -A, --aug-graph FILE       write out the agumented graph in vg format" << endl
-         << "    -r, --ref PATH             use the path with the given name as a reference path (can repeat)" << endl
-         << "    -c, --contig NAME          use the given name as the VCF name for the corresponding reference path" << endl
-         << "    -S, --sample NAME          name the sample in the VCF with the given name [SAMPLE]" << endl
-         << "    -o, --offset INT           offset variant positions by this amount in VCF [0]" << endl
-         << "    -l, --length INT           override total sequence length in VCF for the corresponding reference path" << endl
          << "    -U, --subgraph             expect a subgraph and ignore extra pileup entries outside it" << endl
          << "    -P, --pileup               write pileup under VCF lines (for debugging, output not valid VCF)" << endl
-         << "    -D, --depth INT            maximum depth for path search [default 10 nodes]" << endl
          << "    -F, --min-cov-frac FLOAT   min fraction of average coverage at which to call [0.0]" << endl
          << "    -H, --max-het-bias FLOAT   max imbalance factor between alts to call heterozygous [3]" << endl
          << "    -R, --max-ref-bias FLOAT   max imbalance factor between ref and alts to call heterozygous ref [4]" << endl
@@ -93,7 +86,6 @@ int main_call(int argc, char** argv) {
     int thread_count = 1;
 
     static const struct option long_options[] = {
-        {"no-vcf", no_argument, 0, 'V'},
         {"min-depth", required_argument, 0, 'd'},
         {"max-depth", required_argument, 0, 'e'},
         {"min-support", required_argument, 0, 's'},
@@ -105,12 +97,6 @@ int main_call(int argc, char** argv) {
         {"progress", no_argument, 0, 'p'},
         {"verbose", no_argument, 0, 'v'},
         {"threads", required_argument, 0, 't'},
-        {"ref", required_argument, 0, 'r'},
-        {"contig", required_argument, 0, 'c'},
-        {"sample", required_argument, 0, 'S'},
-        {"offset", required_argument, 0, 'o'},
-        {"depth", required_argument, 0, 'D'},
-        {"length", required_argument, 0, 'l'},
         {"subgraph", no_argument, 0, 'U'},
         {"pileup", no_argument, 0, 'P'},
         {"min-cov-frac", required_argument, 0, 'F'},
@@ -126,7 +112,7 @@ int main_call(int argc, char** argv) {
         {"help", no_argument, 0, 'h'},
         {0, 0, 0, 0}
     };
-    static const char* short_options = "Vd:e:s:f:q:b:A:apvt:r:c:S:o:D:l:UPF:H:R:M:n:B:C:OuE:h";
+    static const char* short_options = "d:e:s:f:q:b:A:apvt:UPF:H:R:M:n:B:C:OuE:h";
     optind = 2; // force optind past command positional arguments
 
     // This is our command-line parser
@@ -134,9 +120,6 @@ int main_call(int argc, char** argv) {
         // Parse all the options we have defined here.
         switch (c)
         {
-        case 'V':
-            call2vcf.convert_to_vcf = false;
-            break;
         case 'd':
             min_depth = atoi(optarg);
             break;
@@ -162,30 +145,6 @@ int main_call(int argc, char** argv) {
             bridge_alts = true;
             break;
         // old glenn2vcf opts start here
-        case 'r':
-            // Remember each reference path name
-            call2vcf.ref_path_names.push_back(optarg);
-            break;
-        case 'c':
-            // Remember each contig name
-            call2vcf.contig_name_overrides.push_back(optarg);
-            break;
-        case 'S':
-            // Set the sample name
-            call2vcf.sample_name = optarg;
-            break;
-        case 'o':
-            // Offset variants
-            call2vcf.variantOffset = std::stoll(optarg);
-            break;
-        case 'D':
-            // Limit max depth for pathing to primary path
-            call2vcf.maxDepth = std::stoll(optarg);
-            break;
-        case 'l':
-            // Remember a length override for the correspondig contig
-            call2vcf.length_overrides.push_back(std::stoll(optarg));
-            break;
         case 'U':
             expectSubgraph = true;
             break;


### PR DESCRIPTION
I've added merging of identical bases on either end of a VCF record (back?) to vg call.

I also have a command line options system I've written, so that we can define options for these thing-doer objects in one place (the class hpp) and have them automatically come out to the command line with their names, descriptions, and default values. This should save a lot of repetitive option parsing code if we apply it in more places.