### PR TITLE
Enable large insert calling

### DIFF
--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -603,20 +603,20 @@ vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
     // TODO: generalize it
     assert(site.type() == ULTRABUBBLE);
 
-#define debug
+
 #ifdef debug
     cerr << "Site " << site << endl;
 #endif
-#undef debug
+
 
     // Get traversals of this Snarl, with Visits to child Snarls
     vector<SnarlTraversal> here_traversals = finder->find_traversals(site);
     
-#define debug
+
 #ifdef debug
     cerr << "Found " << here_traversals.size() << " traversals" << endl;
 #endif
-#undef debug
+
     
     // Make a Locus to hold all our stats for the different traversals
     // available.

--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -108,7 +108,7 @@ void write_vcf_header(ostream& stream, const vector<string>& sample_names,
     stream << "##INFO=<ID=XREF,Number=0,Type=Flag,Description=\"Present in original graph\">" << endl;
     stream << "##INFO=<ID=XSEE,Number=.,Type=String,Description=\"Original graph node:offset cross-references\">" << endl;
     stream << "##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">" << endl;
-    stream << "##INFO=<ID=SVLEN,Number=-1,Type=Integer,Description=\"Difference in length between REF and ALT alleles\">" << endl;
+    stream << "##INFO=<ID=SVLEN,Number=.,Type=Integer,Description=\"Difference in length between REF and ALT alleles\">" << endl;
     stream << "##FILTER=<ID=FAIL,Description=\"Variant does not meet minimum allele read support threshold of " << min_mad_for_filter << "\">" <<endl;
     stream << "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Read Depth\">" << endl;
     stream << "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">" << endl;

--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -603,8 +603,20 @@ vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
     // TODO: generalize it
     assert(site.type() == ULTRABUBBLE);
 
+#define debug
+#ifdef debug
+    cerr << "Site " << site << endl;
+#endif
+#undef debug
+
     // Get traversals of this Snarl, with Visits to child Snarls
     vector<SnarlTraversal> here_traversals = finder->find_traversals(site);
+    
+#define debug
+#ifdef debug
+    cerr << "Found " << here_traversals.size() << " traversals" << endl;
+#endif
+#undef debug
     
     // Make a Locus to hold all our stats for the different traversals
     // available.
@@ -613,11 +625,6 @@ vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
     // How long is the longest traversal?
     // Sort of approximate because of the way nested site sizes are estimated.
     size_t longest_traversal_length = 0;
-    
-#ifdef debug
-    cerr << "Site " << site << endl;
-#endif
-   
     
     // Calculate average and min support for all the traversals of this snarl.
     vector<Support> min_supports;
@@ -1265,8 +1272,8 @@ void Call2Vcf::call(
     }
     
     // Now start looking for traversals of the sites.
-    RepresentativeTraversalFinder traversal_finder(augmented, site_manager, max_search_depth, max_bubble_paths,
-        [&] (const Snarl& site) -> PathIndex* {
+    RepresentativeTraversalFinder traversal_finder(augmented, site_manager, max_search_depth, max_search_width,
+        max_bubble_paths, [&] (const Snarl& site) -> PathIndex* {
         
         // When the TraversalFinder needs a primary path index for a site, it can look it up with this function.
         auto found = find_path(site, primary_paths);

--- a/src/caller.cpp
+++ b/src/caller.cpp
@@ -475,6 +475,19 @@ void Caller::compute_top_frequencies(const BasePileup& bp,
             // toggle inserts
             continue;
         }
+        
+        // We want to know if this pileup supports an N
+        bool all_n = true;
+        for (auto base : val) {
+            if (base != 'N') {
+                all_n = false;
+            }
+        }
+        if (all_n) {
+            // N is not a real base, so we should never augment with it.
+            continue;
+        }
+        
         ++total_count;
         
         // val will always be uppcase / forward strand.  we check

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -552,7 +552,7 @@ public:
     // How many nodes should we be willing to look at on our path back to the
     // primary path? Keep in mind we need to look at all valid paths (and all
     // combinations thereof) until we find a valid pair.
-    Option<int64_t> max_search_depth{this, "max-search-depth", "D", 10,
+    Option<int64_t> max_search_depth{this, "max-search-depth", "D", 1000,
         "maximum depth for path search"};
     
     

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -526,81 +526,87 @@ public:
     
     // Option variables
     
-    // Should we output in VCF (true) or Protobuf Locus (false) format?
+    /// Should we output in VCF (true) or Protobuf Locus (false) format?
     Option<bool> convert_to_vcf{this, "no-vcf", "V", true,
         "output variants in binary Loci format instead of text VCF format"};
-    // How big should our output buffer be?
+    /// How big should our output buffer be?
     size_t locus_buffer_size = 1000;
     
-    // What are the names of the reference paths, if any, in the graph?
+    /// What are the names of the reference paths, if any, in the graph?
     Option<vector<string>> ref_path_names{this, "ref", "r", {},
         "use the path with the given name as a reference path (can repeat)"};
-    // What name should we give each contig in the VCF file? Autodetected from
-    // path names if empty or too short.
+    /// What name should we give each contig in the VCF file? Autodetected from
+    /// path names if empty or too short.
     Option<vector<string>> contig_name_overrides{this, "contig", "c", {},
         "use the given name as the VCF name for the corresponding reference path"};
-    // What should the total sequence length reported in the VCF header be for
-    // each contig? Autodetected from path lengths if empty or too short.
+    /// What should the total sequence length reported in the VCF header be for
+    /// each contig? Autodetected from path lengths if empty or too short.
     Option<vector<size_t>> length_overrides{this, "length", "l", {},
         "override total sequence length in VCF for the corresponding reference path"};
-    // What name should we use for the sample in the VCF file?
+    /// What name should we use for the sample in the VCF file?
     Option<string> sample_name{this, "sample", "S", "SAMPLE",
         "name the sample in the VCF with the given name"};
-    // How far should we offset positions of variants?
+    /// How far should we offset positions of variants?
     Option<int64_t> variant_offset{this, "offset", "o", 0,
         "offset variant positions by this amount in VCF"};
-    // How many nodes should we be willing to look at on our path back to the
-    // primary path? Keep in mind we need to look at all valid paths (and all
-    // combinations thereof) until we find a valid pair.
+    /// How many nodes should we be willing to look at on our path back to the
+    /// primary path? Keep in mind we need to look at all valid paths (and all
+    /// combinations thereof) until we find a valid pair.
     Option<int64_t> max_search_depth{this, "max-search-depth", "D", 1000,
         "maximum depth for path search"};
+    /// How many search states should we allow on the DFS stack when searching
+    /// for traversals?
+    Option<int64_t> max_search_width{this, "max-search-width", "wWmMsS", 1000,
+        "maximum width for path search"};
     
     
-    // What fraction of average coverage should be the minimum to call a variant (or a single copy)?
-    // Default to 0 because vg call is still applying depth thresholding
+    /// What fraction of average coverage should be the minimum to call a
+    /// variant (or a single copy)? Default to 0 because vg call is still
+    /// applying depth thresholding
     Option<double> min_fraction_for_call{this, "min-cov-frac", "F", 0,
         "min fraction of average coverage at which to call"};
-    // What fraction of the reads supporting an alt are we willing to discount?
-    // At 2, if twice the reads support one allele as the other, we'll call
-    // homozygous instead of heterozygous. At infinity, every call will be
-    // heterozygous if even one read supports each allele.
+    /// What fraction of the reads supporting an alt are we willing to discount?
+    /// At 2, if twice the reads support one allele as the other, we'll call
+    /// homozygous instead of heterozygous. At infinity, every call will be
+    /// heterozygous if even one read supports each allele.
     Option<double> max_het_bias{this, "max-het-bias", "H", 4.5,
         "max imbalance factor between alts to call heterozygous"};
-    // Like above, but applied to ref / alt ratio (instead of alt / ref)
+    /// Like above, but applied to ref / alt ratio (instead of alt / ref)
     Option<double> max_ref_het_bias{this, "max-ref-bias", "R", 4.5,
         "max imbalance factor between ref and alts to call heterozygous ref"};
-    // What's the minimum integer number of reads that must support a call? We
-    // don't necessarily want to call a SNP as het because we have a single
+    /// What's the minimum integer number of reads that must support a call? We
+    /// don't necessarily want to call a SNP as het because we have a single
     // supporting read, even if there are only 10 reads on the site.
     Option<size_t> min_total_support_for_call{this, "min-count", "n", 1, 
         "min total supporting read count to call a variant"};
-    // Bin size used for counting coverage along the reference path.  The
-    // bin coverage is used for computing the probability of an allele
-    // of a certain depth
+    /// Bin size used for counting coverage along the reference path.  The
+    /// bin coverage is used for computing the probability of an allele
+    /// of a certain depth
     Option<size_t> ref_bin_size{this, "bin-size", "B", 250,
         "bin size used for counting coverage"};
-    // On some graphs, we can't get the coverage because it's split over
-    // parallel paths.  Allow overriding here
+    /// On some graphs, we can't get the coverage because it's split over
+    /// parallel paths.  Allow overriding here
     Option<double> expected_coverage{this, "avg-coverage", "C", 0.0,
         "specify expected coverage (instead of computing on reference)"};
-    // Should we use average support instead of minimum support for our calculations?
+    /// Should we use average support instead of minimum support for our
+    /// calculations?
     Option<bool> use_average_support{this, "use-avg-support", "u", false,
         "use average instead of minimum support"};
-    // Max traversal length threshold at which we switch from minimum support to
-    // average support (so we don't use average support on pairs of adjacent
-    // errors and miscall them, but we do use it on long runs of reference
-    // inside a deletion where the min support might not be representative.
+    /// Max traversal length threshold at which we switch from minimum support
+    /// to average support (so we don't use average support on pairs of adjacent
+    /// errors and miscall them, but we do use it on long runs of reference
+    /// inside a deletion where the min support might not be representative.
     Option<size_t> average_support_switch_threshold{this, "use-avg-support-above", "uUaAtT", 100,
         "use average instead of minimum support for sites this long or longer"};
     
-    // What's the maximum number of bubble path combinations we can explore
-    // while finding one with maximum support?
+    /// What's the maximum number of bubble path combinations we can explore
+    /// while finding one with maximum support?
     size_t max_bubble_paths = 100;
-    // what's the minimum minimum allele depth to give a PASS in the filter column
-    // (anything below gets FAIL)    
+    /// what's the minimum minimum allele depth to give a PASS in the filter column
+    /// (anything below gets FAIL)    
     Option<size_t> min_mad_for_filter{this, "min-mad", "E", 5,
         "min. minimum allele depth required to PASS filter"};
-    // print warnings etc. to stderr
+    /// print warnings etc. to stderr
     bool verbose = false;
     
 };

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -1321,11 +1321,11 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
         }
     
     };
-#define debug
+
 #ifdef debug
     cerr << "Explore " << contents.first.size() << " nodes" << endl;
 #endif
-#undef debug
+
     for (Node* node : contents.first) {
         // Find the bubble for each node
         
@@ -1377,11 +1377,11 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
         
     }
     
-#define debug
+
 #ifdef debug
     cerr << "Explore " << contents.second.size() << " edges" << endl;
 #endif
-#undef debug
+
     for(Edge* edge : contents.second) {
         // Go through all the edges
         
@@ -1444,11 +1444,11 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
     }
     
     auto children = snarl_manager.children_of(&site);
-#define debug
+
 #ifdef debug
     cerr << "Explore " << children.size() << " children" << endl;
 #endif
-#undef debug
+
     for (const Snarl* child : children) {
         // Go through all the child snarls
         
@@ -1918,12 +1918,12 @@ set<pair<size_t, list<Visit>>> RepresentativeTraversalFinder::bfs_left(Visit vis
         
         searchTicks++;
         
-#define debug
+
 #ifdef debug
         // Report on how much searching we are doing.
         cerr << "Search tick " << searchTicks << ", " << stillToExtend << " options." << endl;
 #endif
-#undef debug
+
         
         // Dequeue a path to extend.
         // Make sure to move out of the list to avoid a useless copy.
@@ -2049,11 +2049,11 @@ set<pair<size_t, list<Visit>>> RepresentativeTraversalFinder::bfs_left(Visit vis
                     // it, we'll always have at least one slot left to fill with
                     // an extension, so we'll at least keep exploring one path.
 
-#define debug                
+                
 #ifdef debug
                     cerr << "Reject " << prevVisit << " because queue is full" << endl;
 #endif
-#undef debug
+
                     
                     continue;
                 }

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -392,6 +392,8 @@ protected:
     
     /// What DFS depth should we search to?
     size_t max_depth;
+    /// How many DFS searches should we let there be on the stack at a time?
+    size_t max_width;
     /// How many search intermediates can we allow?
     size_t max_bubble_paths;
     
@@ -461,8 +463,20 @@ protected:
     
 public:
 
+    /**
+     * Make a new RepresentativeTraversalFinder to find traversals. Uses the
+     * given augmented graph as the graph with coverage annotation, and reasons
+     * about child snarls with the given SnarlManager. Explores up to max_depth
+     * in the BFS search when trying to find its way across snarls, and
+     * considers up to max_width search states at a time. When combining search
+     * results on either side of a graph element to be represented, thinks about
+     * max_bubble_paths combinations.
+     *
+     * Uses the given get_index function to try and find a PathIndex for a
+     * reference path traversing a child snarl.
+     */
     RepresentativeTraversalFinder(AugmentedGraph& augmented, SnarlManager& snarl_manager,
-        size_t max_depth, size_t max_bubble_paths,
+        size_t max_depth, size_t max_width, size_t max_bubble_paths,
         function<PathIndex*(const Snarl&)> get_index = [](const Snarl& s) { return nullptr; });
     
     /// Should we emit verbose debugging info?

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -516,7 +516,7 @@ TEST_CASE("RepresentativeTraversalFinder finds traversals correctly", "[genotype
         augmented.graph = graph;
         
         // Make a RepresentativeTraversalFinder
-        RepresentativeTraversalFinder finder(augmented, snarl_manager, 100, 1000);
+        RepresentativeTraversalFinder finder(augmented, snarl_manager, 100, 100, 1000);
         
         SECTION("there should be two traversals of the substitution") {
             

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 2
+plan tests 3
 
 # Toy example of hand-made pileup (and hand inspected truth) to make sure some
 # obvious (and only obvious) SNPs are detected by vg call
@@ -21,7 +21,24 @@ rm -f calls_l.json calls_l.vg
 vg view -J -l call/pileup.json -L | vg call tiny.vg - -A calls_l.vg -s 10 -d 10 -q 10 -b 0.25 -f 0.2 > /dev/null 2> /dev/null
 vg view -j calls_l.vg | jq . > calls_l.json
 is $(jq --argfile a calls_l.json --argfile b call/truth_l.json -n '($a == $b)') true "vg call -l produces the expected output for toy snp test case."
-
 rm -f calls_l.json calls_l.vg tiny.vg tiny.vgpu
+
+echo '{"node": [{"id": 1, "sequence": "CGTAGCGTGGTCGCATAAGTACAGTAGATCCTCCCCGCGCATCCTATTTATTAAGTTAAT"}]}' | vg view -Jv - > test.vg
+vg index -x test.xg -g test.gcsa -k 16 test.vg
+true >reads.txt
+for REP in seq 1 5; do
+    echo 'CGTAGCGTGGTCGCATAAGTACAGTANATCCTCCCCGCGCATCCTATTTATTAAGTTAAT' >>reads.txt
+done
+vg map -x test.xg -g test.gcsa --reads reads.txt > test.gam
+vg pileup test.vg test.gam > test.vgpu
+vg call test.vg test.vgpu >/dev/null --aug-graph aug.vg
+
+N_COUNT=$(vg view -j aug.vg | grep "N" | wc -l)
+
+is "${N_COUNT}" "0" "N bases are not augmented into the graph"
+
+rm -r reads.txt test.vg test.xg test.gcsa test.gcsa.lcp test.gam test.vgpu aug.vg
+
+
 
 


### PR DESCRIPTION
Previously, we would only explore to a max depth of 10 visits when looking for snarl traversals with the `RepresentativeTraversalFinder`, in order to prevent combinatorial explosions when braids were present off the primary path/backbone traversal of a snarl.

This prevented us from calling large inserts, involving more than 10-20 nodes or nested snarls, because the required insert traversals were too long to ever be enumerated.

I tried lifting the limit, but that resulted in combinatorial explosions, so I added a "max width" limit on the total size of the BFS search queue. If there are too many potential paths in the queue, you can only add one extension of every path you pop off to consider.

This seems to work fine, speed-wise. The accuracy results have improved over my last PR:

```
BRCA1   snp1kg  0.9544
BRCA2   snp1kg  0.8779
SMA     snp1kg  0.8024
LRC-KIR snp1kg  0.7394
MHC     snp1kg  0.8677
```

I also see some large inserts being called now, when I use a graph that contains them and when I make sure to include the improperly paired/mate-not-in-subregion reads in my input. The next step after merging this is to assess and improve on their accuracy.