### PR TITLE
Use a smaller cluster subgraph expansion

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -3111,7 +3111,7 @@ Alignment Mapper::align_cluster(const Alignment& aln, const vector<MaximalExactM
         }
     }
     // get the graph with cluster.hpp's cluster_subgraph
-    Graph graph = cluster_subgraph(*xindex, aln, mems);
+    Graph graph = cluster_subgraph(*xindex, aln, mems, 1);
     // and test each direction for which we have MEM hits
     Alignment aln_fwd;
     Alignment aln_rev;


### PR DESCRIPTION
This should speed up vg map by about 50%. I'll only merge if tests work and I can add a test that demonstrates we can still detect indels under this condition.

Another thing to consider is changing the node length of the graph (via `vg mod -X`), as this might also interact with this parameter.