### PR TITLE
Increase protobuf message limit

### DIFF
--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -20,7 +20,7 @@
 namespace stream {
 
 /// Protobuf will refuse to read messages longer than this size.
-const size_t MAX_PROTOBUF_SIZE = 67108864;
+const size_t MAX_PROTOBUF_SIZE = 1000000000;
 /// We aim to generate messages that are this size
 const size_t TARGET_PROTOBUF_SIZE = MAX_PROTOBUF_SIZE/2;
 


### PR DESCRIPTION
Given that
* vg io always goes through an api where we can adjust limits (currently stream.hpp)
* the world isn't any more secure by us breaking graphs into smaller chunks
* the 64MB default limit can't necessarily hold a whole-chromosome path

I propose boosting it up to a gig.  This seems to work on a few local tests.  Any objections?