### PR TITLE
option (-i) to keep intermediate output in jenkins tests

### DIFF
--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -21,6 +21,8 @@ LOCAL_BUILD=0
 REUSE_VENV=0
 # Should we keep our test output around after uploading the new baseline?
 KEEP_OUTPUT=0
+# Should we keep all intermediate output (ie --force_outstore in toil-vg)?
+KEEP_INTERMEDIATE_FILES=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
@@ -38,13 +40,14 @@ usage() {
     printf "\t\t\tNon-Python dependencies must be installed.\n"
     printf "\t-r\t\tRe-use virtualenvs across script invocations. \n"
     printf "\t-k\t\tKeep on-disk output. \n"
+    printf "\t-i\t\tKeep intermediate on-disk output. \n"
     printf "\t-s\t\tShow test output and error streams (pass -s to pytest). \n"
     printf "\t-p PACKAGE\tUse the given Python package specifier to install toil-vg.\n"
     printf "\t-t TESTSPEC\tUse the given PyTest test specifier to select tests to run.\n"
     exit 1
 }
 
-while getopts "lrksp:t:" o; do
+while getopts "lrkisp:t:" o; do
     case "${o}" in
         l)
             LOCAL_BUILD=1
@@ -55,6 +58,9 @@ while getopts "lrksp:t:" o; do
         k)
             KEEP_OUTPUT=1
             ;;
+        i)
+            KEEP_INTERMEDIATE_FILES=1
+            ;;	  
         s) 
             SHOW_OPT="-s"
             ;;
@@ -171,6 +177,11 @@ git submodule update --init --recursive
 printf "cores ${NUM_CORES}\n" > vgci_cfg.tsv
 printf "teardown False\n" >> vgci_cfg.tsv
 printf "workdir ./vgci-work\n" >> vgci_cfg.tsv
+if [ "${KEEP_INTERMEDIATE_FILES}" == "0" ]; then
+    printf "force_outstore False\n" >> vgci_cfg.tsv
+else
+    printf "force_outstore True\n" >> vgci_cfg.tsv
+fi
 #printf "verify False\n" >> vgci_cfg.tsv
 #printf "baseline ./vgci-baseline\n" >> vgci_cfg.tsv
 

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -294,7 +294,7 @@ class VGCITest(TestCase):
             # toil-vg options
             vg_docker = self.vg_docker,
             container = self.container,
-            force_outstore = self.force_outstre,
+            force_outstore = self.force_outstore,
             # Toil options
             realTimeLogging = True,
             logLevel = "INFO",

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -59,6 +59,7 @@ class VGCITest(TestCase):
         self.do_teardown = True
         self.baseline = 's3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline'
         self.cores = 8
+        self.force_outstore = False
 
         self.loadCFG()
 
@@ -96,6 +97,15 @@ class VGCITest(TestCase):
                             self.baseline = toks[1]
                         elif toks[0] == 'cores':
                             self.cores = int(toks[1])
+                        elif toks[0] == 'force_outstore' and toks[1].lower() == 'true':
+                            self.force_outstore = True
+
+    def _toil_vg_io_opts(self):
+        """ Some common toil-vg options we always want to use """
+        opts = ['--realTimeLogging', '--logInfo', '--workDir', self.workdir]
+        if self.force_outstore:
+            opts += ['--force_outstore']
+        return opts
 
     def _jobstore(self, tag = ''):
         return os.path.join(self.workdir, 'jobstore{}'.format(tag))
@@ -195,7 +205,7 @@ class VGCITest(TestCase):
         """ Wrap toil-vg index.  Files passed are copied from store instead of computed """
         job_store = self._jobstore(dir_tag)
         out_store = self._outstore(dir_tag)
-        opts = '--realTimeLogging --logInfo '
+        opts = ' '.join(self._toil_vg_io_opts()) + ' '
         if self.vg_docker:
             opts += '--vg_docker {} '.format(self.vg_docker)
         if self.container:
@@ -229,7 +239,7 @@ class VGCITest(TestCase):
 
         job_store = self._jobstore(tag)
         out_store = self._outstore(tag)
-        opts = '--realTimeLogging --logInfo '
+        opts = ' '.join(self._toil_vg_io_opts()) + ' '
         if self.vg_docker:
             opts += '--vg_docker {} '.format(self.vg_docker)
         if self.container:
@@ -284,6 +294,7 @@ class VGCITest(TestCase):
             # toil-vg options
             vg_docker = self.vg_docker,
             container = self.container,
+            force_outstore = self.force_outstre,
             # Toil options
             realTimeLogging = True,
             logLevel = "INFO",
@@ -473,7 +484,7 @@ class VGCITest(TestCase):
 
         # start by simulating some reads
         # TODO: why are we using strings here when we could use much safer lists???
-        opts = '--realTimeLogging --logInfo '
+        opts = ' '.join(self._toil_vg_io_opts()) + ' '
         if self.vg_docker:
             opts += '--vg_docker {} '.format(self.vg_docker)
         if self.container:
@@ -982,8 +993,7 @@ class VGCITest(TestCase):
         cmd += ['--call_chunk_cores', str(min(6, self.cores))]
         cmd += ['--gam_index_cores', str(min(4, self.cores))]
         cmd += ['--maxCores', str(self.cores)]
-        cmd += ['--realTimeLogging', '--logInfo']
-        cmd += ['--workDir', self.workdir]
+        cmd += self._toil_vg_io_opts() 
         if self.container:
             cmd += ['--container', self.container]
         # run both gentoype and call


### PR DESCRIPTION
@jeizenga This option should help you debug by dumping many of the intermediate files to the output directory (including the missing .vg)