### PR TITLE
Haplotype-aware linearization for haplotype scoring, with MultipathAlignmentGraph refactoring and bugfixes

### DIFF
--- a/src/algorithms/extract_extending_graph.hpp
+++ b/src/algorithms/extract_extending_graph.hpp
@@ -21,9 +21,11 @@ namespace algorithms {
     /// Fills graph 'into' with the subgraph of the handle graph 'source' that extends in one direction from
     /// a given position, up to a maximum distance. The node containing the position will be "cut" so that only
     /// the portion that is forward in the search direction remains. Node IDs may be changed in the extracted
-    /// graph, but they can be translated back to node IDs in the original graph with the returned map. The
-    /// node containing the source node may optionally be duplicated to preserve cycles on it after its cut,
-    /// but no other nodes will will duplicated.
+    /// graph, but they can be translated back to node IDs in the original graph with the returned map, although
+    /// that translation procedure MUST handle the node that pos is on specially, as it may be cut.
+    /// translate_node_ids from path.hpp can do this as long as you pass along what part of the node was removed.
+    /// The node containing the source position may optionally be duplicated to preserve cycles on it after its
+    /// cut, but no other nodes will will duplicated.
     ///
     /// Args:
     ///  source                  graph to extract subgraph from

--- a/src/haplotypes.cpp
+++ b/src/haplotypes.cpp
@@ -829,6 +829,19 @@ int64_t ScoreProvider::get_haplotype_count() const {
   return -1;
 }
 
+bool ScoreProvider::has_incremental_search() const {
+  // By default, say that we lack incremental search support.
+  return false;
+}
+
+IncrementalSearchState ScoreProvider::incremental_find(const vg::Position& pos) const {
+  throw runtime_error("Incremental search not implemented");
+}
+
+IncrementalSearchState ScoreProvider::incremental_extend(const IncrementalSearchState& state, const vg::Position& pos) const {
+  throw runtime_error("Incremental search not implemented");
+}
+
 /*******************************************************************************
 XGScoreProvider
 *******************************************************************************/

--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -658,7 +658,7 @@ haplo_score_type haplo_DP::score(const gbwt_thread_t& thread, GBWTType& graph, h
       hdp.DP_column.extend(ga);
     }
 #ifdef debug
-    cerr << "After entry " << i << " (" << gbwt::Node::id(thread[i]) << ") height: " << ga.new_height() << " intervals: ";
+    cerr << "After entry " << i << "/" << thread.size() << " (" << gbwt::Node::id(thread[i]) << ") height: " << ga.new_height() << " intervals: ";
     for (auto& interval : hdp.DP_column.get_sizes()) {
       cerr << interval << " ";
     }

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -2046,6 +2046,66 @@ namespace vg {
             }
         }
     }
+    
+    void view_multipath_alignment_as_dot(ostream& out, const MultipathAlignment& multipath_aln) {
+        out << "digraph graphname {" << endl;
+        out << "rankdir=\"LR\";" << endl;
+        
+        // Track graph nodes so we get one node for each
+        unordered_set<id_t> mentioned_nodes;
+        // Similarly for graph edges
+        unordered_set<pair<id_t, id_t>> mentioned_edges;
+        
+        // Do the start node
+        out << "start[label=\"Start\" shape=circle];" << endl;
+        for (size_t start_subpath : multipath_aln.start()) {
+            // Hook it up to each start subpath
+            out << "start -> s" << start_subpath << ";" << endl;
+        }
+        
+        for (size_t i = 0; i < multipath_aln.subpath_size(); i++) {
+            // For each subpath, say it with its score
+            out << "s" << i << " [label=\"" << i << "\" shape=circle tooltip=\"" << multipath_aln.subpath(i).score() << "\"];" << endl;
+            
+            for (size_t next_subpath : multipath_aln.subpath(i).next()) {
+                // For each edge from it, say where it goes
+                out << "s" << i << " -> s" << next_subpath << ";" << endl;
+            }
+            
+            /*
+            auto& path = multipath_aln.subpath(i).path();
+            for (size_t j = 0; j < path.mapping_size(); j++) {
+                // For each mapping in the path, show the vg node in the graph too
+                auto node_id = path.mapping(j).position().node_id();
+                
+                if (!mentioned_nodes.count(node_id)) {
+                    // This graph node eneds to be made
+                    mentioned_nodes.insert(node_id);
+                    out << "g" << node_id << " [label=\"" << node_id << "\" shape=box];" << endl;
+                }
+                
+                // Attach the subpath to each involved graph node.
+                out << "s" << i << " -> g" << node_id << " [dir=none color=blue];" << endl;
+                
+                if (j != 0) {
+                    // We have a previous node in this segment of path. What is it?
+                    auto prev_id = path.mapping(j-1).position().node_id();
+                    pair<id_t, id_t> edge_pair{prev_id, node_id};
+                    
+                    if (!mentioned_edges.count(edge_pair)) {
+                        // This graph edge needs to be made
+                        mentioned_edges.insert(edge_pair);
+                        
+                        out << "g" << prev_id << " -> g" << node_id << ";" << endl;
+                    }
+                }
+            }
+            */
+        }
+        
+        out << "}" << endl;
+    }
+        
 }
 
 

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -2047,7 +2047,7 @@ namespace vg {
         }
     }
     
-    void view_multipath_alignment_as_dot(ostream& out, const MultipathAlignment& multipath_aln) {
+    void view_multipath_alignment_as_dot(ostream& out, const MultipathAlignment& multipath_aln, bool show_graph) {
         out << "digraph graphname {" << endl;
         out << "rankdir=\"LR\";" << endl;
         
@@ -2072,35 +2072,35 @@ namespace vg {
                 out << "s" << i << " -> s" << next_subpath << ";" << endl;
             }
             
-            /*
-            auto& path = multipath_aln.subpath(i).path();
-            for (size_t j = 0; j < path.mapping_size(); j++) {
-                // For each mapping in the path, show the vg node in the graph too
-                auto node_id = path.mapping(j).position().node_id();
-                
-                if (!mentioned_nodes.count(node_id)) {
-                    // This graph node eneds to be made
-                    mentioned_nodes.insert(node_id);
-                    out << "g" << node_id << " [label=\"" << node_id << "\" shape=box];" << endl;
-                }
-                
-                // Attach the subpath to each involved graph node.
-                out << "s" << i << " -> g" << node_id << " [dir=none color=blue];" << endl;
-                
-                if (j != 0) {
-                    // We have a previous node in this segment of path. What is it?
-                    auto prev_id = path.mapping(j-1).position().node_id();
-                    pair<id_t, id_t> edge_pair{prev_id, node_id};
+            if (show_graph) {
+                auto& path = multipath_aln.subpath(i).path();
+                for (size_t j = 0; j < path.mapping_size(); j++) {
+                    // For each mapping in the path, show the vg node in the graph too
+                    auto node_id = path.mapping(j).position().node_id();
                     
-                    if (!mentioned_edges.count(edge_pair)) {
-                        // This graph edge needs to be made
-                        mentioned_edges.insert(edge_pair);
+                    if (!mentioned_nodes.count(node_id)) {
+                        // This graph node eneds to be made
+                        mentioned_nodes.insert(node_id);
+                        out << "g" << node_id << " [label=\"" << node_id << "\" shape=box];" << endl;
+                    }
+                    
+                    // Attach the subpath to each involved graph node.
+                    out << "s" << i << " -> g" << node_id << " [dir=none color=blue];" << endl;
+                    
+                    if (j != 0) {
+                        // We have a previous node in this segment of path. What is it?
+                        auto prev_id = path.mapping(j-1).position().node_id();
+                        pair<id_t, id_t> edge_pair{prev_id, node_id};
                         
-                        out << "g" << prev_id << " -> g" << node_id << ";" << endl;
+                        if (!mentioned_edges.count(edge_pair)) {
+                            // This graph edge needs to be made
+                            mentioned_edges.insert(edge_pair);
+                            
+                            out << "g" << prev_id << " -> g" << node_id << ";" << endl;
+                        }
                     }
                 }
             }
-            */
         }
         
         out << "}" << endl;

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -1,8 +1,7 @@
-//
-//  multipath_alignment.hpp
-//
-// utility functions for the MultipathAlignment protobuf object
-//
+/// \file multipath_alignment.hpp
+///
+/// utility functions for the MultipathAlignment protobuf object
+///
 
 #ifndef multipath_alignment_hpp
 #define multipath_alignment_hpp
@@ -18,6 +17,11 @@
 #include "alignment.hpp"
 #include "utility.hpp"
 #include "handle.hpp"
+
+// Declare the haplo::ScoreProvider we use for haplotype-aware traceback generation.
+namespace haplo {
+    class ScoreProvider;
+}
 
 namespace vg {
     
@@ -87,19 +91,24 @@ namespace vg {
     ///
     vector<Alignment> optimal_alignments_with_disjoint_subpaths(const MultipathAlignment& multipath_aln, size_t count);
     
-    /// Finds all alignments consistent with haplotypes in the given GBWT index. This may result in an empty vector.
+    /// Finds all alignments consistent with haplotypes available by incremental search with the given haplotype
+    /// score provider. This may result in an empty vector.
+    ///
+    /// Output Alignments may not be unique. The input MultipathAlignment may have exponentially many ways to
+    /// spell the same Alignment, and we will look at all of them. We also may have duplicates of the optimal
+    /// alignment if we are asked to produce it unconsitionally.
     ///
     /// Note: Assumes that each subpath's Path object uses one Mapping per node and that
     /// start subpaths have been identified
     ///
-    /// GBWTType must be either gbwt::GBWT or gbwt::DynamicGBWT; we only instantiate the template for those.
     ///
     ///  Args:
     ///    multipath_aln     multipath alignment to find optimal paths through
-    ///    index             GBWT index containing haplotypes
+    ///    score_provider    a haplo::ScoreProvider that supports incremental search over its haplotype database (such as a GBWTScoreProvider)
+    ///    optimal_first     always compute and return first the optimal alignment, even if not haplotype-consistent
     ///
-    template<typename GBWTType>
-    vector<Alignment> haplotype_consistent_alignments(const MultipathAlignment& multipath_aln, const GBWTType& index); 
+    vector<Alignment> haplotype_consistent_alignments(const MultipathAlignment& multipath_aln, const haplo::ScoreProvider& score_provider,
+        bool optimal_first = false); 
     
     /// Stores the reverse complement of a MultipathAlignment in another MultipathAlignment
     ///

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -189,7 +189,7 @@ namespace vg {
     void view_multipath_alignment(ostream& out, const MultipathAlignment& multipath_aln, const HandleGraph& handle_graph);
     
     /// Converts a MultipathAlignment to a GraphViz Dot representation, output to the given ostream.
-    void view_multipath_alignment_as_dot(ostream& out, const MultipathAlignment& multipath_aln);
+    void view_multipath_alignment_as_dot(ostream& out, const MultipathAlignment& multipath_aln, bool show_graph = false);
     
     // TODO: function for adding a graph augmentation to an existing multipath alignment
 }

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -188,6 +188,9 @@ namespace vg {
     /// Send a formatted string representation of the MultipathAlignment into the ostream
     void view_multipath_alignment(ostream& out, const MultipathAlignment& multipath_aln, const HandleGraph& handle_graph);
     
+    /// Converts a MultipathAlignment to a GraphViz Dot representation, output to the given ostream.
+    void view_multipath_alignment_as_dot(ostream& out, const MultipathAlignment& multipath_aln);
+    
     // TODO: function for adding a graph augmentation to an existing multipath alignment
 }
 

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -12,6 +12,7 @@
 #include <list>
 #include <unordered_map>
 #include <algorithm>
+
 #include "vg.pb.h"
 #include "path.hpp"
 #include "alignment.hpp"
@@ -85,6 +86,20 @@ namespace vg {
     ///    count             maximum number of top alignments to return
     ///
     vector<Alignment> optimal_alignments_with_disjoint_subpaths(const MultipathAlignment& multipath_aln, size_t count);
+    
+    /// Finds all alignments consistent with haplotypes in the given GBWT index. This may result in an empty vector.
+    ///
+    /// Note: Assumes that each subpath's Path object uses one Mapping per node and that
+    /// start subpaths have been identified
+    ///
+    /// GBWTType must be either gbwt::GBWT or gbwt::DynamicGBWT; we only instantiate the template for those.
+    ///
+    ///  Args:
+    ///    multipath_aln     multipath alignment to find optimal paths through
+    ///    index             GBWT index containing haplotypes
+    ///
+    template<typename GBWTType>
+    vector<Alignment> haplotype_consistent_alignments(const MultipathAlignment& multipath_aln, const GBWTType& index); 
     
     /// Stores the reverse complement of a MultipathAlignment in another MultipathAlignment
     ///

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -92,7 +92,9 @@ namespace vg {
     vector<Alignment> optimal_alignments_with_disjoint_subpaths(const MultipathAlignment& multipath_aln, size_t count);
     
     /// Finds all alignments consistent with haplotypes available by incremental search with the given haplotype
-    /// score provider. This may result in an empty vector.
+    /// score provider. Pads to a certain count with haplotype-inconsistent alignments that are population-scorable
+    /// (i.e. use only edges used by some haplotype in the index), and then with unscorable alignments if scorable
+    /// ones are unavailable. This may result in an empty vector.
     ///
     /// Output Alignments may not be unique. The input MultipathAlignment may have exponentially many ways to
     /// spell the same Alignment, and we will look at all of them. We also may have duplicates of the optimal
@@ -105,10 +107,11 @@ namespace vg {
     ///  Args:
     ///    multipath_aln     multipath alignment to find optimal paths through
     ///    score_provider    a haplo::ScoreProvider that supports incremental search over its haplotype database (such as a GBWTScoreProvider)
+    ///    count             maximum number of haplotype-inconsistent alignments to pad to
     ///    optimal_first     always compute and return first the optimal alignment, even if not haplotype-consistent
     ///
     vector<Alignment> haplotype_consistent_alignments(const MultipathAlignment& multipath_aln, const haplo::ScoreProvider& score_provider,
-        bool optimal_first = false); 
+        size_t count, bool optimal_first = false); 
     
     /// Stores the reverse complement of a MultipathAlignment in another MultipathAlignment
     ///

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1251,7 +1251,6 @@ namespace vg {
         }
     }
    
-#define debug_multipath_alignment
     void MultipathAlignmentGraph::synthesize_tail_anchors(const Alignment& alignment, VG& align_graph, BaseAligner* aligner,
                                                           size_t max_alt_alns, bool dynamic_alt_alns) {
     
@@ -1424,7 +1423,6 @@ namespace vg {
         // Now we've created new PathNodes for all the perfect matches in the tail alignments.
         // They can be resected out of snarls just like the original ones.
     }
-#undef debug_multipath_alignment
 
     void MultipathAlignmentGraph::add_reachability_edges(VG& vg,
                                                          const unordered_map<id_t, pair<id_t, bool>>& projection_trans,
@@ -3340,7 +3338,6 @@ namespace vg {
         }
     }
     
-#define debug_multipath_alignment
     unordered_map<bool, unordered_map<size_t, vector<Alignment>>>
     MultipathAlignmentGraph::align_tails(const Alignment& alignment, VG& align_graph,
                                          BaseAligner* aligner, size_t max_alt_alns,
@@ -3574,7 +3571,6 @@ namespace vg {
         // Return all the alignments, organized by tail and subpath
         return to_return;
     }
-#undef debug_multipath_alignment
     
     void MultipathAlignmentGraph::groom_graph_for_gssw(Graph& graph) {
         
@@ -3733,10 +3729,6 @@ namespace vg {
             }
         }
         out << "}" << endl;
-        
-        for (size_t i = 0; i < path_nodes.size(); i++) {
-            out << "PathNode " << i << ": " << pb2json(path_nodes.at(i).path) << endl;
-        }
     }
     
     vector<vector<id_t>> MultipathAlignmentGraph::get_connected_components() const {

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3624,7 +3624,7 @@ namespace vg {
         return path_nodes.empty();
     }
     
-    void MultipathAlignmentGraph::to_dot(ostream& out) const {
+    void MultipathAlignmentGraph::to_dot(ostream& out, const Alignment* alignment) const {
         // We track the VG graph nodes we talked about already.
         set<id_t> mentioned_nodes;
         set<pair<id_t, id_t>> mentioned_edges;
@@ -3634,7 +3634,13 @@ namespace vg {
         for (size_t i = 0; i < path_nodes.size(); i++) {
             // For each node, say the node itself as a mapping node, annotated with match length
             out << "m" << i << " [label=\"" << i << "\" shape=circle tooltip=\""
-                << (path_nodes.at(i).end - path_nodes.at(i).begin) << " bp\"];" << endl;
+                << (path_nodes.at(i).end - path_nodes.at(i).begin) << " bp";
+            if (alignment != nullptr) {
+                // Include info on where that falls in the query sequence
+                out << " (" << (path_nodes.at(i).begin - alignment->sequence().begin()) << " - "
+                    << (path_nodes.at(i).end - alignment->sequence().begin()) << ")";
+            }
+            out << "\"];" << endl;
             for (pair<size_t, size_t> edge : path_nodes.at(i).edges) {
                 // For each edge from it, say where it goes and how far it skips
                 out << "m" << i << " -> m" << edge.first << " [label=" << edge.second << "];" << endl;

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3119,8 +3119,10 @@ namespace vg {
                 
                 if (connecting_graph.node_size() == 0) {
                     // the MEMs weren't connectable with a positive score after all, mark the edge for removal
+#ifdef debug_multipath_alignment
                     cerr << "Remove edge " << j << " -> " << edge.first << " because we got no nodes in the connecting graph "
                         << src_pos << " to " << dest_pos << endl;
+#endif
                     edges_for_removal.insert(edge);
                     continue;
                 }

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -42,6 +42,10 @@ namespace vg {
         /// making it a member.
         static unordered_multimap<id_t, pair<id_t, bool>> create_injection_trans(const unordered_map<id_t, pair<id_t, bool>>& projection_trans);
         
+        /// Create an identity projection translation from a DAG that did not
+        /// need to be modified during dagification.
+        static unordered_map<id_t, pair<id_t, bool>> create_identity_projection_trans(const VG& vg);
+        
         /// Construct a graph of the reachability between MEMs in a DAG-ified
         /// graph. If a GCSA is specified, use it to collapse MEMs whose
         /// lengths bump up against the GCSA's order limit on MEM length.

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -116,14 +116,23 @@ namespace vg {
                                     const unordered_map<id_t, pair<id_t, bool>>& projection_trans,
                                     const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans);
                                     
-        /// Do intervening and tail alignments between the anchoring paths and store the result
-        /// in a MultipathAlignment. Reachability edges must be in the graph.
+        /// Do intervening and tail alignments between the anchoring paths and
+        /// store the result in a MultipathAlignment. Reachability edges must
+        /// be in the graph. The Alignment passed *must* be the same Alignment
+        /// that owns the sequence into which iterators were passed when the
+        /// MultipathAlignmentGraph was constructed! TODO: Shouldn't the class
+        /// hold a reference to the Alignment then?
         void align(const Alignment& alignment, VG& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t band_padding, MultipathAlignment& multipath_aln_out);
         
-        /// Do intervening and tail alignments between the anchoring paths and store the result
-        /// in a MultipathAlignment. Reachability edges must be in the graph. Also, choose the
-        /// band padding dynamically as a function of the inter-MEM sequence and graph
+        /// Do intervening and tail alignments between the anchoring paths and
+        /// store the result in a MultipathAlignment. Reachability edges must
+        /// be in the graph. Also, choose the band padding dynamically as a
+        /// function of the inter-MEM sequence and graph. The Alignment passed
+        /// *must* be the same Alignment that owns the sequence into which
+        /// iterators were passed when the MultipathAlignmentGraph was
+        /// constructed! TODO: Shouldn't the class hold a reference to the
+        /// Alignment then?
         void align(const Alignment& alignment, VG& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns,
                    function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -116,11 +116,12 @@ namespace vg {
         /// the outermost existing anchors, and define new anchoring paths from
         /// them. After this, you can call resect_snarls_from_paths, in order
         /// to get better coverage of possible combinations of snarl traversals
-        /// in parts of the alignment that didn't originally have anchors. The
-        /// Alignment passed *must* be the same Alignment that owns the
-        /// sequence into which iterators were passed when the
-        /// MultipathAlignmentGraph was constructed! TODO: Shouldn't the class
-        /// hold a reference to the Alignment then?
+        /// in parts of the alignment that didn't originally have anchors.
+        /// Produces *only* perfect match anchors, so it is still safe to use
+        /// score_anchors_as_matches. The Alignment passed *must* be the same
+        /// Alignment that owns the sequence into which iterators were passed
+        /// when the MultipathAlignmentGraph was constructed! TODO: Shouldn't
+        /// the class hold a reference to the Alignment then?
         void synthesize_tail_anchors(const Alignment& alignment, VG& align_graph, BaseAligner* aligner,
                                      size_t max_alt_alns, bool dynamic_alt_alns);
         

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -173,6 +173,13 @@ namespace vg {
         /// If this is unset and you want it set, use add_reachability_edges().
         bool has_reachability_edges = false;
         
+        /// Trim down the given PathNode of everything except softclips.
+        /// Return true if it all gets trimmed away and should be removed.
+        /// Fills in removed_start_from_length and/or removed_end_from_length
+        /// with the bases in the graph removed from the path on each end
+        /// during trimming, if set.
+        static bool trim_and_check_for_empty(const Alignment& alignment, PathNode& path_node,
+            int64_t* removed_start_from_length = nullptr, int64_t* removed_end_from_length = nullptr);
         
         /// Add the path chunks as nodes to the connectivity graph
         void create_path_chunk_nodes(VG& vg, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -136,6 +136,10 @@ namespace vg {
         /// that owns the sequence into which iterators were passed when the
         /// MultipathAlignmentGraph was constructed! TODO: Shouldn't the class
         /// hold a reference to the Alignment then?
+        ///
+        /// Note that the output alignment may NOT be in topologically-sorted
+        /// order, even if this MultipathAlignmentGraph is. You MUST sort it
+        /// with topologically_order_subpaths() before trying to run DP on it.
         void align(const Alignment& alignment, VG& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t band_padding, MultipathAlignment& multipath_aln_out);
         
@@ -147,6 +151,10 @@ namespace vg {
         /// iterators were passed when the MultipathAlignmentGraph was
         /// constructed! TODO: Shouldn't the class hold a reference to the
         /// Alignment then?
+        ///
+        /// Note that the output alignment may NOT be in topologically-sorted
+        /// order, even if this MultipathAlignmentGraph is. You MUST sort it
+        /// with topologically_order_subpaths() before trying to run DP on it.
         void align(const Alignment& alignment, VG& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns,
                    function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -153,7 +153,8 @@ namespace vg {
                    MultipathAlignment& multipath_aln_out);
         
         /// Converts a MultipathAlignmentGraph to a GraphViz Dot representation, output to the given ostream.
-        void to_dot(ostream& out) const;
+        /// If given the Alignment query we are working on, can produce information about subpath iterators.
+        void to_dot(ostream& out, const Alignment* alignment = nullptr) const;
         
         /// Get lists of the vg node IDs that participate in each connected component in the MultipathAlignmentGraph
         vector<vector<id_t>> get_connected_components() const;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -4,7 +4,7 @@
 //
 //
 
-#define debug_multipath_mapper
+//#define debug_multipath_mapper
 //#define debug_multipath_mapper_alignment
 //#define debug_validate_multipath_alignments
 //#define debug_report_startup_training

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3219,7 +3219,7 @@ namespace vg {
             
             if (query_population) {
                 // We want to do population scoring
-                if (haplo_score_provider->has_incremental_search()) {
+                if (!top_tracebacks && haplo_score_provider->has_incremental_search()) {
                     // We can use incremental haplotype search to find all the linearizations consistent with haplotypes
                     // Make sure to also always include the optimal alignment first, even if inconsistent.
                     // And also include up to population_max_paths non-consistent but hopefully scorable paths
@@ -3519,7 +3519,7 @@ namespace vg {
             
             if (query_population) {
                 // We want to do population scoring
-                if (haplo_score_provider->has_incremental_search()) {
+                if (!top_tracebacks && haplo_score_provider->has_incremental_search()) {
                     // We can use incremental haplotype search to find all the linearizations consistent with haplotypes
                     // Make sure to also always include the optimal alignment first, even if inconsistent.
                     // Also pad out with population_max_paths inconsistent or unscorable paths

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3660,6 +3660,9 @@ namespace vg {
         
         if (include_population_component && all_multipaths_pop_consistent) {
             // Record that we used the population score
+#ifdef debug_multipath_mapper
+            cerr << "Haplotype consistency score is being used." << endl;
+#endif
             for (auto& multipath_aln_pair : multipath_aln_pairs) {
                 // We have to do it on each read in each pair.
                 // TODO: Come up with a simpler way to dump annotations in based on what happens during mapping.
@@ -3668,6 +3671,9 @@ namespace vg {
             }
         } else {
             // Clean up pop score annotations if present and remove scores from all the reads
+#ifdef debug_multipath_mapper
+            cerr << "Haplotype consistency score is not being used." << endl;
+#endif
             for (auto& multipath_aln_pair : multipath_aln_pairs) {
                 // We have to do it on each read in each pair.
                 clear_annotation(multipath_aln_pair.first, "haplotype_score_used");

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -4,7 +4,7 @@
 //
 //
 
-//#define debug_multipath_mapper
+#define debug_multipath_mapper
 //#define debug_multipath_mapper_alignment
 //#define debug_validate_multipath_alignments
 //#define debug_report_startup_training
@@ -1718,7 +1718,7 @@ namespace vg {
                                                 size_t max_alt_mappings) const {
     
 #ifdef debug_multipath_mapper
-        cerr << "linearizing multipath alignment" << endl;
+        cerr << "linearizing multipath alignment to assess positional diversity" << endl;
 #endif        
         // Compute a few optimal alignments using disjoint sets of subpaths.
         // This hopefully gives us a feel for the positional diversity of the MultipathMapping.
@@ -3490,8 +3490,8 @@ namespace vg {
                 if (haplo_score_provider->has_incremental_search()) {
                     // We can use incremental haplotype search to find all the linearizations consistent with haplotypes
                     // Make sure to also always include the optimal alignment first, even if inconsistent.
-                    alignments[0] = haplotype_consistent_alignments(multipath_aln_pair.first, *haplo_score_provider, true);
-                    alignments[1] = haplotype_consistent_alignments(multipath_aln_pair.second, *haplo_score_provider, true);
+                    alignments[0] = haplotype_consistent_alignments(multipath_aln_pair.first, *haplo_score_provider, population_max_paths, true);
+                    alignments[1] = haplotype_consistent_alignments(multipath_aln_pair.second, *haplo_score_provider, population_max_paths, true);
                 } else {
                     // We will just find the top n best-alignment-scoring linearizations and hope some match haplotypes
                     alignments[0] = optimal_alignments(multipath_aln_pair.first, population_max_paths);
@@ -3502,6 +3502,10 @@ namespace vg {
                 alignments[0] = optimal_alignments(multipath_aln_pair.first, 1);
                 alignments[1] = optimal_alignments(multipath_aln_pair.second, 1);
             }
+            
+#ifdef debug_multipath_mapper
+            cerr << "Got " << alignments[0].size() << " and " << alignments[1].size() << " linearizations on each end" << endl;
+#endif
             
             // We used to fail an assert if either list of optimal alignments
             // was empty, but now we handle it as if that side is an unmapped
@@ -3580,6 +3584,11 @@ namespace vg {
                                 << alignments[end][j].name() << ". This should never happen! Changing to failure." << endl;
                             pop_score.second = false;
                         }
+                        
+#ifdef debug_multipath_mapper
+                        cerr << "Linearization " << j << " on end " << end << " gets pop score " << pop_score.first
+                            << " and alignment score " << alignments[end][j].score() << endl;
+#endif
                         
                         if (pop_score.second) {
                             // If the alignment was pop-score-able, mix it in as a candidate for the best linearization

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2968,7 +2968,6 @@ namespace vg {
             multi_aln_graph.prune_to_high_scoring_paths(alignment, get_aligner(),
                                                         max_suboptimal_path_score_ratio, topological_order);
         }
-#define debug_multipath_mapper_alignment        
         if (snarl_manager) {
             // We want to do snarl cutting
             
@@ -3005,7 +3004,6 @@ namespace vg {
             cerr << endl;
         }
 #endif
-#undef debug_multipath_mapper_alignment
         
         function<size_t(const Alignment&, const HandleGraph&)> choose_band_padding = [&](const Alignment& seq, const HandleGraph& graph) {
             size_t read_length = seq.sequence().end() - seq.sequence().begin();

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2282,8 +2282,10 @@ namespace vg {
             
 #ifdef debug_multipath_mapper
             cerr << "finding connected components for mapping:" << endl;
-            cerr  << pb2json(multipath_aln_pairs_out[i].first) << endl;
-            cerr  << pb2json(multipath_aln_pairs_out[i].second) << endl;
+            view_multipath_alignment_as_dot(cerr, multipath_aln_pairs_out[i].first);
+            view_multipath_alignment_as_dot(cerr, multipath_aln_pairs_out[i].second);
+            //cerr  << pb2json(multipath_aln_pairs_out[i].first) << endl;
+            //cerr  << pb2json(multipath_aln_pairs_out[i].second) << endl;
             cerr << "read 1 connected components:" << endl;
             for (vector<int64_t>& comp : connected_components_1) {
                 cerr << "\t";
@@ -2966,7 +2968,7 @@ namespace vg {
             multi_aln_graph.prune_to_high_scoring_paths(alignment, get_aligner(),
                                                         max_suboptimal_path_score_ratio, topological_order);
         }
-        
+#define debug_multipath_mapper_alignment        
         if (snarl_manager) {
             // We want to do snarl cutting
             
@@ -2980,14 +2982,20 @@ namespace vg {
                 multi_aln_graph.synthesize_tail_anchors(alignment, align_graph, get_aligner(), num_alt_alns, dynamic_max_alt_alns);
                 
             }
+       
+#ifdef debug_multipath_mapper_alignment
+            cerr << "MultipathAlignmentGraph going into snarl cutting:" << endl;
+            multi_aln_graph.to_dot(cerr, &alignment);
+#endif
         
             // Do the snarl cutting, which modifies the nodes in the multipath alignment graph
             multi_aln_graph.resect_snarls_from_paths(snarl_manager, node_trans, max_snarl_cut_size);
         }
-        
+
+
 #ifdef debug_multipath_mapper_alignment
         cerr << "MultipathAlignmentGraph going into alignment:" << endl;
-        multi_aln_graph.to_dot(cerr);
+        multi_aln_graph.to_dot(cerr, &alignment);
         
         for (auto& ids : multi_aln_graph.get_connected_components()) {
             cerr << "Component: ";
@@ -2997,6 +3005,7 @@ namespace vg {
             cerr << endl;
         }
 #endif
+#undef debug_multipath_mapper_alignment
         
         function<size_t(const Alignment&, const HandleGraph&)> choose_band_padding = [&](const Alignment& seq, const HandleGraph& graph) {
             size_t read_length = seq.sequence().end() - seq.sequence().begin();

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3192,11 +3192,21 @@ namespace vg {
             // is turned on and it succeeded for the others.
             bool query_population = include_population_component && all_multipaths_pop_consistent;
             
+            /// Get all the linearizations we are going to work with, possibly with duplicates.
+            /// The first alignment will be optimal.
+            vector<Alignment> alignments;
+            
+            // If we can and should do incremental haplotype search, get the top alignment and all haplotype consistent alignments.
+            
+            // Otherwise, if we're evaluating population consistency, get some number of top-alignment-scoring alignments with no regard to haplotype consistency
+            
+            // Otherwise, just get the evry best alignment
+            
             // Generate the top alignment, or the top population_max_paths
             // alignments if we are doing multiple alignments for population
             // scoring.
             auto wanted_alignments = query_population ? population_max_paths : 1;
-            auto alignments = optimal_alignments(multipath_alns[i], wanted_alignments);
+            alignments = optimal_alignments(multipath_alns[i], wanted_alignments);
             
 #ifdef debug_multipath_mapper
             cerr << "Got " << alignments.size() << " / " << wanted_alignments << " tracebacks for multipath " << i << endl;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3339,6 +3339,11 @@ namespace vg {
         
         if (include_population_component && all_multipaths_pop_consistent) {
             // We will go ahead with pop scoring for this read
+            
+#ifdef debug_multipath_mapper
+            cerr << "Haplotype consistency score is being used." << endl;
+#endif
+            
             for (auto& score : pop_adjusted_scores) {
                 // Adjust the adjusted scores up/down by the minimum adjustment to ensure no scores are negative
                 score -= min_adjustment;
@@ -3350,6 +3355,11 @@ namespace vg {
             }
         } else {
             // Clean up pop score annotations and remove scores on all the reads.
+            
+#ifdef debug_multipath_mapper
+            cerr << "Haplotype consistency score is not being used." << endl;
+#endif
+            
             for (auto& mpaln : multipath_alns) {
                 clear_annotation(mpaln, "haplotype_score_used");
                 clear_annotation(mpaln, "haplotype_score");

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2970,12 +2970,16 @@ namespace vg {
         if (snarl_manager) {
             // We want to do snarl cutting
             
+            if (!suppress_tail_anchors) {
+            
 #ifdef debug_multipath_mapper_alignment
-            cerr << "Synthesizing tail anchors for snarl cutting" << endl;
+                cerr << "Synthesizing tail anchors for snarl cutting" << endl;
 #endif
 
-            // Make fake anchor paths to cut the snarls out of in the tails
-            multi_aln_graph.synthesize_tail_anchors(alignment, align_graph, get_aligner(), num_alt_alns, dynamic_max_alt_alns);
+                // Make fake anchor paths to cut the snarls out of in the tails
+                multi_aln_graph.synthesize_tail_anchors(alignment, align_graph, get_aligner(), num_alt_alns, dynamic_max_alt_alns);
+                
+            }
         
             // Do the snarl cutting, which modifies the nodes in the multipath alignment graph
             multi_aln_graph.resect_snarls_from_paths(snarl_manager, node_trans, max_snarl_cut_size);

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2966,9 +2966,12 @@ namespace vg {
             multi_aln_graph.prune_to_high_scoring_paths(alignment, get_aligner(),
                                                         max_suboptimal_path_score_ratio, topological_order);
         }
-                      
+        
         if (snarl_manager) {
             // We want to do snarl cutting
+            
+            // Make fake anchor paths to cut the snarls out of in the tails
+            multi_aln_graph.synthesize_tail_anchors(alignment, align_graph, get_aligner(), num_alt_alns, dynamic_max_alt_alns);
         
             // Do the snarl cutting, which modifies the nodes in the multipath alignment graph
             multi_aln_graph.resect_snarls_from_paths(snarl_manager, node_trans, max_snarl_cut_size);

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3003,6 +3003,9 @@ namespace vg {
         // do the connecting alignments and fill out the MultipathAlignment object
         multi_aln_graph.align(alignment, align_graph, get_aligner(), true, num_alt_alns, dynamic_max_alt_alns, choose_band_padding, multipath_aln_out);
         
+        // Note that we do NOT topologically order the MultipathAlignment. The
+        // caller has to do that, after it is finished breaking it up into
+        // connected components or whatever.
         
 #ifdef debug_multipath_mapper_alignment
         cerr << "multipath alignment before translation: " << pb2json(multipath_aln_out) << endl;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3201,7 +3201,8 @@ namespace vg {
                 if (haplo_score_provider->has_incremental_search()) {
                     // We can use incremental haplotype search to find all the linearizations consistent with haplotypes
                     // Make sure to also always include the optimal alignment first, even if inconsistent.
-                    alignments = haplotype_consistent_alignments(multipath_alns[i], *haplo_score_provider, true);
+                    // And also include up to population_max_paths non-consistent but hopefully scorable paths
+                    alignments = haplotype_consistent_alignments(multipath_alns[i], *haplo_score_provider, population_max_paths, true);
                 } else {
                     // We will just find the top n best-alignment-scoring linearizations and hope some match haplotypes
                     alignments = optimal_alignments(multipath_alns[i], population_max_paths);

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2970,13 +2970,17 @@ namespace vg {
         if (snarl_manager) {
             // We want to do snarl cutting
             
+#ifdef debug_multipath_mapper_alignment
+            cerr << "Synthesizing tail anchors for snarl cutting" << endl;
+#endif
+
             // Make fake anchor paths to cut the snarls out of in the tails
             multi_aln_graph.synthesize_tail_anchors(alignment, align_graph, get_aligner(), num_alt_alns, dynamic_max_alt_alns);
         
             // Do the snarl cutting, which modifies the nodes in the multipath alignment graph
             multi_aln_graph.resect_snarls_from_paths(snarl_manager, node_trans, max_snarl_cut_size);
         }
-
+        
 #ifdef debug_multipath_mapper_alignment
         cerr << "MultipathAlignmentGraph going into alignment:" << endl;
         multi_aln_graph.to_dot(cerr);

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3490,6 +3490,7 @@ namespace vg {
                 if (haplo_score_provider->has_incremental_search()) {
                     // We can use incremental haplotype search to find all the linearizations consistent with haplotypes
                     // Make sure to also always include the optimal alignment first, even if inconsistent.
+                    // Also pad out with population_max_paths inconsistent or unscorable paths
                     alignments[0] = haplotype_consistent_alignments(multipath_aln_pair.first, *haplo_score_provider, population_max_paths, true);
                     alignments[1] = haplotype_consistent_alignments(multipath_aln_pair.second, *haplo_score_provider, population_max_paths, true);
                 } else {

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -176,7 +176,8 @@ namespace vg {
         
         
         /// After clustering MEMs, extracting graphs, and assigning hits to cluster graphs, perform
-        /// multipath alignment
+        /// multipath alignment.
+        /// Produces topologically sorted MultipathAlignments.
         void align_to_cluster_graphs(const Alignment& alignment,
                                      MappingQualityMethod mapq_method,
                                      vector<clustergraph_t>& cluster_graphs,
@@ -187,6 +188,7 @@ namespace vg {
         /// After clustering MEMs, extracting graphs, assigning hits to cluster graphs, and determining
         /// which cluster graph pairs meet the fragment length distance constraints, perform multipath
         /// alignment
+        /// Produces topologically sorted MultipathAlignments.
         void align_to_cluster_graph_pairs(const Alignment& alignment1, const Alignment& alignment2,
                                           vector<clustergraph_t>& cluster_graphs1,
                                           vector<clustergraph_t>& cluster_graphs2,
@@ -196,6 +198,7 @@ namespace vg {
         
         /// Align the read ends independently, but also try to form rescue alignments for each from
         /// the other. Return true if output obeys pair consistency and false otherwise.
+        /// Produces topologically sorted MultipathAlignments.
         bool align_to_cluster_graphs_with_rescue(const Alignment& alignment1, const Alignment& alignment2,
                                                  vector<clustergraph_t>& cluster_graphs1,
                                                  vector<clustergraph_t>& cluster_graphs2,
@@ -204,7 +207,8 @@ namespace vg {
                                                  vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances,
                                                  size_t max_alt_mappings);
         
-        /// Use the rescue routine on strong suboptimal clusters to see if we can find a good secondary
+        /// Use the rescue routine on strong suboptimal clusters to see if we can find a good secondary.
+        /// Produces topologically sorted MultipathAlignments.
         void attempt_rescue_for_secondaries(const Alignment& alignment1, const Alignment& alignment2,
                                             vector<clustergraph_t>& cluster_graphs1,
                                             vector<clustergraph_t>& cluster_graphs2,
@@ -213,7 +217,8 @@ namespace vg {
                                             vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs);
         
         /// Cluster and extract subgraphs for (possibly) only one end, meant to be a non-repeat, and use them to rescue
-        /// an alignment for the other end, meant to be a repeat
+        /// an alignment for the other end, meant to be a repeat.
+        /// Produces topologically sorted MultipathAlignments.
         void attempt_rescue_of_repeat_from_non_repeat(const Alignment& alignment1, const Alignment& alignment2,
                                                       const vector<MaximalExactMatch>& mems1, const vector<MaximalExactMatch>& mems2,
                                                       bool do_repeat_rescue_from_1, bool do_repeat_rescue_from_2,
@@ -257,6 +262,7 @@ namespace vg {
         /// If there are any MultipathAlignments with multiple connected components, split them
         /// up and add them to the return vector.
         /// Properly handles MultipathAlignments that are unmapped.
+        /// Does not depend on or guarantee topological order in the MultipathAlignments.
         void split_multicomponent_alignments(vector<MultipathAlignment>& multipath_alns_out,
                                              vector<size_t>* cluster_idxs = nullptr) const;
         
@@ -264,18 +270,21 @@ namespace vg {
         /// up and add them to the return vector, also measure the distance between them and add
         /// a record to the cluster pairs vector.
         /// Properly handles MultipathAlignments that are unmapped.
+        /// Does not depend on or guarantee topological order in the MultipathAlignments.
         void split_multicomponent_alignments(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
                                              vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs) const;
         
         
         /// Make a multipath alignment of the read against the indicated graph and add it to
         /// the list of multimappings.
+        /// Does NOT necessarily produce a MultipathAlignment in topological order.
         void multipath_align(const Alignment& alignment, VG* vg,
                              memcluster_t& graph_mems,
                              MultipathAlignment& multipath_aln_out) const;
         
         /// Removes the sections of an Alignment's path within snarls and re-aligns them with multiple traceback
-        /// to create a multipath alignment with non-trivial topology
+        /// to create a multipath alignment with non-trivial topology.
+        /// Guarantees that the resulting MultipathAlignment is in topological order.
         void make_nontrivial_multipath_alignment(const Alignment& alignment, VG& subgraph,
                                                  unordered_map<id_t, pair<id_t, bool>>& translator,
                                                  SnarlManager& snarl_manager, MultipathAlignment& multipath_aln_out) const;
@@ -289,6 +298,7 @@ namespace vg {
         /// Sorts mappings by score and store mapping quality of the optimal alignment in the MultipathAlignment object
         /// Optionally also sorts a vector of indexes to keep track of the cluster-of-origin
         /// Allows multipath alignments where the best single path alignment is leaving the read unmapped.
+        /// MultipathAlignments MUST be topologically sorted.
         void sort_and_compute_mapping_quality(vector<MultipathAlignment>& multipath_alns, MappingQualityMethod mapq_method,
                                               vector<size_t>* cluster_idxs = nullptr) const;
         
@@ -296,6 +306,7 @@ namespace vg {
         /// If there are ties between scores, breaks them by the expected distance between pairs as computed by the
         /// OrientedDistanceClusterer::cluster_pairs function (modified cluster_pairs vector)
         /// Allows multipath alignments where the best single path alignment is leaving the read unmapped.
+        /// MultipathAlignments MUST be topologically sorted.
         void sort_and_compute_mapping_quality(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs,
                                               vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                               bool allow_population_component,

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -122,6 +122,7 @@ namespace vg {
         // disambiguate. This lets us get an accurate count of scorable reads.
         bool always_check_population = false;
         size_t population_max_paths = 10;
+        bool top_tracebacks = false;
         // Note that, like the haplotype scoring code, we work with recombiantion penalties in exponent form.
         double recombination_penalty = 20.7; // 20.7 = 9 * 2.3
         size_t rescue_only_min = 128;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -90,6 +90,7 @@ namespace vg {
         // parameters
         
         int64_t max_snarl_cut_size = 5;
+        bool suppress_tail_anchors = false;
         double band_padding_multiplier = 1.0;
         size_t max_expected_dist_approx_error = 8;
         int32_t num_alt_alns = 4;

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -2186,6 +2186,31 @@ void translate_node_ids(Path& path, const unordered_map<id_t, id_t>& translator)
     }
 }
 
+void translate_node_ids(Path& path, const unordered_map<id_t, id_t>& translator, id_t cut_node, size_t bases_removed, bool from_right) {
+    // First just translate the IDs
+    translate_node_ids(path, translator);
+    
+    
+    for (size_t i = 0; i < path.mapping_size(); i++) {
+        // Scan the whole path again. We can't count on the cut node only being in the first and last mappings.
+        Position* position = path.mutable_mapping(i)->mutable_position();
+        if (position->node_id() == cut_node) {
+            // Then adjust offsets to account for the cut on the original node
+            
+            // If the position in the path is counting from the same end of the
+            // node that we didn't keep after the cut, we have to bump up its
+            // offset.
+            if ((!position->is_reverse() && !from_right) || // We cut off the left of the node, and we're counting from the left
+                (position->is_reverse() && from_right)) { // We cut off the right of the node, and we're counting from the right
+                // Update the offset to reflect the removed bases
+                position->set_offset(position->offset() + bases_removed);
+            }
+        }
+    }
+    
+    
+}
+
 void translate_oriented_node_ids(Path& path, const unordered_map<id_t, pair<id_t, bool>>& translator) {
     for (size_t i = 0; i < path.mapping_size(); i++) {
         Position* position = path.mutable_mapping(i)->mutable_position();

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -322,9 +322,14 @@ double overlap(const Path& p1, const Path& p2);
 // helps estimate overapls quickly
 void decompose(const Path& path, map<pos_t, int>& ref_positions, map<pos_t, Edit>& edits);
 
-// switches the node ids in the path to the ones indicated by the translator
+/// Switches the node ids in the path to the ones indicated by the translator
 void translate_node_ids(Path& path, const unordered_map<id_t, id_t>& translator);
-// switches the node ids and orientations in the path to the ones indicated by the translator
+/// Replaces the node IDs in the path with the ones indicated by the
+/// translator. Supports a single cut node in the source graph, where the given
+/// number of bases of the given node were removed from its left or right side
+/// when making the source graph from the destination graph.
+void translate_node_ids(Path& path, const unordered_map<id_t, id_t>& translator, id_t cut_node, size_t bases_removed, bool from_right);
+/// Switches the node ids and orientations in the path to the ones indicated by the translator
 void translate_oriented_node_ids(Path& path, const unordered_map<id_t, pair<id_t, bool>>& translator);
     
 // the first position on the path

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -32,7 +32,7 @@ bool& get_is_rev(pos_t& pos);
 off_t& get_offset(pos_t& pos);
 /// Reverse a pos_t and get a pos_t at the same base, going the other direction.
 pos_t reverse(const pos_t& pos, size_t node_length);
-/// Reverse a Position and get a Position at the same base, going the orther direction.
+/// Reverse a Position and get a Position at the same base, going the other direction.
 Position reverse(const Position& pos, size_t node_length);
 /// Print a pos_t to a stream.
 ostream& operator<<(ostream& out, const pos_t& pos);

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -744,14 +744,63 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
         if (!name_prefixes.empty()) {
             // Make sure we match at least one name prefix
             
-            // TODO: We should be using a trie or something for efficient matching to one of many prefixes.
             bool found = false;
-            for (auto& prefix : name_prefixes) {
-                // For each prefix in turn
-                if (std::equal(prefix.begin(), prefix.end(), aln.name().begin())) {
-                    // If we match it, we found a match!
-                    found = true;
-                    break;
+            
+            // Do a binary search for the closest prefix and see if all of any prefix exists.
+            // We assume the prefixes are sorted.
+            size_t left_bound = 0;
+            size_t left_match = 0;
+            while (left_match < name_prefixes[left_bound].size() &&
+                left_match < aln.name().size() &&
+                name_prefixes[left_bound][left_match] == aln.name()[left_match]) {
+                // Scan all the matches at the start
+                left_match++;
+            }
+            
+            size_t right_bound = name_prefixes.size() - 1;
+            size_t right_match = 0;
+            while (right_match < name_prefixes[right_bound].size() &&
+                right_match < aln.name().size() &&
+                name_prefixes[right_bound][right_match] == aln.name()[right_match]) {
+                // Scan all the matches at the end
+                right_match++;
+            }
+            
+            if (left_match == name_prefixes[left_bound].size() || right_match == name_prefixes[right_bound].size()) {
+                // We found a match already
+                found = true;
+            } else {
+                while (left_bound + 1 < right_bound) {
+                    // Until we run out of unexamined prefixes, do binary search
+                    size_t center = (left_bound + right_bound) / 2;
+                    // No need to re-check any common prefix
+                    size_t center_match = min(left_match, right_match);
+                    
+                    while (center_match < name_prefixes[center].size() &&
+                        center_match < aln.name().size() &&
+                        name_prefixes[center][center_match] == aln.name()[center_match]) {
+                        // Scan all the matches here
+                        center_match++;
+                    }
+                    
+                    if (center_match == name_prefixes[center].size()) {
+                        // We found a hit!
+                        found = true;
+                        break;
+                    }
+                    
+                    if (center_match < name_prefixes[center].size() && center_match < aln.name().size()) {
+                        // There's a character that differs
+                        if (name_prefixes[center][center_match] < aln.name()[center_match]) {
+                            // The match, if it exists, must be after us.
+                            left_bound = center;
+                            left_match = center_match;
+                        } else {
+                            // The match, if it exists, must be before us
+                            right_bound = center;
+                            right_match = center_match;
+                        }
+                    }
                 }
             }
             

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -741,10 +741,25 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
         ++counts.read[co];
         bool keep = true;
         // filter (current) alignment
-        if (!name_prefix.empty() && !std::equal(name_prefix.begin(), name_prefix.end(), aln.name().begin())) {
-            // There's a prefix and a mismatch against it
-            ++counts.wrong_name[co];
-            keep = false;    
+        if (!name_prefixes.empty()) {
+            // Make sure we match at least one name prefix
+            
+            // TODO: We should be using a trie or something for efficient matching to one of many prefixes.
+            bool found = false;
+            for (auto& prefix : name_prefixes) {
+                // For each prefix in turn
+                if (std::equal(prefix.begin(), prefix.end(), aln.name().begin())) {
+                    // If we match it, we found a match!
+                    found = true;
+                    break;
+                }
+            }
+            
+            if (!found) {
+                // There are prefixes and we don't match any, so drop the read.
+                ++counts.wrong_name[co];
+                keep = false;
+            }
         }
         if ((keep || verbose) && !excluded_refpos_contigs.empty() && aln.refpos_size() != 0) {
             // We have refpos exclusion filters and a refpos is set.

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -25,6 +25,7 @@ public:
     // Filtering parameters
     /// Read name must have one of these prefixes, if any are present.
     /// TODO: This should be a trie but I don't have one handy.
+    /// Must be sorted for vaguely efficient search.
     vector<string> name_prefixes;
     /// Read must not have a refpos set with a contig name containing a match to any of these
     vector<regex> excluded_refpos_contigs;

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -23,8 +23,9 @@ class ReadFilter{
 public:
     
     // Filtering parameters
-    /// Read name must have this prefix
-    string name_prefix;
+    /// Read name must have one of these prefixes, if any are present.
+    /// TODO: This should be a trie but I don't have one handy.
+    vector<string> name_prefixes;
     /// Read must not have a refpos set with a contig name containing a match to any of these
     vector<regex> excluded_refpos_contigs;
     double min_secondary = 0.;

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -249,6 +249,9 @@ int main_filter(int argc, char** argv) {
     // What should our return code be?
     int error_code = 0;
     
+    // Sort the prefixes for reads we will accept, for efficient search
+    sort(filter.name_prefixes.begin(), filter.name_prefixes.end());
+    
     get_input_file(optind, argc, argv, [&](istream& in) {
         // Open up the alignment stream
         

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -47,6 +47,7 @@ void help_mpmap(char** argv) {
     << "algorithm:" << endl
     << "  -S, --single-path-mode        produce single-path alignments (GAM) instead of multipath alignments (GAMP) (ignores -sua)" << endl
     << "  -s, --snarls FILE             align to alternate paths in these snarls" << endl
+    << "      --suppress-tail-anchors   don't produce extra anchors when aligning to alternate paths in snarls" << endl
     << "scoring:" << endl
     << "  -A, --no-qual-adjust          do not perform base quality adjusted alignments (required if input does not have base qualities)" << endl
     << "  -E, --long-read-scoring       set alignment scores to long-read defaults: -q1 -z1 -o1 -y1 -L0 (can be overridden)" << endl
@@ -105,6 +106,7 @@ int main_mpmap(int argc, char** argv) {
     #define OPT_ALWAYS_CHECK_POPULATION 1002
     #define OPT_DELAY_POPULATION_SCORING 1003
     #define OPT_FORCE_HAPLOTYPE_COUNT 1004
+    #define OPT_SUPPRESS_TAIL_ANCHORS 1005
     string matrix_file_name;
     string xg_name;
     string gcsa_name;
@@ -123,6 +125,7 @@ int main_mpmap(int argc, char** argv) {
     int full_length_bonus = default_full_length_bonus;
     bool interleaved_input = false;
     int snarl_cut_size = 5;
+    bool suppress_tail_anchors = false;
     int max_paired_end_map_attempts = 24;
     int max_single_end_mappings_for_rescue = 64;
     int max_single_end_map_attempts = 64;
@@ -212,6 +215,7 @@ int main_mpmap(int argc, char** argv) {
             {"same-strand", no_argument, 0, 'e'},
             {"single-path-mode", no_argument, 0, 'S'},
             {"snarls", required_argument, 0, 's'},
+            {"suppress-tail-anchors", no_argument, 0, OPT_SUPPRESS_TAIL_ANCHORS},
             {"tvs-clusterer", no_argument, 0, 'v'},
             {"snarl-max-cut", required_argument, 0, 'X'},
             {"alt-paths", required_argument, 0, 'a'},
@@ -365,6 +369,10 @@ int main_mpmap(int argc, char** argv) {
                     cerr << "error:[vg mpmap] Must provide snarl file with -s." << endl;
                     exit(1);
                 }
+                break;
+                
+            case OPT_SUPPRESS_TAIL_ANCHORS:
+                suppress_tail_anchors = true;
                 break;
                 
             case 'v':
@@ -979,6 +987,7 @@ int main_mpmap(int argc, char** argv) {
     
     // set multipath alignment topology parameters
     multipath_mapper.max_snarl_cut_size = snarl_cut_size;
+    multipath_mapper.suppress_tail_anchors = suppress_tail_anchors;
     multipath_mapper.num_alt_alns = num_alt_alns;
     multipath_mapper.dynamic_max_alt_alns = dynamic_max_alt_alns;
     multipath_mapper.simplify_topologies = simplify_topologies;

--- a/src/unittest/multipath_alignment.cpp
+++ b/src/unittest/multipath_alignment.cpp
@@ -726,7 +726,7 @@ namespace vg {
                 SECTION( "We can find the consistent suboptimal alignment" ) {
 
                     // get haplotype consistent alignments
-                    auto consistent = haplotype_consistent_alignments(multipath_aln, provider);
+                    auto consistent = haplotype_consistent_alignments(multipath_aln, provider, 0);
                     
                     // There should be just one alignment
                     REQUIRE(consistent.size() == 1);
@@ -746,7 +746,7 @@ namespace vg {
                 }
                 
                 SECTION( "We can find the optimal alignment when asked for it" ) {
-                    auto optimal_and_consistent = haplotype_consistent_alignments(multipath_aln, provider, true);
+                    auto optimal_and_consistent = haplotype_consistent_alignments(multipath_aln, provider, 0, true);
                     
                     // There should be two alignments
                     REQUIRE(optimal_and_consistent.size() == 2);
@@ -907,7 +907,7 @@ namespace vg {
                 haplo::GBWTScoreProvider<gbwt::DynamicGBWT> provider(gbwt_index);
 
                 // get haplotype consistent alignments
-                auto consistent = haplotype_consistent_alignments(multipath_aln, provider);
+                auto consistent = haplotype_consistent_alignments(multipath_aln, provider, 0);
                 
                 // There should be 3 alignments
                 REQUIRE(consistent.size() == 3);

--- a/src/unittest/multipath_alignment.cpp
+++ b/src/unittest/multipath_alignment.cpp
@@ -5,6 +5,9 @@
 
 #include <stdio.h>
 #include <iostream>
+
+#include <gbwt/dynamic_gbwt.h>
+
 #include "json2pb.h"
 #include "vg.pb.h"
 #include "vg.hpp"
@@ -622,6 +625,276 @@ namespace vg {
                 }
             }
         
+        }
+        
+        TEST_CASE("Multipath alignment correctly identifies haplotype consistent alignments") {
+        
+            // Make a wrapper to make the compiler shut up about narrowing
+            auto visit = [](id_t id, bool orientation) {
+                return (gbwt::vector_type::value_type) gbwt::Node::encode(id, orientation);
+            };
+            auto end = (gbwt::vector_type::value_type) gbwt::ENDMARKER;
+        
+            SECTION( "Multipath alignment can identify a single haplotype consistent alignment" ) {
+                
+                VG graph;
+                
+                Node* n1 = graph.create_node("GCA");
+                Node* n2 = graph.create_node("T");
+                Node* n3 = graph.create_node("G");
+                Node* n4 = graph.create_node("CTGA");
+                
+                graph.create_edge(n1, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n4);
+                graph.create_edge(n3, n4);
+                
+                string read = string("GCATCTGA");
+                MultipathAlignment multipath_aln;
+                multipath_aln.set_sequence(read);
+                
+                // add subpaths
+                Subpath* subpath0 = multipath_aln.add_subpath();
+                Subpath* subpath1 = multipath_aln.add_subpath();
+                Subpath* subpath2 = multipath_aln.add_subpath();
+                Subpath* subpath3 = multipath_aln.add_subpath();
+                
+                // set edges between subpaths
+                subpath0->add_next(1);
+                subpath0->add_next(2);
+                subpath1->add_next(3);
+                subpath2->add_next(3);
+                
+                // set scores
+                subpath0->set_score(3);
+                subpath1->set_score(1);
+                subpath2->set_score(-1);
+                subpath3->set_score(4);
+                
+                // designate mappings
+                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                mapping0->mutable_position()->set_node_id(1);
+                Edit* edit0 = mapping0->add_edit();
+                edit0->set_from_length(3);
+                edit0->set_to_length(3);
+                
+                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                mapping1->mutable_position()->set_node_id(2);
+                Edit* edit1 = mapping1->add_edit();
+                edit1->set_from_length(1);
+                edit1->set_to_length(1);
+                
+                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                mapping2->mutable_position()->set_node_id(3);
+                Edit* edit2 = mapping2->add_edit();
+                edit2->set_from_length(1);
+                edit2->set_to_length(1);
+                edit2->set_sequence("T");
+                
+                Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+                mapping3->mutable_position()->set_node_id(4);
+                Edit* edit3 = mapping3->add_edit();
+                edit3->set_from_length(4);
+                edit3->set_to_length(4);
+                
+                // Create haplotype database
+                gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+                gbwt::DynamicGBWT gbwt_index;
+             
+                // Make and insert a haplotype
+                gbwt::vector_type hap1fwd = {
+                    visit(1, false),
+                    visit(3, false),
+                    visit(4, false),
+                    end
+                };
+                gbwt_index.insert(hap1fwd);
+                // Do both orienatations
+                gbwt::vector_type hap1rev = {
+                    visit(4, true),
+                    visit(3, true),
+                    visit(1, true),
+                    end
+                };
+                gbwt_index.insert(hap1rev);
+
+                // get haplotype consistent alignments
+                auto consistent = haplotype_consistent_alignments(multipath_aln, gbwt_index);
+                
+                // There should be just one alignment
+                REQUIRE(consistent.size() == 1);
+                
+                // The alignment should have score 3 + 4 - 1 = 6
+                REQUIRE(consistent[0].score() == 6);
+                
+                // The alignment should be nodes 1, 3, 4, all forward
+                REQUIRE(consistent[0].path().mapping_size() == 3);
+                REQUIRE(consistent[0].path().mapping(0).position().node_id() == 1);
+                REQUIRE(consistent[0].path().mapping(0).position().is_reverse() == false);
+                REQUIRE(consistent[0].path().mapping(1).position().node_id() == 3);
+                REQUIRE(consistent[0].path().mapping(1).position().is_reverse() == false);
+                REQUIRE(consistent[0].path().mapping(2).position().node_id() == 4);
+                REQUIRE(consistent[0].path().mapping(2).position().is_reverse() == false);
+            }
+            
+            SECTION( "Multipath alignment can identify multiple haplotype consistent alignments" ) {
+                
+                VG graph;
+                
+                Node* n1 = graph.create_node("GCA");
+                Node* n2 = graph.create_node("T");
+                Node* n3 = graph.create_node("G");
+                Node* n4 = graph.create_node("CTGA");
+                Node* n5 = graph.create_node("ACAC");
+                Node* n6 = graph.create_node("CC");
+                
+                graph.create_edge(n1, n2);
+                graph.create_edge(n1, n3);
+                graph.create_edge(n2, n4);
+                graph.create_edge(n3, n4);
+                graph.create_edge(n4, n5);
+                graph.create_edge(n4, n6);
+                
+                string read = string("GCATCTGAAC");
+                MultipathAlignment multipath_aln;
+                multipath_aln.set_sequence(read);
+                
+                // add subpaths
+                Subpath* subpath0 = multipath_aln.add_subpath();
+                Subpath* subpath1 = multipath_aln.add_subpath();
+                Subpath* subpath2 = multipath_aln.add_subpath();
+                Subpath* subpath3 = multipath_aln.add_subpath();
+                Subpath* subpath4 = multipath_aln.add_subpath();
+                Subpath* subpath5 = multipath_aln.add_subpath();
+                
+                // set edges between subpaths
+                subpath0->add_next(1);
+                subpath0->add_next(2);
+                subpath1->add_next(3);
+                subpath2->add_next(3);
+                subpath3->add_next(4);
+                subpath3->add_next(5);
+                
+                // set scores
+                subpath0->set_score(3);
+                subpath1->set_score(1);
+                subpath2->set_score(-1);
+                subpath3->set_score(4);
+                subpath4->set_score(2);
+                subpath5->set_score(0);
+                
+                // designate mappings
+                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                mapping0->mutable_position()->set_node_id(1);
+                Edit* edit0 = mapping0->add_edit();
+                edit0->set_from_length(3);
+                edit0->set_to_length(3);
+                
+                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                mapping1->mutable_position()->set_node_id(2);
+                Edit* edit1 = mapping1->add_edit();
+                edit1->set_from_length(1);
+                edit1->set_to_length(1);
+                
+                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                mapping2->mutable_position()->set_node_id(3);
+                Edit* edit2 = mapping2->add_edit();
+                edit2->set_from_length(1);
+                edit2->set_to_length(1);
+                edit2->set_sequence("T");
+                
+                Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+                mapping3->mutable_position()->set_node_id(4);
+                Edit* edit3 = mapping3->add_edit();
+                edit3->set_from_length(4);
+                edit3->set_to_length(4);
+                
+                Mapping* mapping4 = subpath4->mutable_path()->add_mapping();
+                mapping4->mutable_position()->set_node_id(5);
+                Edit* edit4 = mapping4->add_edit();
+                edit4->set_from_length(2);
+                edit4->set_to_length(2);
+                
+                Mapping* mapping5 = subpath5->mutable_path()->add_mapping();
+                mapping5->mutable_position()->set_node_id(6);
+                Edit* edit5a = mapping5->add_edit();
+                edit5a->set_from_length(1);
+                edit5a->set_to_length(1);
+                edit5a->set_sequence("A");
+                Edit* edit5b = mapping5->add_edit();
+                edit5b->set_from_length(1);
+                edit5b->set_to_length(1);
+                
+                // Create haplotype database
+                gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+                gbwt::DynamicGBWT gbwt_index;
+             
+                // Make and insert a haplotype
+                gbwt::vector_type hap1fwd = {
+                    visit(1, false),
+                    visit(3, false),
+                    visit(4, false),
+                    visit(6, false),
+                    end
+                };
+                gbwt_index.insert(hap1fwd);
+                // Do both orienatations
+                gbwt::vector_type hap1rev = {
+                    visit(6, true),
+                    visit(4, true),
+                    visit(3, true),
+                    visit(1, true),
+                    end
+                };
+                gbwt_index.insert(hap1rev);
+                
+                // More haplotypes. All except 2, 6
+                gbwt::vector_type hap2fwd = {
+                    visit(1, false),
+                    visit(3, false),
+                    visit(4, false),
+                    visit(5, false),
+                    end
+                };
+                gbwt_index.insert(hap2fwd);
+                gbwt::vector_type hap2rev = {
+                    visit(5, true),
+                    visit(4, true),
+                    visit(3, true),
+                    visit(1, true),
+                    end
+                };
+                gbwt_index.insert(hap2rev);
+                gbwt::vector_type hap3fwd = {
+                    visit(1, false),
+                    visit(2, false),
+                    visit(4, false),
+                    visit(5, false),
+                    end
+                };
+                gbwt_index.insert(hap3fwd);
+                gbwt::vector_type hap3rev = {
+                    visit(5, true),
+                    visit(4, true),
+                    visit(2, true),
+                    visit(1, true),
+                    end
+                };
+                gbwt_index.insert(hap3rev);
+
+                // get haplotype consistent alignments
+                auto consistent = haplotype_consistent_alignments(multipath_aln, gbwt_index);
+                
+                // There should be 3 alignments
+                REQUIRE(consistent.size() == 3);
+                
+                for (auto& aln : consistent) {
+                    // Each should have 4 mappings
+                    REQUIRE(aln.path().mapping_size() == 4);
+                    // None of them should go to nodes 2 and 6
+                    REQUIRE(!(aln.path().mapping(1).position().node_id() == 2 && aln.path().mapping(3).position().node_id() == 6));
+                }
+            }
         }
         
         TEST_CASE( "Reverse complementing multipath alignments works correctly",

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -39,7 +39,8 @@ TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls i
     // We need a fake read
     string read("GATTACA");
     
-    // Pack it into an Alignment
+    // Pack it into an Alignment.
+    // Note that we need to use the Alignment's copy for getting iterators for the MEMs.
     Alignment query;
     query.set_sequence(read);
     
@@ -54,7 +55,7 @@ TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls i
     vector<pair<const MaximalExactMatch*, pos_t>> mem_hits;
     
     // Make a MEM hit
-    mems.emplace_back(read.begin(), ++read.begin(), make_pair(5, 5), 1);
+    mems.emplace_back(query.sequence().begin(), ++query.sequence().begin(), make_pair(5, 5), 1);
     // Drop it on node 1 where it should sit
     mem_hits.emplace_back(&mems.back(), make_pos_t(1, false, 0));
     

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -85,12 +85,12 @@ TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls i
     // Generate 2 fake tail anchors
     mpg.synthesize_tail_anchors(query, vg, &aligner, 2, false);
     
-    mpg.to_dot(cerr);
+    mpg.to_dot(cerr, &query);
     
     // Cut new anchors on snarls
     mpg.resect_snarls_from_paths(&snarl_manager, identity, 5);
     
-    mpg.to_dot(cerr);
+    mpg.to_dot(cerr, &query);
     
     // Make it align, with alignments per gap/tail
     mpg.align(query, vg, &aligner, true, 2, false, 5, out);

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -18,13 +18,17 @@ TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls i
             {"id": 1, "sequence": "GATT"},
             {"id": 2, "sequence": "A"},
             {"id": 3, "sequence": "G"},
-            {"id": 4, "sequence": "CA"}
+            {"id": 4, "sequence": "C"},
+            {"id": 5, "sequence": "A"},
+            {"id": 6, "sequence": "G"}
         ],
         "edge": [
             {"from": 1, "to": 2},
             {"from": 1, "to": 3},
             {"from": 2, "to": 4},
-            {"from": 3, "to": 4}
+            {"from": 3, "to": 4},
+            {"from": 4, "to": 5},
+            {"from": 4, "to": 6}
         ]
     })";
     
@@ -79,6 +83,21 @@ TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls i
     // Make sure it worked at all
     REQUIRE(out.sequence() == read);
     REQUIRE(out.subpath_size() > 0);
+    
+    set<id_t> seen_nodes;
+    for (auto& s : out.subpath()) {
+        // We should have (at least) one on each node. Although we may have divided subpaths on node 1.
+        REQUIRE(s.path().mapping_size() == 1);
+        seen_nodes.insert(s.path().mapping(0).position().node_id());
+    }
+    
+    REQUIRE(seen_nodes.size() == 6);
+    REQUIRE(seen_nodes.count(1));
+    REQUIRE(seen_nodes.count(2));
+    REQUIRE(seen_nodes.count(3));
+    REQUIRE(seen_nodes.count(4));
+    REQUIRE(seen_nodes.count(5));
+    REQUIRE(seen_nodes.count(6));
 }
 
 }

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -1,0 +1,86 @@
+/// \file multipath_alignment_graph.cpp
+///  
+/// unit tests for the multipath mapper's MultipathAlignmentGraph
+
+#include <iostream>
+#include "json2pb.h"
+#include "vg.pb.h"
+#include "../multipath_mapper.hpp"
+#include "../build_index.hpp"
+#include "catch.hpp"
+
+namespace vg {
+namespace unittest {
+
+TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls in tails", "[multipath][mapping][multipathalignmentgraph]" ) {
+
+    string graph_json = R"({
+        "node": [
+            {"id": 1, "sequence": "GATT"},
+            {"id": 2, "sequence": "A"},
+            {"id": 3, "sequence": "G"},
+            {"id": 4, "sequence": "CA"}
+        ],
+        "edge": [
+            {"from": 1, "to": 2},
+            {"from": 1, "to": 3},
+            {"from": 2, "to": 4},
+            {"from", 3, "to": 4}
+        ]
+    })";
+    
+    // Load the JSON
+    Graph proto_graph;
+    json2pb(proto_graph, graph_json.c_str(), graph_json.size());
+    
+    // Make it into a VG
+    VG vg;
+    vg.extend(proto_graph);
+    
+    // We need a fake read
+    string read("GATTACA");
+    
+    // Pack it into an Alignment
+    Alignment query;
+    query.set_sequence(read);
+    
+    // Make up a fake MEM
+    // GCSA range_type is just a pair of [start, end], so we can fake them.
+    
+    // This will actually own the MEMs
+    vector<MaximalExactMatch> mems;
+    
+    // This will hold our MEMs and their start positions in the imaginary graph.
+    // Note that this is also a memcluster_t
+    vector<pair<const MaximalExactMatch*, pos_t>> mem_hits;
+    
+    // Make a MEM hit
+    mems.emplace_back(read.begin() + 1, read.begin() + 2, make_pair(5, 5), 1);
+    // Drop it on node 1 where it should sit
+    mem_hits.emplace_back(&mems.back(), make_pos_t(1, false, 1));
+    
+    // Make an Aligner to use for the actual aligning and the scores
+    Aligner aligner;
+    
+    // Make an identity projection translation
+    auto identity = MultipathAlignmentGraph::create_identity_projection_trans(vg);
+    
+    // Make the MultipathAlignmentGraph to test
+    MultipathAlignmentGraph mpg(vg, mem_hits, identity);
+    
+    // Make the output MultipathAlignment
+    MultipathAlignment out;
+    
+    // Make it align
+    mpg.align(query, vg, &aligner, true, 4, false, 5, out);
+    
+    cerr << pb2json(out) << endl;
+    
+    // Make sure it worked at all
+    REQUIRE(out.sequence() == read);
+    REQUIRE(out.subpath_size() > 0);
+}
+
+}
+
+}

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -5,8 +5,7 @@
 #include <iostream>
 #include "json2pb.h"
 #include "vg.pb.h"
-#include "../multipath_mapper.hpp"
-#include "../build_index.hpp"
+#include "../multipath_alignment_graph.hpp"
 #include "catch.hpp"
 
 namespace vg {
@@ -25,7 +24,7 @@ TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls i
             {"from": 1, "to": 2},
             {"from": 1, "to": 3},
             {"from": 2, "to": 4},
-            {"from", 3, "to": 4}
+            {"from": 3, "to": 4}
         ]
     })";
     
@@ -55,9 +54,9 @@ TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls i
     vector<pair<const MaximalExactMatch*, pos_t>> mem_hits;
     
     // Make a MEM hit
-    mems.emplace_back(read.begin() + 1, read.begin() + 2, make_pair(5, 5), 1);
+    mems.emplace_back(read.begin(), ++read.begin(), make_pair(5, 5), 1);
     // Drop it on node 1 where it should sit
-    mem_hits.emplace_back(&mems.back(), make_pos_t(1, false, 1));
+    mem_hits.emplace_back(&mems.back(), make_pos_t(1, false, 0));
     
     // Make an Aligner to use for the actual aligning and the scores
     Aligner aligner;

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -11,7 +11,7 @@
 namespace vg {
 namespace unittest {
 
-TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls in tails", "[multipath][mapping][multipathalignmentgraph]" ) {
+TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath][mapping][multipathalignmentgraph]" ) {
 
     string graph_json = R"({
         "node": [
@@ -55,6 +55,12 @@ TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls i
     Alignment query;
     query.set_sequence(read);
     
+    // Make an Aligner to use for the actual aligning and the scores
+    Aligner aligner;
+        
+    // Make an identity projection translation
+    auto identity = MultipathAlignmentGraph::create_identity_projection_trans(vg);
+    
     // Make up a fake MEM
     // GCSA range_type is just a pair of [start, end], so we can fake them.
     
@@ -65,72 +71,290 @@ TEST_CASE( "MultipathAlignmentGraph::align tries multiple traversals of snarls i
     // Note that this is also a memcluster_t
     vector<pair<const MaximalExactMatch*, pos_t>> mem_hits;
     
-    // Make a MEM hit over all of node 1's sequence
-    mems.emplace_back(query.sequence().begin(), query.sequence().begin() + 4, make_pair(5, 5), 1);
-    // Drop it on node 1 where it should sit
-    mem_hits.emplace_back(&mems.back(), make_pos_t(1, false, 0));
+    /*
+    SECTION ("Works with right tail only") {
     
-    // Make an Aligner to use for the actual aligning and the scores
-    Aligner aligner;
-    
-    // Make an identity projection translation
-    auto identity = MultipathAlignmentGraph::create_identity_projection_trans(vg);
-    
-    // Make the MultipathAlignmentGraph to test
-    MultipathAlignmentGraph mpg(vg, mem_hits, identity);
-    
-    // Make the output MultipathAlignment
-    MultipathAlignment out;
-    
-    // Generate 2 fake tail anchors
-    mpg.synthesize_tail_anchors(query, vg, &aligner, 2, false);
-    
-    mpg.to_dot(cerr, &query);
-    
-    // Cut new anchors on snarls
-    mpg.resect_snarls_from_paths(&snarl_manager, identity, 5);
-    
-    mpg.to_dot(cerr, &query);
-    
-    // Make it align, with alignments per gap/tail
-    mpg.align(query, vg, &aligner, true, 2, false, 5, out);
-    
-    // Make sure to topologically sort the resulting alignment. TODO: Should
-    // the MultipathAlignmentGraph guarantee this for us by construction?
-    topologically_order_subpaths(out);
-    
-    cerr << pb2json(out) << endl;
-    
-    // Make sure it worked at all
-    REQUIRE(out.sequence() == read);
-    REQUIRE(out.subpath_size() > 0);
-    
-    // Get the top 10 optimal alignments
-    vector<Alignment> opt = optimal_alignments(out, 100);
-    
-    // Convert to a set of vectors of visited node IDs
-    set<vector<id_t>> got;
-    for(size_t i = 0; i < opt.size(); i++) {
-        auto& aln = opt[i];
-        cerr << "Linearization " << i << ": " << pb2json(aln.path()) << endl;
-        vector<id_t> ids;
-        cerr << "\t";
-        for (auto& mapping : aln.path().mapping()) {
-            ids.push_back(mapping.position().node_id());
-            cerr << mapping.position().node_id() << " ";
-        }
-        cerr << endl;
+        // Make a MEM hit over all of node 1's sequence
+        mems.emplace_back(query.sequence().begin(), query.sequence().begin() + 4, make_pair(5, 5), 1);
+        // Drop it on node 1 where it should sit
+        mem_hits.emplace_back(&mems.back(), make_pos_t(1, false, 0));
         
-        // Save each list of visited IDs for checking.
-        got.insert(ids);
+        // Make the MultipathAlignmentGraph to test
+        MultipathAlignmentGraph mpg(vg, mem_hits, identity);
+        
+        // Make the output MultipathAlignment
+        MultipathAlignment out;
+        
+        SECTION("Tries multiple traversals of snarls in tails") {
+        
+            // Generate 2 fake tail anchors
+            mpg.synthesize_tail_anchors(query, vg, &aligner, 2, false);
+            
+            // Cut new anchors on snarls
+            mpg.resect_snarls_from_paths(&snarl_manager, identity, 5);
+            
+            // Make it align, with alignments per gap/tail
+            mpg.align(query, vg, &aligner, true, 2, false, 5, out);
+            
+            // Make sure to topologically sort the resulting alignment. TODO: Should
+            // the MultipathAlignmentGraph guarantee this for us by construction?
+            topologically_order_subpaths(out);
+            
+            // Make sure it worked at all
+            REQUIRE(out.sequence() == read);
+            REQUIRE(out.subpath_size() > 0);
+            
+            // Get the top 10 optimal alignments
+            vector<Alignment> opt = optimal_alignments(out, 100);
+            
+            // Convert to a set of vectors of visited node IDs
+            set<vector<id_t>> got;
+            for(size_t i = 0; i < opt.size(); i++) {
+                auto& aln = opt[i];
+                
+                vector<id_t> ids;
+                for (auto& mapping : aln.path().mapping()) {
+                    ids.push_back(mapping.position().node_id());
+                }
+                
+                // Save each list of visited IDs for checking.
+                got.insert(ids);
+            }
+            
+            // Make sure all combinations are there
+            REQUIRE(got.count({1, 2, 4, 6, 7}));
+            REQUIRE(got.count({1, 2, 4, 5, 7}));
+            REQUIRE(got.count({1, 3, 4, 6, 7}));
+            REQUIRE(got.count({1, 3, 4, 5, 7}));
+            
+        }
+        
+        SECTION("Handles tails when anchors for them are not generated") {
+        
+            // Make it align, with alignments per gap/tail
+            mpg.align(query, vg, &aligner, true, 2, false, 5, out);
+            
+            // Make sure to topologically sort the resulting alignment. TODO: Should
+            // the MultipathAlignmentGraph guarantee this for us by construction?
+            topologically_order_subpaths(out);
+            
+            // Make sure it worked at all
+            REQUIRE(out.sequence() == read);
+            REQUIRE(out.subpath_size() > 0);
+            
+            // Get the top optimal alignments
+            vector<Alignment> opt = optimal_alignments(out, 100);
+            
+            // Convert to a set of vectors of visited node IDs
+            set<vector<id_t>> got;
+            for(size_t i = 0; i < opt.size(); i++) {
+                auto& aln = opt[i];
+                
+                vector<id_t> ids;
+                for (auto& mapping : aln.path().mapping()) {
+                    ids.push_back(mapping.position().node_id());
+                }
+                
+                // Save each list of visited IDs for checking.
+                got.insert(ids);
+            }
+            
+            // Make sure the best alignment is there.
+            REQUIRE(got.count({1, 2, 4, 5, 7}));
+        
+        }
+        
+    }
+    */
+    
+    SECTION ("Works with both tails at once") {
+    
+        // Make a MEM hit over all of node 4's sequence
+        mems.emplace_back(query.sequence().begin() + 5, query.sequence().begin() + 6, make_pair(5, 5), 1);
+        // Drop it on node 4 where it should sit
+        mem_hits.emplace_back(&mems.back(), make_pos_t(4, false, 0));
+        
+        // Make the MultipathAlignmentGraph to test
+        MultipathAlignmentGraph mpg(vg, mem_hits, identity);
+        
+        // Make the output MultipathAlignment
+        MultipathAlignment out;
+        
+        
+        SECTION("Tries multiple traversals of snarls in tails") {
+        
+            // Generate 2 fake tail anchors
+            mpg.synthesize_tail_anchors(query, vg, &aligner, 2, false);
+            
+            // Cut new anchors on snarls
+            mpg.resect_snarls_from_paths(&snarl_manager, identity, 5);
+            
+            // Make it align, with alignments per gap/tail
+            mpg.align(query, vg, &aligner, true, 2, false, 5, out);
+            
+            // Make sure to topologically sort the resulting alignment. TODO: Should
+            // the MultipathAlignmentGraph guarantee this for us by construction?
+            topologically_order_subpaths(out);
+            
+            // Make sure it worked at all
+            REQUIRE(out.sequence() == read);
+            REQUIRE(out.subpath_size() > 0);
+            
+            // Get the top optimal alignments
+            vector<Alignment> opt = optimal_alignments(out, 100);
+            
+            // Convert to a set of vectors of visited node IDs
+            set<vector<id_t>> got;
+            for(size_t i = 0; i < opt.size(); i++) {
+                auto& aln = opt[i];
+                
+                vector<id_t> ids;
+                for (auto& mapping : aln.path().mapping()) {
+                    ids.push_back(mapping.position().node_id());
+                }
+                
+                // Save each list of visited IDs for checking.
+                got.insert(ids);
+            }
+            
+            // Make sure all combinations are there
+            REQUIRE(got.count({1, 2, 4, 6, 7}));
+            REQUIRE(got.count({1, 2, 4, 5, 7}));
+            REQUIRE(got.count({1, 3, 4, 6, 7}));
+            REQUIRE(got.count({1, 3, 4, 5, 7}));
+            
+        }
+        
+        
+        SECTION("Handles tails when anchors for them are not generated") {
+            // Make it align, with alignments per gap/tail
+            mpg.align(query, vg, &aligner, true, 2, false, 5, out);
+            
+            // Make sure to topologically sort the resulting alignment. TODO: Should
+            // the MultipathAlignmentGraph guarantee this for us by construction?
+            topologically_order_subpaths(out);
+            
+            // Make sure it worked at all
+            REQUIRE(out.sequence() == read);
+            REQUIRE(out.subpath_size() > 0);
+            
+            // Get the top optimal alignments
+            vector<Alignment> opt = optimal_alignments(out, 100);
+            
+            // Convert to a set of vectors of visited node IDs
+            set<vector<id_t>> got;
+            for(size_t i = 0; i < opt.size(); i++) {
+                auto& aln = opt[i];
+                
+                vector<id_t> ids;
+                for (auto& mapping : aln.path().mapping()) {
+                    ids.push_back(mapping.position().node_id());
+                }
+                
+                // Save each list of visited IDs for checking.
+                got.insert(ids);
+            }
+            
+            // Make sure the best alignment is there.
+            REQUIRE(got.count({1, 2, 4, 5, 7}));
+        }
+        
     }
     
-    // Make sure all combinations are there
-    REQUIRE(got.count({1, 2, 4, 6, 7}));
-    REQUIRE(got.count({1, 2, 4, 5, 7}));
-    REQUIRE(got.count({1, 3, 4, 6, 7}));
-    REQUIRE(got.count({1, 3, 4, 5, 7}));
     
+    SECTION ("Works with left tail only") {
+    
+        // Make a MEM hit over all of node 7's sequence
+        mems.emplace_back(query.sequence().begin() + 7, query.sequence().begin() + 8, make_pair(5, 5), 1);
+        // Drop it on node 7 where it should sit
+        mem_hits.emplace_back(&mems.back(), make_pos_t(7, false, 0));
+        
+        // Make the MultipathAlignmentGraph to test
+        MultipathAlignmentGraph mpg(vg, mem_hits, identity);
+        
+        // Make the output MultipathAlignment
+        MultipathAlignment out;
+        
+        SECTION("Tries multiple traversals of snarls in tails") {
+        
+            // Generate 2 fake tail anchors
+            mpg.synthesize_tail_anchors(query, vg, &aligner, 2, false);
+            
+            // Cut new anchors on snarls
+            mpg.resect_snarls_from_paths(&snarl_manager, identity, 5);
+            
+            // Make it align, with alignments per gap/tail
+            mpg.align(query, vg, &aligner, true, 2, false, 5, out);
+            
+            // Make sure to topologically sort the resulting alignment. TODO: Should
+            // the MultipathAlignmentGraph guarantee this for us by construction?
+            topologically_order_subpaths(out);
+            
+            // Make sure it worked at all
+            REQUIRE(out.sequence() == read);
+            REQUIRE(out.subpath_size() > 0);
+            
+            // Get the top optimal alignments
+            vector<Alignment> opt = optimal_alignments(out, 100);
+            
+            // Convert to a set of vectors of visited node IDs
+            set<vector<id_t>> got;
+            for(size_t i = 0; i < opt.size(); i++) {
+                auto& aln = opt[i];
+                
+                vector<id_t> ids;
+                for (auto& mapping : aln.path().mapping()) {
+                    ids.push_back(mapping.position().node_id());
+                }
+                
+                // Save each list of visited IDs for checking.
+                got.insert(ids);
+            }
+            
+            // Make sure all combinations are there
+            REQUIRE(got.count({1, 2, 4, 6, 7}));
+            REQUIRE(got.count({1, 2, 4, 5, 7}));
+            REQUIRE(got.count({1, 3, 4, 6, 7}));
+            REQUIRE(got.count({1, 3, 4, 5, 7}));
+            
+        }
+        
+        SECTION("Handles tails when anchors for them are not generated") {
+            // Make it align, with alignments per gap/tail
+            mpg.align(query, vg, &aligner, true, 2, false, 5, out);
+            
+            // Make sure to topologically sort the resulting alignment. TODO: Should
+            // the MultipathAlignmentGraph guarantee this for us by construction?
+            topologically_order_subpaths(out);
+            
+            // Make sure it worked at all
+            REQUIRE(out.sequence() == read);
+            REQUIRE(out.subpath_size() > 0);
+            
+            // Get the top optimal alignments
+            vector<Alignment> opt = optimal_alignments(out, 100);
+            
+            // Convert to a set of vectors of visited node IDs
+            set<vector<id_t>> got;
+            for(size_t i = 0; i < opt.size(); i++) {
+                auto& aln = opt[i];
+                
+                vector<id_t> ids;
+                for (auto& mapping : aln.path().mapping()) {
+                    ids.push_back(mapping.position().node_id());
+                }
+                
+                // Save each list of visited IDs for checking.
+                got.insert(ids);
+            }
+            
+            // Make sure the best alignment is there.
+            REQUIRE(got.count({1, 2, 4, 5, 7})); 
+        }
+        
+    }
+    
+        
 }
 
 }

--- a/test/t/33_vg_mpmap.t
+++ b/test/t/33_vg_mpmap.t
@@ -35,10 +35,10 @@ rm -f gbwt.gam
 # We need to use snarl cutting to actually consider the alignment as not just a single subpath
 vg snarls xy2.vg > xy2.snarls
 
-is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -s xy2.snarls --max-paths 1 -f reads/xy2.discordant.fq -S | vg view -aj - | jq -r '.path.mapping[0].position.node_id')" "50" "Single traceback places read on the wrong contig"
-is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -s xy2.snarls --max-paths 1 -f reads/xy2.discordant.fq -S | vg view -aj - | jq '.mapping_quality')" "null" "Single traceback places read with MAPQ 0"
-is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -s xy2.snarls --max-paths 20 -f reads/xy2.discordant.fq -t 1 -S | vg view -aj - | jq -r '.path.mapping[0].position.node_id')" "1" "Multiple tracebacks place read on the right contig"
-is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -s xy2.snarls --max-paths 10 -f reads/xy2.discordant.fq -S | vg view -aj - | jq '.mapping_quality')" "1" "Multiple tracebacks place read with nonzero MAPQ"
+is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa -s xy2.snarls -f reads/xy2.discordant.fq -S | vg view -aj - | jq -r '.path.mapping[0].position.node_id')" "50" "Haplotype-oblivious mapping places read on the wrong contig"
+is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa -s xy2.snarls -f reads/xy2.discordant.fq -S | vg view -aj - | jq '.mapping_quality')" "null" "Haplotype-oblivious mapping places read with MAPQ 0"
+is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -s xy2.snarls -f reads/xy2.discordant.fq -t 1 -S | vg view -aj - | jq -r '.path.mapping[0].position.node_id')" "1" "Haplotype-aware mapping places read on the right contig"
+is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -s xy2.snarls -f reads/xy2.discordant.fq -S | vg view -aj - | jq '.mapping_quality')" "1" "Haplotype-aware mapping places read with nonzero MAPQ"
 
 rm -f xy2.vg xy2.xg xy2.gcsa xy2.gcsa.lcp xy2.gbwt xy2.snarls
 


### PR DESCRIPTION
This is my attempt to let haplotype information guide traceback generation for haplotype consistency scoring of MultipathMappings.

I'm just generating all tracebacks that are haplotype-consistent. If the multipath has too many ways to spell the same linear alignment, this could explode. So I'm going to try testing it whole-genome before really merging it.

This should resolve #2012.