### PR TITLE
Simplified indexing, part 2

### DIFF
--- a/src/phase_unfolder.cpp
+++ b/src/phase_unfolder.cpp
@@ -1,6 +1,7 @@
 #include "phase_unfolder.hpp"
 #include "progress_bar.hpp"
 
+#include <cassert>
 #include <iostream>
 #include <map>
 
@@ -8,6 +9,7 @@ namespace vg {
 
 PhaseUnfolder::PhaseUnfolder(const xg::XG& xg_index, const gbwt::GBWT& gbwt_index, vg::id_t next_node) :
     xg_index(xg_index), gbwt_index(gbwt_index), mapping(next_node) {
+    assert(this->mapping.begin() > this->xg_index.get_max_id());
 }
 
 void PhaseUnfolder::unfold(VG& graph, bool show_progress) {
@@ -222,6 +224,7 @@ void PhaseUnfolder::read_mapping(const std::string& filename) {
     }
     this->mapping.load(in);
     in.close();
+    assert(this->mapping.begin() > this->xg_index.get_max_id());
 }
 
 vg::id_t PhaseUnfolder::get_mapping(vg::id_t node) const {

--- a/src/subcommand/ids_main.cpp
+++ b/src/subcommand/ids_main.cpp
@@ -31,7 +31,7 @@ void help_ids(char** argv) {
         << "    -j, --join           make a joint id space for all the graphs that are supplied" << endl
         << "                         by iterating through the supplied graphs and incrementing" << endl
         << "                         their ids to be non-conflicting (modifies original files)" << endl
-        << "    -m, --mapping FILE   create an empty node mapping for vg prune (use with -j)" << endl
+        << "    -m, --mapping FILE   create an empty node mapping for vg prune" << endl
         << "    -s, --sort           assign new node IDs in (generalized) topological sort order" << endl;
 }
 
@@ -109,7 +109,7 @@ int main_ids(int argc, char** argv) {
         }
     }
 
-    if (!join) {
+    if (!join && mapping_name.empty()) {
         VG* graph;
         get_input_file(optind, argc, argv, [&](istream& in) {
             graph = new VG(in);
@@ -144,7 +144,7 @@ int main_ids(int argc, char** argv) {
         }
 
         VGset graphs(graph_file_names);
-        vg::id_t max_node_id = graphs.merge_id_space();
+        vg::id_t max_node_id = (join ? graphs.merge_id_space() : graphs.get_max_id());
         if (!mapping_name.empty()) {
             gcsa::NodeMapping mapping(max_node_id + 1);
             std::ofstream out(mapping_name, std::ios_base::binary);

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -445,14 +445,7 @@ int main_index(int argc, char** argv) {
             return 1;
         }
 
-        // Apparently there is no efficient way of determining the max id.
-        size_t id_width = 64;
-        {
-            xg::id_t max_id = 0;
-            size_t max_rank = xg_index->max_node_rank();
-            for (size_t i = 1; i <= max_rank; i++) { max_id = std::max(max_id, xg_index->rank_to_id(i)); }
-            id_width = gbwt::bit_length(gbwt::Node::encode(max_id, true));
-        }
+        size_t id_width = gbwt::bit_length(gbwt::Node::encode(xg_index->get_max_id(), true));
         if (show_progress) {
             cerr << "Node id width: " << id_width << endl;
         }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -177,26 +177,31 @@ string tmpfilename(const string& base) {
     return tmpname;
 }
 
-string find_temp_dir() {
-    // We need to find the system temp directory.
-    const char* system_temp_dir = nullptr;
-    
-    for(const char* var_name : {"TMPDIR", "TMP", "TEMP", "TEMPDIR", "USERPROFILE"}) {
-        // Try all these env vars in order
-        if (system_temp_dir == nullptr) {
-            system_temp_dir = getenv(var_name);
-        }
-    }
-    if (system_temp_dir == nullptr) {
-        // Then if none were set default to /tmp
-        system_temp_dir = "/tmp";
-    }
-    
-    return std::string(system_temp_dir);
-}
-
 string tmpfilename() {
     return tmpfilename("vg-");
+}
+
+namespace {
+    string current_temp_dir;
+}
+
+string find_temp_dir() {
+    // Get the default temp dir from environment variables.
+    if (current_temp_dir.empty()) {
+        const char* system_temp_dir = nullptr;
+        for(const char* var_name : {"TMPDIR", "TMP", "TEMP", "TEMPDIR", "USERPROFILE"}) {
+            if (system_temp_dir == nullptr) {
+                system_temp_dir = getenv(var_name);
+            }
+        }
+        current_temp_dir = (system_temp_dir == nullptr ? "/tmp" : system_temp_dir);
+    }
+
+    return current_temp_dir;
+}
+
+void set_temp_dir(const string& new_temp_dir) {
+    current_temp_dir = new_temp_dir;
 }
 
 string get_or_make_variant_id(const vcflib::Variant& variant) {

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -252,7 +252,10 @@ typename Collection::value_type logprob_sum(const Collection& collection) {
     return pulled_out + prob_to_logprob(total);
 }
 
-/// Find the system temp directory using defaults and environment variables
+/// Set a temp dir, overriding system defaults and environment variables.
+void set_temp_dir(const string& new_temp_dir);
+
+/// Get the current temp dir
 string find_temp_dir();
 
 /// Create a temporary file starting with the given base name in the appropriate system temporary directory

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -150,7 +150,10 @@ public:
     // these provide a way to get an index for each node and edge in the g_iv structure and are used by gPBWT
     size_t node_graph_idx(int64_t id) const;
     size_t edge_graph_idx(const Edge& edge) const;
-    
+
+    int64_t get_min_id() const { return min_id; }
+    int64_t get_max_id() const { return max_id; }
+
     ////////////////////////////////////////////////////////////////////////////
     // Here is the old low-level API that needs to be restated in terms of the 
     // locally traversable graph API and then removed.

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="en_US.utf8" # force ekg's favorite sort order 
 
-plan tests 35
+plan tests 32
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 
@@ -131,17 +131,11 @@ is $(vg index -g x.gcsa -k 16 -V cyclic/self_loops.vg 2>&1 |  grep 'Index verifi
 
 is $(vg index -g x.gcsa -k 16 -V cyclic/all.vg 2>&1 |  grep 'Index verification complete' | wc -l) 1 "GCSA2 index works on general cyclic graphs"
 
-is $(vg index -g x.gcsa -k 16 -V -F cyclic/no_heads.vg 2>&1 |  grep 'Index verification complete' | wc -l) 1 "GCSA2 forward-only indexing works on cyclic graphs with no heads or tails"
-
 rm -f x.gcsa x.gcsa.lcp
 
 is $(vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg index -g t.gcsa -k 16 -V - 2>&1 |  grep 'Index verification complete' | wc -l) 1 "GCSA2 indexing of a tiny graph works"
 
-is $(vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg index -g t.gcsa -k 16 -V - 2>&1 | grep 'Index verification complete' | wc -l) 1 "GCSA2 forward-only indexing of a tiny graph works"
-
 is $(vg construct -r tiny/tiny.fa | vg index -g t.gcsa -k 16 -V - 2>&1 | grep 'Index verification complete' | wc -l) 1 "GCSA2 indexing succeeds on a single-node graph"
-
-is $(vg construct -r tiny/tiny.fa | vg index -g t.gcsa -k 16 -V -F - 2>&1 | grep 'Index verification complete' | wc -l) 1 "GCSA2 forward-only indexing succeeds on a single-node graph"
 
 is $(vg index -g t.gcsa reversing/cactus.vg -k 16 -V 2>&1 | grep 'Index verification complete' | wc -l) 1 "GCSA2 indexing succeeds on graph with heads but no tails"
 

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -11,8 +11,8 @@ plan tests 1
 vg construct -m 32 -a -r small/xy.fa -v small/xy2.vcf.gz -R x -C >xy2_x.vg
 vg construct -m 32 -a -r small/xy.fa -v small/xy2.vcf.gz -R y -C >xy2_y.vg
 vg ids -j xy2_x.vg xy2_y.vg
-vg index -x xy2_x.xg -v small/xy2.vcf.gz --gbwt-name xy2_x.gbwt xy2_x.vg
-vg index -x xy2_y.xg -v small/xy2.vcf.gz --gbwt-name xy2_y.gbwt xy2_y.vg
+vg index -v small/xy2.vcf.gz --gbwt-name xy2_x.gbwt xy2_x.vg
+vg index -v small/xy2.vcf.gz --gbwt-name xy2_y.gbwt xy2_y.vg
 is $(vg gbwt --merge xy2_x.gbwt xy2_y.gbwt --fast --output xy2.gbwt -p | grep Sequences | tail -1 | awk '{ print $2 }' | grep 8 | wc -l) 1  "merged gbwt has correct number of sequences"
 
-rm -f xy2_x.vg xy2_x.xg xy2_x.gbwt xy2_y.vg xy2_y.xg xy2_y.gbwt
+rm -f xy2_x.vg xy2_x.gbwt xy2_y.vg xy2_y.gbwt xy2.gbwt


### PR DESCRIPTION
Implemented some new items from #1475:

* Reorganized `vg index`: GBWT construction is separate from XG; obsolete options were removed, slightly better organized command line help.
* Pass thread names and haplotype counts from GBWT construction to XG construction.
* Detect situations similar to #1483 in `PhaseUnfolder`.
* Override system temp directory with `set_temp_dir()`.
* Updated GCSA2: Avoid issues with >2 GB `read()` calls in GCC on macOS; delete temporary files when `std::exit()` is called.