### PR TITLE
Add GAM check to vg validate

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1608,4 +1608,23 @@ void alignment_set_distance_to_correct(Alignment& aln, const map<string ,vector<
     }
 }
 
+bool alignment_is_valid(Alignment& aln, const HandleGraph* hgraph) {
+    for (size_t i = 0; i < aln.path().mapping_size(); ++i) {
+        const Mapping& mapping = aln.path().mapping(i);
+        if (!hgraph->has_node(mapping.position().node_id())) {
+            cerr << "Invalid Alignment:\n" << pb2json(aln) <<"\nNode " << mapping.position().node_id()
+                 << " not found in graph" << endl;
+            return false;
+        }
+        size_t node_len = hgraph->get_length(hgraph->get_handle(mapping.position().node_id()));
+        if (mapping_from_length(mapping) + mapping.position().offset() > node_len) {
+            cerr << "Invalid Alignment:\n" << pb2json(aln) << "\nLength of node "
+                 << mapping.position().node_id() << " (" << node_len << ") exceeded by Mapping with offset "
+                 << mapping.position().offset() << " and from-length " << mapping_from_length(mapping) << ":\n"
+                 << pb2json(mapping) << endl;
+            return false;
+        }
+    }
+    return true;
+}
 }

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -207,6 +207,8 @@ map<string ,vector<pair<size_t, bool> > > alignment_refpos_to_path_offsets(const
 void alignment_set_distance_to_correct(Alignment& aln, const Alignment& base);
 void alignment_set_distance_to_correct(Alignment& aln, const map<string ,vector<pair<size_t, bool> > >& base_offsets);
 
+/// check to make sure edits on the alignment's path don't assume incorrect node lengths or ids
+bool alignment_is_valid(Alignment& aln, const HandleGraph* hgraph);
 }
 
 #endif

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -214,7 +214,8 @@ public:
     // Interface that needs to be implemented
     ////////////////////////////////////////////////////////////////////////////
    
-    // TODO: Method to check if a node exists by ID?
+    // Method to check if a node exists by ID
+    virtual bool has_node(id_t node_id) const = 0;
    
     /// Look up the handle for the node with the given ID in the given orientation
     virtual handle_t get_handle(const id_t& node_id, bool is_reverse = false) const = 0;

--- a/src/indexed_vg.cpp
+++ b/src/indexed_vg.cpp
@@ -56,6 +56,25 @@ void IndexedVG::print_report() const {
     // here.
 }
 
+bool IndexedVG::has_node(id_t node_id) const {
+    bool id_in_graph = false;
+    find(node_id, [&](const CacheEntry& entry) -> bool {
+            // For each relevant entry (which may just have some edges to the node we are looking for)
+            auto found = entry.id_to_node_index.find(node_id);
+            if (found != entry.id_to_node_index.end()) {
+                // We found the node!
+                id_in_graph = true;
+                // Stop
+                return false;
+            }
+        
+            // Otherwise we don't have the node we want
+            return true;
+        });
+
+    return id_in_graph;
+}
+
 // TODO: We ought to use some kind of handle packing that relates to file offsets for graph chunks contasining nodes.
 // For now we just use the EasyHandlePacking and hit the index every time.
 

--- a/src/indexed_vg.hpp
+++ b/src/indexed_vg.hpp
@@ -68,7 +68,10 @@ public:
     ///////////////
     // Handle Graph Interface
     ///////////////
-    
+
+    /// Check if a node exists by ID
+    virtual bool has_node(id_t node_id) const;
+
     /// Look up the handle for the node with the given ID in the given orientation
     virtual handle_t get_handle(const id_t& node_id, bool is_reverse = false) const;
     

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -1710,6 +1710,10 @@ void NetGraph::add_chain_child(const Chain& chain) {
         connectivity[graph->get_id(chain_start_handle)] = make_tuple(false, false, true);
     }
 }
+
+bool NetGraph::has_node(id_t node_id) const {
+    return graph->has_node(node_id);
+}
     
 handle_t NetGraph::get_handle(const id_t& node_id, bool is_reverse) const {
     // We never let anyone see any node IDs that aren't assigned to child snarls/chains or content nodes.

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -271,7 +271,10 @@ public:
              const vector<Snarl>& child_unary_snarls,
              const HandleGraph* graph,
              bool use_internal_connectivity = false);
-            
+
+    /// Method to check if a node exists by ID
+    virtual bool has_node(id_t node_id) const;
+    
     /// Look up the handle for the node with the given ID in the given orientation
     virtual handle_t get_handle(const id_t& node_id, bool is_reverse = false) const;
     // Copy over the visit version which would otherwise be shadowed.

--- a/src/source_sink_overlay.cpp
+++ b/src/source_sink_overlay.cpp
@@ -85,6 +85,10 @@ handle_t SourceSinkOverlay::get_sink_handle() const {
     return sink_fwd;
 }
 
+bool SourceSinkOverlay::has_node(id_t node_id) const {
+    return backing->has_node(node_id);
+}
+
 handle_t SourceSinkOverlay::get_handle(const id_t& node_id, bool is_reverse) const {
     if (node_id == source_id) {
         // They asked for the source node

--- a/src/source_sink_overlay.hpp
+++ b/src/source_sink_overlay.hpp
@@ -51,6 +51,9 @@ public:
     ////////////////////////////////////////////////////////////////////////////
     // Handle-based interface
     ////////////////////////////////////////////////////////////////////////////
+
+    /// Check if a node exists by ID
+    virtual bool has_node(id_t node_id) const;
     
     /// Look up the handle for the node with the given ID in the given orientation
     virtual handle_t get_handle(const id_t& node_id, bool is_reverse) const;


### PR DESCRIPTION
GAM errors arise from time to time and can go unnoticed until vg augment crashes.  Add check in vg validate to speed up debugging these cases. 