### PR TITLE
Don't allow -e with -g in kmers and index because it won't work

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2613,6 +2613,14 @@ int main_kmers(int argc, char** argv) {
     graphs.show_progress = show_progress;
 
     if (gcsa_out) {
+        if (edge_max != 0) {
+            // I have been passing this option to vg index -g for months
+            // thinking it worked. But it can't work. So we should tell the user
+            // they're wrong.
+            cerr << "error:[vg kmers] Cannot limit edge crossing (-e) when generating GCSA kmers (-g)."
+                << " Use vg mod -p to prune the graph instead." << endl;
+            exit(1);
+        }
         if (!gcsa_binary) {
             graphs.write_gcsa_out(cout, kmer_size, path_only, forward_only, head_id, tail_id);
         } else {

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -42,7 +42,7 @@ is $(vg map -G <(vg sim -a -s 1337 -n 100 -x x.xg) -g x.gcsa -x x.xg | vg surjec
 
 rm -rf j.vg x.vg x.idx j.xg x.xg x.gcsa
 
-vg index -k 11 -e 5 -g f.gcsa -x f.xg graphs/fail.vg
+vg index -k 11 -g f.gcsa -x f.xg graphs/fail.vg
 
 read=TTCCTGTGTTTATTAGCCATGCCTAGAGTGGGATGCGCCATTGGTCATCTTCTGGCCCCTGTTGTCGGCATGTAACTTAATACCACAACCAGGCATAGGTGAAAGATTGGAGGAAAGATGAGTGACAGCATCAACTTCTCTCACAACCTAG
 revcompread=CTAGGTTGTGAGAGAAGTTGATGCTGTCACTCATCTTTCCTCCAATCTTTCACCTATGCCTGGTTGTGGTATTAAGTTACATGCCGACAACAGGGGCCAGAAGATGACCAATGGCGCATCCCACTCTAGGCATGGCTAATAAACACAGGAA
@@ -50,7 +50,7 @@ is $(vg map -s $read -g f.gcsa -x f.xg | vg surject -p 6646393ec651ec49 -x f.xg 
 
 rm -rf f.xg f.gcsa
 
-vg index -k 11 -e 5 -g f.gcsa -x f.xg graphs/fail2.vg
+vg index -k 11 -g f.gcsa -x f.xg graphs/fail2.vg
 
 read=TATTTACGGCGGGGGCCCACCTTTGACCCTTTTTTTTTTTCAAGCAGAAGACGGCATACGAGATCACTTCGAGAGATCGGTCTCGGCATTCCTGCTGAACCGCTCTTCCGATCTACCCTAACCCTAACCCCAACCCCTAACCCTAACCCCA
 is $(vg map -s $read -g f.gcsa -x f.xg | vg surject -p ad93c27f548fc1ae -x f.xg -s - | grep $read | wc -l) 1 "surjection works for another difficult read"


### PR DESCRIPTION
The user will think they are limiting the edge crossing, but they aren't.