### PR TITLE
Add chain suport to snarls

### DIFF
--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -414,6 +414,8 @@ const Snarl& CactusSnarlFinder::recursively_emit_snarls(const Visit& start, cons
     vector<vector<Snarl>> child_chains;
     // And a vector of child unary snarls
     vector<Snarl> child_unary_snarls;
+    // TODO: If we want to track linkages between the children in a chain, and
+    // just to save snarl copies, these should probably be vectors of pointers.
     
 #ifdef debug
     cerr << "Look at " << stList_length(chains_list) << " child chains" << endl;

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -411,11 +411,10 @@ const Snarl& CactusSnarlFinder::recursively_emit_snarls(const Visit& start, cons
     }
     
     // We have a vector of the snarls made for the child snarls in each chain
-    vector<vector<Snarl>> child_chains;
+    vector<vector<const Snarl*>> child_chains;
     // And a vector of child unary snarls
-    vector<Snarl> child_unary_snarls;
-    // TODO: If we want to track linkages between the children in a chain, and
-    // just to save snarl copies, these should probably be vectors of pointers.
+    vector<const Snarl*> child_unary_snarls;
+    // These are both expressed as pointers into the "destination" list
     
 #ifdef debug
     cerr << "Look at " << stList_length(chains_list) << " child chains" << endl;
@@ -454,7 +453,7 @@ const Snarl& CactusSnarlFinder::recursively_emit_snarls(const Visit& start, cons
             child_end.set_backward(cac_child_side2->is_end);
                 
             // Recursively create a snarl for the child, and then add it to this chain in us.
-            chain.push_back(recursively_emit_snarls(child_start, child_end, &snarl,
+            chain.push_back(&recursively_emit_snarls(child_start, child_end, &snarl,
                 child_snarl->chains, child_snarl->unarySnarls, destination));
         }
     }
@@ -485,7 +484,7 @@ const Snarl& CactusSnarlFinder::recursively_emit_snarls(const Visit& start, cons
         child_end.set_backward(cac_child_side2->is_end);
             
         // Recursively create a snarl for the child, and then add it to the unary child snarl vector.
-        child_unary_snarls.push_back(recursively_emit_snarls(child_start, child_end, &snarl,
+        child_unary_snarls.push_back(&recursively_emit_snarls(child_start, child_end, &snarl,
             child_snarl->chains, child_snarl->unarySnarls, destination));
     }
 
@@ -640,7 +639,7 @@ const Snarl& CactusSnarlFinder::recursively_emit_snarls(const Visit& start, cons
         bool all_ultrabubble_children = true;
         for (auto& chain : child_chains) {
             for (auto& child : chain) {
-                if (child.type() != ULTRABUBBLE) {
+                if (child->type() != ULTRABUBBLE) {
                     all_ultrabubble_children = false;
                     break;
                 }

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -22,6 +22,10 @@ namespace vg {
     }
     
     const vector<const Snarl*>& SnarlManager::children_of(const Snarl* snarl) const {
+        if (snarl == nullptr) {
+            // Looking for top level snarls
+            return roots;
+        }
         return children.at(key_form(snarl));
     }
     
@@ -91,7 +95,7 @@ namespace vg {
         vector<vector<const Snarl*>> to_return;
         
         for (const Snarl* child : children_of(snarl)) {
-            // For every snarl in this snarl
+            // For every snarl in this snarl (or, if snarl is null, every top level snarl)
             
             if (seen.count(child)) {
                 // Already in a chain

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -117,7 +117,7 @@ namespace vg {
         /// Define the key type
         using key_t = pair<pair<int64_t, bool>, pair<int64_t, bool>>;
         
-        /// Master list of the snarls in the graph
+        /// Master list of the snarls in the graph.
         vector<Snarl> snarls;
         
         /// Roots of snarl trees

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -63,10 +63,27 @@ namespace vg {
      */
     class NetGraph : public HandleGraph {
     public:
+        
         /// Make a new NetGraph from the given chains and unary snarls in the given backing graph.
+        //NetGraph(const Visit& start, const Visit& end, const vector<vector<Snarl>>& child_chains,
+        //    const vector<Snarl>& child_unary_snarls, const HandleGraph* graph, bool use_internal_connectivity = false);
+            
+        /// Make a new NetGraph for the given snarl in the given backing graph,
+        /// using the given chains as child chains. Unary snarls are stored as
+        /// single-snarl chains just like other trivial chains.
+        NetGraph(const Visit& start, const Visit& end,
+            const vector<vector<const Snarl*>>& child_chains_mixed,
+            const HandleGraph* graph,
+            bool use_internal_connectivity = false);
+            
+        /// Make a net graph from the given chains and unary snarls (as pointers) in the given backing graph.
+        NetGraph(const Visit& start, const Visit& end, const vector<vector<const Snarl*>>& child_chains,
+            const vector<const Snarl*>& child_unary_snarls, const HandleGraph* graph, bool use_internal_connectivity = false);
+            
+        /// Make a net graph from the given chains and unary snarls (as raw values) in the given backing graph.
         NetGraph(const Visit& start, const Visit& end, const vector<vector<Snarl>>& child_chains,
             const vector<Snarl>& child_unary_snarls, const HandleGraph* graph, bool use_internal_connectivity = false);
-    
+            
         /// Look up the handle for the node with the given ID in the given orientation
         virtual handle_t get_handle(const id_t& node_id, bool is_reverse = false) const;
         
@@ -102,10 +119,18 @@ namespace vg {
         using HandleGraph::for_each_handle;
         
         /// Return the number of nodes in the graph
-        /// TODO: can't be node_count because XG has a field named node_count.
         virtual size_t node_size() const;
         
     protected:
+    
+        /// Make a NetGraph without filling in any of the child indexes.
+        NetGraph(const Visit& start, const Visit& end, const HandleGraph* graph, bool use_internal_connectivity = false);
+    
+        /// Add a unary child snarl to the indexes.
+        void add_unary_child(const Snarl* unary);
+        
+        /// Add a chain of one or more non-unary snarls to the index.
+        void add_chain_child(const vector<const Snarl*>& chain);
     
         // Save the backing graph
         const HandleGraph* graph;
@@ -160,22 +185,18 @@ namespace vg {
         ~SnarlManager() = default;
         
         /// Returns a vector of pointers to the children of a Snarl
-        const vector<const Snarl*>& children_of(const Snarl* snarl);
+        const vector<const Snarl*>& children_of(const Snarl* snarl) const;
         
         /// Returns a pointer to the parent of a Snarl or nullptr if there is none
-        const Snarl* parent_of(const Snarl* snarl);
-        
-        /// Get all the snarls in all the chains under the given parent snarl.
-        /// Unary snarls and snarls in trivial chains will be presented as their own chains.
-        /// Snarls are not necessarily oriented appropriately given their ordering in the chain.
-        /// Useful for making a net graph.
-        const vector<vector<const Snarl*>>& chains_of(const Snarl* snarl) const;
+        const Snarl* parent_of(const Snarl* snarl) const;
         
         /// Get the Snarl, if any, that shares this Snarl's start node as either its start or its end.
+        /// Does not count this snarl, even if this snarl is unary.
         /// Basic operation used to traverse a chain. Caller must account for snarls' orientations within a chain.
         const Snarl* snarl_sharing_start(const Snarl* here) const;
         
         /// Get the Snarl, if any, that shares this Snarl's end node as either its start or its end.
+        /// Does not count this snarl, even if this snarl is unary.
         /// Basic operation used to traverse a chain. Caller must account for snarls' orientations within a chain.
         const Snarl* snarl_sharing_end(const Snarl* here) const;
         
@@ -183,40 +204,46 @@ namespace vg {
         /// one snarl.
         bool in_nontrivial_chain(const Snarl* here) const;
         
+        /// Get all the snarls in all the chains under the given parent snarl.
+        /// Unary snarls and snarls in trivial chains will be presented as their own chains.
+        /// Snarls are not necessarily oriented appropriately given their ordering in the chain.
+        /// Useful for making a net graph.
+        const vector<vector<const Snarl*>> chains_of(const Snarl* snarl) const;
+        
         /// Get the net graph of the given Snarl's contents, using the given
-        /// backing HandleGraph. If use_connectivity is false, each chain and
-        /// unary child snarl is treated as an ordinary node which is assumed to
-        /// be only traversable from one side to the other. Otherwise,
-        /// traversing the graph works like it would if you actually went
-        /// through the internal graphs fo child snarls.
-        NetGraph net_graph_of(const Snarl* snarl, const HandleGraph* graph, bool use_connectivity = true) const;
+        /// backing HandleGraph. If use_internal_connectivity is false, each
+        /// chain and unary child snarl is treated as an ordinary node which is
+        /// assumed to be only traversable from one side to the other.
+        /// Otherwise, traversing the graph works like it would if you actually
+        /// went through the internal graphs fo child snarls.
+        NetGraph net_graph_of(const Snarl* snarl, const HandleGraph* graph, bool use_internal_connectivity = true) const;
         
         /// Get a Visit to the snarl in the same chain coming after the given
-        /// Visit to a snarl, or an empty Visit if the end of the chain is hit.
-        /// Accounts for snarls' orientations in their chains.
+        /// Visit to a snarl, or a Visit with no Snarl if the end of the chain
+        /// is hit. Accounts for snarls' orientations in their chains.
         Visit next_in_chain(const Visit& here) const;
         
         /// Get a Visit to the snarl in the same chain coming before the given
-        /// Visit to a snarl, or an empty Visit if the end of the chain is hit.
-        /// Accounts for snarls' orientations in their chains.
+        /// Visit to a snarl, or a Visit with no Snarl if the end of the chain
+        /// is hit. Accounts for snarls' orientations in their chains.
         Visit prev_in_chain(const Visit& here) const;
         
         /// Returns the Snarl that a traversal points into at either the start or end, or nullptr if
         /// the traversal does not point into any Snarl. Note that Snarls store the end Visit pointing
         /// out of rather than into the Snarl, so they must be reversed to query it.
-        const Snarl* into_which_snarl(int64_t id, bool reverse);
+        const Snarl* into_which_snarl(int64_t id, bool reverse) const;
         /// Returns the Snarl that a Visit points into. If the Visit contains a Snarl rather than a node
         /// ID, returns a pointer the managed version of that snarl.
-        const Snarl* into_which_snarl(const Visit& visit);
+        const Snarl* into_which_snarl(const Visit& visit) const;
         
         /// Returns true if snarl has no children and false otherwise
-        bool is_leaf(const Snarl* snarl);
+        bool is_leaf(const Snarl* snarl) const;
         
         /// Returns true if snarl has no parent and false otherwise
-        bool is_root(const Snarl* snarl);
+        bool is_root(const Snarl* snarl) const;
         
         /// Returns a reference to a vector with the roots of the Snarl trees
-        const vector<const Snarl*>& top_level_snarls();
+        const vector<const Snarl*>& top_level_snarls() const;
         
         /// Reverses the orientation of a snarl
         void flip(const Snarl* snarl);
@@ -224,44 +251,44 @@ namespace vg {
         /// Returns the Nodes and Edges contained in this Snarl but not in any child Snarls (always includes the
         /// Nodes that form the boundaries of child Snarls, optionally includes this Snarl's own boundary Nodes)
         pair<unordered_set<Node*>, unordered_set<Edge*> > shallow_contents(const Snarl* snarl, VG& graph,
-                                                                           bool include_boundary_nodes);
+                                                                           bool include_boundary_nodes) const;
         
         /// Returns the Nodes and Edges contained in this Snarl, including those in child Snarls (optionally
         /// includes Snarl's own boundary Nodes)
         pair<unordered_set<Node*>, unordered_set<Edge*> > deep_contents(const Snarl* snarl, VG& graph,
-                                                                        bool include_boundary_nodes);
+                                                                        bool include_boundary_nodes) const;
         
         /// Look left from the given visit in the given graph and gets all the
         /// attached Visits to nodes or snarls.
-        vector<Visit> visits_left(const Visit& visit, VG& graph, const Snarl* in_snarl);
+        vector<Visit> visits_left(const Visit& visit, VG& graph, const Snarl* in_snarl) const;
         
         /// Look left from the given visit in the given graph and gets all the
         /// attached Visits to nodes or snarls.
-        vector<Visit> visits_right(const Visit& visit, VG& graph, const Snarl* in_snarl);
+        vector<Visit> visits_right(const Visit& visit, VG& graph, const Snarl* in_snarl) const;
         
         /// Returns a map from all Snarl boundaries to the Snarl they point into. Note that this means that
         /// end boundaries will be reversed.
-        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_boundary_index();
+        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_boundary_index() const;
         
         /// Returns a map from all Snarl start boundaries to the Snarl they point into.
-        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_start_index();
+        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_start_index() const;
         
         /// Returns a map from all Snarl end boundaries to the Snarl they point into. Note that this means that
         /// end boundaries will be reversed.
-        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_end_index();
+        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_end_index() const;
         
         /// Execute a function on all top level sites
-        void for_each_top_level_snarl(const function<void(const Snarl*)>& lambda);
+        void for_each_top_level_snarl(const function<void(const Snarl*)>& lambda) const;
         
         /// Execute a function on all sites in a preorder traversal
-        void for_each_snarl_preorder(const function<void(const Snarl*)>& lambda);
+        void for_each_snarl_preorder(const function<void(const Snarl*)>& lambda) const;
         
         /// Execute a function on all top level sites in parallel
-        void for_each_top_level_snarl_parallel(const function<void(const Snarl*)>& lambda);
+        void for_each_top_level_snarl_parallel(const function<void(const Snarl*)>& lambda) const;
         
         /// Given a Snarl that we don't own (like from a Visit), find the
         /// pointer to the managed copy of that Snarl.
-        const Snarl* manage(const Snarl& not_owned);
+        const Snarl* manage(const Snarl& not_owned) const;
         
     private:
     
@@ -287,7 +314,7 @@ namespace vg {
         unordered_map<pair<int64_t, bool>, const Snarl*> snarl_into;
         
         /// Converts Snarl to the form used as keys in internal data structures
-        inline key_t key_form(const Snarl* snarl);
+        inline key_t key_form(const Snarl* snarl) const;
         
         /// Builds tree indexes after Snarls have been added
         void build_indexes();

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -25,124 +25,6 @@ using namespace std;
 namespace vg {
     
     /**
-     * A structure to keep track of the tree relationships between Snarls and perform utility algorithms
-     * on them
-     */
-    class SnarlManager {
-    public:
-        
-        /// Construct a SnarlManager for the snarls returned by an iterator
-        template <typename SnarlIterator>
-        SnarlManager(SnarlIterator begin, SnarlIterator end);
-        
-        /// Construct a SnarlManager for the snarls contained in an input stream
-        SnarlManager(istream& in);
-        
-        /// Default constructor
-        SnarlManager() = default;
-        
-        /// Destructor
-        ~SnarlManager() = default;
-        
-        /// Returns a vector of pointers to the children of a Snarl
-        const vector<const Snarl*>& children_of(const Snarl* snarl);
-        
-        /// Returns a pointer to the parent of a Snarl or nullptr if there is none
-        const Snarl* parent_of(const Snarl* snarl);
-        
-        /// Returns the Snarl that a traversal points into at either the start or end, or nullptr if
-        /// the traversal does not point into any Snarl. Note that Snarls store the end Visit pointing
-        /// out of rather than into the Snarl, so they must be reversed to query it.
-        const Snarl* into_which_snarl(int64_t id, bool reverse);
-        /// Returns the Snarl that a Visit points into. If the Visit contains a Snarl rather than a node
-        /// ID, returns a pointer the managed version of that snarl.
-        const Snarl* into_which_snarl(const Visit& visit);
-        
-        /// Returns true if snarl has no children and false otherwise
-        bool is_leaf(const Snarl* snarl);
-        
-        /// Returns true if snarl has no parent and false otherwise
-        bool is_root(const Snarl* snarl);
-        
-        /// Returns a reference to a vector with the roots of the Snarl trees
-        const vector<const Snarl*>& top_level_snarls();
-        
-        /// Reverses the orientation of a snarl
-        void flip(const Snarl* snarl);
-        
-        /// Returns the Nodes and Edges contained in this Snarl but not in any child Snarls (always includes the
-        /// Nodes that form the boundaries of child Snarls, optionally includes this Snarl's own boundary Nodes)
-        pair<unordered_set<Node*>, unordered_set<Edge*> > shallow_contents(const Snarl* snarl, VG& graph,
-                                                                           bool include_boundary_nodes);
-        
-        /// Returns the Nodes and Edges contained in this Snarl, including those in child Snarls (optionally
-        /// includes Snarl's own boundary Nodes)
-        pair<unordered_set<Node*>, unordered_set<Edge*> > deep_contents(const Snarl* snarl, VG& graph,
-                                                                        bool include_boundary_nodes);
-        
-        /// Look left from the given visit in the given graph and gets all the
-        /// attached Visits to nodes or snarls.
-        vector<Visit> visits_left(const Visit& visit, VG& graph, const Snarl* in_snarl);
-        
-        /// Look left from the given visit in the given graph and gets all the
-        /// attached Visits to nodes or snarls.
-        vector<Visit> visits_right(const Visit& visit, VG& graph, const Snarl* in_snarl);
-        
-        /// Returns a map from all Snarl boundaries to the Snarl they point into. Note that this means that
-        /// end boundaries will be reversed.
-        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_boundary_index();
-        
-        /// Returns a map from all Snarl start boundaries to the Snarl they point into.
-        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_start_index();
-        
-        /// Returns a map from all Snarl end boundaries to the Snarl they point into. Note that this means that
-        /// end boundaries will be reversed.
-        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_end_index();
-        
-        /// Execute a function on all top level sites
-        void for_each_top_level_snarl(const function<void(const Snarl*)>& lambda);
-        
-        /// Execute a function on all sites in a preorder traversal
-        void for_each_snarl_preorder(const function<void(const Snarl*)>& lambda);
-        
-        /// Execute a function on all top level sites in parallel
-        void for_each_top_level_snarl_parallel(const function<void(const Snarl*)>& lambda);
-        
-        /// Given a Snarl that we don't own (like from a Visit), find the
-        /// pointer to the managed copy of that Snarl.
-        const Snarl* manage(const Snarl& not_owned);
-        
-    private:
-    
-        /// Define the key type
-        using key_t = pair<pair<int64_t, bool>, pair<int64_t, bool>>;
-        
-        /// Master list of the snarls in the graph.
-        vector<Snarl> snarls;
-        
-        /// Roots of snarl trees
-        vector<const Snarl*> roots;
-        
-        /// Map of snarls to the child snarls they contain
-        unordered_map<key_t, vector<const Snarl*>> children;
-        /// Map of snarls to their parent
-        unordered_map<key_t, const Snarl*> parent;
-        
-        /// Map of snarl keys to the indexes in the snarl array
-        // TODO: should we switch to just pointers here and save an indirection?
-        unordered_map<key_t, size_t> index_of;
-        
-        /// Map of node traversals to the snarls they point into
-        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_into;
-        
-        /// Converts Snarl to the form used as keys in internal data structures
-        inline key_t key_form(const Snarl* snarl);
-        
-        /// Builds tree indexes after Snarls have been added
-        void build_indexes();
-    };
-    
-    /**
      * Allow traversing a graph of nodes and child snarl chains within a snarl
      * within another HandleGraph. Uses its own internal child index because
      * it's used in the construction of snarls to feed to SnarlManagers.
@@ -255,6 +137,160 @@ namespace vg {
         // start handle, is left-left, right-right, or left-right connected.
         unordered_map<id_t, tuple<bool, bool, bool>> connectivity;
         
+    };
+    
+    /**
+     * A structure to keep track of the tree relationships between Snarls and perform utility algorithms
+     * on them
+     */
+    class SnarlManager {
+    public:
+        
+        /// Construct a SnarlManager for the snarls returned by an iterator
+        template <typename SnarlIterator>
+        SnarlManager(SnarlIterator begin, SnarlIterator end);
+        
+        /// Construct a SnarlManager for the snarls contained in an input stream
+        SnarlManager(istream& in);
+        
+        /// Default constructor
+        SnarlManager() = default;
+        
+        /// Destructor
+        ~SnarlManager() = default;
+        
+        /// Returns a vector of pointers to the children of a Snarl
+        const vector<const Snarl*>& children_of(const Snarl* snarl);
+        
+        /// Returns a pointer to the parent of a Snarl or nullptr if there is none
+        const Snarl* parent_of(const Snarl* snarl);
+        
+        /// Get all the snarls in all the chains under the given parent snarl.
+        /// Unary snarls and snarls in trivial chains will be presented as their own chains.
+        /// Snarls are not necessarily oriented appropriately given their ordering in the chain.
+        /// Useful for making a net graph.
+        const vector<vector<const Snarl*>>& chains_of(const Snarl* snarl) const;
+        
+        /// Get the Snarl, if any, that shares this Snarl's start node as either its start or its end.
+        /// Basic operation used to traverse a chain. Caller must account for snarls' orientations within a chain.
+        const Snarl* snarl_sharing_start(const Snarl* here) const;
+        
+        /// Get the Snarl, if any, that shares this Snarl's end node as either its start or its end.
+        /// Basic operation used to traverse a chain. Caller must account for snarls' orientations within a chain.
+        const Snarl* snarl_sharing_end(const Snarl* here) const;
+        
+        /// Return true if a Snarl is part of a nontrivial chain of more than
+        /// one snarl.
+        bool in_nontrivial_chain(const Snarl* here) const;
+        
+        /// Get the net graph of the given Snarl's contents, using the given
+        /// backing HandleGraph. If use_connectivity is false, each chain and
+        /// unary child snarl is treated as an ordinary node which is assumed to
+        /// be only traversable from one side to the other. Otherwise,
+        /// traversing the graph works like it would if you actually went
+        /// through the internal graphs fo child snarls.
+        NetGraph net_graph_of(const Snarl* snarl, const HandleGraph* graph, bool use_connectivity = true) const;
+        
+        /// Get a Visit to the snarl in the same chain coming after the given
+        /// Visit to a snarl, or an empty Visit if the end of the chain is hit.
+        /// Accounts for snarls' orientations in their chains.
+        Visit next_in_chain(const Visit& here) const;
+        
+        /// Get a Visit to the snarl in the same chain coming before the given
+        /// Visit to a snarl, or an empty Visit if the end of the chain is hit.
+        /// Accounts for snarls' orientations in their chains.
+        Visit prev_in_chain(const Visit& here) const;
+        
+        /// Returns the Snarl that a traversal points into at either the start or end, or nullptr if
+        /// the traversal does not point into any Snarl. Note that Snarls store the end Visit pointing
+        /// out of rather than into the Snarl, so they must be reversed to query it.
+        const Snarl* into_which_snarl(int64_t id, bool reverse);
+        /// Returns the Snarl that a Visit points into. If the Visit contains a Snarl rather than a node
+        /// ID, returns a pointer the managed version of that snarl.
+        const Snarl* into_which_snarl(const Visit& visit);
+        
+        /// Returns true if snarl has no children and false otherwise
+        bool is_leaf(const Snarl* snarl);
+        
+        /// Returns true if snarl has no parent and false otherwise
+        bool is_root(const Snarl* snarl);
+        
+        /// Returns a reference to a vector with the roots of the Snarl trees
+        const vector<const Snarl*>& top_level_snarls();
+        
+        /// Reverses the orientation of a snarl
+        void flip(const Snarl* snarl);
+        
+        /// Returns the Nodes and Edges contained in this Snarl but not in any child Snarls (always includes the
+        /// Nodes that form the boundaries of child Snarls, optionally includes this Snarl's own boundary Nodes)
+        pair<unordered_set<Node*>, unordered_set<Edge*> > shallow_contents(const Snarl* snarl, VG& graph,
+                                                                           bool include_boundary_nodes);
+        
+        /// Returns the Nodes and Edges contained in this Snarl, including those in child Snarls (optionally
+        /// includes Snarl's own boundary Nodes)
+        pair<unordered_set<Node*>, unordered_set<Edge*> > deep_contents(const Snarl* snarl, VG& graph,
+                                                                        bool include_boundary_nodes);
+        
+        /// Look left from the given visit in the given graph and gets all the
+        /// attached Visits to nodes or snarls.
+        vector<Visit> visits_left(const Visit& visit, VG& graph, const Snarl* in_snarl);
+        
+        /// Look left from the given visit in the given graph and gets all the
+        /// attached Visits to nodes or snarls.
+        vector<Visit> visits_right(const Visit& visit, VG& graph, const Snarl* in_snarl);
+        
+        /// Returns a map from all Snarl boundaries to the Snarl they point into. Note that this means that
+        /// end boundaries will be reversed.
+        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_boundary_index();
+        
+        /// Returns a map from all Snarl start boundaries to the Snarl they point into.
+        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_start_index();
+        
+        /// Returns a map from all Snarl end boundaries to the Snarl they point into. Note that this means that
+        /// end boundaries will be reversed.
+        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_end_index();
+        
+        /// Execute a function on all top level sites
+        void for_each_top_level_snarl(const function<void(const Snarl*)>& lambda);
+        
+        /// Execute a function on all sites in a preorder traversal
+        void for_each_snarl_preorder(const function<void(const Snarl*)>& lambda);
+        
+        /// Execute a function on all top level sites in parallel
+        void for_each_top_level_snarl_parallel(const function<void(const Snarl*)>& lambda);
+        
+        /// Given a Snarl that we don't own (like from a Visit), find the
+        /// pointer to the managed copy of that Snarl.
+        const Snarl* manage(const Snarl& not_owned);
+        
+    private:
+    
+        /// Define the key type
+        using key_t = pair<pair<int64_t, bool>, pair<int64_t, bool>>;
+        
+        /// Master list of the snarls in the graph.
+        vector<Snarl> snarls;
+        
+        /// Roots of snarl trees
+        vector<const Snarl*> roots;
+        
+        /// Map of snarls to the child snarls they contain
+        unordered_map<key_t, vector<const Snarl*>> children;
+        /// Map of snarls to their parent
+        unordered_map<key_t, const Snarl*> parent;
+        
+        /// Map of snarl keys to the indexes in the snarl array
+        // TODO: should we switch to just pointers here and save an indirection?
+        unordered_map<key_t, size_t> index_of;
+        
+        /// Map of node traversals to the snarls they point into
+        unordered_map<pair<int64_t, bool>, const Snarl*> snarl_into;
+        
+        /// Converts Snarl to the form used as keys in internal data structures
+        inline key_t key_form(const Snarl* snarl);
+        
+        /// Builds tree indexes after Snarls have been added
+        void build_indexes();
     };
     
     /// Converts a Visit to a NodeTraversal. Throws an exception if the Visit is of a Snarl instead

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -184,7 +184,8 @@ namespace vg {
         /// Destructor
         ~SnarlManager() = default;
         
-        /// Returns a vector of pointers to the children of a Snarl
+        /// Returns a vector of pointers to the children of a Snarl.
+        /// If given null, returns the top-level root snarls.
         const vector<const Snarl*>& children_of(const Snarl* snarl) const;
         
         /// Returns a pointer to the parent of a Snarl or nullptr if there is none
@@ -205,6 +206,7 @@ namespace vg {
         bool in_nontrivial_chain(const Snarl* here) const;
         
         /// Get all the snarls in all the chains under the given parent snarl.
+        /// If the parent snarl is null, gives the top-level chains that connect and contain the top-level root snarls.
         /// Unary snarls and snarls in trivial chains will be presented as their own chains.
         /// Snarls are not necessarily oriented appropriately given their ordering in the chain.
         /// Useful for making a net graph.

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -271,6 +271,28 @@ void create_ref_allele(vcflib::Variant& variant, const std::string& allele);
  */
 int add_alt_allele(vcflib::Variant& variant, const std::string& allele);
 
+/**
+ * We have a transforming map function thatw e can chain.
+ */ 
+template <template <class T, class A = std::allocator<T>> class Container, typename Input, typename Output>
+Container<Output> map_over(const Container<Input>& in, const std::function<Output(const Input&)>& lambda) {
+    Container<Output> to_return;
+    for (const Input& item : in) {
+        to_return.push_back(lambda(item));
+    }
+    return to_return;
+}
+
+/**
+ * We have a wrapper of that to turn a container reference into a container of pointers.
+ */
+template <template <class T, class A = std::allocator<T>> class Container, typename Item>
+Container<const Item*> pointerfy(const Container<Item>& in) {
+    return map_over<Container, Item, const Item*>(in, [](const Item& item) -> const Item* {
+        return &item;
+    });
+}
+
 // Simple little tree
 template<typename T>
 struct TreeNode {


### PR DESCRIPTION
Here's my first cut at a china interface to snarls. All the chain stuff is calculated dynamically by looking at the snarl boundary nodes; we don't keep around any of the chain info that we know during snarl finding.

This lets us use the chain interface on serialized collections of snarls, which I think we want to be able to do.

I'm not confident this is all correct yet, because I haven't got enough unit tests, but I think it's correct enough that it can be continuously integrated into master.