### PR TITLE
output path rank overlap information

### DIFF
--- a/scripts/vg-dotplots
+++ b/scripts/vg-dotplots
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ $# -ne 2 ];
+then
+    echo "usage: "$(basename $0) "[vg-graph] [output-dir]"
+    exit
+fi
+
+graph=$1
+outdir=$2
+
+mkdir -p $outdir
+
+vg stats -O $graph | pv -l >$outdir/pathoverlaps.tsv
+
+for cmp in $(cat $outdir/pathoverlaps.tsv | tail -n+2 | cut -f 1 | sort | uniq )
+do
+   echo $cmp
+   cat $outdir/pathoverlaps.tsv \
+       | grep "^comparison\|$cmp" \
+       | Rscript -e 'require(tidyverse); y <- read.delim("stdin"); ggplot(subset(y, comparison == "'$cmp'"), aes(x=x, y=y)) + geom_point(size=0.01) + theme_bw() + labs(title="'$cmp'"); ggsave("'$outdir'/'$cmp'.pdf")'
+done

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 9
+plan tests 10
 
 vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 #is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
@@ -41,3 +41,4 @@ vg map -x x.xg -g x.gcsa -T x.reads >x.gam
 is "$(vg stats -a x.gam x.vg | md5sum | cut -f 1 -d\ )" "$(md5sum correct/10_vg_stats/15.txt | cut -f 1 -d\ )" "aligned read stats are computed correctly"
 rm -f x.vg x.xg x.gcsa x.gam x.reads
 
+is $(vg msga -f msgas/cycle.fa -b s1 -w 32 -t 1 | vg stats -O - | wc -l) 109 "a path overlap description of a cyclic graph built by msga has the expected length"


### PR DESCRIPTION
This is useful if you want to make a kind of pairwise dot plot to understand the alignment between two paths through a genome graph.

For instance:

![x](https://user-images.githubusercontent.com/145425/28998673-2638c42a-79ff-11e7-8175-825a164acd17.png)

These can be made easily with `scripts/vg-dotplot`:

```
vg/scripts/vg-dotplots chrI.all.vg.2 chrI.all.vg.2.dotplots
```