### PR TITLE
Fixes for vg call

### DIFF
--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -798,8 +798,7 @@ vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
             second_best_allele != -1 &&
             bias_limit * bias_multiple * total(second_best_support) >= total(best_support) &&
             total(best_support) >= min_total_support_for_call &&
-            total(second_best_support) >= min_total_support_for_call &&
-            total(second_best_support) >= min_mad_for_filter) {
+            total(second_best_support) >= min_total_support_for_call) {
             // There's a second best allele, and it's not too biased to call,
             // and both alleles exceed the minimum to call them present, and the
             // second-best allele has enough support that it won't torpedo the

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -159,11 +159,14 @@ public:
     static const double Log_zero;
     // use this score when pileup is missing quality
     static const char Default_default_quality;
+    // don't augment graph without minimum support
+    static const int Default_min_aug_support;
     
     Caller(VG* graph,
            int default_quality = Default_default_quality,
-           bool bridge_alts = false);
-    ~Caller();
+           int min_aug_support = Default_min_aug_support);
+
+   ~Caller();
     void clear();
 
     // input graph
@@ -219,13 +222,8 @@ public:
     int _buffer_size;
     // if we don't have a mapping quality for a read position, use this
     char _default_quality;
-    // the base-by-base calling is very limited, and adjacent
-    // variants are not properly phased according to the reads.
-    // so we choose either to add all edges between neighboring
-    // positions (true) or none except via reference (false)
-    // (default to latter as most haplotypes rarely contain
-    // pairs of consecutive alts). 
-    bool _bridge_alts;
+    // minimum support to augment graph
+    int _min_aug_support;
 
     // write the augmented graph
     void write_augmented_graph(ostream& out, bool json);

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -30,7 +30,8 @@ void help_call(char** argv, ConfigurableParser& parser) {
          << "options:" << endl
          << "    -q, --default-read-qual N   phred quality score to use if none found in the pileup ["
          << (int)Caller::Default_default_quality << "]" << endl
-         << "    -a, --link-alts             add all possible edges between adjacent alts" << endl
+         << "    -g, --min-aug-support N     minimum support to augment graph ["
+         << Caller::Default_min_aug_support << "]" << endl
          << "    -A, --aug-graph FILE        write out the agumented graph in vg format" << endl
          << "    -U, --subgraph              expect a subgraph and ignore extra pileup entries outside it" << endl
          << "    -P, --pileup                write pileup under VCF lines (for debugging, output not valid VCF)" << endl
@@ -47,7 +48,7 @@ int main_call(int argc, char** argv) {
 
     int default_read_qual = Caller::Default_default_quality;
     string aug_file;
-    bool bridge_alts = false;
+    int min_aug_support = Caller::Default_min_aug_support;
         
     // Should we expect a subgraph and ignore pileups for missing nodes/edges?
     bool expect_subgraph = false;
@@ -65,7 +66,7 @@ int main_call(int argc, char** argv) {
     static const struct option long_options[] = {
         {"default-read-qual", required_argument, 0, 'q'},
         {"aug-graph", required_argument, 0, 'A'},
-        {"link-alts", no_argument, 0, 'a'},
+        {"min-aug-support", required_argument, 0, 'g'},
         {"progress", no_argument, 0, 'p'},
         {"verbose", no_argument, 0, 'v'},
         {"threads", required_argument, 0, 't'},
@@ -74,7 +75,7 @@ int main_call(int argc, char** argv) {
         {"help", no_argument, 0, 'h'},
         {0, 0, 0, 0}
     };
-    static const char* short_options = "q:A:apvt:UPh";
+    static const char* short_options = "q:A:g:pvt:UPh";
     optind = 2; // force optind past command positional arguments
 
     // This is our command-line parser
@@ -88,8 +89,8 @@ int main_call(int argc, char** argv) {
         case 'A':
             aug_file = optarg;
             break;
-        case 'a':
-            bridge_alts = true;
+        case'g':
+            min_aug_support = atoi(optarg);
             break;
         case 'U':
             expect_subgraph = true;
@@ -163,7 +164,7 @@ int main_call(int argc, char** argv) {
     if (show_progress) {
         cerr << "Computing augmented graph" << endl;
     }
-    Caller caller(graph, default_read_qual, bridge_alts);
+    Caller caller(graph, default_read_qual, min_aug_support);
 
     // setup pileup stream
     get_input_file(pileup_file_name, [&](istream& pileup_stream) {


### PR DESCRIPTION
The whole genome run on HG002 brought some calling problems to the forefront.  This is a patch for the two biggest issues found so far:
* calling homozygous alts for the sole reason that a het would fail the min-ad filter
* missing snps that are adjacent to homozygous alt snps, because no augmented path to explain them