### PR TITLE
Make the MEM reseeding algorithm recursive

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -20,6 +20,7 @@ BaseMapper::BaseMapper(xg::XG* xidex,
       , fast_reseed(true)
       , fast_reseed_length_diff(0.75)
       , adaptive_reseed_diff(false)
+      , use_approximate_sub_mem_hit_count(true)
       , adaptive_diff_exponent(0.05)
       , hit_max(0)
       , alignment_threads(1)
@@ -276,7 +277,8 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
                                                      bool use_diff_based_fast_reseed,
                                                      bool include_parent_in_sub_mem_count,
                                                      bool record_max_lcp,
-                                                     int reseed_below) {
+                                                     int reseed_below,
+                                                     int max_sub_mem_recursion) {
 #ifdef debug_mapper
 #pragma omp critical
     {
@@ -339,7 +341,6 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
     int max_lcp = 0;
     size_t mem_length = 0;
     vector<int> lcp_maxima;
-    
 
     // loop maintains invariant that match.range contains the hits for seq[cursor+1:match.end]
     while (cursor >= seq_begin) {
@@ -459,9 +460,6 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
             --cursor;
         }
     }
-    // TODO: is this where the bug with the duplicated MEMs is occurring? (when the prefix of a read
-    // contains multiple non SMEM hits so that the iteration will loop through the LCP routine multiple
-    // times before escaping out of the loop?
     
     // if we have a MEM at the beginning of the read, record it
     match.begin = seq_begin;
@@ -518,11 +516,14 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
     }
 
     if (reseed_length) {
-        // get the sub_mem_and_parents
-        vector<pair<MaximalExactMatch, vector<size_t> > > sub_mems;
+        // get the sub mems
+        
+        // the top-level SMEMS aren't contained in any other MEM, so we fill this with empty vectors
+        vector<vector<size_t>> mem_containments;
 
         // run the reseeding
-        for (int i = 0; i < mems.size(); ++i) {
+        size_t num_smems = mems.size();
+        for (size_t i = 0; i < num_smems; ++i) {
             auto& mem = mems[i];
             // invalid mem
             if (mem.begin < seq_begin || mem.end > seq_end) continue;
@@ -538,75 +539,100 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
                 if (fast_reseed) {
                     if (use_diff_based_fast_reseed) {
                         if (adaptive_reseed_diff) {
-                            find_sub_mems_fast(mems, i,
-                                               i+1 < mems.size() ? mems[i+1].end : seq_begin,
+                            find_sub_mems_fast(mems,
+                                               mem_containments,
+                                               i,
+                                               0,
+                                               i+1 < num_smems ? mems[i+1].end : seq_begin,
                                                max<int>(get_adaptive_min_reseed_length(mem.length()), min_mem_length),
-                                               sub_mems);
+                                               reseed_length,
+                                               1,
+                                               max_sub_mem_recursion,
+                                               use_approximate_sub_mem_hit_count);
                         }
                         else {
-                            find_sub_mems_fast(mems, i,
-                                               i+1 < mems.size() ? mems[i+1].end : seq_begin,
+                            find_sub_mems_fast(mems,
+                                               mem_containments,
+                                               i,
+                                               0,
+                                               i+1 < num_smems ? mems[i+1].end : seq_begin,
                                                max<int>(ceil(fast_reseed_length_diff * mem.length()), min_mem_length),
-                                               sub_mems);
+                                               reseed_length,
+                                               1,
+                                               max_sub_mem_recursion,
+                                               use_approximate_sub_mem_hit_count);
                         }
                     }
                     else {
-                        find_sub_mems_fast(mems, i,
-                                           i+1 < mems.size() ? mems[i+1].end : seq_begin,
+                        find_sub_mems_fast(mems,
+                                           mem_containments,
+                                           i,
+                                           0,
+                                           i+1 < num_smems ? mems[i+1].end : seq_begin,
                                            min_mem_length,
-                                           sub_mems);
+                                           reseed_length,
+                                           1,
+                                           max_sub_mem_recursion,
+                                           use_approximate_sub_mem_hit_count);
                     }
                 }
                 else {
-                    find_sub_mems(mems, i,
-                                  i+1 < mems.size() ? mems[i+1].end : seq_begin,
+                    find_sub_mems(mems,
+                                  mem_containments,
+                                  i,
+                                  0,
+                                  i+1 < num_smems ? mems[i+1].end : seq_begin,
                                   min_mem_length,
-                                  sub_mems);
+                                  reseed_length,
+                                  1,
+                                  max_sub_mem_recursion);
                 }
             }
             
         }
         
-        // determine counts of matches
-        for (pair<MaximalExactMatch, vector<size_t> >& sub_mem_and_parents : sub_mems) {
-            // count in entire range, including parents
-            sub_mem_and_parents.first.match_count = gcsa->count(sub_mem_and_parents.first.range);
-            if (!include_parent_in_sub_mem_count) {
-                // remove parents from count
-                for (size_t parent_idx : sub_mem_and_parents.second) {
-                    sub_mem_and_parents.first.match_count -= mems[parent_idx].match_count;
-                }
-            }
+        // if we're removing the parent count from the total, we need to make sure
+        // we hold onto the total count so we can subtract it from any children
+        vector<size_t> total_count;
+        if (!include_parent_in_sub_mem_count) {
+            total_count.resize(mems.size() - num_smems);
         }
         
-        // fill MEMs with positions and set flag indicating they are submems
-        for (auto& m : sub_mems) {
-            auto& mem = m.first;
-            mem.primary = false;
-            if (mem.match_count > 0 && (!hit_max || mem.match_count <= hit_max)) {
-                gcsa->locate(mem.range, mem.nodes);
+        for (size_t i = num_smems; i < mems.size(); ++i) {
+            MaximalExactMatch& sub_mem = mems[i];
+            
+            // determine counts of matches
+            sub_mem.match_count = gcsa->count(sub_mem.range);
+            if (!include_parent_in_sub_mem_count) {
+                // record the original total
+                total_count[i - num_smems] = sub_mem.match_count;
+                // remove parents from count
+                for (size_t parent_idx : mem_containments[i - num_smems]) {
+                    sub_mem.match_count -= total_count[parent_idx - num_smems];
+                }
+            }
+            
+            sub_mem.primary = false;
+            
+            if (sub_mem.match_count > 0 && (!hit_max || sub_mem.match_count <= hit_max)) {
+                gcsa->locate(sub_mem.range, sub_mem.nodes);
                 // it may be necessary to impose the cap on mem hits?
-                if (hit_max > 0 && mem.nodes.size() > hit_max) {
-                    filtered_mems += mem.nodes.size();
-                    total_mems += mem.nodes.size();
-                    mem.nodes.clear();
+                if (hit_max > 0 && sub_mem.nodes.size() > hit_max) {
+                    filtered_mems += sub_mem.nodes.size();
+                    total_mems += sub_mem.nodes.size();
+                    sub_mem.nodes.clear();
                 }
             }
 #ifdef debug_mapper
 #pragma omp critical
             {
-                cerr << "sub-MEM " << mem.sequence() << " has " << mem.match_count << " hits: ";
-                for (auto nt : mem.nodes) {
+                cerr << "sub-MEM " << sub_mem.sequence() << " has " << sub_mem.match_count << " hits: ";
+                for (auto nt : sub_mem.nodes) {
                     cerr << make_pos_t(nt) << ", ";
                 }
                 cerr << endl;
             }
 #endif
-        }
-        
-        // combine the MEM and sub-MEM lists
-        for (auto iter = sub_mems.begin(); iter != sub_mems.end(); iter++) {
-            mems.push_back(std::move(iter->first));
         }
     }
 
@@ -633,14 +659,21 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
     return mems;
 }
 
-void BaseMapper::find_sub_mems(const vector<MaximalExactMatch>& mems,
+void BaseMapper::find_sub_mems(vector<MaximalExactMatch>& mems,
+                               vector<vector<size_t>>& mem_containments,
                                int mem_idx,
+                               int parent_layer_begin,
                                string::const_iterator next_mem_end,
-                               int min_mem_length,
-                               vector<pair<MaximalExactMatch, vector<size_t>>>& sub_mems_out) {
+                               int min_sub_mem_length,
+                               int reseed_length,
+                               int recursion_depth,
+                               int max_recursion_depth) {
     
-    // get the most recently added MEM
-    const MaximalExactMatch& mem = mems.back();
+    // look for sub MEMs in this MEM
+    const MaximalExactMatch& mem = mems[mem_idx];
+    
+    // mark the index where the first sub-MEM will be added
+    size_t sub_mem_layer_begin = mems.size();
     
 #ifdef debug_mapper
 #pragma omp critical
@@ -685,8 +718,8 @@ void BaseMapper::find_sub_mems(const vector<MaximalExactMatch>& mems,
             string::const_iterator sub_mem_begin = cursor + 1;
             
             if (sub_mem_end - sub_mem_begin >= min_mem_length && !prev_iter_jumped_lcp) {
-                sub_mems_out.push_back(make_pair(MaximalExactMatch(sub_mem_begin, sub_mem_end, last_range),
-                                                 vector<size_t>{(uint64_t)mem_idx}));
+                mems.emplace_back(sub_mem_begin, sub_mem_end, last_range);
+                mem_containments.emplace_back(1, mem_idx);
 #ifdef debug_mapper
 #pragma omp critical
                 {
@@ -705,10 +738,10 @@ void BaseMapper::find_sub_mems(const vector<MaximalExactMatch>& mems,
                 }
 #endif
                 // identify all previous MEMs that also contain this sub-MEM
-                for (int64_t i = mem_idx - 1; i >= 0; --i) {
-                    if (sub_mem_begin >= mems[i].begin) {
+                for (int64_t i = mem_idx - 1; i >= parent_layer_begin; --i) {
+                    if (sub_mem_end <= mems[i].end) {
                         // contined in next MEM, add its index to sub MEM's list of parents
-                        sub_mems_out.back().second.push_back(i);
+                        mem_containments.back().push_back(i);
                     }
                     else {
                         // not contained in the next MEM, cannot be contained in earlier ones
@@ -746,8 +779,9 @@ void BaseMapper::find_sub_mems(const vector<MaximalExactMatch>& mems,
     
     // add a final sub MEM if there is one and it is not contained in the next parent MEM
     if (sub_mem_end > next_mem_end && sub_mem_end - mem.begin >= min_mem_length && !prev_iter_jumped_lcp) {
-        sub_mems_out.push_back(make_pair(MaximalExactMatch(mem.begin, sub_mem_end, range),
-                                         vector<size_t>{(uint64_t)mem_idx}));
+        mems.emplace_back(mem.begin, sub_mem_end, range);
+        mem_containments.emplace_back(1, mem_idx);
+        
 #ifdef debug_mapper
 #pragma omp critical
         {
@@ -758,21 +792,38 @@ void BaseMapper::find_sub_mems(const vector<MaximalExactMatch>& mems,
             cerr << endl;
         }
 #endif
-        // note: this sub MEM is at the far left side of the parent MEM, so we don't need to
-        // check whether earlier MEMs contain it as well
-    }
-#ifdef debug_mapper
-    else {
-#pragma omp critical
-        {
-            cerr << "minimally more frequent MEM is too short ";
-            for (auto iter = mem.begin; iter != sub_mem_end; iter++) {
-                cerr << *iter;
+        
+        // identify all previous MEMs that also contain this sub-MEM
+        for (int64_t i = mem_idx - 1; i >= parent_layer_begin; --i) {
+            if (sub_mem_end <= mems[i].end) {
+                // contined in next MEM, add its index to sub MEM's list of parents
+                mem_containments.back().push_back(i);
             }
-            cerr << endl;
+            else {
+                // not contained in the next MEM, cannot be contained in earlier ones
+                break;
+            }
         }
     }
-#endif
+    
+    // should we try to find more recursive sub-MEMs?
+    if (recursion_depth < max_recursion_depth) {
+        size_t sub_mem_layer_end = mems.size();
+        for (size_t i = sub_mem_layer_begin; i < sub_mem_layer_end; i++) {
+            if (mems[i].length() >= reseed_length && mems[i].length() > min_sub_mem_length) {
+                // reseed using the technique indicated by the mapper's parameters
+                find_sub_mems(mems,
+                              mem_containments,
+                              i,
+                              sub_mem_layer_begin,
+                              i+1 < sub_mem_layer_end ? mems[i+1].end : mem.begin,
+                              min_sub_mem_length,
+                              reseed_length,
+                              recursion_depth + 1,
+                              max_recursion_depth);
+            }
+        }
+    }
 }
 
 // TODO: rewrite roughly as follows
@@ -783,11 +834,16 @@ void BaseMapper::find_sub_mems(const vector<MaximalExactMatch>& mems,
 // --- hope is that the first call to parent jumps us close to the limit for minimum length ...
 // goal is to get to roughly a linear number of LFs an parent()s per MEM we reseed
 
-void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
+void BaseMapper::find_sub_mems_fast(vector<MaximalExactMatch>& mems,
+                                    vector<vector<size_t>>& mem_containments,
                                     int mem_idx,
+                                    int parent_layer_begin,
                                     string::const_iterator next_mem_end,
                                     int min_sub_mem_length,
-                                    vector<pair<MaximalExactMatch, vector<size_t>>>& sub_mems_out) {
+                                    int reseed_length,
+                                    int recursion_depth,
+                                    int max_recursion_depth,
+                                    bool use_approximate_hit_count) {
 
     // get the indicated MEM
     const MaximalExactMatch& mem = mems[mem_idx];
@@ -802,7 +858,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
 #endif
     
     // how many times does the parent MEM occur in the index?
-    size_t parent_range_length = gcsa::Range::length(mem.range);
+    size_t parent_range_count = use_approximate_hit_count ? gcsa::Range::length(mem.range) : gcsa->count(mem.range);
     
     // the end of the leftmost substring that is at least the minimum length and not contained
     // in the next SMEM
@@ -812,6 +868,8 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
     }
     // the leftmost possible index of the next sub-MEM
     string::const_iterator leftmost_bound = mem.begin;
+    
+    vector<pair<MaximalExactMatch, size_t>> sub_mems;
     
     while (probe_string_end <= mem.end) {
         
@@ -838,7 +896,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
             
             range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
             
-            if (gcsa::Range::length(range) <= parent_range_length) {
+            if ((use_approximate_hit_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
                 probe_string_more_frequent = false;
                 break;
             }
@@ -859,7 +917,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                     gcsa::range_type last_range = range;
                     range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
                     
-                    if (gcsa::Range::length(range) <= parent_range_length) {
+                    if ((use_approximate_hit_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
                         range = last_range;
                         break;
                     }
@@ -905,7 +963,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
 
                     range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
                     
-                    if (gcsa::Range::length(range) <= parent_range_length) {
+                    if ((use_approximate_hit_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
                         // this probe is too long and it no longer is contained in the indendent hit
                         // that we detected
                         contained_in_independent_match = false;
@@ -938,20 +996,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
 #endif
             
             // record the sub-MEM
-            sub_mems_out.push_back(make_pair(MaximalExactMatch(probe_string_begin, right_search_bound, sub_mem_range),
-                                             vector<size_t>{(uint64_t)mem_idx}));
-            
-            // identify all previous MEMs that also contain this sub-MEM
-            for (int64_t i = mem_idx - 1; i >= 0; --i) { //((int64_t) mems.size()) - 2; i >= 0; i--) {
-                if (probe_string_begin >= mems[i].begin) {
-                    // contained in next MEM, add its index to sub MEM's list of parents
-                    sub_mems_out.back().second.push_back(i);
-                }
-                else {
-                    // not contained in the next MEM, cannot be contained in earlier ones
-                    break;
-                }
-            }
+            sub_mems.emplace_back(MaximalExactMatch(probe_string_begin, right_search_bound, sub_mem_range), mem_idx);
             
             // the closest possible independent probe string will now occur one position
             // to the right of this sub-MEM
@@ -968,6 +1013,43 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
             // will not contain it
             
             probe_string_end = cursor + min_sub_mem_length + 1;
+        }
+    }
+    
+    size_t sub_mem_layer_begin = mems.size();
+    
+    // fast algorithm finds MEMs left to right, switch order to match SMEM algorithm when adding to MEM list
+    for (auto riter = sub_mems.rbegin(); riter != sub_mems.rend(); riter++) {
+        mems.emplace_back(riter->first);
+        mem_containments.emplace_back(1, riter->second);
+        // check if any other MEMs in the same layer as the parent also contain this sub-MEM
+        for (int parent_idx = riter->second - 1; parent_idx >= parent_layer_begin; parent_idx--) {
+            if (mems[parent_idx].end >= riter->first.end) {
+                mem_containments.back().push_back(parent_idx);
+            }
+            else {
+                break;
+            }
+        }
+    }
+    
+    // should we try to find more recursive sub-MEMs?
+    if (recursion_depth < max_recursion_depth) {
+        size_t sub_mem_layer_end = mems.size();
+        for (size_t i = sub_mem_layer_begin; i < sub_mem_layer_end; i++) {
+            if (mems[i].length() >= reseed_length && mems[i].length() > min_sub_mem_length) {
+                // reseed using the technique indicated by the mapper's parameters
+                find_sub_mems_fast(mems,
+                                   mem_containments,
+                                   i,
+                                   sub_mem_layer_begin,
+                                   i+1 < sub_mem_layer_end ? mems[i+1].end : mem.begin,
+                                   min_sub_mem_length,
+                                   reseed_length,
+                                   recursion_depth + 1,
+                                   max_recursion_depth,
+                                   use_approximate_sub_mem_hit_count);
+            }
         }
     }
 }

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -21,6 +21,7 @@ BaseMapper::BaseMapper(xg::XG* xidex,
       , fast_reseed_length_diff(0.75)
       , adaptive_reseed_diff(false)
       , use_approximate_sub_mem_hit_count(true)
+      , max_sub_mem_recursion_depth(1)
       , adaptive_diff_exponent(0.05)
       , hit_max(0)
       , alignment_threads(1)

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -191,7 +191,8 @@ public:
                    bool use_diff_based_fast_reseed = false,
                    bool include_parent_in_sub_mem_count = false,
                    bool record_max_lcp = false,
-                   int reseed_below_count = 0);
+                   int reseed_below_count = 0,
+                   int max_sub_mem_recursion = 1);
     
     // Use the GCSA2 index to find super-maximal exact matches.
     vector<MaximalExactMatch>
@@ -209,6 +210,7 @@ public:
     bool adaptive_reseed_diff; // use an adaptive length difference algorithm in reseed algorithm
     double adaptive_diff_exponent; // exponent that describes limiting behavior of adaptive diff algorithm
     int hit_max;       // ignore or MEMs with more than this many hits
+    bool use_approximate_sub_mem_hit_count;
     
     bool strip_bonuses; // remove any bonuses used by the aligners from the final reported scores
     bool assume_acyclic; // the indexed graph is acyclic
@@ -221,20 +223,29 @@ protected:
     /// Locate the sub-MEMs contained in the last MEM of the mems vector that have ending positions
     /// before the end the next SMEM, label each of the sub-MEMs with the indices of all of the SMEMs
     /// that contain it
-    void find_sub_mems(const vector<MaximalExactMatch>& mems,
+    void find_sub_mems(vector<MaximalExactMatch>& mems,
+                       vector<vector<size_t>>& mem_containments,
                        int mem_idx,
+                       int parent_layer_begin,
                        string::const_iterator next_mem_end,
-                       int min_mem_length,
-                       vector<pair<MaximalExactMatch, vector<size_t>>>& sub_mems_out);
+                       int min_sub_mem_length,
+                       int reseed_length,
+                       int recursion_depth,
+                       int max_recursion_depth);
     
     /// Provides same semantics as find_sub_mems but with a different algorithm. This algorithm uses the
     /// min_mem_length as a pruning tool instead of the LCP index. It can be expected to be faster when both
     /// the min_mem_length reasonably large relative to the reseed_length (e.g. 1/2 of SMEM size or similar).
-    void find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
+    void find_sub_mems_fast(vector<MaximalExactMatch>& mems,
+                            vector<vector<size_t>>& mem_containments,
                             int mem_idx,
+                            int parent_layer_begin,
                             string::const_iterator next_mem_end,
                             int min_sub_mem_length,
-                            vector<pair<MaximalExactMatch, vector<size_t>>>& sub_mems_out);
+                            int reseed_length,
+                            int recursion_depth,
+                            int max_recursion_depth,
+                            bool use_approximate_hit_count);
     
     /// finds the nodes of sub MEMs that do not occur inside parent MEMs, each sub MEM should be associated
     /// with a vector of the indices of the SMEMs that contain it in the parent MEMs vector

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -191,8 +191,7 @@ public:
                    bool use_diff_based_fast_reseed = false,
                    bool include_parent_in_sub_mem_count = false,
                    bool record_max_lcp = false,
-                   int reseed_below_count = 0,
-                   int max_sub_mem_recursion = 1);
+                   int reseed_below_count = 0);
     
     // Use the GCSA2 index to find super-maximal exact matches.
     vector<MaximalExactMatch>
@@ -227,7 +226,7 @@ protected:
     void find_sub_mems(vector<MaximalExactMatch>& mems,
                        vector<vector<size_t>>& mem_containments,
                        int mem_idx,
-                       int parent_layer_begin,
+                       int parent_layer_end,
                        string::const_iterator next_mem_end,
                        int min_sub_mem_length,
                        int reseed_length,
@@ -240,7 +239,7 @@ protected:
     void find_sub_mems_fast(vector<MaximalExactMatch>& mems,
                             vector<vector<size_t>>& mem_containments,
                             int mem_idx,
-                            int parent_layer_begin,
+                            int parent_layer_end,
                             string::const_iterator next_mem_end,
                             int min_sub_mem_length,
                             int reseed_length,

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -210,7 +210,8 @@ public:
     bool adaptive_reseed_diff; // use an adaptive length difference algorithm in reseed algorithm
     double adaptive_diff_exponent; // exponent that describes limiting behavior of adaptive diff algorithm
     int hit_max;       // ignore or MEMs with more than this many hits
-    bool use_approximate_sub_mem_hit_count;
+    bool use_approximate_sub_mem_hit_count; // use Range::length instead of GCSA::count to count sub-MEM hits
+    int max_sub_mem_recursion_depth;
     
     bool strip_bonuses; // remove any bonuses used by the aligners from the final reported scores
     bool assume_acyclic; // the indexed graph is acyclic

--- a/src/mem.hpp
+++ b/src/mem.hpp
@@ -26,14 +26,13 @@ class MaximalExactMatch {
 
 public:
 
-    //const string* source;
     string::const_iterator begin;
     string::const_iterator end;
     gcsa::range_type range;
     size_t match_count;
     int fragment;
     bool primary; // if not a sub-MEM
-    std::vector<gcsa::node_type> nodes;
+    vector<gcsa::node_type> nodes;
     map<string, vector<pair<size_t, bool> > > positions;
     
     MaximalExactMatch(string::const_iterator b,

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -608,6 +608,8 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.mem_reseed_length = reseed_length;
     multipath_mapper.fast_reseed = true;
     multipath_mapper.fast_reseed_length_diff = reseed_diff;
+    multipath_mapper.max_sub_mem_recursion_depth = 2;
+    multipath_mapper.use_approximate_sub_mem_hit_count = false;
     multipath_mapper.min_mem_length = min_mem_length;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;


### PR DESCRIPTION
I implemented a fully recursive version of the sub-MEM finding algorithm. Instead of only reseeding SMEMs, you now designate a maximum recursion depth. The old behavior can be mimicked by setting the maximum recursion depth to 1.