### PR TITLE
No lower case

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -172,6 +172,23 @@ namespace vg {
     ConstructedChunk Constructor::construct_chunk(string reference_sequence, string reference_path_name,
             vector<vcflib::Variant> variants, size_t chunk_offset) const {
 
+        // Make sure the input sequence is upper-case
+        string uppercase_sequence = toUppercase(reference_sequence);
+        
+        if (uppercase_sequence != reference_sequence && warn_on_lowercase) {
+            #pragma omp critical (cerr)
+            {
+                // Note that the pragma also protects this mutable map that we update
+                if (!warned_sequences.count(reference_path_name)) {
+                    // We haven't warned about this sequence yet
+                    cerr << "warning:[vg::Constructor] Lowercase characters found in "
+                        << reference_path_name << "; coercing to uppercase." << endl;
+                    warned_sequences.insert(reference_path_name);
+                }    
+            }
+        }
+        swap(reference_sequence, uppercase_sequence);
+
         // Construct a chunk for this sequence with these variants.
         ConstructedChunk to_return;
 

--- a/src/constructor.hpp
+++ b/src/constructor.hpp
@@ -99,6 +99,9 @@ public:
     // graph to allow the longer combined deletion?
     bool chain_deletions = true;
     
+    // Should we warn if lowercase characters are encountered in each input sequence?
+    bool warn_on_lowercase = true;
+    
     // What's the maximum node size we should allow?
     size_t max_node_size = 1000;
     
@@ -210,6 +213,9 @@ private:
      * the base after it and the base before it.
      */
     static pair<int64_t, int64_t> get_bounds(const vector<list<vcflib::VariantAllele>>& trimmed_variant);
+    
+    /// What sequences have we warned about containing lowercase characters?
+    mutable unordered_set<string> warned_sequences;
     
 
 };

--- a/src/unittest/constructor.cpp
+++ b/src/unittest/constructor.cpp
@@ -91,8 +91,10 @@ TEST_CASE( "A small linear chunk with no variants can be constructed", "[constru
     }
 }
 
-TEST_CASE( "A chunk with lower-case letters has them upper-cased", "[constructor]" ) {
+TEST_CASE( "A chunk with lowercase letters has them uppercased", "[constructor]" ) {
     Constructor constructor;
+    // Don't warn during testing
+    constructor.warn_on_lowercase = false;
     
     auto result = constructor.construct_chunk("cangantan", "lower", std::vector<vcflib::Variant>(), 0);
     
@@ -100,7 +102,7 @@ TEST_CASE( "A chunk with lower-case letters has them upper-cased", "[constructor
         REQUIRE(result.graph.node_size() == 1);
         auto& node = result.graph.node(0);
         
-        SECTION("the node should have the upper-case sequence") {
+        SECTION("the node should have the uppercase sequence") {
             REQUIRE(node.sequence() == "CANGANTAN");
         }
     }

--- a/src/unittest/constructor.cpp
+++ b/src/unittest/constructor.cpp
@@ -91,6 +91,22 @@ TEST_CASE( "A small linear chunk with no variants can be constructed", "[constru
     }
 }
 
+TEST_CASE( "A chunk with lower-case letters has them upper-cased", "[constructor]" ) {
+    Constructor constructor;
+    
+    auto result = constructor.construct_chunk("cangantan", "lower", std::vector<vcflib::Variant>(), 0);
+    
+    SECTION("the graph should have one node") {
+        REQUIRE(result.graph.node_size() == 1);
+        auto& node = result.graph.node(0);
+        
+        SECTION("the node should have the upper-case sequence") {
+            REQUIRE(node.sequence() == "CANGANTAN");
+        }
+    }
+    
+}
+
 TEST_CASE( "Max node length is respected", "[constructor]" ) {
     Constructor constructor;
     constructor.max_node_size = 4;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -152,6 +152,16 @@ string nonATGCNtoN(const string& s) {
     return n;
 }
 
+string toUppercase(const string& s) {
+    auto n = s;
+    for (string::iterator c = n.begin(); c != n.end(); ++c) {
+        if (*c >= 'a' && *c <= 'z') {
+            *c -= 'a' - 'A';
+        }
+    }
+    return n;
+}
+
 string tmpfilename(const string& base) {
     string tmpname = base + "XXXXXXXX";
     // hack to use mkstemp to get us a safe temporary file name

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -38,6 +38,8 @@ const std::string sha1head(const std::string& data, size_t head);
 
 bool allATGC(const string& s);
 string nonATGCNtoN(const string& s);
+// Convert ASCII-encoded DNA to upper case
+string toUppercase(const string& s);
 double median(std::vector<int> &v);
 double stdev(const std::vector<double>& v);
 


### PR DESCRIPTION
Fixes #1119.

XG will still strip out lower-case letters and make them Ns, but now vg construct will complain and not let you get them into the graph in the first place.

@ekg Do you think this is the right approach? We can still get lower-case characters in via e.g. GFA import, and XG will still silently delete them.