### PR TITLE
option to run multipe mpmaps each test

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -24,7 +24,7 @@ KEEP_OUTPUT=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/glennhickey/toil-vg.git@6bbe54283c42dd209c430fdabc66913fbbdfe9bf"
+TOIL_VG_PACKAGE="git+https://github.com/glennhickey/toil-vg.git@98f0c62944d08de4e0af728862cd50eb9a9c68cb"
 # What tests should we run?
 # Should be something like "jenkins/vgci.py::VGCITest::test_sim_brca2_snp1kg"
 PYTEST_TEST_SPEC="jenkins/vgci.py"

--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -24,7 +24,7 @@ KEEP_OUTPUT=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/glennhickey/toil-vg.git@98f0c62944d08de4e0af728862cd50eb9a9c68cb"
+TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@7823e1c81f681d0baadba25c83250ca3a4ce7b73"
 # What tests should we run?
 # Should be something like "jenkins/vgci.py::VGCITest::test_sim_brca2_snp1kg"
 PYTEST_TEST_SPEC="jenkins/vgci.py"

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -1049,7 +1049,7 @@ class VGCITest(TestCase):
                            acc_threshold=0.02, auc_threshold=0.02,
                            sim_opts='-d 0.01 -p 1000 -v 75.0 -S 5 -I',
                            sim_fastq=self._input('platinum_NA12878_MHC.fq.gz'),
-                           more_mpmap_opts=['-n'])
+                           more_mpmap_opts=['-u 8'])
 
     @timeout_decorator.timeout(1800)
     def test_sim_yeast_cactus(self):


### PR DESCRIPTION
@jeizenga I applied this to test_sim_mhc_snp1kg_mpmap what now runs mpmap with '-n' in addition to its default options (results come out as -mp2).  You can change as you see fit or apply to a different test.  You can run as many different mpmaps as you want by specifying multiple strings in the more_mpmap_opts list. 