### PR TITLE
Rewrite vg call to be Visit-based and recursive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,32 +161,35 @@ DYNAMIC_DIR:=deps/DYNAMIC
 SSW_DIR:=deps/ssw/src
 STATIC_FLAGS=-static -static-libstdc++ -static-libgcc
 
+# Dependencies that go into libvg's archive
+LIB_DEPS =
+LIB_DEPS += $(LIB_DIR)/libprotobuf.a
+LIB_DEPS += $(LIB_DIR)/libsdsl.a
+LIB_DEPS += $(LIB_DIR)/libssw.a
+LIB_DEPS += $(LIB_DIR)/libsnappy.a
+LIB_DEPS += $(LIB_DIR)/librocksdb.a
+LIB_DEPS += $(LIB_DIR)/libgcsa2.a
+LIB_DEPS += $(OBJ_DIR)/Fasta.o
+LIB_DEPS += $(LIB_DIR)/libhts.a
+LIB_DEPS += $(LIB_DIR)/libxg.a
+LIB_DEPS += $(LIB_DIR)/libvcflib.a
+LIB_DEPS += $(LIB_DIR)/libgssw.a
+LIB_DEPS += $(LIB_DIR)/libvcfh.a
+LIB_DEPS += $(LIB_DIR)/libgfakluge.a
+LIB_DEPS += $(LIB_DIR)/libsupbub.a
+LIB_DEPS += $(LIB_DIR)/libsonlib.a
+LIB_DEPS += $(LIB_DIR)/libpinchesandcacti.a
+LIB_DEPS += $(LIB_DIR)/libraptor2.a
+
 # common dependencies to build before all vg src files
-DEPS = 
-DEPS += $(LIB_DIR)/libprotobuf.a
+DEPS = $(LIB_DEPS)
 DEPS += $(CPP_DIR)/vg.pb.h
-DEPS += $(LIB_DIR)/libsdsl.a
-DEPS += $(LIB_DIR)/libssw.a
-DEPS += $(LIB_DIR)/libsnappy.a
-DEPS += $(LIB_DIR)/librocksdb.a
 DEPS += $(INC_DIR)/gcsa/gcsa.h
-DEPS += $(LIB_DIR)/libgcsa2.a
-DEPS += $(OBJ_DIR)/Fasta.o
-DEPS += $(LIB_DIR)/libhts.a
-DEPS += $(LIB_DIR)/libxg.a
-DEPS += $(LIB_DIR)/libvcflib.a
-DEPS += $(LIB_DIR)/libgssw.a
 DEPS += $(INC_DIR)/lru_cache.h
 DEPS += $(INC_DIR)/dynamic.hpp
 DEPS += $(INC_DIR)/sparsehash/sparse_hash_map
-DEPS += $(LIB_DIR)/libvcfh.a
-DEPS += $(LIB_DIR)/libgfakluge.a
 DEPS += $(INC_DIR)/gfakluge.hpp
-DEPS += $(LIB_DIR)/libsupbub.a
-DEPS += $(LIB_DIR)/libsonlib.a
-DEPS += $(LIB_DIR)/libpinchesandcacti.a
 DEPS += $(INC_DIR)/globalDefs.hpp
-DEPS += $(LIB_DIR)/libraptor2.a
 DEPS += $(INC_DIR)/sha1.hpp
 DEPS += $(INC_DIR)/progress_bar.hpp
 
@@ -207,7 +210,7 @@ static: $(OBJ_DIR)/main.o $(OBJ) $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ)
 	$(CXX) $(CXXFLAGS) -o $(BIN_DIR)/vg $(OBJ_DIR)/main.o $(OBJ) $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(STATIC_FLAGS) $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
 $(LIB_DIR)/libvg.a: $(OBJ) $(DEPS)
-	ar rs $@ $^
+	ar rs $@ $(OBJ) $(LIB_DEPS)
 
 get-deps:
 	sudo apt-get install -qq -y protobuf-compiler libprotoc-dev libjansson-dev libbz2-dev libncurses5-dev automake libtool jq samtools curl unzip redland-utils librdf-dev cmake pkg-config wget bc gtk-doc-tools raptor2-utils rasqal-utils bison flex libgoogle-perftools-dev

--- a/Makefile
+++ b/Makefile
@@ -475,13 +475,13 @@ $(UNITTEST_OBJ_DIR)/banded_global_aligner.o: $(UNITTEST_SRC_DIR)/banded_global_a
 
 $(UNITTEST_OBJ_DIR)/pinned_alignment.o: $(UNITTEST_SRC_DIR)/pinned_alignment.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/gssw_aligner.hpp $(DEPS)
 
-$(UNITTEST_OBJ_DIR)/genotypekit.o: $(UNITTEST_SRC_DIR)/genotypekit.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/genotypekit.hpp $(DEPS)
+$(UNITTEST_OBJ_DIR)/genotypekit.o: $(UNITTEST_SRC_DIR)/genotypekit.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/genotypekit.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
 
 $(UNITTEST_OBJ_DIR)/readfilter.o: $(UNITTEST_SRC_DIR)/readfilter.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/readfilter.hpp $(DEPS)
 
 $(UNITTEST_OBJ_DIR)/multipath_alignment.o: $(UNITTEST_SRC_DIR)/multipath_alignment.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/multipath_alignment.hpp $(SRC_DIR)/multipath_alignment.cpp $(SRC_DIR)/mapper.hpp $(SRC_DIR)/mapper.cpp $(DEPS)
 
-$(UNITTEST_OBJ_DIR)/phased_genome.o: $(UNITTEST_SRC_DIR)/phased_genome.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/phased_genome.hpp $(SRC_DIR)/phased_genome.cpp $(DEPS)
+$(UNITTEST_OBJ_DIR)/phased_genome.o: $(UNITTEST_SRC_DIR)/phased_genome.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/phased_genome.hpp $(SRC_DIR)/phased_genome.cpp $(SRC_DIR)/snarls.hpp $(DEPS)
 
 $(UNITTEST_OBJ_DIR)/vg.o: $(UNITTEST_SRC_DIR)/vg.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(DEPS)
 
@@ -499,7 +499,7 @@ $(UNITTEST_OBJ_DIR)/alignment.o: $(UNITTEST_SRC_DIR)/alignment.cpp $(UNITTEST_SR
 
 $(UNITTEST_OBJ_DIR)/aligner.o: $(UNITTEST_SRC_DIR)/aligner.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/gssw_aligner.hpp $(DEPS)
 
-$(UNITTEST_OBJ_DIR)/snarls.o: $(UNITTEST_SRC_DIR)/snarls.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(DEPS)
+$(UNITTEST_OBJ_DIR)/snarls.o: $(UNITTEST_SRC_DIR)/snarls.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/snarls.hpp $(DEPS)
 	+$(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
 $(UNITTEST_OBJ_DIR)/chunker.o: $(UNITTEST_SRC_DIR)/chunker.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/chunker.hpp $(DEPS)

--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -380,10 +380,12 @@ vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
     for(auto& traversal : here_traversals) {
         // Go through all the SnarlTraversals for this Snarl
         
+#ifdef debug
         cerr << "Evaluate traversal: " << endl;
         for (size_t j = 0; j < traversal.visits_size(); j++) {
             cerr << "\t" << pb2json(traversal.visits(j)) << endl;
         }
+#endif
         
         // What's the total support for this traversal?
         Support total_support;
@@ -449,7 +451,9 @@ vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
                     
                     // These are two back-to-back child snarl visits, which
                     // share a node and have no connecting edge.
+#ifdef debug
                     cerr << "No edge needed for back-to-back child snarls" << endl;
+#endif
                     
                 } else {
                     // Get the edge to it
@@ -784,7 +788,9 @@ vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
                     auto& last_visit = abstract_traversal.visits(i - 1);
                     if (last_visit.node_id() == 0 && to_right_side(last_visit).flip() == to_left_side(abstract_visit)) {
                         // It was indeed a previous back to back site. Don't add the entry node!
+#ifdef debug
                         cerr << "Skip entry node for back-to-back sites" << endl;
+#endif
                     } else {
                         
                         *concrete_traversal.add_visits() = abstract_visit.backward() ? reverse(child->end()) : child->start();

--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -356,6 +356,28 @@ map<string, Call2Vcf::PrimaryPath>::iterator Call2Vcf::find_path(const Snarl& si
     return primary_paths.end();
 }
 
+vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
+    SnarlManager& snarl_manager, TraversalFinder* leaf_finder, const Snarl& site) {
+
+    // Look up the children
+    auto children = snarl_manager.children_of(&site);
+    
+    // We'll fill this in with fully-populated node-resolution SnarlTraversals,
+    // which need to be sorted and clipped into best and second best.
+    vector<SnarlTraversal> found;
+    
+    if (children.empty()) {
+        // This is a leaf, so do the base case
+        found = leaf_finder->find_traversals(site);
+    } else {
+        // Make up some traversals composed of nodes in this site and child sites we encounter.
+        // Be sure to represent all the nodes, edges, and child sites.
+    }
+    
+    return found;
+
+}
+
 // this was main() in glenn2vcf
 void Call2Vcf::call(
     // Augmented graph
@@ -485,12 +507,16 @@ void Call2Vcf::call(
         cout << header_stream.str();
     }
     
-    // Then go through it from the graph's point of view: first over alt nodes
-    // backending into the reference (creating things occupying ranges to which
-    // we can attribute copy number) and then over reference nodes.
-
-    // Do the new thing where we support multiple alleles
-
+    // Loop over all the top-level snarls
+    
+    // For each, recurse down into child snarls
+    
+    // Then return back up with best and second best paths
+    
+    // Then decide on calls at the top
+    
+    // Then recurse back down
+    
     // Find all the top-level sites
     list<const Snarl*> site_queue;
     

--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -928,7 +928,6 @@ void Call2Vcf::call(
         // Store the old source position under the new node ID.
         original_positions[new_mapping.position().node_id()] = make_pos_t(old_mapping.position());
     }
-    assert(!original_positions.empty());
     
     // Make a VCF because we need it in scope later, if we are outputting VCF.
     vcflib::VariantCallFile vcf;
@@ -1180,10 +1179,11 @@ void Call2Vcf::call(
                 is_ref.push_back(is_reference(path, augmented));
             }
             
-            // Since the variable part of the site is after the first anchoring node, where does it start?
-            // TODO: we calculate this twice...
-            size_t variation_start = primary_path.get_index().by_id.at(site->start().node_id()).first
-                + augmented.graph.get_node(site->start().node_id())->sequence().size();
+            // Start off declaring the variable part to start at the start of
+            // the first anchoring node. We'll clip it back later to just what's
+            // after the shared prefix.
+            size_t variation_start = min(primary_path.get_index().by_id.at(site->start().node_id()).first,
+                primary_path.get_index().by_id.at(site->end().node_id()).first);
         
             // Keep track of the alleles that actually need to go in the VCF:
             // ref, best, and second-best (if any), some of which may overlap.

--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -380,6 +380,11 @@ vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
     for(auto& traversal : here_traversals) {
         // Go through all the SnarlTraversals for this Snarl
         
+        cerr << "Evaluate traversal: " << endl;
+        for (size_t j = 0; j < traversal.visits_size(); j++) {
+            cerr << "\t" << pb2json(traversal.visits(j)) << endl;
+        }
+        
         // What's the total support for this traversal?
         Support total_support;
         
@@ -441,6 +446,13 @@ vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
                 
                 // Get the edge to it
                 Edge* next_edge = augmented.graph.get_edge(to_right_side(visit), to_left_side(next_visit));
+                if (next_edge == nullptr) {
+                    cerr << "Missing edge from " << pb2json(visit) << " to " << pb2json(next_visit) << endl;
+                    cerr << "Traversal: " << endl;
+                    for (size_t j = 0; j < traversal.visits_size(); j++) {
+                        cerr << "\t" << pb2json(traversal.visits(j)) << endl;
+                    }
+                }
                 assert(next_edge != nullptr);
                 // Min in its support
                 here_min_support = support_min(here_min_support, augmented.get_support(next_edge));
@@ -1098,7 +1110,7 @@ void Call2Vcf::call(
                 
                 for (size_t j = 0; j < path.mapping_size(); j++) {
                     // For each mapping along the path
-                    auto& mapping = path.mapping(i);
+                    auto& mapping = path.mapping(j);
                     
                     // Record the sequence
                     string node_sequence = augmented.graph.get_node(mapping.position().node_id())->sequence();

--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -902,6 +902,8 @@ void Caller::annotate_augmented_node(Node* node, char call, StrandSupport suppor
         auto* old_edit = old_mapping->add_edit();
         old_edit->set_from_length(node->sequence().size());
         old_edit->set_to_length(node->sequence().size());
+        
+        _augmented_graph.translations.push_back(trans);
     }
 }
 

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -454,22 +454,21 @@ public:
     
     /**
      * For the given snarl, find the best traversal, and the second-best
-     * traversal, recursively.
+     * traversal, recursively, if any exist. These traversals will be fully
+     * filled in with nodes.
      *
-     * For a site with no children, the best traversal is the one with the
-     * highest (minumum or average) coverage, and the second-best traversal is
-     * the one with the second-highest (minimum or average) coverage. Traversals
-     * are found with the given leaf traversal finder.
+     * Will not return more than copy_budget SnarlTraversals, and will return
+     * less if some copies are called as having the same traversal.
      *
-     * For a site with children, the best traversal is formed by plugging
-     * together the best traversals of children, and the second-best traversal
-     * is formed by plugging together the second-best traversals of children.
+     * Uses the given copy number allowance, and emits a Locus for this Snarl
+     * and any child Snarls.
      *
-     * Not all children (and sometimes no children at all) will appear in the
-     * best and second-best traversals.
+     * If no path through the Snarl can be found, emits no Locus and returns no
+     * SnarlTraversals.
      */
     vector<SnarlTraversal> find_best_traversals(AugmentedGraph& augmented,
-        SnarlManager& snarl_manager, TraversalFinder* leaf_finder, const Snarl& site);
+        SnarlManager& snarl_manager, TraversalFinder* finder, const Snarl& site,
+        size_t copy_budget, function<void(Locus)> emit_locus);
     
     /**
      * Decide if the given SnarlTraversal is included in the original base graph

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -472,7 +472,7 @@ public:
      */
     vector<SnarlTraversal> find_best_traversals(AugmentedGraph& augmented,
         SnarlManager& snarl_manager, TraversalFinder* finder, const Snarl& site,
-        const Support& baseline_support, size_t copy_budget, function<void(Locus)> emit_locus);
+        const Support& baseline_support, size_t copy_budget, function<void(const Locus&)> emit_locus);
     
     /**
      * Decide if the given SnarlTraversal is included in the original base graph
@@ -481,13 +481,21 @@ public:
      * Looks at the nodes in the traversal, and sees if their calls are
      * CALL_REFERENCE or not.
      *
-     * Specially handles single-edge traversals.
+     * Handles single-edge traversals.
      *
-     * If given a traversal that's all primary path nodes, it assumes it is non-
-     * reference, because it assumes the caller will never pass it the all-
-     * primary-path reference traversal.
      */
     bool is_reference(const SnarlTraversal& trav, AugmentedGraph& augmented);
+    
+    /**
+     * Decide if the given Path is included in the original base graph (true) or
+     * if it represents a novel variant (false).
+     *
+     * Looks at the nodes, and sees if their calls are CALL_REFERENCE or not.
+     *
+     * The path can't be empty; it has to be anchored to something (probably the
+     * start and end of the snarl it came from).
+     */
+    bool is_reference(const Path& path, AugmentedGraph& augmented);
     
     /**
      * Find the primary path, if any, that the given site is threaded onto.
@@ -541,9 +549,6 @@ public:
     // Like above, but applied to ref / alt ratio (instead of alt / ref)
     Option<double> max_ref_het_bias{this, "max-ref-bias", "R", 4,
         "max imbalance factor between ref and alts to call heterozygous ref"};
-    // How much should we multiply the bias limits for indels?
-    Option<double> indel_bias_multiple{this, "bias-mult", "M", 1,
-        "multiplier for bias limits for indels as opposed to substitutions"};
     // What's the minimum integer number of reads that must support a call? We
     // don't necessarily want to call a SNP as het because we have a single
     // supporting read, even if there are only 10 reads on the site.
@@ -561,10 +566,6 @@ public:
     // Should we use average support instead of minimum support for our calculations?
     Option<bool> use_average_support{this, "use-avg-support", "u", false,
         "use average instead of minimum support"};
-    // What's the max ref length of a site that we genotype as a whole instead
-    // of splitting?
-    Option<size_t> max_ref_length{this, "max-ref-length", "mMrRlL", 100,
-        "max length of a site to genotype as a whole instead of splitting"};
     
     // What's the maximum number of bubble path combinations we can explore
     // while finding one with maximum support?

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -457,6 +457,10 @@ public:
      * traversal, recursively, if any exist. These traversals will be fully
      * filled in with nodes.
      *
+     * Only snarls which are ultrabubbles can be called.
+     *
+     * Expects the given baseline support for a diploid call.
+     *
      * Will not return more than copy_budget SnarlTraversals, and will return
      * less if some copies are called as having the same traversal.
      *
@@ -468,7 +472,7 @@ public:
      */
     vector<SnarlTraversal> find_best_traversals(AugmentedGraph& augmented,
         SnarlManager& snarl_manager, TraversalFinder* finder, const Snarl& site,
-        size_t copy_budget, function<void(Locus)> emit_locus);
+        const Support& baseline_support, size_t copy_budget, function<void(Locus)> emit_locus);
     
     /**
      * Decide if the given SnarlTraversal is included in the original base graph

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -453,6 +453,25 @@ public:
     void call(AugmentedGraph& augmented, string pileup_filename = "");
     
     /**
+     * For the given snarl, find the best traversal, and the second-best
+     * traversal, recursively.
+     *
+     * For a site with no children, the best traversal is the one with the
+     * highest (minumum or average) coverage, and the second-best traversal is
+     * the one with the second-highest (minimum or average) coverage. Traversals
+     * are found with the given leaf traversal finder.
+     *
+     * For a site with children, the best traversal is formed by plugging
+     * together the best traversals of children, and the second-best traversal
+     * is formed by plugging together the second-best traversals of children.
+     *
+     * Not all children (and sometimes no children at all) will appear in the
+     * best and second-best traversals.
+     */
+    vector<SnarlTraversal> find_best_traversals(AugmentedGraph& augmented,
+        SnarlManager& snarl_manager, TraversalFinder* leaf_finder, const Snarl& site);
+    
+    /**
      * Decide if the given SnarlTraversal is included in the original base graph
      * (true), or if it represents a novel variant (false).
      *
@@ -536,10 +555,6 @@ public:
     // parallel paths.  Allow overriding here
     Option<double> expected_coverage{this, "avg-coverage", "C", 0.0,
         "specify expected coverage (instead of computing on reference)"};
-    // Should we drop variants that would overlap old ones? TODO: we really need
-    // a proper system for accounting for usage of graph material.
-    Option<bool> suppress_overlaps{this, "no-overlap", "O", false,
-        "don't emit new variants that overlap old ones"};
     // Should we use average support instead of minimum support for our calculations?
     Option<bool> use_average_support{this, "use-avg-support", "u", false,
         "use average instead of minimum support"};

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -1771,16 +1771,19 @@ Support RepresentativeTraversalFinder::min_support_in_path(const list<Visit>& pa
     
         // check the edge support
         Edge* edge = augmented.graph.get_edge(to_right_side(*cur), to_left_side(*next));
-        assert(edge != NULL);
-        Support edgeSupport = augmented.get_support(edge);
         
-        if (supportFound) {
-            // Min it against existing support
-            minSupport = support_min(minSupport, edgeSupport);
-        } else {
-            // Take as the found support
-            minSupport = edgeSupport;
-            supportFound = true;
+        if (edge != nullptr) {
+            // The edge exists (because we aren't back-to-back child snarls)
+            Support edgeSupport = augmented.get_support(edge);
+            
+            if (supportFound) {
+                // Min it against existing support
+                minSupport = support_min(minSupport, edgeSupport);
+            } else {
+                // Take as the found support
+                minSupport = edgeSupport;
+                supportFound = true;
+            }
         }
     }
 
@@ -1875,12 +1878,13 @@ set<pair<size_t, list<Visit>>> RepresentativeTraversalFinder::bfs_left(Visit vis
             for (auto prevVisit : prevVisits) {
                 // For each node we can get to
                 
-                // Make sure the edge is real
-                Edge* edge = augmented.graph.get_edge(to_right_side(prevVisit), to_left_side(path.front()));
-                assert(edge != NULL);
-                
                 if (prevVisit.node_id() != 0) {
                     // This is a visit to a node
+                    
+                    // Make sure the edge is real, since it can't be a back-to-
+                    // back site
+                    Edge* edge = augmented.graph.get_edge(to_right_side(prevVisit), to_left_side(path.front()));
+                    assert(edge != NULL);
                 
                     // Fetch the actual node
                     Node* prevNode = augmented.graph.get_node(prevVisit.node_id());

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -16,6 +16,14 @@ Support AugmentedGraph::get_support(Node* node) {
 Support AugmentedGraph::get_support(Edge* edge) {
     return edge_supports.count(edge) ? edge_supports.at(edge) : Support();
 }
+
+double AugmentedGraph::get_likelihood(Node* node) {
+    return node_likelihoods.count(node) ? node_likelihoods.at(node) : 0;
+}
+
+double AugmentedGraph::get_likelihood(Edge* edge) {
+    return edge_likelihoods.count(edge) ? edge_likelihoods.at(edge) : 0;
+}
     
 
 SimpleConsistencyCalculator::~SimpleConsistencyCalculator(){

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -24,6 +24,14 @@ double AugmentedGraph::get_likelihood(Node* node) {
 double AugmentedGraph::get_likelihood(Edge* edge) {
     return edge_likelihoods.count(edge) ? edge_likelihoods.at(edge) : 0;
 }
+
+ElementCall AugmentedGraph::get_call(Node* node) {
+    return node_calls.count(node) ? node_calls.at(node) : CALL_UNCALLED;
+}
+
+ElementCall AugmentedGraph::get_call(Edge* edge) {
+    return edge_calls.count(edge) ? edge_calls.at(edge) : CALL_UNCALLED;
+}
     
 
 SimpleConsistencyCalculator::~SimpleConsistencyCalculator(){

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -1239,19 +1239,6 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
                 // continuing from here.
                 break;
             }
-            /*
-            if (!ref_visit.backward() && ref_visit.end() == path.back()) {
-                // We must be exiting this visit on its local right (from the
-                // snarl's end). Put the after-the-bubble visits continuing from
-                // here.
-                break;
-            }
-            if (ref_visit.backward() && reverse(ref_visit.start()) == path.back()) {
-                // We must be exiting this visit on its local right (from the
-                // snarl's start). Put the after-the-bubble visits continuing
-                // from here.
-                break;
-            }*/
             
             // Otherwise this ref visit isn't the right one to match up with our
             // bubble's traversal.
@@ -1414,16 +1401,6 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
     auto emit_traversal = [&](vector<Visit> visits) {
         // Make it into this SnarlTraversal
         SnarlTraversal trav;
-        
-        if (primary_min == site_end) {
-            // The backbone is backward relative to the site, so all the
-            // traversals we have been working with are too. Flip them to be
-            // forward relative to the site.
-            std::reverse(visits.begin(), visits.end());
-            for (auto& v : visits) {
-                v.set_backward(!v.backward());
-            }
-        }
         
         cerr << "Unique traversal's visits:" << endl;
         for(auto& visit : visits) {

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -1153,6 +1153,10 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
         cerr << "Added visit: " << pb2json(ref_path_for_site.back()) << endl;        
     }
     
+    // We leave the ref path in backbone-relative forward orientation, because
+    // all our bubbles we find will also be in backbone-relative forward
+    // orientation.
+    
     for(auto node : nodes_left) {
         // Make sure none of the nodes in the site that we didn't visit
         // while tracing along the ref path are on the ref path.
@@ -1411,12 +1415,23 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
         // Make it into this SnarlTraversal
         SnarlTraversal trav;
         
+        if (primary_min == site_end) {
+            // The backbone is backward relative to the site, so all the
+            // traversals we have been working with are too. Flip them to be
+            // forward relative to the site.
+            std::reverse(visits.begin(), visits.end());
+            for (auto& v : visits) {
+                v.set_backward(!v.backward());
+            }
+        }
+        
         cerr << "Unique traversal's visits:" << endl;
         for(auto& visit : visits) {
             cerr << "\t" << visit << endl;
         }
         
         // Label traversal with the snarl
+        // TODO: use special copy ends function
         *trav.mutable_snarl()->mutable_start() = site.start();
         *trav.mutable_snarl()->mutable_end() = site.end();
         

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -379,21 +379,26 @@ protected:
     
     /**
      * Given an edge or node in the augmented graph, look out from the edge or
-     * node in both directions to find a shortest bubble relative to the path,
-     * with a consistent orientation. The bubble may not visit the same node
-     * twice.
+     * node or snarl in both directions to find a shortest bubble relative to
+     * the path, with a consistent orientation. The bubble may not visit the
+     * same node twice.
      *
-     * Exactly one of edge and node must be null, and one not null.
+     * Exactly one of edge and node and snarl must be not null.
      *
      * Takes a max depth for the searches producing the paths on each side.
      * 
      * Return the ordered and oriented nodes in the bubble, with the outer nodes
-     * being oriented forward along the named path, and with the first node
-     * coming before the last node in the reference.  Also return the minimum
-     * support found on any edge or node in the bubble (including the reference
-     * node endpoints and their edges which aren't stored in the path)
+     * being oriented forward along the path for which an index is provided, and
+     * with the first node coming before the last node in the reference.  Also
+     * return the minimum support found on any edge or node in the bubble
+     * (including the reference node endpoints and their edges which aren't
+     * stored in the path).
+     *
+     * Uses the given child_boundary_index to figure out when Visits to child
+     * snarls are needed.
      */
-    pair<Support, vector<Visit>> find_bubble(Node* node, Edge* edge, PathIndex& index);
+    pair<Support, vector<Visit>> find_bubble(Node* node, Edge* edge, const Snarl* snarl, PathIndex& index,
+        const map<NodeTraversal, const Snarl*>& child_boundary_index);
         
     /**
      * Get the minimum support of all nodes and edges in path
@@ -403,16 +408,26 @@ protected:
     /**
      * Do a breadth-first search left from the given node traversal, and return
      * lengths and paths starting at the given node and ending on the given
-     * indexed path. Refuses to visit nodes with no support.
+     * indexed path. Refuses to visit nodes with no support, if support data is
+     * available in the augmented graph.
+     *
+     * Uses the given child_boundary_index to figure out when Visits to child
+     * snarls are needed.
      */
-    set<pair<size_t, list<Visit>>> bfs_left(Visit visit, PathIndex& index, bool stopIfVisited = false);
+    set<pair<size_t, list<Visit>>> bfs_left(Visit visit, PathIndex& index,
+        const map<NodeTraversal, const Snarl*>& child_boundary_index, bool stopIfVisited = false);
         
     /**
      * Do a breadth-first search right from the given node traversal, and return
      * lengths and paths starting at the given node and ending on the given
-     * indexed path.
+     * indexed path. Refuses to visit nodes with no support, if support data is
+     * available in the augmented graph.
+     *
+     * Uses the given child_boundary_index to figure out when Visits to child
+     * snarls are needed.
      */
-    set<pair<size_t, list<Visit>>> bfs_right(Visit visit, PathIndex& index, bool stopIfVisited = false);
+    set<pair<size_t, list<Visit>>> bfs_right(Visit visit, PathIndex& index,
+        const map<NodeTraversal, const Snarl*>& child_boundary_index, bool stopIfVisited = false);
         
     /**
      * Get the length of a path through nodes, in base pairs.

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -219,6 +219,18 @@ struct AugmentedGraph {
     Support get_support(Edge* edge);
     
     /**
+     * Get the likelihood for a given node, or 0 if it has no recorded
+     * likelihood.
+     */
+    double get_likelihood(Node* node);
+    
+    /**
+     * Get the likelihood for a edge node, or 0 if it has no recorded
+     * likelihood.
+     */
+    double get_likelihood(Edge* edge);
+    
+    /**
      * Clear the contents.
      */
     void clear();

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -204,6 +204,21 @@ struct AugmentedGraph {
     vector<Translation> translations;
     
     /**
+     * Return true if we have support information, and false otherwise.
+     */
+    bool has_supports();
+    
+    /**
+     * Get the Support for a given Node, or 0 if it has no recorded support.
+     */
+    Support get_support(Node* node);
+    
+    /**
+     * Get the Support for a given Edge, or 0 if it has no recorded support.
+     */
+    Support get_support(Edge* edge);
+    
+    /**
      * Clear the contents.
      */
     void clear();

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -378,31 +378,31 @@ protected:
      * support found on any edge or node in the bubble (including the reference
      * node endpoints and their edges which aren't stored in the path)
      */
-    pair<Support, vector<NodeTraversal>> find_bubble(Node* node, Edge* edge, PathIndex& index);
+    pair<Support, vector<Visit>> find_bubble(Node* node, Edge* edge, PathIndex& index);
         
     /**
      * Get the minimum support of all nodes and edges in path
      */
-    Support min_support_in_path(const list<NodeTraversal>& path);
+    Support min_support_in_path(const list<Visit>& path);
         
     /**
      * Do a breadth-first search left from the given node traversal, and return
      * lengths and paths starting at the given node and ending on the given
      * indexed path. Refuses to visit nodes with no support.
      */
-    set<pair<size_t, list<NodeTraversal>>> bfs_left(NodeTraversal node, PathIndex& index, bool stopIfVisited = false);
+    set<pair<size_t, list<Visit>>> bfs_left(Visit visit, PathIndex& index, bool stopIfVisited = false);
         
     /**
      * Do a breadth-first search right from the given node traversal, and return
      * lengths and paths starting at the given node and ending on the given
      * indexed path.
      */
-    set<pair<size_t, list<NodeTraversal>>> bfs_right(NodeTraversal node, PathIndex& index, bool stopIfVisited = false);
+    set<pair<size_t, list<Visit>>> bfs_right(Visit visit, PathIndex& index, bool stopIfVisited = false);
         
     /**
      * Get the length of a path through nodes, in base pairs.
      */
-    size_t bp_length(const list<NodeTraversal>& path);
+    size_t bp_length(const list<Visit>& path);
     
 public:
 

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -191,7 +191,7 @@ struct AugmentedGraph {
     // And for edges
     map<Edge*, Support> edge_supports;
     
-    // This holds the likelihood for each node.
+    // This holds the log10 likelihood for each node.
     // TODO: what exactly does that mean?
     map<Node*, double> node_likelihoods;
     // And for edges
@@ -219,16 +219,28 @@ struct AugmentedGraph {
     Support get_support(Edge* edge);
     
     /**
-     * Get the likelihood for a given node, or 0 if it has no recorded
+     * Get the log10 likelihood for a given node, or 0 if it has no recorded
      * likelihood.
      */
     double get_likelihood(Node* node);
     
     /**
-     * Get the likelihood for a edge node, or 0 if it has no recorded
+     * Get the log10 likelihood for a edge node, or 0 if it has no recorded
      * likelihood.
      */
     double get_likelihood(Edge* edge);
+    
+    /**
+     * Get the call for a given node, or CALL_UNCALLED if it has no associated
+     * call.
+     */
+    ElementCall get_call(Node* node);
+    
+    /**
+     * Get the call for a given edge, or CALL_UNCALLED if it has no associated
+     * call.
+     */
+    ElementCall get_call(Edge* edge);
     
     /**
      * Clear the contents.

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -449,13 +449,14 @@ namespace vg {
         
         // Right now we're stuck with O(n) search and it's horrible
         for(auto& owned : snarls) {
-            if (owned == not_owned) {
+            // Only compare start and end visits, because we may get snarls with
+            // only those set from visits.
+            if (owned.start() == not_owned.start() && owned.end() == not_owned.end()) {
                 return &owned;
             }
         }
-        
         // If we get here it doesn't exist.
-        throw runtime_error("Unable to find snarl in SnarlManager");
+        throw runtime_error("Unable to find snarl " +  pb2json(not_owned) + " in SnarlManager");
     }
     
     vector<Visit> visits_right(const Visit& visit, VG& graph,

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -531,6 +531,18 @@ namespace vg {
         }        
     }
     
+    ostream& operator<<(ostream& out, const Visit& visit) {
+        if (!visit.has_snarl()) {
+            // Use the node ID
+            out << visit.node_id();
+        } else {
+            // Use the two defining visits
+            out << visit.snarl().start() << "-" << visit.snarl().end();
+        }
+        out << " " << (visit.backward() ? "rev" : "fwd");
+        return out;
+    }
+    
     bool operator==(const SnarlTraversal& a, const SnarlTraversal& b) {
         if (a.snarl() != b.snarl()) {
             return false;

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -476,6 +476,37 @@ namespace vg {
         // Find the right side of the visit we're on
         NodeSide right_side = to_right_side(visit);
         
+        if (visit.node_id() == 0) {
+            // We're leaving a child snarl, so we are going to need to check if
+            // another child snarl shares this boundary node in the direction
+            // we're going.
+            
+            // Make a node traversal for going towards that right side
+            NodeTraversal out_of_child(graph.get_node(right_side.node), !right_side.is_end);
+            
+            if (child_boundary_index.count(out_of_child)) {
+                // We leave the one child and immediately enter another!
+                
+                // Make a visit to it
+                Visit child_visit;
+                transfer_boundary_info(*child_boundary_index.at(out_of_child), *child_visit.mutable_snarl());
+                
+                if (right_side.node == child_visit.snarl().end().node_id()) {
+                    // We came in its end
+                    child_visit.set_backward(true);
+                } else {
+                    // We should have come in its start
+                    assert(right_side.node == child_visit.snarl().start().node_id());
+                }
+                
+                // Bail right now, so we don'ttry to explore inside this child snarl.
+                to_return.push_back(child_visit);
+                return to_return;
+                
+            }
+            
+        }
+        
         for (auto attached : graph.sides_of(right_side)) {
             // For every NodeSide attached to the right side of this visit
             

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -445,6 +445,14 @@ namespace vg {
     vector<Visit> visits_right(const Visit& visit, VG& graph,
         const map<NodeTraversal, const Snarl*>& child_boundary_index) {
         
+#ifdef debug
+        cerr << "Look right from " << visit << endl;
+        cerr << "\tChild index:" << endl;
+        for (auto& kv : child_boundary_index) {
+            cerr << "\t\t" << kv.first << " -> " << *kv.second << endl;
+        }
+#endif
+        
         // We'll populate this
         vector<Visit> to_return;
         
@@ -457,11 +465,19 @@ namespace vg {
             // Make it a NodeTraversal reading away from that side
             NodeTraversal attached_traversal(graph.get_node(attached.node), attached.is_end);
             
+#ifdef debug
+            cerr << "\tFind NodeTraversal " << attached_traversal << endl;
+#endif
+            
             if (child_boundary_index.count(attached_traversal)) {
                 // We're reading into a child
                 
                 // Which child is it?
                 const Snarl* child = child_boundary_index.at(attached_traversal);
+                
+#ifdef debug
+                cerr << "\t\tGoes to Snarl " << *child << endl;
+#endif
                 
                 if (attached.node == child->start().node_id()) {
                     // We're reading into the start of the child
@@ -469,6 +485,10 @@ namespace vg {
                     // Make a visit to the child snarl
                     Visit child_visit;
                     transfer_boundary_info(*child, *child_visit.mutable_snarl());
+                    
+#ifdef debug
+                    cerr << "\t\tProduces Visit " << child_visit << endl;
+#endif
                     
                     // Put it in in the forward orientation
                     to_return.push_back(child_visit);
@@ -480,6 +500,10 @@ namespace vg {
                     transfer_boundary_info(*child, *child_visit.mutable_snarl());
                     child_visit.set_backward(true);
                     
+#ifdef debug
+                    cerr << "\t\tProduces Visit " << child_visit << endl;
+#endif
+                    
                     // Put it in in the reverse orientation
                     to_return.push_back(child_visit);
                 } else {
@@ -489,6 +513,11 @@ namespace vg {
             } else {
                 // We just go into a normal node
                 to_return.push_back(to_visit(attached_traversal));
+            
+#ifdef debug
+                cerr << "\t\tProduces Visit " << to_return.back() << endl;
+#endif
+                
             }
         }
         
@@ -544,8 +573,8 @@ namespace vg {
             // Use the node ID
             out << visit.node_id();
         } else {
-            // Use the two defining visits
-            out << visit.snarl().start() << "-" << visit.snarl().end();
+            // Use the snarl
+            out << visit.snarl();
         }
         out << " " << (visit.backward() ? "rev" : "fwd");
         return out;
@@ -623,6 +652,10 @@ namespace vg {
             // Compare with parent
             return make_tuple(a.type(), a.start(), a.end(), a.parent()) < make_tuple(b.type(), b.start(), b.end(), b.parent());
         }
+    }
+    
+    ostream& operator<<(ostream& out, const Snarl& snarl) {
+        return out << snarl.start() << "-" << snarl.end();
     }
 }
 

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -503,8 +503,16 @@ namespace vg {
         Visit reversed = visit;
         reversed.set_backward(!reversed.backward());
         
-        // Return everything right of the reversed version
-        return visits_right(reversed, graph, child_boundary_index);
+        // Get everything right of the reversed version
+        vector<Visit> to_return = visits_right(reversed, graph, child_boundary_index);
+        
+        // Un-reverse them so they are in the correct orientation to be seen
+        // left of here.
+        for (auto& v : to_return) {
+            v = reverse(v);
+        }
+        
+        return to_return;
         
     }
     

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -442,6 +442,22 @@ namespace vg {
         return to_return;
     }
     
+    const Snarl* SnarlManager::manage(const Snarl& not_owned) {
+        // TODO: keep the Snarls in some kind of sorted order to make lookup
+        // efficient. We could also have a map<Snarl, Snarl*> but that would be
+        // a tremendous waste of space.
+        
+        // Right now we're stuck with O(n) search and it's horrible
+        for(auto& owned : snarls) {
+            if (owned == not_owned) {
+                return &owned;
+            }
+        }
+        
+        // If we get here it doesn't exist.
+        throw runtime_error("Unable to find snarl in SnarlManager");
+    }
+    
     vector<Visit> visits_right(const Visit& visit, VG& graph,
         const map<NodeTraversal, const Snarl*>& child_boundary_index) {
         

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -311,7 +311,9 @@ namespace vg {
     
     inline Visit to_visit(const Snarl& snarl) {
         Visit to_return;
-        *to_return.mutable_snarl() = snarl;
+        // Only copy necessary fields
+        *to_return.mutable_snarl()->mutable_start() = snarl.start();
+        *to_return.mutable_snarl()->mutable_end() = snarl.end();
         return to_return;
     }
     

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -138,6 +138,9 @@ namespace vg {
     /// Make a Visit from a node ID and an orientation
     inline Visit to_visit(id_t node_id, bool is_reverse);
     
+    /// Make a Visit from a snarl to traverse
+    inline Visit to_visit(const Snarl& snarl);
+    
     /// Get the reversed version of a visit
     inline Visit reverse(const Visit& visit);
     
@@ -213,6 +216,11 @@ namespace vg {
      * Visit is smaller, or its end Visit is smaller, or its parent is smaller.
      */
     bool operator<(const Snarl& a, const Snarl& b);
+    
+    /**
+     * A Snarl can be printed.
+     */
+    ostream& operator<<(ostream& out, const Snarl& snarl);
     
     /****
      * Template and Inlines:
@@ -294,6 +302,12 @@ namespace vg {
         Visit to_return;
         to_return.set_node_id(node_id);
         to_return.set_backward(is_reverse);
+        return to_return;
+    }
+    
+    inline Visit to_visit(const Snarl& snarl) {
+        Visit to_return;
+        *to_return.mutable_snarl() = snarl;
         return to_return;
     }
     

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -87,6 +87,9 @@ namespace vg {
         const Snarl* manage(const Snarl& not_owned);
         
     private:
+    
+        /// Define the key type
+        using key_t = pair<pair<int64_t, bool>, pair<int64_t, bool>>;
         
         /// Master list of the snarls in the graph
         vector<Snarl> snarls;
@@ -95,14 +98,18 @@ namespace vg {
         vector<const Snarl*> roots;
         
         /// Map of snarls to the child snarls they contain
-        unordered_map<pair<pair<int64_t, bool>, pair<int64_t, bool> >, vector<const Snarl*> > children;
-        unordered_map<pair<pair<int64_t, bool>, pair<int64_t, bool> >, const Snarl*> parent;
+        unordered_map<key_t, vector<const Snarl*>> children;
+        unordered_map<key_t, const Snarl*> parent;
+        
+        /// Map of snarl keys to the indexes in the snarl array
+        // TODO: should we switch to just pointers here and save an indirection?
+        unordered_map<key_t, size_t> index_of;
         
         /// Converts Snarl to the form used as keys in internal data structures
-        inline pair<pair<int64_t, bool>, pair<int64_t, bool> > key_form(const Snarl* snarl);
+        inline key_t key_form(const Snarl* snarl);
         
         /// Builds tree indices after Snarls have been added
-        void build_trees();
+        void build_indexes();
     };
     
     /**
@@ -236,8 +243,8 @@ namespace vg {
         for (auto iter = begin; iter != end; iter++) {
             snarls.push_back(*iter);
         }
-        // record the tree structure
-        build_trees();
+        // record the tree structure and build the other indexes
+        build_indexes();
     }
     
     inline NodeTraversal to_node_traversal(const Visit& visit, VG& graph) {

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -135,6 +135,12 @@ namespace vg {
     /// Converts a Mapping to a Visit. The mapping must represent a full node match.
     inline Visit to_visit(const Mapping& mapping);
     
+    /// Make a Visit from a node ID and an orientation
+    inline Visit to_visit(id_t node_id, bool is_reverse);
+    
+    /// Get the reversed version of a visit
+    inline Visit reverse(const Visit& visit);
+    
     /// Converts a NodeTraversal to a Visit in the opposite orientation.
     inline Visit to_rev_visit(const NodeTraversal& node_traversal);
     
@@ -167,6 +173,11 @@ namespace vg {
      * backward.
      */
     bool operator<(const Visit& a, const Visit& b);
+    
+    /**
+     * A Visit can be printed.
+     */
+    ostream& operator<<(ostream& out, const Visit& visit);
     
     // And some operators for SnarlTraversals
     
@@ -202,7 +213,6 @@ namespace vg {
      * Visit is smaller, or its end Visit is smaller, or its parent is smaller.
      */
     bool operator<(const Snarl& a, const Snarl& b);
-    
     
     /****
      * Template and Inlines:
@@ -277,6 +287,21 @@ namespace vg {
         Visit to_return;
         to_return.set_node_id(mapping.position().node_id());
         to_return.set_backward(mapping.position().is_reverse());
+        return to_return;
+    }
+    
+    inline Visit to_visit(id_t node_id, bool is_reverse) {
+        Visit to_return;
+        to_return.set_node_id(node_id);
+        to_return.set_backward(is_reverse);
+        return to_return;
+    }
+    
+    inline Visit reverse(const Visit& visit) {
+        // Copy the visit
+        Visit to_return = visit;
+        // And flip its orientation bit
+        to_return.set_backward(!visit.backward());
         return to_return;
     }
     

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -82,6 +82,10 @@ namespace vg {
         /// Execute a function on all top level sites in parallel
         void for_each_top_level_snarl_parallel(const function<void(const Snarl*)>& lambda);
         
+        /// Given a Snarl that we don't own (like from a Visit), find the
+        /// pointer to the managed copy of that Snarl.
+        const Snarl* manage(const Snarl& not_owned);
+        
     private:
         
         /// Master list of the snarls in the graph

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -567,6 +567,30 @@ TEST_CASE("RepresentativeTraversalFinder finds traversals correctly", "[genotype
             vector<SnarlTraversal> traversals = finder.find_traversals(*parent);
 
             REQUIRE(traversals.size() == 2);
+            
+            SECTION("one should be empty") {
+                bool found = false;
+                for (auto traversal : traversals) {
+                    if (traversal.visits_size() == 0) {
+                        found = true;
+                    }
+                }
+                REQUIRE(found);
+            }
+            
+            SECTION("one should visit just the child site") {
+                bool found = false;
+                for (auto traversal : traversals) {
+                    if (traversal.visits_size() == 1) {
+                        auto& visit = traversal.visits(0);
+                        
+                        if(visit.node_id() == 0 && visit.snarl() == *child) {
+                            found = true;
+                        }
+                    }
+                }
+                REQUIRE(found);
+            }
                 
         }
     }

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -462,5 +462,116 @@ TEST_CASE("SiteFinder can differntiate ultrabubbles from snarls", "[genotype]") 
 
 }
 
+TEST_CASE("RepresentativeTraversalFinder finds traversals correctly", "[genotype][representativetraversalfinder]") {
+
+    SECTION("Traversal-finding should work on a substitution inside a deletion") {
+    
+        // Build a toy graph
+        // Should be a substitution (2, 3 or 4, 5) nested inside a 1 to 6 deletion
+        const string graph_json = R"(
+    
+        {
+        "node": [
+            {"id": 1, "sequence": "G"},
+            {"id": 2, "sequence": "A"},
+            {"id": 3, "sequence": "T"},
+            {"id": 4, "sequence": "GGG"},
+            {"id": 5, "sequence": "GT"},
+            {"id": 6, "sequence": "GT"}
+        ],
+        "edge": [
+            {"from": 1, "to": 2},
+            {"from": 2, "to": 3},
+            {"from": 2, "to": 4},
+            {"from": 3, "to": 5},
+            {"from": 4, "to": 5},
+            {"from": 5, "to": 6},
+            {"from": 1, "to": 6}
+        ]
+        }
+        )";
+    
+        // Make an actual graph
+        VG graph;
+        Graph chunk;
+        json2pb(chunk, graph_json.c_str(), graph_json.size());
+        graph.merge(chunk);
+
+        // Find the snarls
+        CactusUltrabubbleFinder cubs(graph);
+        SnarlManager snarl_manager = cubs.find_snarls();
+        const vector<const Snarl*>& snarl_roots = snarl_manager.top_level_snarls();
+
+        // We should have a single root snarl
+        REQUIRE(snarl_roots.size() == 1);
+        const Snarl* parent = snarl_roots[0];
+
+        auto children = snarl_manager.children_of(parent);
+        REQUIRE(children.size() == 1);
+        const Snarl* child = children[0];
+        
+        // We need an AugmentedGraph wraping the graph to use the
+        // RepresentativeTraversalFinder
+        AugmentedGraph augmented;
+        augmented.graph = graph;
+        
+        // Make a RepresentativeTraversalFinder
+        RepresentativeTraversalFinder finder(augmented, snarl_manager, 100, 1000);
+        
+        SECTION("there should be two traversals of the substitution") {
+            
+            vector<SnarlTraversal> traversals = finder.find_traversals(*child);
+
+            REQUIRE(traversals.size() == 2);
+            
+            SECTION("all the traversals should be size 1, with just the middle node") {
+                // TODO: this will have to change when we start to support traversals of non-ultrabubbles.
+                for (auto traversal : traversals) {
+                    REQUIRE(traversal.visits_size() == 1);
+                    
+                    // Make sure the middle is a node and not a child snarl
+                    REQUIRE(traversal.visits(0).node_id() != 0);
+                }
+            }
+            
+            SECTION("one should hit node 3") {
+                bool found = false;
+                for (auto traversal : traversals) {
+                    for (size_t i = 0; i < traversal.visits_size(); i++) {
+                        // Check every visit on every traversal
+                        if (traversal.visits(i).node_id() == 3) {
+                            found = true;
+                        }
+                    }
+                }
+                REQUIRE(found);
+            }
+            
+            SECTION("one should hit node 4") {
+                bool found = false;
+                for (auto traversal : traversals) {
+                    for (size_t i = 0; i < traversal.visits_size(); i++) {
+                        // Check every visit on every traversal
+                        if (traversal.visits(i).node_id() == 4) {
+                            found = true;
+                        }
+                    }
+                }
+                REQUIRE(found);
+            }
+                
+        }
+        
+        SECTION("there should be two traversals of the parent deletion") {
+            
+            vector<SnarlTraversal> traversals = finder.find_traversals(*parent);
+
+            REQUIRE(traversals.size() == 2);
+                
+        }
+    }
+
+}
+
 }
 }

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -584,7 +584,8 @@ TEST_CASE("RepresentativeTraversalFinder finds traversals correctly", "[genotype
                     if (traversal.visits_size() == 1) {
                         auto& visit = traversal.visits(0);
                         
-                        if(visit.node_id() == 0 && visit.snarl() == *child) {
+                        if(visit.node_id() == 0 && visit.snarl().start() == child->start() &&
+                            visit.snarl().end() == child->end()) {
                             found = true;
                         }
                     }

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -563,6 +563,145 @@ namespace vg {
                 REQUIRE(contents.first.size() == 2);
                 REQUIRE(contents.second.size() == 1);
                 
+            }
+            
+            SECTION( "SnarlManager does not include child snarls' edges in parent snarls") {
+                
+                // This graph is 3 nodes in a row, with two anchoring nodes on
+                // the end, and an edge deleting the three in the middle and
+                // just linking the anchoring nodes.
+                string graph_json = R"(
+                {
+                  "node": [
+                    {
+                      "sequence": "A",
+                      "id": 178895
+                    },
+                    {
+                      "sequence": "G",
+                      "id": 178896
+                    },
+                    {
+                      "sequence": "A",
+                      "id": 187209
+                    },
+                    {
+                      "sequence": "TCTCAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                      "id": 178894
+                    },
+                    {
+                      "sequence": "AATGTGTCTTCCTGGGT",
+                      "id": 187208
+                    }
+                  ],
+                  "edge": [
+                    {
+                      "from": 187209,
+                      "to": 178895
+                    },
+                    {
+                      "from": 178895,
+                      "to": 178896
+                    },
+                    {
+                      "from": 178896,
+                      "to": 187208
+                    },
+                    {
+                      "from": 178894,
+                      "to": 187209
+                    },
+                    {
+                      "from": 178894,
+                      "to": 187208
+                    }
+                  ],
+                  "path": [
+                    {
+                      "name": "5",
+                      "mapping": [
+                        {
+                          "position": {
+                            "node_id": 178894
+                          },
+                          "rank": 98372
+                        },
+                        {
+                          "position": {
+                            "node_id": 187209
+                          },
+                          "rank": 98373
+                        },
+                        {
+                          "position": {
+                            "node_id": 178895
+                          },
+                          "rank": 98374
+                        },
+                        {
+                          "position": {
+                            "node_id": 178896
+                          },
+                          "rank": 98375
+                        },
+                        {
+                          "position": {
+                            "node_id": 187208
+                          },
+                          "rank": 98376
+                        }
+                      ]
+                    }
+                  ]
+                }
+                )";
+                
+                // We have one parent snarl for the deletion, with two back-to-back trivial child snarls.
+                string snarl1_json = R"({"type": 1, "end": {"node_id": 187208}, "start": {"node_id": 178894}})";
+                string snarl2_json = R"({"type": 1, "end": {"node_id": 187209, "backward": true}, "start": {"node_id": 178895, "backward": true}, "parent": {"end": {"node_id": 187208}, "start": {"node_id": 178894}}})";
+                string snarl3_json = R"({"type": 1, "end": {"node_id": 178896}, "start": {"node_id": 178895}, "parent": {"end": {"node_id": 187208}, "start": {"node_id": 178894}}})";
+                
+                VG graph;
+                
+                // Load up the graph
+                Graph g;
+                json2pb(g, graph_json.c_str(), graph_json.size());
+                graph.extend(g);
+                
+                // Load the snarls
+                Snarl snarl1, snarl2, snarl3;
+                json2pb(snarl1, snarl1_json.c_str(), snarl1_json.size());
+                json2pb(snarl2, snarl2_json.c_str(), snarl2_json.size());
+                json2pb(snarl3, snarl3_json.c_str(), snarl3_json.size());
+                
+                // Put them in a list
+                list<Snarl> snarls;
+                snarls.push_back(snarl1);
+                snarls.push_back(snarl2);
+                snarls.push_back(snarl3);
+                
+                SnarlManager snarl_manager(snarls.begin(), snarls.end());
+                
+                // Find the root snarl again
+                const Snarl* snarl = snarl_manager.manage(snarl1);
+                
+                // Get its contents
+                pair<unordered_set<Node*>, unordered_set<Edge*> > contents = snarl_manager.shallow_contents(snarl, graph, true);
+                
+                // We need the right snarl
+                REQUIRE(snarl->start().node_id() == 178894);
+                REQUIRE(!snarl->start().backward());
+                REQUIRE(snarl->end().node_id() == 187208);
+                REQUIRE(!snarl->end().backward());
+                
+                SECTION("The top-level snarl contains all 5 nodes") {
+                    REQUIRE(contents.first.size() == 5);
+                }
+                
+                SECTION("The top-level snarl only contains the three edges not in any child snarl") {
+                    REQUIRE(contents.second.size() == 3);
+                }
+                
             }  
         }
     }

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -277,6 +277,9 @@ message Locus {
     // We also have a Support for the locus overall, because reads may have
     // supported multiple alleles and we want to know how many total there were.
     Support overall_support = 5;
+    // We track the likelihood of each allele individually, in addition to
+    // genotype likelihoods. Stores the likelihood natural logged.
+    repeated double allele_log_likelihood = 6;
 }
 
 // Describes a genotype at a particular locus.


### PR DESCRIPTION
Now vg call will recursively handle all nested sites in a tree, emitting multiple Loci, or multiple VCF records when parents and children are both on a primary path.

This appears to slightly improve calling performance on @glennhickey 's `bakeoff.sh` script, in my testing (which I did before rebasing onto master).

I've also added the XSEE tag back to the generated VCFs, to point to the un-augmented nodes that are relevant for a variant.

I also improved the way we build `libvg.a` in the Makefile, so we don't dump source files into the static library's archive.