### PR TITLE
Fix surject with full-length option

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -140,9 +140,10 @@ namespace vg {
     tuple<MultipathProblem, int64_t, int32_t> run_multipath_dp(const MultipathAlignment& multipath_aln,
                                                                bool subpath_global = false) {
         
-        // Create and unpack the return value (including setting up the DP table)
+        // Create and unpack the return value (including setting up the DP table). Initialise score according
+        // to whether the alignment is local or global 
         tuple<MultipathProblem, int64_t, int32_t> to_return(MultipathProblem(multipath_aln, subpath_global),
-                                                            -1, 0);
+                                                            -1, subpath_global ? numeric_limits<int32_t>::min() : 0);
         auto& problem = get<0>(to_return);
         auto& opt_subpath = get<1>(to_return);
         auto& opt_score = get<2>(to_return);

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -115,7 +115,7 @@ namespace vg {
         /// Do intervening and tail alignments between the anchoring paths and store the result
         /// in a MultipathAlignment. Reachability edges must be in the graph.
         void align(const Alignment& alignment, VG& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
-                   size_t max_alt_alns, bool dynamic_alt_alns, size_t band_padding, MultipathAlignment& multipath_aln_out);
+                   size_t max_alt_alns, bool dynamic_alt_alns, size_t band_padding, MultipathAlignment& multipath_aln_out, const bool allow_negative_scores = false);
         
         /// Do intervening and tail alignments between the anchoring paths and store the result
         /// in a MultipathAlignment. Reachability edges must be in the graph. Also, choose the
@@ -123,7 +123,7 @@ namespace vg {
         void align(const Alignment& alignment, VG& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns,
                    function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,
-                   MultipathAlignment& multipath_aln_out);
+                   MultipathAlignment& multipath_aln_out, const bool allow_negative_scores = false);
         
         /// Converts a MultipathAlignmentGraph to a GraphViz Dot representation, output to the given ostream.
         void to_dot(ostream& out) const;

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -113,7 +113,7 @@ using namespace std;
             
             // align the intervening segments and store the result in a multipath alignment
             MultipathAlignment mp_aln;
-            mp_aln_graph.align(source, split_path_graph, get_aligner(), false, 1, false, 1, mp_aln);
+            mp_aln_graph.align(source, split_path_graph, get_aligner(), false, 1, false, 1, mp_aln, allow_negative_scores);
             topologically_order_subpaths(mp_aln);
             
             for (size_t i = 0; i < mp_aln.subpath_size(); i++) {


### PR DESCRIPTION
This fixes two small bugs when running surject using the full-length option that allows for outputting surjected alignments with a negative score. Before these, alignments across large deletions were still soft clipped. Now the surjected alignment can cross large deletions if the original alignment to the graph also crossed the same deletions. 

Currently, a read aligning across a large deletion is written as a single surjected alignment using the CIGAR string to represent the deletion. However, I was thinking that we at some point might want to implement an option for outputting it as positive scoring sub-alignments instead, similar to how it is done in other alignment programs. Let me know what you think and I can maybe look into implementing it?
