### PR TITLE
Make chains more real

### DIFF
--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -273,14 +273,17 @@ class CactusSnarlFinder : public SnarlFinder {
     /// Holds the names of reference path hints
     unordered_set<string> hint_paths;
     
-    /// Create a snarl in the given list with the given start and end,
+    /// Create a snarl in the given SnarlManager with the given start and end,
     /// containing the given child snarls in the list of chains of children and
-    /// the given list of unary children. Recursively creates snarls in the list
-    /// for the children. Returns a reference to the finished snarl in the list.
-    /// Start and end may be empty visits, in which case a fake root snarl is
-    /// created.
-    const Snarl& recursively_emit_snarls(const Visit& start, const Visit& end, const Snarl* parent,
-        stList* chains_list, stList* unary_snarls_list, list<Snarl>& destination);
+    /// the given list of unary children. Recursively creates snarls in the
+    /// SnarlManager for the children. Returns a pointer to the finished snarl
+    /// in the SnarlManager. Start and end may be empty visits, in which case no
+    /// snarl is created, all the child chains are added as root chains, and
+    /// null is returned. If parent_start and parent_end are empty Visits, no
+    /// parent() is added to the produced snarl.
+    const Snarl* recursively_emit_snarls(const Visit& start, const Visit& end,
+        const Visit& parent_start, const Visit& parent_end,
+        stList* chains_list, stList* unary_snarls_list, SnarlManager& destination);
     
 public:
     /**
@@ -365,7 +368,7 @@ public:
 
 class PathBasedTraversalFinder : public TraversalFinder{
     vg::VG& graph;
-    SnarlManager snarlmanager;
+    SnarlManager& snarlmanager;
     public:
     PathBasedTraversalFinder(vg::VG& graph, SnarlManager& sm);
     virtual ~PathBasedTraversalFinder() = default;

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -9,6 +9,7 @@
  */
 
 #include "types.hpp"
+#include "vg.pb.h"
 #include <functional>
 #include <cstdint>
 #include <vector>
@@ -87,6 +88,11 @@ using namespace std;
  */
 class HandleGraph {
 public:
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Interface that needs to be implemented
+    ////////////////////////////////////////////////////////////////////////////
+
     /// Look up the handle for the node with the given ID in the given orientation
     virtual handle_t get_handle(const id_t& node_id, bool is_reverse = false) const = 0;
     
@@ -118,6 +124,10 @@ public:
     /// Return the number of nodes in the graph
     /// TODO: can't be node_count because XG has a field named node_count.
     virtual size_t node_size() const = 0;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Interface that needs to be using'd
+    ////////////////////////////////////////////////////////////////////////////
     
     /// Loop over all the handles to next/previous (right/left) nodes. Works
     /// with a callback that just takes all the handles and returns void.
@@ -167,6 +177,15 @@ public:
         
         // Use that
         for_each_handle(lambda);
+    }
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Concrete utility methods
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Get a handle from a Visit Protobuf object.
+    inline handle_t get_handle(const Visit& visit) const {
+        return get_handle(visit.node_id(), visit.backward());
     }
     
     /// Get the locally forward version of a handle

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -358,9 +358,9 @@ namespace vg {
         children[key_form(snarl)] = std::move(children[old_key]);
         children.erase(old_key);
         
-        // Update index index
-        index_of[key_form(snarl)] = std::move(index_of[old_key]);
-        index_of.erase(old_key);
+        // Update self index
+        self[key_form(snarl)] = std::move(self[old_key]);
+        self.erase(old_key);
         
         // note: snarl_into index is invariant to flipping
     }
@@ -419,7 +419,7 @@ namespace vg {
 #endif
             
             // Remember where each snarl is
-            index_of[key_form(&snarl)] = i;
+            self[key_form(&snarl)] = &snarl;
         
             // is this a top-level snarl?
             if (snarl.has_parent()) {
@@ -752,17 +752,17 @@ namespace vg {
         // Work out the key for the snarl
         key_t key = key_form(&not_owned);
         
-        // Get the index of the snarl with that key.
-        auto it = index_of.find(key);
+        // Get the cannonical pointer to the snarl with that key.
+        auto it = self.find(key);
         
-        if (it == index_of.end()) {
+        if (it == self.end()) {
             // It's not there. Someone is trying to manage a snarl we don't
             // really own. Complain.
             throw runtime_error("Unable to find snarl " +  pb2json(not_owned) + " in SnarlManager");
         }
         
         // Return the official copy of that snarl
-        return &snarls.at(it->second);
+        return it->second;
     }
     
     vector<Visit> SnarlManager::visits_right(const Visit& visit, VG& graph, const Snarl* in_snarl) const {

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -327,6 +327,11 @@ namespace vg {
         snarls.push_back(new_snarl);
         Snarl* snarl = &snarls.back();
         
+#ifdef debug
+        cerr << "Adding snarl " << new_snarl.start().node_id() << " " << new_snarl.start().backward() << " -> "
+            << new_snarl.end().node_id() << " " << new_snarl.end().backward() << endl;
+#endif
+        
         // Remember where each snarl is
         self[key_form(snarl)] = snarl;
         
@@ -349,6 +354,10 @@ namespace vg {
         if (chain_parent == nullptr) {
             // This is a root chain
             
+#ifdef debug
+        cerr << "Adding root chain of " << new_chain.size() << " snarls" << endl;
+#endif
+            
             // Save a copy of the chain as a root chain
             root_chains.push_back(new_chain);
             
@@ -360,6 +369,13 @@ namespace vg {
                 parent[key_form(child)] = nullptr;
             }
         } else {
+        
+#ifdef debug
+        cerr << "Adding chain of " << new_chain.size() << " snarls under "
+            << chain_parent->start().node_id() << " " << chain_parent->start().backward() << " -> "
+            << chain_parent->end().node_id() << " " << chain_parent->end().backward()
+            << endl;
+#endif
         
             // Save a copy of the chain as a child chain
             child_chains[key_form(chain_parent)].push_back(new_chain);

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -34,6 +34,16 @@ namespace vg {
     using Chain = vector<const Snarl*>;
     
     /**
+     * Return true if the first snarl in the given chain is backward relative to the chain.
+     */
+    bool start_backward(const Chain& chain);
+    
+    /**
+     * Return true if the last snarl in the given chain is backward relative to the chain.
+     */
+    bool end_backward(const Chain& chain);
+    
+    /**
      * Get the inward-facing start Visit for a chain.
      */
     Visit get_start(const Chain& chain);
@@ -51,14 +61,34 @@ namespace vg {
         /// Advance the iterator
         ChainIterator& operator++();
         /// Get the snarl we're at and whether it is backward 
-        pair<const snarl*, bool> operator*();
-        /// What position in the underlying vector are we in?
-        Chain::iterator pos;
+        pair<const Snarl*, bool> operator*();
+        
         /// Are we a reverse iterator or not?
         bool go_left;
         /// Is the snarl we are at backward or forward in its chain?
         bool backward;
-    }
+        
+        /// What position in the underlying vector are we in?
+        Chain::const_iterator pos;
+        
+        /// What are the bounds of that underlying vector?
+        Chain::const_iterator chain_start;
+        Chain::const_iterator chain_end;
+        
+        /// Since we're using backing random access itarators to provide reverse
+        /// iterators, we need a flag to see if we are rend (i.e. before the
+        /// beginning)
+        bool is_rend;
+    };
+    
+    /**
+     * We define free functions for getting iterators forward and backward through chains.
+     */
+    ChainIterator chain_begin(const Chain& chain);
+    ChainIterator chain_end(const Chain& chain);
+    ChainIterator chain_rbegin(const Chain& chain);
+    ChainIterator chain_rend(const Chain& chain);
+     
     
     
     /**

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -261,6 +261,14 @@ namespace vg {
         /// Destructor
         ~SnarlManager() = default;
         
+        /// Cannot be copied because of all the internal pointer indexes
+        SnarlManager(const SnarlManager& other) = delete;
+        SnarlManager& operator=(const SnarlManager& other) = delete;
+        
+        /// Can be moved
+        SnarlManager(SnarlManager&& other) = default;
+        SnarlManager& operator=(SnarlManager&& other) = default;
+        
         /// Returns a vector of pointers to the children of a Snarl.
         /// If given null, returns the top-level root snarls.
         const vector<const Snarl*>& children_of(const Snarl* snarl) const;

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -61,7 +61,13 @@ namespace vg {
         /// Advance the iterator
         ChainIterator& operator++();
         /// Get the snarl we're at and whether it is backward 
-        pair<const Snarl*, bool> operator*();
+        pair<const Snarl*, bool> operator*() const;
+        /// Get a pointer to the thing we get when we dereference the iterator
+        const pair<const Snarl*, bool>* operator->() const;
+        
+        /// We need to define comparison because C++ doesn't give it to us for free.
+        bool operator==(const ChainIterator& other) const;
+        bool operator!=(const ChainIterator& other) const;
         
         /// Are we a reverse iterator or not?
         bool go_left;
@@ -79,6 +85,10 @@ namespace vg {
         /// iterators, we need a flag to see if we are rend (i.e. before the
         /// beginning)
         bool is_rend;
+        
+        /// In order to dereference to a pair with -> we need a place to put the pair so we can have a pointer to it.
+        /// Gets lazily set to wherever the iterator is pointing when we do ->
+        mutable pair<const Snarl*, bool> scratch;
     };
     
     /**
@@ -88,8 +98,6 @@ namespace vg {
     ChainIterator chain_end(const Chain& chain);
     ChainIterator chain_rbegin(const Chain& chain);
     ChainIterator chain_rend(const Chain& chain);
-     
-    
     
     /**
      * Allow traversing a graph of nodes and child snarl chains within a snarl

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -285,7 +285,7 @@ namespace vg {
         /// Unary snarls and snarls in trivial chains will be presented as their own chains.
         /// Snarls are not necessarily oriented appropriately given their ordering in the chain.
         /// Useful for making a net graph.
-        const vector<Chain> chains_of(const Snarl* snarl) const;
+        const vector<Chain>& chains_of(const Snarl* snarl) const;
         
         /// Get the net graph of the given Snarl's contents, using the given
         /// backing HandleGraph. If use_internal_connectivity is false, each
@@ -377,9 +377,14 @@ namespace vg {
         
         /// Roots of snarl trees
         vector<const Snarl*> roots;
+        /// Chains of root-level snarls
+        vector<Chain> root_chains;
         
         /// Map of snarls to the child snarls they contain
         unordered_map<key_t, vector<const Snarl*>> children;
+        /// Map of snarls to the child chains they contain
+        /// TODO: can we replace children with this? Or do we still need memoized flat children?
+        unordered_map<key_t, vector<Chain>> child_chains;
         /// Map of snarls to their parent
         unordered_map<key_t, const Snarl*> parent;
         
@@ -392,8 +397,12 @@ namespace vg {
         /// Converts Snarl to the form used as keys in internal data structures
         inline key_t key_form(const Snarl* snarl) const;
         
-        /// Builds tree indexes after Snarls have been added
+        /// Builds tree indexes after Snarls have been added to the snarls vector
         void build_indexes();
+        
+        /// Actually compute chains for a set of already indexed snarls, which
+        /// is important when chains were not provided. Returns the chains.
+        vector<Chain> compute_chains(const vector<const Snarl*>& input_snarls);
     };
     
     /// Converts a Visit to a NodeTraversal. Throws an exception if the Visit is of a Snarl instead

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -383,9 +383,8 @@ namespace vg {
         /// Map of snarls to their parent
         unordered_map<key_t, const Snarl*> parent;
         
-        /// Map of snarl keys to the indexes in the snarl array
-        // TODO: should we switch to just pointers here and save an indirection?
-        unordered_map<key_t, size_t> index_of;
+        /// Map of snarl keys to the pointer to the managed copy in the snarls vector.
+        unordered_map<key_t, const Snarl*> self;
         
         /// Map of node traversals to the snarls they point into
         unordered_map<pair<int64_t, bool>, const Snarl*> snarl_into;

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -2519,24 +2519,91 @@ namespace vg {
                     REQUIRE(snarl_manager.in_nontrivial_chain(child3));
                 }
                 
-                SECTION("We should see that chain if we pull it out") {
+                SECTION("We can traverse the chain with iterators") {
                     auto chains = snarl_manager.chains_of(nullptr);
                     
                     REQUIRE(chains.size() == 1);
                     
                     auto& chain = chains.front();
                     
-                    REQUIRE(chain.size() == 3);
+                    auto begin = chain_begin(chain);
+                    auto rbegin = chain_rbegin(chain);
+                    auto end = chain_end(chain);
+                    auto rend = chain_rend(chain);
                     
-                    auto it = chain_begin(chain);
+                    SECTION("Iterator equality works") {
                     
-                    REQUIRE(*it == make_pair(child1, false));
-                    ++it;
-                    REQUIRE(*it == make_pair(child2, false));
-                    ++it;
-                    REQUIRE(*it == make_pair(child3, false));
-                    ++it;
-                    REQUIRE(it == chain_end(chain));
+                        REQUIRE(begin == begin);
+                        REQUIRE(begin != end);
+                        REQUIRE(begin != rbegin);
+                        REQUIRE(begin != rend);
+                        
+                        REQUIRE(rbegin == rbegin);
+                        REQUIRE(rbegin != end);
+                        REQUIRE(rbegin != begin);
+                        REQUIRE(rbegin != rend);
+                        
+                        REQUIRE(end == end);
+                        REQUIRE(end != begin);
+                        REQUIRE(end != rbegin);
+                        REQUIRE(end != rend);
+                        
+                        REQUIRE(rend == rend);
+                        REQUIRE(rend != end);
+                        REQUIRE(rend != rbegin);
+                        REQUIRE(rend != begin);
+                        
+                    }
+                    
+                    SECTION("Iterators traverse the chain left to right and right to left") {
+                        auto it = begin;
+                        auto rit = rbegin;
+                        
+                        REQUIRE(*it == make_pair(child1, false));
+                        REQUIRE(*rit == make_pair(child3, false));
+                        
+                        REQUIRE(it->first == child1);
+                        REQUIRE(it->second == false);
+                        REQUIRE(rit->first == child3);
+                        REQUIRE(rit->second == false);
+                        
+                        ++it;
+                        ++rit;
+                        
+                        REQUIRE(*it == make_pair(child2, false));
+                        REQUIRE(*rit == make_pair(child2, false));
+                        
+                        REQUIRE(it->first == child2);
+                        REQUIRE(it->second == false);
+                        REQUIRE(rit->first == child2);
+                        REQUIRE(rit->second == false);
+                        
+                        ++it;
+                        ++rit;
+                        
+                        REQUIRE(*it == make_pair(child3, false));
+                        REQUIRE(*rit == make_pair(child1, false));
+                        
+                        REQUIRE(it->first == child3);
+                        REQUIRE(it->second == false);
+                        REQUIRE(rit->first == child1);
+                        REQUIRE(rit->second == false);
+                        
+                        ++it;
+                        ++rit;
+                        
+                        REQUIRE(it == end);
+                        REQUIRE(rit == rend);
+                        
+                    }
+                    
+                    SECTION("Empty chains have proper iterators") {
+                        Chain empty;
+                        
+                        REQUIRE(chain_begin(empty) == chain_end(empty));
+                        REQUIRE(chain_rbegin(empty) == chain_rend(empty));
+                    }
+                    
                 }
                 
                 SECTION("We can still see the chain if we flip the snarls around") {

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -2528,9 +2528,15 @@ namespace vg {
                     
                     REQUIRE(chain.size() == 3);
                     
-                    REQUIRE(chain[0] == child1);
-                    REQUIRE(chain[1] == child2);
-                    REQUIRE(chain[2] == child3);
+                    auto it = chain_begin(chain);
+                    
+                    REQUIRE(*it == make_pair(child1, false));
+                    ++it;
+                    REQUIRE(*it == make_pair(child2, false));
+                    ++it;
+                    REQUIRE(*it == make_pair(child3, false));
+                    ++it;
+                    REQUIRE(it == chain_end(chain));
                 }
                 
                 SECTION("We can still see the chain if we flip the snarls around") {
@@ -2545,11 +2551,16 @@ namespace vg {
                     
                     REQUIRE(chain.size() == 3);
                     
-                    // We happen to get it backward.
-                    // TODO: Do some kind of orientation-independent comparison
-                    REQUIRE(chain[0] == child3);
-                    REQUIRE(chain[1] == child2);
-                    REQUIRE(chain[2] == child1);
+                    auto it = chain_begin(chain);
+                    
+                    // Chain should be in the same order but with some orientations flipped.
+                    REQUIRE(*it == make_pair(child1, true));
+                    ++it;
+                    REQUIRE(*it == make_pair(child2, true));
+                    ++it;
+                    REQUIRE(*it == make_pair(child3, false));
+                    ++it;
+                    REQUIRE(it == chain_end(chain));
                 }
                 
                 SECTION("We can look around with Visits") {

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -1770,8 +1770,8 @@ namespace vg {
             
 #ifdef debug
             snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
-                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().is_reverse()
-                    << " to " << snarl->end().node_id() << " " << snarl->end().is_reverse() << " containing ";
+                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().backward()
+                    << " to " << snarl->end().node_id() << " " << snarl->end().backward() << " containing ";
                 for (auto& node : snarl_manager.shallow_contents(snarl, graph, false)) {
                     cerr << node->id() << " ";
                 }
@@ -1867,8 +1867,8 @@ namespace vg {
 
 #ifdef debug
             snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
-                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().is_reverse()
-                    << " to " << snarl->end().node_id() << " " << snarl->end().is_reverse() << " containing ";
+                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().backward()
+                    << " to " << snarl->end().node_id() << " " << snarl->end().backward() << " containing ";
                 for (auto& node : snarl_manager.shallow_contents(snarl, graph, false)) {
                     cerr << node->id() << " ";
                 }
@@ -1954,8 +1954,8 @@ namespace vg {
             
 #ifdef debug
             snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
-                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().is_reverse()
-                    << " to " << snarl->end().node_id() << " " << snarl->end().is_reverse() << " containing ";
+                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().backward()
+                    << " to " << snarl->end().node_id() << " " << snarl->end().backward() << " containing ";
                 for (auto& node : snarl_manager.shallow_contents(snarl, graph, false)) {
                     cerr << node->id() << " ";
                 }
@@ -2069,8 +2069,8 @@ namespace vg {
             
 #ifdef debug
             snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
-                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().is_reverse()
-                    << " to " << snarl->end().node_id() << " " << snarl->end().is_reverse() << " containing ";
+                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().backward()
+                    << " to " << snarl->end().node_id() << " " << snarl->end().backward() << " containing ";
                 for (auto& node : snarl_manager.shallow_contents(snarl, graph, false)) {
                     cerr << node->id() << " ";
                 }
@@ -2176,8 +2176,8 @@ namespace vg {
             
 #ifdef debug
             snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
-                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().is_reverse()
-                    << " to " << snarl->end().node_id() << " " << snarl->end().is_reverse() << " containing ";
+                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().backward()
+                    << " to " << snarl->end().node_id() << " " << snarl->end().backward() << " containing ";
                 for (auto& node : snarl_manager.shallow_contents(snarl, graph, false)) {
                     cerr << node->id() << " ";
                 }
@@ -2234,8 +2234,8 @@ namespace vg {
             
 #ifdef debug
             snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
-                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().is_reverse()
-                    << " to " << snarl->end().node_id() << " " << snarl->end().is_reverse() << " containing ";
+                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().backward()
+                    << " to " << snarl->end().node_id() << " " << snarl->end().backward() << " containing ";
                 for (auto& node : snarl_manager.shallow_contents(snarl, graph, false)) {
                     cerr << node->id() << " ";
                 }
@@ -2312,8 +2312,8 @@ namespace vg {
             
 #ifdef debug
             snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
-                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().is_reverse()
-                    << " to " << snarl->end().node_id() << " " << snarl->end().is_reverse() << " containing ";
+                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().backward()
+                    << " to " << snarl->end().node_id() << " " << snarl->end().backward() << " containing ";
                 for (auto& node : snarl_manager.shallow_contents(snarl, graph, false)) {
                     cerr << node->id() << " ";
                 }
@@ -2374,8 +2374,8 @@ namespace vg {
             
 #ifdef debug
             snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
-                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().is_reverse()
-                    << " to " << snarl->end().node_id() << " " << snarl->end().is_reverse() << " containing ";
+                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().backward()
+                    << " to " << snarl->end().node_id() << " " << snarl->end().backward() << " containing ";
                 for (auto& node : snarl_manager.shallow_contents(snarl, graph, false)) {
                     cerr << node->id() << " ";
                 }
@@ -2403,7 +2403,7 @@ namespace vg {
                     snarl_manager.flip(child3);
                 }
                 
-                SECTION("First child is trivail snarl from 2 start to 5 end") {
+                SECTION("First child is trivial snarl from 2 start to 5 end") {
                     // Not 5 end to 2 start because we seem to be sorting by node ID.
                     REQUIRE(child1->start().node_id() == 2);
                     REQUIRE(!child1->start().backward() == false);
@@ -2429,6 +2429,109 @@ namespace vg {
                 }
                 
             }
+            
+        }
+        
+        TEST_CASE("SnarlManager accepts chain input", "[snarls]") {
+            // Make a little graph where snarl1 and snarl2 are a top-level
+            // chain, and snarl3 and snarl4 are trivial chains inside snarl1
+      
+            Snarl snarl1;
+            snarl1.mutable_start()->set_node_id(1);
+            snarl1.mutable_end()->set_node_id(6);
+            snarl1.set_start_end_reachable(true);
+            
+            Snarl snarl2;
+            snarl2.mutable_start()->set_node_id(6);
+            snarl2.mutable_end()->set_node_id(7);
+            snarl2.set_start_end_reachable(true);
+            
+            Snarl snarl3;
+            snarl3.mutable_start()->set_node_id(2);
+            snarl3.mutable_end()->set_node_id(3);
+            snarl3.set_start_end_reachable(true);
+            transfer_boundary_info(snarl1, *snarl3.mutable_parent());
+            
+            Snarl snarl4;
+            snarl4.mutable_start()->set_node_id(4);
+            snarl4.mutable_end()->set_node_id(5);
+            snarl4.set_start_end_reachable(true);
+            transfer_boundary_info(snarl1, *snarl4.mutable_parent());
+            
+            // Load all this into the SnarlManager
+            SnarlManager snarl_manager;
+            
+            auto ptr3 = snarl_manager.add_snarl(snarl3);
+            auto ptr4 = snarl_manager.add_snarl(snarl4);
+            
+            auto ptr1 = snarl_manager.add_snarl(snarl1);
+            snarl_manager.add_chain(Chain{ptr3}, ptr1);
+            snarl_manager.add_chain(Chain{ptr4}, ptr1);
+            
+            auto ptr2 = snarl_manager.add_snarl(snarl2);
+            snarl_manager.add_chain(Chain{ptr1, ptr2}, nullptr);
+ 
+#ifdef debug
+            snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
+                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().backward()
+                    << " to " << snarl->end().node_id() << " " << snarl->end().backward() << endl;
+            });
+#endif
+
+            SECTION("There should be two top-level snarls") {
+                REQUIRE(snarl_manager.top_level_snarls().size() == 2);
+                
+                const Snarl* child1 = snarl_manager.top_level_snarls()[0];
+                const Snarl* child2 = snarl_manager.top_level_snarls()[1];
+                
+                if (child1->start().node_id() > child1->end().node_id()) {
+                    snarl_manager.flip(child1);
+                }
+                
+                if (child2->start().node_id() > child2->end().node_id()) {
+                    snarl_manager.flip(child2);
+                }
+                
+                SECTION("First child is from 1 to 6") {
+                    REQUIRE(child1->start().node_id() == 1);
+                    REQUIRE(child1->start().backward() == false);
+                    REQUIRE(child1->end().node_id() == 6);
+                    REQUIRE(child1->end().backward() == false);
+                    
+                    SECTION("First child has two children") {
+                        REQUIRE(snarl_manager.children_of(child1).size() == 2);
+                        
+                        const Snarl* subchild1 = snarl_manager.children_of(child1)[0];
+                        const Snarl* subchild2 = snarl_manager.children_of(child1)[1];
+                        
+                        SECTION("First child is from 2 to 3") {
+                            REQUIRE(subchild1->start().node_id() == 2);
+                            REQUIRE(subchild1->start().backward() == false);
+                            REQUIRE(subchild1->end().node_id() == 3);
+                            REQUIRE(subchild1->end().backward() == false);
+                        }
+                        
+                        SECTION("Second child is from 4 to 5") {
+                            REQUIRE(subchild2->start().node_id() == 4);
+                            REQUIRE(subchild2->start().backward() == false);
+                            REQUIRE(subchild2->end().node_id() == 5);
+                            REQUIRE(subchild2->end().backward() == false);
+                        }
+                        
+                    }
+                    
+                }
+                
+                SECTION("Second child from 6 to 7") {
+                    REQUIRE(child2->start().node_id() == 6);
+                    REQUIRE(child2->start().backward() == false);
+                    REQUIRE(child2->end().node_id() == 7);
+                    REQUIRE(child2->end().backward() == false);
+                    
+                }
+                
+            }
+            
             
         }
         
@@ -2484,8 +2587,8 @@ namespace vg {
             
 #ifdef debug
             snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
-                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().is_reverse()
-                    << " to " << snarl->end().node_id() << " " << snarl->end().is_reverse() << " containing ";
+                cerr << "Found snarl " << snarl->start().node_id() << " " << snarl->start().backward()
+                    << " to " << snarl->end().node_id() << " " << snarl->end().backward() << " containing ";
                 for (auto& node : snarl_manager.shallow_contents(snarl, graph, false)) {
                     cerr << node->id() << " ";
                 }


### PR DESCRIPTION
This adds a `Chain` type which is a `vector<const Snarl*>`.

Now chains are copied intact from Cactus to the SnarlManager without having to reconstruct them from all of the snarls.

Also, the SnarlManager stores the precomputed chains, and can give tou chains that stay at  fixed address (so you can use a `Chain*` to identify a chain).

Fixes #1216.

