### PR TITLE
MutableHandleGraph

### DIFF
--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -200,6 +200,7 @@ public:
  * paths. The paths are never allowed to be inconsistent with the graph.
  */
 class WritableHandleGraph : public HandleGraph {
+public:
     /// Create a new node with the given sequence and return the handle.
     virtual handle_t create_handle(const string& sequence) = 0;
     

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -208,9 +208,11 @@ public:
     virtual void destroy_handle(const handle_t& handle) = 0;
     
     /// Create an edge connecting the given handles in the given order and orientations.
+    /// Ignores existing edges.
     virtual void create_edge(const handle_t& left, const handle_t& right) = 0;
     
     /// Remove the edge connecting the given handles in the given order and orientations.
+    /// Ignores nonexistent edges.
     virtual void destroy_edge(const handle_t& left, const handle_t& right) = 0;
     
     /// Swap the nodes corresponding to the given handles, in the ordering used

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -199,7 +199,7 @@ public:
  * graph keeps an index of paths, all operations must also modify the stored
  * paths. The paths are never allowed to be inconsistent with the graph.
  */
-class WritableHandleGraph : public HandleGraph {
+class MutableHandleGraph : public HandleGraph {
 public:
     /// Create a new node with the given sequence and return the handle.
     virtual handle_t create_handle(const string& sequence) = 0;

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -205,13 +205,13 @@ public:
     virtual handle_t create_handle(const string& sequence) = 0;
     
     /// Remove the node belonging to the given handle and all of its edges.
-    virtual void delete_handle(const handle_t& handle) = 0;
+    virtual void destroy_handle(const handle_t& handle) = 0;
     
     /// Create an edge connecting the given handles in the given order and orientations.
     virtual void create_edge(const handle_t& left, const handle_t& right) = 0;
     
     /// Remove the edge connecting the given handles in the given order and orientations.
-    virtual void delete_edge(const handle_t& left, const handle_t& right) = 0;
+    virtual void destroy_edge(const handle_t& left, const handle_t& right) = 0;
     
     /// Swap the nodes corresponding to the given handles, in the ordering used
     /// by for_each_handle when looping over the graph. Other handles to the
@@ -223,12 +223,15 @@ public:
     /// Rewrites all edges pointing to the node and the node's sequence to
     /// reflect this. Invalidates all handles to the node (including the one
     /// passed). Returns a new, valid handle to the node in its new forward
-    /// orientation.
+    /// orientation. Note that it is possible for the node's ID to change.
     virtual handle_t apply_orientation(const handle_t& handle) = 0;
     
     /// Split a handle's underlying node at the given offsets in the handle's
     /// orientation. Returns all of the handles to the parts. Other handles to
-    /// the node being split may be invalidated.
+    /// the node being split may be invalidated. The split pieces stay in the
+    /// same local forward orientation as the original node, but the returned
+    /// handles come in the order and orientation appropriate for the handle
+    /// passed in.
     virtual vector<handle_t> divide_handle(const handle_t& handle, const vector<size_t>& offsets) = 0;
     
     /// Specialization of divide_handle for a single division point

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -116,6 +116,7 @@ public:
     
     /// Loop over all the handles to next/previous (right/left) nodes. Works
     /// with a callback that just takes all the handles and returns void.
+    /// MUST be pulled into implementing classes with `using` in order to work!
     template <typename T>
     auto follow_edges(const handle_t& handle, bool go_left, T&& iteratee) const
     -> typename std::enable_if<std::is_void<decltype(iteratee(get_handle(0, false)))>::value>::type {
@@ -149,6 +150,7 @@ public:
     
     /// Loop over all the nodes in the graph in their local forward
     /// orientations, in their internal stored order. Works with void-returning iteratees.
+    /// MUST be pulled into implementing classes with `using` in order to work!
     template <typename T>
     auto for_each_handle(T&& iteratee) const
     -> typename std::enable_if<std::is_void<decltype(iteratee(get_handle(0, false)))>::value>::type {

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -110,6 +110,10 @@ public:
     /// continue.
     virtual void follow_edges(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const = 0;
     
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee returns false.
+    virtual void for_each_handle(const function<bool(const handle_t&)>& iteratee) const = 0;
+    
     /// Loop over all the handles to next/previous (right/left) nodes. Works
     /// with a callback that just takes all the handles and returns void.
     template <typename T>
@@ -143,6 +147,21 @@ public:
         static_assert(!std::is_void<decltype(lambda(get_handle(0, false)))>::value, "can't take our own lambda");
     }
     
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Works with void-returning iteratees.
+    template <typename T>
+    auto for_each_handle(T&& iteratee) const
+    -> typename std::enable_if<std::is_void<decltype(iteratee(get_handle(0, false)))>::value>::type {
+        // Make a wrapper that puts a bool return type on.
+        function<bool(const handle_t&)> lambda = [&](const handle_t& found) {
+            iteratee(found);
+            return true;
+        };
+        
+        // Use that
+        for_each_handle(lambda);
+    }
+    
     /// Get the locally forward version of a handle
     inline handle_t forward(const handle_t& handle) const {
         return this->get_is_reverse(handle) ? this->flip(handle) : handle;
@@ -174,6 +193,49 @@ public:
         }
     }
 };
+
+/**
+ * This is the interface for a handle graph that supports modification. If the
+ * graph keeps an index of paths, all operations must also modify the stored
+ * paths. The paths are never allowed to be inconsistent with the graph.
+ */
+class WritableHandleGraph : public HandleGraph {
+    /// Create a new node with the given sequence and return the handle.
+    virtual handle_t create_handle(const string& sequence) = 0;
+    
+    /// Remove the node belonging to the given handle and all of its edges.
+    virtual void delete_handle(const handle_t& handle) = 0;
+    
+    /// Create an edge connecting the given handles in the given order and orientations.
+    virtual void create_edge(const handle_t& left, const handle_t& right) = 0;
+    
+    /// Remove the edge connecting the given handles in the given order and orientations.
+    virtual void delete_edge(const handle_t& left, const handle_t& right) = 0;
+    
+    /// Swap the nodes corresponding to the given handles, in the ordering used
+    /// by for_each_handle when looping over the graph. Other handles to the
+    /// nodes being swapped must not be invalidated.
+    virtual void swap_handles(const handle_t& a, const handle_t& b) = 0;
+    
+    /// Alter the node that the given handle corresponds to so the orientation
+    /// indicated by the handle becomes the node's local forward orientation.
+    /// Rewrites all edges pointing to the node and the node's sequence to
+    /// reflect this. Invalidates all handles to the node (including the one
+    /// passed). Returns a new, valid handle to the node in its new forward
+    /// orientation.
+    virtual handle_t apply_orientation(const handle_t& handle) = 0;
+    
+    /// Split a handle's underlying node at the given offsets in the handle's
+    /// orientation. Returns all of the handles to the parts. Other handles to
+    /// the node being split may be invalidated.
+    virtual vector<handle_t> divide_handle(const handle_t& handle, const vector<size_t>& offsets) = 0;
+    
+    /// Specialization of divide_handle for a single division point
+    inline pair<handle_t, handle_t> divide_handle(const handle_t& handle, size_t offset) {
+        auto parts = divide_handle(handle, vector<size_t>{offset});
+        return make_pair(parts.front(), parts.back());
+    }
+}; 
 
 }
 

--- a/src/unittest/handle.cpp
+++ b/src/unittest/handle.cpp
@@ -188,7 +188,7 @@ TEST_CASE("VG and XG handle implementations are correct", "[handle][vg][xg]") {
         }
     }
     
-    SECTION("Iteratees can stop early") {
+    SECTION("Edge iteratees can stop early") {
         for (const HandleGraph* g : {(HandleGraph*) &vg, (HandleGraph*) &xg_index}) {
             for (Node* node : {n0, n1, n2, n3, n4, n5, n6, n7, n8, n9}) {
             
@@ -286,6 +286,33 @@ TEST_CASE("VG and XG handle implementations are correct", "[handle][vg][xg]") {
             
         }
     
+    }
+    
+    SECTION("Node iteration works") {
+        for (const HandleGraph* g : {(HandleGraph*) &vg, (HandleGraph*) &xg_index}) {
+            vector<handle_t> found;
+            g->for_each_handle([&](const handle_t& handle) {
+                // Everything should be in its local forward orientation.
+                REQUIRE(g->get_is_reverse(handle) == false);
+                
+                found.push_back(handle);
+            });
+            
+            // We should have all the nodes and they should all be unique
+            REQUIRE(found.size() == 10);
+            REQUIRE(unordered_set<handle_t>(found.begin(), found.end()).size() == found.size());
+            // They should be in the order we added them
+            REQUIRE(g->get_id(found[0]) == n0->id());
+            REQUIRE(g->get_id(found[1]) == n1->id());
+            REQUIRE(g->get_id(found[2]) == n2->id());
+            REQUIRE(g->get_id(found[3]) == n3->id());
+            REQUIRE(g->get_id(found[4]) == n4->id());
+            REQUIRE(g->get_id(found[5]) == n5->id());
+            REQUIRE(g->get_id(found[6]) == n6->id());
+            REQUIRE(g->get_id(found[7]) == n7->id());
+            REQUIRE(g->get_id(found[8]) == n8->id());
+            REQUIRE(g->get_id(found[9]) == n9->id());
+        }
     }
 
 }

--- a/src/unittest/handle.cpp
+++ b/src/unittest/handle.cpp
@@ -405,7 +405,7 @@ TEST_CASE("Writable handle graphs work", "[handle][writablehandle][vg]") {
                         edges.push_back(g->edge_handle(handle, other));
                     });
                     g->follow_edges(handle, true, [&](const handle_t& other) {
-                        edges.push_back(g->edge_handle(handle, other));
+                        edges.push_back(g->edge_handle(other, handle));
                     });
                     
                     REQUIRE(edges.size() == 0);    
@@ -425,7 +425,7 @@ TEST_CASE("Writable handle graphs work", "[handle][writablehandle][vg]") {
                         edges.push_back(g->edge_handle(handle, other));
                     });
                     g->follow_edges(handle, true, [&](const handle_t& other) {
-                        edges.push_back(g->edge_handle(handle, other));
+                        edges.push_back(g->edge_handle(other, handle));
                     });
                     
                     REQUIRE(edges.size() == 1);
@@ -440,7 +440,7 @@ TEST_CASE("Writable handle graphs work", "[handle][writablehandle][vg]") {
                             edges.push_back(g->edge_handle(modified, other));
                         });
                         g->follow_edges(modified, true, [&](const handle_t& other) {
-                            edges.push_back(g->edge_handle(modified, other));
+                            edges.push_back(g->edge_handle(other, modified));
                         });
                         
                         REQUIRE(edges.size() == 1);

--- a/src/unittest/handle.cpp
+++ b/src/unittest/handle.cpp
@@ -317,9 +317,9 @@ TEST_CASE("VG and XG handle implementations are correct", "[handle][vg][xg]") {
 
 }
 
-TEST_CASE("Writable handle graphs work", "[handle][writablehandle][vg]") {
+TEST_CASE("Mutable handle graphs work", "[handle][vg]") {
     
-    vector<WritableHandleGraph*> implementations;
+    vector<MutableHandleGraph*> implementations;
     
     // Test the VG implementation
     VG vg;

--- a/src/unittest/handle.cpp
+++ b/src/unittest/handle.cpp
@@ -319,8 +319,11 @@ TEST_CASE("VG and XG handle implementations are correct", "[handle][vg][xg]") {
 
 TEST_CASE("Writable handle graphs work", "[handle][writablehandle][vg]") {
     
-    // TODO: populate this with instances of actual implementations.
     vector<WritableHandleGraph*> implementations;
+    
+    // Test the VG implementation
+    VG vg;
+    implementations.push_back(&vg);
     
     for(auto* g : implementations) {
     
@@ -343,8 +346,8 @@ TEST_CASE("Writable handle graphs work", "[handle][writablehandle][vg]") {
             SECTION("Its orientation can be changed") {
                 handle_t modified = g->apply_orientation(g->flip(handle));
                 
-                REQUIRE(g->get_sequence(modified) == reverse_complement("GATTACA"));
                 REQUIRE(g->get_is_reverse(modified) == false);
+                REQUIRE(g->get_sequence(modified) == reverse_complement("GATTACA"));
                 // We don't check the ID. It's possible the ID can change.
                 
                 size_t node_count = 0;

--- a/src/unittest/handle.cpp
+++ b/src/unittest/handle.cpp
@@ -317,5 +317,87 @@ TEST_CASE("VG and XG handle implementations are correct", "[handle][vg][xg]") {
 
 }
 
+TEST_CASE("Writable handle graphs work", "[handle][vg]") {
+    
+    // TODO: populate this with instances of actual implementations.
+    vector<WritableHandleGraph*> implementations;
+    
+    for(auto* g : implementations) {
+    
+        SECTION("No nodes exist by default") {
+            size_t node_count = 0;
+            g->for_each_handle([&](const handle_t& ignored) {
+                node_count++;
+            });
+            REQUIRE(node_count == 0);
+        }
+    
+        SECTION("A node can be added") {
+            
+            handle_t handle = g->create_handle("GATTACA");
+            
+            REQUIRE(g->get_is_reverse(handle) == false);
+            REQUIRE(g->get_sequence(handle) == "GATTACA");
+            REQUIRE(g->get_handle(g->get_id(handle)) == handle);
+            
+            
+            SECTION("Another node can be added") {
+                handle_t handle2 = g->create_handle("CATTAG");
+                
+                REQUIRE(g->get_is_reverse(handle2) == false);
+                REQUIRE(g->get_sequence(handle2) == "CATTAG");
+                REQUIRE(g->get_handle(g->get_id(handle2)) == handle2);
+                
+                SECTION("The graph finds the right number of nodes") {
+                    size_t node_count = 0;
+                    g->for_each_handle([&](const handle_t& ignored) {
+                        node_count++;
+                    });
+                    REQUIRE(node_count == 2);
+                }
+                
+                SECTION("No edges exist by default") {
+                    
+                    // Grab all the edges            
+                    vector<pair<handle_t, handle_t>> edges;
+                    g->follow_edges(handle, false, [&](const handle_t& other) {
+                        edges.push_back(g->edge_handle(handle, other));
+                    });
+                    g->follow_edges(handle, true, [&](const handle_t& other) {
+                        edges.push_back(g->edge_handle(handle, other));
+                    });
+                    
+                    REQUIRE(edges.size() == 0);    
+                    
+                }
+                
+                SECTION("Edges can be added") {
+
+                    // Test deduplication
+                    g->create_edge(handle, handle2);
+                    g->create_edge(g->flip(handle2), g->flip(handle));
+                    g->create_edge(handle, handle2);
+
+                    // Grab all the edges            
+                    vector<pair<handle_t, handle_t>> edges;
+                    g->follow_edges(handle, false, [&](const handle_t& other) {
+                        edges.push_back(g->edge_handle(handle, other));
+                    });
+                    g->follow_edges(handle, true, [&](const handle_t& other) {
+                        edges.push_back(g->edge_handle(handle, other));
+                    });
+                    
+                    REQUIRE(edges.size() == 1);
+                    REQUIRE(edges.front() == make_pair(handle, handle2));
+                
+                }
+                
+            }
+        }
+    }
+    
+    
+}
+
 }
 }

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -152,6 +152,156 @@ void VG::for_each_handle(const function<bool(const handle_t&)>& iteratee) const 
     }
 }
 
+handle_t VG::create_handle(const string& sequence) {
+    Node* node = create_node(sequence);
+    return get_handle(node->id(), false);
+}
+
+void VG::destroy_handle(const handle_t& handle) {
+    destroy_node(get_id(handle));
+    // TODO: does destroy_node update paths?
+}
+
+void VG::create_edge(const handle_t& left, const handle_t& right) {
+    create_edge(get_node(get_id(left)), get_node(get_id(right)),
+        get_is_reverse(left), get_is_reverse(right));
+}
+    
+void VG::destroy_edge(const handle_t& left, const handle_t& right) {
+    // Convert to NodeSides and find the edge between them
+    Edge* found = get_edge(NodeSide(get_id(left), !get_is_reverse(left)),
+        NodeSide(get_id(right), get_is_reverse(right)));
+    if (found != nullptr) {
+        // If there is one, destroy it.
+        destroy_edge(found);
+        // TODO: does destroy_edge update paths?
+    }
+}
+
+void VG::swap_handles(const handle_t& a, const handle_t& b) {
+    swap_nodes(get_node(get_id(a)), get_node(get_id(b)));
+}
+
+handle_t VG::apply_orientation(const handle_t& handle) {
+    if (!get_is_reverse(handle)) {
+        // Nothing to do!
+        return handle;
+    }
+    
+    // Otherwise we need to reverse it
+
+    // Grab a handle to the reverse version that exists now.
+    handle_t rev_handle = flip(handle);
+    
+    // Find all the edges (including self loops)
+    
+    // We represent self loops with the (soon to be invalidated) forward and
+    // reverse handles to the node we're flipping.
+    vector<handle_t> left_nodes;
+    vector<handle_t> right_nodes;
+    
+    auto lambda1 = [&](const handle_t& other) -> void {
+        right_nodes.push_back(other);
+        return;
+    };
+    
+    auto lambda2 = [&](const handle_t& other) -> void {
+        left_nodes.push_back(other);
+        return;
+    };
+    
+    this->HandleGraph::template follow_edges<decltype(lambda1)>(handle, false, std::move(lambda1));
+    this->HandleGraph::template follow_edges<decltype(lambda2)>(handle, true, std::move(lambda2));
+    
+    // Remove them
+    for (auto& left : left_nodes) {
+        destroy_edge(left, handle);
+    }
+    for (auto& right : right_nodes) {
+        destroy_edge(handle, right);
+    }
+    
+    // Reverse complement the sequence
+    string new_sequence = reverse_complement(get_sequence(handle));
+    
+    // Save the ID to reuse
+    id_t id = get_id(handle);
+    
+    // Remove the old node (without destroying the paths???)
+    destroy_handle(handle);
+    
+    // Create a new node, re-using the ID
+    Node* new_node = create_node(new_sequence, id);
+    handle_t new_handle = get_handle(id, false);
+    
+    // Connect up the new node
+    for (handle_t left : left_nodes) {
+        if (left == handle) {
+            // Actually go to the reverse of the new handle
+            left = flip(new_handle);
+        } else if (left == rev_handle) {
+            // Actually go to the new handle forward
+            left = new_handle;
+        }
+        
+        create_edge(left, new_handle);
+    }
+    
+    for (handle_t right : right_nodes) {
+        if (right == handle) {
+            // Actually go to the reverse of the new handle
+            right = flip(new_handle);
+        } else if (right == rev_handle) {
+            // Actually go to the new handle forward
+            right = new_handle;
+        }
+        
+        create_edge(new_handle, right);
+    }
+    
+    // TODO: Fix up the paths
+    return new_handle;
+    
+}
+
+vector<handle_t> VG::divide_handle(const handle_t& handle, const vector<size_t>& offsets) {
+    Node* node = get_node(get_id(handle));
+    bool reverse = get_is_reverse(handle);
+    
+    // We need to convert vector types
+    vector<int> int_offsets;
+    if (reverse) {
+        // We need to fill in the vector of offsets from the end of the node.
+        
+        auto node_size = get_length(handle);
+        
+        for (auto it = offsets.rbegin(); it != offsets.rend(); ++it) {
+            // Flip the order around, and also measure from the other end
+            int_offsets.push_back(node_size - *it);
+        }
+    } else {
+        // Just blit over the offsets
+        int_offsets = vector<int>(offsets.begin(), offsets.end());
+    }
+    
+    // Populate this parts vector by doing the division
+    vector<Node*> parts;
+    divide_node( node, int_offsets, parts);
+    
+    vector<handle_t> to_return;
+    for (Node* n : parts) {
+        // Copy the nodes into handles in their final orientation
+        to_return.push_back(get_handle(n->id(), reverse));
+    }
+    if (reverse) {
+        // And make sure they are in the right order
+        std::reverse(to_return.begin(), to_return.end());
+    }
+    
+    return to_return;
+    
+}
+
 void VG::clear_paths(void) {
     paths.clear();
     graph.clear_path(); // paths.clear() should do this too

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -200,18 +200,15 @@ handle_t VG::apply_orientation(const handle_t& handle) {
     vector<handle_t> left_nodes;
     vector<handle_t> right_nodes;
     
-    auto lambda1 = [&](const handle_t& other) -> void {
+    follow_edges(handle, false, [&](const handle_t& other) -> void {
         right_nodes.push_back(other);
         return;
-    };
+    });
     
-    auto lambda2 = [&](const handle_t& other) -> void {
+    follow_edges(handle, true, [&](const handle_t& other) -> void {
         left_nodes.push_back(other);
         return;
-    };
-    
-    this->HandleGraph::template follow_edges<decltype(lambda1)>(handle, false, std::move(lambda1));
-    this->HandleGraph::template follow_edges<decltype(lambda2)>(handle, true, std::move(lambda2));
+    });
     
     // Remove them
     for (auto& left : left_nodes) {

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -221,8 +221,9 @@ handle_t VG::apply_orientation(const handle_t& handle) {
         destroy_edge(handle, right);
     }
     
-    // Reverse complement the sequence
-    string new_sequence = reverse_complement(get_sequence(handle));
+    // Copy the sequence from the reverse view of the node to become its locally
+    // forward sequence.
+    string new_sequence = get_sequence(handle);
     
     // Save the ID to reuse
     id_t id = get_id(handle);

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -140,6 +140,18 @@ void VG::follow_edges(const handle_t& handle, bool go_left, const function<bool(
     }
 }
 
+void VG::for_each_handle(const function<bool(const handle_t&)>& iteratee) const {
+    for (id_t i = 0; i < graph.node_size(); ++i) {
+        // For each node in the backing graph
+        // Get its ID and make a handle to it forward
+        // And pass it to the iteratee
+        if (!iteratee(get_handle(graph.node(i).id(), false))) {
+            // Iteratee stopped
+            return;
+        }
+    }
+}
+
 void VG::clear_paths(void) {
     paths.clear();
     graph.clear_path(); // paths.clear() should do this too

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -83,7 +83,7 @@ namespace vg {
  * However, edges can connect to either the start or end of either node.
  *
  */
-class VG : public Progressive, public HandleGraph {
+class VG : public Progressive, public WritableHandleGraph {
 
 public:
 
@@ -118,6 +118,43 @@ public:
     /// Loop over all the nodes in the graph in their local forward
     /// orientations, in their internal stored order. Stop if the iteratee returns false.
     virtual void for_each_handle(const function<bool(const handle_t&)>& iteratee) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Writable handle-based interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Create a new node with the given sequence and return the handle.
+    virtual handle_t create_handle(const string& sequence);
+    
+    /// Remove the node belonging to the given handle and all of its edges.
+    virtual void destroy_handle(const handle_t& handle);
+    
+    /// Create an edge connecting the given handles in the given order and orientations.
+    virtual void create_edge(const handle_t& left, const handle_t& right);
+    
+    /// Remove the edge connecting the given handles in the given order and orientations.
+    virtual void destroy_edge(const handle_t& left, const handle_t& right);
+    
+    /// Swap the nodes corresponding to the given handles, in the ordering used
+    /// by for_each_handle when looping over the graph. Other handles to the
+    /// nodes being swapped must not be invalidated.
+    virtual void swap_handles(const handle_t& a, const handle_t& b);
+    
+    /// Alter the node that the given handle corresponds to so the orientation
+    /// indicated by the handle becomes the node's local forward orientation.
+    /// Rewrites all edges pointing to the node and the node's sequence to
+    /// reflect this. Invalidates all handles to the node (including the one
+    /// passed). Returns a new, valid handle to the node in its new forward
+    /// orientation. Note that it is possible for the node's ID to change.
+    virtual handle_t apply_orientation(const handle_t& handle);
+    
+    /// Split a handle's underlying node at the given offsets in the handle's
+    /// orientation. Returns all of the handles to the parts. Other handles to
+    /// the node being split may be invalidated. The split pieces stay in the
+    /// same local forward orientation as the original node, but the returned
+    /// handles come in the order and orientation appropriate for the handle
+    /// passed in.
+    virtual vector<handle_t> divide_handle(const handle_t& handle, const vector<size_t>& offsets);
     
 private:
     // We have some masks for cramming things into handles
@@ -781,7 +818,7 @@ public:
     Edge* get_edge(const pair<NodeSide, NodeSide>& sides);
     /// Get the edge connecting the given oriented nodes in the given order.
     Edge* get_edge(const NodeTraversal& left, const NodeTraversal& right);
-    /// Festroy the edge at the given pointer. This pointer must point to an edge owned by the graph.
+    /// Destroy the edge at the given pointer. This pointer must point to an edge owned by the graph.
     void destroy_edge(Edge* edge);
     /// Destroy the edge between the given sides of nodes. These can be in either order.
     void destroy_edge(const NodeSide& side1, const NodeSide& side2);

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -115,6 +115,10 @@ public:
     /// continue.
     virtual void follow_edges(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const;
     
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee returns false.
+    virtual void for_each_handle(const function<bool(const handle_t&)>& iteratee) const;
+    
 private:
     // We have some masks for cramming things into handles
     const static size_t HIGH_BIT = (size_t)1 << 63;

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -115,9 +115,15 @@ public:
     /// continue.
     virtual void follow_edges(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const;
     
+    // Copy over the template for nice calls
+    using HandleGraph::follow_edges;
+    
     /// Loop over all the nodes in the graph in their local forward
     /// orientations, in their internal stored order. Stop if the iteratee returns false.
     virtual void for_each_handle(const function<bool(const handle_t&)>& iteratee) const;
+    
+    // Copy over the template for nice calls
+    using HandleGraph::for_each_handle;
     
     ////////////////////////////////////////////////////////////////////////////
     // Mutable handle-based interface

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -83,7 +83,7 @@ namespace vg {
  * However, edges can connect to either the start or end of either node.
  *
  */
-class VG : public Progressive, public WritableHandleGraph {
+class VG : public Progressive, public MutableHandleGraph {
 
 public:
 
@@ -120,7 +120,7 @@ public:
     virtual void for_each_handle(const function<bool(const handle_t&)>& iteratee) const;
     
     ////////////////////////////////////////////////////////////////////////////
-    // Writable handle-based interface
+    // Mutable handle-based interface
     ////////////////////////////////////////////////////////////////////////////
     
     /// Create a new node with the given sequence and return the handle.

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1672,7 +1672,8 @@ void XG::for_each_handle(const function<bool(const handle_t&)>& iteratee) const 
     for (size_t g = 0; g < g_iv.size(); g += entry_size) {
         // Make the handle
         // We need to make sure our index won't set the orientation bit.
-        assert(g & (~LOW_BITS) == 0);
+        assert((g & (~LOW_BITS)) == 0);
+        
         // Just make it into a handle; we're always forward.
         handle_t handle = as_handle(g);
         
@@ -1687,7 +1688,7 @@ void XG::for_each_handle(const function<bool(const handle_t&)>& iteratee) const 
         size_t edges_from_count = g_iv[g + G_NODE_FROM_COUNT_OFFSET];
         
         // This record is the header plus all the edge records it contains
-        entry_size = G_NODE_HEADER_LENGTH + G_EDGE_OFFSET_OFFSET * (edges_to_count + edges_from_count);
+        entry_size = G_NODE_HEADER_LENGTH + G_EDGE_LENGTH * (edges_to_count + edges_from_count);
     }
 }
 

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1666,6 +1666,31 @@ void XG::follow_edges(const handle_t& handle, bool go_left, const function<bool(
     }
 }
 
+void XG::for_each_handle(const function<bool(const handle_t&)>& iteratee) const {
+    // How big is the g vector entry size we are on?
+    size_t entry_size = 0;
+    for (size_t g = 0; g < g_iv.size(); g += entry_size) {
+        // Make the handle
+        // We need to make sure our index won't set the orientation bit.
+        assert(g & (~LOW_BITS) == 0);
+        // Just make it into a handle; we're always forward.
+        handle_t handle = as_handle(g);
+        
+        // Run the iteratee
+        if (!iteratee(handle)) {
+            // The iteratee is bored and wants to stop.
+            return;
+        }
+    
+        // How many edges are there of each type on this record?
+        size_t edges_to_count = g_iv[g + G_NODE_TO_COUNT_OFFSET];
+        size_t edges_from_count = g_iv[g + G_NODE_FROM_COUNT_OFFSET];
+        
+        // This record is the header plus all the edge records it contains
+        entry_size = G_NODE_HEADER_LENGTH + G_EDGE_OFFSET_OFFSET * (edges_to_count + edges_from_count);
+    }
+}
+
 vector<Edge> XG::edges_of(int64_t id) const {
     auto e1 = edges_to(id);
     auto e2 = edges_from(id);

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -226,6 +226,9 @@ public:
     /// them to a callback which returns false to stop iterating and true to
     /// continue.
     virtual void follow_edges(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const;
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee returns false.
+    virtual void for_each_handle(const function<bool(const handle_t&)>& iteratee) const;
 
     ////////////////////////////////////////////////////////////////////////////
     // Higher-level graph API


### PR DESCRIPTION
Here's an interface and (as yet incomplete) `vg::VG` implementation for a `MutableHandleGraph`.

The implementation needs work because it doesn't do what the interface says it needs to do with respect to paths, and the interface would be nice if it didn't require the implementer to pull in templates with using to get around the inability to dispatch overloads on `std::function` template parameters until C++14, but it can definitely be merged without actually breaking anything.

Can we upgrade to C++14?

Fixes #1124, although it still could use some polishing.