### PR TITLE
Do away with most of the indexes in the SnarlManager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make get-deps;fi
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git submodule update --recursive && make -j4 && echo Testing && make test && make static -j4; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git submodule update --recursive && timeout 1500 make deps -j4 && make -j4 && echo Testing && make test; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git submodule update --recursive && timeout 1800 make deps -j4 && make -j4 && echo Testing && make test; fi
 # Cache all our dependency directories, and our lib and include
 cache:
   directories:

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -275,7 +275,7 @@ message Visit {
 
     // Indicates:
     //   if node_id is specified     reverse complement of node
-    //   if feature_id is specified  traversal of a child snarl entering backwards through
+    //   if snarl is specified       traversal of a child snarl entering backwards through
     //                               end and leaving backwards through start
     bool backward = 3;
 }


### PR DESCRIPTION
This should fix #1862. It's still not really great in terms of speed, but it is more than twice as fast:

```
time vg.old mpmap --single-path-mode --snarls ./trash/graph.vg.snarls -f empty.fq -t 1 -i -x x.xg -g x.gcsa >/dev/null
real	31m45.393s
user	22m15.431s
sys	9m29.165s

time vg mpmap --single-path-mode --snarls ./trash/graph.vg.snarls -f empty.fq -t 1 -i -x x.xg -g x.gcsa >/dev/null
real	13m17.208s
user	7m41.112s
sys	5m35.912s
```