### PR TITLE
Refactor the mapper so distance estimation lives in another class

### DIFF
--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -276,6 +276,55 @@ protected:
     FragmentLengthDistribution fragment_length_distr;
 };
 
+/**
+ * Keeps track of statistics about fragment length within the Mapper class.
+ * Belongs to a single thread.
+ */
+class FragmentLengthStatistics {
+public:
+
+    void record_fragment_configuration(int length, const Alignment& aln1, const Alignment& aln2);
+    
+    string fragment_model_str(void);
+    void save_frag_lens_to_alns(Alignment& aln1, Alignment& aln2, const map<string, int>& approx_frag_lengths, bool is_consistent);
+    
+    // These functions are the authorities on the estimated parameters
+    double fragment_length_stdev(void);
+    double fragment_length_mean(void);
+    double fragment_length_pdf(double length);
+    double fragment_length_pval(double length);
+    bool fragment_orientation(void);
+    bool fragment_direction(void);
+    
+    // These cached versions of the parameters are updated periodically
+    double cached_fragment_length_mean = 0;
+    double cached_fragment_length_stdev = 0;
+    bool cached_fragment_orientation = 0;
+    bool cached_fragment_direction = 1;
+    
+    // These variables are used to manage the periodic updates
+    int since_last_fragment_length_estimate = 0;
+    int fragment_model_update_interval = 10;
+    
+    // These deques are used for the periodic running estimation of the fragment length distribution
+    deque<double> fragment_lengths;
+    deque<bool> fragment_orientations;
+    deque<bool> fragment_directions;
+
+    int fragment_max = 10000; // the maximum length fragment which we will consider when estimating fragment lengths
+    int fragment_size = 0; // Used to bound clustering of MEMs during paired end mapping, also acts as sentinel to determine
+                       // if consistent pairs should be reported; dynamically estimated at runtime
+    double fragment_sigma = 10; // the number of times the standard deviation above the mean to set the fragment_size
+    int fragment_length_cache_size = 1000;
+    float perfect_pair_identity_threshold = 0.95;
+    bool fixed_fragment_model = true;
+    
+    
+    
+    
+    
+};
+
 class Mapper : public BaseMapper {
 
 
@@ -331,26 +380,6 @@ public:
     // a collection of read pairs which we'd like to realign once we have estimated the fragment_size
     vector<pair<Alignment, Alignment> > imperfect_pairs_to_retry;
 
-    // running estimation of fragment length distribution
-    deque<double> fragment_lengths;
-    deque<bool> fragment_orientations;
-    deque<bool> fragment_directions;
-    void save_frag_lens_to_alns(Alignment& aln1, Alignment& aln2);
-    void record_fragment_configuration(int length, const Alignment& aln1, const Alignment& aln2);
-    string fragment_model_str(void);
-    double fragment_length_stdev(void);
-    double fragment_length_mean(void);
-    double fragment_length_pdf(double length);
-    double fragment_length_pval(double length);
-    bool fragment_orientation(void);
-    bool fragment_direction(void);
-    double cached_fragment_length_mean;
-    double cached_fragment_length_stdev;
-    bool cached_fragment_orientation;
-    bool cached_fragment_direction;
-    int since_last_fragment_length_estimate;
-    int fragment_model_update_interval;
-    
     double graph_entropy(void);
 
     // use the xg index to get the mean position of the nodes in the alignent for each reference that it corresponds to
@@ -534,18 +563,15 @@ public:
     double identity_weight; // scale mapping quality by the alignment score identity to this power
 
     bool always_rescue; // Should rescue be attempted for all imperfect alignments?
-    int fragment_max; // the maximum length fragment which we will consider when estimating fragment lengths
-    int fragment_size; // Used to bound clustering of MEMs during paired end mapping, also acts as sentinel to determine
-                       // if consistent pairs should be reported; dynamically estimated at runtime
-    double fragment_sigma; // the number of times the standard deviation above the mean to set the fragment_size
-    int fragment_length_cache_size;
-    float perfect_pair_identity_threshold;
-    bool fixed_fragment_model;
+    
     bool simultaneous_pair_alignment;
     int max_band_jump; // the maximum length edit we can detect via banded alignment
     float drop_chain; // drop chains shorter than this fraction of the longest overlapping chain
     float mq_overlap; // consider as alternative mappings any alignment with this overlap with our best
     int mate_rescues;
+    
+    // Keep track of fragment length distribution statistics
+    FragmentLengthStatistics frag_stats;
 
 };
 

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -617,17 +617,17 @@ int main_map(int argc, char** argv) {
         m->extra_multimaps = extra_multimaps;
         m->mapping_quality_method = mapping_quality_method;
         m->always_rescue = always_rescue;
-        m->fixed_fragment_model = fixed_fragment_model;
-        m->fragment_max = fragment_max;
-        m->fragment_sigma = fragment_sigma;
+        m->frag_stats.fixed_fragment_model = fixed_fragment_model;
+        m->frag_stats.fragment_max = fragment_max;
+        m->frag_stats.fragment_sigma = fragment_sigma;
         if (fragment_mean) {
-            m->fragment_size = fragment_size;
-            m->cached_fragment_length_mean = fragment_mean;
-            m->cached_fragment_length_stdev = fragment_stdev;
-            m->cached_fragment_orientation = fragment_orientation;
-            m->cached_fragment_direction = fragment_direction;
+            m->frag_stats.fragment_size = fragment_size;
+            m->frag_stats.cached_fragment_length_mean = fragment_mean;
+            m->frag_stats.cached_fragment_length_stdev = fragment_stdev;
+            m->frag_stats.cached_fragment_orientation = fragment_orientation;
+            m->frag_stats.cached_fragment_direction = fragment_direction;
         }
-        m->fragment_model_update_interval = fragment_model_update;
+        m->frag_stats.fragment_model_update_interval = fragment_model_update;
         m->max_mapping_quality = max_mapping_quality;
         m->use_cluster_mq = use_cluster_mq;
         m->mate_rescues = mate_rescues;
@@ -762,7 +762,7 @@ int main_map(int argc, char** argv) {
                 if (!queued_resolve_later) {
                     output_func(aln1, aln2, alnp);
                     // check if we should try to align the queued alignments
-                    if (our_mapper->fragment_size != 0
+                    if (our_mapper->frag_stats.fragment_size != 0
                         && !our_mapper->imperfect_pairs_to_retry.empty()) {
                         int i = 0;
                         for (auto p : our_mapper->imperfect_pairs_to_retry) {
@@ -782,7 +782,7 @@ int main_map(int argc, char** argv) {
             { // clean up buffered alignments that weren't perfect
                 auto our_mapper = mapper[omp_get_thread_num()];
                 // if we haven't yet computed these, assume we couldn't get an estimate for fragment size
-                our_mapper->fragment_size = fragment_max;
+                our_mapper->frag_stats.fragment_size = fragment_max;
                 for (auto p : our_mapper->imperfect_pairs_to_retry) {
                     bool queued_resolve_later = false;
                     auto alnp = our_mapper->align_paired_multi(p.first, p.second,
@@ -849,7 +849,7 @@ int main_map(int argc, char** argv) {
                 if (!queued_resolve_later) {
                     output_func(aln1, aln2, alnp);
                     // check if we should try to align the queued alignments
-                    if (our_mapper->fragment_size != 0
+                    if (our_mapper->frag_stats.fragment_size != 0
                         && !our_mapper->imperfect_pairs_to_retry.empty()) {
                         int i = 0;
                         for (auto p : our_mapper->imperfect_pairs_to_retry) {
@@ -868,7 +868,7 @@ int main_map(int argc, char** argv) {
 #pragma omp parallel
             {
                 auto our_mapper = mapper[omp_get_thread_num()];
-                our_mapper->fragment_size = fragment_max;
+                our_mapper->frag_stats.fragment_size = fragment_max;
                 for (auto p : our_mapper->imperfect_pairs_to_retry) {
                     bool queued_resolve_later = false;
                     auto alnp = our_mapper->align_paired_multi(p.first, p.second,
@@ -923,7 +923,7 @@ int main_map(int argc, char** argv) {
                 if (!queued_resolve_later) {
                     output_func(aln1, aln2, alnp);
                     // check if we should try to align the queued alignments
-                    if (our_mapper->fragment_size != 0
+                    if (our_mapper->frag_stats.fragment_size != 0
                         && !our_mapper->imperfect_pairs_to_retry.empty()) {
                         int i = 0;
                         for (auto p : our_mapper->imperfect_pairs_to_retry) {
@@ -942,7 +942,7 @@ int main_map(int argc, char** argv) {
 #pragma omp parallel
             {
                 auto our_mapper = mapper[omp_get_thread_num()];
-                our_mapper->fragment_size = fragment_max;
+                our_mapper->frag_stats.fragment_size = fragment_max;
                 for (auto p : our_mapper->imperfect_pairs_to_retry) {
                     bool queued_resolve_later = false;
                     auto alnp = our_mapper->align_paired_multi(p.first, p.second,
@@ -985,9 +985,9 @@ int main_map(int argc, char** argv) {
     }
 
     if (print_fragment_model) {
-        if (mapper[0]->fragment_size) {
+        if (mapper[0]->frag_stats.fragment_size) {
             // we've calculated our fragment size, so print it and bail out
-            cout << mapper[0]->fragment_model_str() << endl;
+            cout << mapper[0]->frag_stats.fragment_model_str() << endl;
         } else {
             cerr << "[vg map] Error: could not calculate fragment model" << endl;
         }


### PR DESCRIPTION
This is step 1 of my quest in #991 to replace the one-mapper-per-thread layout with a system that uses a single mapper and some per-thread caches. All I'm doing now is grouping all the fragment modeling members of the Mapper together under a FragmentDistributionStats class.