### PR TITLE
Change Filtering

### DIFF
--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -1553,6 +1553,8 @@ void Call2Vcf::call(
             
             // Set up the depth format field
             variant.format.push_back("DP");
+            // And expected depth
+            variant.format.push_back("XDP");
             // And allelic depth
             variant.format.push_back("AD");
             // And strand bias

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -556,7 +556,7 @@ public:
     Option<size_t> min_mad_for_filter{this, "min-mad", "E", 5,
         "min. minimum allele depth to PASS filter"};
     /// what's the maximum total depth to give a PASS in the filter column
-    Option<size_t> max_dp_for_filter{this, "max-dp", "MmDdAaXxPp", 0,
+    Option<size_t> max_dp_for_filter{this, "max-dp", "MmDdAaXxPp", 60,
         "max depth to PASS filter (0 for unlimited)"};
     /// what's the maximum total depth to give a PASS in the filter column, as a
     /// multiple of the baseline coverage?

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -422,16 +422,19 @@ public:
     void call(AugmentedGraph& augmented, string pileup_filename = "");
     
     /**
-     * For the given snarl, find the best traversal, and the second-best
-     * traversal, recursively, if any exist. These traversals will be fully
-     * filled in with nodes.
+     * For the given snarl, find the reference traversal, the best traversal,
+     * and the second-best traversal, recursively, if any exist. These
+     * traversals will be fully filled in with nodes.
      *
      * Only snarls which are ultrabubbles can be called.
      *
      * Expects the given baseline support for a diploid call.
      *
-     * Will not return more than copy_budget SnarlTraversals, and will return
-     * less if some copies are called as having the same traversal.
+     * Will not return more than 1 + copy_budget SnarlTraversals, and will
+     * return less if some copies are called as having the same traversal.
+     *
+     * Does not deduplicate agains the ref traversal; it may be the same as the
+     * best or second-best.
      *
      * Uses the given copy number allowance, and emits a Locus for this Snarl
      * and any child Snarls.

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -562,10 +562,13 @@ public:
     /// multiple of the baseline coverage?
     Option<double> max_dp_multiple_for_filter{this, "max-dp-multiple", "MmDdAaXxPp", 1.5,
         "max portion of expected depth to PASS filter (0 for unlimited)"};
+    // what's the min log likelihood for allele depth assignments to PASS?
+    Option<double> min_ad_log_likelihood_for_filter{this, "min-ad-log-ligelihood", "MmAaDdLl", -9.0,
+        "min log likelihood for AD assignments to PASS filter (0 for unlimited)"};
         
     Option<bool> write_trivial_calls{this, "trival", "i", false,
         "write trivial vcf calls (ex 0/0 genotypes)"};
-        
+    
     /// print warnings etc. to stderr
     bool verbose = false;
     

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -556,11 +556,11 @@ public:
     Option<size_t> min_mad_for_filter{this, "min-mad", "E", 5,
         "min. minimum allele depth to PASS filter"};
     /// what's the maximum total depth to give a PASS in the filter column
-    Option<size_t> max_dp_for_filter{this, "max-dp", "MmDdAaXxPp", 100,
+    Option<size_t> max_dp_for_filter{this, "max-dp", "MmDdAaXxPp", 0,
         "max depth to PASS filter (0 for unlimited)"};
     /// what's the maximum total depth to give a PASS in the filter column, as a
     /// multiple of the baseline coverage?
-    Option<double> max_dp_multiple_for_filter{this, "max-dp-multiple", "MmDdAaXxPp", 1.5,
+    Option<double> max_dp_multiple_for_filter{this, "max-dp-multiple", "MmDdAaXxPp", 2.5,
         "max portion of expected depth to PASS filter (0 for unlimited)"};
     // what's the min log likelihood for allele depth assignments to PASS?
     Option<double> min_ad_log_likelihood_for_filter{this, "min-ad-log-ligelihood", "MmAaDdLl", -9.0,

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -563,14 +563,18 @@ public:
     Option<size_t> max_dp_for_filter{this, "max-dp", "MmDdAaXxPp", 0,
         "max depth to PASS filter (0 for unlimited)"};
     /// what's the maximum total depth to give a PASS in the filter column, as a
-    /// multiple of the baseline coverage?
-    Option<double> max_dp_multiple_for_filter{this, "max-dp-multiple", "MmDdAaXxPp", 2.5,
-        "max portion of expected depth to PASS filter (0 for unlimited)"};
+    /// multiple of the global baseline coverage?
+    Option<double> max_dp_multiple_for_filter{this, "max-dp-multiple", "MmDdAaXxPp", 0,
+        "max portion of global expected depth to PASS filter (0 for unlimited)"};
+    /// what's the maximum total depth to give a PASS in the filter column, as a
+    /// multiple of the local baseline coverage?
+    Option<double> max_local_dp_multiple_for_filter{this, "max-local-dp-multiple", "MmLlOoDdAaXxPp", 0,
+        "max portion of local expected depth to PASS filter (0 for unlimited)"};
     /// what's the min log likelihood for allele depth assignments to PASS?
-    Option<double> min_ad_log_likelihood_for_filter{this, "min-ad-log-ligelihood", "MmAaDdLl", -9.0,
+    Option<double> min_ad_log_likelihood_for_filter{this, "min-ad-log-likelihood", "MmAaDdLliI", -9.0,
         "min log likelihood for AD assignments to PASS filter (0 for unlimited)"};
         
-    Option<bool> write_trivial_calls{this, "trival", "i", false,
+    Option<bool> write_trivial_calls{this, "trival", "ivtTIRV", false,
         "write trivial vcf calls (ex 0/0 genotypes)"};
     
     /// print warnings etc. to stderr

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -556,11 +556,11 @@ public:
     Option<size_t> min_mad_for_filter{this, "min-mad", "E", 5,
         "min. minimum allele depth to PASS filter"};
     /// what's the maximum total depth to give a PASS in the filter column
-    Option<size_t> max_dp_for_filter{this, "max-dp", "MmDdAaXxPp", 60,
+    Option<size_t> max_dp_for_filter{this, "max-dp", "MmDdAaXxPp", 100,
         "max depth to PASS filter (0 for unlimited)"};
     /// what's the maximum total depth to give a PASS in the filter column, as a
     /// multiple of the baseline coverage?
-    Option<double> max_dp_multiple_for_filter{this, "max-dp-multiple", "MmDdAaXxPp", 3.0,
+    Option<double> max_dp_multiple_for_filter{this, "max-dp-multiple", "MmDdAaXxPp", 1.5,
         "max portion of expected depth to PASS filter (0 for unlimited)"};
         
     Option<bool> write_trivial_calls{this, "trival", "i", false,

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -555,9 +555,10 @@ public:
     /// What's the maximum number of bubble path combinations we can explore
     /// while finding one with maximum support?
     size_t max_bubble_paths = 100;
-    /// what's the minimum minimum allele depth to give a PASS in the filter column
+    /// what's the minimum ref or alt allele depth to give a PASS in the filter
+    /// column? Also used as a min actual support for a second-best allele call
     Option<size_t> min_mad_for_filter{this, "min-mad", "E", 5,
-        "min. minimum allele depth to PASS filter"};
+        "min. ref/alt allele depth to PASS filter or be a second-best allele"};
     /// what's the maximum total depth to give a PASS in the filter column
     Option<size_t> max_dp_for_filter{this, "max-dp", "MmDdAaXxPp", 0,
         "max depth to PASS filter (0 for unlimited)"};
@@ -565,7 +566,7 @@ public:
     /// multiple of the baseline coverage?
     Option<double> max_dp_multiple_for_filter{this, "max-dp-multiple", "MmDdAaXxPp", 2.5,
         "max portion of expected depth to PASS filter (0 for unlimited)"};
-    // what's the min log likelihood for allele depth assignments to PASS?
+    /// what's the min log likelihood for allele depth assignments to PASS?
     Option<double> min_ad_log_likelihood_for_filter{this, "min-ad-log-ligelihood", "MmAaDdLl", -9.0,
         "min log likelihood for AD assignments to PASS filter (0 for unlimited)"};
         

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -553,13 +553,19 @@ public:
     /// while finding one with maximum support?
     size_t max_bubble_paths = 100;
     /// what's the minimum minimum allele depth to give a PASS in the filter column
-    /// (anything below gets FAIL)    
     Option<size_t> min_mad_for_filter{this, "min-mad", "E", 5,
-        "min. minimum allele depth required to PASS filter"};
-
+        "min. minimum allele depth to PASS filter"};
+    /// what's the maximum total depth to give a PASS in the filter column
+    Option<size_t> max_dp_for_filter{this, "max-dp", "MmDdAaXxPp", 0,
+        "max depth to PASS filter (0 for unlimited)"};
+    /// what's the maximum total depth to give a PASS in the filter column, as a
+    /// multiple of the baseline coverage?
+    Option<double> max_dp_multiple_for_filter{this, "max-dp-multiple", "MmDdAaXxPp", 3.0,
+        "max portion of expected depth to PASS filter (0 for unlimited)"};
+        
     Option<bool> write_trivial_calls{this, "trival", "i", false,
-            "write trivial vcf calls (ex 0/0 genotypes)"};
-    
+        "write trivial vcf calls (ex 0/0 genotypes)"};
+        
     /// print warnings etc. to stderr
     bool verbose = false;
     

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -60,7 +60,7 @@ int main_call(int argc, char** argv) {
     Call2Vcf call2vcf;
 
     bool show_progress = false;
-    int thread_count = 1;
+    int thread_count = 0;
 
     static const struct option long_options[] = {
         {"default-read-qual", required_argument, 0, 'q'},
@@ -128,8 +128,10 @@ int main_call(int argc, char** argv) {
     // Parse the command line options, updating optind.
     parser.parse(argc, argv);
 
-    // Set up threading according to info parsed from the options.
-    omp_set_num_threads(thread_count);
+    if (thread_count != 0) {
+        // Use a non-default number of threads
+        omp_set_num_threads(thread_count);
+    }
     thread_count = get_thread_count();
 
     // Parse the arguments


### PR DESCRIPTION
I've made some changes to filtering, to try and improve SV calling performance.

Most of the filters are off by default, except for one on the likelihood of the binomial assignment of support to alleles. OIf the likelihood of minor-allele-depth successes in total-depth trials is less than `e^-9`, by default, the site will be filtered.

I'm also reporting a bunch of extra depth metadata in the VCF, to try and inform filtering choices. Each call now has the global average depth and the local average depth for its bin noted on it.

For SV calling I wanted to use a filter that scraps a variant if its depth is more than 2.5 times the global average depth for the primary path it's on, because there are some false positive SVs with depths in the hundreds that I want to filter out. However, SMA in the bake-off regions has a really low global average depth, so that filter was counterproductive there and it defaults to off.

I've also wired the min AD filter's value into the second-best allele selection logic, so the caller should no longer call a site as best/second best, and then immediately filter it out because the second best allele's depth is too low.

