### PR TITLE
Use return statements instead of dark pacts to return values

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/vgteam/vcflib.git
 [submodule "fastahack"]
 	path = deps/fastahack
-	url = https://github.com/ekg/fastahack.git
+	url = https://github.com/vgteam/fastahack.git
 [submodule "gssw"]
 	path = deps/gssw
 	url = https://github.com/ekg/gssw.git

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ include $(wildcard $(ALGORITHMS_OBJ_DIR)/*.d)
 include $(wildcard $(UNITTEST_OBJ_DIR)/*.d)
 include $(wildcard $(SUBCOMMAND_OBJ_DIR)/*.d)
 
-CXXFLAGS := -O3 -fopenmp -std=c++11 -ggdb -g -MMD -MP $(CXXFLAGS)
+CXXFLAGS := -O3 -fopenmp -Werror=return-type -std=c++11 -ggdb -g -MMD -MP $(CXXFLAGS)
 
 LD_INCLUDE_FLAGS:=-I$(CWD)/$(INC_DIR) -I. -I$(CWD)/$(SRC_DIR) -I$(CWD)/$(UNITTEST_SRC_DIR) -I$(CWD)/$(SUBCOMMAND_SRC_DIR) -I$(CWD)/$(CPP_DIR) -I$(CWD)/$(INC_DIR)/dynamic -I$(CWD)/$(INC_DIR)/sonLib $(shell pkg-config --cflags cairo)
 
@@ -134,7 +134,7 @@ DEP_OBJ =
 DEP_OBJ += $(OBJ_DIR)/vg.pb.o 
 DEP_OBJ += $(OBJ_DIR)/progress_bar.o
 DEP_OBJ += $(OBJ_DIR)/sha1.o
-DEP_ONJ += $(OBJ_DIR)/Fasta.o
+DEP_OBJ += $(OBJ_DIR)/Fasta.o
 
 
 # These are libraries that we need to build before we link vg.

--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -154,9 +154,8 @@ namespace vg {
             start = min(start, (int64_t) var.position);
             end = max(end, (int64_t) var.get_sv_end(0));
             return std::make_pair( start, end);
-        }
-        else{
-            
+        } else {
+            throw runtime_error("get_bounds(Variant, bool) not implemented for non-SV variants!");
         }
     }
 

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -441,6 +441,7 @@ namespace vg{
             return inverse ? Alignment() : aln;
         }
 
+        return inverse ? Alignment() : aln;
 
     }
 
@@ -613,6 +614,7 @@ namespace vg{
         
         if (found){
             //return ret_alns;
+            throw runtime_error("Unimplemented!");
         }
         else {
             return make_pair(Alignment(), Alignment());
@@ -626,16 +628,16 @@ namespace vg{
     * one-end anchored / softclipped portions
     * and read depth, one day
     */
-    pair<Locus, Locus> Filter::insertion_filter(Alignment& aln_first, Alignment& aln_second){
-        
+    pair<Locus, Locus> Filter::insertion_filter(Alignment& aln_first, Alignment& aln_second) {
+        throw runtime_error("Unimplemented!");
     }
 
     /**
     * Find reads that support duplications
     *
     */
-    pair<Locus, Locus> Filter::duplication_filter(Alignment& aln_first, Alignment& aln_second){
-
+    pair<Locus, Locus> Filter::duplication_filter(Alignment& aln_first, Alignment& aln_second) {
+        throw runtime_error("Unimplemented!");
     }
 
     /**
@@ -650,6 +652,8 @@ namespace vg{
         if (pair_orientation_filter(aln_first, aln_second)){
             return true;
         }
+        // TODO: Full implementation
+        return false;
     }
 
     /**
@@ -657,7 +661,7 @@ namespace vg{
     * we'd like to report all possible breakends, even if that don't match an SV type very well.
     */
     pair<Locus, Locus> Filter::breakend_filter(Alignment& aln_first, Alignment& aln_second){
-
+        throw runtime_error("Unimplemented!");
     }
 
 
@@ -763,8 +767,9 @@ namespace vg{
 
 
     Alignment Filter::coverage_filter(Alignment& aln){
-
+        throw runtime_error("Unimplemented!");
     }
+    
     Alignment Filter::avg_qual_filter(Alignment& aln){
         double total_qual = 0.0;
         // If the parameter for window size is zero, set the local equivalent

--- a/src/gamsorter.cpp
+++ b/src/gamsorter.cpp
@@ -11,8 +11,6 @@ using namespace vg;
 class AlnSorter{
     bool invert = false;
 public:
-  bool mycomparison(const bool& reverse=false)
-  {invert = reverse;}
   bool operator() (const Alignment& a_one, const Alignment& a_two) const
   {
 
@@ -309,6 +307,8 @@ void GAMSorter::stream_sort(string gamfile){
                 return true;
             }
         //}
+        
+        return false;
      };
 
 

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -481,6 +481,8 @@ vector<bool> SimpleConsistencyCalculator::calculate_consistency(const Snarl& sit
                 }
 
             }
+            
+        return consistencies;
 }
 
 SimpleTraversalSupportCalculator::~SimpleTraversalSupportCalculator(){

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -510,6 +510,7 @@ string Index::entry_to_string(const string& key, const string& value) {
         return traversal_entry_to_string(key, value);
         break;
     default:
+        throw runtime_error("Unrecognized type " + key.substr(0, 1));
         break;
     }
 }

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -405,6 +405,7 @@ ostream& Packer::as_table(ostream& out, bool show_edits) {
         }
         out << endl;
     }
+    return out;
 }
 
 ostream& Packer::show_structure(ostream& out) {

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -642,6 +642,8 @@ Visit SnarlManager::next_snarl(const Visit& here) const {
         // We came out our end. So the next thing is backward if its start doesn't match our end.
         to_return.set_backward(next->start().node_id() != here_snarl->end().node_id());
     }
+    
+    return to_return;
 }
     
 Visit SnarlManager::prev_snarl(const Visit& here) const {
@@ -1008,7 +1010,7 @@ deque<Chain> SnarlManager::compute_chains(const vector<const Snarl*>& input_snar
         // Make a visit to the child
         Visit here;
         transfer_boundary_info(*snarl, *here.mutable_snarl());
-            
+        
         for (Visit walk_left = prev_snarl(here);
              walk_left.has_snarl() && !seen.count(manage(walk_left.snarl()));
              walk_left = prev_snarl(walk_left)) {

--- a/src/srpe.cpp
+++ b/src/srpe.cpp
@@ -4,15 +4,15 @@ using namespace std;
 namespace vg{
 
     double SRPE::discordance_score(vector<Alignment> alns, VG* subgraph){
-    // Sum up the mapping scores
-    // subtract the soft clips
-    // the discordant insert size reads
-    // and a flat penalty for discordant orientation
-
+        // Sum up the mapping scores
+        // subtract the soft clips
+        // the discordant insert size reads
+        // and a flat penalty for discordant orientation
+        throw runtime_error("Unimplemented!");
     }
 
     void SRPE::call_svs_paired_end(vg::VG* graph, ifstream& gamstream, vector<BREAKPOINT>& bps, string refpath){
-
+        
     }
 
     void SRPE::call_svs_split_read(vg::VG* graph, ifstream& gamstream, vector<BREAKPOINT>& bps, string refpath){

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -31,6 +31,8 @@ const size_t TARGET_PROTOBUF_SIZE = MAX_PROTOBUF_SIZE/2;
 ///
 /// Adaptively sets the chunk size, in elements, so that no too-large Protobuf
 /// records are serialized.
+///
+/// Returns true on success, but throws errors on failure.
 template <typename T>
 bool write(std::ostream& out, uint64_t element_count, uint64_t chunk_elements,
     const std::function<T(uint64_t, uint64_t)>& lambda) {
@@ -93,7 +95,7 @@ bool write(std::ostream& out, uint64_t element_count, uint64_t chunk_elements,
         }
     }
     
-    
+    return true;
 
 }
 

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -628,7 +628,7 @@ int split_gam(istream& gam_stream, size_t chunk_size, const string& out_prefix, 
                 out_file.open(out_name.str());
                 if (!out_file) {
                     cerr << "error[vg chunk]: unable to open output gam: " << out_name.str() << endl;
-                    return 1;
+                    exit(1);
                 }
             }
             gam_buffer.push_back(alignment);

--- a/src/variant_recall.cpp
+++ b/src/variant_recall.cpp
@@ -238,18 +238,6 @@ void variant_recall(VG* graph,
         return ( (double) matches / (double) tot_len) > 0.85;
     };
 
-    std::function<bool(const Mapping& m)> perfect_matches = [&](const Mapping& m){
-
-        for (int i = 0; i < m.edit_size(); i++){
-            Edit e = m.edit(i);
-            if (e.to_length() != e.from_length() || !e.sequence().empty()){
-                return false;
-            }
-            return true;
-        }
-    };
-
-
     std::function<void(Alignment&)> incr = [&](const Alignment& a){
         bool anchored = false;
         bool contained = false;

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -465,6 +465,8 @@ id_t VG::get_node_at_nucleotide(string pathname, int nuc){
             throw std::out_of_range("Nucleotide position not found in path.");
         }
     }
+    
+    throw std::out_of_range("Nucleotide position not found in path.");
 
 }
 


### PR DESCRIPTION
Add -Werror=return-type so this can never happen again.

Also use a Fastahack that fixes string logic errors caused by
its own missing return statements.