### PR TITLE
add trace functionality to vg chunk

### DIFF
--- a/src/haplotype_extracter.cpp
+++ b/src/haplotype_extracter.cpp
@@ -14,8 +14,7 @@ void output_haplotype_counts(ostream& annotation_ostream,
   }
 }
 
-void output_graph_with_embedded_paths(ostream& subgraph_ostream,
-            vector<pair<thread_t,int>>& haplotype_list, xg::XG& index, bool json) {
+Graph output_graph_with_embedded_paths(vector<pair<thread_t,int>>& haplotype_list, xg::XG& index) {
   Graph g;
   set<int64_t> nodes;
   set<pair<int,int> > edges;
@@ -29,6 +28,13 @@ void output_graph_with_embedded_paths(ostream& subgraph_ostream,
     p.set_name(to_string(i));
     *(g.add_path()) = move(p);
   }
+  return g;
+}
+ 
+void output_graph_with_embedded_paths(ostream& subgraph_ostream,
+            vector<pair<thread_t,int>>& haplotype_list, xg::XG& index, bool json) {
+  Graph g = output_graph_with_embedded_paths(haplotype_list, index);
+
   if (json) {
     subgraph_ostream << pb2json(g);
   } else {

--- a/src/haplotype_extracter.cpp
+++ b/src/haplotype_extracter.cpp
@@ -1,22 +1,21 @@
 #include <iostream>
+#include "vg.hpp"
 #include "haplotype_extracter.hpp"
-#include "vg.pb.h"
 #include "json2pb.h"
 #include "xg.hpp"
 
 using namespace std;
 using namespace vg;
 
-void output_haplotype_counts(ofstream& annotation_ofstream,
+void output_haplotype_counts(ostream& annotation_ostream,
             vector<pair<thread_t,int>>& haplotype_list, xg::XG& index) {
   for(int i = 0; i < haplotype_list.size(); i++) {
-    annotation_ofstream << i << "\t" << haplotype_list[i].second << endl;
+    annotation_ostream << i << "\t" << haplotype_list[i].second << endl;
   }
-  annotation_ofstream.close();
 }
 
-void output_graph_with_embedded_paths(ofstream& json_ofstream,
-            vector<pair<thread_t,int>>& haplotype_list, xg::XG& index) {
+void output_graph_with_embedded_paths(ostream& subgraph_ostream,
+            vector<pair<thread_t,int>>& haplotype_list, xg::XG& index, bool json) {
   Graph g;
   set<int64_t> nodes;
   set<pair<int,int> > edges;
@@ -30,8 +29,13 @@ void output_graph_with_embedded_paths(ofstream& json_ofstream,
     p.set_name(to_string(i));
     *(g.add_path()) = move(p);
   }
-  json_ofstream << pb2json(g);
-  json_ofstream.close();
+  if (json) {
+    subgraph_ostream << pb2json(g);
+  } else {
+    VG subgraph;
+    subgraph.extend(g);
+    subgraph.serialize_to_ostream(subgraph_ostream);
+  }
 }
 
 void thread_to_graph_spanned(thread_t& t, Graph& g, xg::XG& index) {

--- a/src/haplotype_extracter.hpp
+++ b/src/haplotype_extracter.hpp
@@ -28,6 +28,8 @@ vector<pair<thread_t,int> > list_haplotypes(xg::XG& index,
 // Paths.  Will output in JSON format if json set to true and Protobuf otherwise.
 void output_graph_with_embedded_paths(ostream& subgraph_ostream,
             vector<pair<thread_t,int>>& haplotype_list, xg::XG& index, bool json = true);
+// get the graph directly
+Graph output_graph_with_embedded_paths(vector<pair<thread_t,int>>& haplotype_list, xg::XG& index);
 
 // writes to annotation_ostream the list of counts of identical subhaplotypes
 // using the same ordering as the Paths from output_graph_with_embedded_paths

--- a/src/haplotype_extracter.hpp
+++ b/src/haplotype_extracter.hpp
@@ -23,15 +23,15 @@ Path path_from_thread_t(thread_t& t);
 vector<pair<thread_t,int> > list_haplotypes(xg::XG& index,
             xg::XG::ThreadMapping start_node, int extend_distance);
 
-// writes to json_ofstream the json representation of the subgraph covered by
+// writes to subgraph_ostream the subgraph covered by
 // the haplotypes in haplotype_list, as well as these haplotypes embedded as
-// Paths
-void output_graph_with_embedded_paths(ofstream& json_ofstream,
-            vector<pair<thread_t,int>>& haplotype_list, xg::XG& index);
+// Paths.  Will output in JSON format if json set to true and Protobuf otherwise.
+void output_graph_with_embedded_paths(ostream& subgraph_ostream,
+            vector<pair<thread_t,int>>& haplotype_list, xg::XG& index, bool json = true);
 
-// writes to annotation_ofstream the list of counts of identical subhaplotypes
+// writes to annotation_ostream the list of counts of identical subhaplotypes
 // using the same ordering as the Paths from output_graph_with_embedded_paths
-void output_haplotype_counts(ofstream& annotation_ofstream,
+void output_haplotype_counts(ostream& annotation_ostream,
             vector<pair<thread_t,int>>& haplotype_list, xg::XG& index);
 
 // Adds to a Graph the nodes and edges touched by a thread_t

--- a/src/subcommand/trace_main.cpp
+++ b/src/subcommand/trace_main.cpp
@@ -21,8 +21,9 @@ void help_trace(char** argv) {
          << "    -n, --start-node INT       start at this node" << endl
         //TODO: implement backwards iteration over graph
         // << "    -b, --backwards            iterate backwards over graph" << endl
-         << "    -d, --extend-distance INT  extend search this many nodes" << endl
-         << "    -j, --output-json          path to which to output json" << endl;
+         << "    -d, --extend-distance INT  extend search this many nodes [default=50]" << endl
+         << "    -a, --annotation-path      output file for haplotype frequency annotations" << endl
+         << "    -j, --json                 output subgraph in json instead of protobuf" << endl;
 }
 
 int main_trace(int argc, char** argv) {
@@ -32,10 +33,11 @@ int main_trace(int argc, char** argv) {
   }
 
   string xg_name;
-  string output_path;
-  int64_t start_node;
+  string annotation_path;
+  int64_t start_node = 0;
   int extend_distance = 50;
   bool backwards = false;
+  bool json = false;
 
   int c;
   optind = 2; // force optind past command positional argument
@@ -45,15 +47,16 @@ int main_trace(int argc, char** argv) {
             /* These options set a flag. */
             //{"verbose", no_argument,       &verbose_flag, 1},
             {"index", required_argument, 0, 'x'},
-            {"output-json", required_argument, 0, 'j'},
+            {"annotation-path", required_argument, 0, 'a'},
             {"start-node", required_argument, 0, 'n'},
             {"extend-distance", required_argument, 0, 'd'},
+            {"json", no_argument, 0, 'j'},
             //{"backwards", no_argument, 0, 'b'},
             {0, 0, 0, 0}
         };
 
     int option_index = 0;
-    c = getopt_long (argc, argv, "x:j:n:d:h",
+    c = getopt_long (argc, argv, "x:a:n:d:jh",
                      long_options, &option_index);
 
     /* Detect the end of the options. */
@@ -66,8 +69,8 @@ int main_trace(int argc, char** argv) {
         xg_name = optarg;
         break;
 
-    case 'j':
-        output_path = optarg;
+    case 'a':
+        annotation_path = optarg;
         break;
 
     case 'n':
@@ -76,6 +79,10 @@ int main_trace(int argc, char** argv) {
 
     case 'd':
         extend_distance = atoi(optarg);
+        break;
+
+    case 'j':
+        json = true;
         break;
 
     //case 'b':
@@ -92,30 +99,37 @@ int main_trace(int argc, char** argv) {
         abort();
     }
   }
-  
-  xg::XG xindex;
-  if (!xg_name.empty()) {
-      ifstream in(xg_name.c_str());
-      xindex.load(in);
+
+  if (xg_name.empty()) {
+    cerr << "[vg trace] xg index must be specified with -x" << endl;
+    return 1;
   }
+  if (start_node < 1) {
+    cerr << "[vg trace] start node must be specified with -n" << endl;
+    return 1;
+  }
+  xg::XG xindex;  
+  ifstream in(xg_name.c_str());
+  xindex.load(in);
   
   xg::XG::ThreadMapping n;
   n.node_id = start_node;
   n.is_reverse = backwards;
   int64_t offset = 0;
   
-  if(!output_path.empty()) {
-    ofstream annotation_ofstream(output_path+".annotation");
-    ofstream json_ofstream(output_path);
-    // what subhaplotypes of length extend_distance starting at n are embedded
-    // in xindex? How many identical copies of each subhaplotype?
-    vector<pair<thread_t,int> > haplotype_list =
-              list_haplotypes(xindex, n, extend_distance);
+  // what subhaplotypes of length extend_distance starting at n are embedded
+  // in xindex? How many identical copies of each subhaplotype?
+  vector<pair<thread_t,int> > haplotype_list =
+     list_haplotypes(xindex, n, extend_distance);
+
+  if (!annotation_path.empty()) {
     // haplotype counts go into annotation_ofstream
+    ofstream annotation_ofstream(annotation_path);
     output_haplotype_counts(annotation_ofstream, haplotype_list, xindex);
-    // json containing graph and paths goes into json_ofstream
-    output_graph_with_embedded_paths(json_ofstream, haplotype_list, xindex);
   }
+    
+  // graph and paths go to cout
+  output_graph_with_embedded_paths(cout, haplotype_list, xindex, json);
 
   return 0;
 }

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -5,10 +5,10 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 9
+plan tests 10
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
-vg index -x x.xg  x.vg
+vg index -x x.xg -v small/x.vcf.gz  x.vg 2> /dev/null
 vg sim -x x.xg -l 100 -n 1000 -s 0 -e 0.01 -i 0.001 -a > x.gam
 vg view -a x.gam > x.gam.json
 
@@ -39,5 +39,7 @@ is $(grep x _chunk_test_out.bed | wc -l) 2 "gam chunker prodcues bed with correc
 is $(vg chunk -x x.xg -r 1:3 | vg view - -j | jq .node | grep id |  wc -l) 3 "id chunker produces correct chunk size"
 is $(vg chunk -x x.xg -r 1 | vg view - -j | jq .node | grep id | wc -l) 1 "id chunker produces correct single chunk"
 
+#check that traces work
+is $(vg chunk -x x.xg -n 1 -d 2 | vg view - -j | jq .node | grep id | wc -l) 3 "id chunker traces correct chunk size"
 rm -rf x.gam.index x.gam.unsrt.index _chunk_test_bed.bed _chunk_test*
 rm -f x.vg x.xg x.gam x.gam.json filter_chunk*.gam chunks.bed


### PR DESCRIPTION
This is to address #848, helping @wolfib get a single api for graph extraction.  

I changed the vg trace command line interface a bit while I was at it to make it a bit more consistent with other tools (streaming protobuf output to stdout by default).  The haplotype extract api should remain fully backwards compatible if anything else was using it. 
