### PR TITLE
remove nodes with high degree

### DIFF
--- a/src/algorithms/remove_high_degree.cpp
+++ b/src/algorithms/remove_high_degree.cpp
@@ -1,0 +1,29 @@
+#include "remove_high_degree.hpp"
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+void remove_high_degree_nodes(MutableHandleGraph& g, int max_degree) {
+    vector<handle_t> to_remove;
+    g.for_each_handle([&](const handle_t& h) {
+            int edge_count = 0;
+            g.follow_edges(h, false, [&](const handle_t& ignored) {
+                    ++edge_count;
+                });
+            g.follow_edges(h, true, [&](const handle_t& ignored) {
+                    ++edge_count;
+                });
+            if (edge_count > max_degree) {
+                to_remove.push_back(h);
+            }
+        });
+    // now destroy the high degree nodes
+    for (auto& h : to_remove) {
+        g.destroy_handle(h);
+    }
+}
+
+}
+}

--- a/src/algorithms/remove_high_degree.hpp
+++ b/src/algorithms/remove_high_degree.hpp
@@ -1,0 +1,24 @@
+#ifndef VG_ALGORITHMS_REMOVE_HIGH_DEGREE_HPP_INCLUDED
+#define VG_ALGORITHMS_REMOVE_HIGH_DEGREE_HPP_INCLUDED
+
+/**
+ * \file remove_high_degree.hpp
+ *
+ * Defines a process that removes high-degree nodes from a graph
+ */
+
+#include "../vg.pb.h"
+#include "../handle.hpp"
+#include <vector>
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+void remove_high_degree_nodes(MutableHandleGraph& g, int max_degree);
+
+}
+}
+
+#endif

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -15,6 +15,7 @@
 #include "../stream.hpp"
 #include "../utility.hpp"
 #include "../algorithms/topological_sort.hpp"
+#include "../algorithms/remove_high_degree.hpp"
 
 using namespace std;
 using namespace vg;
@@ -71,6 +72,7 @@ void help_mod(char** argv) {
          << "                            replace the pair with a single node that is the concatenation of their labels" << endl
          << "    -K, --kill-labels       delete the labels from the graph, resulting in empty nodes" << endl
          << "    -e, --edge-max N        only consider paths which make edge choices at <= this many points" << endl
+         << "    -M, --max-degree N      unlink nodes that have edge degree greater than N" << endl
          << "    -m, --markers           join all head and tails nodes to marker nodes" << endl
          << "                            ('###' starts and '$$$' ends) of --length, for debugging" << endl
          << "    -F, --force-path-match  sets path edits explicitly equal to the nodes they traverse" << endl
@@ -132,6 +134,7 @@ int main_mod(int argc, char** argv) {
     bool cactus = false;
     string vcf_filename;
     string loci_filename;
+    int max_degree = 0;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -184,11 +187,12 @@ int main_mod(int argc, char** argv) {
             {"cactus", no_argument, 0, 'a'},
             {"sample-vcf", required_argument, 0, 'v'},
             {"sample-graph", required_argument, 0, 'G'},
+            {"max-degree", required_argument, 0, 'M'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hk:oi:q:Q:cpl:e:mt:SX:KPsunzNAf:CDFr:Ig:x:RTU:Bbd:Ow:L:y:Z:Eav:G:",
+        c = getopt_long (argc, argv, "hk:oi:q:Q:cpl:e:mt:SX:KPsunzNAf:CDFr:Ig:x:RTU:Bbd:Ow:L:y:Z:Eav:G:M:",
                 long_options, &option_index);
 
 
@@ -374,6 +378,10 @@ int main_mod(int argc, char** argv) {
             
         case 'G':
             loci_filename = optarg;
+            break;
+
+        case 'M':
+            max_degree = atoi(optarg);
             break;
 
         case 'h':
@@ -811,6 +819,10 @@ int main_mod(int argc, char** argv) {
             return 1;
         }
         graph->prune_complex_with_head_tail(path_length, edge_max);
+    }
+
+    if (max_degree) {
+        algorithms::remove_high_degree_nodes(*graph, max_degree);
     }
 
     if (prune_subgraphs) {

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order 
 
-plan tests 42
+plan tests 43
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -k x - | vg view - | grep "^P" | cut -f 3 | grep -o "[0-9]\+" |  wc -l) \
     $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -k x - | vg view - | grep "^S" | wc -l) \
@@ -143,3 +143,5 @@ is "$(vg view -Fv overlaps/two_snvs_assembly1.gfa | vg mod --bluntify - | vg sta
 is "$(vg view -Fv overlaps/two_snvs_assembly4.gfa | vg mod --bluntify - | vg stats -l - | cut -f2)" "335" "bluntifying overlaps works in a more complex graph"
 
 is "$(vg view -Fv overlaps/incorrect_overlap.gfa | vg mod --bluntify - | vg stats -l - | cut -f2)" "283" "bluntifying overlaps works even when we have overlap description errors"
+
+is $(vg mod -M 5 jumble/j.vg|  vg stats -s - | wc -l) 7 "removal of high-degree nodes results in the expected number of subgraphs"


### PR DESCRIPTION
Ultra-high degree nodes can result from bluntification in deBruijn graphs. They prevent indexing and the further use of these graphs. It is questionable what information they provide. This commit provides a simple method in vg mod that lets us remove them.