### PR TITLE
Add cap to MAPQ in mpmap based on rescue behavior

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1905,7 +1905,7 @@ namespace vg {
                 // we missed the mapping just because of the subset of rescues we attempted
                 
                 double fraction_considered = double(max_rescues_attempted_idx) / double(plausible_clusters_end_idx);
-                int32_t rescue_mapq = round(prob_to_phred(fraction_considered));
+                int32_t rescue_mapq = round(prob_to_phred(1.0 - fraction_considered));
                 
 #ifdef debug_multipath_mapper
                 cerr << "capping mapping quality at " << rescue_mapq << endl;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1848,9 +1848,7 @@ namespace vg {
         // did we use an out-of-bounds cluster index to flag either end as coming from a rescue?
         bool opt_aln_1_is_rescued = cluster_pairs.front().first.first >= cluster_graphs1.size();
         bool opt_aln_2_is_rescued = cluster_pairs.front().first.second >= cluster_graphs2.size();
-        
-        cerr << "checked" << endl;
-        
+                
         // was the optimal cluster pair obtained by rescue?
         if (opt_aln_1_is_rescued || opt_aln_2_is_rescued) {
             // let's figure out if we should reduce its mapping quality to reflect the fact that we may not have selected the

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -141,7 +141,8 @@ namespace vg {
                                                   MappingQualityMethod mapq_method,
                                                   vector<clustergraph_t>& cluster_graphs,
                                                   vector<MultipathAlignment>& multipath_alns_out,
-                                                  size_t num_mapping_attempts) {
+                                                  size_t num_mapping_attempts,
+                                                  vector<size_t>* cluster_idxs) {
         
         
 #ifdef debug_multipath_mapper
@@ -199,7 +200,7 @@ namespace vg {
 #ifdef debug_multipath_mapper
         cerr << "computing mapping quality and sorting mappings" << endl;
 #endif
-        sort_and_compute_mapping_quality(multipath_alns_out, mapq_method);
+        sort_and_compute_mapping_quality(multipath_alns_out, mapq_method, cluster_idxs);
         
         if (!multipath_alns_out.empty() ? likely_mismapping(multipath_alns_out.front()) : false) {
             multipath_alns_out.front().set_mapping_quality(0);
@@ -721,13 +722,23 @@ namespace vg {
                                                               size_t max_alt_mappings) {
         
         vector<MultipathAlignment> multipath_alns_1, multipath_alns_2;
+        vector<size_t> cluster_idxs_1, cluster_idxs_2;
         if (!block_rescue_from_1) {
+            // make vectors to
+            cluster_idxs_1.resize(cluster_graphs1.size());
+            for (size_t i = 0; i < cluster_idxs_1.size(); i++) {
+                cluster_idxs_1[i] = i;
+            }
             align_to_cluster_graphs(alignment1, mapping_quality_method == None ? Approx : mapping_quality_method,
-                                    cluster_graphs1, multipath_alns_1, max_single_end_mappings_for_rescue);
+                                    cluster_graphs1, multipath_alns_1, max_single_end_mappings_for_rescue, &cluster_idxs_1);
         }
         if (!block_rescue_from_2) {
+            cluster_idxs_2.resize(cluster_graphs2.size());
+            for (size_t i = 0; i < cluster_idxs_2.size(); i++) {
+                cluster_idxs_2[i] = i;
+            }
             align_to_cluster_graphs(alignment2, mapping_quality_method == None ? Approx : mapping_quality_method,
-                                    cluster_graphs2, multipath_alns_2, max_single_end_mappings_for_rescue);
+                                    cluster_graphs2, multipath_alns_2, max_single_end_mappings_for_rescue, &cluster_idxs_2);
         }
         
         if (multipath_alns_1.empty() || multipath_alns_2.empty() ? false :
@@ -740,7 +751,7 @@ namespace vg {
             cerr << "found consistent, confident pair mapping from independent end mapping" << endl;
 #endif
             multipath_aln_pairs_out.emplace_back(move(multipath_alns_1.front()), move(multipath_alns_2.front()));
-            pair_distances.emplace_back(pair<size_t, size_t>(),
+            pair_distances.emplace_back(make_pair(cluster_idxs_1.front(), cluster_idxs_2.front()),
                                         distance_between(multipath_aln_pairs_out.back().first, multipath_aln_pairs_out.back().second, true));
             return true;
         }
@@ -826,7 +837,7 @@ namespace vg {
                             int64_t dist = distance_between(multipath_alns_1[i], multipath_alns_2[j], true);
                             if (dist != numeric_limits<int64_t>::max() && dist >= 0) {
                                 multipath_aln_pairs_out.emplace_back(move(multipath_alns_1[i]), move(multipath_alns_2[j]));
-                                pair_distances.emplace_back(pair<size_t, size_t>(), dist);
+                                pair_distances.emplace_back(make_pair(cluster_idxs_1[i], cluster_idxs_2[j]), dist);
                                 found_consistent = true;
                             }
                             
@@ -843,7 +854,7 @@ namespace vg {
                     int64_t dist = distance_between(multipath_alns_1[i], rescue_multipath_alns_2[i], true);
                     if (dist != numeric_limits<int64_t>::max() && dist >= 0) {
                         multipath_aln_pairs_out.emplace_back(move(multipath_alns_1[i]), move(rescue_multipath_alns_2[i]));
-                        pair_distances.emplace_back(pair<size_t, size_t>(), dist);
+                        pair_distances.emplace_back(make_pair(cluster_idxs_1[i], cluster_graphs2.size()), dist);
                         found_consistent = true;
                     }
                 }
@@ -861,7 +872,7 @@ namespace vg {
                 int64_t dist = distance_between(rescue_multipath_alns_1[j], multipath_alns_2[j], true);
                 if (dist != numeric_limits<int64_t>::max() && dist >= 0) {
                     multipath_aln_pairs_out.emplace_back(move(rescue_multipath_alns_1[j]), move(multipath_alns_2[j]));
-                    pair_distances.emplace_back(pair<size_t, size_t>(), dist);
+                    pair_distances.emplace_back(make_pair(cluster_graphs1.size(), cluster_idxs_2[j]), dist);
                     found_consistent = true;
                 }
             }
@@ -874,7 +885,7 @@ namespace vg {
                 int64_t dist = distance_between(multipath_alns_1[i], rescue_multipath_alns_2[i], true);
                 if (dist != numeric_limits<int64_t>::max() && dist >= 0) {
                     multipath_aln_pairs_out.emplace_back(move(multipath_alns_1[i]), move(rescue_multipath_alns_2[i]));
-                    pair_distances.emplace_back(pair<size_t, size_t>(), dist);
+                    pair_distances.emplace_back(make_pair(cluster_idxs_1[i], cluster_graphs2.size()), dist);
                     found_consistent = true;
                 }
             }
@@ -887,7 +898,7 @@ namespace vg {
                 int64_t dist = distance_between(rescue_multipath_alns_1[i], multipath_alns_2[i], true);
                 if (dist != numeric_limits<int64_t>::max() && dist >= 0) {
                     multipath_aln_pairs_out.emplace_back(move(rescue_multipath_alns_1[i]), move(multipath_alns_2[i]));
-                    pair_distances.emplace_back(pair<size_t, size_t>(), dist);
+                    pair_distances.emplace_back(make_pair(cluster_graphs1.size(), cluster_idxs_2[i]), dist);
                     found_consistent = true;
                 }
             }
@@ -1048,7 +1059,7 @@ namespace vg {
                             int64_t dist = distance_between(cluster_multipath_alns.front(), rescue_multipath_aln, true);
                             if (dist >= 0 && dist != numeric_limits<int64_t>::max()) {
                                 rescued_secondaries.emplace_back(move(cluster_multipath_alns.front()), move(rescue_multipath_aln));
-                                rescued_distances.emplace_back(pair<size_t, size_t>(), dist);
+                                rescued_distances.emplace_back(make_pair(i, cluster_graphs2.size()), dist);
                                 
                             }
                         }
@@ -1056,7 +1067,7 @@ namespace vg {
                             int64_t dist = distance_between(rescue_multipath_aln, cluster_multipath_alns.front(), true);
                             if (dist >= 0 && dist != numeric_limits<int64_t>::max()) {
                                 rescued_secondaries.emplace_back(move(rescue_multipath_aln), move(cluster_multipath_alns.front()));
-                                rescued_distances.emplace_back(pair<size_t, size_t>(), dist);
+                                rescued_distances.emplace_back(make_pair(cluster_graphs1.size(), i), dist);
                                 
                             }
                         }
@@ -1453,6 +1464,11 @@ namespace vg {
                             multipath_aln_pairs_out.front().first.set_mapping_quality(0);
                             multipath_aln_pairs_out.front().second.set_mapping_quality(0);
                         }
+                        else {
+                            // also account for the possiblity that we selected the wrong ends to rescue with
+                            cap_mapping_quality_by_rescue_probability(multipath_aln_pairs_out, cluster_pairs,
+                                                                      cluster_graphs1, cluster_graphs2, false);
+                        }
                     }
                     else {
                         // rescue didn't find any consistent mappings, revert to the single ended mappings
@@ -1466,6 +1482,10 @@ namespace vg {
                     // so we use this routine to use rescue on other very good looking independent end clusters
                     attempt_rescue_for_secondaries(alignment1, alignment2, cluster_graphs1, cluster_graphs2,
                                                    multipath_aln_pairs_out, cluster_pairs);
+                    
+                    // also account for the possiblity that we selected the wrong ends to rescue with
+                    cap_mapping_quality_by_rescue_probability(multipath_aln_pairs_out, cluster_pairs,
+                                                              cluster_graphs1, cluster_graphs2, true);
                 }
             }
             else {
@@ -1477,6 +1497,9 @@ namespace vg {
                 align_to_cluster_graphs_with_rescue(alignment1, alignment2, cluster_graphs1, cluster_graphs2, do_repeat_rescue_from_1,
                                                     do_repeat_rescue_from_2, multipath_aln_pairs_out, cluster_pairs, max_alt_mappings);
                 
+                // also account for the possiblity that we selected the wrong ends to rescue with
+                cap_mapping_quality_by_rescue_probability(multipath_aln_pairs_out, cluster_pairs,
+                                                          cluster_graphs1, cluster_graphs2, false);
             }
         }
         
@@ -1755,6 +1778,11 @@ namespace vg {
         if (rescue_succeeded_from_1 && rescue_succeeded_from_2) {
             sort_and_compute_mapping_quality(multipath_aln_pairs_out, pair_distances);
         }
+        
+        // consider whether we should cap the mapping quality based on the chance that we rescued from the wrong clusters
+        if (rescue_succeeded_from_1 || rescue_succeeded_from_2) {
+            cap_mapping_quality_by_rescue_probability(multipath_aln_pairs_out, pair_distances, cluster_graphs1, cluster_graphs2, false);
+        }
     }
     
     void MultipathMapper::merge_rescued_mappings(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
@@ -1786,13 +1814,99 @@ namespace vg {
 #ifdef debug_multipath_mapper
                 cerr << "no duplicate, adding to return vector if distance is finite and positive" << endl;
 #endif
-                // add a dummy pair to hold the distance
                 cluster_pairs.emplace_back(rescued_cluster_pairs[j]);
                 multipath_aln_pairs_out.emplace_back(move(rescued_multipath_aln_pairs[j]));
             }
         }
         
         sort_and_compute_mapping_quality(multipath_aln_pairs_out, cluster_pairs);
+    }
+    
+    void MultipathMapper::cap_mapping_quality_by_rescue_probability(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                                                    vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                                                    vector<clustergraph_t>& cluster_graphs1,
+                                                                    vector<clustergraph_t>& cluster_graphs2,
+                                                                    bool from_secondary_rescue) const {
+        
+        // did we use an out-of-bounds cluster index to flag either end as coming from a rescue?
+        bool opt_aln_1_is_rescued = cluster_pairs.front().first.first >= cluster_graphs1.size();
+        bool opt_aln_2_is_rescued = cluster_pairs.front().first.second >= cluster_graphs2.size();
+        
+        // was the optimal cluster pair obtained by rescue?
+        if (opt_aln_1_is_rescued || opt_aln_2_is_rescued) {
+            // let's figure out if we should reduce its mapping quality to reflect the fact that we may not have selected the
+            // correct cluster as a rescue candidate
+            
+#ifdef debug_multipath_mapper
+            cerr << "the optimal alignment is a rescue, checking if we need to cap the mapping quality" << endl;
+#endif
+            
+            vector<clustergraph_t>& anchor_clusters = opt_aln_1_is_rescued ? cluster_graphs2 : cluster_graphs1;
+            size_t anchor_idx = opt_aln_1_is_rescued ? cluster_pairs.front().first.second : cluster_pairs.front().first.first;
+            
+            // find the range of clusters that could plausibly be about as good as the one that rescue succeeded from
+            size_t plausible_clusters_end_idx = anchor_idx;
+            for (; plausible_clusters_end_idx < anchor_clusters.size(); plausible_clusters_end_idx++) {
+                if (get<2>(anchor_clusters[plausible_clusters_end_idx]) < get<2>(anchor_clusters[anchor_idx]) - plausible_rescue_cluster_coverage_diff) {
+                    break;
+                }
+            }
+            
+            // figure out which index corresponds to the end of the range we would have rescued
+            size_t max_rescues_attempted_idx;
+            if (from_secondary_rescue) {
+                // find the indexes that were added by pair clustering
+                unordered_set<size_t> paired_idxs;
+                for (auto& cluster_pair : cluster_pairs) {
+                    paired_idxs.insert(opt_aln_1_is_rescued ? cluster_pair.first.second : cluster_pair.first.first);
+                }
+                
+                // the "budget" of rescues we could have performed
+                size_t rescues_left = secondary_rescue_attempts;
+                size_t i = 0;
+                for (; i < anchor_clusters.size(); i++) {
+                    // did we skip thi index because it was already in a pair?
+                    if (!paired_idxs.count(i)) {
+                        if (rescues_left) {
+                            // we would have tried a secondary rescue here
+                            rescues_left--;
+                        }
+                        else {
+                            // we would have run out of secondary rescues here
+                            break;
+                        }
+                    }
+                }
+                // this is the first index we didn't rescue
+                max_rescues_attempted_idx = i;
+            }
+            else {
+                // simpler without secondary rescue, we would have just rescued up to the maximum allowable
+                max_rescues_attempted_idx = max_rescue_attempts;
+            }
+            
+#ifdef debug_multipath_mapper
+            cerr << "performed up to " << max_rescues_attempted_idx << " out of " << plausible_clusters_end_idx << " plausible rescues" << endl;
+#endif
+            
+            if (max_rescues_attempted_idx < plausible_clusters_end_idx) {
+                // we didn't attempt rescue from all of the plausible clusters, so we have to account for the possibility that
+                // we missed the mapping just because of the subset of rescues we attempted
+                
+                double fraction_considered = double(max_rescues_attempted_idx) / double(plausible_clusters_end_idx);
+                int32_t rescue_mapq = round(prob_to_phred(fraction_considered));
+                
+#ifdef debug_multipath_mapper
+                cerr << "capping mapping quality at " << rescue_mapq << endl;
+#endif
+                
+                // cap the mapping quality at this value
+                multipath_aln_pairs_out.front().first.set_mapping_quality(min(multipath_aln_pairs_out.front().first.mapping_quality(),
+                                                                              rescue_mapq));
+                multipath_aln_pairs_out.front().second.set_mapping_quality(min(multipath_aln_pairs_out.front().second.mapping_quality(),
+                                                                               rescue_mapq));
+            }
+        }
     }
     
     void MultipathMapper::split_multicomponent_alignments(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
@@ -2551,7 +2665,8 @@ namespace vg {
     }
     
     void MultipathMapper::sort_and_compute_mapping_quality(vector<MultipathAlignment>& multipath_alns,
-                                                           MappingQualityMethod mapq_method) const {
+                                                           MappingQualityMethod mapq_method,
+                                                           vector<size_t>* cluster_idxs) const {
         if (multipath_alns.empty()) {
             return;
         }
@@ -2686,11 +2801,14 @@ namespace vg {
             index[order[i]] = i;
         }
         
-        // put the scores and alignments in order
+        // put the scores, clusters-of-origin, and alignments in order
         for (size_t i = 0; i < multipath_alns.size(); i++) {
             while (index[i] != i) {
                 std::swap(scores[index[i]], scores[i]);
                 std::swap(multipath_alns[index[i]], multipath_alns[i]);
+                if (cluster_idxs) {
+                    std::swap(cluster_idxs[index[i]], cluster_idxs[i]);
+                }
                 std::swap(index[index[i]], index[i]);
                 
             }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1500,12 +1500,14 @@ namespace vg {
 #ifdef debug_multipath_mapper
                 cerr << "could not find a consistent pair, reverting to single ended mapping" << endl;
 #endif
-                align_to_cluster_graphs_with_rescue(alignment1, alignment2, cluster_graphs1, cluster_graphs2, do_repeat_rescue_from_1,
-                                                    do_repeat_rescue_from_2, multipath_aln_pairs_out, cluster_pairs, max_alt_mappings);
+                bool rescued = align_to_cluster_graphs_with_rescue(alignment1, alignment2, cluster_graphs1, cluster_graphs2, do_repeat_rescue_from_1,
+                                                                   do_repeat_rescue_from_2, multipath_aln_pairs_out, cluster_pairs, max_alt_mappings);
                 
-                // also account for the possiblity that we selected the wrong ends to rescue with
-                cap_mapping_quality_by_rescue_probability(multipath_aln_pairs_out, cluster_pairs,
-                                                          cluster_graphs1, cluster_graphs2, false);
+                if (rescued) {
+                    // also account for the possiblity that we selected the wrong ends to rescue with
+                    cap_mapping_quality_by_rescue_probability(multipath_aln_pairs_out, cluster_pairs,
+                                                              cluster_graphs1, cluster_graphs2, false);
+                }
             }
         }
         
@@ -1839,9 +1841,15 @@ namespace vg {
                                                                     vector<clustergraph_t>& cluster_graphs2,
                                                                     bool from_secondary_rescue) const {
         
+#ifdef debug_multipath_mapper
+        cerr << "checking whether we should enter rescue mapping quality capping routine" << endl;
+#endif
+        
         // did we use an out-of-bounds cluster index to flag either end as coming from a rescue?
         bool opt_aln_1_is_rescued = cluster_pairs.front().first.first >= cluster_graphs1.size();
         bool opt_aln_2_is_rescued = cluster_pairs.front().first.second >= cluster_graphs2.size();
+        
+        cerr << "checked" << endl;
         
         // was the optimal cluster pair obtained by rescue?
         if (opt_aln_1_is_rescued || opt_aln_2_is_rescued) {

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -227,7 +227,8 @@ namespace vg {
         
         /// If there are any MultipathAlignments with multiple connected components, split them
         /// up and add them to the return vector
-        void split_multicomponent_alignments(vector<MultipathAlignment>& multipath_alns_out) const;
+        void split_multicomponent_alignments(vector<MultipathAlignment>& multipath_alns_out,
+                                             vector<size_t>* cluster_idxs = nullptr) const;
         
         /// If there are any MultipathAlignments with multiple connected components, split them
         /// up and add them to the return vector, also measure the distance between them and add

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -95,6 +95,7 @@ namespace vg {
         bool unstranded_clustering = true;
         size_t max_single_end_mappings_for_rescue = 64;
         size_t max_rescue_attempts = 32;
+        size_t plausible_rescue_cluster_coverage_diff = 5;
         size_t secondary_rescue_attempts = 4;
         double secondary_rescue_score_diff = 1.0;
         double mapq_scaling_factor = 1.0 / 4.0;
@@ -154,7 +155,8 @@ namespace vg {
                                      MappingQualityMethod mapq_method,
                                      vector<clustergraph_t>& cluster_graphs,
                                      vector<MultipathAlignment>& multipath_alns_out,
-                                     size_t num_mapping_attempts);
+                                     size_t num_mapping_attempts,
+                                     vector<size_t>* cluster_idxs = nullptr);
         
         /// After clustering MEMs, extracting graphs, assigning hits to cluster graphs, and determining
         /// which cluster graph pairs meet the fragment length distance constraints, perform multipath
@@ -204,6 +206,14 @@ namespace vg {
                                     vector<pair<MultipathAlignment, MultipathAlignment>>& rescued_multipath_aln_pairs,
                                     vector<pair<pair<size_t, size_t>, int64_t>>& rescued_cluster_pairs) const;
         
+        /// Estimates the probability that the correct cluster was chosen as a cluster to rescue from and caps the
+        /// mapping quality to the minimum of the current mapping quality and this probability (in Phred scale)
+        void cap_mapping_quality_by_rescue_probability(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                                       vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                                       vector<clustergraph_t>& cluster_graphs1,
+                                                       vector<clustergraph_t>& cluster_graphs2,
+                                                       bool from_secondary_rescue) const;
+        
         /// Extracts a subgraph around each cluster of MEMs that encompasses any
         /// graph position reachable (according to the Mapper's aligner) with
         /// local alignment anchored at the MEMs. If any subgraphs overlap, they
@@ -239,7 +249,9 @@ namespace vg {
         int32_t compute_raw_mapping_quality_from_scores(const vector<double>& scores, MappingQualityMethod mapq_method) const;
         
         /// Sorts mappings by score and store mapping quality of the optimal alignment in the MultipathAlignment object
-        void sort_and_compute_mapping_quality(vector<MultipathAlignment>& multipath_alns, MappingQualityMethod mapq_method) const;
+        /// Optionally also sorts a vector of indexes to keep track of the cluster-of-origin
+        void sort_and_compute_mapping_quality(vector<MultipathAlignment>& multipath_alns, MappingQualityMethod mapq_method,
+                                              vector<size_t>* cluster_idxs = nullptr) const;
         
         /// Sorts mappings by score and store mapping quality of the optimal alignment in the MultipathAlignment object
         /// If there are ties between scores, breaks them by the expected distance between pairs as computed by the
@@ -278,7 +290,6 @@ namespace vg {
         /// Return true if any of the initial positions of the source Subpaths are shared between the two
         /// multipath alignments
         bool share_terminal_positions(const MultipathAlignment& multipath_aln_1, const MultipathAlignment& multipath_aln_2) const;
-        
         
         /// Get a thread_local RRMemo with these parameters
         haploMath::RRMemo& get_rr_memo(double recombination_penalty, size_t population_size) const;;


### PR DESCRIPTION
Improve MAPQs by estimating the maximum probability that a rescue would succeed in finding the correct pair.