### PR TITLE
size_t is unsigned and therefore does not need an call to abs. 

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2683,10 +2683,10 @@ int XG::min_distance_in_paths(int64_t id1, bool is_rev1, size_t offset1,
                               int64_t id2, bool is_rev2, size_t offset2) const {
     auto dist = distance_in_paths(id1, is_rev1, offset1,
                                   id2, is_rev2, offset2);
-    int min_dist = std::numeric_limits<int>::max();
+    size_t min_dist = std::numeric_limits<size_t>::max();
     for (auto& c : dist) {
         for (auto& o : c.second) {
-            if (abs(o) < abs(min_dist)) {
+            if (o <  min_dist) {
                 min_dist = o;
             }
         }


### PR DESCRIPTION
If min_value is also a size_t then they are the same type and we can use '<' directly