### PR TITLE
Keep version info in tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,18 +439,21 @@ $(LIB_DIR)/libsublinearLS.a: $(LINLS_DIR)/src/*.cpp $(LINLS_DIR)/src/*.hpp $(LIB
 
 # Auto-git-versioning
 
+# We need to scope this variable here
+GIT_VERSION_FILE_DEPS =
 # Decide if .git exists and needs to be watched
 ifeq ($(shell if [ -d .git ]; then echo present; else echo absent; fi),present)
 	# If so, try and make a git version file
-	GIT_VERSION_FILE_DEPS=.check-git
+	GIT_VERSION_FILE_DEPS = .check-git
 else
 	# Just use the version file we have, if any
-	GIT_VERSION_FILE_DEPS=.no-git
+	GIT_VERSION_FILE_DEPS = .no-git
 endif
  
 # Build a real git version file.
 # If it's not the same as the old one, replace the old one.
 # If it is the same, do nothing and don't rebuild dependent targets.
+
 .check-git:
 	@echo "#define VG_GIT_VERSION \"$(shell git describe --always --tags 2>/dev/null || echo git-error)\"" > $(INC_DIR)/vg_git_version.hpp.tmp
 	@diff $(INC_DIR)/vg_git_version.hpp.tmp $(INC_DIR)/vg_git_version.hpp >/dev/null || cp $(INC_DIR)/vg_git_version.hpp.tmp $(INC_DIR)/vg_git_version.hpp
@@ -458,7 +461,7 @@ endif
 	
 # Make sure the version file exists, if we weren't given one in our tarball
 .no-git:
-	if [ ! -e $(INC_DIR)/vg_git_version.hpp ]; then \
+	@if [ ! -e $(INC_DIR)/vg_git_version.hpp ]; then \
 		touch $(INC_DIR)/vg_git_version.hpp \
 	fi;
  

--- a/Makefile
+++ b/Makefile
@@ -462,7 +462,7 @@ endif
 # Make sure the version file exists, if we weren't given one in our tarball
 .no-git:
 	@if [ ! -e $(INC_DIR)/vg_git_version.hpp ]; then \
-		touch $(INC_DIR)/vg_git_version.hpp \
+		touch $(INC_DIR)/vg_git_version.hpp; \
 	fi;
  
 $(INC_DIR)/vg_git_version.hpp: $(GIT_VERSION_FILE_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,6 @@ endif
 # Build a real git version file.
 # If it's not the same as the old one, replace the old one.
 # If it is the same, do nothing and don't rebuild dependent targets.
-
 .check-git:
 	@echo "#define VG_GIT_VERSION \"$(shell git describe --always --tags 2>/dev/null || echo git-error)\"" > $(INC_DIR)/vg_git_version.hpp.tmp
 	@diff $(INC_DIR)/vg_git_version.hpp.tmp $(INC_DIR)/vg_git_version.hpp >/dev/null || cp $(INC_DIR)/vg_git_version.hpp.tmp $(INC_DIR)/vg_git_version.hpp

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -12,7 +12,7 @@
 // If the VG_GIT_VERSION deosn't exist at all, define a placeholder
 // This lets us be somewhat robust to undeterminable versions
 #ifndef VG_GIT_VERSION
-    #define VG_GIT_VERSION "unknown"
+    #define VG_GIT_VERSION "not-from-git"
 #endif
 
 namespace vg {

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -9,6 +9,12 @@
 #include <iostream>
 #include <sstream>
 
+// If the VG_GIT_VERSION deosn't exist at all, define a placeholder
+// This lets us be somewhat robust to undeterminable versions
+#ifndef VG_GIT_VERSION
+    #define VG_GIT_VERSION "unknown"
+#endif
+
 namespace vg {
 
 using namespace std;


### PR DESCRIPTION
This should fix the auto-version-determining system to work with a static `include/vg_git_version.hpp` in  a tarball, and finally close #2034.