### PR TITLE
Faster wavelet tree for XGPath node IDs

### DIFF
--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -219,8 +219,8 @@ private:
                               xg::XG* xgindex,
                               size_t max_expected_dist_approx_error,
                               size_t min_mem_length,
-                              node_occurrence_on_paths_memo_t* paths_of_node_memo = nullptr,
-                              handle_memo_t* handle_memo = nullptr);
+                              node_occurrence_on_paths_memo_t* paths_of_node_memo,
+                              handle_memo_t* handle_memo);
     
     /**
      * Given a certain number of items, and a callback to get each item's

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -159,6 +159,7 @@ void XG::load(istream& in) {
         switch (file_version) {
         
         case 3:
+        case 4:
             {
                 sdsl::read_member(seq_length, in);
                 sdsl::read_member(node_count, in);

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1066,7 +1066,14 @@ void XG::build(map<id_t, string>& node_label,
             
             cerr << path_name(i + 1) << endl;
             cerr << path->members << endl;
-            cerr << path->ids << endl;
+            // manually print IDs because simplified wavelet tree doesn't support ostream for some reason
+            for (size_t j = 0; j + 1 < path->ids.size(); j++) {
+                cerr << path->ids[j] << " ";
+            }
+            if (path->ids.size() > 0) {
+                cerr << path->ids[path->ids.size() - 1];
+            }
+            cerr << endl;
             cerr << path->ranks << endl;
             cerr << path->directions << endl;
             cerr << path->positions << endl;
@@ -3031,7 +3038,6 @@ vector<size_t> XG::node_ranks_in_path(int64_t id, size_t rank) const {
     size_t occs = node_occs_in_path(id, rank);
     for (size_t i = 1; i <= occs; ++i) {
         ranks.push_back(paths[p]->ids.select(i, id));
-        auto m = paths[p]->mapping(ranks.back());
     }
     return ranks;
 }

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -115,9 +115,9 @@ public:
                bool is_sorted_dag);
                
     // What's the maximum XG version number we can read with this code?
-    const static uint32_t MAX_INPUT_VERSION = 3;
+    const static uint32_t MAX_INPUT_VERSION = 4;
     // What's the version we serialize?
-    const static uint32_t OUTPUT_VERSION = 3;
+    const static uint32_t OUTPUT_VERSION = 4;
                
     // Load this XG index from a stream. Throw an XGFormatError if the stream
     // does not produce a valid XG file.

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -761,7 +761,7 @@ public:
     rrr_vector<> members;
     rrr_vector<>::rank_1_type members_rank;
     rrr_vector<>::select_1_type members_select;
-    wt_int<> ids;
+    wt_gmr<> ids;
     sd_vector<> directions; // forward or backward through nodes
     int_vector<> positions;
     int_vector<> ranks;


### PR DESCRIPTION
A branch off of https://github.com/vgteam/vg/pull/1150 with a simplified wavelet tree representation for IDs in the XGPath. Turns out we were building the most expressive version of the wavelet tree but not using any of the additional functionality.