### PR TITLE
Update to an XG that uses version numbers

### DIFF
--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -81,7 +81,7 @@ vg index -x x.xg -v small/x.vcf.gz x.vg
 is $? 0 "building an xg index containing a gPBWT"
 
 xg -i x.xg -x > part.vg
-is "$(cat x.vg part.vg | vg view -j - | jq '.path[].name' | grep '_thread' | wc -l)" 2 "the gPBWT contains the expected number of threads"
+is "$(cat x.vg part.vg | vg view -j - | jq '.path[].name' | grep '_thread' | wc -l)" 4 "the gPBWT contains one thread for each orientation of each haplotype"
 
 is $(vg find -x x.xg -q _thread_1_x_0 | vg paths -L - | wc -l) 1 "a specific thread may be pulled from the graph by name"
 


### PR DESCRIPTION
New xg files generated after this commit won't be compatible with older vg versions. But old xg files will still be compatible with the new vg build (and should remain so until we have to start dropping support for old xg versions because we can't convert them).