### PR TITLE
Fixed slower move constructor

### DIFF
--- a/src/subcommand/benchmark_main.cpp
+++ b/src/subcommand/benchmark_main.cpp
@@ -166,7 +166,19 @@ int main_benchmark(int argc, char** argv) {
         auto trans = algorithms::extract_connecting_graph(&vg, g, max_len, pos_1, pos_2, false, false, true, true, true);
     
     }));
-    
+
+    results.push_back(run_benchmark("vg copy constructor", 1000, [&]() {
+        vg_mut = vg;   
+    }, [&]() {
+        VG copyVG(vg_mut);
+    }));
+
+    results.push_back(run_benchmark("vg move constructor", 1000, [&]() {
+        vg_mut = vg;   
+    }, [&]() {
+        VG VGmove(std::move(vg_mut)); 
+    }));
+
     // Do the control against itself
     results.push_back(run_benchmark("control", 1000, benchmark_control));
 

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -378,31 +378,8 @@ public:
         }
     }
 
-    /// Move constructor.
-    VG(VG&& other) noexcept {
-        init();
-        // assign class data from source object 
-        // replace copies with moves
-        graph = other.graph;
-        paths = other.paths;
-        // assign data from source object to default values
-        other.graph.Clear();
-        clear_indexes();
-        build_indexes();
-       // try moving indexes instead of copying
-
-    }
-
-    // VG(VG&& other) = default;
-
-    // /// Move constructor using copy constructor.
-    // VG(VG&& other) noexcept {
-    //     init();
-//         clear_indexes();
-//         graph = other.graph;
-//         paths = other.paths;
-//         build_indexes();
-    // }
+    //Default move constructor
+    VG(VG&& other) = default;
 
     /// Copy assignment operator.
     VG& operator=(const VG& other) {
@@ -411,12 +388,7 @@ public:
         return *this;
     }
 
-    /// Move assignment operator.
-    VG& operator=(VG&& other) noexcept {
-        std::swap(graph, other.graph);
-        rebuild_indexes();
-        return *this;
-    }
+    VG& operator=(VG&& other) = default;
 
     // TODO: document all these
 

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -381,12 +381,35 @@ public:
     /// Move constructor.
     VG(VG&& other) noexcept {
         init();
+        // assign class data from source object 
         graph = other.graph;
         paths = other.paths;
+        // assign data from source object to default values
         other.graph.Clear();
-        rebuild_indexes();
-        // should copy over indexes
+        // create move assignment operator
+        VG& operator = (VG&& other) {
+            if (this != &other) {
+                delete[] graph;
+                graph = other.graph;
+                paths = other.paths;
+                other.graph.Clear();
+                rebuild_indexes();
+                // should copy over indexes
+            }
+        }
+        return *this;
     }
+
+    // /// Move constructor using copy constructor.
+    // VG(VG&& other) noexcept {
+    //     init();
+    //     if (this != other) {
+    //         clear_indexes();
+    //         graph = other.graph;
+    //         paths = other.paths;
+    //         build_indexes();
+    //     }
+    // }
 
     /// Copy assignment operator.
     VG& operator=(const VG& other) {

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -382,33 +382,26 @@ public:
     VG(VG&& other) noexcept {
         init();
         // assign class data from source object 
+        // replace copies with moves
         graph = other.graph;
         paths = other.paths;
         // assign data from source object to default values
         other.graph.Clear();
-        // create move assignment operator
-        VG& operator = (VG&& other) {
-            if (this != &other) {
-                delete[] graph;
-                graph = other.graph;
-                paths = other.paths;
-                other.graph.Clear();
-                rebuild_indexes();
-                // should copy over indexes
-            }
-        }
-        return *this;
+        clear_indexes();
+        build_indexes();
+       // try moving indexes instead of copying
+
     }
+
+    // VG(VG&& other) = default;
 
     // /// Move constructor using copy constructor.
     // VG(VG&& other) noexcept {
     //     init();
-    //     if (this != other) {
-    //         clear_indexes();
-    //         graph = other.graph;
-    //         paths = other.paths;
-    //         build_indexes();
-    //     }
+//         clear_indexes();
+//         graph = other.graph;
+//         paths = other.paths;
+//         build_indexes();
     // }
 
     /// Copy assignment operator.


### PR DESCRIPTION
The default move constructor turns out to be faster than the copy constructor and the original move constructor. Since the default move constructor worked properly, we replaced the move assignment operator with the default as well. 

Benchmark results for the original move constructor:
<img width="930" alt="move_original" src="https://user-images.githubusercontent.com/25334342/33575264-e3ae054c-d8f0-11e7-9b40-f31ab6aa2000.png">

Benchmark results for the default move constructor: 
<img width="933" alt="move_default" src="https://user-images.githubusercontent.com/25334342/33575268-e8cce26e-d8f0-11e7-9733-4800f1cf2ecc.png">
