### PR TITLE
GBWT construction from massive VCF files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,9 +281,9 @@ endif
 $(INC_DIR)/gbwt/dynamic_gbwt.h: $(LIB_DIR)/libgbwt.a
 $(LIB_DIR)/libgbwt.a: $(LIB_DIR)/libsdsl.a $(wildcard $(GBWT_DIR)/*.cpp) $(wildcard $(GBWT_DIR)/include/gbwt/*.h)
 ifeq ($(shell uname -s),Darwin)
-	+. ./source_me.sh && cd $(GBWT_DIR) && AS_INTEGRATED_ASSEMBLER=1 $(MAKE) libgbwt.a $(FILTER) && mv libgbwt.a $(CWD)/$(LIB_DIR) && cp -r include/gbwt $(CWD)/$(INC_DIR)/
+	+. ./source_me.sh && cd $(GBWT_DIR) && AS_INTEGRATED_ASSEMBLER=1 $(MAKE) libgbwt.a build_gbwt $(FILTER) && mv libgbwt.a $(CWD)/$(LIB_DIR) && cp -r include/gbwt $(CWD)/$(INC_DIR)/
 else
-	+. ./source_me.sh && cd $(GBWT_DIR) && $(MAKE) libgbwt.a $(FILTER) && mv libgbwt.a $(CWD)/$(LIB_DIR) && cp -r include/gbwt $(CWD)/$(INC_DIR)/
+	+. ./source_me.sh && cd $(GBWT_DIR) && $(MAKE) libgbwt.a build_gbwt $(FILTER) && mv libgbwt.a $(CWD)/$(LIB_DIR) && cp -r include/gbwt $(CWD)/$(INC_DIR)/
 endif
 
 $(INC_DIR)/progress_bar.hpp: $(PROGRESS_BAR_DIR)/progress_bar.hpp

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -470,7 +470,7 @@ int main_index(int argc, char** argv) {
             return 1;
         }
         VGset graphs(file_names);
-        build_gpbwt = !build_gbwt & !write_threads;
+        build_gpbwt = !build_gbwt & !write_threads & !parse_only;
         graphs.to_xg(*xg_index, index_paths & build_gpbwt, Paths::is_alt, index_haplotypes ? &alt_paths : nullptr);
         if (show_progress) {
             cerr << "Built base XG index" << endl;

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -510,7 +510,9 @@ int main_index(int argc, char** argv) {
         // Do we build GBWT?
         gbwt::GBWTBuilder* gbwt_builder = 0;
         if (build_gbwt) {
-            if (show_progress) { cerr << "Building GBWT index" << endl; }
+            if (show_progress) {
+                cerr << "GBWT parameters: buffer size " << gbwt_buffer_size << ", id interval " << id_interval << endl;
+            }
             gbwt::Verbosity::set(gbwt::Verbosity::SILENT);  // Make the construction thread silent.
             gbwt_builder = new gbwt::GBWTBuilder(id_width, gbwt_buffer_size * gbwt::MILLION, id_interval);
         }
@@ -606,7 +608,15 @@ int main_index(int argc, char** argv) {
             sample_range.second = std::min(sample_range.second, num_samples);
             haplotype_count += 2 * (sample_range.second - sample_range.first);  // Assuming a diploid genome
             if (show_progress) {
-                cerr << "Processing samples " << sample_range.first << " to " << (sample_range.second - 1) << " with batch size " << samples_in_batch << endl;
+                cerr << "Haplotype generation parameters:" << endl;
+                cerr << "- Samples " << sample_range.first << " to " << (sample_range.second - 1) << endl;
+                cerr << "- Batch size " << samples_in_batch << endl;
+                if (force_phasing) {
+                    cerr << "- Force phasing" << endl;
+                }
+                if (discard_overlaps) {
+                    cerr << "- Discard overlaps" << endl;
+                }
             }
 
             // Process each VCF contig corresponding to an XG path.

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -435,6 +435,11 @@ int main_index(int argc, char** argv) {
         return 1;
     }
 
+    if (parse_only && (index_paths || index_gam)) {
+        cerr << "error: [vg index] --parse-only does not work with --store-threads or --store-gam" << endl;
+        return 1;
+    }
+
     if (file_names.size() <= 0 && dbg_names.empty()){
         //cerr << "No graph provided for indexing. Please provide a .vg file or GCSA2-format deBruijn graph to index." << endl;
         //return 1;

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -129,6 +129,10 @@ is $(vg paths -g x_gam.gbwt -T -x x_gam.xg -V | vg view -c - | jq -cr '.path[].n
 
 rm -f x.vg x.xg sim.gam x_gam.gbwt
 
+# We do not test GBWT construction parameters (-B, -u, -n) because they matter only for large inputs.
+# We do not test chromosome-length path generation (-P, -o) for the same reason.
+
+
 # Other tests
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg bogus123.vg


### PR DESCRIPTION
New options for GBWT construction (`vg index -G`):

* Parse the VCF file and write the intermediate data to disk instead of building GBWT (use `-e` instead of `-G`). The resulting files can be used as an input for the standalone `build_gbwt` tool. Useful for experimenting with GBWT construction parameters when VCF parsing takes hours or days.
* Change the GBWT construction buffer size with `-u N` to `N` million nodes. Increasing the default value 100 to 500 or even 1000 may be a good time/space trade-off when indexing chromosome-length haplotypes.
* Change the haplotype id sampling interval with `-n N` to `N`. The default value 1024 is a reasonable time/space trade-off for the 1000GP data with 5000 haplotypes.
* Moved some debugging options to the standalone `build_gbwt` tool.