### PR TITLE
Add public methods to get edges count by id

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1897,6 +1897,14 @@ vector<Edge> XG::edges_on_end(int64_t id) const {
     return edges;
 }
 
+int XG::indegree(int64_t id) const {
+  return g_iv[g_bv_select(id_to_rank(id)) + G_NODE_TO_COUNT_OFFSET];
+}
+
+int XG::outdegree(int64_t id) const {
+  return g_iv[g_bv_select(id_to_rank(id)) + G_NODE_FROM_COUNT_OFFSET];
+}
+
 size_t XG::max_node_rank(void) const {
     return s_bv_rank(s_bv.size());
 }

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -173,6 +173,8 @@ public:
     vector<Edge> edges_from(int64_t id) const;
     vector<Edge> edges_on_start(int64_t id) const;
     vector<Edge> edges_on_end(int64_t id) const;
+    int indegree(int64_t id) const;
+    int outdegree(int64_t id) const;
     
     /// Get the rank of the edge, or numeric_limits<size_t>.max() if no such edge exists.
     // Given an edge which is in the graph in some orientation, return the edge


### PR DESCRIPTION
The `g_iv` vector is a private member variable; therefore cannot be
accessed by other or derived classes. And, there is no way to query
the number of forward/backward edges without getting the list of edges.
This commit adds two methods (`outdegree` and `indegree`) returning the
outdegree and indegree of nodes by their ids.