### PR TITLE
Fix VCF misparsing when the reference is soft-masked

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1729,66 +1729,70 @@ namespace vg {
             // We need to decide if we want to use this variant. By default we will use all variants.
             bool variant_acceptable = true;
             
-            if (vvar->isSymbolicSV() && this->do_svs) {
-                // Canonicalize the variant and see if that disqualifies it.
-                // This also takes care of setting the variant's alt sequences.
-                variant_acceptable = vvar->canonicalize(reference, insertions, true);
- 
-                if (variant_acceptable) {
-                    // Worth checking for multiple alts.
-                    if (vvar->alt.size() > 1) {
-                        // We can't handle multiallelic SVs yet.
-                        #pragma omp critical (cerr)
-                        cerr << "warning:[vg::Constructor] Unsupported multiallelic SV being skipped: " << *vvar << endl;
-                        variant_acceptable = false;
-                    }
-                }
-                    
-                if (variant_acceptable) {
-                    // Worth checking for bounds problems.
-                    // We have seen VCFs where the variant positions are on GRCh38 but the END INFO tags are on GRCh37.
-                    // But for inserts the bounds will have the end right before the start, so we have to allow for those.
-                    auto bounds = get_symbolic_bounds(*vvar);
-                    if (bounds.second + 1 < bounds.first) {
-                        #pragma omp critical (cerr)
-                        cerr << "warning:[vg::Constructor] SV with end position " << bounds.second
-                            << " significantly before start " << bounds.first << " being skipped (check liftover?): "
-                            << *vvar << endl;
-                        variant_acceptable = false;
-                    }
-                }
-            }
+            if (vvar->isSymbolicSV()) {
+                // We have a symbolic not-all-filled-in alt.
+                // We need to be processed as a symbolic SV
             
-            for (string& alt : vvar->alt) {
-                // Validate each alt of the variant
-
-                if(!allATGCN(alt)) {
-                    // It may be a symbolic allele or something. Skip this variant.
-                    variant_acceptable = false;
-                    if (this->do_svs && vvar->isSymbolicSV() && vvar->canonicalizable()){
-                        // Only try to normalize SVs if we want to handle SVs,
-                        // the variant is symbolic (i.e. no ref/alts) and the variant
-                        // can be canonicalized (it has at least a type and a length)
-                        variant_acceptable = vvar->canonicalize(reference, insertions, true);
+                if (this->do_svs) {
+                    // We are actually going to try to handle this SV.
+                    
+                    // Canonicalize the variant and see if that disqualifies it.
+                    // This also takes care of setting the variant's alt sequences.
+                    variant_acceptable = vvar->canonicalize(reference, insertions, true);
+     
+                    if (variant_acceptable) {
+                        // Worth checking for multiple alts.
+                        if (vvar->alt.size() > 1) {
+                            // We can't handle multiallelic SVs yet.
+                            #pragma omp critical (cerr)
+                            cerr << "warning:[vg::Constructor] Unsupported multiallelic SV being skipped: " << *vvar << endl;
+                            variant_acceptable = false;
+                        }
                     }
-                    else{
-                        #pragma omp critical (cerr)
-                        {
-                            bool warn = true;
-                            if (!alt.empty() && alt[0] == '<' && alt[alt.size()-1] == '>') {
-                                if (symbolic_allele_warnings.find(alt) != symbolic_allele_warnings.end()) {
-                                    warn = false;
-                                } else {
-                                    symbolic_allele_warnings.insert(alt);
+                        
+                    if (variant_acceptable) {
+                        // Worth checking for bounds problems.
+                        // We have seen VCFs where the variant positions are on GRCh38 but the END INFO tags are on GRCh37.
+                        // But for inserts the bounds will have the end right before the start, so we have to allow for those.
+                        auto bounds = get_symbolic_bounds(*vvar);
+                        if (bounds.second + 1 < bounds.first) {
+                            #pragma omp critical (cerr)
+                            cerr << "warning:[vg::Constructor] SV with end position " << bounds.second
+                                << " significantly before start " << bounds.first << " being skipped (check liftover?): "
+                                << *vvar << endl;
+                            variant_acceptable = false;
+                        }
+                    }
+                } else {
+                    // SV handling is off.
+                    variant_acceptable = false;
+                    
+                    // Figure out exactly what to complain about.
+                    
+                    for (string& alt : vvar->alt) {
+                        // Validate each alt of the variant
+
+                        if(!allATGCN(alt)) {
+                            // This is our problem alt here.
+                            // Either it's a symbolic alt or it is somehow lower case or something.
+                            #pragma omp critical (cerr)
+                            {
+                                bool warn = true;
+                                if (!alt.empty() && alt[0] == '<' && alt[alt.size()-1] == '>') {
+                                    if (symbolic_allele_warnings.find(alt) != symbolic_allele_warnings.end()) {
+                                        warn = false;
+                                    } else {
+                                        symbolic_allele_warnings.insert(alt);
+                                    }
+                                }
+                                if (warn) {
+                                    cerr << "warning:[vg::Constructor] Unsupported variant allele \""
+                                        << alt << "\"; Skipping variant(s) " << *vvar <<" !" << endl;
                                 }
                             }
-                            if (warn) {
-                                cerr << "warning:[vg::Constructor] Unsupported variant allele \"" << alt << "\"; Skipping variant(s) " << *vvar <<" !" << endl;
-                            }
+                            break;
                         }
-                        break;
                     }
-                    
                 }
             }
 

--- a/src/unittest/constructor.cpp
+++ b/src/unittest/constructor.cpp
@@ -2147,6 +2147,68 @@ CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG
 
 }
 
+TEST_CASE( "Letita's SV inversions parse correctly" , "[constructor]") {
+
+    // Note the smart quotes
+
+    auto vcf_data = R"(##fileformat=VCFv4.2
+##INFO=<ID=END,Number=1,Type=Integer,Description=“End position of the variant described in this record”>
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description=“Type of structural variant”>
+##ALT=<ID=IV,Description=“Inversion”>
+#CHROM  POS     ID      REF ALT QUAL    FILTER  INFO
+x	10	SRR026655.22810753-B	N	<INV>	.	.	END=41;SVTYPE=INV)";
+
+    auto fasta_data = R"(>x
+CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG
+)";
+
+    // Build the graph
+    auto result = construct_test_graph(fasta_data, vcf_data, 10, true, false);
+    
+#ifdef debug
+    std::cerr << pb2json(result) << std::endl;
+#endif
+
+    // Inversions are like substitutions, so the POS base is included and inverted.
+
+    SECTION("nodes are as expected") {
+        // Look at each node
+
+        unordered_map<size_t, string> expected;
+        expected.insert({1, "CAAATAAGGC"});
+        expected.insert({2, "TTGGAAATTT"});
+        expected.insert({3, "TCTGGAGTTC"});
+        expected.insert({4, "TATTATATTC"});
+        expected.insert({5, "C"});
+        expected.insert({6, "AACTCTCTG"});
+
+        for (size_t i = 0; i < result.node_size(); i++) {
+            auto& node = result.node(i);
+            REQUIRE(node.sequence()==expected[node.id()]);
+        }
+    }
+    
+    SECTION("edges are as expected") {
+        unordered_set<tuple<id_t, bool, id_t, bool>> edges_wanted;
+        edges_wanted.emplace(1, false, 2, false);
+        edges_wanted.emplace(2, false, 3, false);
+        edges_wanted.emplace(3, false, 4, false);
+        edges_wanted.emplace(4, false, 5, false);
+        edges_wanted.emplace(5, false, 6, false);
+        edges_wanted.emplace(1, false, 5, true);
+        edges_wanted.emplace(2, true, 6, false);
+        
+        // We should have the right number of edges
+        REQUIRE(result.edge_size() == edges_wanted.size());
+        
+        for (auto& edge : result.edge()) {
+            // The edge should be expected
+            REQUIRE(edges_wanted.count(make_tuple(edge.from(), edge.from_start(), edge.to(), edge.to_end())));
+        }
+    }
+
+}
+
 
 TEST_CASE( "A shorter SV inversion is represented properly" , "[constructor]") {
 

--- a/src/unittest/constructor.cpp
+++ b/src/unittest/constructor.cpp
@@ -2147,7 +2147,7 @@ CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG
 
 }
 
-TEST_CASE( "Letita's SV inversions parse correctly" , "[constructor]") {
+TEST_CASE( "SV inversions with smart quotes and a lower-case reference parse correctly" , "[constructor]") {
 
     // Note the smart quotes
 
@@ -2159,7 +2159,7 @@ TEST_CASE( "Letita's SV inversions parse correctly" , "[constructor]") {
 x	10	SRR026655.22810753-B	N	<INV>	.	.	END=41;SVTYPE=INV)";
 
     auto fasta_data = R"(>x
-CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG
+caaataaggcttggaaattttctggagttctattatattccaactctctg
 )";
 
     // Build the graph


### PR DESCRIPTION
VCFlib has neglected to upper-case sequence that it pulls from the reference and demands be upper case. This uses a VCFlib that fixes that, and also now produces correct ref and alt sequences in the variant for inversions.

I've also fixed (and added some protection against) double canonicalization, which (while it ought to be idempotent) was a factor in the other bug; variants were being canonicalized, and then being canonicalized again when lower-case sequence was found in them. Now VCFlib should protect against double-canonicalization (because it's a waste of time and maybe means you made a mistake) and VG shouldn't try to do it anymore.