### PR TITLE
Use smoother mapeval fragment length distribution estimation in the tests

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -463,7 +463,8 @@ class VGCITest(TestCase):
             # Make sure we have the actual scores used to decide on alignments
             # Also force a fixed fragment length distribution to make alignment
             # deterministic for the test.
-            map_opts = ['--include-bonuses', '-I', '816:345.165:47.0999:0:1'], 
+            map_opts = ['--include-bonuses', '-I', '816:345.165:47.0999:0:1',
+                '--fixed-frag-model'], 
             # Toil options
             realTimeLogging = True,
             logLevel = "INFO",

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -460,7 +460,10 @@ class VGCITest(TestCase):
             vg_docker = self.vg_docker,
             container = self.container,
             alignment_cores = self.cores,
-            map_opts = ['--include-bonuses'], # Make sure we have the actual scores used to decide on alignments
+            # Make sure we have the actual scores used to decide on alignments
+            # Also force a fixed fragment length distribution to make alignment
+            # deterministic for the test.
+            map_opts = ['--include-bonuses', '-I', '816:345.165:47.0999:0:1'], 
             # Toil options
             realTimeLogging = True,
             logLevel = "INFO",

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -461,10 +461,8 @@ class VGCITest(TestCase):
             container = self.container,
             alignment_cores = self.cores,
             # Make sure we have the actual scores used to decide on alignments
-            # Also force a fixed fragment length distribution to make alignment
-            # deterministic for the test.
-            map_opts = ['--include-bonuses', '-I', '816:345.165:47.0999:0:1',
-                '--fixed-frag-model'], 
+            # Also try and make the fragment model more stable and consistent.
+            map_opts = ['--include-bonuses', '--frag-calc', '1000'], 
             # Toil options
             realTimeLogging = True,
             logLevel = "INFO",


### PR DESCRIPTION
This should stop the BRCA1 mapeval test from randomly and intermittently failing until #968 is fixed.

The right solution might be to improve the learning model somehow; the learned fragment length distribution pasted in here was learned on data simulated with the vg sim parameters used for mapeval, but it seems to skew much shorter than the length requested from vg sim.

@jeizenga didn't like this idea, but I think we have to do it or our PRs will randomly fail the BRCA1 AUC assert.