### PR TITLE
Convert VCF variants to upper case in constructor (like we do with Fasta)

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -495,9 +495,6 @@ namespace vg {
                     assert(!variant->isSymbolicSV());
                     // If variants have SVTYPE set, though, we will still use that info instead of the base-level sequence.
 
-                    // Check the variant's reference sequence to catch bad VCF/FASTA pairings
-                    auto expected_ref = reference_sequence.substr(variant->zeroBasedPosition() - chunk_offset, variant->ref.size());
-
                     // Since we make the fasta reference uppercase, we do the VCF too (otherwise vcflib get mad)
                     bool reindex = false;
                     for (auto& alt : variant->alt) {
@@ -526,7 +523,9 @@ namespace vg {
                     if (reindex) {
                         variant->updateAlleleIndexes();
                     }
-                    
+
+                    // Check the variant's reference sequence to catch bad VCF/FASTA pairings
+                    auto expected_ref = reference_sequence.substr(variant->zeroBasedPosition() - chunk_offset, variant->ref.size());
                     if(variant->ref != expected_ref) {
                     // TODO: report error to caller somehow
                     #pragma omp critical (cerr)

--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -498,6 +498,35 @@ namespace vg {
                     // Check the variant's reference sequence to catch bad VCF/FASTA pairings
                     auto expected_ref = reference_sequence.substr(variant->zeroBasedPosition() - chunk_offset, variant->ref.size());
 
+                    // Since we make the fasta reference uppercase, we do the VCF too (otherwise vcflib get mad)
+                    bool reindex = false;
+                    for (auto& alt : variant->alt) {
+                        string upper_case_alt = toUppercase(alt);
+                        if (alt != upper_case_alt) {
+                            if (!warned_alt && warn_on_lowercase) {
+                                #pragma omp critical (cerr)
+                                {
+                                    cerr << "warning:[vg::Constructor] Lowercase characters found in "
+                                         << "variant, coercing to uppercase:\n" << *variant << endl;
+                                    warned_alt = true;
+                                }
+                            }
+                            swap(alt, upper_case_alt);
+                            reindex = true;
+                        }
+                    }
+                    for (auto& allele : variant->alleles) {
+                        allele = toUppercase(allele);
+                    }
+                    string upper_case_var_ref = toUppercase(variant->ref);
+                    if (upper_case_var_ref != variant->ref) {
+                        swap(variant->ref, upper_case_var_ref);
+                        reindex = true;
+                    }
+                    if (reindex) {
+                        variant->updateAlleleIndexes();
+                    }
+                    
                     if(variant->ref != expected_ref) {
                     // TODO: report error to caller somehow
                     #pragma omp critical (cerr)

--- a/src/constructor.hpp
+++ b/src/constructor.hpp
@@ -225,6 +225,8 @@ private:
     static pair<int64_t, int64_t> get_symbolic_bounds(vcflib::Variant var);
     /// What sequences have we warned about containing lowercase characters?
     mutable unordered_set<string> warned_sequences;
+    /// Have we given a warning yet about lowercase alt alleles?
+    mutable bool warned_alt = false;
     
 
 };

--- a/test/t/28_translate.t
+++ b/test/t/28_translate.t
@@ -11,10 +11,10 @@ vg construct -m 1000 -v tiny/tiny.vcf.gz -r tiny/tiny.fa > tiny.vg
 vg index -x tiny.xg -g tiny.gcsa -k 16 tiny.vg
 vg sim -n 5 -e 0.01 -i 0.005 -x tiny.xg -l 30 -a | vg view -a - | sort | vg view -JGa - > tiny.sim
 vg map -G tiny.sim -x tiny.xg -g tiny.gcsa -t 1 > tiny.gam
-vg mod -Z tiny.trans -i tiny.gam tiny.vg >tiny.mod.vg
+vg augment -Z tiny.trans -i tiny.vg tiny.gam >tiny.mod.vg
 vg paths -v tiny.mod.vg -X | vg view -a - | grep -v x | sort | vg view -JGa - >tiny.paths.gam
 vg translate -a tiny.paths.gam tiny.trans | vg view -a - | sort | vg view -JGa - >tiny.paths.trans.gam
-vg mod -Z tiny.trans.1 -i tiny.paths.trans.gam tiny.vg >tiny.mod.vg.1
+vg augment -Z tiny.trans.1 -i tiny.vg tiny.paths.trans.gam >tiny.mod.vg.1
 
 is $(vg mod -U 10 tiny.mod.vg | vg mod -c - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) $(vg mod -U 10 tiny.mod.vg.1 | vg mod -c - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) "alignments used to modify a graph may be projected back to the original graph and used to regenerate the same graph"
 
@@ -23,14 +23,14 @@ rm -Rf tiny.vg tiny.xg tiny.gcsa tiny.gcsa.lcp tiny.sim tiny.gam tiny.trans tiny
 vg construct -m 1000 -r tiny/tiny.fa >flat.vg
 vg index -x flat.xg -g flat.gcsa -k 8 flat.vg
 vg map -x flat.xg -g flat.gcsa -G tiny/flat-s69-n1-l50-e0.05.gam >flat.gam
-vg mod -i flat.gam -Z flat1.trans flat.vg >flat1.vg
+vg augment -i -Z flat1.trans flat.vg flat.gam >flat1.vg
 vg index -x flat1.xg -g flat1.gcsa -k 8 flat1.vg
 vg map -x flat1.xg -g flat1.gcsa -G tiny/flat1-s77-n1-l50-e0.05.gam >flat1.gam
-vg mod -i flat1.gam -Z flat2.trans flat1.vg >flat2.vg
+vg augment -i -Z flat2.trans flat1.vg flat1.gam >flat2.vg
 vg translate -o flat2.trans flat1.trans >flatover.trans
 vg paths -v flat2.vg -X | vg view -a - | grep -v x | vg view -JGa - >flat2.paths.gam
 vg translate -a flat2.paths.gam flatover.trans >flatback.gam
-vg mod -i flatback.gam flat.vg >flat2back.vg
+vg augment -i flat.vg flatback.gam >flat2back.vg
 is $(vg view flat2back.vg | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) 3ce4390abe667b24eb5148e216a2f5ec "translation overlay works and produces a sane result"
 
 rm -f flat.vg flat.xg flat.gcsa.lcp flat.gcsa flat.gam flat1.vg flat1.trans flat1.xg flat1.gcsa.lcp flat1.gcsa flat1.gam flat2.vg flat2.trans flatover.trans flat2.paths.gam flatback.gam flat2back.vg


### PR DESCRIPTION
vg construct converts the reference sequence from the fasta into upper case, but lower case bases are left unchanged in the VCF and lead to consistency check failures.  This PR patches construct to convert the VCF to upper case as well...  

Resolves issue recently brought up in thread #1119