### PR TITLE
Fix mpmap crash with low k GCSA indexes

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -186,6 +186,10 @@ namespace vg {
             num_mappings++;
         }
         
+#ifdef debug_multipath_mapper
+        cerr << "splitting multicomponent alignments..." << endl;
+#endif
+        
         // split up any alignments that ended up being disconnected
         split_multicomponent_alignments(multipath_alns_out);
         


### PR DESCRIPTION
Ran into a signal 6 bug in mpmap. Turns out we were probably mostly avoiding it because we're using k-mer lengths longer than our typical reads now, but I figure it's good not to crash either way.