### PR TITLE
VG::edit speedup

### DIFF
--- a/src/path.hpp
+++ b/src/path.hpp
@@ -205,10 +205,11 @@ public:
     void prepend_mapping(const string& name, const Mapping& m, bool warn_on_duplicates = false);
     void prepend_mapping(const string& name, id_t id, bool is_reverse, size_t length, size_t rank, bool warn_on_duplicates = false);
     size_t get_next_rank(const string& name);
-    void append(const Paths& p, bool warn_on_duplicates = false);
-    void append(const Graph& g, bool warn_on_duplicates = false);
-    void extend(const Paths& p, bool warn_on_duplicates = false);
-    void extend(const Path& p, bool warn_on_duplicates = false);
+    void append(const Paths& paths, bool warn_on_duplicates = false, bool rebuild_indexes = true);
+    void append(const Graph& g, bool warn_on_duplicates = false, bool rebuild_indexes = true);
+    void extend(const Paths& paths, bool warn_on_duplicates = false, bool rebuild_indexes = true);
+    void extend(const Path& p, bool warn_on_duplicates = false, bool rebuild_indexes = true);
+    void extend(const vector<Path> & paths, bool warn_on_duplicates = false, bool rebuild_indexes = true);
     void for_each(const function<void(const Path&)>& lambda);
     // Loop over the names of paths without actually extracting the Path objects.
     void for_each_name(const function<void(const string&)>& lambda);

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -752,9 +752,7 @@ int main_mod(int argc, char** argv) {
             }
         } else {
             // just add the path labels to the graph
-            for (auto& path : paths) {
-                graph->paths.extend(path);
-            }
+            graph->paths.extend(paths);
         }
     }
 

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -2670,7 +2670,7 @@ void VG::extend(const Graph& graph, bool warn_on_duplicates) {
         }
     }
     // Append the path mappings from this graph, but don't sort by rank
-    paths.append(graph, warn_on_duplicates);
+    paths.append(graph, warn_on_duplicates, false);
 }
 
 // extend this graph by g, connecting the tails of this graph to the heads of the other
@@ -4713,8 +4713,8 @@ vector<Translation> VG::edit(vector<Path>& paths_to_add, bool save_paths, bool u
         Path added = add_nodes_and_edges(path, node_translation, added_seqs, added_nodes, orig_node_sizes);
         
         if (save_paths) {
-            // Add this path to the graph's paths object
-            paths.extend(added);
+            // Add this path to the graph's paths object without rebuilding path ranks, aux mapping, etc.
+            paths.extend(added, false, false);
         }
         
         if (update_paths) {


### PR DESCRIPTION
Changed VG::edit so that paths indexes are only rebuild after all paths have been added. This makes editing and adding paths using *vg mod -i* significantly faster. 