### PR TITLE
Faster indexing in VG object

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -348,7 +348,7 @@ namespace vg {
         // pull out the graph around the position(s) we jumped to
         VG rescue_graph;
         algorithms::extract_containing_graph(xindex, rescue_graph.graph, jump_positions, backward_dist, forward_dist);
-        rescue_graph.rebuild_indexes();
+        rescue_graph.build_indexes();
         
 #ifdef debug_multipath_mapper
         cerr << "got rescue graph " << pb2json(rescue_graph.graph) << endl;
@@ -814,7 +814,7 @@ namespace vg {
                 
                 // now that we know we're going to save the graph, manually trigger the index building since
                 // we circumvented the constructors
-                cluster_graph->rebuild_indexes();
+                cluster_graph->build_indexes();
             }
             else {
                 // this graph overlaps at least one other graph, so we merge them into one

--- a/src/unittest/vg.cpp
+++ b/src/unittest/vg.cpp
@@ -1183,8 +1183,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
         
-        cerr << "finishes blutifying 2" << endl;
-        
         SECTION("the bluntified graph should have 3 nodes") {
             REQUIRE(graph.node_count() == 3);
             
@@ -1230,7 +1228,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
     }
     
     SECTION("an overlap across a reversing edge should be resolved") {
-        cerr << "section 2" << endl;
         const string graph_json = R"(
         
         {
@@ -1247,8 +1244,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
-        
-        cerr << "finishes blutifying 2" << endl;
         
         SECTION("the bluntified graph should have 3 nodes") {
             REQUIRE(graph.node_count() == 3);
@@ -1300,7 +1295,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
     }
     
     SECTION("extraneous overlap should be pruned back") {
-        cerr << "section 3" << endl;
         const string graph_json = R"(
         
         {
@@ -1318,7 +1312,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
         
-        cerr << "finishes blutifying 3" << endl;
         
         SECTION("the bluntified graph should have 3 nodes") {
             REQUIRE(graph.node_count() == 3);
@@ -1365,7 +1358,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
     }
     
     SECTION("overlaps should be able to overlap in the middle") {
-        cerr << "section 4" << endl;
         const string graph_json = R"(
         
         {
@@ -1384,8 +1376,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
-        
-        cerr << "finishes blutifying 4" << endl;
         
         SECTION("the bluntified graph should have 3 nodes") {
             REQUIRE(graph.node_count() == 3);
@@ -1432,7 +1422,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
     }
     
     SECTION("overlaps should be able to overlap in the middle across reversing edges") {
-        cerr << "section 5" << endl;
         const string graph_json = R"(
         
         {
@@ -1451,8 +1440,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
-        
-        cerr << "finishes blutifying 5" << endl;
         
         SECTION("the bluntified graph should have 3 nodes") {
             REQUIRE(graph.node_count() == 3);
@@ -1504,7 +1491,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
     }
     
     SECTION("non-overlapping edges should be preserved") {
-        cerr << "section 6" << endl;
         const string graph_json = R"(
         
         {
@@ -1526,8 +1512,6 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
         graph.unchop();
-        
-        cerr << "finishes blutifying 6" << endl;
         
         SECTION("the unchopped bluntified graph should have one node") {
             REQUIRE(graph.node_count() == 1);

--- a/src/unittest/vg.cpp
+++ b/src/unittest/vg.cpp
@@ -1183,6 +1183,8 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
         
+        cerr << "finishes blutifying 2" << endl;
+        
         SECTION("the bluntified graph should have 3 nodes") {
             REQUIRE(graph.node_count() == 3);
             
@@ -1228,6 +1230,7 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
     }
     
     SECTION("an overlap across a reversing edge should be resolved") {
+        cerr << "section 2" << endl;
         const string graph_json = R"(
         
         {
@@ -1244,6 +1247,8 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
+        
+        cerr << "finishes blutifying 2" << endl;
         
         SECTION("the bluntified graph should have 3 nodes") {
             REQUIRE(graph.node_count() == 3);
@@ -1295,6 +1300,7 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
     }
     
     SECTION("extraneous overlap should be pruned back") {
+        cerr << "section 3" << endl;
         const string graph_json = R"(
         
         {
@@ -1311,6 +1317,8 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
+        
+        cerr << "finishes blutifying 3" << endl;
         
         SECTION("the bluntified graph should have 3 nodes") {
             REQUIRE(graph.node_count() == 3);
@@ -1357,6 +1365,7 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
     }
     
     SECTION("overlaps should be able to overlap in the middle") {
+        cerr << "section 4" << endl;
         const string graph_json = R"(
         
         {
@@ -1375,6 +1384,8 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
+        
+        cerr << "finishes blutifying 4" << endl;
         
         SECTION("the bluntified graph should have 3 nodes") {
             REQUIRE(graph.node_count() == 3);
@@ -1421,6 +1432,7 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
     }
     
     SECTION("overlaps should be able to overlap in the middle across reversing edges") {
+        cerr << "section 5" << endl;
         const string graph_json = R"(
         
         {
@@ -1439,6 +1451,8 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
+        
+        cerr << "finishes blutifying 5" << endl;
         
         SECTION("the bluntified graph should have 3 nodes") {
             REQUIRE(graph.node_count() == 3);
@@ -1490,6 +1504,7 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
     }
     
     SECTION("non-overlapping edges should be preserved") {
+        cerr << "section 6" << endl;
         const string graph_json = R"(
         
         {
@@ -1511,6 +1526,8 @@ TEST_CASE("bluntify() should resolve overlaps", "[vg][bluntify]") {
         VG graph = string_to_graph(graph_json);
         graph.bluntify();
         graph.unchop();
+        
+        cerr << "finishes blutifying 6" << endl;
         
         SECTION("the unchopped bluntified graph should have one node") {
             REQUIRE(graph.node_count() == 1);

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -3710,7 +3710,9 @@ Edge* VG::get_edge(const NodeTraversal& left, const NodeTraversal& right) {
 }
 
 void VG::set_edge(Edge* edge) {
-    index_edge_by_node_sides(edge);
+    if (!has_edge(edge)) {
+        index_edge_by_node_sides(edge);
+    }
 }
 
 void VG::for_each_edge_parallel(function<void(Edge*)> lambda) {

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -2127,8 +2127,8 @@ void VG::build_node_indexes_no_init_size(void) {
 
 void VG::build_node_indexes(void) {
 #ifdef USE_DENSE_HASH
-    node_by_id.resize(node_by_id.min_load_factor() * graph.node_size() + 1);
-    node_index.resize(node_index.min_load_factor() * graph.node_size() + 1);
+    node_by_id.resize(graph.node_size());
+    node_index.resize(graph.node_size());
 #endif
     build_node_indexes_no_init_size();
 }
@@ -2143,9 +2143,9 @@ void VG::build_edge_indexes_no_init_size(void) {
 
 void VG::build_edge_indexes(void) {
 #ifdef USE_DENSE_HASH
-    edges_on_start.resize(edges_on_start.min_load_factor() * graph.node_size());
-    edges_on_end.resize(edges_on_end.min_load_factor() * graph.node_size());
-    edge_by_sides.resize(edge_by_sides.min_load_factor() * graph.edge_size());
+    edges_on_start.resize(graph.node_size());
+    edges_on_end.resize(graph.node_size());
+    edge_by_sides.resize(graph.edge_size());
 #endif
     build_edge_indexes_no_init_size();
 }

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -407,6 +407,9 @@ public:
     void build_indexes(void);
     void build_node_indexes(void);
     void build_edge_indexes(void);
+    void build_indexes_no_init_size(void);
+    void build_node_indexes_no_init_size(void);
+    void build_edge_indexes_no_init_size(void);
     void index_paths(void);
     void clear_node_indexes(void);
     void clear_node_indexes_no_resize(void);


### PR DESCRIPTION
I pre-allocate the hash tables in the VG object since they're actually all a known size based on the Graph. Speeds up indexing a new VG object significantly in my tests.