### PR TITLE
Improve GBWT use in vg map

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1367,12 +1367,8 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
     // We don't look at strip_bonuses here, because we need these bonuses added
     // always in order to choose between alignments.
     
-    // Build Yohei's recombination probability calculator. TODO: We are feeding
-    // it total contiguous haplotype chunks (the /2 removes the reverse
-    // orientations) when it really wants total actual haplotypes (i.e.
-    // haplotypes per chromosome). In some regions, multiple chunks for a
-    // haplotype may overlap, and if we're getting multiple chunks for a
-    // haplotype, this number will be inflated.
+    // Build Yohei's recombination probability calculator. Feed it the haplotype
+    // count from the XG index that was generated alongside the GBWT.
     haplo::haploMath::RRMemo haplo_memo(NEG_LOG_PER_BASE_RECOMB_PROB, haplotype_count);
     
     // This holds all the computed haplotype logprobs
@@ -1413,6 +1409,8 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
     
         // Convert to points, raise to haplotype consistency exponent power, and apply
         alns[i]->set_score(alns[i]->score() + round(haplotype_consistency_exponent * (haplotype_logprobs[i] / aligner->log_base)));
+        // Note that we successfully corrected the score
+        alns[i]->set_haplotype_scored(true);
     }
 }
     

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1382,6 +1382,9 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
             // Alignments with no actual mappings don't need scoring.
             // But I wouldn't call them successfully scored.
             // So treat it as a scoring failure.
+            if (debug) {
+                cerr << "Not applying haplotype consistency due to empty path" << endl;
+            }
             return;
         }
         
@@ -1394,11 +1397,18 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
         if (!path_valid) {
             // Our path does something the scorer doesn't like.
             // Bail out of applying haplotype scores.
+            if (debug) {
+                cerr << "Not applying haplotype consistency due to scoring failure" << endl;
+            }
             return;
         }
         
         // Otherwise we haven't had a scoring failure yet, so keep going
         haplotype_logprobs.push_back(haplotype_logprob);
+    }
+    
+    if (debug) {
+        cerr << "Applying haplotype consistency to " << alns.size() << " alignment candidates" << endl;
     }
     
     for (size_t i = 0; i < alns.size(); i++) {
@@ -1477,7 +1487,6 @@ Mapper::Mapper(xg::XG* xidex,
     , softclip_threshold(0)
     , max_softclip_iterations(10)
     , min_identity(0)
-    , debug(false)
     , max_target_factor(128)
     , max_query_graph_ratio(128)
     , extra_multimaps(512)

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -230,6 +230,9 @@ public:
     MappingQualityMethod mapping_quality_method; // how to compute mapping qualities
     int max_mapping_quality; // the cap for mapping quality
     
+    /// Set to enable debugging messages to cerr from the mapper, so a user can understand why a read maps the way it does.
+    bool debug = false;
+    
 protected:
     /// Locate the sub-MEMs contained in the last MEM of the mems vector that have ending positions
     /// before the end the next SMEM, label each of the sub-MEMs with the indices of all of the SMEMs
@@ -599,8 +602,6 @@ public:
     // uses the cached information about the graph in the xg index to get an approximate node length
     double average_node_length(void);
     
-    bool debug;
-
     // mem mapper parameters
     //
     //int max_mem_length; // a mem must be <= this length

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -1035,14 +1035,24 @@ int main_index(int argc, char** argv) {
 
             // Flush the buffers and do whatever work is still left.
             if (!gbwt_name.empty()) {
+                // Build a GBWT
+                
                 gbwt_builder->finish();
                 if (show_progress) { cerr << "Saving GBWT to disk..." << endl; }
                 sdsl::store_to_file(gbwt_builder->index, gbwt_name);
                 delete gbwt_builder; gbwt_builder = 0;
+                
+                // The XG keeps the thread names
                 index.set_thread_names(thread_names);
+                // And the haplotype count
+                // TODO: We assume diploid
+                index.set_haplotype_count(sample_names.size() * 2);
             } else if (!binary_haplotype_output.empty()) {
+                // Dump a flat file (which is done)
                 binary_file.close();
             } else {
+                // Build a gPBWT in the XG
+                
                 // Now insert all the threads in a batch into the known-DAG VCF-
                 // derived graph.
                 if (show_progress) {
@@ -1050,6 +1060,12 @@ int main_index(int argc, char** argv) {
                 }
                 index.insert_threads_into_dag(all_phase_threads, thread_names);
                 all_phase_threads.clear();
+                
+                // We also need to copy over the haplotype count, because we
+                // don't want to be deriving it from the thread names except for
+                // when converting.
+                // TODO: We assume diploid
+                index.set_haplotype_count(sample_names.size() * 2);
             }
         }
 

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -137,6 +137,7 @@ message Alignment {
     
     string fragment_length_distribution = 32; // The fragment length distribution under which a paired-end alignment was aligned.
 
+    bool haplotype_scored = 33; // True if this alignment's score is adjusted for haplotype consistency, and false otherwise.
 }
 
 // A subgraph of the unrolled Graph in which each non-branching path is associated with an alignment

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -154,12 +154,16 @@ void XG::load(istream& in) {
         // DO NOT CHANGE THIS CODE without creating a new XG version:
         // 1. Increment OUTPUT_VERSION to a new integer.
         // 2. Change the serialization code.
-        // 3. Add a new case here with new deserialization code.
+        // 3. Add a new case here (or enhance an existing case) with new deserialization code.
         // 4. Up MAX_INPUT_VERSION to allow your new version to be read.
         ////////////////////////////////////////////////////////////////////////
         switch (file_version) {
         
+        case 5: // Fall through
         case 6:
+            cerr << "warning:[XG] Loading an out-of-date XG format. In-memory conversion between versions can be time-consuming. For better performance over repeated loads, consider recreating this XG with 'vg index'." << endl;
+            // Fall through
+        case 7:
             {
                 sdsl::read_member(seq_length, in);
                 sdsl::read_member(node_count, in);
@@ -183,10 +187,19 @@ void XG::load(istream& in) {
                 s_bv_rank.load(in, &s_bv);
                 s_bv_select.load(in, &s_bv);
 
+                // Load thread names
                 tn_csa.load(in);
                 tn_cbv.load(in);
                 tn_cbv_rank.load(in, &tn_cbv);
                 tn_cbv_select.load(in, &tn_cbv);
+                
+                if (file_version >= 7) {
+                    // There is a single haplotype count here for all components
+                    sdsl::read_member(haplotype_count, in);
+                }
+                // Otherwise we will calculate it at the end
+                
+                // Load thread positions in gPBWT
                 tin_civ.load(in);
                 tio_civ.load(in);
                 side_thread_wt.load(in);
@@ -208,12 +221,17 @@ void XG::load(istream& in) {
                 np_bv_rank.load(in, &np_bv);
                 np_bv_select.load(in, &np_bv);
                 
-                // load and unpack the succinct representation of the component path set indexes
-                int_vector<> path_ranks_iv;
-                bit_vector path_ranks_bv;
-                path_ranks_iv.load(in);
-                path_ranks_bv.load(in);
-                unpack_succinct_component_path_sets(path_ranks_iv, path_ranks_bv);
+                if (file_version >= 6) {
+                    // load and unpack the succinct representation of the component path set indexes
+                    int_vector<> path_ranks_iv;
+                    bit_vector path_ranks_bv;
+                    path_ranks_iv.load(in);
+                    path_ranks_bv.load(in);
+                    unpack_succinct_component_path_sets(path_ranks_iv, path_ranks_bv);
+                } else {
+                    // build the component path set indexes that were added in version 6
+                    index_component_path_sets();
+                }
                 
                 h_civ.load(in);
                 ts_civ.load(in);
@@ -221,70 +239,11 @@ void XG::load(istream& in) {
                 // Load all the B_s arrays for sides.
                 // Baking required before serialization.
                 deserialize(bs_single_array, in);
-            }
-            break;
-        case 5:
-            {
-                cerr << "warning:[XG] Loading an out-of-date XG format. In-memory conversion between versions can be time-consuming. For better performance over repeated loads, consider recreating this XG with 'vg index'." << endl;
                 
-                sdsl::read_member(seq_length, in);
-                sdsl::read_member(node_count, in);
-                sdsl::read_member(edge_count, in);
-                sdsl::read_member(path_count, in);
-                size_t entity_count = node_count + edge_count;
-                //cerr << sequence_length << ", " << node_count << ", " << edge_count << endl;
-                sdsl::read_member(min_id, in);
-                sdsl::read_member(max_id, in);
-                
-                i_iv.load(in);
-                r_iv.load(in);
-                
-                g_iv.load(in);
-                g_bv.load(in);
-                g_bv_rank.load(in, &g_bv);
-                g_bv_select.load(in, &g_bv);
-                
-                s_iv.load(in);
-                s_bv.load(in);
-                s_bv_rank.load(in, &s_bv);
-                s_bv_select.load(in, &s_bv);
-                
-                tn_csa.load(in);
-                tn_cbv.load(in);
-                tn_cbv_rank.load(in, &tn_cbv);
-                tn_cbv_select.load(in, &tn_cbv);
-                tin_civ.load(in);
-                tio_civ.load(in);
-                side_thread_wt.load(in);
-                
-                pn_iv.load(in);
-                pn_csa.load(in);
-                pn_bv.load(in);
-                pn_bv_rank.load(in, &pn_bv);
-                pn_bv_select.load(in, &pn_bv);
-                pi_iv.load(in);
-                sdsl::read_member(path_count, in);
-                for (size_t i = 0; i < path_count; ++i) {
-                    auto path = new XGPath;
-                    path->load(in);
-                    paths.push_back(path);
+                if (file_version < 7) {
+                    // No haplotype count; one needs to be genenrated by hackily parsing the thread names.
+                    count_haplotypes();
                 }
-                np_iv.load(in);
-                np_bv.load(in);
-                np_bv_rank.load(in, &np_bv);
-                np_bv_select.load(in, &np_bv);
-                
-                // note: no component path set indexes here
-                
-                h_civ.load(in);
-                ts_civ.load(in);
-                
-                // Load all the B_s arrays for sides.
-                // Baking required before serialization.
-                deserialize(bs_single_array, in);
-                
-                // build the component path set indexes that were added in version 6
-                index_component_path_sets();
             }
             break;
         default:
@@ -473,11 +432,14 @@ size_t XG::serialize(ostream& out, sdsl::structure_tree_node* s, std::string nam
     written += s_bv_rank.serialize(out, child, "seq_node_starts_rank");
     written += s_bv_select.serialize(out, child, "seq_node_starts_select");
 
-    // save the thread name index
+    // save the thread name index and haplotype database
     written += tn_csa.serialize(out, child, "thread_name_csa");
     written += tn_cbv.serialize(out, child, "thread_name_cbv");
     written += tn_cbv_rank.serialize(out, child, "thread_name_cbv_rank");
     written += tn_cbv_select.serialize(out, child, "thread_name_cbv_select");
+    written += sdsl::write_member(haplotype_count, out, child, "haplotype_count");
+    
+    // and the thread to GBWT mapping (which may not be in use)
     written += tin_civ.serialize(out, child, "thread_start_node_civ");
     written += tio_civ.serialize(out, child, "thread_start_offset_civ");
     written += side_thread_wt.serialize(out, child, "side_thread_wt");
@@ -4965,9 +4927,13 @@ pair<int64_t, int64_t> XG::thread_start(int64_t thread_id, bool is_rev) const {
 }
 
 string XG::thread_name(int64_t thread_id) const {
+    // How many forward threads are there?
+    // Don't use side_thread_wt since it is only filled in if the gPBWT is used.
+    size_t thread_count = tn_cbv_rank(tn_cbv.size()) - 1;
+
     // convert to forward thread
-    if (thread_id > side_thread_wt.size()/2) {
-        thread_id -= side_thread_wt.size()/2;
+    if (thread_id > thread_count) {
+        thread_id -= thread_count;
     }
     return extract(tn_csa,
                    tn_cbv_select(thread_id)+1, // skip delimiter
@@ -4983,6 +4949,48 @@ vector<int64_t> XG::threads_named_starting(const string& pattern) const {
         results.push_back(tn_cbv_rank(occs[i])+1);
     }
     return results;
+}
+
+void XG::count_haplotypes() {
+    // Go through the thread names, which we assume are like _thread_<sample>_<contig>_<phase>_<chunk>.
+    // Count the total unique samples and assume diploid.
+    
+    // We will just count unique sample names
+    unordered_set<string> sample_names;
+    auto thread_ids = threads_named_starting("_thread_");
+    for (auto thread_id : thread_ids) {
+        // For each thread, get its full name.
+        auto name = thread_name(thread_id);
+        
+        // Find where the sample name should start
+        size_t sample_start = strlen("_thread_");
+        if (name.size() <= sample_start) {
+            // Too short!
+            continue;
+        }
+        auto sample_end = name.find('_', sample_start);
+        if (sample_end == string::npos) {
+            // Can't find the end of the sample name
+            continue;
+        }
+        
+        // Extract the name of the sample
+        auto sample_name = name.substr(sample_start, sample_end - sample_start);
+        // Put it in the set
+        sample_names.insert(sample_name);
+    }
+    
+    // Now we have a count
+    // TODO: this assumes diploid
+    set_haplotype_count(sample_names.size() * 2);
+}
+
+void XG::set_haplotype_count(size_t count) {
+    haplotype_count = count;
+}
+
+size_t XG::get_haplotype_count() const {
+    return haplotype_count;
 }
 
 XG::ThreadSearchState XG::select_starting(const ThreadMapping& start) const {

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -143,6 +143,6 @@ is "$(vg map -x x.xg -g x.gcsa --gbwt-name x.gbwt --hap-exp 1 --full-l-bonus 0 -
 is "$(vg map -x x.xg -g x.gcsa --gbwt-name x.gbwt --hap-exp 1 --full-l-bonus 0 -s 'CAAATAAGATTTGAAAATTTTCTGGAGTTCTATAAT' -j | jq '.score')" "35" "mapping a read that matches a haplotype gets a small penalty"
 is "$(vg map -x x.xg -g x.gcsa --gbwt-name x.gbwt --hap-exp 0 --full-l-bonus 0 -s 'CAAATAAGATTTGAAAATTTTCTGGAGTTCTATAAT' -j | jq '.score')" "36" "mapping a read that matches a haplotype with exponent 0 gets the base score"
 # This read matches no haplotypes but only visits used nodes
-is "$(vg map -x x.xg -g x.gcsa --gbwt-name x.gbwt --hap-exp 1 --full-l-bonus 0 -s 'CAAATAAGATTTGGAAATTTTCTGGAGTTCTATAAT' -j | jq '.score')" "29" "mapping a read that matches no haplotypes gets a larger penalty"
+is "$(vg map -x x.xg -g x.gcsa --gbwt-name x.gbwt --hap-exp 1 --full-l-bonus 0 -s 'CAAATAAGATTTGGAAATTTTCTGGAGTTCTATAAT' -j | jq '.score')" "30" "mapping a read that matches no haplotypes gets a larger penalty"
 
 rm -f x.vg.idx x.vg.gcsa x.vg.gcsa.lcp x.vg x.reads x.xg x.gcsa x.gcsa.lcp x.gbwt graphs/refonly-lrc_kir.vg.xg graphs/refonly-lrc_kir.vg.gcsa graphs/refonly-lrc_kir.vg.gcsa.lcp


### PR DESCRIPTION
Now we can get the total haplotype count from the XG, which is more or less the number Yohei's code wants.

I also added a flag to reads so you can tell if their scores are corrected.

I am also now allowing score correction even when some mappings have no paths, because it turns out that happens a lot.

With these changes I am able to correct (and see that I can correct) about 93% of read pairs and 96% of single reads, in my testing on snp1kg MHC.
