### PR TITLE
fix the condition of max nodes

### DIFF
--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -225,7 +225,7 @@ int main_snarl(int argc, char** argv) {
             if (!traversal_file.empty() && snarl->type() == ULTRABUBBLE &&
                 (!leaf_only || snarl_manager.is_leaf(snarl)) &&
                 (!top_level_only || snarl_manager.is_root(snarl)) &&
-                (snarl_manager.deep_contents(snarl, *graph, true).first.size() < max_nodes)) {
+                (snarl_manager.deep_contents(snarl, *graph, true).first.size() <= max_nodes)) {
                 
 #ifdef debug
                 cerr << "Look for traversals of " << pb2json(*snarl) << endl;


### PR DESCRIPTION
An equal sign isn't contained in the source code, although `vg snarls` help is as following:

```
    -m, --max-nodes N      only compute traversals for snarls with <= N nodes [10]
```

So, I propose to append an equal sign to the condition of max_nodes.