### PR TITLE
Address performance degradation associated with snarl cutting

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1611,30 +1611,30 @@ namespace vg {
         cerr << "final reachability:" << endl;
         cerr << "\tstarts from starts" << endl;
         for (const auto& record : reachable_starts_from_start) {
-            cerr << "\t\tStart of M" << record.first << ":" << endl;
+            cerr << "\t\tstart of M" << record.first << " is reachable from:" << endl;
             for (const auto& endpoint : record.second) {
-                cerr << "\t\t\tFrom start of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
+                cerr << "\t\t\tstart of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
             }
         }
         cerr << "\tends from starts" << endl;
         for (const auto& record : reachable_ends_from_start) {
-            cerr << "\t\tEnd of M" << record.first << ":" << endl;
+            cerr << "\t\tstart of M" << record.first << " is reachable from:" << endl;
             for (const auto& endpoint : record.second) {
-                cerr << "\t\t\tFrom start of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
+                cerr << "\t\t\tend of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
             }
         }
         cerr << "\tstarts from ends" << endl;
         for (const auto& record : reachable_starts_from_end) {
-            cerr << "\t\tStart of M" << record.first << ":" << endl;
+            cerr << "\t\tstart of M" << record.first << " is reachable from:" << endl;
             for (const auto& endpoint : record.second) {
-                cerr << "\t\t\tFrom end of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
+                cerr << "\t\t\tend of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
             }
         }
         cerr << "\tends from ends" << endl;
         for (const auto& record : reachable_ends_from_end) {
-            cerr << "\t\tEnd of M" << record.first << ":" << endl;
+            cerr << "\t\tend of M" << record.first << " is reachable from:" << endl;
             for (const auto& endpoint : record.second) {
-                cerr << "\t\t\tFrom end of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
+                cerr << "\t\t\tend of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
             }
         }
         cerr << "setting up structure of MEM graph" << endl;

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1611,28 +1611,28 @@ namespace vg {
         cerr << "final reachability:" << endl;
         cerr << "\tstarts from starts" << endl;
         for (const auto& record : reachable_starts_from_start) {
-            cerr << "\t\tstart of M" << record.first << " is reachable from:" << endl;
+            cerr << "\t\tstart of M" << record.first << " can reach:" << endl;
             for (const auto& endpoint : record.second) {
                 cerr << "\t\t\tstart of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
             }
         }
         cerr << "\tends from starts" << endl;
         for (const auto& record : reachable_ends_from_start) {
-            cerr << "\t\tstart of M" << record.first << " is reachable from:" << endl;
+            cerr << "\t\tstart of M" << record.first << " can reach:" << endl;
             for (const auto& endpoint : record.second) {
                 cerr << "\t\t\tend of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
             }
         }
         cerr << "\tstarts from ends" << endl;
         for (const auto& record : reachable_starts_from_end) {
-            cerr << "\t\tstart of M" << record.first << " is reachable from:" << endl;
+            cerr << "\t\end of M" << record.first << " can reach:" << endl;
             for (const auto& endpoint : record.second) {
-                cerr << "\t\t\tend of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
+                cerr << "\t\t\start of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
             }
         }
         cerr << "\tends from ends" << endl;
         for (const auto& record : reachable_ends_from_end) {
-            cerr << "\t\tend of M" << record.first << " is reachable from:" << endl;
+            cerr << "\t\tend of M" << record.first << " can reach:" << endl;
             for (const auto& endpoint : record.second) {
                 cerr << "\t\t\tend of M" << endpoint.first << " (dist " << endpoint.second << ")" << endl;
             }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2316,15 +2316,9 @@ namespace vg {
                       
         if (snarl_manager) {
             // We want to do snarl cutting
-            
-            // We need to have no reachability edges to do it
-            multi_aln_graph.clear_reachability_edges();
         
             // Do the snarl cutting, which modifies the nodes in the multipath alignment graph
             multi_aln_graph.resect_snarls_from_paths(snarl_manager, node_trans, max_snarl_cut_size);
-            
-            // But then we need to reconstruct the reachability edges afterwards
-            multi_aln_graph.add_reachability_edges(align_graph, node_trans, node_inj);
         }
 
 #ifdef debug_multipath_mapper_alignment


### PR DESCRIPTION
I'm not sure if this will fix all performance problems associated with snarl cutting, but it at least addresses https://github.com/vgteam/vg/issues/1583. The issue with this particular case was that the reachability edges were being completely recalculated to fill in the cut-out segments from the snarls, but this was occurring after the edges had been pruned to high-scoring paths. That led to a previously pruned edge being rediscovered in the second reachability calculation, which reconnected two disconnected components, which we were otherwise able to identify as separate mappings. I've modified the snarl-cutting algorithm to record information during the cutting process that can be used to create edges directly, which obviates the need for the second reachability calculation.