### PR TITLE
avoid redundant clusters in MEM chain model traceback

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1396,20 +1396,12 @@ Mapper::align_mem_multi(const Alignment& aln, vector<MaximalExactMatch>& mems, d
             // too far
             return -std::numeric_limits<double>::max();
         } else {
-            // re-enable if more precise distances are desired
-            //int distance = graph_distance(m1_pos, m2_pos, max_length);
-            int distance = approx_dist;
-            if (distance >= max_length) {
-                // couldn't find distance
-                //distance = approx_dist;
-                return -std::numeric_limits<double>::max();
-            }
             if (is_rev(m1_pos) != is_rev(m2_pos)) {
                 // disable inversions
                 return -std::numeric_limits<double>::max();
             } else {
                 // accepted transition
-                double jump = abs((m2.begin - m1.begin) - distance);
+                double jump = abs((m2.begin - m1.begin) - approx_dist);
                 if (jump) {
                     return (double) unique_coverage * match - (gap_open + jump * gap_extension);
                 } else {
@@ -4294,9 +4286,12 @@ MEMChainModel::MEMChainModel(
                     if (redundant_vertexes.count(v2)) continue;
                     if (mems_overlap(v1->mem, v2->mem)
                         && abs(v2->mem.begin - v1->mem.begin) == abs(q->first - p->first)) {
-                        v1->mem.end = v2->mem.end;
-                        v1->weight = v1->mem.length();
-                        redundant_vertexes.insert(v2);
+                        if (v2->mem.length() < v1->mem.length()) {
+                            redundant_vertexes.insert(v2);
+                            if (v2->mem.end > v1->mem.end) {
+                                v1->weight += v2->mem.end - v1->mem.end;
+                            }
+                        }
                     }
                 }
             }
@@ -4313,9 +4308,12 @@ MEMChainModel::MEMChainModel(
                     if (redundant_vertexes.count(v2)) continue;
                     if (mems_overlap(v1->mem, v2->mem)
                         && abs(v2->mem.begin - v1->mem.begin) == abs(p->first - q->first)) {
-                        v1->mem.end = v2->mem.end;
-                        v1->weight = v1->mem.length();
-                        redundant_vertexes.insert(v2);
+                        if (v2->mem.length() < v1->mem.length()) {
+                            redundant_vertexes.insert(v2);
+                            if (v2->mem.end > v1->mem.end) {
+                                v1->weight += v2->mem.end - v1->mem.end;
+                            }
+                        }
                     }
                 }
             }

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -4273,7 +4273,7 @@ MEMChainModel::MEMChainModel(
     for (auto& pos : approx_positions) {
         std::sort(pos.second.begin(), pos.second.end(), [](const vector<MEMChainModelVertex>::iterator& v1,
                                                            const vector<MEMChainModelVertex>::iterator& v2) {
-                      return v1->mem.match_count < v2->mem.match_count;
+                      return v1->mem.length() > v2->mem.length();
                   });
         pos.second.resize(min(pos.second.size(), (size_t)position_depth));
     }

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -4275,6 +4275,11 @@ MEMChainModel::MEMChainModel(
                                                            const vector<MEMChainModelVertex>::iterator& v2) {
                       return v1->mem.length() > v2->mem.length();
                   });
+        if (pos.second.size() > position_depth) {
+            for (int i = position_depth; i < pos.second.size(); ++i) {
+                redundant_vertexes.insert(pos.second[i]);
+            }
+        }
         pos.second.resize(min(pos.second.size(), (size_t)position_depth));
     }
     // for each vertex merge if we go equivalently forward in the positional space and forward in the read to the next position

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -92,6 +92,7 @@ class MEMChainModel {
 public:
     vector<MEMChainModelVertex> model;
     map<int, vector<vector<MEMChainModelVertex>::iterator> > approx_positions;
+    set<vector<MEMChainModelVertex>::iterator> redundant_vertexes;
     MEMChainModel(
         const vector<size_t>& aln_lengths,
         const vector<vector<MaximalExactMatch> >& matches,

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -99,7 +99,7 @@ public:
         Mapper* mapper,
         const function<double(const MaximalExactMatch&, const MaximalExactMatch&)>& transition_weight,
         int band_width = 10,
-        int position_depth = 3,
+        int position_depth = 1,
         int max_connections = 10);
     void score(const set<MEMChainModelVertex*>& exclude);
     MEMChainModelVertex* max_vertex(void);


### PR DESCRIPTION
The MEMChainModel was spitting out duplicate clusters for those nodes that we had marked redundant in the construction phase of the model. By recording these redundant nodes in the model and excluding them from scoring we can make fewer attempts to get the correct alignment.