### PR TITLE
Groundwork for DP-based genotyper

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -24,7 +24,7 @@ KEEP_OUTPUT=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@7823e1c81f681d0baadba25c83250ca3a4ce7b73"
+TOIL_VG_PACKAGE="git+https://github.com/adamnovak/toil-vg.git@955b87983aeeed93cf81a9129d255e3f1e5857c3"
 # What tests should we run?
 # Should be something like "jenkins/vgci.py::VGCITest::test_sim_brca2_snp1kg"
 PYTEST_TEST_SPEC="jenkins/vgci.py"

--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -24,7 +24,7 @@ KEEP_OUTPUT=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/adamnovak/toil-vg.git@955b87983aeeed93cf81a9129d255e3f1e5857c3"
+TOIL_VG_PACKAGE="git+https://github.com/adamnovak/toil-vg.git@105517e81643c308ff70a74b7c13eb203f1bb87a"
 # What tests should we run?
 # Should be something like "jenkins/vgci.py::VGCITest::test_sim_brca2_snp1kg"
 PYTEST_TEST_SPEC="jenkins/vgci.py"

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -1176,14 +1176,14 @@ class VGCITest(TestCase):
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'snp1kg', True)
 
-    @timeout_decorator.timeout(900)        
+    @timeout_decorator.timeout(1600)        
     def test_map_mhc_primary_genotype(self):
         """ Mapping and calling (with vg genotype) bakeoff F1 test for MHC primary graph 
         """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'primary', True, tag_ext='-genotype', genotype=True)
         
-    @timeout_decorator.timeout(1200)        
+    @timeout_decorator.timeout(1600)        
     def test_map_mhc_snp1kg_genotype(self):
         """ Mapping and calling (with vg genotype) bakeoff F1 test for MHC snp1kg graph 
         """

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -266,6 +266,7 @@ class VGCITest(TestCase):
             max(1, self.cores / 2), self.cores)
         
         cmd = 'toil-vg run {} {} {} {}'.format(job_store, sample_name, out_store, opts)
+        print("Run toil-vg with {}".format(cmd))
         
         subprocess.check_call(cmd, shell=True)
 

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -40,9 +40,9 @@ namespace vg {
                 
                 // Get the middle of the traversal that doesn't include the
                 // boundary nodes
-                auto iter = t.visits().begin();
+                auto iter = t.visit().begin();
                 iter++;
-                auto end = t.visits().end();
+                auto end = t.visit().end();
                 end--;
                 for (; iter != end; iter++){
                     auto v = *iter;
@@ -77,9 +77,9 @@ namespace vg {
                 
                 // Get the middle of the traversal that doesn't include the
                 // boundary nodes
-                auto iter = t.visits().begin();
+                auto iter = t.visit().begin();
                 iter++;
-                auto end = t.visits().end();
+                auto end = t.visit().end();
                 end--;
                 for (; iter != end; iter++){
                     auto v = *iter;
@@ -99,8 +99,8 @@ namespace vg {
                 // put our new-found ref base in the 0th index of alleles vector.
                 // Then, prepend that base to each allele in our alleles vector.
                     SnarlTraversal t = ordered_traversals[i];
-                    id_t start_id = t.visits(0).node_id();
-                    id_t end_id = t.visits(t.visits_size() - 1).node_id();
+                    id_t start_id = t.visit(0).node_id();
+                    id_t end_id = t.visit(t.visit_size() - 1).node_id();
                     pair<size_t, bool> pos_orientation_start = pindexes[refpath]->by_id[start_id];
                     pair<size_t, bool> pos_orientation_end = pindexes[refpath]->by_id[end_id];
                     bool use_start = pos_orientation_start.first < pos_orientation_end.first;

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -234,8 +234,8 @@ vector<bool> SimpleConsistencyCalculator::calculate_consistency(const Snarl& sit
                     }
                 }
 
-                for (int i = 0; i < s.visits_size(); ++i){
-                    Visit v = s.visits(i);
+                for (int i = 0; i < s.visit_size(); ++i){
+                    Visit v = s.visit(i);
                     if (v.node_id() != 0){
                         trav_ids.insert(v.node_id());
                     }
@@ -270,8 +270,8 @@ vector<bool> SimpleConsistencyCalculator::calculate_consistency(const Snarl& sit
                 // A read may map to a node multiple times, or it may skip a node
                 // and put an insert there.
                 set<int64_t> common_ids = shared_sites(read, trav);
-                bool maps_to_front = common_ids.count(trav.visits(0).node_id());
-                bool maps_to_end = common_ids.count(trav.visits(trav.visits_size() - 1).node_id());
+                bool maps_to_front = common_ids.count(trav.visit(0).node_id());
+                bool maps_to_end = common_ids.count(trav.visit(trav.visit_size() - 1).node_id());
                 bool maps_internally = false;
 
                 Path read_path;
@@ -470,18 +470,18 @@ vector<SnarlTraversal> PathBasedTraversalFinder::find_traversals(const Snarl& si
                 fresh_trav.set_name(a);
                 
                 // Add the start node to the traversal
-                *fresh_trav.add_visits() = site.start();
+                *fresh_trav.add_visit() = site.start();
                 // Fill in our traversal
                 list<Mapping> ms = gpaths[a];
                 for (auto m : ms){
                     int64_t n_id = m.position().node_id();
                     bool backward = m.position().is_reverse();
-                    Visit* v = fresh_trav.add_visits();
+                    Visit* v = fresh_trav.add_visit();
                     v->set_node_id(n_id);
                     v->set_backward(backward);
                 }
                 // Add the end node to the traversal
-                *fresh_trav.add_visits() = site.end();
+                *fresh_trav.add_visit() = site.end();
                 ret.push_back(fresh_trav);
                 //cerr << "Finished path: " << a << endl;
                 path_processed[a] = true;
@@ -957,10 +957,10 @@ void ExhaustiveTraversalFinder::add_traversals(vector<SnarlTraversal>& traversal
                 
                 // record the traversal in the return value
                 for (auto iter = path.begin(); iter != path.end(); iter++) {
-                    *traversals.back().add_visits() = *iter;
+                    *traversals.back().add_visit() = *iter;
                 }
                 // add the final visit
-                *traversals.back().add_visits() = to_visit(node_traversal);
+                *traversals.back().add_visit() = to_visit(node_traversal);
             }
             
             // don't proceed to add more onto the DFS stack
@@ -1341,7 +1341,7 @@ vector<SnarlTraversal> ReadRestrictedTraversalFinder::find_traversals(const Snar
         // Send out each list of visits
         to_return.emplace_back();
         for (Visit& visit : visits) {
-            *to_return.back().add_visits() = visit;
+            *to_return.back().add_visit() = visit;
         }
     }
     
@@ -1420,7 +1420,7 @@ vector<SnarlTraversal> TrivialTraversalFinder::find_traversals(const Snarl& site
             
             // Translate the path into the traversal
             for (NodeTraversal node_traversal : path) {
-                *(to_return.back().add_visits()) = to_visit(node_traversal);
+                *(to_return.back().add_visit()) = to_visit(node_traversal);
             }
             
             // Stop early after having found one path
@@ -1471,8 +1471,8 @@ Path RepresentativeTraversalFinder::find_backbone(const Snarl& site) {
     
     // Convert it into a path that includes the boundary nodes
     Path to_return;
-    for (size_t i = 0; i < traversal.visits_size(); i++) {
-        *to_return.add_mapping() = to_mapping(traversal.visits(i), augmented.graph);
+    for (size_t i = 0; i < traversal.visit_size(); i++) {
+        *to_return.add_mapping() = to_mapping(traversal.visit(i), augmented.graph);
     }
     
     return to_return;
@@ -2022,7 +2022,7 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
             for(size_t i = 0; i < visits.size(); i++) {
                 // Record a Visit for each Visit but the first and last,
                 // but backward and in reverse order.
-                *trav.add_visits() = reverse(visits[visits.size() - i - 1]);
+                *trav.add_visit() = reverse(visits[visits.size() - i - 1]);
             }
             
         } else {
@@ -2030,7 +2030,7 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
             
             for(size_t i = 0; i < visits.size(); i++) {
                 // Make a Visit for each NodeTraversal but the first and last
-                *trav.add_visits() = visits[i];
+                *trav.add_visit() = visits[i];
             }
             
         }

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -177,7 +177,10 @@ void AugmentedGraph::augment_from_alignment_edits(vector<Alignment>& alignments,
         // Send out the translation
         translator.load(augmentation_translations);
     } else {
+        // No need to add edits from the reads to the graph. We may have done it already with vg augment.
+#ifdef debug
         cerr << "Don't add edits!" << endl;
+#endif
     }
     
     // Steal the alignments for ourselves.

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -176,6 +176,8 @@ void AugmentedGraph::augment_from_alignment_edits(vector<Alignment>& alignments,
         
         // Send out the translation
         translator.load(augmentation_translations);
+    } else {
+        cerr << "Don't add edits!" << endl;
     }
     
     // Steal the alignments for ourselves.

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -82,6 +82,24 @@ pair<const Edge*, bool> AugmentedGraph::base_edge(const Edge* edge) {
     return pair<const Edge*, bool>(found_edge, is_trivial);
 }
 
+vector<const Alignment*> AugmentedGraph::get_alignments(id_t node_id) const {
+    if (alignments_by_node.count(node_id)) {
+        auto& found = alignments_by_node.at(node_id);
+        return vector<const Alignment*>{found.begin(), found.end()};
+    } else {
+        return {};
+    }
+}
+
+vector<const Alignment*> AugmentedGraph::get_alignments() const {
+    vector<const Alignment*> to_return;
+    to_return.reserve(embedded_alignments.size());
+    for (auto& alignment : embedded_alignments) {
+        to_return.push_back(&alignment);
+    }
+    return to_return;
+}
+
 void AugmentedGraph::clear() {
     // Reset to default state
     *this = AugmentedGraph();
@@ -90,6 +108,9 @@ void AugmentedGraph::clear() {
 void AugmentedGraph::augment_from_alignment_edits(vector<Alignment>& alignments,
                                                   bool unique_names, bool leave_edits) {
 
+    // This should only be called once.
+    assert(embedded_alignments.empty());
+    
     if (unique_names) { 
         // Make sure they have unique names.
         set<string> names_seen;
@@ -118,36 +139,64 @@ void AugmentedGraph::augment_from_alignment_edits(vector<Alignment>& alignments,
         names_seen.clear();
     }
     
-    // Suck out paths
-    vector<Path> paths;
     for(auto& alignment : alignments) {
-        // Copy over each path, naming it after its alignment
-        // and trimming so that it begins and ends with a match to avoid
-        // creating a bunch of stubs.
-        Path path = trim_hanging_ends(alignment.path());
-        path.set_name(alignment.name());
-        paths.push_back(path);
+        // Trim the softclips off of every read
+        // Work out were to cut
+        int cut_start = softclip_start(alignment);
+        int cut_end = softclip_end(alignment);
+        // Cut the sequence and quality
+        alignment.set_sequence(alignment.sequence().substr(cut_start, alignment.sequence().size() - cut_start - cut_end));
+        if (alignment.quality().size() != 0) {
+            alignment.set_quality(alignment.quality().substr(cut_start, alignment.quality().size() - cut_start - cut_end));
+        }
+        // Trim the path
+        *alignment.mutable_path() = trim_hanging_ends(alignment.path());
     }
-
+    
     if (!leave_edits) {
-        // Run them through vg::edit() to add them to the graph. Save the translations.
-        vector<Translation> augmentation_translations = graph.edit(paths, true);
+        // We want to actually modify the graph to encompass these reads.
+        
+        // To make the edits and copy them to/from the Alignments, we need a vector of just Paths.
+        // TODO: improve this interface!
+        vector<Path> paths;
+        paths.reserve(alignments.size());
+        for (auto& alignment : alignments) {
+            paths.push_back(alignment.path());
+        }
+    
+        // Run them through vg::edit() to modify the graph, but don't embed them
+        // as paths. Update the paths in place, and save the translations.
+        vector<Translation> augmentation_translations = graph.edit(paths, false, true, false);
+        
+        for (size_t i = 0; i < paths.size(); i++) {
+            // Copy all the modified paths back.
+            *alignments[i].mutable_path() = paths[i];
+        }
+        paths.clear();
+        
+        // Send out the translation
         translator.load(augmentation_translations);
-    } else {
-        // Add the paths to the graphs, but don't embed the edits.  These paths
-        // will not be representable as lists of NodeTraversals.  
-        for (auto& path : paths) {
-            // Note: Paths.extend(Path) is too slow because it re-indexes on each path
-            graph.paths.get_create_path(path.name());
-            for (int i = 0; i < path.mapping_size(); ++i) {
-                graph.paths.append_mapping(path.name(), path.mapping(i));
+    }
+    
+    // Steal the alignments for ourselves.
+    std::swap(alignments, embedded_alignments);
+    
+    // Prepare the index from node ID to alignments that touch the node
+    for (auto& alignment : embedded_alignments) {
+        // For every alignment, grab its path
+        const auto& path = alignment.path();
+        
+        // Keep track of the nodes we already saw it visit so we don't add it twice for a node.
+        unordered_set<id_t> seen;
+        
+        for (const auto& mapping : path.mapping()) {
+            // For each mapping
+            if (!seen.count(mapping.position().node_id())) {
+                // If it is to a new node, remember that the alignment touches the node
+                seen.insert(mapping.position().node_id());
+                alignments_by_node[mapping.position().node_id()].push_back(&alignment);
             }
         }
-        graph.paths.rebuild_node_mapping();
-        graph.paths.sort_by_mapping_rank();
-        graph.paths.rebuild_mapping_aux();
-
-        // trivial translation map?
     }
     
 }

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -182,20 +182,20 @@ struct AugmentedGraph {
     // Translations back to the base graph
     Translator translator;
     
-    // Map an edge back to teh base graph (return NULL if does not exist)
+    // Map an edge back to the base graph (return NULL if does not exist)
     // In the special case that an edge in the augmented graph represents
     // two abutting positions within a node in the base graph, null, true
     // is returned (todo: less tortured interface?)
     pair<const Edge*, bool> base_edge(const Edge* augmented_edge);
 
-    // Is this a node novel?  ie does it not map back to the base graph?
+    // Is this node novel?  ie does it not map back to the base graph?
     bool is_novel_node(const Node* augmented_node) {
         Position pos;
         pos.set_node_id(augmented_node->id());
         return !translator.has_translation(pos);
     }
     
-    // Is this a node novel?  ie does it not map back to the base graph?
+    // Is this edge novel?  ie does it not map back to the base graph?
     bool is_novel_edge(const Edge* augmented_edge) {
         auto be_ret = base_edge(augmented_edge);
         return be_ret.first == NULL && be_ret.second == false;

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -300,12 +300,6 @@ struct SupportAugmentedGraph : public AugmentedGraph {
     
 };
 
-/// AugmentedGraph extension that also keeps track of some reads. Reads are not embedded 
-struct ReadAugmentedGraph : public AugmentedGraph {
-};
-    
-
-
 class SimpleConsistencyCalculator : public ConsistencyCalculator{
     public:
     ~SimpleConsistencyCalculator();

--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -173,14 +173,16 @@ public:
 /// made using edit (such as in vg mod -i) or pileup.
 /// Todo : further abstract to handle graph interface
 struct AugmentedGraph {
-    // This holds all the new nodes and edges
+    /// This holds all the new nodes and edges
     VG graph;
 
-    // This holds the base graph (only required for mapping edges)
-    VG* base_graph = NULL;
+    /// This holds the base graph (only required for mapping edges)
+    VG* base_graph = nullptr;
 
-    // Translations back to the base graph
+    /// Translations back to the base graph
     Translator translator;
+    
+    
     
     // Map an edge back to the base graph (return NULL if does not exist)
     // In the special case that an edge in the augmented graph represents
@@ -201,22 +203,36 @@ struct AugmentedGraph {
         return be_ret.first == NULL && be_ret.second == false;
     }
     
+    /// Get the alignments, if any, embedded in the graph that touch the given
+    /// node ID.
+    vector<const Alignment*> get_alignments(id_t node_id) const;
+    
+    /// Get all the embedded alignments.
+    vector<const Alignment*> get_alignments() const;
+    
     /**
      * Clear the contents.
      */
     virtual void clear();
 
     /** 
-     * Construct an augmented graph using edit() on a set of alignments. Adds
-     * the paths of the alignments to the graph.
-     * 
-     * If unique_names is set, makes sure all the alignments' paths have unique
-     * names, which is a requirement for paths in a graph.
+     * Construct an augmented graph using edit() on a set of alignments.
+     * Modifies the passed-in vector of alignments arbitrarily (in particular,
+     * it may be empty after the call returns).
      *
-     * If leave_edits is set, the alignment's paths are not modified. The
-     * alignments' paths will be the paths they were originally aligned to,
-     * although the graph will be modified to describe the edits that the
-     * alignments found.
+     * Stores a modified version of the reads in the AugmentedGraph. Read
+     * alignments that touch a node in the augmented graph can be retrieved with
+     * get_alignments(). Reads will have softclips removed.
+     *
+     * Must only be called ONCE, because all modifications to the graph have
+     * to be processed together to update the embedded alignment indexes.
+     * 
+     * If unique_names is set, makes sure all the alignments have unique names.
+     *
+     * If leave_edits is set, the alignment's paths are not modified after
+     * trimming softclips. The alignments' paths will be the paths they were
+     * originally aligned to, although the graph will be modified to describe
+     * the edits that the alignments found.
      */
     void augment_from_alignment_edits(vector<Alignment>& alignments, bool unique_names = true,
                                       bool leave_edits = false);
@@ -230,6 +246,16 @@ struct AugmentedGraph {
      * Write the translations to a file
      */
     void write_translations(ostream& out_file);
+    
+protected:
+
+    /// Holds all of the alignments that have been embedded in the graph. They
+    /// aren't in the graph's paths object, but they are fully embedded without
+    /// any edits relative to the graph's sequence.
+    vector<Alignment> embedded_alignments;
+    
+    // Maps from node ID to the alignments that touch that node.
+    unordered_map<id_t, vector<Alignment*>> alignments_by_node;
 };
 
 /// Augmented Graph that holds some Support annotation data specific to vg call
@@ -272,6 +298,10 @@ struct SupportAugmentedGraph : public AugmentedGraph {
      */
     void write_supports(ostream& out_file);
     
+};
+
+/// AugmentedGraph extension that also keeps track of some reads. Reads are not embedded 
+struct ReadAugmentedGraph : public AugmentedGraph {
 };
     
 

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -731,7 +731,7 @@ vector<SnarlTraversal> Genotyper::get_paths_through_snarl(VG& graph, const Snarl
                     *path_traversed.add_visit() = to_visit(!traversal_direction ? *mapping :
                         reverse_complement_mapping(*mapping,[&graph](id_t node_id) {
                             return graph.get_node(node_id)->sequence().length();
-                        }));
+                        }), true);
                     
                     if(mapping->position().node_id() == snarl->end().node_id() && mapping->position().is_reverse() == expected_end_orientation) {
                         // Does our mapping actually cross through the ending side?
@@ -1345,7 +1345,7 @@ SnarlTraversal Genotyper::get_traversal_of_snarl(VG& graph, const Snarl* snarl, 
 
         if(contents.first.count(graph.get_node(mapping.position().node_id()))) {
             // We're inside the bubble. This is super simple when we have the contents!
-            *to_return.add_visit() = to_visit(mapping);
+            *to_return.add_visit() = to_visit(mapping, true);
         }
     }
 

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -182,9 +182,9 @@ public:
     SnarlTraversal get_traversal_of_snarl(VG& graph, const Snarl* snarl, const SnarlManager& manager, const Path& path);
     
     /**
-     * Make a list of NodeTraversals into the string they represent.
+     * Make a SnarlTraversal into the string it represents, including notes for nested child snarls.
      */
-    string traversals_to_string(VG& graph, const SnarlTraversal& path);
+    string traversal_to_string(VG& graph, const SnarlTraversal& path);
 
     /**
      * Check if a mapping corresponds to the beginning or end of snarl by making

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -92,7 +92,7 @@ public:
     int default_sequence_quality = 15;
     
     // How many times must a path recur before we try aligning to it? Also, how
-    // many times must a node in the graph be visnarld before we use it in indel
+    // many times must a node in the graph be visited before we use it in indel
     // realignment for nearby indels? Note that the primary path counts as a
     // recurrence. TODO: novel inserts can't recur, and novel deletions can't be
     // filtered in this way.
@@ -179,12 +179,12 @@ public:
      * the ends at all), collect a list of NodeTraversals in order for the part
      * of the path that is inside the snarl, in the same orientation as the path.
      */
-    list<Mapping> get_traversal_of_snarl(VG& graph, const Snarl* snarl, const SnarlManager& manager, const Path& path);
+    SnarlTraversal get_traversal_of_snarl(VG& graph, const Snarl* snarl, const SnarlManager& manager, const Path& path);
     
     /**
      * Make a list of NodeTraversals into the string they represent.
      */
-    string traversals_to_string(VG& graph, const list<Mapping>& path);
+    string traversals_to_string(VG& graph, const SnarlTraversal& path);
 
     /**
      * Check if a mapping corresponds to the beginning or end of snarl by making
@@ -201,7 +201,7 @@ public:
      * the snarl supported only by reads are subject to a min recurrence count,
      * while those supported by actual embedded named paths are not.
      */
-    vector<list<Mapping>> get_paths_through_snarl(VG& graph, const Snarl* snarl,
+    vector<SnarlTraversal> get_paths_through_snarl(VG& graph, const Snarl* snarl,
         const SnarlManager& manager, const map<string, Alignment*>& reads_by_name);
     
     /**
@@ -227,21 +227,21 @@ public:
      * Affinity is a double out of 1.0. Higher is better.
      */ 
     map<Alignment*, vector<Affinity>> get_affinities(VG& graph, const map<string, Alignment*>& reads_by_name,
-        const Snarl* snarl, const SnarlManager& manager, const vector<list<Mapping>>& superbubble_paths);
+        const Snarl* snarl, const SnarlManager& manager, const vector<SnarlTraversal>& superbubble_paths);
         
     /**
      * Get affinities as above but using only string comparison instead of
      * alignment. Affinities are 0 for mismatch and 1 for a perfect match.
      */
     map<Alignment*, vector<Affinity>> get_affinities_fast(VG& graph, const map<string, Alignment*>& reads_by_name,
-        const Snarl* snarl, const SnarlManager& manager, const vector<list<Mapping>>& superbubble_paths,
+        const Snarl* snarl, const SnarlManager& manager, const vector<SnarlTraversal>& superbubble_paths,
         bool allow_internal_alignments = false);
         
     /**
      * Compute annotated genotype from affinities and superbubble paths.
      * Needs access to the graph so it can chop up the alignments, which requires node sizes.
      */
-    Locus genotype_snarl(VG& graph, const Snarl* snarl, const vector<list<Mapping>>& superbubble_paths, const map<Alignment*, vector<Affinity>>& affinities);
+    Locus genotype_snarl(VG& graph, const Snarl* snarl, const vector<SnarlTraversal>& superbubble_paths, const map<Alignment*, vector<Affinity>>& affinities);
         
     /**
      * Compute the probability of the observed alignments given the genotype.

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -98,8 +98,10 @@ public:
     // filtered in this way.
     int min_recurrence = 2;
     
-    // How much support must an alt have on each strand before we can call it?
-    int min_consistent_per_strand = 2;
+    // How much unique support must an alt have on each strand before we can
+    // call it? Calls that fail this get dropped from the VCF.
+    // TODO: use a VCF filter instead.
+    int min_unique_per_strand = 2;
     
     // When we realign reads, what's the minimum per-base score for a read in
     // order to actually use it as supporting the thing we just aligned it to?

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -235,16 +235,16 @@ public:
      *
      * Affinity is a double out of 1.0. Higher is better.
      */ 
-    map<const Alignment*, vector<Affinity>> get_affinities(VG& graph, const map<string, const Alignment*>& reads_by_name,
+    map<const Alignment*, vector<Affinity>> get_affinities(AugmentedGraph& aug, const map<string, const Alignment*>& reads_by_name,
         const Snarl* snarl, const SnarlManager& manager, const vector<SnarlTraversal>& superbubble_paths);
         
     /**
      * Get affinities as above but using only string comparison instead of
      * alignment. Affinities are 0 for mismatch and 1 for a perfect match.
      */
-    map<const Alignment*, vector<Affinity>> get_affinities_fast(VG& graph, const map<string, const Alignment*>& reads_by_name,
-        const Snarl* snarl, const SnarlManager& manager, const vector<SnarlTraversal>& superbubble_paths,
-        bool allow_internal_alignments = false);
+    map<const Alignment*, vector<Affinity>> get_affinities_fast(AugmentedGraph& aug,
+        const map<string, const Alignment*>& reads_by_name, const Snarl* snarl, const SnarlManager& manager,
+        const vector<SnarlTraversal>& superbubble_paths, bool allow_internal_alignments = false);
         
     /**
      * Compute annotated genotype from affinities and superbubble paths.

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -144,9 +144,9 @@ public:
     Aligner normal_aligner;
     QualAdjAligner quality_aligner;
 
-    // Process and write output
+    /// Process and write output.
+    /// Alignments must be embedded in the AugmentedGraph.
     void run(AugmentedGraph& graph,
-             vector<Alignment>& alignments,
              ostream& out,
              string ref_path_name,
              string contig_name = "",
@@ -202,7 +202,16 @@ public:
      * while those supported by actual embedded named paths are not.
      */
     vector<SnarlTraversal> get_paths_through_snarl(VG& graph, const Snarl* snarl,
-        const SnarlManager& manager, const map<string, Alignment*>& reads_by_name);
+        const SnarlManager& manager, const map<string, const Alignment*>& reads_by_name);
+    
+    /**
+     * For the given snarl, emit all paths through it with unique sequences that
+     * are supported by reads stored in the AugmentedGraph's read index. Paths
+     * through the snarl supported only by reads are subject to a min recurrence
+     * count.
+     */
+    vector<SnarlTraversal> get_paths_through_snarl_from_reads(AugmentedGraph& aug,
+        const Snarl* snarl, const SnarlManager& manager);
     
     /**
      * Get all the quality values in the alignment between the start and end
@@ -226,14 +235,14 @@ public:
      *
      * Affinity is a double out of 1.0. Higher is better.
      */ 
-    map<Alignment*, vector<Affinity>> get_affinities(VG& graph, const map<string, Alignment*>& reads_by_name,
+    map<const Alignment*, vector<Affinity>> get_affinities(VG& graph, const map<string, const Alignment*>& reads_by_name,
         const Snarl* snarl, const SnarlManager& manager, const vector<SnarlTraversal>& superbubble_paths);
         
     /**
      * Get affinities as above but using only string comparison instead of
      * alignment. Affinities are 0 for mismatch and 1 for a perfect match.
      */
-    map<Alignment*, vector<Affinity>> get_affinities_fast(VG& graph, const map<string, Alignment*>& reads_by_name,
+    map<const Alignment*, vector<Affinity>> get_affinities_fast(VG& graph, const map<string, const Alignment*>& reads_by_name,
         const Snarl* snarl, const SnarlManager& manager, const vector<SnarlTraversal>& superbubble_paths,
         bool allow_internal_alignments = false);
         
@@ -241,7 +250,7 @@ public:
      * Compute annotated genotype from affinities and superbubble paths.
      * Needs access to the graph so it can chop up the alignments, which requires node sizes.
      */
-    Locus genotype_snarl(VG& graph, const Snarl* snarl, const vector<SnarlTraversal>& superbubble_paths, const map<Alignment*, vector<Affinity>>& affinities);
+    Locus genotype_snarl(VG& graph, const Snarl* snarl, const vector<SnarlTraversal>& superbubble_paths, const map<const Alignment*, vector<Affinity>>& affinities);
         
     /**
      * Compute the probability of the observed alignments given the genotype.
@@ -255,7 +264,7 @@ public:
      *
      * Returns a natural log likelihood.
      */
-    double get_genotype_log_likelihood(VG& graph, const Snarl* snarl, const vector<int>& genotype, const vector<pair<Alignment*, vector<Affinity>>>& alignment_consistency);
+    double get_genotype_log_likelihood(VG& graph, const Snarl* snarl, const vector<int>& genotype, const vector<pair<const Alignment*, vector<Affinity>>>& alignment_consistency);
     
     /**
      * Compute the prior probability of the given genotype.

--- a/src/nested_traversal_finder.cpp
+++ b/src/nested_traversal_finder.cpp
@@ -52,7 +52,7 @@ vector<SnarlTraversal> NestedTraversalFinder::find_traversals(const Snarl& site)
             // For every visit
             
             // Stick the forward or flipped visit in the traversal
-            *trav.add_visits() = flip_path ? reverse(bubble.second[bubble.second.size() - 1 - i]) : bubble.second[i];;
+            *trav.add_visit() = flip_path ? reverse(bubble.second[bubble.second.size() - 1 - i]) : bubble.second[i];;
         }
             
         // Now emit the actual traversal

--- a/src/pileup_augmenter.cpp
+++ b/src/pileup_augmenter.cpp
@@ -11,7 +11,7 @@ namespace vg {
 const double PileupAugmenter::Log_zero = (double)-1e100;
 
 const char PileupAugmenter::Default_default_quality = 30;
-const int PileupAugmenter::Default_min_aug_support = 2;
+const int PileupAugmenter::Default_min_aug_support = 1;
 
 PileupAugmenter::PileupAugmenter(VG* graph,
                int default_quality,

--- a/src/pileup_augmenter.cpp
+++ b/src/pileup_augmenter.cpp
@@ -11,7 +11,7 @@ namespace vg {
 const double PileupAugmenter::Log_zero = (double)-1e100;
 
 const char PileupAugmenter::Default_default_quality = 30;
-const int PileupAugmenter::Default_min_aug_support = 1;
+const int PileupAugmenter::Default_min_aug_support = 2;
 
 PileupAugmenter::PileupAugmenter(VG* graph,
                int default_quality,

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -161,9 +161,9 @@ pair<size_t, size_t> Simplifier::simplify_once(size_t iteration) {
         
         // Determine the length of the new traversal
         size_t new_site_length = 0;
-        for (size_t i = 1; i < traversal.visits_size() - 1; i++) {
+        for (size_t i = 1; i < traversal.visit_size() - 1; i++) {
             // For every non-anchoring node
-            const Visit& visit = traversal.visits(i);
+            const Visit& visit = traversal.visit(i);
             // Total up the lengths of all the nodes that are newly visited.
             assert(visit.node_id());
             new_site_length += graph.get_node(visit.node_id())->sequence().size();
@@ -528,13 +528,13 @@ pair<size_t, size_t> Simplifier::simplify_once(size_t iteration) {
                 // traversal backwards along the path we are splicing. If
                 // it's a forward path this is just right to left, but if
                 // it's a reverse path it has to be left to right.
-                for (size_t i = 0; i < traversal.visits_size(); i++) {
+                for (size_t i = 0; i < traversal.visit_size(); i++) {
                     // Find the visit we need next, as a function of which
                     // way we need to insert this run of visits. Normally we
                     // go through the visits right to left, but when we have
                     // a backward path we go left to right.
-                    const Visit& visit = backward ? traversal.visits(i)
-                                                  : traversal.visits(traversal.visits_size() - i - 1);
+                    const Visit& visit = backward ? traversal.visit(i)
+                                                  : traversal.visit(traversal.visit_size() - i - 1);
                     
                     // Make a Mapping to represent it
                     Mapping new_mapping;
@@ -649,11 +649,11 @@ pair<size_t, size_t> Simplifier::simplify_once(size_t iteration) {
         // Now delete all edges that aren't connecting adjacent nodes on the
         // blessed traversal (before we delete their nodes).
         set<Edge*> blessed_edges;
-        for (int i = 0; i < traversal.visits_size() - 1; ++i) {
+        for (int i = 0; i < traversal.visit_size() - 1; ++i) {
             // For each node and the next node (which won't be the end)
             
-            const Visit visit = traversal.visits(i);
-            const Visit next = traversal.visits(i);
+            const Visit visit = traversal.visit(i);
+            const Visit next = traversal.visit(i);
             
             // Find the edge between them
             NodeTraversal here(graph.get_node(visit.node_id()), visit.backward());
@@ -666,9 +666,9 @@ pair<size_t, size_t> Simplifier::simplify_once(size_t iteration) {
         }
         
         // Also get the edges from the boundary nodes into the traversal
-        if (traversal.visits_size() > 0) {
-            NodeTraversal first_visit = to_node_traversal(traversal.visits(0), graph);
-            NodeTraversal last_visit = to_node_traversal(traversal.visits(traversal.visits_size() - 1),
+        if (traversal.visit_size() > 0) {
+            NodeTraversal first_visit = to_node_traversal(traversal.visit(0), graph);
+            NodeTraversal last_visit = to_node_traversal(traversal.visit(traversal.visit_size() - 1),
                                                          graph);
             blessed_edges.insert(graph.get_edge(to_node_traversal(leaf->start(), graph), first_visit));
             blessed_edges.insert(graph.get_edge(last_visit, to_node_traversal(leaf->end(), graph)));
@@ -697,8 +697,8 @@ pair<size_t, size_t> Simplifier::simplify_once(size_t iteration) {
         
         // What nodes are on it?
         set<Node*> blessed_nodes;
-        for (int i = 0; i < traversal.visits_size(); i++) {
-            const Visit& visit = traversal.visits(i);
+        for (int i = 0; i < traversal.visit_size(); i++) {
+            const Visit& visit = traversal.visit(i);
             blessed_nodes.insert(graph.get_node(visit.node_id()));
         }
         

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -1763,11 +1763,11 @@ namespace vg {
     }
     
     bool operator==(const SnarlTraversal& a, const SnarlTraversal& b) {
-        if (a.visits_size() != b.visits_size()) {
+        if (a.visit_size() != b.visit_size()) {
             return false;
         }
-        for (size_t i = 0; i < a.visits_size(); i++) {
-            if (a.visits(i) != b.visits(i)) {
+        for (size_t i = 0; i < a.visit_size(); i++) {
+            if (a.visit(i) != b.visit(i)) {
                 return false;
             }
         }
@@ -1780,15 +1780,15 @@ namespace vg {
     }
     
     bool operator<(const SnarlTraversal& a, const SnarlTraversal& b) {
-        for (size_t i = 0; i < b.visits_size(); i++) {
-            if (i >= a.visits_size()) {
+        for (size_t i = 0; i < b.visit_size(); i++) {
+            if (i >= a.visit_size()) {
                 // A has run out and B is still going
                 return true;
             }
             
-            if (a.visits(i) < b.visits(i)) {
+            if (a.visit(i) < b.visit(i)) {
                 return true;
-            } else if (b.visits(i) < a.visits(i)) {
+            } else if (b.visit(i) < a.visit(i)) {
                 return false;
             }
         }

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -540,8 +540,10 @@ namespace vg {
     /// Converts a NodeTraversal to a Visit.
     inline Visit to_visit(const NodeTraversal& node_traversal);
     
-    /// Converts a Mapping to a Visit. The mapping must represent a full node match.
-    inline Visit to_visit(const Mapping& mapping);
+    /// Converts a Mapping to a Visit. The mapping must represent a full node
+    /// match. If make_full_node_match is true, the mapping will automatically
+    /// be made a full node match during the conversion process.
+    inline Visit to_visit(const Mapping& mapping, bool make_full_node_match = false);
     
     /// Make a Visit from a node ID and an orientation
     inline Visit to_visit(id_t node_id, bool is_reverse);
@@ -697,9 +699,12 @@ namespace vg {
         return to_return;
     }
     
-    inline Visit to_visit(const Mapping& mapping) {
-        assert(mapping_is_match(mapping));
-        assert(mapping.position().offset() == 0);
+    inline Visit to_visit(const Mapping& mapping, bool make_full_node_match) {
+        if (!make_full_node_match) {
+            // If we're not explicitly coercing the mapping to a full node match, make sure it already is one.
+            assert(mapping_is_match(mapping));
+            assert(mapping.position().offset() == 0);
+        }
         Visit to_return;
         to_return.set_node_id(mapping.position().node_id());
         to_return.set_backward(mapping.position().is_reverse());

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -263,8 +263,8 @@ int main_augment(int argc, char** argv) {
         // We will need the computed pileups
         
         // compute the pileups from the graph and gam
-        Pileups* pileups = compute_pileups(graph, gam_in_file_name, thread_count, min_quality, max_mismatches,
-                                           window_size, max_depth, use_mapq, show_progress);
+        pileups = compute_pileups(graph, gam_in_file_name, thread_count, min_quality, max_mismatches,
+                                  window_size, max_depth, use_mapq, show_progress);
     }
         
     if (!pileup_file_name.empty()) {

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -50,7 +50,7 @@ void help_augment(char** argv, ConfigurableParser& parser) {
          << "Embed GAM alignments into a graph to facilitate variant calling" << endl
          << endl
          << "general options:" << endl
-         << "    -a, --augmentation-mode M   augmentation mode.  M = {pileup, direct} [direct]" << endl
+         << "    -a, --augmentation-mode M   augmentation mode.  M = {pileup, direct} [pileup]" << endl
          << "    -Z, --translation FILE      save translations from augmented back to base graph to FILE" << endl
          << "    -A, --alignment-out FILE    save augmented GAM reads to FILE" << endl
          << "    -h, --help                  print this help message" << endl
@@ -75,7 +75,7 @@ void help_augment(char** argv, ConfigurableParser& parser) {
 int main_augment(int argc, char** argv) {
 
     // augmentation mode
-    string augmentation_mode = "direct";
+    string augmentation_mode = "pileup";
     
     // load pileupes from here
     string pileup_file_name;

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -300,6 +300,18 @@ int main_augment(int argc, char** argv) {
         vector<Path> read_paths;
         get_input_file(gam_in_file_name, [&](istream& alignment_stream) {
             stream::for_each<Alignment>(alignment_stream, [&](Alignment& alignment) {
+                // Trim the softclips off of every read
+                // Work out were to cut
+                int cut_start = softclip_start(alignment);
+                int cut_end = softclip_end(alignment);
+                // Cut the sequence and quality
+                alignment.set_sequence(alignment.sequence().substr(cut_start, alignment.sequence().size() - cut_start - cut_end));
+                if (alignment.quality().size() != 0) {
+                    alignment.set_quality(alignment.quality().substr(cut_start, alignment.quality().size() - cut_start - cut_end));
+                }
+                // Trim the path
+                *alignment.mutable_path() = trim_hanging_ends(alignment.path());
+                
                 // Save every read
                 reads.push_back(alignment);
                 // And the path for the read, separately

--- a/src/subcommand/genotype_main.cpp
+++ b/src/subcommand/genotype_main.cpp
@@ -35,7 +35,7 @@ void help_genotype(char** argv) {
          << "    -S, --subset-graph      only use the reference and areas of the graph with read support" << endl
          << "    -i, --realign_indels    realign at indels" << endl
          << "    -d, --het_prior_denom   denominator for prior probability of heterozygousness" << endl
-         << "    -P, --min_per_strand    min consistent reads per strand for an allele" << endl
+         << "    -P, --min_per_strand    min unique reads per strand for a called allele to accept a call" << endl
          << "    -E, --no_embed          dont embed gam edits into grpah" << endl
          << "    -p, --progress          show progress" << endl
          << "    -t, --threads N         number of threads to use" << endl;
@@ -89,8 +89,8 @@ int main_genotype(int argc, char** argv) {
     bool subset_graph = false;
     // What should the heterozygous genotype prior be? (1/this)
     double het_prior_denominator = 10.0;
-    // At least how many reads must be consistent per strand for a call?
-    size_t min_consistent_per_strand = 2;
+    // At least how many reads must be unique support for a called allele per strand for a call?
+    size_t min_unique_per_strand = 2;
 
     bool just_call = false;
     int c;
@@ -183,7 +183,7 @@ int main_genotype(int argc, char** argv) {
             break;
         case 'P':
             // Set min consistent reads per strand required to keep an allele
-            min_consistent_per_strand = std::stoll(optarg);
+            min_unique_per_strand = std::stoll(optarg);
             break;
         case 'p':
             show_progress = true;
@@ -337,7 +337,7 @@ int main_genotype(int argc, char** argv) {
     genotyper.realign_indels = realign_indels;
     assert(het_prior_denominator > 0);
     genotyper.het_prior_logprob = prob_to_logprob(1.0/het_prior_denominator);
-    genotyper.min_consistent_per_strand = min_consistent_per_strand;
+    genotyper.min_unique_per_strand = min_unique_per_strand;
 
     // Guess the reference path if not given
     if(ref_path_name.empty()) {

--- a/src/subcommand/genotype_main.cpp
+++ b/src/subcommand/genotype_main.cpp
@@ -361,12 +361,13 @@ int main_genotype(int argc, char** argv) {
     augmented_graph.graph.paths.rebuild_mapping_aux();
     augmented_graph.graph.paths.to_graph(augmented_graph.graph.graph);    
 
-    // Do the actual augmentation using vg edit.
+    // Do the actual augmentation using vg edit. If augmentation was already
+    // done, just embeds the reads. Reads will be taken by the AugmentedGraph
+    // and stored in it.
     augmented_graph.augment_from_alignment_edits(alignments, true, !embed_gam_edits);
     
     // TODO: move arguments below up into configuration
     genotyper.run(augmented_graph,
-                  alignments,
                   cout,
                   ref_path_name,
                   contig_name,

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -363,14 +363,14 @@ TEST_CASE("TrivialTraversalFinder can find traversals", "[genotype]") {
         REQUIRE(!site_traversals.empty());
         
         SECTION("the path must visit 3 node to span the site") {
-            REQUIRE(site_traversals.front().visits_size() == 3);
+            REQUIRE(site_traversals.front().visit_size() == 3);
             
             SECTION("the site must follow one of the two paths in the correct orientation") {
-                bool followed_path_1 = site_traversals.front().visits(1).node_id() == 3 &&
-                                       site_traversals.front().visits(1).backward() == false;
+                bool followed_path_1 = site_traversals.front().visit(1).node_id() == 3 &&
+                                       site_traversals.front().visit(1).backward() == false;
                 
-                bool followed_path_2 = site_traversals.front().visits(1).node_id() == 4 &&
-                                       site_traversals.front().visits(1).backward() == false;
+                bool followed_path_2 = site_traversals.front().visit(1).node_id() == 4 &&
+                                       site_traversals.front().visit(1).backward() == false;
                 
                 REQUIRE(followed_path_1 != followed_path_2);
             }
@@ -410,11 +410,11 @@ TEST_CASE("ExhaustiveTraversalFinder finds all paths on a bubble with an inverte
     for (auto snarl : manager.top_level_snarls()) {
         auto travs = finder.find_traversals(*snarl);
         for (SnarlTraversal trav : travs) {
-            if (trav.visits_size() == 3) {
-                if (trav.visits(1).node_id() == n1->id() && trav.visits(1).backward()) {
+            if (trav.visit_size() == 3) {
+                if (trav.visit(1).node_id() == n1->id() && trav.visit(1).backward()) {
                     found_trav_1 = true;
                 }
-                else if (trav.visits(1).node_id() == n2->id() && !trav.visits(1).backward()) {
+                else if (trav.visit(1).node_id() == n2->id() && !trav.visit(1).backward()) {
                     found_trav_2 = true;
                 }
             }
@@ -619,19 +619,19 @@ TEST_CASE("RepresentativeTraversalFinder finds traversals correctly", "[genotype
             SECTION("all the traversals should be size 1, with just the middle node") {
                 // TODO: this will have to change when we start to support traversals of non-ultrabubbles.
                 for (auto traversal : traversals) {
-                    REQUIRE(traversal.visits_size() == 3);
+                    REQUIRE(traversal.visit_size() == 3);
                     
                     // Make sure the middle is a node and not a child snarl
-                    REQUIRE(traversal.visits(1).node_id() != 0);
+                    REQUIRE(traversal.visit(1).node_id() != 0);
                 }
             }
             
             SECTION("one should hit node 3") {
                 bool found = false;
                 for (auto traversal : traversals) {
-                    for (size_t i = 0; i < traversal.visits_size(); i++) {
+                    for (size_t i = 0; i < traversal.visit_size(); i++) {
                         // Check every visit on every traversal
-                        if (traversal.visits(i).node_id() == 3) {
+                        if (traversal.visit(i).node_id() == 3) {
                             found = true;
                         }
                     }
@@ -642,9 +642,9 @@ TEST_CASE("RepresentativeTraversalFinder finds traversals correctly", "[genotype
             SECTION("one should hit node 4") {
                 bool found = false;
                 for (auto traversal : traversals) {
-                    for (size_t i = 0; i < traversal.visits_size(); i++) {
+                    for (size_t i = 0; i < traversal.visit_size(); i++) {
                         // Check every visit on every traversal
-                        if (traversal.visits(i).node_id() == 4) {
+                        if (traversal.visit(i).node_id() == 4) {
                             found = true;
                         }
                     }
@@ -663,7 +663,7 @@ TEST_CASE("RepresentativeTraversalFinder finds traversals correctly", "[genotype
             SECTION("one should be empty") {
                 bool found = false;
                 for (auto traversal : traversals) {
-                    if (traversal.visits_size() == 2) {
+                    if (traversal.visit_size() == 2) {
                         found = true;
                     }
                 }
@@ -673,8 +673,8 @@ TEST_CASE("RepresentativeTraversalFinder finds traversals correctly", "[genotype
             SECTION("one should visit just the child site") {
                 bool found = false;
                 for (auto traversal : traversals) {
-                    if (traversal.visits_size() == 3) {
-                        auto& visit = traversal.visits(1);
+                    if (traversal.visit_size() == 3) {
+                        auto& visit = traversal.visit(1);
                         
                         if(visit.node_id() == 0 && visit.snarl().start() == child->start() &&
                             visit.snarl().end() == child->end()) {

--- a/src/unittest/genotyper.cpp
+++ b/src/unittest/genotyper.cpp
@@ -92,13 +92,13 @@ TEST_CASE("traversals can be found from reads", "[genotyper]") {
         
         // We should cross the snarl the easy forward way.
         REQUIRE(paths.size() == 1);
-        REQUIRE(paths[0].visits_size() == 5);
+        REQUIRE(paths[0].visit_size() == 5);
         size_t i = 0;
-        REQUIRE(paths[0].visits(i++).node_id() == 1);
-        REQUIRE(paths[0].visits(i++).node_id() == 2);
-        REQUIRE(paths[0].visits(i++).node_id() == 3);
-        REQUIRE(paths[0].visits(i++).node_id() == 5);
-        REQUIRE(paths[0].visits(i++).node_id() == 6);
+        REQUIRE(paths[0].visit(i++).node_id() == 1);
+        REQUIRE(paths[0].visit(i++).node_id() == 2);
+        REQUIRE(paths[0].visit(i++).node_id() == 3);
+        REQUIRE(paths[0].visit(i++).node_id() == 5);
+        REQUIRE(paths[0].visit(i++).node_id() == 6);
         
     }
     
@@ -124,13 +124,13 @@ TEST_CASE("traversals can be found from reads", "[genotyper]") {
         
         // We should cross the snarl the easy forward way.
         REQUIRE(paths.size() == 1);
-        REQUIRE(paths[0].visits_size() == 5);
+        REQUIRE(paths[0].visit_size() == 5);
         size_t i = 0;
-        REQUIRE(paths[0].visits(i++).node_id() == 1);
-        REQUIRE(paths[0].visits(i++).node_id() == 2);
-        REQUIRE(paths[0].visits(i++).node_id() == 3);
-        REQUIRE(paths[0].visits(i++).node_id() == 5);
-        REQUIRE(paths[0].visits(i++).node_id() == 6);
+        REQUIRE(paths[0].visit(i++).node_id() == 1);
+        REQUIRE(paths[0].visit(i++).node_id() == 2);
+        REQUIRE(paths[0].visit(i++).node_id() == 3);
+        REQUIRE(paths[0].visit(i++).node_id() == 5);
+        REQUIRE(paths[0].visit(i++).node_id() == 6);
         
     }
     

--- a/src/unittest/genotyper.cpp
+++ b/src/unittest/genotyper.cpp
@@ -85,7 +85,7 @@ TEST_CASE("traversals can be found from reads", "[genotyper]") {
         graph.paths.extend(fwd.path());
 
         // Make a map to hold it
-        map<string, Alignment*> reads_by_name{{"read1", &fwd}};
+        map<string, const Alignment*> reads_by_name{{"read1", &fwd}};
 
         // Get paths through the 1 to 6 snarl supported by the read's alignment
         vector<SnarlTraversal> paths = genotyper.get_paths_through_snarl(graph, snarls[0], manager, reads_by_name);
@@ -117,7 +117,7 @@ TEST_CASE("traversals can be found from reads", "[genotyper]") {
         graph.paths.extend(rev.path());
 
         // Make a map to hold it
-        map<string, Alignment*> reads_by_name{{"read1", &rev}};
+        map<string, const Alignment*> reads_by_name{{"read1", &rev}};
 
         // Get paths through the 1 to 6 snarl supported by the read's alignment
         vector<SnarlTraversal> paths = genotyper.get_paths_through_snarl(graph, snarls[0], manager, reads_by_name);

--- a/src/unittest/genotyper.cpp
+++ b/src/unittest/genotyper.cpp
@@ -88,17 +88,17 @@ TEST_CASE("traversals can be found from reads", "[genotyper]") {
         map<string, Alignment*> reads_by_name{{"read1", &fwd}};
 
         // Get paths through the 1 to 6 snarl supported by the read's alignment
-        vector<list<Mapping>> paths = genotyper.get_paths_through_snarl(graph, snarls[0], manager, reads_by_name);
+        vector<SnarlTraversal> paths = genotyper.get_paths_through_snarl(graph, snarls[0], manager, reads_by_name);
         
         // We should cross the snarl the easy forward way.
         REQUIRE(paths.size() == 1);
-        REQUIRE(paths[0].size() == 5);
-        auto it = paths[0].begin();
-        REQUIRE(it++->position().node_id() == 1);
-        REQUIRE(it++->position().node_id() == 2);
-        REQUIRE(it++->position().node_id() == 3);
-        REQUIRE(it++->position().node_id() == 5);
-        REQUIRE(it++->position().node_id() == 6);
+        REQUIRE(paths[0].visits_size() == 5);
+        size_t i = 0;
+        REQUIRE(paths[0].visits(i++).node_id() == 1);
+        REQUIRE(paths[0].visits(i++).node_id() == 2);
+        REQUIRE(paths[0].visits(i++).node_id() == 3);
+        REQUIRE(paths[0].visits(i++).node_id() == 5);
+        REQUIRE(paths[0].visits(i++).node_id() == 6);
         
     }
     
@@ -120,17 +120,17 @@ TEST_CASE("traversals can be found from reads", "[genotyper]") {
         map<string, Alignment*> reads_by_name{{"read1", &rev}};
 
         // Get paths through the 1 to 6 snarl supported by the read's alignment
-        vector<list<Mapping>> paths = genotyper.get_paths_through_snarl(graph, snarls[0], manager, reads_by_name);
+        vector<SnarlTraversal> paths = genotyper.get_paths_through_snarl(graph, snarls[0], manager, reads_by_name);
         
         // We should cross the snarl the easy forward way.
         REQUIRE(paths.size() == 1);
-        REQUIRE(paths[0].size() == 5);
-        auto it = paths[0].begin();
-        REQUIRE(it++->position().node_id() == 1);
-        REQUIRE(it++->position().node_id() == 2);
-        REQUIRE(it++->position().node_id() == 3);
-        REQUIRE(it++->position().node_id() == 5);
-        REQUIRE(it++->position().node_id() == 6);
+        REQUIRE(paths[0].visits_size() == 5);
+        size_t i = 0;
+        REQUIRE(paths[0].visits(i++).node_id() == 1);
+        REQUIRE(paths[0].visits(i++).node_id() == 2);
+        REQUIRE(paths[0].visits(i++).node_id() == 3);
+        REQUIRE(paths[0].visits(i++).node_id() == 5);
+        REQUIRE(paths[0].visits(i++).node_id() == 6);
         
     }
     

--- a/src/variant_recall.cpp
+++ b/src/variant_recall.cpp
@@ -168,8 +168,8 @@ void variant_recall(VG* graph,
             name_to_snarl[snarl->name()] = *snarl;
             for (auto x : travs){
                 name_to_traversal[x.name()] = x;
-                for (int i = 0; i < x.visits_size(); i++){
-                    snarl_name_to_node_set[snarl->name()].insert( x.visits(i).node_id());
+                for (int i = 0; i < x.visit_size(); i++){
+                    snarl_name_to_node_set[snarl->name()].insert( x.visit(i).node_id());
                 }    
             }
         }

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -4904,9 +4904,10 @@ vector<Translation> VG::edit(vector<Path>& paths_to_add, bool save_paths, bool u
     map<pair<pos_t, string>, vector<Node*>> added_seqs;
     // we will record the nodes that we add, so we can correctly make the returned translation
     map<Node*, Path> added_nodes;
-    for(auto path : simplified_paths) {
-        // Now go through each new path again, and create new nodes/wire things up.
-        // Get the added version of the path.
+    for(auto& path : simplified_paths) {
+        // Now go through each new path again, by reference so we can overwrite.
+        
+        // Create new nodes/wire things up. Get the added version of the path.
         Path added = add_nodes_and_edges(path, node_translation, added_seqs, added_nodes, orig_node_sizes);
         
         if (save_paths) {

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -4953,7 +4953,7 @@ vector<Translation> VG::edit(vector<Path>& paths_to_add, bool save_paths, bool u
     return make_translation(node_translation, added_nodes, orig_node_sizes);
 }
 
-// The not quite as robust but actually efficient way to edit the graph.
+// The not quite as robust (TODO: how?) but actually efficient way to edit the graph.
 vector<Translation> VG::edit_fast(const Path& path, set<NodeSide>& dangling) {
     // Collect the breakpoints
     map<id_t, set<pos_t>> breakpoints;

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -521,9 +521,14 @@ public:
     /// fragment. Completely novel nodes are not mentioned, and nodes with no
     /// Translations are assumed to be carried through unchanged. Invalidates
     /// the rank-based Paths index. Does not sort the graph. Suitable for
-    /// calling in a loop. Can attach newly created nodes on the left of the
-    /// path to the given set of dangling NodeSides, and populates the set at
-    /// the end with the NodeSide corresponding to the end of the path.
+    /// calling in a loop.
+    ///
+    /// Can attach newly created nodes on the left of the path to the given set
+    /// of dangling NodeSides, and populates the set at the end with the
+    /// NodeSide corresponding to the end of the path. This mechanism allows
+    /// edits that hit the end of a node to be attached to what comes
+    /// before/after the node by the caller, as this function doesn't handle
+    /// that.
     vector<Translation> edit_fast(const Path& path, set<NodeSide>& dangling);
 
     /// Find all the points at which a Path enters or leaves nodes in the graph. Adds

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -508,7 +508,7 @@ public:
     /// not be called in a loop.
     ///
     /// If update_paths is true, the paths will be modified to reflect their
-    /// embedding in the modified graph. If add_paths is true, the paths as
+    /// embedding in the modified graph. If save_paths is true, the paths as
     /// embedded in the graph will be added to the graph's set of paths. If
     /// break_at_ends is true (or save_paths is true), nodes will be broken at
     /// the ends of paths that start/end woth perfect matches, so the paths can

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -273,7 +273,7 @@ message SnarlTraversal {
     // Steps of the walk through a Snarl, including the start and end nodes. If the 
     // traversal includes a Visit that represents a Snarl, both the node entering the Snarl
     // and the node leaving the Snarl should be included in the traversal.
-    repeated Visit visits = 1;
+    repeated Visit visit = 1;
 
     // The name of the traversal can be used for a variant allele id (e.g. <parentSnarlHash>_0, <parentSnarlHash>_1...
     // or by some other arbitrary annotation , unique or non-unique, e.g. deleteterious, gain_of_function, etc., though these

--- a/test/pileup/edit.json
+++ b/test/pileup/edit.json
@@ -1,0 +1,1 @@
+{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 10, "to_length": 1}]}]}}

--- a/test/pileup/edit.json
+++ b/test/pileup/edit.json
@@ -1,1 +1,1 @@
-{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 10, "to_length": 1}]}]}}
+{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}

--- a/test/pileup/edits.json
+++ b/test/pileup/edits.json
@@ -1,0 +1,12 @@
+{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}

--- a/test/t/17_vg_augment.t
+++ b/test/t/17_vg_augment.t
@@ -16,10 +16,10 @@ vg view -J -v pileup/tiny.json > tiny.vg
 vg view -J -a -G pileup/alignment.json > alignment.gam
 vg augment tiny.vg alignment.gam -P tiny.gpu > /dev/null
 vg view tiny.gpu -l -j | jq . > tiny.gpu.json
-is $(jq --argfile a tiny.gpu.json --argfile b pileup/truth.json -n '($a == $b)') true "vg pileup produces the expected output for test case on tiny graph."
+is $(jq --argfile a tiny.gpu.json --argfile b pileup/truth.json -n '($a == $b)') true "vg augment -P produces the expected output for test case on tiny graph."
 rm -f alignment.gam tiny.gpu tiny.gpu.json
 
-# Make sure well-suppeorted edits are augmented in
+# Make sure well-supported edits are augmented in
 vg view -J -a -G pileup/edits.json > edits.gam
 vg augment tiny.vg edits.gam -A edits-embedded.gam > augmented.vg
 

--- a/test/t/17_vg_augment.t
+++ b/test/t/17_vg_augment.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 3
+plan tests 5
 
 vg view -J -v pileup/tiny.json > tiny.vg
 
@@ -19,12 +19,23 @@ vg view tiny.gpu -l -j | jq . > tiny.gpu.json
 is $(jq --argfile a tiny.gpu.json --argfile b pileup/truth.json -n '($a == $b)') true "vg pileup produces the expected output for test case on tiny graph."
 rm -f alignment.gam tiny.gpu tiny.gpu.json
 
+# Make sure well-suppeorted edits are augmented in
+vg view -J -a -G pileup/edits.json > edits.gam
+vg augment tiny.vg edits.gam -A edits-embedded.gam > augmented.vg
+
+# We want 3 edits with no sequence per read, and we have 12 reads in this file.
+is "$(vg view -aj edits-embedded.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "36" "augmentation embeds reads fully for well-supported SNPs"
+is "$(vg stats -N augmented.vg)" "18" "adding a well-supported SNP by augmentation adds 3 more nodes"
+
+rm -f edits.gam edits-embedded.gam augmented.vg
+
 # Make sure every edit is augmented in
 vg view -J -a -G pileup/edit.json > edit.gam
 vg augment tiny.vg edit.gam -A edit-embedded.gam > augmented.vg
 
-is "$(vg view -aj edit-embedded.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "3" "augmentation embeds reads fully"
-is "$(vg stats -N augmented.vg)" "18" "adding a SNP by augmentation adds 3 more nodes"
+# This file only has one read.
+is "$(vg view -aj edit-embedded.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "3" "augmentation embeds reads fully for probable errors"
+is "$(vg stats -N augmented.vg)" "18" "adding a probable error by augmentation adds 3 more nodes"
 
 rm -f edit.gam edit-embedded.gam augmented.vg
 

--- a/test/t/17_vg_augment.t
+++ b/test/t/17_vg_augment.t
@@ -6,14 +6,28 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 1
+plan tests 3
+
+vg view -J -v pileup/tiny.json > tiny.vg
 
 # Compare output of pileup on tiny.vg and pileup/alignment.json
 # with pileup/truth.json, which has been manually vetted.
 # Will also test some vg view functionality. 
 vg view -J -a -G pileup/alignment.json > alignment.gam
-vg view -J -v pileup/tiny.json > tiny.vg
 vg augment tiny.vg alignment.gam -P tiny.gpu > /dev/null
 vg view tiny.gpu -l -j | jq . > tiny.gpu.json
 is $(jq --argfile a tiny.gpu.json --argfile b pileup/truth.json -n '($a == $b)') true "vg pileup produces the expected output for test case on tiny graph."
-rm -f alignment.gam tiny.vg tiny.gpu tiny.gpu.json
+rm -f alignment.gam tiny.gpu tiny.gpu.json
+
+# Make sure every edit is augmented in
+vg view -J -a -G pileup/edit.json > edit.gam
+vg augment tiny.vg edit.gam -A edit-embedded.gam > augmented.vg
+
+is "$(vg view -aj edit-embedded.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "3" "augmentation embeds reads fully"
+is "$(vg stats -N augmented.vg)" "18" "adding a SNP by augmentation adds 3 more nodes"
+
+rm -f edit.gam edit-embedded.gam augmented.vg
+
+rm -f tiny.vg
+
+

--- a/test/t/17_vg_augment.t
+++ b/test/t/17_vg_augment.t
@@ -21,21 +21,21 @@ rm -f alignment.gam tiny.gpu tiny.gpu.json
 
 # Make sure well-supported edits are augmented in
 vg view -J -a -G pileup/edits.json > edits.gam
-vg augment tiny.vg edits.gam -A edits-embedded.gam > augmented.vg
+vg augment -a direct tiny.vg edits.gam -A edits-embedded.gam > augmented.vg
 
 # We want 3 edits with no sequence per read, and we have 12 reads in this file.
-is "$(vg view -aj edits-embedded.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "36" "augmentation embeds reads fully for well-supported SNPs"
-is "$(vg stats -N augmented.vg)" "18" "adding a well-supported SNP by augmentation adds 3 more nodes"
+is "$(vg view -aj edits-embedded.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "36" "direct augmentation embeds reads fully for well-supported SNPs"
+is "$(vg stats -N augmented.vg)" "18" "adding a well-supported SNP by direct augmentation adds 3 more nodes"
 
 rm -f edits.gam edits-embedded.gam augmented.vg
 
 # Make sure every edit is augmented in
 vg view -J -a -G pileup/edit.json > edit.gam
-vg augment tiny.vg edit.gam -A edit-embedded.gam > augmented.vg
+vg augment -a direct tiny.vg edit.gam -A edit-embedded.gam > augmented.vg
 
 # This file only has one read.
-is "$(vg view -aj edit-embedded.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "3" "augmentation embeds reads fully for probable errors"
-is "$(vg stats -N augmented.vg)" "18" "adding a probable error by augmentation adds 3 more nodes"
+is "$(vg view -aj edit-embedded.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "3" "direct augmentation embeds reads fully for probable errors"
+is "$(vg stats -N augmented.vg)" "18" "adding a probable error by direct augmentation adds 3 more nodes"
 
 rm -f edit.gam edit-embedded.gam augmented.vg
 

--- a/test/t/29_vg_locify.t
+++ b/test/t/29_vg_locify.t
@@ -7,30 +7,36 @@ PATH=../bin:$PATH # for vg
 
 plan tests 9
 
+# Make sure there's no existing index or its reads will get scooped up.
+rm -f tiny.gam.index
+
 vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa > tiny.vg
 vg index -x tiny.vg.xg -g tiny.vg.gcsa -k 16 tiny.vg
 vg sim -a -s 1337 -n 100 -x tiny.vg.xg -l 30 > reads.gam
 vg map -G reads.gam -x tiny.vg.xg -g tiny.vg.gcsa > tiny.gam
 vg index -d tiny.gam.index -N tiny.gam
+# Since there are no edits, the graph will not change at all.
+# Snarls are 1-6, 6-9, 9-12, and 12-15.
 vg genotype tiny.vg tiny.gam.index > tiny.loci
 is $(vg locify -g tiny.gam.index -x tiny.vg.xg -l tiny.loci -f -n -s loci.sorted | vg view -a - | wc -l) 100 "locify produces output for each input alignment"
-is $(cat loci.sorted | wc -l) 6 "the sorted list of loci is the right length"
-is $(head -1 loci.sorted) "1+0_1+0" "the first locus is as expected"
-is $(head -4 loci.sorted | tail -1) "9+18_12+0" "a middle locus is as expected"
-is $(tail -1 loci.sorted) "15+9_15+9" "the last locus is as expected"
+is $(cat loci.sorted | wc -l) $(vg stats -R tiny.vg | grep ultrabubble | wc -l) "the sorted list of loci has one locus per snarl"
+is $(head -1 loci.sorted) "1+0_6+0" "the first locus is as expected"
+is $(head -2 loci.sorted | tail -1) "6+0_9+0" "a middle locus is as expected"
+is $(tail -1 loci.sorted) "12+0_15+0" "the last locus is as expected"
 rm -rf tiny.gam.index
 
 vg construct -r tiny/tiny.fa -v tiny/multi.vcf.gz >tiny.vg
+# This has snarls 1-7, 7-12, 12-15, and 15-19
 vg index -x tiny.vg.xg -g tiny.vg.gcsa -k 16 tiny.vg
 vg sim -a -s 1337 -n 500 -x tiny.vg.xg -l 30 > reads.gam
 vg map -G reads.gam -x tiny.vg.xg -g tiny.vg.gcsa > tiny.gam
 vg index -d tiny.gam.index -N tiny.gam
 vg genotype tiny.vg tiny.gam.index >tiny.loci
-is $(vg locify -g tiny.gam.index -b 2 -x tiny.vg.xg -l tiny.loci -f -n -s loci.sorted | vg view -a -| jq -c '.locus[] | [.name, .allele[].name]' | grep "15+3_20+0" | sort | uniq | wc -l) 2 "limitation to 2-best works"
-is $(vg locify -g tiny.gam.index -b 3 -x tiny.vg.xg -l tiny.loci -f -n -s loci.sorted | vg view -a -| jq -c '.locus[] | [.name, .allele[].name]' | grep "15+3_20+0" | sort | uniq | wc -l) 3 "limitation to 3-best works"
-is $(vg locify -g tiny.gam.index -b 4 -x tiny.vg.xg -l tiny.loci -f -n -s loci.sorted | vg view -a -| jq -c '.locus[] | [.name, .allele[].name]' | grep "15+3_20+0" | sort | uniq | wc -l) 4 "limitation to 4-best works"
+is $(vg locify -g tiny.gam.index -b 2 -x tiny.vg.xg -l tiny.loci -f -n -s loci.sorted | vg view -a -| jq -c '.locus[] | [.name, .allele[].name]' | grep "7+0_12+0" | sort | uniq | wc -l) 2 "limitation to 2-best works"
+is $(vg locify -g tiny.gam.index -b 3 -x tiny.vg.xg -l tiny.loci -f -n -s loci.sorted | vg view -a -| jq -c '.locus[] | [.name, .allele[].name]' | grep "7+0_12+0" | sort | uniq | wc -l) 3 "limitation to 3-best works"
+is $(vg locify -g tiny.gam.index -b 4 -x tiny.vg.xg -l tiny.loci -f -n -s loci.sorted | vg view -a -| jq -c '.locus[] | [.name, .allele[].name]' | grep "7+0_12+0" | sort | uniq | wc -l) 4 "limitation to 4-best works"
 
 vg locify -g tiny.gam.index -b 2 -x tiny.vg.xg -l tiny.loci -f -n -o out.loci >/dev/null
-is $(vg view -q out.loci | jq '.allele | length' | sort | uniq -c | wc -l) 2 "output loci alleles are filtered by n-best read support"
+is $(vg view -q out.loci | jq '.allele | length' | sort | uniq -c | wc -l) 1 "we always get one allele when all the reads match the graph"
 
 rm -rf tiny.vg tiny.vg.xg tiny.vg.gcsa tiny.vg.gcsa.lcp tiny.vg reads.gam tiny.gam tiny.gam.index tiny.loci loci.sorted out.loci


### PR DESCRIPTION
This sets up `Genotyper` to pass around `SnarlTraversal`s, although it still assumes all the `Visit`s are to nodes.

I'm also renaming the `visits` field on the `SnarlTraversal` protobuf, since they should be singular. I want to get this in before I write the real refactor.