### PR TITLE
Use parse_region() from xg.hpp

### DIFF
--- a/src/chunker.cpp
+++ b/src/chunker.cpp
@@ -25,14 +25,14 @@ void PathChunker::extract_subgraph(const Region& region, int context, bool forwa
     Graph g;
 
     // convert to 0-based inclusive
-    int64_t start = region.start - 1;
+    int64_t start = region.start;
 
     // extract our path range into the graph
 
     // Commenting out till I can be sure it's not doing weird things to paths
     //xg->get_path_range(region.seq, region.start, region.end - 1, g);
 
-    xg->for_path_range(region.seq, start, region.end - 1, [&](int64_t id) {
+    xg->for_path_range(region.seq, region.start, region.end, [&](int64_t id) {
             *g.add_node() = xg->node(id);
         });
     
@@ -45,13 +45,13 @@ void PathChunker::extract_subgraph(const Region& region, int context, bool forwa
     subgraph.remove_orphan_edges();
 
     // what node contains our input starting position?
-    int64_t input_start_node = xg->node_at_path_position(region.seq, start);
+    int64_t input_start_node = xg->node_at_path_position(region.seq, region.start);
 
     // start could fall inside a node.  we find out where in the path the
     // 0-offset point of the node is. 
-    int64_t input_start_pos = xg->node_start_at_path_position(region.seq, start);
-    assert(input_start_pos <= start &&
-           input_start_pos + xg->node_length(input_start_node) > start);
+    int64_t input_start_pos = xg->node_start_at_path_position(region.seq, region.start);
+    assert(input_start_pos <= region.start &&
+           input_start_pos + xg->node_length(input_start_node) > region.start);
     
     // find out the start position of the first node in the path in the
     // subgraph.  take the last occurance before the input_start_pos
@@ -71,7 +71,7 @@ void PathChunker::extract_subgraph(const Region& region, int context, bool forwa
     assert(chunk_start_pos >= 0);
 
     out_region.seq = region.seq;
-    out_region.start = 1 + chunk_start_pos;
+    out_region.start = chunk_start_pos;
     out_region.end = out_region.start - 1;
     // Is there a better way to get path length? 
     Path output_path = subgraph.paths.path(out_region.seq);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1,6 +1,6 @@
 #include "path.hpp"
 #include "stream.hpp"
-
+#include "region.hpp"
 
 namespace vg {
 
@@ -846,27 +846,6 @@ vector<string> Paths::over_directed_edge(id_t id1, bool rev1, id_t id2, bool rev
                           consecutive.begin(), consecutive.end(),
                           std::back_inserter(continued));
     return continued;
-}
-
-void parse_region(const string& target, string& name, id_t& start, id_t& end) {
-    start = -1;
-    end = -1;
-    size_t foundFirstColon = target.find(":");
-    // we only have a single string, use the whole sequence as the target
-    if (foundFirstColon == string::npos) {
-        name = target;
-    } else {
-        name = target.substr(0, foundFirstColon);
-	    size_t foundRangeDash = target.find("-", foundFirstColon);
-        if (foundRangeDash == string::npos) {
-            start = atoi(target.substr(foundFirstColon + 1).c_str());
-            end = start;
-        } else {
-            start = atoi(target.substr(foundFirstColon + 1, foundRangeDash - foundRangeDash - 1).c_str());
-            end = atoi(target.substr(foundRangeDash + 1).c_str());
-        }
-    }
-
 }
 
 int path_to_length(const Path& path) {

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -199,7 +199,6 @@ string  path_to_string(Path p);
 Path& increment_node_mapping_ids(Path& p, id_t inc);
 Path& append_path(Path& a, const Path& b);
 const Paths paths_from_graph(Graph& g);
-void parse_region(const string& target, string& name, id_t& start, id_t& end);
 int path_to_length(const Path& path);
 int path_from_length(const Path& path);
 int mapping_to_length(const Mapping& m);

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -506,8 +506,7 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
                 // clip region on end of path
                 regions[i].end = min(path_size - 1, regions[i].end);
                 // do path node query
-                // convert to 0-based coordinates as this seems to be what xg wants
-                xindex->get_path_range(regions[i].seq, regions[i].start - 1, regions[i].end - 1, graph);
+                xindex->get_path_range(regions[i].seq, regions[i].start, regions[i].end, graph);
                 if (context_size > 0) {
                     xindex->expand_context(graph, context_size);
                 }

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -497,7 +497,7 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
         for (int i = 0; i < regions.size(); ++i) {
             Graph graph;
             int rank = xindex->path_rank(regions[i].seq);
-            int path_size = rank == 0 ? 0 : xindex->path_length(regions[i].seq);
+            int64_t path_size = rank == 0 ? 0 : xindex->path_length(regions[i].seq);
 
             if (regions[i].start >= path_size) {
                 cerr << "Unable to find region in index: " << regions[i].seq << ":" << regions[i].start

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -31,8 +31,8 @@ void parse_bed_regions(const string& bed_path,
             region.end = std::stoi(ebuf);
             assert(region.end > region.start);
             
-            // convert from BED-style to VCF-style coordinates
-            region.start += 1;
+            // convert from BED-style to 0-based inclusive coordinates
+            region.end -= 1;
 
             out_regions.push_back(region);
         }

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -5,45 +5,6 @@
 
 namespace vg {
 
-void parse_region(
-    string& region,
-    string& startSeq,
-    int& startPos,
-    int& stopPos) {
-
-    size_t foundFirstColon = region.find(":");
-
-    // we only have a single string, use the whole sequence as the target
-    if (foundFirstColon == string::npos) {
-        startSeq = region;
-        startPos = 0;
-        stopPos = -1;
-    } else {
-        startSeq = region.substr(0, foundFirstColon);
-        string sep = "..";
-        size_t foundRangeSep = region.find(sep, foundFirstColon);
-        if (foundRangeSep == string::npos) {
-            sep = "-";
-            foundRangeSep = region.find("-", foundFirstColon);
-        }
-        if (foundRangeSep == string::npos) {
-            startPos = atoi(region.substr(foundFirstColon + 1).c_str());
-            // differ from bamtools in this regard, in that we process only
-            // the specified position if a range isn't given
-            stopPos = startPos + 1;
-        } else {
-            startPos = atoi(region.substr(foundFirstColon + 1, foundRangeSep - foundFirstColon).c_str());
-            // if we have range sep specified, but no second number, read to the end of sequence
-            if (foundRangeSep + sep.size() != region.size()) {
-                stopPos = atoi(region.substr(foundRangeSep + sep.size()).c_str()); // end-exclusive, bed-format
-            } else {
-                //stopPos = reference.sequenceLength(startSeq);
-                stopPos = -1;
-            }
-        }
-    }
-}
-
 void parse_bed_regions(const string& bed_path,
                        vector<Region>& out_regions) {
     out_regions.clear();

--- a/src/region.hpp
+++ b/src/region.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include "xg.hpp"
 
 namespace vg {
 
@@ -12,25 +13,17 @@ using namespace std;
 // wrap up region parse output
 struct Region {
     string seq;
-    int start;
-    int end;
+    int64_t start;
+    int64_t end;
 };
-
-// parse a region in the form: chrom:start-stop
-// (if only chrom given, start, stop will be set to 0,-1)
-void parse_region(
-    string& region,
-    string& startSeq,
-    int& startPos,
-    int& stopPos);
 
 
 inline void parse_region(string& region,
                          Region& out_region) {
-    parse_region(region,
-                 out_region.seq,
-                 out_region.start,
-                 out_region.end);
+    xg::parse_region(region,
+                     out_region.seq,
+                     out_region.start,
+                     out_region.end);
 }
     
 // parse a bed file and return a list of regions (like above)

--- a/src/region.hpp
+++ b/src/region.hpp
@@ -28,7 +28,7 @@ inline void parse_region(string& region,
     
 // parse a bed file and return a list of regions (like above)
 // IMPORTANT: expects usual 0-based BED format.
-// So bedline "chr1   5   10" will return start=6 stop=10
+// So bedline "chr1   5   10" will return start=5 stop=9
 void parse_bed_regions(
     const string& bed_path,
     vector<Region>& out_regions);

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -309,7 +309,7 @@ int main_chunk(int argc, char** argv) {
                 cerr << "error[vg chunk]: input path " << region.seq << " not found in xg index" << endl;
                 return 1;
             }
-            region.start = max(0L, region.start);
+            region.start = max((int64_t)0, region.start);
             if (region.end == -1) {    
                 region.end = xindex.path_length(rank);
             } else if (!id_range) {

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -179,13 +179,13 @@ int main_construct(int argc, char** argv) {
             // We are allowed to parse the region.
             // Break out sequence name and region bounds
             string seq_name;
-            int start_pos = 0, stop_pos = 0;
-            parse_region(region,
-                         seq_name,
-                         start_pos,
-                         stop_pos);
+            int64_t start_pos = -1, stop_pos = -1;
+            xg::parse_region(region,
+                             seq_name,
+                             start_pos,
+                             stop_pos);
                          
-            if (start_pos != 0 && stop_pos != 0) {
+            if (start_pos > 0 && stop_pos > 0) {
                 // These are 0-based, so if both are nonzero we got a real set of coordinates
                 if (constructor.show_progress) {
                     cerr << "Restricting to " << seq_name << " from " << start_pos << " to " << stop_pos << endl;
@@ -193,7 +193,7 @@ int main_construct(int argc, char** argv) {
                 constructor.allowed_vcf_names.insert(seq_name);
                 // Make sure to correct the coordinates to 0-based exclusive-end, from 1-based inclusive-end
                 constructor.allowed_vcf_regions[seq_name] = make_pair(start_pos - 1, stop_pos);
-            } else if (start_pos == 0 && stop_pos == 0) {
+            } else if (start_pos < 0 && stop_pos < 0) {
                 // We just got a name
                 cerr << "Restricting to " << seq_name << " from 1 to end" << endl;
                 constructor.allowed_vcf_names.insert(seq_name);

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -498,11 +498,15 @@ int main_find(int argc, char** argv) {
                 // Grab each target region
                 string name;
                 int64_t start, end;
-                parse_region(target, name, start, end);
+                xg::parse_region(target, name, start, end);
                 if(xindex.path_rank(name) == 0) {
                     // Passing a nonexistent path to get_path_range produces Undefined Behavior
                     cerr << "[vg find] error, path " << name << " not found in index" << endl;
                     exit(1);
+                }
+                // no coordinates given, we do whole thing (0,-1)
+                if (start < 0 && end < 0) {
+                    start = 0;
                 }
                 xindex.get_path_range(name, start, end, graph);
             }
@@ -695,7 +699,11 @@ int main_find(int argc, char** argv) {
             for (auto& target : targets) {
                 string name;
                 int64_t start, end;
-                parse_region(target, name, start, end);
+                xg::parse_region(target, name, start, end);
+                // end coordinate is exclusive for get_path()
+                if (end >= 0) {
+                    ++end;
+                }
                 vindex->get_path(graph, name, start, end);
             }
             if (context_size > 0) {

--- a/src/unittest/chunker.cpp
+++ b/src/unittest/chunker.cpp
@@ -92,7 +92,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
 
     SECTION("Extract whole graph as chunk") {
 
-        // Note: regions are 1-based inclusive
+        // Note: regions are 0-based inclusive
         Region region = {"x", 1, 32};
         VG subgraph;
         Region out_region;
@@ -100,7 +100,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
 
         REQUIRE(subgraph.node_count() == 9);
         REQUIRE(subgraph.edge_count() == 12);
-        REQUIRE(out_region.start == 1);
+        REQUIRE(out_region.start == 0);
     }
 
     SECTION("Extract partial graph as chunk") {
@@ -112,7 +112,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
 
         REQUIRE(subgraph.node_count() == 6);
         REQUIRE(subgraph.edge_count() == 7);
-        REQUIRE(out_region.start == 1);
+        REQUIRE(out_region.start == 0);
     }
 
     SECTION("Extract partial graph as chunk via id range") {
@@ -136,7 +136,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
 
         REQUIRE(subgraph.node_count() == 6);
         REQUIRE(subgraph.edge_count() == 7);
-        REQUIRE(out_region.start == 1);
+        REQUIRE(out_region.start == 0);
     }
 
     SECTION("Extract whole graph via harder path") {
@@ -148,7 +148,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
 
         REQUIRE(subgraph.node_count() == 9);
         REQUIRE(subgraph.edge_count() == 12);
-        REQUIRE(out_region.start == 1);
+        REQUIRE(out_region.start == 0);
 
     }
 
@@ -161,7 +161,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
 
         REQUIRE(subgraph.node_count() == 7);
         REQUIRE(subgraph.edge_count() == 9);
-        REQUIRE(out_region.start == 7);
+        REQUIRE(out_region.start == 6);
     }
     
     SECTION("Extract whole graph via cyclic path") {
@@ -173,7 +173,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         
         REQUIRE(subgraph.node_count() == 9);
         REQUIRE(subgraph.edge_count() == 12);
-        REQUIRE(out_region.start == 1);
+        REQUIRE(out_region.start == 0);
         
     }
     
@@ -186,7 +186,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         
         REQUIRE(subgraph.node_count() == 7);
         REQUIRE(subgraph.edge_count() == 9);
-        REQUIRE(out_region.start == 7);
+        REQUIRE(out_region.start == 6);
         
     }
 

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -29,11 +29,11 @@ is $(vg find -S AGGGCTTTTAACTACTCCACATCCAAAGCTACCCAGGCCATTTTAAGTTTCCTGT -d x.idx
 
 is $(vg find -S AGGGCTTTTAACTACTCCACATCCAAAGCTACCCAGGCCATTTTAAGTTTCCTGT -j 11 -d x.idx | vg view - | wc -l) 24 "vg find returns a correctly-sized graph when using jump-kmers"
 
-is $(vg find -p x:0-100 -d x.idx | vg view -g - | wc -l) 29 "vg find returns a subgraph corresponding to particular reference coordinates"
+is $(vg find -p x:0-99 -d x.idx | vg view -g - | wc -l) 29 "vg find returns a subgraph corresponding to particular reference coordinates"
 
-is $(vg find -p x:0-100 -d x.idx | vg view -j - | jq ".node[].sequence" | tr -d '"\n' | wc -c) 100 "vg find returns a path of the correct length"
+is $(vg find -p x:0-99 -d x.idx | vg view -j - | jq ".node[].sequence" | tr -d '"\n' | wc -c) 100 "vg find returns a path of the correct length"
 
-is $(vg find -p x:0-100 -c 1 -d x.idx | vg view -g - | wc -l) 56 "larger graph is returned when the reference path is queried with context"
+is $(vg find -p x:0-99 -c 1 -d x.idx | vg view -g - | wc -l) 56 "larger graph is returned when the reference path is queried with context"
 
 is $(vg find -p x -c 10 -d x.idx | vg view -g - | wc -l) $(vg view -g x.vg | wc -l) "entire graph is returned when the reference path is queried with context"
 


### PR DESCRIPTION
As complained about in #934, parse_region() was redefined a bunch of times.  This removes the definitions from path.cpp and region.cpp, so that everyone uses the one in xg.cpp.  If xg ever moves into vg, we can put it back in region.cpp which would be a bit cleaner.  

Whatever was using the old region.cpp version, will now be different in that the start coordinate defaults to -1 instead of 0, and the end coordinate defaults to the start instead of start+1, but all the tests seem to pass. 