### PR TITLE
tighten runtime bounds of jenkins tests

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -954,7 +954,7 @@ class VGCITest(TestCase):
                                  acc_threshold, auc_threshold)
 
     @skip("skipping test to keep runtime down")
-    @timeout_decorator.timeout(3600)
+    @timeout_decorator.timeout(600)
     def test_sim_brca1_snp1kg(self):
         """ Mapping and calling bakeoff F1 test for BRCA1 primary graph """
         # Using 100k simulated reads from snp1kg BRCA1, realign against all
@@ -967,7 +967,7 @@ class VGCITest(TestCase):
                            score_baseline_graph='primary',
                            sample='HG00096', acc_threshold=0.02, auc_threshold=0.02)
                            
-    @timeout_decorator.timeout(3600)
+    @timeout_decorator.timeout(900)
     def test_sim_mhc_cactus(self):
         """ Mapping test for MHC cactus graph """
         log.info("Test start at {}".format(datetime.now()))        
@@ -976,7 +976,7 @@ class VGCITest(TestCase):
                            multipath=True,
                            source_path_names=['GI568335986', 'GI568335994'], acc_threshold=0.02, auc_threshold=0.04)
 
-    @timeout_decorator.timeout(16000)        
+    @timeout_decorator.timeout(4800)        
     def test_sim_chr21_snp1kg(self):
         log.info("Test start at {}".format(datetime.now()))
         self._test_mapeval(300000, 'CHR21', 'snp1kg',
@@ -987,7 +987,7 @@ class VGCITest(TestCase):
                            acc_threshold=0.0075, auc_threshold=0.075, multipath=True,
                            sim_opts='-l 150 -p 500 -v 50 -e 0.01 -i 0.002')
 
-    @timeout_decorator.timeout(16000)        
+    @timeout_decorator.timeout(2400)        
     def test_sim_chr21_snp1kg_trained(self):
         self._test_mapeval(100000, 'CHR21', 'snp1kg',
                            ['primary', 'snp1kg'],
@@ -1002,7 +1002,7 @@ class VGCITest(TestCase):
                            sim_fastq='ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/NA12878/NIST_NA12878_HG001_HiSeq_300x/131219_D00360_005_BH814YADXX/Project_RM8398/Sample_U5a/U5a_AGTCAA_L002_R1_007.fastq.gz')
 
     @skip("skipping test to keep runtime down")        
-    @timeout_decorator.timeout(3600)
+    @timeout_decorator.timeout(1200)
     def test_sim_brca2_snp1kg_mpmap(self):
         """ multipath mapper test, which is a smaller version of above.  we catch all errors
         so jenkins doesn't report failures.  vg is run only in single ended with multipath on
@@ -1016,7 +1016,7 @@ class VGCITest(TestCase):
                            acc_threshold=0.02, auc_threshold=0.02)
 
     @skip("skipping test to keep runtime down")        
-    @timeout_decorator.timeout(7200)
+    @timeout_decorator.timeout(2400)
     def test_sim_chr21_snp1kg_mpmap(self):
         """ multipath mapper test, which is a smaller version of above.  we catch all errors
         so jenkins doesn't report failures.  vg is run only in single ended with multipath on
@@ -1030,7 +1030,7 @@ class VGCITest(TestCase):
                            sim_opts='-d 0.01 -p 1000 -v 75.0 -S 5 -I',
                            sim_fastq=self._input('platinum_NA12878_MHC.fq.gz'))
 
-    @timeout_decorator.timeout(7200)
+    @timeout_decorator.timeout(1200)
     def test_sim_mhc_snp1kg_mpmap(self):
         """ multipath mapper test, which is a smaller version of above.  we catch all errors
         so jenkins doesn't report failures.  vg is run only in single ended with multipath on
@@ -1045,7 +1045,7 @@ class VGCITest(TestCase):
                            sim_opts='-d 0.01 -p 1000 -v 75.0 -S 5 -I',
                            sim_fastq=self._input('platinum_NA12878_MHC.fq.gz'))
 
-    @timeout_decorator.timeout(7200)
+    @timeout_decorator.timeout(1800)
     def test_sim_yeast_cactus(self):
         """ Yeast test based on the cactus graphs.  Reads are simulated from the SK1 path
         of the full graph.  The other graphs are made from this graph using vg mod:
@@ -1099,85 +1099,85 @@ class VGCITest(TestCase):
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('BRCA1', 'cactus', True)
 
-    @timeout_decorator.timeout(900)        
+    @timeout_decorator.timeout(600)        
     def test_full_brca2_primary(self):
         """ Indexing, mapping and calling bakeoff F1 test for BRCA2 primary graph """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('BRCA2', 'primary', False)
 
-    @timeout_decorator.timeout(900)        
+    @timeout_decorator.timeout(600)        
     def test_full_brca2_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for BRCA2 snp1kg graph """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('BRCA2', 'snp1kg', False)
 
-    @timeout_decorator.timeout(900)        
+    @timeout_decorator.timeout(600)        
     def test_full_brca2_cactus(self):
         """ Indexing, mapping and calling bakeoff F1 test for BRCA2 cactus graph """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('BRCA2', 'cactus', False)
 
     @skip("skipping test to keep runtime down")
-    @timeout_decorator.timeout(2000)        
+    @timeout_decorator.timeout(900)        
     def test_map_sma_primary(self):
         """ Indexing, mapping and calling bakeoff F1 test for SMA primary graph """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('SMA', 'primary', True)
 
     @skip("skipping test to keep runtime down")        
-    @timeout_decorator.timeout(2000)        
+    @timeout_decorator.timeout(900)        
     def test_map_sma_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for SMA snp1kg graph """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('SMA', 'snp1kg', True)
 
     @skip("skipping test to keep runtime down")        
-    @timeout_decorator.timeout(2000)        
+    @timeout_decorator.timeout(900)        
     def test_map_sma_cactus(self):
         """ Indexing, mapping and calling bakeoff F1 test for SMA cactus graph """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('SMA', 'cactus', True)
 
     @skip("skipping test to keep runtime down")         
-    @timeout_decorator.timeout(2000)        
+    @timeout_decorator.timeout(900)        
     def test_map_lrc_kir_primary(self):
         """ Indexing, mapping and calling bakeoff F1 test for LRC-KIR primary graph """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('LRC-KIR', 'primary', True)
 
     @skip("skipping test to keep runtime down")         
-    @timeout_decorator.timeout(2000)        
+    @timeout_decorator.timeout(900)        
     def test_map_lrc_kir_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for LRC-KIR snp1kg graph """
         self._test_bakeoff('LRC-KIR', 'snp1kg', True)
         
     @skip("skipping test to keep runtime down")         
-    @timeout_decorator.timeout(2000)        
+    @timeout_decorator.timeout(900)        
     def test_map_lrc_kir_cactus(self):
         """ Indexing, mapping and calling bakeoff F1 test for LRC-KIR cactus graph """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('LRC-KIR', 'cactus', True)
 
-    @timeout_decorator.timeout(10000)        
+    @timeout_decorator.timeout(900)        
     def test_map_mhc_primary(self):
         """ Indexing, mapping and calling bakeoff F1 test for MHC primary graph """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'primary', True)
 
-    @timeout_decorator.timeout(10000)        
+    @timeout_decorator.timeout(900)        
     def test_map_mhc_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for MHC snp1kg graph """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'snp1kg', True)
 
-    @timeout_decorator.timeout(100000)        
+    @timeout_decorator.timeout(900)        
     def test_map_mhc_primary_genotype(self):
         """ Mapping and calling (with vg genotype) bakeoff F1 test for MHC primary graph 
         """
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'primary', True, tag_ext='-genotype', genotype=True)
         
-    @timeout_decorator.timeout(100000)        
+    @timeout_decorator.timeout(1200)        
     def test_map_mhc_snp1kg_genotype(self):
         """ Mapping and calling (with vg genotype) bakeoff F1 test for MHC snp1kg graph 
         """
@@ -1185,7 +1185,7 @@ class VGCITest(TestCase):
         self._test_bakeoff('MHC', 'snp1kg', True, tag_ext='-genotype', genotype=True)
 
     @skip("skipping test to keep runtime down (baseline missing as well)")          
-    @timeout_decorator.timeout(10000)        
+    @timeout_decorator.timeout(1200)        
     def test_map_mhc_cactus(self):
         """ Indexing, mapping and calling bakeoff F1 test for MHC cactus graph """
         log.info("Test start at {}".format(datetime.now()))


### PR DESCRIPTION
As discussed in #1294, tripping the global timeout causes there to be to report at all, so try to catch timeouts at the test level instead.   