### PR TITLE
Move CI and scripts from the cgl-pipeline-inputs bucket to the vg-data bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vg
 
-[![Join the chat at https://gitter.im/vgteam/vg](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/vgteam/vg?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/vgteam/vg.svg?branch=master)](https://travis-ci.org/vgteam/vg) [![Performance Report](https://img.shields.io/badge/performance-report-brightgreen.svg)](http://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/vg_ci/jenkins_reports/branch/master/index.html) [![Stories in Ready](https://badge.waffle.io/vgteam/vg.png?label=ready&title=Ready)](https://waffle.io/vgteam/vg)
+[![Join the chat at https://gitter.im/vgteam/vg](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/vgteam/vg?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/vgteam/vg.svg?branch=master)](https://travis-ci.org/vgteam/vg) [![Performance Report](https://img.shields.io/badge/performance-report-brightgreen.svg)](http://vg-data.s3.amazonaws.com/vg_ci/jenkins_reports/branch/master/index.html) [![Stories in Ready](https://badge.waffle.io/vgteam/vg.png?label=ready&title=Ready)](https://waffle.io/vgteam/vg)
 [![Documentation Status](https://readthedocs.org/projects/vg/badge/?version=latest)](http://vg.readthedocs.io/en/latest/?badge=latest)
 
 ## variation graph data structures, interchange formats, alignment, genotyping, and variant calling methods

--- a/jenkins/jenkins.sh
+++ b/jenkins/jenkins.sh
@@ -264,16 +264,16 @@ then
 
     # we publish the results to the archive
     tar czf "${VG_VERSION}_output.tar.gz" vgci-work test-report.xml jenkins/vgci.py jenkins/jenkins.sh vgci_cfg.tsv
-    aws s3 cp --only-show-errors --acl public-read "${VG_VERSION}_output.tar.gz" s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_output_archives/
+    aws s3 cp --only-show-errors --acl public-read "${VG_VERSION}_output.tar.gz" s3://vg-data/vg_ci/jenkins_output_archives/
 
     # if we're merging the PR (and not just testing it), we publish results to the baseline
     if [ -z ${ghprbActualCommit} ]
     then
         echo "Updating baseline"
-        aws s3 sync --acl public-read ./vgci-work/ s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline
+        aws s3 sync --acl public-read ./vgci-work/ s3://vg-data/vg_ci/jenkins_regression_baseline
         printf "${VG_VERSION}\n" > vg_version_${VG_VERSION}.txt
         printf "${ghprbActualCommitAuthor}\n${ghprbPullTitle}\n${ghprbPullLink}\n" >> vg_version_${VG_VERSION}.txt
-        aws s3 cp --only-show-errors --acl public-read vg_version_${VG_VERSION}.txt s3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline/
+        aws s3 cp --only-show-errors --acl public-read vg_version_${VG_VERSION}.txt s3://vg-data/vg_ci/jenkins_regression_baseline/
     fi
 fi
     

--- a/jenkins/mine-logs.py
+++ b/jenkins/mine-logs.py
@@ -415,7 +415,7 @@ def html_testcase(tc, work_dir, report_dir, max_warnings = 10):
                     images.append(new_name)
                     captions.append(plot_name.upper())
                     baseline_images.append(os.path.join(
-                        'https://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/vg_ci/jenkins_regression_baseline',
+                        'https://vg-data.s3.amazonaws.com/vg_ci/jenkins_regression_baseline',
                         os.path.basename(outstore),
                         os.path.basename(plot_path)))
 

--- a/jenkins/post-report
+++ b/jenkins/post-report
@@ -163,31 +163,31 @@ if [ ! -z "${BUILD_NUMBER}" ]; then
         
         if [ "${BUILD_NUMBER}" -gt "${OLD_BUILD_NUMBER}" ]; then
             # Upload to the path for master, overwriting whatever was there.
-            HTML_PATH="vg_cgl/vg_ci/jenkins_reports/branch/master"
+            HTML_PATH="vg_ci/jenkins_reports/branch/master"
             
             # Save the new higher build number
             write_build_number "master_sync" "${BUILD_NUMBER}"
             
         else
             # Just work on the commit, since a newer master build has already finished.
-            HTML_PATH="vg_cgl/vg_ci/jenkins_reports/commit/${GIT_COMMIT}"
+            HTML_PATH="vg_ci/jenkins_reports/commit/${GIT_COMMIT}"
         fi
         
     else
         echo "Running on a pull request"
         
         # Upload to a path specific to this commit.
-        HTML_PATH="vg_cgl/vg_ci/jenkins_reports/commit/${ghprbActualCommit}"
+        HTML_PATH="vg_ci/jenkins_reports/commit/${ghprbActualCommit}"
         
         # Say we had 0 as the last build number
         OLD_BUILD_NUMBER=0
     fi
     
     # Upload the HTML to S3 as the current master report
-    aws s3 sync --acl public-read "${HTML_DIR_IN}" "s3://cgl-pipeline-inputs/${HTML_PATH}"
+    aws s3 sync --acl public-read "${HTML_DIR_IN}" "s3://vg-data/${HTML_PATH}"
     
     # Make the URL for the report HTML
-    REPORT_URL="http://cgl-pipeline-inputs.s3.amazonaws.com/${HTML_PATH}/index.html"
+    REPORT_URL="http://vg-data.s3.amazonaws.com/${HTML_PATH}/index.html"
     
 else
     echo "Running locally"

--- a/jenkins/vgci.py
+++ b/jenkins/vgci.py
@@ -53,12 +53,12 @@ class VGCITest(TestCase):
         # What (additional) portion of reads are allowed to get worse scores
         # when moving to a more inclusive reference?
         self.worse_threshold = 0.005
-        self.input_store = 'https://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/bakeoff'
+        self.input_store = 'https://vg-data.s3.amazonaws.com/bakeoff'
         self.vg_docker = None
         self.container = None # Use default in toil-vg, which is Docker
         self.verify = True
         self.do_teardown = True
-        self.baseline = 's3://cgl-pipeline-inputs/vg_cgl/vg_ci/jenkins_regression_baseline'
+        self.baseline = 's3://vg-data/vg_ci/jenkins_regression_baseline'
         self.cores = 8
         self.sim_chunk_size = 100000
         self.force_outstore = False
@@ -1189,10 +1189,10 @@ class VGCITest(TestCase):
         calling comparison between call, genotype and freebayes on an alignment extracted
         from the HG002 whole genome experiment run from the paper
         """
-        giab = 'https://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/giab/'
-        #self.input_store = 'https://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/CHR21_DEC3'
+        giab = 'https://vg-data.s3.amazonaws.com/giab/'
+        #self.input_store = 'https://vg-data.s3.amazonaws.com/CHR21_DEC3'
         # using this one until above is fixed
-        self.input_store = 'https://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/dnanexus'
+        self.input_store = 'https://vg-data.s3.amazonaws.com/dnanexus'
         log.info("Test start at {}".format(datetime.now()))
         self._test_calleval('CHR21', 'snp1kg', "HG002",
                             self._input('snp1kg_21.vg'),
@@ -1314,7 +1314,7 @@ class VGCITest(TestCase):
         cactus_SK1 : keep only SK1 path
         cactus_S288c : keep only S288c (reference) path
         """
-        self.input_store = 'https://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/cactus_yeast'
+        self.input_store = 'https://vg-data.s3.amazonaws.com/cactus_yeast'
         log.info("Test start at {}".format(datetime.now()))
         self._test_mapeval(100000, 'YEAST', 'cactus',
                            ['cactus', 'cactus_drop_SK1', 'cactus_SK1', 'cactus_S288c'],

--- a/scripts/compare-graphs.sh
+++ b/scripts/compare-graphs.sh
@@ -142,14 +142,14 @@ else
      STORE_TAG="bakeoff"
 fi
 if [[ "${USE_S3}" -eq "1" ]]; then
-     INPUT_STORE="s3://cgl-pipeline-inputs/vg_cgl/${STORE_TAG}"
+     INPUT_STORE="s3://vg-data/${STORE_TAG}"
 else
-     INPUT_STORE="https://cgl-pipeline-inputs.s3.amazonaws.com/vg_cgl/${STORE_TAG}"     
+     INPUT_STORE="https://vg-data.s3.amazonaws.com/${STORE_TAG}"     
 fi
 
 # Where do we save our results from the various jobs responsible for writing them?
-OUTPUT_STORE="aws:us-west-2:cgl-pipeline-inputs/vg_cgl/comparison-script/runs/${RUN_ID}"
-OUTPUT_STORE_URL="s3://cgl-pipeline-inputs/vg_cgl/comparison-script/runs/${RUN_ID}"
+OUTPUT_STORE="aws:us-west-2:vg-data/comparison-script/runs/${RUN_ID}"
+OUTPUT_STORE_URL="s3://vg-data/comparison-script/runs/${RUN_ID}"
 
 # Where do we store our jobs?
 JOB_TREE="aws:us-west-2:${RUN_ID}"

--- a/scripts/test-gbwt.sh
+++ b/scripts/test-gbwt.sh
@@ -23,7 +23,7 @@ REGION_NAME="CHR21"
 VCF_BASENAME="1kg_hg19-CHR21.vcf.gz"
 FASTA_BASENAME="CHR21.fa"
 # Define where to get them
-SOURCE_BASE_URL="s3://cgl-pipeline-inputs/vg_cgl/bakeoff"
+SOURCE_BASE_URL="s3://vg-data/bakeoff"
 # Define the contig we are using
 GRAPH_CONTIG="21"
 # Define the region to build the graph on, as contig[:start-end]


### PR DESCRIPTION
We have to delete the old bucket because UCSC now wants all data in a bucket belonging to a single project.