### PR TITLE
Stabilize chains and merge in path handles

### DIFF
--- a/src/algorithms/dfs.hpp
+++ b/src/algorithms/dfs.hpp
@@ -16,7 +16,7 @@ void dfs(
     const HandleGraph& graph,
     const function<void(const handle_t&)>& handle_begin_fn,  // called when node orientation is first encountered
     const function<void(const handle_t&)>& handle_end_fn,    // called when node orientation goes out of scope
-    const function<bool(void)>& break_fn,                    // called to check if we should stop the DFS
+    const function<bool(void)>& break_fn,                    // called to check if we should stop the DFS; we stop when true is returned.
     const function<void(const edge_t&)>& edge_fn,            // called when an edge is encountered
     const function<void(const edge_t&)>& tree_fn,            // called when an edge forms part of the DFS spanning tree
     const function<void(const edge_t&)>& edge_curr_fn,       // called when we meet an edge in the current tree component

--- a/src/annotation.hpp
+++ b/src/annotation.hpp
@@ -213,7 +213,7 @@ inline void clear_annotation(Annotated* annotated, const string& name) {
     // Get ahold of the struct
     auto* annotation_struct = Annotation<Annotated>::get_mutable(annotated);
     // Clear out that field
-    annotation_struct->mutable_fields()->clear(name);
+    annotation_struct->mutable_fields()->erase(name);
 }
 
 template<typename Annotated>

--- a/src/cactus.cpp
+++ b/src/cactus.cpp
@@ -200,8 +200,6 @@ void addArbitraryTelomerePair(vector<stCactusEdgeEnd*> ends, stList *telomeres) 
     stList_append(telomeres, edgeEnd2);
 }
 
-#define debug
-
 // Step 2) Make a Cactus Graph. Returns the graph and a list of paired
 // cactusEdgeEnd telomeres, one after the other. Both members of the return
 // value must be destroyed.
@@ -383,7 +381,7 @@ pair<stCactusGraph*, stList*> handle_graph_to_cactus(PathHandleGraph& graph, con
     for (auto& strong_component : algorithms::strongly_connected_components(&graph)) {
         // For each strongly connected component
         assert(!strong_component.empty());
-        // Assign it to the weak comnponent that some node in it belongs to
+        // Assign it to the weak component that some node in it belongs to
         component_strong_components[node_to_component[*strong_component.begin()]].emplace_back(move(strong_component));
         strong_component_count++;
     }
@@ -862,10 +860,13 @@ pair<stCactusGraph*, stList*> handle_graph_to_cactus(PathHandleGraph& graph, con
             cerr << "Largest actually cyclic component of " << strong_components.size() << " is "
                 << largest_component << " with " << largest_component_nodes << " nodes" << endl;
             
-            // Pick some arbitrary node in the largest component.
+            // Pick the lowest-ID node in the largest component.
             // Also, assert we found one.
             assert(largest_component_nodes != 0);
-            id_t break_node = *strong_components[largest_component].begin();
+            vector<id_t> sorted_component{strong_components[largest_component].begin(),
+                strong_components[largest_component].end()};
+            std::sort(sorted_component.begin(), sorted_component.end());
+            id_t break_node = sorted_component.front();
             
 #ifdef debug
             cerr << "Elect to break at node " << break_node
@@ -930,7 +931,7 @@ pair<stCactusGraph*, stList*> handle_graph_to_cactus(PathHandleGraph& graph, con
             } else {
             
 #ifdef debug
-                cerr << "Found only a both-strand cycle where we will disconnect the graph by dropping this node. Use one unary snarl." << endl;
+                cerr << "Found only a both-strand cycle where we will disconnect the graph by dropping this node. Use two unary snarls." << endl;
 #endif
             
                 // Otherwise, break with the same side of the node twice, because we went around a unary snarl.
@@ -948,8 +949,6 @@ pair<stCactusGraph*, stList*> handle_graph_to_cactus(PathHandleGraph& graph, con
     
     return make_pair(cactus_graph, telomeres);
 }
-
-#undef debug
 
 VG cactus_to_vg(stCactusGraph* cactus_graph) {
     VG vg_graph;

--- a/src/cactus.cpp
+++ b/src/cactus.cpp
@@ -816,7 +816,9 @@ pair<stCactusGraph*, stList*> handle_graph_to_cactus(PathHandleGraph& graph, con
             for (size_t j = 0; j < strong_components.size(); j++) {
                 // For each strong component
                 
+#ifdef debug
                 cerr << "Component " << j << " has size " << strong_components[j].size() << endl;
+#endif
                 
                 if (strong_components[j].size() > largest_component_nodes) {
                     // If it has more nodes, take it.
@@ -857,8 +859,10 @@ pair<stCactusGraph*, stList*> handle_graph_to_cactus(PathHandleGraph& graph, con
                 }
             }
             
+#ifdef debug
             cerr << "Largest actually cyclic component of " << strong_components.size() << " is "
                 << largest_component << " with " << largest_component_nodes << " nodes" << endl;
+#endif
             
             // Pick the lowest-ID node in the largest component.
             // Also, assert we found one.

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -1063,8 +1063,8 @@ int64_t DistanceIndex::distance(const Snarl* snarl1, const Snarl* snarl2,
         id_t chainStartID = get_start_of(*chain).node_id();
 
         ChainDistances& chainDists = chainIndex.at( chainStartID); 
-        bool snarlRev1 = chainDists.isReverse(snarl1, sm); 
-        bool snarlRev2 = chainDists.isReverse(snarl2, sm);
+        bool snarlRev1 = sm->chain_orientation_of(snarl1);
+        bool snarlRev2 = sm->chain_orientation_of(snarl2);
 
         //Distance from left of s1 (reverse), left of s2 (forward)
         int64_t d1 = chainDists.chainDistanceShort(graph,
@@ -1127,7 +1127,7 @@ int64_t DistanceIndex::distance(const Snarl* snarl1, const Snarl* snarl2,
 
         id_t chainStartID = get_start_of(*chain).node_id();
         ChainDistances& chainDists = chainIndex.at( chainStartID);
-        bool snarlRev = chainDists.isReverse(snarl1, sm); 
+        bool snarlRev = sm->chain_orientation_of(snarl1);
         pair<int64_t, int64_t> endDists = chainDists.distToEnds(
                            make_pair(nodeID1, snarlRev), distL1, distR1);
 
@@ -1142,7 +1142,7 @@ int64_t DistanceIndex::distance(const Snarl* snarl1, const Snarl* snarl2,
         const Chain* chain = sm->chain_of(snarl2);
         id_t chainStartID = get_start_of(*chain).node_id();
         ChainDistances& chainDists = chainIndex.at( chainStartID);
-        bool snarlRev = chainDists.isReverse(snarl2, sm); 
+        bool snarlRev = sm->chain_orientation_of(snarl2); 
 
         pair<int64_t, int64_t> endDists = chainDists.distToEnds(
                        make_pair(nodeID2, snarlRev), distL2, distR2);    
@@ -1237,7 +1237,7 @@ int64_t DistanceIndex::distance(const Snarl* snarl1, const Snarl* snarl2,
             const Chain* currChain= sm->chain_of(currSnarl);
             ChainDistances& chainDists = chainIndex.at(
                                             get_start_of(*currChain).node_id());
-            bool snarlRev = chainDists.isReverse(currSnarl, sm); 
+            bool snarlRev = sm->chain_orientation_of(currSnarl); 
 
             //Distance from start (reverse) to start (forward)
             int64_t d1 = chainDists.chainDistanceShort(graph,
@@ -1425,7 +1425,7 @@ pair<pair<int64_t, int64_t>, const Snarl*> DistanceIndex::distToCommonAncestor(
             const Chain* chain = sm->chain_of(snarl);
             id_t chainStartID = get_start_of(*chain).node_id();
             ChainDistances& chainDists =  chainIndex.at(chainStartID);
-            bool snarlRev = chainDists.isReverse(snarl, sm); 
+            bool snarlRev = sm->chain_orientation_of(snarl);
 
             pair<int64_t, int64_t> endDists = chainDists.distToEnds(
                           make_pair(nodeID, snarlRev), distL, distR);
@@ -1952,34 +1952,7 @@ int64_t DistanceIndex::ChainDistances::chainDistanceShort(VG* graph,
                    d2 - graph->get_node(end.first)->sequence().size());
     }
 }
-bool DistanceIndex::ChainDistances::isReverse(const Snarl* snarl, SnarlManager* sm) {
-    //Return true if the snarl is reversed in the chain
 
-    id_t start = snarl->start().node_id();
-    id_t end = snarl->end().node_id();
-    if (snarlToIndex.size() == (prefixSum.size()/2) -1 ){
-        //If the chain loops
-
-        bool startRev = snarl->start().backward();
-        bool endRev = snarl->end().backward();
-        const Chain* chain = sm->chain_of(snarl);
-
-        ChainIterator chainEnd = chain_end(*chain);
-        for (ChainIterator c = chain_begin(*chain); c != chainEnd; ++c) {
-            const Snarl* s = c->first; 
-            if (start == s->start().node_id() && startRev == s->start().backward()) {
-                return c->second;
-            }
-            
-        }
-         
-        return true; //Should never reach here
-        
-    } else {
-        //If the start of the snarl has a higher index than end, reversed 
-        return snarlToIndex[start] > snarlToIndex[end];
-    }   
-}
 int64_t DistanceIndex::ChainDistances::chainLength() {
     //Get the length of a chain including length of last node
     return prefixSum.back();

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -1737,11 +1737,11 @@ void DistanceIndex::SnarlDistances::printSelf() {
      
     cerr << "Snarl Distances for snarl starting at " << snarlStart.first;
     if (snarlStart.second) {cerr << " reverse and ending at ";} 
-    else                   { cerr << " forward and ending at";}
+    else                   { cerr << " forward and ending at ";}
     cerr << snarlEnd.first;
     if (snarlEnd.second) {cerr << " reverse";} 
     else {cerr << " forward";}
-    cerr << "Indices:" << endl;
+    cerr << endl << "Indices:" << endl;
     
     for (auto n : visitToIndex) {
         cerr << n.first.first << ", " << n.first.second << ": " << n.second << endl;

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -24,11 +24,11 @@ DistanceIndex::DistanceIndex(VG* vg, SnarlManager* snarlManager){
               const Chain* chain = sm->chain_of(snarl);
               calculateIndex(chain);
               for (auto s : *chain) {
-                  seenSnarls.insert(s);
+                  seenSnarls.insert(s.first);
               }
            } else {
                Chain currChain;
-               currChain.push_back(snarl);
+               currChain.emplace_back(snarl, false);
                calculateIndex(&currChain);
                seenSnarls.insert(snarl);
            }
@@ -461,7 +461,7 @@ int64_t DistanceIndex::calculateIndex(const Chain* chain) {
                                 
                                 //Create chain to recurse on and recurse
                                 Chain currChain;
-                                currChain.push_back(currSnarl);
+                                currChain.emplace_back(currSnarl, false);
                                 calculateIndex(&currChain);
 
                                 SnarlDistances& currSnarlDists = 

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -242,10 +242,21 @@ int64_t DistanceIndex::calculateIndex(const Chain* chain) {
     vector<int64_t> chainLoopFd; 
     vector<int64_t> chainLoopRev; 
     Node* firstNode = graph->get_node(get_start_of(*chain).node_id());
-
+    
+    #ifdef indexTraverse
+        cerr << "Prefix sum before chain initial node: " << chainPrefixSum.back() << endl;
+    #endif
     chainPrefixSum.push_back(firstNode->sequence().size());
+    #ifdef indexTraverse
+        cerr << "Prefix sum after chain initial node: " << chainPrefixSum.back() << endl;
+    #endif
+    
     hash_map<id_t, size_t> snarlToIndex;
     snarlToIndex[get_start_of(*chain).node_id()] = 0;
+    #ifdef indexTraverse
+        cerr << "Node " << get_start_of(*chain).node_id() << " represents snarl at index "
+            << snarlToIndex[get_start_of(*chain).node_id()] << endl;
+    #endif
 
     ChainIterator chainEnd = chain_end(*chain);
     for (ChainIterator c = chain_begin(*chain); c != chainEnd; ++c) {
@@ -264,6 +275,15 @@ int64_t DistanceIndex::calculateIndex(const Chain* chain) {
             //already been seen (if the chain loops)
             size_t nextIndex = snarlToIndex.size();
             snarlToIndex[snarlEndID] = nextIndex;
+            
+            #ifdef indexTraverse
+                cerr << "Node " << snarlEndID << " represents snarl at index "
+                    << snarlToIndex[snarlEndID] << endl;
+            #endif
+        } else {
+            #ifdef indexTraverse
+                cerr << "Node " << snarlEndID << " already represents a snarl, at index " << snarlToIndex[snarlEndID] << endl;
+            #endif
         }
 
 
@@ -292,10 +312,16 @@ int64_t DistanceIndex::calculateIndex(const Chain* chain) {
         SnarlDistances& sd = snarlIndex.at(make_pair(snarlStartID, snarlStartRev));
 
         #ifdef indexTraverse
-            cerr << "Snarl  at " << snarl->start().node_id() << endl;
+            cerr << "Snarl at " << snarl->start() << " -> " << snarl->end() << endl;
             cerr << "    Contains nodes : ";
-            for (pair<id_t, bool> node: allNodes) {
-                cerr << node.first << " "; 
+            {
+                unordered_set<id_t> reported;
+                for (pair<id_t, bool> node: allNodes) {
+                    if (!reported.count(node.first)) {
+                        cerr << node.first << " ";
+                        reported.insert(node.first);
+                    }
+                }
             }
             cerr << endl;
         #endif
@@ -311,7 +337,7 @@ int64_t DistanceIndex::calculateIndex(const Chain* chain) {
 
             #ifdef indexTraverse
                 cerr << "  Start Node: " << startID.first << "," 
-                                                   << startID.second << endl;
+                    << startID.second << endl;
             #endif
             bool firstLoop = true;
 
@@ -557,15 +583,19 @@ int64_t DistanceIndex::calculateIndex(const Chain* chain) {
 
 
                     #ifdef indexTraverse
-                         cerr << "    From start node " << startID.first << " " << startID.second<< " in snarl " << snarl->start().node_id() << " at " << ng.get_id(currHandle) << " " << ng.get_is_reverse(currHandle) << endl; 
+                         cerr << "    From start node " << startID.first << " " << startID.second 
+                            << " in snarl " << snarl->start() << " -> " << snarl->end()
+                            << " at " << ng.get_id(currHandle) << " " << ng.get_is_reverse(currHandle) << endl; 
                          cerr << "        Adding next nodes:  ";
                     #endif
 
                     if (nodeLen != -1) {
-
                         ng.follow_edges(currHandle, false, addHandle);
                     } else if (firstLoop) {
-                        //If the nodeLen is -1 then node is a unary snarl that doesn't have a path from start to end. If this is the start of the distance calculation then add subsequent nodes assuming that the node length was 0
+                        //If the nodeLen is -1 then node is a unary snarl that
+                        //doesn't have a path from start to end. If this is the
+                        //start of the distance calculation then add subsequent
+                        //nodes assuming that the node length was 0
                         ng.follow_edges(currHandle, false, addHandle0);
                     } 
                         
@@ -621,7 +651,7 @@ int64_t DistanceIndex::calculateIndex(const Chain* chain) {
         }//End for loop over starting node/directions in a snarl
 
         #ifdef indexTraverse
-            cerr << "End snarl " << snarl->start().node_id() << endl;
+            cerr << "End snarl " << snarl->start() << " -> " << snarl->end() << endl;
         #endif
 
         /*Add to prefix sum the distance to the beginning and end of the last
@@ -636,8 +666,14 @@ int64_t DistanceIndex::calculateIndex(const Chain* chain) {
 
             chainPrefixSum.push_back(chainPrefixSum[chainPrefixSum.size()-2]+
                        dist);
+            #ifdef indexTraverse
+                cerr << "Prefix sum before snarl reverse start: " << chainPrefixSum.back() << endl;
+            #endif
             chainPrefixSum.push_back(chainPrefixSum[chainPrefixSum.size()-1] + 
                     graph->get_node(snarlStartID)->sequence().size());
+            #ifdef indexTraverse
+                cerr << "Prefix sum after snarl reverse start: " << chainPrefixSum.back() << endl;
+            #endif
         
         } else { 
             dist = sd.snarlDistance(
@@ -646,11 +682,17 @@ int64_t DistanceIndex::calculateIndex(const Chain* chain) {
 
             chainPrefixSum.push_back(chainPrefixSum[chainPrefixSum.size()-2]+
                        dist);
+            #ifdef indexTraverse
+                cerr << "Prefix sum before snarl end: " << chainPrefixSum.back() << endl;
+            #endif
             chainPrefixSum.push_back(chainPrefixSum[chainPrefixSum.size()-1] + 
                     graph->get_node(snarlEndID)->sequence().size());
-       }
+            #ifdef indexTraverse
+                cerr << "Prefix sum after snarl end: " << chainPrefixSum.back() << endl;
+            #endif
+        }
         
-         //length of snarl
+        //length of snarl
         if (dist == -1) {
             sd.length = -1;
         } else {
@@ -1796,12 +1838,14 @@ vector<int64_t> DistanceIndex::ChainDistances::toVector() {
 }
 int64_t DistanceIndex::ChainDistances::chainDistance(pair<id_t, bool> start, 
                                                       pair<id_t, bool> end) {
-    /*Returns the distance between start of start and start of end in a chain
-      Bools are true if traversed reverse relative to the start of the chain
-    */
+    /*
+     * Return the distance between the given node sides, except node side is
+     * specified relative to the reading orientation of the chain that the
+     * nodes are in. 
+     */
     size_t i1 = snarlToIndex.at(start.first);
-    size_t i2 = snarlToIndex.at(end.first); 
-
+    size_t i2 = snarlToIndex.at(end.first);
+    
     return chainDistanceHelper(make_pair(i1, start.second), 
                                make_pair(i2, end.second));
 }

--- a/src/distance.hpp
+++ b/src/distance.hpp
@@ -56,10 +56,12 @@ class DistanceIndex {
             vector<int64_t>  toVector();
             
             //Distance between beginning of node start and beginning of node end
+            //Only works for nodes heading their chains (which represent the chains), or snarl boundaries.
             int64_t snarlDistance(pair<id_t, bool> start, pair<id_t, bool> end);
 
  
             //Distance between end of node start and beginning of node end
+            //Only works for nodes heading their chains (which represent the chains), or snarl boundaries.
             int64_t snarlDistanceShort(VG* graph,NetGraph* ng,
                      pair<id_t, bool> start, pair<id_t, bool> end); 
 

--- a/src/distance.hpp
+++ b/src/distance.hpp
@@ -186,9 +186,6 @@ class DistanceIndex {
             int64_t chainDistanceHelper(pair<size_t, bool> start, 
                                        pair<size_t, bool> end     );
 
-            /*Returns true if the snarl is reversed in the chain*/
-            bool isReverse(const Snarl* snarl, SnarlManager* sm);
-
         friend class DistanceIndex;   
         friend class TestDistanceIndex;
     }; 

--- a/src/distance.hpp
+++ b/src/distance.hpp
@@ -87,16 +87,16 @@ class DistanceIndex {
             //Maps node to index to get its distance
             hash_map< pair<id_t, bool>, size_t> visitToIndex;
  
-             //Store the distance between every pair nodes, -1 indicates no path
-             //For child snarls that are unary or only connected to one node
-             //in the snarl, distances between that node leaving the snarl
-             //and any other node is -1
+            //Store the distance between every pair nodes, -1 indicates no path
+            //For child snarls that are unary or only connected to one node
+            //in the snarl, distances between that node leaving the snarl
+            //and any other node is -1
             vector<int64_t> distances;
 
             //ID of the first node in the snarl, also key for distance index 
             pair<id_t, bool> snarlStart;
  
-           //End facing out of snarl
+            //End facing out of snarl
             pair<id_t, bool> snarlEnd;           
 
             //Total length of the snarl- start to end plus length of end
@@ -129,20 +129,31 @@ class DistanceIndex {
 
             /*Convert contents into vector of ints for serialization
                stored as [node_id1, prefixsum1 start, prefixsum1 end,
-                                            loopfd1, loopfd2, node_id2, ...]
+                          loopfd1, loopfd2, node_id2, ...]
             */
             vector<int64_t> toVector();
        
-            /*Distance between two snarls starting from the beginning of the 
-              start node to the beginning of the end node.
-              bool is true if traversing reverse relative to the start of 
-              the chain */
+            /** 
+             * Distance between two node sides in a chain. id_t values specify
+             * the nodes, and bool values specify the sides. Side orientations
+             * are relative to the node's orientation *in the chain*, so if
+             * reading through the chain in its forward orientation you
+             * encounter the node in reverse, then true is the *left* side of
+             * the node and false is the *right* side.
+             */
             int64_t chainDistance(pair<id_t, bool> start, pair<id_t, bool> end);
 
-            /*Distance between two snarls starting from the beginning of 
-              the node after start to the beginning of end */ 
+            /**
+             * Takes the graph and two node sides, with orientations specified
+             * relative to the nodes' orientation in their chain (i.e. nodes
+             * backward in the chain have false represent the *end* of the
+             * node).
+             *
+             * Returns the distance from the **opposite** side of the start
+             * node to the specified side of the end node.
+             */
             int64_t chainDistanceShort(VG* graph, pair<id_t, bool> start, 
-                                                        pair<id_t, bool> end);
+                                                  pair<id_t, bool> end);
             //Length of entire chain
             int64_t chainLength();
 

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -3,8 +3,6 @@
 
 #include <signal.h>
 
-#define debug
-
 namespace vg {
 
 using namespace std;

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -579,9 +579,9 @@ ReplaceLocalHaplotypeCommand GenomeState::replace_snarl_haplotype(const ReplaceS
                     // Get the chain for the child
                     const Chain* child_chain = manager.chain_of(child);
                     
-                    for (const Snarl* s : *child_chain) {
+                    for (auto it = chain_begin(*child_chain); it != chain_end(*child_chain); ++it) {
                         // For each snarl in the chain, remember to delete this overall lane
-                        lanes_to_delete[s].insert(handle_and_lane.second);
+                        lanes_to_delete[it->first].insert(handle_and_lane.second);
                     }
                 }
             }

--- a/src/genome_state.cpp
+++ b/src/genome_state.cpp
@@ -555,7 +555,7 @@ ReplaceLocalHaplotypeCommand GenomeState::replace_snarl_haplotype(const ReplaceS
             auto& overall_lane = *it;
             
 #ifdef debug
-            cerr << "Delete " << overall_lane << " from " << kv.first->start() << " -> " << kv.first->end() << endl;
+            cerr << "Delete " << overall_lane << " from " << snarl->start() << " -> " << snarl->end() << endl;
 #endif
             
             // Remove the haplotype and save a copy
@@ -667,44 +667,64 @@ void GenomeState::trace_haplotype(const pair<const Snarl*, const Snarl*>& telome
             }
             
             if (net_graph.is_child(visit)) {
-                // If the visit enters a real child snarl, we have to do that
-                // child snarl and all the snarls in its chain.
+                // If the visit enters a real child chain, we have to do that
+                // child chain all the snarls in it.
                 
-                // Get the handle in the backing graph that reads into the child
+                // Get the handle in the backing graph that reads into the chain
                 // in the orientation we are visiting it
                 handle_t into = net_graph.get_inward_backing_handle(visit);
-            
-                // Get the child we are actually reading into from the SnarlManager
-                const Snarl* child = manager.into_which_snarl(backing_graph->to_visit(into));
-            
-                // Get the chain for the child
-                const Chain* child_chain = manager.chain_of(child);
-                
-                // Decide if we are entering the child snarl backward or not
-                bool child_orientation = child->start().node_id() != backing_graph->get_id(into);
                 
 #ifdef debug
-                cerr << "\tEnters into snarl " << child->start() << " -> " << child->end() << endl;
+                cerr << "\tInward backing handle is " << backing_graph->get_id(into) << " "
+                    << backing_graph->get_is_reverse(into) << endl;
+#endif
+            
+                // Get the snarl we really are entering, because get_inward_backing_handle works.
+                const Snarl* entered = manager.into_which_snarl(backing_graph->to_visit(into));
+                
+                // Decide if we are entering it through its end
+                bool entered_snarl_via_end = entered->start().node_id() != backing_graph->get_id(into);
+                
+                // Get the chain that is our child
+                const Chain* child_chain = manager.chain_of(entered);
+                
+                // Get this snarl's orientation in that chain
+                bool entered_orientation_in_chain = manager.chain_orientation_of(entered);
+                
+                // If we enter a snarl via its start, and it is forward in the chain, we do the whole chain forward.
+                // If we enter a snarl via its end, and it is forward in its chain, we do the whole chain reverse.
+                // If we enter a snarl via its start, and it is backward in its chain, we do the whole chain reverse.
+                // If we enter a snarl via its end, and it is backward in its chain, we do the whole chain forward.
+                // F F F
+                // T F T
+                // F T T
+                // T T F
+                // So we use xor here.
+                bool chain_orientation = entered_snarl_via_end != entered_orientation_in_chain;
+                
+#ifdef debug
+                cerr << "\tEnters into chain containing " << entered->start() << " -> " << entered->end()
+                    << " which we enter in orientation " << entered_snarl_via_end
+                    << " and is in orientation " << entered_orientation_in_chain << " in its chain" << endl;
+                cerr << "\tOverall, chain should be traversed in orientation " << chain_orientation << endl;
 #endif
                 
-                // Get the iterators to loop over the chain starting at the child inthis orientation
-                auto it = chain_begin_from(*child_chain, child, child_orientation);
-                auto end = chain_end_from(*child_chain, child, child_orientation);
-                
-                // TODO: We can go through a one-snarl chain either forward or
-                // backward. But the chain iterators will always start at the
-                // start and go left to right, and so see the child snarl
-                // forward. We need to account for the orientation in which we
-                // are entering this child snarl.
-                
-                // Track if we had a previous snarl that would have emitted any shaed nodes.
+                // Get the iterators to loop over the chain in the orientation we have reached it
+                auto it = chain_orientation ? chain_rcbegin(*child_chain) : chain_begin(*child_chain);
+                auto end = chain_orientation ? chain_rcend(*child_chain) : chain_end(*child_chain);
+           
+                // Track if we had a previous snarl that would have emitted any shared nodes.
                 bool had_previous = false;
+                
+                // Make sure we have the end of the chain we were expecting.
+                assert(it->first == entered);
                 
                 for (; it != end; ++it) {
                     // Until we run out of snarls in the chain
                 
 #ifdef debug
-                    cerr << "\t\tHandle " << it->first->start() << " -> " << it->first->end() << " in chain" << endl;
+                    cerr << "\t\tHandle " << it->first->start() << " -> " << it->first->end()
+                        << " orientation " << it->second << " in chain" << endl;
 #endif
                 
                     // Handle this one
@@ -765,6 +785,7 @@ void GenomeState::trace_haplotype(const pair<const Snarl*, const Snarl*>& telome
         next = manager.into_which_snarl(here);
     }
 }
+
 
 void GenomeState::dump() const {
     for (auto& kv : state) {
@@ -859,10 +880,19 @@ void GenomeState::insert_handles(const vector<handle_t>& to_add,
                 // And its net graph
                 auto& net_graph = net_graphs.at(parent);
                 
-                // Get a handle_t representing the whole chain. It is numbered
-                // with the start of the chain and is reverse if we aren't
-                // leaving the end of the chain.
-                handle_t chain_handle = net_graph.get_handle(get_start_of(*chain).node_id(), next_visit != get_end_of(*chain));
+                // Get the backing graph handle reading out of the chain
+                handle_t backing_outward = backing_graph->get_handle(next_visit);
+                
+                // Make it inward
+                handle_t backing_inward = backing_graph->flip(backing_outward);
+                
+                // Get a handle_t representing the whole chain.
+                // We get the representative chain handle for the inward backing handle, and flip it back.
+                handle_t chain_handle = net_graph.flip(net_graph.get_handle_from_inward_backing_handle(backing_inward));
+
+#ifdef debug
+                cerr << "Represent chain traversal with " << net_graph.to_visit(chain_handle) << endl;
+#endif
 
                 // Tack it on to the parent
                 stack.front().second.push_back(chain_handle);

--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -45,6 +45,22 @@ pair<handle_t, handle_t> HandleGraph::edge_handle(const handle_t& left, const ha
     }
 }
 
+handle_t HandleGraph::traverse_edge_handle(const edge_t& edge, const handle_t& left) const {
+    if (left == edge.first) {
+        // The cannonical orientation is the one we want
+        return edge.second;
+    } else if (left == this->flip(edge.second)) {
+        // We really want the other orientation
+        return this->flip(edge.first);
+    } else {
+        // This isn't either handle that the edge actually connects. Something has gone wrong.
+        throw runtime_error("Cannot view edge " +
+            to_string(this->get_id(edge.first)) + " " + to_string(this->get_is_reverse(edge.first)) + " -> " +
+            to_string(this->get_id(edge.second)) + " " + to_string(this->get_is_reverse(edge.second)) +
+            " from non-participant " + to_string(this->get_id(left)) + " " + to_string(this->get_is_reverse(left)));
+    }
+}
+
 }
 
 

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -276,9 +276,13 @@ public:
     /// Get the locally forward version of a handle
     handle_t forward(const handle_t& handle) const;
     
-    // A pair of handles can be used as an edge. When so used, the handles have a
-    // canonical order and orientation.
+    /// A pair of handles can be used as an edge. When so used, the handles have a
+    /// canonical order and orientation.
     edge_t edge_handle(const handle_t& left, const handle_t& right) const;
+    
+    /// Such a pair can be viewed from either inward end handle and produce the
+    /// outward handle you would arrive at.
+    handle_t traverse_edge_handle(const edge_t& edge, const handle_t& left) const;
 };
     
 /**

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1,6 +1,7 @@
 #include <unordered_set>
 #include "mapper.hpp"
 #include "haplotypes.hpp"
+#include "annotation.hpp"
 #include "algorithms/extract_containing_graph.hpp"
 
 //#define debug_mapper
@@ -1720,14 +1721,15 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
         if (alns[i]->path().mapping_size() != 0) {
             // We actually did rescore this one
             
-            int64_t score_penalty = round(haplotype_consistency_exponent * (haplotype_logprobs[i] / aligner->log_base));
+            // This is a score "penalty" because it is usually negative. But positive = more score.
+            double score_penalty = haplotype_consistency_exponent * (haplotype_logprobs[i] / aligner->log_base);
 
             // Convert to points, raise to haplotype consistency exponent power, and apply
-            alns[i]->set_score(max((int64_t)0, alns[i]->score() + score_penalty));
+            alns[i]->set_score(max((int64_t) 0, alns[i]->score() + (int64_t) round(score_penalty)));
             // Note that we successfully corrected the score
-            alns[i]->set_haplotype_scored(true);
-            // And save the raw log probability
-            alns[i]->set_haplotype_logprob(haplotype_logprobs[i]);
+            set_annotation(alns[i], "haplotype_score_used", true);
+            // And save the score penalty/bonus
+            set_annotation(alns[i], "haplotype_score", score_penalty);
 
             if (debug) {
                 cerr << "Alignment statring at " << alns[i]->path().mapping(0).position().node_id()
@@ -1735,7 +1737,6 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
                     << " from " << alns[i]->score() - score_penalty << " to " << alns[i]->score() << endl;
             }
         }
-        // Otherwise leave haplotype_scored as false, the default.
     }
 }
     

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -190,9 +190,8 @@ ChainIterator chain_end_from(const Chain& chain, const Snarl* start_snarl, bool 
  * within another HandleGraph. Uses its own internal child index because
  * it's used in the construction of snarls to feed to SnarlManagers.
  *
- * Assumes that the chains we get from Cactus are in a consistent order, so
- * the start of the first snarl is the very first thing in the chain, and
- * the end of the last snarl is the very last.
+ * Assumes that the snarls in the chains we get are in the order they
+ * occur in the graph.
  *
  * We adapt the handle graph abstraction as follows:
  *
@@ -326,11 +325,16 @@ public:
     /// chain or unary snarl, and false if it is a normal node actually in
     /// the net graph snarl's contents.
     bool is_child(const handle_t& handle) const;
-        
+    
     /// Get the handle in the backing graph reading into the child chain or
     /// unary snarl in the orientation represented by this handle to a node
     /// representing a child chain or unary snarl.
     handle_t get_inward_backing_handle(const handle_t& child_handle) const;
+    
+    /// Given a handle to a node in the backing graph that reads into a child
+    /// chain or snarl (in either direction), get the handle in this graph used
+    /// to represent that child chain or snarl in that orientation.
+    handle_t get_handle_from_inward_backing_handle(const handle_t& backing_handle) const;
         
 protected:
     
@@ -366,7 +370,7 @@ protected:
         
     // We keep basically the reverse map, from chain start in chain forward
     // orientation to chain end in chain forward orientation. This lets us
-    // find the edges off the far end of a chian.
+    // find the edges off the far end of a chain.
     unordered_map<handle_t, handle_t> chain_ends_by_start;
         
     // Stores whether a chain or unary snarl, identified by the ID of its
@@ -451,6 +455,10 @@ public:
     /// asking this class to walk the chain for you, use ChainIterators on
     /// this chain.
     const Chain* chain_of(const Snarl* snarl) const;
+    
+    /// If the given Snarl is backward in its chain, return true. Otherwise,
+    /// return false.
+    bool chain_orientation_of(const Snarl* snarl) const;
         
     /// Return true if a Snarl is part of a nontrivial chain of more than
     /// one snarl.
@@ -549,6 +557,8 @@ private:
         
         /// This points to the chain we are in, or null if we are not in a chain.
         Chain* parent_chain = nullptr;
+        /// And this is what index we are at in the chain;
+        size_t parent_chain_index = 0;
         
         /// Allow assignment from a Snarl object, fluffing it up into a full SnarlRecord
         SnarlRecord& operator=(const Snarl& other) {

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -453,15 +453,15 @@ public:
         
     /// Get the Chain that the given snarl participates in. Instead of
     /// asking this class to walk the chain for you, use ChainIterators on
-    /// this chain.
+    /// this chain. This is always non-null.
     const Chain* chain_of(const Snarl* snarl) const;
     
     /// If the given Snarl is backward in its chain, return true. Otherwise,
     /// return false.
     bool chain_orientation_of(const Snarl* snarl) const;
         
-    /// Return true if a Snarl is part of a nontrivial chain of more than
-    /// one snarl.
+    /// Return true if a Snarl is part of a nontrivial chain of more than one
+    /// snarl. Note that chain_of() still works for snarls in trivial chains.
     bool in_nontrivial_chain(const Snarl* here) const;
         
     /// Get all the snarls in all the chains under the given parent snarl.

--- a/src/unittest/annotation.cpp
+++ b/src/unittest/annotation.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Annotations can be populated", "[alignment][annotation]") {
     
 }
 
-TEST_CASE("Multi-value annotations can be set and gotten", "[alignment][annotation]") {
+TEST_CASE("Multi-value annotations can be set and gotten and cleared", "[alignment][annotation]") {
     
     Alignment aln;
     
@@ -64,6 +64,16 @@ TEST_CASE("Multi-value annotations can be set and gotten", "[alignment][annotati
     for (size_t i = 0; i < words.size(); i++) {
         REQUIRE(recovered[i] == words[i]);
     }
+    
+    // Make sure we can clear it
+    clear_annotation(&aln, "words");
+    recovered = get_annotation<vector<string>>(&aln, "words");
+    REQUIRE(recovered.size() == 0);
+    
+    // Make sure we can clear it again, when empty
+    clear_annotation(&aln, "words");
+    recovered = get_annotation<vector<string>>(&aln, "words");
+    REQUIRE(recovered.size() == 0);
     
 }
    

--- a/src/unittest/distance.cpp
+++ b/src/unittest/distance.cpp
@@ -1665,9 +1665,50 @@ class TestDistanceIndex : public DistanceIndex {
             const Snarl* snarl1 = snarl_manager.into_which_snarl(1, false);
             const Chain* chain = snarl_manager.chain_of(snarl1);
             TestDistanceIndex::ChainDistances& cd = di.chainIndex.at(get_start_of(*chain).node_id());
-            REQUIRE(cd.chainDistance(make_pair(1, true), make_pair(8, true)) == 3);
-            REQUIRE(cd.chainDistance(make_pair(8, false), make_pair(1, false)) == 3);
-            REQUIRE(cd.chainDistanceShort(&graph, make_pair(8, false), make_pair(1, false)) == 2);
+            
+            if (get_start_of(*chain).node_id() == 1 && get_start_of(*chain).backward() == false || 
+                get_start_of(*chain).node_id() == 8 && get_start_of(*chain).backward() == false) {
+                // Chain should be 1 fwd -> 8 fwd, 8 fwd -> 1 fwd
+                // or 8 fwd -> 1 fwd, 1 fwd -> 8 fwd
+                // after snarls have been flipped into their in-chain orientations.
+                // Node side flags are normal.
+                
+                // Distance from start of node 1 to start of node 8 should be 1
+                REQUIRE(cd.chainDistance(make_pair(1, false), make_pair(8, false)) == 1);
+                // Distance from start of node 8 to start of node 1 should be 3
+                REQUIRE(cd.chainDistance(make_pair(8, false), make_pair(1, false)) == 3);
+                // Distance from end of node 1 to end of node 8, reading backward, should be 3
+                REQUIRE(cd.chainDistance(make_pair(1, true), make_pair(8, true)) == 3);
+                // Distance from end of node 8 to end of node 1, reading backward, should be 1
+                REQUIRE(cd.chainDistance(make_pair(8, true), make_pair(1, true)) == 1);
+                
+                // Distance from side opposite start of node 8 to start of node 1 should be 2
+                REQUIRE(cd.chainDistanceShort(&graph, make_pair(8, false), make_pair(1, false)) == 2);
+                
+            } else if (get_start_of(*chain).node_id() == 1 && get_start_of(*chain).backward() == true || 
+                get_start_of(*chain).node_id() == 8 && get_start_of(*chain).backward() == true) {
+                // Chain should be 1 rev -> 8 rev, 8 rev -> 1 rev
+                // or 8 rev -> 1 rev, 1 rev -> 8 rev
+                // after snarls have been flipped into their in-chain orientations.
+                // Node side flags are FLIPPED.
+                
+                // Distance from start of node 1 to start of node 8 should be 1
+                REQUIRE(cd.chainDistance(make_pair(1, !false), make_pair(8, !false)) == 1);
+                // Distance from start of node 8 to start of node 1 should be 3
+                REQUIRE(cd.chainDistance(make_pair(8, !false), make_pair(1, !false)) == 3);
+                // Distance from end of node 1 to end of node 8, reading backward, should be 3
+                REQUIRE(cd.chainDistance(make_pair(1, !true), make_pair(8, !true)) == 3);
+                // Distance from end of node 8 to end of node 1, reading backward, should be 1
+                REQUIRE(cd.chainDistance(make_pair(8, !true), make_pair(1, !true)) == 1);
+                
+                // Distance from side opposite start of node 8 to start of node 1 should be 2
+                REQUIRE(cd.chainDistanceShort(&graph, make_pair(8, !false), make_pair(1, !false)) == 2);
+                
+            } else {
+                // Unimplemented view of the graph; we don't know what the chain distance functions should say.
+                // We need to expand the test case for this chain/snarl breakdown.
+                REQUIRE(false);
+            }
           
         }
         SECTION ("Distance functions") {

--- a/src/unittest/distance.cpp
+++ b/src/unittest/distance.cpp
@@ -961,13 +961,19 @@ class TestDistanceIndex : public DistanceIndex {
         TestDistanceIndex di (&graph, &snarl_manager);
 
 
+        // We end up with a big unary snarl of 7 rev -> 7 rev
+        // Inside that we have a chain of two normal snarls 2 rev -> 3 fwd, and 3 fwd -> 6 fwd
+        // And inside 2 rev -> 3 fwd, we get 1 rev -> 1 rev as another unary snarl.
+        
+        // We name the snarls for the distance index by their start nodes.
+
         SECTION("Create distance index") {
             #ifdef print
             di.printSelf();
             #endif
             auto snarl1 = snarl_manager.into_which_snarl(1, true);
             auto snarl2 = snarl_manager.into_which_snarl(2, true);
-            auto snarl6 = snarl_manager.into_which_snarl(6, true);
+            auto snarl3 = snarl_manager.into_which_snarl(3, false);
             auto snarl7 = snarl_manager.into_which_snarl(7, true);
 
             const Chain* chain = snarl_manager.chain_of(snarl2);
@@ -978,9 +984,9 @@ class TestDistanceIndex : public DistanceIndex {
             TestDistanceIndex::SnarlDistances& sd2 = 
                      di.snarlIndex.at(make_pair(snarl2->start().node_id(),
                                               snarl2->start().backward()));
-            TestDistanceIndex::SnarlDistances& sd6 = 
-                     di.snarlIndex.at(make_pair(snarl6->start().node_id(),
-                                              snarl6->start().backward()));
+            TestDistanceIndex::SnarlDistances& sd3 = 
+                     di.snarlIndex.at(make_pair(snarl3->start().node_id(),
+                                              snarl3->start().backward()));
             TestDistanceIndex::SnarlDistances& sd7 = 
                      di.snarlIndex.at(make_pair(snarl7->start().node_id(),
                                               snarl7->start().backward()));  
@@ -1004,38 +1010,38 @@ class TestDistanceIndex : public DistanceIndex {
                                                                          == -1);
             REQUIRE(sd2.snarlDistance(make_pair(3, true), make_pair(3, false))
                                                                          == 7);
-            REQUIRE(sd6.snarlDistance(make_pair(3, false), make_pair(4, false))
+            REQUIRE(sd3.snarlDistance(make_pair(3, false), make_pair(4, false))
                                                                          == 1);
-            REQUIRE(sd6.snarlDistance(make_pair(3, false), make_pair(6, false))
+            REQUIRE(sd3.snarlDistance(make_pair(3, false), make_pair(6, false))
                                                                          == 4);
-            REQUIRE(sd6.snarlDistance(make_pair(6, true), make_pair(3, true))
+            REQUIRE(sd3.snarlDistance(make_pair(6, true), make_pair(3, true))
                                                                          == 4);
-            REQUIRE(sd6.snarlDistance(make_pair(5, true), make_pair(3, false))
+            REQUIRE(sd3.snarlDistance(make_pair(5, true), make_pair(3, false))
                                                                          == -1);
              
-            REQUIRE(cd.chainDistance(make_pair(6, false), make_pair(3, false)) 
+            REQUIRE(cd.chainDistance(make_pair(6, true), make_pair(3, true)) 
                                                                     == 4);
-            REQUIRE(cd.chainDistance(make_pair(3, true), make_pair(6, true)) 
+            REQUIRE(cd.chainDistance(make_pair(3, false), make_pair(6, false)) 
                                                                     == 4);
-            REQUIRE(cd.chainDistance(make_pair(6, false), make_pair(3, true)) 
+            REQUIRE(cd.chainDistance(make_pair(6, true), make_pair(3, false)) 
                                                                     == 11);
-            REQUIRE(cd.chainDistance(make_pair(2, true), make_pair(2, false)) 
+            REQUIRE(cd.chainDistance(make_pair(2, false), make_pair(2, true)) 
                                                                     == 7);
-            REQUIRE(cd.chainDistance(make_pair(6, false), make_pair(2, false)) 
+            REQUIRE(cd.chainDistance(make_pair(6, true), make_pair(2, true)) 
                                                                     == 11);
-            REQUIRE(cd.chainDistance(make_pair(6, false), make_pair(2, true)) 
+            REQUIRE(cd.chainDistance(make_pair(6, true), make_pair(2, false)) 
                                                                     == -1);
             REQUIRE(di.chainIndex.size() == 1);
 
-            REQUIRE(sd7.snarlDistance(make_pair(7, true), make_pair(6, false))
+            REQUIRE(sd7.snarlDistance(make_pair(7, true), make_pair(2, false))
                                                                          == 1);
-            REQUIRE(sd7.snarlDistance(make_pair(7, true), make_pair(6, true))
+            REQUIRE(sd7.snarlDistance(make_pair(7, true), make_pair(2, true))
                                                                          == 1);
             REQUIRE(sd7.snarlDistance(make_pair(7, true), make_pair(7, false))
                                                                          == 9);
-            REQUIRE(sd7.snarlDistance(make_pair(6, true), make_pair(7, false))
+            REQUIRE(sd7.snarlDistance(make_pair(2, true), make_pair(7, false))
                                                                         == 12);
-            REQUIRE(sd7.snarlDistance(make_pair(6, false), make_pair(7, true))
+            REQUIRE(sd7.snarlDistance(make_pair(2, false), make_pair(7, true))
                                                                         == -1);
 
             }

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -12,8 +12,6 @@
 #include "../genotypekit.hpp"
 #include "../genome_state.hpp"
 
-#define debug
-
 namespace vg {
 namespace unittest {
 

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -512,6 +512,9 @@ TEST_CASE("GenomeState can hold and manipulate haplotypes", "[genomestate]") {
         snarl_manager.flip(middle_snarl);
     }
     
+    REQUIRE(middle_snarl->start().node_id() == 2);
+    REQUIRE(middle_snarl->end().node_id() == 7);
+    
     // And the bottom snarl
     const Snarl* bottom_snarl = snarl_manager.children_of(middle_snarl).at(0);
     
@@ -519,6 +522,9 @@ TEST_CASE("GenomeState can hold and manipulate haplotypes", "[genomestate]") {
         // Put it a consistent way around
         snarl_manager.flip(bottom_snarl);
     }
+    
+    REQUIRE(bottom_snarl->start().node_id() == 3);
+    REQUIRE(bottom_snarl->end().node_id() == 5);
     
     // Define the chromosome by telomere snarls (first and last)
     auto chromosome = make_pair(top_snarl, top_snarl);
@@ -536,6 +542,23 @@ TEST_CASE("GenomeState can hold and manipulate haplotypes", "[genomestate]") {
         REQUIRE(top_graph != nullptr);
         REQUIRE(middle_graph != nullptr);
         REQUIRE(bottom_graph != nullptr);
+        
+#ifdef debug
+        cerr << "Top graph " << top_snarl->start().node_id() << " - " << top_snarl->end().node_id() << " contents: " << endl;
+        top_graph->for_each_handle([&](const handle_t h) {
+            cerr << "\t" << top_graph->get_id(h) << endl;
+        });
+        
+        cerr << "Middle graph " << middle_snarl->start().node_id() << " - " << middle_snarl->end().node_id() << " contents: " << endl;
+        middle_graph->for_each_handle([&](const handle_t h) {
+            cerr << "\t" << middle_graph->get_id(h) << endl;
+        });
+        
+        cerr << "Bottom graph " << bottom_snarl->start().node_id() << " - " << bottom_snarl->end().node_id() << " contents: " << endl;
+        bottom_graph->for_each_handle([&](const handle_t h) {
+            cerr << "\t" << bottom_graph->get_id(h) << endl;
+        });
+#endif
     }
     
     SECTION("GenomeState starts empty") {
@@ -552,14 +575,14 @@ TEST_CASE("GenomeState can hold and manipulate haplotypes", "[genomestate]") {
         // For the top snarl we go 1, 2 (child), and 8
         insert.insertions.emplace(top_snarl, vector<vector<pair<handle_t, size_t>>>{{
             {top_graph->get_handle(1, false), 0},
-            {top_graph->get_handle(2, false), 0},
+            {top_graph->get_handle_from_inward_backing_handle(graph.get_handle(2, false)), 0},
             {top_graph->get_handle(8, false), 0}
         }});
         
         // For the middle snarl we go 2, 3 (child), 7
         insert.insertions.emplace(middle_snarl, vector<vector<pair<handle_t, size_t>>>{{
             {middle_graph->get_handle(2, false), 0},
-            {middle_graph->get_handle(3, false), 0},
+            {middle_graph->get_handle_from_inward_backing_handle(graph.get_handle(3, false)), 0},
             {middle_graph->get_handle(7, false), 0}
         }});
         
@@ -603,14 +626,14 @@ TEST_CASE("GenomeState can hold and manipulate haplotypes", "[genomestate]") {
             // For the top snarl we go 1, 2 (child), and 8
             insert2.insertions.emplace(top_snarl, vector<vector<pair<handle_t, size_t>>>{{
                 {top_graph->get_handle(1, false), 0},
-                {top_graph->get_handle(2, false), 0},
+                {top_graph->get_handle_from_inward_backing_handle(graph.get_handle(2, false)), 0},
                 {top_graph->get_handle(8, false), 0}
             }});
             
             // For the middle snarl we go 2, 3 (child), 7
             insert2.insertions.emplace(middle_snarl, vector<vector<pair<handle_t, size_t>>>{{
                 {middle_graph->get_handle(2, false), 0},
-                {middle_graph->get_handle(3, false), 0},
+                {middle_graph->get_handle_from_inward_backing_handle(graph.get_handle(3, false)), 0},
                 {middle_graph->get_handle(7, false), 0}
             }});
             
@@ -936,7 +959,7 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains", "[genomesta
         // For the top snarl we go 1, 2 (child chain), and 8
         insert.insertions.emplace(top_snarl, vector<vector<pair<handle_t, size_t>>>{{
             {top_graph->get_handle(1, false), 0},
-            {top_graph->get_handle(2, false), 0},
+            {top_graph->get_handle_from_inward_backing_handle(graph.get_handle(2, false)), 0},
             {top_graph->get_handle(8, false), 0}
         }});
         
@@ -1082,7 +1105,7 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains with backward
         // For the top snarl we go 1, 2 (child chain), and 8
         insert.insertions.emplace(top_snarl, vector<vector<pair<handle_t, size_t>>>{{
             {top_graph->get_handle(1, false), 0},
-            {top_graph->get_handle(2, false), 0},
+            {top_graph->get_handle_from_inward_backing_handle(graph.get_handle(2, false)), 0},
             {top_graph->get_handle(8, false), 0}
         }});
         
@@ -1093,12 +1116,10 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains with backward
             {left_graph->get_handle(4, false), 0}
         }});
         
-        // For the right child snarl we go backward: 7 rev, 5 rev, 4 rev. Note
-        // that we use 5 rev (start node backward) and not 6 rev (end node
-        // backward) to identify the reverse of the child chain.
+        // For the right child snarl we go backward: 7 rev, 6 rev (child chain), 4 rev.
         insert.insertions.emplace(right_child, vector<vector<pair<handle_t, size_t>>>{{
             {right_graph->get_handle(7, true), 0},
-            {right_graph->get_handle(5, true), 0},
+            {right_graph->get_handle_from_inward_backing_handle(graph.get_handle(6, true)), 0},
             {right_graph->get_handle(4, true), 0}
         }});
         

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -414,8 +414,8 @@ TEST_CASE("SnarlState works on snarls with nontrivial child chains", "[snarlstat
     REQUIRE(chain.size() == 2);
     
     // And the snarls in the chain
-    const Snarl* left_child = chain.at(0);
-    const Snarl* right_child = chain.at(1);
+    const Snarl* left_child = chain.at(0).first;
+    const Snarl* right_child = chain.at(1).first;
     
     REQUIRE(left_child->start().node_id() == 2);
     REQUIRE(left_child->end().node_id() == 4);
@@ -896,8 +896,8 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains", "[genomesta
     REQUIRE(chain.size() == 2);
     
     // And the snarls in the chain
-    const Snarl* left_child = chain.at(0);
-    const Snarl* right_child = chain.at(1);
+    const Snarl* left_child = chain.at(0).first;
+    const Snarl* right_child = chain.at(1).first;
     
     REQUIRE(left_child->start().node_id() == 2);
     REQUIRE(left_child->end().node_id() == 4);
@@ -1042,8 +1042,8 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains with backward
     REQUIRE(chain.size() == 2);
     
     // And the snarls in the chain
-    const Snarl* left_child = chain.at(0);
-    const Snarl* right_child = chain.at(1);
+    const Snarl* left_child = chain.at(0).first;
+    const Snarl* right_child = chain.at(1).first;
     
     REQUIRE(left_child->start().node_id() == 2);
     REQUIRE(left_child->end().node_id() == 4);

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -439,9 +439,7 @@ TEST_CASE("SnarlState works on snarls with nontrivial child chains", "[snarlstat
     
     if (left_child->start().node_id() > right_child->start().node_id()) {
         // Put them in a consistent orientation
-        auto temp = left_child;
-        left_child = right_child;
-        right_child = left_child;
+        std::swap(left_child, right_child);
     }
     
     REQUIRE(left_child->start().node_id() == 2);
@@ -961,9 +959,7 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains", "[genomesta
     
     if (left_child->start().node_id() > right_child->start().node_id()) {
         // Put them in a consistent orientation
-        auto temp = left_child;
-        left_child = right_child;
-        right_child = left_child;
+        std::swap(left_child, right_child);
     }
     
 #ifdef debug
@@ -1135,9 +1131,7 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains with backward
     
     if (left_child->start().node_id() > right_child->start().node_id()) {
         // Put them in a consistent orientation
-        auto temp = left_child;
-        left_child = right_child;
-        right_child = left_child;
+        std::swap(left_child, right_child);
     }
     
     REQUIRE(left_child->start().node_id() == 2);

--- a/src/unittest/genome_state.cpp
+++ b/src/unittest/genome_state.cpp
@@ -439,7 +439,9 @@ TEST_CASE("SnarlState works on snarls with nontrivial child chains", "[snarlstat
     
     if (left_child->start().node_id() > right_child->start().node_id()) {
         // Put them in a consistent orientation
-        swap(left_child, right_child);
+        auto temp = left_child;
+        left_child = right_child;
+        right_child = left_child;
     }
     
     REQUIRE(left_child->start().node_id() == 2);
@@ -959,7 +961,9 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains", "[genomesta
     
     if (left_child->start().node_id() > right_child->start().node_id()) {
         // Put them in a consistent orientation
-        swap(left_child, right_child);
+        auto temp = left_child;
+        left_child = right_child;
+        right_child = left_child;
     }
     
 #ifdef debug
@@ -1131,7 +1135,9 @@ TEST_CASE("GenomeSate works on snarls with nontrivial child chains with backward
     
     if (left_child->start().node_id() > right_child->start().node_id()) {
         // Put them in a consistent orientation
-        swap(left_child, right_child);
+        auto temp = left_child;
+        left_child = right_child;
+        right_child = left_child;
     }
     
     REQUIRE(left_child->start().node_id() == 2);

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -49,11 +49,11 @@ namespace vg {
             top_snarl.mutable_end()->set_node_id(n8->id());
             
             // We have a chain with a snarl in it
-            vector<vector<Snarl>> top_chains;
+            vector<vector<pair<Snarl, bool>>> top_chains;
             top_chains.emplace_back();
             auto& top_chain1 = top_chains.back();
             top_chain1.emplace_back();
-            auto& nested_snarl1 = top_chain1.back();
+            auto& nested_snarl1 = top_chain1.back().first;
             
             // And that snarl has these characteristics
             nested_snarl1.mutable_start()->set_node_id(n2->id());
@@ -143,11 +143,11 @@ namespace vg {
             top_snarl.mutable_end()->set_node_id(n8->id());
             
             // We have a chain with a snarl in it
-            vector<vector<Snarl>> top_chains;
+            vector<vector<pair<Snarl, bool>>> top_chains;
             top_chains.emplace_back();
             auto& top_chain1 = top_chains.back();
             top_chain1.emplace_back();
-            auto& nested_snarl1 = top_chain1.back();
+            auto& nested_snarl1 = top_chain1.back().first;
             
             // And that snarl has these characteristics
             nested_snarl1.mutable_start()->set_node_id(n2->id());
@@ -293,11 +293,11 @@ namespace vg {
             top_snarl.mutable_end()->set_node_id(n8->id());
             
             // We have a chain with a snarl in it
-            vector<vector<Snarl>> top_chains;
+            vector<vector<pair<Snarl, bool>>> top_chains;
             top_chains.emplace_back();
             auto& top_chain1 = top_chains.back();
             top_chain1.emplace_back();
-            auto& nested_snarl1 = top_chain1.back();
+            auto& nested_snarl1 = top_chain1.back().first;
             
             // And that snarl has these characteristics
             nested_snarl1.mutable_start()->set_node_id(n2->id());
@@ -442,11 +442,11 @@ namespace vg {
             top_snarl.mutable_end()->set_node_id(n8->id());
             
             // We have a chain with a snarl in it
-            vector<vector<Snarl>> top_chains;
+            vector<vector<pair<Snarl, bool>>> top_chains;
             top_chains.emplace_back();
             auto& top_chain1 = top_chains.back();
             top_chain1.emplace_back();
-            auto& nested_snarl1 = top_chain1.back();
+            auto& nested_snarl1 = top_chain1.back().first;
             
             // And that snarl has these characteristics
             nested_snarl1.mutable_start()->set_node_id(n2->id());
@@ -614,11 +614,11 @@ namespace vg {
             top_snarl.mutable_end()->set_node_id(n8->id());
             
             // We have a chain with a snarl in it
-            vector<vector<Snarl>> top_chains;
+            vector<vector<pair<Snarl, bool>>> top_chains;
             top_chains.emplace_back();
             auto& top_chain1 = top_chains.back();
             top_chain1.emplace_back();
-            auto& nested_snarl1 = top_chain1.back();
+            auto& nested_snarl1 = top_chain1.back().first;
             
             // And that snarl has these characteristics
             nested_snarl1.mutable_start()->set_node_id(n2->id());
@@ -724,7 +724,7 @@ namespace vg {
             top_snarl.mutable_end()->set_node_id(n8->id());
             
             // We have no chains
-            vector<vector<Snarl>> top_chains;
+            vector<vector<pair<Snarl, bool>>> top_chains;
             
             // We havetwo child unary snarls.
             vector<Snarl> top_unary_snarls;
@@ -952,7 +952,7 @@ namespace vg {
             top_snarl.mutable_end()->set_node_id(n8->id());
             
             // We have no chains
-            vector<vector<Snarl>> top_chains;
+            vector<vector<pair<Snarl, bool>>> top_chains;
             
             // We havetwo child unary snarls.
             vector<Snarl> top_unary_snarls;
@@ -2465,11 +2465,10 @@ namespace vg {
             auto ptr4 = snarl_manager.add_snarl(snarl4);
             
             auto ptr1 = snarl_manager.add_snarl(snarl1);
-            snarl_manager.add_chain(Chain{ptr3}, ptr1);
-            snarl_manager.add_chain(Chain{ptr4}, ptr1);
             
             auto ptr2 = snarl_manager.add_snarl(snarl2);
-            snarl_manager.add_chain(Chain{ptr1, ptr2}, nullptr);
+            
+            snarl_manager.finish();
  
 #ifdef debug
             snarl_manager.for_each_snarl_preorder([&](const Snarl* snarl) {
@@ -2877,8 +2876,8 @@ namespace vg {
             REQUIRE(chain.size() == 2);
             
             // And the snarls in the chain
-            const Snarl* left_child = chain.at(0);
-            const Snarl* right_child = chain.at(1);
+            const Snarl* left_child = chain.at(0).first;
+            const Snarl* right_child = chain.at(1).first;
             
             REQUIRE(left_child->start().node_id() == 2);
             REQUIRE(left_child->end().node_id() == 4);
@@ -2901,8 +2900,8 @@ namespace vg {
                 
                 SECTION("The chain has the two snarls in it") {
                     REQUIRE(chain->size() == 2);
-                    REQUIRE(chain->at(0) == left_child);
-                    REQUIRE(chain->at(1) == right_child);
+                    REQUIRE(chain->at(0).first == left_child);
+                    REQUIRE(chain->at(1).first == right_child);
                 }
                 
                 SECTION("The chain end orientations are correct") {

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -116,6 +116,7 @@ message Alignment {
     int32 mapping_quality = 5; // The mapping quality score for the alignment, in Phreds.
     int32 score = 6; // The score for the alignment, in points.
     int32 query_position = 7; // The offset in the query at which this Alignment occurs.
+    reserved 8; // Old field 8 has been removed
     string sample_name = 9; // The name of the sample that produced the aligned read.
     string read_group = 10; // The name of the read group to which the aligned read belongs.
     Alignment fragment_prev = 11; // The previous Alignment in the fragment. Contains just enough information to locate the full Alignment; e.g. contains an Alignment with only a name, or only a graph mapping position.
@@ -141,9 +142,7 @@ message Alignment {
     bool mate_mapped_to_disjoint_subgraph = 31;
     
     string fragment_length_distribution = 32; // The fragment length distribution under which a paired-end alignment was aligned.
-
-    bool haplotype_scored = 33; // True if this alignment's score is adjusted for haplotype consistency, and false otherwise.
-    double haplotype_logprob = 34; // Actual log probability haplotype consistency likelihood
+    reserved 33 to 34; // Haplotype-scoring-related fields migrated to the annotation system.
     double time_used = 35; // The time this alignment took
     Position to_correct = 36; // A path/offset/orientation pair specifying the distance to the correct alignment
     bool correctly_mapped = 37; // This can be set to true to annotate the Alignment as having been mapped correctly.

--- a/src/vg.proto
+++ b/src/vg.proto
@@ -275,7 +275,7 @@ message Visit {
 
     // Indicates:
     //   if node_id is specified     reverse complement of node
-    //   if feature_id is specified  traversal of a child snarl entering backwards through
+    //   if snarl is specified       traversal of a child snarl entering backwards through
     //                               end and leaving backwards through start
     bool backward = 3;
 }

--- a/test/t/33_vg_mpmap.t
+++ b/test/t/33_vg_mpmap.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 12
+plan tests 13
 
 
 # Exercise the GBWT
@@ -22,7 +22,11 @@ is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -f reads/xy2.m
 # For paired end, don't do any fragment length estimation
 
 is "$(vg mpmap -B -P 1 -I 200 -D 200 -x xy2.xg -g xy2.gcsa -f reads/xy2.matchpaired.fq -i -S | vg view -aj - | head -n1 | jq '.mapping_quality')" "null" "MAPQ is 0 when paired without haplotype info"
-is "$(vg mpmap -B -P 1 -I 200 -D 200 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -f reads/xy2.matchpaired.fq -i -S | vg view -aj - | head -n1 | jq '.mapping_quality')" "1" "haplotype match can disambiguate paired"
+vg mpmap -B -P 1 -I 200 -D 200 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -f reads/xy2.matchpaired.fq -i -S > gbwt.gam
+is "$(vg view -aj gbwt.gam | head -n1 | jq '.mapping_quality')" "1" "haplotype match can disambiguate paired"
+is "$(vg view -aj gbwt.gam | head -n1 | jq '.annotation.haplotype_score_used')" "true" "use of haplotype-aware mapping is recorded"
+
+rm -f gbwt.gam
 
 # Now we map a read with genotype 0,1,0,1 against haplotypes 1,1,1,1|0,1,0,0 and 1,1,0,1|0,0,1,0 on X and Y
 # First 2 variants are inserts; second 2 are SNPs


### PR DESCRIPTION
This is a better version of #1869, and will fix #1797 better.

I've improved the Cactus snarl rooting to pick the lowest-ID node for cycle breaking, instead of an arbitrary one from the unordered_set, which should actually make snarl computation deterministic.

I've also imposed some more invariants on the snarls, after the SnarlManager gets ahold of them. Now the Snarls you see will always be forward in their chains, and the chains will be oriented to maximize the number of snarls that start at lower node IDs than they end. This makes the behavior more predictable when computing snarls and makes it easier to write tests, because you can know how the snarls will come out without manually specifying them all the time.

@xchang1 I'm a bit worried about how the distance index represents entire snarls with single node IDs for the chain distance stuff. I've forced that to work for now, by making sure all the snarls in a chain go the same way, but it won't necessarily work any more if some of the things I want to do with unary snarls happen (because you will be able to have unary snarls abutting each other or abutting/being the ends of chains).

I did all this on top of Jordan's algorithms refactor and path handle stuff, and I have it all working and passing my tests (and I want to use some of the new algorithms), so I'm going to PR it all together.