### PR TITLE
Undo more changes that decreased paired-end performance

### DIFF
--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -105,16 +105,10 @@ size_t to_length_after_pos(const Alignment& aln, const Position& pos);
 size_t from_length_after_pos(const Alignment& aln, const Position& pos);
 size_t to_length_before_pos(const Alignment& aln, const Position& pos);
 size_t from_length_before_pos(const Alignment& aln, const Position& pos);
-
-/// Define a comparison functor for different alignments of the same sequence to
-/// the same graph, ignoring all the metadata.
-struct SameReadAlignmentOrder {
-    bool operator()(const Alignment& a, const Alignment& b) const;
-};
-/// We have a similar functor for pairs of alignments.
-struct SameReadsAlignmentPairOrder {
-    bool operator()(const pair<Alignment, Alignment>& a, const pair<Alignment, Alignment>& b) const;
-};
+string signature(const Alignment& aln);
+pair<string, string> signature(const Alignment& aln1, const Alignment& aln2);
+string middle_signature(const Alignment& aln, int len);
+pair<string, string> middle_signature(const Alignment& aln1, const Alignment& aln2, int len);
 
 // project the alignment's path back into a different ID space
 void translate_nodes(Alignment& a, const unordered_map<id_t, pair<id_t, bool> >& ids, const std::function<size_t(int64_t)>& node_length);

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1561,6 +1561,7 @@ pos_t Mapper::likely_mate_position(const Alignment& aln, bool is_first_mate) {
 }
 
 bool Mapper::pair_rescue(Alignment& mate1, Alignment& mate2, int match_score) {
+    auto pair_sig = signature(mate1, mate2);
     // bail out if we can't figure out how far to go
     if (!fragment_size) return false;
     //double hang_threshold = 0.9;
@@ -1577,7 +1578,7 @@ bool Mapper::pair_rescue(Alignment& mate1, Alignment& mate2, int match_score) {
     double mate1_id = (double) mate1.score() / perfect_score;
     double mate2_id = (double) mate2.score() / perfect_score;
     pos_t mate_pos;
-    if (debug) cerr << "pair rescue: mate1 " << mate1_id << " mate2 " << mate2_id << " consistent? " << consistent << endl;
+    if (debug) cerr << "pair rescue: mate1 " << signature(mate1) << " " << mate1_id << " mate2 " << signature(mate2) << " " << mate2_id << " consistent? " << consistent << endl;
     //if (debug) cerr << "mate1: " << pb2json(mate1) << endl;
     //if (debug) cerr << "mate2: " << pb2json(mate2) << endl;
     if (mate1_id >= mate2_id && mate1_id > hang_threshold && !consistent) {
@@ -2133,9 +2134,7 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         }
     }
     
-    // We keep a set of pairs of alignments that we have already seen, for
-    // deduplication purposes.
-    set<pair<Alignment, Alignment>, SameReadsAlignmentPairOrder> seen_alignments;
+    set<pair<string, string> > seen_alignments;
     for (auto& cluster_ptr : cluster_ptrs) {
         if (alns.size() >= total_multimaps) { break; }
         // break the cluster into two pieces
@@ -2162,10 +2161,11 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
             p.second.clear_identity();
             p.second.clear_path();
         }
-        if (seen_alignments.count(p)) {
+        auto pair_sig = signature(p.first, p.second);
+        if (seen_alignments.count(pair_sig)) {
             alns.pop_back();
         } else {
-            seen_alignments.insert(p);
+            seen_alignments.insert(pair_sig);
         }
     }
 
@@ -2223,10 +2223,11 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         alns.erase(
             std::remove_if(alns.begin(), alns.end(),
                            [&](const pair<Alignment, Alignment>& p) {
-                               if (seen_alignments.count(p)) {
+                               auto pair_sig = signature(p.first, p.second);
+                               if (seen_alignments.count(pair_sig)) {
                                    return true;
                                } else {
-                                   seen_alignments.insert(p);
+                                   seen_alignments.insert(pair_sig);
                                    return false;
                                }
                            }),
@@ -2683,8 +2684,7 @@ Mapper::align_mem_multi(const Alignment& aln,
     vector<Alignment> alns;
     vector<vector<MaximalExactMatch>*> cluster_ptrs;
     //map<vector<MaximalExactMatch>*, int> cluster_cov;
-    // We keep a set of alignments we have already generated.
-    set<Alignment, SameReadAlignmentOrder> seen_alignments;
+    set<string> seen_alignments;
     int multimaps = 0;
     for (auto& cluster : clusters) {
         if (alns.size() >= total_multimaps) { break; }
@@ -2693,10 +2693,21 @@ Mapper::align_mem_multi(const Alignment& aln,
         // skip if we've got enough multimaps to get MQ and we're under the min cluster length
         if (min_cluster_length && cluster_coverage(cluster) < min_cluster_length && alns.size() > 1) continue;
         Alignment candidate = align_cluster(aln, cluster);
-     
-        if (candidate.identity() > min_identity && !seen_alignments.count(candidate)) {
+        string sig = signature(candidate);
+        
+#ifdef debug_mapper
+#pragma omp critical
+        {
+            if (debug) {
+                cerr << "Alignment with signature " << sig << " (seen: " << seen_alignments.count(sig) << ")" << endl;
+                cerr << "\t" << pb2json(candidate) << endl;
+            }
+        }
+#endif
+        
+        if (candidate.identity() > min_identity && !seen_alignments.count(sig)) {
             alns.push_back(candidate);
-            seen_alignments.insert(candidate);
+            seen_alignments.insert(sig);
         }
     }
 

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2917,7 +2917,7 @@ VG Mapper::cluster_subgraph(const Alignment& aln, const vector<MaximalExactMatch
     // Even if the MEM is right up against the start of the read, it may not be
     // part of the best alignment. Make sure to have some padding.
     // TODO: how much padding?
-    int padding = 20;
+    int padding = 1;
     int get_before = padding + (int)(expansion * (int)(start_mem.begin - aln.sequence().begin()));
     VG graph;
     if (get_before) {

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -3012,8 +3012,8 @@ VG Mapper::alignment_subgraph(const Alignment& aln, int context_size) {
 // estimate the fragment length as the difference in mean positions of both alignments
 map<string, int> Mapper::approx_pair_fragment_length(const Alignment& aln1, const Alignment& aln2) {
     map<string, int> lengths;
-    auto pos1 = alignment_mean_path_positions(aln1, true);
-    auto pos2 = alignment_mean_path_positions(aln2, true);
+    auto pos1 = alignment_mean_path_positions(aln1);
+    auto pos2 = alignment_mean_path_positions(aln2);
     for (auto& p : pos1) {
         auto x = pos2.find(p.first);
         if (x != pos2.end()) {
@@ -3034,8 +3034,8 @@ string Mapper::fragment_model_str(void) {
 }
 
 int Mapper::first_approx_pair_fragment_length(const Alignment& aln1, const Alignment& aln2) {
-    auto pos1 = alignment_mean_path_positions(aln1, true);
-    auto pos2 = alignment_mean_path_positions(aln2, true);
+    auto pos1 = alignment_mean_path_positions(aln1);
+    auto pos2 = alignment_mean_path_positions(aln2);
     for (auto& p : pos1) {
         auto x = pos2.find(p.first);
         if (x != pos2.end()) {

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -354,7 +354,7 @@ public:
     double graph_entropy(void);
 
     // use the xg index to get the mean position of the nodes in the alignent for each reference that it corresponds to
-    map<string, double> alignment_mean_path_positions(const Alignment& aln, bool first_hit_only = false);
+    map<string, double> alignment_mean_path_positions(const Alignment& aln, bool first_hit_only = true);
     void annotate_with_mean_path_positions(vector<Alignment>& alns);
 
     // Return true of the two alignments are consistent for paired reads, and false otherwise

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -105,9 +105,7 @@ int main_annotate(int argc, char** argv) {
         if (add_positions) {
             //map<string, double> Mapper::alignment_mean_path_positions(const Alignment& aln, bool first_hit_only);
             function<void(Alignment&)> lambda = [&](Alignment& aln) {
-                for (auto& ref : mapper.alignment_mean_path_positions(aln, false)) {
-                    // For each path position (making sure to get the actual
-                    // median and not just the first hit of anything on a path)
+                for (auto& ref : mapper.alignment_mean_path_positions(aln)) {
                     Position* refpos = aln.add_refpos();
                     refpos->set_name(ref.first);
                     refpos->set_offset(round(ref.second));


### PR DESCRIPTION
It turns out that my alternative actual-alignment-based deduplication mechanism resulted in worse performance than the old end-node-ID-based "signature" deduplication that was being used, even though different alignments might sometimes have the same signature.

Also, it turns out that my change to place the reads at the actual median position, instead of the position of the lowest-ID node, made BWA look really bad, because BWA reads are just getting placed at the read's start position. I still think placing reads at the real median position is better; I just need to fix the bwa position determination in toil-vg to also use a median or middle position.

Fixes #968.