### PR TITLE
Automatically generate chunks over id space

### DIFF
--- a/src/chunker.cpp
+++ b/src/chunker.cpp
@@ -38,9 +38,7 @@ void PathChunker::extract_subgraph(const Region& region, int context, int length
     
     // expand the context and get path information
     // if forward_only true, then we only go forward.
-    if (context) {
-        xg->expand_context(g, context, true, true, true, !forward_only);
-    }
+    xg->expand_context(g, context, true, true, true, !forward_only);
     if (length) {
         xg->expand_context(g, context, true, false, true, !forward_only);
     }
@@ -97,9 +95,7 @@ void PathChunker::extract_id_range(vg::id_t start, vg::id_t end, int context, in
     
     // expand the context and get path information
     // if forward_only true, then we only go forward.
-    if (context) {
-        xg->expand_context(g, context, true, true, true, !forward_only);
-    }
+    xg->expand_context(g, context, true, true, true, !forward_only);
     if (length) {
         xg->expand_context(g, context, true, false, true, !forward_only);
     }

--- a/src/chunker.cpp
+++ b/src/chunker.cpp
@@ -19,8 +19,8 @@ PathChunker::~PathChunker() {
 
 }
 
-void PathChunker::extract_subgraph(const Region& region, int context, bool forward_only,
-                                   VG& subgraph, Region& out_region) {
+void PathChunker::extract_subgraph(const Region& region, int context, int length,
+                                   bool forward_only, VG& subgraph, Region& out_region) {
 
     Graph g;
 
@@ -38,7 +38,12 @@ void PathChunker::extract_subgraph(const Region& region, int context, bool forwa
     
     // expand the context and get path information
     // if forward_only true, then we only go forward.
-    xg->expand_context(g, context, true, true, true, !forward_only);
+    if (context) {
+        xg->expand_context(g, context, true, true, true, !forward_only);
+    }
+    if (length) {
+        xg->expand_context(g, context, true, false, true, !forward_only);
+    }
         
     // build the vg
     subgraph.extend(g);
@@ -81,7 +86,7 @@ void PathChunker::extract_subgraph(const Region& region, int context, bool forwa
     }
 }
 
-void PathChunker::extract_id_range(vg::id_t start, vg::id_t end, int context,
+void PathChunker::extract_id_range(vg::id_t start, vg::id_t end, int context, int length,
                                    bool forward_only, VG& subgraph, Region& out_region) {
 
     Graph g;
@@ -92,8 +97,13 @@ void PathChunker::extract_id_range(vg::id_t start, vg::id_t end, int context,
     
     // expand the context and get path information
     // if forward_only true, then we only go forward.
-    xg->expand_context(g, context, true, true, true, !forward_only);
-        
+    if (context) {
+        xg->expand_context(g, context, true, true, true, !forward_only);
+    }
+    if (length) {
+        xg->expand_context(g, context, true, false, true, !forward_only);
+    }
+
     // build the vg
     subgraph.extend(g);
     subgraph.remove_orphan_edges();

--- a/src/chunker.hpp
+++ b/src/chunker.hpp
@@ -43,13 +43,13 @@ public:
      * NOTE: we follow convention of Region coordinates being 1-based 
      * inclusive. 
      * */
-    void extract_subgraph(const Region& region, int context, bool forward_only,
+    void extract_subgraph(const Region& region, int context, int length, bool forward_only,
                           VG& subgraph, Region& out_region);
 
     /**
      * Like above, but use (inclusive) id range instead of region on path.
      */
-    void extract_id_range(vg::id_t start, vg::id_t end, int context, bool forward_only,
+    void extract_id_range(vg::id_t start, vg::id_t end, int context, int length, bool forward_only,
                          VG& subgraph, Region& out_region);
 
     /** Extract all alignments that touch a node in a subgraph and write them 

--- a/src/counter.cpp
+++ b/src/counter.cpp
@@ -195,8 +195,7 @@ vector<Edit> Counter::edits_at_position(size_t i) {
     string key = pos_key(i);
     auto occs = locate(edit_csa, key);
     for (size_t i = 0; i < occs.size(); ++i) {
-        //cout << occs[i] << endl;
-        // walk from after the key to the next end-sep
+        // walk from after the key and delim1 to the next end-sep
         size_t b = occs[i] + key.size() + 1;
         size_t e = b;
         // look for an odd number of delims
@@ -212,13 +211,9 @@ vector<Edit> Counter::edits_at_position(size_t i) {
                 break;
             }
         }
-        // now run until we don't find a delim
-        //while (!(extract(edit_csa, e, e)[0] == delim && extract(edit_csa, e+1, e+1)[0] != delim)) ++e;
         string value = unescape_delims(extract(edit_csa, b, e));
         Edit edit;
-        //cerr << b << " " << e << endl;
         edit.ParseFromString(value);
-        //cerr << pb2json(edit) << endl;
         edits.push_back(edit);
     }
     return edits;

--- a/src/counter.cpp
+++ b/src/counter.cpp
@@ -77,7 +77,7 @@ void Counter::ensure_edit_tmpfile_open(void) {
 
 void Counter::close_edit_tmpfile(void) {
     if (tmpfstream.is_open()) {
-        tmpfstream << delim; // pad
+        tmpfstream << delim1; // pad
         tmpfstream.close();
     }
 }
@@ -139,7 +139,9 @@ string Counter::pos_key(size_t i) {
     pos.set_node_id(i+offset);
     string pos_repr;
     pos.SerializeToString(&pos_repr);
-    return delim + escape_delim(pos_repr);
+    stringstream s;
+    s << delim1 << delim2 << delim1 << escape_delims(pos_repr);
+    return s.str();
 }
 
 string Counter::edit_value(const Edit& edit, bool revcomp) {
@@ -149,29 +151,39 @@ string Counter::edit_value(const Edit& edit, bool revcomp) {
     } else {
         edit.SerializeToString(&edit_repr);
     }
-    return delim + escape_delim(edit_repr);
+    stringstream s;
+    s << delim1 << escape_delims(edit_repr);
+    return s.str();
 }
 
-string Counter::escape_delim(const string& s) {
+string Counter::escape_delims(const string& s) {
+    return escape_delim(escape_delim(s, delim1), delim2);
+}
+
+string Counter::unescape_delims(const string& s) {
+    return unescape_delim(unescape_delim(s, delim1), delim2);
+}
+
+string Counter::escape_delim(const string& s, char d) {
     string escaped; escaped.reserve(s.size());
     for (size_t i = 0; i < s.size(); ++i) {
         char c = s[i];
         escaped.push_back(c);
-        if (c == delim) escaped.push_back(delim);
+        if (c == d) escaped.push_back(c);
     }
     return escaped;
 }
 
-string Counter::unescape_delim(const string& s) {
+string Counter::unescape_delim(const string& s, char d) {
     string unescaped; unescaped.reserve(s.size());
     for (size_t i = 0; i < s.size()-1; ++i) {
         char c = s[i];
-        char d = s[i+1];
-        if (c == delim && d == delim) {
-            unescaped.push_back(delim);
+        char b = s[i+1];
+        if (c == d && b == d) {
+            unescaped.push_back(c);
         } else {
             unescaped.push_back(c);
-            if (i == s.size()-2) unescaped.push_back(d);
+            if (i == s.size()-2) unescaped.push_back(b);
         }
     }
     return unescaped;
@@ -187,8 +199,22 @@ vector<Edit> Counter::edits_at_position(size_t i) {
         // walk from after the key to the next end-sep
         size_t b = occs[i] + key.size() + 1;
         size_t e = b;
-        while (!(extract(edit_csa, e, e)[0] == delim && extract(edit_csa, e+1, e+1)[0] != delim)) ++e;
-        string value = unescape_delim(extract(edit_csa, b, e));
+        // look for an odd number of delims
+        // run until we find a delim
+        while (true) {
+            while (extract(edit_csa, e, e)[0] != delim1) ++e;
+            // now we are matching the delim... count them
+            size_t f = e;
+            while (extract(edit_csa, f, f)[0] == delim1) ++f;
+            size_t c = f - e;
+            e = f; // set pointer to last delim
+            if (c % 2 != 0) {
+                break;
+            }
+        }
+        // now run until we don't find a delim
+        //while (!(extract(edit_csa, e, e)[0] == delim && extract(edit_csa, e+1, e+1)[0] != delim)) ++e;
+        string value = unescape_delims(extract(edit_csa, b, e));
         Edit edit;
         //cerr << b << " " << e << endl;
         edit.ParseFromString(value);

--- a/src/counter.hpp
+++ b/src/counter.hpp
@@ -61,12 +61,15 @@ private:
     csa_wt<> edit_csa;
     // make separators that are like improbable varints
     // so that they are unlikely to occur in structured data we write
-    char delim = '\xff';
+    char delim1 = '\xff';
+    char delim2 = '\xfe';
     //string delim_sub = string(1, '\xff');
     // double the delimiter in the string
-    string escape_delim(const string& s);
+    string escape_delim(const string& s, char d);
+    string escape_delims(const string& s);
     // take each double delimiter back to a single
-    string unescape_delim(const string& s);
+    string unescape_delim(const string& s, char d);
+    string unescape_delims(const string& s);
 };
 
 // for making a combined matrix output and maybe doing other fun operations

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -41,6 +41,7 @@ void help_chunk(char** argv) {
          << "id range chunking:" << endl
          << "    -r, --node-range N:M     write the chunk for the specified node range\n"
          << "    -R, --node-ranges FILE   write the chunk for each node range in (newline or whitespace separated) file\n"
+         << "    -n, --n-chunks N         generate this many id-range chunks, which are determined using the xg index\n"
          << "general:" << endl
          << "    -s, --chunk-size N       create chunks spanning N bases (or nodes with -r/-R) for all input regions.\n"
          << "    -o, --overlap N          overlap between chunks when using -s [default = 0]" << endl        
@@ -48,7 +49,8 @@ void help_chunk(char** argv) {
          << "    -b, --prefix PATH        prefix output chunk paths with PATH. each chunk will have the following name:\n"
          << "                             <PATH>-<i>-<name>-<start>-<length>. <i> is the line# of the chunk in the\n"
          << "                             output bed. [default=./chunk]" << endl
-         << "    -c, --context STEPS      expand the context of the chunk this many steps [1]" << endl
+         << "    -c, --context-steps N    expand the context of the chunk this many node steps [1]" << endl
+         << "    -l, --context-length N   expand the context of the chunk by this many bp [0]" << endl
          << "    -T, --trace              Trace haplotype threads in chunks (and only expand forward from input coordinates)" << endl
          << "    -f, --fully-contained    Only return GAM alignments that are fully contained within chunk" << endl
          << "    -A, --search-all         Search all nodes of alignment as opposed just the minimum (gam index must be made with -N)" << endl
@@ -74,6 +76,7 @@ int main_chunk(int argc, char** argv) {
     string out_bed_file;
     string out_chunk_prefix = "./chunk";
     int context_steps = -1;
+    int context_length = 0;
     bool id_range = false;
     string node_range_string;
     string node_ranges_file;
@@ -81,6 +84,7 @@ int main_chunk(int argc, char** argv) {
     bool trace = false;
     bool fully_contained = false;
     bool search_all_positions = false;
+    int n_chunks = 0;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -105,11 +109,13 @@ int main_chunk(int argc, char** argv) {
             {"fully-contained", no_argument, 0, 'f'},
             {"search-all-positions", no_argument, 0, 'A'},
             {"threads", required_argument, 0, 't'},
+            {"n-chunks", required_argument, 0, 'n'},
+            {"context-length", required_argument, 0, 'l'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:a:gp:P:s:o:e:E:b:c:r:R:TfAt:",
+        c = getopt_long (argc, argv, "hx:a:gp:P:s:o:e:E:b:c:r:R:TfAt:n:l:",
                 long_options, &option_index);
 
 
@@ -164,6 +170,11 @@ int main_chunk(int argc, char** argv) {
             context_steps = atoi(optarg);
             break;
 
+        case 'l':
+            context_length = atoi(optarg);
+            context_steps = 0;
+            break;
+
         case 'r':
             node_range_string = optarg;
             id_range = true;
@@ -171,6 +182,11 @@ int main_chunk(int argc, char** argv) {
 
         case 'R':
             node_ranges_file = optarg;
+            id_range = true;
+            break;
+
+        case 'n':
+            n_chunks = atoi(optarg);
             id_range = true;
             break;
 
@@ -203,10 +219,10 @@ int main_chunk(int argc, char** argv) {
 
     omp_set_num_threads(threads);            
 
-    // need at most one of -p, -P, -e, -r, -R,  as an input
-    if ((region_string.empty() ? 0 : 1) + (path_list_file.empty() ? 0 : 1) + (in_bed_file.empty() ? 0 : 1) +
+    // need at most one of -n, -p, -P, -e, -r, -R,  as an input
+    if ((n_chunks == 0 ? 0 : 1) + (region_string.empty() ? 0 : 1) + (path_list_file.empty() ? 0 : 1) + (in_bed_file.empty() ? 0 : 1) +
         (node_ranges_file.empty() ? 0 : 1) + (node_range_string.empty() ? 0 : 1) > 1) {
-        cerr << "error:[vg chunk] at most one of {-p, -P, -e, -r, -R} required to specify input regions" << endl;
+        cerr << "error:[vg chunk] at most one of {-n, -p, -P, -e, -r, -R} required to specify input regions" << endl;
         return 1;
     }
     // need -a if using -f
@@ -234,7 +250,7 @@ int main_chunk(int argc, char** argv) {
 
     // Load our index
     xg::XG xindex;
-    if (chunk_graph || trace || context_steps > 0 || !id_range) {
+    if (chunk_graph || trace || context_steps > 0 || context_length > 0 || !id_range) {
         if (xg_file.empty()) {
             cerr << "error:[vg chunk] xg index (-x) required" << endl;
             return 1;
@@ -282,33 +298,53 @@ int main_chunk(int argc, char** argv) {
         parse_bed_regions(in_bed_file, regions);
     }
     else if (id_range) {
-        istream* range_stream;
-        if (!node_range_string.empty()) {
-            range_stream = new stringstream(node_range_string);
-        } else {
-            range_stream = new ifstream(node_ranges_file);
-            if (!(*range_stream)) {
-                cerr << "error:[vg chunk] unable to open id ranges file: " << node_ranges_file << endl;
-                return 1;
-            }
-        }
-        do {
-            string range;
-            *range_stream >> range;
-            if (!range.empty() && isdigit(range[0])) {
+        if (n_chunks) {
+            // determine the ranges from the xg index itself
+            // how many nodes per range?
+            int nodes_per_chunk = xindex.node_count / n_chunks;
+            size_t i = 1;
+            // iterate through the node ranks to build the regions
+            while (i < xindex.node_count) {
+                // make a range from i to i+nodeS_per_range
+                vg::id_t a = xindex.rank_to_id(i);
+                size_t j = i + nodes_per_chunk;
+                if (j > xindex.node_count) j = xindex.node_count;
+                vg::id_t b = xindex.rank_to_id(j);
                 Region region;
-                vector<string> parts = split_delims(range, ":");
-                if (parts.size() == 1) {
-                    convert(parts.front(), region.start);
-                    region.end = region.start;
-                } else {
-                    convert(parts.front(), region.start);
-                    convert(parts.back(), region.end);
-                }
+                region.start = a;
+                region.end = b;
                 regions.push_back(region);
+                i = j + 1;
             }
-        } while (*range_stream);
-        delete range_stream;
+        } else {
+            istream* range_stream;
+            if (!node_range_string.empty()) {
+                range_stream = new stringstream(node_range_string);
+            } else {
+                range_stream = new ifstream(node_ranges_file);
+                if (!(*range_stream)) {
+                    cerr << "error:[vg chunk] unable to open id ranges file: " << node_ranges_file << endl;
+                    return 1;
+                }
+            }
+            do {
+                string range;
+                *range_stream >> range;
+                if (!range.empty() && isdigit(range[0])) {
+                    Region region;
+                    vector<string> parts = split_delims(range, ":");
+                    if (parts.size() == 1) {
+                        convert(parts.front(), region.start);
+                        region.end = region.start;
+                    } else {
+                        convert(parts.front(), region.start);
+                        convert(parts.back(), region.end);
+                    }
+                    regions.push_back(region);
+                }
+            } while (*range_stream);
+            delete range_stream;
+        }
     }
     else {
         // every path
@@ -385,7 +421,6 @@ int main_chunk(int argc, char** argv) {
         chunker.xg = &xindex;
     }
 
-    
     // extract chunks in parallel
 #pragma omp parallel for
     for (int i = 0; i < num_regions; ++i) {
@@ -396,12 +431,14 @@ int main_chunk(int argc, char** argv) {
         map<string, int> trace_thread_frequencies;
         if (id_range == false) {
             subgraph = new VG();
-            chunker.extract_subgraph(region, context_steps, trace, *subgraph, output_regions[i]);
+            chunker.extract_subgraph(region, context_steps, context_length,
+                                     trace, *subgraph, output_regions[i]);
         } else {
             if (chunk_graph || context_steps > 0) {
                 subgraph = new VG();
                 output_regions[i].seq = region.seq;                
-                chunker.extract_id_range(region.start, region.end, context_steps, trace,
+                chunker.extract_id_range(region.start, region.end,
+                                         context_steps, context_length, trace,
                                          *subgraph, output_regions[i]);
             } else {
                 // in this case, there's no need to actually build the subgraph, so we don't

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -172,7 +172,7 @@ int main_chunk(int argc, char** argv) {
 
         case 'l':
             context_length = atoi(optarg);
-            context_steps = 0;
+            context_steps = (context_steps > 0 ? context_steps : -1);
             break;
 
         case 'r':
@@ -234,7 +234,9 @@ int main_chunk(int argc, char** argv) {
     // misunderstandings
     if (context_steps < 0) {
         if (id_range) {
-            context_steps = 1;
+            if (!context_length) {
+                context_steps = 1;
+            }
         } else {
             cerr << "error:[vg chunk] context expansion steps must be specified with -c/--context when chunking on paths" << endl;
             return 1;

--- a/src/unittest/chunker.cpp
+++ b/src/unittest/chunker.cpp
@@ -96,7 +96,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         Region region = {"x", 1, 32};
         VG subgraph;
         Region out_region;
-        chunker.extract_subgraph(region, 1, false, subgraph, out_region);
+        chunker.extract_subgraph(region, 1, 0, false, subgraph, out_region);
 
         REQUIRE(subgraph.node_count() == 9);
         REQUIRE(subgraph.edge_count() == 12);
@@ -108,7 +108,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         Region region = {"x", 9, 16};
         VG subgraph;
         Region out_region;        
-        chunker.extract_subgraph(region, 1, false, subgraph, out_region);
+        chunker.extract_subgraph(region, 1, 0, false, subgraph, out_region);
 
         REQUIRE(subgraph.node_count() == 6);
         REQUIRE(subgraph.edge_count() == 7);
@@ -120,7 +120,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         Region region = {"x", 3, 6};
         VG subgraph;
         Region out_region;        
-        chunker.extract_id_range(region.start, region.end, 1, false, subgraph, out_region);
+        chunker.extract_id_range(region.start, region.end, 1, 0, false, subgraph, out_region);
         
         REQUIRE(subgraph.node_count() == 7);
         REQUIRE(subgraph.edge_count() == 10);
@@ -132,7 +132,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         Region region = {"x", 8, 16};
         VG subgraph;
         Region out_region;        
-        chunker.extract_subgraph(region, 1, false, subgraph, out_region);
+        chunker.extract_subgraph(region, 1, 0, false, subgraph, out_region);
 
         REQUIRE(subgraph.node_count() == 6);
         REQUIRE(subgraph.edge_count() == 7);
@@ -144,7 +144,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         Region region = {"y", 1, 37};
         VG subgraph;
         Region out_region;
-        chunker.extract_subgraph(region, 1, false, subgraph, out_region);
+        chunker.extract_subgraph(region, 1, 0, false, subgraph, out_region);
 
         REQUIRE(subgraph.node_count() == 9);
         REQUIRE(subgraph.edge_count() == 12);
@@ -157,7 +157,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         Region region = {"y", 15, 35};
         VG subgraph;
         Region out_region;
-        chunker.extract_subgraph(region, 1, false, subgraph, out_region);
+        chunker.extract_subgraph(region, 1, 0, false, subgraph, out_region);
 
         REQUIRE(subgraph.node_count() == 7);
         REQUIRE(subgraph.edge_count() == 9);
@@ -169,7 +169,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         Region region = {"z", 1, 60};
         VG subgraph;
         Region out_region;        
-        chunker.extract_subgraph(region, 1, false, subgraph, out_region);
+        chunker.extract_subgraph(region, 1, 0, false, subgraph, out_region);
         
         REQUIRE(subgraph.node_count() == 9);
         REQUIRE(subgraph.edge_count() == 12);
@@ -182,7 +182,7 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         Region region = {"z", 36, 59};
         VG subgraph;
         Region out_region;        
-        chunker.extract_subgraph(region, 1, false, subgraph, out_region);
+        chunker.extract_subgraph(region, 1, 0, false, subgraph, out_region);
         
         REQUIRE(subgraph.node_count() == 7);
         REQUIRE(subgraph.edge_count() == 9);

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 10
+plan tests 11
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -v small/x.vcf.gz  x.vg 2> /dev/null
@@ -41,5 +41,11 @@ is $(vg chunk -x x.xg -r 1 -c 0 | vg view - -j | jq .node | grep id | wc -l) 1 "
 
 #check that traces work
 is $(vg chunk -x x.xg -r 1:1 -c 2 -T | vg view - -j | jq .node | grep id | wc -l) 5 "id chunker traces correct chunk size"
-rm -rf x.gam.index x.gam.unsrt.index _chunk_test_bed.bed _chunk_test*
+
+#check that n-chunking works
+mkdir x.chunk
+vg chunk -x x.xg -n 5 -b x.chunk/
+is $(cat x.chunk/*vg | vg view -V - 2>/dev/null | md5sum | cut -f 1 -d\ ) $(vg view x.vg | md5sum | cut -f 1 -d\ ) "n-chunking works and chunks over the full graph"
+
+rm -rf x.gam.index x.gam.unsrt.index _chunk_test_bed.bed _chunk_test* x.chunk
 rm -f x.vg x.xg x.gam x.gam.json filter_chunk*.gam chunks.bed


### PR DESCRIPTION
Using `vg chunk -n 100 -l 16 -b z.chunk z.vg` generates ~100 chunks from z.vg and make sure that each is extended by >=16bp from the limits of the chunk. Then, generating kmers can be done in parallel over these chunks provided the kmer length is <=16.

This simplifies the graph chunking process when we don't care about reference paths. The goal here is to set up distributed kmer generation on large graphs.