### PR TITLE
Trim identical bases on the left correctly

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -23,6 +23,7 @@ namespace vg {
     void Constructor::trim_to_variable(vector<list<vcflib::VariantAllele>>& parsed_alleles) {
 
 #ifdef debug
+        cerr << "Before trimming to variable region:" << endl;
         for (auto& allele : parsed_alleles) {
             cerr << "Allele:" << endl;
 
@@ -63,6 +64,11 @@ namespace vg {
 
         for(size_t front_match_count = get_match_count(true); front_match_count > 0; front_match_count = get_match_count(true)) {
             // While we have shared matches at the front
+            
+#ifdef debug
+            cerr << "Edits at the front share " << front_match_count << " match bases and need to be trimmed down" << endl;
+#endif
+            
             for (auto& allele : parsed_alleles) {
                 // Trim each allele
                 if (allele.front().ref.size() > front_match_count) {
@@ -74,6 +80,9 @@ namespace vg {
 #endif
                     allele.front().ref = new_match_string;
                     allele.front().alt = new_match_string;
+                    
+                    // Since we're trimming off the front we need to bump the position up.
+                    allele.front().position += front_match_count;
                 } else {
                     // This perfect match can be completely eliminated
 #ifdef debug
@@ -87,6 +96,11 @@ namespace vg {
 
         for(size_t back_match_count = get_match_count(false); back_match_count > 0; back_match_count = get_match_count(false)) {
             // While we have shared matches at the back
+            
+#ifdef debug
+            cerr << "Edits at the back share " << back_match_count << " match bases and need to be trimmed down" << endl;
+#endif
+            
             for (auto& allele : parsed_alleles) {
                 // Trim each allele
                 if (allele.back().ref.size() > back_match_count) {
@@ -112,6 +126,7 @@ namespace vg {
         }
 
 #ifdef debug
+        cerr << "After trimming to variable region:" << endl;
         for (auto& allele : parsed_alleles) {
             cerr << "Allele: " << endl;
             for (auto& edit : allele) {
@@ -268,6 +283,10 @@ namespace vg {
         // path. We need the node so we can get its length.
         // Automatically fills in rank, starting from 1.
         auto add_match = [&](Path* path, Node* node) {
+            #ifdef debug
+            cerr << "Add node " << node->id() << " to path " << path->name() << endl;
+            #endif
+        
             // Make a mapping for it
             auto* mapping = path->add_mapping();
             mapping->mutable_position()->set_node_id(node->id());

--- a/src/constructor.hpp
+++ b/src/constructor.hpp
@@ -195,6 +195,8 @@ private:
      *
      * Postcondition: either all lists of VariantAlleles are empty, or at least
      * one begins with a non-match and at least one ends with a non-match.
+     * Adjacent edits in the list abut; there are no uncovered gaps in the edits.
+     * This means that *internal* perfect match edits will be preserved.
      */
     static void trim_to_variable(vector<list<vcflib::VariantAllele>>& parsed_alleles);
     

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -214,6 +214,10 @@ int main_construct(int argc, char** argv) {
             // Wrap the chunk in a vg object that can properly divide it into
             // reasonably sized serialized chunks.
             VG* g = new VG(big_chunk, false, true);
+            
+            // Check our work. Never output an invalid graph.
+            // But allow for edges where one node isn't there, because we need those to connect segments.
+            assert(g->is_valid(true, false, true, true));
 #pragma omp critical (cout)
             g->serialize_to_ostream_as_part(cout);
         };


### PR DESCRIPTION
This should fix #1889.

The underlying problem is that we were trimming down variants' edits on the left by shortening them without updating their positions. This made us skip nodes when making the allele paths, which led to the GBWT threads skipping nodes, which led to holes in the positive control sample-without-reference graphs and the GCSA index finding MEMs that ran off into those holes in my mapping experiment. This in turn would crash mpmap.

I've fixed the construction problem and added an assert to construct so it will check its work before outputting graphs. We should hopefully never have invalid allele paths again.