### PR TITLE
Compare sim scores with bonuses against realignments to the same graph

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -396,7 +396,7 @@ class VGCITest(TestCase):
         # note, using the same seed only means something if using same
         # number of chunks.  we make that explicit here
         opts += '--maxCores {} --sim_chunks {} --seed {} '.format(self.cores, self.cores, self.cores)
-        opts += '--sim_opts \'-l 150 -p 500 -v 50 -e 0.05 -i 0.01\' '
+        opts += '--sim_opts \'-l 150 -p 500 -v 50 -e 0.05 -i 0.01 --include-bonuses\' '
         opts += '--annotate_xg {} '.format(base_xg_path)
         cmd = 'toil-vg sim {} {} {} {} --gam {}'.format(
             job_store, ' '.join(sim_xg_paths), reads / 2, out_store, opts)

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -470,7 +470,7 @@ int main_view(int argc, char** argv) {
                 });
             } else {
                 // todo
-                cerr << "[vg view] error: (binary) GAM can only be converted to JSON" << endl;
+                cerr << "[vg view] error: (binary) GAM can only be converted to JSON or FASTQ" << endl;
                 return 1;
             }
         } else {


### PR DESCRIPTION
Previously we were comparing sim scores with no bonuses against realignments to every graph (even graphs with less material than the simulated read source graph).

With these changes, the warnings for reads dropping in score versus the input read scores should actually be useful.

Related to #880 