### PR TITLE
Selectively switch to more unordered set data structures in VG

### DIFF
--- a/src/bubbles.cpp
+++ b/src/bubbles.cpp
@@ -241,18 +241,18 @@ static void fill_ultrabubble_contents(VG& graph, Bubble& bubble) {
     // note we treat the source in the opposite direction as a sink here to prevent leaving
     // the bubble in a loop
     id_t sink_id = bubble.end.node;
-    set<NodeTraversal> sinks = {NodeTraversal(graph.get_node(bubble.start.node), bubble.start.is_end),
-                                NodeTraversal(graph.get_node(sink_id), !bubble.start.is_end),
-                                NodeTraversal(graph.get_node(sink_id), bubble.start.is_end)};
+    unordered_set<NodeTraversal> sinks = {NodeTraversal(graph.get_node(bubble.start.node), bubble.start.is_end),
+                                          NodeTraversal(graph.get_node(sink_id), !bubble.start.is_end),
+                                          NodeTraversal(graph.get_node(sink_id), bubble.start.is_end)};
 
     // remember unique node ids we've visited 
-    set<id_t> contents_set;
+    unordered_set<id_t> contents_set;
     
     // the acyclic logic derived from vg::is_acyclic()
     // but changed to make sure we only ever touch the ends of the
     // source and sink (never loop over body of the node)
     // and to look for directed (as opposed to bidirected) cycles
-    set<vg::id_t> seen;
+    unordered_set<vg::id_t> seen;
     bubble.dag = true;
     
     graph.dfs([&](NodeTraversal trav) {

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -675,13 +675,13 @@ public:
         /// Start only at these node traversals.
         const vector<NodeTraversal>* sources,
         /// When hitting a sink, don't keep walking.
-        const set<NodeTraversal>* sinks);         
+        const unordered_set<NodeTraversal>* sinks);
 
     /// Specialization of dfs for only handling nodes.
     void dfs(const function<void(NodeTraversal)>& node_begin_fn,
              const function<void(NodeTraversal)>& node_end_fn,
              const vector<NodeTraversal>* sources = NULL,
-             const set<NodeTraversal>* sinks = NULL);         
+             const unordered_set<NodeTraversal>* sinks = NULL);
 
     /// Specialization of dfs for only handling nodes + break function.
     void dfs(const function<void(NodeTraversal)>& node_begin_fn,
@@ -835,7 +835,7 @@ public:
     /// re-calculated by the caller.
     void divide_node(Node* node, int pos, Node*& left, Node*& right);
     /// Divide a node at a given internal position. This version works on a collection of internal positions, in linear time.
-    void divide_node(Node* node, vector<int> positions, vector<Node*>& parts);
+    void divide_node(Node* node, vector<int>& positions, vector<Node*>& parts);
     /// Divide a path at a position. Also invalidates stored rank information.
     void divide_path(map<long, id_t>& path, long pos, Node*& left, Node*& right);
     //void node_replace_prev(Node* node, Node* before, Node* after);
@@ -876,7 +876,7 @@ public:
     /// Makes sure that Nodes appear in the Protobuf Graph object in their topological sort order.
     void sort(void);
     /// Topological sort helper function, not really meant for external use.
-    void topological_sort(deque<NodeTraversal>& l);
+    void topological_sort(vector<NodeTraversal>& order);
     /// Swap the given nodes. TODO: what does that mean?
     void swap_nodes(Node* a, Node* b);
 


### PR DESCRIPTION
Part of my refactor of the VG object, I've switched it to use unordered data structures when I think they're going to be faster and it won't affect the output.