### PR TITLE
Separate "mutable" and "deletable" in handle graph interface

### DIFF
--- a/src/algorithms/extract_connecting_graph.cpp
+++ b/src/algorithms/extract_connecting_graph.cpp
@@ -15,7 +15,7 @@ namespace algorithms {
 using namespace structures;
 
 unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source,
-                                                   MutableHandleGraph* into,
+                                                   DeletableHandleGraph* into,
                                                    int64_t max_len,
                                                    pos_t pos_1, pos_t pos_2,
                                                    bool detect_terminal_cycles,

--- a/src/algorithms/extract_connecting_graph.hpp
+++ b/src/algorithms/extract_connecting_graph.hpp
@@ -20,7 +20,7 @@
 namespace vg {
 namespace algorithms {
     
-    /// Fills a MutableHandleGraph with the subgraph of a HandleGraph that connects two positions. The nodes that
+    /// Fills a DeletableHandleGraph with the subgraph of a HandleGraph that connects two positions. The nodes that
     /// contain the two positions will be 'cut' at the position and will be tips in the returned graph. By default,
     /// the algorithm provides only one guarantee:
     ///   - 'into' contains all walks between pos_1 and pos_2 under the maximum length except walks that include
@@ -43,7 +43,7 @@ namespace algorithms {
     ///  strict_max_len             only extract nodes and edges if they fall on some walk between pos_1 and pos_2
     ///                             that is under the maximum length (implies only_walks = true)
     unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source,
-                                                       MutableHandleGraph* into,
+                                                       DeletableHandleGraph* into,
                                                        int64_t max_len,
                                                        pos_t pos_1, pos_t pos_2,
                                                        bool detect_terminal_cycles = false,

--- a/src/algorithms/extract_extending_graph.cpp
+++ b/src/algorithms/extract_extending_graph.cpp
@@ -14,7 +14,7 @@ namespace algorithms {
 
 using namespace structures;
 
-unordered_map<id_t, id_t> extract_extending_graph(const HandleGraph* source, MutableHandleGraph* into, int64_t max_dist, pos_t pos,
+unordered_map<id_t, id_t> extract_extending_graph(const HandleGraph* source, DeletableHandleGraph* into, int64_t max_dist, pos_t pos,
                                                   bool backward, bool preserve_cycles_on_src_node) {
     
     if (into->node_size()) {

--- a/src/algorithms/extract_extending_graph.hpp
+++ b/src/algorithms/extract_extending_graph.hpp
@@ -34,7 +34,7 @@ namespace algorithms {
     ///  pos                     extend from this position
     ///  backward                extend in this direction
     ///  preserve_cycles_on_src  if necessary, duplicate starting node to preserve cycles after cutting it
-    unordered_map<id_t, id_t> extract_extending_graph(const HandleGraph* source, MutableHandleGraph* into, int64_t max_dist, pos_t pos,
+    unordered_map<id_t, id_t> extract_extending_graph(const HandleGraph* source, DeletableHandleGraph* into, int64_t max_dist, pos_t pos,
                                                       bool backward, bool preserve_cycles_on_src_node);
                                                       
 }

--- a/src/algorithms/remove_high_degree.cpp
+++ b/src/algorithms/remove_high_degree.cpp
@@ -5,7 +5,7 @@ namespace algorithms {
 
 using namespace std;
 
-void remove_high_degree_nodes(MutableHandleGraph& g, int max_degree) {
+void remove_high_degree_nodes(DeletableHandleGraph& g, int max_degree) {
     vector<handle_t> to_remove;
     g.for_each_handle([&](const handle_t& h) {
             int edge_count = 0;

--- a/src/algorithms/remove_high_degree.hpp
+++ b/src/algorithms/remove_high_degree.hpp
@@ -16,7 +16,7 @@ namespace algorithms {
 
 using namespace std;
 
-void remove_high_degree_nodes(MutableHandleGraph& g, int max_degree);
+void remove_high_degree_nodes(DeletableHandleGraph& g, int max_degree);
 
 }
 }

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -429,7 +429,7 @@ public:
 };
 
 /**
- * This is the interface for a handle graph that supports modification.
+ * This is the interface for a handle graph that supports addition of new graph material.
  */
 class MutableHandleGraph : virtual public HandleGraph {
 public:
@@ -443,14 +443,6 @@ public:
     /// Create a new node with the given id and sequence, then return the handle.
     virtual handle_t create_handle(const string& sequence, const id_t& id) = 0;
     
-    /// Remove the node belonging to the given handle and all of its edges.
-    /// Does not update any stored paths.
-    /// Invalidates the destroyed handle.
-    /// May be called during serial for_each_handle iteration **ONLY** on the node being iterated.
-    /// May **NOT** be called during parallel for_each_handle iteration.
-    /// May **NOT** be called on the node from which edges are being followed during follow_edges.
-    virtual void destroy_handle(const handle_t& handle) = 0;
-    
     /// Create an edge connecting the given handles in the given order and orientations.
     /// Ignores existing edges.
     virtual void create_edge(const handle_t& left, const handle_t& right) = 0;
@@ -459,19 +451,6 @@ public:
     inline void create_edge(const edge_t& edge) {
         create_edge(edge.first, edge.second);
     }
-    
-    /// Remove the edge connecting the given handles in the given order and orientations.
-    /// Ignores nonexistent edges.
-    /// Does not update any stored paths.
-    virtual void destroy_edge(const handle_t& left, const handle_t& right) = 0;
-    
-    /// Convenient wrapper for destroy_edge.
-    inline void destroy_edge(const edge_t& edge) {
-        destroy_edge(edge.first, edge.second);
-    }
-    
-    /// Remove all nodes and edges. Does not update any stored paths.
-    virtual void clear() = 0;
     
     /// Swap the nodes corresponding to the given handles, in the ordering used
     /// by for_each_handle when looping over the graph. Other handles to the
@@ -506,6 +485,35 @@ public:
         auto parts = divide_handle(handle, vector<size_t>{offset});
         return make_pair(parts.front(), parts.back());
     }
+};
+  
+/**
+ * This is the interface for a handle graph that supports both addition of new nodes and edges
+ * as well as deletion of nodes and edges.
+ */
+class DeletableHandleGraph : virtual public MutableHandleGraph {
+public:
+    
+    /// Remove the node belonging to the given handle and all of its edges.
+    /// Does not update any stored paths.
+    /// Invalidates the destroyed handle.
+    /// May be called during serial for_each_handle iteration **ONLY** on the node being iterated.
+    /// May **NOT** be called during parallel for_each_handle iteration.
+    /// May **NOT** be called on the node from which edges are being followed during follow_edges.
+    virtual void destroy_handle(const handle_t& handle) = 0;
+    
+    /// Remove the edge connecting the given handles in the given order and orientations.
+    /// Ignores nonexistent edges.
+    /// Does not update any stored paths.
+    virtual void destroy_edge(const handle_t& left, const handle_t& right) = 0;
+    
+    /// Convenient wrapper for destroy_edge.
+    inline void destroy_edge(const edge_t& edge) {
+        destroy_edge(edge.first, edge.second);
+    }
+    
+    /// Remove all nodes and edges. Does not update any stored paths.
+    virtual void clear() = 0;
 };
 
 /**
@@ -543,7 +551,21 @@ public:
  * This is the interface for a graph which is mutable and which has paths which are also mutable.
  */
 class MutablePathMutableHandleGraph : virtual public MutablePathHandleGraph, virtual public MutableHandleGraph {
-    // No extra methods!
+    
+    // No extra methods. However, some additional semantics are assumed:
+    // - divide_handle() replaces the occurrence of the original handle with its subsegments
+    //   in all occurrences on all paths
+    // - apply_orientation() also applies the orientation to all occurrences of the handle
+    //   in all paths
+    
+};
+
+/**
+ * This is the interface for a graph which is deletable and which has paths which are also mutable.
+ */
+class MutablePathDeletableHandleGraph : virtual public MutablePathHandleGraph, virtual public DeletableHandleGraph {
+    
+    // No extra methods. Deleting a node or edge that is contained in a path is undefined behavior.
 };
 
 }

--- a/src/rare_variant_simplifier.cpp
+++ b/src/rare_variant_simplifier.cpp
@@ -4,7 +4,7 @@ namespace vg {
 
 using namespace std;
 
-RareVariantSimplifier::RareVariantSimplifier(MutablePathMutableHandleGraph& graph, VcfBuffer& variant_source) : Progressive(), graph(graph), variant_source(variant_source) {
+RareVariantSimplifier::RareVariantSimplifier(MutablePathDeletableHandleGraph& graph, VcfBuffer& variant_source) : Progressive(), graph(graph), variant_source(variant_source) {
     // Nothing to do!
 }
 

--- a/src/rare_variant_simplifier.hpp
+++ b/src/rare_variant_simplifier.hpp
@@ -24,7 +24,7 @@ class RareVariantSimplifier : public Progressive {
 public:
     /// Make a simplifier that simplifies the given graph in place, using
     /// variants read using the given buffer.
-    RareVariantSimplifier(MutablePathMutableHandleGraph& graph, VcfBuffer& variant_source);
+    RareVariantSimplifier(MutablePathDeletableHandleGraph& graph, VcfBuffer& variant_source);
     
     /// Simplify the graph.
     void simplify();
@@ -39,7 +39,7 @@ public:
 protected:
 
     /// Holds a reference to the graph we're simplifying
-    MutablePathMutableHandleGraph& graph;
+    MutablePathDeletableHandleGraph& graph;
 
     /// Holds a reference to the variant buffer we are getting avriants from.
     VcfBuffer& variant_source;

--- a/src/unittest/handle.cpp
+++ b/src/unittest/handle.cpp
@@ -363,9 +363,9 @@ TEST_CASE("VG and XG handle implementations are correct", "[handle][vg][xg]") {
 
 }
 
-TEST_CASE("Mutable handle graphs work", "[handle][vg]") {
+TEST_CASE("Deletable handle graphs work", "[handle][vg]") {
     
-    vector<MutableHandleGraph*> implementations;
+    vector<DeletableHandleGraph*> implementations;
     
     // Test the VG implementation
     VG vg;

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -79,7 +79,7 @@ namespace vg {
  * However, edges can connect to either the start or end of either node.
  *
  */
-class VG : public Progressive, public MutablePathMutableHandleGraph {
+class VG : public Progressive, public MutablePathDeletableHandleGraph {
 
 public:
 


### PR DESCRIPTION
This PR partially addresses the concerns discussed in https://github.com/vgteam/vg/issues/2036.

I've subdivided the MutableHandleGraph interface into two. One interface allows addition of new graph material and manipulation of existing graph material. The other interface inherits from the first and adds the ability to delete graph material.

The overriding motivation here is to provide an interface with no deletes, which can then guarantee semantic consistency of embedded paths. However, our implementation is currently lagging behind the specification. The only merged MutableHandleGraph implementation is VG, which doesn't work as hard to maintain path consistency as you might hope. That means there are currently no fully compliant implementations to this interface, but I think it's a good roadmap barring further discussion about what semantics we want to see.

