### PR TITLE
base pair accurate dotplots

### DIFF
--- a/scripts/vg-dotplots
+++ b/scripts/vg-dotplots
@@ -1,22 +1,28 @@
 #!/bin/bash
 
-if [ $# -ne 2 ];
+if [ $# -ne 3 ];
 then
-    echo "usage: "$(basename $0) "[vg-graph] [output-dir]"
+    echo "usage: "$(basename $0) "[vg-graph.xg] [output-dir] [pdf or png]"
     exit
 fi
 
 graph=$1
 outdir=$2
+type=$3
 
 mkdir -p $outdir
 
-vg stats -O $graph | pv -l >$outdir/pathoverlaps.tsv
+vg dotplot -x $graph | gzip >$outdir/pathoverlaps.tsv.gz
+paths=$(vg paths -L -x $graph)
 
-for cmp in $(cat $outdir/pathoverlaps.tsv | tail -n+2 | cut -f 1 | sort | uniq )
+#(zcat $outdir/pathoverlaps.tsv.gz | tail -n+2 | awk '{ print $1, $4 }' | sort | uniq ) | while read cmp
+for path1 in $paths
 do
-   echo $cmp
-   cat $outdir/pathoverlaps.tsv \
-       | grep "^comparison\|$cmp" \
-       | Rscript -e 'require(tidyverse); y <- read.delim("stdin"); c <- "'$cmp'"; d <- subset(y, comparison == c); m <- max(max(d$x),max(d$y)); ggplot(subset(d,x>0&y>0), aes(x=x, y=y)) + geom_point(size=0.01) + theme_bw() + labs(title=c) + scale_x_continuous(strsplit(c, "____")[[1]][1], limits=c(0,m)) + scale_y_continuous(strsplit(c, "____")[[1]][2], limits=c(0,m)) ; ggsave("'$outdir'/'$cmp'.pdf", width=6.99, height=7.07)'
+    for path2 in $paths
+    do
+        echo $path1 $path2
+        zcat $outdir/pathoverlaps.tsv.gz \
+            | awk 'NR==1 || $1=="'$path1'" && $4=="'$path2'" { print }' \
+            | Rscript -e 'require(ggplot2); d <- read.delim("stdin"); ggplot(d, aes(x=query.pos, y=target.pos)) + geom_point(size=0.1) + scale_x_continuous("'$path1'") + scale_y_continuous("'$path2'") + coord_fixed(ratio = 1) + theme_bw(); ggsave("'$outdir/$path1.$path2.dotplot.$type'", height=7, width=7)'
+    done
 done

--- a/src/subcommand/dotplot_main.cpp
+++ b/src/subcommand/dotplot_main.cpp
@@ -1,0 +1,118 @@
+/** \file dotplot_main.cpp
+ *
+ * Defines the "vg dotplot" subcommand, which renders dotplots from an xg index relating the embedded paths
+ */
+
+
+#include <omp.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <iostream>
+
+#include "subcommand.hpp"
+
+#include "../vg.hpp"
+#include "../xg.hpp"
+#include "../position.hpp"
+
+using namespace std;
+using namespace vg;
+using namespace vg::subcommand;
+
+void help_dotplot(char** argv) {
+    cerr << "usage: " << argv[0] << " dotplot [options]" << endl
+         << "options:" << endl
+         << "  input:" << endl
+         << "    -x, --xg FILE         use the graph in the XG index FILE" << endl;
+    //<< "  output:" << endl;
+}
+
+int main_dotplot(int argc, char** argv) {
+
+    if (argc == 2) {
+        help_dotplot(argv);
+        return 1;
+    }
+
+    string xg_file;
+
+    int c;
+    optind = 2; // force optind past command positional argument
+    while (true) {
+        static struct option long_options[] =
+        {
+            {"xg", required_argument, 0, 'x'},
+            {0, 0, 0, 0}
+        };
+
+        int option_index = 0;
+        c = getopt_long (argc, argv, "hx:",
+                long_options, &option_index);
+
+        // Detect the end of the options.
+        if (c == -1)
+            break;
+
+        switch (c)
+        {
+
+        case 'x':
+            xg_file = optarg;
+            break;
+
+        case 'h':
+        case '?':
+            help_dotplot(argv);
+            exit(1);
+            break;
+
+        default:
+            abort ();
+        }
+    }
+
+    if (xg_file.empty()) {
+        cerr << "[vg dotplot] Error: an xg index is required" << endl;
+        exit(1);
+    } else {
+        xg::XG xgidx;
+        ifstream in(xg_file.c_str());
+        xgidx.load(in);
+        cout << "query.name" << "\t"
+             << "query.pos" << "\t"
+             << "orientation" << "\t"
+             << "target.name" << "\t"
+             << "target.pos" << endl;
+        xgidx.for_each_handle([&](const handle_t& h) {
+                vg::id_t id = xgidx.get_id(h);
+                for (size_t i = 0; i < xgidx.node_length(id); ++i) {
+                    pos_t p = make_pos_t(id, false, i);
+                    map<string, vector<pair<size_t, bool> > > offsets = xgidx.offsets_in_paths(p);
+                    // cross the offsets in output
+                    for (auto& o : offsets) {
+                        auto& name1 = o.first;
+                        for (auto& t : o.second) {
+                            for (auto& m : offsets) {
+                                auto& name2 = m.first;
+                                for (auto& w : m.second) {
+                                    cout << name1 << "\t"
+                                         << t.first << "\t"
+                                         << (t.second == w.second ? "+" : "-") << "\t"
+                                         << name2 << "\t"
+                                         << w.first << endl;
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+    }
+    
+    return 0;
+
+}
+
+// Register subcommand
+static Subcommand vg_dotplot("dotplot", "generate the dotplot matrix from the embedded paths in an xg index", main_dotplot);
+


### PR DESCRIPTION
This PR adds a new CLI interface which dumps the XG index into a dotplot .tsv that can be rendered as dotplots using the `vg-dotplots` script (which has been modified to use it).

The point of this change is to get beyond the node-level dotplots, which caused distortion and were hard to interpret in some cases. The output is now base-level. Here is an example from DRB1-3123:

![drb1-3123 example dotplot](https://user-images.githubusercontent.com/145425/43590776-17b2f5ac-9672-11e8-9519-bfbdb936d748.png)
