### PR TITLE
Change default caller loci mode to call the primary path outside snarls

### DIFF
--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -576,6 +576,12 @@ public:
         
     Option<bool> write_trivial_calls{this, "trival", "ivtTIRV", false,
         "write trivial vcf calls (ex 0/0 genotypes)"};
+        
+    /// Should we call on nodes/edges outside of snarls by coverage (true), or
+    /// just assert that primary path things exist and off-path things don't
+    /// (false)?
+    Option<bool> call_other_by_coverage{this, "call-nodes-by-coverage", "cCoObB", false,
+        "make calls on nodes/edges outside snarls by coverage"};
     
     /// print warnings etc. to stderr
     bool verbose = false;

--- a/src/graph_synchronizer.cpp
+++ b/src/graph_synchronizer.cpp
@@ -96,6 +96,9 @@ void GraphSynchronizer::Lock::lock() {
             NodeSide start_left = synchronizer.get_path_index(path_name).at_position(start);
             NodeSide end_right = synchronizer.get_path_index(path_name).at_position(past_end == 0 ? 0 : past_end - 1).flip();
             
+            cerr << "Start: " << start << " at " << start_left << endl;
+            cerr << "End: " << past_end << " at " << end_right << endl;
+            
             // Fill in the endpoints pair
             endpoints = make_pair(start_left, end_right);
             
@@ -355,8 +358,13 @@ vector<Translation> GraphSynchronizer::Lock::apply_full_length_edit(const Path& 
     // Find the left and right outer nodesides of the subgraph
     auto ends = get_endpoints();
     
-    // Find everythign attached to the left
+    // Find everything attached to the left
     auto dangling = get_peripheral_attachments(ends.first);
+    
+    cerr << "First end of graph " << ends.first << " is attached to " << endl;
+    for (auto d : dangling) {
+        cerr << "\t" << d << endl;
+    }
     
     // Apply the edit, attaching its left end to the stuff attached to the left
     // end of the graph. Get back in the dangling set where the right end of the
@@ -366,6 +374,11 @@ vector<Translation> GraphSynchronizer::Lock::apply_full_length_edit(const Path& 
     // Get the places that the right end of the graph attaches to
     auto right_periphery = get_peripheral_attachments(ends.second);
     
+    cerr << "Second end of graph " << ends.second << " is attached to " << endl;
+    for (auto d : right_periphery) {
+        cerr << "\t" << d << endl;
+    }
+    
     // Get ownership of the graph because we're making edges
     std::lock_guard<std::mutex> guard(synchronizer.whole_graph_lock);
     
@@ -373,6 +386,7 @@ vector<Translation> GraphSynchronizer::Lock::apply_full_length_edit(const Path& 
         // For every dangling NodeSide
         for (const NodeSide& attached : right_periphery) {
             // Attach it to each NodeSide the right end of the graph is attached to
+            cerr << "Create edge " << dangled << " -- " << attached << endl;
             synchronizer.graph.create_edge(dangled, attached);
         }
     }

--- a/src/graph_synchronizer.cpp
+++ b/src/graph_synchronizer.cpp
@@ -96,9 +96,6 @@ void GraphSynchronizer::Lock::lock() {
             NodeSide start_left = synchronizer.get_path_index(path_name).at_position(start);
             NodeSide end_right = synchronizer.get_path_index(path_name).at_position(past_end == 0 ? 0 : past_end - 1).flip();
             
-            cerr << "Start: " << start << " at " << start_left << endl;
-            cerr << "End: " << past_end << " at " << end_right << endl;
-            
             // Fill in the endpoints pair
             endpoints = make_pair(start_left, end_right);
             
@@ -361,11 +358,6 @@ vector<Translation> GraphSynchronizer::Lock::apply_full_length_edit(const Path& 
     // Find everything attached to the left
     auto dangling = get_peripheral_attachments(ends.first);
     
-    cerr << "First end of graph " << ends.first << " is attached to " << endl;
-    for (auto d : dangling) {
-        cerr << "\t" << d << endl;
-    }
-    
     // Apply the edit, attaching its left end to the stuff attached to the left
     // end of the graph. Get back in the dangling set where the right end of the
     // edit's material is.
@@ -374,11 +366,6 @@ vector<Translation> GraphSynchronizer::Lock::apply_full_length_edit(const Path& 
     // Get the places that the right end of the graph attaches to
     auto right_periphery = get_peripheral_attachments(ends.second);
     
-    cerr << "Second end of graph " << ends.second << " is attached to " << endl;
-    for (auto d : right_periphery) {
-        cerr << "\t" << d << endl;
-    }
-    
     // Get ownership of the graph because we're making edges
     std::lock_guard<std::mutex> guard(synchronizer.whole_graph_lock);
     
@@ -386,7 +373,6 @@ vector<Translation> GraphSynchronizer::Lock::apply_full_length_edit(const Path& 
         // For every dangling NodeSide
         for (const NodeSide& attached : right_periphery) {
             // Attach it to each NodeSide the right end of the graph is attached to
-            cerr << "Create edge " << dangled << " -- " << attached << endl;
             synchronizer.graph.create_edge(dangled, attached);
         }
     }

--- a/src/pileup.cpp
+++ b/src/pileup.cpp
@@ -274,7 +274,11 @@ void Pileups::compute_from_edit(NodePileup& pileup, int64_t& node_offset,
         for (int64_t i = 0; i < edit.from_length(); ++i) {
             if (pass_filter(alignment, read_offset, 1, mismatch_counts)) {
                 // Don't go outside the node
-                assert(node_offset < _graph->get_node(pileup.node_id())->sequence().size());
+                if (node_offset >= _graph->get_node(pileup.node_id())->sequence().size()) {
+                    cerr << "error [vg::Pileups] node_offset of " << node_offset << " on " << pileup.node_id() << " is too big for node of size " << _graph->get_node(pileup.node_id())->sequence().size() << endl;
+                    cerr << "Alignment: " << pb2json(alignment) << endl;
+                    throw runtime_error("Node offset too large in alignment");
+                }
                 BasePileup* base_pileup = get_create_base_pileup(pileup, node_offset);
                 if (base_pileup->num_bases() < _max_depth) {
                     // reference_base if empty

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -55,6 +55,7 @@ void help_mod(char** argv) {
          << "    -I, --retain-complement keep only paths NOT specified with -r" << endl
          << "    -k, --keep-path NAME    keep only nodes and edges in the path" << endl
          << "    -N, --remove-non-path   keep only nodes and edges which are part of paths" << endl
+         << "    -A, --remove-path       keep only nodes and edges which are not part of any path" << endl
          << "    -o, --remove-orphans    remove orphan edges from graph (edge specified but node missing)" << endl
          << "    -R, --remove-null       removes nodes that have no sequence, forwarding their edges" << endl
          << "    -g, --subgraph ID       gets the subgraph rooted at node ID, multiple allowed" << endl
@@ -105,6 +106,7 @@ int main_mod(int argc, char** argv) {
     bool normalize_graph = false;
     bool sort_graph = false;
     bool remove_non_path = false;
+    bool remove_path = false;
     bool compact_ranks = false;
     bool drop_paths = false;
     bool force_path_match = false;
@@ -159,6 +161,7 @@ int main_mod(int argc, char** argv) {
             {"until-normal", required_argument, 0, 'U'},
             {"sort", no_argument, 0, 'z'},
             {"remove-non-path", no_argument, 0, 'N'},
+            {"remove-path", no_argument, 0, 'A'},
             {"orient-forward", no_argument, 0, 'O'},
             {"unfold", required_argument, 0, 'f'},
             {"force-path-match", no_argument, 0, 'F'},
@@ -183,7 +186,7 @@ int main_mod(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hk:oi:q:Q:cpl:e:mt:SX:KPsunzNf:CDFr:Ig:x:RTU:Bbd:Ow:L:y:Z:Eav:G:",
+        c = getopt_long (argc, argv, "hk:oi:q:Q:cpl:e:mt:SX:KPsunzNAf:CDFr:Ig:x:RTU:Bbd:Ow:L:y:Z:Eav:G:",
                 long_options, &option_index);
 
 
@@ -305,6 +308,10 @@ int main_mod(int argc, char** argv) {
 
         case 'N':
             remove_non_path = true;
+            break;
+            
+        case 'A':
+            remove_path = true;
             break;
 
         case 'T':
@@ -656,6 +663,10 @@ int main_mod(int argc, char** argv) {
 
     if (remove_non_path) {
         graph->remove_non_path();
+    }
+    
+    if (remove_path) {
+        graph->remove_path();
     }
 
     if (force_path_match) {

--- a/src/variant_adder.cpp
+++ b/src/variant_adder.cpp
@@ -20,9 +20,9 @@ VariantAdder::VariantAdder(VG& graph) : graph(graph), sync(graph) {
     graph.dice_nodes(1024);
 }
 
-#define debug
 void VariantAdder::add_variants(vcflib::VariantCallFile* vcf) {
     
+#ifdef debug
     // Count our current heads and tails
     vector<Node*> to_count;
     
@@ -34,6 +34,7 @@ void VariantAdder::add_variants(vcflib::VariantCallFile* vcf) {
     to_count.clear();
     
     cerr << "Starting with heads: " << head_expected << " and tails: " << tail_expected << endl;
+#endif
     
     // Make a buffer
     WindowedVcfBuffer buffer(vcf, variant_range);
@@ -389,6 +390,8 @@ void VariantAdder::add_variants(vcflib::VariantCallFile* vcf) {
                 << (used_haplotypes ? (total_graph_bases / used_haplotypes) : 0) << " bp haplotypes vs. graphs average" << endl;
         }
         
+        
+#ifdef debug
         // Count our current heads and tails
         graph.head_nodes(to_count);
         size_t head_count = to_count.size();
@@ -414,13 +417,8 @@ void VariantAdder::add_variants(vcflib::VariantCallFile* vcf) {
             // Bail out but serialize the graph
             return;
         }
+#endif
         
-        
-        if(variants_processed == 4) {
-            // Stop on our problem variant
-            cerr << "Debug: stop early!" << endl;
-            return;
-        }
     }
 
     // Clean up after the last contig.
@@ -816,11 +814,9 @@ Alignment VariantAdder::smart_align(vg::VG& graph, pair<NodeSide, NodeSide> endp
     // TODO: check if we got alignments that didn't respect our specified
     // endpoints by one of the non-splicing-together alignment methods.
     
-    cerr << pb2json(aln) << endl;
     return aln;
 
 }
-#undef debug
 
 set<vector<int>> VariantAdder::get_unique_haplotypes(const vector<vcflib::Variant*>& variants, WindowedVcfBuffer* cache) const {
     set<vector<int>> haplotypes;

--- a/src/variant_adder.hpp
+++ b/src/variant_adder.hpp
@@ -139,6 +139,15 @@ protected:
     set<string> path_names;
     
     /**
+     * Turn parts of aln that overlap with other into inserts so they don't
+     * overlap anymore. Used to avoid creating cycles when splicing together
+     * end-anchored alignments. TODO: cycles maybe do make the most sense in
+     * those cases, so we should get rid of this when the caller is smart enough
+     * to use them.
+     */
+    Alignment deoverlap_alignment(const Alignment& aln, const Alignment& other);
+    
+    /**
      * Get all the unique combinations of variant alts represented by actual
      * haplotypes. Arbitrarily phases unphased variants.
      *

--- a/src/variant_adder.hpp
+++ b/src/variant_adder.hpp
@@ -139,15 +139,6 @@ protected:
     set<string> path_names;
     
     /**
-     * Turn parts of aln that overlap with other into inserts so they don't
-     * overlap anymore. Used to avoid creating cycles when splicing together
-     * end-anchored alignments. TODO: cycles maybe do make the most sense in
-     * those cases, so we should get rid of this when the caller is smart enough
-     * to use them.
-     */
-    Alignment deoverlap_alignment(const Alignment& aln, const Alignment& other);
-    
-    /**
      * Get all the unique combinations of variant alts represented by actual
      * haplotypes. Arbitrarily phases unphased variants.
      *

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -4655,9 +4655,11 @@ vector<Translation> VG::edit_fast(const Path& path, set<NodeSide>& dangling) {
     // from start positions on old nodes to new nodes.
     map<pos_t, Node*> node_translation = ensure_breakpoints(breakpoints);
     
+#ifdef debug
     for(auto& kv : node_translation) {
         cerr << "Translate old " << kv.first << " to " << (kv.second == nullptr ? (id_t)0 : (id_t)kv.second->id()) << endl;
     }
+#endif
     
     // we remember the sequences of nodes we've added at particular positions on the forward strand
     map<pair<pos_t, string>, vector<Node*>> added_seqs;
@@ -5151,7 +5153,7 @@ void VG::add_nodes_and_edges(const Path& path,
             //get_offset(edit_last_position) += (e.from_length()?e.from_length()-1:0);
             get_offset(edit_last_position) += (e.from_length()?e.from_length()-1:0);
 
-#define debug_edit true
+//#define debug_edit true
 #ifdef debug_edit
             cerr << "Edit on " << node_id << " from " << edit_first_position << " to " << edit_last_position << endl;
             cerr << pb2json(e) << endl;
@@ -5217,11 +5219,13 @@ void VG::add_nodes_and_edges(const Path& path,
                 if (added != added_seqs.end()) {
                     // if we have the node run already, don't make it again, just use the existing one
                     new_nodes = added->second;
+#ifdef debug_edit
                     cerr << "Re-using already added nodes: ";
                     for (auto n : new_nodes) {
                         cerr << n->id() << " ";
                     }
                     cerr << endl;
+#endif
                 } else {
                     // Make a new run of nodes of up to max_node_size each
                     
@@ -5235,12 +5239,15 @@ void VG::add_nodes_and_edges(const Path& path,
                         Node* new_node = create_node(fwd_seq.substr(cursor, max_node_size));
                         cursor += max_node_size;
                         
+#ifdef debug_edit
                         cerr << "Create new node " << pb2json(*new_node) << endl;
-                        
+#endif
                         if (!new_nodes.empty()) {
                             // Connect each to the previous node in the chain.
                             Edge* e = create_edge(new_nodes.back(), new_node);
+#ifdef debug_edit
                             cerr << "Create edge " << pb2json(*e) << endl;
+#endif
                         }
                         
                         // Remember the new node
@@ -5377,7 +5384,7 @@ void VG::add_nodes_and_edges(const Path& path,
             // This way the next one will start at the right place.
             get_offset(edit_first_position) += e.from_length();
 
-#undef debug_edut
+//#undef debug_edut
         }
 
     }

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -256,6 +256,11 @@ public:
     vector<Edge> break_cycles(void);
     /// Remove pieces of the graph which are not part of any path.
     void remove_non_path(void);
+    /// Remove pieces of the graph which are part of some path.
+    void remove_path(void);
+    /// Get all of the edges that are on any path.
+    set<Edge*> get_path_edges(void);
+    
     /// Convert edges that are both from_start and to_end to "regular" ones from end to start.
     void flip_doubly_reversed_edges(void);
 

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 2
+plan tests 5
 
 # Toy example of hand-made pileup (and hand inspected truth) to make sure some
 # obvious (and only obvious) SNPs are detected by vg call
@@ -16,9 +16,30 @@ vg view -J -l call/pileup.json -L > tiny.vgpu
 vg call tiny.vg tiny.vgpu -A calls_l.vg   > /dev/null 2> /dev/null
 is $? "0" "vg call doesn't crash"
 
-rm -f calls_l.json calls_l.vg
+rm -f calls_l.json calls_l.vg tiny.vgpu
 
-rm -f calls_l.json calls_l.vg tiny.vg tiny.vgpu
+# With an empty pileup and loci mode we should assert the primery path.
+true > empty.gam
+vg pileup tiny.vg empty.gam > empty.vgpu
+vg call tiny.vg empty.vgpu --aug-graph augmented.vg --no-vcf > calls.loci
+
+LOCUS_COUNT="$(vg view --locus-in -j calls.loci | wc -l)"
+REF_LOCUS_COUNT="$(vg view --locus-in -j calls.loci | jq -c 'select(.genotype[0].allele == [0, 0])' | wc -l)"
+
+is "${REF_LOCUS_COUNT}" "${LOCUS_COUNT}" "all loci on an empty pileup are called reference"
+
+vg mod --sample-graph calls.loci tiny.vg > sample.vg
+
+is "$(vg stats -l sample.vg)" "$(vg mod -k x tiny.vg | vg stats -l -)"  "called loci describe the primary path"
+
+vg call tiny.vg empty.vgpu --aug-graph augmented.vg --no-vcf --call-nodes-by-coverage > calls.loci
+
+LOCUS_COUNT="$(vg view --locus-in -j calls.loci | wc -l)"
+EMPTY_LOCUS_COUNT="$(vg view --locus-in -j calls.loci | jq -c 'select(.genotype[0].allele == null)' | wc -l)"
+
+is "${EMPTY_LOCUS_COUNT}" "${LOCUS_COUNT}" "all loci on an empty pileup in coverage-calling mode are called deleted"
+
+rm -f tiny.vg empty.vgpu augmented.vg calls.loci sample.vg
 
 echo '{"node": [{"id": 1, "sequence": "CGTAGCGTGGTCGCATAAGTACAGTAGATCCTCCCCGCGCATCCTATTTATTAAGTTAAT"}]}' | vg view -Jv - > test.vg
 vg index -x test.xg -g test.gcsa -k 16 test.vg

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -28,7 +28,7 @@ REF_LOCUS_COUNT="$(vg view --locus-in -j calls.loci | jq -c 'select(.genotype[0]
 
 is "${REF_LOCUS_COUNT}" "${LOCUS_COUNT}" "all loci on an empty pileup are called reference"
 
-vg mod --sample-graph calls.loci tiny.vg > sample.vg
+vg mod --sample-graph calls.loci augmented.vg > sample.vg
 
 is "$(vg stats -l sample.vg)" "$(vg mod -k x tiny.vg | vg stats -l -)"  "called loci describe the primary path"
 


### PR DESCRIPTION
Since we have primary paths for hints, I am now having vg call not decide stuff on it is deleted when there's no actual edge for a deletion. It will prevent you finding new deletion variants without a spanning read, but it will also stop you from deleting anything and everything that has a coverage drop out.