### PR TITLE
Speed up count operations in sub MEMs algorithm

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -803,7 +803,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
 #endif
     
     // how many times does the parent MEM occur in the index?
-    size_t parent_range_count = use_approx_sub_mem_count ? gcsa::Range::length(mem.range) : gcsa->count(mem.range);
+    size_t parent_range_count = use_approx_sub_mem_count ? gcsa::Range::length(mem.range) : mem.match_count;
     
     // the end of the leftmost substring that is at least the minimum length and not contained
     // in the next SMEM

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -909,11 +909,13 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                     
                     range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
                     
-                    if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
-                        // this probe is too long and it no longer is contained in the indendent hit
-                        // that we detected
-                        contained_in_independent_match = false;
-                        break;
+                    if (cursor == probe_string_begin || ((cursor - mem.begin) % sub_mem_count_thinning == 0)) {
+                        if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
+                            // this probe is too long and it no longer is contained in the indendent hit
+                            // that we detected
+                            contained_in_independent_match = false;
+                            break;
+                        }
                     }
                     
                     cursor--;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -839,9 +839,12 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
             
             range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
             
-            if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
-                probe_string_more_frequent = false;
-                break;
+            
+            if (cursor == probe_string_begin || ((cursor - mem.begin) % sub_mem_count_thinning == 0)) {
+                if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
+                    probe_string_more_frequent = false;
+                    break;
+                }
             }
             
             cursor--;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -839,7 +839,6 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
             
             range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
             
-            
             if (cursor == probe_string_begin || ((cursor - mem.begin) % sub_mem_count_thinning == 0)) {
                 if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
                     probe_string_more_frequent = false;
@@ -853,13 +852,6 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
         if (probe_string_more_frequent) {
             // this is the prefix of a sub-MEM of length >= the minimum, now we need to
             // find its end using binary search
-            
-            // a memo of the range we've seen while searching for the end so we can bail out of th
-            // search early if we see a repeat
-            vector<gcsa::range_type> demonstrated_search_ranges;
-            
-            // add the range at the end of the probe search
-            demonstrated_search_ranges.push_back(range);
             
             if (probe_string_begin > leftmost_bound) {
                 // the probe string is contained in a sub-MEM, but that doesn't mean it's been
@@ -875,13 +867,8 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                         break;
                     }
                     
-                    demonstrated_search_ranges.push_back(range);
-                    
                     cursor--;
                 }
-                
-                // put these search ranges in the order they occur along the sub-MEM
-                reverse(demonstrated_search_ranges.begin(), demonstrated_search_ranges.end());
                 
                 // mark this position as the beginning of the probe substring
                 probe_string_begin = cursor + 1;
@@ -916,24 +903,11 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                 cursor = middle - 1;
                 range = gcsa::range_type(0, gcsa->size() - 1);
                 
-                vector<gcsa::range_type> current_search_ranges;
-                
                 // check if there is an independent occurrence of this substring outside of the SMEM
                 bool contained_in_independent_match = true;
-                bool found_demonstrated_range = false;
                 while (cursor >= probe_string_begin) {
                     
                     range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
-                    
-                    if (cursor - mem.begin < demonstrated_search_ranges.size() ?
-                        demonstrated_search_ranges[cursor - mem.begin] == range : false) {
-                        // we've searched to a range that we've previously demonstrated contains independent
-                        // hits, so we can stop extending the search here
-                        
-                        found_demonstrated_range = true;
-                        
-                        break;
-                    }
                     
                     if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
                         // this probe is too long and it no longer is contained in the indendent hit
@@ -941,8 +915,6 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                         contained_in_independent_match = false;
                         break;
                     }
-                    
-                    current_search_ranges.push_back(range);
                     
                     cursor--;
                 }
@@ -952,25 +924,8 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                     // the end of the sub-MEM must be here or to the right
                     left_search_bound = middle;
                     
-                    if (found_demonstrated_range) {
-                        // update the demonstrated search ranges that lead to the current sub mem range
-                        
-                        for (auto iter = cursor + 1; iter < middle; iter++) {
-                            gcsa::range_type search_range = current_search_ranges[(middle - 1) - iter];
-                            if (iter - mem.begin < demonstrated_search_ranges.size()) {
-                                // narrow down the current range at this index
-                                demonstrated_search_ranges[iter - mem.begin] = search_range;
-                            }
-                            else {
-                                // add this index
-                                demonstrated_search_ranges.push_back(search_range);
-                            }
-                        }
-                    }
-                    else {
-                        // update the range of matches (this is the longest match we've verified so far)
-                        sub_mem_range = range;
-                    }
+                    // update the range of matches (this is the longest match we've verified so far)
+                    sub_mem_range = range;
                 }
                 else {
                     // the end of the sub-MEM must be to the left

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -203,6 +203,7 @@ public:
                      int reseed_length = 0);
     
     
+    int sub_mem_count_thinning = 1; // count every this many bases to verify sub-MEM count
     int min_mem_length; // a mem must be >= this length
     int mem_reseed_length; // the length above which we reseed MEMs to get potentially missed hits
     bool fast_reseed; // use the fast reseed algorithm

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2410,10 +2410,8 @@ namespace vg {
     }
             
     double MultipathMapper::fragment_length_log_likelihood(int64_t length) const {
-        double mean = fragment_length_distr.mean();
-        double stdev = fragment_length_distr.stdev();
-        double dev = length - mean;
-        return -dev * dev / (2.0 * stdev * stdev);
+        double dev = length - fragment_length_distr.mean();
+        return -dev * dev / (2.0 * fragment_length_distr.stdev() * fragment_length_distr.stdev());
     }
     
     void MultipathMapper::set_automatic_min_clustering_length(double random_mem_probability) {

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -608,6 +608,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.mem_reseed_length = reseed_length;
     multipath_mapper.fast_reseed = true;
     multipath_mapper.fast_reseed_length_diff = reseed_diff;
+    multipath_mapper.sub_mem_count_thinning = 5;
     multipath_mapper.min_mem_length = min_mem_length;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -608,7 +608,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.mem_reseed_length = reseed_length;
     multipath_mapper.fast_reseed = true;
     multipath_mapper.fast_reseed_length_diff = reseed_diff;
-    multipath_mapper.sub_mem_count_thinning = 5;
+    multipath_mapper.sub_mem_count_thinning = 8;
     multipath_mapper.min_mem_length = min_mem_length;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -608,7 +608,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.mem_reseed_length = reseed_length;
     multipath_mapper.fast_reseed = true;
     multipath_mapper.fast_reseed_length_diff = reseed_diff;
-    multipath_mapper.sub_mem_count_thinning = 8;
+    multipath_mapper.sub_mem_count_thinning = 16;
     multipath_mapper.min_mem_length = min_mem_length;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;


### PR DESCRIPTION
Implements an option to "thin" count operations to reduce the total number of calls to GCSA::count at the expense of more GCSA::LF operations, which are cheaper. The tradeoff is pretty favorable. I might be able to push it even further, but this already brings count to less than 2% of mpmap's run time. If everything is working correctly, the algorithmic guarantees should be unaffected.