### PR TITLE
Wrapping up loose ends on multithreading

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -150,10 +150,13 @@ size_t unpaired_for_each_parallel(function<bool(Alignment&)> get_read_if_availab
 #pragma omp parallel default(none) shared(batches_outstanding, batch, nLines, get_read_if_available, lambda)
 #pragma omp single
     {
-        // max # of such batches to be holding in memory
-        const uint64_t max_batches_outstanding = 1 << 9; // 512
-        // number of pairs in each batch
+        
+        // number of reads in each batch
         const uint64_t batch_size = 1 << 9; // 512
+        // max # of such batches to be holding in memory
+        uint64_t max_batches_outstanding = 1 << 9; // 512
+        // max # we will ever increase the batch buffer to
+        const uint64_t max_max_batches_outstanding = 1 << 13; // 8192
         
         // alignments to hold the incoming data
         Alignment aln;
@@ -194,8 +197,17 @@ size_t unpaired_for_each_parallel(function<bool(Alignment&)> get_read_if_availab
                         lambda(aln);
                     }
                     delete batch;
-#pragma omp atomic update
-                    batches_outstanding--;
+#pragma omp atomic capture
+                    current_batches_outstanding = --batches_outstanding;
+                    
+                    if (4 * current_batches_outstanding / 3 < max_batches_outstanding
+                        && max_batches_outstanding < max_max_batches_outstanding) {
+                        // we went through at least 1/4 of the batch buffer while we were doing this thread's batch
+                        // this looks risky, since we want the batch buffer to stay populated the entire time we're
+                        // occupying this thread on compute, so let's increase the batch buffer size
+                        
+                        max_batches_outstanding *= 2;
+                    }
                 }
                 else {
                     // spawn a new task to take care of this batch
@@ -229,10 +241,12 @@ size_t paired_for_each_parallel_after_wait(function<bool(Alignment&, Alignment&)
 #pragma omp single
     {
         
-        // max # of such batches to be holding in memory
-        const uint64_t max_batches_outstanding = 1 << 9; // 512
         // number of pairs in each batch
         const uint64_t batch_size = 1 << 9; // 512
+        // max # of such batches to be holding in memory
+        uint64_t max_batches_outstanding = 1 << 9; // 512
+        // max # we will ever increase the batch buffer to
+        const uint64_t max_max_batches_outstanding = 1 << 13; // 8192
         
         // alignments to hold the incoming data
         Alignment mate1, mate2;
@@ -265,15 +279,28 @@ size_t paired_for_each_parallel_after_wait(function<bool(Alignment&, Alignment&)
 #pragma omp atomic capture
                 current_batches_outstanding = ++batches_outstanding;
                 
-                if (current_batches_outstanding >= max_batches_outstanding || !single_threaded_until_true()) {
+                bool do_single_threaded = !single_threaded_until_true();
+                if (current_batches_outstanding >= max_batches_outstanding || do_single_threaded) {
                     // do this batch in the current thread because we've spawned the maximum number of
                     // concurrent batch tasks or because we are directed to work in a single thread
                     for (auto& p : *batch) {
                         lambda(p.first, p.second);
                     }
                     delete batch;
-#pragma omp atomic update
-                    batches_outstanding--;
+#pragma omp atomic capture
+                    current_batches_outstanding = --batches_outstanding;
+                    
+                    if (4 * current_batches_outstanding / 3 < max_batches_outstanding
+                        && max_batches_outstanding < max_max_batches_outstanding
+                        && !do_single_threaded) {
+                        // we went through at least 1/4 of the batch buffer while we were doing this thread's batch
+                        // this looks risky, since we want the batch buffer to stay populated the entire time we're
+                        // occupying this thread on compute, so let's increase the batch buffer size
+                        // (skip this adjustment if you're in single-threaded mode and thus expect the buffer to be
+                        // empty)
+                        
+                        max_batches_outstanding *= 2;
+                    }
                 }
                 else {
                     // spawn a new task to take care of this batch

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -232,13 +232,15 @@ void for_each_parallel_impl(std::istream& in,
     const uint64_t batch_size = 256;
     static_assert(batch_size % 2 == 0, "stream::for_each_parallel::batch_size must be even");
     // max # of such batches to be holding in memory
-    const uint64_t max_batches_outstanding = 256;
+    uint64_t max_batches_outstanding = 256;
+    // max # we will ever increase the batch buffer to
+    const uint64_t max_max_batches_outstanding = 1 << 13; // 8192
     // number of batches currently being processed
     uint64_t batches_outstanding = 0;
 
     // this loop handles a chunked file with many pieces
     // such as we might write in a multithreaded process
-    #pragma omp parallel default(none) shared(in, lambda1, lambda2, handle_count, batches_outstanding, single_threaded_until_true)
+    #pragma omp parallel default(none) shared(in, lambda1, lambda2, handle_count, batches_outstanding, max_batches_outstanding, single_threaded_until_true)
     #pragma omp single
     {
         auto handle = [](bool retval) -> void {
@@ -291,7 +293,9 @@ void for_each_parallel_impl(std::istream& in,
                     uint64_t b;
 #pragma omp atomic capture
                     b = ++batches_outstanding;
-                    if (b >= max_batches_outstanding || !single_threaded_until_true()) {
+                    
+                    bool do_single_threaded = !single_threaded_until_true();
+                    if (b >= max_batches_outstanding || do_single_threaded) {
                         
                         // process this batch in the current thread
                         {
@@ -304,8 +308,19 @@ void for_each_parallel_impl(std::istream& in,
                             }
                         } // scope obj1 & obj2
                         delete batch;
-#pragma omp atomic update
-                        batches_outstanding--;
+#pragma omp atomic capture
+                        b = --batches_outstanding;
+                        
+                        if (4 * b / 3 < max_batches_outstanding
+                            && max_batches_outstanding < max_max_batches_outstanding
+                            && !do_single_threaded) {
+                            // we went through at least 1/4 of the batch buffer while we were doing this thread's batch
+                            // this looks risky, since we want the batch buffer to stay populated the entire time we're
+                            // occupying this thread on compute, so let's increase the batch buffer size
+                            // (skip this adjustment if you're in single-threaded mode and thus expect the buffer to be
+                            // empty)
+                            max_batches_outstanding *= 2;
+                        }
                     }
                     else {
                         // spawn a task in another thread to process this batch


### PR DESCRIPTION
https://github.com/vgteam/vg/pull/1466 was mostly merged via https://github.com/vgteam/vg/pull/1456, but I wanted to address some last minute concerns about starving the buffer of loaded alignments if the IO thread got a particularly unbalanced and costly batch. Now it will try to detect when this might happen and increase the buffer size accordingly. Specifically, if more than 1/4 of the buffer gets eaten up while it's trying to process a batch, the buffer doubles (up to a point). It's a little hack-y, but I think it will circumvent this problem most of the time. I'm open to more robust options if anyone has them.