### PR TITLE
Algorithm for nontrivial multipath alignments from standard alignments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,21 @@ before_install:
   - rm -Rf deps
   # Keep the cached deps if the right compiler version was used.
   # Otherwise start fresk
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && -e deps_cached/gcc49 ]]; then mv deps_cached deps; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && -e deps_cached/gcc6 ]]; then mv deps_cached deps; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && -e deps_cached/gcc6 ]]; then mv deps_cached deps; fi
   - (ls -lah deps/; ls -lah bin/; ls -lah lib/; ls -lah include/) || true
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ls /etc/apt/sources.list.d; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo rm /etc/apt/sources.list.d/google-chrome.list; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq gcc-4.9 g++-4.9; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq gcc-6 g++-6; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6; fi
   - gcc --version && g++ --version
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq bc rs jq samtools; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y install cmake; fi
-  # Record that we are building these deps with gcc 4.9
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir -p deps; touch deps/gcc49; fi
+  # Record that we are building these deps with gcc 6
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir -p deps; touch deps/gcc6; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm install ruby-2.3.3; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm use 2.3.3; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"; fi

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1300,7 +1300,7 @@ namespace vg {
                     for (size_t j = 0; j < edit.from_length(); j++, node_idx++, seq_idx++) {
                         if ((mapping.position().is_reverse() ? rev_node_seq[node_idx] : node_seq[node_idx]) != subseq[seq_idx]) {
 #ifdef debug_verbose_validation
-                            cerr << "validation failure on match that does not match" << endl;
+                            cerr << "validation failure on match that does not match for read " << multipath_aln.name() << endl;
                             cerr << pb2json(mapping) << ", " << subseq << endl;
 #endif
                             return false;

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -68,11 +68,24 @@ namespace vg {
         MultipathAlignmentGraph(VG& vg, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
                                 const Alignment& alignment, const unordered_map<id_t, pair<id_t, bool>>& projection_trans);
         
+        /// Make a multipath alignment graph using the path of a single-path alignment
+        MultipathAlignmentGraph(VG& vg, const Alignment& alignment, SnarlManager& snarl_manager, size_t max_snarl_cut_size,
+                                const unordered_map<id_t, pair<id_t, bool>>& projection_trans,
+                                const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans);
+        
+        /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
+        MultipathAlignmentGraph(VG& vg, const Alignment& alignment, SnarlManager& snarl_manager, size_t max_snarl_cut_size,
+                                const unordered_map<id_t, pair<id_t, bool>>& projection_trans);
+        
         ~MultipathAlignmentGraph();
         
         /// Fills input vector with node indices of a topological sort. 
         /// Reachability edges must be in the graph.
         void topological_sort(vector<size_t>& order_out);
+        
+        /// Removes non-softclip indels from path nodes. Does not update edges--should be called
+        /// prior to adding computing edges.
+        void trim_hanging_indels(const Alignment& alignment);
         
         /// Removes all transitive edges from graph (reduces to minimum equivalent graph).
         /// Note: reorders internal representation of adjacency lists.

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -243,8 +243,14 @@ namespace vg {
                              memcluster_t& graph_mems,
                              MultipathAlignment& multipath_aln_out) const;
         
+        /// Removes the sections of an Alignment's path within snarls and re-aligns them with multiple traceback
+        /// to create a multipath alignment with non-trivial topology
+        void make_nontrivial_multipath_alignment(const Alignment& alignment, VG& subgraph,
+                                                 unordered_map<id_t, pair<id_t, bool>>& translator,
+                                                 SnarlManager& snarl_manager, MultipathAlignment& multipath_aln_out) const;
+        
         /// Remove the full length bonus from all source or sink subpaths that received it
-        void strip_full_length_bonuses(MultipathAlignment& mulipath_aln) const;
+        void strip_full_length_bonuses(MultipathAlignment& multipath_aln) const;
         
         /// Compute a mapping quality from a list of scores, using the selected method.
         int32_t compute_raw_mapping_quality_from_scores(const vector<double>& scores, MappingQualityMethod mapq_method) const;


### PR DESCRIPTION
The MultipathMapper uses standard Alignments in its rescue code path. Previously, I was doing the trivial conversion back into MultipathAlignment (with one subpath, no joins). I added an algorithm that will realign inside snarls and look for multiple tracebacks.