### PR TITLE
Remove -Q option from call (turn on by default)

### DIFF
--- a/src/call2vcf.cpp
+++ b/src/call2vcf.cpp
@@ -1057,7 +1057,7 @@ void Call2Vcf::call(
     string pileup_filename) {
 
     // Toggle support counter
-    support_val = use_support_quality ? support_quality : total;
+    support_val = use_support_count ? total : support_quality;
 
     // Set up the graph's paths properly after augmentation modified them.
     augmented.graph.paths.sort_by_mapping_rank();

--- a/src/caller.hpp
+++ b/src/caller.hpp
@@ -608,10 +608,10 @@ public:
     Option<bool> call_other_by_coverage{this, "call-nodes-by-coverage", "cCoObB", false,
         "make calls on nodes/edges outside snarls by coverage"};
 
-    /// Use total quality (true) instead of support count (false) when choosing
+    /// Use total support count (true) instead of total support quality (false) when choosing
     /// top alleles and deciding gentypes based on the biases.  
-    Option<bool> use_support_quality{this, "use-support-quality", "Q", false,
-        "use total support quality instead of total support count"};
+    Option<bool> use_support_count{this, "use-support-count", "T", false,
+        "use total support count instead of total support quality for selecting top alleles"};
     
     /// print warnings etc. to stderr
     bool verbose = false;


### PR DESCRIPTION
This somehow got forgotten in #838 which tries to make vg call work well without any options.  