### PR TITLE
Add a SimpleDB-based mutex for uploading to the master report on S3

### DIFF
--- a/jenkins/post-report
+++ b/jenkins/post-report
@@ -2,7 +2,6 @@
 set -e
 
 # Upload the generated report HTML directory and summary.
-# TODO: replace with a real implementation (maybe in Python).
 
 usage() {
     # Print usage to stderr
@@ -20,6 +19,132 @@ fi
 HTML_DIR_IN="${1}"; shift
 MD_IN="${1}"; shift
 
+# Define mutex functions so that only one upload can happen at a time
+
+init_mutex() {
+    # Set up the mutex system. Takes no arguments.
+    aws configure set preview.sdb true
+    aws sdb create-domain --domain-name vgci 2>/dev/null || true
+}
+
+read_mutex() {
+    # Given the name of a mutex, read the mutex state.
+    # Sets global MUTEX_HOLDER to the mutex holder ID
+    
+    local MUTEX_NAME="${1}"; shift
+    
+    # Make the mutex if it doesn't exist
+    aws sdb put-attributes --domain-name vgci --item-name "${MUTEX_NAME}" --attributes "Name=mutexholder,Value=free,Replace=true" --expected "Name=mutexholder,Exists=false" 2>/dev/null || true
+    
+    # Download the mutex data
+    local RESULT="$(aws sdb get-attributes --domain-name vgci --item-name ${MUTEX_NAME} --consistent-read)"
+    # Pull out the holder
+    MUTEX_HOLDER="$(echo "${RESULT}" | grep -A 1 "mutexholder" | tail -n1 | cut -f2 -d':' | tr -d " \"")"
+
+}
+
+unlock_mutex() {
+    # Unlock the mutex with the given name, if it is still held by the current
+    # value of MUTEX_HOLDER.
+    
+    local MUTEX_NAME="${1}"; shift
+
+    echo "Unlocking ${MUTEX_NAME} for ${MUTEX_HOLDER}"
+    
+    aws sdb put-attributes --domain-name vgci --item-name "${MUTEX_NAME}" --attributes "Name=mutexholder,Value=free,Replace=true" --expected "Name=mutexholder,Value=${MUTEX_HOLDER}" 2>/dev/null || true
+}
+
+lock_mutex() {
+    # Given a mutex name, a wait period, and a max number of loops per previous
+    # lock, lock the mutex. If someone else holds the mutex, we poll again after
+    # the wait period. If we loop for the max number of loops on the same
+    # previous lock holder, we time them out.
+    
+    local MUTEX_NAME="${1}"; shift
+    local POLL_SECONDS="${1}"; shift
+    local TIMEOUT_LOOPS="${1}"; shift
+    
+    # Make a unique value for our mutex sentinel
+    local MUTEX_SENTINEL=$(uuidgen)
+    
+    # Get the mutex state
+    read_mutex "${MUTEX_NAME}"
+    
+    while [ "${MUTEX_HOLDER}" != "${MUTEX_SENTINEL}" ]; do
+        # Until we hold the mutex
+    
+        local LAST_HOLDER="nobody"
+        local WAIT_COUNT=0
+        
+        while [ "${MUTEX_HOLDER}" != "free" ]; do
+            # Someone has the mutex. Wait for them to go away or time them out.
+            
+            echo "Mutex is ${MUTEX_HOLDER}"
+            
+            if [ "${LAST_HOLDER}" != "${MUTEX_HOLDER}" ]; then
+                # It's someone new, so reset the count
+                local LAST_HOLDER="${MUTEX_HOLDER}"
+                local WAIT_COUNT=0
+            fi
+            
+            local WAIT_COUNT=$((WAIT_COUNT+1))
+            if [ "${WAIT_COUNT}" -gt "${TIMEOUT_LOOPS}" ]; then
+                # We need to bump this person
+                echo "Time out ${MUTEX_HOLDER}"
+                unlock_mutex "${MUTEX_NAME}"
+            fi
+            
+            # Wait for things to happen
+            sleep "${POLL_SECONDS}"
+            
+            # See if anyone else has the mutex or if it is free
+            read_mutex "${MUTEX_NAME}"
+            
+        done
+        
+        echo "Mutex is ${MUTEX_HOLDER}"
+        
+        # If we get here we saw it as free
+        # Try to take it
+        aws sdb put-attributes --domain-name vgci --item-name "${MUTEX_NAME}" --attributes "Name=mutexholder,Value=${MUTEX_SENTINEL},Replace=true" --expected "Name=mutexholder,Value=free" || true
+        
+        # See if it worked
+        read_mutex "${MUTEX_NAME}"
+    
+    done
+    
+    # Now we hold the mutex
+    echo "Locked ${MUTEX_NAME} for ${MUTEX_HOLDER}"
+    
+}
+
+
+read_build_number() {
+    # Given the name of a SimpleDB item, read the buildnumber key and set
+    # OLD_BUILD_NUMBER. Defaults it to 0.
+    
+    local ITEM_NAME="${1}"; shift
+    
+    # Make the attribute if it doesn't exist
+    aws sdb put-attributes --domain-name vgci --item-name "${ITEM_NAME}" --attributes "Name=buildnumber,Value=0,Replace=true" --expected "Name=buildnumber,Exists=false" 2>/dev/null || true
+    
+    # Download the data
+    local RESULT="$(aws sdb get-attributes --domain-name vgci --item-name ${ITEM_NAME} --consistent-read)"
+    # Pull out the build number
+    OLD_BUILD_NUMBER="$(echo "${RESULT}" | grep -A 1 "buildnumber" | tail -n1 | cut -f2 -d':' | tr -d " \"")"
+}
+
+write_build_number() {
+    # Given the name of a SimpleDB item, and a build number, save the build number over whatever is there.
+    
+    local ITEM_NAME="${1}"; shift
+    local NEW_BUILD_NUMBER="${1}"; shift
+    
+    # Overwrite the attribute
+    aws sdb put-attributes --domain-name vgci --item-name "${ITEM_NAME}" --attributes "Name=buildnumber,Value=${NEW_BUILD_NUMBER},Replace=true"
+
+}
+
 # Figure out where we are. In the real version this will affect our behavior.
 if [ ! -z "${BUILD_NUMBER}" ]; then
     echo "On Jenkins"
@@ -28,13 +153,34 @@ if [ ! -z "${BUILD_NUMBER}" ]; then
     if [ -z ${ghprbActualCommit} ]; then
         echo "Running on master"
         
-        # Upload to the path for master, overwriting whatever was there.
-        HTML_PATH="vg_cgl/vg_ci/jenkins_reports/branch/master"
+        # On master we need to hold the mutex.
+        # Give anyone before us up to 5 1-minute increments to finish up before we boot them from the mutex.
+        init_mutex
+        lock_mutex "master_sync" 60 5
+        
+        # Load the last build number
+        read_build_number "master_sync"
+        
+        if [ "${BUILD_NUMBER}" -gt "${OLD_BUILD_NUMBER}" ]; then
+            # Upload to the path for master, overwriting whatever was there.
+            HTML_PATH="vg_cgl/vg_ci/jenkins_reports/branch/master"
+            
+            # Save the new higher build number
+            write_build_number "master_sync" "${BUILD_NUMBER}"
+            
+        else
+            # Just work on the commit, since a newer master build has already finished.
+            HTML_PATH="vg_cgl/vg_ci/jenkins_reports/commit/${GIT_COMMIT}"
+        fi
+        
     else
         echo "Running on a pull request"
         
         # Upload to a path specific to this commit.
         HTML_PATH="vg_cgl/vg_ci/jenkins_reports/commit/${ghprbActualCommit}"
+        
+        # Say we had 0 as the last build number
+        OLD_BUILD_NUMBER=0
     fi
     
     # Upload the HTML to S3 as the current master report
@@ -64,13 +210,15 @@ if [ ! -z "${BUILD_NUMBER}" ]; then
         # Normal master build
                 
         # Comment on the commit we built
-        jenkins/post-comment.py vgteam/vg --in_file processed.md --commit "${GIT_COMMIT}" || true        
+        jenkins/post-comment.py vgteam/vg --in_file processed.md --commit "${GIT_COMMIT}" || true    
+        
+        # We grabbed the mutex, so we need to release it
+        unlock_mutex "master_sync"    
     else
         # PR build so we comment on the PR
         # Won't work until GH_TOKEN env var is exposed on Jenkins
         jenkins/post-comment.py vgteam/vg --in_file processed.md --pr "${ghprbPullId}" || true
     fi
-    
 fi
 
 


### PR DESCRIPTION
Fixes #902 by using SimpleDB to coordinate S3 writes. Features a distributed mutex implementation in Bash.

When Glenn does #903 we should be able to use the same mutex to protect against intermingled files from different uploads being visible in S3.