### PR TITLE
Tell Github not to do its own build process

### DIFF
--- a/doc/publish-docs.sh
+++ b/doc/publish-docs.sh
@@ -89,6 +89,10 @@ rsync -avr "${SOURCE_DIR}" "${SCRATCH_DIR}/dest/${DEST_DIR}" --delete --exclude 
 # Go back in to make the commit
 pushd "${SCRATCH_DIR}/dest"
 
+# Disable Jeckyll processing for Github Pages since we did it already
+touch .nojekyll
+git add .nojekyll
+
 # Add all the files here (except hidden ones) and add deletions
 git add -A
 


### PR DESCRIPTION
I'm getting grumpy messages from Github that Jekyll failed to build our gh-pages branch. We don't want Jekyll trying to run on our already-generated docs. Apparently a .nojekyll file is how you stop it, so I added some commands to add one.