### PR TITLE
Test variant filtering

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -125,8 +125,16 @@ class VGCITest(TestCase):
             # Convert to a public HTTPS URL
             url = 'https://{}.s3.amazonaws.com{}'.format(bname, keyname)
             # And download it
-            connection = urllib2.urlopen(url)
-            return connection.read()
+            try:
+                connection = urllib2.urlopen(url)
+                return connection.read()
+            except urllib2.HTTPError as e:
+                if e.code == 404:
+                    # Baseline file doesn't yet exist. Give an empty string.
+                    return ""
+                else:
+                    # Something else is wrong
+                    raise
         else:
             # Assume it's a raw path.
             with open(os.path.join(self.baseline, 'outstore-{}'.format(tag), path)) as f:
@@ -847,23 +855,22 @@ class VGCITest(TestCase):
     @timeout_decorator.timeout(3600)
     def test_sim_brca1_snp1kg(self):
         """ Mapping and calling bakeoff F1 test for BRCA1 primary graph """
-        # Using 50k simulated reads from snp1kg BRCA1, realign against all these
-        # other BRCA1 graphs and make sure the realignments are sufficiently
-        # good.
-        # Compare all realignment scores agaisnt the scores for the primary
-        # graph.
+        # Using 100k simulated reads from snp1kg BRCA1, realign against all
+        # these other BRCA1 graphs and make sure the realignments are
+        # sufficiently good. Compare all realignment scores agaisnt the scores
+        # for the primary graph.
         self._test_mapeval(100000, 'BRCA1', 'snp1kg',
-                           ['primary', 'snp1kg', 'cactus', 'snp1kg_HG00096', 'snp1kg_minus_HG00096'],
+                           ['primary', 'snp1kg', 'common1kg', 'cactus', 'snp1kg_HG00096', 'snp1kg_minus_HG00096'],
                            score_baseline_graph='primary',
                            positive_control='snp1kg_HG00096',
                            negative_control='snp1kg_minus_HG00096',
                            sample='HG00096')
-
+                           
     @timeout_decorator.timeout(3600)
     def test_sim_mhc_snp1kg(self):
         """ Mapping and calling bakeoff F1 test for MHC primary graph """        
         self._test_mapeval(100000, 'MHC', 'snp1kg',
-                           ['primary', 'snp1kg', 'cactus', 'snp1kg_HG00096', 'snp1kg_minus_HG00096'],
+                           ['primary', 'snp1kg', 'common1kg', 'cactus', 'snp1kg_HG00096', 'snp1kg_minus_HG00096'],
                            score_baseline_graph='primary',
                            positive_control='snp1kg_HG00096',
                            negative_control='snp1kg_minus_HG00096',

--- a/scripts/filter_variants_on_repeats.py
+++ b/scripts/filter_variants_on_repeats.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# filter_variants_on_repeats.py: Drop low-frequency variants on repeats
+"""
+
+Low-frequency variants on repeats might be counterproductive in a graph.
+
+They can be more likely to be matched spuriously due to an error than due to a
+genuine instance of the variant.
+
+This script removes such variants from VCFs.
+
+Repeat count information is pulled from the hgsql command, which must be
+available.
+
+"""
+
+import argparse
+import os
+import sys
+import time
+import subprocess
+import collections
+
+import vcf
+import tsv
+from intervaltree import IntervalTree
+import itertools
+
+def parse_args(args):
+    """
+    Takes in the command-line arguments list (args), and returns a nice argparse
+    result with fields for all the options.
+    
+    Borrows heavily from the argparse documentation examples:
+    <http://docs.python.org/library/argparse.html>
+    """
+    
+    # Construct the parser (which is stored in parser)
+    # Module docstring lives in __doc__
+    # See http://python-forum.com/pythonforum/viewtopic.php?f=3&t=36847
+    # And a formatter class so our examples in the docstring look good. Isn't it
+    # convenient how we already wrapped it to 80 characters?
+    # See http://docs.python.org/library/argparse.html#formatter-class
+    parser = argparse.ArgumentParser(description=__doc__, 
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    
+    parser.add_argument("vcf", type=argparse.FileType('r'), default=sys.stdin,
+        help="VCF file to filter")
+    parser.add_argument("--out_vcf", type=argparse.FileType('w'),
+        default=sys.stdout,
+        help="VCF file to write passing entries to")
+    parser.add_argument("--contig", default="chr17",
+        help="contig to pull variants from")
+    parser.add_argument("--start", type=int, default=43044294,
+        help="start position on contig")
+    parser.add_argument("--end", type=int, default=43125484,
+        help="end position on contig")
+    parser.add_argument("--error_rate", type=float, default=0.01,
+        help="error rate to assume for sequencing reads")
+    
+    # The command line arguments start with the program name, which we don't
+    # want to treat as an argument for argparse. So we remove it.
+    args = args[1:]
+        
+    return parser.parse_args(args)
+
+class RepeatDb(object):
+
+    def __init__(self, contig, start, end):
+        """
+        Given a range on a contig, get all the repeats overlapping that range.
+        
+        Keeps an IntervalTree of element names, and a Counter from element
+        name to number of that element in the range.
+        
+        No protection against SQL injection.
+        
+        """
+        
+        # Make the interval tree
+        self.tree = IntervalTree()
+        
+        # Make a counter for repeats with a certain name
+        self.counts = collections.Counter()
+        
+        command = ["hgsql", "-e", "select repName, genoName, genoStart, genoEnd "
+            "from hg38.rmsk where genoName = '{}' and genoStart > '{}' "
+            "and genoEnd < '{}';".format(contig, start, end)]
+        process = subprocess.Popen(command, stdout=subprocess.PIPE)
+        
+        for parts in itertools.islice(tsv.TsvReader(process.stdout), 1, None):
+            # For each line except the first, broken into fields
+            
+            # Add the item to the tree covering its range. Store the repeat type
+            # name as the interval's data.
+            self.tree.addi(int(parts[2]), int(parts[3]), parts[0])
+            
+            # Count it
+            self.counts[parts[0]] += 1
+
+    def get_copies(self, contig, pos):
+        """
+        Given a contig name and a position, estimate the copy number of that
+        position in the genome.
+        
+        Return the number of instances expected (1 for non-repetitive sequence).
+        """
+        
+        # TODO: use contig
+        
+        # Get the set of overlapping things
+        overlaps = self.tree[pos]
+        
+        # Keep track of the number of copies of the most numerous repeat
+        # observed.
+        max_copies = 1
+        
+        for interval in overlaps:
+            # For each repeat we are in
+            
+            # Max in how many copies of it exist
+            max_copies = max(max_copies, self.counts[interval.data])
+            
+        return max_copies
+            
+   
+def main(args):
+    """
+    Parses command line arguments and do the work of the program.
+    "args" specifies the program arguments, with args[0] being the executable
+    name. The return value should be used as the program's exit code.
+    """
+    
+    options = parse_args(args) # This holds the nicely-parsed options object
+    
+    # Make a repeat database
+    db = RepeatDb(options.contig, options.start, options.end)
+    
+    # Strip "chr" from the contig.
+    # TODO: figure out if we need to
+    short_contig = (options.contig[3:] if len(options.contig) > 3
+        else options.contig)
+    
+    # Read the input VCF
+    reader = vcf.Reader(options.vcf)
+    
+    # Make a writer for the passing records
+    writer = vcf.Writer(options.out_vcf, reader)
+    
+    # Track statistics
+    total_variants = 0
+    kept_variants = 0
+    
+    for variant in reader.fetch(short_contig, options.start, options.end):
+        # For each variant in our region
+        
+        # Count it
+        total_variants += 1
+        
+        # See how numerous it should be
+        count = db.get_copies("chr" + variant.CHROM, variant.POS)
+        
+        # And how common it is
+        frequency = variant.INFO["AF"][0]
+        
+        # What's the minimum frequency to get more true than fake hits?
+        min_frequency = (count * options.error_rate /
+            (3 - 2 * options.error_rate))
+            
+        # Should we keep it?
+        keep = (frequency >= min_frequency)
+        
+        sys.stderr.write(
+            "{} {}:{} has {} copies and frequency {:.4f} vs. {:.4f}\n".format(
+            "☑" if keep else "☐", variant.CHROM, variant.POS, count,
+            frequency, min_frequency))
+            
+        if keep:
+            # Pass the variants we're keeping
+            writer.write_record(variant)
+            # Count it
+            kept_variants += 1
+            
+    sys.stderr.write("Finished! Kept {} / {} variants\n".format(kept_variants,
+        total_variants))
+        
+    
+    return 0
+    
+def entrypoint():
+    """
+    0-argument entry point for setuptools to call.
+    """
+    
+    # Provide main with its arguments and handle exit codes
+    sys.exit(main(sys.argv))
+    
+if __name__ == "__main__" :
+    entrypoint()
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2975,8 +2975,8 @@ VG Mapper::alignment_subgraph(const Alignment& aln, int context_size) {
 // estimate the fragment length as the difference in mean positions of both alignments
 map<string, int> Mapper::approx_pair_fragment_length(const Alignment& aln1, const Alignment& aln2) {
     map<string, int> lengths;
-    auto pos1 = alignment_mean_path_positions(aln1);
-    auto pos2 = alignment_mean_path_positions(aln2);
+    auto pos1 = alignment_mean_path_positions(aln1, true);
+    auto pos2 = alignment_mean_path_positions(aln2, true);
     for (auto& p : pos1) {
         auto x = pos2.find(p.first);
         if (x != pos2.end()) {
@@ -2997,8 +2997,8 @@ string Mapper::fragment_model_str(void) {
 }
 
 int Mapper::first_approx_pair_fragment_length(const Alignment& aln1, const Alignment& aln2) {
-    auto pos1 = alignment_mean_path_positions(aln1);
-    auto pos2 = alignment_mean_path_positions(aln2);
+    auto pos1 = alignment_mean_path_positions(aln1, true);
+    auto pos2 = alignment_mean_path_positions(aln2, true);
     for (auto& p : pos1) {
         auto x = pos2.find(p.first);
         if (x != pos2.end()) {

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -353,7 +353,7 @@ public:
     double graph_entropy(void);
 
     // use the xg index to get the mean position of the nodes in the alignent for each reference that it corresponds to
-    map<string, double> alignment_mean_path_positions(const Alignment& aln, bool first_hit_only = true);
+    map<string, double> alignment_mean_path_positions(const Alignment& aln, bool first_hit_only = false);
     void annotate_with_mean_path_positions(vector<Alignment>& alns);
 
     // Return true of the two alignments are consistent for paired reads, and false otherwise

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -105,7 +105,9 @@ int main_annotate(int argc, char** argv) {
         if (add_positions) {
             //map<string, double> Mapper::alignment_mean_path_positions(const Alignment& aln, bool first_hit_only);
             function<void(Alignment&)> lambda = [&](Alignment& aln) {
-                for (auto& ref : mapper.alignment_mean_path_positions(aln)) {
+                for (auto& ref : mapper.alignment_mean_path_positions(aln, false)) {
+                    // For each path position (making sure to get the actual
+                    // median and not just the first hit of anything on a path)
                     Position* refpos = aln.add_refpos();
                     refpos->set_name(ref.first);
                     refpos->set_offset(round(ref.second));


### PR DESCRIPTION
The Travis Mac test will probably fail still, but I'm going to open this anyway to see the Jenkins results.

I've put in "common1kg" graphs next to the snp1kg graphs in the mapeval tests. These are built from filtered VCFs, using Jordan's formula to identify and discard variants that are too rare compared to the repetitiveness of their local region.

I measured "repetitiveness" as copies of the most numerous overlapping repetitive element in the genome browser database, within the region being made into a graph. I estimated the error rate at 1%. I ignored (and just passed along) all the non-SNP variants, since it wasn't clear what the error model for them should be.

Even in regions not part of any repetitive elements, I ended up discarding a lot of stuff. Overall, this method discards most variants (because most variants are very low frequency):

BRCA1: `Finished! Kept 343 (94 non-SNP) / 2051 variants`
MHC: `Finished! Kept 58674 (7624 non-SNP) / 165891 variants`

I had to change the way read positions were counted, because previously we were assigning reads' positions based exclusively on their lowest-numbered overlapping node, which was not precise enough (given read and node sizes) to get reasonable results with our 100-base threshold for being in the right position. I also made sure to chop the nodes of my new graph to 10 bases to make position estimation more accurate; with a 1000-base node you could be off by hundreds of bases if you just take the node's center as the read position.

Fixes #953 