### PR TITLE
Use a trivial paired-end mapper

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1680,6 +1680,34 @@ bool Mapper::pair_consistent(const Alignment& aln1,
     return length_ok && orientation_ok;
 }
 
+pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi_trivial(
+    const Alignment& first_mate,
+    const Alignment& second_mate,
+    bool& queued_resolve_later,
+    int max_mem_length,
+    bool only_top_scoring_pair,
+    bool retrying) {
+    
+    // Align each end
+    auto first_alignments = align_multi(first_mate);
+    auto second_alignments = align_multi(second_mate);
+    
+    // Make sure we have the same number of each
+    size_t min_size = min(first_alignments.size(), second_alignments.size());
+    
+    if (only_top_scoring_pair) {
+        // Do at most one pair
+        min_size = min(min_size, (size_t) 1);
+    }
+    
+    first_alignments.resize(min_size);
+    second_alignments.resize(min_size);
+    
+    // Just pair them up arbitrarily
+    return make_pair(first_alignments, second_alignments);
+    
+}
+
 pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
     const Alignment& first_mate,
     const Alignment& second_mate,

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -486,6 +486,29 @@ public:
                            int max_mem_length = 0,
                            bool only_top_scoring_pair = false,
                            bool retrying = false);
+                           
+    // Here's a super easy paired end mapper that just aligns both reads and
+    // looks for consistent pairs.
+    // TODO: queueing logic and resolving later should be factored out.
+    pair<vector<Alignment>, vector<Alignment>> 
+        align_paired_multi_trivial(const Alignment& read1,
+                                   const Alignment& read2,
+                                   bool& queued_resolve_later,
+                                   int max_mem_length = 0,
+                                   bool only_top_scoring_pair = false,
+                                   bool retrying = false);
+    
+    // Here's a super easy paired end mapper that just aligns both reads and
+    // looks for consistent pairs.
+    // TODO: queueing logic and resolving later should be factored out.
+    pair<vector<Alignment>, vector<Alignment>> 
+        align_paired_multi_easy(const Alignment& read1,
+                                const Alignment& read2,
+                                bool& queued_resolve_later,
+                                int max_mem_length = 0,
+                                bool only_top_scoring_pair = false,
+                                bool retrying = false);
+
 
     // lossily project an alignment into a particular path space of a graph
     // the resulting alignment is equivalent to a SAM record against the chosen path

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -97,7 +97,7 @@ int main_map(int argc, char** argv) {
     string read_group;
     string fastq1, fastq2;
     bool interleaved_input = false;
-    int band_width = 256;
+    int band_width = 1000;
     int band_multimaps = 4;
     int max_band_jump = -1;
     bool always_rescue = false;

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -765,7 +765,7 @@ int main_map(int argc, char** argv) {
                  &output_func](Alignment& aln1, Alignment& aln2) {
                 auto our_mapper = mapper[omp_get_thread_num()];
                 bool queued_resolve_later = false;
-                auto alnp = our_mapper->align_paired_multi(aln1, aln2, queued_resolve_later, max_mem_length, top_pairs_only, false);
+                auto alnp = our_mapper->align_paired_multi_trivial(aln1, aln2, queued_resolve_later, max_mem_length, top_pairs_only, false);
                 if (!queued_resolve_later) {
                     output_func(aln1, aln2, alnp);
                     // check if we should try to align the queued alignments
@@ -773,7 +773,7 @@ int main_map(int argc, char** argv) {
                         && !our_mapper->imperfect_pairs_to_retry.empty()) {
                         int i = 0;
                         for (auto p : our_mapper->imperfect_pairs_to_retry) {
-                            auto alnp = our_mapper->align_paired_multi(p.first, p.second,
+                            auto alnp = our_mapper->align_paired_multi_trivial(p.first, p.second,
                                                                        queued_resolve_later,
                                                                        max_mem_length,
                                                                        top_pairs_only,
@@ -792,7 +792,7 @@ int main_map(int argc, char** argv) {
                 our_mapper->frag_stats.fragment_size = fragment_max;
                 for (auto p : our_mapper->imperfect_pairs_to_retry) {
                     bool queued_resolve_later = false;
-                    auto alnp = our_mapper->align_paired_multi(p.first, p.second,
+                    auto alnp = our_mapper->align_paired_multi_trivial(p.first, p.second,
                                                                queued_resolve_later,
                                                                max_mem_length,
                                                                top_pairs_only,
@@ -932,7 +932,7 @@ int main_map(int argc, char** argv) {
                  &output_func](Alignment& aln1, Alignment& aln2) {
                 auto our_mapper = mapper[omp_get_thread_num()];
                 bool queued_resolve_later = false;
-                auto alnp = our_mapper->align_paired_multi(aln1, aln2, queued_resolve_later, max_mem_length, top_pairs_only, false);
+                auto alnp = our_mapper->align_paired_multi_trivial(aln1, aln2, queued_resolve_later, max_mem_length, top_pairs_only, false);
                 if (!queued_resolve_later) {
                     output_func(aln1, aln2, alnp);
                     // check if we should try to align the queued alignments
@@ -940,7 +940,7 @@ int main_map(int argc, char** argv) {
                         && !our_mapper->imperfect_pairs_to_retry.empty()) {
                         int i = 0;
                         for (auto p : our_mapper->imperfect_pairs_to_retry) {
-                            auto alnp = our_mapper->align_paired_multi(p.first, p.second,
+                            auto alnp = our_mapper->align_paired_multi_trivial(p.first, p.second,
                                                                        queued_resolve_later,
                                                                        max_mem_length,
                                                                        top_pairs_only,
@@ -958,7 +958,7 @@ int main_map(int argc, char** argv) {
                 our_mapper->frag_stats.fragment_size = fragment_max;
                 for (auto p : our_mapper->imperfect_pairs_to_retry) {
                     bool queued_resolve_later = false;
-                    auto alnp = our_mapper->align_paired_multi(p.first, p.second,
+                    auto alnp = our_mapper->align_paired_multi_trivial(p.first, p.second,
                                                                queued_resolve_later,
                                                                max_mem_length,
                                                                top_pairs_only,

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -855,7 +855,7 @@ int main_map(int argc, char** argv) {
                  &output_func](Alignment& aln1, Alignment& aln2) {
                 auto our_mapper = mapper[omp_get_thread_num()];
                 bool queued_resolve_later = false;
-                auto alnp = our_mapper->align_paired_multi(aln1, aln2, queued_resolve_later, max_mem_length, top_pairs_only, false);
+                auto alnp = our_mapper->align_paired_multi_trivial(aln1, aln2, queued_resolve_later, max_mem_length, top_pairs_only, false);
                 if (!queued_resolve_later) {
                     output_func(aln1, aln2, alnp);
                     // check if we should try to align the queued alignments
@@ -863,7 +863,7 @@ int main_map(int argc, char** argv) {
                         && !our_mapper->imperfect_pairs_to_retry.empty()) {
                         int i = 0;
                         for (auto p : our_mapper->imperfect_pairs_to_retry) {
-                            auto alnp = our_mapper->align_paired_multi(p.first, p.second,
+                            auto alnp = our_mapper->align_paired_multi_trivial(p.first, p.second,
                                                                        queued_resolve_later,
                                                                        max_mem_length,
                                                                        top_pairs_only,
@@ -881,7 +881,7 @@ int main_map(int argc, char** argv) {
                 our_mapper->frag_stats.fragment_size = fragment_max;
                 for (auto p : our_mapper->imperfect_pairs_to_retry) {
                     bool queued_resolve_later = false;
-                    auto alnp = our_mapper->align_paired_multi(p.first, p.second,
+                    auto alnp = our_mapper->align_paired_multi_trivial(p.first, p.second,
                                                                queued_resolve_later,
                                                                max_mem_length,
                                                                top_pairs_only,


### PR DESCRIPTION
This will let us get Jenkins results that at least get as high precision
as the single-end mapper.