### PR TITLE
Make the approximate sub-MEM counts optional

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -802,7 +802,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
 #endif
     
     // how many times does the parent MEM occur in the index?
-    size_t parent_range_length = gcsa::Range::length(mem.range);
+    size_t parent_range_count = use_approx_sub_mem_count ? gcsa::Range::length(mem.range) : gcsa->count(mem.range);
     
     // the end of the leftmost substring that is at least the minimum length and not contained
     // in the next SMEM
@@ -838,7 +838,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
             
             range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
             
-            if (gcsa::Range::length(range) <= parent_range_length) {
+            if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
                 probe_string_more_frequent = false;
                 break;
             }
@@ -859,7 +859,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                     gcsa::range_type last_range = range;
                     range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
                     
-                    if (gcsa::Range::length(range) <= parent_range_length) {
+                    if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
                         range = last_range;
                         break;
                     }
@@ -905,7 +905,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
 
                     range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
                     
-                    if (gcsa::Range::length(range) <= parent_range_length) {
+                    if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
                         // this probe is too long and it no longer is contained in the indendent hit
                         // that we detected
                         contained_in_independent_match = false;

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -209,6 +209,7 @@ public:
     bool adaptive_reseed_diff; // use an adaptive length difference algorithm in reseed algorithm
     double adaptive_diff_exponent; // exponent that describes limiting behavior of adaptive diff algorithm
     int hit_max;       // ignore or MEMs with more than this many hits
+    bool use_approx_sub_mem_count = true;
     
     bool strip_bonuses; // remove any bonuses used by the aligners from the final reported scores
     bool assume_acyclic; // the indexed graph is acyclic

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -4,7 +4,7 @@
 //
 //
 
-//#define debug_multipath_mapper
+#define debug_multipath_mapper
 //#define debug_validate_multipath_alignments
 //#define debug_report_frag_distr
 

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -4,7 +4,7 @@
 //
 //
 
-#define debug_multipath_mapper
+//#define debug_multipath_mapper
 //#define debug_validate_multipath_alignments
 //#define debug_report_frag_distr
 

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -611,6 +611,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.min_mem_length = min_mem_length;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;
+    multipath_mapper.use_approx_sub_mem_count = false;
     if (min_clustering_mem_length) {
         multipath_mapper.min_clustering_mem_length = min_clustering_mem_length;
     }


### PR DESCRIPTION
I want to keep the completely accurate count function in the multipath mapper.