### PR TITLE
Compressed read and observation counting

### DIFF
--- a/src/counter.cpp
+++ b/src/counter.cpp
@@ -1,0 +1,21 @@
+#include "counter.hpp"
+
+namespace vg {
+
+Counter::Counter(void) : xgidx(nullptr) { }
+Counter::Counter(xg::XG* xidx) : xgidx(xidx) { }
+Counter::~Counter(void) { }
+
+void Counter::load(const vector<string>& file_names) {
+}
+
+void Counter::write(const string& file_name) {
+}
+
+void Counter::compact(void) {
+}
+
+void Counter::add(const Alignment& aln) {
+}
+
+}

--- a/src/counter.cpp
+++ b/src/counter.cpp
@@ -3,19 +3,160 @@
 namespace vg {
 
 Counter::Counter(void) : xgidx(nullptr) { }
-Counter::Counter(xg::XG* xidx) : xgidx(xidx) { }
-Counter::~Counter(void) { }
 
-void Counter::load(const vector<string>& file_names) {
+Counter::Counter(xg::XG* xidx) : xgidx(xidx) { coverage_dynamic = gcsa::CounterArray(xgidx->seq_length, 8); }
+
+Counter::~Counter(void) {
+    close_edit_tmpfile();
+    remove_edit_tmpfile();
 }
 
-void Counter::write(const string& file_name) {
+void Counter::load_from_file(const string& file_name) {
+    ifstream in(file_name);
+    load(in);
+    is_compacted = true;
 }
 
-void Counter::compact(void) {
+void Counter::save_to_file(const string& file_name) {
+    ofstream out(file_name);
+    serialize(out);
 }
 
-void Counter::add(const Alignment& aln) {
+void Counter::load(istream& in) {
+    coverage_civ.load(in);
+    edit_csa.load(in);
+}
+
+size_t Counter::serialize(std::ostream& out,
+                          sdsl::structure_tree_node* s,
+                          std::string name) {
+    make_compact();
+    sdsl::structure_tree_node* child = sdsl::structure_tree::add_child(s, name, sdsl::util::class_name(*this));
+    size_t written = 0;
+    written += coverage_civ.serialize(out, child, "graph_coverage_" + name);
+    written += edit_csa.serialize(out, child, "edit_csa_" + name);
+    sdsl::structure_tree::add_size(child, written);
+    return written;
+}
+
+void Counter::make_compact(void) {
+    // pack the dynamic countarry and edit coverage into the compact data structure
+    if (is_compacted) return;
+    // sync edit file
+    close_edit_tmpfile();
+    // temporaries for construction
+    size_t basis_length = coverage_dynamic.size();
+    int_vector<> coverage_iv;
+    util::assign(coverage_iv, int_vector<>(basis_length));
+    for (size_t i = 0; i < coverage_dynamic.size(); ++i) {
+        coverage_iv[i] = coverage_dynamic[i];
+    }
+    util::assign(coverage_civ, coverage_iv);
+    construct(edit_csa, edit_tmpfile_name, 1);
+    remove_edit_tmpfile();
+    is_compacted = true;
+}
+
+void Counter::make_dynamic(void) {
+    if (!is_compacted) return;
+    // unpack the compact represenation into the countarray
+    assert(false); // not implemented
+    is_compacted = false;
+}
+
+void Counter::ensure_edit_tmpfile_open(void) {
+    if (!tmpfstream.is_open()) {
+        string base = ".vg-counter";
+        edit_tmpfile_name = tmpfilename(base);
+        tmpfstream.open(edit_tmpfile_name);
+    }
+}
+
+void Counter::close_edit_tmpfile(void) {
+    if (tmpfstream.is_open()) {
+        tmpfstream.close();
+    }
+}
+
+void Counter::remove_edit_tmpfile(void) {
+    if (!edit_tmpfile_name.empty()) {
+        std::remove(edit_tmpfile_name.c_str());
+        edit_tmpfile_name.clear();
+    }
+}
+
+void Counter::add(const Alignment& aln, bool record_edits) {
+    // open tmpfile if needed
+    ensure_edit_tmpfile_open();
+    // count the nodes, edges, and edits
+    for (auto& mapping : aln.path().mapping()) {
+        if (!mapping.has_position()) continue;
+        size_t i = position_in_basis(mapping.position());
+        for (auto& edit : mapping.edit()) {
+            if (edit_is_match(edit)) {
+                if (mapping.position().is_reverse()) {
+                    for (size_t j = 0; j < edit.from_length(); ++j) {
+                        coverage_dynamic.increment(i-j);
+                    }
+                } else {
+                    for (size_t j = 0; j < edit.from_length(); ++j) {
+                        coverage_dynamic.increment(i+j);
+                    }
+                }
+            } else if (record_edits) {
+                // we represent things on the forward strand
+                string pos_repr = pos_key(i);
+                string edit_repr;
+                if (mapping.position().is_reverse()) {
+                    reverse_complement_edit(edit).SerializeToString(&edit_repr);
+                } else {
+                    edit.SerializeToString(&edit_repr);
+                }
+                tmpfstream << pos_repr << edit_repr;
+            }
+            if (mapping.position().is_reverse()) {
+                i -= edit.from_length();
+            } else {
+                i += edit.from_length();
+            }
+        }
+    }
+}
+
+// find the position on the forward strand in the sequence vector
+size_t Counter::position_in_basis(const Position& pos) {
+    // get position on the forward strand
+    if (pos.is_reverse()) {
+        return (int64_t)xg_node_start(pos.node_id(), xgidx)
+            + (int64_t)reverse(pos, xg_node_length(pos.node_id(), xgidx)).offset() - 1;
+    } else {
+        return (int64_t)xg_node_start(pos.node_id(), xgidx) + (int64_t)pos.offset();
+    }
+}
+
+string Counter::pos_key(size_t i) {
+    Position pos;
+    pos.set_node_id(i);
+    string pos_repr;
+    pos.SerializeToString(&pos_repr);
+    string sep_start = string(1, '\xff');
+    string sep_end = string(1, '\xff');
+    return sep_start + pos_repr + sep_end;
+}
+
+ostream& Counter::as_table(ostream& out) {
+    // write the coverage as a vector
+    for (size_t i = 0; i < coverage_civ.size(); ++i) {
+        out << i << "\t" << coverage_civ[i] << "\t" << count(edit_csa, pos_key(i)) << endl;
+    }
+}
+
+ostream& Counter::show_structure(ostream& out) {
+    out << coverage_civ << endl; // graph coverage (compacted coverage_dynamic)
+    out << edit_csa << endl;
+    //out << " i SA ISA PSI LF BWT    T[SA[i]..SA[i]-1]" << endl;
+    //csXprintf(cout, "%2I %2S %3s %3P %2p %3B   %:3T", edit_csa);
+    return out;
 }
 
 }

--- a/src/counter.hpp
+++ b/src/counter.hpp
@@ -1,0 +1,46 @@
+#ifndef VG_MAPPER_HPP_INCLUDED
+#define VG_MAPPER_HPP_INCLUDED
+
+#include <iostream>
+#include <map>
+#include <chrono>
+#include <ctime>
+#include "omp.h"
+#include "xg.hpp"
+#include "alignment.hpp"
+#include "path.hpp"
+#include "position.hpp"
+#include "json2pb.h"
+#include "graph.hpp"
+#include "gcsa/internal.h"
+
+namespace vg {
+
+class Counter {
+public:
+    Counter(void);
+    Counter(xg::XG* xidx);
+    ~Counter(void);
+    xg::XG* xgidx;
+    void load(const vector<string>& file_names);
+    void write(const string& file_name);
+    void make_compact(void);
+    void make_dynamic(void);
+    void add(const Alignment& aln);
+    ostream& as_table(ostream& out);
+private:
+    bool is_compacted;
+    // dynamic model
+    gcsa::CounterArray coverage_dynamic;
+    map<int64_t, map<string, int32_t> > edit_coverage_dynamic;
+    // compact model
+    vlc_vector<> coverage_civ; // graph coverage (compacted coverage_dynamic)
+    wt_gmr<> edit_coverage_wt; // map from graph positions to edits
+    vlc_vector<> edits_coverage_civ; // counts of the edits
+    sd_vector<> edit_cbv; // mark beginning of edit record in edits_civ
+    vlc_vector<> edits_civ; // serialized protobuf of edits
+};
+
+}
+
+#endif

--- a/src/counter.hpp
+++ b/src/counter.hpp
@@ -13,8 +13,12 @@
 #include "json2pb.h"
 #include "graph.hpp"
 #include "gcsa/internal.h"
+#include "xg_position.hpp"
+#include "utility.hpp"
 
 namespace vg {
+
+using namespace sdsl;
 
 class Counter {
 public:
@@ -22,23 +26,42 @@ public:
     Counter(xg::XG* xidx);
     ~Counter(void);
     xg::XG* xgidx;
-    void load(const vector<string>& file_names);
-    void write(const string& file_name);
+    //void load(const vector<string>& file_names);
+    void load_from_file(const string& file_name);
+    void save_to_file(const string& file_name);
+    void load(istream& in);
+    size_t serialize(std::ostream& out,
+                     sdsl::structure_tree_node* s = NULL,
+                     std::string name = "");
+    void ensure_edit_tmpfile_open(void);
+    void close_edit_tmpfile(void);
+    void remove_edit_tmpfile(void);
     void make_compact(void);
     void make_dynamic(void);
-    void add(const Alignment& aln);
+    void add(const Alignment& aln, bool record_edits = true);
+    size_t position_in_basis(const Position& pos);
+    string pos_key(size_t i);
     ostream& as_table(ostream& out);
+    ostream& show_structure(ostream& out); // debugging
 private:
     bool is_compacted;
     // dynamic model
     gcsa::CounterArray coverage_dynamic;
-    map<int64_t, map<string, int32_t> > edit_coverage_dynamic;
+    string edit_tmpfile_name;
+    fstream tmpfstream;
+    //map<size_t, map<string, int32_t> > edits;
     // compact model
+    //size_t total_count; // sum of counts in coverage and edit coverage
+    size_t edit_length;
+    size_t edit_count;
     vlc_vector<> coverage_civ; // graph coverage (compacted coverage_dynamic)
-    wt_gmr<> edit_coverage_wt; // map from graph positions to edits
-    vlc_vector<> edits_coverage_civ; // counts of the edits
-    sd_vector<> edit_cbv; // mark beginning of edit record in edits_civ
-    vlc_vector<> edits_civ; // serialized protobuf of edits
+    csa_sada<enc_vector<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, succinct_byte_alphabet<> > edit_csa;
+};
+
+// for making a combined matrix output and maybe doing other fun operations
+class Counters : public vector<Counter> {
+    void load(const vector<string>& file_names);
+    ostream& as_table(ostream& out);
 };
 
 }

--- a/src/subcommand/count_main.cpp
+++ b/src/subcommand/count_main.cpp
@@ -1,0 +1,117 @@
+#include "subcommand.hpp"
+#include "../vg.hpp"
+#include "../utility.hpp"
+#include "../counter.hpp"
+#include "../stream.hpp"
+
+#include <unistd.h>
+#include <getopt.h>
+
+using namespace vg;
+using namespace vg::subcommand;
+
+void help_count(char** argv) {
+    cerr << "usage: " << argv[0] << " count [options]" << endl
+         << "options:" << endl
+         << "    -x, --xg FILE          use this basis graph" << endl
+         << "    -o, --counts-out FILE  write compressed coverage counts to this output file" << endl
+         << "    -i, --counts-in FILE   begin by summing coverage counts from each provided FILE" << endl
+         << "    -g, --gam FILE         read alignments from this file (could be '-' for stdin)" << endl
+         << "    -d, --as-table         write table on stdout representing counts" << endl
+         << "    -t, --threads N        use N threads (defaults to numCPUs)" << endl;
+}
+
+int main_count(int argc, char** argv) {
+
+    string xg_name;
+    vector<string> counts_in;
+    string counts_out;
+    string gam_in;
+    bool write_table = false;
+    int thread_count = 1;
+
+    if (argc == 2) {
+        help_count(argv);
+        return 1;
+    }
+
+    int c;
+    optind = 2; // force optind past command positional argument
+    while (true) {
+        static struct option long_options[] =
+        {
+            {"help", no_argument, 0, 'h'},
+            {"xg", required_argument,0, 'x'},
+            {"counts-out", required_argument,0, 'o'},
+            {"count-in", required_argument, 0, 'i'},
+            {"gam", required_argument, 0, 'g'},
+            {"as-table", no_argument, 0, 'd'},
+            {"threads", required_argument, 0, 't'},
+            {0, 0, 0, 0}
+
+        };
+        int option_index = 0;
+        c = getopt_long (argc, argv, "hx:o:i:g:dt:",
+                long_options, &option_index);
+
+        // Detect the end of the options.
+        if (c == -1)
+            break;
+
+        switch (c)
+        {
+
+        case '?':
+        case 'h':
+            help_count(argv);
+            return 1;
+        case 'x':
+            xg_name = optarg;
+            break;
+        case 'o':
+            counts_out = optarg;
+            break;
+        case 'i':
+            counts_in.push_back(optarg);
+            break;
+        case 'g':
+            gam_in = optarg;
+            break;
+        case 'd':
+            write_table = true;
+            break;
+        case 't':
+            thread_count = atoi(optarg);
+            break;
+
+        default:
+            abort();
+        }
+    }
+
+    omp_set_num_threads(thread_count);
+
+    xg::XG xgidx;
+    if (xg_name.empty()) {
+        cerr << "No XG index given. An XG index must be provided." << endl;
+        exit(1);
+    } else {
+        ifstream in(xg_name.c_str());
+        xgidx.load(in);
+    }
+
+    // todo one counter per thread and merge
+    vg::Counter counter(&xgidx);
+    if (!counts_in.empty()) {
+        counter.load(counts_in);
+    }
+
+    if (!counts_out.empty()) {
+        counter.write(counts_out);
+    }
+
+    return 0;
+}
+
+// Register subcommand
+static Subcommand vg_count("count", "count features on the graph", main_count);

--- a/src/subcommand/count_main.cpp
+++ b/src/subcommand/count_main.cpp
@@ -114,7 +114,8 @@ int main_count(int argc, char** argv) {
 
     if (!gam_in.empty()) {
         ifstream gam_stream(gam_in);
-        stream::for_each(gam_stream, (const std::function<void(Alignment&)>)[&counter,&record_edits](Alignment& aln) { counter.add(aln, record_edits); });
+        std::function<void(Alignment&)> lambda = [&counter,&record_edits](Alignment& aln) { counter.add(aln, record_edits); };
+        stream::for_each(gam_stream, lambda);
         gam_stream.close();
     }
     if (!counts_out.empty()) {

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -24,6 +24,7 @@ void help_find(char** argv) {
          << "    -L, --use-length       treat STEPS in -c or M in -r as a length in bases" << endl
          << "    -p, --path TARGET      find the node(s) in the specified path range(s) TARGET=path[:pos1[-pos2]]" << endl
          << "    -P, --position-in PATH find the position of the node (specified by -n) in the given path" << endl
+         << "    -R, --rank-in PATH     find the rank of the node (specified by -n) in the given path" << endl
          << "    -X, --approx-pos ID    get the approximate position of this node" << endl
          << "    -r, --node-range N:M   get nodes from N to M" << endl
          << "    -G, --gam GAM          accumulate the graph touched by the alignments in the GAM" << endl
@@ -38,7 +39,7 @@ void help_find(char** argv) {
          << "    -j, --kmer-stride N    step distance between succesive kmers in sequence (default 1)" << endl
          << "    -S, --sequence STR     search for sequence STR using --kmer-size kmers" << endl
          << "    -M, --mems STR         describe the super-maximal exact matches of the STR (gcsa2) in JSON" << endl
-         << "    -R, --reseed-length N  find non-super-maximal MEMs inside SMEMs of length at least N" << endl
+         << "    -B, --reseed-length N  find non-super-maximal MEMs inside SMEMs of length at least N" << endl
          << "    -f, --fast-reseed      use fast SMEM reseeding algorithm" << endl
          << "    -Y, --max-mem N        the maximum length of the MEM (default: GCSA2 order)" << endl
          << "    -Z, --min-mem N        the minimum length of the MEM (default: 1)" << endl
@@ -74,6 +75,8 @@ int main_find(int argc, char** argv) {
     bool kmer_table = false;
     vector<string> targets;
     string path_name;
+    bool position_in = false;
+    bool rank_in = false;
     string range;
     string gcsa_in;
     string xg_name;
@@ -113,7 +116,7 @@ int main_find(int argc, char** argv) {
                 {"table", no_argument, 0, 'T'},
                 {"sequence", required_argument, 0, 'S'},
                 {"mems", required_argument, 0, 'M'},
-                {"reseed-length", required_argument, 0, 'R'},
+                {"reseed-length", required_argument, 0, 'B'},
                 {"fast-reseed", no_argument, 0, 'f'},
                 {"kmer-stride", required_argument, 0, 'j'},
                 {"kmer-size", required_argument, 0, 'z'},
@@ -122,6 +125,7 @@ int main_find(int argc, char** argv) {
                 {"kmer-count", no_argument, 0, 'C'},
                 {"path", required_argument, 0, 'p'},
                 {"position-in", required_argument, 0, 'P'},
+                {"rank-in", required_argument, 0, 'R'},
                 {"node-range", required_argument, 0, 'r'},
                 {"alignments", no_argument, 0, 'a'},
                 {"mappings", no_argument, 0, 'm'},
@@ -140,7 +144,7 @@ int main_find(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "d:x:n:e:s:o:k:hc:LS:z:j:CTp:P:r:amg:M:R:fi:DH:G:N:A:Y:Z:tq:X:",
+        c = getopt_long (argc, argv, "d:x:n:e:s:o:k:hc:LS:z:j:CTp:P:r:amg:M:R:B:fi:DH:G:N:A:Y:Z:tq:X:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -174,7 +178,7 @@ int main_find(int argc, char** argv) {
             get_mems = true;
             break;
             
-        case 'R':
+        case 'B':
             mem_reseed_length = atoi(optarg);
             break;
             
@@ -208,6 +212,12 @@ int main_find(int argc, char** argv) {
 
         case 'P':
             path_name = optarg;
+            position_in = true;
+            break;
+
+        case 'R':
+            path_name = optarg;
+            rank_in = true;
             break;
 
         case 'c':
@@ -458,7 +468,7 @@ int main_find(int argc, char** argv) {
                 cout << (e.from_start() ? -1 : 1) * e.from() << "\t" <<  (e.to_end() ? -1 : 1) * e.to() << endl;
             }
         }
-        if (!node_ids.empty() && !path_name.empty() && !pairwise_distance) {
+        if (!node_ids.empty() && !path_name.empty() && !pairwise_distance && (position_in || rank_in)) {
             // Go get the positions of these nodes in this path
             
             if (xindex.path_rank(path_name) == 0) {
@@ -472,9 +482,9 @@ int main_find(int argc, char** argv) {
             // and then mapping, but need this info right now for scripts/chunked_call
             for (auto node_id : node_ids) {
                 cout << node_id;
-                vector<size_t> positions = xindex.position_in_path(node_id, path_name);
-                for (auto pos : positions) {
-                    cout << "\t" << pos;
+                for (auto r : (position_in ? xindex.position_in_path(node_id, path_name)
+                               : xindex.node_ranks_in_path(node_id, path_name))) {
+                    cout << "\t" << r;
                 }
                 cout << endl;
             }

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -65,7 +65,7 @@ void help_index(char** argv) {
          << "    -M, --metadata         describe aspects of the db stored in metadata" << endl
          << "    -L, --path-layout      describes the path layout of the graph" << endl
          << "    -S, --set-kmer         assert that the kmer size (-k) is in the db" << endl
-        //<< "    -b, --tmp-db-base S    use this base name for temporary indexes" << endl
+         << "    -b, --tmp-db-base S    use this base name for temporary indexes" << endl
          << "    -C, --compact          compact the index into a single level (improves performance)" << endl
          << "    -o, --discard-overlaps if phasing vcf calls alts at overlapping variants, call all but the first one as ref" << endl;
 }
@@ -126,6 +126,7 @@ int main_index(int argc, char** argv) {
     bool store_threads = false; // use gPBWT to store paths
     bool discard_overlaps = false;
     string binary_haplotype_output;
+    string tmp_db_base;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -164,6 +165,7 @@ int main_index(int argc, char** argv) {
             {"dbg-in", required_argument, 0, 'i'},
             {"discard-overlaps", no_argument, 0, 'o'},
             {"write-haps", required_argument, 0, 'H'},
+            {"tmp-db-base", required_argument, 0, 'b'},
             {0, 0, 0, 0}
         };
 
@@ -300,6 +302,10 @@ int main_index(int argc, char** argv) {
 
         case 'Z':
             size_limit = atoi(optarg);
+            break;
+
+        case 'b':
+            tmp_db_base = optarg;
             break;
 
         case 'T':

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1802,7 +1802,6 @@ size_t XG::edge_graph_idx(const Edge& edge_in) const {
     size_t g = g_bv_select(id_to_rank(id));
     int edges_to_count = g_iv[g+G_NODE_TO_COUNT_OFFSET];
     int edges_from_count = g_iv[g+G_NODE_FROM_COUNT_OFFSET];
-    //int64_t t = g + G_NODE_HEADER_LENGTH;
     int64_t f = g + G_NODE_HEADER_LENGTH + G_EDGE_LENGTH * edges_to_count;
     int64_t e = f + G_EDGE_LENGTH * edges_from_count;
     vector<Edge> edges;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -152,6 +152,7 @@ public:
     size_t node_length(int64_t id) const;
     char pos_char(int64_t id, bool is_rev, size_t off) const; // character at position
     string pos_substr(int64_t id, bool is_rev, size_t off, size_t len = 0) const; // substring in range
+    // these provide a way to get an index for each node and edge in the g_iv structure and are used by gPBWT
     size_t node_graph_idx(int64_t id) const;
     size_t edge_graph_idx(const Edge& edge) const;
     

--- a/test/t/34_vg_count.t
+++ b/test/t/34_vg_count.t
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 1
+
+vg construct -r tiny/tiny.fa >flat.vg
+vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
+vg index -x 2snp.xg 2snp.vg
+vg sim -s 420 -l 30 -x 2snp.xg -n 30 -a >2snp.sim
+vg index -x flat.xg -g flat.gcsa -k 16 flat.vg
+vg map -g flat.gcsa -x flat.xg -G 2snp.sim -k 8 >2snp.gam
+vg count -x flat.xg -o 2snp.gam.counts -g 2snp.gam
+is $(vg count -x flat.xg -di 2snp.gam.counts  | cut -f 3 | grep -v ^0$ | wc -l) 2 "allele observation counting detects 2 SNPs"
+
+rm -f flat.vg 2snp.vg 2snp.xg 2snp.sim flat.gcsa flat.gcsa.lcp flat.xg 2snp.xg 2snp.gam 2snp.gam.counts


### PR DESCRIPTION
This implements an index based around a compressed integer vector of coverage and a compressed suffix array of edits keyed by graph position. The idea here is that read sets can be projected through the graph via alignment and collapse into a coverage vector across the graph. Currently everything is recorded on the forward strand. A compact counting interface is used that requires only one byte per graph base for coverages < 256. To count edits, we stream them into a file in a format that allows us to generate a compressed suffix array from them and later query it to obtain edit coverage counts at particular graph positions. There isn't much you can do with it yet, but construction and basic coverage counting appears to work and are tested. I'll flesh out the interface in later PRs.