### PR TITLE
Add Yeast test

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -24,7 +24,7 @@ KEEP_OUTPUT=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@ed49a8290d438814b87db631ff594ed4335c5409"
+TOIL_VG_PACKAGE="git+https://github.com/glennhickey/toil-vg.git@bb8a596968f093dda2240fe40a7ab4868b533aac"
 # What tests should we run?
 # Should be something like "jenkins/vgci.py::VGCITest::test_sim_brca2_snp1kg"
 PYTEST_TEST_SPEC="jenkins/vgci.py"

--- a/jenkins/mine-logs.py
+++ b/jenkins/mine-logs.py
@@ -407,7 +407,7 @@ def html_testcase(tc, work_dir, report_dir, max_warnings = 10):
         images = []
         captions = []
         baseline_images = []
-        for plot_name in 'pr', 'pr.control', 'pr.primary.filter', 'pr.control.primary.filter', 'qq', 'qq.control':
+        for plot_name in 'pr', 'pr.control', 'pr.primary.filter', 'pr.control.primary.filter', 'roc', 'qq', 'qq.control':
             plot_path = os.path.join(outstore, '{}.svg'.format(plot_name))
             if os.path.isfile(plot_path):
                 new_name = '{}-{}.svg'.format(tc['name'], plot_name)

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -124,6 +124,7 @@ class VGCITest(TestCase):
             return 6, 28510119
         elif 'CHR' in region:
             return int(region.replace('CHR', '')), 0
+        return None, None
         
     def _read_baseline_file(self, tag, path):
         """ read a (small) text file from the baseline store """
@@ -914,7 +915,7 @@ class VGCITest(TestCase):
         for graph in set([baseline_graph] + test_graphs):
             chrom, offset = self._bakeoff_coords(region)        
             vg_path = self._input('{}-{}.vg'.format(graph, region))
-            self._toil_vg_index(chrom, vg_path, None, self._input('{}-{}.gcsa'.format(graph, region)),
+            self._toil_vg_index(str(chrom), vg_path, None, self._input('{}-{}.gcsa'.format(graph, region)),
                                 None, tag, '{}-{}'.format(graph, region))
 
         # compute the haplotype graphs to simulate from
@@ -1041,6 +1042,27 @@ class VGCITest(TestCase):
                            sim_opts='-d 0.01 -p 1000 -v 75.0 -S 5',
                            sim_fastq=self._input('platinum_NA12878_MHC.fq.gz'))
 
+    @timeout_decorator.timeout(7200)
+    def test_sim_yeast_cactus(self):
+        """ Yeast test based on the cactus graphs.  Reads are simulated from the SK1 path
+        of the full graph.  The other graphs are made from this graph using vg mod:
+        cactus_drop_SK1 : remove all elements that are only on SK1 path
+        cactus_SK1 : keep only SK1 path
+        cactus_S288c : keep only S288c (reference) path
+        """
+        self.input_store = 'https://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/cactus_yeast'
+        log.info("Test start at {}".format(datetime.now()))
+        self._test_mapeval(100000, 'YEAST', 'cactus',
+                           ['cactus', 'cactus_drop_SK1', 'cactus_SK1', 'cactus_S288c'],
+                           #score_baseline_graph='cactus_S288c',
+                           source_path_names=['SK1.chr{}'.format(i) for i in [
+                               'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII',
+                               'IX', 'X', 'XI', 'XII', 'XIII', 'XIV', 'XV', 'XVI']],
+                           #multipath=True,
+                           paired_only=True,
+                           acc_threshold=0.02, auc_threshold=0.02,
+                           sim_opts='-p 500 -v 50 -S 4 -i 0.002')
+    
     @timeout_decorator.timeout(200)
     def test_map_brca1_primary(self):
         """ Mapping and calling bakeoff F1 test for BRCA1 primary graph """


### PR DESCRIPTION
Yeast test based on the cactus graphs.  Reads are simulated from the SK1 path of the full graph.  The other graphs are made from this graph using vg mod:
* cactus_drop_SK1 : remove all elements that are on no other path but SK1 path
* cactus_SK1 : keep only SK1 path
* cactus_S288c : keep only S288c (reference) path
Position comparison looks for a match in all annotated paths.  

Still working on a few issues
* bwa coordinate extraction needs to be updated to behave like annotate -i.  Doesn't work at all, currently 
* pr plot window needs to be adjusted for this test
* need to spot check a few cases to make sure graphs and extracted positions make sense.  worried about cycles (will try the mgsa graph too).  


