### PR TITLE
Edgepack

### DIFF
--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -125,6 +125,9 @@ void Packer::collect_coverage(const Packer& c) {
     for (size_t i = 0; i < c.graph_length(); ++i) {
         coverage_dynamic.increment(i, c.coverage_at_position(i));
     }
+    for (size_t i = 0; i < c.edge_vector_size(); ++i){
+        edge_coverage_dynamic.increment(i, c.edge_coverage(i));
+    }
 }
 
 size_t Packer::serialize(std::ostream& out,
@@ -394,11 +397,44 @@ size_t Packer::graph_length(void) const {
     }
 }
 
+size_t Packer::edge_count(void) const{
+    return xgidx->edge_count();
+}
+
+size_t Packer::edge_vector_size(void) const{
+    if (is_compacted){
+        return edge_coverage_civ.size();
+    }
+    else{
+        return edge_coverage_dynamic.size()
+    }
+}
+
 size_t Packer::coverage_at_position(size_t i) const {
     if (is_compacted) {
         return coverage_civ[i];
     } else {
         return coverage_dynamic[i];
+    }
+}
+
+size_t Packer::edge_coverage(size_t i) const {
+    if (is_compacted){
+        return 0;
+    }
+    else{
+        return edge_coverage_dynamic[i];
+    }
+}
+
+size_t Packer::edge_coverage(const Edge& e) const {
+    e = xgidx->canonicalize(e);
+    if (is_compacted){
+        return 0;
+    }
+    else{
+        size_t pos = xgidx->edge_graph_idx(e);
+        return edge_coverage_dynamic[pos];
     }
 }
 

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -7,7 +7,8 @@ Packer::Packer(void) : xgidx(nullptr) { }
 
 Packer::Packer(xg::XG* xidx, size_t binsz) : xgidx(xidx), bin_size(binsz) {
     coverage_dynamic = gcsa::CounterArray(xgidx->seq_length, 8);
-    edge_coverage_dynamic = gcsa::CounterArray(xgidx->g_iv.size(), 8);
+    size_t g_iv_sz = xgidx->get_g_iv_size();
+    edge_coverage_dynamic = gcsa::CounterArray(g_iv_sz, 8);
     if (binsz) n_bins = xgidx->seq_length / bin_size + 1;
 }
 
@@ -305,7 +306,7 @@ Edge Packer::edge_from_mappings(const Mapping& m, const Mapping& n){
     if (last_m_edit.to_length() != last_m_edit.from_length() ||
         last_m_edit.sequence() != "" ||
         first_n_edit.to_length()  != first_n_edit.from_length() ||
-        first_n_edit.sequence != ""){
+        first_n_edit.sequence() != ""){
             return Edge();
         }
     e.set_from( m.position().node_id() );
@@ -398,7 +399,7 @@ size_t Packer::graph_length(void) const {
 }
 
 size_t Packer::edge_count(void) const{
-    return xgidx->edge_count();
+    return xgidx->edge_count;
 }
 
 size_t Packer::edge_vector_size(void) const{
@@ -406,7 +407,7 @@ size_t Packer::edge_vector_size(void) const{
         return edge_coverage_civ.size();
     }
     else{
-        return edge_coverage_dynamic.size()
+        return edge_coverage_dynamic.size();
     }
 }
 
@@ -427,7 +428,7 @@ size_t Packer::edge_coverage(size_t i) const {
     }
 }
 
-size_t Packer::edge_coverage(const Edge& e) const {
+size_t Packer::edge_coverage(Edge& e) const {
     e = xgidx->canonicalize(e);
     if (is_compacted){
         return 0;

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -278,12 +278,12 @@ void Packer::add(const Alignment& aln, bool record_edits) {
             }
         }
 
-        Edge e = edge_from_mappings(mapping, prev_mapping);
-        if (e.from() != -1){
-            e = xgidx->canonicalize(e);
-            size_t edge_idx = xgidx->edge_graph_idx(e);
-            edge_coverage_dynamic.increment(edge_idx);
-        }
+        // Edge e = edge_from_mappings(mapping, prev_mapping);
+        // if (e.from() != -1){
+        //    e = xgidx->canonicalize(e);
+        //    size_t edge_idx = xgidx->edge_graph_idx(e);
+        //    edge_coverage_dynamic.increment(edge_idx);
+        //}
 
         prev_mapping = mapping;
     }

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -59,6 +59,7 @@ private:
     bool is_compacted = false;
     // dynamic model
     gcsa::CounterArray coverage_dynamic;
+    gcsa::CounterArray edge_coverage_dynamic;
     vector<string> edit_tmpfile_names;
     vector<ofstream*> tmpfstreams;
     // which bin should we use

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -53,9 +53,8 @@ public:
     bool is_dynamic(void);
     size_t coverage_size(void);
 
-    size_t edge_coverage(const Edge& e) const;
+    size_t edge_coverage(Edge& e) const;
     size_t edge_coverage(size_t i) const;
-    size_t coverage_at_position(size_t i) const ;
     size_t edge_count(void) const;
     size_t edge_vector_size(void) const;
 private:

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -52,6 +52,12 @@ public:
     size_t get_n_bins(void) const;
     bool is_dynamic(void);
     size_t coverage_size(void);
+
+    size_t edge_coverage(const Edge& e) const;
+    size_t edge_coverage(size_t i) const;
+    size_t coverage_at_position(size_t i) const ;
+    size_t edge_count(void) const;
+    size_t edge_vector_size(void) const;
 private:
     void ensure_edit_tmpfiles_open(void);
     void close_edit_tmpfiles(void);
@@ -69,6 +75,7 @@ private:
     size_t edit_length = 0;
     size_t edit_count = 0;
     dac_vector<> coverage_civ; // graph coverage (compacted coverage_dynamic)
+    dac_vector<> edge_coverage_civ; // edge coverage (compacted)
     //
     vector<csa_sada<enc_vector<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, succinct_byte_alphabet<> > > edit_csas;
     // make separators that are somewhat unusual, as we escape these
@@ -82,6 +89,7 @@ private:
     string unescape_delims(const string& s) const;
 
     Edge edge_from_mappings(const Mapping& m, const Mapping& n);
+    
 };
 
 // for making a combined matrix output and maybe doing other fun operations

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -45,6 +45,7 @@ public:
     size_t coverage_at_position(size_t i) const;
     void collect_coverage(const Packer& c);
     ostream& as_table(ostream& out, bool show_edits, vector<vg::id_t> node_ids);
+    ostream& as_edge_table(ostream& out, vector<vg::id_t> node_ids);
     ostream& show_structure(ostream& out); // debugging
     void write_edits(vector<ofstream*>& out) const; // for merge
     void write_edits(ostream& out, size_t bin) const; // for merge

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -75,7 +75,7 @@ private:
     size_t edit_length = 0;
     size_t edit_count = 0;
     dac_vector<> coverage_civ; // graph coverage (compacted coverage_dynamic)
-    dac_vector<> edge_coverage_civ; // edge coverage (compacted)
+    vlc_vector<> edge_coverage_civ; // edge coverage (compacted edge_coverage_dynamic)
     //
     vector<csa_sada<enc_vector<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, succinct_byte_alphabet<> > > edit_csas;
     // make separators that are somewhat unusual, as we escape these

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -80,6 +80,8 @@ private:
     // take each double delimiter back to a single
     string unescape_delim(const string& s, char d) const;
     string unescape_delims(const string& s) const;
+
+    Edge edge_from_mappings(const Mapping& m, const Mapping& n);
 };
 
 // for making a combined matrix output and maybe doing other fun operations

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -19,6 +19,7 @@ void help_pack(char** argv) {
          << "    -i, --packs-in FILE    begin by summing coverage packs from each provided FILE" << endl
          << "    -g, --gam FILE         read alignments from this file (could be '-' for stdin)" << endl
          << "    -d, --as-table         write table on stdout representing packs" << endl
+         << "    -D, --as-edge-table    write table on stdout representing edge coverage" << endl
          << "    -e, --with-edits       record and write edits rather than only recording graph-matching coverage" << endl
          << "    -b, --bin-size N       number of sequence bases per CSA bin [default: inf]" << endl
          << "    -n, --node ID          write table for only specified node(s)" << endl
@@ -33,6 +34,7 @@ int main_pack(int argc, char** argv) {
     string packs_out;
     string gam_in;
     bool write_table = false;
+    bool write_edge_table = false;
     int thread_count = 1;
     bool record_edits = false;
     size_t bin_size = 0;
@@ -55,6 +57,7 @@ int main_pack(int argc, char** argv) {
             {"count-in", required_argument, 0, 'i'},
             {"gam", required_argument, 0, 'g'},
             {"as-table", no_argument, 0, 'd'},
+            {"as-edge-table", no_argument, 0, 'D'},
             {"threads", required_argument, 0, 't'},
             {"with-edits", no_argument, 0, 'e'},
             {"node", required_argument, 0, 'n'},
@@ -64,7 +67,7 @@ int main_pack(int argc, char** argv) {
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:o:i:g:dt:eb:n:N:",
+        c = getopt_long (argc, argv, "hx:o:i:g:dDt:eb:n:N:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -92,6 +95,9 @@ int main_pack(int argc, char** argv) {
             break;
         case 'd':
             write_table = true;
+            break;
+        case 'D':
+            write_edge_table = true;
             break;
         case 'e':
             record_edits = true;
@@ -183,9 +189,14 @@ int main_pack(int argc, char** argv) {
     if (!packs_out.empty()) {
         packer.save_to_file(packs_out);
     }
-    if (write_table) {
+    if (write_table || write_edge_table) {
         packer.make_compact();
-        packer.as_table(cout, record_edits, node_ids);
+        if (write_table) {
+            packer.as_table(cout, record_edits, node_ids);
+        }
+        if (write_edge_table) {
+            packer.as_edge_table(cout, node_ids);
+        }
     }
 
     return 0;

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -482,8 +482,7 @@ void XG::serialize(ostream& out) const {
 }
 
 size_t XG::get_g_iv_size() const {
-   return this->node_count * this->G_NODE_HEADER_LENGTH +
-                       this->edge_count * 2 * this->G_EDGE_LENGTH;
+    return g_iv.size();
 }
 
 size_t XG::serialize_and_measure(ostream& out, sdsl::structure_tree_node* s, std::string name) const {
@@ -2184,6 +2183,16 @@ size_t XG::edge_graph_idx(const Edge& edge_in) const {
     }
     assert(false);
     return 0;
+}
+
+Edge XG::graph_idx_to_edge(size_t idx) const {
+    // find the start of our node in the g_iv vector
+    int64_t from_idx = g_bv_select(g_bv_rank(idx));    
+    // from our idx in the g_iv, we can get our edge:
+    int64_t to_edge_offset = g_iv[idx + G_EDGE_OFFSET_OFFSET];
+    int type = g_iv[idx + G_EDGE_TYPE_OFFSET];
+    // turn our g_iv indices and edge type back into an edge
+    return edge_from_encoding(from_idx, from_idx + to_edge_offset, type);
 }
 
 Edge XG::canonicalize(const Edge& edge) const {

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -481,8 +481,12 @@ void XG::serialize(ostream& out) const {
     serialize_and_measure(out);
 }
 
-size_t XG::serialize_and_measure(ostream& out, sdsl::structure_tree_node* s, std::string name) const {
+size_t XG::get_g_iv_size() const {
+   return this->node_count * this->G_NODE_HEADER_LENGTH +
+                       this->edge_count * 2 * this->G_EDGE_LENGTH;
+}
 
+size_t XG::serialize_and_measure(ostream& out, sdsl::structure_tree_node* s, std::string name) const {
     sdsl::structure_tree_node* child = sdsl::structure_tree::add_child(s, name, sdsl::util::class_name(*this));
     size_t written = 0;
     

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2185,16 +2185,6 @@ size_t XG::edge_graph_idx(const Edge& edge_in) const {
     return 0;
 }
 
-Edge XG::graph_idx_to_edge(size_t idx) const {
-    // find the start of our node in the g_iv vector
-    int64_t from_idx = g_bv_select(g_bv_rank(idx));    
-    // from our idx in the g_iv, we can get our edge:
-    int64_t to_edge_offset = g_iv[idx + G_EDGE_OFFSET_OFFSET];
-    int type = g_iv[idx + G_EDGE_TYPE_OFFSET];
-    // turn our g_iv indices and edge type back into an edge
-    return edge_from_encoding(from_idx, from_idx + to_edge_offset, type);
-}
-
 Edge XG::canonicalize(const Edge& edge) const {
     // An edge is canonical if it is not doubly reversing and, if it is singly
     // reversing, the lower side comes first.

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -162,8 +162,6 @@ public:
     // these provide a way to get an index for each node and edge in the g_iv structure and are used by gPBWT
     size_t node_graph_idx(int64_t id) const;
     size_t edge_graph_idx(const Edge& edge) const;
-    // go back from the g_iv index (as obtained from edge_graph_idx) to an edge
-    Edge graph_idx_to_edge(size_t idx) const;
 
     size_t get_g_iv_size() const;
 

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -163,6 +163,11 @@ public:
     size_t node_graph_idx(int64_t id) const;
     size_t edge_graph_idx(const Edge& edge) const;
 
+    int64_t get_min_id() const { return min_id; }
+    int64_t get_max_id() const { return max_id; }
+
+    size_t get_g_iv_size() const;
+
     ////////////////////////////////////////////////////////////////////////////
     // Here is the old low-level API that needs to be restated in terms of the 
     // locally traversable graph API and then removed.

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -162,9 +162,8 @@ public:
     // these provide a way to get an index for each node and edge in the g_iv structure and are used by gPBWT
     size_t node_graph_idx(int64_t id) const;
     size_t edge_graph_idx(const Edge& edge) const;
-
-    int64_t get_min_id() const { return min_id; }
-    int64_t get_max_id() const { return max_id; }
+    // go back from the g_iv index (as obtained from edge_graph_idx) to an edge
+    Edge graph_idx_to_edge(size_t idx) const;
 
     size_t get_g_iv_size() const;
 
@@ -714,7 +713,7 @@ private:
     /// edges_to := { edge_to, ... }
     /// edges_from := { edge_from, ... }
     /// edge_to := { offset_to_previous_node, edge_type }
-    /// edge_to := { offset_to_next_node, edge_type }
+    /// edge_from := { offset_to_next_node, edge_type }
     int_vector<> g_iv;
     /// delimit node records to allow lookup of nodes in g_civ by rank
     bit_vector g_bv;

--- a/test/t/34_vg_pack.t
+++ b/test/t/34_vg_pack.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 8
+plan tests 11
 
 vg construct -m 1000 -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
@@ -47,4 +47,25 @@ y=$(vg pack -x flat.xg -di 2snp.gam.cx.3x | wc -c)
 
 is $x $y "pack index merging produces the expected result"
 
+vg pack -x flat.xg -o 2snp.gam.cx -g 2snp.gam
+vg pack -x flat.xg -o 2snp.gam.cx.3x -i 2snp.gam.cx -i 2snp.gam.cx -i 2snp.gam.cx
+x=$(vg pack -x flat.xg -Di 2snp.gam.cx.3x | wc -c)
+cat 2snp.gam 2snp.gam 2snp.gam | vg pack -x flat.xg -o 2snp.gam.cx -g -
+y=$(vg pack -x flat.xg -Di 2snp.gam.cx.3x | wc -c)
+
+is $x $y "pack index merging produces the expected result for edges"
+
 rm -f flat.vg 2snp.vg 2snp.xg 2snp.sim flat.gcsa flat.gcsa.lcp flat.xg 2snp.xg 2snp.gam 2snp.gam.cx 2snp.gam.cx.3x 2snp.gam.vgpu
+
+vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
+vg index tiny.vg -x tiny.xg
+vg sim -l 10 -x tiny.xg -n 50 -a  -s 23 > tiny.gam
+vg augment -a pileup tiny.vg tiny.gam -P tiny.vgpu > /dev/null
+x=$(vg view -l tiny.vgpu | jq  '.edge_pileups' | grep num_reads | awk '{print $2}' | sed -e 's/\,//' | awk '{sum+=$1} END {print sum}')
+y=$(vg pack -x tiny.xg -g tiny.gam -D -o tiny.pack | grep -v from | awk '{sum+=$5} END {print sum}')
+is $x $y "pack computes the same total edge coverage as pileup"
+x=$(vg pack -x tiny.xg -i tiny.pack -D | grep -v from | awk '{sum+=$5} END {print sum}')
+is $x $y "pack stores the correct edge pileup to disk"
+
+rm -f tiny.vg tiny.xg tiny.gam tiny.vgpu tiny.pack
+


### PR DESCRIPTION
This adds an edge coverage vector to the pack system, as well as utilities to fill them by normalizing edges using utilities in XG. There are probably more compact ways to do this, but we'll need to maintain an index of edges, which we don't do currently.