### PR TITLE
Try to fix Mac tests

### DIFF
--- a/src/build_index.hpp
+++ b/src/build_index.hpp
@@ -25,7 +25,7 @@ void build_gcsa_lcp(VG& graph,
                     int kmer_size,
                     size_t doubling_steps = 3,
                     size_t size_limit = 500,
-                    const string& base_file_name = ".vg-kmers-tmp-");
+                    const string& base_file_name = "vg-kmers-tmp-");
 
 }
 

--- a/src/kmer.hpp
+++ b/src/kmer.hpp
@@ -59,7 +59,7 @@ void write_gcsa_kmers(const HandleGraph& graph, int kmer_size, ostream& out, id_
 
 /// Open a tempfile and write the kmers to it. The calling context should remove it.
 string write_gcsa_kmers_to_tmpfile(const HandleGraph& graph, int kmer_size, id_t head_id, id_t tail_id,
-                                   const string& base_file_name = ".vg-kmers-tmp-");
+                                   const string& base_file_name = "vg-kmers-tmp-");
 
 }
 

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -187,7 +187,7 @@ bool Packer::is_dynamic(void) {
 
 void Packer::ensure_edit_tmpfiles_open(void) {
     if (tmpfstreams.empty()) {
-        string base = ".vg-pack_";
+        string base = "vg-pack_";
         string edit_tmpfile_name = tmpfilename(base);
         std::remove(edit_tmpfile_name.c_str()); // remove this; we'll use it as a base name
         // for as many bins as we have, make a temp file

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -2022,4 +2022,23 @@ Path path_from_node_traversals(const list<NodeTraversal>& traversals) {
     return toReturn;
 }
 
+void remove_paths(Graph& graph, const std::regex& paths_to_take, std::list<Path>* matching) {
+
+    std::list<Path> non_matching;
+    for (size_t i = 0; i < graph.path_size(); i++) {
+        if (std::regex_match(graph.path(i).name(), paths_to_take)) {
+            if (matching != nullptr) {
+                matching->push_back(graph.path(i));
+            }
+        } else {
+            non_matching.push_back(graph.path(i));
+        }
+    }
+    graph.clear_path();
+
+    for (Path& path : non_matching) {
+        *(graph.add_path()) = path;
+    }
+}
+
 }

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -4,6 +4,8 @@
 
 namespace vg {
 
+const std::regex Paths::is_alt("_alt_.+_[0-9]+");
+
 Paths::Paths(void) {
     // noop
 }

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -294,6 +294,10 @@ pos_t final_position(const Path& path);
 // Turn a list of node traversals into a path
 Path path_from_node_traversals(const list<NodeTraversal>& traversals);
 
+// Remove the paths with names matching the regex from the graph.
+// Store them in the list unless it is nullptr.
+void remove_paths(Graph& graph, const std::regex& paths_to_take, std::list<Path>* matching);
+
 }
 
 #endif

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -7,6 +7,7 @@
 #include <set>
 #include <list>
 #include <sstream>
+#include <regex>
 #include "json2pb.h"
 #include "vg.pb.h"
 #include "edit.hpp"
@@ -24,6 +25,9 @@ using namespace std;
 
 class Paths {
 public:
+
+    // This regex matches the names of alt paths.
+    const static std::regex is_alt;
 
     Paths(void);
 

--- a/src/phase_unfolder.cpp
+++ b/src/phase_unfolder.cpp
@@ -156,9 +156,8 @@ bool verify_path(const PathType& path, VG& unfolded, const hash_map<vg::id_t, st
 size_t PhaseUnfolder::verify_paths(VG& unfolded, bool show_progress) const {
 
     // Create a mapping from original -> duplicates.
-    // TODO Interface for the duplicate range in NodeMapping.
     hash_map<vg::id_t, std::vector<vg::id_t>> reverse_mapping;
-    for (gcsa::size_type duplicate = this->mapping.first_node; duplicate < this->mapping.next_node; duplicate++) {
+    for (gcsa::size_type duplicate = this->mapping.begin(); duplicate < this->mapping.end(); duplicate++) {
         vg::id_t original_id = this->mapping(duplicate);
         reverse_mapping[original_id].push_back(duplicate);
         if (unfolded.has_node(original_id)) {

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -6,7 +6,6 @@
 
 #include <string>
 #include <vector>
-#include <regex>
 
 #include "subcommand.hpp"
 
@@ -475,8 +474,6 @@ int main_index(int argc, char** argv) {
         // threads.
         // TODO: a better way to store path metadata
         map<string, Path> alt_paths;
-        // This is matched against the entire string.
-        regex is_alt("_alt_.+_[0-9]+");
 
         if (file_names.empty()) {
             // VGset or something segfaults when we feed it no graphs.
@@ -488,7 +485,7 @@ int main_index(int argc, char** argv) {
         VGset graphs(file_names);
         // Turn into an XG index, except for the alt paths which we pull out and load into RAM instead.
         xg::XG index;
-        graphs.to_xg(index, store_threads, is_alt, alt_paths);
+        graphs.to_xg(index, store_threads, Paths::is_alt, alt_paths);
 
         if (show_progress) {
             cerr << "Built base XG index" << endl;

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -421,7 +421,7 @@ int main_mod(int argc, char** argv) {
 
         // This is matched against the entire path name string to detect alt
         // paths.
-        regex is_alt("_alt_.+_[0-9]+");
+        const regex& is_alt = Paths::is_alt;
 
         // This holds the VCF file we read the variants from. It needs to be the
         // same one used to construct the graph.

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -153,6 +153,7 @@ int main_prune(int argc, char** argv) {
             { "restore-paths", no_argument, 0, 'r' },
             { "unfold-paths", no_argument, 0, 'u' },
             { "verify-paths", no_argument, 0, 'v' },
+            { "xg-name", no_argument, 0, 'x' }, // no longer needed
             { "gbwt-name", required_argument, 0, 'g' },
             { "mapping", required_argument, 0, 'm' },
             { "append-mapping", no_argument, 0, 'a' },
@@ -163,7 +164,7 @@ int main_prune(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "k:e:s:Pruvg:m:apt:d", long_options, &option_index);
+        c = getopt_long (argc, argv, "k:e:s:Pruvx:getopt_long:m:apt:d", long_options, &option_index);
         if (c == -1) { break; } // End of options.
 
         switch (c)
@@ -191,6 +192,9 @@ int main_prune(int argc, char** argv) {
             break;
         case 'v':
             verify_paths = true;
+            break;
+        case 'x': // no longer needed
+            std::cerr << "[vg prune]: option --xg-name is no longer needed" << std::endl;
             break;
         case 'g':
             gbwt_name = optarg;

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -160,11 +160,12 @@ int main_prune(int argc, char** argv) {
             { "progress", no_argument, 0, 'p' },
             { "threads", required_argument, 0, 't' },
             { "dry-run", no_argument, 0, 'd' },
+            { "help", no_argument, 0, 'h' },
             { 0, 0, 0, 0 }
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "k:e:s:Pruvx:getopt_long:m:apt:d", long_options, &option_index);
+        c = getopt_long(argc, argv, "k:e:s:Pruvx:g:m:apt:dh", long_options, &option_index);
         if (c == -1) { break; } // End of options.
 
         switch (c)
@@ -312,17 +313,7 @@ int main_prune(int argc, char** argv) {
 
     // Remove the paths and build an XG index if needed.
     if (mode == mode_restore || mode == mode_unfold) {
-        std::list<Path> non_alt_paths;
-        for (size_t i = 0; i < graph->graph.path_size(); i++) {
-            if (!std::regex_match(graph->graph.path(i).name(), Paths::is_alt)) {
-                non_alt_paths.emplace_back(graph->graph.path(i));
-            }
-        }
-        graph->graph.clear_path();
-        for (Path& path : non_alt_paths) {
-            *(graph->graph.add_path()) = path;
-        }
-        non_alt_paths.clear();
+        remove_paths(graph->graph, Paths::is_alt, nullptr);
         xg_index.from_graph(graph->graph);
         if (show_progress) {
             std::cerr << "Built a temporary XG index" << std::endl;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -163,7 +163,7 @@ string toUppercase(const string& s) {
 }
 
 string tmpfilename(const string& base) {
-    string tmpname = base + "XXXXXXXX";
+    string tmpname = find_temp_dir() + "/" + base + "XXXXXXXX";
     // hack to use mkstemp to get us a safe temporary file name
     int fd = mkstemp(&tmpname[0]);
     if(fd != -1) {
@@ -196,8 +196,7 @@ string find_temp_dir() {
 }
 
 string tmpfilename() {
-    // Make a temp file in the system temp directory.
-    return tmpfilename(find_temp_dir() + "/vg");
+    return tmpfilename("vg-");
 }
 
 string get_or_make_variant_id(const vcflib::Variant& variant) {

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -255,7 +255,7 @@ typename Collection::value_type logprob_sum(const Collection& collection) {
 /// Find the system temp directory using defaults and environment variables
 string find_temp_dir();
 
-/// Create a temporary file starting with the given base name
+/// Create a temporary file starting with the given base name in the appropriate system temporary directory
 string tmpfilename(const string& base);
 
 /// Create a temporary file in the appropriate system temporary directory

--- a/src/vg_set.cpp
+++ b/src/vg_set.cpp
@@ -104,33 +104,9 @@ void VGset::to_xg(xg::XG& index, bool store_threads, const regex& paths_to_take,
 
                 // We'll move all the paths into one of these.
                 std::list<Path> paths_taken;
-                std::list<Path> paths_kept;
 
-                // Filter out matching paths
-                for(size_t i = 0; i < graph.path_size(); i++) {
-                    if(regex_match(graph.path(i).name(), paths_to_take)) {
-                        // We need to take this path
-#ifdef debug
-                        cerr << "Path " << graph.path(i).name() << " matches regex. Removing." << endl;
-#endif
-                        paths_taken.emplace_back(move(*graph.mutable_path(i)));
-                    } else {
-                        // We need to keep this path
-                        paths_kept.emplace_back(move(*graph.mutable_path(i)));
-#ifdef debug
-                        cerr << "Path " << graph.path(i).name() << " does not match regex. Keeping." << endl;
-#endif
-                    }
-                }
-                
-                // Clear the graph's paths and copy back only the ones that were
-                // kept. I don't think there's a good way to leave an entry and
-                // mark it not real somehow.
-                graph.clear_path();
-                for(Path& path : paths_kept) {
-                    // Move all the paths we keep back.
-                    *(graph.add_path()) = move(path);
-                }
+                // Remove the matching paths.
+                remove_paths(graph, paths_to_take, &paths_taken);
 
                 // Sort out all the mappings from the paths we pulled out
                 for(Path& path : paths_taken) {

--- a/test/t/01_build_graph.t
+++ b/test/t/01_build_graph.t
@@ -8,3 +8,5 @@ PATH=../bin:$PATH # for vg
 plan tests 1
 
 is $(./build_graph | wc -l) 1 "graph building with the API"
+
+rm -rf build_graph.d build_graph.dSYM

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -90,7 +90,7 @@ rm -Rf e.xg e.gcsa e.vg
 vg index -k10 -g g.idx.gcsa -x g.idx.xg graphs/multimap.vg
 is $(vg map -M 2 -s "GCTAAGAGTAGGCCGGGGGTGTAGACCTTTGGGGTTGAATAAATCTATTGTACTAATCGG" -d g.idx -j | jq -c 'select(.is_secondary == true)' | wc -l) 1 "reads multi-map to multiple possible locations"
 
-rm -Rf g.idx
+rm -f g.idx.gcsa g.idx.xg
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 16 x.vg

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -28,6 +28,8 @@ is $subgraph_count 1 "vg stats reports the correct number of subgraphs"
 subgraph_length=$(vg stats -s z.vg | head -1 | cut -f 2)
 is $subgraph_length $graph_length  "vg stats reports the correct subgraph length"
 
+rm -f z.vg
+
 is $(vg view -Fv msgas/q_redundant.gfa | vg stats -S - | md5sum | cut -f 1 -d\ ) 01fadb6a004ddb87e5fc5d056b565218 "perfect to and from siblings are determined"
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-export LC_ALL="C" # force a consistent sort order 
+export LC_ALL="C" # force a consistent sort order
 
 plan tests 43
 
@@ -118,7 +118,7 @@ vg sim -s 1337 -n 100 -e 0.01 -i 0.005 -x x.xg -a >x.sim
 vg map -x x.xg -g x.gcsa -G x.sim -t 1 >x.gam
 vg mod -Z x.trans -i x.gam x.vg >x.mod.vg
 is $(vg view -Z x.trans | wc -l) 1288 "the expected graph translation is exported when the graph is edited"
-rm -rf x.vg x.xg x.gcsa x.reads x.gam x.mod.vg x.trans
+rm -rf x.vg x.xg x.gcsa x.reads x.gam x.mod.vg x.trans x.sim
 
 vg construct -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
@@ -127,7 +127,7 @@ vg sim -s 420 -l 30 -x 2snp.xg -n 30 -a >2snp.sim
 vg index -x flat.xg -g flat.gcsa -k 16 flat.vg
 vg map -g flat.gcsa -x flat.xg -G 2snp.sim -k 8 >2snp.gam
 is $(vg mod -i 2snp.gam flat.vg | vg mod -D - | vg mod -n - | vg view - | grep ^S | wc -l) 7 "editing the graph with many SNP-containing alignments does not introduce duplicate identical nodes"
-rm -f flat.vg 2snp.vg 2snp.xg 2snp.sim 2snp.gam
+rm -f flat.vg flat.gcsa flat.xg 2snp.vg 2snp.xg 2snp.sim 2snp.gam
 
 # Note the math (and subsetting) only works out on a flat alleles graph
 vg construct -r small/x.fa -a -f -v small/x.vcf.gz >x.vg

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -16,6 +16,7 @@ vg view -J -v call/tiny.json > tiny.vg
 true > empty.gam
 vg augment tiny.vg empty.gam -Z empty.aug.trans -S empty.aug.support > empty.aug.vg
 vg call empty.aug.vg -z empty.aug.trans -s empty.aug.support -b tiny.vg --no-vcf > calls.loci
+rm -f empty.gam
 
 LOCUS_COUNT="$(vg view --locus-in -j calls.loci | wc -l)"
 REF_LOCUS_COUNT="$(vg view --locus-in -j calls.loci | jq -c 'select(.genotype[0].allele == [0, 0])' | wc -l)"

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -59,4 +59,5 @@ vg chunk -x x.xg -n 5 -b x.chunk/
 is $(cat x.chunk/*vg | vg view -V - 2>/dev/null | md5sum | cut -f 1 -d\ ) $(vg view x.vg | md5sum | cut -f 1 -d\ ) "n-chunking works and chunks over the full graph"
 
 rm -rf x.gam.index x.gam.unsrt.index _chunk_test_bed.bed _chunk_test* x.chunk
-rm -f x.vg x.xg xg.gbwt x.gam x.gam.json filter_chunk*.gam chunks.bed
+rm -f x.vg x.xg x.gbwt x.gam x.gam.json filter_chunk*.gam chunks.bed
+rm -f chunk_*.annotate.txt

--- a/test/t/31_vg_add.t
+++ b/test/t/31_vg_add.t
@@ -39,5 +39,5 @@ is "$(vg view -Jv add/backward.json | vg add -v add/benedict.vcf - | vg stats -N
 
 is "$(vg view -Jv add/backward_and_forward.json | vg add -v add/benedict.vcf - | vg mod --unchop - | vg stats -N -)" "5" "graphs with backward and forward nodes can be added to"
 
-rm -rf ref.vg benedict.vg benedict.vg x-ref.vg x.vg refN.vg no-n.vg with-n.vg ngap.vg ngap-add.vg
+rm -rf ref.vg benedict.vg benedict2.vg x-ref.vg x.vg refN.vg no-n.vg with-n.vg ngap.vg ngap-add.vg
 

--- a/test/t/33_vg_mpmap.t
+++ b/test/t/33_vg_mpmap.t
@@ -55,7 +55,7 @@ independent_range=$(jq -r ".path.mapping[0].position.node_id" <  temp_independen
 is $(printf "%s\t%s\n" $paired_range $independent_range | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be consistent are closer together in node id space than unrestricted alignments"
 is $(printf "%s\t%s\n" $paired_range $distant_range | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be near each other are closer together in node id space than those forced to be far apart"
 
-rm temp_paired_alignment.json temp_independent_alignment.json
+rm -f temp_paired_alignment.json temp_distant_alignment.json temp_independent_alignment.json
 
 rm -f graphs/refonly-lrc_kir.vg.xg graphs/refonly-lrc_kir.vg.gcsa graphs/refonly-lrc_kir.vg.gcsa.lcp
 


### PR DESCRIPTION
I may have figured out why the Travis tests often time out on Mac.

The first tests in a freshly cloned repository work fine. They do not clean up properly afterwards. One of the files left behind is `x.gbwt`. On the next time, in `06_vg_index.t`, we run the following line:

```
vg map -T <(vg sim -s 1337 -n 100 -x x.xg) -d x > x1337.gam
```

This loads `x.gbwt`, and then things get out of control. For some reason, the `vg map` command uses tens of gigabytes of memory. Macs don't have that much memory, so they use swap instead.

The tests now delete all temporary files that would show up on `git status`. This hopefully fixes the issue.

Also, because I was really working on #1475, this PR includes other changes:

- `vg prune` builds the XG indexes it needs. We should not have to store XG indexes for individual files when indexing multi-file graphs.
- `vg index -g` takes the default values for `--kmer-size` and `--doubling-steps` from GCSA. As a result, it now builds 256-mer indexes by default.
- Temporary files are no longer hidden, and they will be written to the appropriate temp directory instead of the working directory. This is particularly important for the kmer files in `vg index -g`.
