### PR TITLE
Miscelaneous mpmap robustification

### DIFF
--- a/src/haplotypes.cpp
+++ b/src/haplotypes.cpp
@@ -261,6 +261,8 @@ haplo_DP_column::~haplo_DP_column() {
 
 void haplo_DP_column::update_inner_values() {
   for(size_t i = 0; i + 1 < entries.size(); i++) {
+    assert(entries[i].get() != nullptr);
+    assert(entries[i+1].get() != nullptr);
     entries[i]->calculate_I(entries[i+1]->interval_size());
   }
   if(!entries.empty()) {
@@ -285,7 +287,9 @@ void haplo_DP_column::update_inner_values() {
 // }
 
 void haplo_DP_column::update_score_vector(haploMath::RRMemo& memo) {
+  assert(!entries.empty());
   auto r_0 = entries.at(0);
+  assert(r_0.get() != nullptr);
   if(entries.size() == 1 && entries.at(0)->prev_idx() == -1) {
     r_0->R = -memo.log_population_size();
     sum = r_0->R + log(r_0->interval_size());
@@ -299,6 +303,7 @@ void haplo_DP_column::update_score_vector(haploMath::RRMemo& memo) {
     vector<double> continuing_Rs(entries.size() - offset);
     vector<int64_t> continuing_counts(entries.size() - offset);
     for(size_t i = offset; i < entries.size(); i++) {
+      assert(entries[i].get() != nullptr);
       continuing_Rs.at(i - offset) = previous_values[entries[i]->prev_idx()];
       continuing_counts.at(i - offset) = entries[i]->I();
     }
@@ -315,6 +320,7 @@ void haplo_DP_column::update_score_vector(haploMath::RRMemo& memo) {
     }
     if(length == 1) {
       for(i; i < entries.size(); i++) {
+        assert(entries[i].get() != nullptr);
         double logLHS = memo.logT_base +
                         previous_R(i) +
                         memo.logT(length);
@@ -322,6 +328,7 @@ void haplo_DP_column::update_score_vector(haploMath::RRMemo& memo) {
       }
     } else {
       for(i; i < entries.size(); i++) {
+        assert(entries[i].get() != nullptr);
         double logLHS = memo.logT_base +
                         haploMath::logsum(logS1RRD, previous_R(i) + memo.logT(length));
         entries[i]->R = haploMath::logsum(logLHS, logpS1S2RRS);
@@ -334,12 +341,14 @@ void haplo_DP_column::update_score_vector(haploMath::RRMemo& memo) {
 }
 
 double haplo_DP_column::previous_R(size_t i) const {
+  assert(entries.at(i).get() != nullptr);
   return previous_values[(entries.at(i))->prev_idx()];
 }
 
 vector<double> haplo_DP_column::get_scores() const {
   vector<double> to_return;
   for(size_t i = 0; i < entries.size(); i++) {
+    assert(entries[i].get() != nullptr);
     to_return.push_back(entries[i]->R);
   }
   return to_return;
@@ -348,6 +357,7 @@ vector<double> haplo_DP_column::get_scores() const {
 vector<int64_t> haplo_DP_column::get_sizes() const {
   vector<int64_t> to_return;
   for(size_t i = 0; i < entries.size(); i++) {
+    assert(entries[i].get() != nullptr);
     to_return.push_back(entries[i]->I());
   }
   return to_return;
@@ -363,6 +373,7 @@ void haplo_DP_column::print(ostream& out) const {
     for(size_t j = 0; j < get_sizes().size() - i - 1; j++) {
       out << "  ";
     }
+    assert(entries.at(i).get() != nullptr);
     out << entries.at(i)->I() << "] : " << entries.at(i)->interval_size() << endl;
   }
 }

--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -650,6 +650,7 @@ pair<double, bool> GBWTScoreProvider<GBWTType>::score(const vg::Path& path, hapl
 template<class GBWTType>
 int64_t GBWTScoreProvider<GBWTType>::get_haplotype_count() const {
   if (!index.hasMetadata()) {
+    cerr << "GBWT lacks index metadata!" << endl;
     // No metadata available
     return -1;
   }

--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -650,7 +650,6 @@ pair<double, bool> GBWTScoreProvider<GBWTType>::score(const vg::Path& path, hapl
 template<class GBWTType>
 int64_t GBWTScoreProvider<GBWTType>::get_haplotype_count() const {
   if (!index.hasMetadata()) {
-    cerr << "GBWT lacks index metadata!" << endl;
     // No metadata available
     return -1;
   }

--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -498,6 +498,7 @@ void haplo_DP_rectangle::false_extend(accessorType& ga,
 template<class accessorType>
 haplo_DP_column::haplo_DP_column(accessorType& ga) {
   haplo_DP_rectangle* first_rectangle = new haplo_DP_rectangle(ga.inclusive_interval());
+  assert(first_rectangle != nullptr);
   entries.push_back(shared_ptr<haplo_DP_rectangle>(first_rectangle));
   first_rectangle->extend(ga);
   update_inner_values();
@@ -509,6 +510,7 @@ void haplo_DP_column::standard_extend(accessorType& ga) {
   previous_values = get_scores();
   previous_sizes = get_sizes();
   haplo_DP_rectangle* new_rectangle = new haplo_DP_rectangle(ga.inclusive_interval());
+  assert(new_rectangle != nullptr);
   new_rectangle->extend(ga);
   decltype(entries) new_entries;
   new_entries.push_back(shared_ptr<haplo_DP_rectangle>(new_rectangle));
@@ -548,7 +550,7 @@ void haplo_DP_column::extend(accessorType& ga) {
 //------------------------------------------------------------------------------
 
 template<class accessorType>
-haplo_DP::haplo_DP(accessorType& ga) : DP_column(haplo_DP_column(ga)) {
+haplo_DP::haplo_DP(accessorType& ga) : DP_column(ga) {
   
 }
 
@@ -559,6 +561,13 @@ haplo_score_type haplo_DP::score(const vg::Path& path, GBWTType& graph, haploMat
 
 template<class GBWTType>
 haplo_score_type haplo_DP::score(const gbwt_thread_t& thread, GBWTType& graph, haploMath::RRMemo& memo) {
+  if (thread.size() == 0) {
+    if (warn_on_score_fail) {
+      cerr << "[WARNING] Path is empty and cannot be scored" << endl;
+      cerr << "Cannot compute a meaningful haplotype likelihood score" << endl;
+    }
+    return pair<double, bool>(nan(""), false);
+  }
   if (!graph.contains(thread[0])) {
     // We start on a node that has no haplotype index entry
     if (warn_on_score_fail) {

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -144,7 +144,7 @@ namespace vg {
     void merge_non_branching_subpaths(MultipathAlignment& multipath_aln);
     
     /// Returns a vector whose elements are vectors with the indexes of the Subpaths in
-    /// each connected component
+    /// each connected component. An unmapped MultipathAlignment with no subpaths produces an empty vector.
     vector<vector<int64_t>> connected_components(const MultipathAlignment& multipath_aln);
     
     /// Extract the MultipathAlignment consisting of the Subpaths with the given indexes

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3204,9 +3204,14 @@ namespace vg {
             
             if (query_population) {
             
-                // Work out the population size. Try the score provider and then fall back to the xg.
-                auto haplotype_count = haplo_score_provider->get_haplotype_count();
-                if (haplotype_count == -1) {
+                // Work out the population size. Use the override, then try the score provider, and then fall back to the xg.
+                auto haplotype_count = force_haplotype_count;
+                
+                if (haplotype_count == 0) {
+                    haplotype_count = haplo_score_provider->get_haplotype_count();
+                }
+                
+                if (haplotype_count == 0 || haplotype_count == -1) {
                     // The score provider doesn't ahve a haplotype count. Fall back to the count in the XG.
                     haplotype_count = xindex->get_haplotype_count();
                 }
@@ -3462,9 +3467,14 @@ namespace vg {
             if (query_population) {
                 // We also want to select the optimal population-scored alignment on each side and compute a pop-adjusted score.
                 
-                // Work out the population size. Try the score provider and then fall back to the xg.
-                auto haplotype_count = haplo_score_provider->get_haplotype_count();
-                if (haplotype_count == -1) {
+                // Work out the population size. Use the override, then try the score provider, and then fall back to the xg.
+                auto haplotype_count = force_haplotype_count;
+                
+                if (haplotype_count == 0) {
+                    haplotype_count = haplo_score_provider->get_haplotype_count();
+                }
+                
+                if (haplotype_count == 0 || haplotype_count == -1) {
                     // The score provider doesn't ahve a haplotype count. Fall back to the count in the XG.
                     haplotype_count = xindex->get_haplotype_count();
                 }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -691,13 +691,24 @@ namespace vg {
     int64_t MultipathMapper::distance_between(const MultipathAlignment& multipath_aln_1,
                                               const MultipathAlignment& multipath_aln_2,
                                               bool full_fragment, bool forward_strand) const {
+                                              
+        if (multipath_aln_1.subpath_size() == 0 || multipath_aln_2.subpath_size() == 0) {
+            // Something is an unmapped alignment
+            return numeric_limits<int64_t>::max();
+        }
+        
         Alignment aln_1;
         optimal_alignment(multipath_aln_1, aln_1);
+        // We already threw out unmapped things
+        assert(aln_1.path().mapping_size() != 0);
         pos_t pos_1 = initial_position(aln_1.path());
+        assert(id(pos_1) != 0);
         
         Alignment aln_2;
         optimal_alignment(multipath_aln_2, aln_2);
+        assert(aln_2.path().mapping_size() != 0);
         pos_t pos_2 = full_fragment ? final_position(aln_2.path()) : initial_position(aln_2.path());
+        assert(id(pos_2) != 0);
 #ifdef debug_multipath_mapper
         cerr << "measuring left-to-" << (full_fragment ? "right" : "left") << " end distance between " << pos_1 << " and " << pos_2 << endl;
 #endif

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -281,12 +281,14 @@ namespace vg {
         
         /// Sorts mappings by score and store mapping quality of the optimal alignment in the MultipathAlignment object
         /// Optionally also sorts a vector of indexes to keep track of the cluster-of-origin
+        /// Allows multipath alignments where the best single path alignment is leaving the read unmapped.
         void sort_and_compute_mapping_quality(vector<MultipathAlignment>& multipath_alns, MappingQualityMethod mapq_method,
                                               vector<size_t>* cluster_idxs = nullptr) const;
         
         /// Sorts mappings by score and store mapping quality of the optimal alignment in the MultipathAlignment object
         /// If there are ties between scores, breaks them by the expected distance between pairs as computed by the
         /// OrientedDistanceClusterer::cluster_pairs function (modified cluster_pairs vector)
+        /// Allows multipath alignments where the best single path alignment is leaving the read unmapped.
         void sort_and_compute_mapping_quality(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs,
                                               vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                               bool allow_population_component,

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -255,13 +255,15 @@ namespace vg {
                                                     const vector<memcluster_t>& clusters);
         
         /// If there are any MultipathAlignments with multiple connected components, split them
-        /// up and add them to the return vector
+        /// up and add them to the return vector.
+        /// Properly handles MultipathAlignments that are unmapped.
         void split_multicomponent_alignments(vector<MultipathAlignment>& multipath_alns_out,
                                              vector<size_t>* cluster_idxs = nullptr) const;
         
         /// If there are any MultipathAlignments with multiple connected components, split them
         /// up and add them to the return vector, also measure the distance between them and add
-        /// a record to the cluster pairs vector
+        /// a record to the cluster pairs vector.
+        /// Properly handles MultipathAlignments that are unmapped.
         void split_multicomponent_alignments(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
                                              vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs) const;
         
@@ -341,6 +343,7 @@ namespace vg {
         double random_match_p_value(size_t match_length, size_t read_length);
         
         /// Compute the approximate distance between two multipath alignments
+        /// If either is unmapped, or the distance cannot be obtained, returns numeric_limits<int64_t>::max()
         int64_t distance_between(const MultipathAlignment& multipath_aln_1, const MultipathAlignment& multipath_aln_2,
                                  bool full_fragment = false, bool forward_strand = false) const;
         

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -111,6 +111,11 @@ namespace vg {
         double mapq_scaling_factor = 1.0 / 4.0;
         // There must be a ScoreProvider provided, and a positive population_max_paths, if this is true
         bool use_population_mapqs = false;
+        // If this is nonzero, it takes precedence over any haplotype count
+        // available from the score provider or the XG index. If neither of
+        // those has a haplotype count, this must be set for haplotype scoring
+        // to work.
+        size_t force_haplotype_count = 0;
         // If this is set, use_population_mapqs must be set, and we will always
         // try to compute population scores, even if there is nothing to
         // disambiguate. This lets us get an accurate count of scorable reads.

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -75,6 +75,7 @@ void help_mpmap(char** argv) {
     << "  --recombination-penalty FLOAT use this log recombination penalty for GBWT haplotype scoring [20.7]" << endl
     << "  --always-check-population     always try to population-score reads, even if there is only a single mapping" << endl
     << "  --delay-population            do not apply population scoring at intermediate stages of the mapping algorithm" << endl
+    << "  --force-haplotype-count INT   assume that INT haplotypes ought to run through each fixed part of the graph, if nonzero [0]" << endl
     << "  -C, --drop-subgraph FLOAT     drop alignment subgraphs whose MEMs cover this fraction less of the read than the best subgraph [0.2]" << endl
     << "  -U, --prune-exp FLOAT         prune MEM anchors if their approximate likelihood is this root less than the optimal anchors [1.25]" << endl
     << "scoring:" << endl
@@ -103,6 +104,7 @@ int main_mpmap(int argc, char** argv) {
     #define OPT_RECOMBINATION_PENALTY 1001
     #define OPT_ALWAYS_CHECK_POPULATION 1002
     #define OPT_DELAY_POPULATION_SCORING 1003
+    #define OPT_FORCE_HAPLOTYPE_COUNT 1004
     string matrix_file_name;
     string xg_name;
     string gcsa_name;
@@ -151,6 +153,7 @@ int main_mpmap(int argc, char** argv) {
     double recombination_penalty = 20.7;
     bool always_check_population = false;
     bool delay_population_scoring = false;
+    size_t force_haplotype_count = 0;
     bool single_path_alignment_mode = false;
     int max_mapq = 60;
     size_t frag_length_sample_size = 1000;
@@ -231,6 +234,7 @@ int main_mpmap(int argc, char** argv) {
             {"recombination-penalty", required_argument, 0, OPT_RECOMBINATION_PENALTY},
             {"always-check-population", no_argument, 0, OPT_ALWAYS_CHECK_POPULATION},
             {"delay-population", no_argument, 0, OPT_DELAY_POPULATION_SCORING},
+            {"force-haplotype-count", required_argument, 0, OPT_FORCE_HAPLOTYPE_COUNT},
             {"drop-subgraph", required_argument, 0, 'C'},
             {"prune-exp", required_argument, 0, 'U'},
             {"long-read-scoring", no_argument, 0, 'E'},
@@ -455,6 +459,10 @@ int main_mpmap(int argc, char** argv) {
                 delay_population_scoring = true;
                 break;
                 
+            case OPT_FORCE_HAPLOTYPE_COUNT:
+                force_haplotype_count = parse<size_t>(optarg);
+                break;
+                
             case 'C':
                 cluster_ratio = parse<double>(optarg);
                 break;
@@ -631,6 +639,10 @@ int main_mpmap(int argc, char** argv) {
     
     if (delay_population_scoring && gbwt_name.empty() && sublinearLS_name.empty()) {
         cerr << "warning:[vg mpmap] Cannot --delay-population scoring if no population database (-H or --linear-index) is provided. Ignoring option." << endl;
+    }
+    
+    if (force_haplotype_count != 0 && gbwt_name.empty() && sublinearLS_name.empty()) {
+        cerr << "warning:[vg mpmap] Cannot --force-haplotype-count if no population database (-H or --linear-index) is provided. Ignoring option." << endl;
     }
     
     if (!sublinearLS_name.empty() && !gbwt_name.empty()) {
@@ -943,6 +955,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.recombination_penalty = recombination_penalty;
     multipath_mapper.always_check_population = always_check_population;
     multipath_mapper.delay_population_scoring = delay_population_scoring;
+    multipath_mapper.force_haplotype_count = force_haplotype_count;
     
     // set pruning and clustering parameters
     multipath_mapper.use_tvs_clusterer = use_tvs_clusterer;


### PR DESCRIPTION
I came across some errors when testing GBWT mapping.

It looks like my code for annotating alignments with their population scores was never correct, and was looking outside arrays, so I fixed it.

I also made mpmap more robust to MultipathAlignments with no actual subpaths (i.e. which represent leaving the read unmapped) getting in the works.

Finally, I've added some asserts to the haploype scoring code, to catch if it tries to use unset column pointers, because I saw it trying to do that once. I may have solved that problem by changing the member initializes a bit, but I'm not certain, so I want to leave the asserts in.