### PR TITLE
Revise mpmap testing

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -569,17 +569,10 @@ namespace vg {
                                                const vector<MaximalExactMatch>& mems,
                                                const vector<memcluster_t>& clusters) -> vector<clustergraph_t> {
         
-        // Call the static implementation and point it at the parts of us it needs
-        return move(query_cluster_graphs(get_aligner(), xindex, get_node_cache(), alignment, mems, clusters));
-                                               
-    }
-    
-    auto MultipathMapper::query_cluster_graphs(const BaseAligner* aligner,
-                                               xg::XG* xindex,
-                                               LRUCache<id_t, vg::Node>& node_cache,
-                                               const Alignment& alignment,
-                                               const vector<MaximalExactMatch>& mems,
-                                               const vector<memcluster_t>& clusters) -> vector<clustergraph_t> {
+        // Figure out the aligner to use
+        BaseAligner* aligner = get_aligner();
+        // And the node cache
+        LRUCache<id_t, vg::Node>& node_cache = get_node_cache();
         
         // We populate this with all the cluster graphs.
         vector<clustergraph_t> cluster_graphs_out;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -88,29 +88,7 @@ namespace vg {
         /// as a priority).
         using clustergraph_t = tuple<VG*, memcluster_t, size_t>;
         
-        ////////////////////////////////////////////////////////////////////////
-        // Testable utility methods
-        ////////////////////////////////////////////////////////////////////////
-        
-        // TODO: should we break these out into another class or something?
-        
-        /// Computes the number of read bases a cluster of MEM hits covers.
-        static int64_t read_coverage(const memcluster_t& mem_hits);
-        
-        /// Extracts a subgraph around each cluster of MEMs that encompasses any
-        /// graph position reachable with local alignment anchored at the MEMs.
-        /// If any subgraphs overlap, they are merged into one subgraph. Returns
-        /// a vector of all the merged cluster subgraphs, their MEMs assigned
-        /// from the mems vector according to the MEMs' hits, and their read
-        /// coverages in bp. The caller must delete the VG objects produced!
-        static vector<clustergraph_t> query_cluster_graphs(const BaseAligner* aligner,
-                                                           xg::XG* xindex,
-                                                           LRUCache<id_t, vg::Node>& node_cache,
-                                                           const Alignment& alignment,
-                                                           const vector<MaximalExactMatch>& mems,
-                                                           const vector<memcluster_t>& clusters);
-        
-    private:
+    protected:
         
         /// Wrapped internal function that allows some code paths to circumvent the current
         /// mapping quality method option.
@@ -146,10 +124,13 @@ namespace vg {
                                           size_t max_alt_mappings);
         
         
-        /// Extract reachable (according to the Mapper's aligner) subgraphs from
-        /// each MEM cluster from the mapper's XG index, using the mapper's node
-        /// cache.
-        /// The caller must delete the VG objects produced!
+        /// Extracts a subgraph around each cluster of MEMs that encompasses any
+        /// graph position reachable (according to the Mapper's aligner) with
+        /// local alignment anchored at the MEMs. If any subgraphs overlap, they
+        /// are merged into one subgraph. Returns a vector of all the merged
+        /// cluster subgraphs, their MEMs assigned from the mems vector
+        /// according to the MEMs' hits, and their read coverages in bp. The
+        /// caller must delete the VG objects produced!
         vector<clustergraph_t> query_cluster_graphs(const Alignment& alignment,
                                                     const vector<MaximalExactMatch>& mems,
                                                     const vector<memcluster_t>& clusters);
@@ -171,6 +152,9 @@ namespace vg {
         
         /// Sorts mappings by score and store mapping quality of the optimal alignment in the MultipathAlignment object
         void sort_and_compute_mapping_quality(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs) const;
+        
+        /// Computes the number of read bases a cluster of MEM hits covers.
+        static int64_t read_coverage(const memcluster_t& mem_hits);
         
         /// Computes the Z-score of the number of matches against an equal length random DNA string.
         double read_coverage_z_score(int64_t coverage, const Alignment& alignment) const;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -141,7 +141,8 @@ namespace vg {
                              memcluster_t& graph_mems,
                              MultipathAlignment& multipath_aln_out) const;
         
-        /// Reorders the Subpaths in the MultipathAlignment to be in topological order (required by .proto specifications)
+        /// Reorders the Subpaths in the MultipathAlignment to be in topological
+        /// order according to "next" links (required by .proto specifications)
         void topologically_order_subpaths(MultipathAlignment& multipath_aln) const;
         
         /// Remove the full length bonus from all source or sink subpaths that received it

--- a/src/unittest/multipath_mapper.cpp
+++ b/src/unittest/multipath_mapper.cpp
@@ -438,7 +438,7 @@ TEST_CASE( "MultipathMapper can map to a one-node graph", "[multipath][mapping][
     delete lcpidx;
 }
 
-TEST_CASE( "MultipathMapper can map to a bigger graph", "[multipath][mapping][multipathmapper]" ) {
+TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][multipathmapper]" ) {
     
     string graph_json = R"({"node":[{"sequence":"CTTCTCATCCCTCCTCAAGGGCCTTTAACTACTCCACATCCAAAGCTACCCAGGCCATTTTAAGTTTCCTGTGGACTAAGGACAAAGGTGCGGGGAGATG","id":12},{"sequence":"A","id":2},{"sequence":"CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTGGTTCCTGGTGCTATGTGTAACTAGTAATGGTAATGGATATGTTGGGCTTT","id":3},{"sequence":"TTTCTTTGATTTATTTGAAGTGACGTTTGACAATCTATCACTAGGGGTAATGTGGGGAAATGGAAAGAATACAAGATTTGGAGCCAGACAAATCTGGGTT","id":4},{"sequence":"CAAATCCTCACTTTGCCACATATTAGCCATGTGACTTTGAACAAGTTAGTTAATCTCTCTGAACTTCAGTTTAATTATCTCTAATATGGAGATGATACTA","id":5},{"sequence":"CTGACAGCAGAGGTTTGCTGTGAAGATTAAATTAGGTGATGCTTGTAAAGCTCAGGGAATAGTGCCTGGCATAGAGGAAAGCCTCTGACAACTGGTAGTT","id":6},{"sequence":"ACTGTTATTTACTATGAATCCTCACCTTCCTTGACTTCTTGAAACATTTGGCTATTGACCTCTTTCCTCCTTGAGGCTCTTCTGGCTTTTCATTGTCAAC","id":7},{"sequence":"ACAGTCAACGCTCAATACAAGGGACATTAGGATTGGCAGTAGCTCAGAGATCTCTCTGCTCACCGTGATCTTCAAGTTTGAAAATTGCATCTCAAATCTA","id":8},{"sequence":"AGACCCAGAGGGCTCACCCAGAGTCGAGGCTCAAGGACAGCTCTCCTTTGTGTCCAGAGTGTATACGATGTAACTCTGTTCGGGCACTGGTGAAAGATAA","id":9},{"sequence":"CAGAGGAAATGCCTGGCTTTTTATCAGAACATGTTTCCAAGCTTATCCCTTTTCCCAGCTCTCCTTGTCCCTCCCAAGATCTCTTCACTGGCCTCTTATC","id":10},{"sequence":"TTTACTGTTACCAAATCTTTCCAGAAGCTGCTCTTTCCCTCAATTGTTCATTTGTCTTCTTGTCCAGGAATGAACCACTGCTCTCTTCTTGTCAGATCAG","id":11}],"path":[{"name":"x","mapping":[{"position":{"node_id":3},"edit":[{"from_length":100,"to_length":100}],"rank":1},{"position":{"node_id":4},"edit":[{"from_length":100,"to_length":100}],"rank":2},{"position":{"node_id":5},"edit":[{"from_length":100,"to_length":100}],"rank":3},{"position":{"node_id":6},"edit":[{"from_length":100,"to_length":100}],"rank":4},{"position":{"node_id":7},"edit":[{"from_length":100,"to_length":100}],"rank":5},{"position":{"node_id":8},"edit":[{"from_length":100,"to_length":100}],"rank":6},{"position":{"node_id":9},"edit":[{"from_length":100,"to_length":100}],"rank":7},{"position":{"node_id":10},"edit":[{"from_length":100,"to_length":100}],"rank":8},{"position":{"node_id":11},"edit":[{"from_length":100,"to_length":100}],"rank":9},{"position":{"node_id":12},"edit":[{"from_length":100,"to_length":100}],"rank":10},{"position":{"node_id":2},"edit":[{"from_length":1,"to_length":1}],"rank":11}]}],"edge":[{"from":12,"to":2},{"from":3,"to":4},{"from":4,"to":5},{"from":5,"to":6},{"from":6,"to":7},{"from":7,"to":8},{"from":8,"to":9},{"from":9,"to":10},{"from":10,"to":11},{"from":11,"to":12}]})";
     
@@ -466,10 +466,76 @@ TEST_CASE( "MultipathMapper can map to a bigger graph", "[multipath][mapping][mu
     xg::XG xg_index(proto_graph);
     
     // Make a multipath mapper to map against the graph.
-    MultipathMapper mapper(&xg_index, gcsaidx, lcpidx);
+    TestMultipathMapper mapper(&xg_index, gcsaidx, lcpidx);
     // Lower the max mapping quality so that it thinks it can find unambiguous mappings of
     // short sequences
     mapper.max_mapping_quality = 10;
+    
+    SECTION( "topologically_order_subpaths works within a node" ) {
+    
+        string aln_json = R"(
+        {
+            "subpath": [
+                {"path": {"mapping": [
+                    {"position": {"node_id": 3, "offset": 11}, "edit": [{"from_length": 10, "to_length": 10}]}
+                ]}},
+                {"path": {"mapping": [
+                    {"position": {"node_id": 3, "offset": 0}, "edit": [{"from_length": 10, "to_length": 10}]}
+                ]}, "next": [0]}
+            ]
+        }
+        )";
+    
+        MultipathAlignment disordered;
+        json2pb(disordered, aln_json.c_str(), aln_json.size());
+        
+        mapper.topologically_order_subpaths(disordered);
+        
+        REQUIRE(disordered.subpath_size() == 2);
+        // First subpath (used to be last) first
+        REQUIRE(disordered.subpath(0).path().mapping(0).position().node_id() == 3);
+        REQUIRE(disordered.subpath(0).path().mapping(0).position().offset() == 0);
+        // Then second
+        REQUIRE(disordered.subpath(1).path().mapping(0).position().node_id() == 3);
+        REQUIRE(disordered.subpath(1).path().mapping(0).position().offset() == 11);
+        
+    }
+    
+    SECTION( "topologically_order_subpaths works between nodes" ) {
+    
+        string aln_json = R"(
+        {
+            "subpath": [
+                {"path": {"mapping": [
+                    {"position": {"node_id": 4}, "edit": [{"from_length": 10, "to_length": 10}]}
+                ]}, "next": [1]},
+                {"path": {"mapping": [
+                    {"position": {"node_id": 4, "offset": 11}, "edit": [{"from_length": 10, "to_length": 10}]}
+                ]}},
+                {"path": {"mapping": [
+                    {"position": {"node_id": 3, "offset": 5}, "edit": [{"from_length": 10, "to_length": 10}]}
+                ]}, "next": [0]}
+            ]
+        }
+        )";
+    
+        MultipathAlignment disordered;
+        json2pb(disordered, aln_json.c_str(), aln_json.size());
+        
+        mapper.topologically_order_subpaths(disordered);
+        
+        REQUIRE(disordered.subpath_size() == 3);
+        // First subpath (used to be last) first
+        REQUIRE(disordered.subpath(0).path().mapping(0).position().node_id() == 3);
+        REQUIRE(disordered.subpath(0).path().mapping(0).position().offset() == 5);
+        // Then second
+        REQUIRE(disordered.subpath(1).path().mapping(0).position().node_id() == 4);
+        REQUIRE(disordered.subpath(1).path().mapping(0).position().offset() == 0);
+        // Then third
+        REQUIRE(disordered.subpath(2).path().mapping(0).position().node_id() == 4);
+        REQUIRE(disordered.subpath(2).path().mapping(0).position().offset() == 11);
+    
+    }
     
     SECTION( "MultipathMapper buffers pairs that don't map the first time" ) {
         // Here are two reads on the same strand


### PR DESCRIPTION
Rather than refactor everything to be public static methods, I'm making all the internal stuff we might want to test protected (instead of private) and defining a class in the tests that exposes it.
I think this makes sense: we need to test the internal API that derived classes might want to use, but in Catch we can't do friend declarations, so this is the next best way.

I'm also adding a couple of new tests that make sure topologically_ordered_subpaths isn't incredibly broken.