### PR TITLE
re-activate mhc calling test

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -1054,7 +1054,6 @@ class VGCITest(TestCase):
         """ Indexing, mapping and calling bakeoff F1 test for MHC primary graph """
         self._test_bakeoff('MHC', 'primary', True)
 
-    @skip("skipping test to keep runtime down (baseline missing as well)")        
     @timeout_decorator.timeout(10000)        
     def test_map_mhc_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for MHC snp1kg graph """


### PR DESCRIPTION
This will give a better sense of where the calling is than the BRCA1 test.  @ekg, can you please pull this into the mapper branch?  There seems to be something up with map on that branch where this test fails with `vg: src/mapper.cpp:1782: bool vg::Mapper::pair_consistent(const vg::Alignment&, const vg::Alignment&, double): Assertion `aln1.fragment_size() == aln2.fragment_size()' failed.`