### PR TITLE
Divide and conquer count index generation

### DIFF
--- a/src/counter.hpp
+++ b/src/counter.hpp
@@ -26,7 +26,7 @@ public:
     Counter(xg::XG* xidx);
     ~Counter(void);
     xg::XG* xgidx;
-    //void load(const vector<string>& file_names);
+    void merge_from_files(const vector<string>& file_names);
     void load_from_file(const string& file_name);
     void save_to_file(const string& file_name);
     void load(istream& in);
@@ -39,12 +39,16 @@ public:
     void make_compact(void);
     void make_dynamic(void);
     void add(const Alignment& aln, bool record_edits = true);
-    size_t position_in_basis(const Position& pos);
-    string pos_key(size_t i);
-    string edit_value(const Edit& edit, bool revcomp);
-    vector<Edit> edits_at_position(size_t i);
+    size_t graph_length(void) const;
+    size_t position_in_basis(const Position& pos) const;
+    string pos_key(size_t i) const;
+    string edit_value(const Edit& edit, bool revcomp) const;
+    vector<Edit> edits_at_position(size_t i) const;
+    size_t coverage_at_position(size_t i) const;
+    void collect_coverage(const Counter& c);
     ostream& as_table(ostream& out, bool show_edits = true);
     ostream& show_structure(ostream& out); // debugging
+    void write_edits(ostream& out) const; // for merge
 private:
     bool is_compacted;
     // dynamic model
@@ -59,17 +63,16 @@ private:
     vlc_vector<> coverage_civ; // graph coverage (compacted coverage_dynamic)
     //csa_sada<enc_vector<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, succinct_byte_alphabet<> > edit_csa;
     csa_wt<> edit_csa;
-    // make separators that are like improbable varints
-    // so that they are unlikely to occur in structured data we write
+    // make separators that are somewhat unusual, as we escape these
     char delim1 = '\xff';
     char delim2 = '\xfe';
     //string delim_sub = string(1, '\xff');
     // double the delimiter in the string
-    string escape_delim(const string& s, char d);
-    string escape_delims(const string& s);
+    string escape_delim(const string& s, char d) const;
+    string escape_delims(const string& s) const;
     // take each double delimiter back to a single
-    string unescape_delim(const string& s, char d);
-    string unescape_delims(const string& s);
+    string unescape_delim(const string& s, char d) const;
+    string unescape_delims(const string& s) const;
 };
 
 // for making a combined matrix output and maybe doing other fun operations

--- a/src/subcommand/count_main.cpp
+++ b/src/subcommand/count_main.cpp
@@ -108,8 +108,10 @@ int main_count(int argc, char** argv) {
 
     // todo one counter per thread and merge
     vg::Counter counter(&xgidx);
-    if (!counts_in.empty()) {
+    if (counts_in.size() == 1) {
         counter.load_from_file(counts_in.front());
+    } else if (counts_in.size() > 1) {
+        counter.merge_from_files(counts_in);
     }
 
     if (!gam_in.empty()) {

--- a/test/t/34_vg_count.t
+++ b/test/t/34_vg_count.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 2
+plan tests 4
 
 vg construct -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
@@ -13,11 +13,17 @@ vg index -x 2snp.xg 2snp.vg
 vg sim -s 420 -l 30 -x 2snp.xg -n 30 -a >2snp.sim
 vg index -x flat.xg -g flat.gcsa -k 16 flat.vg
 vg map -g flat.gcsa -x flat.xg -G 2snp.sim -k 8 >2snp.gam
-vg count -x flat.xg -o 2snp.gam.counts -g 2snp.gam
-is $(vg count -x flat.xg -di 2snp.gam.counts  | cut -f 3 | grep -v ^0$ | wc -l) 2 "allele observation counting detects 2 SNPs"
+vg count -x flat.xg -o 2snp.gam.cx -g 2snp.gam
+is $(vg count -x flat.xg -di 2snp.gam.cx  | cut -f 3 | grep -v ^0$ | wc -l) 2 "allele observation counting detects 2 SNPs"
 
 vg pileup -p flat.vg 2snp.gam >2snp.gam.vgpu
 is $(vg view -l 2snp.gam.vgpu|  jq '.node_pileups[].base_pileup[].num_bases' | awk '{ print NR-1, $0 }' | head | md5sum | cut -f 1 -d\ )\
-   $(vg count -x flat.xg -di 2snp.gam.counts | awk '{ print $1, $2 }' | head | md5sum | cut -f 1 -d\ ) "pileup counts agree with graph coverage"
+   $(vg count -x flat.xg -di 2snp.gam.cx | awk '{ print $1, $2 }' | head | md5sum | cut -f 1 -d\ ) "pileup counts agree with graph coverage"
 
-rm -f flat.vg 2snp.vg 2snp.xg 2snp.sim flat.gcsa flat.gcsa.lcp flat.xg 2snp.xg 2snp.gam 2snp.gam.counts 2snp.gam.vgpu
+vg count -x flat.xg -i 2snp.gam.cx -i 2snp.gam.cx -i 2snp.gam.cx -o 2snp.gam.cx.3x
+
+is $(echo "("$(vg count -x x.xg -di 2snp.gam.cx.3x | awk '{ print $2 }' | paste -sd+ - )")"/3 | bc) $(echo "("$(vg count -x x.xg -di 2snp.gam.cx | awk '{ print $2 }' | paste -sd+ - )")" | bc) "graph coverages are merged from multiple .cx indexes"
+
+is $(echo "("$(vg count -x x.xg -di 2snp.gam.cx.3x | awk '{ print $3 }' | paste -sd+ - )")"/3 | bc) $(echo "("$(vg count -x x.xg -di 2snp.gam.cx | awk '{ print $3 }' | paste -sd+ - )")" | bc) "edit records are merged from multiple .cx indexes"
+
+rm -f flat.vg 2snp.vg 2snp.xg 2snp.sim flat.gcsa flat.gcsa.lcp flat.xg 2snp.xg 2snp.gam 2snp.gam.cx 2snp.gam.cx.3x 2snp.gam.vgpu

--- a/test/t/34_vg_count.t
+++ b/test/t/34_vg_count.t
@@ -22,8 +22,8 @@ is $(vg view -l 2snp.gam.vgpu|  jq '.node_pileups[].base_pileup[].num_bases' | a
 
 vg count -x flat.xg -i 2snp.gam.cx -i 2snp.gam.cx -i 2snp.gam.cx -o 2snp.gam.cx.3x
 
-is $(echo "("$(vg count -x x.xg -di 2snp.gam.cx.3x | awk '{ print $2 }' | paste -sd+ - )")"/3 | bc) $(echo "("$(vg count -x x.xg -di 2snp.gam.cx | awk '{ print $2 }' | paste -sd+ - )")" | bc) "graph coverages are merged from multiple .cx indexes"
+is $(echo "("$(vg count -x 2snp.xg -di 2snp.gam.cx.3x | awk '{ print $2 }' | paste -sd+ - )")"/3 | bc) $(echo "("$(vg count -x 2snp.xg -di 2snp.gam.cx | awk '{ print $2 }' | paste -sd+ - )")" | bc) "graph coverages are merged from multiple .cx indexes"
 
-is $(echo "("$(vg count -x x.xg -di 2snp.gam.cx.3x | awk '{ print $3 }' | paste -sd+ - )")"/3 | bc) $(echo "("$(vg count -x x.xg -di 2snp.gam.cx | awk '{ print $3 }' | paste -sd+ - )")" | bc) "edit records are merged from multiple .cx indexes"
+is $(echo "("$(vg count -x 2snp.xg -di 2snp.gam.cx.3x | awk '{ print $3 }' | paste -sd+ - )")"/3 | bc) $(echo "("$(vg count -x 2snp.xg -di 2snp.gam.cx | awk '{ print $3 }' | paste -sd+ - )")" | bc) "edit records are merged from multiple .cx indexes"
 
 rm -f flat.vg 2snp.vg 2snp.xg 2snp.sim flat.gcsa flat.gcsa.lcp flat.xg 2snp.xg 2snp.gam 2snp.gam.cx 2snp.gam.cx.3x 2snp.gam.vgpu


### PR DESCRIPTION
Enables parallelism when generating allele count indexes. These can be generated in parallel and then merged.