### PR TITLE
Handle-based weakly_connected_components

### DIFF
--- a/src/algorithms/weakly_connected_components.cpp
+++ b/src/algorithms/weakly_connected_components.cpp
@@ -5,11 +5,10 @@ namespace algorithms {
 
 using namespace std;
 
-vector<unordered_set<handle_t>> weakly_connected_components(const HandleGraph* graph) {
-    // This only holds locally forward handles
-    vector<unordered_set<handle_t>> to_return;
+vector<unordered_set<id_t>> weakly_connected_components(const HandleGraph* graph) {
+    vector<unordered_set<id_t>> to_return;
     
-    // This only holds locally forward handles too
+    // This only holds locally forward handles
     unordered_set<handle_t> traversed;
     
     graph->for_each_handle([&](const handle_t& handle) {
@@ -30,7 +29,7 @@ vector<unordered_set<handle_t>> weakly_connected_components(const HandleGraph* g
             stack.pop_back();
             
             traversed.insert(here);
-            to_return.back().insert(here);
+            to_return.back().insert(graph->get_id(here));
             
             // We have a function to handle all connected handles
             auto handle_other = [&](const handle_t& other) {

--- a/src/algorithms/weakly_connected_components.cpp
+++ b/src/algorithms/weakly_connected_components.cpp
@@ -1,0 +1,55 @@
+#include "weakly_connected_components.hpp"
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+vector<unordered_set<handle_t>> weakly_connected_components(const HandleGraph* graph) {
+    // This only holds locally forward handles
+    vector<unordered_set<handle_t>> to_return;
+    
+    // This only holds locally forward handles too
+    unordered_set<handle_t> traversed;
+    
+    graph->for_each_handle([&](const handle_t& handle) {
+        
+        // Only think about it in the forward orientation
+        auto forward = graph->forward(handle);
+        
+        if (traversed.count(forward)) {
+            // Already have this node, so don't start a search from it.
+            return;
+        }
+        
+        // The stack only holds locally forward handles
+        vector<handle_t> stack{forward};
+        to_return.emplace_back();
+        while (!stack.empty()) {
+            handle_t here = stack.back();
+            stack.pop_back();
+            
+            traversed.insert(here);
+            to_return.back().insert(here);
+            
+            // We have a function to handle all connected handles
+            auto handle_other = [&](const handle_t& other) {
+                // Again, make it forward
+                auto other_forward = graph->forward(other);
+                
+                if (!traversed.count(other_forward)) {
+                    stack.push_back(other_forward);
+                }
+            };
+            
+            // Look at edges in both directions
+            graph->follow_edges(here, false, handle_other);
+            graph->follow_edges(here, true, handle_other);
+            
+        }
+    });
+    return to_return;
+}
+
+}
+}

--- a/src/algorithms/weakly_connected_components.hpp
+++ b/src/algorithms/weakly_connected_components.hpp
@@ -1,0 +1,29 @@
+#ifndef VG_ALGORITHMS_WEAKLY_CONNECTED_COMPONENTS_HPP_INCLUDED
+#define VG_ALGORITHMS_WEAKLY_CONNECTED_COMPONENTS_HPP_INCLUDED
+
+/**
+ * \file weakly_connected_components.hpp
+ *
+ * Defines an algorithm for finding weakly connected components in a graph.
+ */
+
+#include "../handle.hpp"
+
+#include <unordered_set>
+#include <vector>
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+/// Returns sets of handles defining components that are connected by any series
+/// of nodes and edges, even if it is not a valid bidirected walk. All handles
+/// returned are in the local forward orientation.
+vector<unordered_set<handle_t>> weakly_connected_components(const HandleGraph* graph);
+
+
+}
+}
+
+#endif

--- a/src/algorithms/weakly_connected_components.hpp
+++ b/src/algorithms/weakly_connected_components.hpp
@@ -18,7 +18,10 @@ namespace algorithms {
 using namespace std;
 
 /// Returns sets of handles defining components that are connected by any series
-/// of nodes and edges, even if it is not a valid bidirected walk.
+/// of nodes and edges, even if it is not a valid bidirected walk. TODO: It
+/// might make sense to have a handle-returning version, but the consumers of
+/// weakly connected components right now want IDs, and membership in a weakly
+/// connected component is orientation-independent.
 vector<unordered_set<id_t>> weakly_connected_components(const HandleGraph* graph);
 
 

--- a/src/algorithms/weakly_connected_components.hpp
+++ b/src/algorithms/weakly_connected_components.hpp
@@ -17,7 +17,7 @@ namespace algorithms {
 
 using namespace std;
 
-/// Returns sets of handles defining components that are connected by any series
+/// Returns sets of IDs defining components that are connected by any series
 /// of nodes and edges, even if it is not a valid bidirected walk. TODO: It
 /// might make sense to have a handle-returning version, but the consumers of
 /// weakly connected components right now want IDs, and membership in a weakly

--- a/src/algorithms/weakly_connected_components.hpp
+++ b/src/algorithms/weakly_connected_components.hpp
@@ -18,9 +18,8 @@ namespace algorithms {
 using namespace std;
 
 /// Returns sets of handles defining components that are connected by any series
-/// of nodes and edges, even if it is not a valid bidirected walk. All handles
-/// returned are in the local forward orientation.
-vector<unordered_set<handle_t>> weakly_connected_components(const HandleGraph* graph);
+/// of nodes and edges, even if it is not a valid bidirected walk.
+vector<unordered_set<id_t>> weakly_connected_components(const HandleGraph* graph);
 
 
 }

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -11,6 +11,7 @@
 #include "types.hpp"
 #include <functional>
 #include <cstdint>
+#include <vector>
 
 namespace vg {
 

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -22,6 +22,7 @@
 #include "algorithms/extract_connecting_graph.hpp"
 #include "algorithms/extract_extending_graph.hpp"
 #include "algorithms/topological_sort.hpp"
+#include "algorithms/weakly_connected_components.hpp"
 
 namespace vg {
     
@@ -866,7 +867,7 @@ namespace vg {
         
         size_t max_graph_idx = 0;
         for (const pair<size_t, VG*> cluster_graph : cluster_graphs) {
-            vector<unordered_set<id_t>> connected_components = cluster_graph.second->weakly_connected_components();
+            vector<unordered_set<id_t>> connected_components = algorithms::weakly_connected_components(cluster_graph.second);
             if (connected_components.size() > 1) {
                 multicomponent_graphs.emplace_back(cluster_graph.first, std::move(connected_components));
             }

--- a/src/subcommand/benchmark_main.cpp
+++ b/src/subcommand/benchmark_main.cpp
@@ -18,6 +18,7 @@
 #include "../xg.hpp"
 #include "../algorithms/extract_connecting_graph.hpp"
 #include "../algorithms/topological_sort.hpp"
+#include "../algorithms/weakly_connected_components.hpp"
 
 
 
@@ -125,6 +126,23 @@ int main_benchmark(int argc, char** argv) {
         vg_mut = vg;
     }, [&]() {
         algorithms::orient_nodes_forward(&vg_mut);
+    }));
+    
+    
+    results.push_back(run_benchmark("vg::algorithms weakly_connected_components", 1000, [&]() {
+        vg_mut = vg;
+    }, [&]() {
+        auto components = algorithms::weakly_connected_components(&vg_mut);
+        assert(components.size() == 1);
+        assert(components.front().size() == vg_mut.node_size());
+    }));
+    
+    results.push_back(run_benchmark("VG builtin weakly_connected_components", 1000, [&]() {
+        vg_mut = vg;
+    }, [&]() {
+        auto components = vg_mut.weakly_connected_components();
+        assert(components.size() == 1);
+        assert(components.front().size() == vg_mut.node_size());
     }));
     
     results.push_back(run_benchmark("VG::get_node", 1000, [&]() {

--- a/src/subcommand/benchmark_main.cpp
+++ b/src/subcommand/benchmark_main.cpp
@@ -130,19 +130,9 @@ int main_benchmark(int argc, char** argv) {
     
     
     results.push_back(run_benchmark("vg::algorithms weakly_connected_components", 1000, [&]() {
-        vg_mut = vg;
-    }, [&]() {
-        auto components = algorithms::weakly_connected_components(&vg_mut);
+        auto components = algorithms::weakly_connected_components(&vg);
         assert(components.size() == 1);
-        assert(components.front().size() == vg_mut.node_size());
-    }));
-    
-    results.push_back(run_benchmark("VG builtin weakly_connected_components", 1000, [&]() {
-        vg_mut = vg;
-    }, [&]() {
-        auto components = vg_mut.weakly_connected_components();
-        assert(components.size() == 1);
-        assert(components.front().size() == vg_mut.node_size());
+        assert(components.front().size() == vg.node_size());
     }));
     
     results.push_back(run_benchmark("VG::get_node", 1000, [&]() {
@@ -152,7 +142,6 @@ int main_benchmark(int argc, char** argv) {
             }
         }
     }));
-    
     
     results.push_back(run_benchmark("algorithms::extract_connecting_graph on xg", 1000, [&]() {
         pos_t pos_1 = make_pos_t(55, false, 0);

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -3616,38 +3616,6 @@ set<set<id_t> > VG::multinode_strongly_connected_components(void) {
     return components;
 }
     
-vector<unordered_set<id_t>> VG::weakly_connected_components(void) {
-    vector<unordered_set<id_t>> to_return;
-    
-    unordered_set<id_t> traversed;
-    
-    for (size_t i = 0; i < graph.node_size(); i++) {
-        id_t node_id = graph.node(i).id();
-        if (traversed.count(node_id)) {
-            continue;
-        }
-        
-        vector<id_t> stack{node_id};
-        to_return.emplace_back();
-        while (!stack.empty()) {
-            id_t id_here = stack.back();
-            stack.pop_back();
-            
-            traversed.insert(id_here);
-            to_return.back().insert(id_here);
-            for (Edge* edge : edges_of(get_node(id_here))) {
-                if (!traversed.count(edge->to())) {
-                    stack.push_back(edge->to());
-                }
-                if (!traversed.count(edge->from())) {
-                    stack.push_back(edge->from());
-                }
-            }
-        }
-    }
-    return to_return;
-}
-
 // keeping all components would be redundant, as every node is a self-component
 void VG::keep_multinode_strongly_connected_components(void) {
     unordered_set<id_t> keep;

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -300,9 +300,6 @@ public:
     set<set<id_t> > strongly_connected_components(void);
     /// Get only multi-node strongly connected components.
     set<set<id_t> > multinode_strongly_connected_components(void);
-    /// Returns the IDs of components that are connected by any series of nodes and edges,
-    /// even if it is not a valid bidirected walk.
-    vector<unordered_set<id_t>> weakly_connected_components(void);
     /// Returns true if the graph does not contain cycles.
     bool is_acyclic(void);
     /// Returns true if the graph does not contain a directed cycle (but it may contain a reversing cycle)


### PR DESCRIPTION
Closes #1154.


Definitely seems faster (maybe because we iterate over things instead of making lists of them?)

```
# Benchmark results for vg v1.5.0-1519-g7be3eee
# runs	test(us)	stddev(us)	control(us)	stddev(us)	score	err	name
1000	2.10e+02	1.16e+01	4.79e+01	4.52e+00	227.41	24.83	vg::algorithms topological_sort
1000	1.66e+02	2.79e+01	2.90e+01	7.97e+00	175.20	56.42	vg::algorithms sort
1000	1.46e+02	6.17e+00	2.54e+01	1.79e+00	174.59	14.32	vg::algorithms orient_nodes_forward
1000	7.27e+01	6.80e+00	2.53e+01	3.69e+00	347.81	60.33	vg::algorithms weakly_connected_components
1000	1.38e+02	4.22e+00	2.47e+01	8.72e-01	178.64	8.35	VG builtin weakly_connected_components
1000	8.90e+01	3.04e+01	2.65e+01	4.96e+00	297.94	116.12	VG::get_node
1000	3.98e+02	5.39e+01	3.26e+01	5.46e+00	81.99	17.66	algorithms::extract_connecting_graph on xg
1000	2.69e+02	3.53e+01	2.43e+01	4.50e+00	90.33	20.49	algorithms::extract_connecting_graph on vg
1000	3.85e+01	4.72e+00	3.84e+01	4.55e+00	997.30	169.99	control
```
