### PR TITLE
Add a way to set the distribution for mpmap

### DIFF
--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -39,6 +39,8 @@ void help_mpmap(char** argv) {
     << "  -U, --snarl-max-cut INT   do not align to alternate paths in a snarl if an exact match is at least this long (0 for no limit) [5]" << endl
     << "  -a, --alt-paths INT       align to (up to) this many alternate paths in between MEMs or in snarls [4]" << endl
     << "  -b, --frag-sample INT     look for this many unambiguous mappings to estimate the fragment length distribution [1000]" << endl
+    << "  -I, --frag-mean           mean for fixed fragment length distribution" << endl
+    << "  -D, --frag-stddev         standard deviation for fixed fragment length distribution" << endl
     << "  -v, --mq-method OPT       mapping quality method: 0 - none, 1 - fast approximation, 2 - exact [1]" << endl
     << "  -Q, --mq-max OPT          cap mapping quality estimates at this much [60]" << endl
     << "  -p, --band-padding INT    pad dynamic programming bands in inter-MEM alignment by this much [2]" << endl
@@ -108,6 +110,8 @@ int main_mpmap(int argc, char** argv) {
     int max_mapq = 60;
     size_t frag_length_sample_size = 1000;
     double frag_length_robustness_fraction = 0.95;
+    double frag_length_mean = NAN;
+    double frag_length_stddev = NAN;
     bool same_strand = false;
     
     int c;
@@ -127,6 +131,8 @@ int main_mpmap(int argc, char** argv) {
             {"snarl-max-cut", required_argument, 0, 'U'},
             {"alt-paths", required_argument, 0, 'a'},
             {"frag-sample", required_argument, 0, 'b'},
+            {"frag-mean", required_argument, 0, 'I'},
+            {"frag-stddev", required_argument, 0, 'D'},
             {"mq-method", required_argument, 0, 'v'},
             {"mq-max", required_argument, 0, 'Q'},
             {"band-padding", required_argument, 0, 'p'},
@@ -154,7 +160,7 @@ int main_mpmap(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:f:G:ieSs:u:a:b:v:Q:p:M:r:W:k:K:c:d:w:C:R:q:z:o:y:L:mAt:Z:",
+        c = getopt_long (argc, argv, "hx:g:f:G:ieSs:u:a:b:I:D:v:Q:p:M:r:W:k:K:c:d:w:C:R:q:z:o:y:L:mAt:Z:",
                          long_options, &option_index);
 
 
@@ -239,6 +245,14 @@ int main_mpmap(int argc, char** argv) {
                 
             case 'b':
                 frag_length_sample_size = atoi(optarg);
+                break;
+                
+            case 'I':
+                frag_length_mean = atof(optarg);
+                break;
+                
+            case 'D':
+                frag_length_stddev = atof(optarg);
                 break;
                 
             case 'v':
@@ -365,6 +379,21 @@ int main_mpmap(int argc, char** argv) {
     }
     
     // check for valid parameters
+    
+    if (std::isnan(frag_length_mean) != std::isnan(frag_length_stddev)) {
+        cerr << "error:[vg mpmap] Cannot specify only one of fragment length mean (-I) and standard deviation (-D)." << endl;
+        exit(1);
+    }
+    
+    if (!std::isnan(frag_length_mean) && frag_length_mean < 0) {
+        cerr << "error:[vg mpmap] Fragment length mean (-I) must be nonnegative." << endl;
+        exit(1);
+    }
+    
+    if (!std::isnan(frag_length_stddev) && frag_length_stddev < 0) {
+        cerr << "error:[vg mpmap] Fragment length standard deviation (-D) must be nonnegative." << endl;
+        exit(1);
+    }
     
     if (interleaved_input && !fastq_name_2.empty()) {
         cerr << "error:[vg mpmap] Cannot designate both interleaved paired ends (-i) and separate paired end file (-f)." << endl;
@@ -597,9 +626,14 @@ int main_mpmap(int argc, char** argv) {
             buffer_size++;
         }
         
-        // ensure deterministic fragment length estimation by temporarily switching to single-threaded mode
-        multipath_mapper.set_fragment_length_distr_params(frag_length_sample_size, frag_length_sample_size,
-                                                          frag_length_robustness_fraction, true);
+        if (!std::isnan(frag_length_mean) && !std::isnan(frag_length_stddev)) {
+            // Force a fragment length distribution
+            multipath_mapper.force_fragment_length_distr(frag_length_mean, frag_length_stddev);
+        } else {
+            // ensure deterministic fragment length estimation by temporarily switching to single-threaded mode
+            multipath_mapper.set_fragment_length_distr_params(frag_length_sample_size, frag_length_sample_size,
+                                                              frag_length_robustness_fraction, true);
+        }
     }
     
     // note: sufficient to have only one buffer because fragment length distribution enforces single threaded mode

--- a/test/t/33_vg_mpmap.t
+++ b/test/t/33_vg_mpmap.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 3
+
+vg index -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -k 16 graphs/refonly-lrc_kir.vg
+
+vg mpmap -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -I 10 -D 50 -S | vg view -aj -  > temp_paired_alignment.json
+vg mpmap -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -I 100000 -D 5 -S | vg view -aj -  > temp_distant_alignment.json
+vg mpmap -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -i -S | vg view -aj - > temp_independent_alignment.json
+paired_score=$(jq -r ".score" < temp_paired_alignment.json | awk '{ sum+=$1} END {print sum}')
+independent_score=$(jq -r ".score" < temp_independent_alignment.json | awk '{ sum+=$1} END {print sum}')
+is $(printf "%s\t%s\n" $paired_score $independent_score | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be consistent have lower score than unrestricted alignments"
+
+paired_range=$(jq -r ".path.mapping[0].position.node_id" <  temp_paired_alignment.json | sort | rs -T | awk '{print ($2 - $1)}')
+distant_range=$(jq -r ".path.mapping[0].position.node_id" <  temp_distant_alignment.json | sort | rs -T | awk '{print ($2 - $1)}')
+independent_range=$(jq -r ".path.mapping[0].position.node_id" <  temp_independent_alignment.json | sort | rs -T | awk '{print ($2 - $1)}')
+is $(printf "%s\t%s\n" $paired_range $independent_range | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be consistent are closer together in node id space than unrestricted alignments"
+is $(printf "%s\t%s\n" $paired_range $distant_range | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be near each other are closer together in node id space than those forced to be far apart"
+
+rm temp_paired_alignment.json temp_independent_alignment.json
+
+rm -f graphs/refonly-lrc_kir.vg.xg graphs/refonly-lrc_kir.vg.gcsa graphs/refonly-lrc_kir.vg.gcsa.lcp


### PR DESCRIPTION
We also probably want to hint the distribution during the snp1kg test so that we get a runtime more comparable to the other cases.

Fixes #1111 