### PR TITLE
Restrict RepresentativeTraversalFinder to snarls properly to fix #2041

### DIFF
--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -1136,6 +1136,28 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
                 }
             } else {
                 cerr << "\tPath member " << visit << " is to a child snarl" << endl;
+                
+                auto found_start = index.find_in_orientation(visit.snarl().start().node_id(),
+                    visit.snarl().start().backward() != visit.backward());
+                    
+                if (found_start != index.end()) {
+                    cerr << "\t\tStart lives on backbone at "
+                         << found_start->first << endl;
+                } else {
+                    cerr << "\t\tStart does not live on backbone" << endl;
+                }
+                
+                auto found_end = index.find_in_orientation(visit.snarl().end().node_id(),
+                    visit.snarl().end().backward() != visit.backward());
+                
+                if (found_end != index.end()) {
+                    cerr << "\t\tEnd lives on backbone at "
+                         << found_end->first << endl;
+                } else {
+                    cerr << "\t\tEnd does not live on backbone" << endl;
+                }
+                    
+                
             }
         }
 #endif
@@ -1143,7 +1165,16 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
         for(auto& visit : path) {
             if (visit.node_id() != 0) {
                 // Make sure the site actually has the nodes we're visiting.
-                assert(contents.first.count(augmented.graph.get_node(visit.node_id())));
+                if (!contents.first.count(augmented.graph.get_node(visit.node_id()))) {
+                    cerr << "error[RepresentativeTraversalFinder::find_traversals]: Node "
+                        << visit.node_id() << " not in snarl " << pb2json(site) << " contents:" << endl;
+                    
+                    for (auto& node_ptr : contents.first) {
+                        cerr << "\t" << node_ptr->id() << endl;
+                    }
+                
+                    assert(false);
+                }
             }
             // Child snarls will have ownership of their end nodes, so they won't be part of our contents.
         }
@@ -2000,6 +2031,11 @@ RepresentativeTraversalFinder::bfs_left(Visit visit,
     
 #ifdef debug
     cerr << "Start BFS left from " << visit << endl;
+    
+    if (in_snarl != nullptr) {
+        cerr << "Stay inside " << pb2json(*in_snarl) << endl;
+    }
+    
 #endif
 
     // Track how many options we have because size may be O(n).
@@ -2147,10 +2183,29 @@ RepresentativeTraversalFinder::bfs_left(Visit visit,
             }
         }
         
-        if (path_length <= max_depth && extend) {
+        
+        if (path_length >= max_depth) {
+#ifdef debug
+            cerr << "Path has reached max depth! Aborting!" << endl;
+#endif
+        } else if (!extend) {
+            // We chose not to extend.
+#ifdef debug
+            cerr << "Choosing not to extend" << endl;
+#endif
+        } else if (in_snarl != nullptr &&
+            ((node_id == in_snarl->start().node_id() && is_reverse == in_snarl->start().backward()) ||
+            (node_id == in_snarl->end().node_id() && is_reverse != in_snarl->end().backward()))) {
+            // We hit a boundary node of the snarl we are working on, and are
+            // headed out of the snarl (i.e. we're at the start or end in the
+            // into-snarl orientation).
+#ifdef debug
+            cerr << "Path has reached containing snarl boundary! Aborting!" << endl;
+#endif
+        } else {
             // We haven't hit the reference path yet in all orientations, but
-            // we also haven't hit the max depth. Extend with all the possible
-            // extensions.
+            // we also haven't hit the max depth or the snarl bounds. Extend
+            // with all the possible extensions.
             
             // Look left, possibly entering child snarls
             vector<Visit> prevVisits = snarl_manager.visits_left(path.front(), augmented.graph, in_snarl);
@@ -2247,17 +2302,7 @@ RepresentativeTraversalFinder::bfs_left(Visit visit,
                 // visit it other ways.
                 alreadyQueued.insert(prevVisit);
             }
-        } else if (path_length >= max_depth) {
-#ifdef debug
-            cerr << "Path has reached max depth! Aborting!" << endl;
-#endif
-        } else {
-            // We chose not to extend.
-#ifdef debug
-            cerr << "Choosing not to extend" << endl;
-#endif
-        }
-        
+        } 
     }
     
     return toReturn;


### PR DESCRIPTION
The traversal search was escaping the snarl, which caused trouble when the snarl was inside a complex structure and could have a properly oriented reference-anchored path coming out of itself.

This fixes vg call on the provided files from that issue. It now runs through.