### PR TITLE
Add hooks to apply a haplotype consistency bonus in vg map

### DIFF
--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 32
+plan tests 34
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
@@ -120,6 +120,7 @@ vg map -f alignment/mismatch_reduced_qual.fq -x x.xg -g x.gcsa -k 22 -j -A | jq 
 is $(paste temp_scores_full_qual.txt temp_scores_reduced_qual.txt | column -s $'\t' -t | awk '{if ($1 < $2) count++} END{print count}') 10 "base quality adjusted alignment produces higher scores if mismatches have low quality"
 rm temp_scores_full_qual.txt temp_scores_reduced_qual.txt
 
+# Make sure map checks input files to be sure they're there
 vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/NONEXISTENT -u 4 -j
 is $? 1 "error on vg map -f <nonexistent-file> (unpaired)"
 
@@ -132,4 +133,13 @@ is $? 1 "error on vg map -f <nonexistent-file> (paired, LHS)"
 vg map -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/NONEXISTENT -f reads/grch38_lrc_kir_paired.fq -u 4 -j
 is $? 1 "error on vg map -f <nonexistent-file> (paired, RHS)"
 
-rm -f x.vg.idx x.vg.gcsa x.vg.gcsa.lcp x.vg x.reads x.xg x.gcsa graphs/refonly-lrc_kir.vg.xg graphs/refonly-lrc_kir.vg.gcsa graphs/refonly-lrc_kir.vg.gcsa.lcp
+# Now do the GBWT
+vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
+vg index -x x.xg -g x.gcsa -v small/x.vcf.gz --gbwt-name x.gbwt -k 16 x.vg
+
+# This read is all ref which matches no haplotype in x.vcf.gz
+is "$(vg map -x x.xg -g x.gcsa --gbwt-name x.gbwt --hap-bonus 1 --full-l-bonus 0 -s 'CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTAT' -j | jq '.score')" "36" "mapping a read with no haplotype match gets no bonus"
+# This read is all alt which does match a haplotype
+is "$(vg map -x x.xg -g x.gcsa --gbwt-name x.gbwt --hap-bonus 1 --full-l-bonus 0 -s 'CAAATAAGATTTGAAAATTTTCTGGAGTTCTATAAT' -j | jq '.score')" "37" "mapping a read that matches a haplotype gets a bonus" 
+
+rm -f x.vg.idx x.vg.gcsa x.vg.gcsa.lcp x.vg x.reads x.xg x.gcsa x.gcsa.lcp x.gbwt graphs/refonly-lrc_kir.vg.xg graphs/refonly-lrc_kir.vg.gcsa graphs/refonly-lrc_kir.vg.gcsa.lcp


### PR DESCRIPTION
Part of #1331 

This only covers `vg map`; I'm not sure how to do it in `vg mpmap`.

I also don't have any tests that illustrate that using the haplotype information results in better mapping or calling; I am going to try to do those after we get GBWT support merged into toil-vg and we get GBWT indexes generated for the test regions.