### PR TITLE
Change second-best traversal selection logic

### DIFF
--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -108,7 +108,7 @@ void write_vcf_header(ostream& stream, const vector<string>& sample_names,
     stream << "##INFO=<ID=XREF,Number=0,Type=Flag,Description=\"Present in original graph\">" << endl;
     stream << "##INFO=<ID=XSEE,Number=.,Type=String,Description=\"Original graph node:offset cross-references\">" << endl;
     stream << "##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">" << endl;
-    //stream << "##INFO=<ID=SVLEN,Number=-1,Type=Integer,Description=\"Difference in length between REF and ALT alleles\">" << endl;
+    stream << "##INFO=<ID=SVLEN,Number=-1,Type=Integer,Description=\"Difference in length between REF and ALT alleles\">" << endl;
     stream << "##FILTER=<ID=FAIL,Description=\"Variant does not meet minimum allele read support threshold of " << min_mad_for_filter << "\">" <<endl;
     stream << "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Read Depth\">" << endl;
     stream << "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">" << endl;
@@ -1284,11 +1284,6 @@ void Call2Vcf::call(
                 used_alleles.push_back(second_best_allele);
             }
             
-            if (used_alleles.size() == 1) {
-                // We only have the reference. Don't emit the allele.
-                //return;
-            }
-        
             // Rewrite the sequences and variation_start to just represent the
             // actually variable part, by dropping any common prefix and common
             // suffix. We just do the whole thing in place, modifying the used
@@ -1466,7 +1461,7 @@ void Call2Vcf::call(
                 int64_t svlen = (int64_t) variant.alleles.at(i).size() - (int64_t) variant.alleles.at(0).size();
                 
                 // Add it in
-                //variant.info["SVLEN"].push_back(to_string(svlen));
+                variant.info["SVLEN"].push_back(to_string(svlen));
             }
             
             // Set up the depth format field

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -1976,6 +1976,13 @@ size_t RepresentativeTraversalFinder::bp_length(const list<Visit>& path) {
     return length;
 }
 
+Support make_support(double forward, double reverse) {
+    Support to_return;
+    to_return.set_forward(forward);
+    to_return.set_reverse(reverse);
+    return to_return;
+}
+
 double total(const Support& support) {
     return support.forward() + support.reverse();
 }

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -526,6 +526,11 @@ class SimpleTraversalSupportCalculator : public TraversalSupportCalculator{
 // We also supply utility functions for working with genotyping Protobuf objects
 
 /**
+ * Create a Support for the given forward and reverse coverage.
+ */
+Support make_support(double forward, double reverse);
+
+/**
  * Get the total read support in a Support.
  */
 double total(const Support& support);


### PR DESCRIPTION
Now we choose the second-best traversal based on the coverage of graph elements not used by the best traversal.

I've also added the SVLEN tag back in.