### PR TITLE
Use fragment length distribution parameters from chrom21.bam for chrom21 sim tests

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -1241,7 +1241,7 @@ class VGCITest(TestCase):
                            sample='HG00096',
                            assembly="hg19",
                            acc_threshold=0.0075, auc_threshold=0.075, multipath=True,
-                           sim_opts='-l 150 -p 500 -v 50 -e 0.01 -i 0.002')
+                           sim_opts='-l 150 -p 570 -v 150 -e 0.01 -i 0.002')
 
     @timeout_decorator.timeout(2400)        
     def test_sim_chr21_snp1kg_trained(self):
@@ -1252,7 +1252,7 @@ class VGCITest(TestCase):
                            assembly="hg19",
                            acc_threshold=0.0075, auc_threshold=0.075, multipath=True, paired_only=True,
                            tag_ext='-trained',
-                           sim_opts='-p 500 -v 50 -S 4 -i 0.002 -I',
+                           sim_opts='-p 570 -v 150 -S 4 -i 0.002 -I',
                            # 800k 148bp reads from Genome in a Bottle NA12878 library
                            # (placeholder while finding something better)
                            sim_fastq='ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/NA12878/NIST_NA12878_HG001_HiSeq_300x/131219_D00360_005_BH814YADXX/Project_RM8398/Sample_U5a/U5a_AGTCAA_L002_R1_007.fastq.gz')

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -734,7 +734,7 @@ pair<Alignment, Alignment> NGSSimulator::sample_read_pair() {
     
     while (!aln_pair.first.has_path() || !aln_pair.second.has_path()) {
         int64_t insert_length = (int64_t) round(insert_sampler(prng));
-        if (insert_length < transition_distrs_1.size()) {
+        if (insert_length < (int64_t) transition_distrs_1.size()) {
             // don't make reads where the insert length is shorter than one end of the read
             continue;
         }


### PR DESCRIPTION
This doesn't take away the need for a more realistic distribution in vg sim, but it should at least help the existing one be more realistic.   Values are from `samtools stats` on the bwa-mem output for chrom 21 in HG002