### PR TITLE
Benchmarks

### DIFF
--- a/src/algorithms/extract_connecting_graph.hpp
+++ b/src/algorithms/extract_connecting_graph.hpp
@@ -11,8 +11,7 @@
 
 #include "../position.hpp"
 #include "../cached_position.hpp"
-#include "../xg.hpp"
-#include "../vg.hpp"
+#include "../handle.hpp"
 #include "../vg.pb.h"
 #include "../hash_map.hpp"
 
@@ -31,7 +30,7 @@ namespace algorithms {
     /// empty when passed to function.
     ///
     /// Args:
-    ///  vg                         graph to extract subgraph from
+    ///  source                    graph to extract subgraph from
     ///  g                          graph to extract into
     ///  max_len                    guarantee finding paths along which pos_1 and pos_2 are this distance apart
     ///  pos_1                      start position, subgraph paths begin from here in same orientation
@@ -44,26 +43,13 @@ namespace algorithms {
     ///                             pos_2 (implies no_additional_tips = true)
     ///  strict_max_len             only extract nodes and edges if they fall on some path between pos_1 and
     ///                             pos_2 that is under the maximum length (implies only_paths = true)
-    unordered_map<id_t, id_t> extract_connecting_graph(VG& vg, Graph& g, int64_t max_len,
+    unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source, Graph& g, int64_t max_len,
                                                        pos_t pos_1, pos_t pos_2,
                                                        bool include_terminal_positions = false,
                                                        bool detect_terminal_cycles = false,
                                                        bool no_additional_tips = false,
                                                        bool only_paths = false,
                                                        bool strict_max_len = false);
-    
-    
-    /// Same semantics as previous, but accesses graph through an XG instead of a VG. Optionally uses
-    /// an LRUCache to speed up Node queries (recommended for detecting terminal cycles in particular).
-    unordered_map<id_t, id_t> extract_connecting_graph(xg::XG& xg_index, Graph& g, int64_t max_len,
-                                                       pos_t pos_1, pos_t pos_2,
-                                                       bool include_terminal_positions = false,
-                                                       bool detect_terminal_cycles = false,
-                                                       bool no_additional_tips = false,
-                                                       bool only_paths = false,
-                                                       bool strict_max_len = false,
-                                                       LRUCache<id_t, Node>* node_cache = nullptr,
-                                                       LRUCache<id_t, vector<Edge>>* edge_cache = nullptr);
 
 }
 }

--- a/src/algorithms/extract_connecting_graph.hpp
+++ b/src/algorithms/extract_connecting_graph.hpp
@@ -62,7 +62,8 @@ namespace algorithms {
                                                        bool no_additional_tips = false,
                                                        bool only_paths = false,
                                                        bool strict_max_len = false,
-                                                       LRUCache<id_t, Node>* node_cache = nullptr);
+                                                       LRUCache<id_t, Node>* node_cache = nullptr,
+                                                       LRUCache<id_t, vector<Edge>>* edge_cache = nullptr);
 
 }
 }

--- a/src/algorithms/extract_containing_graph.cpp
+++ b/src/algorithms/extract_containing_graph.cpp
@@ -11,9 +11,9 @@
 namespace vg {
 namespace algorithms {
 
-    void extract_containing_graph_internal(const HandleGraph* source, Graph& g, const vector<pos_t>& positions,
-                                           const vector<size_t>& forward_search_lengths,
-                                           const vector<size_t>& backward_search_lengths) {
+    void extract_containing_graph(const HandleGraph* source, Graph& g, const vector<pos_t>& positions,
+                                  const vector<size_t>& forward_search_lengths,
+                                  const vector<size_t>& backward_search_lengths) {
         
         if (forward_search_lengths.size() != backward_search_lengths.size()
             || forward_search_lengths.size() != positions.size()) {
@@ -143,14 +143,6 @@ namespace algorithms {
         
         return extract_containing_graph(source, g, positions, position_max_dist, position_max_dist);
     }
-    
-    void extract_containing_graph(const HandleGraph* source, Graph& g, const vector<pos_t>& positions,
-                                  const vector<size_t>& position_forward_max_dist,
-                                  const vector<size_t>& position_backward_max_dist) {
-        
-        return extract_containing_graph_internal(source, g, positions, position_forward_max_dist, position_backward_max_dist);
-    
-    } 
 
 }
 }

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -1,0 +1,193 @@
+#include "benchmark.hpp"
+#include <vector>
+#include <iostream>
+#include <cassert>
+#include <numeric>
+#include <cmath>
+#include <iomanip>
+
+/**
+ * \file benchmark.hpp: implementations of benchmarking functions
+ */
+ 
+namespace vg {
+using namespace std;
+
+double BenchmarkResult::score() const {
+    // We comnpute a score in points by comparing the experimental and control runtimes.
+    // Higher is better.
+    
+    double tests_per_control = (double)test_mean.count() / (double)control_mean.count();
+    return tests_per_control * 1000;
+}
+
+double BenchmarkResult::score_error() const {
+    // Do error propagation for the score calculation
+    
+    // Set up some abstract variables according to the notation at
+    // <https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulas>
+    double A = test_mean.count();
+    double stddev_A = test_stddev.count();
+    double B = control_mean.count();
+    double stddev_B = control_stddev.count();
+    double f = score() / 1000;
+    
+    // Do the error propagation
+    // Assume the variables are uncorrelated (covariance = 0)
+    // Not because that's really true but because we don't track the covariance
+    double err = abs(f) * sqrt(pow(stddev_A / A, 2) + pow(stddev_B / B, 2));
+    
+    // Scale up because of scaling factor on the score.
+    return err * 1000;
+}
+
+ostream& operator<<(ostream& out, const BenchmarkResult& result) {
+    // Dump it as a partial TSV line
+    
+    // We want to report times in fractional us
+    using frac_secs = chrono::duration<double, std::micro>;
+    
+    // Save stream settings
+    auto initial_precision = out.precision();
+    auto initial_flags = out.flags();
+    
+    // Set up formatting
+    cout << setprecision(2) << scientific;
+    
+    out << result.runs;
+    out << "\t";
+    out << chrono::duration_cast<frac_secs>(result.test_mean).count();
+    out << "\t";
+    out << chrono::duration_cast<frac_secs>(result.test_stddev).count();
+    out << "\t";
+    out << chrono::duration_cast<frac_secs>(result.control_mean).count();
+    out << "\t";
+    out << chrono::duration_cast<frac_secs>(result.control_stddev).count();
+    out << "\t";
+    
+    // Scores get different formatting
+    cout << fixed;
+    
+    out << result.score();
+    out << "\t";
+    out << result.score_error();
+    out << "\t";
+    out << result.name;
+    
+    out.precision(initial_precision);
+    out.flags(initial_flags);
+    
+    return out;
+}
+
+void benchmark_control() {
+    // We need to do something that takes time.
+    
+    vector<size_t> things;
+    
+    for (size_t i = 0; i < 100; i++) {
+        things.push_back(i ^ (i/5));
+    }
+    
+    size_t max_thing = 0;
+    
+    for (auto& thing : things) {
+        for (auto& other_thing : things) {
+            max_thing = max(max_thing, max(thing, other_thing));
+            other_thing = other_thing ^ (thing << 5);
+        }
+    }
+    
+    size_t total = 0;
+    for (auto& thing : things) {
+        total += thing;
+    }
+    
+    // These are the results of that arbitrary math
+    assert(max_thing == 18444166782598024656U);
+    assert(total == 17868247911721767448U);
+    
+}
+
+BenchmarkResult run_benchmark(const string& name, size_t iterations, const function<void(void)>& under_test) {
+    // We'll fill this in with the results of the benchmark run
+    BenchmarkResult to_return;
+    to_return.runs = iterations;
+    to_return.name = name;
+    
+    // Where do we put our test runtime samples?
+    // They need to be normal integral types so we can feasibly square them.
+    vector<benchtime::rep> test_samples;
+    // And the samples for the control?
+    vector<benchtime::rep> control_samples;
+    
+    // We know how big they will be
+    test_samples.reserve(iterations);
+    control_samples.reserve(iterations);
+    
+    for (size_t i = 0; i < iterations; i++) {
+        // For each iteration
+        
+        // Run the function under test
+        auto test_start = chrono::high_resolution_clock::now();
+        under_test();
+        auto test_stop = chrono::high_resolution_clock::now();
+        
+        // And run the control
+        auto control_start = chrono::high_resolution_clock::now();
+        benchmark_control();
+        auto control_stop = chrono::high_resolution_clock::now();
+        
+        // Make sure time went forward and nobody changed the clock (as far as we know)
+        assert(test_stop > test_start);
+        assert(control_stop > control_start);
+        
+        // Compute the runtimes and save them
+        test_samples.push_back(chrono::duration_cast<benchtime>(test_stop - test_start).count());
+        control_samples.push_back(chrono::duration_cast<benchtime>(control_stop - control_start).count());
+    }
+    
+    // Calculate the moments with magic numeric algorithms
+    // See <https://stackoverflow.com/a/7616783>
+    
+    // Total up the ticks for the test
+    benchtime::rep test_total = accumulate(test_samples.begin(), test_samples.end(),
+        benchtime::zero().count());
+    // And make a duration for the mean
+    to_return.test_mean = benchtime(test_total / iterations);
+    
+    // Then total up the squares of the tick counts
+    benchtime::rep test_square_total = inner_product(test_samples.begin(), test_samples.end(),
+        test_samples.begin(), benchtime::zero().count());
+    // Calculate the standard deviation in ticks, and represent it as a duration
+    to_return.test_stddev = benchtime((benchtime::rep) sqrt(test_square_total / iterations -
+        to_return.test_mean.count() * to_return.test_mean.count()));
+    
+    // Similarly for the control
+    benchtime::rep control_total = accumulate(control_samples.begin(), control_samples.end(),
+        benchtime::zero().count());
+    to_return.control_mean = benchtime(control_total / iterations);
+    
+    benchtime::rep control_square_total = inner_product(control_samples.begin(), control_samples.end(), 
+        control_samples.begin(), benchtime::zero().count());
+    to_return.control_stddev = benchtime((benchtime::rep) sqrt(control_square_total / iterations -
+        to_return.control_mean.count() * to_return.control_mean.count()));
+    
+    return to_return;
+    
+}
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -17,7 +17,8 @@ double BenchmarkResult::score() const {
     // We comnpute a score in points by comparing the experimental and control runtimes.
     // Higher is better.
     
-    double tests_per_control = (double)test_mean.count() / (double)control_mean.count();
+    // How many tests can we run per control run?
+    double tests_per_control = (double)control_mean.count() / (double)test_mean.count();
     return tests_per_control * 1000;
 }
 
@@ -26,10 +27,10 @@ double BenchmarkResult::score_error() const {
     
     // Set up some abstract variables according to the notation at
     // <https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulas>
-    double A = test_mean.count();
-    double stddev_A = test_stddev.count();
-    double B = control_mean.count();
-    double stddev_B = control_stddev.count();
+    double A = control_mean.count();
+    double stddev_A = control_stddev.count();
+    double B = test_mean.count();
+    double stddev_B = test_stddev.count();
     double f = score() / 1000;
     
     // Do the error propagation

--- a/src/benchmark.hpp
+++ b/src/benchmark.hpp
@@ -1,0 +1,65 @@
+#ifndef VG_BENCHMARK_HPP
+#define VG_BENCHMARK_HPP
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <string>
+
+/** 
+ * \file benchmark.hpp
+ * Contains utilities for running (micro)benchmarks of vg code.
+ */
+ 
+namespace vg {
+
+using namespace std;
+
+/// We define a duration type for expressing benchmark times in.
+using benchtime = chrono::nanoseconds;
+
+/**
+ * Represents the results of a benchmark run. Tracks the mean and standard
+ * deviation of a number of runs of a function under test, interleaved with runs
+ * of a standard control function.
+ */ 
+struct BenchmarkResult {
+    /// How many runs were done
+    size_t runs;
+    /// What was the mean runtime of each test run
+    benchtime test_mean;
+    /// What was the standard deviation of test run times
+    benchtime test_stddev;
+    /// What was the mean runtime of each control run
+    benchtime control_mean;
+    /// What was the standard deviation of control run times
+    benchtime control_stddev;
+    /// What was the name of the test being run
+    string name;
+    /// How many control-standardized "points" do we score?
+    double score() const;
+    /// What is the uncertainty on the score?
+    double score_error() const;
+};
+
+/**
+ * Benchmark results can be output to streams
+ */
+ostream& operator<<(ostream& out, const BenchmarkResult& result);
+
+/**
+ * The benchmark control function, designed to take some amount of time that might vary with CPU load.
+ */
+void benchmark_control();
+
+/**
+ * Run the given function the given number of times, interleaved with runs of
+ * the control function, and return a BenchmarkResult describing its
+ * performance.
+ */
+BenchmarkResult run_benchmark(const string& name, size_t iterations, const function<void(void)>& under_test);
+
+
+}
+
+#endif

--- a/src/graph_synchronizer.cpp
+++ b/src/graph_synchronizer.cpp
@@ -128,7 +128,7 @@ void GraphSynchronizer::Lock::lock() {
             
             // Extract paths out to the length we need to connect the ends, or a bit further.
             // TODO: be sure to extract really big indels somehow...
-            auto duplications = algorithms::extract_connecting_graph(synchronizer.graph,
+            auto duplications = algorithms::extract_connecting_graph(&synchronizer.graph,
                 context_graph,
                 (past_end - start) * 2,
                 left_pos,

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1010,7 +1010,7 @@ namespace vg {
                 
                 // extract the graph between the matches
                 Graph connecting_graph;
-                unordered_map<id_t, id_t> connect_trans = algorithms::extract_connecting_graph(align_graph,      // DAG with split strands
+                unordered_map<id_t, id_t> connect_trans = algorithms::extract_connecting_graph(&align_graph,     // DAG with split strands
                                                                                                connecting_graph, // graph to extract into
                                                                                                max_dist,         // longest distance necessary
                                                                                                src_pos,          // end of earlier match

--- a/src/subcommand/benchmark_main.cpp
+++ b/src/subcommand/benchmark_main.cpp
@@ -127,7 +127,7 @@ int main_benchmark(int argc, char** argv) {
         
         Graph g;
         
-        auto trans = algorithms::extract_connecting_graph(xg_index, g, max_len, pos_1, pos_2, false, false, true, true, true);
+        auto trans = algorithms::extract_connecting_graph(&xg_index, g, max_len, pos_1, pos_2, false, false, true, true, true);
     
     }));
     
@@ -139,7 +139,7 @@ int main_benchmark(int argc, char** argv) {
         
         Graph g;
         
-        auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+        auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
     
     }));
     

--- a/src/subcommand/benchmark_main.cpp
+++ b/src/subcommand/benchmark_main.cpp
@@ -1,0 +1,95 @@
+/** \file benchmark_main.cpp
+ *
+ * Defines the "vg benchmark" subcommand, which runs and reports on microbenchmarks.
+ */
+
+#include <omp.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <iostream>
+
+#include "subcommand.hpp"
+
+#include "../benchmark.hpp"
+#include "../version.hpp"
+
+
+
+using namespace std;
+using namespace vg;
+using namespace vg::subcommand;
+
+void help_benchmark(char** argv) {
+    cerr << "usage: " << argv[0] << " benchmark [options] >report.tsv" << endl
+         << "options:" << endl
+         << "    -p, --progress         show progress" << endl;
+}
+
+int main_benchmark(int argc, char** argv) {
+
+    bool show_progress = false;
+    
+    int c;
+    optind = 2; // force optind past command positional argument
+    while (true) {
+        static struct option long_options[] =
+            {
+                {"progress",  no_argument, 0, 'p'},
+                {"help", no_argument, 0, 'h'},
+                {0, 0, 0, 0}
+            };
+
+        int option_index = 0;
+        c = getopt_long (argc, argv, "ph?",
+                         long_options, &option_index);
+
+        /* Detect the end of the options. */
+        if (c == -1)
+            break;
+
+        switch (c)
+        {
+
+        case 'p':
+            show_progress = true;
+            break;
+            
+        case 'h':
+        case '?':
+            /* getopt_long already printed an error message. */
+            help_benchmark(argv);
+            exit(1);
+            break;
+
+        default:
+            abort ();
+
+        }
+    }
+    
+    if (optind != argc) {
+        // Extra arguments found
+        help_benchmark(argv);
+        exit(1);
+    }
+    
+    // Do all benchmarking on one thread
+    omp_set_num_threads(1);
+    
+    // Turn on nested parallelism, so we can parallelize over VCFs and over alignment bands
+    omp_set_nested(1);
+    
+    // Do the control against itself
+    auto result = run_benchmark("control", 1000, benchmark_control);
+
+    cout << "# Benchmark results for vg " << VG_VERSION_STRING << endl;
+    cout << "# runs\ttest(us)\tstddev(us)\tcontrol(us)\tstddev(us)\tscore\terr\tname" << endl;
+    cout << result << endl;
+
+    return 0;
+}
+
+// Register subcommand
+static Subcommand vg_benchmark("benchmark", "run and report on performance benchmarks", main_benchmark);
+

--- a/src/subcommand/benchmark_main.cpp
+++ b/src/subcommand/benchmark_main.cpp
@@ -119,7 +119,7 @@ int main_benchmark(int argc, char** argv) {
     }));
     
     
-    results.push_back(run_benchmark("algorithms::extract_connecting_graph", 1000, [&]() {
+    results.push_back(run_benchmark("algorithms::extract_connecting_graph on xg", 1000, [&]() {
         pos_t pos_1 = make_pos_t(55, false, 0);
         pos_t pos_2 = make_pos_t(32, false, 0);
         
@@ -128,6 +128,18 @@ int main_benchmark(int argc, char** argv) {
         Graph g;
         
         auto trans = algorithms::extract_connecting_graph(xg_index, g, max_len, pos_1, pos_2, false, false, true, true, true);
+    
+    }));
+    
+    results.push_back(run_benchmark("algorithms::extract_connecting_graph on vg", 1000, [&]() {
+        pos_t pos_1 = make_pos_t(55, false, 0);
+        pos_t pos_2 = make_pos_t(32, false, 0);
+        
+        int64_t max_len = 500;
+        
+        Graph g;
+        
+        auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
     
     }));
     

--- a/src/unittest/vg_algorithms.cpp
+++ b/src/unittest/vg_algorithms.cpp
@@ -69,7 +69,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 REQUIRE( g.node_size() == 1 );
                 REQUIRE( g.edge_size() == 0 );
@@ -86,7 +86,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 set<int64_t> expected_node_ids{n0->id(), n1->id()};
                 
@@ -119,7 +119,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 set<int64_t> expected_node_ids{n2->id(), n3->id(), n4->id(), n5->id()};
                 
@@ -187,7 +187,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 set<int64_t> expected_node_ids{n2->id(), n4->id()};
                 
@@ -220,7 +220,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 REQUIRE( g.node_size() == 0 );
                 REQUIRE( g.edge_size() == 0 );
@@ -235,7 +235,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 REQUIRE( g.node_size() == 0 );
                 REQUIRE( g.edge_size() == 0 );
@@ -250,7 +250,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 REQUIRE( g.node_size() == 1 );
                 REQUIRE( g.edge_size() == 0 );
@@ -267,7 +267,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 set<int64_t> expected_node_ids{n0->id(), n1->id()};
                 
@@ -300,7 +300,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 set<int64_t> expected_node_ids{n2->id(), n3->id(), n5->id()};
                 
@@ -353,7 +353,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 set<int64_t> expected_node_ids{n5->id(), n8->id(), n9->id()};
                 
@@ -416,7 +416,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 set<int64_t> expected_node_ids{n0->id()};
                 
@@ -462,7 +462,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
                 
                 set<int64_t> expected_node_ids{n0->id()};
                 
@@ -510,7 +510,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, true);
                 
                 set<int64_t> expected_node_ids{n0->id(), n1->id()};
                 
@@ -622,7 +622,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, true);
                 
                 REQUIRE( g.node_size() == 4 );
                 REQUIRE( g.edge_size() == 8 );
@@ -769,7 +769,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, true);
                 
                 REQUIRE( g.node_size() == 6 );
                 REQUIRE( g.edge_size() == 10 );
@@ -943,7 +943,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, true);
                 
                 REQUIRE( g.node_size() == 5 );
                 REQUIRE( g.edge_size() == 8 );
@@ -1090,7 +1090,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, true);
                 
                 REQUIRE( g.node_size() == 4 );
                 REQUIRE( g.edge_size() == 8 );
@@ -1237,7 +1237,7 @@ namespace vg {
                 
                 Graph g;
                 
-                auto trans = algorithms::extract_connecting_graph(vg, g, max_len, pos_1, pos_2, false, true);
+                auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, true);
                 
                 REQUIRE( g.node_size() == 5 );
                 REQUIRE( g.edge_size() == 18 );
@@ -1469,7 +1469,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, max_len,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, max_len,
                                                                       make_pos_t(n0->id(), false, 0),
                                                                       make_pos_t(n0->id(), false, 2),
                                                                       true);
@@ -1482,7 +1482,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, max_len,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, max_len,
                                                                       make_pos_t(n0->id(), true, 0),
                                                                       make_pos_t(n0->id(), true, 2),
                                                                       true);
@@ -1500,7 +1500,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, max_len,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, max_len,
                                                                       make_pos_t(n0->id(), false, 0),
                                                                       make_pos_t(n1->id(), false, 2),
                                                                       true);
@@ -1536,7 +1536,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, max_len,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, max_len,
                                                                       make_pos_t(n1->id(), true, 1),
                                                                       make_pos_t(n0->id(), true, 2),
                                                                       true);
@@ -1575,7 +1575,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, 0,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, 0,
                                                                       make_pos_t(n0->id(), true, 0),
                                                                       make_pos_t(n0->id(), true, 0),
                                                                       true);
@@ -1588,7 +1588,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, 5,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, 5,
                                                                       make_pos_t(n0->id(), false, 0),
                                                                       make_pos_t(n1->id(), false, 2),
                                                                       true);
@@ -1626,7 +1626,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, 4,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, 4,
                                                                       make_pos_t(n0->id(), false, 0),
                                                                       make_pos_t(n1->id(), false, 2),
                                                                       true);
@@ -1640,7 +1640,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, 10,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, 10,
                                                                       make_pos_t(n1->id(), false, 3),
                                                                       make_pos_t(n6->id(), false, 0),
                                                                       true, false);
@@ -1736,7 +1736,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, 10,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, 10,
                                                                       make_pos_t(n1->id(), false, 3),
                                                                       make_pos_t(n6->id(), false, 0),
                                                                       true, false, true);
@@ -1821,7 +1821,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, 10,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, 10,
                                                                       make_pos_t(n1->id(), false, 3),
                                                                       make_pos_t(n6->id(), false, 0),
                                                                       true, false, true, true);
@@ -1889,7 +1889,7 @@ namespace vg {
                 {
                     Graph g;
                     
-                    auto trans = algorithms::extract_connecting_graph(vg, g, 4,
+                    auto trans = algorithms::extract_connecting_graph(&vg, g, 4,
                                                                       make_pos_t(n1->id(), false, 3),
                                                                       make_pos_t(n6->id(), false, 0),
                                                                       true, false, true, true, true);


### PR DESCRIPTION
Adds some benchmarks on top of #1131. You can add new benchmarks in `src/subcommand/benchmark_main.cpp`. If we want more than a few I can try and set up an auto-registration system and a way to call individual benchmarks.

I want to see if the handle-based algorithm is really slow by running it again in this PR; my benchmarks say that my refactor is always faster (at least for the graph and query I am testing), while the Jenkins tests seemed to say that that I got a slowdown on tests that don't even call my function.

My benchmarks work by looping some code under test, interleaved with executions of some constant "control" code, and normalizing the runtime of the code under test by the runtime of the control. This produces a benchmark "score", which is essentially 1000 times the number of times you could run the code under test in the time it takes to run the control code.

I did it this way to try and normalize out variable load on the underlying system; it seems to be pretty necessary, because I am seeing basically the whole program running faster or slower by a factor of 2 on Kolossus between program runs.