### PR TITLE
Change gff parser's delimiter to tab-separated

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1481,6 +1481,7 @@ void parse_gff_regions(istream& gffstream,
     string seq;
     string source;
     string type;
+    string buf;
     size_t sbuf;
     size_t ebuf;
     string name = "";
@@ -1494,19 +1495,21 @@ void parse_gff_regions(istream& gffstream,
             continue;
         }
         istringstream ss(row);
-        ss >> seq;
-        ss >> source;
-        ss >> type;
-        ss >> sbuf;
-        ss >> ebuf;
+        getline(ss, seq, '\t');
+        getline(ss, source, '\t');
+        getline(ss, type, '\t');
+        getline(ss, buf, '\t');
+        sbuf = atoi(buf.c_str());
+        getline(ss, buf, '\t');
+        ebuf = atoi(buf.c_str());
 
         if (ss.fail() || !(sbuf < ebuf)) {
             cerr << "Error parsing gtf/gff line " << line << ": " << row << endl;
         } else {
-            ss >> score;
-            ss >> strand;
-            ss >> num;
-            ss >> annotations;
+            getline(ss, score, '\t');
+            getline(ss, strand, '\t');
+            getline(ss, num, '\t');
+            getline(ss, annotations, '\t');
             vector<string> vals = split(annotations, ";");
             for (auto& s : vals) {
                 if (s.find("Name=") == 0) {


### PR DESCRIPTION
I would like to handle GFF file following using `vg annotate -f`.

```
NC_006873.1    Protein Homology    CDS    36202    36543    .    -    0    ID=cds4543;Parent=gene4636;Dbxref=Genbank:WP_007559113.1;Name=WP_007559113.1;gbkey=CDS;inference=COORDINATES: similar to AA sequence:RefSeq:WP_007559113.1;product=hypothetical protein;protein_id=WP_007559113.1;transl_table=11
```

`Protein Homology` includes space character, but istringstream's `>>` splits lines by any space character. So, it failed. Since GFF format must be tab-separated (https://www.ensembl.org/info/website/upload/gff.html), I changed the delimiter to tab-separated only.