### PR TITLE
Fix msa_converter to handle paths properly

### DIFF
--- a/src/msa_converter.cpp
+++ b/src/msa_converter.cpp
@@ -388,9 +388,11 @@ using namespace std;
                     edit->set_from_length(node_length);
                     edit->set_to_length(node_length);
                 }
+                graph.paths.extend(*path);
             }
             
             graph.destroy_node(dummy_node);
+            graph.sync_paths();
         }
         
         destroy_progress();


### PR DESCRIPTION
```maf.maf
##maf version=1 scoring=tba.v8
# tba.v8 (((human chimp) baboon) (mouse rat))

a score=23262.0
s hg18.chr7    27578828 38 + 158545518 AAA-GGGAATGTTAACCAAATGA---ATTGTCTCTTACGGTG
s panTro1.chr6 28741140 38 + 161576975 AAA-GGGAATGTTAACCAAATGA---ATTGTCTCTTACGGTG
s baboon         116834 38 +   4622798 AAA-GGGAATGTTAACCAAATGA---GTTGTCTCTTATGGTG
s mm4.chr6     53215344 38 + 151104725 -AATGGGAATGTTAAGCAAACGA---ATTGTCTCTCAGTGTG
s rn3.chr4     81344243 40 + 187371129 -AA-GGGGATGCTAAGCCAATGAGTTGTTGTCTCTCAATGTG

a score=5062.0
s hg18.chr7    27699739 6 + 158545518 TAAAGA
s panTro1.chr6 28862317 6 + 161576975 TAAAGA
s baboon         241163 6 +   4622798 TAAAGA
s mm4.chr6     53303881 6 + 151104725 TAAAGA
s rn3.chr4     81444246 6 + 187371129 taagga

a score=6636.0
s hg18.chr7    27707221 13 + 158545518 gcagctgaaaaca
s panTro1.chr6 28869787 13 + 161576975 gcagctgaaaaca
s baboon         249182 13 +   4622798 gcagctgaaaaca
s mm4.chr6     53310102 13 + 151104725 ACAGCTGAAAATA
```

I want to construct VG graph from a maf file like above, but it generated a VG file with no paths.

```
$ vg construct -F maf -M maf.maf > maf.vg
$ vg construct -M maf.maf | vg view - | grep ^P
```

I fixed it by adding a line to extend VG::paths at msa_converter.