### PR TITLE
Tolerate there being no changes to the docs

### DIFF
--- a/doc/publish-docs.sh
+++ b/doc/publish-docs.sh
@@ -96,8 +96,8 @@ git add -A
 git config user.name "${COMMIT_AUTHOR_NAME}"
 git config user.email "${COMMIT_AUTHOR_EMAIL}"
 
-# Make the commit
-git commit -m "Commit new auto-generated docs"
+# Make the commit. Tolerate failure because this fails when there is nothing to commit.
+git commit -m "Commit new auto-generated docs" || true
 
 if [[ "${TRAVIS_PULL_REQUEST}" != "false" || "${TRAVIS_BRANCH}" != "master" ]]; then
     # If we're not a real master commit, we just make sure the docs build.
@@ -108,7 +108,7 @@ if [[ "${TRAVIS_PULL_REQUEST}" != "false" || "${TRAVIS_BRANCH}" != "master" ]]; 
 fi
 
 # If we are on the right branch, actually push the commit.
-# Push the commit
+# Push the commit. This does not fail if there is no commit.
 git push origin "${DEST_BRANCH}"
 
 


### PR DESCRIPTION
Looks like when I changed the Doxygen template in #1923, I made the Doxygen builds fail when there are no doc changes and nothing to commit to the gh-pages branch. This should fix that.