### PR TITLE
More user-friendly construct

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1947,7 +1947,10 @@ namespace vg {
 #endif
 
                 // Also the FASTA reference that has that sequence
-                assert(reference_for.count(fasta_name));
+                if (!reference_for.count(fasta_name)) {
+                    cerr << "[vg::Constructor] Error: \"" << fasta_name << "\" not found in fasta file" <<endl;
+                    exit(1);
+                }
                 FastaReference* reference = reference_for[fasta_name];
 
                 // We'll set this to true if we actually find the VCF that contains

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -38,7 +38,7 @@ void help_construct(char** argv) {
          << "    -F, --msa-format       format of the MSA file (options: fasta, maf, clustal; default fasta)" << endl
          << "    -d, --drop-msa-paths   don't add paths for the MSA sequences into the graph" << endl
          << "shared construction options:" << endl
-         << "    -m, --node-max N       limit the maximum allowable node sequence size (defaults to 1000)" << endl
+         << "    -m, --node-max N       limit the maximum allowable node sequence size (defaults to 32)" << endl
          << "                           nodes greater than this threshold will be divided" << endl
          << "                           Note: nodes larger than ~1024 bp can't be GCSA2-indexed" << endl
          << "    -p, --progress         show progress" << endl;
@@ -62,7 +62,7 @@ int main_construct(int argc, char** argv) {
     string region;
     bool region_is_chrom = false;
     string msa_filename;
-    int max_node_size = 1000;
+    int max_node_size = 32;
     bool keep_paths = true;
     string msa_format = "fasta";
     bool show_progress = false;

--- a/test/t/02_vg_construct.t
+++ b/test/t/02_vg_construct.t
@@ -9,13 +9,13 @@ export LC_ALL="C" # force a consistent sort order
 
 plan tests 24
 
-is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg stats -z - | grep nodes | cut -f 2) 210 "construction produces the right number of nodes"
+is $(vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz | vg stats -z - | grep nodes | cut -f 2) 210 "construction produces the right number of nodes"
 
-is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg stats -z - | grep edges | cut -f 2) 291 "construction produces the right number of edges"
+is $(vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz | vg stats -z - | grep edges | cut -f 2) 291 "construction produces the right number of edges"
 
 is $(vg construct -r small/x.fa --rename chrX=x -R chrX:1-2 | vg stats -l - | cut -f 2 ) 2 "construction obeys rename and region options"
 
-vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
+vg construct -m 1000 -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
 
 nodes=$(vg stats -z z.vg | head -1 | cut -f 2)
@@ -28,7 +28,7 @@ rm -f z.vg
 
 is $(vg construct -r 1mb1kgp/z.fa | vg view -j - | jq -c '.node[] | select((.sequence | length) >= 1024)' | wc -l) 0 "node size is manageable by default"
 
-vg construct -r complex/c.fa -v complex/c.vcf.gz >c.vg
+vg construct -m 1000 -r complex/c.fa -v complex/c.vcf.gz >c.vg
 is $? 0 "construction of a very complex region succeeds"
 
 nodes=$(vg stats -z c.vg | head -1 | cut -f 2)
@@ -92,7 +92,7 @@ max_node_size=$(vg construct -r small/x.fa -v small/x.vcf.gz -m 12 | vg view -g 
 is $max_node_size 12 "nodes are correctly capped in size"
 
 ## Check the length of the longest node
-is $(vg construct -R z:10000-20000 -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz | vg view - | grep "^S" | awk '{ print length($3); }' | sort -n | tail -1) 241 "-R --region flag is respected" 
+is $(vg construct -m 1000 -R z:10000-20000 -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz | vg view - | grep "^S" | awk '{ print length($3); }' | sort -n | tail -1) 241 "-R --region flag is respected" 
 
 vg construct -r small/x.fa >/dev/null
 is $? 0 "vg construct does not require a vcf"

--- a/test/t/03_vg_view.t
+++ b/test/t/03_vg_view.t
@@ -7,8 +7,8 @@ PATH=../bin:$PATH # for vg
 
 plan tests 20
 
-is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg view -d - | wc -l) 505 "view produces the expected number of lines of dot output"
-is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg view -g - | wc -l) 503 "view produces the expected number of lines of GFA output"
+is $(vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz | vg view -d - | wc -l) 505 "view produces the expected number of lines of dot output"
+is $(vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz | vg view -g - | wc -l) 503 "view produces the expected number of lines of GFA output"
 # This one may throw warnings related to dangling edges because we just take an arbitrary subset of the GFA
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg view - | head | vg view -Fv - | vg view - | wc -l) 10 "view converts back and forth between GFA and vg format"
 

--- a/test/t/04_vg_align.t
+++ b/test/t/04_vg_align.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 plan tests 20
 
-vg construct -r small/x.fa -v small/x.vcf.gz > x.vg
+vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz > x.vg
 
 is $(vg align x.vg -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG --full-l-bonus 0 -j | tr ',' '\n' | grep node_id | grep "72\|73\|76\|77" | wc -l) 4 "alignment traverses the correct path"
 
@@ -35,7 +35,7 @@ is $(vg align -js $(cat mapsoftclip/280136066-280136088.seq) mapsoftclip/2801360
 
 is $(vg align -js GGCTATGTCTGAACTAGGAGGGTAGAAAGAATATTCATTTTGGTTGCCACAAACCATCGAAACAAAGATGCAGGTCATTGATGTAAAACTACAGTTAGTTCCTACTGACTCCTTTTCAGCTTCTCTTCATTGCTATGAGCCAGCGTCTCCT graphs/59867692-59867698.vg | jq -r '.path.mapping[0].position.node_id') 59867694 "nodes are only referenced if they have mappings"
 
-vg construct -r tiny/tiny.fa >t.vg
+vg construct -m 1000 -r tiny/tiny.fa >t.vg
 seq=CAAATAAGGCTTGGAAATGTTCTGGAGTTCTATTATATTCCAACTCTCTT
 vg align -s $seq t.vg | vg mod -i - t.vg >t2.vg
 is $(vg align -s $seq -Q query t2.vg | vg mod -i - -P t2.vg | vg view - | grep "query" | cut -f 3 | grep -o "[0-9]\+" | wc -l) 4 "align can use query names and outputs GAM"

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 plan tests 25
 
-vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
+vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 is $? 0 "construction"
 
 vg index -x x.xg x.vg 2>/dev/null
@@ -38,12 +38,12 @@ is $(vg find -n 2308 -c 10 -L -x m.xg | vg view -g - | grep S | wc -l) 10 "vg fi
 is $(vg find -n 2315 -n 183 -n 176 -c 1 -L -x m.xg | vg view -g - | grep S | wc -l) 7 "vg find -L works with more than one input node"
 rm m.xg
 
-vg construct -rmem/h.fa >h.vg
+vg construct -m 1000 -rmem/h.fa >h.vg
 vg index -g h.gcsa -k 16 h.vg
 is $(vg find -M ACCGTTAGAGTCAG -g h.gcsa) '[["ACC",["1:-32"]],["CCGTTAG",["1:5"]],["GTTAGAGT",["1:19"]],["TAGAGTCAG",["1:40"]]]' "we find the 4 canonical SMEMs from @lh3's bwa mem poster"
 rm -f h.gcsa h.gcsa.lcp h.vg
 
-vg construct -r minigiab/q.fa -v minigiab/NA12878.chr22.tiny.giab.vcf.gz -m 64 >giab.vg
+vg construct -m 1000 -r minigiab/q.fa -v minigiab/NA12878.chr22.tiny.giab.vcf.gz -m 64 >giab.vg
 vg index -x giab.xg -g giab.gcsa -k 11 giab.vg
 is $(vg find -M ATTCATNNNNAGTTAA -g giab.gcsa | md5sum | cut -f -1 -d\ ) $(md5sum correct/05_vg_find/28.txt | cut -f -1 -d\ ) "we can find the right MEMs for a sequence with Ns"
 is $(vg find -M ATTCATNNNNAGTTAA -g giab.gcsa | md5sum | cut -f -1 -d\ ) $(vg find -M ATTCATNNNNNNNNAGTTAA -g giab.gcsa | md5sum | cut -f -1 -d\ ) "we find the same MEMs sequences with different lengths of Ns"
@@ -61,7 +61,7 @@ rm -f giab.vg giab.xg giab.gcsa
 #is $(vg find -M ACGTGCCGTTAGCCAGTGGGTTAG -R 10 -Z 10 -f -x s.xg -g s.gcsa) '[["ACGTGCCGTTAGCCAGTGGGTTAG",["3:11"]],["AGCCAGTGGGTTA",["1:0","2:0"]]]' "we can find the same (sufficiently long) sub-MEMs the hard de-duplication case with the fast sub-MEM option"
 #rm -rf s.vg s.xg s.gcsa*
 
-vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
+vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
 vg map -x x.xg -g x.gcsa -T small/x-s1337-n100.reads >x.gam
 vg index -d x.db -N x.gam
@@ -78,7 +78,7 @@ is $(vg find -G small/x-s1337-n1.gam -x x.xg | vg view - | grep ATTAGCCATGTGACTT
 
 rm -rf x.vg x.xg x.gcsa
 
-vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >tiny.vg
+vg construct -m 1000 -r tiny/tiny.fa -v tiny/tiny.vcf.gz >tiny.vg
 vg index -x tiny.xg tiny.vg 
 is $(vg find -x tiny.xg -n 12 -n 13 -n 14 -n 15 | vg view - | grep ^L | wc -l) 4 "find gets connected edges between queried nodes by default"
 echo 12 13 >get.nodes
@@ -93,7 +93,7 @@ is "$(vg find -x test.xg -p ref:0 -c 10 | vg view -j - | jq '.edge | length')" "
 
 rm -f test.vg test.xg
 
-vg construct -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a 2> /dev/null | vg view -j - | sed s/_alt/alt/g | vg view -Jv - >w.vg
+vg construct -m 1000 -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a 2> /dev/null | vg view -j - | sed s/_alt/alt/g | vg view -Jv - >w.vg
 vg index -x w.xg w.vg
 is $(( cat w.vg | vg mod -D - ; vg find -x w.xg -Q alt ) | vg paths -L -v - | wc -l) 38 "pattern based path extraction works"
 rm -f w.xg w.vg

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -165,7 +165,7 @@ rm -f x.vg x.xg sim.gam x_gam.gbwt
 
 
 # Other tests
-vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
+vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg bogus123.vg
 is $? 134 "fail with nonexistent file"
 rm -rf x.idx
@@ -228,7 +228,7 @@ is $(vg find -x xy.xg -t | vg paths -L -v - | wc -l) 4 "a thread is stored per h
 is $(vg find -x xy.xg -q _thread_1_y | vg paths -L -v - | wc -l) 2 "we have the expected number of threads per chromosome"
 rm -f xy.vg xy.xg
 
-vg construct -r small/x.fa -v small/x.vcf.gz -a >x.vg
+vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz -a >x.vg
 vg index -x x.xg -v small/x.vcf.gz -H haps.bin x.vg
 is $(du -b haps.bin | cut -f 1) 329 "threads may be exported to binary for use in GBWT construction"
 

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 plan tests 52
 
-vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
+vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
 
 is  "$(vg map -s GCTGTGAAGATTAAATTAGGTGAT -x x.xg -g x.gcsa -j - | jq -r '.path.mapping[0].position.offset')" "3" "offset counts unused bases from the start of the node on the forward strand"

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -36,7 +36,7 @@ vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg
 is $(vg stats -n 13 -d t.vg | cut -f 2) 38 "distance to head is correct"
 is $(vg stats -n 13 -t t.vg | cut -f 2) 11 "distance to tail is correct"
 
-vg construct -r small/x.fa -a -f -v small/x.vcf.gz >x.vg
+vg construct -m 1000 -r small/x.fa -a -f -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 16 x.vg
 vg map -x x.xg -g x.gcsa -T small/x-s1337-n100.reads >x.gam
 is "$(vg stats -a x.gam x.vg | md5sum | cut -f 1 -d\ )" "$(md5sum correct/10_vg_stats/15.txt | cut -f 1 -d\ )" "aligned read stats are computed correctly"

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -15,7 +15,7 @@ is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -k x - | vg view - | 
 
 is $(vg mod -o graphs/orphans.vg | vg view - | wc -l) 8 "orphan edge removal works"
 
-vg construct -r tiny/tiny.fa >t.vg
+vg construct -m 1000 -r tiny/tiny.fa >t.vg
 vg index -k 11 -g t.idx.gcsa -x t.idx.xg t.vg
 
 is $(vg map -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg mod -i - t.vg | vg view - | grep ^S | wc -l) 1 "path inclusion does not modify the graph when alignment is a perfect match"
@@ -30,7 +30,7 @@ is $(vg map -s CAAATAAGGCTTGGAAATTTTCTGCAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg 
 rm t.vg
 rm -rf t.idx.xg t.idx.gcsa
 
-is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -pl 10 -e 3 - | vg stats -E - ) 285 "graph complexity reduction works as expected"
+is $(vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz | vg mod -pl 10 -e 3 - | vg stats -E - ) 285 "graph complexity reduction works as expected"
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -pl 10 -e 3 -t 16 - | vg mod -S -l 200 - | vg stats -l - | cut -f 2) 983 "short subgraph pruning works"
 
@@ -114,14 +114,14 @@ is $(cat c.vg | vg mod -w 100 - | vg stats -N -) 4 "dagify correctly calculates 
 is $(cat c.vg | vg mod -w 100 - | vg stats -l - | cut -f 2) 200 "dagify produces a graph of the correct size"
 rm -f c.vg
 
-vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
+vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 16 x.vg
 vg map -x x.xg -g x.gcsa -G small/x-s1337-n100-e0.01-i0.005.gam -t 1 >x.gam
 vg mod -Z x.trans -i x.gam x.vg >x.mod.vg
 is $(vg view -Z x.trans | wc -l) 1288 "the expected graph translation is exported when the graph is edited"
 rm -rf x.vg x.xg x.gcsa x.reads x.gam x.mod.vg x.trans
 
-vg construct -r tiny/tiny.fa >flat.vg
+vg construct -m 1000 -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
 vg index -x 2snp.xg 2snp.vg
 vg sim -l 30 -x 2snp.xg -n 30 -a >2snp.sim

--- a/test/t/21_vg_filter.t
+++ b/test/t/21_vg_filter.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 plan tests 10
 
-vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
+vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg  x.vg
 vg sim -x x.xg -l 100 -n 5000 -e 0.01 -i 0.001 -a > x.gam
 

--- a/test/t/28_translate.t
+++ b/test/t/28_translate.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 plan tests 2
 
-vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa > tiny.vg
+vg construct -m 1000 -v tiny/tiny.vcf.gz -r tiny/tiny.fa > tiny.vg
 vg index -x tiny.xg -g tiny.gcsa -k 16 tiny.vg
 vg sim -n 5 -e 0.01 -i 0.005 -x tiny.xg -l 30 -a | vg view -a - | sort | vg view -JGa - > tiny.sim
 vg map -G tiny.sim -x tiny.xg -g tiny.gcsa -t 1 > tiny.gam
@@ -20,7 +20,7 @@ is $(vg mod -U 10 tiny.mod.vg | vg mod -c - | vg view - | grep ^S | cut -f 3 | s
 
 rm -Rf tiny.vg tiny.xg tiny.gcsa tiny.gcsa.lcp tiny.sim tiny.gam tiny.trans tiny.mod.vg tiny.trans.1 tiny.paths.gam tiny.paths.trans.gam tiny.mod.vg.1
 
-vg construct -r tiny/tiny.fa >flat.vg
+vg construct -m 1000 -r tiny/tiny.fa >flat.vg
 vg index -x flat.xg -g flat.gcsa -k 8 flat.vg
 vg map -x flat.xg -g flat.gcsa -G tiny/flat-s69-n1-l50-e0.05.gam >flat.gam
 vg mod -i flat.gam -Z flat1.trans flat.vg >flat1.vg

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -8,7 +8,7 @@ PATH=../bin:$PATH # for vg
 plan tests 17
 
 # Construct a graph with alt paths so we can make a gPBWT and later a GBWT
-vg construct -r small/x.fa -v small/x.vcf.gz -a >x.vg
+vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz -a >x.vg
 vg index -x x.xg -v small/x.vcf.gz  x.vg
 vg view -a small/x-l100-n1000-s10-e0.01-i0.01.gam > x.gam.json
 
@@ -53,7 +53,7 @@ is "$(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -r '.path[] 
 
 #check that n-chunking works
 # We know that it will drop _alt paths so we remake the graph without them for comparison.
-vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
+vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 mkdir x.chunk
 vg chunk -x x.xg -n 5 -b x.chunk/
 is $(cat x.chunk/*vg | vg view -V - 2>/dev/null | sort |  md5sum | cut -f 1 -d\ ) $(vg view x.vg | sort  | md5sum | cut -f 1 -d\ ) "n-chunking works and chunks over the full graph"

--- a/test/t/33_vg_mpmap.t
+++ b/test/t/33_vg_mpmap.t
@@ -10,7 +10,7 @@ plan tests 13
 
 # Exercise the GBWT
 # Index a couple of nearly identical contigs
-vg construct -a -r small/xy.fa -v small/xy2.vcf.gz >xy2.vg
+vg construct -m 1000 -a -r small/xy.fa -v small/xy2.vcf.gz >xy2.vg
 vg index -x xy2.xg -g xy2.gcsa -v small/xy2.vcf.gz --gbwt-name xy2.gbwt -k 16 xy2.vg
 
 # We turn off the background model calibration with -B and ignore it with -P 1

--- a/test/t/34_vg_pack.t
+++ b/test/t/34_vg_pack.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 plan tests 6
 
-vg construct -r tiny/tiny.fa >flat.vg
+vg construct -m 1000 -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
 vg index -x 2snp.xg 2snp.vg
 vg sim -l 30 -x 2snp.xg -n 30 -a >2snp.sim

--- a/test/t/38_vg_prune.t
+++ b/test/t/38_vg_prune.t
@@ -9,7 +9,7 @@ plan tests 15
 
 
 # Build a graph with one path and two threads
-vg construct -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a > x.vg 2> /dev/null
+vg construct -m 1000 -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a > x.vg 2> /dev/null
 vg index -G x.gbwt -v small/xy2.vcf.gz x.vg
 
 # Basic pruning: 5 components, 31 nodes, 31 edges
@@ -44,8 +44,8 @@ rm -f x.vg x.gbwt
 
 
 # Build vg graphs for two chromosomes
-vg construct -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a > x.vg 2> /dev/null
-vg construct -r small/xy.fa -v small/xy2.vcf.gz -R y -C -a > y.vg 2> /dev/null
+vg construct -m 1000 -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a > x.vg 2> /dev/null
+vg construct -m 1000 -r small/xy.fa -v small/xy2.vcf.gz -R y -C -a > y.vg 2> /dev/null
 vg ids -j -m xy.mapping x.vg y.vg
 vg index -G x.gbwt -v small/xy2.vcf.gz x.vg
 vg index -G y.gbwt -v small/xy2.vcf.gz y.vg


### PR DESCRIPTION
Hopefully resolves #2003 by way of slightly more informative error when inputting sequence name that's not in fasta.

Also reduces the default node size out of construct to 32.  This is what was used in the paper as well as most ongoing experiments, and seems like a more useful default than 1000. 