### PR TITLE
Add an interface to convert bed to gam

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1063,8 +1063,7 @@ void parse_bed_regions(istream& bedstream,
             assert(sbuf < ebuf);
             // convert from BED-style to 0-based inclusive coordinates
             ebuf -= 1;
-            Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf);
-            //Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf, name);
+            Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf, name);
 
             out_alignments->push_back(alignment);
         }

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1033,4 +1033,42 @@ pair<string, string> signature(const Alignment& aln1, const Alignment& aln2) {
     return make_pair(signature(aln1), signature(aln2));
 }
 
+void parse_bed_regions(istream& bedstream,
+                       xg::XG* xgindex,
+                       vector<Alignment>* out_alignments) {
+    out_alignments->clear();
+    if (!bedstream) {
+        cerr << "Unable to open bed file." << endl;
+        return;
+    }
+    string row;
+    string seq;
+    size_t sbuf;
+    size_t ebuf;
+    string name;
+
+    for (int line = 1; getline(bedstream, row); ++line) {
+        if (row.size() < 2 || row[0] == '#') {
+            continue;
+        }
+        istringstream ss(row);
+        ss >> seq;
+        ss >> sbuf;
+        ss >> ebuf;
+
+        if (ss.fail()) {
+            cerr << "Error parsing bed line " << line << ": " << row << endl;
+        } else {
+            ss >> name;
+            assert(sbuf < ebuf);
+            // convert from BED-style to 0-based inclusive coordinates
+            ebuf -= 1;
+            Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf);
+            //Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf, name);
+
+            out_alignments->push_back(alignment);
+        }
+    }
+}
+
 }

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -8,6 +8,7 @@
 #include "path.hpp"
 #include "position.hpp"
 #include "vg.pb.h"
+#include "xg.hpp"
 
 #include "htslib/hfile.h"
 #include "htslib/hts.h"
@@ -125,6 +126,8 @@ void write_alignment_to_file(const Alignment& aln, const string& filename);
 
 // quality information; a kind of poor man's pileup
 map<id_t, int> alignment_quality_per_node(const Alignment& aln);
+
+void parse_bed_regions(istream& bedstream, xg::XG* xgindex, vector<Alignment>* out_alignments);
 
 }
 


### PR DESCRIPTION
In order to annotate a path with genes or repeats as a subpath, I propose to add an interface to convert BED format to GAM format.

It intends to work with commands below.

```
vg annotate -p -x input.xg -b input.bed > output.gam
vg mod -P --include-aln output.gam input.vg > output.vg
```
