### PR TITLE
Precombine hits that were artificially shortened by the GCSA order

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -639,6 +639,10 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
     // TODO: I think I already fixed this
     mems.erase(unique(mems.begin(), mems.end()), mems.end());
     // remove MEMs that are overlapping positionally (they may be redundant)
+    
+    if (precollapse_order_length_hits) {
+        precollapse_order_length_runs(seq_begin, mems);
+    }
 
     return mems;
 }
@@ -1135,6 +1139,122 @@ void BaseMapper::prefilter_redundant_sub_mems(vector<MaximalExactMatch>& mems,
         if (removed_so_far) {
             nodes.resize(nodes.size() - removed_so_far);
         }
+    }
+}
+    
+void BaseMapper::precollapse_order_length_runs(string::const_iterator seq_begin,
+                                               vector<MaximalExactMatch>& mems) {
+    
+    // find order length MEMs
+    vector<size_t> order_length_mems;
+    for (size_t i = 0; i < mems.size(); i++) {
+        if (mems[i].length() == gcsa->order()) {
+            order_length_mems.push_back(i);
+        }
+    }
+    
+    if (order_length_mems.empty()) {
+        return;
+    }
+    
+    vector<unordered_map<size_t, size_t>> collapsable_pairs(order_length_mems.size());
+    for (size_t i = 0; i + 1 < order_length_mems.size(); i++) {
+        
+        MaximalExactMatch& extending_mem = mems[order_length_mems[i]];
+        MaximalExactMatch& extend_to_mem = mems[order_length_mems[i + 1]];
+        
+        int64_t relative_offset = extend_to_mem.begin - extending_mem.begin;
+        
+        // find where hits should be if they are collapsable and on the same node
+        unordered_map<pos_t, size_t> extended_hits;
+        for (size_t j = 0; j < extending_mem.nodes.size(); j++) {
+            pos_t pos = make_pos_t(extending_mem.nodes[j]);
+            extended_hits[make_pos_t(id(pos), offset(pos) + relative_offset, is_rev(pos))] = j;
+        }
+        
+        // check if we find any of these hits
+        for (size_t j = 0; j < extend_to_mem.nodes.size(); j++) {
+            pos_t pos = make_pos_t(extend_to_mem.nodes[j]);
+            auto iter = extended_hits.find(pos);
+            if (iter != extended_hits.end()) {
+                collapsable_pairs[i].emplace(iter->second, j);
+            }
+        }
+    }
+    
+    // did we find any order-length MEMs that we can collapse into longer MEMs a priori?
+    if (!collapsable_pairs.empty()) {
+        
+        unordered_set<pair<size_t, size_t>> traversed;
+        unordered_map<pair<int64_t, int64_t>, size_t> collapsed_mems;
+        
+        // make collapsed MEMs and identify their hits
+        
+        for (size_t i = 0; i + 1 < order_length_mems.size(); i++) {
+            
+            for (size_t j = 0; j < mems[order_length_mems[i]].nodes.size(); j++) {
+                
+                if (collapsable_pairs[i].count(j) && !traversed.count(make_pair(i, j))) {
+                    // here's a collapsable hit we haven't yet traversed (i.e. the start of a new collapsed hit)
+                    
+                    // follow the forward links until we've traversed all the collapsable pairs
+                    size_t at = j;
+                    size_t col = i;
+                    traversed.emplace(col, at);
+                    pair<size_t, size_t> collapsable_run(at, at);
+                    while (collapsable_pairs[col].count(at)) {
+                        at = collapsable_pairs[col][at];
+                        col++;
+                        collapsable_run.second = at;
+                        traversed.emplace(col, at);
+                    }
+                    
+                    // find the interval of read indexes that the collapsed MEM will cover
+                    pair<int64_t, int64_t> range(mems[order_length_mems[i]].begin - seq_begin,
+                                                 mems[order_length_mems[col]].end - seq_begin);
+                    
+                    // make a new MEM for this read interval if we don't already have one
+                    if (!collapsed_mems.count(range)) {
+                        collapsed_mems[range] = mems.size();
+                        mems.emplace_back(mems[order_length_mems[i]].begin,
+                                          mems[order_length_mems[col]].end,
+                                          gcsa::range_type());
+                    }
+                    
+                    // get the MEM corresponding to this read interval
+                    MaximalExactMatch& collapsed_mem = mems[collapsed_mems[range]];
+                    
+                    // add the hit to the collapsed MEM's hits
+                    collapsed_mem.nodes.push_back(mems[order_length_mems[i]].nodes[j]);
+                }
+            }
+        }
+        
+        // remove the hits that we collapsed from their MEMs
+        
+        for (size_t i = 0; i < order_length_mems.size(); i++) {
+            
+            size_t removed_so_far = 0;
+            auto& nodes = mems[order_length_mems[i]].nodes;
+            for (size_t j = 0; j < nodes.size(); j++) {
+                
+                if (traversed.count(make_pair(i, j))) {
+                    removed_so_far++;
+                }
+                else if (removed_so_far) {
+                    nodes[j - removed_so_far] = nodes[j];
+                }
+            }
+            
+            if (removed_so_far) {
+                nodes.resize(nodes.size() - removed_so_far);
+            }
+        }
+        
+        // resort the MEMs in lexicographic order by the read interval
+        std::sort(mems.begin(), mems.end(), [](const MaximalExactMatch& m1, const MaximalExactMatch& m2) {
+            return m1.begin < m2.begin || (m1.begin == m2.begin && m1.end < m2.end);
+        });
     }
 }
 

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -210,6 +210,11 @@ public:
     void rescue_high_count_order_length_mems(vector<MaximalExactMatch>& mems,
                                              size_t max_rescue_hit_count);
     
+    /// identifies hits for order-length MEMs that are actually part of longer MEMs above the GCSA's limit and
+    /// merges them. for speed's sake, can have false negatives but no false positives
+    void precollapse_order_length_runs(string::const_iterator seq_begin,
+                                       vector<MaximalExactMatch>& mems);
+    
     /// identifies hits for sub-MEMs that are redundant hits to the parent MEMs and removes them
     /// from the hit lists. for speed's sake, can have false negatives but no false positives
     void prefilter_redundant_sub_mems(vector<MaximalExactMatch>& mems,
@@ -227,6 +232,7 @@ public:
     bool use_approx_sub_mem_count = true;
     int max_sub_mem_recursion_depth = 1;
     bool prefilter_redundant_hits = false;
+    bool precollapse_order_length_hits = false;
     
     // Remove any bonuses used by the aligners from the final reported scores.
     // Does NOT (yet) remove the haplotype consistency bonus.

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3633,8 +3633,7 @@ namespace vg {
 #ifdef debug_multipath_mapper_alignment
             cerr << trans_record.second.first << "->" << trans_record.first << (trans_record.second.second ? "-" : "+") << endl;
 #endif
-            injection_trans.insert(make_pair(trans_record.second.first,
-                                             make_pair(trans_record.first, trans_record.second.second)));
+            injection_trans.emplace(trans_record.second.first, make_pair(trans_record.first, trans_record.second.second));
         }
         
         // initialize the match nodes
@@ -3664,8 +3663,6 @@ namespace vg {
         
         // compute reachability and add edges
         add_reachability_edges(vg, hits, projection_trans, injection_trans);
-        
-        
         
 #ifdef debug_multipath_mapper_alignment
         cerr << "final mem graph:" << endl;
@@ -3932,15 +3929,30 @@ namespace vg {
             
             ExactMatchNode& match_node = match_nodes[i];
             
-            if (match_node.end - match_node.begin != gcsa->order()) {
+            if (match_node.end - match_node.begin < gcsa->order()) {
                 // we have passed all of the order length MEMs, bail out of loop
 #ifdef debug_multipath_mapper_alignment
-                cerr << "finished iterating through " << i << " order length MEMs" << endl;
+                cerr << "found " << i << " order length MEMs" << endl;
 #endif
                 
                 num_order_length_mems = i;
                 break;
             }
+        }
+        
+        // find the order of the order-length MEMs lexicographically along the read
+        vector<size_t> order(num_order_length_mems, 0);
+        for (size_t i = 1; i < order.size(); i++) {
+            order[i] = i;
+        }
+        sort(order.begin(), order.end(), [&](size_t i, size_t j) {
+            return match_nodes[i].begin < match_nodes[j].begin || (match_nodes[i].begin == match_nodes[j].begin &&
+                                                                   match_nodes[i].end < match_nodes[j].end);
+        });
+        
+        for (size_t i : order) {
+            
+            ExactMatchNode& match_node = match_nodes[i];
             
 #ifdef debug_multipath_mapper_alignment
             cerr << "## checking if MEM " << i << " can be an extension: " << endl;
@@ -3972,9 +3984,9 @@ namespace vg {
                 cerr << "\t" << pb2json(last_run_node.path) << endl;
 #endif
                 
-                // do they overhang an amount on the read that indicates they could be merged?
+                // do they overhang an amount on the read that indicates they overlap and could be merged?
                 int64_t overhang = last_run_node.end - match_node.begin;
-                if (overhang >= 0) {
+                if (last_run_node.begin < match_node.begin && match_node.end > last_run_node.end && overhang >= 0) {
                     
 #ifdef debug_multipath_mapper_alignment
                     cerr << "MEMs overlap on the read, checking for consistency with overhang on the path" << endl;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -148,6 +148,7 @@ int main_mpmap(int argc, char** argv) {
     string sample_name = "";
     string read_group = "";
     bool prefilter_redundant_hits = true;
+    bool precollapse_order_length_hits = true;
     int max_sub_mem_recursion_depth = 2;
     
     int c;
@@ -709,6 +710,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.adaptive_diff_exponent = reseed_exp;
     multipath_mapper.use_approx_sub_mem_count = false;
     multipath_mapper.prefilter_redundant_hits = prefilter_redundant_hits;
+    multipath_mapper.precollapse_order_length_hits = precollapse_order_length_hits;
     multipath_mapper.max_sub_mem_recursion_depth = max_sub_mem_recursion_depth;
     multipath_mapper.max_mapping_p_value = max_mapping_p_value;
     if (min_clustering_mem_length) {


### PR DESCRIPTION
Sometimes we can identify hits could have been extended if not for the GCSA order because they overlap and have start positions on the same node. This adds an algorithm to identify them and merge them into a single longer MEM. The idea is to better distinguish good mappings and also to reduce the computational burden in repeats.