### PR TITLE
Make align and map agree about full length bonuses

### DIFF
--- a/src/gssw_aligner.cpp
+++ b/src/gssw_aligner.cpp
@@ -880,12 +880,14 @@ int32_t BaseAligner::score_alignment(const Alignment& aln, const function<size_t
     return max(0, score);
 }
 
-int32_t BaseAligner::remove_bonuses(const Alignment& aln) {
+int32_t BaseAligner::remove_bonuses(const Alignment& aln, bool pinned, bool pin_left) {
     int32_t score = aln.score();
-    if (softclip_start(aln) == 0) {
+    if (softclip_start(aln) == 0 && !(pinned && pin_left)) {
+        // No softclip at the start, and a left end bonus was applied.
         score -= full_length_bonus;
     }
-    if (softclip_end(aln) == 0) {
+    if (softclip_end(aln) == 0 && !(pinned && !pin_left)) {
+        // No softclip at the end, and a right end bonus was applied.
         score -= full_length_bonus;
     }
     return score;

--- a/src/gssw_aligner.cpp
+++ b/src/gssw_aligner.cpp
@@ -880,6 +880,18 @@ int32_t BaseAligner::score_alignment(const Alignment& aln, const function<size_t
     return max(0, score);
 }
 
+int32_t BaseAligner::remove_bonuses(const Alignment& aln) {
+    int32_t score = aln.score();
+    if (softclip_start(aln) == 0) {
+        score -= full_length_bonus;
+    }
+    if (softclip_end(aln) == 0) {
+        score -= full_length_bonus;
+    }
+    return score;
+}
+
+
 Aligner::Aligner(int8_t _match,
                  int8_t _mismatch,
                  int8_t _gap_open,

--- a/src/gssw_aligner.hpp
+++ b/src/gssw_aligner.hpp
@@ -160,6 +160,11 @@ namespace vg {
         /// May include full length bonus or not. TODO: bool flags are bad.
         virtual int32_t score_alignment(const Alignment& aln, const function<size_t(pos_t, pos_t, size_t)>& estimate_distance,
             bool strip_bonuses = false);
+            
+        /// Without necessarily rescoring the entire alignment, return the score
+        /// of the given alignment with bonuses removed. Assumes that bonuses
+        /// are actually included in the score.
+        virtual int32_t remove_bonuses(const Alignment& aln);
         
         // members
         int8_t* nt_table = nullptr;

--- a/src/gssw_aligner.hpp
+++ b/src/gssw_aligner.hpp
@@ -164,7 +164,8 @@ namespace vg {
         /// Without necessarily rescoring the entire alignment, return the score
         /// of the given alignment with bonuses removed. Assumes that bonuses
         /// are actually included in the score.
-        virtual int32_t remove_bonuses(const Alignment& aln);
+        /// Needs to know if the alignment was pinned-end or not, and, if so, which end was pinned.
+        virtual int32_t remove_bonuses(const Alignment& aln, bool pinned = false, bool pin_left = false);
         
         // members
         int8_t* nt_table = nullptr;


### PR DESCRIPTION
Now vg align will also strip out full length bonuses by default.

Fixes #863.

