### PR TITLE
Add a different het bias for indels

### DIFF
--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -768,7 +768,6 @@ vector<SnarlTraversal> Call2Vcf::find_best_traversals(AugmentedGraph& augmented,
         // If best and second best are close enough to be het, we call het.
         // Otherwise, we call hom best.
         
-        
         double bias_limit;
         if (best_allele == 0) {
             // Use ref bias limit

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -523,13 +523,13 @@ public:
     /// homozygous instead of heterozygous. At infinity, every call will be
     /// heterozygous if even one read supports each allele.
     Option<double> max_het_bias{this, "max-het-bias", "H", 4.5,
-        "max imbalance factor between alts to call heterozygous"};
+        "max imbalance factor to call heterozygous, alt major on SNPs"};
     /// Like above, but applied to ref / alt ratio (instead of alt / ref)
     Option<double> max_ref_het_bias{this, "max-ref-bias", "R", 4.5,
-        "max imbalance factor between ref and alts to call heterozygous ref"};
+        "max imbalance factor to call heterozygous, ref major"};
     /// Like the max het bias, but applies to novel indels.
     Option<double> max_indel_het_bias{this, "max-indel-het-bias", "I", 2.5,
-        "max imbalance factor to call heterozygous on novel indels"};
+        "max imbalance factor to call heterozygous, alt major on indels"};
     /// What's the minimum integer number of reads that must support a call? We
     /// don't necessarily want to call a SNP as het because we have a single
     // supporting read, even if there are only 10 reads on the site.

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -527,6 +527,9 @@ public:
     /// Like above, but applied to ref / alt ratio (instead of alt / ref)
     Option<double> max_ref_het_bias{this, "max-ref-bias", "R", 4.5,
         "max imbalance factor between ref and alts to call heterozygous ref"};
+    /// Like the max het bias, but applies to novel indels.
+    Option<double> max_indel_het_bias{this, "max-indel-het-bias", "I", 2.5,
+        "max imbalance factor to call heterozygous on novel indels"};
     /// What's the minimum integer number of reads that must support a call? We
     /// don't necessarily want to call a SNP as het because we have a single
     // supporting read, even if there are only 10 reads on the site.


### PR DESCRIPTION
When the caller thinks it is looking at an indel where the major allele is not the primary path, it can use a different (by default, lower) het bias limit.

This may or may not result in improved performance. It also may or may not be correct always about when it is calling indels; it relies on very heuristic estimation of the lengths of nested child sites, without traversing them.