### PR TITLE
Switch to min-position gam lookup in vg chunk

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -24,7 +24,7 @@ KEEP_OUTPUT=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@bb7220dd460c25bc7620c442878a3590a7e0c03c"
+TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@d050da12e4b6bbc15a46d775ce963ea7c09c4708"
 # What tests should we run?
 # Should be something like "jenkins/vgci.py::VGCITest::test_sim_brca2_snp1kg"
 PYTEST_TEST_SPEC="jenkins/vgci.py"

--- a/src/chunker.hpp
+++ b/src/chunker.hpp
@@ -29,7 +29,7 @@ public:
     // xg index used for all path splitting and subgraphing operations
     xg::XG* xg;
     // number of gams to write at once
-    size_t gam_buffer_size = 1000;
+    size_t gam_buffer_size = 100;
 
     PathChunker(xg::XG* xg = NULL);
     ~PathChunker();
@@ -55,15 +55,16 @@ public:
     /** Extract all alignments that touch a node in a subgraph and write them 
      * to an output stream using the rocksdb index (and this->gam_buffer_size) */
     int64_t extract_gam_for_subgraph(VG& subgraph, Index& index, ostream* out_stream,
-                                     bool only_fully_contained = false);
+                                     bool only_fully_contained = false,
+                                     bool search_all_positions = false,
+                                     bool unsorted_index = false);                                     
     
-    /** Like above, but for (inclusive) node id range */
-    int64_t extract_gam_for_id_range(vg::id_t start, vg::id_t end, Index& index, ostream* out_stream,
-                                     bool only_fully_contained = false);
-
     /** More general interface used by above two functions */
-    int64_t extract_gam_for_ids(const vector<vg::id_t>& graph_ids, Index& index, ostream* out_stream,
-                                bool contiguous = false, bool only_fully_contained = false);
+    int64_t extract_gam_for_ids(vector<vg::id_t>& graph_ids, Index& index, ostream* out_stream,
+                                bool contiguous_id_range = false,
+                                bool only_fully_contained = false,
+                                bool search_all_positions = false,
+                                bool unsorted_index = false);
     
 };
 

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -30,7 +30,7 @@ void help_chunk(char** argv) {
          << endl
          << "options:" << endl
          << "    -x, --xg-name FILE       use this xg index to chunk subgraphs" << endl
-         << "    -a, --gam-index FILE     chunk this gam index (made with vg index -N) instead of the graph" << endl
+         << "    -a, --gam-index FILE     chunk this gam index (made with vg index -a) instead of the graph" << endl
          << "    -g, --gam-and-graph      when used in combination with -a, both gam and graph will be chunked" << endl 
          << "path chunking:" << endl
          << "    -p, --path TARGET        write the chunk in the specified (0-based inclusive)\n"
@@ -51,6 +51,7 @@ void help_chunk(char** argv) {
          << "    -c, --context STEPS      expand the context of the chunk this many steps [0]" << endl
          << "    -T, --trace              Trace haplotype threads in chunks (and only expand forward from input coordinates)" << endl
          << "    -f, --fully-contained    Only return GAM alignments that are fully contained within chunk" << endl
+         << "    -A, --search-all         Search all nodes of alignment as opposed just the minimum (gam index must be made with -N)" << endl
          << "    -t, --threads N          for tasks that can be done in parallel, use this many threads [1]" << endl
          << "    -h, --help" << endl;
 }
@@ -79,6 +80,7 @@ int main_chunk(int argc, char** argv) {
     int threads = 1;
     bool trace = false;
     bool fully_contained = false;
+    bool search_all_positions = false;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -101,12 +103,13 @@ int main_chunk(int argc, char** argv) {
             {"id-range", no_argument, 0, 'R'},
             {"trace", required_argument, 0, 'T'},
             {"fully-contained", no_argument, 0, 'f'},
+            {"search-all-positions", no_argument, 0, 'A'},
             {"threads", required_argument, 0, 't'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:a:gp:P:s:o:e:E:b:c:r:R:Tft:",
+        c = getopt_long (argc, argv, "hx:a:gp:P:s:o:e:E:b:c:r:R:TfAt:",
                 long_options, &option_index);
 
 
@@ -178,6 +181,10 @@ int main_chunk(int argc, char** argv) {
         case 'f':
             fully_contained = true;
             break;
+
+        case 'A':
+            search_all_positions = true;
+            break;
             
         case 't':
             threads = atoi(optarg);
@@ -196,11 +203,6 @@ int main_chunk(int argc, char** argv) {
 
     omp_set_num_threads(threads);            
 
-    // check for invalid options combinations, of which there are many
-    if (xg_file.empty()) {
-        cerr << "error:[vg chunk] xg index (-x) required" << endl;
-        return 1;
-    }
     // need at most one of -p, -P, -e, -r, -R,  as an input
     if ((region_string.empty() ? 0 : 1) + (path_list_file.empty() ? 0 : 1) + (in_bed_file.empty() ? 0 : 1) +
         (node_ranges_file.empty() ? 0 : 1) + (node_range_string.empty() ? 0 : 1) > 1) {
@@ -222,13 +224,20 @@ int main_chunk(int argc, char** argv) {
 
     // Load our index
     xg::XG xindex;
-    ifstream in(xg_file.c_str());
-    if (!in) {
-        cerr << "error:[vg chunk] unable to load xg index file" << endl;
-        return 1;
+    if (chunk_graph || trace || context_steps > 0 || !id_range) {
+        if (xg_file.empty()) {
+            cerr << "error:[vg chunk] xg index (-x) required" << endl;
+            return 1;
+        }
+
+        ifstream in(xg_file.c_str());
+        if (!in) {
+            cerr << "error:[vg chunk] unable to load xg index file" << endl;
+            return 1;
+        }
+        xindex.load(in);
+        in.close();
     }
-    xindex.load(in);
-    in.close();
 
     // This holds the RocksDB index that has all our reads, indexed by the nodes they visit.
     Index gam_index;
@@ -443,11 +452,13 @@ int main_chunk(int argc, char** argv) {
                 exit(1);
             }
             if (subgraph != NULL) {
-                chunker.extract_gam_for_subgraph(*subgraph, gam_index, &out_gam_file, fully_contained);
+                chunker.extract_gam_for_subgraph(*subgraph, gam_index, &out_gam_file,
+                                                 fully_contained, search_all_positions);
             } else {
                 assert(id_range == true);
-                chunker.extract_gam_for_id_range(region.start, region.end, gam_index, &out_gam_file,
-                                                 fully_contained);
+                vector<vg::id_t> region_id_range = {region.start, region.end};
+                chunker.extract_gam_for_ids(region_id_range, gam_index, &out_gam_file,
+                                            true, fully_contained, search_all_positions);
             }
         }
 


### PR DESCRIPTION
In most cases in toil-vg, we don't need to check every position in an alignment when pulling mappings by node id, because we're querying by range.   

So we switch from Index::for_alignment_to_nodes() to Index::for_alignment_in_range() (which is getting fixed to use min instead of first position in #1041).  Old logic preserved with -A option.  