### PR TITLE
use consistent naming for trained read pairs

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -594,8 +594,8 @@ pair<Alignment, Alignment> NGSSimulator::sample_read_pair() {
     });
     
     string name = get_read_name();
-    aln_pair.first.set_name(name + "/1");
-    aln_pair.second.set_name(name + "/2");
+    aln_pair.first.set_name(name + "_1");
+    aln_pair.second.set_name(name + "_2");
     
     return aln_pair;
 }


### PR DESCRIPTION
this is a hack to get tests to run with trained simulator.  

we should eventually change all simulation and tests to use / instead of _ to be more consistent with typical illumina output.  