### PR TITLE
Annotate bed overlaps to fix #1806

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1433,7 +1433,7 @@ void parse_bed_regions(istream& bedstream,
     // Record end position
     size_t ebuf;
     string name;
-    size_t score;
+    size_t score = 0;
     string strand;
 
     for (int line = 1; getline(bedstream, row); ++line) {
@@ -1479,6 +1479,7 @@ void parse_bed_regions(istream& bedstream,
 
         // Make the Alignment
         Alignment alignment = xgindex->target_alignment(seq, sbuf, ebuf, name, is_reverse);
+        alignment.set_score(score);
 
         out_alignments->push_back(alignment);
     }

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -195,6 +195,9 @@ Alignment simplify(const Alignment& a, bool trim_internal_deletions = true);
 // quality information; a kind of poor man's pileup
 map<id_t, int> alignment_quality_per_node(const Alignment& aln);
 
+/// Parse regions from the given BED file into Alignments in a vector.
+/// Reads the optional name, is_reverse, and score fields if present, and populates the relevant Alignment fields.
+/// Skips and warns about malformed or illegal BED records.
 void parse_bed_regions(istream& bedstream, xg::XG* xgindex, vector<Alignment>* out_alignments);
 void parse_gff_regions(istream& gtfstream, xg::XG* xgindex, vector<Alignment>* out_alignments);
 

--- a/src/annotation.hpp
+++ b/src/annotation.hpp
@@ -26,21 +26,45 @@ using namespace std;
 template<typename AnnotationType, typename Annotated>
 AnnotationType get_annotation(const Annotated& annotated, const string& name);
 
-/// Set the annotation with the given name to the given value.
+/// Get the annotation with the given name and return it.
+/// If not present, returns the Protobuf default value for the annotation type.
 /// The value may be a primitive type or an entire Protobuf object.
+/// It is undefined behavior to read a value out into a different type than it was stored with.
+template<typename AnnotationType, typename Annotated>
+AnnotationType get_annotation(Annotated* annotated, const string& name);
+
+// We implement the mutators vor pointers (to match the Protobuf
+// mutable_whatever()) as well as for references (because I kept forgetting to
+// use the pointers)
+
+/// Set the annotation with the given name to the given value. The value may be
+/// a primitive type or a vector of a primitive type.
 template<typename AnnotationType, typename Annotated>
 void set_annotation(Annotated* annotated, const string& name, const AnnotationType& annotation);
+
+/// Set the annotation with the given name to the given value.
+/// The value may be a primitive type or a vector of a primitive type.
+template<typename AnnotationType, typename Annotated>
+void set_annotation(Annotated& annotated, const string& name, const AnnotationType& annotation);
 
 /// Clear the annotation with the given name.
 template<typename Annotated>
 void clear_annotation(Annotated* annotated, const string& name);
 
+/// Clear the annotation with the given name
+template<typename Annotated>
+void clear_annotation(Annotated& annotated, const string& name);
+
 ////////////////////////////////////////////////////////////////////////
 // Internal Definitions
 ////////////////////////////////////////////////////////////////////////
 
-/// We define an adapter for things that are annotated to let us get at the annotation struct.
-template<typename T>
+/// We define an adapter for things that are annotated to let us get at the
+/// annotation struct. It is only defined for the actual types (Alignment,
+/// MultipathAlignment) and not pointers to them. This keeps the API overloads
+/// that are supposed to be for references to the types from operating on
+/// references to pointers to the types instead.
+template<typename T, typename Enabled = typename enable_if<!is_pointer<T>::value>::type>
 struct Annotation {
     /// Get the immutable annotations Struct
     static const google::protobuf::Struct& get(const T& t);
@@ -62,20 +86,22 @@ inline google::protobuf::Value value_cast(const T& wrap);
 // Implementation
 ////////////////////////////////////////////////////////////////////////
 
-template<typename T>
-const google::protobuf::Struct& Annotation<T>::get(const T& t) {
+template<typename T, typename Enabled>
+const google::protobuf::Struct& Annotation<T, Enabled>::get(const T& t) {
     return t.annotation();
 }
 
-template<typename T>
-google::protobuf::Struct* Annotation<T>::get_mutable(T* t) {
+template<typename T, typename Enabled>
+google::protobuf::Struct* Annotation<T, Enabled>::get_mutable(T* t) {
     return t->mutable_annotation();
 }
 
-template<typename T>
-void Annotation<T>::clear(T* t) {
+template<typename T, typename Enabled>
+void Annotation<T, Enabled>::clear(T* t) {
     t->clear_annotation();
 }
+
+// We define all these value_cast implementations, in both directions
 
 template<>
 inline bool value_cast<bool, void>(const google::protobuf::Value& value) {
@@ -116,10 +142,37 @@ inline google::protobuf::Value value_cast<string, void>(const string& wrap) {
     return to_return;
 }
 
-// TODO: more value casts for e.g. vectors and ints and embedded messages.
+// We also have implementations for vectors and other push_back-able containers.
+
+template<typename Container, typename Eabled>
+inline Container value_cast(const google::protobuf::Value& value) {
+    assert(value.kind_case() == google::protobuf::Value::KindCase::kListValue);
+    Container items;
+    for (auto& nested_value : value.list_value().values()) {
+        items.push_back(value_cast<typename Container::value_type>(nested_value));
+    }
+    return items;
+}
+
+template<typename Container, typename Enabled>
+inline google::protobuf::Value value_cast(const Container& wrap) {
+    // Make a new list that the Protobuf Value message will eventually own
+    google::protobuf::ListValue* list = new google::protobuf::ListValue();
+    for (auto& item : wrap) {
+        // Put all the items from the container into it
+        *list->add_values() = value_cast(item);
+    }
+
+    google::protobuf::Value to_return;
+    // Hand it off
+    to_return.set_allocated_list_value(list);
+    return to_return;
+}
+
+// TODO: more value casts for e.g. ints and embedded messages.
 
 template<typename AnnotationType, typename Annotated>
-AnnotationType get_annotation(const Annotated& annotated, const string& name) {
+inline AnnotationType get_annotation(const Annotated& annotated, const string& name) {
     // Grab the whole annotation struct
     auto annotation_struct = Annotation<Annotated>::get(annotated);
     
@@ -137,7 +190,12 @@ AnnotationType get_annotation(const Annotated& annotated, const string& name) {
 }
 
 template<typename AnnotationType, typename Annotated>
-void set_annotation(Annotated* annotated, const string& name, const AnnotationType& annotation) {
+inline AnnotationType get_annotation(Annotated* annotated, const string& name) {
+    return get_annotation<AnnotationType>(*annotated, name);
+}
+
+template<typename AnnotationType, typename Annotated>
+inline void set_annotation(Annotated* annotated, const string& name, const AnnotationType& annotation) {
     // Get ahold of the struct
     auto* annotation_struct = Annotation<Annotated>::get_mutable(annotated);
     
@@ -145,12 +203,22 @@ void set_annotation(Annotated* annotated, const string& name, const AnnotationTy
     (*annotation_struct->mutable_fields())[name] = value_cast(annotation);
 }
 
+template<typename AnnotationType, typename Annotated>
+inline void set_annotation(Annotated& annotated, const string& name, const AnnotationType& annotation) {
+    set_annotation(&annotated, name, annotation);
+}
+
 template<typename Annotated>
-void clear_annotation(Annotated* annotated, const string& name) {
+inline void clear_annotation(Annotated* annotated, const string& name) {
     // Get ahold of the struct
     auto* annotation_struct = Annotation<Annotated>::get_mutable(annotated);
     // Clear out that field
     annotation_struct->mutable_fields()->clear(name);
+}
+
+template<typename Annotated>
+inline void clear_annotation(Annotated& annotated, const string& name) {
+    clear_annotation(&annotated, name);
 }
 
 }

--- a/src/annotation.hpp
+++ b/src/annotation.hpp
@@ -75,11 +75,11 @@ struct Annotation {
 };
 
 /// Cast a Protobuf generic Value to any type.
-template <typename T, typename Enabled = void>
+template <typename T>
 inline T value_cast(const google::protobuf::Value& value);
 
 /// Cast any type to a generic Protobuf value.
-template<typename T,  typename Enabled = void>
+template<typename T>
 inline google::protobuf::Value value_cast(const T& wrap);
 
 ////////////////////////////////////////////////////////////////////////
@@ -104,39 +104,39 @@ void Annotation<T, Enabled>::clear(T* t) {
 // We define all these value_cast implementations, in both directions
 
 template<>
-inline bool value_cast<bool, void>(const google::protobuf::Value& value) {
+inline bool value_cast<bool>(const google::protobuf::Value& value) {
     assert(value.kind_case() == google::protobuf::Value::KindCase::kBoolValue);
     return value.bool_value();
 }
 
 template<>
-inline double value_cast<double, void>(const google::protobuf::Value& value) {
+inline double value_cast<double>(const google::protobuf::Value& value) {
     assert(value.kind_case() == google::protobuf::Value::KindCase::kNumberValue);
     return value.number_value();
 }
 
 template<>
-inline string value_cast<string, void>(const google::protobuf::Value& value) {
+inline string value_cast<string>(const google::protobuf::Value& value) {
     assert(value.kind_case() == google::protobuf::Value::KindCase::kStringValue);
     return value.string_value();
 }
 
 template<>
-inline google::protobuf::Value value_cast<bool, void>(const bool& wrap) {
+inline google::protobuf::Value value_cast<bool>(const bool& wrap) {
     google::protobuf::Value to_return;
     to_return.set_bool_value(wrap);
     return to_return;
 }
 
 template<>
-inline google::protobuf::Value value_cast<double, void>(const double& wrap) {
+inline google::protobuf::Value value_cast<double>(const double& wrap) {
     google::protobuf::Value to_return;
     to_return.set_number_value(wrap);
     return to_return;
 }
 
 template<>
-inline google::protobuf::Value value_cast<string, void>(const string& wrap) {
+inline google::protobuf::Value value_cast<string>(const string& wrap) {
     google::protobuf::Value to_return;
     to_return.set_string_value(wrap);
     return to_return;
@@ -144,7 +144,7 @@ inline google::protobuf::Value value_cast<string, void>(const string& wrap) {
 
 // We also have implementations for vectors and other push_back-able containers.
 
-template<typename Container, typename Eabled>
+template<typename Container>
 inline Container value_cast(const google::protobuf::Value& value) {
     assert(value.kind_case() == google::protobuf::Value::KindCase::kListValue);
     Container items;
@@ -154,7 +154,7 @@ inline Container value_cast(const google::protobuf::Value& value) {
     return items;
 }
 
-template<typename Container, typename Enabled>
+template<typename Container>
 inline google::protobuf::Value value_cast(const Container& wrap) {
     // Make a new list that the Protobuf Value message will eventually own
     google::protobuf::ListValue* list = new google::protobuf::ListValue();

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1970,7 +1970,7 @@ pos_t Mapper::likely_mate_position(const Alignment& aln, bool is_first_mate) {
     }
 }
 
-map<string, vector<pair<size_t, bool> > > Mapper::alignment_path_offsets(const Alignment& aln, bool just_min, bool nearby) {
+map<string, vector<pair<size_t, bool> > > Mapper::alignment_path_offsets(const Alignment& aln, bool just_min, bool nearby) const {
     return xg_alignment_path_offsets(aln, just_min, nearby, xindex);
 }
 
@@ -2953,11 +2953,11 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
 
 }
 
-void Mapper::annotate_with_initial_path_positions(vector<Alignment>& alns) {
+void Mapper::annotate_with_initial_path_positions(vector<Alignment>& alns) const {
     for (auto& aln : alns) annotate_with_initial_path_positions(aln);
 }
 
-void Mapper::annotate_with_initial_path_positions(Alignment& aln) {
+void Mapper::annotate_with_initial_path_positions(Alignment& aln) const {
     if (!aln.refpos_size()) {
         auto init_path_positions = alignment_path_offsets(aln);
         for (const pair<string, vector<pair<size_t, bool> > >& pos_record : init_path_positions) {

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -494,9 +494,9 @@ public:
 
     double graph_entropy(void);
 
-    // use the xg index to get the first position of an alignment on a reference path
-    void annotate_with_initial_path_positions(Alignment& aln);
-    void annotate_with_initial_path_positions(vector<Alignment>& alns);
+    // Use the xg index to get the first position of an alignment on a reference path. Thread safe.
+    void annotate_with_initial_path_positions(Alignment& aln) const;
+    void annotate_with_initial_path_positions(vector<Alignment>& alns) const;
 
     // Return true of the two alignments are consistent for paired reads, and false otherwise
     bool alignments_consistent(const map<string, double>& pos1,
@@ -619,7 +619,7 @@ public:
     // get the approximate position of the alignment or return -1 if it can't be had
     int64_t approx_alignment_position(const Alignment& aln);
     // get the full path offsets for the alignment, considering every mapping if just_first is not set
-    map<string, vector<pair<size_t, bool> > > alignment_path_offsets(const Alignment& aln, bool just_min = true, bool nearby = false);
+    map<string, vector<pair<size_t, bool> > > alignment_path_offsets(const Alignment& aln, bool just_min = true, bool nearby = false) const;
     // get the end position of the alignment
     Position alignment_end_position(const Alignment& aln);
     // get the approximate distance between the starts of the alignments or return -1 if undefined

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -223,14 +223,12 @@ int main_annotate(int argc, char** argv) {
             // TODO: this ends up storing two copies, but is easier than writing the map logic on the unique_ptr value.
             unordered_map<string, unique_ptr<string>> feature_names;
             auto intern = [&feature_names](const string& value) -> const string* {
-                // See if it's in the map
-                auto found = feature_names.find(value);
-                if (found == feature_names.end()) {
+                if (!feature_names.count(value)) {
                     // If it isn't in the map, put it in
-                    found = feature_names.emplace_hint(found, value, new string(value));
+                    feature_names[value] = unique_ptr<srting>(new string(value));
+                    
                 }
-                // Return the pointer to the string owned by the unique_ptr
-                return found->second.get();
+                return feature_names[value].second.get();
             };
             
             // This will hold, for each graph node, the start to past-end

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -4,6 +4,7 @@
 #include "../mapper.hpp"
 #include "../stream.hpp"
 #include "../alignment.hpp"
+#include "../annotation.hpp"
 
 #include <unistd.h>
 #include <getopt.h>
@@ -12,16 +13,62 @@ using namespace vg;
 using namespace vg::subcommand;
 
 void help_annotate(char** argv) {
-    cerr << "usage: " << argv[0] << " annotate [options] >output.{gam,vg}" << endl
-         << "    -x, --xg-name FILE     an xg index describing a graph" << endl
-         << "    -b, --bed-name FILE    a bed file describing a subpath" << endl
-         << "    -f, --gff-name FILE    a gff3/gtf file describing a subpath" << endl
-         << "    -d, --db-name DIR      a rocksdb index of a GAM" << endl
-         << "    -v, --vg FILE          annotate this graph" << endl
-         << "    -g, --gcsa FILE        a GCSA2 index file base name" << endl
-         << "    -a, --gam FILE         alignments to annotate" << endl
+    cerr << "usage: " << argv[0] << " annotate [options] >output.{gam,vg,tsv}" << endl
+         << "graph annotation options:" << endl
+         << "    -x, --xg-name FILE     xg index of the graph to annotate (required)" << endl
+         << "    -b, --bed-name FILE    a BED file to convert to GAM. May repeat." << endl
+         << "    -f, --gff-name FILE    a GFF3/GTF file to convert to GAM. May repeat." << endl
+         << "alignment annotation options:" << endl
+         << "    -a, --gam FILE         file of Alignments to annotate (required)" << endl
+         << "    -x, --xg-name FILE     xg index of the graph against which the Alignments are aligned (required)" << endl
          << "    -p, --positions        annotate alignments with reference positions" << endl
-         << "    -n, --novelty          table for each read: name, bp not in xg, nodes not in xg" << endl;
+         << "    -b, --bed-name FILE    annotate alignments with overlapping region names from this BED. May repeat." << endl
+         << "    -n, --novelty          output TSV table with header describing how much of each Alignment is novel" << endl
+         << "    -t, --threads          use the specified number of threads" << endl;
+}
+
+/// Find the region of the Mapping's node used by the Mapping, in forward strand space, as start to past_end.
+static pair<size_t, size_t> mapping_to_range(const xg::XG* xg_index, const Mapping& mapping) {
+    // How much of the node does it cover?
+    auto mapping_length = mapping_from_length(mapping);
+    
+    // Work out where the start and past-end positions on the node's forward strand are.
+    pair<size_t, size_t> node_range;
+    if (mapping.position().is_reverse()) {
+        // On the reverse strand we need the node length
+        // TODO: getting it can be slow
+        auto node_length = xg_index->node_length(mapping.position().node_id());
+        
+        node_range.first = node_length - mapping.position().offset() - mapping_length;
+        node_range.second = node_length - mapping.position().offset();
+    } else {
+        // On the forward strand this is easy
+        node_range.first = mapping.position().offset();
+        node_range.second = node_range.first + mapping_length;
+    }
+    
+    return node_range;
+}
+
+using feature_t = pair<pair<size_t, size_t>, const string*>;
+
+/// Look up all ranges in the vector of features that overlap the start to past-end search interval.
+/// Return their unique string* interned feature names.
+static unordered_set<const string*> find_overlapping(const vector<feature_t>& ranges, pair<size_t, size_t> search_interval) {
+    // TODO: We expect at most a few features per node, so just do a linear scan
+    
+    unordered_set<const string*> to_return;
+    
+    for (auto& feature : ranges) {
+        auto& feature_range = feature.first;
+        
+        if (feature_range.second > search_interval.first && feature_range.first < search_interval.second) {
+            // There is overlap
+            to_return.insert(feature.second);
+        }
+    }
+    
+    return to_return;
 }
 
 int main_annotate(int argc, char** argv) {
@@ -32,11 +79,8 @@ int main_annotate(int argc, char** argv) {
     }
 
     string xg_name;
-    string rocksdb_name;
-    string gcsa_name;
-    string vg_name;
-    string bed_name;
-    string gff_name;
+    vector<string> bed_names;
+    vector<string> gff_names;
     string gam_name;
     bool add_positions = false;
     bool novelty = false;
@@ -47,19 +91,18 @@ int main_annotate(int argc, char** argv) {
         static struct option long_options[] =
         {
             {"gam", required_argument, 0, 'a'},
-            {"gcsa", required_argument, 0, 'g'},
             {"positions", no_argument, 0, 'p'},
-            {"vg", required_argument, 0, 'v'},
             {"xg-name", required_argument, 0, 'x'},
             {"bed-name", required_argument, 0, 'b'},
             {"gff-name", required_argument, 0, 'f'},
-            {"db-name", required_argument, 0, 'd'},
             {"novelty", no_argument, 0, 'n'},
+            {"threads", required_argument, 0, 't'},
+            {"help", required_argument, 0, 'h'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:d:v:g:a:pb:f:n",
+        c = getopt_long (argc, argv, "hx:a:pb:f:nt:h",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -68,20 +111,8 @@ int main_annotate(int argc, char** argv) {
 
         switch (c)
         {
-        case 'd':
-            rocksdb_name = optarg;
-            break;
-
         case 'x':
             xg_name = optarg;
-            break;
-
-        case 'v':
-            vg_name = optarg;
-            break;
-
-        case 'g':
-            gcsa_name = optarg;
             break;
 
         case 'a':
@@ -89,11 +120,11 @@ int main_annotate(int argc, char** argv) {
             break;
 
         case 'b':
-            bed_name = optarg;
+            bed_names.push_back(optarg);
             break;
 
         case 'f':
-            gff_name = optarg;
+            gff_names.push_back(optarg);
             break;
 
         case 'p':
@@ -102,6 +133,10 @@ int main_annotate(int argc, char** argv) {
             
         case 'n':
             novelty = true;
+            break;
+            
+        case 't':
+            omp_set_num_threads(parse<size_t>(optarg));
             break;
 
         case 'h':
@@ -116,8 +151,10 @@ int main_annotate(int argc, char** argv) {
     }
     xg::XG* xg_index = nullptr;
     if (!xg_name.empty()) {
-        ifstream in(xg_name);
-        xg_index = new xg::XG(in);
+        get_input_file(xg_name, [&](istream& in) {
+            // Read in the XG index
+            xg_index = new xg::XG(in);
+        });
     } else {
         cerr << "error [vg annotate]: no xg index provided" << endl;
         return 1;
@@ -127,19 +164,16 @@ int main_annotate(int argc, char** argv) {
     
     if (!gam_name.empty()) {
         vector<Alignment> buffer;
-        if (add_positions) {
-            //map<string, double> Mapper::alignment_mean_path_positions(const Alignment& aln, bool first_hit_only);
-            function<void(Alignment&)> lambda = [&](Alignment& aln) {
-                aln.clear_refpos();
-                mapper.annotate_with_initial_path_positions(aln);
-                buffer.push_back(aln);
-                stream::write_buffered(cout, buffer, 100);
-            };
-            get_input_file(gam_name, [&](istream& in) {
-                    stream::for_each(in, lambda);
-                });
-            stream::write_buffered(cout, buffer, 0); // flush
-        } else if (novelty) {
+        
+        if (novelty) {
+            // We are computing a novelty table.
+            // TODO: refactor this into novelty annotation and annotation-to-table conversion.
+            if (add_positions || !bed_names.empty()) {
+                // We can't amke the TSV and also annotate the reads
+                cerr << "error [vg annotate]: Cannot annotate reads while computing novelty table" << endl;
+                return 1;
+            }
+            
             cout << "name\tlength.bp\tunaligned.bp\tknown.nodes\tknown.bp\tnovel.nodes\tnovel.bp" << endl;
             function<void(Alignment&)> lambda = [&](Alignment& aln) {
                 // count the number of positions in the alignment that aren't in the graph
@@ -172,28 +206,140 @@ int main_annotate(int argc, char** argv) {
                 << novel_bp << endl;
             };
             get_input_file(gam_name, [&](istream& in) {
-                    stream::for_each(in, lambda);
+                stream::for_each(in, lambda);
+            });
+        } else {
+            // We are annotating the actual reads
+            
+            // Make per-thread buffers for writing them
+            vector<vector<Alignment>> buffers;
+            buffers.resize(get_thread_count());
+            
+            // We will need to track mappings from graph node regions to BED features.
+            // We don't want each of those mappings to have a copy of the feature name, because that could be big.
+            // So we intern the feature name strings.
+            
+            // This will map each string to its cannonical copy.
+            // TODO: this ends up storing two copies, but is easier than writing the map logic on the unique_ptr value.
+            unordered_map<string, unique_ptr<string>> feature_names;
+            auto intern = [&feature_names](const string& value) -> const string* {
+                // See if it's in the map
+                auto found = feature_names.find(value);
+                if (found == feature_names.end()) {
+                    // If it isn't in the map, put it in
+                    found = feature_names.emplace_hint(found, value, new string(value));
+                }
+                // Return the pointer to the string owned by the unique_ptr
+                return found->second.get();
+            };
+            
+            // This will hold, for each graph node, the start to past-end
+            // regions occupied by BED features, and the names of those
+            // features.
+            // TODO: To enable better than linear search within a node, we ought to sort these.
+            unordered_map<vg::id_t, vector<feature_t>> features_on_node;
+            // TODO: We can't use a Paths object because we lack unique names 
+            
+            for (auto& bed_name : bed_names) {
+                // If there are BED files, load them up
+                
+                get_input_file(bed_name, [&](istream& bed_stream) {
+                    // Load all the BED regions as Alignments embedded in the graph.
+                    vector<Alignment> bed_regions;
+                    parse_bed_regions(bed_stream, xg_index, &bed_regions);
+                    
+                    for (auto& region : bed_regions) {
+                        // For each region in the BED
+                        
+                        // Get the cannonical copy of its name (which may be "")
+                        const string* interned_name = intern(region.name());
+                        
+                        for (auto& mapping : region.path().mapping()) {
+                            // Scan the Mappings. We know each Mapping will be all perfect matches.
+                            
+                            // Record that the alignment covers the given region on the given node.
+                            features_on_node[mapping.position().node_id()].emplace_back(mapping_to_range(xg_index, mapping), interned_name);
+                        }
+                    }
                 });
-        }
-    } else if (!bed_name.empty()) {
-        vector<Alignment> buffer;
-        if (add_positions) {
-            ifstream bed_stream(bed_name.c_str());
-
-            parse_bed_regions(bed_stream, xg_index, &buffer);
-            stream::write_buffered(cout, buffer, 0); // flush
-        }
-    } else if (!gff_name.empty()) {
-        vector<Alignment> buffer;
-        if (add_positions) {
-            ifstream gff_stream(gff_name.c_str());
-
-            parse_gff_regions(gff_stream, xg_index, &buffer);
-            stream::write_buffered(cout, buffer, 0); // flush
+            }
+            
+            get_input_file(gam_name, [&](istream& in) {
+                stream::for_each_parallel<Alignment>(in, [&](Alignment& aln) {
+                    // For each read
+                    
+                    if (add_positions) {
+                        // Annotate it with its initial position on each path it touches
+                        aln.clear_refpos();
+                        mapper.annotate_with_initial_path_positions(aln);
+                    }
+                    
+                    if (!features_on_node.empty()) {
+                        // We want to annotate with BED feature overlaps as well.
+                        unordered_set<const string*> touched_features;
+                        
+                        for (auto& mapping : aln.path().mapping()) {
+                            // For each mapping
+                            
+                            auto node_id = mapping.position().node_id();
+                            auto features = features_on_node.find(node_id);
+                            if (features != features_on_node.end()) {
+                                // Some things occur on this node. Find the overlaps with the part of the node touched by this read.
+                                auto overlapping = find_overlapping(features->second, mapping_to_range(xg_index, mapping));
+                                // Save them all to the set (to remove duplicates)
+                                copy(overlapping.begin(), overlapping.end(), inserter(touched_features, touched_features.begin()));
+                            }
+                        }
+                        
+                        // Convert the string pointers to actual string copies, for annotation API.
+                        // Make sure to use an ordered set here to sort, to make output deterministic.
+                        set<string> feature_names;
+                        for (const string* name : touched_features) {
+                            feature_names.insert(*name);
+                        }
+                        
+                        // Annotate the read with the feature name strings.
+                        set_annotation(aln, "features", feature_names);
+                    }
+                    
+                    // Output the alignment
+                    auto& buffer = buffers.at(omp_get_thread_num());
+                    buffer.emplace_back(std::move(aln));
+                    stream::write_buffered(cout, buffer, 1000);
+                });
+            });
+        
+            for (auto& buffer : buffers) {
+                // Finish each buffer
+                stream::write_buffered(cout, buffer, 0);
+            }
         }
     } else {
-        cerr << "only GAM, BED, GFF3, or GTF annotation is implemented" << endl;
-        return 1;
+        // Annotating the graph. We must do something.
+        if (bed_names.empty() && gff_names.empty()) {
+            // We weren't asked to do anything.
+            cerr << "error [vg annotate]: only GAM, BED, or GFF3/GTF annotation is implemented" << endl;
+            return 1;
+        }
+    
+        for (auto& bed_name : bed_names) {
+            // Convert each BED file to GAM
+            get_input_file(bed_name, [&](istream& bed_stream) {
+                vector<Alignment> buffer;
+                parse_bed_regions(bed_stream, xg_index, &buffer);
+                stream::write_buffered(cout, buffer, 0); // flush
+            });
+            
+            // TODO: We'll get an EOF marker per input file.
+        }
+    
+        for (auto& gff_name : gff_names) { 
+            get_input_file(gff_name, [&](istream& gff_stream) {
+                vector<Alignment> buffer;
+                parse_gff_regions(gff_stream, xg_index, &buffer);
+                stream::write_buffered(cout, buffer, 0); // flush
+            });
+        }
     }
 
     if (xg_index) {

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -225,10 +225,10 @@ int main_annotate(int argc, char** argv) {
             auto intern = [&feature_names](const string& value) -> const string* {
                 if (!feature_names.count(value)) {
                     // If it isn't in the map, put it in
-                    feature_names[value] = unique_ptr<srting>(new string(value));
+                    feature_names[value] = unique_ptr<string>(new string(value));
                     
                 }
-                return feature_names[value].second.get();
+                return feature_names[value].get();
             };
             
             // This will hold, for each graph node, the start to past-end

--- a/src/unittest/annotation.cpp
+++ b/src/unittest/annotation.cpp
@@ -49,6 +49,23 @@ TEST_CASE("Annotations can be populated", "[alignment][annotation]") {
     }
     
 }
+
+TEST_CASE("Multi-value annotations can be set and gotten", "[alignment][annotation]") {
+    
+    Alignment aln;
+    
+    vector<string> words{"candy", "cats", "cacaphony"};
+    
+    set_annotation(&aln, "words", words);
+    
+    vector<string> recovered = get_annotation<vector<string>>(&aln, "words");
+    
+    REQUIRE(recovered.size() == words.size());
+    for (size_t i = 0; i < words.size(); i++) {
+        REQUIRE(recovered[i] == words[i]);
+    }
+    
+}
    
 }
 }

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -29,6 +29,8 @@ void reverse_complement_in_place(string& seq);
 /// Return True if the given string is entirely Ns of either case, and false
 /// otherwise.
 bool is_all_n(const string& seq);
+/// Return the number of threads that OMP will produce for a parallel section.
+/// TODO: Assumes that this is the same for every parallel section.
 int get_thread_count(void);
 string wrap_text(const string& str, size_t width);
 bool is_number(const string& s);

--- a/src/xg_position.cpp
+++ b/src/xg_position.cpp
@@ -2,11 +2,11 @@
 
 namespace vg {
 
-Node xg_node(id_t id, xg::XG* xgidx) {
+Node xg_node(id_t id, const xg::XG* xgidx) {
     return xgidx->node(id);
 }
 
-vector<Edge> xg_edges_on_start(id_t id, xg::XG* xgidx) {
+vector<Edge> xg_edges_on_start(id_t id, const xg::XG* xgidx) {
     vector<Edge> all_edges = xgidx->edges_of(id);
     auto new_end = std::remove_if(all_edges.begin(), all_edges.end(),
                                   [&](const Edge& edge) {
@@ -17,7 +17,7 @@ vector<Edge> xg_edges_on_start(id_t id, xg::XG* xgidx) {
     return all_edges;
 }
 
-vector<Edge> xg_edges_on_end(id_t id, xg::XG* xgidx) {
+vector<Edge> xg_edges_on_end(id_t id, const xg::XG* xgidx) {
     vector<Edge> all_edges = xgidx->edges_of(id);
     auto new_end = std::remove_if(all_edges.begin(), all_edges.end(),
                                   [&](const Edge& edge) {
@@ -28,23 +28,23 @@ vector<Edge> xg_edges_on_end(id_t id, xg::XG* xgidx) {
     return all_edges;
 }
 
-string xg_node_sequence(id_t id, xg::XG* xgidx) {
+string xg_node_sequence(id_t id, const xg::XG* xgidx) {
     return xgidx->node(id).sequence();
 }
 
-size_t xg_node_length(id_t id, xg::XG* xgidx) {
+size_t xg_node_length(id_t id, const xg::XG* xgidx) {
     return xgidx->node_length(id);
 }
 
-int64_t xg_node_start(id_t id, xg::XG* xgidx) {
+int64_t xg_node_start(id_t id, const xg::XG* xgidx) {
     return xgidx->node_start(id);
 }
 
-char xg_pos_char(pos_t pos, xg::XG* xgidx) {
+char xg_pos_char(pos_t pos, const xg::XG* xgidx) {
     return xgidx->pos_char(id(pos), is_rev(pos), offset(pos));
 }
 
-map<pos_t, char> xg_next_pos_chars(pos_t pos, xg::XG* xgidx) {
+map<pos_t, char> xg_next_pos_chars(pos_t pos, const xg::XG* xgidx) {
 
     map<pos_t, char> nexts;
     // See if the node is cached (did we just visit it?)
@@ -92,7 +92,7 @@ map<pos_t, char> xg_next_pos_chars(pos_t pos, xg::XG* xgidx) {
     return nexts;
 }
 
-set<pos_t> xg_next_pos(pos_t pos, bool whole_node, xg::XG* xgidx) {
+set<pos_t> xg_next_pos(pos_t pos, bool whole_node, const xg::XG* xgidx) {
     set<pos_t> nexts;
     // See if the node is cached (did we just visit it?)
     Node node = xgidx->node(id(pos));
@@ -134,7 +134,7 @@ set<pos_t> xg_next_pos(pos_t pos, bool whole_node, xg::XG* xgidx) {
     return nexts;
 }
 
-int64_t xg_distance(pos_t pos1, pos_t pos2, int64_t maximum, xg::XG* xgidx) {
+int64_t xg_distance(pos_t pos1, pos_t pos2, int64_t maximum, const xg::XG* xgidx) {
     //cerr << "distance from " << pos1 << " to " << pos2 << endl;
     if (pos1 == pos2) return 0;
     int64_t adj = (offset(pos1) == xg_node_length(id(pos1), xgidx) ? 0 : 1);
@@ -167,7 +167,7 @@ int64_t xg_distance(pos_t pos1, pos_t pos2, int64_t maximum, xg::XG* xgidx) {
     return numeric_limits<int64_t>::max();
 }
 
-set<pos_t> xg_positions_bp_from(pos_t pos, int64_t distance, bool rev, xg::XG* xgidx) {
+set<pos_t> xg_positions_bp_from(pos_t pos, int64_t distance, bool rev, const xg::XG* xgidx) {
     // handle base case
     //size_t xg_node_length(id_t id, xg::XG* xgidx);
     if (rev) {
@@ -212,7 +212,7 @@ set<pos_t> xg_positions_bp_from(pos_t pos, int64_t distance, bool rev, xg::XG* x
     }
 }
 
-map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const Alignment& aln, bool just_min, bool nearby, xg::XG* xgidx) {
+map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const Alignment& aln, bool just_min, bool nearby, const xg::XG* xgidx) {
     map<string, vector<pair<size_t, bool> > > offsets;
     for (auto& mapping : aln.path().mapping()) {
         auto pos_offs = (nearby ?
@@ -244,7 +244,7 @@ map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const Alignm
     return offsets;
 }
 
-void xg_annotate_with_initial_path_positions(Alignment& aln, bool just_min, bool nearby, xg::XG* xgidx) {
+void xg_annotate_with_initial_path_positions(Alignment& aln, bool just_min, bool nearby, const xg::XG* xgidx) {
     if (!aln.refpos_size()) {
         auto init_path_positions = xg_alignment_path_offsets(aln, just_min, nearby, xgidx);
         for (const pair<string, vector<pair<size_t, bool> > >& pos_record : init_path_positions) {

--- a/src/xg_position.hpp
+++ b/src/xg_position.hpp
@@ -20,24 +20,24 @@ using namespace std;
 
 // xg/position traversal helpers with caching
 // used by the Sampler and by the Mapper
-string xg_node_sequence(id_t id, xg::XG* xgidx);
+string xg_node_sequence(id_t id, const xg::XG* xgidx);
 /// Get the length of a Node from an xg::XG index, with cacheing of deserialized nodes.
-size_t xg_node_length(id_t id, xg::XG* xgidx);
+size_t xg_node_length(id_t id, const xg::XG* xgidx);
 /// Get the node start position in the sequence vector
-int64_t xg_node_start(id_t id, xg::XG* xgidx);
+int64_t xg_node_start(id_t id, const xg::XG* xgidx);
 /// Get the character at a position in an xg::XG index, with cacheing of deserialized nodes.
-char xg_pos_char(pos_t pos, xg::XG* xgidx);
+char xg_pos_char(pos_t pos, const xg::XG* xgidx);
 /// Get the characters at positions after the given position from an xg::XG index, with cacheing of deserialized nodes.
-map<pos_t, char> xg_next_pos_chars(pos_t pos, xg::XG* xgidx);
-set<pos_t> xg_next_pos(pos_t pos, bool whole_node, xg::XG* xgidx);
-int64_t xg_distance(pos_t pos1, pos_t pos2, int64_t maximum, xg::XG* xgidx);
-set<pos_t> xg_positions_bp_from(pos_t pos, int64_t distance, bool rev, xg::XG* xgidx);
+map<pos_t, char> xg_next_pos_chars(pos_t pos, const xg::XG* xgidx);
+set<pos_t> xg_next_pos(pos_t pos, bool whole_node, const xg::XG* xgidx);
+int64_t xg_distance(pos_t pos1, pos_t pos2, int64_t maximum, const xg::XG* xgidx);
+set<pos_t> xg_positions_bp_from(pos_t pos, int64_t distance, bool rev, const xg::XG* xgidx);
 //void xg_graph_context(VG& graph, const pos_t& pos, int length, xg::XG* xgidx);
-Node xg_node(id_t id, xg::XG* xgidx);
-vector<Edge> xg_edges_on_start(id_t id, xg::XG* xgidx);
-vector<Edge> xg_edges_on_end(id_t id, xg::XG* xgidx);
-map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const Alignment& aln, bool just_min, bool nearby, xg::XG* xgidx);
-void xg_annotate_with_initial_path_positions(Alignment& aln, bool just_min, bool nearby, xg::XG* xgidx);
+Node xg_node(id_t id, const xg::XG* xgidx);
+vector<Edge> xg_edges_on_start(id_t id, const xg::XG* xgidx);
+vector<Edge> xg_edges_on_end(id_t id, const xg::XG* xgidx);
+map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const Alignment& aln, bool just_min, bool nearby, const xg::XG* xgidx);
+void xg_annotate_with_initial_path_positions(Alignment& aln, bool just_min, bool nearby, const xg::XG* xgidx);
 
 }
 

--- a/test/tiny/tiny.bed
+++ b/test/tiny/tiny.bed
@@ -1,0 +1,5 @@
+x	0	2	feat1	0	+
+x	45	50	feat2	100	-
+x	40	43	feat3	0	+
+x	0	50	featAll
+


### PR DESCRIPTION
This should fix #1806 by allowing you to use `vg annotate -x graph.xg -b features.bed -g reads.gam` to annotate reads with the BED feature names that they overlap. The annotation is "features", accessible with jq as `.annotation.features`, and is string-vector-valued. BED records with no name get the empty string as their feature name. Multiple BED records with the same name appear only once in the annotation. 

This is designed for large-ish, sparse-ish features spanning many nodes; it won't perform well with many small features on a single node, because within a node I am using a linear scan to find overlaps.