### PR TITLE
Add cairo dependency on to Mac build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then build with `. ./source_me.sh && make static`, and run with `./bin/vg`.
 
 VG won't build with XCode's compiler (clang), but it should work with GCC >= 4.9.  One way to install the latter (and other dependencies) is to install [Mac Ports](https://www.macports.org/install.php), then run:
 
-    sudo port install gcc7 libtool jansson jq cmake pkgconfig autoconf automake libtool coreutils samtools redland bison gperftools md5sha1sum rasqal gmake autogen clang-3.8
+    sudo port install gcc7 libtool jansson jq cmake pkgconfig autoconf automake libtool coreutils samtools redland bison gperftools md5sha1sum rasqal gmake autogen cairo clang-3.8
 
 To make GCC 7 the default compiler, run (use `none` instead of `mp-gcc7` to revert back):
 


### PR DESCRIPTION
I'm not going to wait for Jenkins on this one. Resolves https://github.com/vgteam/vg/issues/1670.