### PR TITLE
resolve #1388

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -595,9 +595,12 @@ string alignment_to_sam(const Alignment& alignment,
     // hack much?
     if (!alignment.quality().empty()) {
         const string& quality = alignment.quality();
+        stringstream q;
         for (int i = 0; i < quality.size(); ++i) {
-            sam << quality_short_to_char(quality[i]);
+            q << quality_short_to_char(quality[i]);
+            //sam << quality_short_to_char(quality[i]);
         }
+        sam << percent_url_encode(q.str());
     } else {
         sam << "*";
         //sam << string(alignment.sequence().size(), 'I');

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -645,4 +645,19 @@ string random_sequence(size_t length) {
     return seq;
 }
 
+string replace_in_string(string subject,
+                         const string& search,
+                         const string& replace) {
+    size_t pos = 0;
+    while ((pos = subject.find(search, pos)) != string::npos) {
+        subject.replace(pos, search.length(), replace);
+        pos += replace.length();
+    }
+    return subject;
+}
+
+string percent_url_encode(const string& seq) {
+    return replace_in_string(seq, "%", "%25");
+}
+
 }

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -470,6 +470,10 @@ size_t modular_exponent(uint64_t base, uint64_t exponent, uint64_t modulus);
 
 /// Returns a uniformly random DNA sequence of the given length
 string random_sequence(size_t length);
+
+/// Escape "%" to "%25"
+string percent_url_encode(const string& seq);
+string replace_in_string(string subject, const string& search, const string& replace);
     
 }
 


### PR DESCRIPTION
We build bam_t records using htslib in a crazy way that exposes us to a URL escaper in htslib. As a result we need to sanitize our '%' signs so that we don't risk them being turned into other characters by the sam parser.

Todo: move to SeqLib.