### PR TITLE
Fix corrupt output to fix #1996

### DIFF
--- a/src/blocked_gzip_output_stream.cpp
+++ b/src/blocked_gzip_output_stream.cpp
@@ -73,22 +73,32 @@ BlockedGzipOutputStream::BlockedGzipOutputStream(std::ostream& stream) : handle(
 }
 
 BlockedGzipOutputStream::~BlockedGzipOutputStream() {
+
+#ifdef debug
+    cerr << "Destroying BlockedGzipOutputStream" << endl;
+#endif
+
     // Make sure to finish writing before destructing.
     flush();
     
     if (end_file) {
         // Close the file with an EOF block.
 #ifdef debug
-        cerr << "Close normally" << endl;
+        cerr << "Close BlockedGzipOutputStream normally with EOF" << endl;
 #endif
         bgzf_close(handle);
     } else {
         // Close the BGZF *without* writing an EOF block.
 #ifdef debug
-        cerr << "Force close" << endl;
+        cerr << "Force BlockedGzipOutputStream closed" << endl;
 #endif
         force_close();
     }
+    
+#ifdef debug
+    cerr << "BlockedGzipOutputStream destroyed" << endl;
+#endif
+
 }
 
 bool BlockedGzipOutputStream::Next(void** data, int* size) {
@@ -170,6 +180,9 @@ void BlockedGzipOutputStream::StartFile() {
 }
 
 void BlockedGzipOutputStream::EndFile() {
+#ifdef debug
+    cerr << "Setting BlockedGzipOutputStream end_file flag" << endl;
+#endif
     end_file = true;
 }
 
@@ -200,6 +213,10 @@ void BlockedGzipOutputStream::flush() {
 
 void BlockedGzipOutputStream::force_close() {
     // Sneakily close the BGZF file without letting it write an EOF empty block marker.
+    
+#ifdef debug
+    cerr << "Forcing BlockedGzipOutputStream closed without EOF" << endl;
+#endif
     
     // Flush the data, which the close function won't do in the path we want it to take
     if (bgzf_flush(handle) != 0) {

--- a/src/blocked_gzip_output_stream.hpp
+++ b/src/blocked_gzip_output_stream.hpp
@@ -121,7 +121,6 @@ protected:
     
     /// Flag for whether we are supposed to close out the BGZF file.
     bool end_file;
-    
 };
 
 }

--- a/src/hfile_cppstream.cpp
+++ b/src/hfile_cppstream.cpp
@@ -62,6 +62,10 @@ static ssize_t cppstream_read(hFILE *fpv, void *buffer, size_t nbytes) {
 /// Write data. Return the number of bytes actually written. Return a negative
 /// value and set errno on error.
 static ssize_t cppstream_write(hFILE *fpv, const void *buffer, size_t nbytes) {
+#ifdef debug
+    cerr << "cppstream_write(" << fpv << ", " << buffer << ", " << nbytes << ")" << endl;
+#endif
+    
     // Cast the hFILE to the derived class
     hFILE_cppstream* fp = (hFILE_cppstream*) fpv;
     
@@ -73,6 +77,7 @@ static ssize_t cppstream_write(hFILE *fpv, const void *buffer, size_t nbytes) {
     
     // Write the data and record how much we put
     fp->output->clear();
+    // Note that the stream always takes all the bytes
     fp->output->write((char*) buffer, nbytes);
     
     if (!fp->output->good()) {
@@ -80,6 +85,10 @@ static ssize_t cppstream_write(hFILE *fpv, const void *buffer, size_t nbytes) {
         errno = EIO;
         return -1;
     }
+    
+#ifdef debug
+    cerr << "Successfully wrote " << nbytes << " bytes" << endl;
+#endif
     
     // Otherwise the write worked, and we wrote all the bytes
     return nbytes;
@@ -175,6 +184,10 @@ static off_t cppstream_seek(hFILE *fpv, off_t offset, int whence) {
 /// Flush the output stream, if we are doing output. Return 0 for success, or a
 /// negative number and set errno on error.
 static int cppstream_flush(hFILE *fpv) {
+#ifdef debug
+    cerr << "cppstream_flush(" << fpv << ")" << endl;
+#endif
+
     // Cast the hFILE to the derived class
     hFILE_cppstream* fp = (hFILE_cppstream*) fpv;
 
@@ -197,6 +210,10 @@ static int cppstream_flush(hFILE *fpv) {
 /// failure.
 static int cppstream_close(hFILE *fpv) {
     // This is tricky because we don't own the stream. We also can't close generic istreams and ostreams.
+    
+#ifdef debug
+    cerr << "cppstream_close(" << fpv << ")" << endl;
+#endif
     
     // Cast the hFILE to the derived class
     hFILE_cppstream* fp = (hFILE_cppstream*) fpv;

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -340,9 +340,8 @@ int main_construct(int argc, char** argv) {
         constructor.construct_graph(fasta_pointers, vcf_pointers,
                                     ins_pointers, callback);
                                     
-        // Now all the graph chunks are written out.
-        // Add an EOF marker
-        stream::finish(cout);
+        // The output will be flushed when the ProtobufEmitter we use in the callback goes away.
+        // Don't add an extra EOF marker or anything.
         
         // NB: If you worry about "still reachable but possibly lost" warnings in valgrind,
         // this would free all the memory used by protobuf:

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -210,7 +210,8 @@ int main_construct(int argc, char** argv) {
         // TODO: If we aren't always going to use the Constructor, refactor the subcommand to not always create and configure it.
 
         // Make an emitter that serializes the actual Graph objects, with buffering.
-        stream::ProtobufEmitter<Graph> emitter(cout);
+        // But just serialize one graph at a time in each group.
+        stream::ProtobufEmitter<Graph> emitter(cout, 1);
 
         // We need a callback to handle pieces of graph as they are produced.
         auto callback = [&](Graph& big_chunk) {

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -28,6 +28,7 @@ const unordered_map<string, string> Version::codenames = {
     {"v1.10.0", "Rionero"},
     {"v1.11.0", "Cairano"},
     {"v1.12.0", "Parolise"},
+    {"v1.12.1", "Parolise"},
     {"v1.13.0", "Moschiano"},
     {"v1.14.0", "Quadrelle"},
     {"v1.15.0", "Tufo"},

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -610,7 +610,9 @@ void VG::serialize_to_emitter(stream::ProtobufEmitter<Graph>& emitter, id_t chun
 }
 
 void VG::serialize_to_ostream(ostream& out, id_t chunk_size) {
-    stream::ProtobufEmitter<Graph> emitter(out);
+    // Make an emitter that serializes each chunk as its own group, like we did before using emitters.
+    // This is good for indexing.
+    stream::ProtobufEmitter<Graph> emitter(out, 1);
     serialize_to_emitter(emitter, chunk_size);
 }
 


### PR DESCRIPTION
I forgot to remove a manual call to emit the EOF marker from vg construct when I changed how it serializes its output, and I ended up inserting extra data in the middle of the output stream, corrupting any graph that wasn't all being buffered until the end.

For some reason, it took me like 2 days to work that out.

This fixes that, and also reduces the default group size for serializing vg (which was super high and helped hide this issue from the tests), to make graphs more plausibly indexable.

Once this is in we may want to do a patch release, since any large graph built with v1.12.0 will be affected by #1996.