### PR TITLE
Use haplotype counts stored in the GBWT

### DIFF
--- a/src/haplotypes.cpp
+++ b/src/haplotypes.cpp
@@ -810,6 +810,15 @@ haplo_score_type linear_haplo_structure::score(const vg::Path& path) const {
 }
 
 /*******************************************************************************
+ScoreProvider
+*******************************************************************************/
+
+int64_t ScoreProvider::get_haplotype_count() const {
+  // By default, say that we don't know the haplotype count.
+  return -1;
+}
+
+/*******************************************************************************
 XGScoreProvider
 *******************************************************************************/
 
@@ -819,6 +828,12 @@ XGScoreProvider::XGScoreProvider(xg::XG& index) : index(index) {
 
 pair<double, bool> XGScoreProvider::score(const vg::Path& path, haploMath::RRMemo& memo) {
   return haplo_DP::score(path, index, memo);
+}
+
+int64_t XGScoreProvider::get_haplotype_count() const {
+  // XG indexes track a haplotype count still.
+  // TODO: This should be removed!
+  return index.get_haplotype_count();
 }
 
 /*******************************************************************************

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1654,12 +1654,17 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
         // It won't matter either way
         return;
     }
-    
-    size_t haplotype_count = xindex->get_haplotype_count();
-    
-    if (haplotype_count == 0) {
-        // The XG apparently has no path database information. Maybe it wasn't built with the GBWT?
-        throw runtime_error("Cannot score any haplotypes with a 0 haplotype count; does the XG contain the path database?");
+   
+    // Work out the population size. Try the score provider and then fall back to the xg.
+    auto haplotype_count = haplo_score_provider->get_haplotype_count();
+    if (haplotype_count == -1) {
+        // The score provider doesn't ahve a haplotype count. Fall back to the count in the XG.
+        haplotype_count = xindex->get_haplotype_count();
+    }
+   
+    if (haplotype_count == 0 || haplotype_count == -1) {
+        // We really should have a haplotype count
+        throw runtime_error("Cannot score any haplotypes with a 0 or -1 haplotype count; are haplotypes available?");
     }
     
     // We don't look at strip_bonuses here, because we need these bonuses added

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3197,9 +3197,16 @@ namespace vg {
             base_scores[i] = alignments[0].score();
             
             if (query_population) {
+            
+                // Work out the population size. Try the score provider and then fall back to the xg.
+                auto haplotype_count = haplo_score_provider->get_haplotype_count();
+                if (haplotype_count == -1) {
+                    // The score provider doesn't ahve a haplotype count. Fall back to the count in the XG.
+                    haplotype_count = xindex->get_haplotype_count();
+                }
                 
                 // Make sure to grab the memo
-                auto& memo = get_rr_memo(recombination_penalty, xindex->get_haplotype_count());
+                auto& memo = get_rr_memo(recombination_penalty, haplotype_count);
                 
                 // Now compute population scores for all the top paths
                 vector<double> alignment_pop_scores(alignments.size(), 0.0);
@@ -3432,8 +3439,15 @@ namespace vg {
             if (query_population) {
                 // We also want to select the optimal population-scored alignment on each side and compute a pop-adjusted score.
                 
+                // Work out the population size. Try the score provider and then fall back to the xg.
+                auto haplotype_count = haplo_score_provider->get_haplotype_count();
+                if (haplotype_count == -1) {
+                    // The score provider doesn't ahve a haplotype count. Fall back to the count in the XG.
+                    haplotype_count = xindex->get_haplotype_count();
+                }
+                
                 // Make sure to grab the memo
-                auto& memo = get_rr_memo(recombination_penalty, xindex->get_haplotype_count());
+                auto& memo = get_rr_memo(recombination_penalty, haplotype_count);
                 
                 // What's the base + population score for each alignment?
                 // We need to consider them together because there's a trade off between recombinations and mismatches.

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3205,6 +3205,11 @@ namespace vg {
                     haplotype_count = xindex->get_haplotype_count();
                 }
                 
+                if (haplotype_count == 0 || haplotype_count == -1) {
+                    // We really should have a haplotype count
+                    throw runtime_error("Cannot score any haplotypes with a 0 or -1 haplotype count; are haplotypes available?");
+                }
+                
                 // Make sure to grab the memo
                 auto& memo = get_rr_memo(recombination_penalty, haplotype_count);
                 
@@ -3444,6 +3449,11 @@ namespace vg {
                 if (haplotype_count == -1) {
                     // The score provider doesn't ahve a haplotype count. Fall back to the count in the XG.
                     haplotype_count = xindex->get_haplotype_count();
+                }
+                
+                if (haplotype_count == 0 || haplotype_count == -1) {
+                    // We really should have a haplotype count
+                    throw runtime_error("Cannot score any haplotypes with a 0 or -1 haplotype count; are haplotypes available?");
                 }
                 
                 // Make sure to grab the memo


### PR DESCRIPTION
Up until now, we've been using haplotype count data from the XG index, when using haploytypes stored in the GBWT.

This updates the GBWT submodule to a version that can carry haplotype counts, and lets the haplotype count in the GBWT override anything stored in the XG.

Since eventually we're dropping the gPBWT, we will eventually want to drop the XG haplotype count and require the count to come from the GBWT.