### PR TITLE
Fix worse mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ $(OBJ_DIR)/ssw_aligner.o: $(SRC_DIR)/ssw_aligner.cpp $(SRC_DIR)/ssw_aligner.hpp 
 
 $(OBJ_DIR)/vg_set.o: $(SRC_DIR)/vg_set.cpp $(SRC_DIR)/vg_set.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/index.hpp $(DEPS)
 
-$(OBJ_DIR)/mapper.o: $(SRC_DIR)/mapper.cpp $(SRC_DIR)/mapper.hpp $(SRC_DIR)/mem.hpp $(SRC_DIR)/vg.hpp $(DEPS)
+$(OBJ_DIR)/mapper.o: $(SRC_DIR)/mapper.cpp $(SRC_DIR)/mapper.hpp $(SRC_DIR)/mem.hpp $(SRC_DIR)/vg.hpp $(ALGORITHMS_SRC_DIR)/vg_algorithms.hpp $(DEPS)
 
 $(OBJ_DIR)/mem.o: $(SRC_DIR)/mem.cpp $(SRC_DIR)/mem.hpp $(SRC_DIR)/vg.hpp $(DEPS)
 
@@ -463,7 +463,7 @@ $(OBJ_DIR)/variant_adder.o: $(SRC_DIR)/variant_adder.cpp $(SRC_DIR)/variant_adde
 
 $(OBJ_DIR)/name_mapper.o: $(SRC_DIR)/name_mapper.cpp $(DEPS)
 
-$(OBJ_DIR)/graph_synchronizer.o: $(SRC_DIR)/graph_synchronizer.cpp $(SRC_DIR)/graph_synchronizer.hpp $(SRC_DIR)/algorithms/vg_algorithms.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/vg.hpp $(DEPS)
+$(OBJ_DIR)/graph_synchronizer.o: $(SRC_DIR)/graph_synchronizer.cpp $(SRC_DIR)/graph_synchronizer.hpp $(ALGORITHMS_SRC_DIR)/vg_algorithms.hpp $(SRC_DIR)/path_index.hpp $(SRC_DIR)/vg.hpp $(DEPS)
 
 # We also build the main file from xg, so we can offer it as a command
 # TODO: wrap it as a vg subcommand?
@@ -577,11 +577,11 @@ $(SUBCOMMAND_OBJ_DIR)/construct_main.o: $(SUBCOMMAND_SRC_DIR)/construct_main.cpp
 
 $(SUBCOMMAND_OBJ_DIR)/simplify_main.o: $(SUBCOMMAND_SRC_DIR)/simplify_main.cpp $(SUBCOMMAND_SRC_DIR)/subcommand.hpp $(SRC_DIR)/simplifier.hpp $(SRC_DIR)/vg.hpp $(SRC_DIR)/progressive.hpp $(SRC_DIR)/utility.hpp $(SRC_DIR)/feature_set.hpp $(SRC_DIR)/path.hpp $(SRC_DIR)/path_index.hpp $(DEPS)
 
-$(SUBCOMMAND_OBJ_DIR)/homogenize_main.o: $(SUBCOMMAND_SRC_DIR)/homogenize_main.cpp $(OBJ_DIR)/homogenizer.o $(OBJ_DIR)/filter.o $(OBJ_DIR)/mapper.hpp $(SRC_DIR)/mem.hpp $(OBJ_DIR)/bubbles.o $(OBJ_DIR)/vg.o $(DEPS)
+$(SUBCOMMAND_OBJ_DIR)/homogenize_main.o: $(SUBCOMMAND_SRC_DIR)/homogenize_main.cpp $(SRC_DIR)/homogenizer.hpp $(SRC_DIR)/filter.hpp $(OBJ_DIR)/mapper.hpp $(SRC_DIR)/mem.hpp $(SRC_DIR)/bubbles.hpp $(SRC_DIR)/vg.hpp $(DEPS)
 
-$(SUBCOMMAND_OBJ_DIR)/sift_main.o: $(SUBCOMMAND_SRC_DIR)/sift_main.cpp $(OBJ_DIR)/filter.o $(OBJ_DIR)/vg.o $(DEPS)
+$(SUBCOMMAND_OBJ_DIR)/sift_main.o: $(SUBCOMMAND_SRC_DIR)/sift_main.cpp $(SRC_DIR)/filter.hpp $(SRC_DIR)/vg.hpp $(DEPS)
 
-$(SUBCOMMAND_OBJ_DIR)/srpe_main.o: $(SUBCOMMAND_SRC_DIR)/srpe_main.cpp $(OBJ_DIR)/srpe.o $(OBJ_DIR)/filter.o $(OBJ_DIR)/mapper.o $(OBJ_DIR)/vg.o $(DEPS)
+$(SUBCOMMAND_OBJ_DIR)/srpe_main.o: $(SUBCOMMAND_SRC_DIR)/srpe_main.cpp $(SRC_DIR)/srpe.hpp $(SRC_DIR)/filter.hpp $(SRC_DIR)/mapper.hpp $(SRC_DIR)/mem.hpp $(SRC_DIR)/vg.hpp $(ALGORITHMS_SRC_DIR)/vg_algorithms.hpp $(DEPS)
 
 
 $(SUBCOMMAND_OBJ_DIR)/gamsort_main.o: $(SUBCOMMAND_SRC_DIR)/gamsort_main.cpp $(OBJ_DIR)/gamsorter.o $(DEPS)

--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ $(OBJ_DIR)/progress_bar.o:
 $(OBJ_DIR)/Fasta.o:
 	+cd $(FASTAHACK_DIR) && $(MAKE) && mv Fasta.o $(CWD)/$(OBJ_DIR) && cp Fasta.h $(CWD)/$(INC_DIR)
 
-$(LIB_DIR)/libhts.a:
+$(LIB_DIR)/libhts.a: $(HTSLIB_DIR)/*.c $(HTSLIB_DIR)/*.h
 	+cd $(HTSLIB_DIR) && $(MAKE) lib-static && mv libhts.a $(CWD)/$(LIB_DIR) && cp *.h $(CWD)/$(INC_DIR) && cp -r htslib $(CWD)/$(INC_DIR)/
 
 $(LIB_DIR)/libxg.a: $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libprotobuf.a $(CPP_DIR)/vg.pb.o $(INC_DIR)/dynamic.hpp $(XG_DIR)/src/xg.cpp $(XG_DIR)/src/xg.hpp $(INC_DIR)/sparsehash/sparse_hash_map 

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/pinned_alignment.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/vg.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/multipath_alignment.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/multipath_mapper.o
+UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/mapper.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/mem.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/phased_genome.o
 UNITTEST_OBJ += $(UNITTEST_OBJ_DIR)/constructor.o
@@ -526,6 +527,8 @@ $(UNITTEST_OBJ_DIR)/readfilter.o: $(UNITTEST_SRC_DIR)/readfilter.cpp $(UNITTEST_
 $(UNITTEST_OBJ_DIR)/multipath_alignment.o: $(UNITTEST_SRC_DIR)/multipath_alignment.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/multipath_alignment.hpp $(SRC_DIR)/mapper.hpp $(SRC_DIR)/mem.hpp $(DEPS)
 
 $(UNITTEST_OBJ_DIR)/multipath_mapper.o: $(UNITTEST_SRC_DIR)/multipath_mapper.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/multipath_mapper.hpp $(SRC_DIR)/multipath_alignment.hpp $(SRC_DIR)/mapper.hpp $(SRC_DIR)/mem.hpp $(DEPS)
+
+$(UNITTEST_OBJ_DIR)/mapper.o: $(UNITTEST_SRC_DIR)/mapper.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/mapper.hpp $(SRC_DIR)/mem.hpp $(DEPS)
 
 $(UNITTEST_OBJ_DIR)/mem.o: $(UNITTEST_SRC_DIR)/mem.cpp $(UNITTEST_SRC_DIR)/catch.hpp $(SRC_DIR)/mem.hpp $(DEPS)
 

--- a/src/algorithms/vg_algorithms.cpp
+++ b/src/algorithms/vg_algorithms.cpp
@@ -5,7 +5,7 @@
 
 #include "vg_algorithms.hpp"
 
-#define debug_vg_algorithms
+//#define debug_vg_algorithms
 
 namespace vg {
 namespace algorithms {

--- a/src/algorithms/vg_algorithms.cpp
+++ b/src/algorithms/vg_algorithms.cpp
@@ -5,7 +5,7 @@
 
 #include "vg_algorithms.hpp"
 
-//#define debug_vg_algorithms
+#define debug_vg_algorithms
 
 namespace vg {
 namespace algorithms {

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -88,7 +88,7 @@ bam_hdr_t* hts_string_header(string& header,
     }
     hdr << "@PG\tID:0\tPN:vg\n";
     header = hdr.str();
-    string sam = "data:" + header;
+    string sam = "data:," + header;
     samFile *in = sam_open(sam.c_str(), "r");
     bam_hdr_t *h = sam_hdr_read(in);
     sam_close(in);
@@ -440,7 +440,7 @@ bam1_t* alignment_to_bam(const string& sam_header,
                          const int32_t tlen) {
 
     assert(!sam_header.empty());
-    string sam_file = "data:" + sam_header + alignment_to_sam(alignment, refseq, refpos, refrev, cigar, mateseq, matepos, tlen);
+    string sam_file = "data:," + sam_header + alignment_to_sam(alignment, refseq, refpos, refrev, cigar, mateseq, matepos, tlen);
     const char* sam = sam_file.c_str();
     samFile *in = sam_open(sam, "r");
     bam_hdr_t *header = sam_hdr_read(in);

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1003,33 +1003,135 @@ map<id_t, int> alignment_quality_per_node(const Alignment& aln) {
     return quals;
 }
 
-string middle_signature(const Alignment& aln, int len) {
-    return signature(alignment_middle(aln, len));
-}
-
-pair<string, string> middle_signature(const Alignment& aln1, const Alignment& aln2, int len) {
-    return make_pair(middle_signature(aln1, len), middle_signature(aln1, len));
-}
-
-string signature(const Alignment& aln) {
-    stringstream s;
-    if (aln.has_path() && aln.path().mapping_size()) {
-        auto& pos1 = aln.path().mapping(0).position();
-        s << pos1.node_id();
-        s << (pos1.is_reverse() ? "-" : "+");
-        s << ":" << pos1.offset();
-        s << "_";
-        auto& last = aln.path().mapping(aln.path().mapping_size()-1);
-        auto& pos2 = last.position();
-        s << pos2.node_id();
-        s << (pos2.is_reverse() ? "-" : "+");
-        s << ":" << pos2.offset() + mapping_from_length(last);
+bool SameReadAlignmentOrder::operator()(const Alignment& a, const Alignment& b) const {
+    // Compare two alignments of the same sequence to potentially different
+    // graph paths. We want to order them so we can deduplicate them in a
+    // std::set.
+    
+    // First look at the scores
+    if (a.score() < b.score()) {
+        return true;
     }
-    return s.str();
+    if (b.score() < a.score()) {
+        return false;
+    }
+    
+    // If they are the same, look at the paths.
+    if (a.path().mapping_size() < b.path().mapping_size()) {
+        return true;
+    }
+    if (b.path().mapping_size() < a.path().mapping_size()) {
+        return false;
+    }
+    
+    for (size_t i = 0; i < a.path().mapping_size(); i++) {
+        // For each mapping pair, compare them.
+        auto& a_mapping = a.path().mapping(i);
+        auto& b_mapping = b.path().mapping(i);
+        
+        // Compare the positions
+        auto& a_pos = a_mapping.position();
+        auto& b_pos = b_mapping.position();
+        
+        // Which means to compare the node IDs
+        if (a_pos.node_id() < b_pos.node_id()) {
+            return true;
+        }
+        if (b_pos.node_id() < a_pos.node_id()) {
+            return false;
+        }
+        
+        // And the offsets
+        if (a_pos.offset() < b_pos.offset()) {
+            return true;
+        }
+        if (b_pos.offset() < a_pos.offset()) {
+            return false;
+        }
+        
+        // And the is_reverse flags
+        if (a_pos.is_reverse() < b_pos.is_reverse()) {
+            return true;
+        }
+        if (b_pos.is_reverse() < a_pos.is_reverse()) {
+            return false;
+        }
+        
+        // Then compare the edit counts
+        if (a_mapping.edit_size() < b_mapping.edit_size()) {
+            return true;
+        }
+        if (b_mapping.edit_size() < a_mapping.edit_size()) {
+            return false;
+        }
+        
+        for (size_t j = 0; j < a_mapping.edit_size(); j++) {
+            // And then compare the edits
+            auto& a_edit = a_mapping.edit(j);
+            auto& b_edit = b_mapping.edit(j);
+            
+            // Which means to compare the from length
+            if (a_edit.from_length() < b_edit.from_length()) {
+                return true;
+            }
+            if (b_edit.from_length() < a_edit.from_length()) {
+                return false;
+            }
+            
+            // And the to length
+            if (a_edit.to_length() < b_edit.to_length()) {
+                return true;
+            }
+            if (b_edit.to_length() < a_edit.to_length()) {
+                return false;
+            }
+            
+            // And the sequence
+            if (a_edit.sequence() < b_edit.sequence()) {
+                return true;
+            }
+            if (b_edit.sequence() < a_edit.sequence()) {
+                return false;
+            }
+        }
+        
+    }
+    
+    
+    // And if all that stuff we checked is the same, we assume the alignments
+    // are the same (for aligner output deduplication purposes).
+    // That means that a is not less than b.
+    return false;
+    
 }
 
-pair<string, string> signature(const Alignment& aln1, const Alignment& aln2) {
-    return make_pair(signature(aln1), signature(aln2));
+bool SameReadsAlignmentPairOrder::operator()(const pair<Alignment, Alignment>& a, const pair<Alignment, Alignment>& b) const {
+    // Compare the first elements
+    if (SameReadAlignmentOrder()(a.first, b.first)) {
+        return true;
+    }
+    if (SameReadAlignmentOrder()(b.first, a.first)) {
+        return false;
+    }
+    
+    // Then compare the second elements
+    if (SameReadAlignmentOrder()(a.second, b.second)) {
+        return true;
+    }
+    if (SameReadAlignmentOrder()(b.second, a.second)) {
+        return false;
+    }
+    
+    // Then conclude equality (and not a < b).
+    return false;
 }
 
 }
+
+
+
+
+
+
+
+

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -105,10 +105,16 @@ size_t to_length_after_pos(const Alignment& aln, const Position& pos);
 size_t from_length_after_pos(const Alignment& aln, const Position& pos);
 size_t to_length_before_pos(const Alignment& aln, const Position& pos);
 size_t from_length_before_pos(const Alignment& aln, const Position& pos);
-string signature(const Alignment& aln);
-pair<string, string> signature(const Alignment& aln1, const Alignment& aln2);
-string middle_signature(const Alignment& aln, int len);
-pair<string, string> middle_signature(const Alignment& aln1, const Alignment& aln2, int len);
+
+/// Define a comparison functor for different alignments of the same sequence to
+/// the same graph, ignoring all the metadata.
+struct SameReadAlignmentOrder {
+    bool operator()(const Alignment& a, const Alignment& b) const;
+};
+/// We have a similar functor for pairs of alignments.
+struct SameReadsAlignmentPairOrder {
+    bool operator()(const pair<Alignment, Alignment>& a, const pair<Alignment, Alignment>& b) const;
+};
 
 // project the alignment's path back into a different ID space
 void translate_nodes(Alignment& a, const unordered_map<id_t, pair<id_t, bool> >& ids, const std::function<size_t(int64_t)>& node_length);

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2696,16 +2696,7 @@ Mapper::align_mem_multi(const Alignment& aln,
         // skip if we've got enough multimaps to get MQ and we're under the min cluster length
         if (min_cluster_length && cluster_coverage(cluster) < min_cluster_length && alns.size() > 1) continue;
         Alignment candidate = align_cluster(aln, cluster);
-        
-#pragma omp critical
-        {
-            if (debug) {
-                cerr << "Alignment with score " << candidate.score()
-                    << " (seen: " << seen_alignments.count(candidate) << ")" << endl;
-                cerr << "\t" << pb2json(candidate) << endl;
-            }
-        }
-        
+     
         if (candidate.identity() > min_identity && !seen_alignments.count(candidate)) {
             alns.push_back(candidate);
             seen_alignments.insert(candidate);
@@ -2907,7 +2898,6 @@ void Mapper::cached_graph_context(VG& graph, const pos_t& pos, int length, LRUCa
     return;
 }
 
-#define debug_mapper
 VG Mapper::cluster_subgraph(const Alignment& aln, const vector<MaximalExactMatch>& mems) {
 #ifdef debug_mapper
 #pragma omp critical
@@ -2961,13 +2951,11 @@ VG Mapper::cluster_subgraph(const Alignment& aln, const vector<MaximalExactMatch
         if (debug) {
             cerr << "\tFound " << graph.node_count() << " nodes " << graph.min_node_id() << " - " << graph.max_node_id()
                 << " and " << graph.edge_count() << " edges" << endl;
-            cerr << pb2json(graph.graph) << endl;
         }
     }
 #endif
     return graph;
 }
-#undef debug_mapper
 
 VG Mapper::alignment_subgraph(const Alignment& aln, int context_size) {
     set<id_t> nodes;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2928,8 +2928,9 @@ VG Mapper::cluster_subgraph(const Alignment& aln, const vector<MaximalExactMatch
         
         // search far enough away to get any hit detectable without soft clipping
         forward_max_dist.push_back(aligner->longest_detectable_gap(aln, mem.end)
-                                   + (mem.end - mem.begin));
-        backward_max_dist.push_back(qual_adj_aligner->longest_detectable_gap(aln, mem.begin));
+                                   + (aln.sequence().end() - mem.begin));
+        backward_max_dist.push_back(aligner->longest_detectable_gap(aln, mem.begin)
+                                    + (mem.begin - aln.sequence().begin()));
     }
     
     

--- a/src/subcommand/align_main.cpp
+++ b/src/subcommand/align_main.cpp
@@ -34,12 +34,8 @@ void help_align(char** argv) {
          << "    -b, --banded-global   use the banded global alignment algorithm" << endl
          << "    -p, --pinned          pin the (local) alignment traceback to the optimal edge of the graph" << endl
          << "    -L, --pin-left        pin the first rather than last bases of the graph and sequence" << endl
-         << "    -D, --debug           print out score matrices and other debugging info" << endl
-         << "options:" << endl
-         << "    -s, --sequence STR    align a string to the graph in graph.vg using partial order alignment" << endl
-         << "    -Q, --seq-name STR    name the sequence using this value" << endl
          << "    -r, --reference STR   don't use an input graph--- run SSW alignment between -s and -r" << endl
-         << "    -j, --json            output alignments in JSON format (default GAM)" << endl;
+         << "    -D, --debug           print out score matrices and other debugging info" << endl;
 }
 
 int main_align(int argc, char** argv) {

--- a/src/unittest/mapper.cpp
+++ b/src/unittest/mapper.cpp
@@ -148,6 +148,152 @@ TEST_CASE( "Mapper can map to a one-node graph", "[mapping][mapper]" ) {
     delete lcpidx;
 }
 
+TEST_CASE( "Mapper finds optimal mapping for read starting with node-border MEM", "[mapping][mapper]" ) {
+    
+    // We have a node 9999 in here to bust some MEM we don't want, to trigger the condition we are trying to test
+    string graph_json = R"(
+    {"node":[{"id":1430,"sequence":"GAGATCGTGCTACCGCACTCCATGCACTCTAG"},
+    {"id":1428,"sequence":"C"},
+    {"id":1429,"sequence":"T"},
+    {"id":1431,"sequence":"CCTGGGCAACAGAACGAGATGCTGTC"},
+    {"id":1427,"sequence":"AGGTTGGAGTGAGC"},
+    {"id":1432,"sequence":"ACA"},
+    {"id":1433,"sequence":"ACAACAACAACAACAA"},
+    {"id":1426,"sequence":"GAGGCAGGAAAATCACTTGAACCGGGAGGCGG"},
+    {"id":1434,"sequence":"T"},
+    {"id":1435,"sequence":"C"},
+    {"id":1424,"sequence":"C"},
+    {"id":1425,"sequence":"T"},
+    {"id":1436,"sequence":"AACAACAACAA"},
+    {"id":1423,"sequence":"TCGGGAGGC"},
+    {"id":1437,"sequence":"T"},
+    {"id":1438,"sequence":"C"},
+    {"id":1421,"sequence":"T"},
+    {"id":1422,"sequence":"C"},
+    {"id":1439,"sequence":"AACAACAACAACAA"},
+    {"id":1420,"sequence":"TA"},
+    {"id":1440,"sequence":"A"},
+    {"id":1441,"sequence":"C"},
+    {"id":1418,"sequence":"A"},
+    {"id":1419,"sequence":"C"},
+    {"id":1442,"sequence":"AA"},
+    {"id":1417,"sequence":"TGCCTGTAATCCCAG"},
+    {"id":1443,"sequence":"C"},
+    {"id":1444,"sequence":"A"},
+    {"id":1416,"sequence":"AAATACAAGTATTAGCCAGGCATTGTGGCAGG"},
+    {"id":1445,"sequence":"TTCTCACATCTAAAACAGAGTTCCTGGTTCCA"},
+    {"id":9999,"sequence":"TGTTGTTGTTGTTGTGTTNCTCATTTCGTTGCCAAT"}
+    ],"edge":[{"to":1431,"from":1430},
+    {"to":1430,"from":1428},
+    {"to":1430,"from":1429},
+    {"to":1432,"from":1431},
+    {"to":1433,"from":1431},
+    {"to":1428,"from":1427},
+    {"to":1429,"from":1427},
+    {"to":1433,"from":1432},
+    {"to":1434,"from":1433},
+    {"to":1435,"from":1433},
+    {"to":1427,"from":1426},
+    {"to":1436,"from":1434},
+    {"to":1436,"from":1435},
+    {"to":1426,"from":1424},
+    {"to":1426,"from":1425},
+    {"to":1437,"from":1436},
+    {"to":1438,"from":1436},
+    {"to":1424,"from":1423},
+    {"to":1425,"from":1423},
+    {"to":1439,"from":1437},
+    {"to":1439,"from":1438},
+    {"to":1423,"from":1421},
+    {"to":1423,"from":1422},
+    {"to":1440,"from":1439},
+    {"to":1441,"from":1439},
+    {"to":1421,"from":1420},
+    {"to":1422,"from":1420},
+    {"to":1442,"from":1440},
+    {"to":1442,"from":1441},
+    {"to":1420,"from":1418},
+    {"to":1420,"from":1419},
+    {"to":1443,"from":1442},
+    {"to":1444,"from":1442},
+    {"to":1418,"from":1417},
+    {"to":1419,"from":1417},
+    {"to":1445,"from":1443},
+    {"to":1445,"from":1444},
+    {"to":1417,"from":1416}],"path":[{"name":"17","mapping":[{"position":{"node_id":1416},"rank":1040},
+    {"position":{"node_id":1417},"rank":1041},
+    {"position":{"node_id":1419},"rank":1042},
+    {"position":{"node_id":1420},"rank":1043},
+    {"position":{"node_id":1422},"rank":1044},
+    {"position":{"node_id":1423},"rank":1045},
+    {"position":{"node_id":1425},"rank":1046},
+    {"position":{"node_id":1426},"rank":1047},
+    {"position":{"node_id":1427},"rank":1048},
+    {"position":{"node_id":1429},"rank":1049},
+    {"position":{"node_id":1430},"rank":1050},
+    {"position":{"node_id":1431},"rank":1051},
+    {"position":{"node_id":1433},"rank":1052},
+    {"position":{"node_id":1435},"rank":1053},
+    {"position":{"node_id":1436},"rank":1054},
+    {"position":{"node_id":1438},"rank":1055},
+    {"position":{"node_id":1439},"rank":1056},
+    {"position":{"node_id":1441},"rank":1057},
+    {"position":{"node_id":1442},"rank":1058},
+    {"position":{"node_id":1444},"rank":1059},
+    {"position":{"node_id":1445},"rank":1060}]}]}
+    )";
+    
+    // Load the JSON
+    Graph proto_graph;
+    json2pb(proto_graph, graph_json.c_str(), graph_json.size());
+    
+    // Make it into a VG
+    VG graph;
+    graph.extend(proto_graph);
+    
+    // Configure GCSA temp directory to the system temp directory
+    gcsa::TempFile::setDirectory(find_temp_dir());
+    // And make it quiet
+    gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
+    
+    // Make pointers to fill in
+    gcsa::GCSA* gcsaidx = nullptr;
+    gcsa::LCPArray* lcpidx = nullptr;
+    
+    // Build the GCSA index
+    graph.build_gcsa_lcp(gcsaidx, lcpidx, 16, false, false, 3);
+    
+    // Build the xg index
+    xg::XG xg_index(proto_graph);
+    
+    // Make a multipath mapper to map against the graph.
+    Mapper mapper(&xg_index, gcsaidx, lcpidx);
+    mapper.set_alignment_scores(1, 4, 6, 1, 5);
+    
+    SECTION( "Mapper can map a read starting with a node-border MEM" ) {
+    
+        Alignment aln;
+        aln.set_sequence("TTGTTGTTGTTGTTGTGTTGTTGGGACAGCCATCTCATTTCGTTGCCAATGCTAGAGTGCATGGAG"
+                         "TGCGGTAGCACGATCTCAGCTCACTCCAACATCCGCCTCTCGGTTCAAGAGATTTTCCTGGTTCAG"
+                         "CCTCCCGAGTAGCTGGAT");
+                         
+        // Map to the graph
+        auto results = mapper.align_multi(aln);
+        
+        // We want one alignment.
+        REQUIRE(results.size() == 1);
+        // We want its first mapping to be to 1436 like the optimal alignment.
+        REQUIRE(results.front().path().mapping_size() >= 1);
+        REQUIRE(results.front().path().mapping(0).position().node_id() == 1436);
+    
+    }
+    
+    // Clean up the GCSA/LCP index
+    delete gcsaidx;
+    delete lcpidx;
+    
+}
+
 }
 
 }

--- a/src/unittest/mapper.cpp
+++ b/src/unittest/mapper.cpp
@@ -1,0 +1,153 @@
+/// \file mapper.cpp
+///  
+/// unit tests for the mapper
+
+#include <iostream>
+#include "json2pb.h"
+#include "vg.pb.h"
+#include "../mapper.hpp"
+#include "catch.hpp"
+
+namespace vg {
+namespace unittest {
+    
+TEST_CASE( "Mapper can map to a one-node graph", "[mapping][mapper]" ) {
+    
+    string graph_json = R"({
+        "node": [{"id": 1, "sequence": "GATTACA"}],
+        "path": [
+            {"name": "ref", "mapping": [
+                {"position": {"node_id": 1}, "edit": [{"from_length": 7, "to_length": 7}]}
+            ]}
+        ]
+    })";
+    
+    // Load the JSON
+    Graph proto_graph;
+    json2pb(proto_graph, graph_json.c_str(), graph_json.size());
+    
+    // Make it into a VG
+    VG graph;
+    graph.extend(proto_graph);
+    
+    // Configure GCSA temp directory to the system temp directory
+    gcsa::TempFile::setDirectory(find_temp_dir());
+    // And make it quiet
+    gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
+    
+    // Make pointers to fill in
+    gcsa::GCSA* gcsaidx = nullptr;
+    gcsa::LCPArray* lcpidx = nullptr;
+    
+    // Build the GCSA index
+    graph.build_gcsa_lcp(gcsaidx, lcpidx, 16, false, false, 3);
+    
+    // Build the xg index
+    xg::XG xg_index(proto_graph);
+    
+    // Make a multipath mapper to map against the graph.
+    Mapper mapper(&xg_index, gcsaidx, lcpidx);
+    
+    SECTION( "Mapper can map a short fake read" ) {
+
+        // Make the alignment        
+        string read = "GAT";
+        Alignment aln;
+        aln.set_sequence(read);
+        
+        // Align for just one alignment
+        auto results = mapper.align_multi(aln);
+        
+        SECTION("there should be one alignment") {
+            REQUIRE(results.size() == 1);
+            auto& aligned = results.front();
+            
+                
+            SECTION("which should have one mapping") {
+                REQUIRE(aligned.path().mapping_size() == 1);
+                auto& mapping = aligned.path().mapping(0);
+                
+                SECTION("which should be at the start of node 1") {
+                    REQUIRE(mapping.position().node_id() == 1);
+                    REQUIRE(mapping.position().offset() == 0);
+                    REQUIRE(mapping.position().is_reverse() == false);
+                }
+                
+                SECTION("which should have one edit") {
+                    REQUIRE(mapping.edit_size() == 1);
+                    auto& edit = mapping.edit(0);
+                    
+                    SECTION("which should be a length 3 perfect match") {
+                        REQUIRE(edit.from_length() == 3);
+                        REQUIRE(edit.to_length() == 3);
+                        REQUIRE(edit.sequence() == "");
+                    }
+                }
+            }
+        }
+    }
+    
+    SECTION( "Mapper can map two tiny paired reads" ) {
+    
+        // Here are two reads in opposing, inward-facing directions
+        Alignment read1, read2;
+        read1.set_sequence("GAT");
+        read2.set_sequence("TGT");
+        
+        // Align for just one pair of alignments
+        bool resolve_later = false;
+        auto results = mapper.align_paired_multi(read1, read2, resolve_later);
+        
+        SECTION("there should be one pair of alignments") {
+            REQUIRE(results.first.size() == 1);
+            REQUIRE(results.second.size() == 1);
+            auto& aligned1 = results.first.front();
+            auto& aligned2 = results.second.front();
+            
+                
+            SECTION("each should have one mapping") {
+                REQUIRE(aligned1.path().mapping_size() == 1);
+                REQUIRE(aligned2.path().mapping_size() == 1);
+                auto& mapping1 = aligned1.path().mapping(0);
+                auto& mapping2 = aligned2.path().mapping(0);
+                
+                SECTION("the first should be at the start of node 1") {
+                    REQUIRE(mapping1.position().node_id() == 1);
+                    REQUIRE(mapping1.position().offset() == 0);
+                    REQUIRE(mapping1.position().is_reverse() == false);
+                }
+                
+                SECTION("the second should be at the end of node 1, reversed") {
+                    REQUIRE(mapping2.position().node_id() == 1);
+                    REQUIRE(mapping2.position().offset() == 0);
+                    REQUIRE(mapping2.position().is_reverse() == true);
+                }
+                
+                SECTION("each should have one edit") {
+                    REQUIRE(mapping1.edit_size() == 1);
+                    REQUIRE(mapping2.edit_size() == 1);
+                    auto& edit1 = mapping1.edit(0);
+                    auto& edit2 = mapping2.edit(0);
+                    
+                    SECTION("which should be a length 3 perfect match") {
+                        REQUIRE(edit1.from_length() == 3);
+                        REQUIRE(edit1.to_length() == 3);
+                        REQUIRE(edit1.sequence() == "");
+                        REQUIRE(edit2.from_length() == 3);
+                        REQUIRE(edit2.to_length() == 3);
+                        REQUIRE(edit2.sequence() == "");
+                    }
+                }
+            }
+        }
+    
+    }
+    
+    // Clean up the GCSA/LCP index
+    delete gcsaidx;
+    delete lcpidx;
+}
+
+}
+
+}

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -114,7 +114,7 @@ vg index -x x.xg -g x.gcsa -k 16 x.vg
 vg sim -s 1337 -n 100 -e 0.01 -i 0.005 -x x.xg -a >x.sim
 vg map -x x.xg -g x.gcsa -G x.sim -t 1 >x.gam
 vg mod -Z x.trans -i x.gam x.vg >x.mod.vg
-is $(vg view -Z x.trans | wc -l) 1280 "the expected graph translation is exported when the graph is edited"
+is $(vg view -Z x.trans | wc -l) 1278 "the expected graph translation is exported when the graph is edited"
 rm -rf x.vg x.xg x.gcsa x.reads x.gam x.mod.vg x.trans
 
 vg construct -r tiny/tiny.fa >flat.vg

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -71,8 +71,11 @@ is "$(vg view -Jv reversing/double_reversing.json | vg mod -u - | vg stats -z - 
 
 is $(vg view -Jv msgas/inv-mess.json | vg mod -n - | vg validate - && vg view -Jv msgas/inv-mess.json | vg mod -n - | md5sum | cut -f 1 -d\ ) 02e484f8bc83bf4f37ecda0ad684b235 "normalization works on a graph with an inversion"
 
-vg msga -g s.vg -s TCAGATTCTCATCCCTCCTCAAGGGCTTCTGTAGCTTTGATGTGGAGTAGTTCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAG -w 16 -N | vg mod -u - >/dev/null
+vg msga -w 20 -f msgas/s.fa > s.vg
+vg msga -g s.vg -s TCAGATTCTCATCCCTCCTCAAGGGCTTCTGTAGCTTTGATGTGGAGTAGTTCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAG -w 16 -N > s2.vg
+vg mod -u s2.vg >/dev/null
 is $? 0 "mod successfully unchops a difficult graph"
+rm -f s.vg s2.vg
 
 is $(vg msga -w 20 -f msgas/s.fa  | vg mod -r s1 - | vg view - | grep ^P | cut -f 3 | sort | uniq | wc -l) 1 "a single path may be retained"
 


### PR DESCRIPTION
I found a read that was mapping worse to snp1kg than to primary in the BRCA1 Jenkins test, running locally on kolossus.

This was because the read had a MEM stareting at the beginning of the read and the end of a node (it aligned on the reverse strand), and the cluster subgraph extractor was not looking before that MEM to find any more graph material. The optimal alignment didn't actually use that MEM but instead went a bit further out and matched more repeat units for a better score.

I turned the problem into a unit test, and solved it by cribbing off @jeizenga's cluster graph extractor.

We should pay close attention to how many CI warnings about misbehaving reads Jenkins throws. I want them to come down from 72 (on Jenkins) for BRCA1 and 390 (on Jenkins) for MHC.

Oddly, I get different sets of warnings when I run the Jenkins tests locally versus on Jenkins. I think `toil-vg` is generating different reads with `vg sim`. Maybe @cmarkello knows if there's a difference in how the reads are seeded somehow.

This is related to #881 and may fix it if it's good enough.