### PR TITLE
Add is_reversed option into target_alignment

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1365,6 +1365,9 @@ void parse_bed_regions(istream& bedstream,
     size_t sbuf;
     size_t ebuf;
     string name;
+    size_t score;
+    string strand;
+    bool is_reverse = false;
 
     for (int line = 1; getline(bedstream, row); ++line) {
         if (row.size() < 2 || row[0] == '#') {
@@ -1380,13 +1383,19 @@ void parse_bed_regions(istream& bedstream,
         } else {
             ss >> name;
             assert(sbuf < ebuf);
+            ss >> score;
+            ss >> strand;
+
+            if(!ss.fail() && strand.compare("-") == 0) {
+                is_reverse = true;
+            }
 
             if (xgindex->path_rank(seq) == 0) {
                 // This path doesn't exist, and we'll get a segfault or worse if
                 // we go look for positions in it.
                 cerr << "warning: path \"" << seq << "\" not found in index, skipping" << endl;
             } else {
-                Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf, name);
+                Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf, name, is_reverse);
 
                 out_alignments->push_back(alignment);
             }

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1367,7 +1367,6 @@ void parse_bed_regions(istream& bedstream,
     string name;
     size_t score;
     string strand;
-    bool is_reverse = false;
 
     for (int line = 1; getline(bedstream, row); ++line) {
         if (row.size() < 2 || row[0] == '#') {
@@ -1386,6 +1385,7 @@ void parse_bed_regions(istream& bedstream,
             ss >> score;
             ss >> strand;
 
+            bool is_reverse = false;
             if(!ss.fail() && strand.compare("-") == 0) {
                 is_reverse = true;
             }

--- a/src/unittest/xg.cpp
+++ b/src/unittest/xg.cpp
@@ -323,6 +323,15 @@ TEST_CASE("Target to alignment extraction", "[xg-target-to-aln]") {
         REQUIRE(alignment_from_length(target) == 21);
     }
 
+    SECTION("Subpath getting gives us the expected inverted 7bp alignment") {
+        Alignment target = xg_index.target_alignment("path", 0, 7, "feature", true);
+        REQUIRE(alignment_from_length(target) == 7);
+        REQUIRE(target.path().mapping(0).position().node_id() == n2->id());
+        REQUIRE(target.path().mapping(1).position().node_id() == n0->id());
+        REQUIRE(target.path().mapping(0).position().is_reverse() == true);
+        REQUIRE(target.path().mapping(1).position().is_reverse() == true);
+    }
+
 }
 
 TEST_CASE("Path-based distance approximation in XG produces expected results", "[xg][mapping]") {

--- a/src/unittest/xg.cpp
+++ b/src/unittest/xg.cpp
@@ -304,22 +304,22 @@ TEST_CASE("Target to alignment extraction", "[xg-target-to-aln]") {
     xg::XG xg_index(graph);
 
     SECTION("Subpath getting gives us the expected 1bp alignment") {
-        Alignment target = xg_index.target_alignment("path", 1, 2, "feature");
+        Alignment target = xg_index.target_alignment("path", 1, 2, "feature", false);
         REQUIRE(alignment_from_length(target) == 2 - 1);
     }
 
     SECTION("Subpath getting gives us the expected 10bp alignment") {
-        Alignment target = xg_index.target_alignment("path", 10, 20, "feature");
+        Alignment target = xg_index.target_alignment("path", 10, 20, "feature", false);
         REQUIRE(alignment_from_length(target) == 20 - 10);
     }
 
     SECTION("Subpath getting gives us the expected 14bp alignment") {
-        Alignment target = xg_index.target_alignment("path", 0, 14, "feature");
+        Alignment target = xg_index.target_alignment("path", 0, 14, "feature", false);
         REQUIRE(alignment_from_length(target) == 14);
     }
 
     SECTION("Subpath getting gives us the expected 21bp alignment") {
-        Alignment target = xg_index.target_alignment("path", 0, 21, "feature");
+        Alignment target = xg_index.target_alignment("path", 0, 21, "feature", false);
         REQUIRE(alignment_from_length(target) == 21);
     }
 

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1,5 +1,6 @@
 #include "xg.hpp"
 #include "stream.hpp"
+#include "alignment.hpp"
 
 #include <bitset>
 #include <arpa/inet.h>
@@ -3730,7 +3731,7 @@ pos_t XG::graph_pos_at_path_position(const string& name, size_t path_pos) const 
     return make_pos_t(node_id, is_rev, offset);
 }
 
-Alignment XG::target_alignment(const string& name, size_t pos1, size_t pos2, const string& feature) const {
+Alignment XG::target_alignment(const string& name, size_t pos1, size_t pos2, const string& feature, bool is_reverse) const {
     Alignment aln;
     const XGPath& path = *paths[path_rank(name)-1];
     size_t first_node_start = path.offsets_select(path.offsets_rank(pos1+1));
@@ -3761,6 +3762,9 @@ Alignment XG::target_alignment(const string& name, size_t pos1, size_t pos2, con
         *aln.mutable_path() = cut_path(aln.path(), path_from_length(aln.path()) - trim_end).first;
     }
     aln.set_name(feature);
+    if (is_reverse) {
+       reverse_complement_alignment_in_place(&aln, [&](vg::id_t node_id) { return this->node_length(node_id); });
+    }
     return aln;
 }
 

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -304,7 +304,7 @@ public:
     size_t node_start_at_path_position(const string& name, size_t pos) const;
     /// Get the graph position at the given 0-based path position
     pos_t graph_pos_at_path_position(const string& name, size_t pos) const;
-    Alignment target_alignment(const string& name, size_t pos1, size_t pos2, const string& feature) const;
+    Alignment target_alignment(const string& name, size_t pos1, size_t pos2, const string& feature, bool is_reverse) const;
     size_t path_length(const string& name) const;
     size_t path_length(size_t rank) const;
     // nearest node (in steps) that is in a path, and the paths


### PR DESCRIPTION
Refer: #1544 
Now vg annotate accepts BED format with strands(+/-) -- gene/exon annotations include the direction of strands, which should not discard.