### PR TITLE
Minimized stack traces for Mac and Linux systems

### DIFF
--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -53,6 +53,85 @@ const char* var = "VG_FULL_TRACEBACK";
 // fullTrace = false means env var was not set
 bool fullTrace = false;
 
+void stacktrace_manually(ostream& out, int signalNumber, void* ip, void** bp) {
+    // Now we compute our own stack trace, because backtrace() isn't so good on OS X.
+    // We operate on the same principles as <https://stackoverflow.com/a/5426269>
+
+    // Unfortunately this *only* seems to work even a little well on OS X; on Linux we get ip
+    // wandering off relatively quickly.
+    
+    // Allocate a place to keep the dynamic library info for the address the stack is executing at
+    Dl_info address_library;
+    
+    out << endl;
+    out << "Next ip: " << ip << " Next bp: " << bp << endl;
+    while (true) {
+        // Work out where the ip is.
+        if (!dladdr(ip, &address_library)) {
+            // This address doesn't belong to anything!
+            out << "Stack leaves code at ip=" << ip << endl;
+            break;
+        }
+
+        if (address_library.dli_sname != nullptr) {
+            // Make a place for the demangling function to save its status
+            int status;
+            
+            // Do the demangling
+            char* demangledName = abi::__cxa_demangle(address_library.dli_sname, NULL, NULL, &status);
+            
+            if(status == 0) {
+                // Successfully demangled
+                out << "Address " << ip << " in demangled symbol " << demangledName
+                    << " at offset " << (void*)((size_t)ip - ((size_t)address_library.dli_saddr))
+                    << ", in library " << address_library.dli_fname
+                    << " at offset " << (void*)((size_t)ip - ((size_t)address_library.dli_fbase)) << endl;
+                free(demangledName);
+            } else {
+                // Leave mangled
+                out << "Address " << ip << " in mangled symbol " << address_library.dli_sname
+                    << " at offset " << (void*)((size_t)ip - ((size_t)address_library.dli_saddr))
+                    << ", in library " << address_library.dli_fname
+                    << " at offset " << (void*)((size_t)ip - ((size_t)address_library.dli_fbase)) << endl;
+            }
+            
+            #ifdef __APPLE__
+                #ifdef VG_DO_ATOS
+                    // Try running atos to print a line number. This can be slow so we don't do it by default.
+                    stringstream command;
+                    
+                    command << "atos -o " << address_library.dli_fname << " -l " << address_library.dli_fbase << " " << ip;
+                    out << "Running " << command.str() << "..." << endl;
+                    system(command.str().c_str());
+                #endif
+            #endif
+            
+        } else {
+            out << "Address " << ip << " out of symbol in library " << address_library.dli_fname << endl;
+        }
+
+        if(address_library.dli_sname != nullptr && !strcmp(address_library.dli_sname, "main")) {
+            out << "Stack hit main" << endl;
+            break;
+        }
+
+        if (bp != nullptr) {
+            // Simulate a return
+            ip = bp[1];
+            bp = (void**) bp[0];
+        } else {
+            break;
+        }
+        
+        out << endl;
+        out << "Next ip: " << ip << " Next bp: " << bp << endl;
+    }
+    
+    out << "Stack trace complete" << endl;
+    out << endl;
+    
+}
+
 /// Emit a stack trace when something bad happens. Add as a signal handler with sigaction.
 void emit_stacktrace(int signalNumber, siginfo_t *signalInfo, void *signalContext) {
     ofstream tempStream;
@@ -68,14 +147,34 @@ void emit_stacktrace(int signalNumber, siginfo_t *signalInfo, void *signalContex
         tempStream.open(dirName+ "/stacktrace.txt");
         out = &tempStream;
     }
-
-    static backward::StackTrace stack_trace;
-    stack_trace.load_here(32);
-    static backward::Printer p;
-    p.color_mode = backward::ColorMode::automatic;
-    p.address = true;
-    p.object = true;
-    p.print(stack_trace, *out);
+    
+    #ifdef __APPLE__
+        // OS X 64 bit does it this way
+        // This holds the context that the signal came from, including registers and stuff
+        ucontext_t* context = (ucontext_t*) signalContext;
+        
+        // TODO: This assumes x86
+        // Fetch out the registers
+        // We model IP as a pointer to void (i.e. into code)
+        void* ip;
+        // We model BP as an array of two things: previous BP, and previous IP.
+        void** bp;
+        ip = (void*)context->uc_mcontext->__ss.__rip;
+        bp = (void**)context->uc_mcontext->__ss.__rbp;
+        *out << "Caught signal " << signalNumber << " raised at address " << ip << endl;
+        // Do our own tracing because backtrace doesn't really work on all platforms.
+        stacktrace_manually(*out,signalNumber, ip, bp);
+    #else
+        // Linux 64 bit does it this way
+        static backward::StackTrace stack_trace;
+        stack_trace.load_here(32);
+        static backward::Printer p;
+        p.color_mode = backward::ColorMode::automatic;
+        p.address = true;
+        p.object = true;
+        p.print(stack_trace, *out);
+        tempStream.close();
+    #endif
 
     if (fullTrace == false) {
         cerr << "ERROR: Signal "<< signalNumber << " occurred. VG has crashed. Run 'vg bugs --new' to report a bug." << endl;

--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -31,8 +31,11 @@
 #include <cstring>
 
 #include <cstdlib>
+#include <unistd.h>
 #include <string>
 #include <iostream>
+#include <fstream>
+#include <signal.h>
 
 #ifndef __APPLE__
     // Pull in backward-cpp and use libdw from elfutils.
@@ -44,7 +47,13 @@
 
 namespace vg {
 
-void stacktrace_manually_and_exit(int signalNumber, void* ip, void** bp) {
+// env var for getting full stack trace on cerr instead of a file path
+const char* var = "VG_FULL_TRACEBACK";
+// fullTrace = true means env var was set
+// fullTrace = false means env var was not set
+bool fullTrace = false;
+
+void stacktrace_manually(ostream& out, int signalNumber, void* ip, void** bp) {
     // Now we compute our own stack trace, because backtrace() isn't so good on OS X.
     // We operate on the same principles as <https://stackoverflow.com/a/5426269>
 
@@ -54,13 +63,13 @@ void stacktrace_manually_and_exit(int signalNumber, void* ip, void** bp) {
     // Allocate a place to keep the dynamic library info for the address the stack is executing at
     Dl_info address_library;
     
-    cerr << endl;
-    cerr << "Next ip: " << ip << " Next bp: " << bp << endl;
+    out << endl;
+    out << "Next ip: " << ip << " Next bp: " << bp << endl;
     while (true) {
         // Work out where the ip is.
         if (!dladdr(ip, &address_library)) {
             // This address doesn't belong to anything!
-            cerr << "Stack leaves code at ip=" << ip << endl;
+            out << "Stack leaves code at ip=" << ip << endl;
             break;
         }
 
@@ -73,14 +82,14 @@ void stacktrace_manually_and_exit(int signalNumber, void* ip, void** bp) {
             
             if(status == 0) {
                 // Successfully demangled
-                cerr << "Address " << ip << " in demangled symbol " << demangledName
+                out << "Address " << ip << " in demangled symbol " << demangledName
                     << " at offset " << (void*)((size_t)ip - ((size_t)address_library.dli_saddr))
                     << ", in library " << address_library.dli_fname
                     << " at offset " << (void*)((size_t)ip - ((size_t)address_library.dli_fbase)) << endl;
                 free(demangledName);
             } else {
                 // Leave mangled
-                cerr << "Address " << ip << " in mangled symbol " << address_library.dli_sname
+                out << "Address " << ip << " in mangled symbol " << address_library.dli_sname
                     << " at offset " << (void*)((size_t)ip - ((size_t)address_library.dli_saddr))
                     << ", in library " << address_library.dli_fname
                     << " at offset " << (void*)((size_t)ip - ((size_t)address_library.dli_fbase)) << endl;
@@ -92,17 +101,17 @@ void stacktrace_manually_and_exit(int signalNumber, void* ip, void** bp) {
                     stringstream command;
                     
                     command << "atos -o " << address_library.dli_fname << " -l " << address_library.dli_fbase << " " << ip;
-                    cerr << "Running " << command.str() << "..." << endl;
+                    out << "Running " << command.str() << "..." << endl;
                     system(command.str().c_str());
                 #endif
             #endif
             
         } else {
-            cerr << "Address " << ip << " out of symbol in library " << address_library.dli_fname << endl;
+            out << "Address " << ip << " out of symbol in library " << address_library.dli_fname << endl;
         }
 
         if(address_library.dli_sname != nullptr && !strcmp(address_library.dli_sname, "main")) {
-            cerr << "Stack hit main" << endl;
+            out << "Stack hit main" << endl;
             break;
         }
 
@@ -114,19 +123,30 @@ void stacktrace_manually_and_exit(int signalNumber, void* ip, void** bp) {
             break;
         }
         
-        cerr << endl;
-        cerr << "Next ip: " << ip << " Next bp: " << bp << endl;
+        out << endl;
+        out << "Next ip: " << ip << " Next bp: " << bp << endl;
     }
     
-    cerr << "Stack trace complete" << endl;
-    cerr << endl;
+    out << "Stack trace complete" << endl;
+    out << endl;
     
-    // Make sure to exit with the right code
-    exit(signalNumber + 128);
 }
 
 /// Emit a stack trace when something bad happens. Add as a signal handler with sigaction.
 void emit_stacktrace(int signalNumber, siginfo_t *signalInfo, void *signalContext) {
+    ofstream tempStream;
+    string dirName;
+    ostream* out;
+
+    if (fullTrace == true) {
+        out = &cerr;
+    } else {
+        char temp[] = "/tmp/vg_crash_XXXXXX";
+        char* tempDir = mkdtemp(temp);
+        dirName = tempDir;
+        tempStream.open(dirName+ "/stacktrace.txt");
+        out = &tempStream;
+    }
     // This holds the context that the signal came from, including registers and stuff
     ucontext_t* context = (ucontext_t*) signalContext;
     
@@ -147,17 +167,34 @@ void emit_stacktrace(int signalNumber, siginfo_t *signalInfo, void *signalContex
         bp = (void**)context->uc_mcontext.gregs[REG_RBP];
     #endif
 
-    cerr << "Caught signal " << signalNumber << " raised at address " << ip << endl;
+    *out << "Caught signal " << signalNumber << " raised at address " << ip << endl;
     
     
     // Do our own tracing because backtrace doesn't really work on all platforms.
-    stacktrace_manually_and_exit(signalNumber, ip, bp);
+    stacktrace_manually(*out,signalNumber, ip, bp);
+    if (fullTrace == false) {
+        cerr << "ERROR: Signal "<< signalNumber << " occurred. VG has crashed. Run 'vg bugs --new' to report a bug." << endl;
+        // Print path for stack trace file
+        cerr << "Stack trace path: "<< dirName << "/stacktrace.txt" << endl;
+    }
+    // Make sure to exit with the right code
+    exit(signalNumber + 128);
 }
 
 void enable_crash_handling() {
     // Set up stack trace support
 
     #ifdef __APPLE__
+        if (getenv(var) != nullptr) {
+            if (strcmp(getenv(var), "1") == 0) {
+                // if VG_FULL_TRACEBACK env var is set
+                fullTrace = true;
+            }
+        }
+        else {
+            // if VG_FULL_TRACEBACK env var is not set
+            fullTrace = false;
+        }
         // backtrace() doesn't work in our Mac builds, and backward-cpp uses backtrace().
         // Do this the old-fashioned way.
         

--- a/src/crash.hpp
+++ b/src/crash.hpp
@@ -1,9 +1,16 @@
 #ifndef VG_CRASH_HPP_INCLUDED
 #define VG_CRASH_HPP_INCLUDED
 
-// You will need to #define _POSIX_C_SOURCE 199309L or greater for this header
-// to work, because the types it uses from signal.h are behind that macro.
-#include <signal.h>
+/**
+ * \file crash.hpp
+ *
+ * Implementation for crash handling to create a stack trace when VG crashes.
+ * To use the crash handling system, call enable_crash_handling() early on in the program.
+ * When a crash occurs, you will recieve an error message with the path to the 
+ * stack trace file. To get the full stack trace on standard error, you need to
+ * set the environment variable 'VG_FULL_TRACEBACK=1'. 
+ *
+ */
 
 namespace vg {
 


### PR DESCRIPTION
Modified crash system to print stack trace to a file when a crash occurs. If an environment variable is set (VG_FULL_TRACEBACK=1), then the stack trace will output to standard error like normal. This works on Mac and Linux systems. 