### PR TITLE
don't accept xg version 3

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -158,7 +158,6 @@ void XG::load(istream& in) {
         ////////////////////////////////////////////////////////////////////////
         switch (file_version) {
         
-        case 3:
         case 4:
             {
                 sdsl::read_member(seq_length, in);


### PR DESCRIPTION
This gives

terminate called after throwing an instance of 'xg::XGFormatError'
  what():  Unimplemented XG format version: 3

instead of 

vg: /cluster/home/hickey/genomes/vg.new/include/sdsl/select_support_mcl.hpp:349: sdsl::select_support::size_type sdsl::select_support_mcl<t_bit_pattern, t_pattern_len>::select(sdsl::select_support::size_type) const [with unsigned char t_b = 1u; unsigned char t_pat_len = 1u; sdsl::select_support::size_type = long unsigned int]: Assertion `i > 0 and i <= m_arg_cnt' failed.

when loading previous xg version