### PR TITLE
Foreground just the main pipeline subcommands

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,9 +21,9 @@ void vg_help(char** argv) {
          << endl
          << "usage: " << argv[0] << " <command> [options]" << endl
          << endl
-         << "commands:" << endl;
+         << vg::subcommand::PIPELINE << ":" << endl;
          
-     vg::subcommand::Subcommand::for_each([](const vg::subcommand::Subcommand& command) {
+     vg::subcommand::Subcommand::for_each(vg::subcommand::PIPELINE, [](const vg::subcommand::Subcommand& command) {
         // Announce every subcommand we have
         
         // Pad all the names so the descriptions line up
@@ -31,6 +31,8 @@ void vg_help(char** argv) {
         name.resize(14, ' ');
         cerr << "  -- " << name << command.get_description() << endl;
      });
+     
+     cerr << endl << "For more commands, type `vg help`." << endl;
  }
 
 int main(int argc, char *argv[])

--- a/src/subcommand/benchmark_main.cpp
+++ b/src/subcommand/benchmark_main.cpp
@@ -180,5 +180,5 @@ int main_benchmark(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_benchmark("benchmark", "run and report on performance benchmarks", main_benchmark);
+static Subcommand vg_benchmark("benchmark", "run and report on performance benchmarks", DEVELOPMENT, main_benchmark);
 

--- a/src/subcommand/bugs_main.cpp
+++ b/src/subcommand/bugs_main.cpp
@@ -76,5 +76,5 @@ int main_bugs(int argc, char** argv){
 }
 
 // Register subcommand
-static Subcommand vg_bugs("bugs", "show or create bugs", main_bugs);
+static Subcommand vg_bugs("bugs", "show or create bugs", DEVELOPMENT, main_bugs);
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -232,5 +232,5 @@ int main_call(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_call("call", "call variants on a graph from a pileup", main_call);
+static Subcommand vg_call("call", "call variants on a graph from a pileup", PIPELINE, main_call);
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -232,5 +232,5 @@ int main_call(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_call("call", "call variants on a graph from a pileup", PIPELINE, main_call);
+static Subcommand vg_call("call", "call variants on a graph from a pileup", PIPELINE, 5, main_call);
 

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -294,5 +294,5 @@ int main_construct(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_construct("construct", "graph construction", PIPELINE, main_construct);
+static Subcommand vg_construct("construct", "graph construction", PIPELINE, 1, main_construct);
 

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -294,5 +294,5 @@ int main_construct(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_construct("construct", "graph construction", main_construct);
+static Subcommand vg_construct("construct", "graph construction", PIPELINE, main_construct);
 

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -837,4 +837,4 @@ int main_find(int argc, char** argv) {
 
 }
 
-static Subcommand vg_msga("find", "use an index to find nodes, edges, kmers, paths, or positions", main_find);
+static Subcommand vg_msga("find", "use an index to find nodes, edges, kmers, paths, or positions", TOOLKIT, main_find);

--- a/src/subcommand/help_main.cpp
+++ b/src/subcommand/help_main.cpp
@@ -1,0 +1,55 @@
+/** \file help_main.cpp
+ *
+ * Defines the "vg help" subcommand, which describes subcommands.
+ */
+
+
+#include <omp.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <stdlib.h>
+
+#include <iostream>
+
+#include "subcommand.hpp"
+#include "../version.hpp"
+
+using namespace std;
+using namespace vg;
+using namespace vg::subcommand;
+
+void help_help(char** argv){
+    cerr << "usage: " << argv[0] << " help" << endl
+         << endl;
+}
+
+int main_help(int argc, char** argv){
+
+    cerr << "vg: variation graph tool, version " << VG_VERSION_STRING << endl
+         << endl
+         << "usage: " << argv[0] << " <command> [options]" << endl
+         << endl;
+         
+     for (auto category : {PIPELINE, TOOLKIT, WIDGET, DEVELOPMENT}) {
+
+         cerr << category << ":" << endl;
+         
+         vg::subcommand::Subcommand::for_each(category, [](const vg::subcommand::Subcommand& command) {
+            // Announce every subcommand we have
+            
+            // Pad all the names so the descriptions line up
+            string name = command.get_name();
+            name.resize(14, ' ');
+            cerr << "  -- " << name << command.get_description() << endl;
+         });
+         
+         cerr << endl;
+     }
+     
+    
+    return 0;
+}
+
+// Register subcommand
+static Subcommand vg_help("help", "show all subcommands", PIPELINE, main_help);
+

--- a/src/subcommand/ids_main.cpp
+++ b/src/subcommand/ids_main.cpp
@@ -144,5 +144,5 @@ int main_ids(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_ids("ids", "manipulate node ids", main_ids);
+static Subcommand vg_ids("ids", "manipulate node ids", TOOLKIT, main_ids);
 

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -1121,4 +1121,4 @@ int main_index(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_construct("index", "index graphs or alignments for random access or mapping", PIPELINE, main_index);
+static Subcommand vg_construct("index", "index graphs or alignments for random access or mapping", PIPELINE, 2, main_index);

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -1121,4 +1121,4 @@ int main_index(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_construct("index", "index graphs or alignments for random access or mapping", main_index);
+static Subcommand vg_construct("index", "index graphs or alignments for random access or mapping", PIPELINE, main_index);

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -1016,4 +1016,4 @@ int main_map(int argc, char** argv) {
 
 }
 
-static Subcommand vg_msga("map", "MEM-based read alignment", main_map);
+static Subcommand vg_msga("map", "MEM-based read alignment", PIPELINE, main_map);

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -1016,4 +1016,4 @@ int main_map(int argc, char** argv) {
 
 }
 
-static Subcommand vg_msga("map", "MEM-based read alignment", PIPELINE, main_map);
+static Subcommand vg_map("map", "MEM-based read alignment", PIPELINE, 3, main_map);

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -855,4 +855,4 @@ int main_mod(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_mod("mod", "filter, transform, and edit the graph", main_mod);
+static Subcommand vg_mod("mod", "filter, transform, and edit the graph", TOOLKIT, main_mod);

--- a/src/subcommand/pileup_main.cpp
+++ b/src/subcommand/pileup_main.cpp
@@ -193,5 +193,5 @@ int main_pileup(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_pileup("pileup", "build a pileup from a set of alignments", PIPELINE, main_pileup);
+static Subcommand vg_pileup("pileup", "build a pileup from a set of alignments", PIPELINE, 4, main_pileup);
 

--- a/src/subcommand/pileup_main.cpp
+++ b/src/subcommand/pileup_main.cpp
@@ -193,5 +193,5 @@ int main_pileup(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_pileup("pileup", "build a pileup from a set of alignments", main_pileup);
+static Subcommand vg_pileup("pileup", "build a pileup from a set of alignments", PIPELINE, main_pileup);
 

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -372,5 +372,5 @@ int main_sim(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_sim("sim", "simulate reads from a graph", main_sim);
+static Subcommand vg_sim("sim", "simulate reads from a graph", TOOLKIT, main_sim);
 

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -757,5 +757,5 @@ int main_stats(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_stats("stats", "metrics describing graph properties", main_stats);
+static Subcommand vg_stats("stats", "metrics describing graph properties", TOOLKIT, main_stats);
 

--- a/src/subcommand/subcommand.cpp
+++ b/src/subcommand/subcommand.cpp
@@ -2,6 +2,11 @@
 
 #include "subcommand.hpp"
 
+#include <algorithm>
+#include <utility>
+#include <vector>
+#include <limits>
+
 namespace vg {
 namespace subcommand {
 
@@ -14,7 +19,7 @@ std::ostream& operator<<(std::ostream& out, const CommandCategory& category) {
         out << "useful graph tools";
         break;
     case WIDGET:
-        out << "less useful graph tools";
+        out << "specialized graph tools";
         break;
     case DEVELOPMENT:
         out << "developer commands";
@@ -25,12 +30,21 @@ std::ostream& operator<<(std::ostream& out, const CommandCategory& category) {
 }
 
 Subcommand::Subcommand(std::string name, std::string description,
-    CommandCategory category, 
+    CommandCategory category, int priority,
     std::function<int(int, char**)> main_function) : name(name),
-    category(category), description(description), main_function(main_function) {
+    category(category), priority(priority), description(description),
+    main_function(main_function) {
     
     // Add this subcommand to the registry
     Subcommand::get_registry()[name] = this;
+}
+
+Subcommand::Subcommand(std::string name, std::string description,
+    CommandCategory category, 
+    std::function<int(int, char**)> main_function) : Subcommand(name,
+    description, category, std::numeric_limits<int>::max(), main_function) {
+    
+    // Nothing to do!
 }
 
 Subcommand::Subcommand(std::string name, std::string description,
@@ -44,6 +58,14 @@ const std::string& Subcommand::get_name() const {
 
 const std::string& Subcommand::get_description() const {
     return description;
+}
+
+const CommandCategory& Subcommand::get_category() const {
+    return category;
+}
+
+const int& Subcommand::get_priority() const {
+    return priority;
 }
 
 const int Subcommand::operator()(int argc, char** argv) const {
@@ -73,13 +95,39 @@ void Subcommand::for_each(const std::function<void(const Subcommand&)>& lambda) 
 }
 
 void Subcommand::for_each(CommandCategory category, const std::function<void(const Subcommand&)>& lambda) {
-    for_each([&](const Subcommand& command) {
-        // Loop over all the subcommands
-        if (command.category == category) {
-            // And subset to the ones we want
-            lambda(command);
+    if (category == PIPELINE) {
+        // Pipeline commands get a special priority order
+        
+        // We will store them with their priorities and sort them.
+        // Easier than writing a custom comparator.
+        std::vector<std::pair<int, const Subcommand*>> by_priority;
+        
+        for_each([&](const Subcommand& command) {
+            // Loop over all the subcommands
+            if (command.category == category) {
+                // And add the ones we care about by priority
+                by_priority.push_back(std::make_pair(command.priority, &command));
+            }
+        });
+        
+        std::sort(by_priority.begin(), by_priority.end());
+        
+        for (auto& kv : by_priority) {
+            // Now in order of decreasing priority
+            // Run the lambda
+            lambda(*kv.second);
         }
-    });
+        
+    } else {
+        // All other categories just list in alphabetical order
+        for_each([&](const Subcommand& command) {
+            // Loop over all the subcommands
+            if (command.category == category) {
+                // And subset to the ones we want
+                lambda(command);
+            }
+        });
+    }
 }
 
 std::map<std::string, Subcommand*>& Subcommand::get_registry() {

--- a/src/subcommand/subcommand.cpp
+++ b/src/subcommand/subcommand.cpp
@@ -5,12 +5,37 @@
 namespace vg {
 namespace subcommand {
 
+std::ostream& operator<<(std::ostream& out, const CommandCategory& category) {
+    switch(category) {
+    case PIPELINE:
+        out << "main mapping and calling pipeline";
+        break;
+    case TOOLKIT:
+        out << "useful graph tools";
+        break;
+    case WIDGET:
+        out << "less useful graph tools";
+        break;
+    case DEVELOPMENT:
+        out << "developer commands";
+        break;
+    }
+    
+    return out;
+}
+
 Subcommand::Subcommand(std::string name, std::string description,
+    CommandCategory category, 
     std::function<int(int, char**)> main_function) : name(name),
-    description(description), main_function(main_function) {
+    category(category), description(description), main_function(main_function) {
     
     // Add this subcommand to the registry
     Subcommand::get_registry()[name] = this;
+}
+
+Subcommand::Subcommand(std::string name, std::string description,
+    std::function<int(int, char**)> main_function) : Subcommand(name, description, WIDGET, main_function) {
+    // Nothing to do!
 }
 
 const std::string& Subcommand::get_name() const {
@@ -45,6 +70,16 @@ void Subcommand::for_each(const std::function<void(const Subcommand&)>& lambda) 
         // For every subcommand, call the callback
         lambda(*kv.second);
     }
+}
+
+void Subcommand::for_each(CommandCategory category, const std::function<void(const Subcommand&)>& lambda) {
+    for_each([&](const Subcommand& command) {
+        // Loop over all the subcommands
+        if (command.category == category) {
+            // And subset to the ones we want
+            lambda(command);
+        }
+    });
 }
 
 std::map<std::string, Subcommand*>& Subcommand::get_registry() {

--- a/src/subcommand/subcommand.hpp
+++ b/src/subcommand/subcommand.hpp
@@ -76,7 +76,17 @@ public:
     
     /**
      * Make and register a subcommand with the given name and description, in
-     * the given category, which calls the given main function when invoked.
+     * the given category, with the given priority (lower is better), which
+     * calls the given main function when invoked.
+     */
+    Subcommand(std::string name, std::string description,
+        CommandCategory category, int priority,
+        std::function<int(int, char**)> main_function);
+    
+    /**
+     * Make and register a subcommand with the given name and description, in
+     * the given category, with worst priority, which calls the given main
+     * function when invoked.
      */
     Subcommand(std::string name, std::string description,
         CommandCategory category,
@@ -84,7 +94,8 @@ public:
     
     /**
      * Make and register a subcommand with the given name and description, in
-     * the WIDGET category, which calls the given main function when invoked.
+     * the WIDGET category, with worst priority, which calls the given main
+     * function when invoked.
      */
     Subcommand(std::string name, std::string description,
         std::function<int(int, char**)> main_function);
@@ -98,6 +109,17 @@ public:
      * Get the description of a subcommand.
      */
     const std::string& get_description() const;
+    
+    /**
+     * Get the category of a subcommand, which determines who might want to use
+     * it and why.
+     */
+    const CommandCategory& get_category() const;
+    
+    /**
+     * Get the priority level of a subcommand (lower is more important).
+     */
+    const int& get_priority() const;
     
     /**
      * Run the main function of a subcommand. Return the return code.
@@ -136,6 +158,7 @@ private:
     std::string name;
     std::string description;
     CommandCategory category;
+    int priority;
     std::function<int(int, char**)> main_function;
     
     /**

--- a/src/subcommand/subcommand.hpp
+++ b/src/subcommand/subcommand.hpp
@@ -14,8 +14,13 @@
  *
  * Subcommands are responsible for printing their own help; we can do "vg help"
  * and print all the subcommands that exist (via a help subcommand), but we
- * can't do "vg help subcommand" (because the help subcommand doesn't know how
- * to get help info on the others).
+ * can't do "vg help subcommand" and have that be equivalent to "vg subcommand
+ * --help" (because the help subcommand doesn't know how to get help info on the
+ * others).
+ *
+ * We have a subcommand importance/category system, so we can tell people about
+ * just the main pipeline and keep the subcommands they don't want out of their
+ * brains and off their screen.
  *
  * Subcommands get passed all of argv, so they have to skip past their names
  * when parsing arguments.
@@ -38,9 +43,27 @@
 #include <map>
 #include <functional>
 #include <string>
+#include <iostream>
 
 namespace vg {
 namespace subcommand {
+
+/**
+ * Defines what kind of command each subcommand is.
+ */
+enum CommandCategory {
+    /// Some commands are part of the main build-graph, align, call variants pipeline
+    PIPELINE, 
+    /// Some subcommands are important parts of the toolkit/swiss army knife for working with graphs and data
+    TOOLKIT,
+    /// Some commands are less important but potentially useful widgets that let you do a thing you might need
+    WIDGET,
+    /// Some commands are useful really only for developers
+    DEVELOPMENT  
+};
+
+/// Define a way to print the titles of the different categories
+std::ostream& operator<<(std::ostream& out, const CommandCategory& category);
 
 /**
  * Represents a subcommand with a name, a description, and some functions.
@@ -50,13 +73,22 @@ namespace subcommand {
 class Subcommand {
 
 public:
+    
     /**
-     * Make and register a subcommand with the given name and description, which
-     * calls the given main function when invoked.
+     * Make and register a subcommand with the given name and description, in
+     * the given category, which calls the given main function when invoked.
+     */
+    Subcommand(std::string name, std::string description,
+        CommandCategory category,
+        std::function<int(int, char**)> main_function);
+    
+    /**
+     * Make and register a subcommand with the given name and description, in
+     * the WIDGET category, which calls the given main function when invoked.
      */
     Subcommand(std::string name, std::string description,
         std::function<int(int, char**)> main_function);
-
+        
     /**
      * Get the name of a subcommand.
      */
@@ -82,6 +114,12 @@ public:
      * Call the given lambda with each known subcommand, in order.
      */
     static void for_each(const std::function<void(const Subcommand&)>& lambda);
+    
+    /**
+     * Call the given lambda with each known subcommand in the given category,
+     * in order.
+     */
+    static void for_each(CommandCategory category, const std::function<void(const Subcommand&)>& lambda);
 
 
 private:
@@ -97,6 +135,7 @@ private:
     // These hold the actual fields defining the subcommand
     std::string name;
     std::string description;
+    CommandCategory category;
     std::function<int(int, char**)> main_function;
     
     /**

--- a/src/subcommand/test_main.cpp
+++ b/src/subcommand/test_main.cpp
@@ -27,5 +27,5 @@ int main_test(int argc, char** argv){
 }
 
 // Register subcommand
-static Subcommand vg_test("test", "run unit tests", main_test);
+static Subcommand vg_test("test", "run unit tests", DEVELOPMENT, main_test);
 

--- a/src/subcommand/validate_main.cpp
+++ b/src/subcommand/validate_main.cpp
@@ -114,5 +114,5 @@ int main_validate(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_validate("validate", "validate the semantics of a graph", main_validate);
+static Subcommand vg_validate("validate", "validate the semantics of a graph", DEVELOPMENT, main_validate);
 

--- a/src/subcommand/version_main.cpp
+++ b/src/subcommand/version_main.cpp
@@ -35,5 +35,5 @@ int main_version(int argc, char** argv){
     return 0;
 }
 // Register subcommand
-static Subcommand vg_version("version", "version information", main_version);
+static Subcommand vg_version("version", "version information", DEVELOPMENT, main_version);
 

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -836,5 +836,5 @@ int main_view(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_view("view", "format conversions for graphs and alignments", main_view);
+static Subcommand vg_view("view", "format conversions for graphs and alignments", TOOLKIT, main_view);
 

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -272,7 +272,7 @@ void create_ref_allele(vcflib::Variant& variant, const std::string& allele);
 int add_alt_allele(vcflib::Variant& variant, const std::string& allele);
 
 /**
- * We have a transforming map function thatw e can chain.
+ * We have a transforming map function that we can chain.
  */ 
 template <template <class T, class A = std::allocator<T>> class Container, typename Input, typename Output>
 Container<Output> map_over(const Container<Input>& in, const std::function<Output(const Input&)>& lambda) {


### PR DESCRIPTION
This makes running just `vg` describe only the `construct`, `index`, `map`, `pileup`, `call`, and `help` subcommands. The first 5 are needed as the basic vg pipeline, while `vg help` when run will list all the other subcommands.

Subcommands are assigned to categories: `PIPELINE` for the main pipeline, `TOOLKIT` for useful stuff like `vg mod`, `WIDGET` for mostly useless stuff like `vg explode`, and `DEVELOPMENT` for developer commands like `vg test`. Commands can also have a "priority", which is used to put the pipeline commands in the order that you actually need to use them.

Closes #1204.

