### PR TITLE
Move alignment rescoring into the Aligner

### DIFF
--- a/src/gssw_aligner.cpp
+++ b/src/gssw_aligner.cpp
@@ -822,6 +822,64 @@ size_t BaseAligner::longest_detectable_gap(const Alignment& alignment) const {
     
 }
 
+int32_t BaseAligner::score_alignment(const Alignment& aln, const function<size_t(pos_t, pos_t, size_t)>& estimate_distance,
+    bool strip_bonuses) {
+    
+    int score = 0;
+    int read_offset = 0;
+    auto& path = aln.path();
+    for (int i = 0; i < path.mapping_size(); ++i) {
+        // For each mapping
+        auto& mapping = path.mapping(i);
+        for (int j = 0; j < mapping.edit_size(); ++j) {
+            // For each edit in the mapping
+            auto& edit = mapping.edit(j);
+            
+            // Score the edit according to its type
+            if (edit_is_match(edit)) {
+                score += score_exact_match(aln, read_offset, edit.to_length());
+            } else if (edit_is_sub(edit)) {
+                score -= mismatch * edit.sequence().size();
+            } else if (edit_is_deletion(edit)) {
+                score -= gap_open + edit.from_length() * gap_extension;
+            } else if (edit_is_insertion(edit)
+                       && !((i == 0 && j == 0)
+                            || (i == path.mapping_size()-1
+                                && j == mapping.edit_size()-1))) {
+                // todo how do we score this qual adjusted?
+                score -= gap_open + edit.to_length() * gap_extension;
+            }
+            read_offset += edit.to_length();
+        }
+        // score any intervening gaps in mappings using approximate distances
+        if (i+1 < path.mapping_size()) {
+            // what is the distance between the last position of this mapping
+            // and the first of the next
+            Position last_pos = mapping.position();
+            last_pos.set_offset(last_pos.offset() + mapping_from_length(mapping));
+            Position next_pos = path.mapping(i+1).position();
+            // Estimate the distance
+            int dist = estimate_distance(make_pos_t(last_pos), make_pos_t(next_pos), aln.sequence().size());
+            if (dist > 0) {
+                // If it's nonzero, score it as a deletion gap
+                score -= gap_open + dist * gap_extension;
+            }
+        }
+    }
+    
+    if (!strip_bonuses) {
+        // We should report any bonuses used in the DP in the final score
+        if (!softclip_start(aln)) {
+            score += full_length_bonus;
+        }
+        if (!softclip_end(aln)) {
+            score += full_length_bonus;
+        }
+    }
+    
+    return max(0, score);
+}
+
 Aligner::Aligner(int8_t _match,
                  int8_t _mismatch,
                  int8_t _gap_open,
@@ -1141,6 +1199,12 @@ void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>&
     }
 }
 
+// Scoring an exact match is very simple in an ordinary Aligner
+
+int32_t Aligner::score_exact_match(const Alignment& aln, size_t read_offset, size_t length) {
+    return match * length;
+}
+
 int32_t Aligner::score_exact_match(const string& sequence) const {
     return match * sequence.length();
 }
@@ -1402,6 +1466,18 @@ void QualAdjAligner::align_global_banded_multi(Alignment& alignment, vector<Alig
     
     band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     
+}
+
+int32_t QualAdjAligner::score_exact_match(const Alignment& aln, size_t read_offset, size_t length) {
+    auto& sequence = aln.sequence();
+    auto& base_quality = aln.quality();
+    int32_t score = 0;
+    for (int32_t i = 0; i < sequence.length(); i++) {
+        // index 5 x 5 score matrices (ACGTN)
+        // always have match so that row and column index are same and can combine algebraically
+        score += score_matrix[25 * base_quality[i] + 6 * nt_table[sequence[i]]];
+    }
+    return score;
 }
 
 int32_t QualAdjAligner::score_exact_match(const string& sequence, const string& base_quality) const {

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2672,7 +2672,7 @@ Alignment Mapper::align_maybe_flip(const Alignment& base, VG& graph, bool flip, 
                          pinned_alignment,
                          pinned_reverse,
                          banded_global);
-    if (strip_bonuses && !banded_global) aln.set_score(rescore_without_full_length_bonus(aln));
+    if (strip_bonuses && !banded_global) aln.set_score(remove_full_length_bonus(aln));
     if (flip) {
         aln = reverse_complement_alignment(
             aln,
@@ -4117,14 +4117,18 @@ Alignment Mapper::patch_alignment(const Alignment& aln, int max_patch_length) {
 // handles split alignments, where gaps of unknown length are
 // by estimating length using the positional paths embedded in the graph
 int32_t Mapper::score_alignment(const Alignment& aln, bool use_approx_distance) {
+    
+    // Find the right aligner to score with
+    BaseAligner* aligner = adjust_alignments_for_base_quality ? (BaseAligner*) qual_adj_aligner : (BaseAligner*) regular_aligner;
+    
     if (use_approx_distance) {
         // Use an approximation
-        return score_alignment(aln, [&](pos_t last, pos_t next, size_t max_search) {
+        return aligner->score_alignment(aln, [&](pos_t last, pos_t next, size_t max_search) {
             return approx_distance(last, next);
-        });
+        }, strip_bonuses);
     } else {
         // Use the exact method, and if we hit the limit, fall back to the approximate method.
-        return score_alignment(aln, [&](pos_t last, pos_t next, size_t max_search) {
+        return aligner->score_alignment(aln, [&](pos_t last, pos_t next, size_t max_search) {
             auto dist = graph_distance(last, next, max_search);
             if (dist == max_search) {
 #ifdef debug_mapper
@@ -4136,91 +4140,12 @@ int32_t Mapper::score_alignment(const Alignment& aln, bool use_approx_distance) 
                 dist = abs(approx_distance(last, next));
             }
             return dist;
-        });
+        }, strip_bonuses);
     }
+    
 }
 
-// generate a score from the alignment without realigning
-// handles split alignments with a callback that estimates distance (with a max search limit)
-int32_t Mapper::score_alignment(const Alignment& aln, const function<size_t(pos_t, pos_t, size_t)>& estimate_distance) {
-    int score = 0;
-    int read_offset = 0;
-    auto& path = aln.path();
-    for (int i = 0; i < path.mapping_size(); ++i) {
-        auto& mapping = path.mapping(i);
-        //cerr << "looking at mapping " << pb2json(mapping) << endl;
-        for (int j = 0; j < mapping.edit_size(); ++j) {
-            auto& edit = mapping.edit(j);
-            //cerr << "looking at edit " << pb2json(edit) << endl;
-            if (edit_is_match(edit)) {
-                if (!aln.quality().empty() && adjust_alignments_for_base_quality) {
-                    score += qual_adj_aligner->score_exact_match(
-                        aln.sequence().substr(read_offset, edit.to_length()),
-                        aln.quality().substr(read_offset, edit.to_length()));
-                } else {
-                    score += edit.from_length()*regular_aligner->match;
-                }
-            } else if (edit_is_sub(edit)) {
-                score -= regular_aligner->mismatch * edit.sequence().size();
-            } else if (edit_is_deletion(edit)) {
-                score -= regular_aligner->gap_open + edit.from_length()*regular_aligner->gap_extension;
-            } else if (edit_is_insertion(edit)
-                       && !((i == 0 && j == 0)
-                            || (i == path.mapping_size()-1
-                                && j == mapping.edit_size()-1))) {
-                // todo how do we score this qual adjusted?
-                score -= regular_aligner->gap_open + edit.to_length()*regular_aligner->gap_extension;
-            }
-            read_offset += edit.to_length();
-        }
-        // score any intervening gaps in mappings using approximate distances
-        if (i+1 < path.mapping_size()) {
-            // what is the distance between the last position of this mapping
-            // and the first of the next
-            Position last_pos = mapping.position();
-            last_pos.set_offset(last_pos.offset() + mapping_from_length(mapping));
-            Position next_pos = path.mapping(i+1).position();
-#ifdef debug_mapper
-#pragma omp critical
-            {
-                if (debug) cerr << "gap: " << make_pos_t(last_pos) << " to " << make_pos_t(next_pos) << endl;
-            }
-#endif
-            int dist = estimate_distance(make_pos_t(last_pos), make_pos_t(next_pos), aln.sequence().size());
-#ifdef debug_mapper
-#pragma omp critical
-            {
-                if (debug) cerr << "distance from " << pb2json(last_pos) << " to " << pb2json(next_pos) << " is " << dist << endl;
-            }
-#endif
-            if (dist > 0) {
-                score -= regular_aligner->gap_open + dist * regular_aligner->gap_extension;
-            }
-        }
-    }
-    if (!strip_bonuses) {
-        // We should report any bonuses used in the DP in the final score
-        if (!softclip_start(aln)) {
-            score += (adjust_alignments_for_base_quality ?
-                qual_adj_aligner->full_length_bonus : 
-                regular_aligner->full_length_bonus);
-        }
-        if (!softclip_end(aln)) {
-            score += (adjust_alignments_for_base_quality ? 
-                qual_adj_aligner->full_length_bonus : 
-                regular_aligner->full_length_bonus);
-        }
-    }
-#ifdef debug_mapper
-#pragma omp critical
-    {
-        if (debug) cerr << "score from score_alignment " << score << endl;
-    }
-#endif
-    return max(0, score);
-}
-
-int32_t Mapper::rescore_without_full_length_bonus(const Alignment& aln) {
+int32_t Mapper::remove_full_length_bonus(const Alignment& aln) {
 #ifdef debug_mapper
 #pragma omp critical
     {

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -465,16 +465,13 @@ public:
     /// Use the scoring provided by the internal aligner to re-score the
     /// alignment, scoring gaps between nodes using graph distance from the XG
     /// index. Can use either approximate or exact (with approximate fallback)
-    /// XG-based distance estimation.
+    /// XG-based distance estimation. Will strip out bonuses if the appropriate
+    /// Mapper flag is set.
     int32_t score_alignment(const Alignment& aln, bool use_approx_distance = false);
-    /// Use the scoring provided by the internal aligner to re-score the
-    /// alignment, scoring gaps between nodes using a custom function (which
-    /// takes the from position, the to position, and a search limit in bp that
-    /// happens to be the read length). Doesn't touch the XG index.
-    int32_t score_alignment(const Alignment& aln, const function<size_t(pos_t, pos_t, size_t)>& estimate_distance);
     
-    // lightweight, assumes we've aligned the full read with one alignment step, just subtract the bonus from the final score
-    int32_t rescore_without_full_length_bonus(const Alignment& aln);
+    /// Given an alignment scored with full length bonuses on, subtract out the full length bonus if it was applied.
+    int32_t remove_full_length_bonus(const Alignment& aln);
+    
     // run through the alignment and attempt to align unaligned parts of the alignment to the graph in the region where they are anchored
     Alignment patch_alignment(const Alignment& aln, int max_patch_length);
     // get the graph context of a particular cluster, using a given alignment to describe the required size


### PR DESCRIPTION
There's still `rescore_without_full_length_bonus`, which I am renaming to `remove_full_length_bonus`, to move. But this moves the main `score_alignment` function, leaving only a convenience wrapper in the Mapper that dispatches with one of the the Mapper's available distance estimation methods and the appropriate aligner.