### PR TITLE
Add prefiltering for redundant sub-MEMs

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1014,9 +1014,10 @@ void BaseMapper::prefilter_redundant_sub_mems(vector<MaximalExactMatch>& mems) {
     
     // for each MEM
     for (size_t i = 0; i < mems.size(); i++) {
+        // for the range of its sub-MEMs
         for (size_t j = i + 1; j < sub_mem_range_end[i]; j++) {
             
-            // how much farther the sub-MEM should be
+            // how much farther should the sub-MEM be?
             int64_t relative_offset = mems[j].begin - mems[i].begin;
             
             // get the supposed position this will be for each hit (if it is on the same node)
@@ -1035,12 +1036,12 @@ void BaseMapper::prefilter_redundant_sub_mems(vector<MaximalExactMatch>& mems) {
                     removed_so_far++;
                 }
                 else if (removed_so_far > 0) {
-                    // move this one up in the list past
+                    // move this one up in the list to its new index accounting for skips
                     nodes[k - removed_so_far] = nodes[k];
                 }
             }
             
-            // take off the end of the list, all of which have been moved up
+            // take off the end of the list, which only contains skipped hits and hits that have moved up
             if (removed_so_far) {
                 nodes.resize(nodes.size() - removed_so_far);
             }

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -210,6 +210,10 @@ public:
     void rescue_high_count_order_length_mems(vector<MaximalExactMatch>& mems,
                                              size_t max_rescue_hit_count);
     
+    /// identifies hits for sub-MEMs that are redundant hits to the parent MEMs and removes them
+    /// from the hit lists. for speed's sake, can have false negatives but no false positives
+    void prefilter_redundant_sub_mems(vector<MaximalExactMatch>& mems);
+    
     int sub_mem_thinning_burn_in = 0; // start counting at this many bases to verify sub-MEM count
     int sub_mem_count_thinning = 1; // count every this many bases to verify sub-MEM count
     int min_mem_length; // a mem must be >= this length
@@ -220,6 +224,7 @@ public:
     double adaptive_diff_exponent; // exponent that describes limiting behavior of adaptive diff algorithm
     int hit_max;       // ignore or MEMs with more than this many hits
     bool use_approx_sub_mem_count = true;
+    bool prefilter_redundant_hits = false;
     
     // Remove any bonuses used by the aligners from the final reported scores.
     // Does NOT (yet) remove the haplotype consistency bonus.

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -141,6 +141,7 @@ int main_mpmap(int argc, char** argv) {
     size_t rescue_only_anchor_max = 16;
     string sample_name = "";
     string read_group = "";
+    bool prefilter_redundant_hits = true;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -663,6 +664,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;
     multipath_mapper.use_approx_sub_mem_count = false;
+    multipath_mapper.prefilter_redundant_hits = prefilter_redundant_hits;
     if (min_clustering_mem_length) {
         multipath_mapper.min_clustering_mem_length = min_clustering_mem_length;
     }


### PR DESCRIPTION
Sometimes we can identify which hits to sub-MEMs are redundant with the full MEM just by their position. This PR adds an algorithm that will detect the redundant hits in this case and remove them a priori so that they don't slow down later steps.