### PR TITLE
Fix hang in Travis by removing subset graph option in Genotyper

### DIFF
--- a/src/algorithms/count_walks.cpp
+++ b/src/algorithms/count_walks.cpp
@@ -11,6 +11,7 @@ using namespace std;
         unordered_map<handle_t, size_t> count;
         count.reserve(graph->node_size());
         
+        // identify sources and sinks
         graph->for_each_handle([&](const handle_t& handle) {
             bool is_source = true, is_sink = true;
             graph->follow_edges(handle, true, [&](const handle_t& prev) {
@@ -22,6 +23,7 @@ using namespace std;
                 return false;
             });
             
+            // base case for dynamic programming
             if (is_source) {
                 count[handle] = 1;
             }
@@ -30,6 +32,7 @@ using namespace std;
             }
         });
         
+        // count walks by dynamic programming
         for (const handle_t& handle : lazier_topological_order(graph)) {
             size_t count_here = count[handle];
             graph->follow_edges(handle, false, [&](const handle_t& next) {
@@ -37,6 +40,7 @@ using namespace std;
             });
         }
         
+        // total up the walks at the sinks
         size_t total_count = 0;
         for (handle_t& sink : sinks) {
             total_count += count[sink];

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -24,7 +24,6 @@ void Genotyper::run(AugmentedGraph& augmented_graph,
                     string contig_name,
                     string sample_name,
                     string augmented_file_name,
-                    bool subset_graph,
                     bool output_vcf,
                     bool output_json,
                     int length_override,
@@ -81,21 +80,26 @@ void Genotyper::run(AugmentedGraph& augmented_graph,
 
     // Find all the snarls in either the main graph or the subset, and put them
     // in this SnarlManager
-    SnarlManager manager;
+    SnarlManager manager = CactusSnarlFinder(graph, ref_path_name).find_snarls();
 
-    // We need to decide if we want to work on the full graph or just on the subgraph that has any support.
-    // We make the subset a local out here so it will stick around as long as we
-    // use the SnarlManager.
-    VG subset;
-    if (subset_graph) {
-        subset = make_subset_graph(graph, ref_path_name, reads_by_name); 
-        manager = subset.paths.has_path(ref_path_name) ?
-            CactusSnarlFinder(subset, ref_path_name).find_snarls()
-            : CactusSnarlFinder(subset).find_snarls();
-    } else {
-        algorithms::sort(&graph);
-        manager = CactusSnarlFinder(graph, ref_path_name).find_snarls();
-    }
+    // TODO: I've removed this option because it has the chance to create incorrect Snarls from the subset
+    // graph that are not actually snarls in the full graph. If we are going to retain this feature, we need
+    // to use the subset graph throughout the genotyping process, but that's currently not possible because
+    // the rest of the code uses an AugmentedGraph instead of a VG.
+    
+//    // We need to decide if we want to work on the full graph or just on the subgraph that has any support.
+//    // We make the subset a local out here so it will stick around as long as we
+//    // use the SnarlManager.
+//    VG subset;
+//    if (subset_graph) {
+//        subset = make_subset_graph(graph, ref_path_name, reads_by_name); 
+//        manager = subset.paths.has_path(ref_path_name) ?
+//            CactusSnarlFinder(subset, ref_path_name).find_snarls()
+//            : CactusSnarlFinder(subset).find_snarls();
+//    } else {
+//        algorithms::sort(&graph);
+//        manager = CactusSnarlFinder(graph, ref_path_name).find_snarls();
+//    }
 
     if(show_progress) {
         // Count up the ultrabubbles

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -158,7 +158,6 @@ public:
              string contig_name = "",
              string sample_name = "",
              string augmented_file_name = "",
-             bool subset_graph = false,
              bool output_vcf = false,
              bool output_json = false,
              int length_override = 0,

--- a/src/subcommand/genotype_main.cpp
+++ b/src/subcommand/genotype_main.cpp
@@ -32,7 +32,6 @@ void help_genotype(char** argv) {
          << "    -l, --length INT        override total sequence length" << endl
          << "    -a, --augmented FILE    dump augmented graph to FILE" << endl
          << "    -Q, --ignore_mapq       do not use mapping qualities" << endl
-         << "    -S, --subset-graph      only use the reference and areas of the graph with read support" << endl
          << "    -A, --no_indel_realign  disable indel realignment" << endl
          << "    -d, --het_prior_denom   denominator for prior probability of heterozygousness" << endl
          << "    -P, --min_per_strand    min unique reads per strand for a called allele to accept a call" << endl
@@ -87,9 +86,7 @@ int main_genotype(int argc, char** argv) {
 
     // Should we dump the augmented graph to a file?
     string augmented_file_name;
-
-    // Should we find superbubbles on the supported subset (true) or the whole graph (false)?
-    bool subset_graph = false;
+    
     // What should the heterozygous genotype prior be? (1/this)
     double het_prior_denominator = 10.0;
     // At least how many reads must be unique support for a called allele per strand for a call?
@@ -110,7 +107,6 @@ int main_genotype(int argc, char** argv) {
                 {"length", required_argument, 0, 'l'},
                 {"augmented", required_argument, 0, 'a'},
                 {"ignore_mapq", no_argument, 0, 'Q'},
-                {"subset-graph", no_argument, 0, 'S'},
                 {"no_indel_realign", no_argument, 0, 'A'},
                 {"het_prior_denom", required_argument, 0, 'd'},
                 {"min_per_strand", required_argument, 0, 'P'},
@@ -127,7 +123,7 @@ int main_genotype(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hjvr:c:s:o:l:a:QSAd:P:pt:V:I:G:F:zET:",
+        c = getopt_long (argc, argv, "hjvr:c:s:o:l:a:QAd:P:pt:V:I:G:F:zET:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -169,10 +165,6 @@ int main_genotype(int argc, char** argv) {
         case 'Q':
             // Ignore mapping qualities
             use_mapq = false;
-            break;
-        case 'S':
-            // Find sites on the graph subset with any read support
-            subset_graph = true;
             break;
         case 'z':
             just_call = true;
@@ -394,7 +386,6 @@ int main_genotype(int argc, char** argv) {
                   contig_name,
                   sample_name,
                   augmented_file_name,
-                  subset_graph,
                   output_vcf,
                   output_json,
                   length_override,

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -449,7 +449,7 @@ vector<SnarlTraversal> PathRestrictedTraversalFinder::find_traversals(const Snar
 
 #ifdef debug
 #pragma omp critical (cerr)
-                cerr << "Trying mapping of read/path " << name_and_mappings.first << " to " << pb2json(mapping->position()) << endl;
+                cerr << "Trying mapping of read/path " << name_and_mappings.first << " to " << mapping->node_id() << (mapping->is_reverse() ? "-" : "+") << endl;
 #endif
 
                 // How many times have we gone to the next mapping looking for a
@@ -514,7 +514,7 @@ vector<SnarlTraversal> PathRestrictedTraversalFinder::find_traversals(const Snar
 
 #ifdef debug
 #pragma omp critical (cerr)
-                    cerr << "\tTraversing " << pb2json(*mapping) << endl;
+                    cerr << "\tTraversing " << mapping->node_id() << (mapping->is_reverse() ? "-" : "+") << endl;
 #endif
 
                     // Say we visit this node along the path, in this orientation

--- a/test/t/27_vg_genotype.t
+++ b/test/t/27_vg_genotype.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 7
+plan tests 5
 
 vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa > tiny.vg
 vg index -x tiny.vg.xg -g tiny.vg.gcsa -k 16 tiny.vg
@@ -21,18 +21,6 @@ vg genotype tiny.vg tiny.gam.index -v > /dev/null
 is "$?" "0" "vg genotype runs successfully when emitting vcf"
 
 rm -Rf tiny.vg tiny.vg.xg tiny.gam.index tiny.gam reads.txt
-
-vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa > tiny.vg
-vg index -x tiny.vg.xg -g tiny.vg.gcsa -k 16 tiny.vg
-# Make empty gam
-printf "" > tiny.gam
-vg index -d tiny.gam.index -N tiny.gam
-
-is "$(vg genotype tiny.vg tiny.gam.index -Sp --ref notARealPath 2>&1 | grep 'Found 0 ultrabubbles' | wc -l)" "1" "vg genotype finds no ultrabubbles for an empty subset"
-
-is "$(vg genotype tiny.vg tiny.gam.index -vSp 2>&1 | grep 'Found 9 ultrabubbles' | wc -l)" "1" "vg genotype finds few ultrabubbles for a subset of just the reference"
-
-rm -Rf tiny.vg tiny.vg.xg tiny.vg.gcsa tiny.vg.gcsa.lcp tiny.gam.index tiny.gam reads.txt
 
 vg construct -r tiny/tiny.fa >flat.vg
 vg index -x flat.xg -g flat.gcsa -k 8 flat.vg


### PR DESCRIPTION
Resolves https://github.com/vgteam/vg/issues/1856

Not the most elegant solution, but I removed the subset_graph option in the Genotyper. We were only using it for the part of the code that did snarl detection, but snarls from a subset graph are not necessarily snarls in the full graph. That was breaking some of the algorithms' expectations and leading to segfaults. 

In the future, we could also have the Genotyper use the subset graph throughout the genotyping process, but this would take a significant refactor since much of the code base uses the AugmentedGraph class rather than the VG class, which is what the subset graph is.