### PR TITLE
Make simulation options in tests more paramaterized

### DIFF
--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -92,7 +92,7 @@ int main_sim(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hl:n:s:e:i:fax:Jp:v:Nd:F:s:",
+        c = getopt_long (argc, argv, "hl:n:s:e:i:fax:Jp:v:Nd:F:S:",
                 long_options, &option_index);
 
         // Detect the end of the options.


### PR DESCRIPTION
Simulation options now defined at the test level.  Used this to change test_sim_mhc_snp1kg_mpmap to use the trained simulator.  Other tests' options default to previous values.  