### PR TITLE
Add filter plots to jenkins report

### DIFF
--- a/jenkins/mine-logs.py
+++ b/jenkins/mine-logs.py
@@ -92,7 +92,7 @@ def scrape_mapeval_runtimes(text):
                 elif 'paired-end' in read_type:
                     key += '-pe'
                 runtimes[key] += seconds
-            except int:
+            except:
                 pass
 
     return runtimes
@@ -206,7 +206,6 @@ def parse_testcase_xml(testcase):
 
     if testcase.find('system-err') is not None:
         tc['stderr'] = unicode(testcase.find('system-err').text)
-        tc['stderr'] = tc['stdout']
     else:
         tc['stderr'] = None
 
@@ -396,7 +395,7 @@ def html_testcase(tc, work_dir, report_dir, max_warnings = 10):
 
         images = []
         captions = []
-        for plot_name in 'roc', 'roc.control', 'qq', 'qq.control':
+        for plot_name in 'roc', 'roc.control', 'roc.primary.filter', 'roc.control.primary.filter', 'qq', 'qq.control':
             plot_path = os.path.join(outstore, '{}.svg'.format(plot_name))
             if os.path.isfile(plot_path):
                 new_name = '{}-{}.svg'.format(tc['name'], plot_name)
@@ -421,9 +420,9 @@ def html_testcase(tc, work_dir, report_dir, max_warnings = 10):
                 i += row_size
             report += '</table>\n'
 
-        # extract running times from stdout (only for mapeval)
+        # extract running times from stderr (only for mapeval)
         map_time_table = None
-        if 'sim' in tc['name']:
+        if tc['stderr'] and 'sim' in tc['name']:
             map_time_table = scrape_mapeval_runtimes(tc['stderr'])
             
         if tc['stdout']:

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -450,7 +450,7 @@ class VGCITest(TestCase):
         # note, using the same seed only means something if using same
         # number of chunks.  we make that explicit here
         opts += '--maxCores {} --sim_chunks {} --seed {} '.format(self.cores, 8, 8)
-        opts += '--sim_opts \'-l 150 -p 500 -v 50 -e 0.05 -i 0.01 --include-bonuses\' '
+        opts += '--sim_opts \'-l 150 -p 500 -v 50 -e 0.01 -i 0.002 --include-bonuses\' '
         opts += '--annotate_xg {} '.format(base_xg_path)
         cmd = 'toil-vg sim {} {} {} {} --gam {}'.format(
             job_store, ' '.join(sim_xg_paths), reads / 2, out_store, opts)

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -450,7 +450,7 @@ class VGCITest(TestCase):
         # note, using the same seed only means something if using same
         # number of chunks.  we make that explicit here
         opts += '--maxCores {} --sim_chunks {} --seed {} '.format(self.cores, 8, 8)
-        opts += '--sim_opts \'-l 150 -p 500 -v 50 -e 0.01 -i 0.002 --include-bonuses\' '
+        opts += '--sim_opts \'-l 150 -p 500 -v 50 -e 0.05 -i 0.01 --include-bonuses\' '
         opts += '--annotate_xg {} '.format(base_xg_path)
         cmd = 'toil-vg sim {} {} {} {} --gam {}'.format(
             job_store, ' '.join(sim_xg_paths), reads / 2, out_store, opts)


### PR DESCRIPTION
These are the ROC plots where all reads getting poorer scores than primary are ignored.
(also fix bug where stderr was getting lost when reading the test-report xml)