### PR TITLE
Switch to vg annotate -i in simulation tests

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -24,7 +24,7 @@ KEEP_OUTPUT=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@ed49a8290d438814b87db631ff594ed4335c5409"
+TOIL_VG_PACKAGE="git+https://github.com/glennhickey/toil-vg.git@bb8a596968f093dda2240fe40a7ab4868b533aac"
 # What tests should we run?
 # Should be something like "jenkins/vgci.py::VGCITest::test_sim_brca2_snp1kg"
 PYTEST_TEST_SPEC="jenkins/vgci.py"


### PR DESCRIPTION
Need this for the cactus yeast test to run.  Shouldn't change anything in the current tests, but we'll see here. 