### PR TITLE
Activate trained simulator in Jenkins

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -236,10 +236,10 @@ then
     tar czf "${VG_VERSION}_output.tar.gz" vgci-work test-report.xml jenkins/vgci.py jenkins/jenkins.sh vgci_cfg.tsv
     aws s3 cp --acl public-read "${VG_VERSION}_output.tar.gz" s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_output_archives/
 
-    # if success and we're merging the PR (and not just testing it), we publish results to the baseline
-    if [ "$PYRET" -eq 0 ] && [ -z ${ghprbActualCommit} ]
+    # if we're merging the PR (and not just testing it), we publish results to the baseline
+    [ -z ${ghprbActualCommit} ]
     then
-        echo "Tests passed. Updating baseline"
+        echo "Updating baseline"
         aws s3 sync --acl public-read ./vgci-work/ s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline
         printf "${VG_VERSION}\n" > vg_version_${VG_VERSION}.txt
         printf "${ghprbActualCommitAuthor}\n${ghprbPullTitle}\n${ghprbPullLink}\n" >> vg_version_${VG_VERSION}.txt


### PR DESCRIPTION
This is just to see what happens when switching over to @jeizenga's fancier simulation model.  I think a better fastq (longer reads?), as well as more thought on the parameters is required before merging. 