### PR TITLE
Fix #1949 by implementing rare-variant-removing simplification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,16 +485,21 @@ $(OBJ_DIR)/version.o: $(SRC_DIR)/version.cpp $(SRC_DIR)/version.hpp $(INC_DIR)/v
 
 # Define a default rule for building objects from CPP files
 # Depend on the .d file so we rebuild if dependency info is missing/deleted
+# Make sure to touch the .o file after the compiler finishes so it is always newer than the .d file
 # Use static pattern rules so the dependency files will not be ignored if the output exists
 # See <https://stackoverflow.com/a/34983297>
 $(OBJ) $(OBJ_DIR)/main.o: $(OBJ_DIR)/%.o : $(SRC_DIR)/%.cpp $(OBJ_DIR)/%.d $(DEPS)
 	. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(FILTER)
+	@touch $@
 $(ALGORITHMS_OBJ): $(ALGORITHMS_OBJ_DIR)/%.o : $(ALGORITHMS_SRC_DIR)/%.cpp $(ALGORITHMS_OBJ_DIR)/%.d $(DEPS)
 	. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(FILTER)
+	@touch $@
 $(SUBCOMMAND_OBJ): $(SUBCOMMAND_OBJ_DIR)/%.o : $(SUBCOMMAND_SRC_DIR)/%.cpp $(SUBCOMMAND_OBJ_DIR)/%.d $(DEPS)
 	. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(FILTER)
+	@touch $@
 $(UNITTEST_OBJ): $(UNITTEST_OBJ_DIR)/%.o : $(UNITTEST_SRC_DIR)/%.cpp $(UNITTEST_OBJ_DIR)/%.d $(DEPS)
 	. ./source_me.sh && $(CXX) $(CXXFLAGS) -c -o $@ $< $(LD_INCLUDE_FLAGS) $(FILTER)
+	@touch $@
         
 # Protobuf stuff builds into its same directory
 $(CPP_DIR)/%.o : $(CPP_DIR)/%.cc $(DEPS)

--- a/src/crash.hpp
+++ b/src/crash.hpp
@@ -14,8 +14,6 @@
 
 namespace vg {
 
-using namespace std;
-
 /// Main should call this to turn on our stack tracing support.
 void enable_crash_handling();
 

--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -84,10 +84,12 @@ void PathHandleGraph::for_each_occurrence_in_path(const path_handle_t& path, con
     
     // Otherwise the path is nonempty so it is safe to try and grab a first occurrence
     auto here = get_first_occurrence(path);
+    auto last = get_last_occurrence(path);
     // Run for the first occurrence
     iteratee(here);
-    while (has_next_occurrence(here)) {
+    while (here != last) {
         // Run for all subsequent occurrences on the path
+        // TODO: This loop doesn't work with has_next_occurrence because VG's is broken!
         here = get_next_occurrence(here);
         iteratee(here);
     }

--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -73,12 +73,20 @@ handle_t HandleGraph::traverse_edge_handle(const edge_t& edge, const handle_t& l
 bool PathHandleGraph::is_empty(const path_handle_t& path_handle) const {
     // By default, we can answer emptiness queries with the length query.
     // But some implementations may have an expensive length query and a cheaper emptiness one
-    return get_occurrence_count(path_handle) > 0;
+    return get_occurrence_count(path_handle) == 0;
 }
 
 void PathHandleGraph::for_each_occurrence_in_path(const path_handle_t& path, const function<void(const occurrence_handle_t&)>& iteratee) const {
+    
+#ifdef debug
+    cerr << "Go over occurrences in path " << get_path_name(path) << " with " <<  get_occurrence_count(path) << " occurrences in it" << endl;
+#endif
+
     if (is_empty(path)) {
         // Nothing to do!
+#ifdef debug
+        cerr << "Path is empty!" << endl;
+#endif
         return;
     }
     

--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -92,12 +92,10 @@ void PathHandleGraph::for_each_occurrence_in_path(const path_handle_t& path, con
     
     // Otherwise the path is nonempty so it is safe to try and grab a first occurrence
     auto here = get_first_occurrence(path);
-    auto last = get_last_occurrence(path);
     // Run for the first occurrence
     iteratee(here);
-    while (here != last) {
+    while (has_next_occurrence(here)) {
         // Run for all subsequent occurrences on the path
-        // TODO: This loop doesn't work with has_next_occurrence because VG's is broken!
         here = get_next_occurrence(here);
         iteratee(here);
     }

--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -70,6 +70,29 @@ handle_t HandleGraph::traverse_edge_handle(const edge_t& edge, const handle_t& l
     }
 }
 
+bool PathHandleGraph::is_empty(const path_handle_t& path_handle) const {
+    // By default, we can answer emptiness queries with the length query.
+    // But some implementations may have an expensive length query and a cheaper emptiness one
+    return get_occurrence_count(path_handle) > 0;
+}
+
+void PathHandleGraph::for_each_occurrence_in_path(const path_handle_t& path, const function<void(const occurrence_handle_t&)>& iteratee) const {
+    if (is_empty(path)) {
+        // Nothing to do!
+        return;
+    }
+    
+    // Otherwise the path is nonempty so it is safe to try and grab a first occurrence
+    auto here = get_first_occurrence(path);
+    // Run for the first occurrence
+    iteratee(here);
+    while (has_next_occurrence(here)) {
+        // Run for all subsequent occurrences on the path
+        here = get_next_occurrence(here);
+        iteratee(here);
+    }
+}
+
 }
 
 

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -109,7 +109,8 @@ struct wang_hash<handle_t> {
         return wang_hash<std::int64_t>()(as_integer(handle));
     }
 };
-    
+
+/// A path handle is an opaque reference to a named path in a graph.
 struct path_handle_t {
     char data[sizeof(int64_t)];
 };
@@ -144,6 +145,8 @@ inline bool operator!=(const path_handle_t& a, const path_handle_t& b) {
     return as_integer(a) != as_integer(b);
 }
 
+/// An occurrence handle is an opaque reference to an occurrence of an oriented
+/// node along a path in a graph
 struct occurrence_handle_t {
     char data[2 * sizeof(int64_t)];
 };
@@ -468,7 +471,36 @@ public:
         auto parts = divide_handle(handle, vector<size_t>{offset});
         return make_pair(parts.front(), parts.back());
     }
-}; 
+};
+
+/**
+ * This is the interface for a handle graph with embedded paths where the paths can be modified.
+ * Note that if the *graph* can also be modified, the implementation will also need to inherit from Mutable HandleGraph.
+ * TODO: This is a very limited interface at the moment. It will probably need to be extended.
+ */
+class MutablePathHandleGraph : virtual public PathHandleGraph {
+public:
+    
+    /**
+     * Destroy the given path. Invalidates handles to the path and its node occurrences.
+     */
+    virtual void destroy_path(const path_handle_t& path) = 0;
+
+    /**
+     * Create a path with the given name. The caller must ensure that no path
+     * with the given name exists already, or the behavior is undefined.
+     * Returns a handle to the created empty path. Handles to other paths must
+     * remain valid.
+     */
+    virtual path_handle_t create_path_handle(const string& name) = 0;
+    
+    /**
+     * Append a visit to a node to the given path. Returns a handle to the new
+     * final occurrence on the path which is appended. Handles to prior
+     * occurrences on the path, and to other paths, must remain valid.
+     */
+    virtual occurrence_handle_t append_occurrence(const path_handle_t& path, const handle_t& to_append) = 0;
+};
 
 }
 

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -213,7 +213,9 @@ public:
     ////////////////////////////////////////////////////////////////////////////
     // Interface that needs to be implemented
     ////////////////////////////////////////////////////////////////////////////
-    
+   
+    // TODO: Method to check if a node exists by ID?
+   
     /// Look up the handle for the node with the given ID in the given orientation
     virtual handle_t get_handle(const id_t& node_id, bool is_reverse = false) const = 0;
     
@@ -355,7 +357,11 @@ public:
     // Path handle interface that needs to be implemented
     ////////////////////////////////////////////////////////////////////////////
     
-    /// Look up the path handle for the given path name
+    /// Determine if a path name exists and is legal to get a path handle for.
+    virtual bool has_path(const string& path_name) const = 0;
+    
+    /// Look up the path handle for the given path name.
+    /// The path with that name must exist.
     virtual path_handle_t get_path_handle(const string& path_name) const = 0;
     
     /// Look up the name of a path from a handle to it

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -50,6 +50,10 @@ void mapping_t::set_is_reverse(bool is_rev) {
     traversal = abs(traversal) * (is_rev ? -1 : 1);
 }
 
+ostream& operator<<(ostream& out, mapping_t mapping) {
+    return out << mapping.node_id() << " " << (mapping.is_reverse() ? "rev" : "fwd");
+}
+
 Paths::Paths(void) {
     max_path_id = 0;
     // noop

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -124,7 +124,7 @@ void Paths::for_each(const function<void(const Path&)>& lambda) {
     }
 }
 
-void Paths::for_each_name(const function<void(const string&)>& lambda) {
+void Paths::for_each_name(const function<void(const string&)>& lambda) const {
     for (auto& p : _paths) {
         const string& name = p.first;
         lambda(name);
@@ -294,9 +294,11 @@ void Paths::append_mapping(const string& name, const mapping_t& m, bool warn_on_
     }
 }
 
-int64_t Paths::get_path_id(const string& name) {
+int64_t Paths::get_path_id(const string& name) const {
     auto f = name_to_id.find(name);
     if (f == name_to_id.end()) {
+        // Assign an ID.
+        // These members are mutable.
         ++max_path_id;
         name_to_id[name] = max_path_id;
         id_to_name[max_path_id] = name;
@@ -304,7 +306,7 @@ int64_t Paths::get_path_id(const string& name) {
     return name_to_id[name];
 }
 
-const string& Paths::get_path_name(int64_t id) {
+const string& Paths::get_path_name(int64_t id) const {
     return id_to_name[id];
 }
 
@@ -421,7 +423,7 @@ pair<mapping_t*, mapping_t*> Paths::replace_mapping(mapping_t* m, pair<mapping_t
     }
 }
 
-bool Paths::has_path(const string& name) {
+bool Paths::has_path(const string& name) const {
     return _paths.find(name) != _paths.end();
 }
 

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -75,11 +75,19 @@ public:
 
     // This maps from path name to the list of Mappings for that path.
     map<string, list<mapping_t> > _paths;
-    int64_t max_path_id;
-    map<string, int64_t> name_to_id;
-    int64_t get_path_id(const string& name);
-    map<int64_t, string> id_to_name;
-    const string& get_path_name(int64_t id);
+
+private:
+    // These need to be private because path names are lazily assigned IDs by the accessors
+    // They also need to be mutable because we want our accessors to treat our object as logical const
+    mutable int64_t max_path_id;
+    mutable map<string, int64_t> name_to_id;
+    mutable map<int64_t, string> id_to_name;
+public:
+    /// Get the lazily assigned numeric ID for a path, by name.
+    int64_t get_path_id(const string& name) const;
+    /// Get the name of a path, by numeric ID.
+    const string& get_path_name(int64_t id) const;
+    
     // This maps from mapping_t* pointer to its iterator in its list of Mappings
     // for its path and the id of the path.
     // The list in question is stored above in _paths.
@@ -133,7 +141,7 @@ public:
     void remove_path(const string& name);
     void keep_paths(const set<string>& name);
     void remove_node(id_t id);
-    bool has_path(const string& name);
+    bool has_path(const string& name) const;
     void to_json(ostream& out);
     list<mapping_t>& get_path(const string& name);
     list<mapping_t>& get_create_path(const string& name);
@@ -212,7 +220,7 @@ public:
     void extend(const vector<Path> & paths, bool warn_on_duplicates = false, bool rebuild_indexes = true);
     void for_each(const function<void(const Path&)>& lambda);
     // Loop over the names of paths without actually extracting the Path objects.
-    void for_each_name(const function<void(const string&)>& lambda);
+    void for_each_name(const function<void(const string&)>& lambda) const;
     void for_each_stream(istream& in, const function<void(Path&)>& lambda);
     void increment_node_ids(id_t inc);
     // Replace the node IDs used as keys with those used as values.

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -37,6 +37,9 @@ public:
     void set_is_reverse(bool is_rev);
 };
 
+/// Allow a mapping_t to be printed, for debugging purposes
+ostream& operator<<(ostream& out, mapping_t mapping);
+
 class Paths {
 public:
 

--- a/src/preflight.hpp
+++ b/src/preflight.hpp
@@ -8,8 +8,6 @@
 
 namespace vg {
 
-using namespace std;
-
 /// Run a preflight check to make sure that the system is usable for this build of vg.
 /// Aborts with a helpful message if this is not the case.
 /// We make sure to build it for a lowest-common-denominator architecture.

--- a/src/rare_variant_simplifier.cpp
+++ b/src/rare_variant_simplifier.cpp
@@ -9,7 +9,19 @@ RareVariantSimplifier::RareVariantSimplifier(VG& graph, VcfBuffer& variant_sourc
 }
 
 void RareVariantSimplifier::simplify() {
+    // This holds the IDs of all the nodes we want to keep around
+    unordered_set<id_t> to_keep;
+
+    // Mark the entire reference path(s) as to-keep
     
+
+    // For each variant
+
+    // If it is sufficiently common, mark all its alt path nodes as to-keep
+
+    // Otherwise delete all its alt paths and als its ref path
+
+    // After going through all the variants, delete all nodes that aren't to-keep
 }
 
 }

--- a/src/rare_variant_simplifier.cpp
+++ b/src/rare_variant_simplifier.cpp
@@ -4,24 +4,140 @@ namespace vg {
 
 using namespace std;
 
-RareVariantSimplifier::RareVariantSimplifier(VG& graph, VcfBuffer& variant_source) : Progressive(), graph(graph), variant_source(variant_source) {
+RareVariantSimplifier::RareVariantSimplifier(MutablePathMutableHandleGraph& graph, VcfBuffer& variant_source) : Progressive(), graph(graph), variant_source(variant_source) {
     // Nothing to do!
+}
+
+/// Return true if the given path name is a variant ref or alt allele alt path
+bool is_alt_path(const string& name) {
+    // See <https://stackoverflow.com/a/40441240>; we have no startswith, but we have rfind at pos <= 0.
+    return name.rfind("_alt_", 0) == 0;
 }
 
 void RareVariantSimplifier::simplify() {
     // This holds the IDs of all the nodes we want to keep around
     unordered_set<id_t> to_keep;
 
-    // Mark the entire reference path(s) as to-keep
+    graph.for_each_path_handle([&](const path_handle_t& path) {
+        // For each path
+
+        if (!is_alt_path(graph.get_path_name(path))) {
+            // If it isn't an alt path, we want to trace it
+
+            graph.for_each_occurrence_in_path(path, [&](const occurrence_handle_t& occurrence) {
+                // For each occurrence from start to end
+                // Put the ID of the node we are visiting in the to-keep set
+                to_keep.insert(graph.get_id(graph.get_occurrence(occurrence)));
+            });
+        }
+    });
+
+    variant_source.fill_buffer();
+    while(variant_source.get() != nullptr) {
+        // For each variant
+        auto* variant = variant_source.get();
+
+        // Determine the total frequency of alt alleles of this variant.
+        // Sum that AF values if they exist, and sum the AC and AN values and divide otherwise.
+        double frequency = 0;
+        
+        // TODO: We will use getInfoValueFloat from vcflib, but that API
+        // doesn't have support for sniffing the existence of fields, so we
+        // have to grab stuff manually too.
+
+        const map<string, vector<string> >& info = variant->info;
+
+        // Count the AF, AC, and AN values
+        size_t af_count = info.count("AF") ? info.at("AF").size() : 0;
+        size_t ac_count = info.count("AC") ? info.at("AC").size() : 0;
+        size_t an_count = info.count("AN") ? info.at("AN").size() : 0;
+
+        if (af_count == 0 && (ac_count == 0 || an_count == 0)) {
+            cerr << "error[vg::RareVariantSimplifier]: variant at " << variant->sequenceName << ":"
+                << variant->position << " is missing sufficient AF, AC, and/or AN INFO tags to compute frequency" << endl;
+            exit(1);
+        }
+
+        if (af_count >= ac_count && af_count >= an_count) {
+            // AF is the best tag to use
+            for (size_t i = 0; i < af_count; i++) {
+                frequency += variant->getInfoValueFloat("AF", i);
+            }
+        } else {
+            // We have to use AC and AN
+
+            if (ac_count != an_count) {
+                cerr << "error[vg::RareVariantSimplifier]: variant at " << variant->sequenceName << ":"
+                    << variant->position << " has " << ac_count << " AC values but " << an_count << " AN values. "
+                    << "Can't compute frequency!" << endl;
+                exit(1);
+            }
+
+            size_t ac_total = 0;
+            size_t an_total = 0;
+
+            for (size_t i = 0; i < ac_count; i++) {
+                // Sum up the AC and AN values.
+                // TODO: vcflib has no way to get an int except as a float.
+                ac_total += (size_t) variant->getInfoValueFloat("AC", i);
+                an_total += (size_t) variant->getInfoValueFloat("AN", i);
+            }
+
+            if (an_total == 0) {
+                // There are no calls so we can't compute a frequency
+                cerr << "error[vg::RareVariantSimplifier]: variant at " << variant->sequenceName << ":"
+                    << variant->position << " has total AN of 0."
+                    << "Can't compute frequency!" << endl;
+                exit(1);
+            }
+
+            // Compute the frequency
+            frequency = (double) ac_total / (double) an_total;
+        }
+
+        // Work out the variant's alt path names, to either trace or destroy
+        vector<string> variant_alt_paths;
+
+        // TODO: this should be factored out of here, construction, and GBWT generation into some central place.
+        string var_name = make_variant_id(*variant);
+        variant_alt_paths.push_back("_alt_" + var_name + "_0");
+        for (size_t alt_index = 1; alt_index < variant->alleles.size(); alt_index++) {
+            variant_alt_paths.push_back("_alt_" + var_name + "_" + to_string(alt_index));
+        }
+
+        if (frequency >= this->min_frequency_to_keep) {
+            // If it is sufficiently common, mark all its alt path nodes as to-keep
+            for (auto& path_name : variant_alt_paths) {
+                // For each alt path
+                path_handle_t path = graph.get_path_handle(path_name);
+
+                graph.for_each_occurrence_in_path(path, [&](const occurrence_handle_t& occurrence) {
+                    // For each occurrence from start to end
+                    // Put the ID of the node we are visiting in the to-keep set
+                    to_keep.insert(graph.get_id(graph.get_occurrence(occurrence)));
+                });
+            }
+        } else {
+            // Otherwise delete all its alt paths and also its ref path
+            for (auto& path_name : variant_alt_paths) {
+                // For each alt path
+                path_handle_t path = graph.get_path_handle(path_name);
+
+                // Destroy it
+                graph.destroy_path(path);
+
+            }
+
+            // The nodes will get destroyed if nothing else sufficiently frequent visited them.
+        }
+    }
     
-
-    // For each variant
-
-    // If it is sufficiently common, mark all its alt path nodes as to-keep
-
-    // Otherwise delete all its alt paths and als its ref path
-
-    // After going through all the variants, delete all nodes that aren't to-keep
+    graph.for_each_handle([&](const handle_t& handle) {
+        // After going through all the variants, delete all nodes that aren't to-keep
+        if (!to_keep.count(graph.get_id(handle))) {
+            graph.destroy_handle(handle);
+        }
+    });
 }
 
 }

--- a/src/rare_variant_simplifier.cpp
+++ b/src/rare_variant_simplifier.cpp
@@ -143,6 +143,11 @@ void RareVariantSimplifier::simplify() {
             // If it is sufficiently common, mark all its alt path nodes as to-keep
             for (auto& path_name : variant_alt_paths) {
                 // For each alt path
+                if (!graph.has_path(path_name)) {
+                    // Skip those that do not exist
+                    continue;
+                }
+                
                 path_handle_t path = graph.get_path_handle(path_name);
 
                 graph.for_each_occurrence_in_path(path, [&](const occurrence_handle_t& occurrence) {
@@ -154,6 +159,11 @@ void RareVariantSimplifier::simplify() {
         } else {
             // Otherwise delete all its alt paths and also its ref path
             for (auto& path_name : variant_alt_paths) {
+                if (!graph.has_path(path_name)) {
+                    // This path doesn't exist at all, so skip it
+                    continue;
+                }
+                
                 // For each alt path
                 path_handle_t path = graph.get_path_handle(path_name);
 
@@ -164,6 +174,10 @@ void RareVariantSimplifier::simplify() {
 
             // The nodes will get destroyed if nothing else sufficiently frequent visited them.
         }
+
+        // Load the next variant
+        variant_source.handle_buffer();
+        variant_source.fill_buffer();
     }
     
     graph.for_each_handle([&](const handle_t& handle) {

--- a/src/rare_variant_simplifier.cpp
+++ b/src/rare_variant_simplifier.cpp
@@ -37,10 +37,6 @@ void RareVariantSimplifier::simplify() {
         // For each variant
         auto* variant = variant_source.get();
 
-        // Determine the total frequency of alt alleles of this variant.
-        // Sum that AF values if they exist, and sum the AC and AN values and divide otherwise.
-        double frequency = 0;
-        
         // TODO: We will use getInfoValueFloat from vcflib, but that API
         // doesn't have support for sniffing the existence of fields, so we
         // have to grab stuff manually too.
@@ -52,48 +48,86 @@ void RareVariantSimplifier::simplify() {
         size_t ac_count = info.count("AC") ? info.at("AC").size() : 0;
         size_t an_count = info.count("AN") ? info.at("AN").size() : 0;
 
-        if (af_count == 0 && (ac_count == 0 || an_count == 0)) {
-            cerr << "error[vg::RareVariantSimplifier]: variant at " << variant->sequenceName << ":"
-                << variant->position << " is missing sufficient AF, AC, and/or AN INFO tags to compute frequency" << endl;
-            exit(1);
-        }
+        // Default to keeping this variant
+        bool keep = true;
 
-        if (af_count >= ac_count && af_count >= an_count) {
-            // AF is the best tag to use
-            for (size_t i = 0; i < af_count; i++) {
-                frequency += variant->getInfoValueFloat("AF", i);
-            }
-        } else {
-            // We have to use AC and AN
+        if (keep && min_frequency_to_keep != 0) {
+            // A frequency condition is imposed, so we have to compute frequency
 
-            if (ac_count != an_count) {
+            // Determine the total frequency of alt alleles of this variant.
+            // Sum that AF values if they exist, and sum the AC and AN values and divide otherwise.
+            double frequency = 0;
+
+            if (af_count == 0 && (ac_count == 0 || an_count == 0)) {
+                // Bail out if any variant doesn't have a well-defined frequency
                 cerr << "error[vg::RareVariantSimplifier]: variant at " << variant->sequenceName << ":"
-                    << variant->position << " has " << ac_count << " AC values but " << an_count << " AN values. "
-                    << "Can't compute frequency!" << endl;
+                    << variant->position << " is missing sufficient AF, AC, and/or AN INFO tags to compute frequency" << endl;
                 exit(1);
             }
 
+            if (af_count >= ac_count && af_count >= an_count) {
+                // AF is the best tag to use
+                for (size_t i = 0; i < af_count; i++) {
+                    frequency += variant->getInfoValueFloat("AF", i);
+                }
+            } else {
+                // We have to use AC and AN
+
+                if (ac_count != an_count) {
+                    cerr << "error[vg::RareVariantSimplifier]: variant at " << variant->sequenceName << ":"
+                        << variant->position << " has " << ac_count << " AC values but " << an_count << " AN values. "
+                        << "Can't compute frequency!" << endl;
+                    exit(1);
+                }
+
+                size_t ac_total = 0;
+                size_t an_total = 0;
+
+                for (size_t i = 0; i < ac_count; i++) {
+                    // Sum up the AC and AN values.
+                    // TODO: vcflib has no way to get an int except as a float.
+                    ac_total += (size_t) variant->getInfoValueFloat("AC", i);
+                    an_total += (size_t) variant->getInfoValueFloat("AN", i);
+                }
+
+                if (an_total == 0) {
+                    // There are no calls so we can't compute a frequency
+                    cerr << "error[vg::RareVariantSimplifier]: variant at " << variant->sequenceName << ":"
+                        << variant->position << " has total AN of 0."
+                        << "Can't compute frequency!" << endl;
+                    exit(1);
+                }
+
+                // Compute the frequency
+                frequency = (double) ac_total / (double) an_total;
+            }
+
+            // Keep only if frequency is sufficiently high
+            keep = keep && (frequency >= min_frequency_to_keep);
+        }
+
+        if (keep && min_count_to_keep != 0) {
+            // A count condition is imposed, so we need to check the raw count.
+
+            if (ac_count == 0) {
+                // If we have no AC info we can't do this threshold
+                cerr << "error[vg::RareVariantSimplifier]: variant at " << variant->sequenceName << ":"
+                    << variant->position << " has no AC INFO tag; can't apply count threshold." << endl;
+                exit(1);
+            }
+            
+            // Sum up the AC tags.
+            // TODO: if using both conditions we do this loop twice!
             size_t ac_total = 0;
-            size_t an_total = 0;
-
             for (size_t i = 0; i < ac_count; i++) {
-                // Sum up the AC and AN values.
-                // TODO: vcflib has no way to get an int except as a float.
                 ac_total += (size_t) variant->getInfoValueFloat("AC", i);
-                an_total += (size_t) variant->getInfoValueFloat("AN", i);
             }
 
-            if (an_total == 0) {
-                // There are no calls so we can't compute a frequency
-                cerr << "error[vg::RareVariantSimplifier]: variant at " << variant->sequenceName << ":"
-                    << variant->position << " has total AN of 0."
-                    << "Can't compute frequency!" << endl;
-                exit(1);
-            }
-
-            // Compute the frequency
-            frequency = (double) ac_total / (double) an_total;
+            // Keep the variant if it has a sufficient count
+            keep = keep && (ac_total >= min_count_to_keep);
         }
+
+        // Now we know if we are keeping the variant or not
 
         // Work out the variant's alt path names, to either trace or destroy
         vector<string> variant_alt_paths;
@@ -105,7 +139,7 @@ void RareVariantSimplifier::simplify() {
             variant_alt_paths.push_back("_alt_" + var_name + "_" + to_string(alt_index));
         }
 
-        if (frequency >= this->min_frequency_to_keep) {
+        if (keep) {
             // If it is sufficiently common, mark all its alt path nodes as to-keep
             for (auto& path_name : variant_alt_paths) {
                 // For each alt path

--- a/src/rare_variant_simplifier.cpp
+++ b/src/rare_variant_simplifier.cpp
@@ -1,0 +1,15 @@
+#include "rare_variant_simplifier.hpp"
+
+namespace vg {
+
+using namespace std;
+
+RareVariantSimplifier::RareVariantSimplifier(VG& graph, VcfBuffer& variant_source) : Progressive(), graph(graph), variant_source(variant_source) {
+    // Nothing to do!
+}
+
+void RareVariantSimplifier::simplify() {
+    
+}
+
+}

--- a/src/rare_variant_simplifier.hpp
+++ b/src/rare_variant_simplifier.hpp
@@ -1,0 +1,43 @@
+#ifndef VG_RARE_VARIANT_SIMPLIFIER_HPP_INCLUDED
+#define VG_RARE_VARIANT_SIMPLIFIER_HPP_INCLUDED
+
+
+#include "progressive.hpp"
+#include "vg.hpp"
+#include "vcf_buffer.hpp"
+
+
+/** \file 
+ * Provides a class for simplifying graphs by removing rare variants.
+ */
+ 
+namespace vg {
+
+using namespace std;
+
+/**
+ * A class that can be used to simplify a graph, by removing rare variants' alt
+ * and ref paths and their exclusively-used nodes.
+ */
+class RareVariantSimplifier : public Progressive {
+
+public:
+    /// Make a simplifier that simplifies the given graph in place, using
+    /// variants read using the given buffer.
+    RareVariantSimplifier(VG& graph, VcfBuffer& variant_source);
+    
+    /// Simplify the graph.
+    void simplify();
+     
+protected:
+
+    /// Holds a reference to the graph we're simplifying
+    VG& graph;
+
+    /// Holds a reference to the variant buffer we are getting avriants from.
+    VcfBuffer& variant_source;
+};
+
+}
+
+#endif

--- a/src/rare_variant_simplifier.hpp
+++ b/src/rare_variant_simplifier.hpp
@@ -24,15 +24,18 @@ class RareVariantSimplifier : public Progressive {
 public:
     /// Make a simplifier that simplifies the given graph in place, using
     /// variants read using the given buffer.
-    RareVariantSimplifier(VG& graph, VcfBuffer& variant_source);
+    RareVariantSimplifier(MutablePathMutableHandleGraph& graph, VcfBuffer& variant_source);
     
     /// Simplify the graph.
     void simplify();
+
+    /// Keep variants at this total alt allele frequency or higher
+    double min_frequency_to_keep = 0.001;
      
 protected:
 
     /// Holds a reference to the graph we're simplifying
-    VG& graph;
+    MutablePathMutableHandleGraph& graph;
 
     /// Holds a reference to the variant buffer we are getting avriants from.
     VcfBuffer& variant_source;

--- a/src/rare_variant_simplifier.hpp
+++ b/src/rare_variant_simplifier.hpp
@@ -29,8 +29,12 @@ public:
     /// Simplify the graph.
     void simplify();
 
-    /// Keep variants at this total alt allele frequency or higher
-    double min_frequency_to_keep = 0.001;
+    /// Keep variants at this total alt allele frequency or higher.
+    double min_frequency_to_keep = 0;
+
+    /// Keep variants with this total alt allele count or higher.
+    /// AND'd with the frequency condition.
+    size_t min_count_to_keep = 0;
      
 protected:
 

--- a/src/small_snarl_simplifier.cpp
+++ b/src/small_snarl_simplifier.cpp
@@ -1,17 +1,17 @@
-#include "simplifier.hpp"
+#include "small_snarl_simplifier.hpp"
 
 namespace vg {
 
 using namespace std;
 
-Simplifier::Simplifier(VG& graph) : Progressive(), graph(graph), traversal_finder(graph) {
+SmallSnarlSimplifier::SmallSnarlSimplifier(VG& graph) : Progressive(), graph(graph), traversal_finder(graph) {
     
     // create a SnarlManager using Cactus
     CactusSnarlFinder site_finder(graph);
     site_manager = site_finder.find_snarls();
 }
 
-pair<size_t, size_t> Simplifier::simplify_once(size_t iteration) {
+pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
 
     // Set up the deleted node and edge counts
     pair<size_t, size_t> to_return {0, 0};
@@ -20,7 +20,7 @@ pair<size_t, size_t> Simplifier::simplify_once(size_t iteration) {
 
     if(!graph.is_valid(true, true, true, true)) {
         // Make sure the graph is valid and not missing nodes or edges
-        cerr << "error:[vg::Simplifier] Invalid graph on iteration " << iteration << endl;
+        cerr << "error:[vg::SmallSnarlSimplifier] Invalid graph on iteration " << iteration << endl;
         exit(1);
     }
 
@@ -421,7 +421,7 @@ pair<size_t, size_t> Simplifier::simplify_once(size_t iteration) {
                     
                     // Make sure we have an edge so we can traverse this node and then the node we're going to.
                     if(graph.get_edge(here_traversal, next_traversal) == nullptr) {
-                        cerr << "error:[vg::Simplifier] No edge " << here_traversal << " to " << next_traversal << endl;
+                        cerr << "error:[vg::SmallSnarlSimplifier] No edge " << here_traversal << " to " << next_traversal << endl;
                         exit(1);
                     }
                     
@@ -748,7 +748,7 @@ pair<size_t, size_t> Simplifier::simplify_once(size_t iteration) {
 
 }
 
-void Simplifier::simplify() {
+void SmallSnarlSimplifier::simplify() {
     for (size_t i = 0; i < max_iterations; i++) {
         // Try up to the max number of iterations
         auto deleted_elements = simplify_once(i);

--- a/src/small_snarl_simplifier.cpp
+++ b/src/small_snarl_simplifier.cpp
@@ -142,7 +142,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
 #ifdef debug
         cerr << "Found " << total_size << " bp leaf" << endl;
         for (auto* node : nodes) {
-            cerr << "\t" << node->id() << ": " << node->sequence() << endl;
+            cerr << "\t" << node << " = " << node->id() << ": " << node->sequence() << endl;
         }
 #endif
         
@@ -159,11 +159,20 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
         // Get the traversal out of the vector
         SnarlTraversal& traversal = traversals.front();
         
+#ifdef debug
+        cerr << "Chosen traversal has: " << traversal.visit_size() << " visits" << endl;
+#endif
+
         // Determine the length of the new traversal
         size_t new_site_length = 0;
         for (size_t i = 1; i < traversal.visit_size() - 1; i++) {
             // For every non-anchoring node
             const Visit& visit = traversal.visit(i);
+
+#ifdef debug
+            cerr << "Chosen traversal has: " << visit << endl;
+#endif
+
             // Total up the lengths of all the nodes that are newly visited.
             assert(visit.node_id());
             new_site_length += graph.get_node(visit.node_id())->sequence().size();
@@ -230,7 +239,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                         if (here->node_id() == leaf->start().node_id() &&
                             here->is_reverse() != (leaf->start().backward() != backward)) {
                             // We have encountered the start node with an incorrect orientation.
-                            cerr << "warning:[vg simplify] Path " << path_name
+                            cerr << "warning:[vg::SmallSnarlSimplifier] Path " << path_name
                                 << " doubles back through start of site "
                                 << to_node_traversal(leaf->start(), graph) << " - "
                                 << to_node_traversal(leaf->end(), graph) << "; skipping site!" << endl;
@@ -281,7 +290,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                         if (here->node_id() == leaf->end().node_id() &&
                             here->is_reverse() != (leaf->end().backward() != backward)) {
                             // We have encountered the end node with an incorrect orientation.
-                            cerr << "warning:[vg simplify] Path " << path_name
+                            cerr << "warning:[vg::SmallSnarlSimplifier] Path " << path_name
                                 << " doubles back through end of site "
                                 << to_node_traversal(leaf->start(), graph) << " - "
                                 << to_node_traversal(leaf->end(), graph) << "; dropping site!" << endl;
@@ -301,7 +310,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
             
             if (found_hairpin) {
                 // We found a hairpin, so we want to skip the site.
-                cerr << "warning:[vg simplify] Site " << to_node_traversal(leaf->start(), graph) << " - " << to_node_traversal(leaf->end(), graph) << " skipped due to hairpin path." << endl;
+                cerr << "warning:[vg::SmallSnarlSimplifier] Site " << to_node_traversal(leaf->start(), graph) << " - " << to_node_traversal(leaf->end(), graph) << " skipped due to hairpin path." << endl;
                 continue;
             }
             
@@ -344,7 +353,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                 mapping_t* end_mapping = nullptr;
                 
 #ifdef debug
-                cerr << "Scanning " << path_name << " from " << pb2json(*here)
+                cerr << "Scanning " << path_name << " from " << *here
                     << " for " << to_node_traversal(leaf->end(), graph) << " orientation " << backward << endl;
 #endif
                 
@@ -352,7 +361,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                     // Until we hit the start/end of the path or the mapping we want
                     
 #ifdef debug
-                    cerr << "\tat " << pb2json(*here) << endl;
+                    cerr << "\tat " << *here << endl;
 #endif
                     
                     if (here->node_id() == leaf->end().node_id() &&
@@ -376,7 +385,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                     if (here->node_id() == leaf->start().node_id() &&
                         here->is_reverse() != (leaf->start().backward() != backward)) {
                         // We have encountered the start node with an incorrect orientation.
-                        cerr << "warning:[vg simplify] Path " << path_name
+                        cerr << "warning:[vg::SmallSnarlSimplifier] Path " << path_name
                             << " doubles back through start of site "
                             << to_node_traversal(leaf->start(), graph) << " - "
                             << to_node_traversal(leaf->end(), graph) << "; dropping!" << endl;
@@ -386,11 +395,16 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                         break;
                     }
                     
-                    if (!nodes.count(graph.get_node(here->node_id()))) {
+                    if (here->node_id() != leaf->start().node_id() &&
+                        here->node_id() != leaf->end().node_id() && 
+                        !nodes.count(graph.get_node(here->node_id()))) {
+                        // We aren't the start, the end, or any internal contained node.
+                        // That's an error!
                         // We really should stay inside the site!
-                        cerr << "error:[vg simplify] Path " << path_name
+                        cerr << "error:[vg::SmallSnarlSimplifier] Path " << path_name
                             << " somehow escapes site " << to_node_traversal(leaf->start(), graph)
-                            << " - " << to_node_traversal(leaf->end(), graph) << endl;
+                            << " - " << to_node_traversal(leaf->end(), graph) << " and reaches non-contained node "
+                            << here->node_id() << " at address " << graph.get_node(here->node_id()) << endl;
                             
                         exit(1);
                     }
@@ -401,8 +415,12 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                         existing_mappings.push_back(here);
                     }
                     
-                    // Scan left along ther path if we found the site start backwards, and right if we found it forwards.
+                    // Scan left along the path if we found the site start backwards, and right if we found it forwards.
                     mapping_t* next = backward ? graph.paths.traverse_left(here) : graph.paths.traverse_right(here);
+
+#ifdef debug
+                    cerr << "Here is " << *here << " at " << here << " and next is " << *next << " at " << next << endl;
+#endif
                     
                     if (next == nullptr) {
                         // We hit the end of the path without finding the end of the site.
@@ -507,7 +525,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                         // mapping to the end of the site.
                         
 #ifdef debug
-                        cerr << path_name << ": Drop mapping " << pb2json(*mapping) << endl;
+                        cerr << path_name << " forward: Drop mapping " << *mapping << endl;
 #endif
                         
                         insert_position = graph.paths.remove_mapping(mapping);
@@ -526,11 +544,19 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                     assert(insert_position->node_id() == leaf->end().node_id());
                 }
                 
+#ifdef debug
+                cerr << "Chosen traversal has " << traversal.visit_size() << " visits" << endl;
+#endif
+
                 // Loop through the internal visits in the canonical
                 // traversal backwards along the path we are splicing. If
                 // it's a forward path this is just right to left, but if
                 // it's a reverse path it has to be left to right.
-                for (size_t i = 0; i < traversal.visit_size(); i++) {
+                for (size_t i = 1; i + 1 < traversal.visit_size(); i++) {
+                    // Don't visit the first or last node on the traversal
+                    // because they are the snarl start and end which we didn't
+                    // remove.
+
                     // Find the visit we need next, as a function of which
                     // way we need to insert this run of visits. Normally we
                     // go through the visits right to left, but when we have
@@ -551,7 +577,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                     new_mapping.length = node_seq_length;
                     
 #ifdef debug
-                    cerr << path_name << ": Add mapping " << pb2json(new_mapping) << endl;
+                    cerr << path_name << " backward: Add mapping " << new_mapping << endl;
 #endif
                     
                     // Insert the mapping in the path, moving right to left
@@ -606,7 +632,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                     if (here->node_id() == leaf->end().node_id() &&
                         here->is_reverse() != (leaf->end().backward() != backward)) {
                         // We have encountered the end node with an incorrect orientation.
-                        cerr << "warning:[vg simplify] Path " << path_name
+                        cerr << "warning:[vg::SmallSnarlSimplifier] Path " << path_name
                             << " doubles back through end of site "
                             << to_node_traversal(leaf->start(), graph) << " - "
                             << to_node_traversal(leaf->end(), graph) << "; dropping!" << endl;
@@ -653,8 +679,12 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
             // For each node and the next node (which won't be the end)
             
             const Visit visit = traversal.visit(i);
-            const Visit next = traversal.visit(i);
-            
+            const Visit next = traversal.visit(i+1);
+
+#ifdef debug
+            cerr << "Follow edge from " << visit << " to " << next << endl;
+#endif
+
             // Find the edge between them
             NodeTraversal here(graph.get_node(visit.node_id()), visit.backward());
             NodeTraversal next_traversal(graph.get_node(next.node_id()), next.backward());
@@ -664,20 +694,8 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
             // Remember we need it
             blessed_edges.insert(edge);
         }
-        
-        // Also get the edges from the boundary nodes into the traversal
-        if (traversal.visit_size() > 0) {
-            NodeTraversal first_visit = to_node_traversal(traversal.visit(0), graph);
-            NodeTraversal last_visit = to_node_traversal(traversal.visit(traversal.visit_size() - 1),
-                                                         graph);
-            blessed_edges.insert(graph.get_edge(to_node_traversal(leaf->start(), graph), first_visit));
-            blessed_edges.insert(graph.get_edge(last_visit, to_node_traversal(leaf->end(), graph)));
-        }
-        else {
-            // This is a deletion traversal, so get the edge from the start to end of the site
-            blessed_edges.insert(graph.get_edge(to_node_traversal(leaf->start(), graph),
-                                                to_node_traversal(leaf->end(), graph)));
-        }
+
+        // The traversal also touches the boundary nodes, so don't do anything special for them.
         
         for (auto* edge : edges) {
             if (!blessed_edges.count(edge)) {
@@ -727,7 +745,7 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
                 }
                 for (auto& path : paths_to_kill) {
                     graph.paths.remove_path(path);
-                    cerr << "warning:[vg simplify] Path " << path << " removed" << endl;
+                    cerr << "warning:[vg::SmallSnarlSimplifier] Path " << path << " removed" << endl;
                 }
 
                 graph.destroy_node(node);

--- a/src/small_snarl_simplifier.cpp
+++ b/src/small_snarl_simplifier.cpp
@@ -490,7 +490,9 @@ pair<size_t, size_t> SmallSnarlSimplifier::simplify_once(size_t iteration) {
 #endif
 
                 // Actually update any BED features
-                features.on_path_edit(path_name, variable_start, old_site_length, new_site_length);
+                if (features != nullptr) {
+                    features->on_path_edit(path_name, variable_start, old_site_length, new_site_length);
+                }
                 
                 // Where will we insert the new site traversal into the path?
                 list<mapping_t>::iterator insert_position;

--- a/src/small_snarl_simplifier.hpp
+++ b/src/small_snarl_simplifier.hpp
@@ -1,5 +1,5 @@
-#ifndef VG_SIMPLIFIER_HPP_INCLUDED
-#define VG_SIMPLIFIER_HPP_INCLUDED
+#ifndef VG_SMALL_SNARL_SIMPLIFIER_HPP_INCLUDED
+#define VG_SMALL_SNARL_SIMPLIFIER_HPP_INCLUDED
 
 
 #include "progressive.hpp"
@@ -26,11 +26,11 @@ using namespace std;
  * like features up to date. TODO: doesn't handle path start and end positions
  * within nodes.
  */
-class Simplifier : public Progressive {
+class SmallSnarlSimplifier : public Progressive {
 
 public:
     /// Make a simplifier that simplifies the given graph in place.
-    Simplifier(VG& graph);
+    SmallSnarlSimplifier(VG& graph);
     
     /// Simplify the graph by one step. Returns the number of nodes deleted and
     /// the number of edges deleted. Can be passed an iteration for its progress

--- a/src/small_snarl_simplifier.hpp
+++ b/src/small_snarl_simplifier.hpp
@@ -53,9 +53,11 @@ public:
     /// bubbles unsimplified?
     bool drop_hairpin_paths = false;
     
-    /// Stores the features in the graph, and gets updated as simplification
-    /// proceeds. The user should load the features in and pull them out.
-    FeatureSet features;
+    /// If the user points this to a FeatureSet, that FeatureSet will get its
+    /// features updated with changes to the graph as simplification proceeds.
+    /// The user should load the features in and pull them out.
+    /// TODO: Replace this with an on_path_edit event on this object that can be listened on.
+    FeatureSet* features = nullptr;
     
 protected:
 

--- a/src/subcommand/simplify_main.cpp
+++ b/src/subcommand/simplify_main.cpp
@@ -10,7 +10,7 @@
 #include "subcommand.hpp"
 
 #include "../vg.hpp"
-#include "../simplifier.hpp"
+#include "../small_snarl_simplifier.hpp"
 
 
 
@@ -123,10 +123,10 @@ int main_simplify(int argc, char** argv) {
     }
     
     {
-        // Make a Simplifier for the graph and copy over settings. Need sto be
+        // Make a SmallSnarlSimplifier for the graph and copy over settings. Needs to be
         // in a block so that the graph doesn't get deleted before the
         // simplifier goes out of scope.
-        Simplifier simplifier(*graph);
+        SmallSnarlSimplifier simplifier(*graph);
         simplifier.show_progress = show_progress;
         simplifier.max_iterations = max_iterations;
         simplifier.min_size = min_size;

--- a/src/subcommand/simplify_main.cpp
+++ b/src/subcommand/simplify_main.cpp
@@ -11,7 +11,7 @@
 
 #include "../vg.hpp"
 #include "../small_snarl_simplifier.hpp"
-
+#include "../rare_variant_simplifier.hpp"
 
 
 
@@ -21,13 +21,19 @@ using namespace vg::subcommand;
 
 void help_simplify(char** argv) {
     cerr << "usage: " << argv[0] << " simplify [options] old.vg >new.vg" << endl
-         << "options:" << endl
-         << "    -m, --min-size N       remove leaf sites with fewer than N bases involved (default: 10)" << endl
-         << "    -i, --max-iterations N perform up to N iterations of simplification (default: 10)" << endl
+         << "general options:" << endl
+         << "    -a, --algorithm NAME   simplify using the given algorithm (small, rare; default: small)" << endl
+         << "    -t, --threads N        use N threads to construct graph (defaults to numCPUs)" << endl
          << "    -p, --progress         show progress" << endl
          << "    -b, --bed-in           read in the given BED file in the cordinates of the original paths" << endl
          << "    -B, --bed-out          output transformed features in the coordinates of the new paths" << endl
-         << "    -t, --threads N        use N threads to construct graph (defaults to numCPUs)" << endl;
+         << "small snarl simplifier options:" << endl
+         << "    -m, --min-size N       remove leaf sites with fewer than N bases involved (default: 10)" << endl
+         << "    -i, --max-iterations N perform up to N iterations of simplification (default: 10)" << endl
+         << "rare variant simplifier options:" << endl
+         << "    -v, --vcf FILE         use the given VCF file to determine variant frequency (required)" << endl
+         << "    -f, --min-freq FLOAT   remove variants with total alt frequency under FLOAT (default: 0)" << endl
+         << "    -c, --min-count N      remove variants with total alt occurrence count under N (default: 0)" << endl;
 }
 
 int main_simplify(int argc, char** argv) {
@@ -37,32 +43,44 @@ int main_simplify(int argc, char** argv) {
         return 1;
     }
 
+    // What algorithm should we use for simplification ("small" or "rare").
+    string algorithm = "small";
 
-    // TODO: The simplifier needs the graph when we make it, so we can't store
-    // our settings in it directly.
-    size_t min_size = 10;
-    size_t max_iterations = 10;
+    // General options
     string bed_in_filename;
     string bed_out_filename;
     bool show_progress = false;
+
+    // For simplifying small variants
+    size_t min_size = 10;
+    size_t max_iterations = 10;
+
+    // For simplifying rare variants
+    string vcf_filename;
+    double min_frequency = 0;
+    size_t min_count = 0;
 
     int c;
     optind = 2; // force optind past command positional argument
     while (true) {
         static struct option long_options[] =
             {
-                {"min-size", required_argument, 0, 'm'},
-                {"max-iterations", required_argument, 0, 'i'},
+                {"algorithm", required_argument, 0, 'a'},
                 {"progress",  no_argument, 0, 'p'},
+                {"threads", required_argument, 0, 't'},
                 {"bed-in", required_argument, 0, 'b'},
                 {"bed-out", required_argument, 0, 'B'},
-                {"threads", required_argument, 0, 't'},
+                {"min-size", required_argument, 0, 'm'},
+                {"max-iterations", required_argument, 0, 'i'},
+                {"vcf", required_argument, 0, 'v'},
+                {"min-freq", required_argument, 0, 'f'},
+                {"min-count", required_argument, 0, 'c'},
                 {"help", no_argument, 0, 'h'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "m:i:pb:B:t:h?",
+        c = getopt_long (argc, argv, "a:pt:b:B:m:i:v:f:c:h?",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -72,16 +90,16 @@ int main_simplify(int argc, char** argv) {
         switch (c)
         {
 
-        case 'm':
-            min_size = parse<int>(optarg);
-            break;
-            
-        case 'i':
-            max_iterations = parse<int>(optarg);
+        case 'a':
+            algorithm = optarg;
             break;
 
         case 'p':
             show_progress = true;
+            break;
+
+        case 't':
+            omp_set_num_threads(parse<int>(optarg));
             break;
             
         case 'b':
@@ -92,8 +110,24 @@ int main_simplify(int argc, char** argv) {
             bed_out_filename = optarg;
             break;
 
-        case 't':
-            omp_set_num_threads(parse<int>(optarg));
+        case 'm':
+            min_size = parse<int>(optarg);
+            break;
+            
+        case 'i':
+            max_iterations = parse<int>(optarg);
+            break;
+
+        case 'v':
+            vcf_filename = optarg;
+            break;
+
+        case 'f':
+            min_frequency = parse<double>(optarg);
+            break;
+
+        case 'c':
+            min_count = parse<size_t>(optarg);
             break;
 
         case 'h':
@@ -108,55 +142,93 @@ int main_simplify(int argc, char** argv) {
 
         }
     }
-    
-    // TODO: move all this to a simplifier object
+
+    // Do preliminary options checks
+    if (!bed_out_filename.empty() && bed_in_filename.empty()) {
+        // Don't allow writing out a BED without reading one
+        cerr << "error[vg simplify]: Cannot output a bed (-B) unless a BED is read in first (-b)" << endl;
+        exit(1);
+    }
     
     // Load the graph
-    VG* graph;
+    unique_ptr<VG> graph;
     get_input_file(optind, argc, argv, [&](istream& in) {
-        graph = new VG(in, show_progress);
+        graph = unique_ptr<VG>(new VG(in, show_progress));
     });
     
     if (graph == nullptr) {
         cerr << "error:[vg simplify]: Could not load graph" << endl;
         exit(1);
     }
-    
-    {
-        // Make a SmallSnarlSimplifier for the graph and copy over settings. Needs to be
-        // in a block so that the graph doesn't get deleted before the
-        // simplifier goes out of scope.
+
+    // This will hold BED features if we are tracking those
+    unique_ptr<FeatureSet> features;
+    if (!bed_in_filename.empty()) {
+        // Go and ,oad up the BED features
+        get_input_file(bed_in_filename, [&](istream& bed_stream) {
+            features = unique_ptr<FeatureSet>(new FeatureSet());
+            features->load_bed(bed_stream);
+        });
+    }
+
+    if (algorithm == "small") {
+        if (!vcf_filename.empty()) {
+            cerr << "error[vg simplify]: A VCF file (-v) cannot be used with small snarl simplification" << endl;
+            exit(1);
+        }
+
+        // Make a SmallSnarlSimplifier for the graph and copy over settings.
         SmallSnarlSimplifier simplifier(*graph);
         simplifier.show_progress = show_progress;
         simplifier.max_iterations = max_iterations;
         simplifier.min_size = min_size;
-        
-        if (!bed_in_filename.empty()) {
-            // Load BED features
-            ifstream bed_stream(bed_in_filename.c_str());
-            simplifier.features.load_bed(bed_stream);
-        }
-        
+        simplifier.features = features.get();
+         
         // Do the simplification
         simplifier.simplify();
-        
-        // Serialize the graph
-        graph->serialize_to_ostream(std::cout);
-        
-        if (!bed_out_filename.empty()) {
-            // Save BED features
-            ofstream bed_stream(bed_out_filename.c_str());
-            simplifier.features.save_bed(bed_stream);
+    } else if (algorithm == "rare") {
+        // We are going to remove rare variants as noted in a VCF
+        if (vcf_filename.empty()) {
+            cerr << "error[vg simplify]: \"rare\" simplification algorithm requires a VCF (-v)" << endl;
+            exit(1);
         }
+
+        // Load the VCF
+        vcflib::VariantCallFile variant_file;
+        variant_file.parseSamples = false; // Major speedup if there are many samples.
+        variant_file.open(vcf_filename);
+        if (!variant_file.is_open()) {
+            cerr << "error:[vg simplify] could not open" << vcf_filename << endl;
+            exit(1);
+        }
+
+        // Buffer it
+        VcfBuffer buffer(&variant_file);
+
+        // Make a RareVariantSimplifier for the graph
+        RareVariantSimplifier simplifier(*graph, buffer);
+
+        // Set its settings
+        simplifier.min_frequency_to_keep = min_frequency;
+        simplifier.min_count_to_keep = min_count;
+
+        // Run it
+        simplifier.simplify();
+    } else {
+        cerr << "error[vg simplify]: Unknown algorithm \"" << algorithm << "\"; use \"small\" or \"rare\"." << endl;
+        exit(1);
+    }
+
+    // Serialize the graph
+    graph->serialize_to_ostream(std::cout);
         
+    if (!bed_out_filename.empty()) {
+        // Save BED features
+        assert(features.get() != nullptr);
+        ofstream bed_stream(bed_out_filename.c_str());
+        features->save_bed(bed_stream);
     }
     
-    delete graph;
-
-    // NB: If you worry about "still reachable but possibly lost" warnings in valgrind,
-    // this would free all the memory used by protobuf:
-    //ShutdownProtobufLibrary();
-
     return 0;
 }
 

--- a/src/unittest/handle.cpp
+++ b/src/unittest/handle.cpp
@@ -717,7 +717,31 @@ TEST_CASE("VG and XG path handle implementations are correct", "[handle][vg][xg]
                 check_occurrence(occurrence_handle, i);
                 occurrence_handle = graph.get_next_occurrence(occurrence_handle);
             }
-            
+
+            // iterate front to back with a while
+            {
+                occurrence_handle = graph.get_first_occurrence(path_handle);
+                int i = 0;
+                check_occurrence(occurrence_handle, i);
+                i++;
+                while(graph.has_next_occurrence(occurrence_handle)) {
+                    occurrence_handle = graph.get_next_occurrence(occurrence_handle);
+                    check_occurrence(occurrence_handle, i);
+                    i++;
+                }
+                REQUIRE(i == path.mapping_size());
+            }
+
+            // iterate front to back with the iteration function
+            {
+                int i = 0;
+                graph.for_each_occurrence_in_path(path_handle, [&i, &check_occurrence](const occurrence_handle_t& occurrence_handle) {
+                    check_occurrence(occurrence_handle, i);
+                    i++;
+                });
+                REQUIRE(i == path.mapping_size());
+            }
+
             // iterate back to front
             occurrence_handle = graph.get_last_occurrence(path_handle);
             for (int i = path.mapping_size() - 1; i >= 0; i--) {
@@ -737,6 +761,20 @@ TEST_CASE("VG and XG path handle implementations are correct", "[handle][vg][xg]
                 
                 check_occurrence(occurrence_handle, i);
                 occurrence_handle = graph.get_previous_occurrence(occurrence_handle);
+            }
+
+            // iterate back to front with a while
+            {
+                occurrence_handle = graph.get_last_occurrence(path_handle);
+                int i = path.mapping_size() - 1;
+                check_occurrence(occurrence_handle, i);
+                i--;
+                while(graph.has_previous_occurrence(occurrence_handle)) {
+                    occurrence_handle = graph.get_previous_occurrence(occurrence_handle);
+                    check_occurrence(occurrence_handle, i);
+                    i--;
+                }
+                REQUIRE(i == -1);
             }
         };
         

--- a/src/vcf_buffer.hpp
+++ b/src/vcf_buffer.hpp
@@ -22,16 +22,13 @@ using namespace std;
  * construction functions peek and see if they want the next variant, or lets
  * them ignore it for the next construction function for a different contig to
  * handle. Ought not to be copied.
- *
- * Handles conversion from 1-based vcflib coordinates to 0-based vg coordinates.
  */
 class VcfBuffer {
 
 public:
     /**
      * Return a pointer to the buffered variant, or null if no variant is
-     * buffered. Pointer is invalidated when the buffer is handled. The variant
-     * will have a 0-based start coordinate.
+     * buffered. Pointer is invalidated when the buffer is handled.
      *
      * Although the variant is not const, it may not be moved out of or modified
      * in ways that confuse vcflib.

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -261,16 +261,20 @@ size_t VG::get_degree(const handle_t& handle, bool go_left) const {
     return 0;
 }
     
+bool VG::has_path(const string& path_name) const {
+    return paths.has_path(path_name);
+}
+    
 path_handle_t VG::get_path_handle(const string& path_name) const {
-    return as_path_handle(paths.name_to_id.at(path_name));
+    return as_path_handle(paths.get_path_id(path_name));
 }
     
 string VG::get_path_name(const path_handle_t& path_handle) const {
-    return paths.id_to_name.at(as_integer(path_handle));
+    return paths.get_path_name(as_integer(path_handle));
 }
 
 size_t VG::get_occurrence_count(const path_handle_t& path_handle) const {
-    return paths._paths.at(paths.id_to_name.at(as_integer(path_handle))).size();
+    return paths._paths.at(paths.get_path_name(as_integer(path_handle))).size();
 }
 
 size_t VG::get_path_count() const {
@@ -278,9 +282,9 @@ size_t VG::get_path_count() const {
 }
 
 void VG::for_each_path_handle(const function<void(const path_handle_t&)>& iteratee) const {
-    for (const pair<int64_t, string>& path_record : paths.id_to_name) {
-        iteratee(as_path_handle(path_record.first));
-    }
+    paths.for_each_name([&](const string& name) {
+        iteratee(get_path_handle(name));
+    });
 }
 
 handle_t VG::get_occurrence(const occurrence_handle_t& occurrence_handle) const {
@@ -291,26 +295,26 @@ handle_t VG::get_occurrence(const occurrence_handle_t& occurrence_handle) const 
 occurrence_handle_t VG::get_first_occurrence(const path_handle_t& path_handle) const {
     occurrence_handle_t occurrence_handle;
     as_integers(occurrence_handle)[0] = as_integer(path_handle);
-    as_integers(occurrence_handle)[1] = reinterpret_cast<int64_t>(&paths._paths.at(paths.id_to_name.at(as_integer(path_handle))).front());
+    as_integers(occurrence_handle)[1] = reinterpret_cast<int64_t>(&paths._paths.at(paths.get_path_name(as_integer(path_handle))).front());
     return occurrence_handle;
 }
 
 occurrence_handle_t VG::get_last_occurrence(const path_handle_t& path_handle) const {
     occurrence_handle_t occurrence_handle;
     as_integers(occurrence_handle)[0] = as_integer(path_handle);
-    as_integers(occurrence_handle)[1] = reinterpret_cast<int64_t>(&paths._paths.at(paths.id_to_name.at(as_integer(path_handle))).back());
+    as_integers(occurrence_handle)[1] = reinterpret_cast<int64_t>(&paths._paths.at(paths.get_path_name(as_integer(path_handle))).back());
     return occurrence_handle;
 }
 
 bool VG::has_next_occurrence(const occurrence_handle_t& occurrence_handle) const {
     list<mapping_t>::iterator iter = paths.mapping_itr.at(reinterpret_cast<mapping_t*>(as_integers(occurrence_handle)[1])).first;
     iter++;
-    return iter != paths._paths.at(paths.id_to_name.at(as_integers(occurrence_handle)[0])).end();
+    return iter != paths._paths.at(paths.get_path_name(as_integers(occurrence_handle)[0])).end();
 }
 
 bool VG::has_previous_occurrence(const occurrence_handle_t& occurrence_handle) const {
     list<mapping_t>::iterator iter = paths.mapping_itr.at(reinterpret_cast<mapping_t*>(as_integers(occurrence_handle)[1])).first;
-    return iter != paths._paths.at(paths.id_to_name.at(as_integers(occurrence_handle)[0])).begin();
+    return iter != paths._paths.at(paths.get_path_name(as_integers(occurrence_handle)[0])).begin();
 }
 
 occurrence_handle_t VG::get_next_occurrence(const occurrence_handle_t& occurrence_handle) const {

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -498,6 +498,25 @@ vector<handle_t> VG::divide_handle(const handle_t& handle, const vector<size_t>&
     
 }
 
+void VG::destroy_path(const path_handle_t& path) {
+    paths.remove_path(get_path_name(path));
+}
+
+path_handle_t VG::create_path_handle(const string& name) {
+    // Create the path
+    paths.create_path(name);
+    // Grab the handle
+    return get_path_handle(name);
+    
+}
+    
+occurrence_handle_t VG::append_occurrence(const path_handle_t& path, const handle_t& to_append) {
+    // Make the new path mapping/visit (which weirdly requires the node length)
+    paths.append_mapping(get_path_name(path), get_id(to_append), get_is_reverse(to_append), get_length(to_append));
+    // Get the occurrence we just made, now last on the path.
+    return get_last_occurrence(path);
+}
+
 void VG::clear_paths(void) {
     paths.clear();
     graph.clear_path(); // paths.clear() should do this too

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -78,7 +78,7 @@ namespace vg {
  * However, edges can connect to either the start or end of either node.
  *
  */
-class VG : public Progressive, public MutableHandleGraph, public PathHandleGraph {
+class VG : public Progressive, public MutableHandleGraph, public MutablePathHandleGraph {
 
 public:
 
@@ -223,6 +223,19 @@ public:
     /// handles come in the order and orientation appropriate for the handle
     /// passed in.
     virtual vector<handle_t> divide_handle(const handle_t& handle, const vector<size_t>& offsets);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Mutable path handle interface
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// Destroy the given path. Invalidates handles to the path and its node occurrences.
+    virtual void destroy_path(const path_handle_t& path);
+
+    /// Create a path with the given name.
+    virtual path_handle_t create_path_handle(const string& name);
+    
+    /// Append a visit to a node to the given path
+    virtual occurrence_handle_t append_occurrence(const path_handle_t& path, const handle_t& to_append);
     
 public:
     

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -78,7 +78,7 @@ namespace vg {
  * However, edges can connect to either the start or end of either node.
  *
  */
-class VG : public Progressive, public MutableHandleGraph, public MutablePathHandleGraph {
+class VG : public Progressive, public MutablePathMutableHandleGraph {
 
 public:
 

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -139,6 +139,9 @@ public:
     // Path handle interface
     ////////////////////////////////////////////////////////////////////////////
     
+    /// Determine if a path name exists and is legal to get a path handle for.
+    virtual bool has_path(const string& path_name) const;
+    
     /// Look up the path handle for the given path name
     virtual path_handle_t get_path_handle(const string& path_name) const;
     

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1820,6 +1820,10 @@ void XG::for_each_handle(const function<bool(const handle_t&)>& iteratee, bool p
     }
 }
 
+bool XG::has_path(const string& path_name) const {
+    return path_rank(path_name) != 0;
+}
+
 path_handle_t XG::get_path_handle(const string& path_name) const {
     return as_path_handle(path_rank(path_name));
 }

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -245,7 +245,9 @@ public:
     ////////////////////////
     // Path handle graph API
     ////////////////////////
-    
+   
+    /// Determine if a path with a given name exists
+    virtual bool has_path(const string& path_name) const;
     /// Look up the path handle for the given path name
     virtual path_handle_t get_path_handle(const string& path_name) const;
     /// Look up the name of a path from a handle to it

--- a/test/t/43_vg_simplify.t
+++ b/test/t/43_vg_simplify.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 5
+
+vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
+
+vg simplify --algorithm small x.vg > x.small.vg
+is "${?}" "0" "vg simplify runs through when popping small bubbles"
+
+is "$(vg mod --unchop x.small.vg | vg stats -N -)" "1" "simplification pops all the bubbles in a simple graph"
+
+vg simplify --algorithm rare --min-count 2 -v small/x.vcf.gz x.vg > x.rare.vg
+is "${?}" "0" "vg simplify runs through when removing rare variants"
+
+vg validate x.rare.vg
+is "${?}" "0" "the graph is valid after removing rare variants"
+
+is "$(vg mod --unchop x.rare.vg | vg stats -N -)" "109" "simplification keeps only some variants"
+
+rm -f x.vg x.small.vg x.rare.vg
+ 
+

--- a/test/t/43_vg_simplify.t
+++ b/test/t/43_vg_simplify.t
@@ -5,16 +5,15 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 3
+plan tests 5
 
 vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
 
-# TODO: These tests don't pass! They really should!
+# Make sure to discard all the warnings about having removed alt paths.
+vg simplify --algorithm small x.vg > x.small.vg 2>/dev/null
+is "${?}" "0" "vg simplify runs through when popping small bubbles"
 
-#vg simplify --algorithm small x.vg > x.small.vg
-#is "${?}" "0" "vg simplify runs through when popping small bubbles"
-
-#is "$(vg mod --unchop x.small.vg | vg stats -N -)" "1" "simplification pops all the bubbles in a simple graph"
+is "$(vg mod --drop-paths x.small.vg | vg mod --unchop - | vg stats -N -)" "1" "simplification pops all the bubbles in a simple graph"
 
 vg simplify --algorithm rare --min-count 2 -v small/x.vcf.gz x.vg > x.rare.vg
 is "${?}" "0" "vg simplify runs through when removing rare variants"

--- a/test/t/43_vg_simplify.t
+++ b/test/t/43_vg_simplify.t
@@ -21,7 +21,7 @@ is "${?}" "0" "vg simplify runs through when removing rare variants"
 vg validate x.rare.vg
 is "${?}" "0" "the graph is valid after removing rare variants"
 
-is "$(vg mod --unchop x.rare.vg | vg stats -N -)" "104" "simplification keeps only some variants"
+is "$(vg mod --drop-paths x.rare.vg | vg mod --unchop - | vg stats -N -)" "118" "simplification keeps only some variants"
 
 rm -f x.vg x.small.vg x.rare.vg
  

--- a/test/t/43_vg_simplify.t
+++ b/test/t/43_vg_simplify.t
@@ -5,14 +5,16 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 5
+plan tests 3
 
 vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
 
-vg simplify --algorithm small x.vg > x.small.vg
-is "${?}" "0" "vg simplify runs through when popping small bubbles"
+# TODO: These tests don't pass! They really should!
 
-is "$(vg mod --unchop x.small.vg | vg stats -N -)" "1" "simplification pops all the bubbles in a simple graph"
+#vg simplify --algorithm small x.vg > x.small.vg
+#is "${?}" "0" "vg simplify runs through when popping small bubbles"
+
+#is "$(vg mod --unchop x.small.vg | vg stats -N -)" "1" "simplification pops all the bubbles in a simple graph"
 
 vg simplify --algorithm rare --min-count 2 -v small/x.vcf.gz x.vg > x.rare.vg
 is "${?}" "0" "vg simplify runs through when removing rare variants"
@@ -20,7 +22,7 @@ is "${?}" "0" "vg simplify runs through when removing rare variants"
 vg validate x.rare.vg
 is "${?}" "0" "the graph is valid after removing rare variants"
 
-is "$(vg mod --unchop x.rare.vg | vg stats -N -)" "109" "simplification keeps only some variants"
+is "$(vg mod --unchop x.rare.vg | vg stats -N -)" "104" "simplification keeps only some variants"
 
 rm -f x.vg x.small.vg x.rare.vg
  


### PR DESCRIPTION
This modifies `vg simplify` to have another simplification algorithm, which removes rare variants from the graph using a VCF file, leaving the subset that #1949 demands.

I wanted to do this through handle graphs, so I had to add a path-modification handle graph interface. It's about as empty as I could make it to make this work; all you can do is append to paths, create paths, and delete paths.

I also had to tinker with the handle graph path interface itself, because we had no way to know if a path name was valid for grabbing a handle besides trying and crashing the program if it wasn't. Similarly for trying to get the first/last occurrences, because a path can be empty and not have them.

Also, some of the logic to go between path IDs and path names didn't use the accessors, so paths were sometimes not getting assigned IDs, which caused all sorts of trouble.

I also had to fix vcflib to take string constants as info tag names in its accessors.

Still TODO:

- [x] Work out why the old simplifier (SmallSnarlSimplifier) doesn't pass its tests. I suspect it was broken before, since it never had any real unit tests, but it's possible this PR breaks it.
- [x] Fix `VG::has_next_occurrence`, which crashes my loop when I use it to loop over all the occurrences on a path. I'm using a comparison against the last occurrence right now instead.