### PR TITLE
Add basic framework for a log miner

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -203,6 +203,15 @@ set +e
 pytest -vv "${PYTEST_TEST_SPEC}" --junitxml=test-report.xml ${SHOW_OPT}
 PYRET="$?"
 
+# Generate a report in two files: HTML full output, and a Markdown summary.
+# Takes as input the Jenkins test result XML and the work directory with the
+# test output files.
+jenkins/mine-logs test-report.xml vgci-work/ report.html summary.md
+
+# Put the report on Github for the current pull request or commit.
+jenkins/post-report report.html summary.md
+
+
 if [ ! -z "${BUILD_NUMBER}" ]
 then
     # We are running on Jenkins (and not manually running the Jenkins tests), so

--- a/jenkins/mine-logs
+++ b/jenkins/mine-logs
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Mine the Jenkins test log XML and the test output files and generate a report
+# of how good VG is at various tasks.
+# TODO: replace with a real implementation (maybe in Python).
+
+usage() {
+    # Print usage to stderr
+    exec 1>&2
+    printf "Usage: $0 XML_IN WORKDIR_IN HTML_OUT MD_OUT \n"
+    exit 1
+}
+
+if [[ "$#" -ne 4 ]]; then
+    # We need all the arguments
+    usage
+fi
+
+# Gather all the arguments
+XML_IN="${1}"; shift
+WORKDIR_IN="${1}"; shift
+HTML_OUT="${1}"; shift
+MD_OUT="${1}"; shift
+
+# Have a stub implementation
+cat >"${HTML_OUT}" <<EOF
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Test Report</title>
+    </head>
+    <body>
+        <h1>Test Report</h1>
+EOF
+
+XML_SIZE=$(stat --printf='%s' "${XML_IN}")
+echo "<p>Tests created ${XML_SIZE} bytes of XML.</p>" >>"${HTML_OUT}"
+
+cat >>"${HTML_OUT}" <<EOF
+    </body>
+</html>
+EOF
+
+echo "Generated HTML report ${HTML_OUT}"
+
+# In the Markdown, "{{REPORT_URL}}" will be replaced with the URL to the uploaded HTML report.
+cat >"${MD_OUT}" <<EOF
+This is a summary of the performance of this commit or PR.
+
+The full report is available [here]({{REPORT_URL}}).
+EOF
+
+echo "Generated Markdown summary ${MD_OUT}"
+
+

--- a/jenkins/post-report
+++ b/jenkins/post-report
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+# Upload the generated report HTML and summary.
+# TODO: replace with a real implementation (maybe in Python).
+
+usage() {
+    # Print usage to stderr
+    exec 1>&2
+    printf "Usage: $0 HTML_IN MD_IN \n"
+    exit 1
+}
+
+if [[ "$#" -ne 2 ]]; then
+    # We need all the arguments
+    usage
+fi
+
+# Gather all the arguments
+HTML_IN="${1}"; shift
+MD_IN="${1}"; shift
+
+# Figure out where we are. In the real version this will affect our behavior.
+if [ ! -z "${BUILD_NUMBER}" ]; then
+    echo "On Jenkins"
+    
+    if [ -z ${ghprbActualCommit} ]; then
+        echo "Running on a branch"
+    else
+        echo "Running on a pull request"
+    fi
+    
+else
+    echo "Running locally"
+fi
+
+# TODO: upload HTML
+echo "HTML to upload:"
+cat "${HTML_IN}"
+
+# TODO: upload Markdown
+# In the Markdown, "{{REPORT_URL}}" will be replaced with the URL to the uploaded HTML report.
+echo "Markdown to post:"
+cat "${MD_IN}" | sed "s|{{REPORT_URL}}|file://${HTML_IN}|g"
+
+
+
+
+


### PR DESCRIPTION
We're going to have one script crunch the test logs and make a report.
Another script will upload the report to the Web somewhere and post
about it on the relevant PR or commit.

The upshot of all this is that we will be able to have nice reports
with performance statistics and maybe even plots in the Github
comments for PRs.

Fixes #889