### PR TITLE
Fix indels and short softclips in surjection

### DIFF
--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -79,7 +79,7 @@ string alignment_to_sam(const Alignment& alignment,
                         const int32_t matepos,
                         const int32_t tlen);
 
-string cigar_against_path(const Alignment& alignment, bool on_reverse_strand);
+string cigar_against_path(const Alignment& alignment, bool on_reverse_strand, int64_t& pos, size_t path_len, size_t softclip_suppress);
 
 int32_t sam_flag(const Alignment& alignment, bool on_reverse_strand);
 short quality_char_to_short(char c);

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -4817,7 +4817,7 @@ Alignment Mapper::surject_alignment(const Alignment& source,
             surjection = translator.translate(surjection_forward);
         }
     }
-    
+    //cerr << "surj " << pb2json(surjection) << endl;
 #ifdef debug_mapper
 
 #pragma omp critical (cerr)
@@ -4893,7 +4893,7 @@ Alignment Mapper::surject_alignment(const Alignment& source,
     cerr << "Surjected alignment: " << pb2json(surjection) << endl;
     
 #endif
-    
+    //cerr << "final " << pb2json(surjection) << endl;
     return surjection;
 }
 

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1130,7 +1130,7 @@ Path simplify(const Path& p, bool trim_internal_deletions) {
                        && l->position().node_id() == m.position().node_id()
                        && l->position().offset() + mapping_from_length(*l) == m.position().offset()) {
                 // we can merge the current mapping onto the old one
-                *l = concat_mappings(*l, m);
+                *l = concat_mappings(*l, m, trim_internal_deletions);
             } else {
                 *s.add_mapping() = m;
             }
@@ -1212,14 +1212,14 @@ Path simplify(const Path& p, bool trim_internal_deletions) {
 }
 
 // simple merge
-Mapping concat_mappings(const Mapping& m, const Mapping& n) {
+Mapping concat_mappings(const Mapping& m, const Mapping& n, bool trim_internal_deletions) {
     Mapping c = m;
     // add the edits on
     for (size_t i = 0; i < n.edit_size(); ++i) {
         *c.add_edit() = n.edit(i);
     }
     // merge anything that's identical
-    return simplify(c);
+    return simplify(c, trim_internal_deletions);
 }
 
 Mapping simplify(const Mapping& m, bool trim_internal_deletions) {

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -248,7 +248,7 @@ Mapping merge_adjacent_edits(const Mapping& m);
 // trim path so it starts and begins with a match (or is empty)
 Path trim_hanging_ends(const Path& p);
 // make a new mapping that concatenates the mappings
-Mapping concat_mappings(const Mapping& m, const Mapping& n);
+Mapping concat_mappings(const Mapping& m, const Mapping& n, bool trim_internal_deletions = true);
 // make a new path that concatenates the two given paths
 Path concat_paths(const Path& path1, const Path& path2);
 // extend the first path by the second, avoiding copy operations

--- a/src/translator.cpp
+++ b/src/translator.cpp
@@ -126,7 +126,7 @@ Path Translator::translate(const Path& path) {
     for (int i = 0; i < path.mapping_size(); ++i) {
         *result.add_mapping() = translate(path.mapping(i));
     }
-    return simplify(result);
+    return simplify(result, false);
 }
 
 Alignment Translator::translate(const Alignment& aln) {


### PR DESCRIPTION
This resolves two major problems with surject. The first is that we mishandled deletions, resulting in errors in the surjection cigar where they were omitted. The second is that surjection as implemented generates a lot of short soft clips, as if the alignment ends in non-reference sides of bubbles it will be aligned against a reference sequence that is shorter than it. To resolve the problem we can force the softclips to be "matches" in the cigar sense and adjust the position of the alignment as needed. The reference bounds are checked to make sure we don't fall outside them.