### PR TITLE
Fix multithreading in mpmap paired end mapping

### DIFF
--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -30,9 +30,24 @@ size_t fastq_unpaired_for_each(const string& filename, function<void(Alignment&)
 size_t fastq_paired_interleaved_for_each(const string& filename, function<void(Alignment&, Alignment&)> lambda);
 size_t fastq_paired_two_files_for_each(const string& file1, const string& file2, function<void(Alignment&, Alignment&)> lambda);
 // parallel versions of above
-size_t fastq_unpaired_for_each_parallel(const string& filename, function<void(Alignment&)> lambda);
-size_t fastq_paired_interleaved_for_each_parallel(const string& filename, function<void(Alignment&, Alignment&)> lambda);
-size_t fastq_paired_two_files_for_each_parallel(const string& file1, const string& file2, function<void(Alignment&, Alignment&)> lambda);
+size_t fastq_unpaired_for_each_parallel(const string& filename,
+                                        function<void(Alignment&)> lambda);
+    
+size_t fastq_paired_interleaved_for_each_parallel(const string& filename,
+                                                  function<void(Alignment&, Alignment&)> lambda);
+    
+size_t fastq_paired_interleaved_for_each_parallel_after_wait(const string& filename,
+                                                             function<void(Alignment&, Alignment&)> lambda,
+                                                             function<bool(void)> wait_until_true,
+                                                             function<void(void)> call_on_complete);
+    
+size_t fastq_paired_two_files_for_each_parallel(const string& file1, const string& file2,
+                                                function<void(Alignment&, Alignment&)> lambda);
+    
+size_t fastq_paired_two_files_for_each_parallel_after_wait(const string& file1, const string& file2,
+                                                           function<void(Alignment&, Alignment&)> lambda,
+                                                           function<bool(void)> wait_until_true,
+                                                           function<void(void)> call_on_complete);
 
 bam_hdr_t* hts_file_header(string& filename, string& header);
 bam_hdr_t* hts_string_header(string& header,

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -98,14 +98,6 @@ public:
     /// Instead of estimating anything, just use these parameters.
     void force_parameters(double mean, double stddev);
     
-    /// Switches the entire program to single-threaded mode until reaching the maximum
-    /// sample size so that estimation is deterministic. After reaching the maximum, the
-    /// thread count is automatically switched back.
-    void determinize_estimation();
-    
-    /// Manually switches back to multithreaded mode
-    void unlock_determinization();
-    
     /// Record an observed fragment length
     void register_fragment_length(int64_t length);
 
@@ -145,8 +137,6 @@ private:
     double mu = 0.0;
     double sigma = 1.0;
     
-    int multithread_reset = 0;
-    
     void estimate_distribution();
 };
     
@@ -166,7 +156,7 @@ public:
     
     // TODO: setting alignment threads could mess up the internal memory for how many threads to reset to
     void set_fragment_length_distr_params(size_t maximum_sample_size = 1000, size_t reestimation_frequency = 1000,
-                                          double robust_estimation_fraction = 0.95, bool deterministic = true);
+                                          double robust_estimation_fraction = 0.95);
     
     /// Set the alignment thread count, updating internal data structures that
     /// are per thread. Note that this resets aligner scores to their default values!
@@ -176,9 +166,6 @@ public:
     
     /// Returns true if fragment length distribution has been fixed
     bool has_fixed_fragment_length_distr();
-    
-    /// Gives up on deterministic estimation regardless of whether the distribution has been fixed
-    void abandon_fragment_length_distr();
     
     /// Use the given fragment length distribution parameters instead of
     /// estimating them.

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -233,13 +233,13 @@ namespace vg {
             
 #ifdef debug_multipath_mapper
             cerr << "single ended mappings achieves scores " << optimal_alignment_score(multipath_aln_1) << " and " << optimal_alignment_score(multipath_aln_2) << ", looking for scores " << .8 * max_score_1 << " and " << .8 * max_score_2 << endl;
-            cerr << "single ended mappings achieves mapping qualities " << multipath_aln_1.mapping_quality() << " and " << multipath_aln_2.mapping_quality() << ", looking for mapq " << min(max_mapping_quality, 60) << endl;
+            cerr << "single ended mappings achieves mapping qualities " << multipath_aln_1.mapping_quality() << " and " << multipath_aln_2.mapping_quality() << ", looking for mapq " << min(max_mapping_quality, 45) << endl;
 #endif
             
             // are these reads unambiguously mapped and well-aligned?
             // TODO: i don't like having constants floating around in here
-            if (multipath_aln_1.mapping_quality() >= min(max_mapping_quality, 60)
-                && multipath_aln_2.mapping_quality() >= min(max_mapping_quality, 60)
+            if (multipath_aln_1.mapping_quality() >= min(max_mapping_quality, 45)
+                && multipath_aln_2.mapping_quality() >= min(max_mapping_quality, 45)
                 && optimal_alignment_score(multipath_aln_1) >= .8 * max_score_1
                 && optimal_alignment_score(multipath_aln_2) >= .8 * max_score_2) {
                 

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -607,7 +607,7 @@ int main_mpmap(int argc, char** argv) {
         
         // ensure deterministic fragment length estimation by temporarily switching to single-threaded mode
         multipath_mapper.set_fragment_length_distr_params(frag_length_sample_size, frag_length_sample_size,
-                                                          frag_length_robustness_fraction, true);
+                                                          frag_length_robustness_fraction);
     }
     
 #ifdef record_read_run_times
@@ -737,16 +737,35 @@ int main_mpmap(int argc, char** argv) {
 #endif
     };
     
+    // for FASTQ input all but the first thread go into spinlock until the distribution is estimated or abandoned
+    bool input_finished = false;
+    function<bool(void)> distribution_spinlock = [&](void) {
+        return omp_get_thread_num() == 0 || multipath_mapper.has_fixed_fragment_length_distr() || input_finished;
+    };
+    
+    // mark the input as finished to get any remaining threads out of the spinlock
+    function<void(void)> abandon_distribution = [&](void) {
+        input_finished = true;
+    };
+    
+    // for GAM input, don't spawn new tasks unless this evalutes to true
+    function<bool(void)> multi_threaded_condition = [&](void) {
+        return multipath_mapper.has_fixed_fragment_length_distr();
+    };
+    
+    
     // FASTQ input
     if (!fastq_name_1.empty()) {
         if (interleaved_input) {
-            fastq_paired_interleaved_for_each_parallel(fastq_name_1, do_paired_alignments);
+            fastq_paired_interleaved_for_each_parallel_after_wait(fastq_name_1, do_paired_alignments,
+                                                                  distribution_spinlock, abandon_distribution);
         }
         else if (fastq_name_2.empty()) {
             fastq_unpaired_for_each_parallel(fastq_name_1, do_unpaired_alignments);
         }
         else {
-            fastq_paired_two_files_for_each_parallel(fastq_name_1, fastq_name_2, do_paired_alignments);
+            fastq_paired_two_files_for_each_parallel_after_wait(fastq_name_1, fastq_name_2, do_paired_alignments,
+                                                                distribution_spinlock, abandon_distribution);
         }
     }
     
@@ -758,7 +777,8 @@ int main_mpmap(int argc, char** argv) {
                 exit(1);
             }
             if (interleaved_input) {
-                stream::for_each_interleaved_pair_parallel(gam_in, do_paired_alignments);
+                stream::for_each_interleaved_pair_parallel_after_wait(gam_in, do_paired_alignments,
+                                                                      multi_threaded_condition);
             }
             else {
                 stream::for_each_parallel(gam_in, do_unpaired_alignments);
@@ -786,9 +806,6 @@ int main_mpmap(int argc, char** argv) {
         }
         else {
             cerr << "warning:[vg mpmap] Could not find " << frag_length_sample_size << " unambiguous read pair mappings to estimate fragment length ditribution. Mapping read pairs as independent single ended reads. Consider decreasing sample size (-b)." << endl;
-            
-            // force reversion to multithreaded mode
-            multipath_mapper.abandon_fragment_length_distr();
             
 #pragma omp parallel for
             for (size_t i = 0; i < ambiguous_pair_buffer.size(); i++) {

--- a/src/unittest/multipath_mapper.cpp
+++ b/src/unittest/multipath_mapper.cpp
@@ -324,7 +324,7 @@ TEST_CASE( "MultipathMapper can map to a one-node graph", "[multipath][mapping][
     mapper.max_mapping_quality = 10;
     // In case we're using compile time forced fragment length distribution, set a max sample
     // size
-    mapper.set_fragment_length_distr_params(10, 10, .95, true);
+    mapper.set_fragment_length_distr_params(10, 10, .95);
     
     SECTION( "MultipathMapper can map a short fake read" ) {
 
@@ -475,7 +475,7 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
     mapper.max_mapping_quality = 10;
     // In case we're using compile time forced fragment length distribution, set a max sample
     // size
-    mapper.set_fragment_length_distr_params(10, 10, .95, true);
+    mapper.set_fragment_length_distr_params(10, 10, .95);
     
     SECTION( "topologically_order_subpaths works within a node" ) {
     


### PR DESCRIPTION
Another premature PR from https://github.com/vgteam/vg/pull/1145. Edits the parallel functions for FASTQ and GAM so that they have the option to switch from single threaded to multithreaded mode. Before the multithreading on mpmap paired end mapping wasn't working, so it ran in single threaded the entire run.