### PR TITLE
Likelihoods and priors for non-diploid genotypes

### DIFF
--- a/src/distributions.hpp
+++ b/src/distributions.hpp
@@ -127,6 +127,16 @@ real_t binomial_cmf_ln(ProbIn success_logprob, size_t trials, size_t successes) 
     return logprob_sum(case_logprobs);
 }
 
+/**
+ * Get the log probability for sampling the given value from a geometric
+ * distribution with the given success log probability. The geometric
+ * distribution is the distribution of the number of trials, with a given
+ * success probability, required to observe a single success.
+ */
+template <typename ProbIn>
+real_t geometric_sampling_prob_ln(ProbIn success_logprob, size_t trials) {
+    return logprob_invert(success_logprob) * (trials - 1) + success_logprob;
+}
 
 
 }

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -1772,10 +1772,13 @@ double Genotyper::get_genotype_log_likelihood(VG& graph, const Snarl* snarl, con
              << " = " << logprob_to_prob(alleles_as_specified) << endl;
 #endif
 
-    } else if(genotype.size() != 2) {
+    } else if(genotype.size() > 2) {
 #pragma omp critical (cerr)
-        cerr << "Warning: not accounting for allele assignment likelihood in non-diploid genotype!" << endl;
+        cerr << "Warning: not accounting for allele assignment likelihood in polyploid genotype!" << endl;
     }
+    // Haploid or 0-ploid genotypes will always have all the reads drawn from
+    // their source alleles in the distribution observed, as only one is
+    // possible.
 
     // Now we've looked at all the reads, so AND everything together
     double total_logprob = all_non_supporting_wrong + all_supporting_drawn + strands_as_specified + alleles_as_specified;

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -105,8 +105,21 @@ public:
     // order to actually use it as supporting the thing we just aligned it to?
     double min_score_per_base = 0.90;
     
-    // What should our prior on being heterozygous at a snarl be?
+    // Now define the prior distribution on genotypes.
+    
+    // What should the prior probability of a snarl being diploid be?
+    double diploid_prior_logprob = prob_to_logprob(0.999);
+    // What should our prior on being heterozygous at a snarl be, given that it is diploid?
     double het_prior_logprob = prob_to_logprob(0.1);
+    // What should the prior probability of a non-diploid snarl being haploid be?
+    double haploid_prior_logprob = prob_to_logprob(0.5);
+    // What should the prior probability of a non-diploid, non-haploid snarl
+    // being completely deleted be?
+    double deleted_prior_logprob = prob_to_logprob(0.1);
+    // If not diploid, not haploid, and not deleted, the snarl is polyploid. We
+    // model the number of additional copies over 2 with a geometric prior. What
+    // should the parameter (success probability for stopping adding copies) be?
+    double polyploid_prior_success_logprob = prob_to_logprob(0.5);
 
     // Provides a mechanism to translate back to the original graph
     Translator translator;

--- a/src/unittest/distributions.cpp
+++ b/src/unittest/distributions.cpp
@@ -18,10 +18,23 @@ TEST_CASE( "Factorials are computed", "[distributions][factorial]" ) {
 
 TEST_CASE( "Ambiguous multinomial works", "[distributions][multinomial]" ) {
 
+    // Define some category probabilities
     vector<double> probs{0.5, 0.25, 0.25};
+    
+    // And an ambiguous observation: 1 in category 1, 2 split between 2 and 3.
     unordered_map<vector<bool>, int> obs{{{true, false, false}, 1}, {{false, true, true}, 2}};
+    
+    // Define the 3 real possible cases matching the observations
+    vector<int> case1{1, 2, 0};
+    vector<int> case2{1, 1, 1};
+    vector<int> case3{1, 0, 2};
+    
+    // Sum up their probabilities
+    auto case_total = logprob_add(logprob_add(multinomial_sampling_prob_ln(probs, case1),
+        multinomial_sampling_prob_ln(probs, case2)), multinomial_sampling_prob_ln(probs, case3));
 
-    REQUIRE(multinomial_censored_sampling_prob_ln(probs, obs) == Approx(log(0.125)).epsilon(1E-10));
+    // Make sure we get the same answer for the probability of matching those constraints.
+    REQUIRE(multinomial_censored_sampling_prob_ln(probs, obs) == Approx(case_total).epsilon(1E-10));
 
 }
 

--- a/src/unittest/distributions.cpp
+++ b/src/unittest/distributions.cpp
@@ -16,5 +16,14 @@ TEST_CASE( "Factorials are computed", "[distributions][factorial]" ) {
     REQUIRE(factorial_ln(10) == Approx(log(3628800)).epsilon(1E-10));
 }
 
+TEST_CASE( "Ambiguous multinomial works", "[distributions][multinomial]" ) {
+
+    vector<double> probs{0.5, 0.25, 0.25};
+    unordered_map<vector<bool>, int> obs{{{true, false, false}, 1}, {{false, true, true}, 2}};
+
+    REQUIRE(multinomial_censored_sampling_prob_ln(probs, obs) == Approx(log(0.125)).epsilon(1E-10));
+
+}
+
 }
 }

--- a/src/unittest/distributions.cpp
+++ b/src/unittest/distributions.cpp
@@ -18,23 +18,127 @@ TEST_CASE( "Factorials are computed", "[distributions][factorial]" ) {
 
 TEST_CASE( "Ambiguous multinomial works", "[distributions][multinomial]" ) {
 
-    // Define some category probabilities
-    vector<double> probs{0.5, 0.25, 0.25};
+    SECTION("An empty case can be handled") {
     
-    // And an ambiguous observation: 1 in category 1, 2 split between 2 and 3.
-    unordered_map<vector<bool>, int> obs{{{true, false, false}, 1}, {{false, true, true}, 2}};
+        // Define some category probabilities
+        vector<double> probs{0.5, 0.25, 0.25};
+        
+        // Try classes but no reads
+        unordered_map<vector<bool>, int> obs{{{true, false, false}, 0}, {{false, true, false}, 0}};
+        
+        // No reads are always matching
+        REQUIRE(logprob_to_prob(multinomial_censored_sampling_prob_ln(probs, obs)) == Approx(1.0).epsilon(1E-10));
+        
+        obs.clear();
+        
+        // No reads are still always matching
+        REQUIRE(logprob_to_prob(multinomial_censored_sampling_prob_ln(probs, obs)) == Approx(1.0).epsilon(1E-10));
     
-    // Define the 3 real possible cases matching the observations
-    vector<int> case1{1, 2, 0};
-    vector<int> case2{1, 1, 1};
-    vector<int> case3{1, 0, 2};
+    }
     
-    // Sum up their probabilities
-    auto case_total = logprob_add(logprob_add(multinomial_sampling_prob_ln(probs, case1),
-        multinomial_sampling_prob_ln(probs, case2)), multinomial_sampling_prob_ln(probs, case3));
+    SECTION("An empty case with no categories can be handled") {
+        vector<double> probs;
+        // Define 0 observations of things that match all of no categories.
+        unordered_map<vector<bool>, int> obs{{vector<bool>{}, 0}};
+        
+        // No reads are always matching
+        REQUIRE(logprob_to_prob(multinomial_censored_sampling_prob_ln(probs, obs)) == Approx(1.0).epsilon(1E-10));
+        
+        obs.clear();
+        
+        // No reads are still always matching
+        REQUIRE(logprob_to_prob(multinomial_censored_sampling_prob_ln(probs, obs)) == Approx(1.0).epsilon(1E-10));
+    }
 
-    // Make sure we get the same answer for the probability of matching those constraints.
-    REQUIRE(multinomial_censored_sampling_prob_ln(probs, obs) == Approx(case_total).epsilon(1E-10));
+    SECTION("An unambiguous case can be handled") {
+
+        // Define some category probabilities
+        vector<double> probs{0.5, 0.25, 0.25};
+        
+        // And an ambiguous observation: 1 in category 1, 2 split between 2 and 3.
+        unordered_map<vector<bool>, int> obs{{{true, false, false}, 15}, {{false, true, false}, 36}};
+        
+        // Define the only real possible case matching the observations
+        vector<int> case1{15, 36, 0};
+        
+        // Sum up case probabilities
+        auto case_total = multinomial_sampling_prob_ln(probs, case1);
+
+        // Make sure we get the same answer for the probability of matching those constraints.
+        REQUIRE(multinomial_censored_sampling_prob_ln(probs, obs) == Approx(case_total).epsilon(1E-10));
+    }
+
+    SECTION("A simple 3-category ambiguous case can be handled") {
+
+        // Define some category probabilities
+        vector<double> probs{0.5, 0.25, 0.25};
+        
+        // And an ambiguous observation: 1 in category 1, 2 split between 2 and 3.
+        unordered_map<vector<bool>, int> obs{{{true, false, false}, 1}, {{false, true, true}, 2}};
+        
+        // Define the 3 real possible cases matching the observations
+        vector<int> case1{1, 2, 0};
+        vector<int> case2{1, 1, 1};
+        vector<int> case3{1, 0, 2};
+        
+        // Sum up their probabilities
+        auto case_total = logprob_add(logprob_add(multinomial_sampling_prob_ln(probs, case1),
+            multinomial_sampling_prob_ln(probs, case2)), multinomial_sampling_prob_ln(probs, case3));
+
+        // Make sure we get the same answer for the probability of matching those constraints.
+        REQUIRE(multinomial_censored_sampling_prob_ln(probs, obs) == Approx(case_total).epsilon(1E-10));
+        
+    }
+    
+    SECTION("A case with multiple kinds of highly ambiguous reads can be handled") {
+        
+        vector<double> probs{0.5, 0.20, 0.25, 0.05};
+        
+        // And an ambiguous observation: 1 read in each of a few classes
+        unordered_map<vector<bool>, int> obs{
+            {{true, true, false, false}, 1},
+            {{false, true, true, false}, 1},
+            {{false, true, true, true}, 1}
+        };
+        
+        // Define the real possible cases matching the observations
+        vector<vector<int>> cases;
+        cases.emplace_back(vector<int>{1, 2, 0, 0});
+        cases.emplace_back(vector<int>{1, 1, 1, 0});
+        cases.emplace_back(vector<int>{1, 1, 0, 1});
+        cases.emplace_back(vector<int>{1, 1, 1, 0});
+        cases.emplace_back(vector<int>{1, 0, 2, 0});
+        cases.emplace_back(vector<int>{1, 0, 1, 1});
+        cases.emplace_back(vector<int>{0, 3, 0, 0});
+        cases.emplace_back(vector<int>{0, 2, 1, 0});
+        cases.emplace_back(vector<int>{0, 2, 0, 1});
+        cases.emplace_back(vector<int>{0, 2, 1, 0});
+        cases.emplace_back(vector<int>{0, 1, 2, 0});
+        cases.emplace_back(vector<int>{0, 1, 1, 1});
+        
+        vector<double> case_logprobs;
+        for (auto this_case : cases) {
+            // Compute probs for all these real cases
+            case_logprobs.push_back(multinomial_sampling_prob_ln(probs, this_case));
+        }
+        
+        // Make sure we get the same answer for the probability of matching those constraints.
+        REQUIRE(multinomial_censored_sampling_prob_ln(probs, obs) == Approx(logprob_sum(case_logprobs)).epsilon(1E-10));
+    }
+    
+    SECTION("A class with a lot of reads can be handled") {
+        vector<double> probs{0.5, 0.20, 0.25, 0.05};
+        
+        // Just make everything ambiguous.
+        unordered_map<vector<bool>, int> obs{
+            {{true, true, true, true}, 100}
+        };
+        
+        // The likelihood overall should be 1, because all assignments of 100 reads match the constraint.
+        // But we have to give a bit more tolerance because we're summing up really tiny numbers. Also, compare in prob space.
+        REQUIRE(logprob_to_prob(multinomial_censored_sampling_prob_ln(probs, obs)) == Approx(1.0).epsilon(1E-9));
+    
+    }
 
 }
 


### PR DESCRIPTION
This mostly completes #1258, although I want to add some more unit tests before merging. This should allow 0-ploid and 1-ploid genotypes to be assigned likelihoods and priors.

Space in the prior is reserved for polyploid genotypes, but the likelihood function still can't really handle them, because it doesn't know how to do an arbitrarily censored/ambiguous multinomial likelihood yet.