### PR TITLE
Use a function instead of a regex to identify alt paths, to not waste loads of time

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -4,7 +4,33 @@
 
 namespace vg {
 
-const std::regex Paths::is_alt("_alt_.+_[0-9]+");
+const std::function<bool(const string&)> Paths::is_alt = [](const string& path_name) {
+    // Really we want things that match the regex "_alt_.+_[0-9]+"
+    // But std::regex was taking loads and loads of time (probably matching .+) so we're replacing it with special-purpose code.
+    
+    string prefix("_alt_");
+    
+    if (path_name.length() < prefix.length() || !std::equal(prefix.begin(), prefix.end(), path_name.begin())) {
+        // We lack the prefix
+        return false;
+    }
+    
+    // Otherwise it's almost certainly an alt, but make sure it ends with numbers after '_' to be sure.
+    
+    size_t found_digits = 0;
+    for (auto it = path_name.rbegin(); it != path_name.rend() && *it != '_'; ++it) {
+        // Scan in reverse until '_' (which we know exists)
+        if (*it < '0' || *it > '9') {
+            // Out of range character
+            return false;
+        }
+        found_digits++;
+    }
+    
+    // If there were any digits, and ony digits, it matches.
+    return (found_digits > 0);
+    
+};
 
 mapping_t::mapping_t(void) : traversal(0), length(0), rank(1) { }
 
@@ -2270,11 +2296,11 @@ Path path_from_node_traversals(const list<NodeTraversal>& traversals) {
     return toReturn;
 }
 
-void remove_paths(Graph& graph, const std::regex& paths_to_take, std::list<Path>* matching) {
+void remove_paths(Graph& graph, const function<bool(const string&)>& paths_to_take, std::list<Path>* matching) {
 
     std::list<Path> non_matching;
     for (size_t i = 0; i < graph.path_size(); i++) {
-        if (std::regex_match(graph.path(i).name(), paths_to_take)) {
+        if (paths_to_take(graph.path(i).name())) {
             if (matching != nullptr) {
                 matching->push_back(graph.path(i));
             }

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -7,7 +7,6 @@
 #include <set>
 #include <list>
 #include <sstream>
-#include <regex>
 #include "json2pb.h"
 #include "vg.pb.h"
 #include "edit.hpp"
@@ -43,8 +42,9 @@ ostream& operator<<(ostream& out, mapping_t mapping);
 class Paths {
 public:
 
-    // This regex matches the names of alt paths.
-    const static std::regex is_alt;
+    // This predicate matches the names of alt paths.
+    // We used to use a regex but that's a very slow way to check a prefix.
+    const static function<bool(const string&)> is_alt;
 
     Paths(void);
 
@@ -341,9 +341,9 @@ pos_t final_position(const Path& path);
 // Turn a list of node traversals into a path
 Path path_from_node_traversals(const list<NodeTraversal>& traversals);
 
-// Remove the paths with names matching the regex from the graph.
+// Remove the paths with names matching the predicate from the graph.
 // Store them in the list unless it is nullptr.
-void remove_paths(Graph& graph, const std::regex& paths_to_take, std::list<Path>* matching);
+void remove_paths(Graph& graph, const function<bool(const string&)>& paths_to_take, std::list<Path>* matching);
 
 }
 

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -410,9 +410,9 @@ int main_mod(int argc, char** argv) {
         // We need to throw out the parts of the graph that are on alt paths,
         // but not on alt paths for alts used by the first sample in the VCF.
 
-        // This is matched against the entire path name string to detect alt
+        // This is called with the entire path name string to detect alt
         // paths.
-        const regex& is_alt = Paths::is_alt;
+        const function<bool(const string&)>& is_alt = Paths::is_alt;
 
         // This holds the VCF file we read the variants from. It needs to be the
         // same one used to construct the graph.
@@ -436,7 +436,7 @@ int main_mod(int argc, char** argv) {
         graph->paths.for_each_name([&](const string& alt_path_name) {
             // For every path name in the graph
 
-            if(regex_match(alt_path_name, is_alt)) {
+            if(is_alt(alt_path_name)) {
                 // If it's an alt path
 
                 for(auto& mapping : graph->paths.get_path(alt_path_name)) {

--- a/src/vg_set.cpp
+++ b/src/vg_set.cpp
@@ -75,12 +75,20 @@ int64_t VGset::merge_id_space(void) {
 }
 
 void VGset::to_xg(xg::XG& index, bool store_threads) {
-    // Nothing matches the default-constructed regex, so nothing will ever be
-    // sent to the map.
-    to_xg(index, store_threads, regex());
+    // Send a predicate to match nothing
+    to_xg(index, store_threads, [](const string& ignored) {
+        return false;
+    });
 }
 
 void VGset::to_xg(xg::XG& index, bool store_threads, const regex& paths_to_take, map<string, Path>* removed_paths) {
+    to_xg(index, store_threads, [&](const string& path_name) -> bool {
+        // Take paths that match the regex.
+        return std::regex_match(path_name, paths_to_take);
+    }, removed_paths);
+}
+
+void VGset::to_xg(xg::XG& index, bool store_threads, const function<bool(const string&)>& paths_to_take, map<string, Path>* removed_paths) {
     
     // We need to recostruct full removed paths from fragmentary paths encountered in each chunk.
     // This maps from path name to all the Mappings in the path in the order we encountered them

--- a/src/vg_set.hpp
+++ b/src/vg_set.hpp
@@ -3,6 +3,7 @@
 
 #include <set>
 #include <regex>
+#include <functional>
 #include <stdlib.h>
 #include <gcsa/gcsa.h>
 #include "vg.hpp"
@@ -38,6 +39,10 @@ public:
 
     /// Transforms to a succinct, queryable representation
     void to_xg(xg::XG& index, bool store_threads = false);
+    /// As above, except paths with names matching the given predicate are removed.
+    /// They are returned separately by inserting them into the provided map if not null.
+    void to_xg(xg::XG& index, bool store_threads, const function<bool(const string&)>& paths_to_take,
+        map<string, Path>* removed_paths = nullptr);
     /// As above, except paths with names matching the given regex are removed.
     /// They are returned separately by inserting them into the provided map if not null.
     void to_xg(xg::XG& index, bool store_threads, const regex& paths_to_take, map<string, Path>* removed_paths = nullptr);


### PR DESCRIPTION
Some profiling I did to look for slowness in my vpkg code found that we were spening a lot of time on the regex execution for identifying alt paths by name.

I've replaced it with a dedicated function that does the same thing but without having to touch all the characters in the middle of the strings, and I've successfully cut down on the work done by `vg::remove_paths()`.