### PR TITLE
correct multimapping for banded alignment

### DIFF
--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -175,12 +175,13 @@ private:
                                            int max_mem_length,
                                            int band_width,
                                            double& cluster_mq,
+                                           int keep_multimaps = 0,
                                            int additional_multimaps = 0,
                                            vector<MaximalExactMatch>* restricted_mems = nullptr);
     void compute_mapping_qualities(vector<Alignment>& alns, double cluster_mq, double mq_estimate, double mq_cap);
     void compute_mapping_qualities(pair<vector<Alignment>, vector<Alignment>>& pair_alns, double cluster_mq, double mq_estmate1, double mq_estimate2, double mq_cap1, double mq_cap2);
     vector<Alignment> score_sort_and_deduplicate_alignments(vector<Alignment>& all_alns, const Alignment& original_alignment);
-    void filter_and_process_multimaps(vector<Alignment>& all_alns, int additional_multimaps);
+    void filter_and_process_multimaps(vector<Alignment>& all_alns, int total_multimaps);
     // Return the one best banded alignment.
     vector<Alignment> align_banded(const Alignment& read,
                                    int kmer_size = 0,
@@ -190,7 +191,13 @@ private:
     // alignment based on the MEM approach
 //    vector<Alignment> align_mem_multi(const Alignment& alignment, vector<MaximalExactMatch>& mems, double& cluster_mq, double lcp_avg, int max_mem_length, int additional_multimaps = 0);
     // uses approximate-positional clustering based on embedded paths in the xg index to find and align against alignment targets
-    vector<Alignment> align_mem_multi(const Alignment& aln, vector<MaximalExactMatch>& mems, double& cluster_mq, double lcp_avg, int max_mem_length, int additional_multimaps);
+    vector<Alignment> align_mem_multi(const Alignment& aln,
+                                      vector<MaximalExactMatch>& mems,
+                                      double& cluster_mq,
+                                      double lcp_avg,
+                                      int max_mem_length,
+                                      int keep_multimaps,
+                                      int additional_multimaps);
 
     // Locate the sub-MEMs contained in the last MEM of the mems vector that have ending positions
     // before the end the next SMEM, label each of the sub-MEMs with the indices of all of the SMEMs
@@ -507,6 +514,7 @@ public:
     // paired-end consistency enforcement
     int extra_multimaps; // Extra mappings considered
     int min_multimaps; // Minimum number of multimappings
+    int band_multimaps; // the number of multimaps for to attempt for each band in a banded alignment
     
     bool adjust_alignments_for_base_quality; // use base quality adjusted alignments
     MappingQualityMethod mapping_quality_method; // how to compute mapping qualities

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -57,9 +57,10 @@ void help_map(char** argv) {
          << "output:" << endl
          << "    -j, --output-json       output JSON rather than an alignment stream (helpful for debugging)" << endl
          << "    -Z, --buffer-size INT   buffer this many alignments together before outputting in GAM [100]" << endl
-         << "    -B, --compare           realign GAM input (-G), writing: name, overlap with input, identity, score, mq, time" << endl
+         << "    -X, --compare           realign GAM input (-G), writing: name, overlap with input, identity, score, mq, time" << endl
          << "    -K, --keep-secondary    produce alignments for secondary input alignments in addition to primary ones" << endl
          << "    -M, --max-multimaps INT produce up to INT alignments for each read [1]" << endl
+         << "    -B, --band-multi INT    consider this many alignments of each band in banded alignment [4]" << endl
          << "    -Q, --mq-max INT        cap the mapping quality at INT [60]" << endl
          << "    -D, --debug             print debugging information about alignment to stderr" << endl;
 
@@ -92,6 +93,7 @@ int main_map(int argc, char** argv) {
     string fastq1, fastq2;
     bool interleaved_input = false;
     int band_width = 256;
+    int band_multimaps = 4;
     int max_band_jump = -1;
     bool always_rescue = false;
     bool top_pairs_only = false;
@@ -159,6 +161,7 @@ int main_map(int argc, char** argv) {
                 {"fastq", required_argument, 0, 'f'},
                 {"interleaved", no_argument, 0, 'i'},
                 {"band-width", required_argument, 0, 'w'},
+                {"band-multi", required_argument, 0, 'B'},
                 {"band-jump", required_argument, 0, 'J'},
                 {"min-ident", required_argument, 0, 'P'},
                 {"debug", no_argument, 0, 'D'},
@@ -176,7 +179,7 @@ int main_map(int argc, char** argv) {
                 {"gap-extend", required_argument, 0, 'y'},
                 {"qual-adjust", no_argument, 0, 'A'},
                 {"try-up-to", required_argument, 0, 'u'},
-                {"compare", no_argument, 0, 'B'},
+                {"compare", no_argument, 0, 'X'},
                 {"fragment", required_argument, 0, 'I'},
                 {"fragment-x", required_argument, 0, 'S'},
                 {"full-l-bonus", required_argument, 0, 'L'},
@@ -192,7 +195,7 @@ int main_map(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "s:J:Q:d:x:g:T:N:R:c:M:t:G:jb:Kf:iw:P:Dk:Y:r:W:6aH:Z:q:z:o:y:Au:BI:S:l:e:C:v:V:O:L:n:E:",
+        c = getopt_long (argc, argv, "s:J:Q:d:x:g:T:N:R:c:M:t:G:jb:Kf:iw:P:Dk:Y:r:W:6aH:Z:q:z:o:y:Au:B:I:S:l:e:C:v:V:O:L:n:E:X:",
                          long_options, &option_index);
 
 
@@ -308,6 +311,10 @@ int main_map(int argc, char** argv) {
             band_width = atoi(optarg);
             break;
 
+        case 'B':
+            band_multimaps = atoi(optarg);
+            break;
+
         case 'J':
             max_band_jump = atoi(optarg);
             break;
@@ -368,7 +375,7 @@ int main_map(int argc, char** argv) {
             method_code = atoi(optarg);
             break;
 
-        case 'B':
+        case 'X':
             compare_gam = true;
             output_json = true;
             break;
@@ -552,6 +559,7 @@ int main_map(int argc, char** argv) {
         m->hit_max = hit_max;
         m->max_multimaps = max_multimaps;
         m->min_multimaps = min_multimaps;
+        m->band_multimaps = band_multimaps;
         m->maybe_mq_threshold = maybe_mq_threshold;
         m->debug = debug;
         m->min_identity = min_score;

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -36,6 +36,7 @@ void help_msga(char** argv) {
          << "    -H, --max-target-x N    skip cluster subgraphs with length > N*read_length [100]" << endl
          << "    -w, --band-width INT    band width for long read alignment [256]" << endl
          << "    -J, --band-jump INT     the maximum jump we can see between bands (maximum length variant we can detect) [2*{-w}]" << endl
+         << "    -B, --band-multi INT    consider this many alignments of each band in banded alignment [4]" << endl
          << "    -M, --max-multimaps INT when set > 1, thread an optimal alignment through the multimappings of each band [1]" << endl
          << "local alignment parameters:" << endl
          << "    -q, --match INT         use this match score [1]" << endl
@@ -87,6 +88,7 @@ int main_msga(int argc, char** argv) {
     float min_identity = 0.0;
     int band_width = 256;
     int max_band_jump = -1;
+    int band_multimaps = 4;
     size_t doubling_steps = 3;
     bool debug = false;
     bool debug_align = false;
@@ -139,6 +141,7 @@ int main_msga(int argc, char** argv) {
                 {"idx-doublings", required_argument, 0, 'X'},
                 {"band-width", required_argument, 0, 'w'},
                 {"band-jump", required_argument, 0, 'J'},
+                {"band-multi", required_argument, 0, 'B'},
                 {"debug", no_argument, 0, 'D'},
                 {"debug-align", no_argument, 0, 'A'},
                 {"context-depth", required_argument, 0, 'c'},
@@ -171,7 +174,7 @@ int main_msga(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:w:DAc:P:E:Q:NY:H:t:m:M:q:OI:i:o:y:ZW:z:k:L:e:r:u:l:C:F:SJ:",
+        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:w:DAc:P:E:Q:NY:H:t:m:M:q:OI:i:o:y:ZW:z:k:L:e:r:u:l:C:F:SJ:B:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -252,6 +255,10 @@ int main_msga(int argc, char** argv) {
 
         case 'J':
             max_band_jump = atoi(optarg);
+            break;
+
+        case 'B':
+            band_multimaps = atoi(optarg);
             break;
 
         case 'D':
@@ -516,6 +523,7 @@ int main_msga(int argc, char** argv) {
             mapper->min_identity = min_identity;
             mapper->min_banded_mq = min_banded_mq;
             mapper->max_band_jump = max_band_jump > -1 ? max_band_jump : band_width;
+            mapper->band_multimaps = band_multimaps;
             mapper->drop_chain = drop_chain;
             mapper->min_mem_length = (min_mem_length > 0 ? min_mem_length
                                  : mapper->random_match_length(chance_match));

--- a/test/t/16_vg_msga.t
+++ b/test/t/16_vg_msga.t
@@ -12,7 +12,7 @@ is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 4 | vg mod -U 10 - | vg mod
 
 is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 | vg mod -U 10 - | vg mod -c - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) 16e56f0090b310d2b1479d49cf790324 "MSGA produces the expected graph for GRCh38 HLA-V with the MEM threader off"
 
-is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -n 'gi|568815592:29791752-29792749' -n 'gi|568815454:1057585-1058559' -b 'gi|568815454:1057585-1058559' -w 10000 -N | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -n 'gi|568815592:29791752-29792749' -n 'gi|568815454:1057585-1058559' -b 'gi|568815454:1057585-1058559' -w 300 -N | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ )  "varying alignment bandwidth does not affect output graph"
+is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -n 'gi|568815592:29791752-29792749' -n 'gi|568815454:1057585-1058559' -b 'gi|568815454:1057585-1058559' -w 512 | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -n 'gi|568815592:29791752-29792749' -n 'gi|568815454:1057585-1058559' -b 'gi|568815454:1057585-1058559' -w 1024 | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ )  "varying alignment bandwidth does not affect output graph"
 ## TODO this test is bad??
 is $(vg msga -f msgas/s.fa -w 20 | vg mod -U 10 - | vg mod -c - | vg view - | md5sum | cut -f 1 -d\ ) 603a3c92233e27fc018aa7d3b399b5ac "msga alignment can detect and include large deletions in the graph"
 


### PR DESCRIPTION
This adds a band-multimap parameter to both `vg map` and `vg msga` so that we can multi-map inside the chaining but still emit only `--max-multimaps` alignments.