### PR TITLE
use global alignment in surjection by default

### DIFF
--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -174,6 +174,7 @@ int main_map(int argc, char** argv) {
     int max_sub_mem_recursion_depth = 2;
     bool xdrop_alignment = false;
     uint32_t max_gap_length = 40;
+    bool surject_subpath_global = true; // force full length alignment in mpmap surjection resolution
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -745,7 +746,7 @@ int main_map(int argc, char** argv) {
 
     // TODO: Refactor the surjection code out of surject_main and intto somewhere where we can just use it here!
 
-    auto surject_alignments = [&hdr, &sam_header, &mapper, &rg_sample, &setup_sam_header, &path_names, &sam_out, &xgidx, &surjectors] (const vector<Alignment>& alns1, const vector<Alignment>& alns2) {
+    auto surject_alignments = [&hdr, &sam_header, &mapper, &rg_sample, &setup_sam_header, &path_names, &sam_out, &xgidx, &surjectors, &surject_subpath_global] (const vector<Alignment>& alns1, const vector<Alignment>& alns2) {
         
         if (alns1.empty()) return;
         setup_sam_header();
@@ -757,7 +758,7 @@ int main_map(int argc, char** argv) {
             int64_t path_pos = -1;
             bool path_reverse = false;
             
-            auto surj = surjectors[omp_get_thread_num()]->surject(aln, path_names, path_name, path_pos, path_reverse);
+            auto surj = surjectors[omp_get_thread_num()]->surject(aln, path_names, path_name, path_pos, path_reverse, surject_subpath_global);
             surjects1.push_back(make_tuple(path_name, path_pos, path_reverse, surj));
             
             // hack: if we haven't established the header, we look at the reads to guess which read groups to put in it
@@ -773,7 +774,7 @@ int main_map(int argc, char** argv) {
             int64_t path_pos = -1;
             bool path_reverse = false;
             
-            auto surj = surjectors[omp_get_thread_num()]->surject(aln, path_names, path_name, path_pos, path_reverse);
+            auto surj = surjectors[omp_get_thread_num()]->surject(aln, path_names, path_name, path_pos, path_reverse, surject_subpath_global);
             surjects2.push_back(make_tuple(path_name, path_pos, path_reverse, surj));
             
             // Don't try and populate the header; it should have happened already

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -28,7 +28,7 @@ void help_surject(char** argv) {
          << "    -t, --threads N         number of threads to use" << endl
          << "    -p, --into-path NAME    surject into this path (many allowed, default: all in xg)" << endl
          << "    -F, --into-paths FILE   surject into nonoverlapping path names listed in FILE (one per line)" << endl
-         << "    -f, --full-length       use the full length of the graph alignment, even if it makes a negative score" << endl
+         << "    -l, --subpath-local     let the multipath mapping surjection produce local (rather than global) alignments" << endl
          << "    -i, --interleaved       GAM is interleaved paired-ended, so when outputting HTS formats, pair reads" << endl
          << "    -c, --cram-output       write CRAM to stdout" << endl
          << "    -b, --bam-output        write BAM to stdout" << endl
@@ -50,7 +50,7 @@ int main_surject(int argc, char** argv) {
     string input_type = "gam";
     bool interleaved = false;
     int compress_level = 9;
-    bool full_length = false;
+    bool subpath_global = true; // force full length alignments in mpmap resolution
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -62,7 +62,7 @@ int main_surject(int argc, char** argv) {
             {"threads", required_argument, 0, 't'},
             {"into-path", required_argument, 0, 'p'},
             {"into-paths", required_argument, 0, 'F'},
-            {"full-length", required_argument, 0, 'f'},
+            {"subpath-local", required_argument, 0, 'l'},
             {"interleaved", no_argument, 0, 'i'},
             {"cram-output", no_argument, 0, 'c'},
             {"bam-output", no_argument, 0, 'b'},
@@ -72,7 +72,7 @@ int main_surject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:p:F:ficbsC:t:",
+        c = getopt_long (argc, argv, "hx:p:F:licbsC:t:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -94,8 +94,8 @@ int main_surject(int argc, char** argv) {
             path_file = optarg;
             break;
 
-        case 'f':
-            full_length = true;
+        case 'l':
+            subpath_global = false;
             break;
 
         case 'i':
@@ -192,7 +192,7 @@ int main_surject(int argc, char** argv) {
                                                                                 path_name,
                                                                                 path_pos,
                                                                                 path_reverse,
-                                                                                full_length));
+                                                                                subpath_global));
                 stream::write_buffered(cout, buffer[tid], 100);
             };
             get_input_file(file_name, [&](istream& in) {
@@ -256,7 +256,7 @@ int main_surject(int argc, char** argv) {
                                                                       path_name,
                                                                       path_pos,
                                                                       path_reverse,
-                                                                      full_length);
+                                                                      subpath_global);
                 // Always use the surjected alignment, even if it surjects to unmapped.
                 
                 if (!hdr && !surj.read_group().empty() && !surj.sample_name().empty()) {


### PR DESCRIPTION
This makes a big difference in our ancient DNA tests. Without it, we get more softclips with vg when aligning against a graph with variation than we do with bwa on the linear reference.

Here's an example:

Here are results on a small simulated test of reference bias. I've sampled reads randomly from a pretty dense graph over 1mb of the 1000GP. It's the same test graph that's in the vg/test/1mb1kgp directory. Commands below, for my reference.

REF/ALT for all biallelic variants (the simulation will make them all look like hets)
bwa 0.4708778
vg-default 0.4936337
vg-neg-surj 0.4982379

We also see fewer and shorter softclips with the changed parameter:

bwa: 3441 softclips, mean 5.375bp
vg-default: 2032 softclips, mean 5.998bp
vg-neg-surj: 573 softclips, mean 4.194bp

Code for my later reference:

```
vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz -m 32 -p >z.vg
vg index -x z.xg -g z.gcsa -p z.vg
vg sim -n 200000 -l 50 -e 0.005 -i 0.001 -s 588568 -x z.xg -a >z.50bp.sim
vg view -X z.50bp.sim | gzip >z.50bp.sim.fastq.gz
i=bwa; time bwa mem 1mb1kgp/z.fa z.50bp.sim.fastq.gz | samtools view -b - | pv >z.51bp.ENCFF000ATK.sim.$i.bam && sambamba sort z.51bp.ENCFF000ATK.sim.$i.bam && freebayes -E 0 -f 1mb1kgp/z.fa -l@ 1mb1kgp/z.vcf.gz -m 0 -q -1 z.51bp.ENCFF000ATK.sim.$i.sorted.bam | pv -l | vcfbiallelic | vcfkeepinfo - TYPE AO RO DP | vcf2tsv | gzip >z.51bp.ENCFF000ATK.sim.$i.sorted.bam.tsv.gz
i=vg.1; time vg map -d z -G z.50bp.sim --surject-to bam | pv >z.51bp.ENCFF000ATK.sim.$i.bam && sambamba sort z.51bp.ENCFF000ATK.sim.$i.bam && freebayes -E 0 -f 1mb1kgp/z.fa -l@ 1mb1kgp/z.vcf.gz -m 0 -q -1 z.51bp.ENCFF000ATK.sim.$i.sorted.bam | pv -l | vcfbiallelic | vcfkeepinfo - TYPE AO RO DP | vcf2tsv | gzip >z.51bp.ENCFF000ATK.sim.$i.sorted.bam.tsv.gz
i=vg.2; time vg map -d z -G z.50bp.sim | vg surject -x z.xg -b -f - | pv >z.51bp.ENCFF000ATK.sim.$i.bam && sambamba sort z.51bp.ENCFF000ATK.sim.$i.bam && freebayes -E 0 -f 1mb1kgp/z.fa -l@ 1mb1kgp/z.vcf.gz -m 0 -q -1 z.51bp.ENCFF000ATK.sim.$i.sorted.bam | pv -l | vcfbiallelic | vcfkeepinfo - TYPE AO RO DP | vcf2tsv | gzip >z.51bp.ENCFF000ATK.sim.$i.sorted.bam.tsv.gz

in R
require(dplyr)
> summarize(read.delim("z.51bp.ENCFF000ATK.sim.bwa.sorted.bam.tsv.gz"), count=n(), alt=sum(AO), ref=sum(RO), bias=mean(sum(AO)/sum(RO+AO)))
  count    alt    ref      bias
1 28732 127501 143272 0.4708778
> summarize(read.delim("z.51bp.ENCFF000ATK.sim.vg.1.sorted.bam.tsv.gz"), count=n(), alt=sum(AO), ref=sum(RO), bias=mean(sum(AO)/sum(RO+AO)))
  count    alt    ref      bias
1 28732 143331 147028 0.4936337
> summarize(read.delim("z.51bp.ENCFF000ATK.sim.vg.2.sorted.bam.tsv.gz"), count=
n(), alt=sum(AO), ref=sum(RO), bias=mean(sum(AO)/sum(RO+AO)))
  count    alt    ref      bias
1 28732 146180 147214 0.4982379
```