### PR TITLE
Genotype long indels

### DIFF
--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -139,6 +139,7 @@ void Genotyper::run(AugmentedGraph& augmented_graph,
 
         if (snarl->type() != ULTRABUBBLE) {
             // We only work on ultrabubbles right now
+            cerr << "Skip snarl " << snarl->start() << " - " << snarl->end() << " due to not being an ultrabubble" << endl;
             return;
         }
 
@@ -153,10 +154,24 @@ void Genotyper::run(AugmentedGraph& augmented_graph,
             use_traversal_alg = read_bounded ? TraversalAlg::Reads : TraversalAlg::Representative;
         }
 
-        if ((use_traversal_alg != TraversalAlg::Reads && !manager.is_leaf(snarl)) ||
-            (use_traversal_alg == TraversalAlg::Reads && !manager.is_root(snarl))) {
+        if (use_traversal_alg != TraversalAlg::Reads && !manager.is_leaf(snarl)) {
             // Todo : support nesting hierarchy!
-            
+            if (show_progress) {
+                cerr << "Skip snarl " << snarl->start() << " - " << snarl->end()
+                    << " because it isn't a leaf and traversal algorithm "
+                    << alg2name[use_traversal_alg] << " only works on leaves" << endl;
+            }
+            return;
+        }
+
+
+        if (use_traversal_alg == TraversalAlg::Reads && !manager.is_root(snarl)) {
+            // Todo : support nesting hierarchy!
+            if (show_progress) {
+                cerr << "Skip snarl " << snarl->start() << " - " << snarl->end()
+                    << " because it isn't a root and traversal algorithm "
+                    << alg2name[use_traversal_alg] << " only works on roots" << endl;
+            }
             return;
         }
         

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -154,7 +154,11 @@ void Genotyper::run(AugmentedGraph& augmented_graph,
             use_traversal_alg = read_bounded ? TraversalAlg::Reads : TraversalAlg::Representative;
         }
 
-        if (use_traversal_alg != TraversalAlg::Reads && !manager.is_leaf(snarl)) {
+        if (use_traversal_alg == TraversalAlg::Exhaustive &&
+            !manager.is_leaf(snarl)) {
+            // The SupportRestrictedTraversalFinder we use in Exhaustive mode
+            // can only handle leaf snarls.
+
             // Todo : support nesting hierarchy!
             if (show_progress) {
                 cerr << "Skip snarl " << snarl->start() << " - " << snarl->end()
@@ -164,8 +168,26 @@ void Genotyper::run(AugmentedGraph& augmented_graph,
             return;
         }
 
+        if (use_traversal_alg == TraversalAlg::Representative && !manager.all_children_trivial(snarl, graph)) {
+            // The RepresentativeTraversalFinder works for root and leaf
+            // snarls, but unless we're in a leaf snarl, or a snarl with only
+            // trivial children, it outputs traversals with child snarls in
+            // them that the rest of genotype can't yet handle.
+
+            // Todo : support nesting hierarchy!
+            if (show_progress) {
+                cerr << "Skip snarl " << snarl->start() << " - " << snarl->end()
+                    << " because it has nontrivial children and traversal algorithm "
+                    << alg2name[use_traversal_alg] << " will produce nested child snarl traversals" << endl;
+            }
+            return;
+        }
+
 
         if (use_traversal_alg == TraversalAlg::Reads && !manager.is_root(snarl)) {
+            // The ReadRestrictedTraversalFinder only works for root snarls.
+            // TODO: How do we know this?
+            
             // Todo : support nesting hierarchy!
             if (show_progress) {
                 cerr << "Skip snarl " << snarl->start() << " - " << snarl->end()
@@ -445,11 +467,16 @@ vector<SnarlTraversal> Genotyper::get_snarl_traversals(AugmentedGraph& augmented
     } else if (use_traversal_alg == TraversalAlg::Representative) {
         // representative search from vg call.  only current implementation that works for big sites
         // Now start looking for traversals of the sites.
-        read_trav_finder = unique_ptr<TraversalFinder>(new RepresentativeTraversalFinder(
+        auto* finder = new RepresentativeTraversalFinder(
             augmented_graph, manager, 1000, 1000,
             100, [&] (const Snarl& site) -> PathIndex* {
                 return ref_path_index;
-            }));
+            });
+
+        // Since we can't sensibly handle any children, glom trivial children in.
+        finder->eat_trivial_children = true;
+
+        read_trav_finder = unique_ptr<TraversalFinder>(finder);
     } else {
         assert(false);
     }

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -145,6 +145,12 @@ public:
 
     // Toggle traversal finder for testing
     enum TraversalAlg { Reads, Exhaustive, Representative, Adaptive };
+    map<TraversalAlg, string> alg2name = {
+        {Reads, "Reads"},
+        {Exhaustive, "Exhaustive"},
+        {Representative, "Representative"},
+        {Adaptive, "Adaptive"}
+    };
     TraversalAlg traversal_alg = TraversalAlg::Reads;
 
     // Show progress

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -668,6 +668,22 @@ bool SnarlManager::is_leaf(const Snarl* snarl) const {
 bool SnarlManager::is_root(const Snarl* snarl) const {
     return parent_of(snarl) == nullptr;
 }
+
+bool SnarlManager::is_trivial(const Snarl* snarl, VG& graph) const {
+    // If it's an ultrabubble with no children and no contained nodes, it is a trivial snarl.
+    return snarl->type() == ULTRABUBBLE &&
+        is_leaf(snarl)
+        && shallow_contents(snarl, graph, false).first.size() == 0;
+}
+
+bool SnarlManager::all_children_trivial(const Snarl* snarl, VG& graph) const {
+    for (auto& child : children_of(snarl)) {
+        if (!is_trivial(child, graph)) {
+            return false;
+        }
+    }
+    return true;
+}
     
 const vector<const Snarl*>& SnarlManager::top_level_snarls() const {
     return roots;

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -493,7 +493,15 @@ public:
         
     /// Returns true if snarl has no parent and false otherwise
     bool is_root(const Snarl* snarl) const;
-        
+
+    /// Returns true if the sanrl is trivial (an ultrabubble with just the
+    /// start and end nodes) and false otherwise.
+    /// TODO: Implement without needing the vg graph, by adding a flag to trivial snarls.
+    bool is_trivial(const Snarl* snarl, VG& graph) const;
+    
+    /// Returns true if the snarl lacks any nontrivial children.
+    bool all_children_trivial(const Snarl* snarl, VG& graph) const;
+
     /// Returns a reference to a vector with the roots of the Snarl trees
     const vector<const Snarl*>& top_level_snarls() const;
         

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -21,7 +21,7 @@ vector<SnarlTraversal> PathBasedTraversalFinder::find_traversals(const Snarl& si
     vector<SnarlTraversal> ret;
 
     // If the snarl is not an ultrabubble, just return an empty set of traversals.
-    if (!site.type() == ULTRABUBBLE){
+    if (site.type() != ULTRABUBBLE){
         return ret;
     }
    
@@ -994,9 +994,11 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
         Node* visited_node = augmented.graph.get_node(found_visit.node_id());
         
         const Snarl* child = snarl_manager.into_which_snarl(found_visit);
-        if (child != nullptr && child != managed_site
-            && snarl_manager.into_which_snarl(reverse(found_visit)) != managed_site) {
-            // If the node in this orientation enters a child
+        if (child != nullptr && child != managed_site &&
+            snarl_manager.into_which_snarl(reverse(found_visit)) != managed_site &&
+            !(eat_trivial_children && snarl_manager.is_trivial(child, augmented.graph))) {
+            // If the node in this orientation enters a child, and it's not a
+            // trivial child we are taking care of ourselves
         
             // Visit the child
             Visit child_visit;
@@ -1394,6 +1396,11 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
 
     for (const Snarl* child : children) {
         // Go through all the child snarls
+
+        if (eat_trivial_children && snarl_manager.is_trivial(child, augmented.graph)) {
+            // Skip trivial children
+            continue;
+        }
         
 #ifdef debug
         cerr << "Base path on " << *child << endl;

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -275,7 +275,7 @@ protected:
      * Get the length of a path through nodes, in base pairs.
      */
     size_t bp_length(const list<Visit>& path);
-    
+
 public:
 
     /**
@@ -296,6 +296,9 @@ public:
     
     /// Should we emit verbose debugging info?
     bool verbose = false;
+
+    /// Should trivial child snarls have their traversals glommed into ours?
+    bool eat_trivial_children = false;
     
     virtual ~RepresentativeTraversalFinder() = default;
     


### PR DESCRIPTION
This is a hack to fix #1957 by telling the RepresentativeTraversalFinder to (mostly) ignore trivial child snarls when running in vg genotype.

We still can't handle nontrivial child snarls, and we won't be able to until genotype can deal with traversals that involve non-fully-specified child snarl visits. We need to implement recursive typing in genotype for that to happen, I think.