### PR TITLE
Up padding (again)

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2558,6 +2558,7 @@ Mapper::align_mem_multi(const Alignment& aln,
     double mq_cap = max_mapping_quality;
 
     {
+        // Estimate the maximum mapping quality we can get if the alignments based on the good MEMs are the best ones.
         int mem_max_length = 0;
         for (auto& mem : mems) if (mem.primary && mem.match_count) mem_max_length = max(mem_max_length, (int)mem.length());
         double maybe_max = estimate_max_possible_mapping_quality(aln.sequence().size(),
@@ -2567,8 +2568,9 @@ Mapper::align_mem_multi(const Alignment& aln,
         if (maybe_max < maybe_mq_threshold) {
             mq_cap = maybe_max;
         }
+        // TODO: why should we limit our number of MEM chains to examine to max_multimaps / max estimated mapping quality?
         total_multimaps = max(min_multimaps, (int)round(total_multimaps/maybe_max));
-        if (debug) cerr << "maybe_mq " << aln.name() << " " << maybe_max << " " << total_multimaps << " " << mem_max_length << " " << longest_lcp << endl;
+        if (debug) cerr << "maybe_mq " << aln.name() << " max estimate: " << maybe_max << " estimated multimap limit: " << total_multimaps << " max mem length: " << mem_max_length << " longest LCP: " << longest_lcp << endl;
     }
 
     double avg_node_len = average_node_length();

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2326,6 +2326,16 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         results.second.clear();
     }
     
+    // Before we update the fragment length distribution, remember the
+    // distribution used here.
+    
+    stringstream fragment_dist;
+    fragment_dist << fragment_size
+        << ':' << cached_fragment_length_mean 
+        << ':' << cached_fragment_length_stdev 
+        << ':' << cached_fragment_orientation 
+        << ':' << cached_fragment_direction;
+    
     // we tried to align
     // if we don't have a fragment_size yet determined
     // and we didn't get a perfect, unambiguous hit on both reads
@@ -2381,13 +2391,14 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         aln.clear_score();
         aln.clear_identity();
     }
-
+    
     // Make sure to link up alignments even if they aren't mapped.
     for (auto& aln : results.first) {
         aln.set_name(read1.name());
         aln.mutable_fragment_next()->set_name(read2.name());
         aln.set_sequence(read1.sequence());
         aln.set_quality(read1.quality());
+        aln.set_fragment_length_distribution(fragment_dist.str());
     }
 
     for (auto& aln : results.second) {
@@ -2395,6 +2406,7 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         aln.mutable_fragment_prev()->set_name(read1.name());
         aln.set_sequence(read2.sequence());
         aln.set_quality(read2.quality());
+        aln.set_fragment_length_distribution(fragment_dist.str());
     }
 
     // if we have references, annotate the alignments with their reference positions

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2917,7 +2917,7 @@ VG Mapper::cluster_subgraph(const Alignment& aln, const vector<MaximalExactMatch
     // Even if the MEM is right up against the start of the read, it may not be
     // part of the best alignment. Make sure to have some padding.
     // TODO: how much padding?
-    int padding = 20;
+    int padding = 1;
     int get_before = padding + (int)(expansion * (int)(start_mem.begin - aln.sequence().begin()));
     VG graph;
     if (get_before) {

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2919,7 +2919,7 @@ VG Mapper::cluster_subgraph(const Alignment& aln, const vector<MaximalExactMatch
     // Even if the MEM is right up against the start of the read, it may not be
     // part of the best alignment. Make sure to have some padding.
     // TODO: how much padding?
-    int padding = 1;
+    int padding = 5;
     int get_before = padding + (int)(expansion * (int)(start_mem.begin - aln.sequence().begin()));
     VG graph;
     if (get_before) {

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -134,6 +134,8 @@ message Alignment {
     repeated int32 secondary_score = 29; // The ordered list of scores of secondary mappings
     double fragment_score = 30; // Score under the given fragment model, assume higher is better
     bool mate_mapped_to_disjoint_subgraph = 31;
+    
+    string fragment_length_distribution = 32; // The fragment length distribution under which a paired-end alignment was aligned.
 
 }
 


### PR DESCRIPTION
Not having enough padding increases the chances that unused MEMs near the ends of reads and nodes will cause an alignment to too little graph.

This should fix #975, but really we either want to have a large amount of padding (and not let that cause false positives on the mapeval tests) or have some other way of knowing if a better alignment would or could happen if we pulled in more graph material.