### PR TITLE
Allow indexing XG to GCSA with a SourceSinkOverlay

### DIFF
--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -286,7 +286,7 @@ vector<handle_t> lazy_topological_order_internal(const HandleGraph* g, bool lazi
         
         if (orientation.size() != g->node_size()) {
             cerr << "error:[algorithms] attempting to use lazy topological sort on unorientable graph" << endl;
-            exit(1);
+            assert(false);
         }
         
         // compute the degrees by following the edges backward
@@ -331,7 +331,7 @@ vector<handle_t> lazy_topological_order_internal(const HandleGraph* g, bool lazi
     
     if (order.size() != g->node_size()) {
         cerr << "error:[algorithms] lazy topological sort is invalid on non-DAG graph, cannot complete algorithm" << endl;
-        exit(1);
+        assert(false);
     }
     
     return order;

--- a/src/algorithms/weakly_connected_components.cpp
+++ b/src/algorithms/weakly_connected_components.cpp
@@ -50,5 +50,68 @@ vector<unordered_set<id_t>> weakly_connected_components(const HandleGraph* graph
     return to_return;
 }
 
+vector<pair<unordered_set<id_t>, vector<handle_t>>> weakly_connected_components_with_tips(const HandleGraph* graph) {
+    // TODO: deduplicate with above
+    
+    vector<pair<unordered_set<id_t>, vector<handle_t>>> to_return;
+    
+    // This only holds locally forward handles
+    unordered_set<handle_t> traversed;
+    
+    graph->for_each_handle([&](const handle_t& handle) {
+        
+        // Only think about it in the forward orientation
+        auto forward = graph->forward(handle);
+        
+        if (traversed.count(forward)) {
+            // Already have this node, so don't start a search from it.
+            return;
+        }
+        
+        // The stack only holds locally forward handles
+        vector<handle_t> stack{forward};
+        to_return.emplace_back();
+        while (!stack.empty()) {
+            handle_t here = stack.back();
+            stack.pop_back();
+            
+            traversed.insert(here);
+            to_return.back().first.insert(graph->get_id(here));
+            
+            // We have a counter for the number of edges we saw.
+            // If it is 0 after traversing edges we know we have a tip.
+            size_t edge_counter = 0;
+            
+            // We have a function to handle all connected handles
+            auto handle_other = [&](const handle_t& other) {
+                // Again, make it forward
+                auto other_forward = graph->forward(other);
+                
+                if (!traversed.count(other_forward)) {
+                    stack.push_back(other_forward);
+                }
+                
+                edge_counter++;
+            };
+            
+            // Look at edges in both directions
+            graph->follow_edges(here, false, handle_other);
+            if (edge_counter == 0) {
+                // This is a tail node. Put it in reverse as a tip.
+                to_return.back().second.push_back(graph->flip(here));
+            }
+            
+            edge_counter = 0;
+            graph->follow_edges(here, true, handle_other);
+            if (edge_counter == 0) {
+                // This is a head node. Put it as a tip.
+                to_return.back().second.push_back(here);
+            }
+            
+        }
+    });
+    return to_return;
+}
+
 }
 }

--- a/src/algorithms/weakly_connected_components.hpp
+++ b/src/algorithms/weakly_connected_components.hpp
@@ -24,6 +24,10 @@ using namespace std;
 /// connected component is orientation-independent.
 vector<unordered_set<id_t>> weakly_connected_components(const HandleGraph* graph);
 
+/// Return pairs of weakly connected component ID sets and the handles that are
+/// their tips, oriented inward. If a node is both a head and a tail, it will
+/// appear in tips in both orientations.
+vector<pair<unordered_set<id_t>, vector<handle_t>>> weakly_connected_components_with_tips(const HandleGraph* graph);
 
 }
 }

--- a/src/build_index.cpp
+++ b/src/build_index.cpp
@@ -1,36 +1,31 @@
 #include "build_index.hpp"
+#include "source_sink_overlay.hpp"
 
 namespace vg {
 
-void build_gcsa_lcp(VG& graph,
+void build_gcsa_lcp(const HandleGraph& graph,
                     gcsa::GCSA*& gcsa,
                     gcsa::LCPArray*& lcp,
                     int kmer_size,
                     size_t doubling_steps,
                     size_t size_limit,
                     const string& base_file_name) {
-    id_t max_id=0;
-    graph.for_each_handle([&max_id,&graph](const handle_t& h) { max_id = max(graph.get_id(h), max_id); });
-    id_t head_id = max_id+1;
-    id_t tail_id = max_id+2;
-    Node* head_node = nullptr; Node* tail_node = nullptr;
-    // TODO add this for MutableHandleGraphs
-    graph.add_start_end_markers(kmer_size, '#', '$', head_node, tail_node, head_id, tail_id);
-
+    
+    // Add an overlay with the source and sink nodes for GCSA
+    SourceSinkOverlay overlay(&graph, kmer_size);
     gcsa::ConstructionParameters params;
     params.setSteps(doubling_steps);
     params.setLimit(size_limit);
 
     // Generate the kmers and reduce the size limit by their size.
     size_t kmer_bytes = params.getLimitBytes();
-    string tmpfile = write_gcsa_kmers_to_tmpfile(graph, kmer_size,
+    string tmpfile = write_gcsa_kmers_to_tmpfile(overlay, kmer_size,
                                                  kmer_bytes,
-                                                 head_id, tail_id,
+                                                 overlay.get_id(overlay.get_source_handle()),
+                                                 overlay.get_id(overlay.get_sink_handle()),
                                                  base_file_name);
     params.reduceLimit(kmer_bytes);
 
-    graph.destroy_node(head_node);
-    graph.destroy_node(tail_node);
     // set up the input graph using the kmers
     gcsa::InputGraph input_graph({ tmpfile }, true);
     // run the GCSA construction

--- a/src/build_index.hpp
+++ b/src/build_index.hpp
@@ -19,7 +19,7 @@ namespace vg {
 
 using namespace std;
 
-void build_gcsa_lcp(VG& graph,
+void build_gcsa_lcp(const HandleGraph& graph,
                     gcsa::GCSA*& gcsa,
                     gcsa::LCPArray*& lcp,
                     int kmer_size,

--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -13,6 +13,15 @@ handle_t HandleGraph::get_handle(const Visit& visit) const {
     return get_handle(visit.node_id(), visit.backward());
 }
 
+size_t HandleGraph::get_degree(const handle_t& handle, bool go_left) const {
+    size_t count = 0;
+    follow_edges(handle, go_left, [&](const handle_t& ignored) {
+        // Just manually count every edge we get by looking at the handle in that orientation
+        count++;
+    });
+    return count;
+}
+
 Visit HandleGraph::to_visit(const handle_t& handle) const {
     return vg::to_visit(this->get_id(handle), this->get_is_reverse(handle));
 }

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -25,8 +25,13 @@ using namespace std;
 /// Two handles are equal iff they refer to the same orientation of the same node.
 /// Only handles in the same graph may be compared.
 /// Handles have no ordering, but can be hashed.
-struct handle_t {
-    char data[sizeof(id_t)];
+/// Bit usage should be right-justified in machine endian order (i.e. a graph
+/// implementation must use the lowest bits of the lowest byte first, and must
+/// only use other bits of other bytes when the number of nodes/handles is
+/// sufficiently large as to require itin the chosen representation).
+/// This allows for overlays that can wrap their backing graphs' handles without using any more space.
+/// TODO: Note that this precludes us using pointers as handles unless we make them wider.
+struct handle_t { char data[sizeof(id_t)];
 };
 
 typedef pair<handle_t, handle_t> edge_t;

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -206,7 +206,10 @@ public:
     virtual bool follow_edges(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const = 0;
     
     /// Loop over all the nodes in the graph in their local forward
-    /// orientations, in their internal stored order. Stop if the iteratee returns false.
+    /// orientations, in their internal stored order. Stop if the iteratee
+    /// returns false. Can be told to run in parallel, in which case stopping
+    /// after a false return value is on a best-effort basis and iteration
+    /// order is not defined.
     virtual void for_each_handle(const function<bool(const handle_t&)>& iteratee, bool parallel = false) const = 0;
     
     /// Return the number of nodes in the graph
@@ -275,13 +278,23 @@ public:
         for_each_handle(lambda, parallel);
     }
     
-    ////////////////////////////////////////////////////////////////////////////
-    // Concrete utility methods
-    ////////////////////////////////////////////////////////////////////////////
-    
     /// Get a handle from a Visit Protobuf object.
     /// Must be using'd to avoid shadowing.
     handle_t get_handle(const Visit& visit) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Additional optional interface with a default implementation
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Get the number of edges on the right (go_left = false) or left (go_left
+    /// = true) side of the given handle. The default implementation is O(n) in
+    /// the number of edges returned, but graph implementations that track this
+    /// information more efficiently can override this method.
+    virtual size_t get_degree(const handle_t& handle, bool go_left) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Concrete utility methods
+    ////////////////////////////////////////////////////////////////////////////
     
     /// Get a Protobuf Visit from a handle.
     Visit to_visit(const handle_t& handle) const;

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -213,6 +213,14 @@ public:
     /// TODO: can't be node_count because XG has a field named node_count.
     virtual size_t node_size() const = 0;
     
+    /// Return the smallest ID in the graph, or some smaller number if the
+    /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
+    virtual id_t min_node_id() const = 0;
+    
+    /// Return the largest ID in the graph, or some larger number if the
+    /// largest ID is unavailable. Return value is unspecified if the graph is empty.
+    virtual id_t max_node_id() const = 0;
+    
     ////////////////////////////////////////////////////////////////////////////
     // Interface that needs to be using'd
     ////////////////////////////////////////////////////////////////////////////

--- a/src/kmer.cpp
+++ b/src/kmer.cpp
@@ -8,11 +8,16 @@ void for_each_kmer(const HandleGraph& graph, size_t k,
     // for each position on the forward and reverse of the graph
     // TODO -- add parallel interface in handlegraph
     bool using_head_tail = head_id + tail_id > 0;
+#ifdef debug
+    cerr << "Looping over kmers" << endl;
+#endif
     graph.for_each_handle([&](const handle_t& h) {
+#ifdef debug
+            cerr << "Process handle " << graph.get_id(h) << endl;
+#endif
             // for the forward and reverse of this handle
             // walk k bases from the end, so that any kmer starting on the node will be represented in the tree we build
             for (auto handle_is_rev : { false, true }) {
-                //cerr << "###########################################" << endl;
                 handle_t handle = handle_is_rev ? graph.flip(h) : h;
                 list<kmer_t> kmers;
                 // for each position in the node, set up a kmer with that start position and the node end or kmer length as the end position

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2910,12 +2910,13 @@ namespace vg {
         }
 
         // if necessary, convert from cyclic to acylic
-        if (!algorithms::is_directed_acyclic(vg)) {
+        if (!algorithms::is_directed_acyclic(&align_graph)) {
             unordered_map<id_t, pair<id_t, bool> > dagify_trans;
             align_graph = align_graph.dagify(target_length, // high enough that num SCCs is never a limiting factor
                                              dagify_trans,
                                              target_length,
                                              0); // no maximum on size of component
+                                             
             node_trans = align_graph.overlay_node_translations(dagify_trans, node_trans);
         }
         

--- a/src/phase_unfolder.cpp
+++ b/src/phase_unfolder.cpp
@@ -10,7 +10,7 @@ namespace vg {
 
 PhaseUnfolder::PhaseUnfolder(const xg::XG& xg_index, const gbwt::GBWT& gbwt_index, vg::id_t next_node) :
     xg_index(xg_index), gbwt_index(gbwt_index), mapping(next_node) {
-    assert(this->mapping.begin() > this->xg_index.get_max_id());
+    assert(this->mapping.begin() > this->xg_index.max_node_id());
 }
 
 void PhaseUnfolder::unfold(VG& graph, bool show_progress) {
@@ -247,7 +247,7 @@ void PhaseUnfolder::read_mapping(const std::string& filename) {
     }
     this->mapping.load(in);
     in.close();
-    assert(this->mapping.begin() > this->xg_index.get_max_id());
+    assert(this->mapping.begin() > this->xg_index.max_node_id());
 }
 
 vg::id_t PhaseUnfolder::get_mapping(vg::id_t node) const {

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -2176,6 +2176,24 @@ size_t NetGraph::node_size() const {
         });
     return size;
 }
+
+id_t NetGraph::min_node_id() const {
+    // TODO: this is inefficient!
+    id_t winner = numeric_limits<id_t>::max();
+    for_each_handle([&](const handle_t& handle) {
+            winner = min(winner, this->get_id(handle));
+        });
+    return winner;
+}
+
+id_t NetGraph::max_node_id() const {
+    // TODO: this is inefficient!
+    id_t winner = numeric_limits<id_t>::min();
+    for_each_handle([&](const handle_t& handle) {
+            winner = max(winner, this->get_id(handle));
+        });
+    return winner;
+}
     
 const handle_t& NetGraph::get_start() const {
     return start;

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -310,6 +310,12 @@ public:
         
     /// Return the number of nodes in the graph
     virtual size_t node_size() const;
+    
+    /// Return the smallest ID used. 
+    virtual id_t min_node_id() const;
+    
+    /// Return the largest ID used.
+    virtual id_t max_node_id() const;
         
     // We also have some extra functions
         

--- a/src/source_sink_overlay.cpp
+++ b/src/source_sink_overlay.cpp
@@ -1,0 +1,248 @@
+#include "source_sink_overlay.hpp"
+#include "algorithms/weakly_connected_components.hpp"
+
+namespace vg {
+
+using namespace std;
+
+SourceSinkOverlay::SourceSinkOverlay(HandleGraph* backing, size_t length, bool break_disconnected) : node_length(length),
+    backing(backing), backing_max_node(backing->node_size() > 0 ? backing->max_node_id() : 0),
+    source_id(backing_max_node + 1), sink_id(source_id + 1), backing_heads(), backing_tails() {
+    
+    // We have to divide the graph into connected components and get ahold of the tips.
+    vector<pair<unordered_set<id_t>, vector<handle_t>>> components = algorithms::weakly_connected_components_with_tips(backing);
+    
+    for (auto& component : components) {
+        // Unpack each component
+        auto& component_ids = component.first;
+        auto& component_tips = component.second;
+        
+        // All the components need to be nonempty
+        assert(!component_ids.empty());
+        
+        for (auto& handle : component_tips) {
+            // We need to cache the heads and tails as sets of handles, so we know to
+            // make edges to all of them when reading out of our synthetic source and
+            // sink nodes.
+            
+            if (backing->get_is_reverse(handle)) {
+                // It's a tail. Insert it forward as a tail.
+                backing_tails.insert(backing->flip(handle));
+            } else {
+                // It's a head
+                backing_heads.insert(handle);
+            }
+            
+        }
+        
+        if (component_tips.empty() && break_disconnected) {
+            // If we're supposed to break open cycles, we also mix in an arbitrary node
+            // from each tipless component as a head, and each handle that reads into
+            // it as a tail.
+            
+            // Choose a fake head arbitrarily
+            handle_t fake_head = backing->get_handle(*component_ids.begin(), false);
+            backing_heads.insert(fake_head);
+            
+            // Find the fake tails that are to the left of it
+            backing->follow_edges(fake_head, true, [&](const handle_t& fake_tail) {
+                backing_tails.insert(fake_tail);
+            });
+        }
+    }
+    
+    
+}
+
+handle_t SourceSinkOverlay::get_handle(const id_t& node_id, bool is_reverse) const {
+    if (node_id == source_id) {
+        // They asked for the source node
+        return is_reverse ? source_rev : source_fwd;
+    } else if (node_id == sink_id) {
+        // They asked for the sink node
+        return is_reverse ? sink_rev : sink_fwd;
+    } else {
+        // Otherwise they asked for something in the backing graph
+        handle_t backing_handle = backing->get_handle(node_id, is_reverse);
+        
+        // Budge up to make room for the source and sink in each orientation
+        return as_handle(as_integer(backing_handle) + 4);
+    }
+}
+
+id_t SourceSinkOverlay::get_id(const handle_t& handle) const {
+    if (handle == source_fwd || handle == source_rev) {
+        return source_id;
+    } else if (handle == sink_fwd || handle == sink_rev) {
+        return sink_id;
+    } else {
+        return backing->get_id(to_backing(handle));
+    }
+}
+
+bool SourceSinkOverlay::get_is_reverse(const handle_t& handle) const {
+    if (handle == source_fwd || handle == sink_fwd) {
+        return false;
+    } else if (handle == source_rev || handle == sink_rev) {
+        return true;
+    } else {
+        return backing->get_is_reverse(to_backing(handle));
+    }
+}
+
+handle_t SourceSinkOverlay::flip(const handle_t& handle) const {
+    if (is_ours(handle)) {
+        // In our block of two handles, orientation is the low bit
+        return as_handle(as_integer(handle) ^ 1);
+    } else {
+        // Make the backing graph flip it
+        return from_backing(backing->flip(to_backing(handle)));
+    }
+}
+
+size_t SourceSinkOverlay::get_length(const handle_t& handle) const {
+    if (is_ours(handle)) {
+        // Both our fake nodes are the same length
+        return node_length;
+    } else {
+        return backing->get_length(to_backing(handle));
+    }
+}
+
+string SourceSinkOverlay::get_sequence(const handle_t& handle) const {
+    if (handle == source_fwd || handle == sink_rev) {
+        // Reading into the graph is all '$'
+        return string(node_length, '$');
+    } else if (handle == source_rev || handle == sink_fwd) {
+        // Reading out of the graph is all '#'
+        return string(node_length, '#');
+    } else {
+        return backing->get_sequence(to_backing(handle));
+    }
+}
+
+bool SourceSinkOverlay::follow_edges(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const {
+    if (is_ours(handle)) {
+        // We only care about the right of the source and the left of the sink
+        if ((handle == source_fwd && !go_left) || (handle == source_rev && go_left)) {
+            // We want the right of the source (every head node in the backing graph)
+            // Make sure to put it in the appropriate orientation.
+            
+            for (const handle_t& backing_head : backing_heads) {
+                // Feed each backing graph head to the iteratee, in the
+                // appropriate orientation depending on which way we want to
+                // go.
+                if (!iteratee(from_backing(go_left ? backing->flip(backing_head) : backing_head))) {
+                    // If they say to stop, stop
+                    return false;
+                }
+            }
+            
+        } else if ((handle == sink_fwd && go_left) || (handle == sink_rev && !go_left)) {
+            // We want the left of the sink (every tail node in the backing graph)
+            // Make sure to put it in the appropriate orientation.
+            
+            for (const handle_t& backing_tail : backing_tails) {
+                // Feed each backing graph tail to the iteratee, in the
+                // appropriate orientation depending on which way we want to
+                // go.
+                if (!iteratee(from_backing(go_left ? backing_tail : backing->flip(backing_tail)))) {
+                    // If they say to stop, stop
+                    return false;
+                }
+            }
+        }
+        return true;
+    } else {
+        // The handle refers to a node in the backing graph
+        auto backing_handle = to_backing(handle);
+        
+        if ((backing_heads.count(backing_handle) && go_left) || (backing_heads.count(backing->flip(backing_handle)) && !go_left)) {
+            // We want to read left off a head (possibly in reverse) into the synthetic source
+            if (!iteratee(go_left ? source_fwd : source_rev)) {
+                // If they say stop, stop
+                return false;
+            }
+        }
+        
+        if ((backing_tails.count(backing_handle) && !go_left) || (backing_tails.count(backing->flip(backing_handle)) && go_left)) {
+            // We want to read right off a tail (possibly in reverse) into the synthetic sink
+            if (!iteratee(go_left ? sink_rev : sink_fwd)) {
+                // If they say stop, stop
+                return false;
+            }
+        }
+    
+        // If we get through those, do the actual edges in the backing graph
+        return backing->follow_edges(backing_handle, go_left, [&](const handle_t& found) -> bool {
+            return iteratee(from_backing(found));
+        });
+    }
+}
+
+void SourceSinkOverlay::for_each_handle(const function<bool(const handle_t&)>& iteratee, bool parallel) const {
+    
+    // First do the sourece and sink we added
+    if (!iteratee(source_fwd)) {
+        return;
+    }
+    if (!iteratee(sink_fwd)) {
+        return;
+    }
+    
+    backing->for_each_handle([&](const handle_t& backing_handle) -> bool {
+        // Now do each backing node, possibly in parallel.
+        return iteratee(from_backing(backing_handle));
+    }, parallel);
+}
+
+size_t SourceSinkOverlay::node_size() const {
+    return backing->node_size() + 2;
+}
+
+id_t SourceSinkOverlay::min_node_id() const {
+    return backing->min_node_id();
+}
+    
+id_t SourceSinkOverlay::max_node_id() const {
+    return sink_id;
+}
+
+size_t SourceSinkOverlay::get_degree(const handle_t& handle, bool go_left) const {
+    if (is_ours(handle)) {
+        if ((handle == source_fwd && !go_left) || (handle == source_rev && go_left)) {
+            // We are reading into every graph head
+            return backing_heads.size();
+        } else if ((handle == sink_fwd && go_left) || (handle == sink_rev && !go_left)) {
+            // We are reading into every graph tail
+            return backing_tails.size();
+        }
+        // Otherwise we're reading off the outside ends of the source/sink nodes
+        return 0;
+    } else {
+        // We need to find the backing graph degree and possibly adjust it if this is a head or tail
+        handle_t backing_handle = to_backing(handle);
+        
+        size_t degree = backing->get_degree(backing_handle, go_left);
+        
+        if (backing_heads.count(backing->forward(backing_handle))) {
+            // We are a head. Are we going off the left end when forward, or the right end when reverse?
+            if (go_left != backing->get_is_reverse(backing_handle)) {
+                // If so we count the synthetic edge.
+                degree++;
+            }
+        }
+        if (backing_tails.count(backing->forward(backing_handle))) {
+            // We are a tial. Are we going off the left end when reverse, or the right end when forward?
+            if (go_left != !backing->get_is_reverse(backing_handle)) {
+                // If so we count the synthetic edge.
+                degree++;
+            }
+        }
+        
+        return degree;
+    }
+}
+    
+
+}

--- a/src/source_sink_overlay.cpp
+++ b/src/source_sink_overlay.cpp
@@ -222,8 +222,14 @@ void SourceSinkOverlay::for_each_handle(const function<bool(const handle_t&)>& i
         return;
     }
     
+#ifdef debug
+    cerr << "Try backing graph " << (parallel ? "in parallel" : "") << endl;
+#endif
     backing->for_each_handle([&](const handle_t& backing_handle) -> bool {
         // Now do each backing node, possibly in parallel.
+#ifdef debug
+        cerr << "Invoke iteratee on " << backing->get_id(backing_handle) << endl;
+#endif
         return iteratee(from_backing(backing_handle));
     }, parallel);
 }

--- a/src/source_sink_overlay.hpp
+++ b/src/source_sink_overlay.hpp
@@ -27,11 +27,12 @@ public:
      * Make a new SourceSinkOverlay. The backing graph must not be modified
      * while the overlay exists.
      *
-     * The overlay will project a source node consisting of '$' characters, and
-     * a sink node consisting of '#' characters. The lengths of the nodes may
+     * The overlay will project a source node consisting of '#' characters, and
+     * a sink node consisting of '$' characters. The lengths of the nodes may
      * be specified, and default to 1024, the max length that GCSA2 supports.
      * The IDs of the nodes will be autodetected from the backing graph's max
-     * ID if not specified. If either is specified, both must be specified.
+     * ID if not specified (or given as 0). If either is specified, both must
+     * be specified.
      *
      * Also breaks into disconnected components with no tips, unless
      * break_disconnected is false. When breaking into such a component, we
@@ -136,7 +137,7 @@ protected:
     
     /// Convert our handle to a backing graph node into a backing graph handle to the same node
     inline handle_t to_backing(const handle_t& our_handle) const {
-        return as_handle(as_integer(our_handle) + 4);
+        return as_handle(as_integer(our_handle) - 4);
     }
     
     /// Determine if a handle points to an overlay-added node or not

--- a/src/source_sink_overlay.hpp
+++ b/src/source_sink_overlay.hpp
@@ -1,0 +1,146 @@
+#ifndef VG_SOURCE_SINK_OVERLAY_HPP_INCLUDED
+#define VG_SOURCE_SINK_OVERLAY_HPP_INCLUDED
+
+/**
+ * \file source_sink_overlay.hpp
+ *
+ * Provides SourceSinkOverlay, a HandleGraph implementation that joins all the
+ * heads and tails of a backing graph to single source and sink nodes. 
+ *
+ */
+
+
+#include "handle.hpp"
+
+
+namespace vg {
+
+/**
+ * Present a HandleGraph that is a backing HandleGraph with all its head nodes
+ * connected to a single source node, and all its tail nodes connected to a
+ * single sink node.
+ */
+class SourceSinkOverlay : public HandleGraph {
+
+public:
+    /**
+     * Make a new SourceSinkOverlay. The backing graph must not be modified
+     * while the overlay exists.
+     *
+     * The overlay will project a source node consisting of '$' characters, and
+     * a sink node consisting of '#' characters. The lengths of the nodes may
+     * be specified, and default to 1024, the max length that GCSA2 supports.
+     *
+     * Also breaks into disconnected components with no tips, unless
+     * break_disconnected is false. When breaking into such a component, we
+     * choose an arbitrary node, link the source node to its start, and link
+     * everything that also went to its start to the sink node.
+     */
+    SourceSinkOverlay(HandleGraph* backing, size_t length = 1024, bool break_disconnected = true);
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Handle-based interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Look up the handle for the node with the given ID in the given orientation
+    virtual handle_t get_handle(const id_t& node_id, bool is_reverse) const;
+    
+    // Copy over the visit version which would otherwise be shadowed.
+    using HandleGraph::get_handle;
+    
+    /// Get the ID from a handle
+    virtual id_t get_id(const handle_t& handle) const;
+    
+    /// Get the orientation of a handle
+    virtual bool get_is_reverse(const handle_t& handle) const;
+    
+    /// Invert the orientation of a handle (potentially without getting its ID)
+    virtual handle_t flip(const handle_t& handle) const;
+    
+    /// Get the length of a node
+    virtual size_t get_length(const handle_t& handle) const;
+    
+    /// Get the sequence of a node, presented in the handle's local forward
+    /// orientation.
+    virtual string get_sequence(const handle_t& handle) const;
+    
+    /// Loop over all the handles to next/previous (right/left) nodes. Passes
+    /// them to a callback which returns false to stop iterating and true to
+    /// continue. Returns true if we finished and false if we stopped early.
+    virtual bool follow_edges(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const;
+    
+    // Copy over the template for nice calls
+    using HandleGraph::follow_edges;
+    
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee returns false.
+    virtual void for_each_handle(const function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+    
+    // Copy over the template for nice calls
+    using HandleGraph::for_each_handle;
+    
+    /// Return the number of nodes in the graph
+    virtual size_t node_size() const;
+    
+    /// Return the smallest ID in the graph.
+    virtual id_t min_node_id() const;
+    
+    /// Return the largest ID in the graph.
+    virtual id_t max_node_id() const;
+    
+    /// Compute the degree of one side of a handle in O(1) time, if the backing
+    /// graph also provides this facility in O(1) time. Takes O(n) time
+    /// otherwise in the returned degree.
+    virtual size_t get_degree(const handle_t& handle, bool go_left) const;
+    
+protected:
+    
+    /// How long are the projected nodes?
+    size_t node_length;
+    
+    /// What backing graph do we overlay?
+    HandleGraph* backing;
+    
+    /// What is the backing graph's max node ID?
+    id_t backing_max_node;
+    
+    /// What is our projected source node ID?
+    id_t source_id;
+    /// What is our projected sink node ID?
+    id_t sink_id;
+    
+    /// We keep a set of backing graph head handles, in backing graph handle
+    /// space. This also includes anything else we need to hook up to our
+    /// source node to break into tipless components.
+    unordered_set<handle_t> backing_heads;
+    /// And similarly for the tails. These handles read out of their components.
+    unordered_set<handle_t> backing_tails;
+    
+    // We reserve the 4 low numbers of the handles for our new source and sink, and shift everything else up.
+    // These could have been static, but I couldn't figure out how to properly initialize them using constexpr functions.
+    const handle_t source_fwd = as_handle(0);
+    const handle_t source_rev = as_handle(1);
+    const handle_t sink_fwd = as_handle(2);
+    const handle_t sink_rev = as_handle(3);
+    
+    /// Convert a backing graph handle to our handle to the same node
+    inline handle_t from_backing(const handle_t& backing_handle) const {
+        return as_handle(as_integer(backing_handle) + 4);
+    }
+    
+    /// Convert our handle to a backing graph node into a backing graph handle to the same node
+    inline handle_t to_backing(const handle_t& our_handle) const {
+        return as_handle(as_integer(our_handle) + 4);
+    }
+    
+    /// Determine if a handle points to an overlay-added node or not
+    inline bool is_ours(const handle_t& our_handle) const {
+        return ((uint64_t) as_integer(our_handle)) < 4;
+    }
+    
+};
+
+
+}
+
+#endif

--- a/src/source_sink_overlay.hpp
+++ b/src/source_sink_overlay.hpp
@@ -30,13 +30,22 @@ public:
      * The overlay will project a source node consisting of '$' characters, and
      * a sink node consisting of '#' characters. The lengths of the nodes may
      * be specified, and default to 1024, the max length that GCSA2 supports.
+     * The IDs of the nodes will be autodetected from the backing graph's max
+     * ID if not specified. If either is specified, both must be specified.
      *
      * Also breaks into disconnected components with no tips, unless
      * break_disconnected is false. When breaking into such a component, we
      * choose an arbitrary node, link the source node to its start, and link
      * everything that also went to its start to the sink node.
      */
-    SourceSinkOverlay(HandleGraph* backing, size_t length = 1024, bool break_disconnected = true);
+    SourceSinkOverlay(const HandleGraph* backing, size_t length = 1024, id_t source_id = 0, id_t sink_id = 0,
+        bool break_disconnected = true);
+    
+    /// Expose the handle to the synthetic source
+    handle_t get_source_handle() const;
+    
+    /// Expose the handle to the synthetic sink
+    handle_t get_sink_handle() const;
     
     ////////////////////////////////////////////////////////////////////////////
     // Handle-based interface
@@ -99,10 +108,7 @@ protected:
     size_t node_length;
     
     /// What backing graph do we overlay?
-    HandleGraph* backing;
-    
-    /// What is the backing graph's max node ID?
-    id_t backing_max_node;
+    const HandleGraph* backing;
     
     /// What is our projected source node ID?
     id_t source_id;

--- a/src/subcommand/ids_main.cpp
+++ b/src/subcommand/ids_main.cpp
@@ -144,7 +144,7 @@ int main_ids(int argc, char** argv) {
         }
 
         VGset graphs(graph_file_names);
-        vg::id_t max_node_id = (join ? graphs.merge_id_space() : graphs.get_max_id());
+        vg::id_t max_node_id = (join ? graphs.merge_id_space() : graphs.max_node_id());
         if (!mapping_name.empty()) {
             gcsa::NodeMapping mapping(max_node_id + 1);
             std::ofstream out(mapping_name, std::ios_base::binary);

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -19,6 +19,7 @@
 #include "../region.hpp"
 #include "../snarls.hpp"
 #include "../distance.hpp"
+#include "../source_sink_overlay.hpp"
 
 #include <gcsa/gcsa.h>
 #include <gcsa/algorithms.h>
@@ -38,7 +39,7 @@ void help_index(char** argv) {
          << "    -t, --threads N        number of threads to use" << endl
          << "    -p, --progress         show progress" << endl
          << "xg options:" << endl
-         << "    -x, --xg-name FILE     use this file to store a succinct, queryable version of the graph(s)" << endl
+         << "    -x, --xg-name FILE     use this file to store a succinct, queryable version of the graph(s), or read for GCSA indexing" << endl
          << "    -F, --thread-db FILE   read thread database from FILE (may repeat)" << endl
          << "gbwt options:" << endl
          << "    -v, --vcf-phasing FILE generate threads from the haplotypes in the VCF file FILE" << endl
@@ -58,7 +59,7 @@ void help_index(char** argv) {
          << "    -I, --region C:S-E     operate on only the given 1-based region of the given VCF contig (may repeat)" << endl
          << "    -E, --exclude SAMPLE   exclude any samples with the given name from haplotype indexing" << endl
          << "gcsa options:" << endl
-         << "    -g, --gcsa-out FILE    output a GCSA2 index instead of a rocksdb index" << endl
+         << "    -g, --gcsa-out FILE    output a GCSA2 index to the given file" << endl
          << "    -i, --dbg-in FILE      use kmers from FILE instead of input VG (may repeat)" << endl
          << "    -f, --mapping FILE     use this node mapping in GCSA2 construction" << endl
          << "    -k, --kmer-size N      index kmers of size N in the graph (default " << gcsa::Key::MAX_LENGTH << ")" << endl
@@ -478,6 +479,12 @@ int main_index(int argc, char** argv) {
         cerr << "error: [vg index] cannot use multiple thread database files with -G or -H" << endl;
         return 1;
     }
+    
+    if (build_xg && build_gcsa && file_names.empty()) {
+        // Really we want to build a GCSA by *reading* and XG
+        build_xg = false;
+        // We'll continue in the build_gcsa section
+    }
 
     // Build XG
     xg::XG* xg_index = new xg::XG();
@@ -876,7 +883,7 @@ int main_index(int argc, char** argv) {
     } // End of thread indexing.
 
     // Save XG
-    if (!xg_name.empty()) {
+    if (build_xg && !xg_name.empty()) {
         if (!thread_db_names.empty()) {
             vector<string> thread_names;
             size_t haplotype_count = 0;
@@ -918,12 +925,43 @@ int main_index(int argc, char** argv) {
             if (show_progress) {
                 cerr << "Generating kmer files..." << endl;
             }
-            VGset graphs(file_names);
-            graphs.show_progress = show_progress;
-            size_t kmer_bytes = params.getLimitBytes();
-            dbg_names = graphs.write_gcsa_kmers_binary(kmer_size, kmer_bytes);
-            params.reduceLimit(kmer_bytes);
-            delete_kmer_files = true;
+            
+            if (!file_names.empty()) {
+                // Get the kmers from a VGset.
+                VGset graphs(file_names);
+                graphs.show_progress = show_progress;
+                size_t kmer_bytes = params.getLimitBytes();
+                dbg_names = graphs.write_gcsa_kmers_binary(kmer_size, kmer_bytes);
+                params.reduceLimit(kmer_bytes);
+                delete_kmer_files = true;
+            } else if (!xg_name.empty()) {
+                // Get the kmers from an XG
+                
+                get_input_file(xg_name, [&](istream& xg_stream) {
+                    // Load the XG
+                    xg::XG xg(xg_stream);
+                
+                    // Make an overlay on it to add source and sink nodes
+                    // TODO: Don't use this directly; unify this code with VGset's code.
+                    SourceSinkOverlay overlay(&xg, kmer_size);
+                    
+                    // Get the size limit
+                    size_t kmer_bytes = params.getLimitBytes();
+                    
+                    // Write just the one kmer temp file
+                    dbg_names.push_back(write_gcsa_kmers_to_tmpfile(overlay, kmer_size, kmer_bytes,
+                        overlay.get_id(overlay.get_source_handle()),
+                        overlay.get_id(overlay.get_sink_handle())));
+                        
+                    // Feed back into the size limit
+                    params.reduceLimit(kmer_bytes);
+                    delete_kmer_files = true;
+                
+                });
+            } else {
+                cerr << "error[vg index]: Can't generate GCSA index without either a vg or an xg" << endl;
+                exit(1);
+            }
         }
 
         // Build the index

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -510,7 +510,7 @@ int main_index(int argc, char** argv) {
         // if we already made the xg index we can determine the
         size_t id_width;
         if (!index_gam) {
-            id_width = gbwt::bit_length(gbwt::Node::encode(xg_index->get_max_id(), true));
+            id_width = gbwt::bit_length(gbwt::Node::encode(xg_index->max_node_id(), true));
         } else { // indexing a GAM
             if (show_progress) {
                 cerr << "Finding maximum node id in GAM..." << endl;

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -840,6 +840,7 @@ int main_mod(int argc, char** argv) {
             cerr << "[vg mod]: when adding start and end markers you must provide a --path-length" << endl;
             return 1;
         }
+        // TODO: replace this with the SourceSinkOverlay somehow?
         Node* head_node = NULL;
         Node* tail_node = NULL;
         vg::id_t head_id = 0, tail_id = 0;

--- a/src/unittest/source_sink_overlay.cpp
+++ b/src/unittest/source_sink_overlay.cpp
@@ -31,100 +31,103 @@ TEST_CASE("SourceSinkOverlay adds a source and a sink to a 1-node graph", "[over
     // Make an overlay
     SourceSinkOverlay overlay(&vg, 10);
     
-    bool found_node = false;
-    bool found_source = false;
-    bool found_sink = false;
+    SECTION("we see the right graph") {
     
-    // Make sure the nodes are as expected
-    overlay.for_each_handle([&](const handle_t& handle) {
+        bool found_node = false;
+        bool found_source = false;
+        bool found_sink = false;
         
+        // Make sure the nodes are as expected
+        overlay.for_each_handle([&](const handle_t& handle) {
+            
 #ifdef debug
-        cerr << "Observed node " << overlay.get_id(handle) << " orientation " << overlay.get_is_reverse(handle)
-            << " with sequence " << overlay.get_sequence(handle) << endl;
+            cerr << "Observed node " << overlay.get_id(handle) << " orientation " << overlay.get_is_reverse(handle)
+                << " with sequence " << overlay.get_sequence(handle) << endl;
 #endif
-    
-        if (overlay.get_id(handle) == n1->id()) {
-            // This is the real node
-            REQUIRE(!found_node);
-            found_node = true;
-            
-            REQUIRE(overlay.get_sequence(handle) == "GATTACA");
-            REQUIRE(overlay.get_degree(handle, false) == 1);
-            REQUIRE(overlay.get_degree(handle, true) == 1);
-            
-            unordered_set<pair<id_t, bool>> overlay_neighbors;
-            overlay.follow_edges(handle, false, [&](const handle_t& neighbor) {
-                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
-            });
-            
-            REQUIRE(overlay_neighbors.size() == 1);
-            REQUIRE(overlay_neighbors.count(make_pair(overlay.get_id(overlay.get_sink_handle()), false)));
-            
-            overlay_neighbors.clear();
-            overlay.follow_edges(handle, true, [&](const handle_t& neighbor) {
-                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
-            });
-            
-            REQUIRE(overlay_neighbors.size() == 1);
-            REQUIRE(overlay_neighbors.count(make_pair(overlay.get_id(overlay.get_source_handle()), false)));
-            
-        } else if (handle == overlay.get_source_handle()) {
-            // This is the fake source
-            REQUIRE(!found_source);
-            found_source = true;
-            
-            REQUIRE(overlay.get_sequence(handle) == "##########");
-            REQUIRE(overlay.get_degree(handle, false) == 1);
-            REQUIRE(overlay.get_degree(handle, true) == 0);
-            
-            unordered_set<pair<id_t, bool>> overlay_neighbors;
-            overlay.follow_edges(handle, false, [&](const handle_t& neighbor) {
-                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
-            });
-            
-            REQUIRE(overlay_neighbors.size() == 1);
-            REQUIRE(overlay_neighbors.count(make_pair(n1->id(), false)));
-            
-            overlay_neighbors.clear();
-            overlay.follow_edges(handle, true, [&](const handle_t& neighbor) {
-                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
-            });
-            
-            REQUIRE(overlay_neighbors.empty());
-            
-        } else if (handle == overlay.get_sink_handle()) {
-            // This is the fake sink
-            REQUIRE(!found_sink);
-            found_sink = true;
-            
-            REQUIRE(overlay.get_sequence(handle) == "$$$$$$$$$$");
-            REQUIRE(overlay.get_degree(handle, false) == 0);
-            REQUIRE(overlay.get_degree(handle, true) == 1);
-            
-            unordered_set<pair<id_t, bool>> overlay_neighbors;
-            overlay.follow_edges(handle, false, [&](const handle_t& neighbor) {
-                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
-            });
-            
-            REQUIRE(overlay_neighbors.empty());
-            
-            overlay_neighbors.clear();
-            overlay.follow_edges(handle, true, [&](const handle_t& neighbor) {
-                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
-            });
-            
-            REQUIRE(overlay_neighbors.size() == 1);
-            REQUIRE(overlay_neighbors.count(make_pair(n1->id(), false)));
-            
-        } else {
-            // This is an unrecognized node!
-            REQUIRE(false);
-        }
-    });
-    
-    REQUIRE(found_node);
-    REQUIRE(found_source);
-    REQUIRE(found_sink);
+        
+            if (overlay.get_id(handle) == n1->id()) {
+                // This is the real node
+                REQUIRE(!found_node);
+                found_node = true;
+                
+                REQUIRE(overlay.get_sequence(handle) == "GATTACA");
+                REQUIRE(overlay.get_degree(handle, false) == 1);
+                REQUIRE(overlay.get_degree(handle, true) == 1);
+                
+                unordered_set<pair<id_t, bool>> overlay_neighbors;
+                overlay.follow_edges(handle, false, [&](const handle_t& neighbor) {
+                    overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+                });
+                
+                REQUIRE(overlay_neighbors.size() == 1);
+                REQUIRE(overlay_neighbors.count(make_pair(overlay.get_id(overlay.get_sink_handle()), false)));
+                
+                overlay_neighbors.clear();
+                overlay.follow_edges(handle, true, [&](const handle_t& neighbor) {
+                    overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+                });
+                
+                REQUIRE(overlay_neighbors.size() == 1);
+                REQUIRE(overlay_neighbors.count(make_pair(overlay.get_id(overlay.get_source_handle()), false)));
+                
+            } else if (handle == overlay.get_source_handle()) {
+                // This is the fake source
+                REQUIRE(!found_source);
+                found_source = true;
+                
+                REQUIRE(overlay.get_sequence(handle) == "##########");
+                REQUIRE(overlay.get_degree(handle, false) == 1);
+                REQUIRE(overlay.get_degree(handle, true) == 0);
+                
+                unordered_set<pair<id_t, bool>> overlay_neighbors;
+                overlay.follow_edges(handle, false, [&](const handle_t& neighbor) {
+                    overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+                });
+                
+                REQUIRE(overlay_neighbors.size() == 1);
+                REQUIRE(overlay_neighbors.count(make_pair(n1->id(), false)));
+                
+                overlay_neighbors.clear();
+                overlay.follow_edges(handle, true, [&](const handle_t& neighbor) {
+                    overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+                });
+                
+                REQUIRE(overlay_neighbors.empty());
+                
+            } else if (handle == overlay.get_sink_handle()) {
+                // This is the fake sink
+                REQUIRE(!found_sink);
+                found_sink = true;
+                
+                REQUIRE(overlay.get_sequence(handle) == "$$$$$$$$$$");
+                REQUIRE(overlay.get_degree(handle, false) == 0);
+                REQUIRE(overlay.get_degree(handle, true) == 1);
+                
+                unordered_set<pair<id_t, bool>> overlay_neighbors;
+                overlay.follow_edges(handle, false, [&](const handle_t& neighbor) {
+                    overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+                });
+                
+                REQUIRE(overlay_neighbors.empty());
+                
+                overlay_neighbors.clear();
+                overlay.follow_edges(handle, true, [&](const handle_t& neighbor) {
+                    overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+                });
+                
+                REQUIRE(overlay_neighbors.size() == 1);
+                REQUIRE(overlay_neighbors.count(make_pair(n1->id(), false)));
+                
+            } else {
+                // This is an unrecognized node!
+                REQUIRE(false);
+            }
+        });
+        
+        REQUIRE(found_node);
+        REQUIRE(found_source);
+        REQUIRE(found_sink);
+    }
     
 }
 
@@ -150,73 +153,101 @@ TEST_CASE("SourceSinkOverlay agrees with VG::add_start_end_markers in a tiny gra
     
     // We know this graph has no tipless components.
     
-    // Get handles for all the nodes
-    unordered_map<id_t, handle_t> copy_handles;
-    copy.for_each_handle([&](const handle_t& handle) {
-        copy_handles[copy.get_id(handle)] = handle;
-    });
+    SECTION("graphs agree") {
     
-    unordered_map<id_t, handle_t> overlay_handles;
-    overlay.for_each_handle([&](const handle_t& handle) {
-        overlay_handles[overlay.get_id(handle)] = handle;
-    });
-    
-    REQUIRE(copy_handles.size() == overlay_handles.size());
-    
-    for (auto& kv : copy_handles) {
-        // Unpack the copy handle
-        auto& id = kv.first;
-        auto& copy_handle = kv.second;
+        // Get handles for all the nodes
+        unordered_map<id_t, handle_t> copy_handles;
+        copy.for_each_handle([&](const handle_t& handle) {
+            copy_handles[copy.get_id(handle)] = handle;
+        });
         
-        // Find the corresponding overlay handle
-        REQUIRE(overlay_handles.count(id));
-        auto& overlay_handle = overlay_handles.at(id);
+        unordered_map<id_t, handle_t> overlay_handles;
+        overlay.for_each_handle([&](const handle_t& handle) {
+            overlay_handles[overlay.get_id(handle)] = handle;
+        });
         
-        // Both should be forward
-        REQUIRE(!copy.get_is_reverse(copy_handle));
-        REQUIRE(!overlay.get_is_reverse(overlay_handle));
+        REQUIRE(copy_handles.size() == overlay_handles.size());
         
-        // Both should have the same sequence
-        REQUIRE(copy.get_sequence(copy_handle) == overlay.get_sequence(overlay_handle));
-        
-        for (bool go_left : {false, true}) {
-            // Both should have the same neighbors
-            unordered_set<pair<id_t, bool>> copy_neighbors;
-            unordered_set<pair<id_t, bool>> overlay_neighbors;
+        for (auto& kv : copy_handles) {
+            // Unpack the copy handle
+            auto& id = kv.first;
+            auto& copy_handle = kv.second;
             
-#ifdef debug
-            cerr << "Look " << (go_left ? "left" : "right") << " from " << id << endl;
-#endif
+            // Find the corresponding overlay handle
+            REQUIRE(overlay_handles.count(id));
+            auto& overlay_handle = overlay_handles.at(id);
             
-            copy.follow_edges(copy_handle, go_left, [&](const handle_t& neighbor) {
+            // Both should be forward
+            REQUIRE(!copy.get_is_reverse(copy_handle));
+            REQUIRE(!overlay.get_is_reverse(overlay_handle));
+            
+            // Both should have the same sequence
+            REQUIRE(copy.get_sequence(copy_handle) == overlay.get_sequence(overlay_handle));
+            
+            for (bool go_left : {false, true}) {
+                // Both should have the same neighbors
+                unordered_set<pair<id_t, bool>> copy_neighbors;
+                unordered_set<pair<id_t, bool>> overlay_neighbors;
+                
 #ifdef debug
-                cerr << "\tIn copy find node " << copy.get_id(neighbor) << " orientation " << copy.get_is_reverse(neighbor) << endl;
+                cerr << "Look " << (go_left ? "left" : "right") << " from " << id << endl;
 #endif
                 
-                copy_neighbors.emplace(copy.get_id(neighbor), copy.get_is_reverse(neighbor));
-            });
-            
-            overlay.follow_edges(overlay_handle, go_left, [&](const handle_t& neighbor) {
+                copy.follow_edges(copy_handle, go_left, [&](const handle_t& neighbor) {
 #ifdef debug
-                cerr << "\tIn overlay find node " << overlay.get_id(neighbor) << " orientation " << overlay.get_is_reverse(neighbor) << endl;
+                    cerr << "\tIn copy find node " << copy.get_id(neighbor) << " orientation " << copy.get_is_reverse(neighbor) << endl;
 #endif
+                    
+                    copy_neighbors.emplace(copy.get_id(neighbor), copy.get_is_reverse(neighbor));
+                });
                 
-                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
-            });
-            
-            REQUIRE(copy_neighbors.size() == overlay_neighbors.size());
-            for (auto& item : copy_neighbors) {
-                REQUIRE(overlay_neighbors.count(item));
+                overlay.follow_edges(overlay_handle, go_left, [&](const handle_t& neighbor) {
+#ifdef debug
+                    cerr << "\tIn overlay find node " << overlay.get_id(neighbor) << " orientation " << overlay.get_is_reverse(neighbor) << endl;
+#endif
+                    
+                    overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+                });
+                
+                REQUIRE(copy_neighbors.size() == overlay_neighbors.size());
+                for (auto& item : copy_neighbors) {
+                    REQUIRE(overlay_neighbors.count(item));
+                }
             }
         }
+        
+    }
+        
+    
+    SECTION("kmer generation works") {
+        // Now test kmer generation
+        size_t size_limit = 10000;
+        temp_file::remove(write_gcsa_kmers_to_tmpfile(copy, 10, size_limit, start_id, end_id));
+        size_limit = 10000;
+        temp_file::remove(write_gcsa_kmers_to_tmpfile(overlay, 10, size_limit, start_id, end_id));
     }
     
+    SECTION("for_each_handle works in parallel mode") {
     
-    // Now test kmer generation
-    size_t size_limit = 10000;
-    temp_file::remove(write_gcsa_kmers_to_tmpfile(copy, 10, size_limit, start_id, end_id));
-    size_limit = 10000;
-    temp_file::remove(write_gcsa_kmers_to_tmpfile(overlay, 10, size_limit, start_id, end_id));
+        size_t found = 0;
+    
+        overlay.for_each_handle([&](const handle_t& handle) {
+            
+            #pragma omp critical
+            {
+            
+#ifdef debug
+                cerr << "Observed node " << overlay.get_id(handle) << " orientation " << overlay.get_is_reverse(handle)
+                    << " with sequence " << overlay.get_sequence(handle) << endl;
+#endif
+        
+            
+                found++;
+            }
+        }, true);
+        
+        REQUIRE(found == produced.node_size() + 2);
+    }
 }
 
 TEST_CASE("SourceSinkOverlay agrees with VG::add_start_end_markers in a random graph", "[overlay]") {

--- a/src/unittest/source_sink_overlay.cpp
+++ b/src/unittest/source_sink_overlay.cpp
@@ -1,0 +1,343 @@
+/**
+ * \file 
+ * unittest/source_sink_overlay.cpp: test cases for the source and sink node adding overlay.
+ */
+
+#include "catch.hpp"
+
+#include "random_graph.hpp"
+
+#include "../source_sink_overlay.hpp"
+#include "../algorithms/weakly_connected_components.hpp"
+#include "../kmer.hpp"
+#include "../vg.hpp"
+#include "../json2pb.h"
+
+#include <iostream>
+#include <vector>
+#include <unordered_set>
+
+namespace vg {
+namespace unittest {
+
+using namespace std;
+
+TEST_CASE("SourceSinkOverlay adds a source and a sink to a 1-node graph", "[overlay]") {
+
+    // Make a vg graph
+    VG vg;
+    Node* n1 = vg.create_node("GATTACA");
+    
+    // Make an overlay
+    SourceSinkOverlay overlay(&vg, 10);
+    
+    bool found_node = false;
+    bool found_source = false;
+    bool found_sink = false;
+    
+    // Make sure the nodes are as expected
+    overlay.for_each_handle([&](const handle_t& handle) {
+        
+#ifdef debug
+        cerr << "Observed node " << overlay.get_id(handle) << " orientation " << overlay.get_is_reverse(handle)
+            << " with sequence " << overlay.get_sequence(handle) << endl;
+#endif
+    
+        if (overlay.get_id(handle) == n1->id()) {
+            // This is the real node
+            REQUIRE(!found_node);
+            found_node = true;
+            
+            REQUIRE(overlay.get_sequence(handle) == "GATTACA");
+            REQUIRE(overlay.get_degree(handle, false) == 1);
+            REQUIRE(overlay.get_degree(handle, true) == 1);
+            
+            unordered_set<pair<id_t, bool>> overlay_neighbors;
+            overlay.follow_edges(handle, false, [&](const handle_t& neighbor) {
+                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+            });
+            
+            REQUIRE(overlay_neighbors.size() == 1);
+            REQUIRE(overlay_neighbors.count(make_pair(overlay.get_id(overlay.get_sink_handle()), false)));
+            
+            overlay_neighbors.clear();
+            overlay.follow_edges(handle, true, [&](const handle_t& neighbor) {
+                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+            });
+            
+            REQUIRE(overlay_neighbors.size() == 1);
+            REQUIRE(overlay_neighbors.count(make_pair(overlay.get_id(overlay.get_source_handle()), false)));
+            
+        } else if (handle == overlay.get_source_handle()) {
+            // This is the fake source
+            REQUIRE(!found_source);
+            found_source = true;
+            
+            REQUIRE(overlay.get_sequence(handle) == "##########");
+            REQUIRE(overlay.get_degree(handle, false) == 1);
+            REQUIRE(overlay.get_degree(handle, true) == 0);
+            
+            unordered_set<pair<id_t, bool>> overlay_neighbors;
+            overlay.follow_edges(handle, false, [&](const handle_t& neighbor) {
+                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+            });
+            
+            REQUIRE(overlay_neighbors.size() == 1);
+            REQUIRE(overlay_neighbors.count(make_pair(n1->id(), false)));
+            
+            overlay_neighbors.clear();
+            overlay.follow_edges(handle, true, [&](const handle_t& neighbor) {
+                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+            });
+            
+            REQUIRE(overlay_neighbors.empty());
+            
+        } else if (handle == overlay.get_sink_handle()) {
+            // This is the fake sink
+            REQUIRE(!found_sink);
+            found_sink = true;
+            
+            REQUIRE(overlay.get_sequence(handle) == "$$$$$$$$$$");
+            REQUIRE(overlay.get_degree(handle, false) == 0);
+            REQUIRE(overlay.get_degree(handle, true) == 1);
+            
+            unordered_set<pair<id_t, bool>> overlay_neighbors;
+            overlay.follow_edges(handle, false, [&](const handle_t& neighbor) {
+                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+            });
+            
+            REQUIRE(overlay_neighbors.empty());
+            
+            overlay_neighbors.clear();
+            overlay.follow_edges(handle, true, [&](const handle_t& neighbor) {
+                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+            });
+            
+            REQUIRE(overlay_neighbors.size() == 1);
+            REQUIRE(overlay_neighbors.count(make_pair(n1->id(), false)));
+            
+        } else {
+            // This is an unrecognized node!
+            REQUIRE(false);
+        }
+    });
+    
+    REQUIRE(found_node);
+    REQUIRE(found_source);
+    REQUIRE(found_sink);
+    
+}
+
+TEST_CASE("SourceSinkOverlay agrees with VG::add_start_end_markers in a tiny graph", "[overlay]") {
+    const string graph_json = R"({"node":[{"sequence":"CAAATAAG","id":"1"},{"sequence":"A","id":"2"},{"sequence":"G","id":"3"},{"sequence":"T","id":"4"},{"sequence":"C","id":"5"},{"sequence":"TTG","id":"6"},{"sequence":"A","id":"7"},{"sequence":"G","id":"8"},{"sequence":"AAATTTTCTGGAGTTCTAT","id":"9"},{"sequence":"A","id":"10"},{"sequence":"T","id":"11"},{"sequence":"ATAT","id":"12"},{"sequence":"A","id":"13"},{"sequence":"T","id":"14"},{"sequence":"CCAACTCTCTG","id":"15"}],"edge":[{"from":"1","to":"2"},{"from":"1","to":"3"},{"from":"2","to":"4"},{"from":"2","to":"5"},{"from":"3","to":"4"},{"from":"3","to":"5"},{"from":"4","to":"6"},{"from":"5","to":"6"},{"from":"6","to":"7"},{"from":"6","to":"8"},{"from":"7","to":"9"},{"from":"8","to":"9"},{"from":"9","to":"10"},{"from":"9","to":"11"},{"from":"10","to":"12"},{"from":"11","to":"12"},{"from":"12","to":"13"},{"from":"12","to":"14"},{"from":"13","to":"15"},{"from":"14","to":"15"}],"path":[{"name":"x","mapping":[{"position":{"node_id":"1"},"edit":[{"from_length":8,"to_length":8}],"rank":"1"},{"position":{"node_id":"3"},"edit":[{"from_length":1,"to_length":1}],"rank":"2"},{"position":{"node_id":"5"},"edit":[{"from_length":1,"to_length":1}],"rank":"3"},{"position":{"node_id":"6"},"edit":[{"from_length":3,"to_length":3}],"rank":"4"},{"position":{"node_id":"8"},"edit":[{"from_length":1,"to_length":1}],"rank":"5"},{"position":{"node_id":"9"},"edit":[{"from_length":19,"to_length":19}],"rank":"6"},{"position":{"node_id":"11"},"edit":[{"from_length":1,"to_length":1}],"rank":"7"},{"position":{"node_id":"12"},"edit":[{"from_length":4,"to_length":4}],"rank":"8"},{"position":{"node_id":"14"},"edit":[{"from_length":1,"to_length":1}],"rank":"9"},{"position":{"node_id":"15"},"edit":[{"from_length":11,"to_length":11}],"rank":"10"}]}]})";
+    
+    Graph graph;
+    json2pb(graph, graph_json);
+    
+    VG produced(graph);
+    
+    id_t highest_id = produced.max_node_id();
+    id_t start_id = highest_id + 1;
+    id_t end_id = start_id + 1;
+    
+    Node* start_node = nullptr;
+    Node* end_node = nullptr;
+    
+    VG copy = produced;
+    copy.add_start_end_markers(10, '#', '$', start_node, end_node, start_id, end_id);
+    
+    SourceSinkOverlay overlay(&produced, 10, start_id, end_id);
+    
+    // We know this graph has no tipless components.
+    
+    // Get handles for all the nodes
+    unordered_map<id_t, handle_t> copy_handles;
+    copy.for_each_handle([&](const handle_t& handle) {
+        copy_handles[copy.get_id(handle)] = handle;
+    });
+    
+    unordered_map<id_t, handle_t> overlay_handles;
+    overlay.for_each_handle([&](const handle_t& handle) {
+        overlay_handles[overlay.get_id(handle)] = handle;
+    });
+    
+    REQUIRE(copy_handles.size() == overlay_handles.size());
+    
+    for (auto& kv : copy_handles) {
+        // Unpack the copy handle
+        auto& id = kv.first;
+        auto& copy_handle = kv.second;
+        
+        // Find the corresponding overlay handle
+        REQUIRE(overlay_handles.count(id));
+        auto& overlay_handle = overlay_handles.at(id);
+        
+        // Both should be forward
+        REQUIRE(!copy.get_is_reverse(copy_handle));
+        REQUIRE(!overlay.get_is_reverse(overlay_handle));
+        
+        // Both should have the same sequence
+        REQUIRE(copy.get_sequence(copy_handle) == overlay.get_sequence(overlay_handle));
+        
+        for (bool go_left : {false, true}) {
+            // Both should have the same neighbors
+            unordered_set<pair<id_t, bool>> copy_neighbors;
+            unordered_set<pair<id_t, bool>> overlay_neighbors;
+            
+#ifdef debug
+            cerr << "Look " << (go_left ? "left" : "right") << " from " << id << endl;
+#endif
+            
+            copy.follow_edges(copy_handle, go_left, [&](const handle_t& neighbor) {
+#ifdef debug
+                cerr << "\tIn copy find node " << copy.get_id(neighbor) << " orientation " << copy.get_is_reverse(neighbor) << endl;
+#endif
+                
+                copy_neighbors.emplace(copy.get_id(neighbor), copy.get_is_reverse(neighbor));
+            });
+            
+            overlay.follow_edges(overlay_handle, go_left, [&](const handle_t& neighbor) {
+#ifdef debug
+                cerr << "\tIn overlay find node " << overlay.get_id(neighbor) << " orientation " << overlay.get_is_reverse(neighbor) << endl;
+#endif
+                
+                overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+            });
+            
+            REQUIRE(copy_neighbors.size() == overlay_neighbors.size());
+            for (auto& item : copy_neighbors) {
+                REQUIRE(overlay_neighbors.count(item));
+            }
+        }
+    }
+    
+    
+    // Now test kmer generation
+    size_t size_limit = 10000;
+    temp_file::remove(write_gcsa_kmers_to_tmpfile(copy, 10, size_limit, start_id, end_id));
+    size_limit = 10000;
+    temp_file::remove(write_gcsa_kmers_to_tmpfile(overlay, 10, size_limit, start_id, end_id));
+}
+
+TEST_CASE("SourceSinkOverlay agrees with VG::add_start_end_markers in a random graph", "[overlay]") {
+
+    for (size_t trial = 0; trial < 1000; trial++) {
+        
+        VG random = randomGraph(100, 3, 30);
+        
+#ifdef debug
+        cerr << "Trial " << trial << ": " << pb2json(random.graph) << endl;
+#endif
+        
+        id_t highest_id = random.max_node_id();
+        id_t start_id = highest_id + 1;
+        id_t end_id = start_id + 1;
+        
+        Node* start_node = nullptr;
+        Node* end_node = nullptr;
+        
+        VG copy = random;
+        copy.add_start_end_markers(10, '#', '$', start_node, end_node, start_id, end_id);
+        
+        SourceSinkOverlay overlay(&random, 10, start_id, end_id);
+        
+        // Now we compare copy and overlay. They ought to match. Except that if
+        // we have to break into a component with no real tips, we might break
+        // in at a different place. So work out which components to not worry about so much.
+        unordered_set<id_t> in_tipless_component;
+        vector<pair<unordered_set<id_t>, vector<handle_t>>> components = algorithms::weakly_connected_components_with_tips(&random);
+        for (auto& component : components) {
+            if (component.second.empty()) {
+                for (auto& id : component.first) {
+                    // Mark all the nodes in this tipless component as in a tipless component
+                    in_tipless_component.insert(id);
+                }
+            }
+        }
+        
+        // Get handles for all the nodes
+        unordered_map<id_t, handle_t> copy_handles;
+        copy.for_each_handle([&](const handle_t& handle) {
+            copy_handles[copy.get_id(handle)] = handle;
+        });
+        
+        unordered_map<id_t, handle_t> overlay_handles;
+        overlay.for_each_handle([&](const handle_t& handle) {
+            overlay_handles[overlay.get_id(handle)] = handle;
+        });
+        
+        REQUIRE(copy_handles.size() == overlay_handles.size());
+        
+        for (auto& kv : copy_handles) {
+            // Unpack the copy handle
+            auto& id = kv.first;
+            auto& copy_handle = kv.second;
+            
+            // Find the corresponding overlay handle
+            REQUIRE(overlay_handles.count(id));
+            auto& overlay_handle = overlay_handles.at(id);
+            
+            // Both should be forward
+            REQUIRE(!copy.get_is_reverse(copy_handle));
+            REQUIRE(!overlay.get_is_reverse(overlay_handle));
+            
+            // Both should have the same sequence
+            REQUIRE(copy.get_sequence(copy_handle) == overlay.get_sequence(overlay_handle));
+            
+            for (bool go_left : {false, true}) {
+                // Both should have the same neighbors
+                unordered_set<pair<id_t, bool>> copy_neighbors;
+                unordered_set<pair<id_t, bool>> overlay_neighbors;
+                
+#ifdef debug
+                cerr << "Look " << (go_left ? "left" : "right") << " from " << id << endl;
+#endif
+                
+                copy.follow_edges(copy_handle, go_left, [&](const handle_t& neighbor) {
+#ifdef debug
+                    cerr << "\tIn copy find node " << copy.get_id(neighbor) << " orientation " << copy.get_is_reverse(neighbor) << endl;
+#endif
+                    
+                    if ((in_tipless_component.count(id) && (copy.get_id(neighbor) == start_id || copy.get_id(neighbor) == end_id)) ||
+                        (in_tipless_component.count(copy.get_id(neighbor)) && (id == start_id || id == end_id))) {
+                        // This edge constitutes breaking into a tipless component. Ignore it.
+#ifdef debug
+                        cerr << "\t\tDrop entry to tipless component" << endl;
+#endif
+                        return;
+                    }
+                    
+                    copy_neighbors.emplace(copy.get_id(neighbor), copy.get_is_reverse(neighbor));
+                });
+                
+                overlay.follow_edges(overlay_handle, go_left, [&](const handle_t& neighbor) {
+#ifdef debug
+                    cerr << "\tIn overlay find node " << overlay.get_id(neighbor) << " orientation " << overlay.get_is_reverse(neighbor) << endl;
+#endif
+                    
+                    if ((in_tipless_component.count(id) && (overlay.get_id(neighbor) == start_id || overlay.get_id(neighbor) == end_id)) ||
+                        (in_tipless_component.count(overlay.get_id(neighbor)) && (id == start_id || id == end_id))) {
+                        // This edge constitutes breaking into a tipless component. Ignore it.
+#ifdef debug
+                        cerr << "\t\tDrop entry to tipless component" << endl;
+#endif
+                        return;
+                    }
+                     
+                    overlay_neighbors.emplace(overlay.get_id(neighbor), overlay.get_is_reverse(neighbor));
+                });
+                
+                REQUIRE(copy_neighbors.size() == overlay_neighbors.size());
+                for (auto& item : copy_neighbors) {
+                    REQUIRE(overlay_neighbors.count(item));
+                }
+            }
+        }
+        
+    
+    }
+
+}
+
+}
+}

--- a/src/unittest/vg.cpp
+++ b/src/unittest/vg.cpp
@@ -145,6 +145,84 @@ TEST_CASE("is_acyclic() should return whether the graph is acyclic", "[vg][cycle
     }
 }
 
+TEST_CASE("dagify() should render the graph acyclic", "[vg][cycles][dagify]") {
+   
+    unordered_map<id_t, pair<id_t, bool> > node_translation;
+   
+    SECTION("a tiny DAG should remain unmodified") {
+        const string graph_json = R"(
+        
+        {
+            "node": [
+                {"id": 1, "sequence": "G"},
+                {"id": 2, "sequence": "A"}
+            ],
+            "edge": [
+                {"from": 1, "to": 2}
+            ]
+        }
+    
+        )";
+        
+        VG graph = string_to_graph(graph_json);
+        
+        VG dag = graph.dagify(5, node_translation, 5, 0);
+        
+        REQUIRE(dag.is_acyclic() == true);
+        REQUIRE(dag.node_size() == 2);
+        REQUIRE(dag.edge_count() == 1);
+    }
+    
+    SECTION("a tiny cyclic graph should become acyclic") {
+        const string graph_json = R"(
+        
+        {
+            "node": [
+                {"id": 1, "sequence": "G"},
+                {"id": 2, "sequence": "A"}
+            ],
+            "edge": [
+                {"from": 1, "to": 2},
+                {"from": 2, "to": 1}
+            ]
+        }
+    
+        )";
+        
+        VG graph = string_to_graph(graph_json);
+        
+        VG dag = graph.dagify(5, node_translation, 5, 0);
+        
+        REQUIRE(dag.is_acyclic() == true);
+        REQUIRE(dag.node_size() >= 2);
+    }
+    
+    SECTION("a tiny cyclic graph with doubly reversing edges should become acyclic") {
+        const string graph_json = R"(
+        
+        {
+            "node": [
+                {"id": 1, "sequence": "G"},
+                {"id": 2, "sequence": "A"}
+            ],
+            "edge": [
+                {"from": 1, "to": 2},
+                {"from": 1, "from_start": true, "to": 2, "to_end": true}
+            ]
+        }
+    
+        )";
+        
+        VG graph = string_to_graph(graph_json);
+        
+        VG dag = graph.dagify(5, node_translation, 5, 0);
+        
+        REQUIRE(dag.is_acyclic() == true);
+        REQUIRE(dag.node_size() >= 2);
+    }
+    
+}
+
 TEST_CASE("unfold() should properly unfold a graph out to the requested length", "[vg][unfold]") {
 
     SECTION("Unfolding a graph with no reversing edges should create an isomorphic graph") {

--- a/src/unittest/xg.cpp
+++ b/src/unittest/xg.cpp
@@ -678,5 +678,31 @@ TEST_CASE("Path component memoization produces expected results", "[xg]") {
     }
 }
 
+TEST_CASE("Looping over XG handles in parallel works", "[xg]") {
+
+    string graph_json = R"(
+    {"node":[{"id":1,"sequence":"GATT"},
+    {"id":2,"sequence":"ACA"}],
+    "edge":[{"to":2,"from":1}]}
+    )";
+    
+    // Load the JSON
+    Graph proto_graph;
+    json2pb(proto_graph, graph_json.c_str(), graph_json.size());
+    
+    // Build the xg index
+    xg::XG xg_index(proto_graph);
+
+    size_t count = 0;
+
+    xg_index.for_each_handle([&](const handle_t& got) {
+        #pragma omp critical
+        count++;
+    }, true);
+    
+    REQUIRE(count == 2);
+
+}
+
 }
 }

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -230,6 +230,47 @@ void VG::for_each_handle(const function<bool(const handle_t&)>& iteratee, bool p
 size_t VG::node_size() const {
     return graph.node_size();
 }
+
+id_t VG::max_node_id(void) const {
+    id_t max_id = 0;
+    for (int i = 0; i < graph.node_size(); ++i) {
+        const Node& n = graph.node(i);
+        if (n.id() > max_id) {
+            max_id = n.id();
+        }
+    }
+    return max_id;
+}
+
+id_t VG::min_node_id(void) const {
+    id_t min_id = numeric_limits<id_t>::max();
+    for (int i = 0; i < graph.node_size(); ++i) {
+        const Node& n = graph.node(i);
+        if (n.id() < min_id) {
+            min_id = n.id();
+        }
+    }
+    return min_id;
+}
+
+size_t VG::get_degree(const handle_t& handle, bool go_left) const {
+    // Are we reverse?
+    bool is_reverse = get_is_reverse(handle);
+    
+    // Which edges will we look at?
+    auto& edge_set = (go_left != is_reverse) ? edges_on_start : edges_on_end;
+    
+    // Look up edges of this node specifically
+    auto found = edge_set.find(get_id(handle));
+    if (found != edge_set.end()) {
+        // There are (or may be) edges.
+        // Return the count.
+        return found->second.size();
+    }
+    
+    // Otherwise there can be no edges
+    return 0;
+}
     
 path_handle_t VG::get_path_handle(const string& path_name) const {
     return as_path_handle(paths.name_to_id.at(path_name));
@@ -2747,28 +2788,6 @@ void VG::include(const Path& path) {
         }
     }
     paths.extend(path);
-}
-
-id_t VG::max_node_id(void) const {
-    id_t max_id = 0;
-    for (int i = 0; i < graph.node_size(); ++i) {
-        const Node& n = graph.node(i);
-        if (n.id() > max_id) {
-            max_id = n.id();
-        }
-    }
-    return max_id;
-}
-
-id_t VG::min_node_id(void) const {
-    id_t min_id = numeric_limits<id_t>::max();
-    for (int i = 0; i < graph.node_size(); ++i) {
-        const Node& n = graph.node(i);
-        if (n.id() < min_id) {
-            min_id = n.id();
-        }
-    }
-    return min_id;
 }
 
 void VG::compact_ids(void) {

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -125,23 +125,28 @@ VG::VG(const Graph& from, bool showp, bool warn_on_duplicates) {
 handle_t VG::get_handle(const id_t& node_id, bool is_reverse) const {
     // Handle is ID in low bits and orientation in high bit
     
-    // Where in the g vector do we need to be
+    // What node ID are we encoding?
     size_t handle = node_id;
-    // And set the high bit if it's reverse
-    if (is_reverse) handle |= HIGH_BIT;
+    // Make room for the orientation bit.
+    handle = handle << 1;
+    // And set the low bit if it's reverse
+    if (is_reverse) handle |= 1;
     return as_handle(handle);
 }
 
 id_t VG::get_id(const handle_t& handle) const {
-    return as_integer(handle) & LOW_BITS;
+    // Drop the low bit that encodes orientation
+    return ((size_t) as_integer(handle)) >> 1;
 }
 
 bool VG::get_is_reverse(const handle_t& handle) const {
-    return as_integer(handle) & HIGH_BIT;
+    // Orientation is stored in the low bit
+    return as_integer(handle) & 1;
 }
 
 handle_t VG::flip(const handle_t& handle) const {
-    return as_handle(as_integer(handle) ^ HIGH_BIT);
+    // Toggle the orientation, in the low bit
+    return as_handle(as_integer(handle) ^ 1);
 }
 
 size_t VG::get_length(const handle_t& handle) const {
@@ -163,7 +168,7 @@ string VG::get_sequence(const handle_t& handle) const {
         // We found a node. Grab its sequence
         auto sequence = (*found).second->sequence();
         
-        if (as_integer(handle) & HIGH_BIT) {
+        if (get_is_reverse(handle)) {
             // Needs to be reverse-complemented
             return reverse_complement(sequence);
         } else {

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -2749,23 +2749,23 @@ void VG::include(const Path& path) {
     paths.extend(path);
 }
 
-id_t VG::max_node_id(void) {
+id_t VG::max_node_id(void) const {
     id_t max_id = 0;
     for (int i = 0; i < graph.node_size(); ++i) {
-        Node* n = graph.mutable_node(i);
-        if (n->id() > max_id) {
-            max_id = n->id();
+        const Node& n = graph.node(i);
+        if (n.id() > max_id) {
+            max_id = n.id();
         }
     }
     return max_id;
 }
 
-id_t VG::min_node_id(void) {
-    id_t min_id = max_node_id();
+id_t VG::min_node_id(void) const {
+    id_t min_id = numeric_limits<id_t>::max();
     for (int i = 0; i < graph.node_size(); ++i) {
-        Node* n = graph.mutable_node(i);
-        if (n->id() < min_id) {
-            min_id = n->id();
+        const Node& n = graph.node(i);
+        if (n.id() < min_id) {
+            min_id = n.id();
         }
     }
     return min_id;

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -126,6 +126,11 @@ public:
     /// Return the number of nodes in the graph
     virtual size_t node_size() const;
     
+    /// Get the minimum node ID used in the graph, if any are used
+    virtual id_t min_node_id() const;
+    /// Get the maximum node ID used in the graph, if any are used
+    virtual id_t max_node_id() const;
+    
     ////////////////////////////////////////////////////////////////////////////
     // Path handle interface
     ////////////////////////////////////////////////////////////////////////////
@@ -505,10 +510,6 @@ public:
     // can we handle this with merge?
     //void concatenate(VG& g);
 
-    /// Get the maximum node ID in the graph.
-    id_t max_node_id(void);
-    /// Get the minimum node ID in the graph.
-    id_t min_node_id(void);
     /// Squish the node IDs down into as small a space as possible. Fixes up paths itself.
     void compact_ids(void);
     /// Add the given value to all node IDs. Preserves the paths.

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -379,6 +379,8 @@ public:
     void bluntify(void);
     /// Turn the graph into a dag by copying strongly connected components expand_scc_steps times
     /// and translating the edges in the component to flow through the copies in one direction.
+    /// Assumes that all nodes in the graph are articulated on one consistent strand.
+    /// Tolerates doubly-reversing edges in the input graph.
     VG dagify(uint32_t expand_scc_steps,
               unordered_map<id_t, pair<id_t, bool> >& node_translation,
               size_t target_min_walk_length = 0,

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -131,6 +131,10 @@ public:
     /// Get the maximum node ID used in the graph, if any are used
     virtual id_t max_node_id() const;
     
+    /// Efficiently get the number of edges attached to one side of a handle.
+    /// Uses the VG graph's internal degree index.
+    virtual size_t get_degree(const handle_t& handle, bool go_left) const;
+    
     ////////////////////////////////////////////////////////////////////////////
     // Path handle interface
     ////////////////////////////////////////////////////////////////////////////

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -215,11 +215,6 @@ public:
     /// passed in.
     virtual vector<handle_t> divide_handle(const handle_t& handle, const vector<size_t>& offsets);
     
-private:
-    // We have some masks for cramming things into handles
-    const static size_t HIGH_BIT = (size_t)1 << 63;
-    const static size_t LOW_BITS = 0x7FFFFFFFFFFFFFFF;
-    
 public:
     
     ////////////////////////////////////////////////////////////////////////////

--- a/src/vg_set.cpp
+++ b/src/vg_set.cpp
@@ -178,6 +178,7 @@ void VGset::for_each_kmer_parallel(int kmer_size, const function<void(const kmer
 void VGset::write_gcsa_kmers_ascii(ostream& out, int kmer_size,
                                    id_t head_id, id_t tail_id) {
     if (filenames.size() > 1 && (head_id == 0 || tail_id == 0)) {
+        // Detect head and tail IDs in advance if we have multiple graphs
         id_t max_id = max_node_id(); // expensive, as we'll stream through all the files
         head_id = max_id + 1;
         tail_id = max_id + 2;
@@ -197,6 +198,10 @@ void VGset::write_gcsa_kmers_ascii(ostream& out, int kmer_size,
         // Make sure to use a consistent head and tail ID across all graphs in the set.
         SourceSinkOverlay overlay(g, kmer_size, head_id, tail_id);
         
+        // Read back the head and tail IDs in case we have only one graph and we just detected them now.
+        head_id = overlay.get_id(overlay.get_source_handle());
+        tail_id = overlay.get_id(overlay.get_sink_handle());
+        
         // Now get the kmers in the graph that pretends to have single head and tail nodes
         for_each_kmer(overlay, kmer_size, write_kmer, head_id, tail_id);
     });
@@ -206,6 +211,7 @@ void VGset::write_gcsa_kmers_ascii(ostream& out, int kmer_size,
 void VGset::write_gcsa_kmers_binary(ostream& out, int kmer_size, size_t& size_limit,
                                     id_t head_id, id_t tail_id) {
     if (filenames.size() > 1 && (head_id == 0 || tail_id == 0)) {
+        // Detect head and tail IDs in advance if we have multiple graphs
         id_t max_id = max_node_id(); // expensive, as we'll stream through all the files
         head_id = max_id + 1;
         tail_id = max_id + 2;
@@ -216,6 +222,10 @@ void VGset::write_gcsa_kmers_binary(ostream& out, int kmer_size, size_t& size_li
         // Make an overlay for each graph, without modifying it. Break into tip-less cycle components.
         // Make sure to use a consistent head and tail ID across all graphs in the set.
         SourceSinkOverlay overlay(g, kmer_size, head_id, tail_id);
+        
+        // Read back the head and tail IDs in case we have only one graph and we just detected them now.
+        head_id = overlay.get_id(overlay.get_source_handle());
+        tail_id = overlay.get_id(overlay.get_sink_handle());
         
         size_t current_bytes = size_limit - total_size;
         write_gcsa_kmers(overlay, kmer_size, out, current_bytes, head_id, tail_id);
@@ -228,6 +238,7 @@ void VGset::write_gcsa_kmers_binary(ostream& out, int kmer_size, size_t& size_li
 vector<string> VGset::write_gcsa_kmers_binary(int kmer_size, size_t& size_limit,
                                               id_t head_id, id_t tail_id) {
     if (filenames.size() > 1 && (head_id == 0 || tail_id == 0)) {
+        // Detect head and tail IDs in advance if we have multiple graphs
         id_t max_id = max_node_id(); // expensive, as we'll stream through all the files
         head_id = max_id + 1;
         tail_id = max_id + 2;
@@ -239,6 +250,10 @@ vector<string> VGset::write_gcsa_kmers_binary(int kmer_size, size_t& size_limit,
         // Make an overlay for each graph, without modifying it. Break into tip-less cycle components.
         // Make sure to use a consistent head and tail ID across all graphs in the set.
         SourceSinkOverlay overlay(g, kmer_size, head_id, tail_id);
+        
+        // Read back the head and tail IDs in case we have only one graph and we just detected them now.
+        head_id = overlay.get_id(overlay.get_source_handle());
+        tail_id = overlay.get_id(overlay.get_sink_handle());
         
         size_t current_bytes = size_limit - total_size;
         tmpnames.push_back(write_gcsa_kmers_to_tmpfile(overlay, kmer_size, current_bytes, head_id, tail_id));

--- a/src/vg_set.cpp
+++ b/src/vg_set.cpp
@@ -53,7 +53,7 @@ void VGset::for_each_graph_chunk(std::function<void(Graph&)> lamda) {
     }
 }
 
-id_t VGset::get_max_id(void) {
+id_t VGset::max_node_id(void) {
     id_t max_id = 0;
     for_each_graph_chunk([&](const Graph& graph) {
             for (size_t i = 0; i < graph.node_size(); ++i) {
@@ -177,7 +177,7 @@ void VGset::for_each_kmer_parallel(int kmer_size, const function<void(const kmer
 void VGset::write_gcsa_kmers_ascii(ostream& out, int kmer_size,
                                    id_t head_id, id_t tail_id) {
     if (filenames.size() > 1 && (head_id == 0 || tail_id == 0)) {
-        id_t max_id = get_max_id(); // expensive, as we'll stream through all the files
+        id_t max_id = max_node_id(); // expensive, as we'll stream through all the files
         head_id = max_id + 1;
         tail_id = max_id + 2;
     }
@@ -204,7 +204,7 @@ void VGset::write_gcsa_kmers_ascii(ostream& out, int kmer_size,
 void VGset::write_gcsa_kmers_binary(ostream& out, int kmer_size, size_t& size_limit,
                                     id_t head_id, id_t tail_id) {
     if (filenames.size() > 1 && (head_id == 0 || tail_id == 0)) {
-        id_t max_id = get_max_id(); // expensive, as we'll stream through all the files
+        id_t max_id = max_node_id(); // expensive, as we'll stream through all the files
         head_id = max_id + 1;
         tail_id = max_id + 2;
     }
@@ -225,7 +225,7 @@ void VGset::write_gcsa_kmers_binary(ostream& out, int kmer_size, size_t& size_li
 vector<string> VGset::write_gcsa_kmers_binary(int kmer_size, size_t& size_limit,
                                               id_t head_id, id_t tail_id) {
     if (filenames.size() > 1 && (head_id == 0 || tail_id == 0)) {
-        id_t max_id = get_max_id(); // expensive, as we'll stream through all the files
+        id_t max_id = max_node_id(); // expensive, as we'll stream through all the files
         head_id = max_id + 1;
         tail_id = max_id + 2;
     }

--- a/src/vg_set.hpp
+++ b/src/vg_set.hpp
@@ -30,7 +30,7 @@ public:
     void for_each_graph_chunk(std::function<void(Graph&)> lamda);
 
     /// Stream through the files and determine the max node id
-    id_t get_max_id(void);
+    id_t max_node_id(void);
     
     /// merges the id space of a set of graphs on-disk
     /// necessary when storing many graphs in the same index

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1782,7 +1782,7 @@ void XG::for_each_handle(const function<bool(const handle_t&)>& iteratee, bool p
         
         if (parallel) {
             // Run the iteratee as a task
-            # pragma omp task shared(iteratee)
+            # pragma omp task shared(iteratee, stop_early)
             {
                 // Run the iteratee
                 if (!iteratee(handle)) {
@@ -1810,7 +1810,7 @@ void XG::for_each_handle(const function<bool(const handle_t&)>& iteratee, bool p
     };
     
     if (parallel) {
-        #pragma omp parallel
+        #pragma omp parallel shared(iteratee, stop_early)
         {
             #pragma omp single 
             {

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1782,7 +1782,7 @@ void XG::for_each_handle(const function<bool(const handle_t&)>& iteratee, bool p
         
         if (parallel) {
             // Run the iteratee as a task
-            # pragma omp task
+            # pragma omp task shared(iteratee)
             {
                 // Run the iteratee
                 if (!iteratee(handle)) {

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1896,6 +1896,14 @@ size_t XG::node_size() const {
     return this->node_count;
 }
 
+id_t XG::min_node_id() const {
+    return min_id;
+}
+    
+id_t XG::max_node_id() const {
+    return max_id;
+}
+
 vector<Edge> XG::edges_of(int64_t id) const {
     size_t g = g_bv_select(id_to_rank(id));
     int edges_to_count = g_iv[g+G_NODE_TO_COUNT_OFFSET];

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1623,30 +1623,32 @@ Graph XG::graph_context_g(const pos_t& g_pos, int64_t length) const {
 }
 
 handle_t XG::get_handle(const id_t& node_id, bool is_reverse) const {
-    // Handles will be g vector index with is_reverse in the high bit
+    // Handles will be g vector index with is_reverse in the low bit
     
     // Where in the g vector do we need to be
     size_t handle = g_bv_select(id_to_rank(node_id));
-    // And set the high bit if it's reverse
-    if (is_reverse) handle |= HIGH_BIT;
+    // Make room for the orientation
+    handle = handle << 1;
+    // And set the low bit if it's reverse
+    if (is_reverse) handle |= 1;
     return as_handle(handle);
 }
 
 id_t XG::get_id(const handle_t& handle) const {
     // Go get the g offset and then look up the noder ID
-    return g_iv[(as_integer(handle) & LOW_BITS) + G_NODE_ID_OFFSET];
+    return g_iv[(((size_t) as_integer(handle)) >> 1) + G_NODE_ID_OFFSET];
 }
 
 bool XG::get_is_reverse(const handle_t& handle) const {
-    return as_integer(handle) & HIGH_BIT;
+    return as_integer(handle) & 1;
 }
 
 handle_t XG::flip(const handle_t& handle) const {
-    return as_handle(as_integer(handle) ^ HIGH_BIT);
+    return as_handle(as_integer(handle) ^ 1);
 }
 
 size_t XG::get_length(const handle_t& handle) const {
-    return g_iv[(as_integer(handle) & LOW_BITS) + G_NODE_LENGTH_OFFSET];
+    return g_iv[(((size_t) as_integer(handle)) >> 1) + G_NODE_LENGTH_OFFSET];
 }
 
 string XG::get_sequence(const handle_t& handle) const {
@@ -1656,7 +1658,7 @@ string XG::get_sequence(const handle_t& handle) const {
     // Allocate the sequence string
     string sequence(sequence_size, '\0');
     // Extract the node record start
-    size_t g = as_integer(handle) & LOW_BITS;
+    size_t g = ((size_t) as_integer(handle)) >> 1;
     // Figure out where the sequence starts
     size_t sequence_start = g_iv[g + G_NODE_SEQ_START_OFFSET];
     for (int64_t i = 0; i < sequence_size; i++) {
@@ -1664,7 +1666,7 @@ string XG::get_sequence(const handle_t& handle) const {
         sequence[i] = revdna3bit(s_iv[sequence_start + i]);
     }
     
-    if (as_integer(handle) & HIGH_BIT) {
+    if (as_integer(handle) & 1) {
         return reverse_complement(sequence);
     } else {
         return sequence;
@@ -1721,7 +1723,7 @@ bool XG::do_edges(const size_t& g, const size_t& start, const size_t& count, boo
             bool new_reverse = is_reverse != (type == 2 || type == 3);
             
             // Compose the handle for where we are going
-            handle_t next_handle = as_handle((g + offset) | (new_reverse ? HIGH_BIT : 0));
+            handle_t next_handle = as_handle(((g + offset) << 1) | (new_reverse ? 1 : 0));
             
             // We want this edge
             
@@ -1734,7 +1736,7 @@ bool XG::do_edges(const size_t& g, const size_t& start, const size_t& count, boo
             // TODO: delete this after using it to debug
             int64_t offset = g_iv[start + i * G_EDGE_LENGTH + G_EDGE_OFFSET_OFFSET];
             bool new_reverse = is_reverse != (type == 2 || type == 3);
-            handle_t next_handle = as_handle((g + offset) | (new_reverse ? HIGH_BIT : 0));
+            handle_t next_handle = as_handle(((g + offset) << 1) | (new_reverse ? 1 : 0));
         }
     }
     // Iteratee didn't stop us.
@@ -1744,7 +1746,7 @@ bool XG::do_edges(const size_t& g, const size_t& start, const size_t& count, boo
 bool XG::follow_edges(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const {
 
     // Unpack the handle
-    size_t g = as_integer(handle) & LOW_BITS;
+    size_t g = ((size_t) as_integer(handle)) >> 1;
     bool is_reverse = get_is_reverse(handle);
 
     // How many edges are there of each type?
@@ -1771,11 +1773,11 @@ void XG::for_each_handle(const function<bool(const handle_t&)>& iteratee, bool p
     bool stop_early = false;
     auto lambda = [&](size_t g) {
         // Make the handle
-        // We need to make sure our index won't set the orientation bit.
-        assert((g & (~LOW_BITS)) == 0);
+        // We need to make sure our index isn't trying to use the high bit we shift off
+        assert((g & ((size_t)1 << 63)) == 0);
         
-        // Just make it into a handle; we're always forward.
-        handle_t handle = as_handle(g);
+        // Make it into a handle, packing it as the node ID and using 0 for orientation
+        handle_t handle = as_handle(g << 1);
         
         // Run the iteratee
         if (!iteratee(handle)) {

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -659,10 +659,6 @@ private:
     const static int G_EDGE_TYPE_OFFSET = 1;
     const static int G_EDGE_LENGTH = 2;
     
-    // And some masks
-    const static size_t HIGH_BIT = (size_t)1 << 63;
-    const static size_t LOW_BITS = 0x7FFFFFFFFFFFFFFF;
-    
     /// This is a utility function for the edge exploration. It says whether we
     /// want to visit an edge depending on its type, whether we're the to or
     /// from node, whether we want to look left or right, and whether we're

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -238,6 +238,10 @@ public:
     /// Get the maximum node ID used in the graph, if any are used
     virtual id_t max_node_id() const;
     
+    // TODO: There's currently no really good efficient way to implement
+    // get_degree; we have to decode each edge to work out what node side it is
+    // on. So we use the default implementation.
+    
     ////////////////////////
     // Path handle graph API
     ////////////////////////

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -155,9 +155,6 @@ public:
     size_t node_graph_idx(int64_t id) const;
     size_t edge_graph_idx(const Edge& edge) const;
 
-    int64_t get_min_id() const { return min_id; }
-    int64_t get_max_id() const { return max_id; }
-
     ////////////////////////////////////////////////////////////////////////////
     // Here is the old low-level API that needs to be restated in terms of the 
     // locally traversable graph API and then removed.
@@ -236,6 +233,10 @@ public:
     using HandleGraph::for_each_handle;
     /// Return the number of nodes in the graph
     virtual size_t node_size() const;
+    /// Get the minimum node ID used in the graph, if any are used
+    virtual id_t min_node_id() const;
+    /// Get the maximum node ID used in the graph, if any are used
+    virtual id_t max_node_id() const;
     
     ////////////////////////
     // Path handle graph API

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="en_US.utf8" # force ekg's favorite sort order 
 
-plan tests 60
+plan tests 61
 
 # Single graph without haplotypes
 vg construct -r small/x.fa -v small/x.vcf.gz > x.vg
@@ -26,6 +26,9 @@ is $? 0 "the indexes are identical when built one at a time and together"
 
 vg index -x x.xg -g x3.gcsa
 is $? 0 "building GCSA from XG"
+
+cmp x.gcsa x3.gcsa && cmp x.gcsa.lcp x3.gcsa.lcp
+is $? 0 "the GCSA indexes are identical when built from vg and from xg"
 
 rm -f x.vg
 rm -f x.xg x.gcsa x.gcsa.lcp

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="en_US.utf8" # force ekg's favorite sort order 
 
-plan tests 59
+plan tests 60
 
 # Single graph without haplotypes
 vg construct -r small/x.fa -v small/x.vcf.gz > x.vg
@@ -22,11 +22,15 @@ vg index -x x2.xg -g x2.gcsa x.vg
 is $? 0 "building both indexes at once"
 
 cmp x.xg x2.xg && cmp x.gcsa x2.gcsa && cmp x.gcsa.lcp x2.gcsa.lcp
-is $? 0 "the indexes are identical"
+is $? 0 "the indexes are identical when built one at a time and together"
+
+vg index -x x.xg -g x3.gcsa
+is $? 0 "building GCSA from XG"
 
 rm -f x.vg
 rm -f x.xg x.gcsa x.gcsa.lcp
 rm -f x2.xg x2.gcsa x2.gcsa.lcp
+rm -f x3.gcsa x3.gcsa.lcp
 
 
 # Single graph with haplotypes


### PR DESCRIPTION
This properly finishes off #1933. Our kpath code was already in terms of handle graphs, but in practice we could only index vg files, since GCSA indexing needs single start and end nodes hooked up to every graph component, and the code to do that depended on inserting nodes into the vg graph.

I've replaced that code along all the indexing codepaths with a `SourceSinkOverlay`, which synthesizes source and sink nodes on top of any backing `HandleGraph` implementation. I've had to extend the `HandleGraph` interface to report a few more statistics than it did before to make this work (e.g. I need to be able to get ahold of the max node ID in the backing graph to make IDs for the new nodes).

Using this, you can now produce a GCSA index directly from an XG index with:

```
vg index -x input.xg -g output.gcsa
```

I also had to fix parallel mode in XG's `for_each_handle` implementation, which would just loop forever on the first node and never make any progress.

We still use the old `add_start_end_markers` in `vg mod`, because applying it to mutate a graph is a `vg mod` option, and in `VG::prune_complex_with_head_tail`, because again we're mutating the graph. It's also used in the unit tests and checked against `SourceSinkOverlay` behavior. The two approaches can vary in what nodes they arbitrarily select to break into connected components with no tips, but beyond that they produce the same results.