### PR TITLE
Report full-length bonuses in scores from vg map again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/trace_main.o
 SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/gamsort_main.o
 SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/msga_main.o
 SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/map_main.o
+SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/align_main.o
 SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/surject_main.o
 SUBCOMMAND_OBJ += $(SUBCOMMAND_OBJ_DIR)/find_main.o
 
@@ -574,6 +575,8 @@ $(SUBCOMMAND_OBJ_DIR)/call_main.o: $(SUBCOMMAND_SRC_DIR)/call_main.cpp $(SUBCOMM
 $(SUBCOMMAND_OBJ_DIR)/genotype_main.o: $(SUBCOMMAND_SRC_DIR)/genotype_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/genotyper.hpp $(SRC_DIR)/genotyper.cpp $(SRC_DIR)/snarls.hpp $(SRC_DIR)/path_index.hpp $(DEPS)
 
 $(SUBCOMMAND_OBJ_DIR)/msga_main.o: $(SUBCOMMAND_SRC_DIR)/msga_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/mapper.hpp $(DEPS)
+
+$(SUBCOMMAND_OBJ_DIR)/align_main.o: $(SUBCOMMAND_SRC_DIR)/align_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/ssw_aligner.hpp $(DEPS)
 
 $(SUBCOMMAND_OBJ_DIR)/map_main.o: $(SUBCOMMAND_SRC_DIR)/map_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/mapper.hpp $(DEPS)
 

--- a/Makefile
+++ b/Makefile
@@ -576,7 +576,7 @@ $(SUBCOMMAND_OBJ_DIR)/genotype_main.o: $(SUBCOMMAND_SRC_DIR)/genotype_main.cpp $
 
 $(SUBCOMMAND_OBJ_DIR)/msga_main.o: $(SUBCOMMAND_SRC_DIR)/msga_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/mapper.hpp $(DEPS)
 
-$(SUBCOMMAND_OBJ_DIR)/align_main.o: $(SUBCOMMAND_SRC_DIR)/align_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/ssw_aligner.hpp $(DEPS)
+$(SUBCOMMAND_OBJ_DIR)/align_main.o: $(SUBCOMMAND_SRC_DIR)/align_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/gssw_aligner.hpp $(DEPS)
 
 $(SUBCOMMAND_OBJ_DIR)/map_main.o: $(SUBCOMMAND_SRC_DIR)/map_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/stream.hpp $(SRC_DIR)/mapper.hpp $(DEPS)
 

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -313,6 +313,7 @@ class VGCITest(TestCase):
             vg_docker = self.vg_docker,
             container = self.container,
             alignment_cores = self.cores,
+            map_opts = ['--include-bonuses'], # Make sure we have the actual scores used to decide on alignments
             # Toil options
             realTimeLogging = True,
             logLevel = "INFO",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2659,190 +2659,6 @@ int main_paths(int argc, char** argv) {
 
 }
 
-void help_align(char** argv) {
-    cerr << "usage: " << argv[0] << " align [options] <graph.vg> >alignments.gam" << endl
-         << "options:" << endl
-         << "    -s, --sequence STR    align a string to the graph in graph.vg using partial order alignment" << endl
-         << "    -Q, --seq-name STR    name the sequence using this value" << endl
-         << "    -j, --json            output alignments in JSON format (default GAM)" << endl
-         << "    -m, --match N         use this match score (default: 1)" << endl
-         << "    -M, --mismatch N      use this mismatch penalty (default: 4)" << endl
-         << "    -g, --gap-open N      use this gap open penalty (default: 6)" << endl
-         << "    -e, --gap-extend N    use this gap extension penalty (default: 1)" << endl
-         << "    -T, --full-l-bonus N  provide this bonus for alignments that are full length (default: 5)" << endl
-         << "    -b, --banded-global   use the banded global alignment algorithm" << endl
-         << "    -p, --pinned          pin the (local) alignment traceback to the optimal edge of the graph" << endl
-         << "    -L, --pin-left        pin the first rather than last bases of the graph and sequence" << endl
-         << "    -D, --debug           print out score matrices and other debugging info" << endl
-         << "options:" << endl
-         << "    -s, --sequence STR    align a string to the graph in graph.vg using partial order alignment" << endl
-         << "    -Q, --seq-name STR    name the sequence using this value" << endl
-         << "    -r, --reference STR   don't use an input graph--- run SSW alignment between -s and -r" << endl
-         << "    -j, --json            output alignments in JSON format (default GAM)" << endl;
-}
-
-int main_align(int argc, char** argv) {
-
-    string seq;
-    string seq_name;
-
-    if (argc == 2) {
-        help_align(argv);
-        return 1;
-    }
-
-    bool print_cigar = false;
-    bool output_json = false;
-    int match = 1;
-    int mismatch = 4;
-    int gap_open = 6;
-    int gap_extend = 1;
-    int full_length_bonus = 5;
-    string ref_seq;
-    bool debug = false;
-    bool banded_global = false;
-    bool pinned_alignment = false;
-    bool pin_left = false;
-
-    int c;
-    optind = 2; // force optind past command positional argument
-    while (true) {
-        static struct option long_options[] =
-        {
-            /* These options set a flag. */
-            //{"verbose", no_argument,       &verbose_flag, 1},
-            {"sequence", required_argument, 0, 's'},
-            {"seq-name", no_argument, 0, 'Q'},
-            {"json", no_argument, 0, 'j'},
-            {"match", required_argument, 0, 'm'},
-            {"mismatch", required_argument, 0, 'M'},
-            {"gap-open", required_argument, 0, 'g'},
-            {"gap-extend", required_argument, 0, 'e'},
-            {"reference", required_argument, 0, 'r'},
-            {"debug", no_argument, 0, 'D'},
-            {"banded-global", no_argument, 0, 'b'},
-            {"full-l-bonus", required_argument, 0, 'T'},
-            {"pinned", no_argument, 0, 'p'},
-            {"pinned-left", no_argument, 0, 'L'},
-            {0, 0, 0, 0}
-        };
-
-        int option_index = 0;
-        c = getopt_long (argc, argv, "s:jhQ:m:M:g:e:Dr:F:O:bT:pL",
-                long_options, &option_index);
-
-        /* Detect the end of the options. */
-        if (c == -1)
-            break;
-
-        switch (c)
-        {
-        case 's':
-            seq = optarg;
-            break;
-
-        case 'Q':
-            seq_name = optarg;
-            break;
-
-        case 'j':
-            output_json = true;
-            break;
-
-        case 'm':
-            match = atoi(optarg);
-            break;
-
-        case 'M':
-            mismatch = atoi(optarg);
-            break;
-
-        case 'g':
-            gap_open = atoi(optarg);
-            break;
-
-        case 'e':
-            gap_extend = atoi(optarg);
-            break;
-
-        case 'T':
-            full_length_bonus = atoi(optarg);
-            break;
-
-        case 'r':
-            ref_seq = optarg;
-            break;
-
-        case 'D':
-            debug = true;
-            break;
-
-        case 'b':
-            banded_global = true;
-            break;
-
-        case 'p':
-            pinned_alignment = true;
-            break;
-
-        case 'L':
-            pin_left = true;
-            break;
-
-        case 'h':
-        case '?':
-            /* getopt_long already printed an error message. */
-            help_align(argv);
-            exit(1);
-            break;
-
-        default:
-            abort ();
-        }
-    }
-
-    VG* graph = nullptr;
-    if (ref_seq.empty()) {
-        // Only look at a filename if we don't have an explicit reference
-        // sequence.
-        get_input_file(optind, argc, argv, [&](istream& in) {
-            graph = new VG(in);
-        });
-    }
-    
-    Alignment alignment;
-    if (!ref_seq.empty()) {
-        SSWAligner ssw = SSWAligner(match, mismatch, gap_open, gap_extend);
-        alignment = ssw.align(seq, ref_seq);
-    } else {
-        Aligner aligner = Aligner(match, mismatch, gap_open, gap_extend, full_length_bonus);
-        alignment = graph->align(seq, &aligner, 0, pinned_alignment, pin_left,
-            banded_global, 0, max(seq.size(), graph->length()), debug);
-    }
-
-    if (!seq_name.empty()) {
-        alignment.set_name(seq_name);
-    }
-
-    if (output_json) {
-        cout << pb2json(alignment) << endl;
-    } else {
-        function<Alignment(uint64_t)> lambda =
-            [&alignment] (uint64_t n) {
-                return alignment;
-            };
-        stream::write(cout, 1, lambda);
-    }
-
-    if (graph != nullptr) {
-        delete graph;
-    }
-
-    return 0;
-
-}
-
-
 void help_view(char** argv) {
     cerr << "usage: " << argv[0] << " view [options] [ <graph.vg> | <graph.json> | <aln.gam> | <read1.fq> [<read2.fq>] ]" << endl
          << "options:" << endl
@@ -4076,7 +3892,6 @@ void vg_help(char** argv) {
          << "  -- view          format conversions for graphs and alignments" << endl
          << "  -- vectorize     transform alignments to simple ML-compatible vectors" << endl
          << "  -- paths         traverse paths in the graph" << endl
-         << "  -- align         local alignment" << endl
          << "  -- stats         metrics describing graph properties" << endl
          << "  -- join          combine graphs via a new head" << endl
          << "  -- ids           manipulate node ids" << endl
@@ -4121,8 +3936,6 @@ int main(int argc, char *argv[])
         return main_deconstruct(argc, argv);
     } else if (command == "view") {
         return main_view(argc, argv);
-    } else if (command == "align") {
-        return main_align(argc, argv);
     } else if (command == "paths") {
         return main_paths(argc, argv);
     } else if (command == "stats") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4084,7 +4084,6 @@ void vg_help(char** argv) {
          << "  -- kmers         enumerate kmers of the graph" << endl
          << "  -- sim           simulate reads from the graph" << endl
          << "  -- mod           filter, transform, and edit the graph" << endl
-         << "  -- homogenize    homogenize long variants in the graph to improve genotyping" << endl
          << "  -- pileup        build a pileup from a set of alignments" << endl
          << "  -- genotype      compute genotypes from aligned reads" << endl
          << "  -- compare       compare the kmer space of two graphs" << endl

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -22,7 +22,7 @@ BaseMapper::BaseMapper(xg::XG* xidex,
     , regular_aligner(nullptr)
     , adjust_alignments_for_base_quality(false)
     , mapping_quality_method(Approx)
-    , strip_bonuses(false)
+    , strip_bonuses(true)
 {
     init_aligner(default_match, default_mismatch, default_gap_open,
                  default_gap_extension, default_full_length_bonus);

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -4194,6 +4194,12 @@ int32_t Mapper::score_alignment(const Alignment& aln, bool use_approx_distance) 
 }
 
 int32_t Mapper::rescore_without_full_length_bonus(const Alignment& aln) {
+#ifdef debug_mapper
+#pragma omp critical
+    {
+        cerr << "dropping full length bonus" << endl;
+    }
+#endif
     int32_t score = aln.score();
     if (softclip_start(aln) == 0) {
         score -= (adjust_alignments_for_base_quality ? qual_adj_aligner->full_length_bonus : regular_aligner->full_length_bonus);

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -4184,6 +4184,12 @@ int32_t Mapper::score_alignment(const Alignment& aln, bool use_approx_distance) 
             }
         }
     }
+    if (!softclip_start(aln)) {
+        score += full_length_alignment_bonus;
+    }
+    if (!softclip_end(aln)) {
+        score += full_length_alignment_bonus;
+    }
 #ifdef debug_mapper
 #pragma omp critical
     {

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -22,7 +22,7 @@ BaseMapper::BaseMapper(xg::XG* xidex,
     , regular_aligner(nullptr)
     , adjust_alignments_for_base_quality(false)
     , mapping_quality_method(Approx)
-    , report_bonuses(true)
+    , strip_bonuses(false)
 {
     init_aligner(default_match, default_mismatch, default_gap_open,
                  default_gap_extension, default_full_length_bonus);
@@ -2672,7 +2672,7 @@ Alignment Mapper::align_maybe_flip(const Alignment& base, VG& graph, bool flip, 
                          pinned_alignment,
                          pinned_reverse,
                          banded_global);
-    if (!report_bonuses && !banded_global) aln.set_score(rescore_without_full_length_bonus(aln));
+    if (strip_bonuses && !banded_global) aln.set_score(rescore_without_full_length_bonus(aln));
     if (flip) {
         aln = reverse_complement_alignment(
             aln,
@@ -4185,7 +4185,7 @@ int32_t Mapper::score_alignment(const Alignment& aln, bool use_approx_distance) 
             }
         }
     }
-    if (report_bonuses) {
+    if (!strip_bonuses) {
         // We should report any bonuses used in the DP in the final score
         if (!softclip_start(aln)) {
             score += (adjust_alignments_for_base_quality ?

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -265,7 +265,7 @@ public:
     bool adjust_alignments_for_base_quality; // use base quality adjusted alignments
     MappingQualityMethod mapping_quality_method; // how to compute mapping qualities
     
-    bool report_bonuses; // keep the bonuses used by the aligners in the final reported scores
+    bool strip_bonuses; // remove any bonuses used by the aligners from the final reported scores
     
 protected:
     /// Locate the sub-MEMs contained in the last MEM of the mems vector that have ending positions

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -265,6 +265,8 @@ public:
     bool adjust_alignments_for_base_quality; // use base quality adjusted alignments
     MappingQualityMethod mapping_quality_method; // how to compute mapping qualities
     
+    bool report_bonuses; // keep the bonuses used by the aligners in the final reported scores
+    
 protected:
     /// Locate the sub-MEMs contained in the last MEM of the mems vector that have ending positions
     /// before the end the next SMEM, label each of the sub-MEMs with the indices of all of the SMEMs

--- a/src/subcommand/align_main.cpp
+++ b/src/subcommand/align_main.cpp
@@ -1,0 +1,207 @@
+/** \file align_main.cpp
+ *
+ * Defines the "vg align" subcommand, which aligns a read against an entire
+ * graph.
+ */
+
+#include <omp.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <list>
+#include <fstream>
+
+#include "subcommand.hpp"
+
+#include "../vg.hpp"
+
+using namespace std;
+using namespace vg;
+using namespace vg::subcommand;
+
+void help_align(char** argv) {
+    cerr << "usage: " << argv[0] << " align [options] <graph.vg> >alignments.gam" << endl
+         << "options:" << endl
+         << "    -s, --sequence STR    align a string to the graph in graph.vg using partial order alignment" << endl
+         << "    -Q, --seq-name STR    name the sequence using this value" << endl
+         << "    -j, --json            output alignments in JSON format (default GAM)" << endl
+         << "    -m, --match N         use this match score (default: 1)" << endl
+         << "    -M, --mismatch N      use this mismatch penalty (default: 4)" << endl
+         << "    -g, --gap-open N      use this gap open penalty (default: 6)" << endl
+         << "    -e, --gap-extend N    use this gap extension penalty (default: 1)" << endl
+         << "    -T, --full-l-bonus N  provide this bonus for alignments that are full length (default: 5)" << endl
+         << "    -b, --banded-global   use the banded global alignment algorithm" << endl
+         << "    -p, --pinned          pin the (local) alignment traceback to the optimal edge of the graph" << endl
+         << "    -L, --pin-left        pin the first rather than last bases of the graph and sequence" << endl
+         << "    -D, --debug           print out score matrices and other debugging info" << endl
+         << "options:" << endl
+         << "    -s, --sequence STR    align a string to the graph in graph.vg using partial order alignment" << endl
+         << "    -Q, --seq-name STR    name the sequence using this value" << endl
+         << "    -r, --reference STR   don't use an input graph--- run SSW alignment between -s and -r" << endl
+         << "    -j, --json            output alignments in JSON format (default GAM)" << endl;
+}
+
+int main_align(int argc, char** argv) {
+
+    string seq;
+    string seq_name;
+
+    if (argc == 2) {
+        help_align(argv);
+        return 1;
+    }
+
+    bool print_cigar = false;
+    bool output_json = false;
+    int match = 1;
+    int mismatch = 4;
+    int gap_open = 6;
+    int gap_extend = 1;
+    int full_length_bonus = 5;
+    string ref_seq;
+    bool debug = false;
+    bool banded_global = false;
+    bool pinned_alignment = false;
+    bool pin_left = false;
+
+    int c;
+    optind = 2; // force optind past command positional argument
+    while (true) {
+        static struct option long_options[] =
+        {
+            /* These options set a flag. */
+            //{"verbose", no_argument,       &verbose_flag, 1},
+            {"sequence", required_argument, 0, 's'},
+            {"seq-name", no_argument, 0, 'Q'},
+            {"json", no_argument, 0, 'j'},
+            {"match", required_argument, 0, 'm'},
+            {"mismatch", required_argument, 0, 'M'},
+            {"gap-open", required_argument, 0, 'g'},
+            {"gap-extend", required_argument, 0, 'e'},
+            {"reference", required_argument, 0, 'r'},
+            {"debug", no_argument, 0, 'D'},
+            {"banded-global", no_argument, 0, 'b'},
+            {"full-l-bonus", required_argument, 0, 'T'},
+            {"pinned", no_argument, 0, 'p'},
+            {"pinned-left", no_argument, 0, 'L'},
+            {0, 0, 0, 0}
+        };
+
+        int option_index = 0;
+        c = getopt_long (argc, argv, "s:jhQ:m:M:g:e:Dr:F:O:bT:pL",
+                long_options, &option_index);
+
+        /* Detect the end of the options. */
+        if (c == -1)
+            break;
+
+        switch (c)
+        {
+        case 's':
+            seq = optarg;
+            break;
+
+        case 'Q':
+            seq_name = optarg;
+            break;
+
+        case 'j':
+            output_json = true;
+            break;
+
+        case 'm':
+            match = atoi(optarg);
+            break;
+
+        case 'M':
+            mismatch = atoi(optarg);
+            break;
+
+        case 'g':
+            gap_open = atoi(optarg);
+            break;
+
+        case 'e':
+            gap_extend = atoi(optarg);
+            break;
+
+        case 'T':
+            full_length_bonus = atoi(optarg);
+            break;
+
+        case 'r':
+            ref_seq = optarg;
+            break;
+
+        case 'D':
+            debug = true;
+            break;
+
+        case 'b':
+            banded_global = true;
+            break;
+
+        case 'p':
+            pinned_alignment = true;
+            break;
+
+        case 'L':
+            pin_left = true;
+            break;
+
+        case 'h':
+        case '?':
+            /* getopt_long already printed an error message. */
+            help_align(argv);
+            exit(1);
+            break;
+
+        default:
+            abort ();
+        }
+    }
+
+    VG* graph = nullptr;
+    if (ref_seq.empty()) {
+        // Only look at a filename if we don't have an explicit reference
+        // sequence.
+        get_input_file(optind, argc, argv, [&](istream& in) {
+            graph = new VG(in);
+        });
+    }
+    
+    Alignment alignment;
+    if (!ref_seq.empty()) {
+        SSWAligner ssw = SSWAligner(match, mismatch, gap_open, gap_extend);
+        alignment = ssw.align(seq, ref_seq);
+    } else {
+        Aligner aligner = Aligner(match, mismatch, gap_open, gap_extend, full_length_bonus);
+        alignment = graph->align(seq, &aligner, 0, pinned_alignment, pin_left,
+            banded_global, 0, max(seq.size(), graph->length()), debug);
+    }
+
+    if (!seq_name.empty()) {
+        alignment.set_name(seq_name);
+    }
+
+    if (output_json) {
+        cout << pb2json(alignment) << endl;
+    } else {
+        function<Alignment(uint64_t)> lambda =
+            [&alignment] (uint64_t n) {
+                return alignment;
+            };
+        stream::write(cout, 1, lambda);
+    }
+
+    if (graph != nullptr) {
+        delete graph;
+    }
+
+    return 0;
+
+}
+
+// Register subcommand
+static Subcommand vg_align("align", "local alignment", main_align);
+

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -46,7 +46,7 @@ void help_map(char** argv) {
          << "    -o, --gap-open INT      use this gap open penalty [6]" << endl
          << "    -y, --gap-extend INT    use this gap extension penalty [1]" << endl
          << "    -L, --full-l-bonus INT  the full-length alignment bonus [5]" << endl
-         << "    -m, --strip-bonuses     exclude bonuses from reported scores" << endl
+         << "    -m, --include-bonuses   include bonuses in reported scores" << endl
          << "    -A, --qual-adjust       perform base quality adjusted alignments (requires base quality input)" << endl
          << "input:" << endl
          << "    -s, --sequence STR      align a string to the graph in graph.vg using partial order alignment" << endl
@@ -114,7 +114,7 @@ int main_map(int argc, char** argv) {
     int8_t gap_open = 6;
     int8_t gap_extend = 1;
     int8_t full_length_bonus = 5;
-    bool strip_bonus = false;
+    bool strip_bonuses = true;
     bool qual_adjust_alignments = false;
     int extra_multimaps = 64;
     int min_multimaps = 4;
@@ -191,7 +191,7 @@ int main_map(int argc, char** argv) {
                 {"fragment", required_argument, 0, 'I'},
                 {"fragment-x", required_argument, 0, 'S'},
                 {"full-l-bonus", required_argument, 0, 'L'},
-                {"strip-bonuses", no_argument, 0, 'm'},
+                {"include-bonuses", no_argument, 0, 'm'},
                 {"seed-chance", required_argument, 0, 'e'},
                 {"drop-chain", required_argument, 0, 'C'},
                 {"mq-overlap", required_argument, 0, 'n'},
@@ -258,7 +258,7 @@ int main_map(int argc, char** argv) {
             break;
         
         case 'm':
-            strip_bonus = true;
+            strip_bonuses = false;
             break;
 
         case 'T':
@@ -606,7 +606,7 @@ int main_map(int argc, char** argv) {
         m->mem_chaining = mem_chaining;
         m->max_target_factor = max_target_factor;
         m->set_alignment_scores(match, mismatch, gap_open, gap_extend, full_length_bonus);
-        m->strip_bonuses = strip_bonus;
+        m->strip_bonuses = strip_bonuses;
         m->adjust_alignments_for_base_quality = qual_adjust_alignments;
         m->extra_multimaps = extra_multimaps;
         m->mapping_quality_method = mapping_quality_method;

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -46,6 +46,7 @@ void help_map(char** argv) {
          << "    -o, --gap-open INT      use this gap open penalty [6]" << endl
          << "    -y, --gap-extend INT    use this gap extension penalty [1]" << endl
          << "    -L, --full-l-bonus INT  the full-length alignment bonus [5]" << endl
+         << "    -m, --strip-bonuses     exclude bonuses from reported scores" << endl
          << "    -A, --qual-adjust       perform base quality adjusted alignments (requires base quality input)" << endl
          << "input:" << endl
          << "    -s, --sequence STR      align a string to the graph in graph.vg using partial order alignment" << endl
@@ -113,6 +114,7 @@ int main_map(int argc, char** argv) {
     int8_t gap_open = 6;
     int8_t gap_extend = 1;
     int8_t full_length_bonus = 5;
+    bool strip_bonus = false;
     bool qual_adjust_alignments = false;
     int extra_multimaps = 64;
     int min_multimaps = 4;
@@ -189,6 +191,7 @@ int main_map(int argc, char** argv) {
                 {"fragment", required_argument, 0, 'I'},
                 {"fragment-x", required_argument, 0, 'S'},
                 {"full-l-bonus", required_argument, 0, 'L'},
+                {"strip-bonuses", no_argument, 0, 'm'},
                 {"seed-chance", required_argument, 0, 'e'},
                 {"drop-chain", required_argument, 0, 'C'},
                 {"mq-overlap", required_argument, 0, 'n'},
@@ -204,7 +207,7 @@ int main_map(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "s:J:Q:d:x:g:T:N:R:c:M:t:G:jb:Kf:iw:P:Dk:Y:r:W:6aH:Z:q:z:o:y:Au:B:I:S:l:e:C:v:V:O:L:n:E:X:UpF:",
+        c = getopt_long (argc, argv, "s:J:Q:d:x:g:T:N:R:c:M:t:G:jb:Kf:iw:P:Dk:Y:r:W:6aH:Z:q:z:o:y:Au:B:I:S:l:e:C:v:V:O:L:n:E:X:UpF:m",
                          long_options, &option_index);
 
 
@@ -252,6 +255,10 @@ int main_map(int argc, char** argv) {
 
         case 'L':
             full_length_bonus = atoi(optarg);
+            break;
+        
+        case 'm':
+            strip_bonus = true;
             break;
 
         case 'T':
@@ -599,6 +606,7 @@ int main_map(int argc, char** argv) {
         m->mem_chaining = mem_chaining;
         m->max_target_factor = max_target_factor;
         m->set_alignment_scores(match, mismatch, gap_open, gap_extend, full_length_bonus);
+        m->strip_bonuses = strip_bonus;
         m->adjust_alignments_for_base_quality = qual_adjust_alignments;
         m->extra_multimaps = extra_multimaps;
         m->mapping_quality_method = mapping_quality_method;

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -16,9 +16,9 @@ is  "$(vg map -s ATCACCTAATTTAATCTTCACAGC -x x.xg -g x.gcsa -j - | jq '.path.map
 
 is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -j | tr ',' '\n' | grep node_id | grep "72\|73\|76\|77" | wc -l) 4 "global alignment traverses the correct path"
 
-is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 48 "alignment score is as expected"
+is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 58 "alignment score is as expected"
 
-is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 96 "scoring parameters are respected"
+is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 106 "scoring parameters are respected"
 
 is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --full-l-bonus 5 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 58 "full length bonus works"
 

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -57,8 +57,8 @@ is $(samtools bam2fq minigiab/NA12878.chr22.tiny.bam 2>/dev/null | vg map -f - -
 
 is $(samtools bam2fq minigiab/NA12878.chr22.tiny.bam 2>/dev/null | vg map -f - -x giab.xg -g giab.gcsa -M 2 -j | jq -c 'select(.is_secondary | not)' | wc -l) $(samtools bam2fq minigiab/NA12878.chr22.tiny.bam 2>/dev/null | vg map -f - -x giab.xg -g giab.gcsa -M 1 -j | wc -l) "allowing secondary alignments with MEM mapping does not change number of primary alignments"
 
-count_prev=$(samtools sort -no minigiab/NA12878.chr22.tiny.bam x | samtools bam2fq - 2>/dev/null | vg map -if - -x giab.xg -g giab.gcsa | vg view -a - | jq .fragment_prev.name | grep null | wc -l)
-count_next=$(samtools sort -no minigiab/NA12878.chr22.tiny.bam x | samtools bam2fq - 2>/dev/null | vg map -if - -x giab.xg -g giab.gcsa | vg view -a - | jq .fragment_next.name | grep null | wc -l)
+count_prev=$(samtools sort -n minigiab/NA12878.chr22.tiny.bam | samtools bam2fq - 2>/dev/null | vg map -if - -x giab.xg -g giab.gcsa | vg view -a - | jq .fragment_prev.name | grep null | wc -l)
+count_next=$(samtools sort -n minigiab/NA12878.chr22.tiny.bam | samtools bam2fq - 2>/dev/null | vg map -if - -x giab.xg -g giab.gcsa | vg view -a - | jq .fragment_next.name | grep null | wc -l)
 
 is $count_prev $count_next "vg connects paired-end reads in gam output"
 

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 32
+plan tests 34
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
@@ -19,6 +19,10 @@ is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcs
 is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 48 "alignment score is as expected"
 
 is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 96 "scoring parameters are respected"
+
+is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --full-l-bonus 5 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 58 "full length bonus works"
+
+is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 --full-l-bonus 0 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 96 "full length bonus can be set to 0"
 
 vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -d x >/dev/null
 is $? 0 "vg map takes -d as input without a variant graph"

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 34
+plan tests 35
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
@@ -21,6 +21,8 @@ is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcs
 is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 106 "scoring parameters are respected"
 
 is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --full-l-bonus 5 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 58 "full length bonus works"
+
+is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --full-l-bonus 5 --strip-bonuses -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 48 "full length bonus can be stripped"
 
 is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 --full-l-bonus 0 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 96 "full length bonus can be set to 0"
 

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -31,7 +31,7 @@ is $? 0 "vg map takes -d as input without a variant graph"
 
 is $(vg map -s TCAGATTCTCATCCCTCCTCAAGGGCGTCTAACTACTCCACATCAAAGCTACCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAG -x x.xg -g x.gcsa -j | jq . | grep '"sequence": "G"' | wc -l) 1 "vg map can align across a SNP"
 
-is $(vg map -r <(vg sim -s 69 -n 1000 -l 100 x.vg) -x x.xg -g x.gcsa  | vg view -a - | jq -c '.score == 100 // [.score, .sequence]' | grep -v true | wc -l) 0 "alignment works on a small graph"
+is $(vg map --strip-bonuses --reads <(vg sim -s 69 -n 1000 -l 100 -x x.xg) -x x.xg -g x.gcsa  | vg view -a - | jq -c '.score == 100 // [.score, .sequence]' | grep true | wc -l) 1000 "alignment works on a small graph"
 
 seq=TCAGATTCTCATCCCTCCTCAAGGGCTTCTAACTACTCCACATCAAAGCTACCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAG
 is $(vg map -s $seq -x x.xg -g x.gcsa | vg view -a - | jq -c '[.score, .sequence, .path.node_id]' | md5sum | awk '{print $1}') \

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -16,22 +16,22 @@ is  "$(vg map -s ATCACCTAATTTAATCTTCACAGC -x x.xg -g x.gcsa -j - | jq '.path.map
 
 is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -j | tr ',' '\n' | grep node_id | grep "72\|73\|76\|77" | wc -l) 4 "global alignment traverses the correct path"
 
-is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 58 "alignment score is as expected"
+is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 48 "alignment score is as expected"
 
-is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 106 "scoring parameters are respected"
+is $(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }') 96 "scoring parameters are respected"
 
-is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --full-l-bonus 5 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 58 "full length bonus works"
+is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --full-l-bonus 5 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 48 "full length bonus is stripped by default"
 
-is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --full-l-bonus 5 --strip-bonuses -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 48 "full length bonus can be stripped"
+is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --full-l-bonus 5 --include-bonuses -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 58 "full length bonus can be included"
 
-is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 --full-l-bonus 0 -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 96 "full length bonus can be set to 0"
+is "$(vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --match 2 --mismatch 2 --gap-open 3 --gap-extend 1 --full-l-bonus 0 --include-bonuses -x x.xg -g x.gcsa -j | tr ',' '\n' | grep score | sed "s/}//g" | awk '{ print $2 }')" 96 "full length bonus can be set to 0"
 
 vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -d x >/dev/null
 is $? 0 "vg map takes -d as input without a variant graph"
 
 is $(vg map -s TCAGATTCTCATCCCTCCTCAAGGGCGTCTAACTACTCCACATCAAAGCTACCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAG -x x.xg -g x.gcsa -j | jq . | grep '"sequence": "G"' | wc -l) 1 "vg map can align across a SNP"
 
-is $(vg map --strip-bonuses --reads <(vg sim -s 69 -n 1000 -l 100 -x x.xg) -x x.xg -g x.gcsa  | vg view -a - | jq -c '.score == 100 // [.score, .sequence]' | grep true | wc -l) 1000 "alignment works on a small graph"
+is $(vg map --reads <(vg sim -s 69 -n 1000 -l 100 -x x.xg) -x x.xg -g x.gcsa  | vg view -a - | jq -c '.score == 100 // [.score, .sequence]' | grep true | wc -l) 1000 "alignment works on a small graph"
 
 seq=TCAGATTCTCATCCCTCCTCAAGGGCTTCTAACTACTCCACATCAAAGCTACCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAG
 is $(vg map -s $seq -x x.xg -g x.gcsa | vg view -a - | jq -c '[.score, .sequence, .path.node_id]' | md5sum | awk '{print $1}') \


### PR DESCRIPTION
This restores the old score reporting behavior, which is to report the score that the DP actually used to select the alignment.

(There are also some other fixes in the branch, like a patch for #839, conversion of vg align to a real subcommand, and fixes for mapper tests that were throwing errors but succeeding.)

If you want scores without bonuses (maybe because you want score to conveniently equal number of matches, or because some downstream tool works better with those scores), there's a new `--strip-bonuses` option.

I'm still not quite happy with the design here (@jeizenga is right that we probably should consolidate all the scoring stuff in the aligner, but the mapper needs to do re-scoring to account for distances when jumping between nodes). I could also swap the `--strip-bonuses` option for an `--include-bonuses` option and change the default.

This fixes #865 and #863.