### PR TITLE
Clean up jenkins markdown message

### DIFF
--- a/jenkins/mine-logs.py
+++ b/jenkins/mine-logs.py
@@ -11,6 +11,7 @@ import argparse
 import xml.etree.ElementTree as ET
 import textwrap
 import shutil
+import datetime
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser(description=__doc__, 
@@ -38,166 +39,170 @@ def testname_to_outstore(test_name):
     assert toks[0] == 'test' and len(toks) == 4
     return 'outstore-{}-{}-{}'.format(
         toks[1], toks[2].replace('lrc-kir', 'lrc_kir').upper(), toks[3])
-    
-def parse_junit_xml(xml_path, work_dir, suite_html_fn, case_html_fn, out_html,
-                    suite_md_fn, case_md_fn, out_md):
+
+
+def parse_testsuite_xml(testsuite):
     """
-    Scan through the JUnit Report.  Run the callbacks on the testsuitres as
-    well as each testcase for markdown and html
+    Flatten fields of interset from a TestSuite XML element into a dict
     """
-    xml_tree = ET.parse(xml_path)
-    xml_root = xml_tree.getroot()
-    
-    for testsuite in xml_root.iter('testsuite'):
-        ts_name = testsuite.attrib['name']
-        ts_tests = int(testsuite.attrib['tests'])
-        ts_fails = int(testsuite.attrib['failures'])
-        ts_skips = int(testsuite.attrib['skips'])
-        ts_time = int(float(testsuite.attrib['time']))
-
-        if suite_html_fn:
-            suite_html_fn(out_html, ts_name, ts_tests, ts_fails, ts_skips, ts_time)
-        if suite_md_fn:
-            suite_md_fn(out_md, ts_name, ts_tests, ts_fails, ts_skips, ts_time)
-    
-        for testcase in xml_root.iter('testcase'):
-            try:
-                if testcase.find('skipped') is not None:
-                    # skip skipped tests for now
-                    continue
-
-                if 'name' in testcase.attrib:
-                    tc_name = testcase.attrib['name']
-                else:
-                    name = 'Error: Name not found'
-
-                if testcase.find('system-out') is not None:
-                    tc_out = testcase.find('system-out').text
-                else:
-                    tc_out = None
-                
-                if testcase.find('system-err') is not None:
-                    tc_err = testcase.find('system-err').text
-                else:
-                    tc_err = None
-
-                if 'time' in testcase.attrib:
-                    tc_time = int(float(testcase.attrib['time']))
-                else:
-                    tc_time = -1
-                
-                failure = testcase.find('failure')
-                if failure is not None:
-                    tc_failure_txt = failure.text
-                    tc_failure_msg = failure.attrib['message']
-                else:
-                    tc_failure_txt = None
-                    tc_failure_msg = None
-                    
-                if case_html_fn:
-                    case_html_fn(out_html, tc_name, os.path.join(work_dir, testname_to_outstore(tc_name)),
-                                 tc_out, tc_err, tc_time, tc_failure_txt, tc_failure_msg)
-                if case_md_fn:
-                    case_md_fn(out_md, tc_name, os.path.join(work_dir, testname_to_outstore(tc_name)),
-                               tc_out, tc_err, tc_time, tc_failure_txt, tc_failure_msg)
-                    
-            except Exception as e:
-                logging.warning('Unable to parse test case: {}'.format(ET.tostring(testcase)))
-            
-
-def write_md_header(md_file):
-    """
-    Write the top of the MarkDown file
-    """
-    md_file.write('## vg Test Report Summary\n')
-    md_file.write('The full report')
-
-    if os.getenv('ghprbPullTitle'):
-        md_file.write(' for [PR \'{}\']({})'.format(os.getenv('ghprbPullTitle'), os.getenv('ghprbPullLink')))
-    elif os.getenv('ghprbActualCommit'):
-        md_file.write(' for commit {}'.format('ghprbActualCommit'))
-
-    md_file.write(' is available here [here]({{REPORT_URL}})\n\n')
-
-
-def write_md_testsuite(md_file, name, num_tests, num_fails, num_skips, total_time):
-    """
-    Write some statistics for the whole test suite
-    """
-    md_file.write('{} tests passed, {} tests failed and {} tests skipped in {} seconds\n\n'.format(
-        num_tests-num_fails-num_skips, num_fails, num_skips, total_time))
-    
-def write_md_testcase(html_file, name, outstore, stdout, stderr, seconds, fail_txt, fail_msg):
-    """
-    Given some information extracted from the XML, write a MarkDown summary
-    """
-    md = '### {}\n\n'.format(name)
-    if fail_txt is None:
-        md += 'Passed in {} seconds\n\n'.format(seconds)
-    else:
-        md += 'Failed in {} seconds\n\n'.format(seconds)
-        md += 'Failure Message: `{}`\n\n'.format(fail_msg)
-    if stdout:
-        md += 'Standard Output:\n\n'
-        for line in textwrap.wrap(stdout, 80):
-            md += '     ' + line + '\n'
-        md += '\n'
+    ts = dict()
+    ts['name'] = testsuite.get('name')
+    ts['tests'] = int(testsuite.get('tests', 0))
+    ts['fails'] = int(testsuite.get('failures', 0))
+    ts['skips'] = int(testsuite.get('skips', 0))
+    ts['errors'] = int(testsuite.get('errors', 0))
+    ts['passes'] = ts['tests'] - ts['fails'] - ts['skips']
+    ts['time'] = int(float(testsuite.get('time', 0)))
+    return ts
         
-    html_file.write(md)
-
-
-def write_html_header(html_file):
-    """
-    Write the top of the HTML file
-    """
-    html_file.write('''\
-<!DOCTYPE html>
-<html>
-    <head>
-        <title>vg Test Report</title>
-    </head>
-    <body>
-''')
-    html_file.write('<h2>vg Test Report</h2>\n')
-    if os.getenv('ghprbPullTitle'):
-        html_file.write('Pull Request \"{}\" <a href="{}"> (Link) </a>\n'.format(
-            os.getenv('ghprbPullTitle'), os.getenv('ghprbPullLink')))
-    elif os.getenv('ghprbActualCommit'):
-        html_file.write('<p>Commit ID {}</p>'.format('ghprbActualCommit'))
     
-def write_html_testsuite(html_file, name, num_tests, num_fails, num_skips, total_time):
+def parse_testcase_xml(testcase):
     """
-    Write some statistics for the whole test suite
+    Flatten fields of interest from a TestCase XML element into a dict,
+    where anything not found is None
     """
-    html_file.write('<p>{} tests passed, {} tests failed and {} tests skipped in {} seconds</p>\n'.format(
-        num_tests-num_fails-num_skips, num_fails, num_skips, total_time))
+    tc = dict()
+    tc['name'] = testcase.get('name')
+    tc['time'] = int(float(testcase.get('time', 0)))
 
-def write_html_testcase(html_file, name, outstore, stdout, stderr, seconds, fail_txt, fail_msg):
-    """
-    Given some information extracted from the XML, write a HTML view
-    """
-    html_file.write('<h3>{}</h3>\n'.format(name))
-    if fail_txt is None:
-        html_file.write('<p>Passed in {} seconds</p>\n'.format(seconds))
+    if testcase.find('system-out') is not None:
+        tc['stdout'] = testcase.find('system-out').text
     else:
-        html_file.write('<p>Failed in {} seconds</p>\n'.format(seconds))
-        html_file.write('<p>Failure Message: `{}`</p>\n'.format(fail_msg))
-    
-    # should just pass this in
-    report_dir = os.path.dirname(os.path.abspath(html_file.name))
-    
-    for plot_name in 'roc', 'qq':
-        plot_path = os.path.join(outstore, '{}.pdf'.format(plot_name))
-        if os.path.isfile(plot_path):
-            new_name = '{}-{}.pdf'.format(name, plot_name)
-            shutil.copy2(plot_path, os.path.join(report_dir, new_name))
-            html_file.write('<p><a href={}>{} Plot</a></p>\n'.format(new_name, plot_name.upper()))
+        tc['stdout'] = None
 
-    if stdout:
-        html_file.write('<p>Standard Output:</p>\n<p>')
-        for line in textwrap.wrap(stdout, 80):
-            html_file.write(line + '&#10')
-        html_file.write('</p>')
+    if testcase.find('system-err') is not None:
+        tc['stderr'] = testcase.find('system-err').text
+    else:
+        tc['stderr'] = None
+
+    failure = testcase.find('failure')
+    if failure is not None:
+        tc['fail-txt'] = failure.text
+        tc['fail-msg'] = failure.get('message')
+        tc['failed'] = True
+    else:
+        tc['fail-txt'] = None
+        tc['fail-msg'] = None
+        tc['failed'] = False
+
+    return tc
+
+def md_summary(xml_root):
+    """
+    Make a brief summary in Markdown of a testsuite
+    """
+    md = 'Jenkins vg tests complete'
+    try:
+        if os.getenv('ghprbPullId'):
+            md += ' for [PR {}]({})'.format(os.getenv('ghprbPullId'), os.getenv('ghprbPullLink'))
+        elif os.getenv('BUILD_NUMBER'):
+            md += ' for merge to master'
+        md += '.  View the [full report here]({{REPORT_URL}}).\n\n'
+
+        # will have to modify this if we ever add another test suite
+        testsuite = xml_root
+        
+        ts = parse_testsuite_xml(testsuite)
+
+        md += '{} tests passed, {} tests failed and {} tests skipped in {} seconds\n\n'.format(
+            ts['passes'], ts['fails'], ts['skips'], ts['time'])
+
+        if ts['fails'] is not None and int(ts['fails']) > 1:
+            md += 'Failed tests:\n\n'
+
+        for testcase in testsuite.iter('testcase'):
+            try:
+                tc = parse_testcase_xml(testcase)
+                if tc['failed']:
+                    md += '* {} ({} seconds)\n'.format(tc['name'], tc['time'])
+            except:
+                md += '**Error parsing Test Case XML**\n'                
+    except:
+        md += ' **Error parsing Test Suite XML**\n'
+    return md
+        
+def html_header(xml_root):
+    """
+    Make an HTML header for the test suite XML
+    """
+    try:
+        report = '<!DOCTYPE html><html><head>\n'
+        report += '<title>vg Test Report</title>\n'
+        report += '</head><body>\n'
+
+        # will have to modify this if we ever add another test suite
+        testsuite = xml_root
+        
+        ts = parse_testsuite_xml(testsuite)
+
+        report += '<h2>vg Test Report'
+        if os.getenv('ghprbPullId'):
+            report += ' for <a href={}>PR {}</a>'.format(os.getenv('ghprbPullLink'),
+                                                         os.getenv('ghprbPullId'))
+        elif os.getenv('BUILD_NUMBER'):
+            report += ' for merge to master'
+        report += '</h2>\n'
+
+        report += '<p> {} tests passed, {} tests failed and {} tests skipped in {} seconds'.format(
+            ts['passes'], ts['fails'], ts['skips'], ts['time'])
+        report += '.</p>\n'
+
+        report += '<p> Report generated on {} </p>\n'.format(str(datetime.datetime.now()))
+        
+    except:
+        report += ' Error parsing Test Suite XML\n'
+    return report
+
+def html_testcase(testcase, work_dir, report_dir):
+    """
+    Make an HTML report for a single test case
+    """
+    report = ''
+    try:
+        tc = parse_testcase_xml(testcase)
+
+        report += '<h3>{}</h3>\n'.format(tc['name'])
+        if tc['failed']:
+            report += '<p>Failed in {} seconds</p>\n'.format(tc['time'])
+            report += '<p>Failure Message: `{}`</p>\n'.format(tc['fail-msg'])
+        else:
+            report += '<p>Passed in {} seconds</p>\n'.format(tc['time'])
+
+        outstore = os.path.join(work_dir, testname_to_outstore(tc['name']))
+
+        for plot_name in 'roc', 'qq':
+            plot_path = os.path.join(outstore, '{}.pdf'.format(plot_name))
+            if os.path.isfile(plot_path):
+                new_name = '{}-{}.pdf'.format(tc['name'], plot_name)
+                shutil.copy2(plot_path, os.path.join(report_dir, new_name))
+                report += '<p><a href={}>{} Plot</a></p>\n'.format(new_name, plot_name.upper())
+
+        if tc['stdout']:
+            report += '<p>Standard Output:</p>\n<p>'
+            for line in textwrap.wrap(tc['stdout'], 80):
+                report += line + '&#10'
+            report += '</p>\n'
+
+    except:
+        report += 'Error parseing Test Case XML\n'
+
+    return report
+
+def write_html_report(xml_root, work_dir, html_dir, html_name = 'index.html'):
+    """ Write the HTML report in a given directory
+    """
+    if not os.path.isdir(html_dir):
+        os.makedirs(html_dir)
+    
+    html_path = os.path.join(html_dir, html_name)
+    with open(html_path, 'w') as html_file:
+        header = html_header(xml_root)
+        html_file.write(header)
+        for testcase in xml_root.iter('testcase'):
+            tc_body = html_testcase(testcase, work_dir, html_dir)
+            html_file.write(tc_body)
+        html_file.write('</body>\n</html>\n')
+        
 
 def main(args):
     """
@@ -206,22 +211,17 @@ def main(args):
     """    
     options = parse_args(args)
 
-    if not os.path.isdir(options.html_out_dir):
-        os.makedirs(options.html_out_dir)
+    # Load up the XML
+    xml_tree = ET.parse(options.xml_in)
+    xml_root = xml_tree.getroot()
 
-    # just scrape stdout and a few stats for for now 
-    with open(options.md_out, 'w') as md_file, \
-         open(os.path.join(options.html_out_dir, 'index.html'), 'w') as html_file:
+    # Write our Markdown summary
+    markdown = md_summary(xml_root)
+    with open(options.md_out, 'w') as md_file:
+        md_file.write(markdown)
 
-        write_md_header(md_file)
-        write_html_header(html_file)
-                                  
-        parse_junit_xml(options.xml_in, options.work_dir,
-                        write_html_testsuite, write_html_testcase, html_file,
-                        write_md_testsuite, write_md_testcase, md_file)
-
-        html_file.write('</body>\n</html>\n')
-    
+    # Write our HTML report
+    write_html_report(xml_root, options.work_dir, options.html_out_dir)
     
 if __name__ == "__main__" :
     sys.exit(main(sys.argv))


### PR DESCRIPTION
Make markdown message more concise, and less error-ridden (#898).  HTML report still needs work. 