### PR TITLE
Simulator for RNA

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -4,19 +4,35 @@
 
 namespace vg {
 
-/// Make a path sampling distribution based on relative lengths
-void Sampler::set_source_paths(const vector<string>& source_paths) {
-    this->source_paths = source_paths;
-    if (!source_paths.empty()) {
+
+void Sampler::set_source_paths(const vector<string>& source_paths,
+                               const vector<pair<string, double>>& transcript_expressions) {
+    if (!source_paths.empty() && !transcript_expressions.empty()) {
+        cerr << "error:[Sampler] cannot sample from list of paths and from list of transcripts simultaneously" << endl;
+        exit(1);
+    }
+    else if (!transcript_expressions.empty()) {
+        this->source_paths.clear();
+        vector<double> expression_values;
+        for (const pair<string, double>& transcript_expression : transcript_expressions) {
+            this->source_paths.push_back(transcript_expression.first);
+            expression_values.push_back(transcript_expression.second);
+        }
+        path_sampler = vg::discrete_distribution<>(expression_values.begin(), expression_values.end());
+    }
+    else if (!source_paths.empty()) {
+        this->source_paths = source_paths;
         vector<size_t> path_lengths;
         for (auto& source_path : source_paths) {
             path_lengths.push_back(xgidx->path_length(source_path));
         }
         path_sampler = vg::discrete_distribution<>(path_lengths.begin(), path_lengths.end());
-    } else {
+    }
+    else {
         path_sampler = vg::discrete_distribution<>();
     }
 }
+    
 
 /// We have a helper function to convert path positions and orientations to
 /// pos_t values.
@@ -551,7 +567,8 @@ const string NGSSimulator::alphabet = "ACGT";
 NGSSimulator::NGSSimulator(xg::XG& xg_index,
                            const string& ngs_fastq_file,
                            bool interleaved_fastq,
-                           const vector<string>& source_paths,
+                           const vector<string>& source_paths_input,
+                           const vector<pair<string, double>>& transcript_expressions,
                            double substition_polymorphism_rate,
                            double indel_polymorphism_rate,
                            double indel_error_proportion,
@@ -576,18 +593,12 @@ NGSSimulator::NGSSimulator(xg::XG& xg_index,
     , prob_sampler(0.0, 1.0)
     , insert_sampler(insert_length_mean, insert_length_stdev)
     , seed(seed)
-    , source_paths(source_paths)
+    , source_paths(source_paths_input)
     , joint_initial_distr(seed - 1)
 {
-    if (source_paths.empty()) {
-        start_pos_samplers.emplace_back(1, xg_index.seq_length);
-    } else {
-        vector<size_t> path_sizes;
-        for (const auto& source_path : source_paths) {
-            path_sizes.push_back(xg_index.path_length(source_path));
-            start_pos_samplers.emplace_back(0, path_sizes.back() - 1);
-        }
-        path_sampler = vg::discrete_distribution<>(path_sizes.begin(), path_sizes.end());
+    if (!source_paths.empty() && !transcript_expressions.empty()) {
+        cerr << "error:[NGSSimulator] cannot simultaneously limit sampling to paths and match an expresssion profile" << endl;
+        exit(1);
     }
     
     if (substition_polymorphism_rate < 0.0 || substition_polymorphism_rate > 1.0
@@ -615,6 +626,27 @@ NGSSimulator::NGSSimulator(xg::XG& xg_index,
     if (insert_length_mean < 5.0 * insert_length_stdev) {
         cerr << "warning:[NGSSimulator] Recommended that insert length mean (" << insert_length_mean
             << ") > 5 * insert length standard deviation (" << insert_length_stdev << ")" << endl;
+    }
+    
+    if (source_paths.empty() && transcript_expressions.empty()) {
+        start_pos_samplers.emplace_back(1, xg_index.seq_length);
+    }
+    else if (!source_paths.empty()) {
+        vector<size_t> path_sizes;
+        for (const auto& source_path : source_paths) {
+            path_sizes.push_back(xg_index.path_length(source_path));
+            start_pos_samplers.emplace_back(0, path_sizes.back() - 1);
+        }
+        path_sampler = vg::discrete_distribution<>(path_sizes.begin(), path_sizes.end());
+    }
+    else {
+        vector<double> expression_values;
+        for (const pair<string, double>& transcript_expression : transcript_expressions) {
+            source_paths.push_back(transcript_expression.first);
+            start_pos_samplers.emplace_back(0, xg_index.path_length(transcript_expression.first) - 1);
+            expression_values.push_back(transcript_expression.second);
+        }
+        path_sampler = vg::discrete_distribution<>(expression_values.begin(), expression_values.end());
     }
     
     // memoize phred conversions

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -57,7 +57,8 @@ public:
             int seed = 0,
             bool forward_only = false,
             bool allow_Ns = false,
-            const vector<string>& source_paths = {})
+            const vector<string>& source_paths = {},
+            const vector<pair<string, double>>& transcript_expressions = {})
         : xgidx(x),
           node_cache(100),
           edge_cache(100),
@@ -69,10 +70,13 @@ public:
             seed = time(NULL);
         }
         rng.seed(seed);
-        set_source_paths(source_paths);
+        set_source_paths(source_paths, transcript_expressions);
     }
 
-    void set_source_paths(const vector<string>& source_paths);
+    /// Make a path sampling distribution based on relative lengths or on transcript expressions
+    /// (at most one should be non-empty)
+    void set_source_paths(const vector<string>& source_paths,
+                          const vector<pair<string, double>>& transcript_expressions);
 
     pos_t position(void);
     string sequence(size_t length);
@@ -137,10 +141,13 @@ public:
     /// Most reads in the FASTQ should be the same length. Polymorphism rates apply
     /// uniformly along a read, whereas errors are distributed as indicated by the learned
     /// distribution. The simulation can also be restricted to named paths in the graph.
+    /// Alternatively, it can match an expression profile. However, it cannot be simulateously
+    /// restricted to paths and to an expression profile.
     NGSSimulator(xg::XG& xg_index,
                  const string& ngs_fastq_file,
                  bool interleaved_fastq = false,
                  const vector<string>& source_paths = {},
+                 const vector<pair<string, double>>& transcript_expressions = {},
                  double substition_polymorphism_rate = 0.001,
                  double indel_polymorphism_rate = 0.0002,
                  double indel_error_proportion = 0.01,

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -26,6 +26,9 @@ using namespace vg::subcommand;
 vector<pair<string, double>> parse_rsem_expression_file(istream& rsem_in) {
     vector<pair<string, double>> return_val;
     string line;
+    // skip the header line
+    getline(rsem_in, line);
+    line.clear();
     while (getline(rsem_in, line)) {
         vector<string> tokens;
         stringstream strm(line);

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -22,6 +22,28 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+// Gets the transcript IDs and TPM values from an RSEM output .tsv file
+vector<pair<string, double>> parse_rsem_expression_file(istream& rsem_in) {
+    vector<pair<string, double>> return_val;
+    string line;
+    while (getline(rsem_in, line)) {
+        vector<string> tokens;
+        stringstream strm(line);
+        string token;
+        while (getline(strm, token, '\t')) {
+            tokens.push_back(move(token));
+            token.clear();
+        }
+        if (tokens.size() != 8) {
+            cerr << "[vg sim] error: Cannot parse transcription file. Expected 8-column TSV file as produced by RSEM, got " << tokens.size() << " columns." << endl;
+            exit(1);
+        }
+        return_val.emplace_back(tokens[0], parse<double>(tokens[5]));
+        line.clear();
+    }
+    return return_val;
+}
+
 void help_sim(char** argv) {
     cerr << "usage: " << argv[0] << " sim [options]" << endl
          << "Samples sequences from the xg-indexed graph." << endl
@@ -30,7 +52,8 @@ void help_sim(char** argv) {
          << "    -x, --xg-name FILE          use the xg index in FILE" << endl
          << "    -F, --fastq FILE            superpose errors matching the error profile of NGS reads in FILE (ignores -l,-f)" << endl
          << "    -I, --interleaved           reads in FASTQ (-F) are interleaved read pairs" << endl
-         << "    -P, --path PATH             simulate from the given names path (multiple allowed)" << endl
+         << "    -P, --path PATH             simulate from the given names path (multiple allowed, cannot also give -T)" << endl
+         << "    -T, --tx-expr-file FILE     simulate from an expression profile formatted as RSEM output (cannot also give -P)" << endl
          << "    -l, --read-length N         write reads of length N" << endl
          << "    -n, --num-reads N           simulate N reads or read pairs" << endl
          << "    -s, --random-seed N         use this specific seed for the PRNG" << endl
@@ -72,6 +95,9 @@ int main_sim(int argc, char** argv) {
     string fastq_name;
     // What path should we sample from? Empty string = the whole graph.
     vector<string> path_names;
+    // Alternatively, which transcripts with how much expression?
+    string rsem_file_name;
+    vector<pair<string, double>> transcript_expressions;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -83,6 +109,7 @@ int main_sim(int argc, char** argv) {
             {"fastq", required_argument, 0, 'F'},
             {"interleaved", no_argument, 0, 'I'},
             {"path", required_argument, 0, 'P'},
+            {"tx-expr-file", required_argument, 0, 'T'},
             {"read-length", required_argument, 0, 'l'},
             {"num-reads", required_argument, 0, 'n'},
             {"random-seed", required_argument, 0, 's'},
@@ -124,6 +151,10 @@ int main_sim(int argc, char** argv) {
             
         case 'P':
             path_names.push_back(optarg);
+            break;
+            
+        case 'T':
+            rsem_file_name = optarg;
             break;
 
         case 'l':
@@ -199,6 +230,15 @@ int main_sim(int argc, char** argv) {
         cerr << "[vg sim] error: we need an xg index to sample reads from" << endl;
         return 1;
     }
+    
+    if (!rsem_file_name.empty()) {
+        ifstream rsem_in(rsem_file_name);
+        if (!rsem_in) {
+            cerr << "[vg sim] error: could not open transcription profile file " << rsem_file_name << endl;
+            return 1;
+        }
+        transcript_expressions = parse_rsem_expression_file(rsem_in);
+    }
 
     xg::XG* xgidx = nullptr;
     ifstream xg_stream(xg_name);
@@ -216,6 +256,13 @@ int main_sim(int argc, char** argv) {
             return 1;
         }
     }
+    
+    for (auto& transcript_expression : transcript_expressions) {
+        if (xgidx->path_rank(transcript_expression.first) == 0) {
+            cerr << "[vg sim] error: transcript path for \""<< transcript_expression.first << "\" not found in index" << endl;
+            return 1;
+        }
+    }
 
     // Make a Mapper to score reads, with the default parameters
     Mapper rescorer(xgidx, nullptr, nullptr);
@@ -229,7 +276,7 @@ int main_sim(int argc, char** argv) {
         // Use the fixed error rate sampler
         
         // Make a sample to sample reads with
-        Sampler sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns, path_names);
+        Sampler sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns, path_names, transcript_expressions);
         
         // Make a Mapper to score reads, with the default parameters
         Mapper rescorer(xgidx, nullptr, nullptr);
@@ -327,6 +374,7 @@ int main_sim(int argc, char** argv) {
                              fastq_name,
                              interleaved,
                              path_names,
+                             transcript_expressions,
                              base_error,
                              indel_error,
                              indel_prop,

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -127,7 +127,7 @@ int main_sim(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hl:n:s:e:i:fax:Jp:v:Nd:F:P:S:I",
+        c = getopt_long (argc, argv, "hl:n:s:e:i:fax:Jp:v:Nd:F:P:T:S:I",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/unittest/sampler.cpp
+++ b/src/unittest/sampler.cpp
@@ -65,7 +65,7 @@ TEST_CASE( "Sampler can sample from a 1-node graph", "[sampler]" ) {
     SECTION( "Can sample all bases in both directions from a path" ) {
         
         // Same as above except we do this
-        sampler.set_source_paths({"ref"});
+        sampler.set_source_paths({"ref"}, {});
         
         unordered_set<pair<size_t, bool>> seen;
         
@@ -207,7 +207,7 @@ TEST_CASE( "Sampler can sample from a loop-containing path", "[sampler]" ) {
     SECTION( "Can sample entire path" ) {
         
         // Same as above except we do this
-        sampler.set_source_paths({"ref"});
+        sampler.set_source_paths({"ref"}, {});
         
         unordered_set<string> found;
         
@@ -270,7 +270,7 @@ TEST_CASE( "Sampler can across reversing edges", "[sampler]" ) {
     SECTION( "Can sample entire path" ) {
         
         // Same as above except we do this
-        sampler.set_source_paths({"ref"});
+        sampler.set_source_paths({"ref"}, {});
         
         unordered_set<string> found;
         


### PR DESCRIPTION
We can now create a simulated RNA-seq dataset that matches a given expression profile with both the trained and untrained read samplers. Turned out to be simpler than I though because of the path-sampling functionality that someone already added. 