### PR TITLE
Fix #153 by checking for SSE4.2 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ include $(wildcard $(ALGORITHMS_OBJ_DIR)/*.d)
 include $(wildcard $(UNITTEST_OBJ_DIR)/*.d)
 include $(wildcard $(SUBCOMMAND_OBJ_DIR)/*.d)
 
-CXXFLAGS := -O3 -fopenmp -Werror=return-type -std=c++11 -ggdb -g -MMD -MP $(CXXFLAGS)
+CXXFLAGS := -O3 -fopenmp -Werror=return-type -std=c++11 -ggdb -g -MMD -MP -msse4.2 $(CXXFLAGS)
 
 LD_INCLUDE_FLAGS:=-I$(CWD)/$(INC_DIR) -I. -I$(CWD)/$(SRC_DIR) -I$(CWD)/$(UNITTEST_SRC_DIR) -I$(CWD)/$(SUBCOMMAND_SRC_DIR) -I$(CWD)/$(CPP_DIR) -I$(CWD)/$(INC_DIR)/dynamic -I$(CWD)/$(INC_DIR)/sonLib $(shell pkg-config --cflags cairo)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "version.hpp"
 #include "utility.hpp"
 #include "crash.hpp"
+#include "preflight.hpp"
 
 // New subcommand system provides all the subcommands that used to live here
 #include "subcommand/subcommand.hpp"
@@ -46,6 +47,9 @@ int main(int argc, char *argv[])
 
     // Set up stack trace support from crash.hpp
     enable_crash_handling();
+    
+    // Make sure the system meets system requirements (i.e. has all the instructions we need)
+    preflight_check();
 
     // set a higher value for tcmalloc warnings
     setenv("TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD", "1000000000000000", 1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,15 +42,18 @@ void vg_help(char** argv) {
      cerr << endl << "For more commands, type `vg help`." << endl;
  }
 
-int main(int argc, char *argv[])
-{
+// We make sure to compile main for the lowest common denominator architecture.
+// This works on GCC and Clang. But we have to decalre main and then define it.
+int main(int argc, char *argv[]) __attribute__((__target__("arch=x86-64")));
+
+int main(int argc, char *argv[]) {
+
+    // Make sure the system meets system requirements (i.e. has all the instructions we need)
+    preflight_check();
 
     // Set up stack trace support from crash.hpp
     enable_crash_handling();
     
-    // Make sure the system meets system requirements (i.e. has all the instructions we need)
-    preflight_check();
-
     // set a higher value for tcmalloc warnings
     setenv("TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD", "1000000000000000", 1);
 

--- a/src/preflight.cpp
+++ b/src/preflight.cpp
@@ -1,0 +1,33 @@
+#include "preflight.hpp"
+
+#include <iostream>
+#include <cstdlib>
+#include <cpuid.h>
+
+namespace vg {
+
+using namespace std;
+
+void preflight_check() {
+    
+    // We assume we are on x86_64 on POSIX (and not Windows).
+    // We use the method of dlib's dlib/simd/simd_check.h
+    
+    // Define a place to put the cpuid info
+    unsigned int cpuid_info[4];
+    
+    // Call cpuid function 1 (which reports SSE4.2, and other stuff up to original AVX)
+    __cpuid(1, cpuid_info[0], cpuid_info[1], cpuid_info[2], cpuid_info[3]);
+    
+    // Bit 20 of result 2 is the SSE 4.2 flag.
+    bool have_sse4_2 = cpuid_info[2] & (1 << 20);
+    
+    if (!have_sse4_2) {
+        cerr << "error[vg::preflight_check]: The CPU does not support SSE4.2 instructions. VG cannot run here. "
+            << "Please use a system with SSE4.2 support." << endl;
+        exit(1);
+    }
+    
+}
+
+}

--- a/src/preflight.hpp
+++ b/src/preflight.hpp
@@ -12,7 +12,8 @@ using namespace std;
 
 /// Run a preflight check to make sure that the system is usable for this build of vg.
 /// Aborts with a helpful message if this is not the case.
-void preflight_check();
+/// We make sure to build it for a lowest-common-denominator architecture.
+void preflight_check() __attribute__((__target__("arch=x86-64")));
 
 }
 

--- a/src/preflight.hpp
+++ b/src/preflight.hpp
@@ -1,0 +1,19 @@
+#ifndef VG_PREFLIGHT_HPP_INCLUDED
+#define VG_PREFLIGHT_HPP_INCLUDED
+
+/** \file 
+ * Pre-flight checks to see if the vg binary is going to work on this system.
+ * Mostly exists to check for SSE4.2 support which is still not universal.
+ */
+
+namespace vg {
+
+using namespace std;
+
+/// Run a preflight check to make sure that the system is usable for this build of vg.
+/// Aborts with a helpful message if this is not the case.
+void preflight_check();
+
+}
+
+#endif


### PR DESCRIPTION
I've made vg check the CPUID bits as the first thing it does, using methodology borrowed from what dlib does, and bail out if SSE2 is not available.

I've also added -msse4.2 to the vg cflags, because `dozeu.h` was warning that it was forcing SSE4.1 on one of its functions, since the default was to build vg itself without any fancy instructions. This should let the majority of vg code use SSE4.2 instructions when the compiler thinks it appropriate, and quash the warning. The code that checks for SSE4.2 support and complains if it can't find it is built to run on lowest-common-denominator x86-64, and works in practice on my machine which lacks SSE4.2:

```
[anovak@hex Desktop]$ ./vg
error[vg::preflight_check]: The CPU does not support SSE4.2 instructions. VG cannot run here. Please use a system with SSE4.2 support.
```

This is a bit blunt, but it should make it much more clear what the problem is than a signal 4 and a crash report that makes it look like vg has a terrible bug.

Since GCC and Clang now have [function multi-versioning](https://lwn.net/Articles/691932/), we really should be able to have the appropriate implementation (SSE4.2 or not) for anything that requires it chosen at runtime automatically, if we want to support systems without SSE4.2.