### PR TITLE
Safen option argument parsing

### DIFF
--- a/src/subcommand/add_main.cpp
+++ b/src/subcommand/add_main.cpp
@@ -107,11 +107,11 @@ int main_add(int argc, char** argv) {
             break;
             
         case 'r':
-            variant_range = atoi(optarg);
+            variant_range = parse<int>(optarg);
             break;
             
         case 'f':
-            flank_range = atoi(optarg);
+            flank_range = parse<int>(optarg);
             break;
 
         case 'p':
@@ -119,7 +119,7 @@ int main_add(int argc, char** argv) {
             break;
             
         case 't':
-            omp_set_num_threads(atoi(optarg));
+            omp_set_num_threads(parse<int>(optarg));
             break;
 
         case 'h':

--- a/src/subcommand/align_main.cpp
+++ b/src/subcommand/align_main.cpp
@@ -13,6 +13,7 @@
 
 #include "subcommand.hpp"
 
+#include "../utility.hpp"
 #include "../vg.hpp"
 
 using namespace std;
@@ -110,23 +111,23 @@ int main_align(int argc, char** argv) {
             break;
 
         case 'm':
-            match = atoi(optarg);
+            match = parse<int>(optarg);
             break;
 
         case 'M':
-            mismatch = atoi(optarg);
+            mismatch = parse<int>(optarg);
             break;
 
         case 'g':
-            gap_open = atoi(optarg);
+            gap_open = parse<int>(optarg);
             break;
 
         case 'e':
-            gap_extend = atoi(optarg);
+            gap_extend = parse<int>(optarg);
             break;
 
         case 'T':
-            full_length_bonus = atoi(optarg);
+            full_length_bonus = parse<int>(optarg);
             break;
 
         case OPT_SCORE_MATRIX:

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -172,7 +172,7 @@ int main_augment(int argc, char** argv) {
             verbose = true;
             break;            
         case 't':
-            thread_count = atoi(optarg);
+            thread_count = parse<int>(optarg);
             break;
 
             // Pileup Options
@@ -183,19 +183,19 @@ int main_augment(int argc, char** argv) {
             support_file_name = optarg;
             break;            
         case 'q':
-            min_quality = atoi(optarg);
+            min_quality = parse<int>(optarg);
             break;
         case 'm':
-            max_mismatches = atoi(optarg);
+            max_mismatches = parse<int>(optarg);
             break;
         case 'w':
-            window_size = atoi(optarg);
+            window_size = parse<int>(optarg);
             break;
         case 'M':
             use_mapq = false;
             break;            
         case 'g':
-            min_aug_support = atoi(optarg);
+            min_aug_support = parse<int>(optarg);
             break;            
         case 'U':
             expect_subgraph = true;

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -86,7 +86,7 @@ int main_call(int argc, char** argv) {
             support_caller.verbose = true;
             break;
         case 't':
-            thread_count = atoi(optarg);
+            thread_count = parse<int>(optarg);
             break;
         case 'h':
         case '?':

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -166,11 +166,11 @@ int main_chunk(int argc, char** argv) {
             break;
 
         case 's':
-            chunk_size = atoi(optarg);
+            chunk_size = parse<int>(optarg);
             break;
 
         case 'o':
-            overlap = atoi(optarg);
+            overlap = parse<int>(optarg);
             break;
 
         case 'e':
@@ -186,11 +186,11 @@ int main_chunk(int argc, char** argv) {
             break;
 
         case'c':
-            context_steps = atoi(optarg);
+            context_steps = parse<int>(optarg);
             break;
 
         case 'l':
-            context_length = atoi(optarg);
+            context_length = parse<int>(optarg);
             context_steps = (context_steps > 0 ? context_steps : -1);
             break;
 
@@ -205,12 +205,12 @@ int main_chunk(int argc, char** argv) {
             break;
 
         case 'n':
-            n_chunks = atoi(optarg);
+            n_chunks = parse<int>(optarg);
             id_range = true;
             break;
 
         case 'm':
-            gam_split_size = atoi(optarg);
+            gam_split_size = parse<int>(optarg);
             break;
 
         case 'T':
@@ -226,7 +226,7 @@ int main_chunk(int argc, char** argv) {
             break;
             
         case 't':
-            threads = atoi(optarg);
+            threads = parse<int>(optarg);
             break;
 
         case 'h':

--- a/src/subcommand/circularize_main.cpp
+++ b/src/subcommand/circularize_main.cpp
@@ -68,10 +68,10 @@ int main_circularize(int argc, char** argv){
 
         switch(c){
             case 'a':
-                head = atoi(optarg);
+                head = parse<int>(optarg);
                 break;
             case 'z':
-                tail = atoi(optarg);
+                tail = parse<int>(optarg);
                 break;
             case 'p':
                 path = optarg;

--- a/src/subcommand/compare_main.cpp
+++ b/src/subcommand/compare_main.cpp
@@ -72,7 +72,7 @@ int main_compare(int argc, char** argv) {
                 break;
 
             case 't':
-                num_threads = atoi(optarg);
+                num_threads = parse<int>(optarg);
                 break;
 
             case 'h':

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -158,7 +158,7 @@ int main_construct(int argc, char** argv) {
             break;
 
         case 'z':
-            constructor.vars_per_chunk = atoi(optarg);
+            constructor.vars_per_chunk = parse<int>(optarg);
             break;
 
         case 'R':
@@ -170,11 +170,11 @@ int main_construct(int argc, char** argv) {
             break;
 
         case 't':
-            omp_set_num_threads(atoi(optarg));
+            omp_set_num_threads(parse<int>(optarg));
             break;
 
         case 'm':
-            max_node_size = atoi(optarg);
+            max_node_size = parse<int>(optarg);
             break;
 
         case 'f':

--- a/src/subcommand/crash_main.cpp
+++ b/src/subcommand/crash_main.cpp
@@ -16,6 +16,7 @@
 #include "subcommand.hpp"
 
 #include "../benchmark.hpp"
+#include "../utility.hpp"
 
 using namespace std;
 using namespace vg;
@@ -69,7 +70,7 @@ int main_crash(int argc, char** argv){
         {
 
         case 't':
-            omp_set_num_threads(atoi(optarg));
+            omp_set_num_threads(parse<int>(optarg));
             break;
 
         case 'h':

--- a/src/subcommand/explode_main.cpp
+++ b/src/subcommand/explode_main.cpp
@@ -59,7 +59,7 @@ int main_explode(int argc, char** argv) {
         {
 
         case 't':
-            omp_set_num_threads(atoi(optarg));
+            omp_set_num_threads(parse<int>(optarg));
             break;
 
         case 'h':

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -107,10 +107,10 @@ int main_filter(int argc, char** argv) {
             filter.name_prefix = optarg;
             break;
         case 's':
-            filter.min_secondary = atof(optarg);
+            filter.min_secondary = parse<double>(optarg);
             break;
         case 'r':
-            filter.min_primary = atof(optarg);
+            filter.min_primary = parse<double>(optarg);
             break;
         case 'O':
             filter.rescore = true;
@@ -122,10 +122,10 @@ int main_filter(int argc, char** argv) {
             filter.sub_score = true;
             break;
         case 'o':
-            filter.max_overhang = atoi(optarg);
+            filter.max_overhang = parse<int>(optarg);
             break;
         case 'm':
-            filter.min_end_matches = atoi(optarg);
+            filter.min_end_matches = parse<int>(optarg);
             break;            
         case 'S':
             filter.drop_split = true;
@@ -142,28 +142,28 @@ int main_filter(int argc, char** argv) {
             filter.append_regions = true;
             break;
         case 'c':
-            filter.context_size = atoi(optarg);
+            filter.context_size = parse<int>(optarg);
             break;
         case 'q':
-            filter.min_mapq = atof(optarg);
+            filter.min_mapq = parse<double>(optarg);
             break;
         case 'v':
             filter.verbose = true;
             break;
         case 'E':
-            filter.repeat_size = atoi(optarg);
+            filter.repeat_size = parse<int>(optarg);
             break;
         case 'D':
-            filter.defray_length = atoi(optarg);
+            filter.defray_length = parse<int>(optarg);
             break;
         case 'C':
-            filter.defray_count = atoi(optarg);
+            filter.defray_count = parse<int>(optarg);
             break;
         case 'd':
-            filter.downsample_probability = atof(optarg);
+            filter.downsample_probability = parse<double>(optarg);
             break;
         case 't':
-            filter.threads = atoi(optarg);
+            filter.threads = parse<int>(optarg);
             break;
 
         case 'h':

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -187,7 +187,7 @@ int main_find(int argc, char** argv) {
             break;
             
         case 'B':
-            mem_reseed_length = atoi(optarg);
+            mem_reseed_length = parse<int>(optarg);
             break;
             
         case 'f':
@@ -195,19 +195,19 @@ int main_find(int argc, char** argv) {
             break;
 
         case 'Y':
-            max_mem_length = atoi(optarg);
+            max_mem_length = parse<int>(optarg);
             break;
             
         case 'Z':
-            min_mem_length = atoi(optarg);
+            min_mem_length = parse<int>(optarg);
             break;
             
         case 'j':
-            kmer_stride = atoi(optarg);
+            kmer_stride = parse<int>(optarg);
             break;
 
         case 'z':
-            kmer_size = atoi(optarg);
+            kmer_size = parse<int>(optarg);
             break;
 
         case 'C':
@@ -229,7 +229,7 @@ int main_find(int argc, char** argv) {
             break;
 
         case 'c':
-            context_size = atoi(optarg);
+            context_size = parse<int>(optarg);
             break;
 
         case 'L':
@@ -237,7 +237,7 @@ int main_find(int argc, char** argv) {
             break;
 
         case 'n':
-            node_ids.push_back(atoi(optarg));
+            node_ids.push_back(parse<int>(optarg));
             break;
 
         case 'N':
@@ -245,11 +245,11 @@ int main_find(int argc, char** argv) {
             break;
 
         case 'e':
-            end_id = atoi(optarg);
+            end_id = parse<int>(optarg);
             break;
 
         case 's':
-            start_id = atoi(optarg);
+            start_id = parse<int>(optarg);
             break;
 
         case 'T':
@@ -303,7 +303,7 @@ int main_find(int argc, char** argv) {
             break;
 
         case 'X':
-            approx_id = atoi(optarg);
+            approx_id = parse<int>(optarg);
             break;
 
         case 'G':
@@ -355,7 +355,7 @@ int main_find(int argc, char** argv) {
         string line;
         while (getline(nli, line)){
             for (auto& idstr : split_delims(line, " \t")) {
-                node_ids.push_back(atol(idstr.c_str()));
+                node_ids.push_back(parse<int64_t>(idstr.c_str()));
             }
         }
         nli.close();

--- a/src/subcommand/gamcompare_main.cpp
+++ b/src/subcommand/gamcompare_main.cpp
@@ -63,7 +63,7 @@ int main_gamcompare(int argc, char** argv) {
         {
 
         case 'r':
-            range = atoi(optarg);
+            range = parse<int>(optarg);
             break;
             
         case 'T':
@@ -75,7 +75,7 @@ int main_gamcompare(int argc, char** argv) {
             break;
 
         case 't':
-            threads = atoi(optarg);
+            threads = parse<int>(optarg);
             omp_set_num_threads(threads);
             break;
 

--- a/src/subcommand/genotype_main.cpp
+++ b/src/subcommand/genotype_main.cpp
@@ -156,11 +156,11 @@ int main_genotype(int argc, char** argv) {
             break;
         case 'o':
             // Offset variants
-            variant_offset = std::stoll(optarg);
+            variant_offset = parse<int64_t>(optarg);
             break;
         case 'l':
             // Set a length override
-            length_override = std::stoll(optarg);
+            length_override = parse<int64_t>(optarg);
             break;
         case 'a':
             // Dump augmented graph
@@ -187,13 +187,13 @@ int main_genotype(int argc, char** argv) {
             break;
         case 'P':
             // Set min consistent reads per strand required to keep an allele
-            min_unique_per_strand = std::stoll(optarg);
+            min_unique_per_strand = parse<int64_t>(optarg);
             break;
         case 'p':
             show_progress = true;
             break;
         case 't':
-            thread_count = atoi(optarg);
+            thread_count = parse<int>(optarg);
             break;
         case 'V':
             recall_vcf = optarg;

--- a/src/subcommand/genotype_main.cpp
+++ b/src/subcommand/genotype_main.cpp
@@ -183,7 +183,7 @@ int main_genotype(int argc, char** argv) {
             break;
         case 'd':
             // Set heterozygous genotype prior denominator
-            het_prior_denominator = std::stod(optarg);
+            het_prior_denominator = parse<double>(optarg);
             break;
         case 'P':
             // Set min consistent reads per strand required to keep an allele

--- a/src/subcommand/ids_main.cpp
+++ b/src/subcommand/ids_main.cpp
@@ -79,11 +79,11 @@ int main_ids(int argc, char** argv) {
                 break;
 
             case 'i':
-                increment = atoi(optarg);
+                increment = parse<int>(optarg);
                 break;
 
             case 'd':
-                decrement = atoi(optarg);
+                decrement = parse<int>(optarg);
                 break;
 
             case 'j':

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -221,7 +221,7 @@ int main_index(int argc, char** argv) {
             temp_file::set_dir(optarg);
             break;
         case 't':
-            omp_set_num_threads(atoi(optarg));
+            omp_set_num_threads(parse<int>(optarg));
             break;
         case 'p':
             show_progress = true;

--- a/src/subcommand/inject_main.cpp
+++ b/src/subcommand/inject_main.cpp
@@ -60,7 +60,7 @@ int main_inject(int argc, char** argv) {
             break;
 
         case 't':
-          threads = atoi(optarg);
+          threads = parse<int>(optarg);
           omp_set_num_threads(threads);
           break;
 

--- a/src/subcommand/kmers_main.cpp
+++ b/src/subcommand/kmers_main.cpp
@@ -100,19 +100,19 @@ int main_kmers(int argc, char** argv) {
         {
 
             case 'k':
-                kmer_size = atoi(optarg);
+                kmer_size = parse<int>(optarg);
                 break;
 
             case 'j':
-                kmer_stride = atoi(optarg);
+                kmer_stride = parse<int>(optarg);
                 break;
 
             case 'e':
-                edge_max = atoi(optarg);
+                edge_max = parse<int>(optarg);
                 break;
 
             case 't':
-                omp_set_num_threads(atoi(optarg));
+                omp_set_num_threads(parse<int>(optarg));
                 break;
 
             case 'g':
@@ -141,11 +141,11 @@ int main_kmers(int argc, char** argv) {
                 break;
 
             case 'H':
-                head_id = atoi(optarg);
+                head_id = parse<int>(optarg);
                 break;
 
             case 'T':
-                tail_id = atoi(optarg);
+                tail_id = parse<int>(optarg);
                 break;
 
             case 'B':

--- a/src/subcommand/locify_main.cpp
+++ b/src/subcommand/locify_main.cpp
@@ -104,7 +104,7 @@ int main_locify(int argc, char** argv){
             break;
 
         case 'b':
-            n_best = atoi(optarg);
+            n_best = parse<int>(optarg);
             name_alleles = true;
             break;
 

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -277,27 +277,27 @@ int main_map(int argc, char** argv) {
             break;
 
         case 'c':
-            hit_max = atoi(optarg);
+            hit_max = parse<int>(optarg);
             break;
 
         case 'M':
-            max_multimaps = atoi(optarg);
+            max_multimaps = parse<int>(optarg);
             break;
 
         case '7':
-            identity_weight = atof(optarg);
+            identity_weight = parse<double>(optarg);
             break;
 
         case 'Q':
-            max_mapping_quality = atoi(optarg);
+            max_mapping_quality = parse<int>(optarg);
             break;
 
         case 'E':
-            maybe_mq_threshold = atof(optarg);
+            maybe_mq_threshold = parse<double>(optarg);
             break;
 
         case 'L':
-            full_length_bonus = atoi(optarg);
+            full_length_bonus = parse<int>(optarg);
             break;
 
         case '2':
@@ -305,7 +305,7 @@ int main_map(int argc, char** argv) {
             break;
 
         case 'a':
-            haplotype_consistency_exponent = atof(optarg);
+            haplotype_consistency_exponent = parse<double>(optarg);
             break;
         
         case 'm':
@@ -347,7 +347,7 @@ int main_map(int argc, char** argv) {
             break;
 
         case 't':
-            omp_set_num_threads(atoi(optarg));
+            omp_set_num_threads(parse<int>(optarg));
             break;
 
         case 'D':
@@ -355,19 +355,19 @@ int main_map(int argc, char** argv) {
             break;
 
         case 'e':
-            chance_match = atof(optarg);
+            chance_match = parse<double>(optarg);
             break;
 
         case 'C':
-            drop_chain = atof(optarg);
+            drop_chain = parse<double>(optarg);
             break;
 
         case 'l':
-            min_multimaps = atoi(optarg);
+            min_multimaps = parse<int>(optarg);
             break;
 
         case 'n':
-            mq_overlap = atof(optarg);
+            mq_overlap = parse<double>(optarg);
             break;
 
         case 'G':
@@ -379,59 +379,59 @@ int main_map(int argc, char** argv) {
             break;
 
         case 'w':
-            band_width = atoi(optarg);
+            band_width = parse<int>(optarg);
             break;
 
         case 'O':
-            band_overlap = atoi(optarg);
+            band_overlap = parse<int>(optarg);
             break;
 
         case 'B':
-            band_multimaps = atoi(optarg);
+            band_multimaps = parse<int>(optarg);
             break;
 
         case 'J':
-            max_band_jump = atoi(optarg);
+            max_band_jump = parse<int>(optarg);
             break;
 
         case 'Z':
-            min_banded_mq = atoi(optarg);
+            min_banded_mq = parse<int>(optarg);
             break;
 
         case 'P':
-            min_score = atof(optarg);
+            min_score = parse<double>(optarg);
             break;
 
         case 'k':
-            min_mem_length = atoi(optarg);
+            min_mem_length = parse<int>(optarg);
             break;
 
         case 'Y':
-            max_mem_length = atoi(optarg);
+            max_mem_length = parse<int>(optarg);
             break;
 
         case 'r':
-            mem_reseed_factor = atof(optarg);
+            mem_reseed_factor = parse<double>(optarg);
             break;
 
         case 'W':
-            min_cluster_length = atoi(optarg);
+            min_cluster_length = parse<int>(optarg);
             break;
 
         case 'H':
-            max_target_factor = atoi(optarg);
+            max_target_factor = parse<int>(optarg);
             break;
 
         case '9':
-            buffer_size = atoi(optarg);
+            buffer_size = parse<int>(optarg);
             break;
 
         case 'q':
-            match = atoi(optarg);
+            match = parse<int>(optarg);
             break;
 
         case 'z':
-            mismatch = atoi(optarg);
+            mismatch = parse<int>(optarg);
             break;
 
         case OPT_SCORE_MATRIX:
@@ -443,11 +443,11 @@ int main_map(int argc, char** argv) {
             break;
 
         case 'o':
-            gap_open = atoi(optarg);
+            gap_open = parse<int>(optarg);
             break;
 
         case 'y':
-            gap_extend = atoi(optarg);
+            gap_extend = parse<int>(optarg);
             break;
 
         case 'A':
@@ -455,7 +455,7 @@ int main_map(int argc, char** argv) {
             break;
 
         case 'u':
-            extra_multimaps = atoi(optarg);
+            extra_multimaps = parse<int>(optarg);
             break;
 
         case 'X':
@@ -494,15 +494,15 @@ int main_map(int argc, char** argv) {
         break;
 
         case '3':
-            fragment_sigma = atof(optarg);
+            fragment_sigma = parse<double>(optarg);
             break;
 
         case 'S':
-            unpaired_penalty = atoi(optarg);
+            unpaired_penalty = parse<int>(optarg);
             break;
 
         case '0':
-            mate_rescues = atoi(optarg);
+            mate_rescues = parse<int>(optarg);
             break;
 
         case 'U':
@@ -514,7 +514,7 @@ int main_map(int argc, char** argv) {
             break;
 
         case '4':
-            fragment_model_update = atoi(optarg);
+            fragment_model_update = parse<int>(optarg);
             break;
 
         case 'h':

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -250,11 +250,11 @@ int main_mod(int argc, char** argv) {
             break;
 
         case 'l':
-            path_length = atoi(optarg);
+            path_length = parse<int>(optarg);
             break;
 
         case 'X':
-            chop_to = atoi(optarg);
+            chop_to = parse<int>(optarg);
             break;
 
         case 'u':
@@ -270,7 +270,7 @@ int main_mod(int argc, char** argv) {
             break;
 
         case 'e':
-            edge_max = atoi(optarg);
+            edge_max = parse<int>(optarg);
             break;
 
         case 'm':
@@ -278,11 +278,11 @@ int main_mod(int argc, char** argv) {
             break;
 
         case 't':
-            omp_set_num_threads(atoi(optarg));
+            omp_set_num_threads(parse<int>(optarg));
             break;
 
         case 'f':
-            unfold_to = atoi(optarg);
+            unfold_to = parse<int>(optarg);
             break;
 
         case 'O':
@@ -318,19 +318,19 @@ int main_mod(int argc, char** argv) {
             break;
 
         case 'U':
-            until_normal_iter = atoi(optarg);
+            until_normal_iter = parse<int>(optarg);
             break;
 
         case 'd':
-            dagify_steps = atoi(optarg);
+            dagify_steps = parse<int>(optarg);
             break;
 
         case 'w':
-            dagify_to = atoi(optarg);
+            dagify_to = parse<int>(optarg);
             break;
 
         case 'L':
-            dagify_component_length_max = atoi(optarg);
+            dagify_component_length_max = parse<int>(optarg);
             break;
 
         case 'B':
@@ -346,11 +346,11 @@ int main_mod(int argc, char** argv) {
             break;
 
         case 'g':
-            root_nodes.push_back(atoi(optarg));
+            root_nodes.push_back(parse<int>(optarg));
             break;
 
         case 'x':
-            context_steps = atoi(optarg);
+            context_steps = parse<int>(optarg);
             break;
 
         case 'R':
@@ -358,7 +358,7 @@ int main_mod(int argc, char** argv) {
             break;
 
         case 'y':
-            destroy_node_id = atoi(optarg);
+            destroy_node_id = parse<int>(optarg);
             break;
 
         case 'a':
@@ -374,7 +374,7 @@ int main_mod(int argc, char** argv) {
             break;
 
         case 'M':
-            max_degree = atoi(optarg);
+            max_degree = parse<int>(optarg);
             break;
 
         case 'h':

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -328,11 +328,11 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'X':
-                snarl_cut_size = atoi(optarg);
+                snarl_cut_size = parse<int>(optarg);
                 break;
                 
             case 'a':
-                num_alt_alns = atoi(optarg);
+                num_alt_alns = parse<int>(optarg);
                 break;
                 
             case 'n':
@@ -340,15 +340,15 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'b':
-                frag_length_sample_size = atoi(optarg);
+                frag_length_sample_size = parse<int>(optarg);
                 break;
                 
             case 'I':
-                frag_length_mean = atof(optarg);
+                frag_length_mean = parse<double>(optarg);
                 break;
                 
             case 'D':
-                frag_length_stddev = atof(optarg);
+                frag_length_stddev = parse<double>(optarg);
                 break;
                 
             case 'B':
@@ -356,12 +356,12 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'P':
-                max_mapping_p_value = atof(optarg);
+                max_mapping_p_value = parse<double>(optarg);
                 break;
                 
             case 'v':
             {
-                int mapq_arg = atoi(optarg);
+                int mapq_arg = parse<int>(optarg);
                 if (mapq_arg == 0) {
                     mapq_method = None;
                 }
@@ -382,15 +382,15 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'Q':
-                max_mapq = atoi(optarg);
+                max_mapq = parse<int>(optarg);
                 break;
                 
             case 'p':
-                band_padding = atoi(optarg);
+                band_padding = parse<int>(optarg);
                 break;
                 
             case 'u':
-                max_map_attempts_arg = atoi(optarg);
+                max_map_attempts_arg = parse<int>(optarg);
                 // let 0 be a sentinel for no limit and also a sentinel for not giving an arg
                 if (max_map_attempts_arg == 0) {
                     max_map_attempts_arg == numeric_limits<int>::max();
@@ -398,55 +398,55 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'O':
-                population_max_paths = atoi(optarg);
+                population_max_paths = parse<int>(optarg);
                 break;
                 
             case 'M':
-                max_num_mappings = atoi(optarg);
+                max_num_mappings = parse<int>(optarg);
                 break;
                 
             case 'r':
-                reseed_length = atoi(optarg);
+                reseed_length = parse<int>(optarg);
                 break;
                 
             case 'W':
-                reseed_diff = atof(optarg);
+                reseed_diff = parse<double>(optarg);
                 break;
                 
             case 'k':
-                min_mem_length = atoi(optarg);
+                min_mem_length = parse<int>(optarg);
                 break;
                 
             case 'K':
-                min_clustering_mem_length = atoi(optarg);
+                min_clustering_mem_length = parse<int>(optarg);
                 break;
                 
             case 'c':
-                hit_max = atoi(optarg);
+                hit_max = parse<int>(optarg);
                 break;
                 
             case 'd':
-                max_dist_error = atoi(optarg);
+                max_dist_error = parse<int>(optarg);
                 break;
                 
             case 'w':
-                likelihood_approx_exp = atof(optarg);
+                likelihood_approx_exp = parse<double>(optarg);
                 break;
                 
             case 'C':
-                cluster_ratio = atof(optarg);
+                cluster_ratio = parse<double>(optarg);
                 break;
                 
             case 'U':
-                suboptimal_path_exponent = atof(optarg);
+                suboptimal_path_exponent = parse<double>(optarg);
                 break;
                 
             case 'q':
-                match_score = atoi(optarg);
+                match_score = parse<int>(optarg);
                 break;
                 
             case 'z':
-                mismatch_score = atoi(optarg);
+                mismatch_score = parse<int>(optarg);
                 break;
                 
             case OPT_SCORE_MATRIX:
@@ -458,11 +458,11 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'o':
-                gap_open_score = atoi(optarg);
+                gap_open_score = parse<int>(optarg);
                 break;
                 
             case 'y':
-                gap_extension_score = atoi(optarg);
+                gap_extension_score = parse<int>(optarg);
                 break;
                 
             case 'm':
@@ -470,7 +470,7 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'L':
-                full_length_bonus = atoi(optarg);
+                full_length_bonus = parse<int>(optarg);
                 break;
                 
             case 'A':
@@ -479,7 +479,7 @@ int main_mpmap(int argc, char** argv) {
                 
             case 't':
             {
-                int num_threads = atoi(optarg);
+                int num_threads = parse<int>(optarg);
                 if (num_threads <= 0) {
                     cerr << "error:[vg mpmap] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
                     exit(1);
@@ -489,7 +489,7 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'Z':
-                buffer_size = atoi(optarg);
+                buffer_size = parse<int>(optarg);
                 break;
                 
             case 'h':

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -196,43 +196,43 @@ int main_msga(int argc, char** argv) {
         {
 
         case 'k':
-            min_mem_length = atoi(optarg);
+            min_mem_length = parse<int>(optarg);
             break;
 
         case 'r':
-            mem_reseed_factor = atof(optarg);
+            mem_reseed_factor = parse<double>(optarg);
             break;
 
         case 'W':
-            min_cluster_length = atoi(optarg);
+            min_cluster_length = parse<int>(optarg);
             break;
 
         case 'e':
-            chance_match = atof(optarg);
+            chance_match = parse<double>(optarg);
             break;
 
         case 'Y':
-            max_mem_length = atoi(optarg);
+            max_mem_length = parse<int>(optarg);
             break;
 
         case 'c':
-            hit_max = atoi(optarg);
+            hit_max = parse<int>(optarg);
             break;
 
         case 'M':
-            max_multimaps = atoi(optarg);
+            max_multimaps = parse<int>(optarg);
             break;
 
         case 'l':
-            min_multimaps = atoi(optarg);
+            min_multimaps = parse<int>(optarg);
             break;
 
         case 'u':
-            extra_multimaps = atoi(optarg);
+            extra_multimaps = parse<int>(optarg);
             break;
             
         case 'H':
-            max_target_factor = atoi(optarg);
+            max_target_factor = parse<int>(optarg);
             break;
 
         case 'f':
@@ -261,15 +261,15 @@ int main_msga(int argc, char** argv) {
             break;
 
         case 'w':
-            band_width = atoi(optarg);
+            band_width = parse<int>(optarg);
             break;
 
         case 'J':
-            max_band_jump = atoi(optarg);
+            max_band_jump = parse<int>(optarg);
             break;
 
         case 'B':
-            band_multimaps = atoi(optarg);
+            band_multimaps = parse<int>(optarg);
             break;
 
         case 'D':
@@ -285,19 +285,19 @@ int main_msga(int argc, char** argv) {
             break;
 
         case 'X':
-            doubling_steps = atoi(optarg);
+            doubling_steps = parse<int>(optarg);
             break;
 
         case 'K':
-            idx_kmer_size = atoi(optarg);
+            idx_kmer_size = parse<int>(optarg);
             break;
 
         case 'O':
-            band_overlap = atoi(optarg);
+            band_overlap = parse<int>(optarg);
             break;
 
         case 'm':
-            node_max = atoi(optarg);
+            node_max = parse<int>(optarg);
             break;
 
         case 'N':
@@ -309,48 +309,48 @@ int main_msga(int argc, char** argv) {
             break;
 
         case 'C':
-            drop_chain = atof(optarg);
+            drop_chain = parse<double>(optarg);
             break;
 
         case 'P':
-            min_identity = atof(optarg);
+            min_identity = parse<double>(optarg);
             break;
 
         case 'F':
-            min_banded_mq = atoi(optarg);
+            min_banded_mq = parse<int>(optarg);
             break;
 
         case 't':
-            omp_set_num_threads(atoi(optarg));
-            alignment_threads = atoi(optarg);
+            omp_set_num_threads(parse<int>(optarg));
+            alignment_threads = parse<int>(optarg);
             break;
 
         case 'Q':
-            subgraph_prune = atoi(optarg);
+            subgraph_prune = parse<int>(optarg);
             break;
 
         case 'E':
-            edge_max = atoi(optarg);
+            edge_max = parse<int>(optarg);
             break;
 
         case 'q':
-            match = atoi(optarg);
+            match = parse<int>(optarg);
             break;
 
         case 'z':
-            mismatch = atoi(optarg);
+            mismatch = parse<int>(optarg);
             break;
 
         case 'o':
-            gap_open = atoi(optarg);
+            gap_open = parse<int>(optarg);
             break;
 
         case 'y':
-            gap_extend = atoi(optarg);
+            gap_extend = parse<int>(optarg);
             break;
 
         case 'L':
-            full_length_bonus = atoi(optarg);
+            full_length_bonus = parse<int>(optarg);
             break;
 
         case 'a':

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -93,7 +93,7 @@ int main_pack(int argc, char** argv) {
             bin_size = atoll(optarg);
             break;
         case 't':
-            thread_count = atoi(optarg);
+            thread_count = parse<int>(optarg);
             break;
 
         default:

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -171,11 +171,11 @@ int main_prune(int argc, char** argv) {
         switch (c)
         {
         case 'k':
-            kmer_length = stoi(optarg);
+            kmer_length = parse<int>(optarg);
             kmer_length_set = true;
             break;
         case 'e':
-            edge_max = stoi(optarg);
+            edge_max = parse<int>(optarg);
             edge_max_set = true;
             break;
         case 's':
@@ -210,7 +210,7 @@ int main_prune(int argc, char** argv) {
             show_progress = true;
             break;
         case 't':
-            threads = stoi(optarg);
+            threads = parse<int>(optarg);
             threads = std::min(threads, omp_get_max_threads());
             threads = std::max(threads, 1);
             omp_set_num_threads(threads);

--- a/src/subcommand/recalibrate_main.cpp
+++ b/src/subcommand/recalibrate_main.cpp
@@ -108,7 +108,7 @@ int main_recalibrate(int argc, char** argv) {
             break;
 
         case 't':
-            threads = atoi(optarg);
+            threads = parse<int>(optarg);
             omp_set_num_threads(threads);
             break;
 

--- a/src/subcommand/sift_main.cpp
+++ b/src/subcommand/sift_main.cpp
@@ -131,7 +131,7 @@ int main_sift(int argc, char** argv){
                 help_sift(argv);
                 return 1;
             case 't':
-                threads = atoi(optarg);
+                threads = parse<int>(optarg);
                 break;
             case 'G':
                 graph_name = optarg;
@@ -143,12 +143,12 @@ int main_sift(int argc, char** argv){
             case 'c':
                 do_softclip = true;
                 do_all = false;
-                softclip_max = atoi(optarg);
+                softclip_max = parse<int>(optarg);
                 ff.set_soft_clip_limit(softclip_max);
                 break;
             case 's':
                 do_split_read = true;
-                split_read_limit = atoi(optarg);
+                split_read_limit = parse<int>(optarg);
                 if (softclip_max < 0){
                     softclip_max = 15;
                     ff.set_soft_clip_limit(15);
@@ -158,12 +158,12 @@ int main_sift(int argc, char** argv){
             case 'q':
                 do_quality = true;
                 do_all = false;
-                quality = atof(optarg);
+                quality = parse<double>(optarg);
                 break;
             case 'd':
                 do_depth = true;
                 do_all = false;
-                depth = atof(optarg);
+                depth = parse<double>(optarg);
                 break;
             case 'R':
                 remap = true;
@@ -181,13 +181,13 @@ int main_sift(int argc, char** argv){
                 do_all = false;
                 break;
             case 'I':
-                insert_size = atof(optarg);
+                insert_size = parse<double>(optarg);
                 ff.insert_mean = insert_size;
                 do_all = false;
                 do_insert_size = true;
                 break;
             case 'W':
-                insert_size_sigma = atof(optarg);
+                insert_size_sigma = parse<double>(optarg);
                 ff.insert_sd = insert_size_sigma;
                 do_all = false;
                 break;

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -126,31 +126,31 @@ int main_sim(int argc, char** argv) {
             break;
 
         case 'l':
-            read_length = atoi(optarg);
+            read_length = parse<int>(optarg);
             break;
 
         case 'n':
-            num_reads = atoi(optarg);
+            num_reads = parse<int>(optarg);
             break;
 
         case 's':
-            seed_val = atoi(optarg);
+            seed_val = parse<int>(optarg);
             break;
 
         case 'e':
-            base_error = atof(optarg);
+            base_error = parse<double>(optarg);
             break;
 
         case 'i':
-            indel_error = atof(optarg);
+            indel_error = parse<double>(optarg);
             break;
             
         case 'd':
-            indel_prop = atof(optarg);
+            indel_prop = parse<double>(optarg);
             break;
             
         case 'S':
-            error_scale_factor = atof(optarg);
+            error_scale_factor = parse<double>(optarg);
             break;
 
         case 'f':
@@ -171,11 +171,11 @@ int main_sim(int argc, char** argv) {
             break;
 
         case 'p':
-            fragment_length = atoi(optarg);
+            fragment_length = parse<int>(optarg);
             break;
 
         case 'v':
-            fragment_std_dev = atof(optarg);
+            fragment_std_dev = parse<double>(optarg);
             break;
             
         case 'h':

--- a/src/subcommand/simplify_main.cpp
+++ b/src/subcommand/simplify_main.cpp
@@ -73,11 +73,11 @@ int main_simplify(int argc, char** argv) {
         {
 
         case 'm':
-            min_size = atoi(optarg);
+            min_size = parse<int>(optarg);
             break;
             
         case 'i':
-            max_iterations = atoi(optarg);
+            max_iterations = parse<int>(optarg);
             break;
 
         case 'p':
@@ -93,7 +93,7 @@ int main_simplify(int argc, char** argv) {
             break;
 
         case 't':
-            omp_set_num_threads(atoi(optarg));
+            omp_set_num_threads(parse<int>(optarg));
             break;
 
         case 'h':

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -89,7 +89,7 @@ int main_snarl(int argc, char** argv) {
             break;
 
         case 'm':
-            max_nodes = atoi(optarg);
+            max_nodes = parse<int>(optarg);
             break;
             
         case 't':

--- a/src/subcommand/srpe_main.cpp
+++ b/src/subcommand/srpe_main.cpp
@@ -110,11 +110,11 @@ int main_srpe(int argc, char** argv){
                 remap = true;
                 break;
             case 'm':
-                max_iter = atoi(optarg);
+                max_iter = parse<int>(optarg);
                 break;
 
             case 't':
-                threads = atoi(optarg);
+                threads = parse<int>(optarg);
                 break;
 
             case 'R':

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -163,7 +163,7 @@ int main_stats(int argc, char** argv) {
             break;
 
         case 'n':
-            ids.insert(atoi(optarg));
+            ids.insert(parse<vg::id_t>(optarg));
             break;
 
         case 'A':

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -121,11 +121,11 @@ int main_surject(int argc, char** argv) {
             break;
 
         case 't':
-            omp_set_num_threads(atoi(optarg));
+            omp_set_num_threads(parse<int>(optarg));
             break;
 
         case 'C':
-            compress_level = atoi(optarg);
+            compress_level = parse<int>(optarg);
             break;
 
         case 'h':

--- a/src/subcommand/trace_main.cpp
+++ b/src/subcommand/trace_main.cpp
@@ -83,11 +83,11 @@ int main_trace(int argc, char** argv) {
         break;
 
     case 'n':
-        start_node = atoi(optarg);
+        start_node = parse<int>(optarg);
         break;
 
     case 'd':
-        extend_distance = atoi(optarg);
+        extend_distance = parse<int>(optarg);
         break;
 
     case 'j':

--- a/src/subcommand/vectorize_main.cpp
+++ b/src/subcommand/vectorize_main.cpp
@@ -152,7 +152,7 @@ int main_vectorize(int argc, char** argv){
             mem_positions = true;
             break;
         case 'H':
-            mem_hit_max = atoi(optarg);
+            mem_hit_max = parse<int>(optarg);
             break;
         case 'a':
             a_hot = true;

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -235,7 +235,7 @@ int main_view(int argc, char** argv) {
             break;
 
         case 's':
-            seed_val = atoi(optarg);
+            seed_val = parse<int>(optarg);
             break;
 
         case 'g':
@@ -386,7 +386,7 @@ int main_view(int argc, char** argv) {
             break;
 
         case '7':
-            omp_set_num_threads(atoi(optarg));
+            omp_set_num_threads(parse<int>(optarg));
             break;
 
         case 'h':

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -87,13 +87,13 @@ int main_viz(int argc, char** argv) {
             image_out = optarg;
             break;
         case 'X':
-            image_width = atoi(optarg);
+            image_width = parse<int>(optarg);
             break;
         case 'Y':
-            image_height = atoi(optarg);
+            image_height = parse<int>(optarg);
             break;
         case 's':
-            scale_factor = atof(optarg);
+            scale_factor = parse<double>(optarg);
             break;
         case 'C':
             show_cnv = true;

--- a/src/subcommand/xg_main.cpp
+++ b/src/subcommand/xg_main.cpp
@@ -174,41 +174,41 @@ int main_xg(int argc, char** argv) {
             break;
 
         case 'n':
-            node_id = atol(optarg);
+            node_id = parse<int64_t>(optarg);
             node_context = true;
             break;
 
         case 'c':
-            context_steps = atoi(optarg);
+            context_steps = parse<int>(optarg);
             break;
 
         case 'f':
-            node_id = atol(optarg);
+            node_id = parse<int64_t>(optarg);
             edges_from = true;
             break;
             
         case 't':
-            node_id = atol(optarg);
+            node_id = parse<int64_t>(optarg);
             edges_to = true;
             break;
 
         case 'O':
-            node_id = atol(optarg);
+            node_id = parse<int64_t>(optarg);
             edges_of = true;
             break;
 
         case 'S':
-            node_id = atol(optarg);
+            node_id = parse<int64_t>(optarg);
             edges_on_start = true;
             break;
 
         case 'E':
-            node_id = atol(optarg);
+            node_id = parse<int64_t>(optarg);
             edges_on_end = true;
             break;
 
         case 's':
-            node_id = atol(optarg);
+            node_id = parse<int64_t>(optarg);
             node_sequence = true;
             break;
 

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -544,6 +544,11 @@ void get_input_file(const string& file_name, function<void(istream&)> callback);
 template<typename Result>
 Result parse(const string& arg);
 
+/// Parse a command-line argument C string. Exits with an error if the string
+/// does not contain exactly an item fo the appropriate type.
+template<typename Result>
+Result parse(const char* arg);
+
 /// Parse the appropriate type from the string to the destination value.
 /// Return true if parsing is successful and false (or throw something) otherwise.
 /// Does not throw.
@@ -557,11 +562,17 @@ inline bool parse(const string& arg, int& dest) {
     size_t after;
     dest = std::stoi(arg, &after);
     return(after == arg.size());
-    if (after != arg.size()) {
-        return false;
-    }
-    return true;
 }
+
+template<>
+inline bool parse(const string& arg, long& dest) {
+    size_t after;
+    dest = std::stol(arg, &after);
+    return(after == arg.size());
+}
+
+// TODO: We assume long == int64_t. We can't define both in case it is true,
+// but if it isn't true we will be missing one.
 
 template<>
 inline bool parse(const string& arg, size_t& dest) {
@@ -595,6 +606,12 @@ Result parse(const string& arg) {
         cerr << "error: could not parse " << typeid(to_return).name() << " from argument \"" << arg << "\"" << endl;
         exit(1);
     }
+}
+
+// Implement the C string version in terms of that
+template<typename Result>
+Result parse(const char* arg) {
+    return parse<Result>(string(arg));
 }
  
 }

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -552,7 +552,7 @@ bool parse(const string& arg, Result& dest);
 
 // Define specializations of the second version
 template<>
-bool parse(const string& arg, int& dest) {
+inline bool parse(const string& arg, int& dest) {
     // This will hold the next character after the number parsed
     size_t after;
     dest = std::stoi(arg, &after);
@@ -564,14 +564,14 @@ bool parse(const string& arg, int& dest) {
 }
 
 template<>
-bool parse(const string& arg, size_t& dest) {
+inline bool parse(const string& arg, size_t& dest) {
     size_t after;
     dest = std::stoull(arg, &after);
     return(after == arg.size());
 }
 
 template<>
-bool parse(const string& arg, double& dest) {
+inline bool parse(const string& arg, double& dest) {
     size_t after;
     dest = std::stod(arg, &after);
     return(after == arg.size());

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -408,26 +408,6 @@ private:
     
 size_t integer_power(size_t x, size_t power);
 
-// Get a callback with an istream& to an open file if a file name argument is
-// present after the parsed options, or print an error message and exit if one
-// is not. Handles "-" as a filename as indicating standard input. The reference
-// passed is guaranteed to be valid only until the callback returns. Bumps up
-// optind to the next argument if a filename is found.
-void get_input_file(int& optind, int argc, char** argv, function<void(istream&)> callback);
-
-// Parse out the name of an input file (i.e. the next positional argument), or
-// throw an error. File name must be nonempty, but may be "-" or may not exist.
-string get_input_file_name(int& optind, int argc, char** argv);
-
-// Parse out the name of an output file (i.e. the next positional argument), or
-// throw an error. File name must be nonempty.
-string get_output_file_name(int& optind, int argc, char** argv);
-
-// Get a callback with an istream& to an open file. Handles "-" as a filename as
-// indicating standard input. The reference passed is guaranteed to be valid
-// only until the callback returns.
-void get_input_file(const string& file_name, function<void(istream&)> callback);
-
 double slope(const std::vector<double>& x, const std::vector<double>& y);
 double fit_zipf(const vector<double>& y);
 
@@ -539,8 +519,84 @@ void sort_shuffling_ties(RandomIt begin, RandomIt end, Compare comp) {
 
 }
 
+/// Get a callback with an istream& to an open file if a file name argument is
+/// present after the parsed options, or print an error message and exit if one
+/// is not. Handles "-" as a filename as indicating standard input. The reference
+/// passed is guaranteed to be valid only until the callback returns. Bumps up
+/// optind to the next argument if a filename is found.
+void get_input_file(int& optind, int argc, char** argv, function<void(istream&)> callback);
 
-    
+/// Parse out the name of an input file (i.e. the next positional argument), or
+/// throw an error. File name must be nonempty, but may be "-" or may not exist.
+string get_input_file_name(int& optind, int argc, char** argv);
+
+/// Parse out the name of an output file (i.e. the next positional argument), or
+/// throw an error. File name must be nonempty.
+string get_output_file_name(int& optind, int argc, char** argv);
+
+/// Get a callback with an istream& to an open file. Handles "-" as a filename as
+/// indicating standard input. The reference passed is guaranteed to be valid
+/// only until the callback returns.
+void get_input_file(const string& file_name, function<void(istream&)> callback);
+
+/// Parse a command-line argument string. Exits with an error if the string
+/// does not contain exactly an item fo the appropriate type.
+template<typename Result>
+Result parse(const string& arg);
+
+/// Parse the appropriate type from the string to the destination value.
+/// Return true if parsing is successful and false (or throw something) otherwise.
+/// Does not throw.
+template<typename Result>
+bool parse(const string& arg, Result& dest);
+
+// Define specializations of the second version
+template<>
+bool parse(const string& arg, int& dest) {
+    // This will hold the next character after the number parsed
+    size_t after;
+    dest = std::stoi(arg, &after);
+    return(after == arg.size());
+    if (after != arg.size()) {
+        return false;
+    }
+    return true;
+}
+
+template<>
+bool parse(const string& arg, size_t& dest) {
+    size_t after;
+    dest = std::stoull(arg, &after);
+    return(after == arg.size());
+}
+
+template<>
+bool parse(const string& arg, double& dest) {
+    size_t after;
+    dest = std::stod(arg, &after);
+    return(after == arg.size());
+}
+
+// Implement the first version in terms of the second, for any type
+template<typename Result>
+Result parse(const string& arg) {
+    Result to_return;
+    bool success;
+    try {
+        success = parse<Result>(arg, to_return);
+    } catch(exception& e) {
+        success = false;
+    }
+    if (success) {
+        // Parsing worked
+        return to_return;
+    } else {
+        // Parsing failed
+        cerr << "error: could not parse " << typeid(to_return).name() << " from argument \"" << arg << "\"" << endl;
+        exit(1);
+    }
+}
+ 
 }
 
 #endif


### PR DESCRIPTION
This should fix #1704:

```
[anovak@courtyard vg]$ vg sim -a -x test_alignments.xg -s "test_alignment"
error: could not parse i from argument "test_alignment"
```

The error message might want to be a little less mechanically generated, but this should at least catch a bunch of invalid argument problems.

In the future, we should use the `parse<int>(optarg)` pattern for option arguments, using the parse function templates I defined in utility.hpp. This will generate an informative error when the argument can't be parsed, or when it leaves leftover garbage (as in `123abc`).