### PR TITLE
Use negative values for penalties in SLLS to avoid NANs

### DIFF
--- a/src/haplotypes.cpp
+++ b/src/haplotypes.cpp
@@ -773,6 +773,15 @@ inputHaplotype* linear_haplo_structure::path_to_input_haplotype(const vg::Path& 
 }
 
 linear_haplo_structure::linear_haplo_structure(istream& slls_index, double log_mut_penalty, double log_recomb_penalty, xg::XG& xg_index, size_t xg_ref_rank) : xg_index(xg_index), xg_ref_rank(xg_ref_rank) {
+  
+  if (log_mut_penalty > 0) {
+    throw runtime_error("log mutation penalty must be negative");
+  }
+  
+  if (log_recomb_penalty > 0) {
+    throw runtime_error("log recombination penalty must be negative");
+  }
+  
   if(xg_ref_rank > xg_index.max_path_rank()) {
     throw runtime_error("reference path rank out of bounds");
   }
@@ -824,9 +833,10 @@ pair<double, bool> LinearScoreProvider::score(const vg::Path& path, haploMath::R
   // Memo is ignored; all penalties come from the index itself.
   auto scored = index.score(path);
   
-  // If we got a NAN, we can't very well say scoring succeeded.
-  // We can delete this when <https://github.com/vgteam/vg/issues/1534> is fixed.
-  scored.second &= !std::isnan(scored.first);
+  if (scored.second) {
+      // Yohei says there should never be NANs when it worked
+      assert(!std::isnan(scored.first));
+  }
   
   return scored;
 }

--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -347,6 +347,8 @@ public:
     size_t size() const;
   };
   
+  /// Make a new linear_haplo_structure with the given indexes, mutation and recombination scoring parameters, and reference path in the XG.
+  /// Penalties *must* be negative, and ought to be something like -9*2.3 mutation and -6*2.3 recombination.
   linear_haplo_structure(istream& slls_index, double log_mut_penalty, double log_recomb_penalty, xg::XG& xg_index, size_t xg_ref_rank);
   ~linear_haplo_structure();
   haplo_score_type score(const vg::Path& path) const;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -722,7 +722,7 @@ int main_mpmap(int argc, char** argv) {
         // What is the rank of our one and only reference path
         auto xg_ref_rank = xg_index.path_rank(sublinearLS_ref_path);
         
-        sublinearLS = new linear_haplo_structure(ls_stream, 9 * 2.3, 9 * 2.3, xg_index, xg_ref_rank);
+        sublinearLS = new linear_haplo_structure(ls_stream, -9 * 2.3, -6 * 2.3, xg_index, xg_ref_rank);
         haplo_score_provider = new haplo::LinearScoreProvider(*sublinearLS);
     }
     


### PR DESCRIPTION
Also use Yohei's suggested less severe recombination penalty.

This ought to fix #1534 and make sure it won't happen again.