### PR TITLE
Fix large inserts not being connected when added

### DIFF
--- a/src/variant_adder.cpp
+++ b/src/variant_adder.cpp
@@ -567,6 +567,9 @@ Alignment VariantAdder::smart_align(vg::VG& graph, pair<NodeSide, NodeSide> endp
                     // If the aligner can't find any valid alignment in the restrictive
                     // band, we will need to knock together an alignment manually.
                     aligned_in_band = false;
+#ifdef debug
+                    cerr << "\t\tFailed." << endl;
+#endif
                 }
 
 #ifdef debug                
@@ -759,7 +762,6 @@ Alignment VariantAdder::smart_align(vg::VG& graph, pair<NodeSide, NodeSide> endp
     return aln;
 
 }
-
 
 set<vector<int>> VariantAdder::get_unique_haplotypes(const vector<vcflib::Variant*>& variants, WindowedVcfBuffer* cache) const {
     set<vector<int>> haplotypes;

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -5222,6 +5222,13 @@ void VG::add_nodes_and_edges(const Path& path,
                         // Until we used up all the sequence, make nodes
                         Node* new_node = create_node(fwd_seq.substr(cursor, max_node_size));
                         cursor += max_node_size;
+                        
+                        if (!new_nodes.empty()) {
+                            // Connect each to the previous node in the chain.
+                            create_edge(new_nodes.back(), new_node);
+                        }
+                        
+                        // Remember the new node
                         new_nodes.push_back(new_node);
                         
                         // Chop the front of the from path off and associate it


### PR DESCRIPTION
Some of the editing code was creating runs of nodes to represent insertions but not actually linking those nodes together, resulting in cut-in-half inserts or disconnected nodes for inserts longer than ~1024 bp.

This fixes that issue.