### PR TITLE
Make read names unique across seeds in trained simulator

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -909,7 +909,7 @@ pos_t NGSSimulator::sample_start_pos() {
 
 string NGSSimulator::get_read_name() {
     stringstream sstrm;
-    sstrm << "fragment_" << sample_counter;
+    sstrm << "fragment_" << seed << "_" << sample_counter;
     sample_counter++;
     return sstrm.str();
 }


### PR DESCRIPTION
This is for toil-vg sim, which runs of a bunch of independent simulation processes in parallel (with different seeds)