### PR TITLE
increasing the version number seems to fix issue #1642

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -145,11 +145,12 @@ void XG::load(istream& in) {
         case 5: // Fall through
         case 6:
         case 7:
+        case 8:
             cerr << "warning:[XG] Loading an out-of-date XG format. In-memory conversion between versions can be time-consuming. "
                  << "For better performance over repeated loads, consider recreating this XG with 'vg index' "
                  << "or upgrading it with 'vg xg'." << endl;
             // Fall through
-        case 8:
+        case 9:
             {
                 sdsl::read_member(seq_length, in);
                 sdsl::read_member(node_count, in);
@@ -160,7 +161,7 @@ void XG::load(istream& in) {
                 sdsl::read_member(min_id, in);
                 sdsl::read_member(max_id, in);
                 
-                if (file_version <= 7) {
+                if (file_version <= 8) {
                     // Load the old id int vector to skip
                     int_vector<> i_iv;
                     i_iv.load(in);

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -111,9 +111,9 @@ public:
                bool is_sorted_dag);
                
     // What's the maximum XG version number we can read with this code?
-    const static uint32_t MAX_INPUT_VERSION = 8;
+    const static uint32_t MAX_INPUT_VERSION = 9;
     // What's the version we serialize?
-    const static uint32_t OUTPUT_VERSION = 8;
+    const static uint32_t OUTPUT_VERSION = 9;
                
     // Load this XG index from a stream. Throw an XGFormatError if the stream
     // does not produce a valid XG file.


### PR DESCRIPTION
Conversion code for xg changed from version 8 to 9 so that i_iv is not loaded in version 9