### PR TITLE
No more empty edits in MultipathAlignments from mpmap

### DIFF
--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -59,7 +59,9 @@ void BandedGlobalAligner<IntType>::BABuilder::update_state(matrix_t matrix, Node
         cerr << "[BABuilder::update_state] transitioning into a new matrix" << endl;
 #endif
         // transitioned into another matrix, finish current edit and begin new one
-        finish_current_edit();
+        if (!empty_node_seq) {
+            finish_current_edit();
+        }
         matrix_state = matrix;
         if (matrix_state == Match) {
             matching = (alignment.sequence()[read_idx] == current_node->sequence()[node_idx]);
@@ -84,7 +86,7 @@ void BandedGlobalAligner<IntType>::BABuilder::update_state(matrix_t matrix, Node
     }
     
 #ifdef debug_banded_aligner_traceback
-    cerr << "[BABuilder::update_state] finished updating state, matrix is " << (matrix_state == Match ? "match" : (matrix_state == InsertRow ? "insert column" : "insert row" )) << ", is matching? " << (matching ? "yes" : "no") << ", edit length " << edit_length << ", edit end index (on read) " << edit_read_end_idx << ", current node " << current_node->id() << endl;
+    cerr << "[BABuilder::update_state] finished updating state, matrix is " << (matrix_state == Match ? "match" : (matrix_state == InsertRow ? "insert row" : "insert column" )) << ", is matching? " << (matching ? "yes" : "no") << ", edit length " << edit_length << ", edit end index (on read) " << edit_read_end_idx << ", current node " << current_node->id() << endl;
 #endif
 }
 
@@ -1579,7 +1581,8 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
             cerr << "[BAMatrix::traceback_internal] initial row gaps are present, adding read char " << top_diag + i - 1 << ": " << read[top_diag + i - 1] << endl;
 #endif
             i--;
-            builder.update_state(InsertRow, empty_source_path.empty() ? node : empty_source_path.back()->node, i + top_diag, -1);
+            Node* end_node = empty_source_path.empty() ? node : empty_source_path.back()->node;
+            builder.update_state(InsertRow, end_node, i + top_diag, -1, end_node->sequence().empty());
         }
         return;
     }

--- a/src/unittest/banded_global_aligner.cpp
+++ b/src/unittest/banded_global_aligner.cpp
@@ -3408,6 +3408,35 @@ namespace vg {
                 REQUIRE(found_first_opt);
                 REQUIRE(found_second_opt);
             }
+            
+            
+            
+            SECTION( "Banded global aligner does not produce empty edits when there is an insertion an empty node") {
+                string graph_json = R"({"edge": [{"to_end": true, "from_start": true, "to": 22, "from": 20}, {"to": 26, "from": 20}, {"to": 24, "from": 20}, {"to_end": true, "from_start": true, "to": 26, "from": 4}, {"to_end": true, "from_start": true, "to": 24, "from": 4}], "node": [{"sequence": "C", "id": 24}, {"sequence": "GAGA", "id": 20}, {"sequence": "T", "id": 26}, {"sequence": "GGAGTCT", "id": 4}, {"id": 22}]})";
+                
+                Graph graph;
+                json2pb(graph, graph_json.c_str(), graph_json.size());
+                
+                Aligner aligner;
+                
+                string read = "TTTTGATGGAGGCC";
+                Alignment aln;
+                aln.set_sequence(read);
+                
+                int band_width = 1;
+                bool permissive_banding = true;
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
+                
+                const Path& p = aln.path();
+                for (int i = 0; i < p.mapping_size();i++) {
+                    const auto& m = p.mapping(i);
+                    for (int j = 0; j < m.edit_size(); j++) {
+                        const auto& e = m.edit(j);
+                        bool empty = e.to_length() == 0 && e.from_length() == 0;
+                        REQUIRE(!empty);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed a bug in the banded global aligner that could cause empty edits when the graph had empty nodes. Resolves issue discussed in https://github.com/vgteam/vg/pull/1129