### PR TITLE
Fix an interface to convert bed to gam

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1241,9 +1241,16 @@ void parse_bed_regions(istream& bedstream,
         } else {
             ss >> name;
             assert(sbuf < ebuf);
-            Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf, name);
 
-            out_alignments->push_back(alignment);
+            if (xgindex->path_rank(seq) == 0) {
+                // This path doesn't exist, and we'll get a segfault or worse if
+                // we go look for positions in it.
+                cerr << "warning: path \"" << seq << "\" not found in index, skipping" << endl;
+            } else {
+                Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf, name);
+
+                out_alignments->push_back(alignment);
+            }
         }
     }
 }

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1241,8 +1241,6 @@ void parse_bed_regions(istream& bedstream,
         } else {
             ss >> name;
             assert(sbuf < ebuf);
-            // convert from BED-style to 0-based inclusive coordinates
-            ebuf -= 1;
             Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf, name);
 
             out_alignments->push_back(alignment);

--- a/src/unittest/xg.cpp
+++ b/src/unittest/xg.cpp
@@ -303,6 +303,11 @@ TEST_CASE("Target to alignment extraction", "[xg-target-to-aln]") {
             
     xg::XG xg_index(graph);
 
+    SECTION("Subpath getting gives us the expected 1bp alignment") {
+        Alignment target = xg_index.target_alignment("path", 1, 2, "feature");
+        REQUIRE(alignment_from_length(target) == 2 - 1);
+    }
+
     SECTION("Subpath getting gives us the expected 10bp alignment") {
         Alignment target = xg_index.target_alignment("path", 10, 20, "feature");
         REQUIRE(alignment_from_length(target) == 20 - 10);

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -3684,7 +3684,7 @@ Alignment XG::target_alignment(const string& name, size_t pos1, size_t pos2, con
         Mapping* first_mapping = aln.mutable_path()->add_mapping();
         *first_mapping = mapping_at_path_position(name, pos1);
         Edit* e = first_mapping->add_edit();
-        e->set_to_length(node_length(first_mapping->position().node_id())-trim_start);
+        e->set_to_length(node_length(first_mapping->position().node_id()));
         e->set_from_length(e->to_length());
     }
     // get p to point to the next step (or past it, if we're a feature on a single node)


### PR DESCRIPTION
I found some unexpected behaviors on bed2gam(https://github.com/vgteam/vg/pull/1036).

1. Although `target_alignment` requires BED-styled coordinates as arguments, `parse_bed_regions` calls this function with 0-based inclusive coordinates.
2. When the first segment should be trimmed, sometimes `path_from_length(aln.path()) - trim_end` is overflowed since trim_start is subtracted.  (I checked on an additional test.)
3. The path doesn't exist, and we'll get a segfault if we go look for positions in it.

I fixed these problems.