### PR TITLE
Change vg chunk's id-range extraction interface

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -66,7 +66,7 @@ export PATH=$PATH:${PWD}/bin
 pip install numpy scipy sklearn dateutils requests timeout_decorator pytest boto
 
 # Install toil-vg itself
-pip install toil[aws,mesos] "toil-vg==1.2.0a1.dev400"
+pip install toil[aws,mesos] "toil-vg==1.2.1a1.dev409"
 if [ "$?" -ne 0 ]
 then
     echo "pip install toil-vg fail"

--- a/src/chunker.cpp
+++ b/src/chunker.cpp
@@ -127,7 +127,7 @@ int64_t PathChunker::extract_gam_for_id_range(vg::id_t start, vg::id_t end, Inde
 int64_t PathChunker::extract_gam_for_ids(const vector<vg::id_t>& graph_ids,
                                          Index& index, ostream* out_stream,
                                          bool contiguous) {
-    
+  
     // Load all the reads matching the graph into memory
     vector<Alignment> gam_buffer;
     int64_t gam_count = 0;

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 7
+plan tests 9
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg  x.vg
@@ -13,8 +13,8 @@ vg sim -x x.xg -l 100 -n 1000 -s 0 -e 0.01 -i 0.001 -a > x.gam
 vg view -a x.gam > x.gam.json
 
 # sanity check: does passing no options preserve input
-is $(vg chunk -x x.xg -p x | vg stats - -N) 210 "vg chunk with no options preserves nodes"
-is $(vg chunk -x x.xg -p x | vg stats - -E) 291 "vg chunk with no options preserves edges"
+is $(vg chunk -x x.xg -p x -c 10| vg stats - -N) 210 "vg chunk with no options preserves nodes"
+is $(vg chunk -x x.xg -p x -c 10| vg stats - -E) 291 "vg chunk with no options preserves edges"
 
 # check a small chunk
 is $(vg chunk -x x.xg -p x:20-30 | vg view - -j | jq -c '.path[0].mapping[].position' | jq 'select ((.node_id == 9))' | grep node | sed s/,// | sort | uniq | wc -l) 1 "chunk has path going through node 9"
@@ -27,12 +27,17 @@ is $(ls -l _chunk_test*.vg | wc -l) 6 "-s produces correct number of chunks"
 rm -f _chunk_test*
 
 #check that gam chunker runs through without crashing
-vg index -N x.gam -d x.gam.index
+vg index -a x.gam -d x.gam.unsrt.index
+vg index -A -d x.gam.unsrt.index | vg index -N - -d x.gam.index
 printf "x\t2\t200\nx\t500\t600\n" > _chunk_test_bed.bed
-vg chunk -x x.xg -a x.gam.index -g -b _chunk_test -r _chunk_test_bed.bed -R _chunk_test_out.bed
+vg chunk -x x.xg -a x.gam.index -g -b _chunk_test -e _chunk_test_bed.bed -E _chunk_test_out.bed
 is $(ls -l _chunk_test*.vg | wc -l) 2 "gam chunker produces correct number of graphs"
 is $(ls -l _chunk_test*.gam | wc -l) 2 "gam chunker produces correct number of gams"
 is $(grep x _chunk_test_out.bed | wc -l) 2 "gam chunker prodcues bed with correct number of chunks"
 
-rm -rf x.gam.index _chunk_test_bed.bed _chunk_test*
+#check that id ranges work
+is $(vg chunk -x x.xg -r 1:3 | vg view - -j | jq .node | grep id |  wc -l) 3 "id chunker produces correct chunk size"
+is $(vg chunk -x x.xg -r 1 | vg view - -j | jq .node | grep id | wc -l) 1 "id chunker produces correct single chunk"
+
+rm -rf x.gam.index x.gam.unsrt.index _chunk_test_bed.bed _chunk_test*
 rm -f x.vg x.xg x.gam x.gam.json filter_chunk*.gam chunks.bed


### PR DESCRIPTION
Was previously a hack that worked on top of the path coordinates interface.  Change it to separate options that are more consistent with the analogous operations in vg find.