### PR TITLE
Errors to warnings for whole genome population-aware mapping

### DIFF
--- a/src/gssw_aligner.cpp
+++ b/src/gssw_aligner.cpp
@@ -366,7 +366,7 @@ double BaseAligner::maximum_mapping_quality_exact(vector<double>& scaled_scores,
     if (padded && *max_idx_out == 1) {
         // Force us not to try to return the injected 0 as the winner.
         // TODO: doesn't this mean the score is negative?
-        cerr << "warning:[BaseAligner::maximum_mapping_quality_exact]: Max score of " << *max_idx_out
+        cerr << "warning:[BaseAligner::maximum_mapping_quality_exact]: Max score of " << max_score
             << " is the padding score; changing to " << scaled_scores[0] << endl;
         max_score = scaled_scores[0];
         *max_idx_out = 0;

--- a/src/gssw_aligner.cpp
+++ b/src/gssw_aligner.cpp
@@ -363,8 +363,14 @@ double BaseAligner::maximum_mapping_quality_exact(vector<double>& scaled_scores,
         }
     }
     
-    // We should never try to return an injected 0 score as the winner.
-    assert(!(padded && *max_idx_out == 1));
+    if (padded && *max_idx_out == 1) {
+        // Force us not to try to return the injected 0 as the winner.
+        // TODO: doesn't this mean the score is negative?
+        cerr << "warning:[BaseAligner::maximum_mapping_quality_exact]: Max score of " << *max_idx_out
+            << " is the padding score; changing to " << scaled_scores[0] << endl;
+        max_score = scaled_scores[0];
+        *max_idx_out = 0;
+    }
     
     double direct_mapq = -quality_scale_factor * subtract_log(0.0, max_score - log_sum_exp);
     return std::isinf(direct_mapq) ? (double) numeric_limits<int32_t>::max() : direct_mapq;
@@ -442,10 +448,14 @@ double BaseAligner::maximum_mapping_quality_approx(vector<double>& scaled_scores
         }
     }
    
-    // Since we loop through from start to end, all the numbers should be
-    // nonnegative, and we break ties in favor of the old max, we should never
-    // try to return an injected 0 score as the winner.
-    assert(!(padded && max_idx == 1));
+    if (padded && max_idx == 1) {
+        // Force us not to try to return the injected 0 as the winner.
+        // TODO: doesn't this mean the score is negative?
+        cerr << "warning:[BaseAligner::maximum_mapping_quality_approx]: Max score of " << max_score
+            << " is the padding score; changing to " << scaled_scores[0] << endl;
+        max_score = scaled_scores[0];
+        max_idx = 0;
+    }
    
     *max_idx_out = max_idx;
 

--- a/src/gssw_aligner.hpp
+++ b/src/gssw_aligner.hpp
@@ -63,16 +63,18 @@ namespace vg {
                                        bool print_score_matrices = false);
         string graph_cigar(gssw_graph_mapping* gm);
         
+    public:
         /// Given a nonempty vector of nonnegative scaled alignment scores,
         /// compute the mapping quality of the maximal score in the vector.
         /// Sets max_idx_out to the index of that score in the vector. May
         /// modify the input vector.
-        double maximum_mapping_quality_exact(vector<double>& scaled_scores, size_t* max_idx_out);
+        static double maximum_mapping_quality_exact(vector<double>& scaled_scores, size_t* max_idx_out);
         /// Given a nonempty vector of nonnegative scaled alignment scores,
         /// approximate the mapping quality of the maximal score in the vector.
         /// Sets max_idx_out to the index of that score in the vector. May
         /// modify the input vector.
-        double maximum_mapping_quality_approx(vector<double>& scaled_scores, size_t* max_idx_out);
+        static double maximum_mapping_quality_approx(vector<double>& scaled_scores, size_t* max_idx_out);
+    protected:
         double group_mapping_quality_exact(vector<double>& scaled_scores, vector<size_t>& group);
         double estimate_next_best_score(int length, double min_diffs);
         

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2614,6 +2614,20 @@ namespace vg {
                    
                     alignment_pop_scores[j] = pop_score.first / log_base;
                     
+                    if (std::isnan(alignment_pop_scores[i])) {
+                        // This shouldn't happen. Bail out on haplotype adjustment for this read and warn.
+                        cerr << "warning:[vg::MultipathMapper]: NAN population score obtained for read "
+                            << alignments[j].name() << " with ostensibly successful query. Changing to failure." << endl;
+                        pop_score.second = false;
+                    }
+                    
+                    if (std::isnan(alignments[j].score())) {
+                        // This is even worse! The alignment score itself is somehow NAN.
+                        cerr << "warning:[vg::MultipathMapper]: NAN alignment score obtained in alignment being considered for read "
+                            << alignments[j].name() << ". This should never happen! Bailing out on population scoring." << endl;
+                        pop_score.second = false;
+                    }
+
                     all_paths_pop_consistent &= pop_score.second;
                 }
                 
@@ -2630,8 +2644,6 @@ namespace vg {
                 for (size_t j = 0; j < alignments.size(); j++) {
                     // Compute the adjusted score for each alignment
                     auto adjusted_score = alignments[j].score() + alignment_pop_scores[j];
-                   
-                    assert(!std::isnan(adjusted_score));
                    
                     if (adjusted_score > pop_adjusted_scores[i]) {
                         // It is the best, so use it.
@@ -2774,6 +2786,14 @@ namespace vg {
                     // Pop score the first alignments
                     auto pop_score = haplo_score_provider->score(alignments1[j].path(), memo);
                     base_pop_scores1[j] = alignments1[j].score() + pop_score.first / log_base;
+                    
+                    if (std::isnan(base_pop_scores1[i])) {
+                        // This shouldn't happen. Bail out on haplotype adjustment for this read and warn.
+                        cerr << "warning:[vg::MultipathMapper]: NAN population adjusted score obtained for paired read "
+                            << alignments1[j].name() << " with ostensibly successful query. Changing to failure." << endl;
+                        pop_score.second = false;
+                    }
+                    
                     all_paths_pop_consistent &= pop_score.second;
                 }
                 
@@ -2781,6 +2801,14 @@ namespace vg {
                     // Pop score the second alignments
                     auto pop_score = haplo_score_provider->score(alignments2[j].path(), memo);
                     base_pop_scores2[j] = alignments2[j].score() + pop_score.first / log_base;
+                    
+                    if (std::isnan(base_pop_scores2[i])) {
+                        // This shouldn't happen. Bail out on haplotype adjustment for this read and warn.
+                        cerr << "warning:[vg::MultipathMapper]: NAN population adjusted score obtained for paired read "
+                            << alignments2[j].name() << " with ostensibly successful query. Changing to failure." << endl;
+                        pop_score.second = false;
+                    }
+                    
                     all_paths_pop_consistent &= pop_score.second;
                 }
                 

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2614,7 +2614,7 @@ namespace vg {
                    
                     alignment_pop_scores[j] = pop_score.first / log_base;
                     
-                    if (std::isnan(alignment_pop_scores[i])) {
+                    if (std::isnan(alignment_pop_scores[i]) && pop_score.second) {
                         // This shouldn't happen. Bail out on haplotype adjustment for this read and warn.
                         cerr << "warning:[vg::MultipathMapper]: NAN population score obtained for read "
                             << alignments[j].name() << " with ostensibly successful query. Changing to failure." << endl;
@@ -2787,7 +2787,7 @@ namespace vg {
                     auto pop_score = haplo_score_provider->score(alignments1[j].path(), memo);
                     base_pop_scores1[j] = alignments1[j].score() + pop_score.first / log_base;
                     
-                    if (std::isnan(base_pop_scores1[i])) {
+                    if (std::isnan(base_pop_scores1[i]) && pop_score.second) {
                         // This shouldn't happen. Bail out on haplotype adjustment for this read and warn.
                         cerr << "warning:[vg::MultipathMapper]: NAN population adjusted score obtained for paired read "
                             << alignments1[j].name() << " with ostensibly successful query. Changing to failure." << endl;
@@ -2802,7 +2802,7 @@ namespace vg {
                     auto pop_score = haplo_score_provider->score(alignments2[j].path(), memo);
                     base_pop_scores2[j] = alignments2[j].score() + pop_score.first / log_base;
                     
-                    if (std::isnan(base_pop_scores2[i])) {
+                    if (std::isnan(base_pop_scores2[i]) && pop_score.second) {
                         // This shouldn't happen. Bail out on haplotype adjustment for this read and warn.
                         cerr << "warning:[vg::MultipathMapper]: NAN population adjusted score obtained for paired read "
                             << alignments2[j].name() << " with ostensibly successful query. Changing to failure." << endl;

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -43,6 +43,8 @@ public:
     int defray_count = 99999;
     // Should we drop split reads that follow edges not in the graph?
     bool drop_split = false;
+    // We can also pseudorandomly drop reads. What's the probability that we keep a read?
+    double downsample_probability = 1.0;
     // default to 1 thread (as opposed to all)
     int threads = 1;
 
@@ -58,9 +60,10 @@ public:
         vector<size_t> split;
         vector<size_t> repeat;
         vector<size_t> defray;
+        vector<size_t> random;
         Counts() : read(2, 0), filtered(2, 0), wrong_name(2, 0), min_score(2, 0),
                    max_overhang(2, 0), min_end_matches(2, 0), min_mapq(2, 0),
-                   split(2, 0), repeat(2, 0), defray(2, 0) {}
+                   split(2, 0), repeat(2, 0), defray(2, 0), random(2, 0) {}
         Counts& operator+=(const Counts& other) {
             for (int i = 0; i < 2; ++i) {
                 read[i] += other.read[i];
@@ -73,6 +76,7 @@ public:
                 split[i] += other.split[i];
                 repeat[i] += other.repeat[i];
                 defray[i] += other.defray[i];
+                random[i] += other.random[i];
             }
             return *this;
         }
@@ -134,6 +138,12 @@ private:
      * Throws an error if no XG index is specified.
      */
     bool is_split(xg::XG* index, Alignment& alignment);
+    
+    /**
+     * Return true with the given probability, and false otherwise.
+     * Thread safe. May or may not be deterministic within or between threads.
+     */
+    static bool sample_bool(double probability);
     
 };
 }

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -44,6 +44,7 @@ void help_filter(char** argv) {
          << "    -E, --repeat-ends N     filter reads with tandem repeat (motif size <= 2N, spanning >= N bases) at either end" << endl
          << "    -D, --defray-ends N     clip back the ends of reads that are ambiguously aligned, up to N bases" << endl
          << "    -C, --defray-count N    stop defraying after N nodes visited (used to keep runtime in check) [default=99999]" << endl
+         << "    -d, --downsample P      filter out all but the given portion P of the reads, at random" << endl
          << "    -t, --threads N         number of threads [1]" << endl;
 }
 
@@ -87,12 +88,13 @@ int main_filter(int argc, char** argv) {
                 {"repeat-ends", required_argument, 0, 'E'},
                 {"defray-ends", required_argument, 0, 'D'},
                 {"defray-count", required_argument, 0, 'C'},
+                {"downsample", required_argument, 0, 'd'},
                 {"threads", required_argument, 0, 't'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "n:s:r:Od:e:fauo:m:Sx:R:B:Ac:vq:E:D:C:t:",
+        c = getopt_long (argc, argv, "n:s:r:Od:e:fauo:m:Sx:R:B:Ac:vq:E:D:C:d:t:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -156,7 +158,10 @@ int main_filter(int argc, char** argv) {
             break;
         case 'C':
             filter.defray_count = atoi(optarg);
-            break;          
+            break;
+        case 'd':
+            filter.downsample_probability = atof(optarg);
+            break;
         case 't':
             filter.threads = atoi(optarg);
             break;
@@ -171,6 +176,11 @@ int main_filter(int argc, char** argv) {
         default:
             abort ();
         }
+    }
+
+    if (filter.threads < 1) {
+        cerr << "error:[vg filter]: Cannot use " << filter.threads << " threads." << endl;
+        exit(1);
     }
 
     omp_set_num_threads(filter.threads);

--- a/src/unittest/aligner.cpp
+++ b/src/unittest/aligner.cpp
@@ -8,7 +8,10 @@
 #include <string>
 #include "../json2pb.h"
 #include "../vg.pb.h"
+// Undefined behavior hack!
+#define protected public
 #include "../gssw_aligner.hpp"
+#undef protected
 #include "catch.hpp"
 
 namespace vg {
@@ -314,6 +317,78 @@ TEST_CASE("Full-length bonus is applied to both ends by rescoring", "[aligner][a
     REQUIRE(aligner2.score_ungapped_alignment(aln) == 129);
     // And with a full length bonus at each end it's 139.
     REQUIRE(aligner1.score_ungapped_alignment(aln) == 139);
+}
+
+TEST_CASE("Aligner mapping quality estimation is robust", "[aligner][alignment][mapping][mapq]") {
+    
+    Aligner aligner(1, 4, 6, 1, 0);
+    
+    vector<double> scaled_scores;
+    size_t max_idx;
+    
+    SECTION("exact mapping quality is robust") {
+        
+        // Empty vector disallowed
+        
+        SECTION("a 1-element positive vector has its element chosen") {
+            scaled_scores = {10};
+            aligner.maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            REQUIRE(max_idx == 0);
+        }
+        
+        SECTION("a 1-element zero vector has its element chosen") {
+            scaled_scores = {0};
+            aligner.maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            REQUIRE(max_idx == 0);
+        }
+        
+        SECTION("a 1-element negative vector has its element chosen") {
+            scaled_scores = {-10};
+            aligner.maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            REQUIRE(max_idx == 0);
+        }
+        
+        SECTION("a multi-element vector has a maximal element chosen") {
+            scaled_scores = {1, 5, 2, 5, 4};
+            aligner.maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            REQUIRE(max_idx >= 1);
+            REQUIRE(max_idx != 2);
+            REQUIRE(max_idx <= 3);
+        }
+    }
+    
+    SECTION("inexact mapping quality is robust") {
+
+        // Empty vector disallowed
+
+        SECTION("a 1-element positive vector has its element chosen") {
+            scaled_scores = {10};
+            aligner.maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            REQUIRE(max_idx == 0);
+        }
+        
+        SECTION("a 1-element zero vector has its element chosen") {
+            scaled_scores = {0};
+            aligner.maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            REQUIRE(max_idx == 0);
+        }
+        
+        SECTION("a 1-element negative vector has its element chosen") {
+            scaled_scores = {-10};
+            aligner.maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            REQUIRE(max_idx == 0);
+        }
+        
+        SECTION("a multi-element vector has a maximal element chosen") {
+            scaled_scores = {1, 5, 2, 5, 4};
+            aligner.maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            REQUIRE(max_idx >= 1);
+            REQUIRE(max_idx != 2);
+            REQUIRE(max_idx <= 3);
+        }
+    
+    }
+    
 }
    
 }

--- a/src/unittest/aligner.cpp
+++ b/src/unittest/aligner.cpp
@@ -8,10 +8,7 @@
 #include <string>
 #include "../json2pb.h"
 #include "../vg.pb.h"
-// Undefined behavior hack!
-#define protected public
 #include "../gssw_aligner.hpp"
-#undef protected
 #include "catch.hpp"
 
 namespace vg {
@@ -319,9 +316,7 @@ TEST_CASE("Full-length bonus is applied to both ends by rescoring", "[aligner][a
     REQUIRE(aligner1.score_ungapped_alignment(aln) == 139);
 }
 
-TEST_CASE("Aligner mapping quality estimation is robust", "[aligner][alignment][mapping][mapq]") {
-    
-    Aligner aligner(1, 4, 6, 1, 0);
+TEST_CASE("BaseAligner mapping quality estimation is robust", "[aligner][alignment][mapping][mapq]") {
     
     vector<double> scaled_scores;
     size_t max_idx;
@@ -332,25 +327,25 @@ TEST_CASE("Aligner mapping quality estimation is robust", "[aligner][alignment][
         
         SECTION("a 1-element positive vector has its element chosen") {
             scaled_scores = {10};
-            aligner.maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            BaseAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a 1-element zero vector has its element chosen") {
             scaled_scores = {0};
-            aligner.maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            BaseAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a 1-element negative vector has its element chosen") {
             scaled_scores = {-10};
-            aligner.maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            BaseAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a multi-element vector has a maximal element chosen") {
             scaled_scores = {1, 5, 2, 5, 4};
-            aligner.maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            BaseAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
             REQUIRE(max_idx >= 1);
             REQUIRE(max_idx != 2);
             REQUIRE(max_idx <= 3);
@@ -363,25 +358,25 @@ TEST_CASE("Aligner mapping quality estimation is robust", "[aligner][alignment][
 
         SECTION("a 1-element positive vector has its element chosen") {
             scaled_scores = {10};
-            aligner.maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            BaseAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a 1-element zero vector has its element chosen") {
             scaled_scores = {0};
-            aligner.maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            BaseAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a 1-element negative vector has its element chosen") {
             scaled_scores = {-10};
-            aligner.maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            BaseAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a multi-element vector has a maximal element chosen") {
             scaled_scores = {1, 5, 2, 5, 4};
-            aligner.maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            BaseAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
             REQUIRE(max_idx >= 1);
             REQUIRE(max_idx != 2);
             REQUIRE(max_idx <= 3);


### PR DESCRIPTION
I've had to convert some errors to warnings to get my whole-genome run to run through. All of these probably represent bugs we will need to characterize and fix. But I don't know if we want e.g. a NAN coming out of population scoring, or a negative score being generated in vg map, to crash the program when we have plausible ways of handling them.

