### PR TITLE
Skip SVs in VCF when running vg construct without -S

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1417,12 +1417,9 @@ namespace vg {
                 variant_source.get()->position + variant_source.get()->ref.size() <= reference_end) {
 
             // While we have variants we want to include
-
-            bool variant_acceptable = true;
-
-
             auto vvar = variant_source.get();
 
+            bool variant_acceptable = !vvar->is_sv();
             if (do_svs) {
                 variant_acceptable = vvar->canonicalize_sv(reference, insertions, true, -1);
                // now called implicitly in canonicalize: vvar->set_insertion_sequences(insertions);


### PR DESCRIPTION
Resolves #1488.  Does this look okay @edawson @adamnovak ?   It won't fix handling structure variants with -S, but at least it seems to skip them without -S, which is what I need to get into the docker image asap. 