### PR TITLE
Faster VCF parsing

### DIFF
--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -273,6 +273,7 @@ int main_construct(int argc, char** argv) {
                 return 1;
             }
             vcflib::VariantCallFile* variant_file = new vcflib::VariantCallFile();
+            variant_file->parseSamples = false; // Major speedup if there are many samples.
             variant_files.emplace_back(variant_file);
             variant_file->open(vcf_filename);
             if (!variant_file->is_open()) {


### PR DESCRIPTION
Disable sample parsing using vcflib in `vg construct` and `vg index -G`. Find the genotype strings using lightweight parsing in `vg index -G`.

Resolves #1838.

I am not sure if VCF files with a large number of samples are used in other subcommands.