### PR TITLE
Fix paired-end AUC regression

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2906,7 +2906,11 @@ VG Mapper::cluster_subgraph(const Alignment& aln, const vector<MaximalExactMatch
     auto start_pos = make_pos_t(start_mem.nodes.front());
     auto rev_start_pos = reverse(start_pos, get_node_length(id(start_pos)));
     float expansion = 1.61803;
-    int get_before = (int)(expansion * (int)(start_mem.begin - aln.sequence().begin()));
+    // Even if the MEM is right up against the start of the read, it may not be
+    // part of the best alignment. Make sure to have some padding.
+    // TODO: how much padding?
+    int padding = 20;
+    int get_before = padding + (int)(expansion * (int)(start_mem.begin - aln.sequence().begin()));
     VG graph;
     if (get_before) {
         cached_graph_context(graph, rev_start_pos, get_before, node_cache, edge_cache);
@@ -2914,9 +2918,9 @@ VG Mapper::cluster_subgraph(const Alignment& aln, const vector<MaximalExactMatch
     for (int i = 0; i < mems.size(); ++i) {
         auto& mem = mems[i];
         auto pos = make_pos_t(mem.nodes.front());
-        int get_after = (i+1 == mems.size() ?
-                         expansion * (int)(aln.sequence().end() - mem.begin)
-                         : expansion * max(mem.length(), (int)(mems[i+1].end - mem.begin)));
+        int get_after = padding + (i+1 == mems.size() ?
+                                   expansion * (int)(aln.sequence().end() - mem.begin)
+                                   : expansion * max(mem.length(), (int)(mems[i+1].end - mem.begin)));
         cached_graph_context(graph, pos, get_after, node_cache, edge_cache);
     }
     graph.remove_orphan_edges();

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2899,6 +2899,31 @@ void Mapper::cached_graph_context(VG& graph, const pos_t& pos, int length, LRUCa
 }
 
 VG Mapper::cluster_subgraph(const Alignment& aln, const vector<MaximalExactMatch>& mems) {
+    auto& node_cache = get_node_cache();
+    auto& edge_cache = get_edge_cache();
+    assert(mems.size());
+    auto& start_mem = mems.front();
+    auto start_pos = make_pos_t(start_mem.nodes.front());
+    auto rev_start_pos = reverse(start_pos, get_node_length(id(start_pos)));
+    float expansion = 1.61803;
+    int get_before = (int)(expansion * (int)(start_mem.begin - aln.sequence().begin()));
+    VG graph;
+    if (get_before) {
+        cached_graph_context(graph, rev_start_pos, get_before, node_cache, edge_cache);
+    }
+    for (int i = 0; i < mems.size(); ++i) {
+        auto& mem = mems[i];
+        auto pos = make_pos_t(mem.nodes.front());
+        int get_after = (i+1 == mems.size() ?
+                         expansion * (int)(aln.sequence().end() - mem.begin)
+                         : expansion * max(mem.length(), (int)(mems[i+1].end - mem.begin)));
+        cached_graph_context(graph, pos, get_after, node_cache, edge_cache);
+    }
+    graph.remove_orphan_edges();
+    return graph;
+}
+
+VG Mapper::cluster_subgraph_strict(const Alignment& aln, const vector<MaximalExactMatch>& mems) {
 #ifdef debug_mapper
 #pragma omp critical
     {

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -401,6 +401,8 @@ public:
     Alignment patch_alignment(const Alignment& aln, int max_patch_length);
     // get the graph context of a particular cluster, using a given alignment to describe the required size
     VG cluster_subgraph(const Alignment& aln, const vector<MaximalExactMatch>& mems);
+    // Get the graph context of a particular cluster, not expanding beyond the middles of MEMs.
+    VG cluster_subgraph_strict(const Alignment& aln, const vector<MaximalExactMatch>& mems);
     // helper to cluster subgraph
     void cached_graph_context(VG& graph, const pos_t& pos, int length, LRUCache<id_t, Node>& node_cache, LRUCache<id_t, vector<Edge> >& edge_cache);
     // for aligning to a particular MEM cluster

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -117,7 +117,7 @@ vg index -x x.xg -g x.gcsa -k 16 x.vg
 vg sim -s 1337 -n 100 -e 0.01 -i 0.005 -x x.xg -a >x.sim
 vg map -x x.xg -g x.gcsa -G x.sim -t 1 >x.gam
 vg mod -Z x.trans -i x.gam x.vg >x.mod.vg
-is $(vg view -Z x.trans | wc -l) 1278 "the expected graph translation is exported when the graph is edited"
+is $(vg view -Z x.trans | wc -l) 1280 "the expected graph translation is exported when the graph is edited"
 rm -rf x.vg x.xg x.gcsa x.reads x.gam x.mod.vg x.trans
 
 vg construct -r tiny/tiny.fa >flat.vg


### PR DESCRIPTION
This fixes the problem I introduced in #943 that caused paired-end performance to tank, and which Jordan talked about in #962.

It does it by ripping out my port of Jordan's cluster graph extractor, and replacing it with Erik's cluster graph extractor again, but with a little more padding.

Once Glenn tuns the AUC testing back on, we can try to get the performance of the more principled method up. But there's a significant impedance mismatch between the way Jordan's extractor thinks and the way the rest of the mapper thinks (for example, it assumes the MEMs themselves are basically always used in the alignment and doesn't extend off them in the middle), and getting the two to be really happy together might be hard without rearchitecting things to look a lot more like the multipath mapper overall.