### PR TITLE
Remove assertion on parsing bed format (#1775)

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1443,11 +1443,10 @@ void parse_bed_regions(istream& bedstream,
         ss >> sbuf;
         ss >> ebuf;
 
-        if (ss.fail()) {
+        if (ss.fail() || !(sbuf < ebuf)) {
             cerr << "Error parsing bed line " << line << ": " << row << endl;
         } else {
             ss >> name;
-            assert(sbuf < ebuf);
             ss >> score;
             ss >> strand;
 


### PR DESCRIPTION
This is a naive solution to handle #1775.