### PR TITLE
Make vg remember and report its build environment

### DIFF
--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -12,6 +12,7 @@
 #define _XOPEN_SOURCE 1
 
 #include "crash.hpp"
+#include "version.hpp"
 
 // iostream wants this on Travis on Mac
 #include <pthread.h>
@@ -147,6 +148,8 @@ void emit_stacktrace(int signalNumber, siginfo_t *signalInfo, void *signalContex
         tempStream.open(dirName+ "/stacktrace.txt");
         out = &tempStream;
     }
+    
+    *out << "Crash report for vg " << Version::get_short() << endl;
    
     // This holds the context that the signal came from, including registers and stuff
     ucontext_t* context = (ucontext_t*) signalContext;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@ using namespace vg;
 
 
 void vg_help(char** argv) {
-    cerr << "vg: variation graph tool, version " << VG_VERSION_STRING << endl
+    cerr << "vg: variation graph tool, version " << Version::get_short() << endl
          << endl
          << "usage: " << argv[0] << " <command> [options]" << endl
          << endl

--- a/src/subcommand/benchmark_main.cpp
+++ b/src/subcommand/benchmark_main.cpp
@@ -170,7 +170,7 @@ int main_benchmark(int argc, char** argv) {
     // Do the control against itself
     results.push_back(run_benchmark("control", 1000, benchmark_control));
 
-    cout << "# Benchmark results for vg " << VG_VERSION_STRING << endl;
+    cout << "# Benchmark results for vg " << Version::get_short() << endl;
     cout << "# runs\ttest(us)\tstddev(us)\tcontrol(us)\tstddev(us)\tscore\terr\tname" << endl;
     for (auto& result : results) {
         cout << result << endl;

--- a/src/subcommand/help_main.cpp
+++ b/src/subcommand/help_main.cpp
@@ -25,7 +25,7 @@ void help_help(char** argv){
 
 int main_help(int argc, char** argv){
 
-    cerr << "vg: variation graph tool, version " << VG_VERSION_STRING << endl
+    cerr << "vg: variation graph tool, version " << Version::get_short() << endl
          << endl
          << "usage: " << argv[0] << " <command> [options]" << endl
          << endl;

--- a/src/subcommand/version_main.cpp
+++ b/src/subcommand/version_main.cpp
@@ -31,7 +31,7 @@ int main_version(int argc, char** argv){
         return 1;
     }
 
-    cout << VG_VERSION_STRING << endl;
+    cout << Version::get_long() << endl;
     return 0;
 }
 // Register subcommand

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,18 +1,35 @@
 #include "version.hpp"
 
-// Get the actual macro from the build system
+// Get the git version macro from the build system
 #include "vg_git_version.hpp"
 
-// Make sure the version macro is a thing
-#ifndef VG_GIT_VERSION
-    #define VG_GIT_VERSION "missing"
-#endif
+// Do the same for the build environment info
+#include "vg_environment_version.hpp"
+
+#include <iostream>
+#include <sstream>
 
 namespace vg {
 
 using namespace std;
 
-// Define the constant equal to the macro.
-const char* VG_VERSION_STRING = VG_GIT_VERSION;
+// Define all the strings as the macros' values
+const string Version::VERSION = VG_GIT_VERSION;
+const string Version::COMPILER = VG_COMPILER_VERSION;
+const string Version::OS = VG_OS;
+const string Version::BUILD_USER = VG_BUILD_USER;
+const string Version::BUILD_HOST = VG_BUILD_HOST;
+
+const string& Version::get_short() {
+    return VERSION;
+}
+
+string Version::get_long() {
+    stringstream s;
+    s << "vg version " << VERSION << endl;
+    s << "Compiled with " << COMPILER << " on " << OS << endl;
+    s << "Built by " << BUILD_USER << "@" << BUILD_HOST;
+    return s.str();
+}
 
 }

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -1,14 +1,38 @@
 #ifndef VG_VERSION_HPP_INCLUDED
 #define VG_VERSION_HPP_INCLUDED
 
-// version.hpp: Store the VG Git version in its own compilation unit for fast
-// rebuilds when Git state changes.
+// version.hpp: Version reflection information for vg builds.
+
+#include <string>
 
 namespace vg {
 
 using namespace std;
 
-extern const char* VG_VERSION_STRING;
+/// Class for holding vg version and build environment information.
+class Version {
+public:
+    /// The Git version description of this build of vg
+    const static string VERSION;
+    /// The compiler used to build vg
+    const static string COMPILER;
+    /// The OS that vg was built on
+    const static string OS;
+    /// The user who built vg
+    const static string BUILD_USER;
+    /// The host that built vg
+    const static string BUILD_HOST;
+    
+    /// Get a short description of the current version of vg.
+    static const string& get_short();
+    
+    /// Get a long, potentially multi-line description of the current version
+    /// of vg with no terminating newline.
+    static string get_long();
+private:
+    // Not constructable
+    Version() = delete;
+};
 
 }
 


### PR DESCRIPTION
Confusion about what compiler vg was built with should now be a thing of the past.

`vg version` now reports the compiler version used, as well as the user and host that did the build.