### PR TITLE
Find snarls we are reading out of when finding traversals

### DIFF
--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -1172,11 +1172,54 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
                     for (auto& node_ptr : contents.first) {
                         cerr << "\t" << node_ptr->id() << endl;
                     }
+                    
+                    cerr << "children:" << endl;
+                    
+                    for (auto& snarl_ptr : snarl_manager.children_of(&site)) {
+                        cerr << pb2json(*snarl_ptr) << endl;
+                    }
+                    
+                    cerr << "Input path: " << endl;
+                    for(auto& visit : path) {
+                        if(visit.node_id() != 0) {
+                            auto found = index.find_in_orientation(visit.node_id(), visit.backward());
+                            if (found != index.end()) {
+                                cerr << "\tPath member " << visit << " lives on backbone at "
+                                     << found->first << endl;
+                            } else {
+                                cerr << "\tPath member " << visit << " does not live on backbone" << endl;
+                            }
+                        } else {
+                            cerr << "\tPath member " << visit << " is to a child snarl" << endl;
+                            
+                            auto found_start = index.find_in_orientation(visit.snarl().start().node_id(),
+                                visit.snarl().start().backward() != visit.backward());
+                                
+                            if (found_start != index.end()) {
+                                cerr << "\t\tStart lives on backbone at "
+                                     << found_start->first << endl;
+                            } else {
+                                cerr << "\t\tStart does not live on backbone" << endl;
+                            }
+                            
+                            auto found_end = index.find_in_orientation(visit.snarl().end().node_id(),
+                                visit.snarl().end().backward() != visit.backward());
+                            
+                            if (found_end != index.end()) {
+                                cerr << "\t\tEnd lives on backbone at "
+                                     << found_end->first << endl;
+                            } else {
+                                cerr << "\t\tEnd does not live on backbone" << endl;
+                            }
+                                
+                            
+                        }
+                    }
                 
                     assert(false);
                 }
             }
-            // Child snarls will have ownership of their end nodes, so they won't be part of our contents.
+            // Child snarl end nodes will still appear in our contents.
         }
         
         size_t ref_path_index = 0;
@@ -1579,12 +1622,14 @@ pair<Support, vector<Visit>> RepresentativeTraversalFinder::find_bubble(Node* no
         left_visit = to_visit(edge->from(), edge->from_start());
         right_visit = to_visit(edge->to(), edge->to_end());
         
+        // Find any child snarls looking out form the edge
         const Snarl* right_child = snarl_manager.into_which_snarl(right_visit);
-        const Snarl* left_child = snarl_manager.into_which_snarl(left_visit);
+        const Snarl* left_child = snarl_manager.into_which_snarl(reverse(left_visit));
         
         if (right_child != nullptr && right_child != managed_site
             && snarl_manager.into_which_snarl(reverse(right_visit)) != managed_site) {
             // We're reading into a child snarl on the right.
+            // And we're not reading out of ourselves.
 #ifdef debug
             cerr << "Child to right of edge " << pb2json(*right_child) << endl;
 #endif
@@ -1602,8 +1647,9 @@ pair<Support, vector<Visit>> RepresentativeTraversalFinder::find_bubble(Node* no
         }
         
         if (left_child != nullptr && left_child != managed_site
-            && snarl_manager.into_which_snarl(reverse(left_visit)) != managed_site) {
+            && snarl_manager.into_which_snarl(left_visit) != managed_site) {
             // We're reading out of a child snarl on the left.
+            // And we're not reading into ourselves.
 #ifdef debug
             cerr << "Child to left of edge " << pb2json(*left_child) << endl;
 #endif


### PR DESCRIPTION
I think this should fix https://github.com/vgteam/vg/issues/2041 again. We weren't catching the case where we read out of a snarl (backward?) in our seed edge.