### PR TITLE
Turn the main MHC test back on and add Cactus to it

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -949,8 +949,7 @@ class VGCITest(TestCase):
         """ Mapping and calling bakeoff F1 test for MHC primary graph """
         log.info("Test start at {}".format(datetime.now()))        
         self._test_mapeval(100000, 'MHC', 'snp1kg',
-                           ['primary', 'snp1kg', 'cactus'],
-                           score_baseline_graph='primary',
+                           ['snp1kg', 'cactus'],
                            multipath=True,
                            sample='HG00096', acc_threshold=0.02, auc_threshold=0.02)
 

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -944,13 +944,12 @@ class VGCITest(TestCase):
                            score_baseline_graph='primary',
                            sample='HG00096', acc_threshold=0.02, auc_threshold=0.02)
                            
-    @skip("skipping test to keep runtime down")
     @timeout_decorator.timeout(3600)
     def test_sim_mhc_snp1kg(self):
         """ Mapping and calling bakeoff F1 test for MHC primary graph """
         log.info("Test start at {}".format(datetime.now()))        
         self._test_mapeval(100000, 'MHC', 'snp1kg',
-                           ['primary', 'snp1kg', 'common1kg'],
+                           ['primary', 'snp1kg', 'cactus'],
                            score_baseline_graph='primary',
                            positive_control='snp1kg_HG00096',
                            negative_control='snp1kg_minus_HG00096',

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -951,8 +951,7 @@ class VGCITest(TestCase):
         self._test_mapeval(100000, 'MHC', 'snp1kg',
                            ['primary', 'snp1kg', 'cactus'],
                            score_baseline_graph='primary',
-                           positive_control='snp1kg_HG00096',
-                           negative_control='snp1kg_minus_HG00096',
+                           multipath=True,
                            sample='HG00096', acc_threshold=0.02, auc_threshold=0.02)
 
     @timeout_decorator.timeout(16000)        


### PR DESCRIPTION
This means we have at least a basic cactus test, though in #1147 I want an actually-good Cactus test that doesn't just throw reads from ref-topology genomes at it.