### PR TITLE
Enable default progress bar width

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/illusori/bash-tap.git
 [submodule "progress_bar"]
 	path = deps/progress_bar
-	url = https://github.com/ekg/cpp_progress_bar.git
+	url = https://github.com/vgteam/cpp_progress_bar.git
 [submodule "lru_cache"]
 	path = deps/lru_cache
 	url = https://github.com/ekg/lru_cache.git


### PR DESCRIPTION
Fix #600 and its duplicate #1376

You will need a `git submodule sync` to set the new
progress_bar submodule URL. I made a vgteam repo since I
couldn't merge Jouni's PR against Erik's repo.