### PR TITLE
Tighten threshold for chr21 simulation test

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -48,8 +48,6 @@ class VGCITest(TestCase):
         self.tempdir = tempfile.mkdtemp()
         
         self.f1_threshold = 0.005
-        self.acc_threshold = 0.02
-        self.auc_threshold = 0.05
         # What (additional) portion of reads are allowed to get worse scores
         # when moving to a more inclusive reference?
         self.worse_threshold = 0.005
@@ -668,7 +666,7 @@ class VGCITest(TestCase):
         return stats_dict
 
     def _verify_mapeval(self, reads, read_source_graph, score_baseline_name,
-                        positive_control, negative_control, tag):
+                        positive_control, negative_control, tag, acc_threshold):
         """
         Check the simulated mapping evaluation results.
         
@@ -753,9 +751,9 @@ class VGCITest(TestCase):
                 if len(stats_dict[key]) > 0:
                     self.assertTrue(stats_dict[key][0] == reads)
                 if len(stats_dict[key]) > 1 and len(val) > 1:
-                    self.assertTrue(stats_dict[key][1] >= val[1] - self.acc_threshold)
+                    self.assertTrue(stats_dict[key][1] >= val[1] - acc_threshold)
                 if len(stats_dict[key]) > 2 and len(val) > 2:
-                    self.assertTrue(stats_dict[key][2] >= val[2] - self.auc_threshold)
+                    self.assertTrue(stats_dict[key][2] >= val[2] - acc_threshold)
                 if len(stats_dict[key]) > 4 and len(val) > 4:
                     self.assertTrue(stats_dict[key][4] >= val[4] - self.f1_threshold)
                 if len(stats_dict[key]) != len(val):
@@ -846,7 +844,7 @@ class VGCITest(TestCase):
             
     def _test_mapeval(self, reads, region, baseline_graph, test_graphs, score_baseline_graph=None,
                       positive_control=None, negative_control=None, sample=None, multipath=False,
-                      assembly="hg38", tag_ext=""):
+                      assembly="hg38", tag_ext="", acc_threshold=0):
         """ Run simulation on a bakeoff graph
         
         Simulate the given number of reads from the given baseline_graph
@@ -907,7 +905,8 @@ class VGCITest(TestCase):
                              test_graphs, score_baseline_graph, multipath, tag)
         if self.verify:
             self._verify_mapeval(reads, baseline_graph, score_baseline_graph,
-                                 positive_control, negative_control, tag)
+                                 positive_control, negative_control, tag,
+                                 acc_threshold)
 
     @skip("skipping test to keep runtime down")
     @timeout_decorator.timeout(3600)
@@ -922,7 +921,7 @@ class VGCITest(TestCase):
                            score_baseline_graph='primary',
                            positive_control='snp1kg_HG00096',
                            negative_control='snp1kg_minus_HG00096',
-                           sample='HG00096')
+                           sample='HG00096', acc_threshold=0.02)
                            
     @skip("skipping test to keep runtime down")
     @timeout_decorator.timeout(3600)
@@ -933,7 +932,7 @@ class VGCITest(TestCase):
                            score_baseline_graph='primary',
                            positive_control='snp1kg_HG00096',
                            negative_control='snp1kg_minus_HG00096',
-                           sample='HG00096')
+                           sample='HG00096', acc_threshold=0.02)
 
     @timeout_decorator.timeout(16000)        
     def test_sim_chr21_snp1kg(self):
@@ -943,7 +942,8 @@ class VGCITest(TestCase):
                            positive_control='snp1kg_HG00096',
                            negative_control='snp1kg_minus_HG00096',
                            sample='HG00096',
-                           assembly="hg19")
+                           assembly="hg19",
+                           acc_threshold=0.002)
 
     @timeout_decorator.timeout(3600)
     def test_sim_brca2_snp1kg_mpmap(self):
@@ -966,8 +966,8 @@ class VGCITest(TestCase):
         self._test_mapeval(50000, 'MHC', 'snp1kg',
                            ['primary', 'snp1kg'],
                            score_baseline_graph='primary',
-                           sample='HG00096', multipath=True, tag_ext='-mpmap')
-        
+                           sample='HG00096', multipath=True, tag_ext='-mpmap',
+                           acc_threshold=0.02)        
 
     @timeout_decorator.timeout(200)
     def test_map_brca1_primary(self):


### PR DESCRIPTION
Specify test threshold in test (rather than just default value), since bigger tests need smaller thresholds (looking at your chr21).  