### PR TITLE
Sort alignments by lowest id rather than by first id

### DIFF
--- a/scripts/plot-roc.R
+++ b/scripts/plot-roc.R
@@ -1,0 +1,38 @@
+#!/usr/bin/env Rscript
+#
+# plots a pseudo-ROC that allows the comparison of different alignment methods and their mapping quality calculations
+# the format is clarified in the map-sim script, and should be a table (tab separated) of:
+#      correct   mq    score   aligner
+# where "correct" is 0 or 1 depending on whether the alignnment is correct or not and "aligner" labels the mapping method
+#
+# This is not a true ROC because we are not purely plotting the binary classification performance of
+# each of the methods' mapping quality calculation over the same set of candidate alignments.
+# Rather, we are mixing both the alignment sensitivity of the method with the MQ classification performance.
+# As such we do not ever achieve 100% sensitivity, as we have effectively scaled the y axis (TPR) by the total
+# sensitivity of each mapper.
+
+list.of.packages <- c("tidyverse", "ggrepel")
+new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
+if(length(new.packages)) install.packages(new.packages)
+require("tidyverse")
+require("ggrepel")
+
+dat <- read.table(commandArgs(TRUE)[1], header=T)
+dat$bin <- cut(dat$mq, c(-Inf,seq(0,60,1),Inf))
+dat.roc <- dat %>%
+    mutate(Positive = correct == 1, Negative = correct == 0) %>%
+    group_by(aligner, mq) %>%
+    summarise(Positive = sum(Positive), Negative = sum(Negative)) %>%
+    arrange(-mq) %>%
+    mutate(TPR = cumsum(Positive) / sum(Positive+Negative), FPR = cumsum(Negative) / sum(Positive+Negative))
+
+dat.roc %>% ggplot(aes( x= FPR, y = TPR, color = aligner, label=mq)) +
+    geom_line() + geom_text_repel(data = subset(dat.roc, mq %% 10 == 0), size=3.5, point.padding=unit(0.7, "lines"), segment.alpha=I(1/2.5)) +
+    geom_point(aes(size=Positive+Negative)) +
+    scale_color_manual(values=c("#1f78b4","#a6cee3","#e31a1c","#fb9a99","#33a02c","#b2df8a","#6600cc","#e5ccff","#ff8000","#ffe5cc")) +
+    scale_size_continuous("number") +
+    scale_x_log10(breaks=c(1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e-0)) +
+    theme_bw()
+
+filename <- commandArgs(TRUE)[2]
+ggsave(filename, height=4, width=5.45)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -409,7 +409,14 @@ const string Index::key_for_alignment_prefix(int64_t node_id) {
 const string Index::key_for_alignment(const Alignment& alignment) {
     string key;
     if (alignment.has_path()) {
-        key = key_for_alignment_prefix(alignment.path().mapping(0).position().node_id());
+        // key the alignment by the lowest node id it maps to
+        int64_t min_id = 0;
+        for (auto& mapping : alignment.path().mapping()) {
+            if (mapping.position().node_id() < min_id || min_id == 0) {
+                min_id = mapping.position().node_id();
+            }
+        }
+        key = key_for_alignment_prefix(min_id);
     } else {
         // make our key using the alignment, to try to bin similar alignments together
         key = key_for_alignment_prefix(0) + alignment.sequence().substr(0,32);

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -102,7 +102,7 @@ vg index -d x.db -N x.gam
 is $(vg find -o 127 -d x.db | vg view -a - | wc -l) 6 "the index can return the set of alignments mapping to a particular node"
 is $(vg find -A <(vg find -N <(seq 37 52 ) -x x.xg ) -d x.db | vg view -a - | wc -l) 15 "a subgraph query may be used to obtain a particular subset of alignments"
 vg index -d x.db -a x.gam
-is $(vg find -i 100:127 -d x.db | vg view -a - | wc -l) 20 "the index can return the set of alignments whose start node is within a given range"
+is $(vg find -i 100:127 -d x.db | vg view -a - | wc -l) 19 "the index can return the set of alignments whose start node is within a given range"
 rm -rf x.db x.gam x.reads
 
 vg sim -s 1337 -n 1 -x x.xg -a >x.gam


### PR DESCRIPTION
This should make range-based queries more sensible for partially ordered components of graphs, provided the node ids are set by the partial order.