### PR TITLE
Fix downsampling behavior with explicit 0 seed

### DIFF
--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -184,9 +184,15 @@ int main_filter(int argc, char** argv) {
                     
                     // Everything before that is the seed
                     auto seed_string = opt_string.substr(0, point);
+                    // Use the 0 seed by default even if no actual seed shows up
+                    int32_t seed = 0;
                     if (seed_string != "") {
                         // If there was a seed (even 0), parse it
-                        int32_t seed = parse<int32_t>(seed_string);
+                        seed = parse<int32_t>(seed_string);
+                    }
+                    
+                    if (seed != 0) {
+                        // We want a nonempty mask.
                         
                         // Use the C rng like Samtools does to get a mask.
                         // See https://github.com/samtools/samtools/blob/60138c42cf04c5c473dc151f3b9ca7530286fb1b/sam_view.c#L298-L299

--- a/test/t/21_vg_filter.t
+++ b/test/t/21_vg_filter.t
@@ -52,7 +52,7 @@ vg sim -l 100 -n 100 -x x.xg -s 1 -a > single.gam
 # Check downsampling against samtools 1.0+
 # If the installed samtools isn't new enough, fall back on precalculated hashes
 PAIRED_HASH=a31e81e05f86224b5aec73f6f8e2d9a9
-SINGLE_HASH=028711c7ec6189442095698cfbeab356
+SINGLE_HASH=854be75583698d41023bf073d26833d6
 if samtools 2>&1 | grep "Version" | grep -v ": 0" >/dev/null; then
     # We can calculate hashes ourselves
     vg surject -x x.xg -s -i paired.gam > paired.sam
@@ -61,7 +61,7 @@ if samtools 2>&1 | grep "Version" | grep -v ": 0" >/dev/null; then
     PAIRED_HASH="$(cat filtered.sam | grep -v "^@" | cut -f1 | sort | md5sum | cut -f1 -d' ')"
     
     vg surject -x x.xg -s single.gam > single.sam
-    samtools view -s 456.2 -S single.sam > filtered.sam
+    samtools view -s .2 -S single.sam > filtered.sam
     
     SINGLE_HASH="$(cat filtered.sam | grep -v "^@" | cut -f1 | sort | md5sum | cut -f1 -d' ')"
 fi
@@ -70,7 +70,8 @@ vg filter -d 123.5 -t 10 paired.gam > filtered.gam
 
 is "$(vg view -aj filtered.gam | jq -rc '.name' | sed 's/_[12]//g' | sort | md5sum | cut -f1 -d' ')" "${PAIRED_HASH}"  "samtools 1.0+ and vg filter agree on how to select downsampled paired reads"
 
-vg filter -d 456.2 -t 10 single.gam > filtered.gam
+# "0." and "." syntax need to mean the same thing.
+vg filter -d 0.2 -t 10 single.gam > filtered.gam
 
 is "$(vg view -aj filtered.gam | jq -rc '.name' | sort | md5sum | cut -f1 -d' ')" "${SINGLE_HASH}" "samtools 1.0+ and vg filter agree on how to select downsampled unpaired reads"
 


### PR DESCRIPTION
Previously, we were handling a seed of "0", as in "0.5", differently than a seed of "", as in ".5", in the downsampling rate parsing in vg filter. Samtools handles them the same, so this was an incompatibility with samtools downsampling.

I've fixed the mask computation to work like samtools does for seed "0".