### PR TITLE
Save results with an ACL that makes them world-readable

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -174,7 +174,7 @@ PYRET="$?"
 
 # we publish the results to the archive
 tar czf "${VG_VERSION}_output.tar.gz" vgci-work test-report.xml jenkins/vgci.py jenkins/jenkins.sh vgci_cfg.tsv
-aws s3 cp "${VG_VERSION}_output.tar.gz" s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_output_archives/
+aws s3 cp --acl public-read "${VG_VERSION}_output.tar.gz" s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_output_archives/
 
 # if success and we're merging the PR, we publish results to the baseline
 if [ "$PYRET" -eq 0 ] && [ -z ${ghprbActualCommit} ]
@@ -183,7 +183,7 @@ then
     aws s3 sync ./vgci-work/ s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline
     printf "${VG_VERSION}\n" > vg_version_${VG_VERSION}.txt
     printf "${ghprbActualCommitAuthor}\n${ghprbPullTitle}\n${ghprbPullLink}\n" >> vg_version_${VG_VERSION}.txt
-    aws s3 cp vg_version_${VG_VERSION}.txt s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline/
+    aws s3 cp --acl public-read vg_version_${VG_VERSION}.txt s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline/
 fi
 
 # clean up changes to bin


### PR DESCRIPTION
This solves the problem where you can't read the baseline results off of AWS unless you are Jenkins.