### PR TITLE
Normalization improvements

### DIFF
--- a/src/unittest/vg.cpp
+++ b/src/unittest/vg.cpp
@@ -1765,5 +1765,41 @@ TEST_CASE("create_handle() correctly creates handles using given sequence and id
     
 }
 
+TEST_CASE("normalize() can join nodes and merge siblings", "[vg][normalize]") {
+
+    SECTION("Two redundant SNP values should be merged") {
+        const string graph_json = R"(
+        
+        {
+            "node": [
+                {"id": 1, "sequence": "GAT"},
+                {"id": 2, "sequence": "T"},
+                {"id": 3, "sequence": "T"},
+                {"id": 4, "sequence": "G"},
+                {"id": 5, "sequence": "ACA"}
+            ],
+            "edge": [
+                {"from": 1, "to": 2},
+                {"from": 1, "to": 3},
+                {"from": 1, "to": 4},
+                {"from": 2, "to": 5},
+                {"from": 3, "to": 5},
+                {"from": 4, "to": 5}
+            ]
+        }
+    
+        )";
+        
+        VG graph = string_to_graph(graph_json);
+        graph.normalize();
+        
+        // One of the two alternative Ts should have been eliminated
+        REQUIRE(graph.node_size() == 4);
+        
+    }
+        
+    
+}
+
 }
 }

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -1055,6 +1055,7 @@ set<NodeTraversal> VG::full_siblings_from(const NodeTraversal& trav) {
     return full_sibs_from;
 }
 
+
 // returns sets of sibling nodes that are only in one set of sibling nodes
 set<set<NodeTraversal>> VG::transitive_sibling_sets(const set<set<NodeTraversal>>& sibs) {
     set<set<NodeTraversal>> trans_sibs;
@@ -1082,6 +1083,13 @@ set<set<NodeTraversal>> VG::transitive_sibling_sets(const set<set<NodeTraversal>
         }
         if (is_transitive) {
             trans_sibs.insert(s);
+        } else {
+#ifdef debug
+            cerr << "Rejected non-transitive set:" << endl;
+            for (auto& sibling : s) {
+                cerr << "\t" << sibling << endl;
+            }
+#endif
         }
     }
     return trans_sibs;
@@ -1102,6 +1110,13 @@ set<set<NodeTraversal>> VG::identically_oriented_sibling_sets(const set<set<Node
         // if they are all forward or all reverse
         if (forward == 0 || reverse == 0) {
             iosibs.insert(s);
+        } else {
+#ifdef debug
+            cerr << "Rejected non-identically-oriented set:" << endl;
+            for (auto& sibling : s) {
+                cerr << "\t" << sibling << endl;
+            }
+#endif
         }
     }
     return iosibs;
@@ -1113,9 +1128,19 @@ void VG::simplify_siblings(void) {
     for_each_node([this, &to_sibs](Node* n) {
             auto trav = NodeTraversal(n, false);
             auto tsibs = full_siblings_to(trav);
+#ifdef debug
+            cerr << "Node " << n->id() << " has " << tsibs.size() << " to-siblings" << endl;
+#endif
             tsibs.insert(trav);
             if (tsibs.size() > 1) {
                 to_sibs.insert(tsibs);
+                
+#ifdef debug
+                cerr << "To-Sibling Set:" << endl;
+                for (auto& sibling : tsibs) {
+                    cerr << "\t" << sibling << endl;
+                }
+#endif
             }
         });
         
@@ -1133,9 +1158,19 @@ void VG::simplify_siblings(void) {
     for_each_node([this, &from_sibs](Node* n) {
             auto trav = NodeTraversal(n, false);
             auto fsibs = full_siblings_from(trav);
+#ifdef debug
+            cerr << "Node " << n->id() << " has " << fsibs.size() << " from-siblings" << endl;
+#endif
             fsibs.insert(trav);
             if (fsibs.size() > 1) {
                 from_sibs.insert(fsibs);
+                
+#ifdef debug
+                cerr << "From-Sibling Set:" << endl;
+                for (auto& sibling : fsibs) {
+                    cerr << "\t" << sibling << endl;
+                }
+#endif
             }
         });
     // then do the from direction
@@ -1148,196 +1183,289 @@ void VG::simplify_siblings(void) {
 }
 
 void VG::simplify_to_siblings(const set<set<NodeTraversal>>& to_sibs) {
-    for (auto& sibs : to_sibs) {
-        // determine the amount of sharing at the start
+    for (set<NodeTraversal> sibs : to_sibs) {
+        // Grab a copy of each sibling set, which we can filter
+        
+        for (auto it = sibs.begin(); it != sibs.end();) {
+            if (it->node->sequence().empty()) {
+                // We want to remove any empty siblings from the set
+                it = sibs.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    
+    
         // the to-sibs have the same parent(s) feeding into them
         // so we can safely make a single node out of the shared sequence
         // and link this to them and their parent to remove node level redundancy
-        vector<string*> seqs;
-        size_t min_seq_size = sibs.begin()->node->sequence().size();
+        
+        
+        // Identify the most common shared leading sequence, and the nodes that have it
+        // The shared sequence runs out to the first differing base after the first base overall.
+        
+        // First we find the most common leading character and the nodes that have it
+        unordered_map<char, vector<NodeTraversal>> nodes_by_char;
         for (auto& sib : sibs) {
-            auto seqp = sib.node->mutable_sequence();
-            seqs.push_back(seqp);
-            if (seqp->size() < min_seq_size) {
-                min_seq_size = seqp->size();
-            }
+            // Bucket each node by its first character.
+            // TODO: shouldn't we use orientation to get the "first" character?
+            auto& bucket = nodes_by_char[sib.node->sequence().front()];
+            bucket.push_back(sib);
         }
-        size_t i = 0;
-        size_t j = 0;
-        bool similar = true;
-        for ( ; similar && i < min_seq_size; ++i) {
-            //cerr << i << endl;
-            char c = seqs.front()->at(i);
-            for (auto s : seqs) {
-                //cerr << "checking " << c << " vs " << s->at(i) << endl;
-                if (c != s->at(i)) {
-                    similar = false;
-                    break;
+        
+        while (!nodes_by_char.empty()) {
+            // Find the bucket with the most nodes in it.
+            // TODO: use a sorted list or something.
+            size_t most_matching = 0;
+            char most_matching_bucket;
+            for (auto& kv : nodes_by_char) {
+                // Go through all the buckets that are still there
+                if (kv.second.size() > most_matching) {
+                    // We have a new most-full bucket.
+                    most_matching = kv.second.size();
+                    most_matching_bucket = kv.first;
                 }
             }
-            if (!similar) break;
-            ++j;
-        }
-        size_t shared_start = j;
-        //cerr << "sharing is " << shared_start << " for to-sibs of "
-        //<< sibs.begin()->node->id() << endl;
-        if (shared_start == 0) continue;
-
-        // make a new node with the shared sequence
-        string seq = seqs.front()->substr(0,shared_start);
-        auto new_node = create_node(seq);
-        //if (!is_valid()) cerr << "invalid before sibs iteration" << endl;
-        /*
-        {
-            VG subgraph;
-            for (auto& sib : sibs) {
-                nonoverlapping_node_context_without_paths(sib.node, subgraph);
+            
+            if (most_matching <= 1) {
+                // No common characters were found.
+                // We are done with this set of siblings.
+                break;
             }
-            expand_context(subgraph, 5);
-            stringstream s;
-            for (auto& sib : sibs) s << sib.node->id() << "+";
-            subgraph.serialize_to_file(s.str() + "-before.vg");
-        }
-        */
-
-        // remove the sequence of the new node from the old nodes
-        for (auto& sib : sibs) {
-            //cerr << "to sib " << pb2json(*sib.node) << endl;
-            *sib.node->mutable_sequence() = sib.node->sequence().substr(shared_start);
-            // for each node mapping of the sibling
-            // divide the mapping at the cut point
-
-            // and then switch the node assignment for the cut nodes
-            // for each mapping of the node
-            auto node_mapping = paths.get_node_mapping(sib.node);
-            for (auto& p : node_mapping) {
-                vector<mapping_t*> v;
-                for (auto& m : p.second) {
-                    v.push_back(m);
-                }
-                for (auto m : v) {
-                    auto mpts = paths.divide_mapping(m, shared_start);
-                    // and then assign the first part of the mapping to the new node
-                    auto o = mpts.first;
-                    auto n = mpts.second;
-                    paths.reassign_node(new_node->id(), n);
-                    // note that the other part now maps to the correct (old) node
-                }
+            
+            // Get the bucket that has the most matching nodes in it
+            auto& best_bucket = nodes_by_char[most_matching_bucket];
+            
+            // And one string of a node in the bucket
+            auto& first_string = best_bucket.front().node->sequence();
+            
+            // Work out how much sequence the nodes in the bucket have in common
+            size_t shared_start = numeric_limits<size_t>::max();
+            for (size_t i = 1; i < best_bucket.size(); i++) {
+                // For each other node in the bucket, limit the shared prefix length down
+                auto mismatch_iterators = std::mismatch(first_string.begin(), first_string.end(), best_bucket[i].node->sequence().begin());
+                
+                // The common prefix is no longer than the distance to the first mismatch
+                shared_start = min(shared_start, (size_t)std::distance(first_string.begin(), mismatch_iterators.first));
             }
-        }
+            
+#ifdef debug
+            cerr << "sharing is " << shared_start << " for " << best_bucket.size() << most_matching_bucket << " to-sibs of "
+                << best_bucket.begin()->node->id() << endl;
+#endif
+            if (shared_start == 0) continue;
 
-        // connect the new node to the common *context* (the union of sides of the old nodes)
-
-        // by definition we are only working with nodes that have exactly the same set of parents
-        // so we just use the first node in the set to drive the reconnection
-        auto new_left_side = NodeSide(new_node->id(), false);
-        auto new_right_side = NodeSide(new_node->id(), true);
-        for (auto side : sides_to(NodeSide(sibs.begin()->node->id(), sibs.begin()->backward))) {
-            create_edge(side, new_left_side);
-        }
-        // disconnect the old nodes from their common parents
-        for (auto& sib : sibs) {
-            auto old_side = NodeSide(sib.node->id(), sib.backward);
-            for (auto side : sides_to(old_side)) {
-                destroy_edge(side, old_side);
-            }
-            // connect the new node to the old nodes
-            create_edge(new_right_side, old_side);
-        }
-        /*
-        if (!is_valid()) { cerr << "invalid after sibs simplify" << endl;
+            // make a new node with the shared sequence
+            string seq = first_string.substr(0, shared_start);
+            auto new_node = create_node(seq);
+            
+#ifdef debug
+            cerr << "Created new node " << new_node->id() << " to represent shared sequence" << endl;
+#endif
+            
+            //if (!is_valid()) cerr << "invalid before sibs iteration" << endl;
+            /*
             {
                 VG subgraph;
-                for (auto& sib : sibs) {
+                for (auto& sib : best_bucket) {
                     nonoverlapping_node_context_without_paths(sib.node, subgraph);
                 }
                 expand_context(subgraph, 5);
                 stringstream s;
-                for (auto& sib : sibs) s << sib.node->id() << "+";
-                subgraph.serialize_to_file(s.str() + "-sub-after-corrupted.vg");
-                serialize_to_file(s.str() + "-all-after-corrupted.vg");
-                exit(1);
+                for (auto& sib : best_bucket) s << sib.node->id() << "+";
+                subgraph.serialize_to_file(s.str() + "-before.vg");
             }
+            */
+
+            // remove the sequence of the new node from the old nodes
+            for (auto& sib : best_bucket) {
+#ifdef debug
+                cerr << "Trim to sib " << pb2json(*sib.node) << " by " << shared_start << endl;
+#endif
+                *sib.node->mutable_sequence() = sib.node->sequence().substr(shared_start);
+                // for each node mapping of the sibling
+                // divide the mapping at the cut point
+
+                // and then switch the node assignment for the cut nodes
+                // for each mapping of the node
+                auto node_mapping = paths.get_node_mapping(sib.node);
+                for (auto& p : node_mapping) {
+                    vector<mapping_t*> v;
+                    for (auto& m : p.second) {
+                        v.push_back(m);
+                    }
+                    for (auto m : v) {
+                        auto mpts = paths.divide_mapping(m, shared_start);
+                        // and then assign the first part of the mapping to the new node
+                        auto o = mpts.first;
+                        auto n = mpts.second;
+                        paths.reassign_node(new_node->id(), n);
+                        // note that the other part now maps to the correct (old) node
+                    }
+                }
+            }
+
+            // connect the new node to the common *context* (the union of sides of the old nodes)
+
+            // by definition we are only working with nodes that have exactly the same set of parents
+            // so we just use the first node in the bucket to drive the reconnection
+            auto new_left_side = NodeSide(new_node->id(), false);
+            auto new_right_side = NodeSide(new_node->id(), true);
+            for (auto side : sides_to(NodeSide(best_bucket.begin()->node->id(), best_bucket.begin()->backward))) {
+                create_edge(side, new_left_side);
+            }
+            // disconnect the old nodes from their common parents
+            for (auto& sib : best_bucket) {
+                auto old_side = NodeSide(sib.node->id(), sib.backward);
+                for (auto side : sides_to(old_side)) {
+                    destroy_edge(side, old_side);
+                }
+                // connect the new node to the old nodes
+                create_edge(new_right_side, old_side);
+            }
+            /*
+            if (!is_valid()) { cerr << "invalid after sibs simplify" << endl;
+                {
+                    VG subgraph;
+                    for (auto& sib : best_bucket) {
+                        nonoverlapping_node_context_without_paths(sib.node, subgraph);
+                    }
+                    expand_context(subgraph, 5);
+                    stringstream s;
+                    for (auto& sib : best_bucket) s << sib.node->id() << "+";
+                    subgraph.serialize_to_file(s.str() + "-sub-after-corrupted.vg");
+                    serialize_to_file(s.str() + "-all-after-corrupted.vg");
+                    exit(1);
+                }
+            }
+            */
+            
+            // No more siblings here starting with this character matter. But consider the other characters
+            nodes_by_char.erase(most_matching_bucket);
         }
-        */
     }
     // rebuild path ranks; these may have been affected in the process
     paths.compact_ranks();
 }
 
 void VG::simplify_from_siblings(const set<set<NodeTraversal>>& from_sibs) {
-    for (auto& sibs : from_sibs) {
-        // determine the amount of sharing at the end
+    for (set<NodeTraversal> sibs : from_sibs) {
+        // Grab a copy of each sibling set, which we can filter
+        
+        for (auto it = sibs.begin(); it != sibs.end();) {
+            if (it->node->sequence().empty()) {
+                // We want to remove any empty siblings from the set
+                it = sibs.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    
+    
         // the from-sibs have the same downstream nodes ("parents")
         // so we can safely make a single node out of the shared sequence at the end
         // and link this to them and their parent to remove node level redundancy
-        vector<string*> seqs;
-        size_t min_seq_size = sibs.begin()->node->sequence().size();
+        
+        // Identify the most common shared trailing sequence, and the nodes that have it
+        // The shared sequence runs out to the first differing base before the last base overall.
+        
+        // First we find the most common leading character and the nodes that have it
+        unordered_map<char, vector<NodeTraversal>> nodes_by_char;
         for (auto& sib : sibs) {
-            auto seqp = sib.node->mutable_sequence();
-            seqs.push_back(seqp);
-            if (seqp->size() < min_seq_size) {
-                min_seq_size = seqp->size();
-            }
+            // Bucket each node by its last character.
+            // TODO: shouldn't we use orientation to get the "last" character?
+            auto& bucket = nodes_by_char[sib.node->sequence().back()];
+            bucket.push_back(sib);
         }
-        size_t i = 0;
-        size_t j = 0;
-        bool similar = true;
-        for ( ; similar && i < min_seq_size; ++i) {
-            char c = seqs.front()->at(seqs.front()->size()-(i+1));
-            for (auto s : seqs) {
-                if (c != s->at(s->size()-(i+1))) {
-                    similar = false;
-                    break;
+        
+        while (!nodes_by_char.empty()) {
+            // Find the bucket with the most nodes in it.
+            // TODO: use a sorted list or something.
+            size_t most_matching = 0;
+            char most_matching_bucket;
+            for (auto& kv : nodes_by_char) {
+                // Go through all the buckets that are still there
+                if (kv.second.size() > most_matching) {
+                    // We have a new most-full bucket.
+                    most_matching = kv.second.size();
+                    most_matching_bucket = kv.first;
                 }
             }
-            if (!similar) break;
-            ++j;
-        }
-        size_t shared_end = j;
-        if (shared_end == 0) continue;
-        // make a new node with the shared sequence
-        string seq = seqs.front()->substr(seqs.front()->size()-shared_end);
-        auto new_node = create_node(seq);
-        // chop it off of the old nodes
-        for (auto& sib : sibs) {
-            *sib.node->mutable_sequence()
-                = sib.node->sequence().substr(0, sib.node->sequence().size()-shared_end);
+            
+            if (most_matching <= 1) {
+                // No common characters were found.
+                // We are done with this set of siblings.
+                break;
+            }
+            
+            // Get the bucket that has the most matching nodes in it
+            auto& best_bucket = nodes_by_char[most_matching_bucket];
+            
+            // And one string of a node in the bucket
+            auto& first_string = best_bucket.front().node->sequence();
+            
+            // Work out how much sequence the nodes in the bucket have in common
+            size_t shared_end = numeric_limits<size_t>::max();
+            for (size_t i = 1; i < best_bucket.size(); i++) {
+                // For each other node in the bucket, limit the shared suffix length down
+                auto mismatch_iterators = std::mismatch(first_string.rbegin(), first_string.rend(), best_bucket[i].node->sequence().rbegin());
+                
+                // The common suffix is no longer than the reverse distance to the first mismatch
+                shared_end = min(shared_end, (size_t)std::distance(first_string.rbegin(), mismatch_iterators.first));
+            }
+            
+#ifdef debug
+            cerr << "sharing is " << shared_end << " for " << best_bucket.size() << most_matching_bucket << " from-sibs of "
+                << best_bucket.begin()->node->id() << endl;
+#endif
+            if (shared_end == 0) continue;
+            
+            // make a new node with the shared sequence
+            string seq = first_string.substr(first_string.size()-shared_end);
+            auto new_node = create_node(seq);
+            // chop it off of the old nodes
+            for (auto& sib : best_bucket) {
+                *sib.node->mutable_sequence()
+                    = sib.node->sequence().substr(0, sib.node->sequence().size()-shared_end);
 
-            // and then switch the node assignment for the cut nodes
-            // for each mapping of the node
-            auto node_mapping = paths.get_node_mapping(sib.node);
-            for (auto& p : node_mapping) {
-                vector<mapping_t*> v;
-                for (auto& m : p.second) {
-                    v.push_back(m);
-                }
-                for (auto m : v) {
-                    auto mpts = paths.divide_mapping(m, sib.node->sequence().size());
-                    // and then assign the second part of the mapping to the new node
-                    auto o = mpts.first;
-                    paths.reassign_node(new_node->id(), o);
-                    auto n = mpts.second;
-                    // note that the other part now maps to the correct (old) node
+                // and then switch the node assignment for the cut nodes
+                // for each mapping of the node
+                auto node_mapping = paths.get_node_mapping(sib.node);
+                for (auto& p : node_mapping) {
+                    vector<mapping_t*> v;
+                    for (auto& m : p.second) {
+                        v.push_back(m);
+                    }
+                    for (auto m : v) {
+                        auto mpts = paths.divide_mapping(m, sib.node->sequence().size());
+                        // and then assign the second part of the mapping to the new node
+                        auto o = mpts.first;
+                        paths.reassign_node(new_node->id(), o);
+                        auto n = mpts.second;
+                        // note that the other part now maps to the correct (old) node
+                    }
                 }
             }
-        }
-        // connect the new node to the common downstream nodes
-        // by definition we are only working with nodes that have exactly the same set of "children"
-        // so we just use the first node in the set to drive the reconnection
-        auto new_left_side = NodeSide(new_node->id(), false);
-        auto new_right_side = NodeSide(new_node->id(), true);
-        for (auto side : sides_from(NodeSide(sibs.begin()->node->id(), !sibs.begin()->backward))) {
-            create_edge(new_right_side, side);
-        }
-        // disconnect the old nodes from their common "children"
-        for (auto& sib : sibs) {
-            auto old_side = NodeSide(sib.node->id(), !sib.backward);
-            for (auto side : sides_from(old_side)) {
-                destroy_edge(old_side, side);
+            // connect the new node to the common downstream nodes
+            // by definition we are only working with nodes that have exactly the same set of "children"
+            // so we just use the first node in the set to drive the reconnection
+            auto new_left_side = NodeSide(new_node->id(), false);
+            auto new_right_side = NodeSide(new_node->id(), true);
+            for (auto side : sides_from(NodeSide(best_bucket.begin()->node->id(), !best_bucket.begin()->backward))) {
+                create_edge(new_right_side, side);
             }
-            // connect the new node to the old nodes
-            create_edge(old_side, new_left_side);
+            // disconnect the old nodes from their common "children"
+            for (auto& sib : best_bucket) {
+                auto old_side = NodeSide(sib.node->id(), !sib.backward);
+                for (auto side : sides_from(old_side)) {
+                    destroy_edge(old_side, side);
+                }
+                // connect the new node to the old nodes
+                create_edge(old_side, new_left_side);
+            }
+            
+            // No more siblings here ending with this character matter. But consider the other characters
+            nodes_by_char.erase(most_matching_bucket);
         }
     }
     // rebuild path ranks; these may have been affected in the process

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -733,6 +733,7 @@ public:
     /// Get general siblings of a node.
     set<Node*> siblings_of(Node* node);
     /// Remove easily-resolvable redundancy in the graph.
+    /// TODO: Cannot yet handle reversing edges! They will prevent the identification of siblings.
     void simplify_siblings(void);
     /// Remove easily-resolvable redundancy in the graph for all provided to-sibling sets.
     void simplify_to_siblings(const set<set<NodeTraversal>>& to_sibs);

--- a/test/graphs/redundant-snp.gfa
+++ b/test/graphs/redundant-snp.gfa
@@ -1,0 +1,12 @@
+H	VN:Z:1.0
+S	20	AAATTT
+S	22	T
+S	30	G
+S	31	G
+S	24	CTGGAGTTC
+L	20	+	22	+	0M
+L	30	-	20	-	0M
+L	20	+	31	+	0M
+L	22	+	24	+	0M
+L	24	-	30	-	0M
+L	31	+	24	+	0M

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order
 
-plan tests 40
+plan tests 41
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -k x - | vg view - | grep "^P" | cut -f 3 | grep -o "[0-9]\+" |  wc -l) \
     $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -k x - | vg view - | grep "^S" | wc -l) \
@@ -41,6 +41,8 @@ is $(vg mod -i t.gam t.vg | vg view - | grep ^S | grep $(vg mod -i t.gam t.vg | 
 rm -rf t.vg t.gam
 
 is $(vg mod -n msgas/q_redundant.vg | vg view - | grep ^S | wc -l) 4 "normalization produces the correct number of nodes"
+
+is $(vg view -vF graphs/redundant-snp.gfa | vg mod -n - | vg view - | grep ^S | wc -l) 4 "normalization removes redundant SNP alleles"
 
 vg mod -n msgas/q_redundant.vg | vg validate -
 is $? 0 "normalization produces a valid graph"


### PR DESCRIPTION
This will fix #1897 and provide more effective sibling merging and normalization for fully-directed graphs.

But the normalization code still seems worryingly unaware of bidirected graphs. I haven't *seen* it do anything actually incorrect, but reversing edges do prevent identical nodes and prefizes/suffixes from being merged.

I think we ought to do it over again in terms of handle graphs, without the to-sibling/from-sibling distinction.