### PR TITLE
Upgrade rocksdb to version 5.7.3

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -957,7 +957,8 @@ class VGCITest(TestCase):
         self._test_mapeval(50000, 'BRCA2', 'snp1kg',
                            ['primary', 'snp1kg'],
                            score_baseline_graph='primary',
-                           sample='HG00096', multipath=True, tag_ext='-mpmap')
+                           sample='HG00096', multipath=True, tag_ext='-mpmap',
+                           acc_threshold=0.02)
 
     @timeout_decorator.timeout(3600)
     def test_sim_mhc_snp1kg_mpmap(self):

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -44,7 +44,6 @@ rocksdb::Options Index::GetOptions(bool read_only) {
     }
     options.max_open_files = -1;
     options.allow_mmap_reads = true;
-    options.disableDataSync = true; // like disableWAL above
 
     // set up table format
     rocksdb::BlockBasedTableOptions topt;
@@ -76,13 +75,8 @@ rocksdb::Options Index::GetOptions(bool read_only) {
     options.level0_file_num_compaction_trigger = 5;
     options.target_file_size_base = 16 * size_t(1<<30);
     options.access_hint_on_compaction_start = rocksdb::Options::AccessHint::SEQUENTIAL;
-    options.compaction_readahead_size = 16 << 20;
 
     if (bulk_load) {
-        // vector memtable provides much faster loading provided there's no
-        // concurrent reading happening
-        options.memtable_factory.reset(new rocksdb::VectorRepFactory(1000));
-
         // disable write throttling because we'll have other logic to let
         // background compactions converge.
         options.level0_slowdown_writes_trigger = (1<<30);


### PR DESCRIPTION
Main goal is to fix compilation on gcc7 on which current rocksdb (4.11.2) doesn't compile.  Needed to remove a few option settings.

In order to compile: `options.disableDataSync = true;`
In order to run: `options.compaction_readahead_size = 16 << 20;` and `options.memtable_factory.reset(new rocksdb::VectorRepFactory(1000));`

In a small test (indexing and querying a 1.5G gam), I didn't notice any performance degradation.  @mlin what do you think?  