### PR TITLE
Add --ignore-site-config option to b2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ $(LIB_DIR)/libvw.a: $(LIB_DIR)/libboost_program_options.a $(VOWPALWABBIT_DIR)/* 
 $(LIB_DIR)/liballreduce.a: $(LIB_DIR)/libvw.a
 
 $(LIB_DIR)/libboost_program_options.a: $(BOOST_DIR)/libs/program_options/src/* $(BOOST_DIR)/boost/program_options/*
-	+. ./source_me.sh && cd $(BOOST_DIR) && ./bootstrap.sh --with-libraries=program_options --libdir=$(CWD)/$(LIB_DIR) --includedir=$(CWD)/$(INC_DIR) $(FILTER) && ./b2 --link=static install $(FILTER)
+	+. ./source_me.sh && cd $(BOOST_DIR) && ./bootstrap.sh --with-libraries=program_options --libdir=$(CWD)/$(LIB_DIR) --includedir=$(CWD)/$(INC_DIR) $(FILTER) && ./b2 --ignore-site-config --link=static install $(FILTER)
 	+. ./source_me.sh && if [[ $(shell uname -s) == "Darwin" ]]; then install_name_tool -id $(CWD)/$(LIB_DIR)/libboost_program_options.dylib $(CWD)/$(LIB_DIR)/libboost_program_options.dylib; fi
 
 $(INC_DIR)/sha1.hpp: $(SHA1_DIR)/sha1.hpp


### PR DESCRIPTION
Fixes an issue building on distributions with a site-wide configuration file (in my case Gentoo Linux).

Without this option the build fails with:

```
...
[ 33%] Building C object src/CMakeFiles/raptor2.dir/turtle_common.c.o
/home/garetjax/workspace/vgteam/vg/deps/boost-subset/tools/build/src/build/feature.jam:491: in feature.validate-value-string from module feature
error: "none" is not a known value of feature <optimization>
error: legal values: "off" "speed" "space"
/home/garetjax/workspace/vgteam/vg/deps/boost-subset/tools/build/src/build/property.jam:341: in validate1 from module property
/home/garetjax/workspace/vgteam/vg/deps/boost-subset/tools/build/src/build/property.jam:367: in property.validate from module property
/home/garetjax/workspace/vgteam/vg/deps/boost-subset/tools/build/src/tools/features/variant-feature.jam:70: in variant from module variant-feature
/usr/share/boost-build/site-config.jam:9: in modules.load from module site-config
/home/garetjax/workspace/vgteam/vg/deps/boost-subset/tools/build/src/build-system.jam:255: in load-config from module build-system
/home/garetjax/workspace/vgteam/vg/deps/boost-subset/tools/build/src/build-system.jam:425: in load-configuration-files from module build-system
/home/garetjax/workspace/vgteam/vg/deps/boost-subset/tools/build/src/build-system.jam:607: in load from module build-system
/home/garetjax/workspace/vgteam/vg/deps/boost-subset/tools/build/src/kernel/modules.jam:295: in import from module modules
/home/garetjax/workspace/vgteam/vg/deps/boost-subset/tools/build/src/kernel/bootstrap.jam:139: in boost-build from module
/home/garetjax/workspace/vgteam/vg/deps/boost-subset/boost-build.jam:17: in module scope from module

make: *** [Makefile:362: lib/libboost_program_options.a] Error 1
make: *** Waiting for unfinished jobs....
...
```