### PR TITLE
Exclude contigs based on regexes when filtering

### DIFF
--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -732,6 +732,29 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
             ++counts.wrong_name[co];
             keep = false;    
         }
+        if ((keep || verbose) && !excluded_refpos_contigs.empty() && aln.refpos_size() != 0) {
+            // We have refpos exclusion filters and a refpos is set.
+            // We need to bang every refpos anme against every filter.
+            
+            bool found_match = false;
+            for (auto& expression : excluded_refpos_contigs) {
+                for (auto& refpos : aln.refpos()) {
+                    if (regex_search(refpos.name(), expression)) {
+                        // We don't want this read because of this match
+                        found_match = true;
+                        break;
+                    }
+                }
+                if (found_match) {
+                    break;
+                }
+            }
+            
+            if (found_match) {
+                ++counts.wrong_refpos[co];
+                keep = false;    
+            }
+        }
         if ((keep || verbose) && ((aln.is_secondary() && score < min_secondary) ||
             (!aln.is_secondary() && score < min_primary))) {
             ++counts.min_score[co];
@@ -807,6 +830,8 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
              << counts.read[1] << endl
              << "Read Name Filter (primary):        " << counts.wrong_name[0] << endl
              << "Read Name Filter (secondary):      " << counts.wrong_name[1] << endl
+             << "refpos Contig Filter (primary):    " << counts.wrong_refpos[0] << endl
+             << "refpos Contig Filter (secondary):  " << counts.wrong_refpos[1] << endl
              << "Min Identity Filter (primary):     " << counts.min_score[0] << endl
              << "Min Identity Filter (secondary):   " << counts.min_score[1] << endl
              << "Max Overhang Filter (primary):     " << counts.max_overhang[0] << endl
@@ -818,9 +843,9 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
              << "Repeat Ends Filter (primary):      " << counts.repeat[0] << endl
              << "Repeat Ends Filter (secondary):    " << counts.repeat[1] << endl
              << "Min Quality Filter (primary):      " << counts.min_mapq[0] << endl
-             << "Min Quality Filter (secondary):   " << counts.min_mapq[1] << endl
-             << "Random Filter (primary):      " << counts.random[0] << endl
-             << "Random Filter (secondary):   " << counts.random[1] << endl
+             << "Min Quality Filter (secondary):    " << counts.min_mapq[1] << endl
+             << "Random Filter (primary):           " << counts.random[0] << endl
+             << "Random Filter (secondary):         " << counts.random[1] << endl
                         
             
              << endl;

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <regex>
 #include "vg.hpp"
 #include "xg.hpp"
 #include "vg.pb.h"
@@ -22,7 +23,10 @@ class ReadFilter{
 public:
     
     // Filtering parameters
+    /// Read name must have this prefix
     string name_prefix;
+    /// Read must not have a refpos set with a contig name containing a match to any of these
+    vector<regex> excluded_refpos_contigs;
     double min_secondary = 0.;
     double min_primary = 0.;
     // Should we rescore each alignment with default parameters and no e.g.
@@ -56,6 +60,7 @@ public:
         vector<size_t> read;
         vector<size_t> filtered;
         vector<size_t> wrong_name;
+        vector<size_t> wrong_refpos;
         vector<size_t> min_score;
         vector<size_t> max_overhang;
         vector<size_t> min_end_matches;
@@ -64,14 +69,15 @@ public:
         vector<size_t> repeat;
         vector<size_t> defray;
         vector<size_t> random;
-        Counts() : read(2, 0), filtered(2, 0), wrong_name(2, 0), min_score(2, 0),
-                   max_overhang(2, 0), min_end_matches(2, 0), min_mapq(2, 0),
-                   split(2, 0), repeat(2, 0), defray(2, 0), random(2, 0) {}
+        Counts() : read(2, 0), filtered(2, 0), wrong_name(2, 0), wrong_refpos(2, 0),
+                   min_score(2, 0), max_overhang(2, 0), min_end_matches(2, 0),
+                   min_mapq(2, 0), split(2, 0), repeat(2, 0), defray(2, 0), random(2, 0) {}
         Counts& operator+=(const Counts& other) {
             for (int i = 0; i < 2; ++i) {
                 read[i] += other.read[i];
                 filtered[i] += other.filtered[i];
                 wrong_name[i] += other.wrong_name[i];
+                wrong_refpos[i] += other.wrong_refpos[i];
                 min_score[i] += other.min_score[i];
                 max_overhang[i] += other.max_overhang[i];
                 min_end_matches[i] += other.min_end_matches[i];

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -25,27 +25,28 @@ void help_filter(char** argv) {
          << "Filter alignments by properties." << endl
          << endl
          << "options:" << endl
-         << "    -n, --name-prefix NAME  keep only reads with this prefix in their names [default='']" << endl
-         << "    -s, --min-secondary N   minimum score to keep secondary alignment [default=0]" << endl
-         << "    -r, --min-primary N     minimum score to keep primary alignment [default=0]" << endl
-         << "    -O, --rescore           re-score reads using default parameters and only alignment information" << endl
-         << "    -f, --frac-score        normalize score based on length" << endl
-         << "    -u, --substitutions     use substitution count instead of score" << endl
-         << "    -o, --max-overhang N    filter reads whose alignments begin or end with an insert > N [default=99999]" << endl
-         << "    -m, --min-end-matches N filter reads that don't begin with at least N matches on each end" << endl
-         << "    -S, --drop-split        remove split reads taking nonexistent edges" << endl
-         << "    -x, --xg-name FILE      use this xg index (required for -R, -S, and -D)" << endl
-         << "    -R, --regions-file      only output alignments that intersect regions (BED file with 0-based coordinates expected)" << endl
-         << "    -B, --output-basename   output to file(s) (required for -R).  The ith file will correspond to the ith BED region" << endl
-         << "    -A, --append-regions    append to alignments created with -RB" << endl
-         << "    -c, --context STEPS     expand the context of the subgraph this many steps when looking up chunks" << endl
-         << "    -v, --verbose           print out statistics on numbers of reads filtered by what." << endl
-         << "    -q, --min-mapq N        filter alignments with mapping quality < N" << endl
-         << "    -E, --repeat-ends N     filter reads with tandem repeat (motif size <= 2N, spanning >= N bases) at either end" << endl
-         << "    -D, --defray-ends N     clip back the ends of reads that are ambiguously aligned, up to N bases" << endl
-         << "    -C, --defray-count N    stop defraying after N nodes visited (used to keep runtime in check) [default=99999]" << endl
-         << "    -d, --downsample S.P    filter out all but the given portion 0.P of the reads. S may be an integer seed as in SAMtools" << endl
-         << "    -t, --threads N         number of threads [1]" << endl;
+         << "    -n, --name-prefix NAME     keep only reads with this prefix in their names [default='']" << endl
+         << "    -X, --exclude-contig REGEX drop reads with refpos annotations on contigs matching the given regex (may repeat)" << endl
+         << "    -s, --min-secondary N      minimum score to keep secondary alignment [default=0]" << endl
+         << "    -r, --min-primary N        minimum score to keep primary alignment [default=0]" << endl
+         << "    -O, --rescore              re-score reads using default parameters and only alignment information" << endl
+         << "    -f, --frac-score           normalize score based on length" << endl
+         << "    -u, --substitutions        use substitution count instead of score" << endl
+         << "    -o, --max-overhang N       filter reads whose alignments begin or end with an insert > N [default=99999]" << endl
+         << "    -m, --min-end-matches N    filter reads that don't begin with at least N matches on each end" << endl
+         << "    -S, --drop-split           remove split reads taking nonexistent edges" << endl
+         << "    -x, --xg-name FILE         use this xg index (required for -R, -S, and -D)" << endl
+         << "    -R, --regions-file         only output alignments that intersect regions (BED file with 0-based coordinates expected)" << endl
+         << "    -B, --output-basename      output to file(s) (required for -R).  The ith file will correspond to the ith BED region" << endl
+         << "    -A, --append-regions       append to alignments created with -RB" << endl
+         << "    -c, --context STEPS        expand the context of the subgraph this many steps when looking up chunks" << endl
+         << "    -v, --verbose              print out statistics on numbers of reads filtered by what." << endl
+         << "    -q, --min-mapq N           filter alignments with mapping quality < N" << endl
+         << "    -E, --repeat-ends N        filter reads with tandem repeat (motif size <= 2N, spanning >= N bases) at either end" << endl
+         << "    -D, --defray-ends N        clip back the ends of reads that are ambiguously aligned, up to N bases" << endl
+         << "    -C, --defray-count N       stop defraying after N nodes visited (used to keep runtime in check) [default=99999]" << endl
+         << "    -d, --downsample S.P       filter out all but the given portion 0.P of the reads. S may be an integer seed as in SAMtools" << endl
+         << "    -t, --threads N            number of threads [1]" << endl;
 }
 
 int main_filter(int argc, char** argv) {
@@ -70,6 +71,7 @@ int main_filter(int argc, char** argv) {
         static struct option long_options[] =
             {
                 {"name-prefix", required_argument, 0, 'n'},
+                {"exclude-contig", required_argument, 0, 'X'},
                 {"min-secondary", required_argument, 0, 's'},
                 {"min-primary", required_argument, 0, 'r'},
                 {"rescore", no_argument, 0, 'O'},
@@ -94,7 +96,7 @@ int main_filter(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "n:s:r:Od:e:fauo:m:Sx:R:B:Ac:vq:E:D:C:d:t:",
+        c = getopt_long (argc, argv, "n:X:s:r:Od:e:fauo:m:Sx:R:B:Ac:vq:E:D:C:d:t:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -105,6 +107,9 @@ int main_filter(int argc, char** argv) {
         {
         case 'n':
             filter.name_prefix = optarg;
+            break;
+        case 'X':
+            filter.excluded_refpos_contigs.push_back(parse<std::regex>(optarg));
             break;
         case 's':
             filter.min_secondary = parse<double>(optarg);

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -31,12 +31,10 @@ void help_paths(char** argv) {
          << "  inspection:" << endl
          << "    -X, --extract-gam     return (as GAM alignments) the stored paths in the graph" << endl
          << "    -V, --extract-vg      return (as path-only .vg) the queried paths (requires -x -g and -q or -Q)" << endl
-        //<< "    -X, --extract         return (as a chunked graph) the stored paths in the graph" << endl
-         << "    -L, --list            return (as a list of names, one per line) the path names" << endl
-         << "    -T, --threads         return the threads (requires GBWT)" << endl
-         << "    -q, --threads-by STR  return the threads with the given prefix (requires GBWT)" << endl
+         << "    -L, --list            return (as a list of names, one per line) the path (or thread) names" << endl
+         << "    -T, --threads         operate on threads instead of paths (requires GBWT)" << endl
+         << "    -q, --threads-by STR  operate on threads with the given prefix instead of paths (requires GBWT)" << endl
          << "    -Q, --paths-by STR    return the paths with the given prefix" << endl;
-    //<< "    -s, --as-seqs         write each path as a sequence" << endl;
 }
 
 int main_paths(int argc, char** argv) {
@@ -46,10 +44,9 @@ int main_paths(int argc, char** argv) {
         return 1;
     }
 
-    bool as_seqs = false;
     bool extract_as_gam = false;
     bool extract_as_vg = false;
-    bool list_paths = false;
+    bool list_names = false;
     string xg_file;
     string vg_file;
     string gbwt_file;
@@ -70,7 +67,6 @@ int main_paths(int argc, char** argv) {
             {"extract-vg", no_argument, 0, 'V'},
             {"list", no_argument, 0, 'L'},
             {"max-length", required_argument, 0, 'l'},
-            {"as-seqs", no_argument, 0, 's'},
             {"threads-by", required_argument, 0, 'q'},
             {"paths-by", required_argument, 0, 'Q'},
             {"threads", no_argument, 0, 'T'},
@@ -78,7 +74,7 @@ int main_paths(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hs:LXv:x:g:q:Q:VT",
+        c = getopt_long (argc, argv, "hLXv:x:g:q:Q:VT",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -109,11 +105,7 @@ int main_paths(int argc, char** argv) {
             break;
 
         case 'L':
-            list_paths = true;
-            break;
-
-        case 's':
-            as_seqs = true;
+            list_names = true;
             break;
 
         case 'q':
@@ -143,112 +135,160 @@ int main_paths(int argc, char** argv) {
         cerr << "[vg paths] Error: both vg and xg index given" << endl;
         exit(1);
     }
-
+    
+    if (!thread_prefix.empty() && extract_threads) {
+        cerr << "[vg paths] Error: cannot extract all threads (-T) and also prefixed threads (-q)" << endl;
+        exit(1);
+    }
+    
+    // Load whatever indexes we were given
+    unique_ptr<VG> graph;
     if (!vg_file.empty()) {
-        VG graph;
-        if (vg_file == "-") {
-            graph.from_istream(std::cin);
-        } else {
-            ifstream in(vg_file.c_str());
-            graph.from_istream(in);
+        // We want a vg
+        graph = unique_ptr<VG>(new VG());
+        // Load the vg
+        get_input_file(vg_file, [&](istream& in) {
+            graph->from_istream(in);
+        });
+    }
+    unique_ptr<xg::XG> xg_index;
+    if (!xg_file.empty()) {
+        // We want an xg
+        xg_index = unique_ptr<xg::XG>(new xg::XG());
+        // Load the xg
+        get_input_file(xg_file, [&](istream& in) {
+            xg_index->load(in);
+        });
+    }
+    unique_ptr<gbwt::GBWT> gbwt_index;
+    if (!gbwt_file.empty()) {
+        // We want a gbwt
+        gbwt_index = unique_ptr<gbwt::GBWT>(new gbwt::GBWT());
+        // Load the gbwt (TODO: support streams)
+        sdsl::load_from_file(*gbwt_index, gbwt_file);
+    }
+    
+    
+    if (!thread_prefix.empty() || extract_threads) {
+        // We are looking for threads, so we need the GBWT and the xg (which holds the thread name metadata)
+        
+        if (xg_index.get() == nullptr) {
+            cerr << "[vg paths] Error: thread extraction requires an XG for thread metadata" << endl;
+            exit(1);
         }
-        if (list_paths) {
-            graph.paths.for_each_name([&](const string& name) {
+        if (gbwt_index.get() == nullptr) {
+            cerr << "[vg paths] Error: thread extraction requires a GBWT" << endl;
+            exit(1);
+        }
+        if (extract_as_gam == extract_as_vg && extract_as_vg == list_names) {
+            cerr << "[vg paths] Error: thread extraction requires -V, -X, or -L to specifiy output format" << endl;
+            exit(1);
+        }
+        vector<int64_t> thread_ids;
+        if (extract_threads) {
+            for (gbwt::size_type id = 1; id <= gbwt_index->sequences()/2; id += 1) {
+                thread_ids.push_back(id);
+            }
+        } else if (!thread_prefix.empty()) {
+            thread_ids = xg_index->threads_named_starting(thread_prefix);
+        }
+        
+        for (auto& id : thread_ids) {
+            // For each matching thread
+            
+            // Get its name
+            auto thread_name = xg_index->thread_name(id); 
+        
+            if (list_names) {
+                // We are only interested in the name
+                cout << thread_name << endl;
+                continue;
+            }
+            
+            // Otherwise we need the actual thread data
+            gbwt::vector_type sequence = gbwt_index->extract(gbwt::Path::encode(id-1, false));
+            Path path;
+            path.set_name(thread_name);
+            size_t rank = 1;
+            for (auto node : sequence) {
+                Mapping* m = path.add_mapping();
+                Position* p = m->mutable_position();
+                p->set_node_id(gbwt::Node::id(node));
+                p->set_is_reverse(gbwt::Node::is_reverse(node));
+                Edit* e = m->add_edit();
+                size_t len = xg_index->node_length(p->node_id());
+                e->set_to_length(len);
+                e->set_from_length(len);
+                m->set_rank(rank++);
+            }
+            if (extract_as_gam) {
+                vector<Alignment> alns;
+                alns.emplace_back(xg_index->path_as_alignment(path));
+                write_alignments(cout, alns);
+                stream::finish(cout);
+            } else if (extract_as_vg) {
+                Graph g;
+                *(g.add_path()) = path;
+                vector<Graph> gb = { g };
+                stream::write_buffered(cout, gb, 0);
+            }
+        }
+    } else if (graph.get() != nullptr) {
+        // Handle non-thread queries from vg
+        
+        if (!path_prefix.empty()) {
+            cerr << "[vg paths] Error: path prefix not supported for extracting from vg, only for extracting from xg" << endl;
+            exit(1);
+        }
+        
+        if (list_names) {
+            graph->paths.for_each_name([&](const string& name) {
                     cout << name << endl;
                 });
         } else if (extract_as_gam) {
-            vector<Alignment> alns = graph.paths_as_alignments();
+            vector<Alignment> alns = graph->paths_as_alignments();
             write_alignments(cout, alns);
             stream::finish(cout);
         } else if (extract_as_vg) {
             cerr << "[vg paths] Error: vg extraction is only defined for prefix queries against a XG/GBWT index pair" << endl;
             exit(1);
-        } else if (!thread_prefix.empty()) {
-            cerr << "[vg paths] Error: a thread prefix query requires a XG/GBWT index pair" << endl;
-            exit(1);
+        } else {
+            cerr << "[vg paths] Error: specify an operation to perform" << endl;
         }
-        
-    } else if (!xg_file.empty()) {
-        xg::XG xgidx;
-        ifstream in(xg_file.c_str());
-        xgidx.load(in);
-        if (list_paths) {
-            size_t max_path = xgidx.max_path_rank();
+    } else if (xg_index.get() != nullptr) {
+        // Handle non-thread queries from xg
+        if (list_names) {
+            // We aren't looking for threads, but we are looking for names.
+            size_t max_path = xg_index->max_path_rank();
             for (size_t i = 1; i <= max_path; ++i) {
-                cout << xgidx.path_name(i) << endl;
+                cout << xg_index->path_name(i) << endl;
             }
-        } else if (!thread_prefix.empty() || extract_threads) {
-            if (gbwt_file.empty()) {
-                cerr << "[vg paths] Error: thread extraction requires a GBWT" << endl;
-                exit(1);
-            } else if (extract_as_gam == extract_as_vg) {
-                cerr << "[vg paths] Error: thread extraction requires -V or -X to specifiy output format" << endl;
-                exit(1);
-            }
-            gbwt::GBWT index;
-            sdsl::load_from_file(index, gbwt_file);
-            vector<int64_t> thread_ids;
-            if (extract_threads) {
-                for (gbwt::size_type id = 1; id <= index.sequences()/2; id += 1) {
-                    thread_ids.push_back(id);
+        } else if (extract_as_gam) {
+            auto alns = xg_index->paths_as_alignments();
+            write_alignments(cout, alns);
+            stream::finish(cout);
+        } else if (!path_prefix.empty()) {
+            vector<Path> got = xg_index->paths_by_prefix(path_prefix);
+            if (extract_as_gam) {
+                vector<Alignment> alns;
+                for (auto& path : got) {
+                    alns.emplace_back(xg_index->path_as_alignment(path));
                 }
-            } else if (!thread_prefix.empty()) {
-                thread_ids = xgidx.threads_named_starting(thread_prefix);
-            }
-            for (auto& id : thread_ids) {
-                gbwt::vector_type sequence = index.extract(gbwt::Path::encode(id-1, false));
-                Path path;
-                path.set_name(xgidx.thread_name(id));
-                size_t rank = 1;
-                for (auto node : sequence) {
-                    Mapping* m = path.add_mapping();
-                    Position* p = m->mutable_position();
-                    p->set_node_id(gbwt::Node::id(node));
-                    p->set_is_reverse(gbwt::Node::is_reverse(node));
-                    Edit* e = m->add_edit();
-                    size_t len = xgidx.node_length(p->node_id());
-                    e->set_to_length(len);
-                    e->set_from_length(len);
-                    m->set_rank(rank++);
-                }
-                if (extract_as_gam) {
-                    vector<Alignment> alns;
-                    alns.emplace_back(xgidx.path_as_alignment(path));
-                    write_alignments(cout, alns);
-                    stream::finish(cout);
-                } else if (extract_as_vg) {
+                write_alignments(cout, alns);
+                stream::finish(cout);
+            } else if (extract_as_vg) {
+                for(auto& path : got) {
                     Graph g;
-                    *(g.add_path()) = path;
+                    *(g.add_path()) = xg_index->path(path.name());
                     vector<Graph> gb = { g };
                     stream::write_buffered(cout, gb, 0);
                 }
             }
         } else {
-            if (extract_as_gam) {
-                auto alns = xgidx.paths_as_alignments();
-                write_alignments(cout, alns);
-                stream::finish(cout);
-            } else if (!path_prefix.empty()) {
-                vector<Path> got = xgidx.paths_by_prefix(path_prefix);
-                if (extract_as_gam) {
-                    vector<Alignment> alns;
-                    for (auto& path : got) {
-                        alns.emplace_back(xgidx.path_as_alignment(path));
-                    }
-                    write_alignments(cout, alns);
-                    stream::finish(cout);
-                } else if (extract_as_vg) {
-                    for(auto& path : got) {
-                        Graph g;
-                        *(g.add_path()) = xgidx.path(path.name());
-                        vector<Graph> gb = { g };
-                        stream::write_buffered(cout, gb, 0);
-                    }
-                }
-            }
+            cerr << "[vg paths] Error: specify an operation to perform" << endl;
         }
     } else {
-        cerr << "[vg paths] Error: a xg (-x) or vg (-v) file is required" << endl;
+        cerr << "[vg paths] Error: an xg (-x) or vg (-v) file is required" << endl;
         exit(1);
     }
     

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -13,6 +13,7 @@
 #include <unordered_set>
 #include <random>
 #include <type_traits>
+#include <regex>
 #include <signal.h>
 #include <unistd.h>
 #include "vg.pb.h"
@@ -603,6 +604,15 @@ inline bool parse(const string& arg, double& dest) {
     size_t after;
     dest = std::stod(arg, &after);
     return(after == arg.size());
+}
+
+// And one for regular expressions
+template<>
+inline bool parse(const string& arg, std::regex& dest) {
+    // This throsw std::regex_error if it can't parse.
+    // That contains a kind of useless error code that we can't turn itno a string without switching on all the values.
+    dest = std::regex(arg);
+    return true;
 }
 
 // Implement the first version in terms of the second, for any type

--- a/test/t/11_vg_paths.t
+++ b/test/t/11_vg_paths.t
@@ -7,6 +7,14 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order 
 
-plan tests 1
+plan tests 3
 
-is "$(vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg paths --list -v -)" "x" "path listing works"
+is "$(vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg paths --list -v -)" "x" "path listing works from a vg"
+
+vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
+vg index -x x.xg -G x.gbwt -v small/x.vcf.gz x.vg
+
+is "$(vg paths --list -x x.xg)" "x" "path listing works from an xg"
+is "$(vg paths --threads --list -x x.xg -g x.gbwt | wc -l)" "2" "thread listing works from a gbwt"
+
+rm -f x.xg x.gbwt x.vg

--- a/test/t/21_vg_filter.t
+++ b/test/t/21_vg_filter.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 8
+plan tests 10
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg  x.vg
@@ -72,7 +72,11 @@ is "$(vg view -aj filtered.gam | jq -rc '.name' | sed 's/_[12]//g' | sort | md5s
 
 vg filter -d 456.2 -t 10 single.gam > filtered.gam
 
-is "$(vg view -aj filtered.gam | jq -rc '.name' | sort | md5sum | cut -f1 -d' ')" "${SINGLE_HASH}" "samtools 1.0+ and vg filter agree on how to select downsampled unpaired reads"   
+is "$(vg view -aj filtered.gam | jq -rc '.name' | sort | md5sum | cut -f1 -d' ')" "${SINGLE_HASH}" "samtools 1.0+ and vg filter agree on how to select downsampled unpaired reads"
 
-rm -f x.vg x.xg paired.gam paired.sam single.gam single.sam filtered.gam filtered.sam
+vg annotate -p -x x.xg -a paired.gam > paired.annotated.gam
+is "$(vg filter -X "[a-f]" paired.annotated.gam | vg view -aj - | wc -l)" "200" "reads with refpos annotations not matching an exclusion regex are let through"
+is "$(vg filter -X "[w-z]" paired.annotated.gam | vg view -aj - | wc -l)" "0" "reads with refpos annotations matching an exclusion regex are removed"
+
+rm -f x.vg x.xg paired.gam paired.sam paired.annotated.gam single.gam single.sam filtered.gam filtered.sam
                                                                


### PR DESCRIPTION
This is something I need in order to drop simulated reads that end up having come from decoy sequences (by the time we get the truth position annotations on them) in toil-vg.

Really this could live in vg sim, if the extracted haplotype thread graphs that vg sim uses could hold sufficient data about the paths to allow us to annotate the reads there. But since some nodes of the reference paths are excluded, and we don't support partial paths, we can't do that.

This is on top of #1831.