### PR TITLE
Fix XG handles and refactor another algorithm

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -234,7 +234,7 @@ then
 
     # we publish the results to the archive
     tar czf "${VG_VERSION}_output.tar.gz" vgci-work test-report.xml jenkins/vgci.py jenkins/jenkins.sh vgci_cfg.tsv
-    aws s3 cp --acl public-read "${VG_VERSION}_output.tar.gz" s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_output_archives/
+    aws s3 cp --only-show-errors --acl public-read "${VG_VERSION}_output.tar.gz" s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_output_archives/
 
     # if we're merging the PR (and not just testing it), we publish results to the baseline
     if [ -z ${ghprbActualCommit} ]
@@ -243,7 +243,7 @@ then
         aws s3 sync --acl public-read ./vgci-work/ s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline
         printf "${VG_VERSION}\n" > vg_version_${VG_VERSION}.txt
         printf "${ghprbActualCommitAuthor}\n${ghprbPullTitle}\n${ghprbPullLink}\n" >> vg_version_${VG_VERSION}.txt
-        aws s3 cp --acl public-read vg_version_${VG_VERSION}.txt s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline/
+        aws s3 cp --only-show-errors --acl public-read vg_version_${VG_VERSION}.txt s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline/
     fi
 fi
     

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -20,6 +20,7 @@ import shutil
 import glob
 import traceback
 import io
+from datetime import datetime
 
 import tsv
 
@@ -927,6 +928,7 @@ class VGCITest(TestCase):
         # these other BRCA1 graphs and make sure the realignments are
         # sufficiently good. Compare all realignment scores agaisnt the scores
         # for the primary graph.
+        log.info("Test start at {}".format(datetime.now()))
         self._test_mapeval(100000, 'BRCA1', 'snp1kg',
                            ['primary', 'snp1kg'],
                            score_baseline_graph='primary',
@@ -935,7 +937,8 @@ class VGCITest(TestCase):
     @skip("skipping test to keep runtime down")
     @timeout_decorator.timeout(3600)
     def test_sim_mhc_snp1kg(self):
-        """ Mapping and calling bakeoff F1 test for MHC primary graph """        
+        """ Mapping and calling bakeoff F1 test for MHC primary graph """
+        log.info("Test start at {}".format(datetime.now()))        
         self._test_mapeval(100000, 'MHC', 'snp1kg',
                            ['primary', 'snp1kg', 'common1kg'],
                            score_baseline_graph='primary',
@@ -945,6 +948,7 @@ class VGCITest(TestCase):
 
     @timeout_decorator.timeout(16000)        
     def test_sim_chr21_snp1kg(self):
+        log.info("Test start at {}".format(datetime.now()))
         self._test_mapeval(300000, 'CHR21', 'snp1kg',
                            ['primary', 'snp1kg', 'thresholded10'],
                            score_baseline_graph='primary',
@@ -958,6 +962,7 @@ class VGCITest(TestCase):
         so jenkins doesn't report failures.  vg is run only in single ended with multipath on
         and off. 
         """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_mapeval(50000, 'BRCA2', 'snp1kg',
                            ['primary', 'snp1kg'],
                            score_baseline_graph='primary',
@@ -970,6 +975,7 @@ class VGCITest(TestCase):
         so jenkins doesn't report failures.  vg is run only in single ended with multipath on
         and off.
         """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_mapeval(50000, 'MHC', 'snp1kg',
                            ['primary', 'snp1kg'],
                            score_baseline_graph='primary',
@@ -981,55 +987,65 @@ class VGCITest(TestCase):
     @timeout_decorator.timeout(200)
     def test_map_brca1_primary(self):
         """ Mapping and calling bakeoff F1 test for BRCA1 primary graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('BRCA1', 'primary', True)
 
     @timeout_decorator.timeout(200)        
     def test_map_brca1_snp1kg(self):
         """ Mapping and calling bakeoff F1 test for BRCA1 snp1kg graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('BRCA1', 'snp1kg', True)
 
     @timeout_decorator.timeout(200)        
     def test_map_brca1_cactus(self):
         """ Mapping and calling bakeoff F1 test for BRCA1 cactus graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('BRCA1', 'cactus', True)
 
     @timeout_decorator.timeout(900)        
     def test_full_brca2_primary(self):
         """ Indexing, mapping and calling bakeoff F1 test for BRCA2 primary graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('BRCA2', 'primary', False)
 
     @timeout_decorator.timeout(900)        
     def test_full_brca2_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for BRCA2 snp1kg graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('BRCA2', 'snp1kg', False)
 
     @timeout_decorator.timeout(900)        
     def test_full_brca2_cactus(self):
         """ Indexing, mapping and calling bakeoff F1 test for BRCA2 cactus graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('BRCA2', 'cactus', False)
 
     @skip("skipping test to keep runtime down")
     @timeout_decorator.timeout(2000)        
     def test_map_sma_primary(self):
         """ Indexing, mapping and calling bakeoff F1 test for SMA primary graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('SMA', 'primary', True)
 
     @skip("skipping test to keep runtime down")        
     @timeout_decorator.timeout(2000)        
     def test_map_sma_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for SMA snp1kg graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('SMA', 'snp1kg', True)
 
     @skip("skipping test to keep runtime down")        
     @timeout_decorator.timeout(2000)        
     def test_map_sma_cactus(self):
         """ Indexing, mapping and calling bakeoff F1 test for SMA cactus graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('SMA', 'cactus', True)
 
     @skip("skipping test to keep runtime down")         
     @timeout_decorator.timeout(2000)        
     def test_map_lrc_kir_primary(self):
         """ Indexing, mapping and calling bakeoff F1 test for LRC-KIR primary graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('LRC-KIR', 'primary', True)
 
     @skip("skipping test to keep runtime down")         
@@ -1042,21 +1058,25 @@ class VGCITest(TestCase):
     @timeout_decorator.timeout(2000)        
     def test_map_lrc_kir_cactus(self):
         """ Indexing, mapping and calling bakeoff F1 test for LRC-KIR cactus graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('LRC-KIR', 'cactus', True)
 
     @timeout_decorator.timeout(10000)        
     def test_map_mhc_primary(self):
         """ Indexing, mapping and calling bakeoff F1 test for MHC primary graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'primary', True)
 
     @skip("skipping test to keep runtime down (baseline missing as well)")        
     @timeout_decorator.timeout(10000)        
     def test_map_mhc_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for MHC snp1kg graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'snp1kg', True)
 
     @skip("skipping test to keep runtime down (baseline missing as well)")          
     @timeout_decorator.timeout(10000)        
     def test_map_mhc_cactus(self):
         """ Indexing, mapping and calling bakeoff F1 test for MHC cactus graph """
+        log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'cactus', True)

--- a/src/algorithms/extract_containing_graph.cpp
+++ b/src/algorithms/extract_containing_graph.cpp
@@ -162,59 +162,13 @@ namespace algorithms {
         
         // make a dummy vector for all positions at the same distance
         vector<size_t> dists(positions.size(), max_dist);
-        return extract_containing_graph_internal(g, positions, dists, dists,
-                                                 [&](id_t id) {
-                                                     vector<Edge> to_return;
-                                                     for (Edge* edge : vg.edges_of(vg.get_node(id))) {
-                                                         if ((edge->from() == id && edge->from_start())
-                                                             || (edge->to() == id && !edge->to_end())) {
-                                                             to_return.push_back(*edge);
-                                                         }
-                                                     }
-                                                     return to_return;
-                                                 },
-                                                 [&](id_t id) {
-                                                     vector<Edge> to_return;
-                                                     for (Edge* edge : vg.edges_of(vg.get_node(id))) {
-                                                         if ((edge->from() == id && !edge->from_start())
-                                                             || (edge->to() == id && edge->to_end())) {
-                                                             to_return.push_back(*edge);
-                                                         }
-                                                     }
-                                                     return to_return;
-                                                 },
-                                                 [&](id_t id) {
-                                                     return vg.get_node(id)->sequence();
-                                                 });
+        return extract_containing_graph(vg, g, positions, dists);
     }
     
     void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions,
                                   const vector<size_t>& position_max_dist) {
         
-        return extract_containing_graph_internal(g, positions, position_max_dist, position_max_dist,
-                                                 [&](id_t id) {
-                                                     vector<Edge> to_return;
-                                                     for (Edge* edge : vg.edges_of(vg.get_node(id))) {
-                                                         if ((edge->from() == id && edge->from_start())
-                                                             || (edge->to() == id && !edge->to_end())) {
-                                                             to_return.push_back(*edge);
-                                                         }
-                                                     }
-                                                     return to_return;
-                                                 },
-                                                 [&](id_t id) {
-                                                     vector<Edge> to_return;
-                                                     for (Edge* edge : vg.edges_of(vg.get_node(id))) {
-                                                         if ((edge->from() == id && !edge->from_start())
-                                                             || (edge->to() == id && edge->to_end())) {
-                                                             to_return.push_back(*edge);
-                                                         }
-                                                     }
-                                                     return to_return;
-                                                 },
-                                                 [&](id_t id) {
-                                                     return vg.get_node(id)->sequence();
-                                                 });
+        return extract_containing_graph(vg, g, positions, position_max_dist, position_max_dist);
     }
     
     void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions,
@@ -252,60 +206,14 @@ namespace algorithms {
         
         // make a dummy vector for all positions at the same distance
         vector<size_t> dists(positions.size(), max_dist);
-        if (node_cache && edge_cache) {
-            return extract_containing_graph_internal(g, positions, dists, dists,
-                                                     [&](id_t id) {return xg_cached_edges_on_start(id, &xg_index, *edge_cache);},
-                                                     [&](id_t id) {return xg_cached_edges_on_end(id, &xg_index, *edge_cache);},
-                                                     [&](id_t id) {return xg_cached_node_sequence(id, &xg_index, *node_cache);});
-        }
-        else if (node_cache) {
-            return extract_containing_graph_internal(g, positions, dists, dists,
-                                                     [&](id_t id) {return xg_index.edges_on_start(id);},
-                                                     [&](id_t id) {return xg_index.edges_on_end(id);},
-                                                     [&](id_t id) {return xg_cached_node_sequence(id, &xg_index, *node_cache);});
-        }
-        else if (edge_cache) {
-            return extract_containing_graph_internal(g, positions, dists, dists,
-                                                     [&](id_t id) {return xg_cached_edges_on_start(id, &xg_index, *edge_cache);},
-                                                     [&](id_t id) {return xg_cached_edges_on_end(id, &xg_index, *edge_cache);},
-                                                     [&](id_t id) {return xg_index.node_sequence(id);});
-        }
-        else {
-            return extract_containing_graph_internal(g, positions, dists, dists,
-                                                     [&](id_t id) {return xg_index.edges_on_start(id);},
-                                                     [&](id_t id) {return xg_index.edges_on_end(id);},
-                                                     [&](id_t id) {return xg_index.node_sequence(id);});
-        }
+        return extract_containing_graph(xg_index, g, positions, dists, node_cache, edge_cache);
     }
     
     void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions,
                                   const vector<size_t>& position_max_dist,
                                   LRUCache<id_t, Node>* node_cache, LRUCache<id_t, vector<Edge>>* edge_cache) {
         
-        if (node_cache && edge_cache) {
-            return extract_containing_graph_internal(g, positions, position_max_dist, position_max_dist,
-                                                     [&](id_t id) {return xg_cached_edges_on_start(id, &xg_index, *edge_cache);},
-                                                     [&](id_t id) {return xg_cached_edges_on_end(id, &xg_index, *edge_cache);},
-                                                     [&](id_t id) {return xg_cached_node_sequence(id, &xg_index, *node_cache);});
-        }
-        else if (node_cache) {
-            return extract_containing_graph_internal(g, positions, position_max_dist, position_max_dist,
-                                                     [&](id_t id) {return xg_index.edges_on_start(id);},
-                                                     [&](id_t id) {return xg_index.edges_on_end(id);},
-                                                     [&](id_t id) {return xg_cached_node_sequence(id, &xg_index, *node_cache);});
-        }
-        else if (edge_cache) {
-            return extract_containing_graph_internal(g, positions, position_max_dist, position_max_dist,
-                                                     [&](id_t id) {return xg_cached_edges_on_start(id, &xg_index, *edge_cache);},
-                                                     [&](id_t id) {return xg_cached_edges_on_end(id, &xg_index, *edge_cache);},
-                                                     [&](id_t id) {return xg_index.node_sequence(id);});
-        }
-        else {
-            return extract_containing_graph_internal(g, positions, position_max_dist, position_max_dist,
-                                                     [&](id_t id) {return xg_index.edges_on_start(id);},
-                                                     [&](id_t id) {return xg_index.edges_on_end(id);},
-                                                     [&](id_t id) {return xg_index.node_sequence(id);});
-        }
+        return extract_containing_graph(xg_index, g, positions, position_max_dist, position_max_dist, node_cache, edge_cache);
     }
     
     void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions,

--- a/src/algorithms/extract_containing_graph.cpp
+++ b/src/algorithms/extract_containing_graph.cpp
@@ -158,47 +158,17 @@ namespace algorithms {
         }
     }
     
-    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions, size_t max_dist) {
+    void extract_containing_graph(const HandleGraph* source, Graph& g, const vector<pos_t>& positions, size_t max_dist) {
         
         // make a dummy vector for all positions at the same distance
         vector<size_t> dists(positions.size(), max_dist);
-        return extract_containing_graph(vg, g, positions, dists);
+        return extract_containing_graph(source, g, positions, dists);
     }
     
-    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions,
+    void extract_containing_graph(const HandleGraph* source, Graph& g, const vector<pos_t>& positions,
                                   const vector<size_t>& position_max_dist) {
         
-        return extract_containing_graph(vg, g, positions, position_max_dist, position_max_dist);
-    }
-    
-    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions,
-                                  const vector<size_t>& position_forward_max_dist,
-                                  const vector<size_t>& position_backward_max_dist) {
-        
-        return extract_containing_graph(&vg, g, positions, position_forward_max_dist, position_backward_max_dist);
-    }
-    
-    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions, size_t max_dist,
-                                  LRUCache<id_t, Node>* node_cache, LRUCache<id_t, vector<Edge>>* edge_cache) {
-        
-        // make a dummy vector for all positions at the same distance
-        vector<size_t> dists(positions.size(), max_dist);
-        return extract_containing_graph(xg_index, g, positions, dists, node_cache, edge_cache);
-    }
-    
-    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions,
-                                  const vector<size_t>& position_max_dist,
-                                  LRUCache<id_t, Node>* node_cache, LRUCache<id_t, vector<Edge>>* edge_cache) {
-        
-        return extract_containing_graph(xg_index, g, positions, position_max_dist, position_max_dist, node_cache, edge_cache);
-    }
-    
-    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions,
-                                  const vector<size_t>& position_forward_max_dist,
-                                  const vector<size_t>& position_backward_max_dist,
-                                  LRUCache<id_t, Node>* node_cache, LRUCache<id_t, vector<Edge>>* edge_cache) {
-        
-        return extract_containing_graph(&xg_index, g, positions, position_forward_max_dist, position_backward_max_dist);
+        return extract_containing_graph(source, g, positions, position_max_dist, position_max_dist);
     }
     
     void extract_containing_graph(const HandleGraph* source, Graph& g, const vector<pos_t>& positions,

--- a/src/algorithms/extract_containing_graph.cpp
+++ b/src/algorithms/extract_containing_graph.cpp
@@ -11,12 +11,9 @@
 namespace vg {
 namespace algorithms {
 
-    void extract_containing_graph_internal(Graph& g, const vector<pos_t>& positions,
+    void extract_containing_graph_internal(const HandleGraph* source, Graph& g, const vector<pos_t>& positions,
                                            const vector<size_t>& forward_search_lengths,
-                                           const vector<size_t>& backward_search_lengths,
-                                           function<vector<Edge>(id_t)> edges_on_start,
-                                           function<vector<Edge>(id_t)> edges_on_end,
-                                           function<string(id_t)> node_sequence) {
+                                           const vector<size_t>& backward_search_lengths) {
         
         if (forward_search_lengths.size() != backward_search_lengths.size()
             || forward_search_lengths.size() != positions.size()) {
@@ -38,30 +35,13 @@ namespace algorithms {
         
         // TODO: these structs are duplicative with extract_connecting_graph
         
-        // a local struct that packages a node traversal with its distance from the first position
-        // note: we don't use NodeTraversals because we may be using an XG, in which case we don't
-        // have Node*'s
+        // a local struct that packages a handle with its distance from the first position
         struct Traversal {
-            Traversal(id_t id, bool rev, int64_t dist) : id(id), rev(rev), dist(dist) {}
-            int64_t dist; // distance to the right side of this node
-            id_t id;      // node ID
-            bool rev;     // strand
+            Traversal(handle_t handle, int64_t dist) : handle(handle), dist(dist) {}
+            int64_t dist; // distance from pos to the right side of this node
+            handle_t handle; // Oriented node traversal
             inline bool operator<(const Traversal& other) const {
                 return dist > other.dist; // opposite order so priority queue selects minimum
-            }
-        };
-        
-        // represent an edge in a canonical ((from, from_start), (to, to_end)) format so that a hash can
-        // identify edges as the same or different
-        auto canonical_form_edge = [](const id_t& id, const bool& left_side, const id_t& to_id, const bool& reversing) {
-            if (id < to_id) {
-                return make_pair(make_pair(id, left_side), make_pair(to_id, left_side != reversing));
-            }
-            else if (to_id < id) {
-                return make_pair(make_pair(to_id, left_side == reversing), make_pair(id, !left_side));
-            }
-            else {
-                return make_pair(make_pair(id, reversing && left_side), make_pair(id, reversing && !left_side));
             }
         };
         
@@ -79,7 +59,9 @@ namespace algorithms {
             // add all of the initial nodes to the graph
             if (!graph.count(id(pos))) {
                 Node* node = g.add_node();
-                node->set_sequence(node_sequence(id(pos)));
+                // TODO: this might require more get_handle calls than we want
+                auto handle = source->get_handle(id(pos), false);
+                node->set_sequence(source->get_sequence(handle));
                 node->set_id(id(pos));
                 graph[id(pos)] = node;
             }
@@ -91,15 +73,15 @@ namespace algorithms {
             size_t dist_forward = graph[id(pos)]->sequence().size() - offset(pos) + max_search_length - forward_search_lengths[i];
             size_t dist_backward = offset(pos) + max_search_length - backward_search_lengths[i];
             if (dist_forward < max_search_length) {
-                queue.emplace(id(pos), is_rev(pos), dist_forward);
+                queue.emplace(source->get_handle(id(pos), is_rev(pos)), dist_forward);
             }
             if (dist_backward < max_search_length) {
-                queue.emplace(id(pos), !is_rev(pos), dist_backward);
+                queue.emplace(source->get_handle(id(pos), !is_rev(pos)), dist_backward);
             }
         }
         
-        unordered_set<pair<id_t, bool>> traversed;
-        unordered_set<pair<pair<id_t, bool>, pair<id_t, bool>>> observed_edges;
+        unordered_set<handle_t> traversed;
+        unordered_set<pair<handle_t, handle_t>> observed_edges;
         
         while (!queue.empty()) {
             // get the next shortest distance traversal from either the init
@@ -107,57 +89,48 @@ namespace algorithms {
             queue.pop();
             
             // make sure we haven't traversed this node already
-            if (traversed.count(make_pair(trav.id, trav.rev))) {
+            if (traversed.count(trav.handle)) {
                 continue;
             }
             // mark the node as traversed
-            traversed.emplace(trav.id, trav.rev);
+            traversed.emplace(trav.handle);
             
-            // which side are we traversing out of?
-            for (Edge& edge : (trav.rev ? edges_on_start(trav.id) : edges_on_end(trav.id))) {
+            source->follow_edges(trav.handle, false, [&](const handle_t& next) {
+                // Look locally right from this position
                 
-                // get the orientation and id of the other side of the edge
-                id_t next_id;
-                bool next_rev;
-                if (edge.from() == trav.id && edge.from_start() == trav.rev) {
-                    next_id = edge.to();
-                    next_rev = edge.to_end();
-                }
-                else {
-                    next_id = edge.from();
-                    next_rev = !edge.from_start();
-                }
+                // Get the ID of where we're going.
+                auto next_id = source->get_id(next);
                 
                 // record the edge
-                observed_edges.insert(canonical_form_edge(trav.id, trav.rev, next_id, next_rev != trav.rev));
+                observed_edges.insert(source->edge_handle(trav.handle, next));
                 
                 // make sure the node is in the graph
                 if (!graph.count(next_id)) {
                     Node* node = g.add_node();
-                    node->set_sequence(node_sequence(next_id));
+                    node->set_sequence(source->get_sequence(source->forward(next)));
                     node->set_id(next_id);
                     graph[next_id] = node;
                 }
                 
                 // distance to the end of this node
                 int64_t dist_thru = trav.dist + graph[next_id]->sequence().size();
-                if (!traversed.count(make_pair(next_id, next_rev)) && dist_thru < max_search_length) {
+                if (!traversed.count(next) && dist_thru < max_search_length) {
                     // we can add more nodes along same path without going over the max length
-                    queue.emplace(next_id, next_rev, dist_thru);
+                    queue.emplace(next, dist_thru);
                 }
-            }
+            });
         }
         
         // add the edges to the graph
-        for (const pair<pair<id_t, bool>, pair<id_t, bool>>& edge : observed_edges) {
+        for (const pair<handle_t, handle_t>& edge : observed_edges) {
             Edge* e = g.add_edge();
-            e->set_from(edge.first.first);
-            e->set_to(edge.second.first);
-            e->set_from_start(edge.first.second);
-            e->set_to_end(edge.second.second);
+            e->set_from(source->get_id(edge.first));
+            e->set_from_start(source->get_is_reverse(edge.first));
+            e->set_to(source->get_id(edge.second));
+            e->set_to_end(source->get_is_reverse(edge.second));
         }
     }
-    
+
     void extract_containing_graph(const HandleGraph* source, Graph& g, const vector<pos_t>& positions, size_t max_dist) {
         
         // make a dummy vector for all positions at the same distance
@@ -175,31 +148,7 @@ namespace algorithms {
                                   const vector<size_t>& position_forward_max_dist,
                                   const vector<size_t>& position_backward_max_dist) {
         
-        return extract_containing_graph_internal(g, positions, position_forward_max_dist, position_backward_max_dist,
-                                                 [&](id_t id) {
-                                                    // Get edges on start
-                                                    vector<Edge> to_return;
-                                                    auto here = source->get_handle(id, false);
-                                                    source->follow_edges(here, true, [&](const handle_t& left) {
-                                                        to_return.push_back(xg::make_edge(source->get_id(left),
-                                                            source->get_is_reverse(left), id, false));
-                                                    });
-                                                    return to_return;
-                                                },
-                                                [&](id_t id) {
-                                                    // Get edges on end
-                                                    vector<Edge> to_return;
-                                                    auto here = source->get_handle(id, false);
-                                                    source->follow_edges(here, false, [&](const handle_t& right) {
-                                                        to_return.push_back(xg::make_edge(id, false, source->get_id(right),
-                                                            source->get_is_reverse(right)));
-                                                    });
-                                                    return to_return;
-                                                },
-                                                [&](id_t id) {
-                                                    // Get sequence
-                                                    return source->get_sequence(source->get_handle(id, false));
-                                                });
+        return extract_containing_graph_internal(source, g, positions, position_forward_max_dist, position_backward_max_dist);
     
     } 
 

--- a/src/algorithms/extract_containing_graph.hpp
+++ b/src/algorithms/extract_containing_graph.hpp
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "../position.hpp"
-#include "../cached_position.hpp"
 #include "../xg.hpp"
 #include "../vg.hpp"
 #include "../vg.pb.h"
@@ -20,7 +19,7 @@
 namespace vg {
 namespace algorithms {
 
-    /// Fills graph g with the subgraph of the VG graph vg that contains all of the positions in
+    /// Fills graph g with the subgraph of the handle graph source that contains all of the positions in
     /// the positions vector and all other nodes and edges that can be reached within a maximum
     /// distance from any of these positions. Node IDs in the subgraph are retained from the full graph.
     ///
@@ -29,45 +28,20 @@ namespace algorithms {
     ///  g                          graph to extract into
     ///  positions                  search outward from these positions
     ///  max_dist                   include all nodes and edges that can be reached in at most this distance
-    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions, size_t max_dist);
-    
-    /// Same semantics as previous, but accesses graph through an XG instead of a VG. Optionally uses
-    /// an LRUCache to speed up Node queries.
-    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions, size_t max_dist,
-                                  LRUCache<id_t, Node>* node_cache = nullptr,
-                                  LRUCache<id_t, vector<Edge>>* edge_cache = nullptr);
+    void extract_containing_graph(const HandleGraph* source, Graph& g, const vector<pos_t>& positions, size_t max_dist);
     
     /// Same semantics as previous except that there is a separate maximum distance for different
     /// positions in the graph. Each distance is associated with the position with the same index. Throws
     /// an error if the position and distance vectors are not the same length.
-    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions,
+    void extract_containing_graph(const HandleGraph* source, Graph& g, const vector<pos_t>& positions,
                                   const vector<size_t>& position_max_dist);
     
-    /// Same semantics as previous, but accesses graph through an XG instead of a VG. Optionally uses
-    /// an LRUCache to speed up Node queries.
-    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions,
-                                  const vector<size_t>& position_max_dist,
-                                  LRUCache<id_t, Node>* node_cache = nullptr,
-                                  LRUCache<id_t, vector<Edge>>* edge_cache = nullptr);
     
     /// Same semantics as previous except that there is a separate maximum distance for different
     /// positions in the graph and for each search direction. Each distance is associated with the
     /// position with the same index. The forward distance is in the same orientation as the position,
     /// and the backward distance is in the reverse orientation of the position. Throws an error if
     /// the position and distance vectors are not the same length.
-    void extract_containing_graph(VG& vg, Graph& g, const vector<pos_t>& positions,
-                                  const vector<size_t>& position_forward_max_dist,
-                                  const vector<size_t>& position_backward_max_dist);
-    
-    /// Same semantics as previous, but accesses graph through an XG instead of a VG. Optionally uses
-    /// an LRUCache to speed up Node queries.
-    void extract_containing_graph(xg::XG& xg_index, Graph& g, const vector<pos_t>& positions,
-                                  const vector<size_t>& position_forward_max_dist,
-                                  const vector<size_t>& position_backward_max_dist,
-                                  LRUCache<id_t, Node>* node_cache = nullptr,
-                                  LRUCache<id_t, vector<Edge>>* edge_cache = nullptr);
-    
-    /// Extract the containing graph from a handle graph.               
     void extract_containing_graph(const HandleGraph* source, Graph& g, const vector<pos_t>& positions,
                                   const vector<size_t>& position_forward_max_dist,
                                   const vector<size_t>& position_backward_max_dist);

--- a/src/algorithms/extract_containing_graph.hpp
+++ b/src/algorithms/extract_containing_graph.hpp
@@ -14,6 +14,7 @@
 #include "../xg.hpp"
 #include "../vg.hpp"
 #include "../vg.pb.h"
+#include "../handle.hpp"
 #include "../hash_map.hpp"
 
 namespace vg {
@@ -65,6 +66,11 @@ namespace algorithms {
                                   const vector<size_t>& position_backward_max_dist,
                                   LRUCache<id_t, Node>* node_cache = nullptr,
                                   LRUCache<id_t, vector<Edge>>* edge_cache = nullptr);
+    
+    /// Extract the containing graph from a handle graph.               
+    void extract_containing_graph(const HandleGraph* source, Graph& g, const vector<pos_t>& positions,
+                                  const vector<size_t>& position_forward_max_dist,
+                                  const vector<size_t>& position_backward_max_dist);
 
 }
 }

--- a/src/algorithms/extract_extending_graph.cpp
+++ b/src/algorithms/extract_extending_graph.cpp
@@ -103,7 +103,6 @@ namespace algorithms {
 #endif
                 
                 // Get the ID of where we're going.
-                // TODO: this costs a select. Can we avoid it somehow?
                 auto next_id = source->get_id(next);
                 
                 // do we ever return to the source node?

--- a/src/algorithms/extract_extending_graph.cpp
+++ b/src/algorithms/extract_extending_graph.cpp
@@ -11,8 +11,8 @@
 namespace vg {
 namespace algorithms {
 
-    unordered_map<id_t, id_t> extract_extending_graph_internal(const HandleGraph* source, Graph& g, int64_t max_dist, pos_t pos,
-                                                               bool backward, bool preserve_cycles_on_src) {
+    unordered_map<id_t, id_t> extract_extending_graph(const HandleGraph* source, Graph& g, int64_t max_dist, pos_t pos,
+                                                      bool backward, bool preserve_cycles_on_src) {
         
         if (g.node_size() || g.edge_size()) {
             cerr << "error:[extract_extending_graph] must extract into an empty graph" << endl;
@@ -253,30 +253,5 @@ namespace algorithms {
         
         return id_trans;
     }
-    
-    unordered_map<id_t, id_t> extract_extending_graph(const HandleGraph* source, Graph& g, int64_t max_dist, pos_t pos,
-                                                      bool backward, bool preserve_cycles_on_src) {
-        return extract_extending_graph_internal(source, g, max_dist, pos, backward, preserve_cycles_on_src);
-        
-    }
-    
-    unordered_map<id_t, id_t> extract_extending_graph(VG& vg, Graph& g, int64_t max_dist, pos_t pos,
-                                                      bool backward, bool preserve_cycles_on_src){
-        
-        // Just view the vg as a handle graph                                              
-        return extract_extending_graph(&vg, g, max_dist, pos, backward, preserve_cycles_on_src);
-                                                      
-    }
-    
-    unordered_map<id_t, id_t> extract_extending_graph(xg::XG& xg_index, Graph& g, int64_t max_dist, pos_t pos,
-                                                      bool backward, bool preserve_cycles_on_src,
-                                                      LRUCache<id_t, Node>* node_cache,
-                                                      LRUCache<id_t, vector<Edge>>* edge_cache) {
-                                                      
-                                                      
-        // Just view the xg as a handle graph and ignore the caches.                                          
-        return extract_extending_graph(&xg_index, g, max_dist, pos, backward, preserve_cycles_on_src);
-    }
-
 }
 }

--- a/src/algorithms/extract_extending_graph.hpp
+++ b/src/algorithms/extract_extending_graph.hpp
@@ -11,8 +11,6 @@
 
 #include "../position.hpp"
 #include "../cached_position.hpp"
-#include "../xg.hpp"
-#include "../vg.hpp"
 #include "../vg.pb.h"
 #include "../hash_map.hpp"
 #include "../handle.hpp"
@@ -20,31 +18,20 @@
 namespace vg {
 namespace algorithms {
     
-    /// Fills graph g with the subgraph of the VG graph vg that extends in one direction from a given
+    /// Fills graph g with the subgraph of the handle graph source that extends in one direction from a given
     /// position, up to a maximum distance. The node containing the position will be "cut" so that only
     /// the portion that is forward in the search direction remains.
     ///
     /// Args:
-    ///  vg                      graph to extract subgraph from
+    ///  source                  graph to extract subgraph from
     ///  g                       graph to extract into
     ///  max_dist                include all nodes and edges that can be reached in at most this distance
     ///  pos                     extend from this position
     ///  backward                extend in this direction
     ///  preserve_cycles_on_src  if necessary, duplicate starting node to preserve cycles after cutting it
-    unordered_map<id_t, id_t> extract_extending_graph(VG& vg, Graph& g, int64_t max_dist, pos_t pos,
-                                                      bool backward, bool preserve_cycles_on_src);
-    
-    /// Same semantics as previous, but accesses graph through an XG instead of a VG. Optionally uses
-    /// an LRUCache to speed up Node queries.
-    unordered_map<id_t, id_t> extract_extending_graph(xg::XG& xg_index, Graph& g, int64_t max_dist, pos_t pos,
-                                                      bool backward, bool preserve_cycles_on_src,
-                                                      LRUCache<id_t, Node>* node_cache = nullptr,
-                                                      LRUCache<id_t, vector<Edge>>* edge_cache = nullptr);
-    
-    /// Same semantics as previous, but accesses graph through a handle graph interface instead of a VG.
     unordered_map<id_t, id_t> extract_extending_graph(const HandleGraph* source, Graph& g, int64_t max_dist, pos_t pos,
                                                       bool backward, bool preserve_cycles_on_src);
-    
+                                                      
 }
 }
 

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -82,6 +82,7 @@ using namespace std;
 
 /**
  * This is the interface that a graph that uses handles needs to support.
+ * It is also the interface that users should code against.
  */
 class HandleGraph {
 public:

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -3110,8 +3110,7 @@ VG Mapper::cluster_subgraph_strict(const Alignment& aln, const vector<MaximalExa
     
     // extract the protobuf Graph
     Graph proto_graph;
-    algorithms::extract_containing_graph(*xindex, proto_graph, positions, forward_max_dist,
-                                         backward_max_dist, &get_node_cache());
+    algorithms::extract_containing_graph(xindex, proto_graph, positions, forward_max_dist, backward_max_dist);
                                          
     // Wrap it in a vg
     VG graph;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1266,7 +1266,7 @@ namespace vg {
                     get_offset(end_pos)++;
                     
                     Graph tail_graph;
-                    unordered_map<id_t, id_t> tail_trans = algorithms::extract_extending_graph(align_graph,
+                    unordered_map<id_t, id_t> tail_trans = algorithms::extract_extending_graph(&align_graph,
                                                                                                tail_graph,
                                                                                                target_length,
                                                                                                end_pos,
@@ -1362,7 +1362,7 @@ namespace vg {
 
                     
                     Graph tail_graph;
-                    unordered_map<id_t, id_t> tail_trans = algorithms::extract_extending_graph(align_graph,
+                    unordered_map<id_t, id_t> tail_trans = algorithms::extract_extending_graph(&align_graph,
                                                                                                tail_graph,
                                                                                                target_length,
                                                                                                begin_pos,

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -630,8 +630,8 @@ namespace vg {
             Graph& graph = cluster_graph->graph;
             
             // extract the protobuf Graph in place in the VG
-            algorithms::extract_containing_graph(*xindex, graph, positions, forward_max_dist,
-                                                 backward_max_dist, &node_cache);
+            algorithms::extract_containing_graph(xindex, graph, positions, forward_max_dist,
+                                                 backward_max_dist);
             
             // check if this subgraph overlaps with any previous subgraph (indicates a probable clustering failure where
             // one cluster was split into multiple clusters)

--- a/src/unittest/vg_algorithms.cpp
+++ b/src/unittest/vg_algorithms.cpp
@@ -1968,7 +1968,7 @@ namespace vg {
                 size_t max_len = 3;
                 vector<pos_t> positions{make_pos_t(n0->id(), false, 2), make_pos_t(n5->id(), true, 1)};
                 
-                algorithms::extract_containing_graph(vg, g, positions, max_len);
+                algorithms::extract_containing_graph(&vg, g, positions, max_len);
                 
                 REQUIRE(g.node_size() == 6);
                 REQUIRE(g.edge_size() == 4);
@@ -2047,7 +2047,7 @@ namespace vg {
                 vector<size_t> max_lens{2, 3};
                 vector<pos_t> positions{make_pos_t(n0->id(), false, 2), make_pos_t(n5->id(), true, 1)};
                 
-                algorithms::extract_containing_graph(vg, g, positions, max_lens);
+                algorithms::extract_containing_graph(&vg, g, positions, max_lens);
                 
                 REQUIRE(g.node_size() == 3);
                 REQUIRE(g.edge_size() == 1);
@@ -2096,7 +2096,7 @@ namespace vg {
                 vector<size_t> backward_max_lens{2, 3};
                 vector<pos_t> positions{make_pos_t(n0->id(), true, 2), make_pos_t(n5->id(), false, 1)};
                 
-                algorithms::extract_containing_graph(vg, g, positions, forward_max_lens, backward_max_lens);
+                algorithms::extract_containing_graph(&vg, g, positions, forward_max_lens, backward_max_lens);
                                 
                 REQUIRE(g.node_size() == 4);
                 REQUIRE(g.edge_size() == 2);

--- a/src/unittest/vg_algorithms.cpp
+++ b/src/unittest/vg_algorithms.cpp
@@ -2181,7 +2181,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto id_trans = algorithms::extract_extending_graph(vg, g, max_dist, pos, search_backward, preserve_cycles);
+                auto id_trans = algorithms::extract_extending_graph(&vg, g, max_dist, pos, search_backward, preserve_cycles);
                 
                 REQUIRE(g.node_size() == 1);
                 REQUIRE(g.edge_size() == 0);
@@ -2207,7 +2207,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto id_trans = algorithms::extract_extending_graph(vg, g, max_dist, pos, search_backward, preserve_cycles);
+                auto id_trans = algorithms::extract_extending_graph(&vg, g, max_dist, pos, search_backward, preserve_cycles);
                 
                 REQUIRE(g.node_size() == 2);
                 REQUIRE(g.edge_size() == 1);
@@ -2250,7 +2250,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto id_trans = algorithms::extract_extending_graph(vg, g, max_dist, pos, search_backward, preserve_cycles);
+                auto id_trans = algorithms::extract_extending_graph(&vg, g, max_dist, pos, search_backward, preserve_cycles);
                 
                 REQUIRE(g.node_size() == 2);
                 REQUIRE(g.edge_size() == 1);
@@ -2293,7 +2293,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto id_trans = algorithms::extract_extending_graph(vg, g, max_dist, pos, search_backward, preserve_cycles);
+                auto id_trans = algorithms::extract_extending_graph(&vg, g, max_dist, pos, search_backward, preserve_cycles);
                 
                 REQUIRE(g.node_size() == 2);
                 REQUIRE(g.edge_size() == 1);
@@ -2336,7 +2336,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto id_trans = algorithms::extract_extending_graph(vg, g, max_dist, pos, search_backward, preserve_cycles);
+                auto id_trans = algorithms::extract_extending_graph(&vg, g, max_dist, pos, search_backward, preserve_cycles);
                 
                 REQUIRE(g.node_size() == 3);
                 REQUIRE(g.edge_size() == 2);
@@ -2390,7 +2390,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto id_trans = algorithms::extract_extending_graph(vg, g, max_dist, pos, search_backward, preserve_cycles);
+                auto id_trans = algorithms::extract_extending_graph(&vg, g, max_dist, pos, search_backward, preserve_cycles);
                 
                 REQUIRE(g.node_size() == 3);
                 REQUIRE(g.edge_size() == 2);
@@ -2444,7 +2444,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto id_trans = algorithms::extract_extending_graph(vg, g, max_dist, pos, search_backward, preserve_cycles);
+                auto id_trans = algorithms::extract_extending_graph(&vg, g, max_dist, pos, search_backward, preserve_cycles);
                 
                 REQUIRE(g.node_size() == 7);
                 REQUIRE(g.edge_size() == 8);
@@ -2554,7 +2554,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto id_trans = algorithms::extract_extending_graph(vg, g, max_dist, pos, search_backward, preserve_cycles);
+                auto id_trans = algorithms::extract_extending_graph(&vg, g, max_dist, pos, search_backward, preserve_cycles);
                 
                 REQUIRE(g.node_size() == 3);
                 REQUIRE(g.edge_size() == 4);
@@ -2626,7 +2626,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto id_trans = algorithms::extract_extending_graph(vg, g, max_dist, pos, search_backward, preserve_cycles);
+                auto id_trans = algorithms::extract_extending_graph(&vg, g, max_dist, pos, search_backward, preserve_cycles);
                                 
                 REQUIRE(g.node_size() == 5);
                 REQUIRE(g.edge_size() == 6);

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1546,7 +1546,7 @@ handle_t XG::get_handle(const id_t& node_id, bool is_reverse) const {
 
 id_t XG::get_id(const handle_t& handle) const {
     // Go get the g offset and then look up the noder ID
-    return g_iv[as_integer(handle) & LOW_BITS + G_NODE_ID_OFFSET];
+    return g_iv[(as_integer(handle) & LOW_BITS) + G_NODE_ID_OFFSET];
 }
 
 bool XG::get_is_reverse(const handle_t& handle) const {
@@ -1558,7 +1558,7 @@ handle_t XG::flip(const handle_t& handle) const {
 }
 
 size_t XG::get_length(const handle_t& handle) const {
-    return g_iv[as_integer(handle) & LOW_BITS + G_NODE_LENGTH_OFFSET];
+    return g_iv[(as_integer(handle) & LOW_BITS) + G_NODE_LENGTH_OFFSET];
 }
 
 string XG::get_sequence(const handle_t& handle) const {
@@ -1569,9 +1569,11 @@ string XG::get_sequence(const handle_t& handle) const {
     string sequence(sequence_size, '\0');
     // Extract the node record start
     size_t g = as_integer(handle) & LOW_BITS;
+    // Figure out where the sequence starts
+    size_t sequence_start = g_iv[g + G_NODE_SEQ_START_OFFSET];
     for (int64_t i = 0; i < sequence_size; i++) {
         // Blit the sequence out
-        sequence[i] = revdna3bit(g_iv[i + g + G_NODE_HEADER_LENGTH]);
+        sequence[i] = revdna3bit(s_iv[sequence_start + i]);
     }
     
     if (as_integer(handle) & HIGH_BIT) {

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -491,8 +491,8 @@ private:
     /// edges_from_count := integer
     /// edges_to := { edge_to, ... }
     /// edges_from := { edge_from, ... }
-    /// edge_to := { edge_type, offset_to_previous_node }
-    /// edge_to := { edge_type, offset_to_next_node }
+    /// edge_to := { offset_to_previous_node, edge_type }
+    /// edge_to := { offset_to_next_node, edge_type }
     int_vector<> g_iv;
     /// delimit node records to allow lookup of nodes in g_civ by rank
     bit_vector g_bv;
@@ -508,8 +508,8 @@ private:
     const static int G_NODE_FROM_COUNT_OFFSET = 4;
     const static int G_NODE_HEADER_LENGTH = 5;
     
-    const static int G_EDGE_TYPE_OFFSET = 0;
-    const static int G_EDGE_OFFSET_OFFSET = 1;
+    const static int G_EDGE_OFFSET_OFFSET = 0;
+    const static int G_EDGE_TYPE_OFFSET = 1;
     const static int G_EDGE_LENGTH = 2;
     
     // And some masks


### PR DESCRIPTION
It looks like the XG-based handle interface never actually worked; it was trying to pull sequence data from the wrong vector. But it was also pulling sequence length wrong, so it managed to even out and not crash.

I've fixed that, and also refactored another one of the vg::algorithms to use handles.