### PR TITLE
Compressed chunked count indexes

### DIFF
--- a/src/counter.cpp
+++ b/src/counter.cpp
@@ -4,13 +4,14 @@ namespace vg {
 
 Counter::Counter(void) : xgidx(nullptr) { }
 
-Counter::Counter(xg::XG* xidx) : xgidx(xidx) {
+Counter::Counter(xg::XG* xidx, size_t binsz) : xgidx(xidx), bin_size(binsz) {
     coverage_dynamic = gcsa::CounterArray(xgidx->seq_length, 8);
+    n_bins = xgidx->seq_length / bin_size + 1;
 }
 
 Counter::~Counter(void) {
-    close_edit_tmpfile();
-    remove_edit_tmpfile();
+    close_edit_tmpfiles();
+    remove_edit_tmpfiles();
 }
 
 void Counter::load_from_file(const string& file_name) {
@@ -25,24 +26,43 @@ void Counter::save_to_file(const string& file_name) {
 }
 
 void Counter::load(istream& in) {
+    sdsl::read_member(bin_size, in);
+    sdsl::read_member(n_bins, in);
     coverage_civ.load(in);
-    edit_csa.load(in);
+    edit_csas.resize(n_bins);
+    for (size_t i = 0; i < n_bins; ++i) {
+        edit_csas[i].load(in);
+    }
 }
 
 void Counter::merge_from_files(const vector<string>& file_names) {
     // load into our dynamic structures, then compact
-    ensure_edit_tmpfile_open();
+    ensure_edit_tmpfiles_open();
     for (auto& file_name : file_names) {
         Counter c;
         ifstream f(file_name);
         c.load(f);
-        c.write_edits(tmpfstream);
+        c.write_edits(tmpfstreams);
         collect_coverage(c);
     }
 }
 
-void Counter::write_edits(ostream& out) const {
-    out << extract(edit_csa, 0, edit_csa.size()-2) << delim1; // chomp trailing null, add back delim
+size_t Counter::bin_for_position(size_t i) const {
+    if (bin_size > 0) {
+        return i / bin_size;
+    } else {
+        return 0;
+    }
+}
+
+void Counter::write_edits(vector<ofstream>& out) const {
+    for (size_t i = 0; i < n_bins; ++i) {
+        write_edits(out[i], i);
+    }
+}
+
+void Counter::write_edits(ostream& out, size_t bin) const {
+    out << extract(edit_csas[bin], 0, edit_csas[bin].size()-2) << delim1; // chomp trailing null, add back delim
 }
 
 void Counter::collect_coverage(const Counter& c) {
@@ -58,8 +78,12 @@ size_t Counter::serialize(std::ostream& out,
     make_compact();
     sdsl::structure_tree_node* child = sdsl::structure_tree::add_child(s, name, sdsl::util::class_name(*this));
     size_t written = 0;
+    written += sdsl::write_member(bin_size, out, child, "bin_size_" + name);
+    written += sdsl::write_member(edit_csas.size(), out, child, "n_bins_" + name);
     written += coverage_civ.serialize(out, child, "graph_coverage_" + name);
-    written += edit_csa.serialize(out, child, "edit_csa_" + name);
+    for (auto& edit_csa : edit_csas) {
+        written += edit_csa.serialize(out, child, "edit_csa_" + name);
+    }
     sdsl::structure_tree::add_size(child, written);
     return written;
 }
@@ -68,7 +92,7 @@ void Counter::make_compact(void) {
     // pack the dynamic countarry and edit coverage into the compact data structure
     if (is_compacted) return;
     // sync edit file
-    close_edit_tmpfile();
+    close_edit_tmpfiles();
     // temporaries for construction
     size_t basis_length = coverage_dynamic.size();
     int_vector<> coverage_iv;
@@ -76,10 +100,13 @@ void Counter::make_compact(void) {
     for (size_t i = 0; i < coverage_dynamic.size(); ++i) {
         coverage_iv[i] = coverage_dynamic[i];
     }
+    edit_csas.resize(edit_tmpfile_names.size());
     util::assign(coverage_civ, coverage_iv);
-    construct(edit_csa, edit_tmpfile_name, 1);
+    for (size_t i = 0; i < edit_tmpfile_names.size(); ++i) {
+        construct(edit_csas[i], edit_tmpfile_names[i], 1);
+    }
     // construct the record marker bitvector
-    remove_edit_tmpfile();
+    remove_edit_tmpfiles();
     is_compacted = true;
 }
 
@@ -90,31 +117,44 @@ void Counter::make_dynamic(void) {
     is_compacted = false;
 }
 
-void Counter::ensure_edit_tmpfile_open(void) {
-    if (!tmpfstream.is_open()) {
+void Counter::ensure_edit_tmpfiles_open(void) {
+    if (tmpfstreams.empty()) {
         string base = ".vg-counter";
-        edit_tmpfile_name = tmpfilename(base);
-        tmpfstream.open(edit_tmpfile_name);
+        string edit_tmpfile_name = tmpfilename(base);
+        std::remove(edit_tmpfile_name.c_str()); // remove this; we'll use it as a base name
+        // for as many bins as we have, make a temp file
+        tmpfstreams.resize(n_bins);
+        edit_tmpfile_names.resize(n_bins);
+        for (size_t i = 0; i < n_bins; ++i) {
+            edit_tmpfile_names[i] = edit_tmpfile_name+"_"+convert(i);
+            tmpfstreams[i].open(edit_tmpfile_names[i]);
+            assert(tmpfstreams[i].is_open());
+        }
     }
 }
 
-void Counter::close_edit_tmpfile(void) {
-    if (tmpfstream.is_open()) {
-        tmpfstream << delim1; // pad
-        tmpfstream.close();
+void Counter::close_edit_tmpfiles(void) {
+    if (!tmpfstreams.empty()) {
+        for (auto& tmpfstream : tmpfstreams) {
+            tmpfstream << delim1; // pad
+            tmpfstream.close();
+        }
+        tmpfstreams.clear();
     }
 }
 
-void Counter::remove_edit_tmpfile(void) {
-    if (!edit_tmpfile_name.empty()) {
-        std::remove(edit_tmpfile_name.c_str());
-        edit_tmpfile_name.clear();
+void Counter::remove_edit_tmpfiles(void) {
+    if (!edit_tmpfile_names.empty()) {
+        for (auto& name : edit_tmpfile_names) {
+            std::remove(name.c_str());
+        }
+        edit_tmpfile_names.clear();
     }
 }
 
 void Counter::add(const Alignment& aln, bool record_edits) {
     // open tmpfile if needed
-    ensure_edit_tmpfile_open();
+    ensure_edit_tmpfiles_open();
     // count the nodes, edges, and edits
     for (auto& mapping : aln.path().mapping()) {
         if (!mapping.has_position()) continue;
@@ -134,7 +174,8 @@ void Counter::add(const Alignment& aln, bool record_edits) {
                 // we represent things on the forward strand
                 string pos_repr = pos_key(i);
                 string edit_repr = edit_value(edit, mapping.position().is_reverse());
-                tmpfstream << pos_repr << edit_repr;
+                size_t bin = bin_for_position(i);
+                tmpfstreams[bin] << pos_repr << edit_repr;
             }
             if (mapping.position().is_reverse()) {
                 i -= edit.from_length();
@@ -224,6 +265,8 @@ vector<Edit> Counter::edits_at_position(size_t i) const {
     vector<Edit> edits;
     if (i == 0) return edits;
     string key = pos_key(i);
+    size_t bin = bin_for_position(i);
+    auto& edit_csa = edit_csas[bin];
     auto occs = locate(edit_csa, key);
     for (size_t i = 0; i < occs.size(); ++i) {
         // walk from after the key and delim1 to the next end-sep
@@ -255,7 +298,7 @@ ostream& Counter::as_table(ostream& out, bool show_edits) {
     for (size_t i = 0; i < coverage_civ.size(); ++i) {
         out << i << "\t" << coverage_civ[i];
         if (show_edits) {
-            out << "\t" << count(edit_csa, pos_key(i));
+            out << "\t" << count(edit_csas[bin_for_position(i)], pos_key(i));
             for (auto& edit : edits_at_position(i)) out << " " << pb2json(edit);
         }
         out << endl;
@@ -264,7 +307,9 @@ ostream& Counter::as_table(ostream& out, bool show_edits) {
 
 ostream& Counter::show_structure(ostream& out) {
     out << coverage_civ << endl; // graph coverage (compacted coverage_dynamic)
-    out << edit_csa << endl;
+    for (auto& edit_csa : edit_csas) {
+        out << edit_csa << endl;
+    }
     //out << " i SA ISA PSI LF BWT    T[SA[i]..SA[i]-1]" << endl;
     //csXprintf(cout, "%2I %2S %3s %3P %2p %3B   %:3T", edit_csa);
     return out;

--- a/src/counter.cpp
+++ b/src/counter.cpp
@@ -37,14 +37,31 @@ void Counter::load(istream& in) {
 
 void Counter::merge_from_files(const vector<string>& file_names) {
     // load into our dynamic structures, then compact
-    ensure_edit_tmpfiles_open();
+    bool first = true;
     for (auto& file_name : file_names) {
         Counter c;
         ifstream f(file_name);
         c.load(f);
+        // take bin size and counts from the first, assume they are all the same
+        if (first) {
+            bin_size = c.get_bin_size();
+            n_bins = c.get_n_bins();
+            ensure_edit_tmpfiles_open();
+        } else {
+            assert(bin_size == c.get_bin_size());
+            assert(n_bins == c.get_n_bins());
+        }
         c.write_edits(tmpfstreams);
         collect_coverage(c);
     }
+}
+
+size_t Counter::get_bin_size(void) const {
+    return bin_size;
+}
+
+size_t Counter::get_n_bins(void) const {
+    return n_bins;
 }
 
 size_t Counter::bin_for_position(size_t i) const {

--- a/src/counter.hpp
+++ b/src/counter.hpp
@@ -47,6 +47,8 @@ public:
     ostream& show_structure(ostream& out); // debugging
     void write_edits(vector<ofstream>& out) const; // for merge
     void write_edits(ostream& out, size_t bin) const; // for merge
+    size_t get_bin_size(void) const;
+    size_t get_n_bins(void) const;
 private:
     void ensure_edit_tmpfiles_open(void);
     void close_edit_tmpfiles(void);

--- a/src/counter.hpp
+++ b/src/counter.hpp
@@ -23,7 +23,7 @@ using namespace sdsl;
 class Counter {
 public:
     Counter(void);
-    Counter(xg::XG* xidx);
+    Counter(xg::XG* xidx, size_t bin_size);
     ~Counter(void);
     xg::XG* xgidx;
     void merge_from_files(const vector<string>& file_names);
@@ -33,9 +33,6 @@ public:
     size_t serialize(std::ostream& out,
                      sdsl::structure_tree_node* s = NULL,
                      std::string name = "");
-    void ensure_edit_tmpfile_open(void);
-    void close_edit_tmpfile(void);
-    void remove_edit_tmpfile(void);
     void make_compact(void);
     void make_dynamic(void);
     void add(const Alignment& aln, bool record_edits = true);
@@ -48,25 +45,29 @@ public:
     void collect_coverage(const Counter& c);
     ostream& as_table(ostream& out, bool show_edits = true);
     ostream& show_structure(ostream& out); // debugging
-    void write_edits(ostream& out) const; // for merge
+    void write_edits(vector<ofstream>& out) const; // for merge
+    void write_edits(ostream& out, size_t bin) const; // for merge
 private:
+    void ensure_edit_tmpfiles_open(void);
+    void close_edit_tmpfiles(void);
+    void remove_edit_tmpfiles(void);
     bool is_compacted;
     // dynamic model
     gcsa::CounterArray coverage_dynamic;
-    string edit_tmpfile_name;
-    fstream tmpfstream;
-    //map<size_t, map<string, int32_t> > edits;
-    // compact model
-    //size_t total_count; // sum of counts in coverage and edit coverage
+    vector<string> edit_tmpfile_names;
+    vector<ofstream> tmpfstreams;
+    // which bin should we use
+    size_t bin_for_position(size_t i) const;
+    size_t n_bins = 1;
+    size_t bin_size = 0;
     size_t edit_length;
     size_t edit_count;
     vlc_vector<> coverage_civ; // graph coverage (compacted coverage_dynamic)
-    //csa_sada<enc_vector<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, succinct_byte_alphabet<> > edit_csa;
-    csa_wt<> edit_csa;
+    //
+    vector<csa_sada<enc_vector<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, succinct_byte_alphabet<> > > edit_csas;
     // make separators that are somewhat unusual, as we escape these
     char delim1 = '\xff';
     char delim2 = '\xfe';
-    //string delim_sub = string(1, '\xff');
     // double the delimiter in the string
     string escape_delim(const string& s, char d) const;
     string escape_delims(const string& s) const;

--- a/src/subcommand/count_main.cpp
+++ b/src/subcommand/count_main.cpp
@@ -19,6 +19,7 @@ void help_count(char** argv) {
          << "    -g, --gam FILE         read alignments from this file (could be '-' for stdin)" << endl
          << "    -d, --as-table         write table on stdout representing counts" << endl
          << "    -n, --no-edits         don't record or write edits, just graph-matching coverage" << endl
+         << "    -b, --bin-size N       number of sequence bases per CSA bin" << endl
          << "    -t, --threads N        use N threads (defaults to numCPUs)" << endl;
 }
 
@@ -31,6 +32,7 @@ int main_count(int argc, char** argv) {
     bool write_table = false;
     int thread_count = 1;
     bool record_edits = true;
+    size_t bin_size = 1 << 20;
 
     if (argc == 2) {
         help_count(argv);
@@ -50,11 +52,12 @@ int main_count(int argc, char** argv) {
             {"as-table", no_argument, 0, 'd'},
             {"threads", required_argument, 0, 't'},
             {"no-edits", no_argument, 0, 'n'},
+            {"bin-size", required_argument, 0, 'b'},
             {0, 0, 0, 0}
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:o:i:g:dt:n",
+        c = getopt_long (argc, argv, "hx:o:i:g:dt:nb:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -86,6 +89,9 @@ int main_count(int argc, char** argv) {
         case 'n':
             record_edits = false;
             break;
+        case 'b':
+            bin_size = atoll(optarg);
+            break;
         case 't':
             thread_count = atoi(optarg);
             break;
@@ -107,7 +113,7 @@ int main_count(int argc, char** argv) {
     }
 
     // todo one counter per thread and merge
-    vg::Counter counter(&xgidx);
+    vg::Counter counter(&xgidx, bin_size);
     if (counts_in.size() == 1) {
         counter.load_from_file(counts_in.front());
     } else if (counts_in.size() > 1) {

--- a/test/t/34_vg_count.t
+++ b/test/t/34_vg_count.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 4
+plan tests 5
 
 vg construct -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
@@ -25,5 +25,10 @@ vg count -x flat.xg -i 2snp.gam.cx -i 2snp.gam.cx -i 2snp.gam.cx -o 2snp.gam.cx.
 is $(echo "("$(vg count -x 2snp.xg -di 2snp.gam.cx.3x | awk '{ print $2 }' | paste -sd+ - )")"/3 | bc) $(echo "("$(vg count -x 2snp.xg -di 2snp.gam.cx | awk '{ print $2 }' | paste -sd+ - )")" | bc) "graph coverages are merged from multiple .cx indexes"
 
 is $(echo "("$(vg count -x 2snp.xg -di 2snp.gam.cx.3x | awk '{ print $3 }' | paste -sd+ - )")"/3 | bc) $(echo "("$(vg count -x 2snp.xg -di 2snp.gam.cx | awk '{ print $3 }' | paste -sd+ - )")" | bc) "edit records are merged from multiple .cx indexes"
+
+x=$(vg count -x flat.xg -di 2snp.gam.cx | wc -c )
+vg count -x flat.xg -o 2snp.gam.cx -b 10 -g 2snp.gam
+y=$(vg count -x flat.xg -di 2snp.gam.cx | wc -c )
+is $x $y "binned edit accumulation does not affect the result"
 
 rm -f flat.vg 2snp.vg 2snp.xg 2snp.sim flat.gcsa flat.gcsa.lcp flat.xg 2snp.xg 2snp.gam 2snp.gam.cx 2snp.gam.cx.3x 2snp.gam.vgpu

--- a/test/t/34_vg_count.t
+++ b/test/t/34_vg_count.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 5
+plan tests 6
 
 vg construct -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
@@ -30,5 +30,13 @@ x=$(vg count -x flat.xg -di 2snp.gam.cx | wc -c )
 vg count -x flat.xg -o 2snp.gam.cx -b 10 -g 2snp.gam
 y=$(vg count -x flat.xg -di 2snp.gam.cx | wc -c )
 is $x $y "binned edit accumulation does not affect the result"
+
+vg count -x flat.xg -o 2snp.gam.cx -g 2snp.gam
+vg count -x flat.xg -o 2snp.gam.cx.3x -i 2snp.gam.cx -i 2snp.gam.cx -i 2snp.gam.cx
+x=$(vg count -x flat.xg -di 2snp.gam.cx.3x | wc -c)
+cat 2snp.gam 2snp.gam 2snp.gam | vg count -x flat.xg -o 2snp.gam.cx -g -
+y=$(vg count -x flat.xg -di 2snp.gam.cx.3x | wc -c)
+
+is $x $y "count index merging produces the expected result"
 
 rm -f flat.vg 2snp.vg 2snp.xg 2snp.sim flat.gcsa flat.gcsa.lcp flat.xg 2snp.xg 2snp.gam 2snp.gam.cx 2snp.gam.cx.3x 2snp.gam.vgpu


### PR DESCRIPTION
This is work to improve the chunked count index handling of edits. These are now broken up into 1MB bins and the CSA is computed for these independently.