### PR TITLE
Remove system-dependent behavior in mpmap

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1916,12 +1916,14 @@ namespace vg {
         };
         
         // sort the pairs descending by total unique sequence coverage
-        std::sort(cluster_pairs.begin(), cluster_pairs.end(),
-                  [&](const pair<pair<size_t, size_t>, int64_t>& a, const pair<pair<size_t, size_t>, int64_t>& b) {
-                      // We need to be able to look up the coverage for the graph an input cluster went into.
-                      // Compute total coverage following all the redirects and see if
-                      // it's in the right order.
-                      return get_pair_coverage(a.first) > get_pair_coverage(b.first);
+        stable_sort(cluster_pairs.begin(), cluster_pairs.end(),
+                    [&](const pair<pair<size_t, size_t>, int64_t>& a, const pair<pair<size_t, size_t>, int64_t>& b) {
+                        // We need to be able to look up the coverage for the graph an input cluster went into.
+                        // Compute total coverage following all the redirects and see if
+                        // it's in the right order.
+                        // We also add a total ordering over the pair indexes to remove system dependencies
+                        size_t cov_1 = get_pair_coverage(a.first), cov_2 = get_pair_coverage(b.first);
+                        return (cov_1 > cov_2 || (cov_1 == cov_2 && a.first < b.first));
                   });
         
 #ifdef debug_multipath_mapper

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2697,7 +2697,9 @@ namespace vg {
 #ifdef debug_multipath_mapper
         cerr << "scores obtained of multi-mappings:" << endl;
         for (size_t i = 0; i < scores.size(); i++) {
-            cerr << "\t" << scores[i] << endl;
+            Alignment aln;
+            optimal_alignment(multipath_alns[i], aln);
+            cerr << "\t" << scores[i] << " " << make_pos_t(aln.path().mapping(0).position()) << endl;
         }
 #endif
         

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -451,8 +451,11 @@ void deterministic_shuffle(RandomIt begin, RandomIt end, const uint32_t& seed) {
     // Make an RNG from the string
     minstd_rand rng(seed);
     
-    // Shuffle with it
-    std::shuffle(begin, end, rng);
+    // Perform Knuth shuffle algorithm using RNG
+    int64_t width = end - begin;
+    for (int64_t i = 1; i < width; i++) {
+        std::swap(*(begin + (rng() % (i + 1))), *(begin + i));
+    }
 }
 
 /// Given a pair of random access iterators defining a range, deterministically
@@ -500,7 +503,7 @@ template<class RandomIt, class Compare, class MakeSeed>
 void sort_shuffling_ties(RandomIt begin, RandomIt end, Compare comp, MakeSeed seed) {
     
     // Sort everything
-    std::sort(begin, end, comp);
+    std::stable_sort(begin, end, comp);
     
     // Comparison returns true if first argument must come before second, and
     // false otherwise. So the ties will be a run where the top thing doesn't

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -463,7 +463,7 @@ void deterministic_shuffle(RandomIt begin, RandomIt end, const uint32_t& seed) {
 template<class RandomIt>
 void deterministic_shuffle(RandomIt begin, RandomIt end, const string& seed) {
     // Turn the string into a 32-bit number.
-    uint32_t seedNumber;
+    uint32_t seedNumber = 0;
     for (uint8_t byte : seed) {
         // Sum up with primes and overflow.
         // TODO: this is a bit of a bad hash function but it should be good enough.


### PR DESCRIPTION
We're switching to a new server at CGL, which revealed some library-dependent behavior I didn't like. This PR (hopefully) rectifies that problem.