### PR TITLE
Add ability to query occurrences of a node on paths to handle interface

### DIFF
--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -409,6 +409,11 @@ public:
     
     /// Returns a handle to the path that an occurrence is on
     virtual path_handle_t get_path_handle_of_occurrence(const occurrence_handle_t& occurrence_handle) const = 0;
+    
+    /// Returns a vector of all occurrences of a node on paths. Optionally restricts to
+    /// occurrences that match the handle in orientation.
+    virtual vector<occurrence_handle_t> occurrences_of_handle(const handle_t& handle,
+                                                              bool match_orientation = false) const = 0;
 
     ////////////////////////////////////////////////////////////////////////////
     // Additional optional interface with a default implementation

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -784,6 +784,35 @@ namespace vg {
         return as_path_handle(as_integers(occurrence_handle)[0]);
     }
     
+    vector<occurrence_handle_t> PackedGraph::occurrences_of_handle(const handle_t& handle, bool match_orientation) const {
+        vector<occurrence_handle_t> return_val;
+        
+        size_t path_membership = path_membership_node_iv.get(graph_index_to_node_member_index(graph_iv_index(handle)));
+        while (path_membership) {
+            
+            // get the path that this membership record is on
+            uint64_t path_id = get_membership_path(path_membership);
+            const PackedPath& packed_path = paths[path_id];
+            
+            // get the traversal
+            size_t occ_idx = get_membership_occurrence(path_membership);
+            handle_t trav = decode_traversal(get_occurrence_trav(packed_path, occ_idx));
+            
+            // add this occurrence to the return value if we're supposed to
+            if (!match_orientation || get_is_reverse(trav) == get_is_reverse(handle)) {
+                occurrence_handle_t occ_handle;
+                as_integers(occ_handle)[0] = path_id;
+                as_integers(occ_handle)[1] = occ_idx;
+                return_val.push_back(occ_handle);
+            }
+            
+            // move to the next membership record
+            path_membership = get_next_membership(path_membership);
+        }
+        
+        return return_val;
+    }
+    
     void PackedGraph::destroy_path(const path_handle_t& path) {
         
         PackedPath& packed_path = paths.at(as_integer(path));

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -687,6 +687,10 @@ bool Paths::has_node_mapping(Node* n) {
 map<int64_t, set<mapping_t*>>& Paths::get_node_mapping(id_t id) {
     return node_mapping[id];
 }
+    
+const map<int64_t, set<mapping_t*>>& Paths::get_node_mapping(id_t id) const {
+    return node_mapping.at(id);
+}
 
 map<int64_t, set<mapping_t*>>& Paths::get_node_mapping(Node* n) {
     return node_mapping[n->id()];

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -160,6 +160,7 @@ public:
     bool has_node_mapping(Node* n);
     map<int64_t, set<mapping_t*> >& get_node_mapping(Node* n);
     map<int64_t, set<mapping_t*> >& get_node_mapping(id_t id);
+    const map<int64_t, set<mapping_t*> >& get_node_mapping(id_t id) const;
     map<string, set<mapping_t*> > get_node_mapping_by_path_name(Node* n);
     map<string, set<mapping_t*> > get_node_mapping_by_path_name(id_t id);
     map<string, map<int, mapping_t*> > get_node_mappings_by_rank(id_t id);

--- a/src/unittest/packed_graph.cpp
+++ b/src/unittest/packed_graph.cpp
@@ -1121,6 +1121,76 @@ using namespace std;
         
         check_path(p2, {h1, graph.flip(h2), h3});
         
+        SECTION("PackedGraph can query occurrences of a node on paths") {
+            
+            bool found1 = false, found2 = false;
+            vector<occurrence_handle_t> occs = graph.occurrences_of_handle(h1);
+            for (auto& occ : occs) {
+                if (graph.get_path_handle_of_occurrence(occ) == p1 &&
+                    graph.get_occurrence(occ) == h1) {
+                    found1 = true;
+                }
+                else if (graph.get_path_handle_of_occurrence(occ) == p2 &&
+                         graph.get_occurrence(occ) == h1) {
+                    found2 = true;
+                }
+                else {
+                    REQUIRE(false);
+                }
+            }
+            REQUIRE(found1);
+            REQUIRE(found2);
+            found1 = found2 = false;
+            
+            occs = graph.occurrences_of_handle(h1, true);
+            for (auto& occ : occs) {
+                if (graph.get_path_handle_of_occurrence(occ) == p1 &&
+                    graph.get_occurrence(occ) == h1) {
+                    found1 = true;
+                }
+                else if (graph.get_path_handle_of_occurrence(occ) == p2 &&
+                         graph.get_occurrence(occ) == h1) {
+                    found2 = true;
+                }
+                else {
+                    REQUIRE(false);
+                }
+            }
+            REQUIRE(found1);
+            REQUIRE(found2);
+            found1 = found2 = false;
+            
+            occs = graph.occurrences_of_handle(graph.flip(h1), true);
+            for (auto& occ : occs) {
+                REQUIRE(false);
+            }
+            
+            occs = graph.occurrences_of_handle(h2, true);
+            for (auto& occ : occs) {
+                if (graph.get_path_handle_of_occurrence(occ) == p1 &&
+                    graph.get_occurrence(occ) == h2) {
+                    found1 = true;
+                }
+                else {
+                    REQUIRE(false);
+                }
+            }
+            occs = graph.occurrences_of_handle(graph.flip(h2), true);
+            for (auto& occ : occs) {
+                if (graph.get_path_handle_of_occurrence(occ) == p2 &&
+                    graph.get_occurrence(occ) == graph.flip(h2)) {
+                    found2 = true;
+                }
+                else {
+                    REQUIRE(false);
+                }
+            }
+            REQUIRE(found1);
+            REQUIRE(found2);
+            found1 = found2 = false;
+            
+        }
+        
         vector<handle_t> segments = graph.divide_handle(h2, {size_t(2), size_t(4)});
         
         SECTION("PackedGraph preserves paths when dividing nodes") {

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -338,6 +338,24 @@ occurrence_handle_t VG::get_previous_occurrence(const occurrence_handle_t& occur
 path_handle_t VG::get_path_handle_of_occurrence(const occurrence_handle_t& occurrence_handle) const {
     return as_path_handle(as_integers(occurrence_handle)[0]);
 }
+    
+vector<occurrence_handle_t> VG::occurrences_of_handle(const handle_t& handle, bool match_orientation) const {
+    
+    vector<occurrence_handle_t> return_val;
+    const map<int64_t, set<mapping_t*>>& node_mapping = paths.get_node_mapping(get_id(handle));
+    for (const pair<int64_t, set<mapping_t*>>& path_occs : node_mapping) {
+        for (const mapping_t* mapping : path_occs.second) {
+            if (!match_orientation || mapping->is_reverse() == get_is_reverse(handle)) {
+                occurrence_handle_t occurrence_handle;
+                as_integers(occurrence_handle)[0] = path_occs.first;
+                as_integers(occurrence_handle)[1] = reinterpret_cast<int64_t>(mapping);
+                return_val.push_back(occurrence_handle);
+            }
+        }
+    }
+    
+    return return_val;
+}
 
 handle_t VG::create_handle(const string& sequence) {
     Node* node = create_node(sequence);

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -182,6 +182,11 @@ public:
     /// Returns a handle to the path that an occurrence is on
     virtual path_handle_t get_path_handle_of_occurrence(const occurrence_handle_t& occurrence_handle) const;
     
+    /// Returns a vector of all occurrences of a node on paths. Optionally restricts to
+    /// occurrences that match the handle in orientation.
+    virtual vector<occurrence_handle_t> occurrences_of_handle(const handle_t& handle,
+                                                              bool match_orientation = false) const;
+    
     ////////////////////////////////////////////////////////////////////////////
     // Mutable handle-based interface
     ////////////////////////////////////////////////////////////////////////////

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1899,6 +1899,25 @@ occurrence_handle_t XG::get_previous_occurrence(const occurrence_handle_t& occur
 path_handle_t XG::get_path_handle_of_occurrence(const occurrence_handle_t& occurrence_handle) const {
     return as_path_handle(as_integers(occurrence_handle)[0]);
 }
+    
+vector<occurrence_handle_t> XG::occurrences_of_handle(const handle_t& handle, bool match_orientation) const {
+    vector<pair<size_t, vector<pair<size_t, bool>>>> oriented_paths = oriented_paths_of_node(get_id(handle));
+    
+    vector<occurrence_handle_t> return_val;
+    for (const pair<size_t, vector<pair<size_t, bool>>>& path_occs : oriented_paths) {
+        for (const pair<size_t, bool>& oriented_occ : path_occs.second) {
+            if (!match_orientation || oriented_occ.second == get_is_reverse(handle)) {
+                
+                occurrence_handle_t occurrence_handle;
+                as_integers(occurrence_handle)[0] = path_occs.first;
+                as_integers(occurrence_handle)[1] = oriented_occ.first;
+                return_val.push_back(occurrence_handle);
+            }
+        }
+    }
+    
+    return return_val;
+}
 
 size_t XG::node_size() const {
     return this->node_count;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -276,7 +276,10 @@ public:
     virtual occurrence_handle_t get_previous_occurrence(const occurrence_handle_t& occurrence_handle) const;
     /// Returns a handle to the path that an occurrence is on
     virtual path_handle_t get_path_handle_of_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    
+    /// Returns a vector of all occurrences of a node on paths. Optionally restricts to
+    /// occurrences that match the handle in orientation.
+    virtual vector<occurrence_handle_t> occurrences_of_handle(const handle_t& handle,
+                                                              bool match_orientation = false) const;
     
     ////////////////////////////////////////////////////////////////////////////
     // Higher-level graph API


### PR DESCRIPTION
Turns out all of our handle graph interfaces already have this capability and it seemed useful to me. In fact, it's more or less a necessity for efficient online updates to paths in the mutable types.