### PR TITLE
Added mapq and annotation to the second read in mpmap alignment output

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -831,6 +831,7 @@ namespace vg {
         rev_comp_out.set_name(multipath_aln.name());
         rev_comp_out.set_sample_name(multipath_aln.sample_name());
         rev_comp_out.set_paired_read_name(multipath_aln.paired_read_name());
+        rev_comp_out.set_mapping_quality(multipath_aln.mapping_quality());
         
         vector< vector<size_t> > reverse_edge_lists(multipath_aln.subpath_size());
         vector<size_t> reverse_starts;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1109,6 +1109,11 @@ int main_mpmap(int argc, char** argv) {
                                              [&](vg::id_t node_id) { return xg_index.node_length(node_id); },
                                              output_buf.back());
             }
+
+            if (mp_aln_pair.second.has_annotation()) {
+                // Move over annotations
+                output_buf.back().set_allocated_annotation(mp_aln_pair.second.release_annotation());
+            }
             
             // label with read group and sample name
             if (!read_group.empty()) {


### PR DESCRIPTION
Mapping quality and annotation were lost when computing the reverse complement of multipath alignments. This resolves #1986 