### PR TITLE
Make warnings show up in CI reports that don't run Toil in-process

### DIFF
--- a/jenkins/mine-logs.py
+++ b/jenkins/mine-logs.py
@@ -237,7 +237,7 @@ def get_vgci_warnings(tc):
     if tc['stderr']:
         for line in tc['stderr'].split('\n'):
             # For each line
-            if "WARNING vgci" in line:
+            if "WARNING" in line and "vgci" in line:
                 # If it is a CI warning, keep it
                 warnings.append(line.rstrip())
     return warnings

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -38,6 +38,9 @@ class VGCITest(TestCase):
     much slower.  
     """
     def setUp(self):
+        # Make sure logging is available for all the tests
+        logging.basicConfig()
+
         self.workdir = tempfile.mkdtemp()
         self.tempdir = tempfile.mkdtemp()
         
@@ -162,7 +165,7 @@ class VGCITest(TestCase):
             # Convert to a public HTTPS URL
             src = 'https://{}.s3.amazonaws.com{}'.format(bname, keyname)
         
-        sys.stderr.write('Download {}...\n'.format(src))
+        log.info('Download {}...\n'.format(src))
         
         with open(tgt, 'w') as f:
             # Download the file from the URL


### PR DESCRIPTION
~The warnings disappeared around when I merged https://github.com/vgteam/vg/pull/998, but those commits don't seem to actually be the cause.~

~Now the logger needs to be manually configured for some reason, and the message format is slightly different. But this makes it work again.~