### PR TITLE
Fix find

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -3509,10 +3509,12 @@ void XG::get_path_range(const string& name, int64_t start, int64_t stop, Graph& 
     for_path_range(name, start, stop, [&](int64_t id) {
             nodes.insert(id);
             for (auto& e : edges_from(id)) {
-                edges.insert(make_pair(make_side(e.from(), e.from_start()), make_side(e.to(), e.to_end())));
+                // For each edge where this is a from node, turn it into a pair of side_ts, each of which holds an id and an is_end flag.
+                edges.insert(make_pair(make_side(e.from(), !e.from_start()), make_side(e.to(), e.to_end())));
             }
             for (auto& e : edges_to(id)) {
-                edges.insert(make_pair(make_side(e.from(), e.from_start()), make_side(e.to(), e.to_end())));
+                // Do the same for the edges where this is a to node
+                edges.insert(make_pair(make_side(e.from(), !e.from_start()), make_side(e.to(), e.to_end())));
             }
         }, is_rev);
 

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 35
+plan tests 36
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 is $? 0 "construction"
@@ -118,4 +118,10 @@ echo 14 >>get.nodes
 echo 15 >>get.nodes
 is $(vg find -x tiny.xg -N get.nodes | vg view - | grep ^S | wc -l) 4 "find gets nodes provided in a node file list"
 rm -rf tiny.xg tiny.vg get.nodes
+
+echo '{"node": [{"id": 1, "sequence": "A"}, {"id": 2, "sequence": "A"}], "edge": [{"from": 1, "to": 2}], "path": [{"name": "ref", "mapping": [{"position": {"node_id": 1}}]}]}' | vg view -Jv - >test.vg
+vg index -x test.xg test.vg
+is "$(vg find -x test.xg -p ref:0 -c 10 | vg view -j - | jq '.edge | length')" "1" "extracting by path adds no extra edges"
+
+rm -f test.vg test.xg
 


### PR DESCRIPTION
Previously `vg find` with a path argument would duplicate edges to produce reversing edges. This patch fixes that misbehavior.