### PR TITLE
Activate haplotype simulator

### DIFF
--- a/jenkins/mine-logs.py
+++ b/jenkins/mine-logs.py
@@ -107,7 +107,7 @@ def md_summary(xml_root):
         md += '{} tests passed, {} tests failed and {} tests skipped in {} seconds\n\n'.format(
             ts['passes'], ts['fails'], ts['skips'], ts['time'])
 
-        if ts['fails'] is not None and int(ts['fails']) > 1:
+        if ts['fails'] is not None and int(ts['fails']) >= 1:
             md += 'Failed tests:\n\n'
 
         for testcase in testsuite.iter('testcase'):


### PR DESCRIPTION
(on top of #899, which I think failed due to s3 idiocy on my part)

Relies on updated snp1kg graphs and indexes in S3.  Using temporary bucket for now, will move to cgl-pipeline-inputs when it passes.  