### PR TITLE
New way of calling toil-vg

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -20,7 +20,7 @@ LOCAL_BUILD=0
 # Should we re-use and keep around the same virtualenv?
 REUSE_VENV=0
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/bd2kgenomics/toil-vg.git@a5976b8cf5d90bd80bee28d9886d9fefd1d66c0d"
+TOIL_VG_PACKAGE="git+https://github.com/adamnovak/toil-vg.git@3adb2390156887bad052da0240bf92ff3dc24edc"
 # What tests should we run?
 # Should be something like "jenkins/vgci.py::VGCITest::test_sim_brca2_snp1kg"
 PYTEST_TEST_SPEC="jenkins/vgci.py"

--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -174,7 +174,7 @@ PYRET="$?"
 
 # we publish the results to the archive
 tar czf "${VG_VERSION}_output.tar.gz" vgci-work test-report.xml jenkins/vgci.py jenkins/jenkins.sh vgci_cfg.tsv
-aws s3 cp "${VG_VERSION}_output.tar.gz" s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_output_archives/
+aws s3 cp --acl public-read "${VG_VERSION}_output.tar.gz" s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_output_archives/
 
 # if success and we're merging the PR, we publish results to the baseline
 if [ "$PYRET" -eq 0 ] && [ -z ${ghprbActualCommit} ]
@@ -183,7 +183,7 @@ then
     aws s3 sync ./vgci-work/ s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline
     printf "${VG_VERSION}\n" > vg_version_${VG_VERSION}.txt
     printf "${ghprbActualCommitAuthor}\n${ghprbPullTitle}\n${ghprbPullLink}\n" >> vg_version_${VG_VERSION}.txt
-    aws s3 cp vg_version_${VG_VERSION}.txt s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline/
+    aws s3 cp --acl public-read vg_version_${VG_VERSION}.txt s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline/
 fi
 
 # clean up changes to bin

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -13,8 +13,14 @@ import os, sys
 import argparse
 import collections
 import timeout_decorator
-from boto.s3.connection import S3Connection
+import urllib2
+import shutil
+
 import tsv
+
+from toil_vg.vg_mapeval import mapeval_main
+from toil_vg.vg_toil import parse_args
+from toil_vg.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +39,7 @@ class VGCITest(TestCase):
         # What (additional) portion of reads are allowed to get worse scores
         # when moving to a more inclusive reference?
         self.worse_threshold = 0.01
-        self.input_store = 's3://cgl-pipeline-inputs/vg_cgl/bakeoff'
+        self.input_store = 'https://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/bakeoff'
         self.vg_docker = None
         self.container = None # Use default in toil-vg, which is Docker
         self.verify = True
@@ -103,27 +109,39 @@ class VGCITest(TestCase):
             toks = self.baseline[5:].split('/')
             bname = toks[0]
             keyname = '/{}/outstore-{}/{}'.format('/'.join(toks[1:]), tag, path)
-            bucket = S3Connection().get_bucket(bname)
-            key = bucket.get_key(keyname)
-            return key.get_contents_as_string()
+            
+            # Convert to a public HTTPS URL
+            url = 'https://{}.s3.amazonaws.com{}'.format(bname, keyname)
+            # And download it
+            connection = urllib2.urlopen(url)
+            return connection.read()
         else:
+            # Assume it's a raw path.
             with open(os.path.join(self.baseline, 'outstore-{}'.format(tag), path)) as f:
                 return f.read()
 
     def _get_remote_file(self, src, tgt):
-        """ get a file from a store """
+        """
+        get a file from a store
+        
+        src must be a URL.
+        
+        """
         if not os.path.exists(os.path.dirname(tgt)):
             os.makedirs(os.path.dirname(tgt))
+            
         if src.startswith('s3://'):
             toks = src[5:].split('/')
             bname = toks[0]
             keyname = '/' + '/'.join(toks[1:])
-            bucket = S3Connection().get_bucket(bname)
-            key = bucket.get_key(keyname)
-            with open(tgt, 'w') as f:
-                return key.get_contents_to_file(f)
-        else:
-            shutil.copy2(src, tgt_file)
+
+            # Convert to a public HTTPS URL
+            src = 'https://{}.s3.amazonaws.com{}'.format(bname, keyname)
+        
+        with open(tgt, 'w') as f:
+            # Download the file from the URL
+            connection = urllib2.urlopen(src)
+            shutil.copyfileobj(connection, f)
 
     def _toil_vg_index(self, chrom, graph_path, xg_path, gcsa_path, misc_opts, dir_tag, file_tag):
         """ Wrap toil-vg index.  Files passed are copied from store instead of computed """
@@ -301,8 +319,19 @@ class VGCITest(TestCase):
         
         cmd = 'toil-vg mapeval {} {} {} {}'.format(
             job_store, out_store, os.path.join(out_store, 'true.pos'), opts)
-        subprocess.check_call(cmd, shell=True)
-
+            
+        # Now parse the command line
+        args = cmd.strip().split(' ')
+        print(args)
+        options = parse_args(args[1:])
+        print(options)
+        # Make a toil-vg context with these options as the configuration
+        context = Context(options.out_store, options)
+        
+        # Run the whole mapeval workflow. Internally sets up Toil using the
+        # passed options.
+        mapeval_main(context, options)
+            
     def _tsv_to_dict(self, stats, row_1 = 1):
         """ convert tsv string into dictionary """
         stats_dict = dict()

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -308,9 +308,7 @@ class VGCITest(TestCase):
             
         # Now parse the command line
         args = cmd.strip().split(' ')
-        print(args)
         options = parse_args(args[1:])
-        print(options)
         # Make a toil-vg context with these options as the configuration
         context = Context(options.out_store, options)
         


### PR DESCRIPTION
I want to check to make sure we can call toil-vg as a library, and the easiest way to do that, before #858 goes in, is a pull request.