### PR TITLE
Use Quay instead of Gitlab artifacts to store built VG CI containers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,13 +25,11 @@ stages:
 build-job:
   stage: build
   script: 
-    - bash vgci/vgci.sh -t None -d vgci-docker-vg-local.tar.gz -H
-    - ls -lah vgci-docker-vg-local.tar.gz
-  artifacts:
-    paths:
-      - vgci-docker-vg-local.tar.gz
-    # This is huge and needs to expire fast
-    expire_in: 1 day
+    - bash vgci/vgci.sh -t None -H
+    - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
+    - docker tag vgci-docker-vg-local "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"
+    - docker push "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"
+    # No more artifacts here; we now use this deterministic name to get the container.
     
 # We define a second follow-on phase to run the tests
 # Note that WE ONLY RUN TESTS LISTED IN vgci/test-list.txt
@@ -41,10 +39,11 @@ test-job:
   # We will find our share of tests from vgci/test-list.txt and run them
   # We ought to run one job per test, but we can wrap around.
   parallel: 19 
-  # All artifacts from previous stages are available
-  script: 
+  script:
+    - docker pull "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"
+    - docker tag "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" vgci-docker-vg-local
     - mkdir -p junit
-    - bash vgci/vgci-parallel-wrapper.sh vgci/test-list.txt vgci-docker-vg-local.tar.gz ${CI_NODE_INDEX} ${CI_NODE_TOTAL} ./junit ./test_output
+    - bash vgci/vgci-parallel-wrapper.sh vgci/test-list.txt vgci-docker-vg-local ${CI_NODE_INDEX} ${CI_NODE_TOTAL} ./junit ./test_output
   artifacts:
     # Let Gitlab see the junit report
     reports:
@@ -52,17 +51,21 @@ test-job:
     paths:
       - junit/*.xml
       - test_output/*
-    expire_in: 1 week
+    expire_in: 3 days
 
 # We have a final job in the last stage to compose an HTML report
 report-job:
   stage: report
   # All artifacts from previous stages are available
-  script: 
+  script:
+    # Get the Docker for version detection
+    - docker pull "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"
+    - docker tag "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" vgci-docker-vg-local
     # Collect all the junit files from all the test jobs into one
     - junit-merge -o junit.all.xml junit/*.xml
     # All the test output folder artifacts should automatically merge.
     # Make the report and post it.
-    - bash vgci/vgci.sh -J junit.all.xml -D vgci-docker-vg-local.tar.gz -W test_output
+    # We still need the Docker for version detection.
+    - bash vgci/vgci.sh -J junit.all.xml -T vgci-docker-vg-local -W test_output
    
   

--- a/vgci/vgci-parallel-wrapper.sh
+++ b/vgci/vgci-parallel-wrapper.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # vgci-parallel-wrapper.sh: run a subset of the available tests with vgci.sh
-# Usage: vgci-paralell-wrapper.sh vgci/test-list.txt vgci-docker-vg-local.tar.gz $CI_NODE_INDEX $CI_NODE_TOTAL junit test_output
+# Usage: vgci-paralell-wrapper.sh vgci/test-list.txt vgci-docker-vg-local $CI_NODE_INDEX $CI_NODE_TOTAL junit test_output
 # Finds our share of the tests in the test list, given our 0-based index and the total node count.
-# Runs each of them with the given loadable Docker image and drops a unique junit xml for the test in the given output 
+# Runs each of them with the given Docker tag and drops a unique junit xml for the test in the given output 
 # directory, while keeping the test output in the other given output directory in per-test folders.
 # If we have to run more than 1 test we will duplicate vgci.sh's setup work creating venvs and so on.
 # Meant to be run fromn the vg project root.
@@ -16,7 +16,7 @@ set -x
 # Parse arguments
 TEST_LIST="${1}"
 shift
-DOCKER_ARCHIVE="${1}"
+DOCKER_TAG="${1}"
 shift
 NODE_INDEX="${1}"
 shift
@@ -37,7 +37,7 @@ do
     # And for each
    
     # Run the main vgci script for that test
-    vgci/vgci.sh -D "${DOCKER_ARCHIVE}" -t "${TEST_SPEC}" -j "${JUNIT_OUT_DIR}/junit.${NODE_INDEX}.${TEST_NUMBER}.xml" -w "${TEST_OUT_DIR}" -H
+    vgci/vgci.sh -T "${DOCKER_TAG}" -t "${TEST_SPEC}" -j "${JUNIT_OUT_DIR}/junit.${NODE_INDEX}.${TEST_NUMBER}.xml" -w "${TEST_OUT_DIR}" -H
     TEST_EXIT="${?}"
     
     if [ "${TEST_EXIT}" != "0" ]

--- a/vgci/vgci.sh
+++ b/vgci/vgci.sh
@@ -18,7 +18,9 @@ SAVE_DOCKER=""
 LOAD_DOCKER=""
 # What tag will our Docker use?
 # We need exclusive control of the Docker daemon for the duration of the test, so nobody moves it!
-DOCKER_TAG="vgci-docker-vg-local"
+DOCKER_TAG=""
+# If not specified, use this default
+DOCKER_TAG_DEFAULT="vgci-docker-vg-local"
 # Should we re-use and keep around the same virtualenv?
 REUSE_VENV=0
 # Should we keep our test output around after uploading the new baseline?
@@ -63,6 +65,7 @@ usage() {
     printf "\t\t\tNon-Python dependencies must be installed.\n"
     printf "\t-d FILE\tSave built Docker to the given file.\n"
     printf "\t-D FILE\tLoad a previously built Docker from a file instead of building.\n"
+    printf "\t-T TAG\tLoad a previously built Docker from the given tag/specifier instead of building.\n"
     printf "\t-r\t\tRe-use virtualenvs across script invocations. \n"
     printf "\t-k\t\tKeep on-disk output from tests. \n"
     printf "\t-i\t\tKeep intermediate on-disk output from tests. \n"
@@ -77,7 +80,7 @@ usage() {
     exit 1
 }
 
-while getopts "ld:D:rkisp:t:w:W:j:J:H" o; do
+while getopts "ld:D:T:rkisp:t:w:W:j:J:H" o; do
     case "${o}" in
         l)
             LOCAL_BUILD=1
@@ -87,6 +90,9 @@ while getopts "ld:D:rkisp:t:w:W:j:J:H" o; do
             ;;
         D)
             LOAD_DOCKER="${OPTARG}"
+            ;;
+        T)
+            DOCKER_TAG="${OPTARG}"
             ;;
         r)
             REUSE_VENV=1
@@ -164,6 +170,15 @@ if [ ! -z "${LOAD_DOCKER}" ]
 then
     # Skip the build phase
     DO_BUILD=0
+fi
+
+if [ ! -z "${DOCKER_TAG}" ]
+then
+    # Skip build and use this tag
+    DO_BUILD=0
+else
+    # Use the default tag
+    DOCKER_TAG="${DOCKER_TAG_DEFAULT}"
 fi
 
 if [ "${PYTEST_TEST_SPEC}" == "None" ]


### PR DESCRIPTION
I totally thought I had merged this already.

This lets Quay handle holding onto our CI Docker images rather than shipping them back and forth to the Gitlab main server as artifacts. It should free up space on Gitlab for real artifacts and prevent being unable to rerun tests due to expired artifacts.