### PR TITLE
Fix intermittent CI failure in mpmap tests

### DIFF
--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -38,16 +38,14 @@ size_t fastq_paired_interleaved_for_each_parallel(const string& filename,
     
 size_t fastq_paired_interleaved_for_each_parallel_after_wait(const string& filename,
                                                              function<void(Alignment&, Alignment&)> lambda,
-                                                             function<bool(void)> wait_until_true,
-                                                             function<void(void)> call_on_complete);
+                                                             function<bool(void)> single_threaded_until_true);
     
 size_t fastq_paired_two_files_for_each_parallel(const string& file1, const string& file2,
                                                 function<void(Alignment&, Alignment&)> lambda);
     
 size_t fastq_paired_two_files_for_each_parallel_after_wait(const string& file1, const string& file2,
                                                            function<void(Alignment&, Alignment&)> lambda,
-                                                           function<bool(void)> wait_until_true,
-                                                           function<void(void)> call_on_complete);
+                                                           function<bool(void)> single_threaded_until_true);
 
 bam_hdr_t* hts_file_header(string& filename, string& header);
 bam_hdr_t* hts_string_header(string& header,

--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -1029,9 +1029,9 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
     }
     
     BAMatrix* traceback_seed = nullptr;
-    int64_t traceback_seed_row;
-    int64_t traceback_seed_col;
-    matrix_t traceback_mat;
+    int64_t traceback_seed_row = std::numeric_limits<int64_t>::min();
+    int64_t traceback_seed_col = std::numeric_limits<int64_t>::min();
+    matrix_t traceback_mat = Match;
     
     int64_t curr_diag = top_diag + i;
     

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -526,7 +526,8 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
             auto& mem = mems[i];
             // invalid mem
             if (mem.begin < seq_begin || mem.end > seq_end) continue;
-            int lcpmax = lcp_maxima[i];
+            int lcpmax = 0;
+            if (record_max_lcp) lcpmax = lcp_maxima[i];
             // reseed when...
             if (mem.length() >= min_mem_length // our mem is greater than the min mem length (should be by default)
                 && (use_lcp_reseed_heuristic ? lcpmax : mem.length()) >= reseed_length // is the right length to reseed

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -300,7 +300,11 @@ namespace vg {
 #ifdef debug_multipath_mapper
             cerr << "couldn't find unambiguous mapping, adding pair to ambiguous buffer" << endl;
 #endif
-            ambiguous_pair_buffer.emplace_back(alignment1, alignment2);
+            
+#pragma omp critical (ambiguous_pair_buffer)
+            {
+                ambiguous_pair_buffer.emplace_back(alignment1, alignment2);
+            }
         }
         
         

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -301,10 +301,7 @@ namespace vg {
             cerr << "couldn't find unambiguous mapping, adding pair to ambiguous buffer" << endl;
 #endif
             
-#pragma omp critical (ambiguous_pair_buffer)
-            {
-                ambiguous_pair_buffer.emplace_back(alignment1, alignment2);
-            }
+            ambiguous_pair_buffer.emplace_back(alignment1, alignment2);
         }
         
         

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -792,18 +792,7 @@ int main_mpmap(int argc, char** argv) {
 #endif
     };
     
-    // for FASTQ input all but the first thread go into spinlock until the distribution is estimated or abandoned
-    bool input_finished = false;
-    function<bool(void)> distribution_spinlock = [&](void) {
-        return omp_get_thread_num() == 0 || multipath_mapper.has_fixed_fragment_length_distr() || input_finished;
-    };
-    
-    // mark the input as finished to get any remaining threads out of the spinlock
-    function<void(void)> abandon_distribution = [&](void) {
-        input_finished = true;
-    };
-    
-    // for GAM input, don't spawn new tasks unless this evalutes to true
+    // for streaming paired input, don't spawn new tasks unless this evalutes to true
     function<bool(void)> multi_threaded_condition = [&](void) {
         return multipath_mapper.has_fixed_fragment_length_distr();
     };
@@ -813,14 +802,14 @@ int main_mpmap(int argc, char** argv) {
     if (!fastq_name_1.empty()) {
         if (interleaved_input) {
             fastq_paired_interleaved_for_each_parallel_after_wait(fastq_name_1, do_paired_alignments,
-                                                                  distribution_spinlock, abandon_distribution);
+                                                                  multi_threaded_condition);
         }
         else if (fastq_name_2.empty()) {
             fastq_unpaired_for_each_parallel(fastq_name_1, do_unpaired_alignments);
         }
         else {
             fastq_paired_two_files_for_each_parallel_after_wait(fastq_name_1, fastq_name_2, do_paired_alignments,
-                                                                distribution_spinlock, abandon_distribution);
+                                                                multi_threaded_condition);
         }
     }
     


### PR DESCRIPTION
I think it was caused by some changes to the FASTQ streaming functions that made its single-threaded switch not actually cause it to run with a single-thread, leading to some rare invalid accesses.