### PR TITLE
More surject improvements

### DIFF
--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -561,7 +561,7 @@ public:
     // lossily project an alignment into a particular path space of a graph
     // the resulting alignment is equivalent to a SAM record against the chosen path
     Alignment surject_alignment(const Alignment& source,
-                                set<string>& path_names,
+                                const set<string>& path_names,
                                 string& path_name,
                                 int64_t& path_pos,
                                 bool& path_reverse);

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -4140,7 +4140,7 @@ void VG::remove_orphan_edges(void) {
     }
 }
 
-void VG::keep_paths(set<string>& path_names, set<string>& kept_names) {
+void VG::keep_paths(const set<string>& path_names, set<string>& kept_names) {
 
     set<id_t> to_keep;
     paths.for_each([&](const Path& path) {

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -796,7 +796,7 @@ public:
 
     /// Keep paths in the given set of path names. Populates kept_names with the names of the paths it actually found to keep.
     /// The paths specified may not overlap. Removes all nodes and edges not used by one of the specified paths.
-    void keep_paths(set<string>& path_names, set<string>& kept_names);
+    void keep_paths(const set<string>& path_names, set<string>& kept_names);
     void keep_path(const string& path_name);
 
     /// Path stats.


### PR DESCRIPTION
Make quality strings be reversed by the correct functions.

Make MAPQ be cleared and an unaligned Alignment come out when surject fails.

Make SAM conversion respect the unmapped flag as the one true mappedness
indicator. If reads marked mapped are missing things, refuse to serialize them
as BAM. If reads are marked unmapped, do not serialize things that unmapped
reads should not have.

Should help with #1424.