### PR TITLE
Suppress duplicate warnings

### DIFF
--- a/scripts/filter_variants_on_repeats.py
+++ b/scripts/filter_variants_on_repeats.py
@@ -50,6 +50,8 @@ def parse_args(args):
     parser.add_argument("--out_vcf", type=argparse.FileType('w'),
         default=sys.stdout,
         help="VCF file to write passing entries to")
+    parser.add_argument("--assembly", default="hg38",
+        help="assembly database name to query")
     parser.add_argument("--contig", default="chr17",
         help="contig to pull variants from")
     parser.add_argument("--start", type=int, default=43044294,
@@ -67,7 +69,7 @@ def parse_args(args):
 
 class RepeatDb(object):
 
-    def __init__(self, contig, start, end):
+    def __init__(self, assembly, contig, start, end):
         """
         Given a range on a contig, get all the repeats overlapping that range.
         
@@ -85,8 +87,8 @@ class RepeatDb(object):
         self.counts = collections.Counter()
         
         command = ["hgsql", "-e", "select repName, genoName, genoStart, genoEnd "
-            "from hg38.rmsk where genoName = '{}' and genoStart > '{}' "
-            "and genoEnd < '{}';".format(contig, start, end)]
+            "from {}.rmsk where genoName = '{}' and genoStart > '{}' "
+            "and genoEnd < '{}';".format(assembly, contig, start, end)]
         process = subprocess.Popen(command, stdout=subprocess.PIPE)
         
         for parts in itertools.islice(tsv.TsvReader(process.stdout), 1, None):
@@ -135,7 +137,7 @@ def main(args):
     options = parse_args(args) # This holds the nicely-parsed options object
     
     # Make a repeat database
-    db = RepeatDb(options.contig, options.start, options.end)
+    db = RepeatDb(options.assembly, options.contig, options.start, options.end)
     
     # Strip "chr" from the contig.
     # TODO: figure out if we need to

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -23,57 +23,58 @@ using namespace vg::subcommand;
 void help_view(char** argv) {
     cerr << "usage: " << argv[0] << " view [options] [ <graph.vg> | <graph.json> | <aln.gam> | <read1.fq> [<read2.fq>] ]" << endl
          << "options:" << endl
-         << "    -g, --gfa            output GFA format (default)" << endl
-         << "    -F, --gfa-in         input GFA format" << endl
+         << "    -g, --gfa                  output GFA format (default)" << endl
+         << "    -F, --gfa-in               input GFA format" << endl
 
-         << "    -v, --vg             output VG format" << endl
-         << "    -V, --vg-in          input VG format (default)" << endl
+         << "    -v, --vg                   output VG format" << endl
+         << "    -V, --vg-in                input VG format (default)" << endl
 
-         << "    -j, --json           output JSON format" << endl
-         << "    -J, --json-in        input JSON format" << endl
-         << "    -c, --json-stream    streaming conversion of a VG format graph in line delimited JSON format" << endl
-         << "                         (this cannot be loaded directly via -J)" << endl
+         << "    -j, --json                 output JSON format" << endl
+         << "    -J, --json-in              input JSON format" << endl
+         << "    -c, --json-stream          streaming conversion of a VG format graph in line delimited JSON format" << endl
+         << "                               (this cannot be loaded directly via -J)" << endl
 
-         << "    -G, --gam            output GAM format (vg alignment format: Graph " << endl
-         << "                         Alignment/Map)" << endl
-         << "    -Z, --translation-in input is a graph translation description" << endl
+         << "    -G, --gam                  output GAM format (vg alignment format: Graph " << endl
+         << "                               Alignment/Map)" << endl
+         << "    -Z, --translation-in       input is a graph translation description" << endl
 
-         << "    -t, --turtle         output RDF/turtle format (can not be loaded by VG)" << endl
-         << "    -T, --turtle-in      input turtle format." << endl
-         << "    -r, --rdf_base_uri   set base uri for the RDF output" << endl
+         << "    -t, --turtle               output RDF/turtle format (can not be loaded by VG)" << endl
+         << "    -T, --turtle-in            input turtle format." << endl
+         << "    -r, --rdf_base_uri         set base uri for the RDF output" << endl
 
-         << "    -a, --align-in       input GAM format" << endl
-         << "    -A, --aln-graph GAM  add alignments from GAM to the graph" << endl
+         << "    -a, --align-in             input GAM format" << endl
+         << "    -A, --aln-graph GAM        add alignments from GAM to the graph" << endl
 
-         << "    -q, --locus-in       input stream is Locus format" << endl
-         << "    -z, --locus-out      output stream Locus format" << endl
-         << "    -Q, --loci FILE      input is Locus format for use by dot output" << endl
+         << "    -q, --locus-in             input stream is Locus format" << endl
+         << "    -z, --locus-out            output stream Locus format" << endl
+         << "    -Q, --loci FILE            input is Locus format for use by dot output" << endl
 
-         << "    -d, --dot            output dot format" << endl
-         << "    -S, --simple-dot     simplify the dot output; remove node labels, simplify alignments" << endl
-         << "    -B, --bubble-label   label nodes with emoji/colors that correspond to superbubbles" << endl
-         << "    -Y, --ultra-label    same as -Y but using ultrabubbles" << endl
-         << "    -m, --skip-missing   skip mappings to nodes not in the graph when drawing alignments" << endl
-         << "    -C, --color          color nodes that are not in the reference path (DOT OUTPUT ONLY)" << endl
-         << "    -p, --show-paths     show paths in dot output" << endl
-         << "    -w, --walk-paths     add labeled edges to represent paths in dot output" << endl
-         << "    -n, --annotate-paths add labels to normal edges to represent paths in dot output" << endl
-         << "    -M, --show-mappings  with -p print the mappings in each path in JSON" << endl
-         << "    -I, --invert-ports   invert the edge ports in dot so that ne->nw is reversed" << endl
-         << "    -s, --random-seed N  use this seed when assigning path symbols in dot output" << endl
+         << "    -d, --dot                  output dot format" << endl
+         << "    -S, --simple-dot           simplify the dot output; remove node labels, simplify alignments" << endl
+         << "    -B, --bubble-label         label nodes with emoji/colors that correspond to superbubbles" << endl
+         << "    -Y, --ultra-label          same as -Y but using ultrabubbles" << endl
+         << "    -m, --skip-missing         skip mappings to nodes not in the graph when drawing alignments" << endl
+         << "    -C, --color                color nodes that are not in the reference path (DOT OUTPUT ONLY)" << endl
+         << "    -p, --show-paths           show paths in dot output" << endl
+         << "    -w, --walk-paths           add labeled edges to represent paths in dot output" << endl
+         << "    -n, --annotate-paths       add labels to normal edges to represent paths in dot output" << endl
+         << "    -M, --show-mappings        with -p print the mappings in each path in JSON" << endl
+         << "    -I, --invert-ports         invert the edge ports in dot so that ne->nw is reversed" << endl
+         << "    -s, --random-seed N        use this seed when assigning path symbols in dot output" << endl
 
-         << "    -b, --bam            input BAM or other htslib-parseable alignments" << endl
+         << "    -b, --bam                  input BAM or other htslib-parseable alignments" << endl
 
-         << "    -f, --fastq-in       input fastq (output defaults to GAM). Takes two " << endl
-         << "                         positional file arguments if paired" << endl
-         << "    -X, --fastq-out      output fastq (input defaults to GAM)" << endl
-         << "    -i, --interleaved    fastq is interleaved paired-ended" << endl
+         << "    -f, --fastq-in             input fastq (output defaults to GAM). Takes two " << endl
+         << "                               positional file arguments if paired" << endl
+         << "    -X, --fastq-out            output fastq (input defaults to GAM)" << endl
+         << "    -i, --interleaved          fastq is interleaved paired-ended" << endl
 
-         << "    -L, --pileup         ouput VG Pileup format" << endl
-         << "    -l, --pileup-in      input VG Pileup format" << endl
+         << "    -L, --pileup               ouput VG Pileup format" << endl
+         << "    -l, --pileup-in            input VG Pileup format" << endl
 
-         << "    -R, --snarl-in       input VG Snarl format" << endl
-         << "    -E, --snarl-traversal-in input VG SnarlTraversal format" << endl;
+         << "    -R, --snarl-in             input VG Snarl format" << endl
+         << "    -E, --snarl-traversal-in   input VG SnarlTraversal format" << endl
+         << "    -D, --expect-duplicates    don't warn if encountering the same node or edge multiple times" << endl;
     
     // TODO: Can we regularize the option names for input and output types?
 
@@ -120,6 +121,7 @@ int main_view(int argc, char** argv) {
     bool superbubble_labeling = false;
     bool ultrabubble_labeling = false;
     bool skip_missing_nodes = false;
+    bool expect_duplicates = false;
 
     int c;
     optind = 2; // force optind past "view" argument
@@ -165,11 +167,12 @@ int main_view(int argc, char** argv) {
                 {"locus-out", no_argument, 0, 'z'},
                 {"snarls", no_argument, 0, 'R'},
                 {"snarltraversals", no_argument, 0, 'E'},
+                {"expect-duplicates", no_argument, 0, 'D'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "dgFjJhvVpaGbifA:s:wnlLIMcTtr:SCZBYmqQ:zXRE",
+        c = getopt_long (argc, argv, "dgFjJhvVpaGbifA:s:wnlLIMcTtr:SCZBYmqQ:zXRED",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -362,6 +365,10 @@ int main_view(int argc, char** argv) {
                 output_type = "json";
             }
             break;
+            
+        case 'D':
+            expect_duplicates = true;
+            break;
 
         case 'h':
         case '?':
@@ -415,7 +422,7 @@ int main_view(int argc, char** argv) {
             return 0;
         } else {
             get_input_file(file_name, [&](istream& in) {
-                graph = new VG(in);
+                graph = new VG(in, false, !expect_duplicates);
             });
         }
         // VG can convert to any of the graph formats, so keep going
@@ -429,7 +436,7 @@ int main_view(int argc, char** argv) {
         assert(input_json == true);
         JSONStreamHelper<Graph> json_helper(file_name);
         function<bool(Graph&)> get_next_graph = json_helper.get_read_fn();
-        graph = new VG(get_next_graph, false);
+        graph = new VG(get_next_graph, false, !expect_duplicates);
     } else if(input_type == "turtle-in") {
         graph = new VG;
         bool pre_compress=color_variants;

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -155,11 +155,11 @@ public:
     VG(void);
 
     /// Construct from protobufs.
-    VG(istream& in, bool showp = false);
+    VG(istream& in, bool showp = false, bool warn_on_duplicates = true);
 
     /// Construct from an arbitrary source of Graph protobuf messages (which
     /// populates the given Graph and returns a flag for whether it's valid).
-    VG(function<bool(Graph&)>& get_next_graph, bool showp = false);
+    VG(function<bool(Graph&)>& get_next_graph, bool showp = false, bool warn_on_duplicates = true);
 
     /// Construct from sets of nodes and edges. For example, from a subgraph of
     /// another graph.

--- a/test/t/03_vg_view.t
+++ b/test/t/03_vg_view.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 13
+plan tests 14
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg view -d - | wc -l) 505 "view produces the expected number of lines of dot output"
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg view -g - | wc -l) 503 "view produces the expected number of lines of GFA output"
@@ -27,7 +27,7 @@ is $? 0 "view can pass through VG"
 
 rm -f x.vg
 
-is $(samtools view -u minigiab/NA12878.chr22.tiny.bam | vg view -bG - | vg view -a - | jq .sample_name | grep -v ^\"1\"$ | wc -l ) 0 "view parses sample names"
+is $(samtools view -u minigiab/NA12878.chr22.tiny.bam | vg view -bG - | vg view -a - | jq .sample_name | grep -v '^"1"$' | wc -l ) 0 "view parses sample names"
 
 is $(vg view -f ./small/x.fa_1.fastq  ./small/x.fa_2.fastq | vg view -a - | wc -l) 2000 "view can handle fastq input"
 
@@ -40,4 +40,9 @@ is $(vg view -d ./cyclic/all.vg | wc -l) 23 "view produces the expected number o
 # We need to make a single-chunk graph
 vg construct -r small/x.fa -v small/x.vcf.gz | vg view -v - >x.vg
 is $(cat x.vg x.vg x.vg x.vg | vg view -c - | wc -l) 4 "streaming JSON output produces the expected number of chunks"
+
+is "$(cat x.vg x.vg | vg view -vD - 2>&1 > /dev/null | wc -l)" 0 "duplicate warnings can be suppressed"
+
 rm x.vg
+
+


### PR DESCRIPTION
Now you can pass `-D` or `--expect-duplicates` to `vg view` when reading VG or JSON to tell it not to throw warnings when the same node or edge exists multiple times. This is useful when combining overlapping subgraphs during the pruning step.

After I merge this I am going to update https://github.com/vgteam/vg/wiki/working-with-a-whole-genome-variation-graph to include the option, which will address #933, but then you will need to be using master vg (and not the last release) in order for the instructions to work.

I've also attached some updates to the variant filter script, to save on Jenkins runs.