### PR TITLE
Better mapping to tandem repeats in mpmap

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -1110,22 +1110,7 @@ void OrientedDistanceClusterer::extend_dist_tree_by_permutations(int64_t max_fai
         // slowly lower the number of distances we need to check before we believe that two clusters are on
         // separate strands
 #ifdef debug_od_clusterer
-        size_t direct_merges_remaining = 0;
-        vector<vector<size_t>> groups = component_union_find.all_groups();
-        for (size_t i = 1; i < groups.size(); i++) {
-            for (size_t j = 0; j < i; j++) {
-                size_t strand_1 = component_union_find.find_group(groups[i].front());
-                size_t strand_2 = component_union_find.find_group(groups[j].front());
-                
-                if (num_infinite_dists.count(make_pair(strand_1, strand_2))) {
-                    if (num_infinite_dists[make_pair(strand_1, strand_2)] >= current_max_num_probes) {
-                        continue;
-                    }
-                }
-                direct_merges_remaining += groups[i].size() * groups[j].size();
-            }
-        }
-        cerr << "checked " << pairs_checked << " pairs with max probes " << current_max_num_probes << ", decrement frequency " << decrement_frequency << ", directly calculated merges " << direct_merges_remaining << " and maintained merges " << num_possible_merges_remaining << endl;
+        cerr << "checked " << pairs_checked << " pairs with max probes " << current_max_num_probes << ", decrement frequency " << decrement_frequency << ", merges remaining " << num_possible_merges_remaining << endl;
 #endif
         
         if (pairs_checked % decrement_frequency == 0 && pairs_checked != 0) {

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1021,12 +1021,13 @@ void BaseMapper::rescue_high_count_order_length_mems(vector<MaximalExactMatch>& 
         if (min_hit_count <= max_rescue_hit_count && has_order_length_mem) {
             // treat the minimum count MEM as a representative for this tract and fill it
             // to rescue the repeat mappings
-            gcsa->locate(mems[min_hit_mem].range, mems[min_hit_mem].nodes);
             
 #ifdef debug_mapper
             cerr << "found unfilled order length tract from MEM indexes " << mem_range.first << ":" << mem_range.second << ", filling with representative " << mems[min_hit_mem] << " with " << min_hit_count << " hits" << endl;
 #endif
             
+            gcsa->locate(mems[min_hit_mem].range, mems[min_hit_mem].nodes);
+          
         }
     }
 }

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -633,6 +633,13 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
     // TODO: I think I already fixed this
     mems.erase(unique(mems.begin(), mems.end()), mems.end());
     // remove MEMs that are overlapping positionally (they may be redundant)
+    
+    
+    // are we rescuing tracts of MEMs that are high count and length at the order of the GCSA index?
+    if (order_length_repeat_hit_max) {
+        rescue_high_count_order_length_mems(mems, order_length_repeat_hit_max);
+    }
+    
     return mems;
 }
 
@@ -977,6 +984,45 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
             // will not contain it
             
             probe_string_end = cursor + min_sub_mem_length + 1;
+        }
+    }
+}
+    
+void BaseMapper::rescue_high_count_order_length_mems(vector<MaximalExactMatch>& mems,
+                                                     size_t max_rescue_hit_count) {
+    
+    vector<pair<size_t, size_t>> unfilled_mem_ranges;
+    
+    // identify the ranges of MEMs that are unfilled
+    for (size_t i = 0; i < mems.size(); i++) {
+        if (mems[i].nodes.empty()) {
+            unfilled_mem_ranges.emplace_back(i, 0);
+            while (i < mems.size() ? mems[i].nodes.empty() : false) {
+                i++;
+            }
+            unfilled_mem_ranges.back().second = i;
+        }
+    }
+    
+    for (pair<size_t, size_t>& mem_range : unfilled_mem_ranges) {
+        // check that the range has a MEM that is maxed out at the order of the GCSA2
+        // and also find the MEM in the tract with the minimum hit count
+        bool has_order_length_mem = false;
+        size_t min_hit_count = numeric_limits<size_t>::max();
+        size_t min_hit_mem = numeric_limits<size_t>::max();
+        for (size_t i = mem_range.first; i < mem_range.second; i++) {
+            has_order_length_mem = has_order_length_mem || mems[i].length() == gcsa->order();
+            if (mems[i].match_count < min_hit_count) {
+                min_hit_count = mems[i].match_count;
+                min_hit_mem = i;
+            }
+        }
+        
+        if (min_hit_count <= max_rescue_hit_count && has_order_length_mem) {
+            // treat the minimum count MEM as a representative for this tract and fill it
+            // to rescue the repeat mappings
+            gcsa->locate(mems[min_hit_mem].range, mems[min_hit_mem].nodes);
+            
         }
     }
 }

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1023,6 +1023,10 @@ void BaseMapper::rescue_high_count_order_length_mems(vector<MaximalExactMatch>& 
             // to rescue the repeat mappings
             gcsa->locate(mems[min_hit_mem].range, mems[min_hit_mem].nodes);
             
+#ifdef debug_mapper
+            cerr << "found unfilled order length tract from MEM indexes " << mem_range.first << ":" << mem_range.second << ", filling with representative " << mems[min_hit_mem] << " with " << min_hit_count << " hits" << endl;
+#endif
+            
         }
     }
 }
@@ -4700,7 +4704,6 @@ Alignment Mapper::surject_alignment(const Alignment& source,
     }
 
 #ifdef debug_mapper
-    cerr << "target " << target_id << endl;
     cerr << "fwd " << pb2json(surjection_forward) << endl;
     cerr << "rev " << pb2json(surjection_reverse) << endl;
 #endif

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -204,6 +204,10 @@ public:
                      int min_mem_length = 1,
                      int reseed_length = 0);
     
+    /// identifies tracts of order-length MEMs that were unfilled because their hit count was above the max
+    /// and fills one MEM in the tract (the one with the smallest hit count)
+    void rescue_high_count_order_length_mems(vector<MaximalExactMatch>& mems,
+                                             size_t max_rescue_hit_count);
     
     int sub_mem_count_thinning = 1; // count every this many bases to verify sub-MEM count
     int min_mem_length; // a mem must be >= this length
@@ -214,6 +218,7 @@ public:
     double adaptive_diff_exponent; // exponent that describes limiting behavior of adaptive diff algorithm
     int hit_max;       // ignore or MEMs with more than this many hits
     bool use_approx_sub_mem_count = true;
+    size_t order_length_repeat_hit_max = 0; // in tracts of order-length MEMs above the hit max, fill one
     
     // Remove any bonuses used by the aligners from the final reported scores.
     // Does NOT (yet) remove the haplotype consistency bonus.

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -205,7 +205,8 @@ public:
                      int reseed_length = 0);
     
     /// identifies tracts of order-length MEMs that were unfilled because their hit count was above the max
-    /// and fills one MEM in the tract (the one with the smallest hit count)
+    /// and fills one MEM in the tract (the one with the smallest hit count), assumes MEMs are lexicographically
+    /// ordered by read index
     void rescue_high_count_order_length_mems(vector<MaximalExactMatch>& mems,
                                              size_t max_rescue_hit_count);
     

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -573,7 +573,7 @@ namespace vg {
         if (numeric_limits<int64_t>::max() == xindex->closest_shared_path_oriented_distance(id(pos_1), offset(pos_1), is_rev(pos_1),
                                                                                             id(pos_2), offset(pos_2), is_rev(pos_2),
                                                                                             forward_strand)) {
-            cerr << "####\n###\nTHIS ONE IS INFINITE\n###\n###\n";
+            cerr << "distance is infinite";
         }
 #endif
         return xindex->closest_shared_path_oriented_distance(id(pos_1), offset(pos_1), is_rev(pos_1),

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -335,7 +335,7 @@ namespace vg {
         Alignment opt_anchoring_aln;
         optimal_alignment(multipath_aln, opt_anchoring_aln);
         pos_t pos_from = rescue_forward ? initial_position(opt_anchoring_aln.path()) : final_position(opt_anchoring_aln.path());
-        int64_t jump_dist = rescue_forward ? fragment_length_distr.mean() : -fragment_length_distr.mean();
+        int64_t jump_dist = rescue_forward ? fragment_length_distr.mean() - other_aln.sequence().size() : -fragment_length_distr.mean();
         
         // get the seed position(s) for the rescue by jumping along paths
         vector<pos_t> jump_positions = xindex->jump_along_closest_path(id(pos_from), is_rev(pos_from), offset(pos_from), jump_dist, 250);

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2671,7 +2671,7 @@ namespace vg {
             }
             
             // arbitrary scaling, seems to help performance
-            raw_mapq /= 2.5;
+            raw_mapq *= mapq_scaling_factor;
             
 #ifdef debug_multipath_mapper_mapping
             cerr << "scores yield a raw MAPQ of " << raw_mapq << endl;
@@ -2740,7 +2740,7 @@ namespace vg {
             }
             
             // arbitrary scaling, seems to help performance
-            raw_mapq /= 2.5;
+            raw_mapq *= mapq_scaling_factor;
             
 #ifdef debug_multipath_mapper_mapping
             cerr << "scores yield a raw MAPQ of " << raw_mapq << endl;
@@ -2775,7 +2775,7 @@ namespace vg {
                     }
                     
                     // arbitrary scaling, seems to help performance
-                    raw_mapq /= 2.5;
+                    raw_mapq *= mapq_scaling_factor;
                     
 #ifdef debug_multipath_mapper_mapping
                     cerr << "deduplicated scores yield a raw MAPQ of " << raw_mapq << endl;
@@ -2815,7 +2815,7 @@ namespace vg {
                     }
                     
                     // arbitrary scaling, seems to help performance
-                    raw_non_dup_mapq /= 2.5;
+                    raw_non_dup_mapq *= mapq_scaling_factor;
                     
                     int32_t non_dup_mapq = min(raw_non_dup_mapq, max_mapping_quality);
                     
@@ -2839,7 +2839,7 @@ namespace vg {
                     }
                     
                     // arbitrary scaling, seems to help performance
-                    raw_non_dup_mapq /= 2.5;
+                    raw_non_dup_mapq *= mapq_scaling_factor;
                     
                     int32_t non_dup_mapq = min(raw_non_dup_mapq, max_mapping_quality);
                     

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -334,7 +334,7 @@ namespace vg {
         // get the position to jump from and the distance to jump
         Alignment opt_anchoring_aln;
         optimal_alignment(multipath_aln, opt_anchoring_aln);
-        pos_t pos_from = initial_position(opt_anchoring_aln.path());
+        pos_t pos_from = rescue_forward ? initial_position(opt_anchoring_aln.path()) : final_position(opt_anchoring_aln.path());
         int64_t jump_dist = rescue_forward ? fragment_length_distr.mean() : -fragment_length_distr.mean();
         
         // get the seed position(s) for the rescue by jumping along paths

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -80,7 +80,7 @@ namespace vg {
         bool unstranded_clustering = true;
         size_t secondary_rescue_attempts = 4;
         double secondary_rescue_score_diff = 1.0;
-        double mapq_scaling_factor = 1.0 / 2.5;
+        double mapq_scaling_factor = 1.0 / 3.5;
         
         //static size_t PRUNE_COUNTER;
         //static size_t SUBGRAPH_TOTAL;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -80,6 +80,7 @@ namespace vg {
         bool unstranded_clustering = true;
         size_t secondary_rescue_attempts = 4;
         double secondary_rescue_score_diff = 1.0;
+        double mapq_scaling_factor = 1.0 / 2.5;
         
         //static size_t PRUNE_COUNTER;
         //static size_t SUBGRAPH_TOTAL;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -61,7 +61,7 @@ void help_mpmap(char** argv) {
     << "  -W, --reseed-diff FLOAT   require internal MEMs to have length within this much of the SMEM's length [0.45]" << endl
     << "  -k, --min-mem-length INT  minimum MEM length to anchor multipath alignments [1]" << endl
     << "  -K, --clust-length INT    minimum MEM length form clusters [automatic]" << endl
-    << "  -c, --hit-max INT         ignore MEMs that occur greater than this many times in the graph (0 for no limit) [128]" << endl
+    << "  -c, --hit-max INT         ignore MEMs that occur greater than this many times in the graph (0 for no limit) [256]" << endl
     << "  -d, --max-dist-error INT  maximum typical deviation between distance on a reference path and distance in graph [8]" << endl
     << "  -w, --approx-exp FLOAT    let the approximate likelihood miscalculate likelihood ratios by this power [6.5]" << endl
     << "  -C, --drop-subgraph FLOAT drop alignment subgraphs whose MEMs cover this fraction less of the read than the best subgraph [0.2]" << endl
@@ -103,7 +103,7 @@ int main_mpmap(int argc, char** argv) {
     int max_map_attempts = 64;
     int max_num_mappings = 1;
     int buffer_size = 100;
-    int hit_max = 128;
+    int hit_max = 256;
     int min_mem_length = 1;
     int min_clustering_mem_length = 0;
     int reseed_length = 28;
@@ -130,7 +130,7 @@ int main_mpmap(int argc, char** argv) {
     size_t num_calibration_simulations = 250;
     size_t calibration_read_length = 150;
     bool unstranded_clustering = false;
-    size_t order_length_repeat_hit_max = 2048;
+    size_t order_length_repeat_hit_max = 0;
     size_t sub_mem_count_thinning = 16;
     
     int c;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -130,6 +130,8 @@ int main_mpmap(int argc, char** argv) {
     size_t num_calibration_simulations = 250;
     size_t calibration_read_length = 150;
     bool unstranded_clustering = false;
+    size_t order_length_repeat_hit_max = 2048;
+    size_t sub_mem_count_thinning = 16;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -627,7 +629,8 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.mem_reseed_length = reseed_length;
     multipath_mapper.fast_reseed = true;
     multipath_mapper.fast_reseed_length_diff = reseed_diff;
-    multipath_mapper.sub_mem_count_thinning = 16;
+    multipath_mapper.sub_mem_count_thinning = sub_mem_count_thinning;
+    multipath_mapper.order_length_repeat_hit_max = order_length_repeat_hit_max;
     multipath_mapper.min_mem_length = min_mem_length;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;


### PR DESCRIPTION
I handled some bad interactions between the mapping de-duplication code and alignments to tandem repeats. The code that allows a higher maximum hit count for one order length MEM is experimental. I may revert it later after I've tested it on whole genomes.