### PR TITLE
Shuffle alignment hits before sorts

### DIFF
--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -1473,7 +1473,7 @@ class VGCITest(TestCase):
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'primary', True, tag_ext='-genotype', genotype=True)
         
-    @timeout_decorator.timeout(1600)        
+    @timeout_decorator.timeout(1800)        
     def test_map_mhc_snp1kg_genotype(self):
         """ Mapping and calling (with vg genotype) bakeoff F1 test for MHC snp1kg graph 
         """

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2627,18 +2627,18 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
             frag_stats.save_frag_lens_to_alns(aln1, aln2, approx_frag_lengths, pair_consistent(aln1, aln2, 1e-6));
         }
         // sort the aligned pairs by score
-        std::sort(aln_ptrs.begin(), aln_ptrs.end(),
-                  [&](pair<Alignment, Alignment>* pair1,
-                      pair<Alignment, Alignment>* pair2) {
-                      double weight1=0, weight2=0;
-                      if (frag_stats.fragment_size) {
-                          weight1 = pair1->first.fragment_score();
-                          weight2 = pair2->first.fragment_score();
-                      }
-                      double score1 = (pair1->first.score() + pair1->second.score());
-                      double score2 = (pair2->first.score() + pair2->second.score());
-                      return score1 + weight1 > score2 + weight2;
-                  });
+        sort_shuffling_ties(aln_ptrs.begin(), aln_ptrs.end(),
+                            [&](pair<Alignment, Alignment>* pair1,
+                                pair<Alignment, Alignment>* pair2) {
+                                double weight1=0, weight2=0;
+                                if (frag_stats.fragment_size) {
+                                    weight1 = pair1->first.fragment_score();
+                                    weight2 = pair2->first.fragment_score();
+                                }
+                                double score1 = (pair1->first.score() + pair1->second.score());
+                                double score2 = (pair2->first.score() + pair2->second.score());
+                                return score1 + weight1 > score2 + weight2;
+                            });
         seen_alignments.clear();
         // remove duplicates (same score and same start position of both pairs)
         aln_ptrs.erase(
@@ -2771,9 +2771,6 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         flat_alns.push_back(&aln_pair->second);
     }
     apply_haplotype_consistency_scores(flat_alns);
-
-    // Before the final sort, shuffle everything to avoid bias to one strand/contig/etc.
-    deterministic_shuffle(aln_ptrs.begin(), aln_ptrs.end(), first_mate.sequence() + second_mate.sequence()); 
 
     sort_and_dedup();
     show_alignments("mixed");
@@ -3263,14 +3260,11 @@ Mapper::align_mem_multi(const Alignment& aln,
     // Apply haplotype consistency scoring if possible
     apply_haplotype_consistency_scores(aln_ptrs);
     
-    // Shuffle alignments deterministically to prevent bias towards one strand/contig/etc.
-    deterministic_shuffle(aln_ptrs.begin(), aln_ptrs.end(), aln.sequence()); 
-    
     // sort alignments by score
-    std::sort(aln_ptrs.begin(), aln_ptrs.end(),
-              [&](Alignment* a1, Alignment* a2) {
-                  return a1->score() > a2->score();
-              });
+    sort_shuffling_ties(aln_ptrs.begin(), aln_ptrs.end(),
+                        [&](Alignment* a1, Alignment* a2) {
+                            return a1->score() > a2->score();
+                        });
     // remove likely perfect duplicates
     aln_ptrs.erase(
         std::unique(
@@ -4098,10 +4092,12 @@ vector<Alignment> Mapper::score_sort_and_deduplicate_alignments(vector<Alignment
         return all_alns;
     }
 
-    map<int, set<Alignment*> > alignment_by_score;
+    // Hold all the alignments bucketed by score.
+    // The buckets are vectors and not sets to avoild introducing a dependency on pointer value or unordered set order.
+    map<int, vector<Alignment*> > alignment_by_score;
     for (auto& ta : all_alns) {
         Alignment* aln = &ta;
-        alignment_by_score[aln->score()].insert(aln);
+        alignment_by_score[aln->score()].push_back(aln);
     }
     // TODO: Filter down subject to a minimum score per base or something?
     // Collect all the unique alignments (to compute mapping quality) and order by score
@@ -4128,6 +4124,13 @@ vector<Alignment> Mapper::score_sort_and_deduplicate_alignments(vector<Alignment
                 serializedAlignmentsUsed.insert(serialized);
             }
         }
+        
+        if (it == alignment_by_score.rbegin()) {
+            // We just did the top-scoring group of alignments.
+            // Shuffle them to avoid bias.
+            deterministic_shuffle(sorted_unique_alignments.begin(), sorted_unique_alignments.end());
+        }
+    
     }
     return sorted_unique_alignments;
 }

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2772,6 +2772,9 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
     }
     apply_haplotype_consistency_scores(flat_alns);
 
+    // Before the final sort, shuffle everything to avoid bias to one strand/contig/etc.
+    deterministic_shuffle(aln_ptrs.begin(), aln_ptrs.end(), first_mate.sequence() + second_mate.sequence()); 
+
     sort_and_dedup();
     show_alignments("mixed");
 
@@ -3259,6 +3262,9 @@ Mapper::align_mem_multi(const Alignment& aln,
     
     // Apply haplotype consistency scoring if possible
     apply_haplotype_consistency_scores(aln_ptrs);
+    
+    // Shuffle alignments deterministically to prevent bias towards one strand/contig/etc.
+    deterministic_shuffle(aln_ptrs.begin(), aln_ptrs.end(), aln.sequence()); 
     
     // sort alignments by score
     std::sort(aln_ptrs.begin(), aln_ptrs.end(),

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -196,11 +196,6 @@ namespace vg {
         }
         
 #ifdef debug_multipath_mapper
-        cerr << "deterministically shuffling mappings" << endl;
-#endif
-        deterministic_shuffle(multipath_alns_out.begin(), multipath_alns_out.end(), alignment.sequence());
-        
-#ifdef debug_multipath_mapper
         cerr << "computing mapping quality and sorting mappings" << endl;
 #endif
         sort_and_compute_mapping_quality(multipath_alns_out, mapq_method);
@@ -875,10 +870,6 @@ namespace vg {
         }
         
         if (found_consistent) {
-            // shuffle to get rid of any strand or contig bias
-            deterministic_shuffle(multipath_aln_pairs_out.begin(), multipath_aln_pairs_out.end(),
-                alignment1.sequence() + alignment2.sequence());
-            
             // compute the paired mapping quality
             sort_and_compute_mapping_quality(multipath_aln_pairs_out, pair_distances);
         }
@@ -1019,10 +1010,6 @@ namespace vg {
                 
                 // if we split it up, move the best one to the front
                 if (cluster_multipath_alns.size() > 1) {
-                    // shuffle to get rid of any strand or contig bias
-                    deterministic_shuffle(cluster_multipath_alns.begin(), cluster_multipath_alns.end(),
-                        alignment1.sequence() + alignment2.sequence());
-                        
                     sort_and_compute_mapping_quality(cluster_multipath_alns, None);
                 }
                 
@@ -1721,9 +1708,6 @@ namespace vg {
         
         // re-sort the rescued alignments if we actually did it from both sides
         if (rescue_succeeded_from_1 && rescue_succeeded_from_2) {
-            deterministic_shuffle(multipath_aln_pairs_out.begin(), multipath_aln_pairs_out.end(),
-                alignment1.sequence() + alignment2.sequence());
-                        
             sort_and_compute_mapping_quality(multipath_aln_pairs_out, pair_distances);
         }
     }
@@ -1762,9 +1746,6 @@ namespace vg {
                 multipath_aln_pairs_out.emplace_back(move(rescued_multipath_aln_pairs[j]));
             }
         }
-        
-        // TODO: it might make sense to shuffle here to avoid bias between rescue and non-rescue alignments.
-        // But we don't have easy access to the read sequence for a deterministic shuffle.
         
         sort_and_compute_mapping_quality(multipath_aln_pairs_out, cluster_pairs);
     }
@@ -1961,10 +1942,6 @@ namespace vg {
         if (unstranded_clustering) {
             establish_strand_consistency(multipath_aln_pairs_out, cluster_pairs, paths_of_node_memo, oriented_occurences_memo, handle_memo);
         }
-        
-        // shuffle to avoid strand or contig bias
-        deterministic_shuffle(multipath_aln_pairs_out.begin(), multipath_aln_pairs_out.end(),
-            alignment1.sequence() + alignment2.sequence());
         
         // put pairs in score sorted order and compute mapping quality of best pair using the score
         sort_and_compute_mapping_quality(multipath_aln_pairs_out, cluster_pairs);
@@ -2599,7 +2576,10 @@ namespace vg {
         for (size_t i = 1; i < multipath_alns.size(); i++) {
             order[i] = i;
         }
-        sort(order.begin(), order.end(), [&](const size_t i, const size_t j) { return scores[i] > scores[j]; });
+        // Sort, shuffling based on the aligned sequence to break ties.
+        sort_shuffling_ties(order.begin(), order.end(),
+            [&](const size_t i, const size_t j) { return scores[i] > scores[j]; },
+            [&](const size_t seed_source) {return multipath_alns[seed_source].sequence(); });
         
         // translate the order to an index
         vector<size_t> index(multipath_alns.size());
@@ -2756,7 +2736,13 @@ namespace vg {
         for (size_t i = 1; i < multipath_aln_pairs.size(); i++) {
             order[i] = i;
         }
-        sort(order.begin(), order.end(), [&](const size_t i, const size_t j) { return scores[i] > scores[j]; });
+        sort_shuffling_ties(order.begin(), order.end(),
+            [&](const size_t i, const size_t j) {
+                return scores[i] > scores[j]; 
+            },
+            [&](const size_t seed_source) {
+                return multipath_aln_pairs[seed_source].first.sequence() + multipath_aln_pairs[seed_source].second.sequence();
+            });
         
         // translate the order to an index
         vector<size_t> index(multipath_aln_pairs.size());

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -196,6 +196,11 @@ namespace vg {
         }
         
 #ifdef debug_multipath_mapper
+        cerr << "deterministically shuffling mappings" << endl;
+#endif
+        deterministic_shuffle(multipath_alns_out.begin(), multipath_alns_out.end(), alignment.sequence());
+        
+#ifdef debug_multipath_mapper
         cerr << "computing mapping quality and sorting mappings" << endl;
 #endif
         sort_and_compute_mapping_quality(multipath_alns_out, mapq_method);
@@ -870,6 +875,10 @@ namespace vg {
         }
         
         if (found_consistent) {
+            // shuffle to get rid of any strand or contig bias
+            deterministic_shuffle(multipath_aln_pairs_out.begin(), multipath_aln_pairs_out.end(),
+                alignment1.sequence() + alignment2.sequence());
+            
             // compute the paired mapping quality
             sort_and_compute_mapping_quality(multipath_aln_pairs_out, pair_distances);
         }
@@ -1010,6 +1019,10 @@ namespace vg {
                 
                 // if we split it up, move the best one to the front
                 if (cluster_multipath_alns.size() > 1) {
+                    // shuffle to get rid of any strand or contig bias
+                    deterministic_shuffle(cluster_multipath_alns.begin(), cluster_multipath_alns.end(),
+                        alignment1.sequence() + alignment2.sequence());
+                        
                     sort_and_compute_mapping_quality(cluster_multipath_alns, None);
                 }
                 
@@ -1708,6 +1721,9 @@ namespace vg {
         
         // re-sort the rescued alignments if we actually did it from both sides
         if (rescue_succeeded_from_1 && rescue_succeeded_from_2) {
+            deterministic_shuffle(multipath_aln_pairs_out.begin(), multipath_aln_pairs_out.end(),
+                alignment1.sequence() + alignment2.sequence());
+                        
             sort_and_compute_mapping_quality(multipath_aln_pairs_out, pair_distances);
         }
     }
@@ -1746,6 +1762,9 @@ namespace vg {
                 multipath_aln_pairs_out.emplace_back(move(rescued_multipath_aln_pairs[j]));
             }
         }
+        
+        // TODO: it might make sense to shuffle here to avoid bias between rescue and non-rescue alignments.
+        // But we don't have easy access to the read sequence for a deterministic shuffle.
         
         sort_and_compute_mapping_quality(multipath_aln_pairs_out, cluster_pairs);
     }
@@ -1942,6 +1961,10 @@ namespace vg {
         if (unstranded_clustering) {
             establish_strand_consistency(multipath_aln_pairs_out, cluster_pairs, paths_of_node_memo, oriented_occurences_memo, handle_memo);
         }
+        
+        // shuffle to avoid strand or contig bias
+        deterministic_shuffle(multipath_aln_pairs_out.begin(), multipath_aln_pairs_out.end(),
+            alignment1.sequence() + alignment2.sequence());
         
         // put pairs in score sorted order and compute mapping quality of best pair using the score
         sort_and_compute_mapping_quality(multipath_aln_pairs_out, cluster_pairs);

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -442,6 +442,26 @@ string random_sequence(size_t length);
 /// Escape "%" to "%25"
 string percent_url_encode(const string& seq);
 string replace_in_string(string subject, const string& search, const string& replace);
+
+/// Given a pair of random access iterators defining a range, deterministically
+/// shuffle the contents of the range based on the given string seed.
+template<typename iter>
+void deterministic_shuffle(iter begin, iter end, const string& seed) {
+    // Turn the string into a 32-bit number.
+    uint32_t seedNumber;
+    for (uint8_t byte : seed) {
+        // Sum up with primes and overflow.
+        // TODO: this is a bit of a bad hash function but it should be good enough.
+        seedNumber = seedNumber * 13 + byte;
+    }
+
+    // Make an RNG from the string
+    minstd_rand rng(seedNumber);
+    
+    // Shuffle with it
+    std::shuffle(begin, end, rng);
+    
+}
     
 }
 

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -529,7 +529,7 @@ template<class RandomIt, class Compare>
 void sort_shuffling_ties(RandomIt begin, RandomIt end, Compare comp) {
     
     // Make the seed using the pre-defined seed making approaches
-    sort_shuffling_ties(begin, end, comp, [](const decltype (*begin)& item) {
+    sort_shuffling_ties(begin, end, comp, [](decltype (*begin)& item) {
         return make_shuffle_seed(item);
     });
 

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -444,9 +444,20 @@ string percent_url_encode(const string& seq);
 string replace_in_string(string subject, const string& search, const string& replace);
 
 /// Given a pair of random access iterators defining a range, deterministically
+/// shuffle the contents of the range based on the given integer seed.
+template<class RandomIt>
+void deterministic_shuffle(RandomIt begin, RandomIt end, const uint32_t& seed) {
+    // Make an RNG from the string
+    minstd_rand rng(seed);
+    
+    // Shuffle with it
+    std::shuffle(begin, end, rng);
+}
+
+/// Given a pair of random access iterators defining a range, deterministically
 /// shuffle the contents of the range based on the given string seed.
-template<typename iter>
-void deterministic_shuffle(iter begin, iter end, const string& seed) {
+template<class RandomIt>
+void deterministic_shuffle(RandomIt begin, RandomIt end, const string& seed) {
     // Turn the string into a 32-bit number.
     uint32_t seedNumber;
     for (uint8_t byte : seed) {
@@ -455,13 +466,76 @@ void deterministic_shuffle(iter begin, iter end, const string& seed) {
         seedNumber = seedNumber * 13 + byte;
     }
 
-    // Make an RNG from the string
-    minstd_rand rng(seedNumber);
-    
-    // Shuffle with it
-    std::shuffle(begin, end, rng);
-    
+    // Shuffle with the derived integer seed
+    deterministic_shuffle(begin, end, seedNumber);
 }
+
+/// Make seeds for Alignments based on their sequences.
+inline string make_shuffle_seed(const Alignment& aln) {
+    return aln.sequence();
+}
+
+/// Make seeds for Alignments based on their sequences.
+inline string make_shuffle_seed(const Alignment* aln) {
+    return aln->sequence();
+}
+
+/// Make seeds for pairs of Alignments based on their concatenated sequences
+inline string make_shuffle_seed(const pair<Alignment, Alignment>* alns) {
+    return alns->first.sequence() + alns->second.sequence();
+}
+
+/// Do a deterministic shuffle with automatic seed determination.
+template<class RandomIt>
+void deterministic_shuffle(RandomIt begin, RandomIt end) {
+    deterministic_shuffle(begin, end, make_shuffle_seed(*begin));
+}
+
+/**
+ * Sort the items between the two given random-access iterators, as with std::sort.
+ * Deterministically shuffle the ties, if any, at the top end, using the given seed generator function.
+ */
+template<class RandomIt, class Compare, class MakeSeed>
+void sort_shuffling_ties(RandomIt begin, RandomIt end, Compare comp, MakeSeed seed) {
+    
+    // Sort everything
+    std::sort(begin, end, comp);
+    
+    // Comparison returns true if first argument must come before second, and
+    // false otherwise. So the ties will be a run where the top thing doesn't
+    // necessarily come before each other thing (i.e. comparison returns
+    // false).
+    
+    // Count the ties at the top
+    RandomIt ties_end = begin;
+    while (ties_end != end && !comp(*begin, *ties_end)) {
+        // We haven't hit the end of the list, and the top thing isn't strictly better than this thing.
+        // So mark it as a tie and advance.
+        ++ties_end;
+    }
+    
+    if (begin != ties_end) {
+        // Shuffle the ties.
+        deterministic_shuffle(begin, ties_end, seed(*begin));
+    }
+
+}
+
+/**
+ * Sort the items between the two given random-access iterators, as with std::sort.
+ * Deterministically shuffle the ties, if any, at the top end, using automatic seed determination.
+ */
+template<class RandomIt, class Compare>
+void sort_shuffling_ties(RandomIt begin, RandomIt end, Compare comp) {
+    
+    // Make the seed using the pre-defined seed making approaches
+    sort_shuffling_ties(begin, end, comp, [](const decltype (*begin)& item) {
+        return make_shuffle_seed(item);
+    });
+
+}
+
+
     
 }
 


### PR DESCRIPTION
This will hopefully fix #1725 by deterministically (based on read sequence) randomizing the order of equivalent alignments, so we don't always pick e.g. one contig or earlier positions or one strand over any other when equivalent mappings exist.