### PR TITLE
#2017 pair_consistent orientation checks on same node, map fallback to ignore approx dist

### DIFF
--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -507,7 +507,7 @@ public:
     /// use the fragment length annotations to assess if the pair is consistent or not
     bool pair_consistent(Alignment& aln1, // may modify the alignments to store the reference positions
                          Alignment& aln2,
-                         double pval);
+                         double pval, bool ignore_length = false, bool ignore_orientation = false);
 
     /// use the fragment configuration statistics to rescue more precisely
     pair<bool, bool> pair_rescue(Alignment& mate1, Alignment& mate2, bool& tried1, bool& tried2, int match_score, int full_length_bonus, bool traceback, bool xdrop_alignment);


### PR DESCRIPTION
…ignore approx dist
Some workarounds for issue #2017
* option args to pair_consistency to ignore dist and orientation
* during pair_consistency where there are no Paths, find a common node between the two alns and compare orientation. Will return a more accurate answer than previous, but relies on alns having a common node.
* for vg map: retry with pair_consistency ignoring approx dist, if the first check fails. Current implementation unfortunately will repeat the check for orientation on the retry