### PR TITLE
Adjust haplotype scoring

### DIFF
--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -343,8 +343,6 @@ size_t hDP_gbwt_graph_accessor<GBWTType>::new_side() const {
 
 template<class GBWTType>
 size_t hDP_gbwt_graph_accessor<GBWTType>::new_height() const {
-  cerr << "Is node in GBWT? " << graph.contains(new_node) << endl;
-  cerr << "Attempt to get GBWT node size..." << endl;
   return graph.nodeSize(new_node);
 }
 
@@ -446,21 +444,15 @@ haplo_score_type haplo_DP::score(const vg::Path& path, GBWTType& graph, haploMat
 
 template<class GBWTType>
 haplo_score_type haplo_DP::score(const gbwt_thread_t& thread, GBWTType& graph, haploMath::RRMemo& memo) {
-  cerr << "Starting score of thread of size " << thread.size() << endl;
-  cerr << "Starting at " << gbwt::Node::id(thread[0]) << " " << gbwt::Node::is_reverse(thread[0]) << endl;
-  cerr << "Node length: " << thread.nodelength(0) << endl;
-  
   if (!graph.contains(thread[0])) {
     // We start on a node that has no haplotype index entry
     cerr << "[WARNING] Path starts outside of haplotype index and cannot be scored" << endl;
+    cerr << "Cannot compute a meaningful haplotype likelihood score" << endl;
     return pair<double, bool>(nan(""), false);
   }
   
   hDP_gbwt_graph_accessor<GBWTType> ga_i(graph, thread[0], thread.nodelength(0), memo);
-  cerr << "Made graph accessor" << endl;
-  ga_i.print(cerr);
   haplo_DP hdp(ga_i);
-  cerr << "Made haplo_DP" << endl;
   if(ga_i.new_height() == 0) {
     cerr << "[WARNING] Initial node in path is visited by 0 reference haplotypes" << endl;
     cerr << "Cannot compute a meaningful haplotype likelihood score" << endl;
@@ -468,11 +460,9 @@ haplo_score_type haplo_DP::score(const gbwt_thread_t& thread, GBWTType& graph, h
     return pair<double, bool>(nan(""), false);
   }
   for(size_t i = 1; i < thread.size(); i++) {
-    cerr << "Now go to thread entry " << i << ": " << gbwt::Node::id(thread[i]) << " " << gbwt::Node::is_reverse(thread[i]) << endl;
-    cerr << "Came from " << i-1 << ": " << gbwt::Node::id(thread[i-1]) << " " << gbwt::Node::is_reverse(thread[i-1]) << endl;
-    
     if (!graph.contains(thread[i])) {
       cerr << "[WARNING] Node " << i + 1 << " in path leaves haplotype index and cannot be scored" << endl;
+      cerr << "Cannot compute a meaningful haplotype likelihood score" << endl;
       return pair<double, bool>(nan(""), false);
     }
     

--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -339,7 +339,8 @@ size_t hDP_gbwt_graph_accessor<GBWTType>::new_height() const {
 
 template<class GBWTType>
 void hDP_gbwt_graph_accessor<GBWTType>::print(ostream& output_stream) const {
-  output_stream << "From node: ID " << gbwt::Node::id(old_node) << " is_reverse " << gbwt::Node::is_reverse(old_node) << " ; To node: ID " << gbwt::Node::id(new_node) << " is_reverse " << gbwt::Node::is_reverse(new_node) << " ; Reference haplotypes visiting To Node: " << new_height() << endl;
+  output_stream << "From node: ID " << gbwt::Node::id(old_node) << " is_reverse " << gbwt::Node::is_reverse(old_node) << " ; To node: ID " << gbwt::Node::id(new_node) << " is_reverse " << gbwt::Node::is_reverse(new_node);
+  output_stream << " ; Reference haplotypes visiting To Node: " << new_height() << endl;
 }
 
 template<class GBWTType>

--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -449,6 +449,13 @@ haplo_score_type haplo_DP::score(const gbwt_thread_t& thread, GBWTType& graph, h
   cerr << "Starting score of thread of size " << thread.size() << endl;
   cerr << "Starting at " << gbwt::Node::id(thread[0]) << " " << gbwt::Node::is_reverse(thread[0]) << endl;
   cerr << "Node length: " << thread.nodelength(0) << endl;
+  
+  if (!graph.contains(thread[0])) {
+    // We start on a node that has no haplotype index entry
+    cerr << "[WARNING] Path starts outside of haplotype index and cannot be scored" << endl;
+    return pair<double, bool>(nan(""), false);
+  }
+  
   hDP_gbwt_graph_accessor<GBWTType> ga_i(graph, thread[0], thread.nodelength(0), memo);
   cerr << "Made graph accessor" << endl;
   ga_i.print(cerr);
@@ -463,6 +470,12 @@ haplo_score_type haplo_DP::score(const gbwt_thread_t& thread, GBWTType& graph, h
   for(size_t i = 1; i < thread.size(); i++) {
     cerr << "Now go to thread entry " << i << ": " << gbwt::Node::id(thread[i]) << " " << gbwt::Node::is_reverse(thread[i]) << endl;
     cerr << "Came from " << i-1 << ": " << gbwt::Node::id(thread[i-1]) << " " << gbwt::Node::is_reverse(thread[i-1]) << endl;
+    
+    if (!graph.contains(thread[i])) {
+      cerr << "[WARNING] Node " << i + 1 << " in path leaves haplotype index and cannot be scored" << endl;
+      return pair<double, bool>(nan(""), false);
+    }
+    
     hDP_gbwt_graph_accessor<GBWTType> ga(graph, thread[i-1], thread[i], thread.nodelength(i), memo);
     if(ga.new_height() == 0 || !ga.has_edge()) {
       if(ga.new_height() == 0) {

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1322,6 +1322,8 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
             return;
         }
         
+        cerr << "Try to score " << pb2json(*aln) << endl;
+        
         // Score the path
         // This is a logprob (so, negative), and expresses the probability of the haplotype path being followed
         double haplotype_logprob;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1322,8 +1322,6 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
             return;
         }
         
-        cerr << "Try to score " << pb2json(*aln) << endl;
-        
         // Score the path
         // This is a logprob (so, negative), and expresses the probability of the haplotype path being followed
         double haplotype_logprob;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1317,8 +1317,9 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
         
         if (aln->path().mapping_size() == 0) {
             // Alignments with no actual mappings don't need scoring.
-            // But I wouldn't call them successfully scored...
-            throw runtime_error("Path is empty for alignment: " + pb2json(*aln));
+            // But I wouldn't call them successfully scored.
+            // So treat it as a scoring failure.
+            return;
         }
         
         // Score the path


### PR DESCRIPTION
Now reads that have empty paths are not submitted for haplotype scoring but not treated as errors, and reads that start outside of the haplotype index are detected and treated as unscoreable instead of causing segfaults.