### PR TITLE
Allow better support for SV recall in vg call

### DIFF
--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -469,7 +469,7 @@ vector<SnarlTraversal> Genotyper::get_snarl_traversals(AugmentedGraph& augmented
         // Now start looking for traversals of the sites.
         auto* finder = new RepresentativeTraversalFinder(
             augmented_graph, manager, 1000, 1000,
-            100, [&] (const Snarl& site) -> PathIndex* {
+            100, 1, 1, [&] (const Snarl& site) -> PathIndex* {
                 return ref_path_index;
             });
 

--- a/src/support_caller.cpp
+++ b/src/support_caller.cpp
@@ -1328,8 +1328,10 @@ void SupportCaller::call(
     }
     
     // Now start looking for traversals of the sites.
-    RepresentativeTraversalFinder traversal_finder(augmented, site_manager, max_search_depth, max_search_width,
-        max_bubble_paths, [&] (const Snarl& site) -> PathIndex* {
+    RepresentativeTraversalFinder traversal_finder(augmented, site_manager, max_search_depth,
+                                                   max_search_width, max_bubble_paths,
+                                                   min_total_support_for_call, min_total_support_for_call,
+                                                   [&] (const Snarl& site) -> PathIndex* {
         
         // When the TraversalFinder needs a primary path index for a site, it can look it up with this function.
         auto found = find_path(site, primary_paths);

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -871,9 +871,16 @@ vector<SnarlTraversal> TrivialTraversalFinder::find_traversals(const Snarl& site
 
 
 RepresentativeTraversalFinder::RepresentativeTraversalFinder(AugmentedGraph& augmented,
-                                                             SnarlManager& snarl_manager, size_t max_depth, size_t max_width, size_t max_bubble_paths,
-                                                             function<PathIndex*(const Snarl&)> get_index) : augmented(augmented), snarl_manager(snarl_manager),
-                                                                                                             max_depth(max_depth), max_width(max_width), max_bubble_paths(max_bubble_paths), get_index(get_index) {
+                                                             SnarlManager& snarl_manager,
+                                                             size_t max_depth,
+                                                             size_t max_width,
+                                                             size_t max_bubble_paths,
+                                                             size_t min_node_support,
+                                                             size_t min_edge_support,
+                                                             function<PathIndex*(const Snarl&)> get_index) :
+  augmented(augmented), snarl_manager(snarl_manager), max_depth(max_depth), max_width(max_width),
+  max_bubble_paths(max_bubble_paths), min_node_support(min_node_support), min_edge_support(min_edge_support),
+  get_index(get_index) {
     
     // Nothing to do!
 
@@ -1331,7 +1338,7 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
             continue;
         }
         
-        if (augmented.has_supports() && total(augmented.get_support(node)) == 0) {
+        if (augmented.has_supports() && total(augmented.get_support(node)) < min_node_support) {
             // Don't bother with unsupported nodes
             continue;
         }
@@ -1375,7 +1382,7 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
     for(Edge* edge : contents.second) {
         // Go through all the edges
         
-        if(augmented.has_supports() && total(augmented.get_support(edge)) == 0) {
+        if(augmented.has_supports() && total(augmented.get_support(edge)) < min_edge_support) {
             // Don't bother with unsupported edges
 #ifdef debug
             cerr << "Skip unsupported edge " << edge->from() << " -> " << edge->to() << endl;
@@ -2170,7 +2177,8 @@ RepresentativeTraversalFinder::bfs_left(Visit visit,
                     Node* prevNode = augmented.graph.get_node(prevVisit.node_id());
                     
                     if (augmented.has_supports() && 
-                        (total(augmented.get_support(prevNode)) == 0 || total(augmented.get_support(edge)) == 0)) {
+                        (total(augmented.get_support(prevNode)) < min_node_support ||
+                         total(augmented.get_support(edge)) < min_edge_support)) {
                         // We have no support at all for visiting this node by this
                         // edge (but we do have some read support data)
                         
@@ -2187,7 +2195,7 @@ RepresentativeTraversalFinder::bfs_left(Visit visit,
                     // That node can't be shared with a snarl we are already at.
                     Node* prevNode = augmented.graph.get_node(to_left_side(prevVisit).node);
                     
-                    if (augmented.has_supports() && total(augmented.get_support(prevNode)) == 0) {
+                    if (augmented.has_supports() && total(augmented.get_support(prevNode)) < min_node_support) {
                         // We have no support at all for visiting the far node of this snarl
                         
 #ifdef debug

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -224,6 +224,10 @@ protected:
     size_t max_width;
     /// How many search intermediates can we allow?
     size_t max_bubble_paths;
+    /// Minimum support for a node to consider travnersal through it
+    size_t min_node_support;
+    /// Minimum support for a edge to consider travnersal through it
+    size_t min_edge_support;
     
     /**
      * Find a Path that runs from the start of the given snarl to the end, which
@@ -310,6 +314,7 @@ public:
      */
     RepresentativeTraversalFinder(AugmentedGraph& augmented, SnarlManager& snarl_manager,
         size_t max_depth, size_t max_width, size_t max_bubble_paths,
+        size_t min_node_support = 1, size_t min_edge_support = 1,
         function<PathIndex*(const Snarl&)> get_index = [](const Snarl& s) { return nullptr; });
     
     /// Should we emit verbose debugging info?


### PR DESCRIPTION
#1975 showed examples of toil-vg's --recall option missing some large insertions.  This was happening because the reads were not supporting the insertion sequence exactly as it is in the graph, presumably due to sequencing errors somewhere.  

Using this patch, along with caller options '-u -n 0' seems to work for the examples.  I'll fix toil-vg call --recall to use these options by default in a minute. 
