### PR TITLE
reduce variance in estimate for minimum mem length

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1296,8 +1296,8 @@ double BaseMapper::estimate_gc_content(void) {
 }
 
 int BaseMapper::random_match_length(double chance_random) {
-    if (gcsa) {
-        size_t length = gcsa::Range::length(gcsa->find(string("")));
+    if (xindex) {
+        size_t length = xindex->seq_length;
         return ceil(- (log(1.0 - pow(pow(1.0-chance_random, -1), (-1.0/length))) / log(4.0)));
     } else {
         return 0;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2937,7 +2937,7 @@ Alignment Mapper::align_cluster(const Alignment& aln, const vector<MaximalExactM
         }
     }
     // get the graph with cluster.hpp's cluster_subgraph
-    Graph graph = cluster_subgraph(*xindex, aln, mems, 1.1);
+    Graph graph = cluster_subgraph(*xindex, aln, mems);
     // and test each direction for which we have MEM hits
     Alignment aln_fwd;
     Alignment aln_rev;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1916,10 +1916,10 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
     }
 
     // use the estimated mapping quality to avoid hard work when the results are likely noninformative
-    double maybe_pair_mq = max(maybe_mq1, maybe_mq2);
+    double maybe_pair_mq = maybe_mq1+maybe_mq2;
 
     // if estimated mq is high scale difficulty using the estimated mapping quality
-    if (min(maybe_mq1, maybe_mq2) > max_mapping_quality) {
+    if (maybe_pair_mq > max_mapping_quality) {
         total_multimaps = max(max(min_multimaps, max_multimaps), min(total_multimaps, (int)round(maybe_pair_mq)));
     }
 

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -20,9 +20,9 @@ void help_map(char** argv) {
          << "    -g, --gcsa-name FILE    use this GCSA2 index (defaults to <graph>" << gcsa::GCSA::EXTENSION << ")" << endl
          << "algorithm:" << endl
          << "    -t, --threads N         number of compute threads to use" << endl
-         << "    -k, --min-seed INT      minimum seed (MEM) length (set to -1 to estimate given -e) [19]" << endl
+         << "    -k, --min-seed INT      minimum seed (MEM) length (set to -1 to estimate given -e) [-1]" << endl
          << "    -c, --hit-max N         ignore MEMs who have >N hits in our index [1024]" << endl
-         << "    -e, --seed-chance FLOAT set {-k} such that this fraction of {-k} length hits will by chance [0/off]" << endl
+         << "    -e, --seed-chance FLOAT set {-k} such that this fraction of {-k} length hits will by chance [1e-4]" << endl
          << "    -Y, --max-seed INT      ignore seeds longer than this length [0]" << endl
          << "    -r, --reseed-x FLOAT    look for internal seeds inside a seed longer than {-k} * FLOAT [1.5]" << endl
          << "    -u, --try-up-to INT     attempt to align up to the INT best candidate chains of seeds [512]" << endl
@@ -106,7 +106,7 @@ int main_map(int argc, char** argv) {
     bool always_rescue = false;
     bool top_pairs_only = false;
     int max_mem_length = 0;
-    int min_mem_length = 19;
+    int min_mem_length = -1;
     int min_cluster_length = 0;
     float mem_reseed_factor = 1.5;
     int max_target_factor = 100;
@@ -132,11 +132,11 @@ int main_map(int argc, char** argv) {
     double fragment_sigma = 10;
     bool fragment_orientation = false;
     bool fragment_direction = true;
-    float chance_match = 0;
+    float chance_match = 1e-4;
     bool use_fast_reseed = true;
     float drop_chain = 0.0;
     float mq_overlap = 0.0;
-    int kmer_size = 0;
+    int kmer_size = 0; // if we set to positive, we'd revert to the old kmer based mapper
     int kmer_stride = 0;
     int pair_window = 64; // unused
     int mate_rescues = 64;
@@ -618,9 +618,8 @@ int main_map(int argc, char** argv) {
         m->min_identity = min_score;
         m->drop_chain = drop_chain;
         m->mq_overlap = mq_overlap;
-        m->min_mem_length = (chance_match > 0 ?
-                             m->random_match_length(chance_match)
-                             : min_mem_length);
+        m->min_mem_length = (min_mem_length > 0 ? min_mem_length
+                             : m->random_match_length(chance_match));
         m->mem_reseed_length = round(mem_reseed_factor * m->min_mem_length);
         m->min_cluster_length = min_cluster_length;
         if (debug && i == 0) {

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -20,9 +20,9 @@ void help_map(char** argv) {
          << "    -g, --gcsa-name FILE    use this GCSA2 index (defaults to <graph>" << gcsa::GCSA::EXTENSION << ")" << endl
          << "algorithm:" << endl
          << "    -t, --threads N         number of compute threads to use" << endl
-         << "    -k, --min-seed INT      minimum seed (MEM) length (set to -1 to estimate given -e) [-1]" << endl
+         << "    -k, --min-seed INT      minimum seed (MEM) length (set to -1 to estimate given -e) [19]" << endl
          << "    -c, --hit-max N         ignore MEMs who have >N hits in our index [1024]" << endl
-         << "    -e, --seed-chance FLOAT set {-k} such that this fraction of {-k} length hits will by chance [1e-4]" << endl
+         << "    -e, --seed-chance FLOAT set {-k} such that this fraction of {-k} length hits will by chance [0/off]" << endl
          << "    -Y, --max-seed INT      ignore seeds longer than this length [0]" << endl
          << "    -r, --reseed-x FLOAT    look for internal seeds inside a seed longer than {-k} * FLOAT [1.5]" << endl
          << "    -u, --try-up-to INT     attempt to align up to the INT best candidate chains of seeds [512]" << endl
@@ -106,7 +106,7 @@ int main_map(int argc, char** argv) {
     bool always_rescue = false;
     bool top_pairs_only = false;
     int max_mem_length = 0;
-    int min_mem_length = -1;
+    int min_mem_length = 19;
     int min_cluster_length = 0;
     float mem_reseed_factor = 1.5;
     int max_target_factor = 100;
@@ -132,11 +132,11 @@ int main_map(int argc, char** argv) {
     double fragment_sigma = 10;
     bool fragment_orientation = false;
     bool fragment_direction = true;
-    float chance_match = 1e-4;
+    float chance_match = 0;
     bool use_fast_reseed = true;
     float drop_chain = 0.0;
     float mq_overlap = 0.0;
-    int kmer_size = 0; // if we set to positive, we'd revert to the old kmer based mapper
+    int kmer_size = 0;
     int kmer_stride = 0;
     int pair_window = 64; // unused
     int mate_rescues = 64;
@@ -618,8 +618,9 @@ int main_map(int argc, char** argv) {
         m->min_identity = min_score;
         m->drop_chain = drop_chain;
         m->mq_overlap = mq_overlap;
-        m->min_mem_length = (min_mem_length > 0 ? min_mem_length
-                             : m->random_match_length(chance_match));
+        m->min_mem_length = (chance_match > 0 ?
+                             m->random_match_length(chance_match)
+                             : min_mem_length);
         m->mem_reseed_length = round(mem_reseed_factor * m->min_mem_length);
         m->min_cluster_length = min_cluster_length;
         if (debug && i == 0) {


### PR DESCRIPTION
Previously we estimated based on the size of the gcsa2 index. However, this results in lower performance on pan graphs at the benefit of lower runtime. As this confuses a number of analyses that are important for the paper I'd like to test fixing the value at 19 as it is in bwa mem.