### PR TITLE
Checking for single stranded graphs in mpmap

### DIFF
--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -304,6 +304,8 @@ public:
     bool is_acyclic(void);
     /// Returns true if the graph does not contain a directed cycle (but it may contain a reversing cycle)
     bool is_directed_acyclic(void);
+    /// Return true if there are no reversing edges in the graph
+    bool is_single_stranded(void);
     /// Remove all elements which are not in a strongly connected component.
     void keep_multinode_strongly_connected_components(void);
     /// Does the specified node have any self-loops?
@@ -339,6 +341,10 @@ public:
     /// Create reverse complement nodes and edges for the entire graph. Doubles the size. Converts all inverting
     /// edges into non-inverting edges.
     VG split_strands(unordered_map<id_t, pair<id_t, bool> >& node_translation);
+    /// Create the reverse complemented graph with topology preserved. Record translation in provided map.
+    VG reverse_complement_graph(unordered_map<id_t, pair<id_t, bool>>& node_translation);
+    /// Record the translation of this graph into itself in the provided map.
+    void identity_translation(unordered_map<id_t, pair<id_t, bool>>& node_translation);
     
     /// Assume two node translations, the over is based on the under; merge them.
     unordered_map<id_t, pair<id_t, bool> > overlay_node_translations(const unordered_map<id_t, pair<id_t, bool> >& over,

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -380,7 +380,7 @@ public:
             graph = other.graph;
             paths = other.paths;
             // re-index
-            rebuild_indexes();
+            build_indexes();
         }
     }
 


### PR DESCRIPTION
Adds a simple check for when a cluster-graph pair is single stranded, in which case we can reduce computational burden by working with a single stranded graph