### PR TITLE
Always use same seed for jenkins simulation

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -434,7 +434,7 @@ class VGCITest(TestCase):
             opts += '--container {} '.format(self.container)
         # note, using the same seed only means something if using same
         # number of chunks.  we make that explicit here
-        opts += '--maxCores {} --sim_chunks {} --seed {} '.format(self.cores, self.cores, self.cores)
+        opts += '--maxCores {} --sim_chunks {} --seed {} '.format(self.cores, 8, 8)
         opts += '--sim_opts \'-l 150 -p 500 -v 50 -e 0.05 -i 0.01 --include-bonuses\' '
         opts += '--annotate_xg {} '.format(base_xg_path)
         cmd = 'toil-vg sim {} {} {} {} --gam {}'.format(


### PR DESCRIPTION
Should now get same results as Jenkins when running locally with != 8 cores. 