### PR TITLE
Data Structure for MCMC Genotyping

### DIFF
--- a/src/cactus.cpp
+++ b/src/cactus.cpp
@@ -259,6 +259,11 @@ pair<stCactusGraph*, stList*> vg_to_cactus(VG& graph, const unordered_set<string
     // We also want a map so we can efficiently find which component a node lives in.
     unordered_map<id_t, size_t> node_to_component;
     for (size_t i = 0; i < weak_components.size(); i++) {
+        if (weak_components[i].size() == 1) {
+            // If we feed this through to Cactus it will crash.
+            throw runtime_error("Cactus does not currently support finding snarls in a single-node connected component");
+        }
+    
         for (auto& id : weak_components[i]) {
             node_to_component[id] = i;
         }
@@ -305,6 +310,11 @@ pair<stCactusGraph*, stList*> vg_to_cactus(VG& graph, const unordered_set<string
             // sometimes (like in the tests) the mapping edits haven't been
             // populated.
             path_length[name] += graph.get_length(graph.get_handle(mapping.position().node_id(), false));
+            
+            if (node_to_component[mapping.position().node_id()] != component) {
+                // If we use a path like this to pick telomeres we will segfault Cactus.
+                throw runtime_error("Path " + name + " spans multiple connected components!");
+            }
         }
         
 #ifdef debug

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -1,0 +1,1 @@
+#include "genome_state.hpp"

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -1,1 +1,25 @@
 #include "genome_state.hpp"
+
+namespace vg {
+
+using namespace std;
+
+GenomeState::GenomeState(const SnarlManager& manager, const HandleGraph* graph,
+    const unordered_set<pair<const Snarl*, const Snarl*>> telomeres) : telomeres(telomeres), manager(manager) {
+
+    manager.for_each_snarl_preorder([&](const Snarl* snarl) {
+        // For each snarl
+        
+        // Make an empty state for it
+        state.emplace(snarl, SnarlState());
+        
+        // Make a net graph for it. TODO: we're not considering internal
+        // connectivity, but what we really should do is consider internal
+        // connectivity but only allowing for start to end traversals (but
+        // including in unary snarls)
+        net_graphs.emplace(snarl, manager.net_graph_of(snarl, graph, false));
+    });
+}
+
+
+}

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -380,8 +380,6 @@ size_t GenomeState::count_haplotypes(const pair<const Snarl*, const Snarl*>& tel
 void GenomeState::trace_haplotype(const pair<const Snarl*, const Snarl*>& telomere_pair,
     size_t overall_lane, const function<void(const handle_t&)>& iteratee) {
     
-    cerr << "Trace overall lane " << overall_lane << endl;
-    
     // We need to traverse this hierarchy while not emitting visits twice. The
     // hard part is that the same handle represents entering a snarl and the
     // start visit of that snarl. The other hard part is that for back-to-back
@@ -395,9 +393,6 @@ void GenomeState::trace_haplotype(const pair<const Snarl*, const Snarl*>& telome
     // We define a recursive function to traverse a snarl and all its visited children.
     function<void(const Snarl*, size_t, bool, bool)> recursively_traverse_snarl =
         [&](const Snarl* here, size_t lane, bool orientation, bool skip_first) {
-
-        cerr << "Traverse snarl " << pb2json(*here) << endl;
-        state.at(here).dump();
 
         // We need to remember if the last visit we did was a child snarl.
         bool last_was_child = false;

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -195,6 +195,24 @@ const vector<pair<handle_t, size_t>>& SnarlState::insert(size_t overall_lane, co
     return inserted;
 }
 
+vector<pair<handle_t, size_t>> SnarlState::erase(size_t overall_lane) {
+    // Copy what we're erasing
+    auto copy = haplotypes.at(overall_lane);
+    
+    for (auto it = copy.rbegin(); it != copy.rend(); ++it) {
+        // Trace from end to start and remove from the net node lanes collections.
+        // We have to do it backward so we can handle duplicate visits properly.
+        auto& node_lanes = net_node_lanes[graph->forward(it->first)];
+        node_lanes.erase(node_lanes.begin() + it->second);
+    }
+
+    // Drop the actual haplotype
+    haplotypes.erase(haplotypes.begin() + overall_lane);
+    
+    // Return the copy
+    return copy;
+}
+
 GenomeStateCommand* DeleteHaplotypeCommand::execute(GenomeState& state) const {
     // Allocate and populate the reverse command.
     return new InsertHaplotypeCommand(state.delete_haplotype(*this));

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -125,7 +125,7 @@ const vector<pair<handle_t, size_t>>& SnarlState::append(const vector<handle_t>&
         // Find the appropriate node lanes collection
         auto& node_lanes = net_node_lanes[graph->forward(handle)];
         // Save the local lane assignment
-        inserted_iterator->second = node_lanes.size() - 1;
+        inserted_iterator->second = node_lanes.size();
         // And do the insert
         node_lanes.emplace_back(inserted_iterator);
         
@@ -182,7 +182,7 @@ const vector<pair<handle_t, size_t>>& SnarlState::insert(size_t overall_lane, co
             // Interior visits just get appended, which is simplest. No need to bump anything up.
             
             // Save the local lane assignment
-            inserted_iterator->second = node_lanes.size() - 1;
+            inserted_iterator->second = node_lanes.size();
             // And do the insert
             node_lanes.emplace_back(inserted_iterator);
         }

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -370,6 +370,8 @@ size_t GenomeState::count_haplotypes(const pair<const Snarl*, const Snarl*>& tel
 void GenomeState::trace_haplotype(const pair<const Snarl*, const Snarl*>& telomere_pair,
     size_t overall_lane, const function<void(const handle_t&)>& iteratee) {
     
+    cerr << "Trace overall lane " << overall_lane << endl;
+    
     // We need to traverse this hierarchy while not emitting visits twice. The
     // hard part is that the same handle represents entering a snarl and the
     // start visit of that snarl. The other hard part is that for back-to-back
@@ -383,6 +385,9 @@ void GenomeState::trace_haplotype(const pair<const Snarl*, const Snarl*>& telome
     // We define a recursive function to traverse a snarl and all its visited children.
     function<void(const Snarl*, size_t, bool, bool)> recursively_traverse_snarl =
         [&](const Snarl* here, size_t lane, bool orientation, bool skip_first) {
+
+        cerr << "Traverse snarl " << pb2json(*here) << endl;
+        state.at(here).dump();
 
         // We need to remember if the last visit we did was a child snarl.
         bool last_was_child = false;

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -265,9 +265,14 @@ GenomeStateCommand* SwapHaplotypesCommand::execute(GenomeState& state) const {
     return new SwapHaplotypesCommand(state.swap_haplotypes(*this));
 }
 
-GenomeStateCommand* CreateHaplotypeCommand::execute(GenomeState& state) const {
+GenomeStateCommand* AppendHaplotypeCommand::execute(GenomeState& state) const {
     // Allocate and populate the reverse command.
-    return new DeleteHaplotypeCommand(state.create_haplotype(*this));
+    return new DeleteHaplotypeCommand(state.append_haplotype(*this));
+}
+
+GenomeStateCommand* ReplaceLocalHaplotypeCommand::execute(GenomeState& state) const {
+    // Allocate and populate the reverse command.
+    return new ReplaceLocalHaplotypeCommand(state.replace_local_haplotype(*this));
 }
 
 
@@ -296,10 +301,10 @@ const NetGraph* GenomeState::get_net_graph(const Snarl* snarl) {
     return &net_graphs.at(snarl);
 }
 
-DeleteHaplotypeCommand GenomeState::create_haplotype(const CreateHaplotypeCommand& c) {
-    // Sample a new haplotype recursively
-    
-    // TODO: what RNG are we going to use?
+DeleteHaplotypeCommand GenomeState::append_haplotype(const AppendHaplotypeCommand& c) {
+}
+
+ReplaceLocalHaplotypeCommand GenomeState::replace_local_haplotype(const ReplaceLocalHaplotypeCommand& c) {
 }
 
 DeleteHaplotypeCommand GenomeState::insert_haplotype(const InsertHaplotypeCommand& c) {

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -34,6 +34,11 @@ void SnarlState::trace(size_t overall_lane, bool backward, const function<void(c
 
 void SnarlState::insert(const vector<pair<handle_t, size_t>>& haplotype) {
     assert(!haplotype.empty());
+    
+    if (haplotype.front().first != graph->get_start() || haplotype.back().first != graph->get_end()) {
+        // Fail if it's not actually from start to end.
+        throw runtime_error("Tried to add a haplotype to a snarl that is not a start-to-end traversal of that snarl.");
+    }
 
     // TODO: all these inserts at indexes are O(N).
 

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -212,7 +212,17 @@ vector<pair<handle_t, size_t>> SnarlState::erase(size_t overall_lane) {
         // Trace from end to start and remove from the net node lanes collections.
         // We have to do it backward so we can handle duplicate visits properly.
         auto& node_lanes = net_node_lanes[graph->forward(it->first)];
-        node_lanes.erase(node_lanes.begin() + it->second);
+        auto lane_iterator = node_lanes.erase(node_lanes.begin() + it->second);
+        
+        while (lane_iterator != node_lanes.end()) {
+            // Update all the subsequent records in that net node's lane list and bump down their internal lane assignments
+            
+            // First dereference to get the iterator that points to the actual
+            // record, then dereference that, and decrement the lane number.
+            (*(*lane_iterator)).second--;
+            
+            ++lane_iterator;
+        }
     }
 
     // Drop the actual haplotype

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -454,31 +454,24 @@ void GenomeState::trace_haplotype(const pair<const Snarl*, const Snarl*>& telome
                 // If the visit enters a real child snarl, we have to do that
                 // child snarl and all the snarls in its chain.
                 
-                // Work out if we go through it backward
-                bool child_backward = net_graph.get_id(visit) != child->start().node_id();
+                // Get the chain for the child
+                const Chain* child_chain = manager.chain_of(child);
                 
-                // Make a visit to track where we are in the child snarl's
-                // chain. We snart with this snarl
-                Visit chain_cursor;
-                transfer_boundary_info(*child, *chain_cursor.mutable_snarl());
-                chain_cursor.set_backward(child_backward);
+                // Get the iterators to loop over it starting at the child
+                auto here = chain_begin_from(*child_chain, child);
+                auto end = chain_end_from(*child_chain, child);
                 
                 // Track if we had a previous snarl that would have emitted any shaed nodes.
                 bool had_previous = false;
                 
-                while (chain_cursor.has_snarl()) {
+                for (; here != end; ++here) {
                     // Until we run out of snarls in the chain
                 
                     // Handle this one
-                    recursively_traverse_snarl(manager.manage(chain_cursor.snarl()), child_lane,
-                        chain_cursor.backward(), had_previous);
+                    recursively_traverse_snarl(here->first, child_lane, here->second, had_previous);
                     
                     // Say we did a snarl previously
                     had_previous = true;
-                    
-                    // Go to the next snarl (or off the chain)
-                    chain_cursor = manager.next_in_chain(chain_cursor);
-                    
                 }                                                               
             } else {
                 // This is a visit to a normal handle in this snarl.

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -14,7 +14,7 @@ size_t SnarlState::size() const {
 
 void SnarlState::trace(size_t overall_lane, bool backward, const function<void(const handle_t&, size_t)>& iteratee) const {
     // Get the haplotype we want to loop over
-    auto& haplotype = haplotypes.at(rank);
+    auto& haplotype = haplotypes.at(overall_lane);
     
     auto process_traversal = [&](const pair<handle_t, size_t>& handle_and_lane) {
         // For every handle in the haplotype, yield it either forward or
@@ -33,13 +33,35 @@ void SnarlState::trace(size_t overall_lane, bool backward, const function<void(c
 }
 
 void SnarlState::insert(const vector<pair<handle_t, size_t>>& haplotype) {
+    assert(!haplotype.empty());
+
+    // TODO: all these inserts at indexes are O(N).
+
     // Insert the whole traversal into haplotypes at the appropriate index for the overall lane
+    size_t overall_lane = haplotype.front().second;
+    assert(overall_lane == haplotype.back().second);
+    auto inserted = haplotypes.insert(haplotypes.begin() + overall_lane, haplotype);
     
-    // For each handle visit
+    for (auto it = inserted->begin(); it != inserted->end(); ++it) {
+        // For each handle visit
+        auto& handle_visit = *it;
+        
+        // Insert the iterator record at the right place in net_node_lanes
+        auto& node_lanes = net_node_lanes[graph->forward(handle_visit.first)];
+        auto lane_iterator = node_lanes.insert(node_lanes.begin() + handle_visit.second, it);
     
-    // Insert the iterator record at the right place in net_node_lanes
-    
-    // Update all the subsequent records in that net node's lane list and bump up their internal lane assignments
+        // Look at whatever is after the lane we just inserted
+        ++lane_iterator;
+        while (lane_iterator != node_lanes.end()) {
+            // Update all the subsequent records in that net node's lane list and bump up their internal lane assignments
+            
+            // First dereference to get the iterator that points to the actual
+            // record, then dereference that, and increment the lane number.
+            (*(*lane_iterator)).second++;
+            
+            ++lane_iterator;
+        }
+    }
 }
 
 void SnarlState::append(const vector<handle_t>& haplotype) {
@@ -50,6 +72,17 @@ void SnarlState::append(const vector<handle_t>& haplotype) {
     // Append its iterator to net_node_lanes for the net node it is on
     
     // Set its internal lane assignment that results
+}
+
+vector<pair<handle_t, size_t>> SnarlState::insert(size_t overall_lane, const vector<handle_t>& haplotype) {
+    // Insert the first and last handles with the assigned overall lane
+    
+    // Insert everything lese with the last overall lane, in order.
+}
+
+GenomeStateCommand* DeleteHaplotypeCommand::execute(GenomeState& state) const {
+    // Allocate and populate the reverse command.
+    return new InsertHaplotypeCommand(state.delete_haplotype(*this));
 }
 
 
@@ -95,6 +128,8 @@ DeleteHaplotypeCommand GenomeState::insert_haplotype(const InsertHaplotypeComman
     return to_return;
 }
 
+InsertHaplotypeCommand GenomeState::delete_haplotype(const DeleteHaplotypeCommand& c) {
+}
 
 GenomeStateCommand* GenomeState::execute(GenomeStateCommand* command) {
     // Just make the command tell us what type it is

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -449,6 +449,7 @@ void GenomeState::trace_haplotype(const pair<const Snarl*, const Snarl*>& telome
             
             // What child, if any, do we enter on this node?
             const Snarl* child = manager.into_which_snarl(net_graph.get_id(visit), net_graph.get_is_reverse(visit));
+            // TODO: This is also catching subsequent snarls in our chain. We should not recurse into those!
             
             if (child != nullptr && child != here) {
                 // If the visit enters a snarl (other than this one)

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -4,21 +4,117 @@ namespace vg {
 
 using namespace std;
 
+SnarlState::SnarlState(const NetGraph* graph) : graph(graph) {
+    // Nothing to do!
+}
+
+size_t SnarlState::size() const {
+    return haplotypes.size();
+}
+
+void SnarlState::trace(size_t rank, bool backward, const function<void(const handle_t&, size_t)>& iteratee) const {
+    // Get the haplotype we want to loop over
+    auto& haplotype = haplotypes.at(rank);
+    
+    auto process_traversal = [&](const pair<handle_t, size_t>& handle_and_rank) {
+        // For every handle in the haplotype, yield it either forward or
+        // backward as determined by our traversal direction.
+        iteratee(backward ? graph->flip(handle_and_rank.first) : handle_and_rank.first, handle_and_rank.second);
+    };
+    
+    if (backward) {
+        // If we're going backward, go in reverse order.
+        // See <https://stackoverflow.com/a/23094303>
+        for_each(haplotype.rbegin(), haplotype.rend(), process_traversal);
+    } else {
+        // Otherwise go in forward order
+        for_each(haplotype.begin(), haplotype.end(), process_traversal);
+    }
+}
+
+void SnarlState::insert(size_t rank, const vector<handle_t>& haplotype) {
+    // We're going to insert the given haplotype at the given initial rank.
+    
+    // For each handle in the haplotype
+    
+    // If it's the first or the last
+    
+    // Insert it at the specified rank and push everything else up
+    
+    // Otherwise just append it at the next available rank.
+    
+    // Insert it at the last rank for all visits to the forward version of that handle.
+    
+    // For the first visit (and the last if it isn't equal to the first), actually make it be at the specified rank and move all the other things at or after that rank up.
+}
+
+
 GenomeState::GenomeState(const SnarlManager& manager, const HandleGraph* graph,
     const unordered_set<pair<const Snarl*, const Snarl*>> telomeres) : telomeres(telomeres), manager(manager) {
 
     manager.for_each_snarl_preorder([&](const Snarl* snarl) {
         // For each snarl
         
-        // Make an empty state for it
-        state.emplace(snarl, SnarlState());
-        
         // Make a net graph for it. TODO: we're not considering internal
         // connectivity, but what we really should do is consider internal
         // connectivity but only allowing for start to end traversals (but
         // including in unary snarls)
         net_graphs.emplace(snarl, manager.net_graph_of(snarl, graph, false));
+        
+        // Make an empty state for it using the net graph
+        state.emplace(snarl, SnarlState(&net_graphs.at(snarl)));
+        
+        // TODO: can we just make the net graph live in the state?
+        
+        
     });
+}
+
+DeleteHaplotypeCommand GenomeState::create_haplotype(const CreateHaplotypeCommand& c) {
+    // Sample a new haplotype recursively
+    
+    // TODO: what RNG are we going to use?
+}
+
+DeleteHaplotypeCommand GenomeState::insert_haplotype(const InsertHaplotypeCommand& c) {
+    DeleteHaplotypeCommand to_return;
+    
+    for (const tuple<const Snarl*, size_t, vector<handle_t>>& action : c.insertions) {
+        // For every insert action we have to do, in order, do it
+        // Insert into this snarl at this rank this haplotype
+        state.at(get<0>(action)).insert(get<1>(action), get<2>(action));
+        
+        // Record how to undo it (delete from this snarl at this rank).
+        to_return.deletions.emplace_back(get<0>(action), get<1>(action));
+    }
+    
+    return to_return;
+}
+
+
+GenomeStateCommand* GenomeState::execute(GenomeStateCommand* command) {
+    // Just make the command tell us what type it is
+    return command->execute(*this);
+}
+
+size_t GenomeState::count_haplotypes(const pair<const Snarl*, const Snarl*>& telomere_pair) {
+    // We assume all the traversals go through the whole chromosome from telomere to telomere.
+    return state.at(telomere_pair.first).size();
+}
+
+void GenomeState::trace_haplotype(const pair<const Snarl*, const Snarl*>& telomere_pair,
+    size_t rank, const function<void(const handle_t&)> iteratee) {
+    
+    // Start at the first snarl in the telomere pair
+    
+    // Start at the rank we were given
+    
+    // Trace out its traversal
+    
+    // If we visit a real node, yield it.
+    
+    // If we visit a child snarl, we need to recurse into it with the appropriate rank.
+    
 }
 
 

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -12,14 +12,14 @@ size_t SnarlState::size() const {
     return haplotypes.size();
 }
 
-void SnarlState::trace(size_t rank, bool backward, const function<void(const handle_t&, size_t)>& iteratee) const {
+void SnarlState::trace(size_t overall_lane, bool backward, const function<void(const handle_t&, size_t)>& iteratee) const {
     // Get the haplotype we want to loop over
     auto& haplotype = haplotypes.at(rank);
     
-    auto process_traversal = [&](const pair<handle_t, size_t>& handle_and_rank) {
+    auto process_traversal = [&](const pair<handle_t, size_t>& handle_and_lane) {
         // For every handle in the haplotype, yield it either forward or
         // backward as determined by our traversal direction.
-        iteratee(backward ? graph->flip(handle_and_rank.first) : handle_and_rank.first, handle_and_rank.second);
+        iteratee(backward ? graph->flip(handle_and_lane.first) : handle_and_lane.first, handle_and_lane.second);
     };
     
     if (backward) {
@@ -32,20 +32,24 @@ void SnarlState::trace(size_t rank, bool backward, const function<void(const han
     }
 }
 
-void SnarlState::insert(size_t rank, const vector<handle_t>& haplotype) {
-    // We're going to insert the given haplotype at the given initial rank.
+void SnarlState::insert(const vector<pair<handle_t, size_t>>& haplotype) {
+    // Insert the whole traversal into haplotypes at the appropriate index for the overall lane
     
-    // For each handle in the haplotype
+    // For each handle visit
     
-    // If it's the first or the last
+    // Insert the iterator record at the right place in net_node_lanes
     
-    // Insert it at the specified rank and push everything else up
+    // Update all the subsequent records in that net node's lane list and bump up their internal lane assignments
+}
+
+void SnarlState::append(const vector<handle_t>& haplotype) {
+    // Append the whole traversal to haplotypes, with 0s for the lane assignments
     
-    // Otherwise just append it at the next available rank.
+    // For each handle visit in the haplotype in haplotypes
     
-    // Insert it at the last rank for all visits to the forward version of that handle.
+    // Append its iterator to net_node_lanes for the net node it is on
     
-    // For the first visit (and the last if it isn't equal to the first), actually make it be at the specified rank and move all the other things at or after that rank up.
+    // Set its internal lane assignment that results
 }
 
 

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -213,6 +213,24 @@ vector<pair<handle_t, size_t>> SnarlState::erase(size_t overall_lane) {
     return copy;
 }
 
+void SnarlState::swap(size_t rank1, size_t rank2) {
+    
+    // Swap the start and end annotation values
+    std::swap(haplotypes.at(rank1).front().second, haplotypes.at(rank2).front().second);
+    std::swap(haplotypes.at(rank1).back().second, haplotypes.at(rank2).back().second);
+    
+    // Swap the start net node index entries
+    auto& start_node_lanes = net_node_lanes[graph->forward(graph->get_start())];
+    std::swap(start_node_lanes.at(rank1), start_node_lanes.at(rank2));
+    
+    // Swap the end net node index entries
+    auto& end_node_lanes = net_node_lanes[graph->forward(graph->get_end())];
+    std::swap(end_node_lanes.at(rank1), end_node_lanes.at(rank2));
+    
+    // Swap the actual haplotype vectors
+    std::swap(haplotypes.at(rank1), haplotypes.at(rank2));
+}
+
 GenomeStateCommand* DeleteHaplotypeCommand::execute(GenomeState& state) const {
     // Allocate and populate the reverse command.
     return new InsertHaplotypeCommand(state.delete_haplotype(*this));

--- a/src/genome_state.hpp
+++ b/src/genome_state.hpp
@@ -39,13 +39,16 @@ class SnarlState {
 protected:
     
     // This stores, for each overall lane, the traversal in that lane, annotated with its internal lane assignments
-    vector<list<pair<handle_t, size_t>>> haplotypes;
+    vector<vector<pair<handle_t, size_t>>> haplotypes;
     
-    // This stores, for each forward handle, a list of all the lanes in order.
+    // This stores, for each forward handle, a vector of all the lanes in order.
     // Each lane is holding an iterator to the entry in the haplotyope that
-    // occupies that lane. When we insert into or delete out of the lists in
-    // this map, we update the lane numbers where all the iterators point.
-    unordered_map<handle_t, list<decltype(haplotypes)::iterator>> net_node_lanes;
+    // occupies that lane. When we insert into or delete out of the vectors in
+    // this map, we update the lane numbers where all the iterators point. TODO:
+    // really we need to hold skip lists or something; we need efficient insert
+    // at index. But since we still need to pay O(N) fixing up stuff after the
+    // insert, it might not be worth it.
+    unordered_map<handle_t, vector<decltype(haplotypes)::value_type::iterator>> net_node_lanes;
     
     /// We need to keep track of the net graph, because we may need to traverse
     /// haplotypes forward or reverse and we need to flip things.

--- a/src/genome_state.hpp
+++ b/src/genome_state.hpp
@@ -59,6 +59,9 @@ public:
     /// Create a SnarlState that uses the given net graph.
     SnarlState(const NetGraph* graph);
     
+    /// Dump internal state to cerr.
+    void dump() const;
+    
     /// How many haplotypes traverse this snarl?
     size_t size() const;
     
@@ -77,8 +80,11 @@ public:
     void insert(const vector<pair<handle_t, size_t>>& haplotype);
     
     /// Insert the given traversal of this snarl from start to end, assigning
-    /// each visit to a handle to the next available lane.
-    void append(const vector<handle_t>& haplotype);
+    /// each visit to a handle to the next available lane. Returns the haplotype
+    /// annotated with lane assignments. If handles to the same node or child
+    /// snarl appear more than once, their lane numbers will be strictly
+    /// increasing.
+    const vector<pair<handle_t, size_t>>& append(const vector<handle_t>& haplotype);
     
     /// Insert the given traversal of this snarl from start to end, assigning it
     /// to the given overall lane. Returns the haplotype annotated with lane
@@ -86,8 +92,9 @@ public:
     /// represent child snarls, this can be used to recurse down and insert
     /// traversals of them at the right lanes. If handles to the same node or
     /// child snarl appear more than once, their assigned lane numbers will be
-    /// strictly increasing.
-    vector<pair<handle_t, size_t>> insert(size_t overall_lane, const vector<handle_t>& haplotype);
+    /// strictly increasing. Returns the haplotype annotated with lane
+    /// assignments.
+    const vector<pair<handle_t, size_t>>& insert(size_t overall_lane, const vector<handle_t>& haplotype);
     
     // TODO: can we do an efficient replace? Or should we just drop and add.
     

--- a/src/genome_state.hpp
+++ b/src/genome_state.hpp
@@ -1,0 +1,100 @@
+#ifndef VG_GENOME_STATE_HPP_INCLUDED
+#define VG_GENOME_STATE_HPP_INCLUDED
+
+/**
+ * \file genome_state.hpp
+ *
+ * MCMC-friendly genome state representation.
+ */
+
+#include "handle.hpp"
+#include "snarls.hpp"
+
+#include <vector>
+#include <unordered_map>
+#include <utility>
+#include <tuple>
+
+
+
+namespace vg {
+
+using namespace std;
+
+/**
+ * Represents the state of a snarl: zero or more haplotypes traversing its
+ * NetGraph.
+ *
+ * Only admits full-length traversals of a snarl from start to end.
+ */
+class SnarlState {
+
+public:
+    
+    /**
+     * How many haplotypes traverse this snarl?
+     */
+    size_t size();
+
+    // We can add, remove, and swap haplotypes by rank.
+    // All these operations are meant to be reversible.
+    // TODO: Write real operation descriptions
+    void insert(size_t rank, const vector<handle_t>& haplotype);
+    vector<handle_t> replace(size_t rank, const vector<handle_t>& haplotype);
+    vector<handle_t> erase(size_t rank);
+    void swap(size_t rank1, size_t rank2);
+
+protected:
+    /**
+     * Store a vector of haplotype traversals of this snarl from start to end.
+     * Handles are in the Snarl's NetGraph, and represent visits to either the
+     * snarl's own nodes or to child snarls. The handles visiting the snarl's
+     * start and end nodes are included.
+     */
+    vector<vector<handle_t>> haplotypes;
+    
+    
+};
+ 
+/**
+ * Define a way to represent a phased set of haplotypes on a graph that is under
+ * consideration as a variant calling solution.
+ *
+ * There should only be one of these for any genotyping run; operations all
+ * mutate the single copy and, if you don't like the result, can be rolled back
+ * by doing the reverse mutation.
+ */
+class GenomeState {
+
+public:
+    
+    /**
+     * Sample and add a new traversal of the given snarl. Recursively samples
+     * and adds new traversals of all the child snarls that need to be
+     * traversed. Returns the rank of the new traversal in the given snarl.
+     */
+    size_t sample_new(const Snarl* snarl);
+    
+    /**
+     * Erase the haplotype of the given rank form the given snarl. Also erases
+     * all the corresponding haplotypes in child snarls, recursively. Returns
+     * all the insert operations needed to undo the erase.
+     */
+     vector<tuple<const Snarl*, size_t, vector<handle_t>>> erase(const Snarl* snarl, size_t rank);
+     
+protected:
+    /// We have a state for every snarl
+    unordered_map<const Snarl*, SnarlState> state;
+    
+    /// We precompute all the net graphs and keep them around.
+    unordered_map<const Snarl*, NetGraph> net_graphs;
+    
+    /// We keep a reference to the SnarlManager that knows what children are
+    /// where.
+    const SnarlManager& manager;
+
+};
+
+}
+
+#endif

--- a/src/genome_state.hpp
+++ b/src/genome_state.hpp
@@ -29,21 +29,6 @@ using namespace std;
  */
 class SnarlState {
 
-public:
-    
-    /**
-     * How many haplotypes traverse this snarl?
-     */
-    size_t size();
-
-    // We can add, remove, and swap haplotypes by rank.
-    // All these operations are meant to be reversible.
-    // TODO: Write real operation descriptions
-    void insert(size_t rank, const vector<handle_t>& haplotype);
-    vector<handle_t> replace(size_t rank, const vector<handle_t>& haplotype);
-    vector<handle_t> erase(size_t rank);
-    void swap(size_t rank1, size_t rank2);
-
 protected:
     /**
      * Store a vector of haplotype traversals of this snarl from start to end.
@@ -52,7 +37,42 @@ protected:
      * start and end nodes are included.
      */
     vector<vector<handle_t>> haplotypes;
+
+public:
     
+    /// How many haplotypes traverse this snarl?
+    size_t size() const;
+    
+    /// We define a way to iterate over the contained haplotypes
+    using const_iterator = decltype(haplotypes)::const_iterator;
+    
+    /// Get an iterator to the first haplotype
+    const_iterator begin() const;
+    
+    /// Get an iterator to the past-the-end haplotype
+    const_iterator end() const;
+    
+    /// Get the haplotype at the given rank.
+    const vector<handle_t>& at(size_t rank) const;
+
+    // We can add, remove, and swap haplotypes by rank.
+    // All these operations are meant to be reversible.
+    
+    /// Insert the given traversal of this snarl from start to end as a
+    /// haplotype with the given overall rank. The first rank is 0. Pushes
+    /// everything with a higher rank 1 rank up.
+    void insert(size_t rank, const vector<handle_t>& haplotype);
+    
+    /// Replace the traversal of this haplotype at the given rank with the given
+    /// new traversal from start to end. Returns the replaced haplotype.
+    vector<handle_t> replace(size_t rank, const vector<handle_t>& haplotype);
+    
+    /// Erase the traversal of this haplotype with the given rank. Shifts
+    /// everything with a higher rank 1 rank down. Returns the erased haplotype.
+    vector<handle_t> erase(size_t rank);
+    
+    /// Swap the traversals of this haplotype with the two given ranks.
+    void swap(size_t rank1, size_t rank2);
     
 };
 
@@ -67,7 +87,8 @@ struct GenomeStateCommand {
     virtual ~GenomeStateCommand() = default;
     
     /// Execute this command on the given state and return the reverse command.
-    virtual GenomeStateCommand* execute(GenomeState& state) const;
+    /// Generally ends up calling a command-type-specific method on the GenomeState that does the actual work.
+    virtual GenomeStateCommand* execute(GenomeState& state) const = 0;
 };
 
 struct InsertHaplotypeCommand : public GenomeStateCommand {
@@ -77,19 +98,25 @@ struct InsertHaplotypeCommand : public GenomeStateCommand {
     /// To be executed in order from left to right (becasue inserting at ranks changes ranks).
     vector<tuple<const Snarl*, size_t, vector<handle_t>>> insertions;
     
+    virtual GenomeStateCommand* execute(GenomeState& state) const;
+    
     virtual ~InsertHaplotypeCommand() = default;
 };
 
 struct DeleteHaplotypeCommand : public GenomeStateCommand {
     /// In each (top level) snarl's state, delete the haplotype at the given rank.
-    
     vector<pair<const Snarl*, size_t>> deletions;
+    
+    virtual GenomeStateCommand* execute(GenomeState& state) const;
 
     virtual ~DeleteHaplotypeCommand() = default;
 };
 
 struct SwapHaplotypesCommand : public GenomeStateCommand {
+    /// Swap the haplotypes at the given ranks
     pair<size_t, size_t> to_swap;
+    
+    virtual GenomeStateCommand* execute(GenomeState& state) const;
     
     virtual ~SwapHaplotypesCommand() = default;
 };
@@ -98,6 +125,8 @@ struct CreateHaplotypeCommand : public GenomeStateCommand {
     /// This is the root snarl to create a new traversal of.
     /// TODO: maybe should be a chain?
     const Snarl* root;
+    
+    virtual GenomeStateCommand* execute(GenomeState& state) const;
     
     virtual ~CreateHaplotypeCommand() = default;
 };
@@ -114,32 +143,46 @@ class GenomeState {
 
 public:
     
+    /// Make a new GenomeState on the given SnarlManager, manageing snarls in
+    /// the given graph, with the given telomere pairs
+    GenomeState(const SnarlManager& manager, const HandleGraph* graph,
+        const unordered_set<pair<const Snarl*, const Snarl*>> telomeres);
+    
     // We execute commands and return the inverse commands
     
+    /// Create a haplotype and return a command to delete it
     DeleteHaplotypeCommand create_haplotype(const CreateHaplotypeCommand& c);
     
+    /// Insert a haplotype and return a command to delete it
     DeleteHaplotypeCommand insert_haplotype(const InsertHaplotypeCommand& c);
     
+    /// Delete a haplotype and return a command to insert it
     InsertHaplotypeCommand delete_haplotype(const DeleteHaplotypeCommand& c);
     
+    /// Swap two haplotypes and return a command to swap them back
     SwapHaplotypesCommand swap_haplotypes(const SwapHaplotypesCommand& c);
     
-    /// Execute a command.
-    /// Return a new heap-allocated command that undoes the command being executed.
-    /// Frees the passed command. TODO: does that make sense?
+    /// Execute a command. Return a new heap-allocated command that undoes the
+    /// command being executed. Frees the passed command. TODO: does that make
+    /// sense?
     GenomeStateCommand* execute(GenomeStateCommand* command);
      
 protected:
-    /// We have a state for every snarl. TODO: What about how top-level snarls
-    /// form chains? Mightn't you need to traverse several? We don't really have
-    /// a root-level state.
+    /// We keep track of pairs of telomere unary snarls. The haplotypes we work
+    /// on connect a left telomere and its corresponding right telomere. We can
+    /// traverse the snarl decomposition from one telomere to the other either
+    /// following chains or pollowing paths inside of some snarl we are in.
+    unordered_set<pair<const Snarl*, const Snarl*>> telomeres;
+
+    /// We have a state for every snarl.
     unordered_map<const Snarl*, SnarlState> state;
     
     /// We precompute all the net graphs and keep them around.
     unordered_map<const Snarl*, NetGraph> net_graphs;
     
     /// We keep a reference to the SnarlManager that knows what children are
-    /// where.
+    /// where and which snarl we should look at next after leaving a previous
+    /// snarl.
     const SnarlManager& manager;
 
 };

--- a/src/genome_state.hpp
+++ b/src/genome_state.hpp
@@ -106,7 +106,7 @@ public:
     /// Swap the traversals of this haplotype in the two given overall lanes.
     /// Internal lane assignments (as are used by child snarls) are not
     /// affected.
-    void swap(size_t rank1, size_t rank2);
+    void swap(size_t lane1, size_t lane2);
     
 };
 
@@ -161,6 +161,8 @@ struct DeleteHaplotypeCommand : public GenomeStateCommand {
 };
 
 struct SwapHaplotypesCommand : public GenomeStateCommand {
+    /// Work on the given pair of telomeres
+    pair<const Snarl*, const Snarl*> telomere_pair;
     /// Swap the haplotypes at the given ranks
     pair<size_t, size_t> to_swap;
     

--- a/src/genome_state.hpp
+++ b/src/genome_state.hpp
@@ -223,15 +223,17 @@ public:
     size_t count_haplotypes(const pair<const Snarl*, const Snarl*>& telomere_pair);
     
     /// Trace the haplotype starting at the given start telomere snarl with the
-    /// given rank. Calls the callback with each backing HandleGraph handle.
+    /// given overall lane. Calls the callback with each backing HandleGraph
+    /// handle.
     void trace_haplotype(const pair<const Snarl*, const Snarl*>& telomere_pair,
-        size_t rank, const function<void(const handle_t&)> iteratee);
+        size_t overall_lane, const function<void(const handle_t&)>& iteratee);
      
 protected:
-    /// We keep track of pairs of telomere unary snarls. The haplotypes we work
-    /// on connect a left telomere and its corresponding right telomere. We can
+    /// We keep track of pairs of telomere snarls. The haplotypes we work on
+    /// connect a left telomere and its corresponding right telomere. We can
     /// traverse the snarl decomposition from one telomere to the other either
     /// following chains or pollowing paths inside of some snarl we are in.
+    /// The start snarl of a pair must be in its local forward orientation.
     unordered_set<pair<const Snarl*, const Snarl*>> telomeres;
 
     /// We precompute all the net graphs and keep them around.

--- a/src/genome_state.hpp
+++ b/src/genome_state.hpp
@@ -267,6 +267,10 @@ protected:
     /// We have a state for every snarl, which depends on the corresponding net graph.
     unordered_map<const Snarl*, SnarlState> state;
     
+    /// We remember the backing graph, because sometimes we need to translate
+    /// from backing graph handles to IDs and orientations to look up snarls.
+    const HandleGraph* backing_graph;
+    
     /// We keep a reference to the SnarlManager that knows what children are
     /// where and which snarl we should look at next after leaving a previous
     /// snarl.

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -403,7 +403,7 @@ const Snarl* CactusSnarlFinder::recursively_emit_snarls(const Visit& start, cons
         if (parent_start.node_id() != 0 && parent_end.node_id() != 0) {
             // We have a parent that isn't the fake root, so fill in its ends
             *snarl.mutable_parent()->mutable_start() = parent_start;
-            *snarl.mutable_parent()->mutable_start() = parent_end;
+            *snarl.mutable_parent()->mutable_end() = parent_end;
         }
     } 
     

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -24,12 +24,12 @@ namespace vg {
             chain.back()->end().node_id() == (*++chain.rbegin())->end().node_id()));
     }
 
-    Visit get_start(const Chain& chain) {
+    Visit get_start_of(const Chain& chain) {
         // Get a bounding visit and return it.
         return start_backward(chain) ? reverse(chain.front()->end()) : chain.front()->start();
     }
     
-    Visit get_end(const Chain& chain) {
+    Visit get_end_of(const Chain& chain) {
         // Get a bounding visit and return it.
         return end_backward(chain) ? reverse(chain.front()->start()) : chain.front()->end();
     }
@@ -1065,8 +1065,8 @@ namespace vg {
     
     void NetGraph::add_chain_child(const Chain& chain) {
         // For every chain, get its bounding handles in the base graph
-        handle_t chain_start_handle = graph->get_handle(get_start(chain));
-        handle_t chain_end_handle = graph->get_handle(get_end(chain));
+        handle_t chain_start_handle = graph->get_handle(get_start_of(chain));
+        handle_t chain_end_handle = graph->get_handle(get_end_of(chain));
         
         // Save the links that let us cross the chain.
         chain_ends_by_start[chain_start_handle] = chain_end_handle;
@@ -1612,6 +1612,14 @@ namespace vg {
             size++;
         });
         return size;
+    }
+    
+    const handle_t& NetGraph::get_start() const {
+        return start;
+    }
+    
+    const handle_t& NetGraph::get_end() const {
+        return end;
     }
     
     bool operator==(const Visit& a, const Visit& b) {

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -149,6 +149,32 @@ namespace vg {
         
         return to_return;
     }
+    
+    ChainIterator chain_begin_from(const Chain& chain, const Snarl* start_snarl) {
+        assert(!chain.empty());
+        if (start_snarl == chain.front()) {
+            // We are at the left end of the chain, so go forward
+            return chain_begin(chain);
+        } else if (start_snarl == chain.back()) {
+            // We are at the right end of the chain, so go reverse
+            return chain_rbegin(chain);
+        } else {
+            throw runtime_error("Tried to view a chain from a snarl not at either end!");
+        }
+    }
+    
+    ChainIterator chain_end_from(const Chain& chain, const Snarl* start_snarl) {
+        assert(!chain.empty());
+        if (start_snarl == chain.front()) {
+            // We are at the left end of the chain, so go forward
+            return chain_end(chain);
+        } else if (start_snarl == chain.back()) {
+            // We are at the right end of the chain, so go reverse
+            return chain_rend(chain);
+        } else {
+            throw runtime_error("Tried to view a chain from a snarl not at either end!");
+        }
+    } 
 
     // TODO: this is duplicative with the other constructor, but protobuf won't let me make
     // a deserialization iterator to match its signature because its internal file streams
@@ -191,11 +217,15 @@ namespace vg {
         return next == here ? nullptr : next;
     }
     
-    bool SnarlManager::in_nontrivial_chain(const Snarl* here) const {
-        return (snarl_sharing_start(here) != nullptr || snarl_sharing_end(here) != nullptr);
+    const Chain* SnarlManager::chain_of(const Snarl* snarl) const {
+        return parent_chain.at(key_form(snarl));
     }
     
-    Visit SnarlManager::next_in_chain(const Visit& here) const {
+    bool SnarlManager::in_nontrivial_chain(const Snarl* here) const {
+        return chain_of(here)->size() > 1;
+    }
+    
+    Visit SnarlManager::next_snarl(const Visit& here) const {
         // Must be a snarl visit
         assert(here.node_id() == 0);
         const Snarl* here_snarl = manage(here.snarl());
@@ -224,11 +254,11 @@ namespace vg {
         }
     }
     
-    Visit SnarlManager::prev_in_chain(const Visit& here) const {
-        return reverse(next_in_chain(reverse(here)));
+    Visit SnarlManager::prev_snarl(const Visit& here) const {
+        return reverse(next_snarl(reverse(here)));
     }
     
-    const vector<Chain>& SnarlManager::chains_of(const Snarl* snarl) const {
+    const deque<Chain>& SnarlManager::chains_of(const Snarl* snarl) const {
         if (snarl == nullptr) {
             // We want the root chains
             return root_chains;
@@ -315,6 +345,10 @@ namespace vg {
         child_chains[key_form(snarl)] = std::move(child_chains[old_key]);
         child_chains.erase(old_key);
         
+        // And the parent chain index
+        parent_chain[key_form(snarl)] = std::move(parent_chain[old_key]);
+        parent_chain.erase(old_key);
+        
         // Update self index
         self[key_form(snarl)] = std::move(self[old_key]);
         self.erase(old_key);
@@ -338,7 +372,7 @@ namespace vg {
         // It has an empty vector of children
         children[key_form(snarl)] = vector<const Snarl*>();
         // It has an empty list of child chains.
-        child_chains[key_form(snarl)] = vector<Chain>();
+        child_chains[key_form(snarl)] = deque<Chain>();
         
         // We will set the parent later when we add the snarl's chain.
         // Every snarl has to be in a chain. Even the unary ones, in trivial chains.
@@ -366,7 +400,16 @@ namespace vg {
                 roots.push_back(child);
                 
                 // Save its parent, which is null
-                parent[key_form(child)] = nullptr;
+                parent.emplace(key_form(child), nullptr);
+                
+                // Save its chain. Relies on the Chain in root_chains never
+                // moving.
+                parent_chain.emplace(key_form(child), &root_chains.back());
+                
+#ifdef debug
+                cerr << "Stored parent of " << child << endl;
+#endif
+                
             }
         } else {
         
@@ -385,9 +428,22 @@ namespace vg {
                 children[key_form(chain_parent)].push_back(child);
                 
                 // Save its parent
-                parent[key_form(child)] = chain_parent;
+                parent.emplace(key_form(child), chain_parent);
+                
+                // Save its chain. Relies on the Chain in child_chains never
+                // moving.
+                parent_chain.emplace(key_form(child), &child_chains[key_form(chain_parent)].back());
+                
+#ifdef debug
+                cerr << "Stored parent of " << child << endl;
+#endif
+                
             }
         }
+        
+#ifdef debug
+        cerr << "Now have " << parent_chain.size() << " chain index entries for " << snarls.size() << " snarls" << endl;
+#endif
     }
     
     const Snarl* SnarlManager::into_which_snarl(int64_t id, bool reverse) const {
@@ -491,6 +547,13 @@ namespace vg {
         
             // Compute the chains for the root level snarls
             root_chains = compute_chains(roots);
+            
+            // Build the back index from root snarl to containing chain
+            for (auto& chain : root_chains) {
+                for (const Snarl* snarl : chain) {
+                    parent_chain.emplace(key_form(snarl), &chain);
+                }
+            }
         
             for (auto& kv : children) {
                 // For each parent snarl
@@ -499,14 +562,23 @@ namespace vg {
                 vector<const Snarl*>& snarl_children = kv.second;
                 
                 // Compute chains of the children and store it under the parent.
-                child_chains.insert(make_pair(parent_key, compute_chains(snarl_children)));
+                // Keep the iterator.
+                auto inserted = child_chains.emplace(make_pair(parent_key, compute_chains(snarl_children))).first;
+                
+                // Build the back index from child snarl to containing chain
+                for (auto& chain : inserted->second) {
+                    for (const Snarl* snarl : chain) {
+                        parent_chain.emplace(key_form(snarl), &chain);
+                    }
+                }
+                
             }
         }
     }
     
-    vector<Chain> SnarlManager::compute_chains(const vector<const Snarl*>& input_snarls) {
+    deque<Chain> SnarlManager::compute_chains(const vector<const Snarl*>& input_snarls) {
         // We populate this
-        vector<Chain> to_return;
+        deque<Chain> to_return;
         
         // We track the snarls we have seen in chain traversals so we only have to see each chain once.
         unordered_set<const Snarl*> seen;
@@ -529,9 +601,9 @@ namespace vg {
             Visit here;
             transfer_boundary_info(*snarl, *here.mutable_snarl());
             
-            for (Visit walk_left = prev_in_chain(here);
+            for (Visit walk_left = prev_snarl(here);
                 walk_left.has_snarl() && !seen.count(manage(walk_left.snarl()));
-                walk_left = prev_in_chain(walk_left)) {
+                walk_left = prev_snarl(walk_left)) {
             
                 // For everything in the chain left from here, until we hit the
                 // end or come back to the start, add it to the chain
@@ -540,9 +612,9 @@ namespace vg {
                 seen.insert(chain.front());
             }
             
-            for (Visit walk_right = next_in_chain(here);
+            for (Visit walk_right = next_snarl(here);
                 walk_right.has_snarl() && !seen.count(manage(walk_right.snarl()));
-                walk_right = next_in_chain(walk_right)) {
+                walk_right = next_snarl(walk_right)) {
                 
                 // For everything in the chain right from here, until we hit the
                 // end or come back to the start, add it to the chain
@@ -989,41 +1061,6 @@ namespace vg {
         end(graph->get_handle(end.node_id(), end.backward())),
         use_internal_connectivity(use_internal_connectivity) {
         // Nothing to do!
-    }
-    
-    NetGraph::NetGraph(const Visit& start, const Visit& end,
-        const vector<Chain>& child_chains_mixed,
-        const HandleGraph* graph,
-        bool use_internal_connectivity) : NetGraph(start, end, graph, use_internal_connectivity) {
-        
-        // All we need to do is index the children. They come mixed as real chains and unary snarls.
-        
-        for (auto& chain : child_chains_mixed) {
-            if (chain.size() == 1 && chain.front()->type() == UNARY) {
-                // This is a unary snarl wrapped in a chain
-                add_unary_child(chain.front());
-            } else {
-                // This is a real (but possibly trivial) chain
-                add_chain_child(chain);
-            }
-        }
-        
-    }
-    
-    NetGraph::NetGraph(const Visit& start, const Visit& end,
-        const vector<Chain>& child_chains,
-        const vector<const Snarl*>& child_unary_snarls, const HandleGraph* graph,
-        bool use_internal_connectivity) : NetGraph(start, end, graph, use_internal_connectivity) {
-        
-        // All we need to do is index the children.
-        
-        for (const Snarl* unary : child_unary_snarls) {
-            add_unary_child(unary);
-        }
-        
-        for (auto& chain : child_chains) {
-            add_chain_child(chain);
-        }
     }
     
     NetGraph::NetGraph(const Visit& start, const Visit& end,

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -47,12 +47,12 @@ namespace vg {
     /**
      * Get the inward-facing start Visit for a chain.
      */
-    Visit get_start(const Chain& chain);
+    Visit get_start_of(const Chain& chain);
     
     /**
      * Get the outward-facing end Visit for a chain.
      */
-    Visit get_end(const Chain& chain);
+    Visit get_end_of(const Chain& chain);
     
     /**
      * We want to be able to loop over a chain and get iterators to pairs of the
@@ -196,6 +196,16 @@ namespace vg {
         
         /// Return the number of nodes in the graph
         virtual size_t node_size() const;
+        
+        // We also have some extra functions
+        
+        /// Get the inward-facing start handle for this net graph. Useful when
+        /// working with traversals.
+        const handle_t& get_start() const;
+        
+        /// Get the outward-facing end handle for this net graph. Useful when
+        /// working with traversals.
+        const handle_t& get_end() const;
         
     protected:
     

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -87,6 +87,10 @@ namespace vg {
         /// beginning)
         bool is_rend;
         
+        /// When dereferencing, should we flip snarl orientations form the
+        /// orientations they appear at in the chain when read left to right?
+        bool complement;
+        
         /// In order to dereference to a pair with -> we need a place to put the pair so we can have a pointer to it.
         /// Gets lazily set to wherever the iterator is pointing when we do ->
         mutable pair<const Snarl*, bool> scratch;
@@ -100,10 +104,21 @@ namespace vg {
     ChainIterator chain_rbegin(const Chain& chain);
     ChainIterator chain_rend(const Chain& chain);
     
-    /// We also define a function for getting the ChainIterator for a chain starting with a given snarl
-    ChainIterator chain_begin_from(const Chain& chain, const Snarl* start_snarl);
-    /// And the end iterator for the chain viewed from a given snarl.
-    ChainIterator chain_end_from(const Chain& chain, const Snarl* start_snarl);
+    /// We also define some reverse complement iterators, which go from right to
+    /// left through the chains, but give us the reverse view. For ecample, if
+    /// all the snarls are oriented forward in the chain, we will iterate
+    /// through the snarls in reverse order, with each individual snarl also
+    /// reversed.
+    ChainIterator chain_rcbegin(const Chain& chain);
+    ChainIterator chain_rcend(const Chain& chain);
+    
+    /// We also define a function for getting the ChainIterator (forward or
+    /// reverse complement) for a chain starting with a given snarl in the given
+    /// inward orientation
+    ChainIterator chain_begin_from(const Chain& chain, const Snarl* start_snarl, bool snarl_orientation);
+    /// And the end iterator for the chain (forward or reverse complement)
+    /// viewed from a given snarl in the given inward orientation
+    ChainIterator chain_end_from(const Chain& chain, const Snarl* start_snarl, bool snarl_orientation);
     
     /**
      * Allow traversing a graph of nodes and child snarl chains within a snarl
@@ -240,6 +255,16 @@ namespace vg {
         /// Get the outward-facing end handle for this net graph. Useful when
         /// working with traversals.
         const handle_t& get_end() const;
+        
+        /// Returns true if the given handle represents a meta-node for a child
+        /// chain or unary snarl, and false if it is a normal node actually in
+        /// the net graph snarl's contents.
+        bool is_child(const handle_t& handle) const;
+        
+        /// Get the handle in the backing graph reading into the child chain or
+        /// unary snarl in the orientation represented by this handle to a node
+        /// representing a child chain or unary snarl.
+        handle_t get_inward_backing_handle(const handle_t& child_handle) const;
         
     protected:
     

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -150,7 +150,7 @@ TEST_CASE("SnarlState can hold haplotypes", "[snarlstate][genomestate]") {
         
     }
     
-    SECTION("A haplotype with lane numbers can be added in lane 0 in reverse when the SnarlState is empty") {
+    SECTION("Haplotypes cannot be added in reverse") {
         // Make a haplotype
         vector<pair<handle_t, size_t>> annotated_haplotype;
         
@@ -159,38 +159,8 @@ TEST_CASE("SnarlState can hold haplotypes", "[snarlstate][genomestate]") {
         annotated_haplotype.emplace_back(net_graph.get_handle(2, true), 0);
         annotated_haplotype.emplace_back(net_graph.get_handle(1, true), 0);
         
-        // Put it in the state
-        state.insert(annotated_haplotype);
-        
-        SECTION("The state now has 1 haplotype") {
-            REQUIRE(state.size() == 1);
-        }
-        
-        SECTION("The haplotype can be traced back again, and comes out in snarl-forward orientation") {
-            vector<pair<handle_t, size_t>> recovered;
-            
-            state.trace(0, false, [&](const handle_t& visit, size_t local_lane) {
-                recovered.emplace_back(visit, local_lane);
-            });
-            
-            REQUIRE(recovered.size() == 3);
-            REQUIRE(net_graph.get_id(recovered[0].first) == 1);
-            REQUIRE(net_graph.get_is_reverse(recovered[0].first) == false);
-            REQUIRE(net_graph.get_id(recovered[1].first) == 2);
-            REQUIRE(net_graph.get_is_reverse(recovered[1].first) == false);
-            REQUIRE(net_graph.get_id(recovered[2].first) == 8);
-            REQUIRE(net_graph.get_is_reverse(recovered[2].first) == false);
-        }
-        
-        SECTION("The haplotype can be traced in reverse and comes out in its original order and orientation") {
-            vector<pair<handle_t, size_t>> recovered;
-            
-            state.trace(0, true, [&](const handle_t& visit, size_t local_lane) {
-                recovered.emplace_back(visit, local_lane);
-            });
-            
-            REQUIRE(recovered == annotated_haplotype);
-        }
+        // Try and fail to put it in the state
+        REQUIRE_THROWS(state.insert(annotated_haplotype));
         
     }
     

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -215,6 +215,70 @@ TEST_CASE("SnarlState can hold haplotypes", "[snarlstate][genomestate]") {
                     
                 }
                 
+                SECTION("It can be swapped with another haplotype") {
+                    state.swap(0, 2);
+                    
+                    SECTION("Swapping haplotypes dows not change the overall size") {
+                        REQUIRE(state.size() == 3);
+                    }
+                    
+                    SECTION("The second haplotype added is now in overall lane 2") {
+                        vector<pair<handle_t, size_t>> recovered;
+                        
+                        
+                        state.trace(2, false, [&](const handle_t& visit, size_t local_lane) {
+                            recovered.emplace_back(visit, local_lane);
+                        });
+                        
+                        
+                        
+                        REQUIRE(recovered.size() == 2);
+                        REQUIRE(recovered[0].first == hap2[0].first);
+                        REQUIRE(recovered[0].second == 2);
+                        REQUIRE(recovered[1].first == hap2[1].first);
+                        REQUIRE(recovered[1].second == 2);
+                    }
+                    
+                    SECTION("The third haplotype added is now in overall lane 0") {
+                        vector<pair<handle_t, size_t>> recovered;
+                        
+                        state.trace(0, false, [&](const handle_t& visit, size_t local_lane) {
+                            recovered.emplace_back(visit, local_lane);
+                        });
+                        
+                        REQUIRE(recovered.size() == 3);
+                        REQUIRE(recovered[0].first == hap3[0]);
+                        REQUIRE(recovered[0].second == 0);
+                        SECTION("Swapping haplotypes does not change interior child snarl lane assignments") {
+                            // The second mapping should stay in place in its assigned lane
+                            REQUIRE(recovered[1].first == hap3[1]);
+                            REQUIRE(recovered[1].second == 1);
+                        }
+                        REQUIRE(recovered[2].first == hap3[2]);
+                        REQUIRE(recovered[2].second == 0);
+                    }
+                    
+                    SECTION("The first haplotype added is unaffected in overall lane 1") {
+                        vector<pair<handle_t, size_t>> recovered;
+                        
+                        state.trace(1, false, [&](const handle_t& visit, size_t local_lane) {
+                            recovered.emplace_back(visit, local_lane);
+                        });
+                        
+                        REQUIRE(recovered.size() == 3);
+                        REQUIRE(recovered[0].first == annotated_haplotype[0].first);
+                        REQUIRE(recovered[0].second == annotated_haplotype[0].second + 1);
+                        // The second mapping should not get bumped up.
+                        REQUIRE(recovered[1].first == annotated_haplotype[1].first);
+                        REQUIRE(recovered[1].second == annotated_haplotype[1].second);
+                        REQUIRE(recovered[2].first == annotated_haplotype[2].first);
+                        REQUIRE(recovered[2].second == annotated_haplotype[2].second + 1);
+                        
+                    }
+                    
+                    
+                }
+                
             }
             
             SECTION("A haplotype without lane numbers can be inserted") {

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -161,13 +161,6 @@ TEST_CASE("SnarlState can hold haplotypes", "[snarlstate][genomestate]") {
                 }
                 
                 SECTION("The returned annotated haplotype is correct") {
-                    
-                    for (auto record : added) {
-                        cerr << "Added to " << net_graph.get_id(record.first) << " at lane " << record.second << endl;
-                    }
-                    
-                    state.dump();
-                    
                     REQUIRE(added.size() == 3);
                     REQUIRE(added[0].first == hap3[0]);
                     REQUIRE(added[0].second == 2);
@@ -204,7 +197,10 @@ TEST_CASE("SnarlState can hold haplotypes", "[snarlstate][genomestate]") {
                     REQUIRE(added[0].first == hap3[0]);
                     REQUIRE(added[0].second == 1);
                     REQUIRE(added[1].first == hap3[1]);
-                    REQUIRE(added[1].second == 0);
+                    // We don't actually care about our middle node lane assignment.
+                    // It could be before or after other haplotypes; they're allowed to cross over each other arbitrarily.
+                    REQUIRE(added[1].second >= 0);
+                    REQUIRE(added[1].second <= 1);
                     REQUIRE(added[2].first == hap3[2]);
                     REQUIRE(added[2].second == 1);
                 }
@@ -230,7 +226,10 @@ TEST_CASE("SnarlState can hold haplotypes", "[snarlstate][genomestate]") {
                     REQUIRE(net_graph.get_id(recovered[0].first) == 1);
                     REQUIRE(recovered[0].second == 2);
                     REQUIRE(net_graph.get_id(recovered[1].first) == 2);
-                    REQUIRE(recovered[1].second == 1);
+                    // Lane assignment at the middle visit may or may not have been pushed up.
+                    REQUIRE(recovered[1].second >= 0);
+                    REQUIRE(recovered[1].second <= 1);
+                    REQUIRE(recovered[1].second != added[1].second);
                     REQUIRE(net_graph.get_id(recovered[2].first) == 8);
                     REQUIRE(recovered[2].second == 2);
                 }

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -180,6 +180,41 @@ TEST_CASE("SnarlState can hold haplotypes", "[snarlstate][genomestate]") {
                     REQUIRE(recovered == added);
                 }
                 
+                SECTION("It can be deleted again") {
+                    state.erase(2);
+                    
+                    REQUIRE(state.size() == 2);
+                        
+                    SECTION("The second haplotype can be traced back again") {
+                        vector<pair<handle_t, size_t>> recovered;
+                        
+                        state.trace(0, false, [&](const handle_t& visit, size_t local_lane) {
+                            recovered.emplace_back(visit, local_lane);
+                        });
+                        
+                        REQUIRE(recovered == hap2);
+                    }
+                    
+                    SECTION("The first haplotype can be traced back again") {
+                        vector<pair<handle_t, size_t>> recovered;
+                        
+                        state.trace(1, false, [&](const handle_t& visit, size_t local_lane) {
+                            recovered.emplace_back(visit, local_lane);
+                        });
+                        
+                        REQUIRE(recovered.size() == 3);
+                        REQUIRE(recovered[0].first == annotated_haplotype[0].first);
+                        REQUIRE(recovered[0].second == annotated_haplotype[0].second + 1);
+                        // The second mapping should not get bumped up.
+                        REQUIRE(recovered[1].first == annotated_haplotype[1].first);
+                        REQUIRE(recovered[1].second == annotated_haplotype[1].second);
+                        REQUIRE(recovered[2].first == annotated_haplotype[2].first);
+                        REQUIRE(recovered[2].second == annotated_haplotype[2].second + 1);
+                        
+                    }
+                    
+                }
+                
             }
             
             SECTION("A haplotype without lane numbers can be inserted") {

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -973,6 +973,141 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains", "[snarlstat
             REQUIRE(traced[5] == graph.get_handle(7, false));
             REQUIRE(traced[6] == graph.get_handle(8, false));
         }
+        
+        delete undo;
+    }
+    
+}
+
+TEST_CASE("GenomeSate works on snarls with nontrivial child chains with backward snarls", "[snarlstate][genomestate]") {
+    
+
+    // This graph will have a snarl from 1 to 8, a snarl from 2 to 4,
+    // and a snarl from 4 to 7, with a chain in the top snarl.
+    VG graph;
+        
+    Node* n1 = graph.create_node("GCA");
+    Node* n2 = graph.create_node("T");
+    Node* n3 = graph.create_node("G");
+    Node* n4 = graph.create_node("CTGA");
+    Node* n5 = graph.create_node("GCA");
+    Node* n6 = graph.create_node("T");
+    Node* n7 = graph.create_node("G");
+    Node* n8 = graph.create_node("CTGA");
+    
+    Edge* e1 = graph.create_edge(n1, n2);
+    Edge* e2 = graph.create_edge(n1, n8);
+    Edge* e3 = graph.create_edge(n2, n3);
+    Edge* e4 = graph.create_edge(n2, n4);
+    Edge* e5 = graph.create_edge(n3, n4);
+    Edge* e6 = graph.create_edge(n4, n5);
+    Edge* e7 = graph.create_edge(n4, n6);
+    Edge* e8 = graph.create_edge(n5, n7);
+    Edge* e9 = graph.create_edge(n6, n7);
+    Edge* e10 = graph.create_edge(n7, n8);
+    
+    // Work out its snarls
+    CactusSnarlFinder bubble_finder(graph);
+    SnarlManager snarl_manager = bubble_finder.find_snarls();
+    
+    // Get the top snarl
+    const Snarl* top_snarl = snarl_manager.top_level_snarls().at(0);
+    
+    if (top_snarl->end().node_id() < top_snarl->start().node_id()) {
+        // Put it a consistent way around
+        snarl_manager.flip(top_snarl);
+    }
+    
+    // Make sure it's what we expect.
+    REQUIRE(top_snarl->start().node_id() == 1);
+    REQUIRE(top_snarl->end().node_id() == 8);
+
+    // Make sure we have one chain    
+    auto& chains = snarl_manager.chains_of(top_snarl);
+    REQUIRE(chains.size() == 1);
+    
+    // Get the chain
+    auto& chain = chains.at(0);
+    REQUIRE(chain.size() == 2);
+    
+    // And the snarls in the chain
+    const Snarl* left_child = chain.at(0);
+    const Snarl* right_child = chain.at(1);
+    
+    REQUIRE(left_child->start().node_id() == 2);
+    REQUIRE(left_child->end().node_id() == 4);
+    
+    // Make sure the right child is BACKWARD in the chain
+    snarl_manager.flip(right_child);
+    
+    REQUIRE(right_child->start().node_id() == 7);
+    REQUIRE(right_child->end().node_id() == 4);
+    
+    // Define the chromosome by telomere snarls (first and last)
+    auto chromosome = make_pair(top_snarl, top_snarl);
+    
+    // Make a genome state for this genome, with the only top snarl being the
+    // telomere snarls for the main chromosome
+    GenomeState state(snarl_manager, &graph, {chromosome});
+    
+    // Make sure to get all the net graphs
+    const NetGraph* top_graph = state.get_net_graph(top_snarl);
+    const NetGraph* left_graph = state.get_net_graph(left_child);
+    const NetGraph* right_graph = state.get_net_graph(right_child);
+    
+    SECTION("A haplotype can be added") {
+        // Define a haplotype across the entire graph, in three levels
+        InsertHaplotypeCommand insert;
+        
+        // We fill these with handles from the appropriate net graphs.
+        // TODO: really we could just use the backing graph. Would that be better???
+        
+        // For the top snarl we go 1, 2 (child chain), and 8
+        insert.insertions.emplace(top_snarl, vector<vector<pair<handle_t, size_t>>>{{
+            {top_graph->get_handle(1, false), 0},
+            {top_graph->get_handle(2, false), 0},
+            {top_graph->get_handle(8, false), 0}
+        }});
+        
+        // For the left child snarl we go 2, 3, 4
+        insert.insertions.emplace(left_child, vector<vector<pair<handle_t, size_t>>>{{
+            {left_graph->get_handle(2, false), 0},
+            {left_graph->get_handle(3, false), 0},
+            {left_graph->get_handle(4, false), 0}
+        }});
+        
+        // For the right child snarl we go backward: 7, 5, 4
+        insert.insertions.emplace(right_child, vector<vector<pair<handle_t, size_t>>>{{
+            {right_graph->get_handle(7, true), 0},
+            {right_graph->get_handle(5, true), 0},
+            {right_graph->get_handle(4, true), 0}
+        }});
+        
+        // Execute the command and get the undo command
+        GenomeStateCommand* undo = state.execute(&insert);
+        
+        SECTION("The haplotype can be traced") {
+            // We trace out all the handles in the backing graph
+            vector<handle_t> traced;
+            
+            state.trace_haplotype(chromosome, 0, [&](const handle_t& visit) {
+                // Put every handle in the vector
+                traced.push_back(visit);
+            });
+         
+            // We should visit nodes 1, 2, 3, 4, 5, 7, 8 in that order
+            REQUIRE(traced.size() == 7);
+            REQUIRE(traced[0] == graph.get_handle(1, false));
+            REQUIRE(traced[1] == graph.get_handle(2, false));
+            REQUIRE(traced[2] == graph.get_handle(3, false));
+            REQUIRE(traced[3] == graph.get_handle(4, false));
+            REQUIRE(traced[4] == graph.get_handle(5, false));
+            REQUIRE(traced[5] == graph.get_handle(7, false));
+            REQUIRE(traced[6] == graph.get_handle(8, false));
+        }
+        
+        delete undo;
+        
     }
     
 }

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -1,0 +1,120 @@
+//
+//  genome_state.cpp
+//
+//  Unit tests for SnarlState, GenomeState and related functions
+//
+
+#include <stdio.h>
+#include <iostream>
+#include <set>
+#include "catch.hpp"
+#include "../json2pb.h"
+#include "../genotypekit.hpp"
+#include "../genome_state.hpp"
+
+
+namespace vg {
+namespace unittest {
+
+using namespace std;
+
+TEST_CASE("SnarlState can hold haplotypes", "[snarlstate][genomestate]") {
+    
+
+    // This graph will have a snarl from 1 to 8, a snarl from 2 to 7,
+    // and a snarl from 3 to 5, all nested in each other.
+    VG graph;
+        
+    Node* n1 = graph.create_node("GCA");
+    Node* n2 = graph.create_node("T");
+    Node* n3 = graph.create_node("G");
+    Node* n4 = graph.create_node("CTGA");
+    Node* n5 = graph.create_node("GCA");
+    Node* n6 = graph.create_node("T");
+    Node* n7 = graph.create_node("G");
+    Node* n8 = graph.create_node("CTGA");
+    
+    Edge* e1 = graph.create_edge(n1, n2);
+    Edge* e2 = graph.create_edge(n1, n8);
+    Edge* e3 = graph.create_edge(n2, n3);
+    Edge* e4 = graph.create_edge(n2, n6);
+    Edge* e5 = graph.create_edge(n3, n4);
+    Edge* e6 = graph.create_edge(n3, n5);
+    Edge* e7 = graph.create_edge(n4, n5);
+    Edge* e8 = graph.create_edge(n5, n7);
+    Edge* e9 = graph.create_edge(n6, n7);
+    Edge* e10 = graph.create_edge(n7, n8);
+    
+    // Work out its snarls
+    CactusSnarlFinder bubble_finder(graph);
+    SnarlManager snarl_manager = bubble_finder.find_snarls();
+    
+    // Get the top snarl
+    const Snarl* top_snarl = snarl_manager.top_level_snarls().at(0);
+    
+    // Make sure it's what we expect.
+    REQUIRE(top_snarl->start().node_id() == 1);
+    REQUIRE(top_snarl->end().node_id() == 8);
+    
+    // And get its net graph
+    NetGraph net_graph = snarl_manager.net_graph_of(top_snarl, &graph, true);
+    
+    // Make a SnarlState for it
+    SnarlState state(&net_graph);
+    
+    SECTION("The state starts empty") {
+        REQUIRE(state.size() == 0);
+    }
+    
+    SECTION("A haplotype with lane numbers can be added in lane 0 when the SnarlState is empty") {
+        // Make a haplotype
+        vector<pair<handle_t, size_t>> annotated_haplotype;
+        
+        // Say we go 1, 2 (which is a child snarl), 8
+        annotated_haplotype.emplace_back(net_graph.get_handle(1, false), 0);
+        annotated_haplotype.emplace_back(net_graph.get_handle(2, false), 0);
+        annotated_haplotype.emplace_back(net_graph.get_handle(8, false), 0);
+        
+        // Put it in the state
+        state.insert(annotated_haplotype);
+        
+        SECTION("The state now has 1 haplotype") {
+            REQUIRE(state.size() == 1);
+        }
+        
+        SECTION("The haplotype can be traced back again") {
+            vector<pair<handle_t, size_t>> recovered;
+            
+            state.trace(0, false, [&](const handle_t& visit, size_t local_lane) {
+                recovered.emplace_back(visit, local_lane);
+            });
+            
+            REQUIRE(recovered == annotated_haplotype);
+        }
+        
+    }
+    
+    
+
+}
+    
+        
+}
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -150,6 +150,50 @@ TEST_CASE("SnarlState can hold haplotypes", "[snarlstate][genomestate]") {
         
     }
     
+    SECTION("A haplotype with lane numbers can be added in lane 0 in reverse when the SnarlState is empty") {
+        // Make a haplotype
+        vector<pair<handle_t, size_t>> annotated_haplotype;
+        
+        // Say we go 8 rev, 2 rev (which is a child snarl), 1 rev
+        annotated_haplotype.emplace_back(net_graph.get_handle(8, true), 0);
+        annotated_haplotype.emplace_back(net_graph.get_handle(2, true), 0);
+        annotated_haplotype.emplace_back(net_graph.get_handle(1, true), 0);
+        
+        // Put it in the state
+        state.insert(annotated_haplotype);
+        
+        SECTION("The state now has 1 haplotype") {
+            REQUIRE(state.size() == 1);
+        }
+        
+        SECTION("The haplotype can be traced back again, and comes out in snarl-forward orientation") {
+            vector<pair<handle_t, size_t>> recovered;
+            
+            state.trace(0, false, [&](const handle_t& visit, size_t local_lane) {
+                recovered.emplace_back(visit, local_lane);
+            });
+            
+            REQUIRE(recovered.size() == 3);
+            REQUIRE(net_graph.get_id(recovered[0].first) == 1);
+            REQUIRE(net_graph.get_is_reverse(recovered[0].first) == false);
+            REQUIRE(net_graph.get_id(recovered[1].first) == 2);
+            REQUIRE(net_graph.get_is_reverse(recovered[1].first) == false);
+            REQUIRE(net_graph.get_id(recovered[2].first) == 8);
+            REQUIRE(net_graph.get_is_reverse(recovered[2].first) == false);
+        }
+        
+        SECTION("The haplotype can be traced in reverse and comes out in its original order and orientation") {
+            vector<pair<handle_t, size_t>> recovered;
+            
+            state.trace(0, true, [&](const handle_t& visit, size_t local_lane) {
+                recovered.emplace_back(visit, local_lane);
+            });
+            
+            REQUIRE(recovered == annotated_haplotype);
+        }
+        
+    }
+    
     
 
 }

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -976,7 +976,6 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains", "[snarlstat
     }
     
 }
-    
         
 }
 }

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -391,6 +391,11 @@ TEST_CASE("GenomeState can hold and manipulate haplotypes", "[genomestate]") {
     // Get the top snarl
     const Snarl* top_snarl = snarl_manager.top_level_snarls().at(0);
     
+    if (top_snarl->end().node_id() < top_snarl->start().node_id()) {
+        // Put it a consistent way around
+        snarl_manager.flip(top_snarl);
+    }
+    
     // Make sure it's what we expect.
     REQUIRE(top_snarl->start().node_id() == 1);
     REQUIRE(top_snarl->end().node_id() == 8);
@@ -398,8 +403,18 @@ TEST_CASE("GenomeState can hold and manipulate haplotypes", "[genomestate]") {
     // Get the middle snarl
     const Snarl* middle_snarl = snarl_manager.children_of(top_snarl).at(0);
     
+    if (middle_snarl->end().node_id() < middle_snarl->start().node_id()) {
+        // Put it a consistent way around
+        snarl_manager.flip(middle_snarl);
+    }
+    
     // And the bottom snarl
     const Snarl* bottom_snarl = snarl_manager.children_of(middle_snarl).at(0);
+    
+    if (bottom_snarl->end().node_id() < bottom_snarl->start().node_id()) {
+        // Put it a consistent way around
+        snarl_manager.flip(bottom_snarl);
+    }
     
     // Define the chromosome by telomere snarls (first and last)
     auto chromosome = make_pair(top_snarl, top_snarl);

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -189,7 +189,35 @@ TEST_CASE("sites can be found with Cactus", "[genotype]") {
 
 }
 
-TEST_CASE("CactusSnarlFinder throws an error when paths span multiple components", "[genotype]") {
+TEST_CASE("CactusSnarlFinder safely rejects a single node graph", "[genotype]") {
+    
+    // Build a toy graph
+    const string graph_json = R"(
+    
+    {
+        "node": [
+            {"id": 1, "sequence": "GATTACA"}
+        ]
+    }
+    
+    )";
+    
+    // Make an actual graph
+    VG graph;
+    Graph chunk;
+    json2pb(chunk, graph_json.c_str(), graph_json.size());
+    graph.merge(chunk);
+    
+    // Make a CactusSnarlFinder
+    SnarlFinder* finder = new CactusSnarlFinder(graph);
+    
+    SECTION("CactusSnarlFinder throws instead of crashing") {
+        REQUIRE_THROWS(finder->find_snarls());
+    }
+    
+}
+
+TEST_CASE("CactusSnarlFinder throws an error instead of crashing when the graph has no edges", "[genotype]") {
     
     // Build a toy graph
     const string graph_json = R"(
@@ -205,16 +233,6 @@ TEST_CASE("CactusSnarlFinder throws an error when paths span multiple components
             {"id": 7, "sequence": "C"},
             {"id": 8, "sequence": "A"},
             {"id": 9, "sequence": "A"}
-        ],
-        "edge": [
-        ],
-        "path": [
-            {"name": "hint", "mapping": [
-                {"position": {"node_id": 1}, "rank" : 1 },
-                {"position": {"node_id": 6}, "rank" : 2 },
-                {"position": {"node_id": 8}, "rank" : 3 },
-                {"position": {"node_id": 9}, "rank" : 4 }
-            ]}
         ]
     }
     

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -189,6 +189,52 @@ TEST_CASE("sites can be found with Cactus", "[genotype]") {
 
 }
 
+TEST_CASE("CactusSnarlFinder throws an error when paths span multiple components", "[genotype]") {
+    
+    // Build a toy graph
+    const string graph_json = R"(
+    
+    {
+        "node": [
+            {"id": 1, "sequence": "G"},
+            {"id": 2, "sequence": "A"},
+            {"id": 3, "sequence": "T"},
+            {"id": 4, "sequence": "GGG"},
+            {"id": 5, "sequence": "T"},
+            {"id": 6, "sequence": "A"},
+            {"id": 7, "sequence": "C"},
+            {"id": 8, "sequence": "A"},
+            {"id": 9, "sequence": "A"}
+        ],
+        "edge": [
+        ],
+        "path": [
+            {"name": "hint", "mapping": [
+                {"position": {"node_id": 1}, "rank" : 1 },
+                {"position": {"node_id": 6}, "rank" : 2 },
+                {"position": {"node_id": 8}, "rank" : 3 },
+                {"position": {"node_id": 9}, "rank" : 4 }
+            ]}
+        ]
+    }
+    
+    )";
+    
+    // Make an actual graph
+    VG graph;
+    Graph chunk;
+    json2pb(chunk, graph_json.c_str(), graph_json.size());
+    graph.merge(chunk);
+    
+    // Make a CactusSnarlFinder
+    SnarlFinder* finder = new CactusSnarlFinder(graph);
+    
+    SECTION("CactusSnarlFinder should fail gracefully") {
+        REQUIRE_THROWS(finder->find_snarls());
+    }
+    
+}
+
 TEST_CASE("fixed priors can be assigned to genotypes", "[genotype]") {
     
     GenotypePriorCalculator* calculator = new FixedGenotypePriorCalculator();

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -2733,40 +2733,34 @@ namespace vg {
                     REQUIRE(it == chain_end(chain));
                 }
                 
-                SECTION("We can look around with Visits") {
-                    Visit here;
-                    transfer_boundary_info(*child1, *here.mutable_snarl());
+                SECTION("We can look around from a snarl") {
+                    const Chain* chain = snarl_manager.chain_of(child1);
                     
-                    SECTION("Looking left off the end of the chain gives us a Visit with no Snarl") {
-                        Visit left = snarl_manager.prev_in_chain(here);
+                    ChainIterator here = chain_begin_from(*chain, child1);
+                    ChainIterator end = chain_end_from(*chain, child1);
+                    
+                    SECTION("Looking right into the chain gives us the Snarl to the right") {
+                        ChainIterator right = here;
+                        ++right;
                         
-                        REQUIRE(!left.has_snarl());
+                        REQUIRE(right != end);
+                        REQUIRE(right->first == child2);
+                        // Must not be backward
+                        REQUIRE(right->second == false);
                     }
                     
-                    SECTION("Looking right into the chain gives us a Visit to the right Snarl") {
-                        Visit right = snarl_manager.next_in_chain(here);
-                        
-                        REQUIRE(right.has_snarl());
-                        REQUIRE(right.snarl().start().node_id() == child2->start().node_id());
-                        REQUIRE(right.snarl().end().node_id() == child2->end().node_id());
-                        REQUIRE(!right.backward());
-                    }
-                    
-                    here.set_backward(true);
-                    
-                    SECTION("Looking right off the end of the chain gives us a Visit with no Snarl") {
-                        Visit right = snarl_manager.next_in_chain(here);
-                        
-                        REQUIRE(!right.has_snarl());
-                    }
+                    // Now look from the other end
+                    here = chain_begin_from(*chain, child3);
+                    end = chain_end_from(*chain, child3);
                     
                     SECTION("Looking left into the chain gives us a Visit to the right Snarl") {
-                        Visit left = snarl_manager.prev_in_chain(here);
+                        ChainIterator left = here;
+                        ++left;
                         
-                        REQUIRE(left.has_snarl());
-                        REQUIRE(left.snarl().start().node_id() == child2->start().node_id());
-                        REQUIRE(left.snarl().end().node_id() == child2->end().node_id());
-                        REQUIRE(left.backward());
+                        REQUIRE(left != end);
+                        REQUIRE(left->first == child2);
+                        // Must be backward
+                        REQUIRE(left->second == true);
                     }
                     
                     

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -2736,8 +2736,8 @@ namespace vg {
                 SECTION("We can look around from a snarl") {
                     const Chain* chain = snarl_manager.chain_of(child1);
                     
-                    ChainIterator here = chain_begin_from(*chain, child1);
-                    ChainIterator end = chain_end_from(*chain, child1);
+                    ChainIterator here = chain_begin_from(*chain, child1, false);
+                    ChainIterator end = chain_end_from(*chain, child1, false);
                     
                     SECTION("Looking right into the chain gives us the Snarl to the right") {
                         ChainIterator right = here;
@@ -2750,8 +2750,8 @@ namespace vg {
                     }
                     
                     // Now look from the other end
-                    here = chain_begin_from(*chain, child3);
-                    end = chain_end_from(*chain, child3);
+                    here = chain_begin_from(*chain, child3, true);
+                    end = chain_end_from(*chain, child3, true);
                     
                     SECTION("Looking left into the chain gives us a Visit to the right Snarl") {
                         ChainIterator left = here;


### PR DESCRIPTION
This is most of an implementation of a `GenomeState` data structure, for representing haplotypes under consideration in an MCMC genotyper. The state takes and executes commands to update itself, and returns undo commands that can be applied to wind back the state if the new state is not accepted by the MCMC process.

Still to be implemented:

- [ ] Commands to swap or resample individual snarls
- [ ] Easy-to-construct haplotype insertion commands
- [ ] Some solution to (and tests demonstrating) the problem of chains abutting unary snarls and their representation in the net graph.

We could continuously integrate this now, although it's not really done.

When done, will fix #1207.