### PR TITLE
Trained read simulator

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -142,7 +142,7 @@ bool get_next_alignment_pair_from_fastqs(gzFile fp1, gzFile fp2, char* buffer, s
 }
 
 
-size_t fastq_unpaired_for_each_parallel(string& filename, function<void(Alignment&)> lambda) {
+size_t fastq_unpaired_for_each_parallel(const string& filename, function<void(Alignment&)> lambda) {
     gzFile fp = (filename != "-") ? gzopen(filename.c_str(), "r") : gzdopen(fileno(stdin), "r");
     if (!fp) {
         cerr << "[vg::alignment.cpp] couldn't open " << filename << endl; exit(1);
@@ -182,7 +182,7 @@ size_t fastq_unpaired_for_each_parallel(string& filename, function<void(Alignmen
     return nLines;
 }
 
-size_t fastq_paired_interleaved_for_each_parallel(string& filename, function<void(Alignment&, Alignment&)> lambda) {
+size_t fastq_paired_interleaved_for_each_parallel(const string& filename, function<void(Alignment&, Alignment&)> lambda) {
     gzFile fp = (filename != "-") ? gzopen(filename.c_str(), "r") : gzdopen(fileno(stdin), "r");
     if (!fp) {
         cerr << "[vg::alignment.cpp] couldn't open " << filename << endl; exit(1);
@@ -222,7 +222,7 @@ size_t fastq_paired_interleaved_for_each_parallel(string& filename, function<voi
     return nLines;
 }
 
-size_t fastq_paired_two_files_for_each_parallel(string& file1, string& file2, function<void(Alignment&, Alignment&)> lambda) {
+size_t fastq_paired_two_files_for_each_parallel(const string& file1, const string& file2, function<void(Alignment&, Alignment&)> lambda) {
     gzFile fp1 = (file1 != "-") ? gzopen(file1.c_str(), "r") : gzdopen(fileno(stdin), "r");
     if (!fp1) {
         cerr << "[vg::alignment.cpp] couldn't open " << file1 << endl; exit(1);
@@ -269,7 +269,7 @@ size_t fastq_paired_two_files_for_each_parallel(string& file1, string& file2, fu
 
 
 
-size_t fastq_unpaired_for_each(string& filename, function<void(Alignment&)> lambda) {
+size_t fastq_unpaired_for_each(const string& filename, function<void(Alignment&)> lambda) {
     gzFile fp = (filename != "-") ? gzopen(filename.c_str(), "r") : gzdopen(fileno(stdin), "r");
     if (!fp) {
         cerr << "[vg::alignment.cpp] couldn't open " << filename << endl; exit(1);
@@ -287,7 +287,7 @@ size_t fastq_unpaired_for_each(string& filename, function<void(Alignment&)> lamb
     return nLines;
 }
 
-size_t fastq_paired_interleaved_for_each(string& filename, function<void(Alignment&, Alignment&)> lambda) {
+size_t fastq_paired_interleaved_for_each(const string& filename, function<void(Alignment&, Alignment&)> lambda) {
     gzFile fp = (filename != "-") ? gzopen(filename.c_str(), "r") : gzdopen(fileno(stdin), "r");
     if (!fp) {
         cerr << "[vg::alignment.cpp] couldn't open " << filename << endl; exit(1);
@@ -305,7 +305,7 @@ size_t fastq_paired_interleaved_for_each(string& filename, function<void(Alignme
     return nLines;
 }
 
-size_t fastq_paired_two_files_for_each(string& file1, string& file2, function<void(Alignment&, Alignment&)> lambda) {
+size_t fastq_paired_two_files_for_each(const string& file1, const string& file2, function<void(Alignment&, Alignment&)> lambda) {
     gzFile fp1 = (file1 != "-") ? gzopen(file1.c_str(), "r") : gzdopen(fileno(stdin), "r");
     if (!fp1) {
         cerr << "[vg::alignment.cpp] couldn't open " << file1 << endl; exit(1);

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -25,13 +25,13 @@ bool get_next_alignment_from_fastq(gzFile fp, char* buffer, size_t len, Alignmen
 bool get_next_interleaved_alignment_pair_from_fastq(gzFile fp, char* buffer, size_t len, Alignment& mate1, Alignment& mate2);
 bool get_next_alignment_pair_from_fastqs(gzFile fp1, gzFile fp2, char* buffer, size_t len, Alignment& mate1, Alignment& mate2);
 
-size_t fastq_unpaired_for_each(string& filename, function<void(Alignment&)> lambda);
-size_t fastq_paired_interleaved_for_each(string& filename, function<void(Alignment&, Alignment&)> lambda);
-size_t fastq_paired_two_files_for_each(string& file1, string& file2, function<void(Alignment&, Alignment&)> lambda);
+size_t fastq_unpaired_for_each(const string& filename, function<void(Alignment&)> lambda);
+size_t fastq_paired_interleaved_for_each(const string& filename, function<void(Alignment&, Alignment&)> lambda);
+size_t fastq_paired_two_files_for_each(const string& file1, const string& file2, function<void(Alignment&, Alignment&)> lambda);
 // parallel versions of above
-size_t fastq_unpaired_for_each_parallel(string& filename, function<void(Alignment&)> lambda);
-size_t fastq_paired_interleaved_for_each_parallel(string& filename, function<void(Alignment&, Alignment&)> lambda);
-size_t fastq_paired_two_files_for_each_parallel(string& file1, string& file2, function<void(Alignment&, Alignment&)> lambda);
+size_t fastq_unpaired_for_each_parallel(const string& filename, function<void(Alignment&)> lambda);
+size_t fastq_paired_interleaved_for_each_parallel(const string& filename, function<void(Alignment&, Alignment&)> lambda);
+size_t fastq_paired_two_files_for_each_parallel(const string& file1, const string& file2, function<void(Alignment&, Alignment&)> lambda);
 
 bam_hdr_t* hts_file_header(string& filename, string& header);
 bam_hdr_t* hts_string_header(string& header,

--- a/src/gssw_aligner.cpp
+++ b/src/gssw_aligner.cpp
@@ -649,7 +649,7 @@ size_t BaseAligner::longest_detectable_gap(const Alignment& alignment) const {
     
 }
 
-int32_t BaseAligner::score_alignment(const Alignment& aln, const function<size_t(pos_t, pos_t, size_t)>& estimate_distance,
+int32_t BaseAligner::score_gappy_alignment(const Alignment& aln, const function<size_t(pos_t, pos_t, size_t)>& estimate_distance,
     bool strip_bonuses) {
     
     int score = 0;
@@ -688,6 +688,7 @@ int32_t BaseAligner::score_alignment(const Alignment& aln, const function<size_t
             // Estimate the distance
             int dist = estimate_distance(make_pos_t(last_pos), make_pos_t(next_pos), aln.sequence().size());
             if (dist > 0) {
+                cerr << "estimated dist between " << make_pos_t(last_pos) << " and " << make_pos_t(next_pos) << " at " << dist << endl;
                 // If it's nonzero, score it as a deletion gap
                 score -= gap_open + (dist - 1) * gap_extension;
             }
@@ -705,6 +706,10 @@ int32_t BaseAligner::score_alignment(const Alignment& aln, const function<size_t
     }
     
     return score;
+}
+
+int32_t BaseAligner::score_ungapped_alignment(const Alignment& aln, bool strip_bonuses){
+    return score_gappy_alignment(aln, [](pos_t, pos_t, size_t){return (size_t) 0;}, strip_bonuses);
 }
 
 int32_t BaseAligner::remove_bonuses(const Alignment& aln, bool pinned, bool pin_left) {

--- a/src/gssw_aligner.hpp
+++ b/src/gssw_aligner.hpp
@@ -69,7 +69,6 @@ namespace vg {
         // TODO: this algorithm has numerical problems, just removing it for now
         //vector<double> all_mapping_qualities_exact(vector<double> scaled_scores);
         
-        
     public:
 
         double estimate_max_possible_mapping_quality(int length, double min_diffs, double next_min_diffs);
@@ -171,9 +170,14 @@ namespace vg {
         /// length).
         ///
         /// May include full length bonus or not. TODO: bool flags are bad.
-        virtual int32_t score_alignment(const Alignment& aln,
+        virtual int32_t score_gappy_alignment(const Alignment& aln,
             const function<size_t(pos_t, pos_t, size_t)>& estimate_distance,
             bool strip_bonuses = false);
+        
+        /// Use the score values in the aligner to score the given alignment assuming
+        /// that there are no gaps between Mappings in the Path
+        virtual int32_t score_ungapped_alignment(const Alignment& aln,
+                                                 bool strip_bonuses = false);
             
         /// Without necessarily rescoring the entire alignment, return the score
         /// of the given alignment with bonuses removed. Assumes that bonuses

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -4359,12 +4359,12 @@ int32_t Mapper::score_alignment(const Alignment& aln, bool use_approx_distance) 
     
     if (use_approx_distance) {
         // Use an approximation
-        return aligner->score_alignment(aln, [&](pos_t last, pos_t next, size_t max_search) {
+        return aligner->score_gappy_alignment(aln, [&](pos_t last, pos_t next, size_t max_search) {
             return approx_distance(last, next);
         }, strip_bonuses);
     } else {
         // Use the exact method, and if we hit the limit, fall back to the approximate method.
-        return aligner->score_alignment(aln, [&](pos_t last, pos_t next, size_t max_search) {
+        return aligner->score_gappy_alignment(aln, [&](pos_t last, pos_t next, size_t max_search) {
             auto dist = graph_distance(last, next, max_search);
             if (dist == max_search) {
 #ifdef debug_mapper

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -748,10 +748,11 @@ bool NGSSimulator::advance_on_graph_by_distance(pos_t& pos, size_t distance) {
             get_id(pos) = edge.from();
             get_is_rev(pos) = !edge.from_start();
         }
+        get_offset(pos) = 0;
         node_length = xg_index.node_length(id(pos));
     }
     
-    get_offset(pos) = remaining;
+    get_offset(pos) += remaining;
     
     return false;
 }

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -1,5 +1,6 @@
 #include "sampler.hpp"
-#include "path.hpp"
+
+//#define debug_ngs_sim
 
 namespace vg {
 
@@ -426,6 +427,578 @@ bool Sampler::is_valid(const Alignment& aln) {
     // For now, we just say an alignment is valid if it accounts for all the
     // bases on its source nodes.
     return true;
+}
+    
+    
+const string NGSSimulator::alphabet = "ACGT";
+    
+NGSSimulator::NGSSimulator(xg::XG& xg_index,
+                           const string& ngs_fastq_file,
+                           double substition_polymorphism_rate,
+                           double indel_polymorphism_rate,
+                           double indel_error_proportion,
+                           double insert_length_mean,
+                           double insert_length_stdev,
+                           size_t seed) :
+      xg_index(xg_index)
+    , node_cache(100)
+    , edge_cache(100)
+    , sub_poly_rate(substition_polymorphism_rate)
+    , indel_poly_rate(indel_polymorphism_rate)
+    , indel_error_prop(indel_error_proportion)
+    , insert_mean(insert_length_mean)
+    , insert_sd(insert_length_stdev)
+    , prng(seed ? seed : random_device()())
+    , start_pos_sampler(1, xg_index.seq_length)
+    , strand_sampler(0, 1)
+    , background_sampler(0, alphabet.size() - 1)
+    , mut_sampler(0, alphabet.size() - 2)
+    , prob_sampler(0.0, 1.0)
+    , insert_sampler(insert_length_mean, insert_length_stdev)
+    , seed(seed)
+{
+    if (substition_polymorphism_rate < 0.0 || substition_polymorphism_rate > 1.0
+        || indel_polymorphism_rate < 0.0 || indel_polymorphism_rate > 1.0
+        || indel_error_proportion < 0.0 || indel_error_proportion > 1.0) {
+        cerr << "error:[NGSSimulator] All proportions must be between 0.0 and 1.0" << endl;
+        exit(1);
+    }
+    
+    if (substition_polymorphism_rate + indel_polymorphism_rate > 1.0) {
+        cerr << "error:[NGSSimulator] Indel polymorphism rate and substitution polymorphism rate cannot sum to greater than 1.0" << endl;
+        exit(1);
+    }
+    
+    if (insert_length_mean <= 0.0) {
+        cerr << "error:[NGSSimulator] Mean insert length must be positive" << endl;
+        exit(1);
+    }
+    
+    if (insert_length_stdev < 0.0) {
+        cerr << "error:[NGSSimulator] Insert length standard deviation must be positive" << endl;
+        exit(1);
+    }
+    
+    if (insert_length_mean < 5.0 * insert_length_stdev) {
+        cerr << "warning:[NGSSimulator] Recommended that insert length mean > 5 * insert length standard deviation" << endl;
+    }
+    
+    // memoize phred conversions
+    phred_prob.resize(256);
+    for (int i = 1; i < phred_prob.size(); i++) {
+        phred_prob[i] = phred_to_prob(i);
+    }
+    
+    for (size_t i = 0; i < alphabet.size(); i++) {
+        mutation_alphabets[alphabet[i]] = string();
+        for (size_t j = 0; j < alphabet.size(); j++) {
+            if (j == i) {
+                continue;
+            }
+            mutation_alphabets[alphabet[i]].push_back(alphabet[j]);
+        }
+    }
+    
+    unordered_map<size_t, size_t> length_count;
+    fastq_unpaired_for_each(ngs_fastq_file, [&](const Alignment& aln) {
+        length_count[aln.quality().size()]++;
+    });
+    
+    size_t modal_length = std::max_element(length_count.begin(), length_count.end(),
+                                           [](const pair<size_t, size_t>& a, const pair<size_t, size_t>& b) {
+                                               return a.second < b.second;
+                                           })->first;
+    
+    transition_distrs.reserve(modal_length);
+    for (size_t i = 0; i < modal_length; i++) {
+        transition_distrs.emplace_back(seed ? seed + i + 1 : random_device()());
+    }
+    
+    fastq_unpaired_for_each(ngs_fastq_file, [&](const Alignment& aln) {
+        record_read_quality(aln);
+    });
+    
+    finalize();
+    
+#ifdef debug_ngs_sim
+    cerr << "finished initializing simulator" << endl;
+#endif
+}
+
+Alignment NGSSimulator::sample_read() {
+#ifdef debug_ngs_sim
+        cerr << "new single ended sample" << endl;
+#endif
+    
+    Alignment aln;
+    
+    // sample a quality string based on the trained distribution
+    aln.set_quality(sample_read_quality());
+    
+#ifdef debug_ngs_sim
+    cerr << "got quality string " << string_quality_short_to_char(aln.quality()) << endl;
+#endif
+    
+    // attempt samples until we get one that succeeds without walking
+    // off the end of the graph
+    while (!aln.has_path()) {
+        pos_t pos = sample_start_pos();
+#ifdef debug_ngs_sim
+        cerr << "attempting walk starting at " << pos << endl;
+#endif
+        sample_read_internal(aln, pos);
+    }
+    
+    aln.set_name(get_read_name());
+    
+    return aln;
+}
+
+pair<Alignment, Alignment> NGSSimulator::sample_read_pair() {
+    pair<Alignment, Alignment> aln_pair;
+    aln_pair.first.set_quality(sample_read_quality());
+    aln_pair.second.set_quality(sample_read_quality());
+    std::reverse(aln_pair.second.mutable_quality()->begin(),
+                 aln_pair.second.mutable_quality()->end());
+    
+    
+    while (!aln_pair.first.has_path() || !aln_pair.second.has_path()) {
+        
+        // align the first end
+        pos_t pos = sample_start_pos();
+        sample_read_internal(aln_pair.first, pos);
+        
+        if (!aln_pair.first.has_path()) {
+            continue;
+        }
+        
+        // walk out the insert
+        size_t insert_length = (size_t) round(insert_sampler(prng));
+        size_t walked_length = path_from_length(aln_pair.first.path());
+        
+        if (insert_length < walked_length) {
+            continue;
+        }
+        
+        size_t remaining_length = insert_length - walked_length;
+        
+        if (advance_on_graph_by_distance(pos, remaining_length)) {
+            continue;
+        }
+        
+        sample_read_internal(aln_pair.second, pos);
+    }
+    
+    aln_pair.second = reverse_complement_alignment(aln_pair.second, [&](id_t node_id) {
+        return xg_index.node_length(node_id);
+    });
+    
+    string name = get_read_name();
+    aln_pair.first.set_name(name + "/1");
+    aln_pair.second.set_name(name + "/2");
+    
+    return aln_pair;
+}
+
+void NGSSimulator::sample_read_internal(Alignment& aln, pos_t& curr_pos) {
+    
+    aln.clear_path();
+    aln.clear_sequence();
+    
+    char graph_char = xg_cached_pos_char(curr_pos, &xg_index, node_cache);
+    bool hit_end = false;
+    
+    // walk a path and generate a read sequence at the same time
+    while (aln.sequence().size() < aln.quality().size() && !hit_end) {
+        // sample insertion in the true graph path
+        while (aln.sequence().size() < aln.quality().size() && prob_sampler(prng) < indel_poly_rate * 0.5) {
+            // TODO: no allowance for indel errors on inserted sequence
+            
+#ifdef debug_ngs_sim
+            cerr << "insertion polymorphism at read idx " << aln.sequence().size() << ", graph pos " << curr_pos << endl;
+#endif
+            
+            apply_insertion(aln, curr_pos);
+        }
+        if (aln.sequence().size() >= aln.quality().size() || hit_end) {
+            break;
+        }
+        
+        // sample errors
+        double err_sample = prob_sampler(prng);
+        double err_prob = phred_prob[aln.quality()[aln.sequence().size()]];
+        while (err_sample < err_prob * indel_error_prop && !hit_end) {
+            // indel errors
+            if (prob_sampler(prng) < 0.5) {
+#ifdef debug_ngs_sim
+                cerr << "insertion error at read idx " << aln.sequence().size() << ", graph pos " << curr_pos << endl;
+#endif
+                // insert error
+                apply_insertion(aln, curr_pos);
+                
+                if (aln.sequence().size() >= aln.quality().size() || hit_end) {
+                    break;
+                }
+            }
+            else {
+#ifdef debug_ngs_sim
+                cerr << "deletion error at read idx " << aln.sequence().size() << ", graph pos " << curr_pos << endl;
+#endif
+                // deletion error
+                apply_deletion(aln, curr_pos);
+                hit_end = advance_on_graph(curr_pos, graph_char);
+            }
+            
+            err_sample = prob_sampler(prng);
+            err_prob = phred_prob[aln.quality()[aln.sequence().size()]];
+        }
+        if (aln.sequence().size() >= aln.quality().size() || hit_end) {
+            break;
+        }
+        
+        // get the true graph char, possibly with a substitution polymorphism
+        char poly_graph_char = graph_char != 'N' ? graph_char : alphabet[background_sampler(prng)];
+        if (prob_sampler(prng) < sub_poly_rate) {
+            poly_graph_char = mutation_alphabets[poly_graph_char][mut_sampler(prng)];
+        }
+        
+        // by default the read matches the true graph char
+        char read_char = poly_graph_char;
+        
+        // sample substitution errors with the remaining err sample
+        if (err_sample < err_prob) {
+            // substitution error
+            read_char = mutation_alphabets[read_char][mut_sampler(prng)];
+        }
+        
+#ifdef debug_ngs_sim
+        cerr << "aligned base at read idx " << aln.sequence().size() << ", graph pos " << curr_pos << endl;
+#endif
+        
+        // add an aligned base (allowing errors to mask polymorphisms)
+        apply_aligned_base(aln, curr_pos, graph_char, read_char);
+        hit_end = advance_on_graph(curr_pos, graph_char);
+        
+        if (aln.sequence().size() >= aln.quality().size() || hit_end) {
+            break;
+        }
+        
+        // sample deletions in the true graph path
+        while (prob_sampler(prng) < indel_poly_rate * 0.5 && !hit_end) {
+#ifdef debug_ngs_sim
+            cerr << "deletion polymorphism at read idx " << aln.sequence().size() << ", graph pos " << curr_pos << endl;
+#endif
+            
+            apply_deletion(aln, curr_pos);
+            hit_end = advance_on_graph(curr_pos, graph_char);
+        }
+    }
+    
+    // remove the sequence and path if we hit the end the graph before finishing
+    // the alignment
+    if (aln.sequence().size() != aln.quality().size()) {
+        aln.clear_path();
+        aln.clear_sequence();
+    }
+    
+#ifdef debug_ngs_sim
+    cerr << "completed read: " << pb2json(aln) << endl;
+#endif
+}
+
+bool NGSSimulator::advance_on_graph(pos_t& pos, char& graph_char) {
+    
+    // choose a next position at random
+    map<pos_t, char> next_pos_chars = xg_cached_next_pos_chars(pos,
+                                                               &xg_index,
+                                                               node_cache,
+                                                               edge_cache);
+    if (next_pos_chars.empty()) {
+        return true;
+    }
+    
+    uniform_int_distribution<size_t> pos_distr(0, next_pos_chars.size() - 1);
+    size_t next = pos_distr(prng);
+    auto iter = next_pos_chars.begin();
+    for (size_t i = 0; i != next; i++) {
+        iter++;
+    }
+    pos = iter->first;
+    graph_char = iter->second;
+    
+    return false;
+}
+
+bool NGSSimulator::advance_on_graph_by_distance(pos_t& pos, size_t distance) {
+    int64_t remaining = distance;
+    int64_t node_length = xg_index.node_length(id(pos)) - offset(pos);
+    while (remaining >= node_length) {
+        remaining -= node_length;
+        vector<Edge> edges = is_rev(pos) ? xg_index.edges_on_start(id(pos)) : xg_index.edges_on_end(id(pos));
+        if (edges.empty()) {
+            return true;
+        }
+        size_t choice = uniform_int_distribution<size_t>(0, edges.size() - 1)(prng);
+        Edge& edge = edges[choice];
+        if (id(pos) == edge.from() && is_rev(pos) == edge.from_start()) {
+            get_id(pos) = edge.to();
+            get_is_rev(pos) = edge.to_end();
+        }
+        else {
+            get_id(pos) = edge.from();
+            get_is_rev(pos) = !edge.from_start();
+        }
+        node_length = xg_index.node_length(id(pos));
+    }
+    
+    get_offset(pos) = remaining;
+    
+    return false;
+}
+
+
+void NGSSimulator::apply_aligned_base(Alignment& aln, const pos_t& pos, char graph_char,
+                                      char read_char) {
+    Path* path = aln.mutable_path();
+    aln.mutable_sequence()->push_back(read_char);
+    bool is_match = (graph_char == read_char);
+    
+    if (path->mapping_size() == 0) {
+        Mapping* new_mapping = path->add_mapping();
+        new_mapping->set_rank(1);
+        
+        Position* mapping_pos = new_mapping->mutable_position();
+        mapping_pos->set_node_id(id(pos));
+        mapping_pos->set_is_reverse(is_rev(pos));
+        
+        Edit* new_edit = new_mapping->add_edit();
+        new_edit->set_from_length(1);
+        new_edit->set_to_length(1);
+        if (!is_match) {
+            new_edit->mutable_sequence()->push_back(read_char);
+        }
+    }
+    else {
+        Mapping* last_mapping = path->mutable_mapping(path->mapping_size() - 1);
+        if (last_mapping->position().node_id() == id(pos) &&
+            last_mapping->position().is_reverse() == is_rev(pos)) {
+            
+            Edit* last_edit = last_mapping->mutable_edit(last_mapping->edit_size() - 1);
+            if (last_edit->from_length() > 0 && last_edit->to_length() > 0) {
+                if (last_edit->sequence().size() > 0 && !is_match) {
+                    last_edit->set_from_length(last_edit->from_length() + 1);
+                    last_edit->set_to_length(last_edit->to_length() + 1);
+                    last_edit->mutable_sequence()->push_back(read_char);
+                }
+                else if (last_edit->sequence().size() == 0 && is_match) {
+                    last_edit->set_from_length(last_edit->from_length() + 1);
+                    last_edit->set_to_length(last_edit->to_length() + 1);
+                }
+                else {
+                    Edit* new_edit = last_mapping->add_edit();
+                    new_edit->set_from_length(1);
+                    new_edit->set_to_length(1);
+                    if (!is_match) {
+                        new_edit->mutable_sequence()->push_back(read_char);
+                    }
+                }
+            }
+            else {
+                Edit* new_edit = last_mapping->add_edit();
+                new_edit->set_from_length(1);
+                new_edit->set_to_length(1);
+                if (!is_match) {
+                    new_edit->mutable_sequence()->push_back(read_char);
+                }
+            }
+        }
+        else {
+            Mapping* new_mapping = path->add_mapping();
+            new_mapping->set_rank(last_mapping->rank() + 1);
+            
+            Position* mapping_pos = new_mapping->mutable_position();
+            mapping_pos->set_node_id(id(pos));
+            mapping_pos->set_is_reverse(is_rev(pos));
+            
+            Edit* new_edit = new_mapping->add_edit();
+            new_edit->set_from_length(1);
+            new_edit->set_to_length(1);
+            if (!is_match) {
+                new_edit->mutable_sequence()->push_back(read_char);
+            }
+        }
+    }
+}
+
+void NGSSimulator::apply_deletion(Alignment& aln, const pos_t& pos) {
+    Path* path = aln.mutable_path();
+    if (path->mapping_size() == 0) {
+        // don't introduce a deletion at the beginning of a read
+        // TODO: check for deletions at the end of a read?
+        return;
+    }
+    
+    Mapping* last_mapping = path->mutable_mapping(path->mapping_size() - 1);
+    if (last_mapping->position().node_id() == id(pos) &&
+        last_mapping->position().is_reverse() == is_rev(pos)) {
+        
+        Edit* last_edit = last_mapping->mutable_edit(last_mapping->edit_size() - 1);
+        if (last_edit->from_length() > 0 && last_edit->to_length() == 0) {
+            last_edit->set_from_length(last_edit->from_length() + 1);
+        }
+        else {
+            Edit* new_edit = last_mapping->add_edit();
+            new_edit->set_from_length(1);
+        }
+    }
+    else {
+        Mapping* new_mapping = path->add_mapping();
+        new_mapping->set_rank(last_mapping->rank() + 1);
+        
+        Position* mapping_pos = new_mapping->mutable_position();
+        mapping_pos->set_node_id(id(pos));
+        mapping_pos->set_is_reverse(is_rev(pos));
+        
+        Edit* new_edit = new_mapping->add_edit();
+        new_edit->set_from_length(1);
+    }
+}
+
+void NGSSimulator::apply_insertion(Alignment& aln, const pos_t& pos) {
+    Path* path = aln.mutable_path();
+    char insert_char = alphabet[background_sampler(prng)];
+    aln.mutable_sequence()->push_back(insert_char);
+    
+    if (path->mapping_size() == 0) {
+        Mapping* new_mapping = path->add_mapping();
+        new_mapping->set_rank(1);
+        
+        Position* mapping_pos = new_mapping->mutable_position();
+        mapping_pos->set_node_id(id(pos));
+        mapping_pos->set_is_reverse(is_rev(pos));
+        
+        Edit* new_edit = new_mapping->add_edit();
+        new_edit->set_to_length(1);
+        new_edit->set_sequence(string(1, insert_char));
+    }
+    else {
+        Mapping* last_mapping = path->mutable_mapping(path->mapping_size() - 1);
+        Edit* last_edit = last_mapping->mutable_edit(last_mapping->edit_size() - 1);
+        if (last_edit->from_length() == 0 && last_edit->to_length() > 0) {
+            last_edit->set_to_length(last_edit->to_length() + 1);
+            last_edit->mutable_sequence()->push_back(insert_char);
+        }
+        else {
+            Edit* new_edit = last_mapping->add_edit();
+            new_edit->set_to_length(1);
+            new_edit->set_sequence(string(1, insert_char));
+        }
+    }
+}
+
+pos_t NGSSimulator::sample_start_pos() {
+    size_t idx = start_pos_sampler(prng);
+    
+    id_t id = xg_index.node_at_seq_pos(idx);
+    bool rev = strand_sampler(prng);
+    size_t node_offset = idx - xg_index.node_start(id) - 1;
+    
+    return make_pos_t(id, rev, node_offset);
+}
+
+string NGSSimulator::get_read_name() {
+    stringstream sstrm;
+    sstrm << "fragment_" << sample_counter;
+    sample_counter++;
+    return sstrm.str();
+}
+
+void NGSSimulator::record_read_quality(const Alignment& aln) {
+    const string& quality = aln.quality();
+    if (quality.empty()) {
+        return;
+    }
+    size_t end = min(quality.size(), transition_distrs.size());
+    transition_distrs[0].record_transition(0, quality[0]);
+    for (size_t i = 1; i < end; i++) {
+        transition_distrs[i].record_transition(quality[i - 1], quality[i]);
+    }
+}
+
+void NGSSimulator::finalize() {
+    for (MarkovDistribution& markov_distr : transition_distrs) {
+        markov_distr.finalize();
+    }
+}
+
+string NGSSimulator::sample_read_quality() {
+    string quality(transition_distrs.size(), 0);
+    uint8_t at = 0;
+    for (size_t i = 0; i < transition_distrs.size(); i++) {
+        at = transition_distrs[i].sample_transition(at);
+        quality[i] = at;
+    }
+    return quality;
+}
+
+NGSSimulator::MarkovDistribution::MarkovDistribution(size_t seed) : prng(seed) {
+    // nothing to do
+}
+
+void NGSSimulator::MarkovDistribution::record_transition(uint8_t from, uint8_t to) {
+    if (!cond_distrs.count(from)) {
+        cond_distrs[from] = vector<size_t>(value_at.size(), 0);
+    }
+    
+    if (!column_of.count(to)) {
+        column_of[to] = value_at.size();
+        value_at.push_back(to);
+        for (pair<const uint8_t, vector<size_t>>& cond_distr : cond_distrs) {
+            cond_distr.second.push_back(0);
+        }
+    }
+    
+    cond_distrs[from][column_of[to]]++;
+}
+
+void NGSSimulator::MarkovDistribution::finalize() {
+    for (pair<const uint8_t, vector<size_t>>& cond_distr : cond_distrs) {
+        for (size_t i = 1; i < cond_distr.second.size(); i++) {
+            cond_distr.second[i] += cond_distr.second[i - 1];
+        }
+        
+        samplers[cond_distr.first] = uniform_int_distribution<size_t>(0, cond_distr.second.back() - 1);
+    }
+}
+
+
+uint8_t NGSSimulator::MarkovDistribution::sample_transition(uint8_t from) {
+    // return randomly if a transition has never been observed
+    if (!cond_distrs.count(from)) {
+        return value_at[uniform_int_distribution<size_t>(0, value_at.size() - 1)(prng)];
+    }
+    
+    size_t sample_val = samplers[from](prng);
+    
+    vector<size_t>& cdf = cond_distrs[from];
+    
+    if (sample_val <= cdf[0]) {
+        return value_at[0];
+    }
+    
+    size_t low = 0;
+    size_t hi = cdf.size() - 1;
+    while (hi > low + 1) {
+        int64_t mid = (hi + low) / 2;
+        
+        if (sample_val <= cdf[mid]) {
+            hi = mid;
+        }
+        else {
+            low = mid;
+        }
+    }
+    return value_at[hi];
 }
 
 }

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -3,6 +3,10 @@
 
 #include <iostream>
 #include <map>
+#include <unordered_map>
+#include <vector>
+#include <sstream>
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 #include "vg.hpp"
@@ -94,6 +98,121 @@ public:
     /// need to be accounted for by deletions.
     bool is_valid(const Alignment& aln);
 
+};
+
+/**
+ * Class that simulates reads with alignments to a graph that mimic the error
+ * profile of NGS sequencing data.
+ */
+class NGSSimulator {
+public:
+    /// Initialize simulator. FASTQ file will be used to train an error distribution.
+    /// Every read must be the same length. Polymorphism rates apply uniformly along a
+    /// read, whereas errors are distributed as indicated by the learned distribution.
+    NGSSimulator(xg::XG& xg_index,
+                 const string& ngs_fastq_file,
+                 double substition_polymorphism_rate = 0.001,
+                 double indel_polymorphism_rate = 0.0002,
+                 double indel_error_proportion = 0.01,
+                 double insert_length_mean = 1000.0,
+                 double insert_length_stdev = 75.0,
+                 size_t seed = 0);
+    
+    /// Sample an individual read and alignment
+    Alignment sample_read();
+    
+    /// Sample a pair of reads an alignments
+    pair<Alignment, Alignment> sample_read_pair();
+    
+private:
+    class MarkovDistribution;
+    
+    NGSSimulator(void) = delete;
+    
+    /// DNA alphabet
+    static const string alphabet;
+    /// Remainder of the alphabet after removing a given character
+    unordered_map<char, string> mutation_alphabets;
+    
+    /// Add a quality string to the training data
+    void record_read_quality(const Alignment& aln);
+    /// Indicate that there is no more training data
+    void finalize();
+    /// Get a quality string that mimics the training data
+    string sample_read_quality();
+    
+    /// Internal method called by paired and unpaired samplers
+    void sample_read_internal(Alignment& aln, pos_t& curr_pos);
+    /// Get a random position in the graph
+    pos_t sample_start_pos();
+    /// Get an unclashing read name
+    string get_read_name();
+    
+    /// Move forward one position in the graph along a random path, return true if we can't
+    /// because we hit a tip or false otherwise
+    bool advance_on_graph(pos_t& pos, char& graph_char);
+    /// Move forward a certain distance in the graph along a random path, return true if we
+    /// can't because we hit a tip or false otherwise
+    bool advance_on_graph_by_distance(pos_t& pos, size_t distance);
+    /// Add a deletion to the alignment
+    void apply_deletion(Alignment& aln, const pos_t& pos);
+    /// Add an insertion to the alignment
+    void apply_insertion(Alignment& aln, const pos_t& pos);
+    /// Add a match/mismatch to the alignment
+    void apply_aligned_base(Alignment& aln, const pos_t& pos, char graph_char, char read_char);
+    
+    /// Memo for Phred -> probability conversion
+    vector<double> phred_prob;
+    
+    /// A Markov distribution for each read position
+    vector<MarkovDistribution> transition_distrs;
+    
+    xg::XG& xg_index;
+    
+    LRUCache<id_t, Node> node_cache;
+    LRUCache<id_t, vector<Edge> > edge_cache;
+    
+    default_random_engine prng;
+    uniform_int_distribution<size_t> start_pos_sampler;
+    uniform_int_distribution<uint8_t> strand_sampler;
+    uniform_int_distribution<size_t> background_sampler;
+    uniform_int_distribution<size_t> mut_sampler;
+    uniform_real_distribution<double> prob_sampler;
+    normal_distribution<double> insert_sampler;
+    
+    const double sub_poly_rate;
+    const double indel_poly_rate;
+    const double indel_error_prop;
+    const double insert_mean;
+    const double insert_sd;
+    
+    size_t sample_counter = 0;
+    size_t seed;
+};
+    
+/**
+ * A finite state Markov distribution that supports sampling
+ */
+class NGSSimulator::MarkovDistribution {
+public:
+    MarkovDistribution(size_t seed);
+    
+    /// record a transition from the input data
+    void record_transition(uint8_t from, uint8_t to);
+    /// indicate that there is no more data and prepare for sampling
+    void finalize();
+    /// sample according to the training data
+    uint8_t sample_transition(uint8_t from);
+    
+private:
+    
+    default_random_engine prng;
+    unordered_map<uint8_t, uniform_int_distribution<size_t>> samplers;
+    
+    unordered_map<uint8_t, size_t> column_of;
+    vector<uint8_t> value_at;
+    unordered_map<uint8_t, vector<size_t>> cond_distrs;
+    
 };
 
 }

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -26,19 +26,21 @@ void help_sim(char** argv) {
          << "Samples sequences from the xg-indexed graph." << endl
          << endl
          << "options:" << endl
-         << "    -x, --xg-name FILE    use the xg index in FILE" << endl
-         << "    -l, --read-length N   write reads of length N" << endl
-         << "    -n, --num-reads N     simulate N reads" << endl
-         << "    -s, --random-seed N   use this specific seed for the PRNG" << endl
-         << "    -e, --base-error N    base substitution error rate (default 0.0)" << endl
-         << "    -i, --indel-error N   indel error rate (default 0.0)" << endl
-         << "    -f, --forward-only    don't simulate from the reverse strand" << endl
-         << "    -p, --frag-len N      make paired end reads with given fragment length N" << endl
-         << "    -v, --frag-std-dev N  use this standard deviation for fragment length estimation" << endl
-         << "    -N, --allow-Ns        allow reads to be sampled from the graph with Ns in them" << endl
-         << "    -a, --align-out       generate true alignments on stdout rather than reads" << endl
-         << "    -J, --json-out        write alignments in json" << endl
-         << "    -m, --include-bonuses include bonuses in reported scores" << endl;
+         << "    -x, --xg-name FILE          use the xg index in FILE" << endl
+         << "    -F, --fastq FILE            superpose errors matching the error profile of NGS reads in FILE (ignores -l,-N,-f)" << endl
+         << "    -l, --read-length N         write reads of length N" << endl
+         << "    -n, --num-reads N           simulate N reads" << endl
+         << "    -s, --random-seed N         use this specific seed for the PRNG" << endl
+         << "    -e, --sub-rate FLOAT        base substitution rate (default 0.0)" << endl
+         << "    -i, --indel-rate FLOAT      indel rate (default 0.0)" << endl
+         << "    -d, --indel-err-prop FLOAT  proportion of trained errors from -f that are indels (default 0.0)" << endl
+         << "    -f, --forward-only          don't simulate from the reverse strand" << endl
+         << "    -p, --frag-len N            make paired end reads with given fragment length N" << endl
+         << "    -v, --frag-std-dev FLOAT    use this standard deviation for fragment length estimation" << endl
+         << "    -N, --allow-Ns              allow reads to be sampled from the graph with Ns in them" << endl
+         << "    -a, --align-out             generate true alignments on stdout rather than reads" << endl
+         << "    -J, --json-out              write alignments in json" << endl
+         << "    -m, --include-bonuses       include bonuses in reported scores" << endl;
 }
 
 int main_sim(int argc, char** argv) {
@@ -61,6 +63,8 @@ int main_sim(int argc, char** argv) {
     bool reads_may_contain_Ns = false;
     string xg_name;
     bool strip_bonuses = true;
+    double indel_prop = 0.0;
+    string fastq_name;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -69,6 +73,7 @@ int main_sim(int argc, char** argv) {
         {
             {"help", no_argument, 0, 'h'},
             {"xg-name", required_argument, 0, 'x'},
+            {"fastq", required_argument, 0, 'F'},
             {"read-length", required_argument, 0, 'l'},
             {"num-reads", required_argument, 0, 'n'},
             {"random-seed", required_argument, 0, 's'},
@@ -76,8 +81,9 @@ int main_sim(int argc, char** argv) {
             {"align-out", no_argument, 0, 'a'},
             {"json-out", no_argument, 0, 'J'},
             {"allow-Ns", no_argument, 0, 'N'},
-            {"base-error", required_argument, 0, 'e'},
-            {"indel-error", required_argument, 0, 'i'},
+            {"base-rate", required_argument, 0, 'e'},
+            {"indel-rate", required_argument, 0, 'i'},
+            {"indel-err-prop", required_argument, 0, 'd'},
             {"frag-len", required_argument, 0, 'p'},
             {"frag-std-dev", required_argument, 0, 'v'},
             {"include-bonuses", no_argument, 0, 'm'},
@@ -85,7 +91,7 @@ int main_sim(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hl:n:s:e:i:fax:Jp:v:Nm",
+        c = getopt_long (argc, argv, "hl:n:s:e:i:fax:Jp:v:NmF:d:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -97,6 +103,10 @@ int main_sim(int argc, char** argv) {
 
         case 'x':
             xg_name = optarg;
+            break;
+            
+        case 'F':
+            fastq_name = optarg;
             break;
 
         case 'l':
@@ -117,6 +127,10 @@ int main_sim(int argc, char** argv) {
 
         case 'i':
             indel_error = atof(optarg);
+            break;
+            
+        case 'd':
+            indel_prop = atof(optarg);
             break;
 
         case 'f':
@@ -176,95 +190,154 @@ int main_sim(int argc, char** argv) {
         cerr << "[vg sim] error: could not open xg index" << endl;
         return 1;
     }
-
-    // Make a sample to sample reads with
-    Sampler sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns);
     
-    // Make a Mapper to score reads, with the default parameters
-    Mapper rescorer(xgidx, nullptr, nullptr);
-    // Override the "default" full length bonus, just like every other subcommand that uses a mapper ends up doing.
-    // TODO: is it safe to change the default?
-    rescorer.set_alignment_scores(default_match, default_mismatch, default_gap_open, default_gap_extension, 5);
-    // Include the full length bonuses if requested.
-    rescorer.strip_bonuses = strip_bonuses;
-    // We define a function to score a generated alignment under the mapper
-    auto rescore = [&] (Alignment& aln) {
-        // Score using exact distance.
-        aln.set_score(rescorer.score_alignment(aln, false));
-    };
-    
-    size_t max_iter = 1000;
-    int nonce = 1;
-    for (int i = 0; i < num_reads; ++i) {
-        // For each read we are going to generate
+    if (fastq_name.empty()) {
+        // Use the fixed error rate sampler
         
-        if (fragment_length) {
-            // fragment_lenght is nonzero so make it two paired reads
-            auto alns = sampler.alignment_pair(read_length, fragment_length, fragment_std_dev, base_error, indel_error);
+        // Make a sample to sample reads with
+        Sampler sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns);
+        
+        // Make a Mapper to score reads, with the default parameters
+        Mapper rescorer(xgidx, nullptr, nullptr);
+        // Override the "default" full length bonus, just like every other subcommand that uses a mapper ends up doing.
+        // TODO: is it safe to change the default?
+        rescorer.set_alignment_scores(default_match, default_mismatch, default_gap_open, default_gap_extension, 5);
+        // Include the full length bonuses if requested.
+        rescorer.strip_bonuses = strip_bonuses;
+        // We define a function to score a generated alignment under the mapper
+        auto rescore = [&] (Alignment& aln) {
+            // Score using exact distance.
+            aln.set_score(rescorer.score_alignment(aln, false));
+        };
+        
+        size_t max_iter = 1000;
+        int nonce = 1;
+        for (int i = 0; i < num_reads; ++i) {
+            // For each read we are going to generate
             
-            size_t iter = 0;
-            while (iter++ < max_iter) {
-                // For up to max_iter iterations
-                if (alns.front().sequence().size() < read_length
-                    || alns.back().sequence().size() < read_length) {
-                    // If our read was too short, try again
-                    alns = sampler.alignment_pair(read_length, fragment_length, fragment_std_dev, base_error, indel_error);
-                }
-            }
-            
-            // write the alignment or its string
-            if (align_out) {
-                // write it out as requested
+            if (fragment_length) {
+                // fragment_lenght is nonzero so make it two paired reads
+                auto alns = sampler.alignment_pair(read_length, fragment_length, fragment_std_dev, base_error, indel_error);
                 
-                // We will need scores
-                rescore(alns.front());
-                rescore(alns.back());
-                
-                if (json_out) {
-                    cout << pb2json(alns.front()) << endl;
-                    cout << pb2json(alns.back()) << endl;
-                } else {
-                    function<Alignment(uint64_t)> lambda = [&alns](uint64_t n) { return alns[n]; };
-                    stream::write(cout, 2, lambda);
-                }
-            } else {
-                cout << alns.front().sequence() << "\t" << alns.back().sequence() << endl;
-            }
-        } else {
-            // Do single-end reads
-            auto aln = sampler.alignment_with_error(read_length, base_error, indel_error);
-            
-            size_t iter = 0;
-            while (iter++ < max_iter) {
-                // For up to max_iter iterations
-                if (aln.sequence().size() < read_length) {
-                    // If our read is too short, try again
-                    auto aln_prime = sampler.alignment_with_error(read_length, base_error, indel_error);
-                    if (aln_prime.sequence().size() > aln.sequence().size()) {
-                        // But only keep the new try if it is longer
-                        aln = aln_prime;
+                size_t iter = 0;
+                while (iter++ < max_iter) {
+                    // For up to max_iter iterations
+                    if (alns.front().sequence().size() < read_length
+                        || alns.back().sequence().size() < read_length) {
+                        // If our read was too short, try again
+                        alns = sampler.alignment_pair(read_length, fragment_length, fragment_std_dev, base_error, indel_error);
                     }
                 }
-            }
-            
-            // write the alignment or its string
-            if (align_out) {
-                // write it out as requested
                 
-                // We will need scores
-                rescore(aln);
-                
-                if (json_out) {
-                    cout << pb2json(aln) << endl;
+                // write the alignment or its string
+                if (align_out) {
+                    // write it out as requested
+                    
+                    // We will need scores
+                    rescore(alns.front());
+                    rescore(alns.back());
+                    
+                    if (json_out) {
+                        cout << pb2json(alns.front()) << endl;
+                        cout << pb2json(alns.back()) << endl;
+                    } else {
+                        function<Alignment(uint64_t)> lambda = [&alns](uint64_t n) { return alns[n]; };
+                        stream::write(cout, 2, lambda);
+                    }
                 } else {
-                    function<Alignment(uint64_t)> lambda = [&aln](uint64_t n) { return aln; };
-                    stream::write(cout, 1, lambda);
+                    cout << alns.front().sequence() << "\t" << alns.back().sequence() << endl;
                 }
             } else {
-                cout << aln.sequence() << endl;
+                // Do single-end reads
+                auto aln = sampler.alignment_with_error(read_length, base_error, indel_error);
+                
+                size_t iter = 0;
+                while (iter++ < max_iter) {
+                    // For up to max_iter iterations
+                    if (aln.sequence().size() < read_length) {
+                        // If our read is too short, try again
+                        auto aln_prime = sampler.alignment_with_error(read_length, base_error, indel_error);
+                        if (aln_prime.sequence().size() > aln.sequence().size()) {
+                            // But only keep the new try if it is longer
+                            aln = aln_prime;
+                        }
+                    }
+                }
+                
+                // write the alignment or its string
+                if (align_out) {
+                    // write it out as requested
+                    
+                    // We will need scores
+                    rescore(aln);
+                    
+                    if (json_out) {
+                        cout << pb2json(aln) << endl;
+                    } else {
+                        function<Alignment(uint64_t)> lambda = [&aln](uint64_t n) { return aln; };
+                        stream::write(cout, 1, lambda);
+                    }
+                } else {
+                    cout << aln.sequence() << endl;
+                }
+            }
+        }
+        
+    }
+    else {
+        // Use the trained error rate aligner
+        Aligner aligner(default_match, default_mismatch, default_gap_open, default_gap_extension, 5);
+        
+        NGSSimulator sampler(*xgidx, fastq_name, base_error, indel_error, indel_prop,
+                             fragment_length ? fragment_length : std::numeric_limits<double>::max(),
+                             fragment_std_dev, seed_val);
+        
+        if (fragment_length) {
+            for (size_t i = 0; i < num_reads; i++) {
+                pair<Alignment, Alignment> read_pair = sampler.sample_read_pair();
+                read_pair.first.set_score(aligner.score_ungapped_alignment(read_pair.first, strip_bonuses));
+                read_pair.second.set_score(aligner.score_ungapped_alignment(read_pair.second, strip_bonuses));
+                
+                if (align_out) {
+                    if (json_out) {
+                        cout << pb2json(read_pair.first) << endl;
+                        cout << pb2json(read_pair.second) << endl;
+                    }
+                    else {
+                        function<Alignment(uint64_t)> lambda = [&read_pair](uint64_t n) {
+                            return n % 2 ? read_pair.first : read_pair.second;
+                        };
+                        stream::write(cout, 2, lambda);
+                    }
+                }
+                else {
+                    cout << read_pair.first.sequence() << "\t" << read_pair.second.sequence() << endl;
+                }
+            }
+        }
+        else {
+            for (size_t i = 0; i < num_reads; i++) {
+                Alignment read = sampler.sample_read();
+                read.set_score(aligner.score_ungapped_alignment(read, strip_bonuses));
+                
+                if (align_out) {
+                    if (json_out) {
+                        cout << pb2json(read) << endl;
+                    }
+                    else {
+                        function<Alignment(uint64_t)> lambda = [&read](uint64_t n) {
+                            return read;
+                        };
+                        stream::write(cout, 1, lambda);
+                    }
+                }
+                else {
+                    cout << read.sequence() << endl;
+                }
             }
         }
     }
+    
 
     return 0;
 }

--- a/src/variant_adder.cpp
+++ b/src/variant_adder.cpp
@@ -635,17 +635,11 @@ Alignment VariantAdder::smart_align(vg::VG& graph, pair<NodeSide, NodeSide> endp
         // Rescore the alignments as if N/N substitutions are matches so that we
         // can use the score as a proxy for how many matches there are.
         
-        // We need a function to score jumps. But score them all as 0 since we
-        // shouldn't have any.
-        auto ignore_jumps = [](pos_t, pos_t, size_t) {
-            return 0;
-        };
-        
         // Turn N/N subs into matches and score the alignments without end bonuses.
         align_ns(left_subgraph, aln_left);
-        aln_left.set_score(aligner.score_alignment(aln_left, ignore_jumps, true));
+        aln_left.set_score(aligner.score_ungapped_alignment(aln_left, true));
         align_ns(right_subgraph, aln_right);
-        aln_right.set_score(aligner.score_alignment(aln_right, ignore_jumps, true));
+        aln_right.set_score(aligner.score_ungapped_alignment(aln_right, true));
         
         
 #ifdef debug
@@ -694,7 +688,7 @@ Alignment VariantAdder::smart_align(vg::VG& graph, pair<NodeSide, NodeSide> endp
 
                 // Rescore with Ns as matches again
                 align_ns(left_subgraph, aln);
-                aln.set_score(aligner.score_alignment(aln, ignore_jumps, true));
+                aln.set_score(aligner.score_ungapped_alignment(aln, true));
 
 #ifdef debug                
                 if (aligned_in_band) {
@@ -805,7 +799,7 @@ Alignment VariantAdder::smart_align(vg::VG& graph, pair<NodeSide, NodeSide> endp
                 
                 // Rescore with Ns as matches again
                 align_ns(left_subgraph, aln);
-                aln.set_score(aligner.score_alignment(aln, ignore_jumps, true));
+                aln.set_score(aligner.score_ungapped_alignment(aln, true));
                 
 #ifdef debug
                 cerr << "\tScore: " << aln.score() << "/" << (to_align.size() * aligner.match * min_score_factor)


### PR DESCRIPTION
I added a new read simulator that I think will more closely mimic the properties of NGS data. I think this is important because having evenly distributed errors throughout the read changes the MEM profile of a read a lot, which affects how good of a heuristic the MEMs are.

The new sampler trains a Markovian error model based on a FASTQ file, and then it superposes this "sequencing error" distribution, which varies over the length of the read, over a parameterized "polymorphism" distribution, which is evenly distributed along the read. I added the new simulator as an option in `vg sim`. For example, I got pretty nice human Illumina-looking data with this call:

```
vg sim -x snp1kg-BRCA1.xg -F platinum_NA12878_BRCA1.fq -d 0.01 -e 0.001 -i 0.0005 -p 1000 -v 75.0
```