### PR TITLE
Record fragment length distributions used for alignments

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2326,6 +2326,16 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         results.second.clear();
     }
     
+    // Before we update the fragment length distribution, remember the
+    // distribution used here.
+    
+    stringstream fragment_dist;
+    fragment_dist << fragment_size
+        << ':' << cached_fragment_length_mean 
+        << ':' << cached_fragment_length_stdev 
+        << ':' << cached_fragment_orientation 
+        << ':' << cached_fragment_direction;
+    
     // we tried to align
     // if we don't have a fragment_size yet determined
     // and we didn't get a perfect, unambiguous hit on both reads
@@ -2381,13 +2391,14 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         aln.clear_score();
         aln.clear_identity();
     }
-
+    
     // Make sure to link up alignments even if they aren't mapped.
     for (auto& aln : results.first) {
         aln.set_name(read1.name());
         aln.mutable_fragment_next()->set_name(read2.name());
         aln.set_sequence(read1.sequence());
         aln.set_quality(read1.quality());
+        aln.set_fragment_length_distribution(fragment_dist.str());
     }
 
     for (auto& aln : results.second) {
@@ -2395,6 +2406,7 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         aln.mutable_fragment_prev()->set_name(read1.name());
         aln.set_sequence(read2.sequence());
         aln.set_quality(read2.quality());
+        aln.set_fragment_length_distribution(fragment_dist.str());
     }
 
     // if we have references, annotate the alignments with their reference positions

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -134,6 +134,8 @@ message Alignment {
     repeated int32 secondary_score = 29; // The ordered list of scores of secondary mappings
     double fragment_score = 30; // Score under the given fragment model, assume higher is better
     bool mate_mapped_to_disjoint_subgraph = 31;
+    
+    string fragment_length_distribution = 32; // The fragment length distribution under which a paired-end alignment was aligned.
 
 }
 


### PR DESCRIPTION
This makes replicating alignments much easier, because you can just pass in the same parameters to vg map with `-I`.