### PR TITLE
Stop pr plots from breaking for single points

### DIFF
--- a/scripts/plot-pr.R
+++ b/scripts/plot-pr.R
@@ -30,6 +30,10 @@ dat.roc <- dat %>%
     # Given the confusion matrix entries, calculate Precision and Recall for each MAPQ
     mutate(Precision = TP / (TP + FP), Recall = TP / (TP + FN));
 
+# Keep only the rows that don't have NANs
+# See <https://stackoverflow.com/a/5961999>
+dat.roc <- dat.roc[complete.cases(dat.roc), ]
+
 # Now we pipe that into ggplot and use + to assemble a bunch of ggplot layers together into a plot.
 dat.roc %>% 
     # Make a base plot mapping each of these variable names to each of these "aesthetic" attributes (like x position and color)
@@ -45,7 +49,9 @@ dat.roc %>%
         # And we want a size legend
         scale_size_continuous("number") +
         # And we want a log X axis
-        scale_x_log10(breaks=c(1e-7, 1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e-0)) +
+        scale_x_log10(breaks=c(1e-8,1e-7,1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e-0), limits=c(1e-8, 1e-0)) +
+        # And a normal Y axis
+        scale_y_continuous(limits=c(0.9, 1.0)) +
         # And we want this cool theme
         theme_bw()
 

--- a/scripts/plot-pr.R
+++ b/scripts/plot-pr.R
@@ -49,7 +49,7 @@ dat.roc %>%
         # And we want a size legend
         scale_size_continuous("number") +
         # And we want a log X axis
-        scale_x_log10(breaks=c(1e-8,1e-7,1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e-0), limits=c(1e-8, 1e-0)) +
+        scale_x_log10(breaks=c(1e-7,1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e-0), limits=c(1e-6, 1e-0)) +
         # And a normal Y axis
         scale_y_continuous(limits=c(0.9, 1.0)) +
         # And we want this cool theme

--- a/scripts/plot-pr.R
+++ b/scripts/plot-pr.R
@@ -49,7 +49,7 @@ dat.roc %>%
         # And we want a size legend
         scale_size_continuous("number") +
         # And we want a log X axis
-        scale_x_log10(breaks=c(1e-7,1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e-0), limits=c(1e-6, 1e-0)) +
+        scale_x_log10(breaks=c(1e-7,1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e-0), limits=c(1e-6, 1e-2)) +
         # And a normal Y axis
         scale_y_continuous(limits=c(0.9, 1.0)) +
         # And we want this cool theme


### PR DESCRIPTION
This should fix #1014 by manually setting the PR plot bounds to reasonable values.