### PR TITLE
Bring simulation rate back to reasonable level

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -950,7 +950,8 @@ class VGCITest(TestCase):
                            score_baseline_graph='primary',
                            sample='HG00096',
                            assembly="hg19",
-                           acc_threshold=0.0075, multipath=True)
+                           acc_threshold=0.0075, multipath=True,
+                           sim_opts='-l 150 -p 500 -v 50 -e 0.01 -i 0.002')
 
     @skip("skipping test to keep runtime down")        
     @timeout_decorator.timeout(3600)


### PR DESCRIPTION
We have enough reads on the chromosome 21 test to get a signal from more realistic reasonable parameters, as opposed the the 5X rate boost currently used.  

The result of lowering the rates is here (but don't want to merge the messy PR):
http://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/vg_ci/jenkins_reports/commit/50db1eeb35ba9bfb9726c6dd0f2ecdc66823e761/index.html