### PR TITLE
Sketch out an annotation API over structs

### DIFF
--- a/src/annotation.hpp
+++ b/src/annotation.hpp
@@ -150,7 +150,10 @@ void set_annotation(Annotated* annotated, const string& name, const AnnotationTy
 
 template<typename Annotated>
 void clear_annotation(Annotated* annotated, const string& name) {
-    Annotation<Annotated>::clear(annotated, name);
+    // Get ahold of the struct
+    auto* annotation_struct = Annotation<Annotated>::get_mutable(annotated);
+    // Clear out that field
+    annotation_struct->mutable_fields()->clear(name);
 }
 
 }

--- a/src/annotation.hpp
+++ b/src/annotation.hpp
@@ -1,0 +1,160 @@
+/// \file annotation.hpp
+/// utilities for working with Struct-formatted annotations on Protobuf objects
+
+
+#ifndef VG_ANNOTATION_HPP_INCLUDED
+#define VG_ANNOTATION_HPP_INCLUDED
+
+#include <vector>
+#include <string>
+#include <type_traits>
+
+#include <google/protobuf/struct.pb.h>
+
+namespace vg {
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////
+// Internal Types
+////////////////////////////////////////////////////////////////////////
+
+/// We define an adapter for things that are annotated to let us get at the annotation struct.
+template<typename T>
+struct Annotation {
+    /// Get the immutable annotations Struct
+    static const google::protobuf::Struct& get(const T& t);
+    /// Get the mutable annotations struct.
+    static google::protobuf::Struct* get_mutable(T* t);
+    /// Clear all annotations
+    void clear(T* t);
+};
+
+/// Cast a Protobuf generic Value to any type.
+template <typename T, typename Enabled = void>
+T value_cast(const google::protobuf::Value& value);
+
+/// Cast any type to a generic Protobuf value.
+template<typename T,  typename Enabled = void>
+google::protobuf::Value value_cast(const T& wrap);
+
+
+////////////////////////////////////////////////////////////////////////
+// API
+////////////////////////////////////////////////////////////////////////
+
+
+/// Get the annotation with the given name and return it.
+/// If not present, returns the Protobuf default value for the annotation type.
+/// The value may be a primitive type or an entire Protobuf object.
+/// It is undefined behavior to read a value out into a different type than it was stored with.
+template<typename AnnotationType, typename Annotated>
+AnnotationType get_annotation(const Annotated& annotated, const string& name);
+
+/// Set the annotation with the given name to the given value.
+/// The value may be a primitive type or an entire Protobuf object.
+template<typename AnnotationType, typename Annotated>
+void set_annotation(Annotated* annotated, const string& name, const AnnotationType& annotation);
+
+/// Clear the annotation with the given name.
+template<typename Annotated>
+void clear_annotation(Annotated* annotated, const string& name);
+
+
+////////////////////////////////////////////////////////////////////////
+// Implementation
+////////////////////////////////////////////////////////////////////////
+
+template<typename T>
+const google::protobuf::Struct& Annotation<T>::get(const T& t) {
+    return t.annotation();
+}
+
+template<typename T>
+google::protobuf::Struct* Annotation<T>::get_mutable(T* t) {
+    return t->mutable_annotation();
+}
+
+template<typename T>
+void Annotation<T>::clear(T* t) {
+    t->clear_annotation();
+}
+
+template<>
+bool value_cast<bool, void>(const google::protobuf::Value& value) {
+    assert(value.kind_case() == google::protobuf::Value::KindCase::kBoolValue);
+    return value.bool_value();
+}
+
+template<>
+double value_cast<double, void>(const google::protobuf::Value& value) {
+    assert(value.kind_case() == google::protobuf::Value::KindCase::kNumberValue);
+    return value.number_value();
+}
+
+template<>
+string value_cast<string, void>(const google::protobuf::Value& value) {
+    assert(value.kind_case() == google::protobuf::Value::KindCase::kStringValue);
+    return value.string_value();
+}
+
+template<>
+google::protobuf::Value value_cast<bool, void>(const bool& wrap) {
+    google::protobuf::Value to_return;
+    to_return.set_bool_value(wrap);
+    return to_return;
+}
+
+template<>
+google::protobuf::Value value_cast<double, void>(const double& wrap) {
+    google::protobuf::Value to_return;
+    to_return.set_number_value(wrap);
+    return to_return;
+}
+
+template<>
+google::protobuf::Value value_cast<string, void>(const string& wrap) {
+    google::protobuf::Value to_return;
+    to_return.set_string_value(wrap);
+    return to_return;
+}
+
+// TODO: more value casts for e.g. vectors and ints and embedded messages.
+
+template<typename AnnotationType, typename Annotated>
+AnnotationType get_annotation(const Annotated& annotated, const string& name) {
+    // Grab the whole annotation struct
+    auto annotation_struct = Annotation<Annotated>::get(annotated);
+    
+    if (!annotation_struct.fields().count(name)) {
+        // Nothing is there.
+        // Return the Proto default value, by value-initializing.
+        return AnnotationType();
+    }
+    
+    // Get the Protobuf Value for this annotation name
+    auto value = annotation_struct.fields().at(name);
+    
+    // Pull out the right type.
+    return value_cast<AnnotationType>(value);
+}
+
+template<typename AnnotationType, typename Annotated>
+void set_annotation(Annotated* annotated, const string& name, const AnnotationType& annotation) {
+    // Get ahold of the struct
+    auto* annotation_struct = Annotation<Annotated>::get_mutable(annotated);
+    
+    // Set the key to the wrapped value
+    (*annotation_struct->mutable_fields())[name] = value_cast(annotation);
+}
+
+template<typename Annotated>
+void clear_annotation(Annotated* annotated, const string& name) {
+    Annotation<Annotated>::clear(annotated, name);
+}
+
+}
+
+
+
+#endif

--- a/src/unittest/annotation.cpp
+++ b/src/unittest/annotation.cpp
@@ -1,4 +1,4 @@
-/// \file annotations.cpp
+/// \file annotation.cpp
 ///  
 /// Unit tests for the annotations system on Alignments and MultipathAlignments
 ///
@@ -7,7 +7,9 @@
 #include <string>
 #include "../json2pb.h"
 #include "../vg.pb.h"
+#include "../annotation.hpp"
 #include "catch.hpp"
+
 
 namespace vg {
 namespace unittest {
@@ -24,12 +26,17 @@ TEST_CASE("Annotations can be populated", "[alignment][annotation]") {
         
         // It's undefined behavior to have a completely empty Value in the annotations Struct.
         // So put in a NullValue-holding Value.
-        (*aln.mutable_annotations()->mutable_fields())[key_name].set_null_value(google::protobuf::NullValue::NULL_VALUE);
+        (*aln.mutable_annotation()->mutable_fields())[key_name].set_null_value(google::protobuf::NullValue::NULL_VALUE);
         
-        (*aln.mutable_annotations()->mutable_fields())[key2_name].set_number_value(1000);
+        (*aln.mutable_annotation()->mutable_fields())[key2_name].set_number_value(1000);
         
-        REQUIRE(aln.annotations().fields().at(key_name).kind_case() == google::protobuf::Value::KindCase::kNullValue);
-        REQUIRE(aln.annotations().fields().at(key2_name).number_value() == 1000);
+        REQUIRE(aln.annotation().fields().at(key_name).kind_case() == google::protobuf::Value::KindCase::kNullValue);
+        REQUIRE(aln.annotation().fields().at(key2_name).number_value() == 1000);
+        
+        set_annotation(&aln, "exploding", true);
+        
+        REQUIRE(get_annotation<double>(aln, "dogs") == 1000.0);
+        REQUIRE(get_annotation<bool>(aln, "exploding") == true);
        
         string serialized = pb2json(aln);
         
@@ -37,8 +44,8 @@ TEST_CASE("Annotations can be populated", "[alignment][annotation]") {
         Alignment aln2;
         json2pb(aln2, serialized.c_str(), serialized.size());
        
-        REQUIRE(aln2.annotations().fields().count(key_name));
-        REQUIRE(aln2.annotations().fields().count(key2_name));
+        REQUIRE(aln2.annotation().fields().count(key_name));
+        REQUIRE(aln2.annotation().fields().count(key2_name));
     }
     
 }

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -148,7 +148,7 @@ message Alignment {
     Position to_correct = 36; // A path/offset/orientation pair specifying the distance to the correct alignment
     bool correctly_mapped = 37; // This can be set to true to annotate the Alignment as having been mapped correctly.
     
-    google.protobuf.Struct annotations = 100; // Annotations carried along with the Alignment.
+    google.protobuf.Struct annotation = 100; // Annotations carried along with the Alignment.
 }
 
 // A subgraph of the unrolled Graph in which each non-branching path is associated with an alignment
@@ -173,6 +173,8 @@ message MultipathAlignment {
     repeated uint32 start = 8;
 
     string paired_read_name = 9;
+    
+    google.protobuf.Struct annotation = 100; // Annotations carried along with the Alignment.
 }
 
 // A non-branching path of a MultipathAlignment


### PR DESCRIPTION
Here's a follow-on to #1616.

We can put annotations in Structs in the alignments, and read/write them with some templates:

```
set_annotation(&aln, "exploding", true);
get_annotation<double>(aln, "dogs") == 1000.0;
```

The JSON looks like:

```
{"annotation":{"cats":null,"dogs":1000,"exploding":true}}
```

Annotations are identified by strings, which isn't as safe (because you can typo them), but which may be sufficiently good.

If we like this I can extend the implementation to storing lists of things and entire protobuf messages (so we can annotate with Paths and so on), and I can start swapping out this API for some of the lesser-used annotation fields.

One caveat is that a Struct can't hold an int64 as a number; we'll get strings for node IDs inside Paths, just like in JSON. But converting back to Protobuf Path objects ought to take care of that.