### PR TITLE
add min-end-match filter (-m) to vg filter

### DIFF
--- a/jenkins/toil_vg_config.yaml
+++ b/jenkins/toil_vg_config.yaml
@@ -212,7 +212,7 @@ call-chunk-size: 10000000
 chunk_context: 50
 
 # Options to pass to chunk_gam. (do not include file names or -t/--threads)
-filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-o', '0', '-q', '15']
+filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15']
 
 # Options to pass to vg pileup. (do not include file names or -t/--threads)
 pileup-opts: ['-q', '10']

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,6 +201,7 @@ void help_filter(char** argv) {
          << "    -f, --frac-score        normalize score based on length" << endl
          << "    -u, --substitutions     use substitution count instead of score" << endl
          << "    -o, --max-overhang N    filter reads whose alignments begin or end with an insert > N [default=99999]" << endl
+         << "    -m, --min-end-matches N filter reads that don't begin with at least N matches on each end" << endl
          << "    -S, --drop-split        remove split reads taking nonexistent edges" << endl
          << "    -x, --xg-name FILE      use this xg index (required for -R, -S, and -D)" << endl
          << "    -R, --regions-file      only output alignments that intersect regions (BED file with 0-based coordinates expected)" << endl
@@ -241,6 +242,7 @@ int main_filter(int argc, char** argv) {
                 {"frac-score", required_argument, 0, 'f'},
                 {"substitutions", required_argument, 0, 'u'},
                 {"max-overhang", required_argument, 0, 'o'},
+                {"min-end-matches", required_argument, 0, 'm'},
                 {"drop-split",  no_argument, 0, 'S'},
                 {"xg-name", required_argument, 0, 'x'},
                 {"regions-file",  required_argument, 0, 'R'},
@@ -257,7 +259,7 @@ int main_filter(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "s:r:d:e:fauo:Sx:R:B:Ac:vq:E:D:C:t:",
+        c = getopt_long (argc, argv, "s:r:d:e:fauo:m:Sx:R:B:Ac:vq:E:D:C:t:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -281,6 +283,9 @@ int main_filter(int argc, char** argv) {
         case 'o':
             filter.max_overhang = atoi(optarg);
             break;
+        case 'm':
+            filter.min_end_matches = atoi(optarg);
+            break;            
         case 'S':
             filter.drop_split = true;
         case 'x':

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -27,6 +27,7 @@ public:
     bool frac_score = false;
     bool sub_score = false;
     int max_overhang = 99999;
+    int min_end_matches = 0;
     int context_size = 0;
     bool verbose = false;
     double min_mapq = 0.;
@@ -47,12 +48,13 @@ public:
         vector<size_t> filtered;
         vector<size_t> min_score;
         vector<size_t> max_overhang;
+        vector<size_t> min_end_matches;
         vector<size_t> min_mapq;
         vector<size_t> split;
         vector<size_t> repeat;
         vector<size_t> defray;
         Counts() : read(2, 0), filtered(2, 0), min_score(2, 0),
-                   max_overhang(2, 0), min_mapq(2, 0),
+                   max_overhang(2, 0), min_end_matches(2, 0), min_mapq(2, 0),
                    split(2, 0), repeat(2, 0), defray(2, 0) {}
         Counts& operator+=(const Counts& other) {
             for (int i = 0; i < 2; ++i) {
@@ -60,6 +62,7 @@ public:
                 filtered[i] += other.filtered[i];
                 min_score[i] += other.min_score[i];
                 max_overhang[i] += other.max_overhang[i];
+                min_end_matches[i] += other.min_end_matches[i];
                 min_mapq[i] += other.min_mapq[i];
                 split[i] += other.split[i];
                 repeat[i] += other.repeat[i];


### PR DESCRIPTION
This is similar to the overhang filter -o, but works similarly when mapping without -L 0