### PR TITLE
Allow defraying away all of a read's sequence, and filter the read if that happens

### DIFF
--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -347,24 +347,34 @@ bool ReadFilter::trim_ambiguous_end(xg::XG* index, Alignment& alignment, int k) 
     // OK we know the first mapping to drop. We need to work out the to_size,
     // including all softclips, from there to the end, so we know how much to
     // trim off of the sequence and quality.
-    size_t to_length = 0;
+    size_t to_length_to_remove = 0;
     for(size_t i = first_mapping_to_drop; i < alignment.path().mapping_size(); i++) {
         // Go through all the mappings
         auto& mapping = alignment.path().mapping(i);
         for(size_t j = 0; j < mapping.edit_size(); j++) {
             // Add up the to_length of all the edits
-            to_length += mapping.edit(j).to_length();
+            to_length_to_remove += mapping.edit(j).to_length();
         }
     }
     
+#ifdef debug
+    cerr << "Want to trim " << alignment.sequence().size() << " bp sequence and " << alignment.quality().size()
+        << " quality values to remove " << to_length_to_remove << endl;
+#endif
+        
+    // Make sure we have at least enough to trim.
+    // Note that we allow the entire alignment to be trimmed away!
+    assert(alignment.sequence().size() >= to_length_to_remove);
+    assert(alignment.quality().empty() || alignment.quality().size() >= to_length_to_remove);
+    // And that we made sence before trimming
+    assert(alignment.quality().empty() || alignment.quality().size() == alignment.sequence().size());
+   
     // Trim sequence
-    alignment.set_sequence(alignment.sequence().substr(0, alignment.sequence().size() - to_length));
+    alignment.set_sequence(alignment.sequence().substr(0, alignment.sequence().size() - to_length_to_remove));
     
     // Trim quality
     if(!alignment.quality().empty()) {
-        // If we have a quality, it always ought to have been the same length as the sequence.
-        assert(alignment.quality().size() > to_length);
-        alignment.set_quality(alignment.quality().substr(0, alignment.quality().size() - to_length));
+        alignment.set_quality(alignment.quality().substr(0, alignment.quality().size() - to_length_to_remove));
     }
     
     // Now we can discard the extra mappings
@@ -646,6 +656,11 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
     // we assume that every primary alignment has 0 or 1 secondary alignment
     // immediately following in the stream
     function<void(Alignment&)> lambda = [&](Alignment& aln) {
+#ifdef debug
+        cerr << "Encountered read named \"" << aln.name() << "\" with " << aln.sequence().size()
+            << " bp sequence and " << aln.quality().size() << " quality values" << endl;
+#endif
+    
         int tid = omp_get_thread_num();        
         Counts& counts = counts_vec[tid];
         double score = (double)aln.score();
@@ -792,6 +807,11 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
         if ((keep || verbose) && defray_length && trim_ambiguous_ends(xindex, aln, defray_length)) {
             ++counts.defray[co];
             // We keep these, because the alignments get modified.
+            // Unless the *entire* read gets trimmed
+            if (aln.sequence().size() == 0) {
+                keep = false;
+                ++counts.defray_all[co];
+            }
         }
         if ((keep || verbose) && downsample_probability != 1.0 && !sample_read(aln)) {
             ++counts.random[co];
@@ -841,6 +861,8 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
              << "Split Read Filter (secondary):     " << counts.split[1] << endl
              << "Repeat Ends Filter (primary):      " << counts.repeat[0] << endl
              << "Repeat Ends Filter (secondary):    " << counts.repeat[1] << endl
+             << "All Defrayed Filter (primary):     " << counts.defray_all[0] << endl
+             << "All Defrayed Filter (secondary):   " << counts.defray_all[1] << endl
              << "Min Quality Filter (primary):      " << counts.min_mapq[0] << endl
              << "Min Quality Filter (secondary):    " << counts.min_mapq[1] << endl
              << "Random Filter (primary):           " << counts.random[0] << endl

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -68,10 +68,12 @@ public:
         vector<size_t> split;
         vector<size_t> repeat;
         vector<size_t> defray;
+        vector<size_t> defray_all;
         vector<size_t> random;
         Counts() : read(2, 0), filtered(2, 0), wrong_name(2, 0), wrong_refpos(2, 0),
                    min_score(2, 0), max_overhang(2, 0), min_end_matches(2, 0),
-                   min_mapq(2, 0), split(2, 0), repeat(2, 0), defray(2, 0), random(2, 0) {}
+                   min_mapq(2, 0), split(2, 0), repeat(2, 0), defray(2, 0),
+                   defray_all(2, 0), random(2, 0) {}
         Counts& operator+=(const Counts& other) {
             for (int i = 0; i < 2; ++i) {
                 read[i] += other.read[i];
@@ -85,6 +87,7 @@ public:
                 split[i] += other.split[i];
                 repeat[i] += other.repeat[i];
                 defray[i] += other.defray[i];
+                defray_all[i] += other.defray_all[i];
                 random[i] += other.random[i];
             }
             return *this;


### PR DESCRIPTION
This should fix https://github.com/vgteam/toil-vg/issues/585

The problem is that (I think from the perspective of a deletion edit), all the actual matched bases in a read can be ambiguous (i.e. there's a different path through the graph starting at the same point onto which you could have placed the matches).

Previously in this case we would crash, because we would try to trim away all the bases in the read and hit an assert that was using a `>` to compare against the quality length.

I've changed our behavior so now we do in fact trim away all the actual matching bases in such a case, but then I made it so we also filter out the read if it has no sequence left in it after trimming. (An alignment of 0 bases of sequence to a deletion in the reference is not very convenient to work with or useful to keep around.)