### PR TITLE
fill out the mapping edits in thread extraction

### DIFF
--- a/src/haplotype_extracter.hpp
+++ b/src/haplotype_extracter.hpp
@@ -30,7 +30,7 @@ void trace_haplotypes_and_paths(xg::XG& index, const gbwt::GBWT* haplotype_datab
                                 bool expand_graph = true);
 
 // Turns an (xg-based) thread_t into a (vg-based) Path
-Path path_from_thread_t(thread_t& t);
+Path path_from_thread_t(thread_t& t, xg::XG& index);
 
 // Lists all the sub-haplotypes of length extend_distance nodes starting at node
 // start_node from the set of haplotypes embedded as thread_t's in xg index.

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -467,7 +467,7 @@ int main_chunk(int argc, char** argv) {
         } else {
             if (chunk_graph || context_steps > 0) {
                 subgraph = new VG();
-                output_regions[i].seq = region.seq;                
+                output_regions[i].seq = region.seq;
                 chunker.extract_id_range(region.start, region.end,
                                          context_steps, context_length, trace,
                                          *subgraph, output_regions[i]);

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -3563,8 +3563,6 @@ void XG::get_path_range(const string& name, int64_t start, int64_t stop, Graph& 
                 p->set_name(m.first);
             }
             Path* new_path = local_paths[m.first];
-            // TODO output mapping direction
-            //if () { m.second.is_reverse(true); }
             for (auto& n : m.second) {
                 *new_path->add_mapping() = n;
             }


### PR DESCRIPTION
This resolves some warnings in tests and ensures that the chunked graph contains thread paths with the correct format.