### PR TITLE
Make haplotype scoring robust to graphs made from unphased VCFs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,11 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir -p deps; touch deps/gcc6; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$INSTALL_GCC" == "1" ]]; then brew install gcc6 || true; fi
+  # Try installing gcc6 twice in case of errors like this:
+  # Error: HOMEBREW_LOGS was not exported!
+  # Please don't worry, you likely hit a bug auto-updating from an old version.
+  # Rerun your command, everything is up-to-date and fine now.
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$INSTALL_GCC" == "1" ]]; then brew install gcc6 || brew install gcc6 || true; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$INSTALL_GCC" == "1" ]]; then brew link --overwrite gcc@6; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$INSTALL_GCC" == "1" ]]; then mkdir -p ./bin; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$INSTALL_GCC" == "1" ]]; then ln -sf `which g++-6` ./bin/g++; fi

--- a/src/gssw_aligner.cpp
+++ b/src/gssw_aligner.cpp
@@ -420,7 +420,8 @@ double BaseAligner::maximum_mapping_quality_approx(vector<double>& scaled_scores
         scaled_scores.push_back(0.0);
         padded = true;
     }
-    
+   
+    assert(!scaled_scores.empty());
     double max_score = scaled_scores[0];
     size_t max_idx = 0;
     

--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -668,7 +668,6 @@ haplo_score_type haplo_DP::score(const gbwt_thread_t& thread, GBWTType& graph, h
   return pair<double, bool>(hdp.DP_column.current_sum(), true);
 }
 
-
 //------------------------------------------------------------------------------
 
 template<class GBWTType>

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1700,6 +1700,12 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
         bool path_valid;
         std::tie(haplotype_logprob, path_valid) = haplo_score_provider->score(aln->path(), haplo_memo);
         
+        if (std::isnan(haplotype_logprob) && path_valid) {
+            // This shouldn't happen. Bail out on haplotype adjustment for this read and warn.
+            cerr << "warning:[vg::Mapper]: NAN population score obtained for read with ostensibly successful query. Changing to failure." << endl;
+            path_valid = false;
+        }
+        
         if (!path_valid) {
             // Our path does something the scorer doesn't like.
             // Bail out of applying haplotype scores.
@@ -1727,10 +1733,12 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
             // We actually did rescore this one
             
             // This is a score "penalty" because it is usually negative. But positive = more score.
+            // Convert to points, raise to haplotype consistency exponent power.
             double score_penalty = haplotype_consistency_exponent * (haplotype_logprobs[i] / aligner->log_base);
-
-            // Convert to points, raise to haplotype consistency exponent power, and apply
-            alns[i]->set_score(max((int64_t) 0, alns[i]->score() + (int64_t) round(score_penalty)));
+            
+            // Apply "penalty"
+            int64_t old_score = alns[i]->score();
+            alns[i]->set_score(max((int64_t) 0, old_score + (int64_t) round(score_penalty)));
             // Note that we successfully corrected the score
             set_annotation(alns[i], "haplotype_score_used", true);
             // And save the score penalty/bonus
@@ -1738,8 +1746,9 @@ void BaseMapper::apply_haplotype_consistency_scores(const vector<Alignment*>& al
 
             if (debug) {
                 cerr << "Alignment statring at " << alns[i]->path().mapping(0).position().node_id()
-                    << " got logprob " << haplotype_logprobs[i] << " moving score " << score_penalty
-                    << " from " << alns[i]->score() - score_penalty << " to " << alns[i]->score() << endl;
+                    << " got logprob " << haplotype_logprobs[i] << " vs " << haplotype_count
+                    << " haplotypes, moving score by " << score_penalty
+                    << " from " << old_score << " to " << alns[i]->score() << endl;
             }
         }
     }
@@ -4267,7 +4276,8 @@ vector<Alignment> Mapper::align_multi_internal(bool compute_unpaired_quality,
                                                         max_mem_length,
                                                         min_mem_length,
                                                         mem_reseed_length,
-                                                        false, true, true, false);
+                                                        false, true, true, true); // Make sure to actually fill in the longest LCP.
+        
         // query mem hits
         alignments = align_mem_multi(aln, mems, cluster_mq, longest_lcp, fraction_filtered, max_mem_length, keep_multimaps, additional_multimaps_for_quality, xdrop_alignment);
     }


### PR DESCRIPTION
This should fix #2046, although @yoheirosen might want to weigh in on whether I've extended the haplotype scoring algorithm appropriately to the case where there are more hits in the GBWT than real haplotypes.

I've also fixed some uninitialized reads of `longest_lcp`, which we hadn't asked to be filled in.