### PR TITLE
Tolerate badly-unmapped reads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,8 @@ CXXFLAGS := -O3 -fopenmp -std=c++11 -ggdb -g -MMD -MP $(CXXFLAGS)
 LD_INCLUDE_FLAGS:=-I$(CWD)/$(INC_DIR) -I. -I$(CWD)/$(SRC_DIR) -I$(CWD)/$(UNITTEST_SRC_DIR) -I$(CWD)/$(SUBCOMMAND_SRC_DIR) -I$(CWD)/$(CPP_DIR) -I$(CWD)/$(INC_DIR)/dynamic -I$(CWD)/$(INC_DIR)/sonLib $(shell pkg-config --cflags cairo)
 
 LD_LIB_FLAGS:= -L$(CWD)/$(LIB_DIR) -lvcflib -lgssw -lssw -lprotobuf -lsublinearLS -lhts -lpthread -ljansson -lncurses -lgcsa2 -lgbwt -ldivsufsort -ldivsufsort64 -lvcfh -lgfakluge -lraptor2 -lsdsl -lpinchesandcacti -l3edgeconnected -lsonlib -lfml -llz4 -lstructures -lvw -lboost_program_options -lallreduce
-LD_LIB_FLAGS += $(shell pkg-config --libs cairo)
-LD_LIB_FLAGS += $(shell pkg-config --libs pixman-1)
-LD_LIB_FLAGS += $(shell pkg-config --libs freetype2)
-LD_LIB_FLAGS += $(shell pkg-config --libs libpng)
-LD_LIB_FLAGS += $(shell pkg-config --libs fontconfig)
-LD_LIB_FLAGS += $(shell pkg-config --libs expat)
+# Use pkg-config to find Cairo and all the libs it uses
+LD_LIB_FLAGS += $(shell pkg-config --libs --static cairo)
 
 ifeq ($(shell uname -s),Darwin)
 	# We may need libraries from Macports

--- a/jenkins/Dockerfile.jenkins
+++ b/jenkins/Dockerfile.jenkins
@@ -19,7 +19,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
     make \
     git \
     zlib1g-dev \
-    rs
+    rs \
+    libffi-dev
 
 ADD http://mirrors.kernel.org/ubuntu/pool/universe/b/bwa/bwa_0.7.15-5_amd64.deb /tmp/bwa.deb
 RUN dpkg -i /tmp/bwa.deb

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -663,6 +663,13 @@ int main_find(int argc, char** argv) {
             function<void(Alignment&)> lambda = [&nodes](Alignment& aln) {
                 // accumulate nodes matched by the path
                 auto& path = aln.path();
+                if (path.mapping_size() == 1 && !path.mapping(0).has_position() &&
+                    path.mapping(0).edit_size() == 1 && edit_is_insertion(path.mapping(0).edit(0))) {
+                    // This read is a (presumably full length) insert to no
+                    // position. The aligner (used to?) generate these for some
+                    // unmapped reads. We should skip it.
+                    return;
+                }
                 for (int i = 0; i < path.mapping_size(); ++i) {
                     nodes.insert(path.mapping(i).position().node_id());
                 }

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1330,7 +1330,10 @@ Node XG::node(int64_t id) const {
 
 string XG::node_sequence(int64_t id) const {
     size_t rank = id_to_rank(id);
-    assert(rank != 0); // We can crash if we try to look up rank 0.
+    if (rank == 0) {
+        // Node isn't there
+        throw runtime_error("xg cannot get sequence for nonexistent node " + to_string(id));
+    }
     size_t start = s_bv_select(rank);
     size_t end = rank == node_count ? s_bv.size() : s_bv_select(rank+1);
     string s; s.resize(end-start);


### PR DESCRIPTION
Also use pkg-config to recursively find libs for Cairo.