### PR TITLE
Skip snarls that aren't ultrabubbles with vg call

### DIFF
--- a/src/chunker.cpp
+++ b/src/chunker.cpp
@@ -111,23 +111,27 @@ void PathChunker::extract_subgraph(const Region& region, int context, int length
     // Cut our graph so that our reference path end points are graph tips.  This will let the
     // snarl finder use the path to find telomeres.
     Node* start_node = subgraph.get_node(mappings.begin()->node_id());
-    if (!mappings.begin()->is_reverse() && subgraph.start_degree(start_node) != 0) {
-        for (auto edge : subgraph.edges_to(start_node)) {
-            subgraph.destroy_edge(edge);
-        }
-    } else if (mappings.begin()->is_reverse() && subgraph.end_degree(start_node) != 0) {
-        for (auto edge : subgraph.edges_from(start_node)) {
-            subgraph.destroy_edge(edge);
+    if (rewrite_paths && xg->position_in_path(start_node->id(), region.seq).size() == 1) {
+        if (!mappings.begin()->is_reverse() && subgraph.start_degree(start_node) != 0) {
+            for (auto edge : subgraph.edges_to(start_node)) {
+                subgraph.destroy_edge(edge);
+            }
+        } else if (mappings.begin()->is_reverse() && subgraph.end_degree(start_node) != 0) {
+            for (auto edge : subgraph.edges_from(start_node)) {
+                subgraph.destroy_edge(edge);
+            }
         }
     }
     Node* end_node = subgraph.get_node(mappings.rbegin()->node_id());
-    if (!mappings.rbegin()->is_reverse() && subgraph.end_degree(end_node) != 0) {
-        for (auto edge : subgraph.edges_from(end_node)) {
-            subgraph.destroy_edge(edge);
-        }
-    } else if (mappings.rbegin()->is_reverse() && subgraph.start_degree(end_node) != 0) {
-        for (auto edge : subgraph.edges_to(end_node)) {
-            subgraph.destroy_edge(edge);
+    if (rewrite_paths && xg->position_in_path(end_node->id(), region.seq).size() == 1) {
+        if (!mappings.rbegin()->is_reverse() && subgraph.end_degree(end_node) != 0) {
+            for (auto edge : subgraph.edges_from(end_node)) {
+                subgraph.destroy_edge(edge);
+            }
+        } else if (mappings.rbegin()->is_reverse() && subgraph.start_degree(end_node) != 0) {
+            for (auto edge : subgraph.edges_to(end_node)) {
+                subgraph.destroy_edge(edge);
+            }
         }
     }
     

--- a/src/chunker.cpp
+++ b/src/chunker.cpp
@@ -107,6 +107,29 @@ void PathChunker::extract_subgraph(const Region& region, int context, int length
             });
         rewrite_paths = true;
     }
+
+    // Cut our graph so that our reference path end points are graph tips.  This will let the
+    // snarl finder use the path to find telomeres.
+    Node* start_node = subgraph.get_node(mappings.begin()->node_id());
+    if (!mappings.begin()->is_reverse() && subgraph.start_degree(start_node) != 0) {
+        for (auto edge : subgraph.edges_to(start_node)) {
+            subgraph.destroy_edge(edge);
+        }
+    } else if (mappings.begin()->is_reverse() && subgraph.end_degree(start_node) != 0) {
+        for (auto edge : subgraph.edges_from(start_node)) {
+            subgraph.destroy_edge(edge);
+        }
+    }
+    Node* end_node = subgraph.get_node(mappings.rbegin()->node_id());
+    if (!mappings.rbegin()->is_reverse() && subgraph.end_degree(end_node) != 0) {
+        for (auto edge : subgraph.edges_from(end_node)) {
+            subgraph.destroy_edge(edge);
+        }
+    } else if (mappings.rbegin()->is_reverse() && subgraph.start_degree(end_node) != 0) {
+        for (auto edge : subgraph.edges_to(end_node)) {
+            subgraph.destroy_edge(edge);
+        }
+    }
     
     // Sync our updated paths lists back into the Graph protobuf
     if (rewrite_paths) {

--- a/src/support_caller.cpp
+++ b/src/support_caller.cpp
@@ -1262,7 +1262,7 @@ void SupportCaller::call(
         // We can handle some things that aren't ultrabubbles, but we can't yet
         // handle general snarls.
         auto is_traversable = [](const Snarl* s) {
-            return s->start_end_reachable() && s->directed_acyclic_net_graph();
+            return s->start_end_reachable() && s->directed_acyclic_net_graph() && s->type() == ULTRABUBBLE;
         };
         
         // We don't just need to check the top snarl; we also need to enforce


### PR DESCRIPTION
This fixes an error like this that I'm getting on a non-ultrabubble snarl:
```
vg: src/traversal_finder.cpp:1176: vg::RepresentativeTraversalFinder::find_traversals(const vg::Snarl&)::<lambda(std::vector<vg::Visit>)>: Assertion `false' failed.
```

Stacks on #2067