### PR TITLE
Sim from paths

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -5,17 +5,14 @@
 namespace vg {
 
 pos_t Sampler::position(void) {
-    // We sample either from the entire graph sequence, or the selected path.
-    size_t max_pos = source_path.empty() ? xgidx->seq_length : xgidx->path_length(source_path);
+    // We sample from the entire graph sequence
     uniform_int_distribution<size_t> xdist(1, xgidx->seq_length);
     size_t offset = xdist(rng);
-    id_t id = source_path.empty() ? xgidx->node_at_seq_pos(offset) : xgidx->node_at_path_position(source_path, offset);
+    id_t id = xgidx->node_at_seq_pos(offset);
     uniform_int_distribution<size_t> flip(0, 1);
     bool rev = forward_only ? false : flip(rng);
     // 1-0 base conversion
-    size_t node_offset = offset - (source_path.empty() ?
-        xgidx->node_start(id) :
-        xgidx->node_start_at_path_position(source_path, offset)) - 1;
+    size_t node_offset = offset - xgidx->node_start(id) - 1;
     return make_pos_t(id, rev, node_offset);
 }
 
@@ -401,14 +398,7 @@ char Sampler::pos_char(pos_t pos) {
 }
 
 map<pos_t, char> Sampler::next_pos_chars(pos_t pos) {
-    map<pos_t, char> possible = xg_cached_next_pos_chars(pos, xgidx, node_cache, edge_cache);
-    
-    if (!source_path.empty()) {
-        // Subset to only the positions available within nodes/across edges that are on the path.
-        // TODO: we can't actually constrain to the *path*, buts to the graph it touches.
-    }
-    
-    return possible;
+    return xg_cached_next_pos_chars(pos, xgidx, node_cache, edge_cache);
 }
 
 bool Sampler::is_valid(const Alignment& aln) {

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -13,6 +13,7 @@ pos_t Sampler::position(void) {
     bool rev = forward_only ? false : flip(rng);
     // 1-0 base conversion
     size_t node_offset = offset - xgidx->node_start(id) - 1;
+    // Ignore flipping the node offset because we're uniform over both strands
     return make_pos_t(id, rev, node_offset);
 }
 
@@ -327,7 +328,12 @@ Alignment Sampler::alignment_to_path(size_t length) {
         id_t id = xgidx->node_at_path_position(source_path, path_offset);
         
         // Work out where in that mapping we should be.
-        size_t node_offset = path_offset - (xgidx->node_start_at_path_position(source_path, id));
+        size_t node_offset = path_offset - (xgidx->node_start_at_path_position(source_path, path_offset));
+
+        if (path_mapping.position().is_reverse() != rev) {
+            // Flip the node offset around to be from the end and not the start
+            node_offset = xgidx->node_length(id) - node_offset - 1;
+        }
 
         // Make a pos_t for where we are, on the appropriate strand
         pos_t pos = make_pos_t(path_mapping.position().node_id(), path_mapping.position().is_reverse() != rev, node_offset);

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -5,7 +5,7 @@
 namespace vg {
 
 pos_t Sampler::position(void) {
-    // We sample from the entire graph sequence
+    // We sample from the entire graph sequence, 1-based.
     uniform_int_distribution<size_t> xdist(1, xgidx->seq_length);
     size_t offset = xdist(rng);
     id_t id = xgidx->node_at_seq_pos(offset);
@@ -308,7 +308,6 @@ Alignment Sampler::alignment(size_t length) {
 Alignment Sampler::alignment_to_path(size_t length) {
     
     // Pick a starting point along the path and an orientation
-    // Should be 1-based for now.
     uniform_int_distribution<size_t> xdist(0, xgidx->path_length(source_path) - 1);
     size_t path_offset = xdist(rng);
     uniform_int_distribution<size_t> flip(0, 1);
@@ -324,7 +323,6 @@ Alignment Sampler::alignment_to_path(size_t length) {
     
     while (seq.size() < length) {
         // Get the mapping here, encoding the node and its orientation.
-        // TODO: should this be given a 0-based or 1-based coordinate?
         Mapping path_mapping = xgidx->mapping_at_path_position(source_path, path_offset);
         id_t id = xgidx->node_at_path_position(source_path, path_offset);
         

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -40,18 +40,22 @@ public:
     // If set, only sample positions/start reads on the forward strands of their
     // nodes.
     bool forward_only;
-    // A flag that we set if we don't want to generate sequences with Ns (on by dfault)
+    // A flag that we set if we don't want to generate sequences with Ns (on by default)
     bool no_Ns;
-    Sampler(xg::XG* x,
+    // A string which, if nonempty, gives the name of the path to restrict simulated reads to.
+    string source_path;
+    inline Sampler(xg::XG* x,
             int seed = 0,
             bool forward_only = false,
-            bool allow_Ns = false)
+            bool allow_Ns = false,
+            const string& source_path = "")
         : xgidx(x),
           node_cache(100),
           edge_cache(100),
           forward_only(forward_only),
           no_Ns(!allow_Ns),
-          nonce(0) {
+          nonce(0),
+          source_path(source_path) {
         if (!seed) {
             seed = time(NULL);
         }

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -64,7 +64,17 @@ public:
 
     pos_t position(void);
     string sequence(size_t length);
+    
+    /// Get an alignment against the whole graph, or against the source path if
+    /// one is selected.
     Alignment alignment(size_t length);
+    
+    /// Get an alignment against the whole graph.
+    Alignment alignment_to_graph(size_t length);
+    
+    /// Get an alignment against the currently set source_path.
+    Alignment alignment_to_path(size_t length);
+    
     Alignment alignment_with_error(size_t length,
                                    double base_error,
                                    double indel_error);

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -27,7 +27,8 @@ void help_sim(char** argv) {
          << endl
          << "options:" << endl
          << "    -x, --xg-name FILE          use the xg index in FILE" << endl
-         << "    -F, --fastq FILE            superpose errors matching the error profile of NGS reads in FILE (ignores -l,-f)" << endl
+         << "    -F, --fastq FILE            superpose errors matching the error profile of NGS reads in FILE (ignores -l,-f,-P)" << endl
+         << "    -P, --path PATH             simulate from the given names path" << endl
          << "    -l, --read-length N         write reads of length N" << endl
          << "    -n, --num-reads N           simulate N reads or read pairs" << endl
          << "    -s, --random-seed N         use this specific seed for the PRNG" << endl
@@ -66,6 +67,8 @@ int main_sim(int argc, char** argv) {
     double indel_prop = 0.0;
     double error_scale_factor = 1.0;
     string fastq_name;
+    // What path should we sample from? Empty string = the whole graph.
+    string path_name;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -75,6 +78,7 @@ int main_sim(int argc, char** argv) {
             {"help", no_argument, 0, 'h'},
             {"xg-name", required_argument, 0, 'x'},
             {"fastq", required_argument, 0, 'F'},
+            {"path", required_argument, 0, 'P'},
             {"read-length", required_argument, 0, 'l'},
             {"num-reads", required_argument, 0, 'n'},
             {"random-seed", required_argument, 0, 's'},
@@ -92,7 +96,7 @@ int main_sim(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hl:n:s:e:i:fax:Jp:v:Nd:F:S:",
+        c = getopt_long (argc, argv, "hl:n:s:e:i:fax:Jp:v:Nd:F:P:S:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -108,6 +112,10 @@ int main_sim(int argc, char** argv) {
             
         case 'F':
             fastq_name = optarg;
+            break;
+            
+        case 'P':
+            path_name = optarg;
             break;
 
         case 'l':
@@ -207,7 +215,7 @@ int main_sim(int argc, char** argv) {
         // Use the fixed error rate sampler
         
         // Make a sample to sample reads with
-        Sampler sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns);
+        Sampler sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns, path_name);
         
         // Make a Mapper to score reads, with the default parameters
         Mapper rescorer(xgidx, nullptr, nullptr);

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -199,6 +199,11 @@ int main_sim(int argc, char** argv) {
         cerr << "[vg sim] error: could not open xg index" << endl;
         return 1;
     }
+    
+    if (!path_name.empty() && xgidx->path_rank(path_name) == 0) {
+        cerr << "[vg sim] error: path \""<< path_name << "\" not found in index" << endl;
+        return 1;
+    }
 
     // Make a sample to sample reads with
     Sampler sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns);

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -27,7 +27,7 @@ void help_sim(char** argv) {
          << endl
          << "options:" << endl
          << "    -x, --xg-name FILE          use the xg index in FILE" << endl
-         << "    -F, --fastq FILE            superpose errors matching the error profile of NGS reads in FILE (ignores -l,-f,-P)" << endl
+         << "    -F, --fastq FILE            superpose errors matching the error profile of NGS reads in FILE (ignores -l,-f)" << endl
          << "    -P, --path PATH             simulate from the given names path" << endl
          << "    -l, --read-length N         write reads of length N" << endl
          << "    -n, --num-reads N           simulate N reads or read pairs" << endl
@@ -309,7 +309,7 @@ int main_sim(int argc, char** argv) {
         
         Aligner aligner(default_match, default_mismatch, default_gap_open, default_gap_extension, 5);
         
-        NGSSimulator sampler(*xgidx, fastq_name, base_error, indel_error, indel_prop,
+        NGSSimulator sampler(*xgidx, fastq_name, path_name, base_error, indel_error, indel_prop,
                              fragment_length ? fragment_length : std::numeric_limits<double>::max(), // suppresses warnings about fragment length
                              fragment_std_dev ? fragment_std_dev : 0.000001, // eliminates errors from having 0 as stddev without substantial difference
                              error_scale_factor, !reads_may_contain_Ns, seed_val);

--- a/src/unittest/sampler.cpp
+++ b/src/unittest/sampler.cpp
@@ -1,0 +1,98 @@
+/// \file sampler.cpp
+///  
+/// unit tests for the Sampler
+
+#include <iostream>
+#include <unordered_set>
+#include <utility>
+
+#include "json2pb.h"
+#include "vg.pb.h"
+#include "../sampler.hpp"
+#include "catch.hpp"
+
+namespace vg {
+namespace unittest {
+    
+TEST_CASE( "Sampler can sample from a 1-node graph", "[sampler]" ) {
+    
+    string graph_json = R"({
+        "node": [{"id": 1, "sequence": "GATTACA"}],
+        "path": [
+            {"name": "ref", "mapping": [
+                {"position": {"node_id": 1}, "edit": [{"from_length": 7, "to_length": 7}]}
+            ]}
+        ]
+    })";
+    
+    // Load the JSON
+    Graph proto_graph;
+    json2pb(proto_graph, graph_json.c_str(), graph_json.size());
+    
+    // Make it into a VG
+    VG graph;
+    graph.extend(proto_graph);
+    
+    // Build the xg index
+    xg::XG xg_index(proto_graph);
+    
+    // Define a sampler    
+    Sampler sampler(&xg_index, 1337);
+    
+    SECTION( "Can sample all bases in both directions" ) {
+        
+        unordered_set<pair<size_t, bool>> seen;
+        
+        for (size_t i = 0; i < 100; i++) {
+            // Sample a bunch of alignments of 1 base
+            Alignment aln = sampler.alignment(1);
+            
+            // Make sure we got 1 base
+            REQUIRE(aln.sequence().size() == 1);
+            
+            // And that it's on the right node
+            REQUIRE(aln.path().mapping(0).position().node_id() == 1);
+            
+            // Remember what offset and orientation we got.
+            seen.emplace(aln.path().mapping(0).position().offset(), aln.path().mapping(0).position().is_reverse());
+        }
+        
+        // We need to see all 7 bases in both orientations.
+        REQUIRE(seen.size() == 7 * 2);
+        
+    }
+    
+    SECTION( "Can sample all bases in both directions from a path" ) {
+        
+        // Same as above except we do this
+        sampler.source_path = "ref";
+        
+        unordered_set<pair<size_t, bool>> seen;
+        
+        for (size_t i = 0; i < 100; i++) {
+            // Sample a bunch of alignments of 1 base
+            Alignment aln = sampler.alignment(1);
+            
+            // Make sure we got 1 base
+            REQUIRE(aln.sequence().size() == 1);
+            
+            // And that it's on the right node
+            REQUIRE(aln.path().mapping(0).position().node_id() == 1);
+            
+            // Remember what offset and orientation we got.
+            seen.emplace(aln.path().mapping(0).position().offset(), aln.path().mapping(0).position().is_reverse());
+        }
+        
+        // We need to see all 7 bases in both orientations.
+        REQUIRE(seen.size() == 7 * 2);
+        
+        
+    }
+    
+}
+
+}
+
+}
+
+    

--- a/src/unittest/sampler.cpp
+++ b/src/unittest/sampler.cpp
@@ -143,9 +143,12 @@ TEST_CASE( "Sampler can sample from a loop-containing path", "[sampler]" ) {
         
         // We need to see the proper ref path all the way through.
         REQUIRE(found.count("GATTACA") == 1);
+        // In both orientations
+        REQUIRE(found.count("TGTAATC") == 1);
         
         // And that we don't have the version that skips the loop
         REQUIRE(found.count("GATACA") == 0);
+        REQUIRE(found.count("TGTATC") == 0);
         
         
     }

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -142,6 +142,7 @@ public:
     size_t id_to_rank(int64_t id) const;
     int64_t rank_to_id(size_t rank) const;
     size_t max_node_rank(void) const;
+    /// Get the node ID at the given sequence position. Works in 1-based coordinates.
     int64_t node_at_seq_pos(size_t pos) const;
     size_t node_start(int64_t id) const;
     Node node(int64_t id) const; // gets node sequence
@@ -300,8 +301,11 @@ public:
                                                    int64_t id2, bool is_rev2, size_t offset2) const;
     int64_t min_distance_in_paths(int64_t id1, bool is_rev1, size_t offset1,
                                   int64_t id2, bool is_rev2, size_t offset2) const;
+    /// Get the ID of the node that covers the given 0-based position along the path.
     int64_t node_at_path_position(const string& name, size_t pos) const;
+    /// Get the Mapping that covers the given 0-based position along the path.
     Mapping mapping_at_path_position(const string& name, size_t pos) const;
+    /// Get the 0-based start position in the path that covers the given 0-based position along the path.
     size_t node_start_at_path_position(const string& name, size_t pos) const;
     Alignment target_alignment(const string& name, size_t pos1, size_t pos2, const string& feature) const;
     size_t path_length(const string& name) const;

--- a/test/t/13_vg_sim.t
+++ b/test/t/13_vg_sim.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 10
+plan tests 11
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
@@ -25,6 +25,11 @@ is $(vg sim -s 1337 -l 100 -n 100 -e 0.1 -i 0.1 -J -x x.xg | jq .sequence | wc -
 
 is $(vg sim -l 100 -n 100 -x x.xg -aJ | jq 'select(.path.mapping[0].is_reverse)' | wc -l) 0 \
    "vg sim creates forward-strand reads when asked"
+   
+vg view -j x.vg | jq -r '.path[].mapping[].position.node_id' | sort > path.txt
+is $(vg sim -s 1337 -l 100 -n 100 -x x.xg -P "x" -aJ | jq -r '.path.mapping[].position.node_id' | sort | uniq | comm -23 - path.txt | wc -l) "0" "vg sim can simulate from just a path"
+
+rm -f path.txt
 
 is $(vg sim -n 10 -i 0.005 -l 10 -p 50 -v 50 -s 42 -x x.xg -J | wc -l) 20 "pairs simulated even when fragments overlap"
 


### PR DESCRIPTION
Closes #1167 

Allows you to specify `-P path_name` and restrict vg sim to reads that follow a path.

This isn't just the subset of the graph covered by the path; it correctly accounts for cycles.

Right now the changes to the trained simulator need the most testing (because I haven't tested them).