### PR TITLE
Fix sim bonus

### DIFF
--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -182,6 +182,9 @@ int main_sim(int argc, char** argv) {
     
     // Make a Mapper to score reads, with the default parameters
     Mapper rescorer(xgidx, nullptr, nullptr);
+    // Override the "default" full length bonus, just like every other subcommand that uses a mapper ends up doing.
+    // TODO: is it safe to change the default?
+    rescorer.set_alignment_scores(default_match, default_mismatch, default_gap_open, default_gap_extension, 5);
     // Include the full length bonuses if requested.
     rescorer.strip_bonuses = strip_bonuses;
     // We define a function to score a generated alignment under the mapper

--- a/test/t/13_vg_sim.t
+++ b/test/t/13_vg_sim.t
@@ -6,13 +6,15 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 9
+plan tests 10
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
 
 is $(vg sim -l 100 -n 100 -x x.xg | wc -l) 100 \
     "vg sim creates the correct number of reads"
+    
+is $(vg sim -s 1337 -l 100 -n 1 -e 0.0 -i 0.0 -J -x x.xg --include-bonuses | jq .score) 110 "end bonuses can be included"
 
 is $(vg sim -l 100 -n 100 -a -x x.xg | vg view -a - | wc -l) 100 \
    "alignments may be generated rather than read sequences"


### PR DESCRIPTION
Fixes #987 and makes vg sim have a nonzero full length bonus.

Still TODO is letting the user set the scoring parameters for vg sim.