### PR TITLE
Lower simulation error rates to match with map-sim example

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -450,7 +450,7 @@ class VGCITest(TestCase):
         # note, using the same seed only means something if using same
         # number of chunks.  we make that explicit here
         opts += '--maxCores {} --sim_chunks {} --seed {} '.format(self.cores, 8, 8)
-        opts += '--sim_opts \'-l 150 -p 500 -v 50 -e 0.05 -i 0.01 --include-bonuses\' '
+        opts += '--sim_opts \'-l 150 -p 500 -v 50 -e 0.01 -i 0.002 --include-bonuses\' '
         opts += '--annotate_xg {} '.format(base_xg_path)
         cmd = 'toil-vg sim {} {} {} {} --gam {}'.format(
             job_store, ' '.join(sim_xg_paths), reads / 2, out_store, opts)


### PR DESCRIPTION
Current rates are unrealistically high, as pointed out in #1005. 