### PR TITLE
Long read mapping in mpmap

### DIFF
--- a/src/algorithms/count_walks.cpp
+++ b/src/algorithms/count_walks.cpp
@@ -30,11 +30,22 @@ using namespace std;
             }
         });
         
+        bool overflowed = false;
         for (const handle_t& handle : lazier_topological_order(graph)) {
             size_t count_here = count[handle];
             graph->follow_edges(handle, false, [&](const handle_t& next) {
-                count[next] += count_here;
+                size_t& count_next = count[next];
+                if (numeric_limits<size_t>::max() - count_here < count_next) {
+                    overflowed = true;
+                }
+                else {
+                    count_next += count_here;
+                }
             });
+            
+            if (overflowed) {
+                return numeric_limits<size_t>::max();
+            }
         }
         
         size_t total_count = 0;

--- a/src/algorithms/count_walks.hpp
+++ b/src/algorithms/count_walks.hpp
@@ -21,6 +21,8 @@ using namespace std;
     /// Returns the number of source-to-sink walks through the graph. Assumes that
     /// the graph is a single-stranded DAG. Consider checking these properties with
     /// algorithms::is_single_stranded and algorithms::is_directed_acyclic for safety.
+    /// Returns numeric_limits<size_t>::max() if the actual number of walks is larger
+    /// than this.
     size_t count_walks(const HandleGraph* graph);
 
 }

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 //#define debug_multiple_tracebacks
-#define debug_verbose_validation
+//#define debug_verbose_validation
 
 using namespace std;
 using namespace structures;
@@ -1414,6 +1414,7 @@ namespace vg {
             
             int64_t read_at = subpath_read_interval[i].first;
             
+            bool first_mapping = true;
             for (size_t j = 0; j < subpath.path().mapping_size(); j++) {
                 const Mapping& mapping = subpath.path().mapping(j);
                 string pos_string = format_position(mapping.position());
@@ -1449,14 +1450,17 @@ namespace vg {
                 string mapping_read_str = mapping_read_strm.str();
                 string mapping_node_str = mapping_node_strm.str();
                 
-                if (line_length + mapping_node_str.size() + 1 <= max_line_length) {
+                if (line_length + mapping_node_str.size() + 1 <= max_line_length || first_mapping) {
                     read_strm << " " << mapping_read_str;
                     node_strm << " " << mapping_node_str;
                     line_length += mapping_node_str.size() + 1;
+                    
+                    first_mapping = false;
                 }
                 else {
                     out << read_strm.str() << endl;
-                    out << node_strm.str() << endl << endl;;
+                    out << node_strm.str() << endl << endl;
+                    
                     read_strm.str("");
                     node_strm.str("");
                     read_strm << "\tread" << string(read_header.size() - 4, ' ') << " " << mapping_read_str;
@@ -1464,6 +1468,7 @@ namespace vg {
                     
                     line_length = 9 + read_header.size() + mapping_node_str.size();
                 }
+                
             }
             
             out << read_strm.str() << endl;

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -147,7 +147,10 @@ namespace vg {
     /// Debugging function to check that multipath alignment meets the formalism's basic
     /// invariants. Returns true if multipath alignment is valid, else false. Does not
     /// validate alignment score.
-    bool validate_multipath_alignment(const MultipathAlignment& multipath_aln, HandleGraph& xg_index);
+    bool validate_multipath_alignment(const MultipathAlignment& multipath_aln, const HandleGraph& handle_graph);
+    
+    /// Send a formatted string representation of the MultipathAlignment into the ostream
+    void view_multipath_alignment(ostream& out, const MultipathAlignment& multipath_aln, const HandleGraph& handle_graph);
     
     // TODO: function for adding a graph augmentation to an existing multipath alignment
 }

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1977,10 +1977,13 @@ namespace vg {
                     
                     if (candidate_end_node.end <= start_node.begin) {
                         // these MEMs are read colinear and graph reachable, so connect them
-                        candidate_end_node.edges.push_back(make_pair(start, candidate_dist));
+                        candidate_end_node.edges.emplace_back(start, candidate_dist);
                         
 #ifdef debug_multipath_alignment
-                        cerr << "connection is read colinear, adding edge for total of " << candidate_end_node.edges.size() << " edges so far" << endl;
+                        cerr << "connection is read colinear, adding edge on " << candidate_end << " for total of " << candidate_end_node.edges.size() << " edges so far" << endl;
+                        for (auto& edge : candidate_end_node.edges) {
+                            cerr << "\t-> " << edge.first << " dist " << edge.second << endl;
+                        }
 #endif
                         
                         // skip to the predecessor's noncolinear shell, whose connections might not be blocked by

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -2917,7 +2917,7 @@ namespace vg {
                 }
                 
 #ifdef debug_multipath_alignment
-                cerr << "aligning sequence " << intervening_sequence.sequence() << " to connecting graph: " << pb2json(connecting_graph.graph) << endl;
+                cerr << "making " << num_alt_alns << " alignments of sequence " << intervening_sequence.sequence() << " to connecting graph: " << pb2json(connecting_graph.graph) << endl;
 #endif
                 
                 bool added_direct_connection = false;
@@ -3063,7 +3063,7 @@ namespace vg {
                     }
                     
 #ifdef debug_multipath_alignment
-                    cerr << "aligning sequence: " << right_tail_sequence.sequence() << endl << "to right tail graph: " << pb2json(tail_graph) << endl;
+                    cerr << "making " << num_alt_alns << " alignments of sequence: " << right_tail_sequence.sequence() << endl << "to right tail graph: " << pb2json(tail_graph) << endl;
 #endif
                     
                     vector<Alignment> alt_alignments;
@@ -3174,7 +3174,7 @@ namespace vg {
                     
                     
 #ifdef debug_multipath_alignment
-                    cerr << "aligning sequence: " << left_tail_sequence.sequence() << endl << "to left tail graph: " << pb2json(tail_graph) << endl;
+                    cerr << "making " << num_alt_alns << " alignments of sequence: " << left_tail_sequence.sequence() << endl << "to left tail graph: " << pb2json(tail_graph) << endl;
 #endif
                     vector<Alignment> alt_alignments;
                     if (tail_graph.node_size() == 0) {

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -116,7 +116,15 @@ namespace vg {
         /// in a MultipathAlignment. Reachability edges must be in the graph.
         void align(const Alignment& alignment, VG& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t band_padding, MultipathAlignment& multipath_aln_out);
-                   
+        
+        /// Do intervening and tail alignments between the anchoring paths and store the result
+        /// in a MultipathAlignment. Reachability edges must be in the graph. Also, choose the
+        /// band padding dynamically as a function of the inter-MEM sequence and graph
+        void align(const Alignment& alignment, VG& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
+                   size_t max_alt_alns, bool dynamic_alt_alns,
+                   function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,
+                   MultipathAlignment& multipath_aln_out);
+        
         /// Converts a MultipathAlignmentGraph to a GraphViz Dot representation, output to the given ostream.
         void to_dot(ostream& out) const;
         

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -101,7 +101,7 @@ namespace vg {
         // extract graphs around the clusters
         auto cluster_graphs = query_cluster_graphs(alignment, mems, clusters);
         
-        // actually perform the alignments and post-process to meeth MultipathAlignment invariants
+        // actually perform the alignments and post-process to meet MultipathAlignment invariants
         vector<size_t> cluster_idxs = range_vector(cluster_graphs.size());
         align_to_cluster_graphs(alignment, mapq_method, cluster_graphs, multipath_alns_out, num_mapping_attempts, &cluster_idxs);
         
@@ -183,10 +183,10 @@ namespace vg {
         for (auto& cluster_graph : cluster_graphs) {
             // if we have a cluster graph with small enough MEM coverage compared to the best one or we've made
             // the maximum number of alignments we stop producing alternate alignments
-            if (get<2>(cluster_graph) < mem_coverage_min_ratio * get<2>(cluster_graphs[0])
+            if (get<2>(cluster_graph) < mem_coverage_min_ratio * get<2>(cluster_graphs.front())
                 || num_mappings >= num_mappings_to_compute) {
 #ifdef debug_multipath_mapper
-                cerr << "halting further alignments, either because MEM coverage of " << get<2>(cluster_graph) << " is too far below optimum of " << get<2>(cluster_graphs[0]) << " or because already made " << num_mappings << " of " << num_mappings_to_compute << " mappings" << endl;
+                cerr << "halting further alignments, either because MEM coverage of " << get<2>(cluster_graph) << " is too far below optimum of " << get<2>(cluster_graphs.front()) << " or because already made " << num_mappings << " of " << num_mappings_to_compute << " mappings" << endl;
 #endif
                 
 //#pragma omp atomic

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -460,6 +460,21 @@ namespace vg {
         return true;
     }
     
+    void MultipathMapper::init_band_padding_memo() {
+        band_padding_memo.clear();
+        band_padding_memo.resize(band_padding_memo_size);
+        
+        for (size_t i = 0; i < band_padding_memo.size(); i++) {
+            band_padding_memo[i] = size_t(band_padding_multiplier * sqrt(i)) + 1;
+        }
+    }
+    
+    size_t MultipathMapper::get_band_padding(string::const_iterator read_begin, string::const_iterator read_end) {
+        size_t read_length = read_end - read_begin;
+        return read_length < band_padding_memo.size() ? band_padding_memo[read_length]
+                                                      : size_t(band_padding_multiplier * sqrt(read_length)) + 1;
+    }
+    
     bool MultipathMapper::likely_mismapping(const MultipathAlignment& multipath_aln) {
     
         // empirically, we get better results by scaling the pseudo-length down, I have no good explanation for this probabilistically
@@ -519,6 +534,7 @@ namespace vg {
             return p_value;
         }
     }
+    
     
     void MultipathMapper::calibrate_mismapping_detection(size_t num_simulations, size_t simulated_read_length) {
         // we don't want to do base quality adjusted alignments for this stage since we are just simulating random sequences

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -8,6 +8,7 @@
 //#define debug_multipath_mapper_alignment
 //#define debug_validate_multipath_alignments
 //#define debug_report_startup_training
+//#define debug_pretty_print_alignments
 
 #include "multipath_mapper.hpp"
 #include "multipath_alignment_graph.hpp"
@@ -143,6 +144,12 @@ namespace vg {
         for (auto cluster_graph : cluster_graphs) {
             delete get<0>(cluster_graph);
         }
+#ifdef debug_pretty_print_alignments
+        cerr << "final alignments being returned:" << endl;
+        for (const MultipathAlignment& multipath_aln : multipath_alns_out) {
+            view_multipath_alignment(cerr, multipath_aln, *xindex);
+        }
+#endif
     }
     
     void MultipathMapper::align_to_cluster_graphs(const Alignment& alignment,
@@ -1632,6 +1639,16 @@ namespace vg {
         for (auto cluster_graph : cluster_graphs2) {
             delete get<0>(cluster_graph);
         }
+        
+#ifdef debug_pretty_print_alignments
+        cerr << "final alignments being returned:" << endl;
+        for (const pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair : multipath_aln_pairs_out) {
+            cerr << "read 1: " << endl;
+            view_multipath_alignment(cerr, multipath_aln_pair.first, *xindex);
+            cerr << "read 2: " << endl;
+            view_multipath_alignment(cerr, multipath_aln_pair.second, *xindex);
+        }
+#endif
     }
     
     void MultipathMapper::reduce_to_single_path(const MultipathAlignment& multipath_aln, vector<Alignment>& alns_out,

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -82,10 +82,13 @@ namespace vg {
         /// when mappings are likely to have occurred by chance
         void calibrate_mismapping_detection(size_t num_simulations = 1000, size_t simulated_read_length = 150);
         
+        /// Should be called once after construction, or any time the band padding multiplier is changed
+        void init_band_padding_memo();
+        
         // parameters
         
         int64_t max_snarl_cut_size = 5;
-        double band_padding_multiplier = 0.33;
+        double band_padding_multiplier = 1.0;
         size_t max_expected_dist_approx_error = 8;
         int32_t num_alt_alns = 4;
         double mem_coverage_min_ratio = 0.5;
@@ -340,12 +343,6 @@ namespace vg {
                                           OrientedDistanceClusterer::paths_of_node_memo_t* paths_of_node_memo = nullptr,
                                           OrientedDistanceClusterer::oriented_occurences_memo_t* oriented_occurences_memo = nullptr,
                                           OrientedDistanceClusterer::handle_memo_t* handle_memo = nullptr);
-        
-        /// Should be called once after construction, or any time the band padding multiplier is changed
-        void init_band_padding_memo();
-        
-        /// Computes the band padding for inter-MEM alignment
-        size_t get_band_padding(string::const_iterator read_begin, string::const_iterator read_end);
         
         SnarlManager* snarl_manager;
         

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -84,7 +84,7 @@ namespace vg {
         // parameters
         
         int64_t max_snarl_cut_size = 5;
-        int32_t band_padding = 2;
+        double band_padding_multiplier = 0.33;
         size_t max_expected_dist_approx_error = 8;
         int32_t num_alt_alns = 4;
         double mem_coverage_min_ratio = 0.5;
@@ -93,6 +93,7 @@ namespace vg {
         double log_likelihood_approx_factor = 1.0;
         size_t min_clustering_mem_length = 0;
         size_t max_p_value_memo_size = 500;
+        size_t band_padding_memo_size = 500;
         double pseudo_length_multiplier = 1.65;
         double max_mapping_p_value = 0.00001;
         bool unstranded_clustering = true;
@@ -337,6 +338,12 @@ namespace vg {
                                           OrientedDistanceClusterer::oriented_occurences_memo_t* oriented_occurences_memo = nullptr,
                                           OrientedDistanceClusterer::handle_memo_t* handle_memo = nullptr);
         
+        /// Should be called once after construction, or any time the band padding multiplier is changed
+        void init_band_padding_memo();
+        
+        /// Computes the band padding for inter-MEM alignment
+        size_t get_band_padding(string::const_iterator read_begin, string::const_iterator read_end);
+        
         SnarlManager* snarl_manager;
         
         /// Memos used by population model
@@ -344,6 +351,9 @@ namespace vg {
         
         // a memo for the transcendental p-value function (thread local to maintain threadsafety)
         static thread_local unordered_map<pair<size_t, size_t>, double> p_value_memo;
+        
+        // a memo for transcendental band padidng function (gets initialized at construction)
+        vector<size_t> band_padding_memo;
     };
         
 }

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -175,6 +175,7 @@ int main_mpmap(int argc, char** argv) {
     int mismatch_score_arg = std::numeric_limits<int>::min();
     int gap_open_score_arg = std::numeric_limits<int>::min();
     int gap_extension_score_arg = std::numeric_limits<int>::min();
+    int full_length_bonus_arg = std::numeric_limits<int>::min();
     
     
     int c;
@@ -484,7 +485,7 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'L':
-                full_length_bonus = parse<int>(optarg);
+                full_length_bonus_arg = parse<int>(optarg);
                 break;
                 
             case 'A':
@@ -691,6 +692,9 @@ int main_mpmap(int argc, char** argv) {
     }
     if (gap_extension_score_arg != std::numeric_limits<int>::min()) {
         gap_extension_score = gap_extension_score_arg;
+    }
+    if (full_length_bonus_arg != std::numeric_limits<int>::min()) {
+        full_length_bonus = full_length_bonus_arg;
     }
     
     if (match_score > std::numeric_limits<int8_t>::max() || mismatch_score > std::numeric_limits<int8_t>::max()

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -11,7 +11,7 @@
 #include "../multipath_mapper.hpp"
 #include "../path.hpp"
 
-#define record_read_run_times
+//#define record_read_run_times
 
 #ifdef record_read_run_times
 #define READ_TIME_FILE "_read_times.tsv"


### PR DESCRIPTION
I did some basic development to be able to map noisy long reads in mpmap. Highlights include:
- Alternate scoring defaults
- Dynamic selection of band padding for MEM-connecting alignments
- A few small bug fixes that only occurred in long reads.

My initial experiments suggest that this is quite a bit slower than for NGS, probably mostly due to the noisiness of the reads. Something like 10-15% of the speed normalizing for read length. However, I'm mostly not seeing a lot of quadratic blowup, which is good. I may have some work to do on handling softclips appropriately to completely avoid quadratic behavior. 