### PR TITLE
Fix MAF parsing in MSA constructor

### DIFF
--- a/src/msa_converter.hpp
+++ b/src/msa_converter.hpp
@@ -20,18 +20,19 @@ namespace vg {
 
 using namespace std;
 
-    class MSAConverter {
+    class MSAConverter : public Progressive  {
     public:
         
-        MSAConverter(istream& in, string format = "fasta", size_t max_node_length = numeric_limits<size_t>::max());
+        MSAConverter();
         ~MSAConverter();
         
-        VG make_graph(bool keep_paths = true);
+        void load_alignments(istream& in, string format = "fasta");
+        
+        VG make_graph(bool keep_paths = true, size_t max_node_length = numeric_limits<size_t>::max());
         
     private:
         
-        unordered_map<string, string> alignments;
-        size_t max_node_length;
+        vector<unordered_map<string, string>> alignments;
         
     };
 

--- a/src/unittest/msa_converter.cpp
+++ b/src/unittest/msa_converter.cpp
@@ -27,7 +27,8 @@ namespace vg {
                 
                 istringstream strm(input);
                 
-                MSAConverter msa_converter(strm, "fasta");
+                MSAConverter msa_converter;
+                msa_converter.load_alignments(strm, "fasta");
                 
                 VG graph = msa_converter.make_graph();
             }
@@ -38,7 +39,20 @@ namespace vg {
                 
                 istringstream strm(input);
                 
-                MSAConverter msa_converter(strm, "maf");
+                MSAConverter msa_converter;
+                msa_converter.load_alignments(strm, "maf");
+                
+                VG graph = msa_converter.make_graph();
+            }
+            
+            SECTION("MSAConverter can build from MAF input with multiple alignments") {
+                
+                string input = "##maf version=1\n\n# SNP\na score=0 mafExtractor_splicedBlock=true splice_id=1_0\ns human.1           0  3 +  10 GCA\ns chimp.2       0  3 +  8 GCA\ns cat.3    0  3 +  7 GTA\n\n# Indel and strand change\na score=0 mafExtractor_splicedBlock=true splice_id=1_0\ns human.1           3  7 +  10 GCAGAAT\ns chimp.2       3  5 +  8 GCAG--T\ns cat.3    0  4 -  7 --A-AAT";
+                
+                istringstream strm(input);
+                
+                MSAConverter msa_converter;
+                msa_converter.load_alignments(strm, "maf");
                 
                 VG graph = msa_converter.make_graph();
             }
@@ -49,7 +63,8 @@ namespace vg {
                 
                 istringstream strm(input);
                 
-                MSAConverter msa_converter(strm, "clustal");
+                MSAConverter msa_converter;
+                msa_converter.load_alignments(strm, "clustal");
                 
                 VG graph = msa_converter.make_graph();
             }
@@ -63,7 +78,8 @@ namespace vg {
                 
                 istringstream strm(input);
                 
-                MSAConverter msa_converter(strm, "fasta");
+                MSAConverter msa_converter;
+                msa_converter.load_alignments(strm, "fasta");
                 
                 VG graph = msa_converter.make_graph();
                 
@@ -80,9 +96,10 @@ namespace vg {
                 
                 istringstream strm(input);
                 
-                MSAConverter msa_converter(strm, "fasta", 1);
+                MSAConverter msa_converter;
+                msa_converter.load_alignments(strm, "fasta");
                 
-                VG graph = msa_converter.make_graph();
+                VG graph = msa_converter.make_graph(true, 1);
                 
                 Graph& g = graph.graph;
                 
@@ -96,7 +113,8 @@ namespace vg {
                 
                 istringstream strm(input);
                 
-                MSAConverter msa_converter(strm, "fasta");
+                MSAConverter msa_converter;
+                msa_converter.load_alignments(strm, "fasta");
                 
                 VG graph = msa_converter.make_graph();
                 
@@ -128,7 +146,8 @@ namespace vg {
                 
                 istringstream strm(input);
                 
-                MSAConverter msa_converter(strm, "fasta");
+                MSAConverter msa_converter;
+                msa_converter.load_alignments(strm, "fasta");
                 
                 VG graph = msa_converter.make_graph();
                 
@@ -158,7 +177,8 @@ namespace vg {
                 
                 istringstream strm(input);
                 
-                MSAConverter msa_converter(strm, "fasta");
+                MSAConverter msa_converter;
+                msa_converter.load_alignments(strm, "fasta");
                 
                 VG graph = msa_converter.make_graph();
                 
@@ -193,7 +213,8 @@ namespace vg {
                 
                 istringstream strm(input);
                 
-                MSAConverter msa_converter(strm, "fasta");
+                MSAConverter msa_converter;
+                msa_converter.load_alignments(strm, "fasta");
                 
                 VG graph = msa_converter.make_graph();
                 


### PR DESCRIPTION
The MAF parser would break on files with multiple contigs (https://github.com/vgteam/vg/issues/1563). This fixes the bug and also pretties-up some of the factoring and the user friendliness.