### PR TITLE
Make vg add more robust

### DIFF
--- a/src/graph_synchronizer.hpp
+++ b/src/graph_synchronizer.hpp
@@ -120,14 +120,14 @@ public:
          * The set will be populated with the NodeSides for the ends of nodes
          * created/visited at the end of the alignment.
          */
-        vector<Translation> apply_edit(const Path& path, set<NodeSide>& dangling);
+        vector<Translation> apply_edit(const Path& path, set<NodeSide>& dangling, size_t max_node_size = 1024);
         
         /**
          * May only be called when locked. Apply a path as an edit to the base
          * graph, leaving new nodes at the ends of the path unattached on their
          * outer sides.
          */
-        vector<Translation> apply_edit(const Path& path);
+        vector<Translation> apply_edit(const Path& path, size_t max_node_size = 1024);
         
         /**
          * May only be called when locked. Apply a path as an edit to the base
@@ -139,7 +139,7 @@ public:
          * The alignment must be in the local forward orientation of the graph
          * for this to make sense.
          */
-        vector<Translation> apply_full_length_edit(const Path& path);
+        vector<Translation> apply_full_length_edit(const Path& path, size_t max_node_size = 1024);
         
     protected:
     

--- a/src/variant_adder.cpp
+++ b/src/variant_adder.cpp
@@ -20,7 +20,7 @@ VariantAdder::VariantAdder(VG& graph) : graph(graph), sync(graph) {
     
     // Make sure to dice nodes to 1024 or smaller, the max size that GCSA2
     // supports, in case we need to GCSA-index part of the graph.
-    graph.dice_nodes(1024);
+    graph.dice_nodes(max_node_size);
     
     // Configure the aligner to use a full length bonus
     aligner.full_length_bonus = 5;
@@ -348,7 +348,7 @@ void VariantAdder::add_variants(vcflib::VariantCallFile* vcf) {
                     
                     // Make this path's edits to the original graph. We don't need to do
                     // anything with the translations.
-                    lock.apply_full_length_edit(aln.path());
+                    lock.apply_full_length_edit(aln.path(), max_node_size);
                     
                     // Count all the bases in the haplotype
                     total_haplotype_bases += to_align.str().size();

--- a/src/variant_adder.hpp
+++ b/src/variant_adder.hpp
@@ -67,6 +67,12 @@ public:
      */
     void align_ns(vg::VG& graph, Alignment& aln);
     
+    /// What's the maximum node size we should produce, and the size we should
+    /// chop the input graph to? Since alt sequences are forced out to node
+    /// boundaries, it makes sense for this to be small relative to
+    /// whole_alignment_cutoff.
+    size_t max_node_size = 32;
+    
     /// How wide of a range in bases should we look for nearby variants in?
     size_t variant_range = 50;
     
@@ -85,11 +91,11 @@ public:
     /// which we can just use permissive banding and large band padding? If
     /// either is larger than this, we use the pinned-alignment-based do-each-
     /// end-and-splice mode.
-    size_t whole_alignment_cutoff = 1000;
+    size_t whole_alignment_cutoff = 4096;
     
     /// When we're above that cutoff, what amount of band padding can we use
     /// looking for an existing version of our sequence?
-    size_t large_alignment_band_padding = 20;
+    size_t large_alignment_band_padding = 30;
     
     /// When we're doing a restricted band padding alignment, how good does it
     /// have to be, as a fraction of the perfect match score for the whole

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -4757,7 +4757,7 @@ vector<Translation> VG::edit(vector<Path>& paths_to_add, bool save_paths, bool u
 }
 
 // The not quite as robust (TODO: how?) but actually efficient way to edit the graph.
-vector<Translation> VG::edit_fast(const Path& path, set<NodeSide>& dangling) {
+vector<Translation> VG::edit_fast(const Path& path, set<NodeSide>& dangling, size_t max_node_size) {
     // Collect the breakpoints
     map<id_t, set<pos_t>> breakpoints;
 
@@ -4795,7 +4795,7 @@ vector<Translation> VG::edit_fast(const Path& path, set<NodeSide>& dangling) {
     // we will record the nodes that we add, so we can correctly make the returned translation for novel insert nodes
     map<Node*, Path> added_nodes;
     // create new nodes/wire things up.
-    add_nodes_and_edges(path, node_translation, added_seqs, added_nodes, orig_node_sizes, dangling);
+    add_nodes_and_edges(path, node_translation, added_seqs, added_nodes, orig_node_sizes, dangling, max_node_size);
 
     // Make the translations (in about the same format as VG::edit(), but
     // without a translation for every single node and with just the nodes we

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -585,7 +585,7 @@ public:
     /// edits that hit the end of a node to be attached to what comes
     /// before/after the node by the caller, as this function doesn't handle
     /// that.
-    vector<Translation> edit_fast(const Path& path, set<NodeSide>& dangling);
+    vector<Translation> edit_fast(const Path& path, set<NodeSide>& dangling, size_t max_node_size = 1024);
 
     /// Find all the points at which a Path enters or leaves nodes in the graph. Adds
     /// them to the given map by node ID of sets of bases in the node that will need

--- a/test/t/31_vg_add.t
+++ b/test/t/31_vg_add.t
@@ -35,7 +35,7 @@ is "$?" "0" "vg add can create a slightly larger graph"
 
 is "$(vg view -c x.vg | jq -c '.path[].mapping[] | select(.rank | not)' | wc -l)" "0" "ranks are calculated for emitted paths"
 
-is "$(vg view -Jv add/backward.json | vg add -v add/benedict.vcf - | vg stats -N -)" "5" "graphs with backward nodes can be added to"
+is "$(vg view -Jv add/backward.json | vg add -v add/benedict.vcf - | vg mod --unchop - | vg stats -N -)" "5" "graphs with backward nodes can be added to"
 
 is "$(vg view -Jv add/backward_and_forward.json | vg add -v add/benedict.vcf - | vg mod --unchop - | vg stats -N -)" "5" "graphs with backward and forward nodes can be added to"
 


### PR DESCRIPTION
I've upped the sizes of things that it is willing to align directly,
on the assumption that the underlying aligner is less likely to
outright crash now. I have also given it the ability to chop its
input graph and its created nodes to a more reasonable 32 bp, which
is a much smaller default relative to the sizes of the things it
s trying to align, so there should be fewer problems caused by the
sequences it is aligning expanding out to node boundaries.

This should fix #1912.