### PR TITLE
Make jenkins f1 test stricter.

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -126,12 +126,13 @@ PYRET="$?"
 tar czf "${VG_VERSION}_output.tar.gz" vgci-work test-report.xml jenkins/vgci.py jenkins/jenkins.sh vgci_cfg.tsv
 aws s3 cp "${VG_VERSION}_output.tar.gz" s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_output_archives/
 
-# if success, we publish results to the baseline
-if [ "$PYRET" -eq 0 ]
+# if success and we're merging the PR, we publish results to the baseline
+if [ "$PYRET" -eq 0 ] && [[ ${ghprbActualCommit+x} ]]
 then
     echo "Tests passed. Updating baseline"
     aws s3 sync ./vgci-work/ s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline
     printf "${VG_VERSION}\n" > vg_version_${VG_VERSION}.txt
+    printf "${ghprbActualCommitAuthor}\n${ghprbPullTitle}\n${ghprbPullLink}\n" >> vg_version_${VG_VERSION}.txt
     aws s3 cp vg_version_${VG_VERSION}.txt s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline/
 fi
 

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -25,7 +25,7 @@ class VGCITest(TestCase):
     def setUp(self):
         self.workdir = tempfile.mkdtemp()
         
-        self.f1_threshold = 0.02
+        self.f1_threshold = 0.005
         self.auc_threshold = 0.02
         self.input_store = 's3://cgl-pipeline-inputs/vg_cgl/bakeoff'
         self.vg_docker = None
@@ -124,6 +124,7 @@ class VGCITest(TestCase):
         if true_vcf_path:
             opts += '--vcfeval_baseline {} '.format(true_vcf_path)
             opts += '--vcfeval_fasta {} '.format(fasta_path)
+            opts += '--vcfeval_opts \" --ref-overlap\" '
         if interleaved:
             opts += '--interleaved '
         if misc_opts:


### PR DESCRIPTION
This should work better now due to toil-vg being more robust about F1s it returns. 
Also fix baseline update to only happen on merged PRs.  