### PR TITLE
XG circular path support

### DIFF
--- a/src/handle_to_vg.cpp
+++ b/src/handle_to_vg.cpp
@@ -1,9 +1,9 @@
-#include "converter.hpp"
+#include "handle_to_vg.hpp"
 
 namespace vg {
 	using namespace std;
 	
-	VG converter(const HandleGraph* xg) {
+	VG handle_to_vg(const HandleGraph* xg) {
 		// If xg is a null pointer, throw a runtime error
 		if (xg == nullptr) {
 			throw runtime_error("There is no xg to convert"); 

--- a/src/handle_to_vg.hpp
+++ b/src/handle_to_vg.hpp
@@ -1,14 +1,13 @@
-#ifndef VG_CONVERTER_HPP_INCLUDED
-#define VG_CONVERTER_HPP_INCLUDED
+#ifndef VG_HANDLE_TO_VG_HPP_INCLUDED
+#define VG_HANDLE_TO_VG_HPP_INCLUDED
 
 #include "handle.hpp"
-#include "xg.hpp"
 #include "vg.hpp"
 
 namespace vg {
 	using namespace std;
 	/// Takes in a pointer to a HandleGraph and converts it to a VG graph.
-	VG converter(const HandleGraph* g);
+	VG handle_to_vg(const HandleGraph* g);
 }
 
 #endif

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -140,7 +140,7 @@ int main_paths(int argc, char** argv) {
 
     if (!vg_file.empty() && !xg_file.empty()) {
         cerr << "[vg paths] Error: both vg and xg index given" << endl;
-        assert(false);
+        exit(1);
     }
 
     if (!vg_file.empty()) {
@@ -160,10 +160,10 @@ int main_paths(int argc, char** argv) {
             write_alignments(cout, alns);
         } else if (extract_as_vg) {
             cerr << "[vg paths] Error: vg extraction is only defined for prefix queries against a XG/GBWT index pair" << endl;
-            assert(false);
+            exit(1);
         } else if (!thread_prefix.empty()) {
             cerr << "[vg paths] Error: a thread prefix query requires a XG/GBWT index pair" << endl;
-            assert(false);
+            exit(1);
         }
         
     } else if (!xg_file.empty()) {
@@ -178,10 +178,10 @@ int main_paths(int argc, char** argv) {
         } else if (!thread_prefix.empty() || extract_threads) {
             if (gbwt_file.empty()) {
                 cerr << "[vg paths] Error: thread extraction requires a GBWT" << endl;
-                assert(false);
+                exit(1);
             } else if (extract_as_gam == extract_as_vg) {
                 cerr << "[vg paths] Error: thread extraction requires -V or -X to specifiy output format" << endl;
-                assert(false);
+                exit(1);
             }
             gbwt::GBWT index;
             sdsl::load_from_file(index, gbwt_file);
@@ -242,8 +242,8 @@ int main_paths(int argc, char** argv) {
             }
         }
     } else {
-        cerr << "[vg paths] Error: a xg or vg file is required" << endl;
-        assert(false);
+        cerr << "[vg paths] Error: a xg (-x) or vg (-v) file is required" << endl;
+        exit(1);
     }
     
     return 0;

--- a/src/subcommand/xg_main.cpp
+++ b/src/subcommand/xg_main.cpp
@@ -19,7 +19,7 @@
 #include "../cpp/vg.pb.h"
 #include "../xg.hpp"
 #include "../region.hpp"
-#include "../converter.hpp"
+#include "../handle_to_vg.hpp"
 
 using namespace std;
 using namespace vg;
@@ -282,9 +282,9 @@ int main_xg(int argc, char** argv) {
              return 1;
         }
         if (vg_out == "-") {
-            converter(graph).serialize_to_ostream(std::cout);
+            handle_to_vg(graph).serialize_to_ostream(std::cout);
         } else {
-            converter(graph).serialize_to_file(vg_out);
+            handle_to_vg(graph).serialize_to_file(vg_out);
         }
     }
 

--- a/src/subcommand/xg_main.cpp
+++ b/src/subcommand/xg_main.cpp
@@ -281,10 +281,29 @@ int main_xg(int argc, char** argv) {
              cerr << "error [vg xg] no xg graph exists to convert; Try: vg xg -i graph.xg -X graph.vg" << endl;
              return 1;
         }
+        
+        // Convert the xg graph to vg format
+        VG converted = handle_to_vg(graph);
+        
+        // TODO: The converter doesn't copy paths yet. When it does, we can
+        // remove all this path copying code.
+        
+        // Make a raw Proto Graph to hold Path objects
+        Graph path_graph;
+        
+        // Since paths are not copied, copy the paths.
+        for (size_t rank = 1; rank <= graph->max_path_rank(); rank++) {
+            // Extract each path into the path graph
+            *path_graph.add_path() = graph->path(graph->path_name(rank));
+        }
+        
+        // Merge in all the paths
+        converted.extend(path_graph);
+        
         if (vg_out == "-") {
-            handle_to_vg(graph).serialize_to_ostream(std::cout);
+            converted.serialize_to_ostream(std::cout);
         } else {
-            handle_to_vg(graph).serialize_to_file(vg_out);
+            converted.serialize_to_file(vg_out);
         }
     }
 

--- a/src/unittest/handle_to_vg.cpp
+++ b/src/unittest/handle_to_vg.cpp
@@ -1,5 +1,5 @@
 #include "catch.hpp"
-#include "converter.hpp"
+#include "../handle_to_vg.hpp"
 #include "../handle.hpp"
 #include "../vg.hpp"
 #include "../xg.hpp"
@@ -9,13 +9,13 @@ namespace vg {
 
 		using namespace std;
 
-		TEST_CASE("Converter works on empty graph", "[handle][vg][xg]") {
+		TEST_CASE("Handle-to-vg converter works on empty graph", "[handle][vg][xg]") {
 		    xg::XG xg;
-			VG vg = converter(&xg);
+			VG vg = handle_to_vg(&xg);
 			REQUIRE(vg.node_count() == 0);
 			REQUIRE(vg.edge_count() == 0);
 		}
-		TEST_CASE("Converter works on graphs with one node", "[handle][vg][xg]") {
+		TEST_CASE("Handle-to-vg converter works on graphs with one node", "[handle][vg][xg]") {
 			string graph_json = R"(
 				{
 					"node": [
@@ -27,12 +27,12 @@ namespace vg {
 				json2pb(proto_graph, graph_json.c_str(), graph_json.size());
 
 				xg::XG xg(proto_graph);
-				VG vg = converter(&xg);
+				VG vg = handle_to_vg(&xg);
 
 				REQUIRE(xg.node_size() == 1);
 				REQUIRE(vg.node_size() == 1);
 		}
-		TEST_CASE("Converter works on graphs with one reversing edge", "[handle][vg][xg]") {
+		TEST_CASE("Handle-to-vg converter works on graphs with one reversing edge", "[handle][vg][xg]") {
 			string graph_json = R"(
 				{
 					"node": [
@@ -53,7 +53,7 @@ namespace vg {
 				json2pb(proto_graph, graph_json.c_str(), graph_json.size());
 
 				xg::XG xg(proto_graph);
-				VG vg = converter(&xg);
+				VG vg = handle_to_vg(&xg);
 
 				REQUIRE(xg.node_size() == 4);
 				REQUIRE(vg.node_size() == 4);
@@ -61,7 +61,7 @@ namespace vg {
 				REQUIRE(vg.length() == 16);
 
 		}
-		TEST_CASE("Converter works on graphs with reversing edges and loops", "[handle][vg][xg]") {
+		TEST_CASE("Handle-to-vg converter works on graphs with reversing edges and loops", "[handle][vg][xg]") {
 			string graph_json = R"(
 				{
 					"node": [
@@ -85,7 +85,7 @@ namespace vg {
 				json2pb(proto_graph, graph_json.c_str(), graph_json.size());
 
 				xg::XG xg(proto_graph);
-				VG vg = converter(&xg);
+				VG vg = handle_to_vg(&xg);
 
 				REQUIRE(xg.node_sequence(1) == "GATT");
 				REQUIRE(xg.node_sequence(3) == "CGAT");

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -601,7 +601,7 @@ void XG::from_callback(function<void(function<void(Graph&)>)> get_chunks,
     unordered_map<side_t, vector<side_t> > from_to;
     unordered_map<side_t, vector<side_t> > to_from;
     // And the nodes on each path
-    unordered_map<string, vector<trav_t> > path_nodes;
+    map<string, vector<trav_t> > path_nodes;
     // And which paths are circular
     unordered_set<string> circular_paths;
 
@@ -711,7 +711,7 @@ void XG::from_callback(function<void(function<void(Graph&)>)> get_chunks,
 void XG::build(vector<pair<id_t, string> >& node_label,
                unordered_map<side_t, vector<side_t> >& from_to,
                unordered_map<side_t, vector<side_t> >& to_from,
-               unordered_map<string, vector<trav_t> >& path_nodes,
+               map<string, vector<trav_t> >& path_nodes,
                unordered_set<string>& circular_paths,
                bool validate_graph,
                bool print_graph,

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -146,11 +146,12 @@ void XG::load(istream& in) {
         case 6:
         case 7:
         case 8:
+        case 9:
             cerr << "warning:[XG] Loading an out-of-date XG format. In-memory conversion between versions can be time-consuming. "
                  << "For better performance over repeated loads, consider recreating this XG with 'vg index' "
                  << "or upgrading it with 'vg xg'." << endl;
             // Fall through
-        case 9:
+        case 10:
             {
                 sdsl::read_member(seq_length, in);
                 sdsl::read_member(node_count, in);
@@ -312,6 +313,14 @@ void XGPath::load(istream& in, uint32_t file_version, const function<int64_t(siz
     offsets.load(in);
     offsets_rank.load(in, &offsets);
     offsets_select.load(in, &offsets);
+    
+    if (file_version >= 10) {
+        // As of v10 we support the is_circular flag
+        sdsl::read_member(is_circular, in);
+    } else {
+        // Previous versions are interpreted as not circular
+        is_circular = false;
+    }
 }
 
 size_t XGPath::serialize(std::ostream& out,
@@ -327,6 +336,7 @@ size_t XGPath::serialize(std::ostream& out,
     written += offsets.serialize(out, child, "path_node_starts_" + name);
     written += offsets_rank.serialize(out, child, "path_node_starts_rank_" + name);
     written += offsets_select.serialize(out, child, "path_node_starts_select_" + name);
+    written += sdsl::write_member(is_circular, out, child, "is_circular_" + name);
     
     sdsl::structure_tree::add_size(child, written);
     
@@ -335,9 +345,13 @@ size_t XGPath::serialize(std::ostream& out,
 
 XGPath::XGPath(const string& path_name,
                const vector<trav_t>& path,
+               bool is_circular,
                size_t node_count,
                XG& graph,
                size_t* unique_member_count_out) {
+
+    // The circularity flag is just a normal bool
+    this->is_circular = is_circular;
 
     // node ids, the literal path
     int_vector<> ids_iv;
@@ -586,14 +600,18 @@ void XG::from_callback(function<void(function<void(Graph&)>)> get_chunks,
     // need to store node sides
     unordered_map<side_t, vector<side_t> > from_to;
     unordered_map<side_t, vector<side_t> > to_from;
-    map<string, vector<trav_t> > path_nodes;
+    // And the nodes on each path
+    unordered_map<string, vector<trav_t> > path_nodes;
+    // And which paths are circular
+    unordered_set<string> circular_paths;
 
     // This takes in graph chunks and adds them into our temporary storage.
     function<void(Graph&)> lambda = [this,
                                      &node_label,
                                      &from_to,
                                      &to_from,
-                                     &path_nodes](Graph& graph) {
+                                     &path_nodes,
+                                     &circular_paths](Graph& graph) {
 
         for (int64_t i = 0; i < graph.node_size(); ++i) {
             const Node& n = graph.node(i);
@@ -617,13 +635,19 @@ void XG::from_callback(function<void(function<void(Graph&)>)> get_chunks,
             }
         }
 
-        // Print out all the paths in the graph we are loading
         for (int64_t i = 0; i < graph.path_size(); ++i) {
             const Path& p = graph.path(i);
             const string& name = p.name();
 #ifdef VERBOSE_DEBUG
+            // Print out all the paths in the graph we are loading
             cerr << "Path " << name << ": ";
 #endif
+            
+            if (p.is_circular()) {
+                // Remember the circular paths
+                circular_paths.insert(name);
+            }
+
             vector<trav_t>& path = path_nodes[name];
             for (int64_t j = 0; j < p.mapping_size(); ++j) {
                 const Mapping& m = p.mapping(j);
@@ -679,15 +703,16 @@ void XG::from_callback(function<void(function<void(Graph&)>)> get_chunks,
         }
     }
 
-    build(node_label, from_to, to_from, path_nodes, validate_graph, print_graph,
-        store_threads, is_sorted_dag);
+    build(node_label, from_to, to_from, path_nodes, circular_paths, validate_graph,
+        print_graph, store_threads, is_sorted_dag);
     
 }
 
 void XG::build(vector<pair<id_t, string> >& node_label,
                unordered_map<side_t, vector<side_t> >& from_to,
                unordered_map<side_t, vector<side_t> >& to_from,
-               map<string, vector<trav_t> >& path_nodes,
+               unordered_map<string, vector<trav_t> >& path_nodes,
+               unordered_set<string>& circular_paths,
                bool validate_graph,
                bool print_graph,
                bool store_threads,
@@ -837,7 +862,8 @@ void XG::build(vector<pair<id_t, string> >& node_label,
         path_names += start_marker + path_name + end_marker;
         // The path constructor helpfully counts unique path members for us
         size_t unique_member_count;
-        XGPath* path = new XGPath(path_name, pathpair.second, node_count, *this, &unique_member_count);
+        XGPath* path = new XGPath(path_name, pathpair.second, circular_paths.count(path_name),
+            node_count, *this, &unique_member_count);
         paths.push_back(path);
         path_node_count += unique_member_count;
     }
@@ -1944,6 +1970,8 @@ Path XG::path(const string& name) const {
     Path to_return;
     // Fill in the name
     to_return.set_name(name);
+    // And the circularity flag
+    to_return.set_is_circular(xgpath.is_circular);
     
     // There's one ID entry per node visit    
     size_t total_nodes = xgpath.ids.size();
@@ -2447,6 +2475,19 @@ size_t XG::path_length(const string& name) const {
 
 size_t XG::path_length(size_t rank) const {
     return paths[rank-1]->offsets.size();
+}
+
+bool XG::path_is_circular(const string& name) const {
+    auto rank = path_rank(name);
+    if (rank == 0) {
+        // Existence checking might be slightly slower but it will be worth it in saved head scratching
+        throw runtime_error("Path \"" + name + "\" not found in xg index");
+    }
+    return paths[rank-1]->is_circular;
+}
+
+bool XG::path_is_circular(size_t rank) const {
+    return paths[rank-1]->is_circular;
 }
 
 pair<pos_t, int64_t> XG::next_path_position(pos_t pos, int64_t max_search) const {
@@ -3629,6 +3670,50 @@ pos_t XG::graph_pos_at_path_position(const string& name, size_t path_pos) const 
 Alignment XG::target_alignment(const string& name, size_t pos1, size_t pos2, const string& feature, bool is_reverse, Mapping& cigar_mapping) const {
     Alignment aln;
     const XGPath& path = *paths[path_rank(name)-1];
+    
+    if (pos2 < pos1) {
+        // Looks like we want to span the origin of a circular path
+        if (!path.is_circular) {
+            // But the path isn't circular, which is a problem
+            throw runtime_error("Cannot extract Alignment from " + to_string(pos1) +
+                " to " + to_string(pos2) + " across the junction of non-circular path " + name);
+        }
+        
+        // How long is the path?
+        auto path_len = path_length(name);
+        
+        if (pos1 >= path_len) {
+            // We want to start off the end of the path, which is no good.
+            throw runtime_error("Cannot extract Alignment starting at " + to_string(pos1) +
+                " which is past end " + to_string(path_len) + " of path " + name);
+        }
+        
+        if (pos2 > path_len) {
+            // We want to end off the end of the path, which is no good either.
+            throw runtime_error("Cannot extract Alignment ending at " + to_string(pos2) +
+                " which is past end " + to_string(path_len) + " of path " + name);
+        }
+        
+        // Split the proivided Mapping of edits at the path end/start junction
+        auto part_mappings = cut_mapping_offset(cigar_mapping, path_len - pos1);
+        
+        // We extract from pos1 to the end
+        Alignment aln1 = target_alignment(name, pos1, path_len, feature, is_reverse, part_mappings.first); 
+        
+        // And then from the start to pos2
+        Alignment aln2 = target_alignment(name, 0, pos2, feature, is_reverse, part_mappings.second); 
+        
+        if (is_reverse) {
+            // The alignments were flipped, so the second has to be first
+            return merge_alignments(aln2, aln1);
+        } else {
+            // The alignments get merged in the same order
+            return merge_alignments(aln1, aln2);
+        }
+    }
+    
+    // Otherwise, the base case is that we don't go over the circular path junction
+    
     size_t first_node_start = path.offsets_select(path.offsets_rank(pos1+1));
     int64_t trim_start = pos1 - first_node_start;
     {
@@ -3743,6 +3828,47 @@ Alignment XG::target_alignment(const string& name, size_t pos1, size_t pos2, con
 Alignment XG::target_alignment(const string& name, size_t pos1, size_t pos2, const string& feature, bool is_reverse) const {
     Alignment aln;
     const XGPath& path = *paths[path_rank(name)-1];
+    
+    if (pos2 < pos1) {
+        // Looks like we want to span the origin of a circular path
+        if (!path.is_circular) {
+            // But the path isn't circular, which is a problem
+            throw runtime_error("Cannot extract Alignment from " + to_string(pos1) +
+                " to " + to_string(pos2) + " across the junction of non-circular path " + name);
+        }
+        
+        // How long is the path?
+        auto path_len = path_length(name);
+        
+        if (pos1 >= path_len) {
+            // We want to start off the end of the path, which is no good.
+            throw runtime_error("Cannot extract Alignment starting at " + to_string(pos1) +
+                " which is past end " + to_string(path_len) + " of path " + name);
+        }
+        
+        if (pos2 > path_len) {
+            // We want to end off the end of the path, which is no good either.
+            throw runtime_error("Cannot extract Alignment ending at " + to_string(pos2) +
+                " which is past end " + to_string(path_len) + " of path " + name);
+        }
+        
+        // We extract from pos1 to the end
+        Alignment aln1 = target_alignment(name, pos1, path_len, feature, is_reverse); 
+        
+        // And then from the start to pos2
+        Alignment aln2 = target_alignment(name, 0, pos2, feature, is_reverse); 
+        
+        if (is_reverse) {
+            // The alignments were flipped, so the second has to be first
+            return merge_alignments(aln2, aln1);
+        } else {
+            // The alignments get merged in the same order
+            return merge_alignments(aln1, aln2);
+        }
+    }
+   
+    // If we get here, we do the normal non-circular path case.
+    
     size_t first_node_start = path.offsets_select(path.offsets_rank(pos1+1));
     int64_t trim_start = pos1 - first_node_start;
     {

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -100,11 +100,14 @@ public:
     // is faster.
     void from_callback(function<void(function<void(Graph&)>)> get_chunks,
         bool validate_graph = false, bool print_graph = false,
-        bool store_threads = false, bool is_sorted_dag = false); 
+        bool store_threads = false, bool is_sorted_dag = false);
+        
+    /// Actually build the graph
+    /// Note that path_nodes is a map to make the output deterministic in path order.
     void build(vector<pair<id_t, string> >& node_label,
                unordered_map<side_t, vector<side_t> >& from_to,
                unordered_map<side_t, vector<side_t> >& to_from,
-               unordered_map<string, vector<trav_t> >& path_nodes,
+               map<string, vector<trav_t> >& path_nodes,
                unordered_set<string>& circular_paths,
                bool validate_graph,
                bool print_graph,

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -104,16 +104,17 @@ public:
     void build(vector<pair<id_t, string> >& node_label,
                unordered_map<side_t, vector<side_t> >& from_to,
                unordered_map<side_t, vector<side_t> >& to_from,
-               map<string, vector<trav_t> >& path_nodes,
+               unordered_map<string, vector<trav_t> >& path_nodes,
+               unordered_set<string>& circular_paths,
                bool validate_graph,
                bool print_graph,
                bool store_threads,
                bool is_sorted_dag);
                
     // What's the maximum XG version number we can read with this code?
-    const static uint32_t MAX_INPUT_VERSION = 9;
+    const static uint32_t MAX_INPUT_VERSION = 10;
     // What's the version we serialize?
-    const static uint32_t OUTPUT_VERSION = 9;
+    const static uint32_t OUTPUT_VERSION = 10;
                
     // Load this XG index from a stream. Throw an XGFormatError if the stream
     // does not produce a valid XG file.
@@ -317,10 +318,20 @@ public:
     size_t node_start_at_path_position(const string& name, size_t pos) const;
     /// Get the graph position at the given 0-based path position
     pos_t graph_pos_at_path_position(const string& name, size_t pos) const;
+    /// Make an Alignment corresponding to a subregion of a stored path.
+    /// Positions are 0-based, and pos2 is excluded.
+    /// Respects path circularity, so pos2 < pos1 is not a problem.
+    /// If pos1 == pos2, returns an empty alignment.
     Alignment target_alignment(const string& name, size_t pos1, size_t pos2, const string& feature, bool is_reverse) const;
+    /// Same as above, but uses the given Mapping, translated directly form a CIGAR string, as a source of edits.
+    /// The edits are inserted into the generated Alignment, cut as necessary to fit into the Alignment's Mappings.
     Alignment target_alignment(const string& name, size_t pos1, size_t pos2, const string& feature, bool is_reverse, Mapping& cigar_mapping) const;
     size_t path_length(const string& name) const;
     size_t path_length(size_t rank) const;
+    /// Return true if the path with the given name is circular, and false if it is not. The path must exist.
+    bool path_is_circular(const string& name) const;
+    /// Return true if the path with the given rank is circular, and false if it is not. The path must exist.
+    bool path_is_circular(size_t rank) const;
     // nearest node (in steps) that is in a path, and the paths
     pair<int64_t, vector<size_t> > nearest_path_node(int64_t id, int max_steps = 16) const;
     int64_t min_approx_path_distance(int64_t id1, int64_t id2) const;
@@ -805,6 +816,7 @@ public:
     // because in here is the most efficient place to count them.
     XGPath(const string& path_name,
            const vector<trav_t>& path,
+           bool is_circular,
            size_t node_count,
            XG& graph,
            size_t* unique_member_count_out = nullptr);
@@ -825,6 +837,7 @@ public:
     bit_vector offsets;
     rank_support_v<1> offsets_rank;
     bit_vector::select_1_type offsets_select;
+    bool is_circular = false;
     void load(istream& in, uint32_t file_version, const function<int64_t(size_t)>& rank_to_id);
     size_t serialize(std::ostream& out,
                      sdsl::structure_tree_node* v = NULL,

--- a/test/cyclic/circular_path.json
+++ b/test/cyclic/circular_path.json
@@ -1,0 +1,51 @@
+{
+  "node": [
+    {
+      "id": "1",
+      "sequence": "GATTACA"
+    }
+  ],
+  "edge": [
+    {
+      "from": "1",
+      "to": 1
+    }
+  ],
+  "path": [
+    {
+      "name": "round",
+      "is_circular": true,
+      "mapping": [
+        {
+          "position": {
+            "node_id": 1
+          },
+          "edit": [
+            {
+              "from_length": 7,
+              "to_length": 7
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "linear",
+      "is_circular": false,
+      "mapping": [
+        {
+          "position": {
+            "node_id": 1
+          },
+          "edit": [
+            {
+              "from_length": 7,
+              "to_length": 7
+            }
+          ]
+        }
+      ]
+    }
+    
+  ]
+}

--- a/test/cyclic/circular_path_origin.bed
+++ b/test/cyclic/circular_path_origin.bed
@@ -1,0 +1,1 @@
+round	5	2	origin

--- a/test/t/25_circularize.t
+++ b/test/t/25_circularize.t
@@ -5,6 +5,16 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 1
+plan tests 2
 
-is $(vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg circularize -p x - | vg view -j - | grep is_circular | wc -l) 1 "a path may be circularized"
+vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg circularize -p x - > circular.vg
+
+is $(vg view -j circular.vg | jq -c '.path[] | select(.is_circular)' | wc -l) 1 "a path may be circularized"
+
+vg index -x circular.xg circular.vg
+vg xg -i circular.xg -X extracted.vg
+
+is $(vg view -j extracted.vg | jq -c '.path[] | select(.is_circular)' | wc -l) 1 "a circular path survives a round trip to/from xg"
+
+rm -f circular.vg circular.xg extracted.vg
+

--- a/test/t/36_vg_annotate.t
+++ b/test/t/36_vg_annotate.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 1
+plan tests 2
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg
 
@@ -13,6 +13,14 @@ vg mod -N t.vg >t.ref.vg
 vg index -x t.xg t.vg
 vg index -x t.ref.xg t.ref.vg
 
-is $(vg sim -s 7331 -n 10 -l 50 -x t.xg -a | vg annotate -n -x t.ref.xg -a - | awk '{ if ($5 < 50) print }' | wc -l) 10 "we can detect when reads contain non-reference variation"
+is "$(vg sim -s 7331 -n 10 -l 50 -x t.xg -a | vg annotate -n -x t.ref.xg -a - | awk '{ if ($5 < 50) print }' | wc -l)" "10" "we can detect when reads contain non-reference variation"
 
 rm -f t.vg t.ref.vg t.xg t.ref.xg
+
+vg view -Jv cyclic/circular_path.json > circular_path.vg
+vg index -x circular_path.xg circular_path.vg
+vg annotate -p -x circular_path.xg -b cyclic/circular_path_origin.bed > circular_path_origin.gam
+
+is "$(vg view -aj circular_path_origin.gam | jq -c '.path.mapping[].position')" "$(printf '{"node_id":"1","offset":"5"}\n{"node_id":"1"}')" "annotations derived from BED can span the end/start joins of circular paths"
+
+rm -f circular_path.vg circular_path.xg circular_path_origin.gam


### PR DESCRIPTION
This ought to fix #1775.

Now the `is_circular` flag can be stored in the xg index, so we know when paths are circular. We can also round-trip circular (and non-circular) paths through xg now with `vg index` and `vg xg -X`.

There's also code for BED parsing to accept end-before-start records against circular paths, and to generate Alignments that go over the end/start junction of the path for them.