### PR TITLE
vg filter cleanup

### DIFF
--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -493,71 +493,141 @@ bool ReadFilter::sample_read(const Alignment& aln) {
     return (sample < downsample_probability);
 }
 
-
-int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
-
-
-    if(defray_length > 0 && xindex == nullptr) {
-        cerr << "xg index required for end de-fraying" << endl;
-        return 1;
+ReadFilter::Counts ReadFilter::filter_alignment(Alignment& aln) {
+    Counts counts;
+    
+    double score = (double)aln.score();
+    double denom = aln.sequence().length();
+    // toggle substitution score
+    if (sub_score == true) {
+        // hack in ident to replace old counting logic.
+        score = aln.identity() * aln.sequence().length();
+        assert(score <= denom);
+    } else if (rescore == true) {
+        // We need to recalculate the score with the base aligner always
+        const static Aligner unadjusted;
+        BaseAligner* aligner = (BaseAligner*)&unadjusted;
+            
+        // Rescore and assign the score
+        aln.set_score(aligner->score_ungapped_alignment(aln));
+        // Also use the score
+        score = aln.score();
     }
 
-    // output buffers
-    vector<vector<Alignment> > output_buffer(threads);
-    
-    // keep counts of what's filtered to report (in verbose mode)
-    vector<Counts> counts_vec(threads);
-
-    auto output_alignment = [&](Alignment& aln) {
-        auto& output_buf = output_buffer[omp_get_thread_num()];
-        output_buf.emplace_back(move(aln));
-        stream::write_buffered(cout, output_buf, buffer_size);
-    };
-
-    auto flush_buffer = [&output_buffer]() {
-        for (auto& output_buf : output_buffer) {
-            stream::write_buffered(cout, output_buf, 0);
+    // toggle absolute or fractional score
+    if (frac_score == true) {
+        if (denom > 0.) {
+            score /= denom;
         }
-        cout.flush();
-    };
-    
-    // we assume that every primary alignment has 0 or 1 secondary alignment
-    // immediately following in the stream
-    function<void(Alignment&)> lambda = [&](Alignment& aln) {
-#ifdef debug
-        cerr << "Encountered read named \"" << aln.name() << "\" with " << aln.sequence().size()
-            << " bp sequence and " << aln.quality().size() << " quality values" << endl;
-#endif
-    
-        int tid = omp_get_thread_num();        
-        Counts& counts = counts_vec[tid];
-        double score = (double)aln.score();
-        double denom = aln.sequence().length();
-        // toggle substitution score
-        if (sub_score == true) {
-            // hack in ident to replace old counting logic.
-            score = aln.identity() * aln.sequence().length();
-            assert(score <= denom);
-        } else if (rescore == true) {
-            // We need to recalculate the score with the base aligner always
-            const static Aligner unadjusted;
-            BaseAligner* aligner = (BaseAligner*)&unadjusted;
+        else {
+            assert(score == 0.);
+        }
+    }
+        
+    ++counts.counts[Counts::FilterName::read];
+    bool keep = true;
+    // filter (current) alignment
+    if (!name_prefixes.empty()) {
+        // Make sure we match at least one name prefix
             
-            // Rescore and assign the score
-            aln.set_score(aligner->score_ungapped_alignment(aln));
-            // Also use the score
-            score = aln.score();
+        bool found = false;
+            
+        // Do a binary search for the closest prefix and see if all of any prefix exists.
+        // We assume the prefixes are sorted.
+        size_t left_bound = 0;
+        size_t left_match = 0;
+        while (left_match < name_prefixes[left_bound].size() &&
+               left_match < aln.name().size() &&
+               name_prefixes[left_bound][left_match] == aln.name()[left_match]) {
+            // Scan all the matches at the start
+            left_match++;
         }
-
-        // toggle absolute or fractional score
-        if (frac_score == true) {
-            if (denom > 0.) {
-                score /= denom;
-            }
-            else {
-                assert(score == 0.);
+            
+        size_t right_bound = name_prefixes.size() - 1;
+        size_t right_match = 0;
+        while (right_match < name_prefixes[right_bound].size() &&
+               right_match < aln.name().size() &&
+               name_prefixes[right_bound][right_match] == aln.name()[right_match]) {
+            // Scan all the matches at the end
+            right_match++;
+        }
+            
+        if (left_match == name_prefixes[left_bound].size() || right_match == name_prefixes[right_bound].size()) {
+            // We found a match already
+            found = true;
+        } else {
+            while (left_bound + 1 < right_bound) {
+                // Until we run out of unexamined prefixes, do binary search
+                size_t center = (left_bound + right_bound) / 2;
+                // No need to re-check any common prefix
+                size_t center_match = min(left_match, right_match);
+                    
+                while (center_match < name_prefixes[center].size() &&
+                       center_match < aln.name().size() &&
+                       name_prefixes[center][center_match] == aln.name()[center_match]) {
+                    // Scan all the matches here
+                    center_match++;
+                }
+                    
+                if (center_match == name_prefixes[center].size()) {
+                    // We found a hit!
+                    found = true;
+                    break;
+                }
+                    
+                if (center_match < name_prefixes[center].size() && center_match < aln.name().size()) {
+                    // There's a character that differs
+                    if (name_prefixes[center][center_match] < aln.name()[center_match]) {
+                        // The match, if it exists, must be after us.
+                        left_bound = center;
+                        left_match = center_match;
+                    } else {
+                        // The match, if it exists, must be before us
+                        right_bound = center;
+                        right_match = center_match;
+                    }
+                }
             }
         }
+            
+        if (!found) {
+            // There are prefixes and we don't match any, so drop the read.
+            ++counts.counts[Counts::FilterName::wrong_name];
+            keep = false;
+        }
+    }
+    if ((keep || verbose) && !excluded_refpos_contigs.empty() && aln.refpos_size() != 0) {
+        // We have refpos exclusion filters and a refpos is set.
+        // We need to bang every refpos anme against every filter.
+            
+        bool found_match = false;
+        for (auto& expression : excluded_refpos_contigs) {
+            for (auto& refpos : aln.refpos()) {
+                if (regex_search(refpos.name(), expression)) {
+                    // We don't want this read because of this match
+                    found_match = true;
+                    break;
+                }
+            }
+            if (found_match) {
+                break;
+            }
+        }
+            
+        if (found_match) {
+            ++counts.counts[Counts::FilterName::wrong_refpos];
+            keep = false;    
+        }
+    }
+    if ((keep || verbose) && (!aln.is_secondary() && score < min_primary)) {
+        ++counts.counts[Counts::FilterName::min_score];
+        keep = false;
+    }
+    if ((keep || verbose) && (aln.is_secondary() && score < min_secondary)) {
+        ++counts.counts[Counts::FilterName::min_sec_score];
+        keep = false;
+    }
+    if (keep || verbose) {
         // compute overhang
         int overhang = 0;
         if (aln.path().mapping_size() > 0) {
@@ -573,6 +643,12 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
         } else {
             overhang = aln.sequence().length();
         }
+        if (overhang > max_overhang) {
+            ++counts.counts[Counts::FilterName::max_overhang];
+            keep = false;
+        }
+    }        
+    if (keep || verbose) {
         // compute end matches.
         int end_matches = 0;
         // from the left
@@ -601,155 +677,112 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
                     }
                 }
             }
-        }                
+        }                        
+        if (end_matches < min_end_matches) {
+            ++counts.counts[Counts::FilterName::min_end_matches];
+            keep = false;
+        }
+    }
+    if ((keep || verbose) && aln.mapping_quality() < min_mapq) {
+        ++counts.counts[Counts::FilterName::min_mapq];
+        keep = false;
+    }
+    if ((keep || verbose) && min_base_quality > 0 && min_base_quality_fraction > 0.0) {
+        int mq_count = 0;
+        const string& base_qualities = aln.quality();
+        for (int i = 0; i < base_qualities.length(); ++i) {
+            if (short(base_qualities[i]) >= min_base_quality) {
+                ++mq_count;
+            }
+        }
+        if ((double)mq_count / (double)base_qualities.length() < min_base_quality_fraction) {
+            ++counts.counts[Counts::FilterName::min_base_qual];
+            keep = false;
+        }
+    }
+    if ((keep || verbose) && drop_split && is_split(xindex, aln)) {
+        ++counts.counts[Counts::FilterName::split];
+        keep = false;
+    }
+    if ((keep || verbose) && has_repeat(aln, repeat_size)) {
+        ++counts.counts[Counts::FilterName::repeat];
+        keep = false;
+    }
+    if ((keep || verbose) && defray_length && trim_ambiguous_ends(xindex, aln, defray_length)) {
+        ++counts.counts[Counts::FilterName::defray];
+        // We keep these, because the alignments get modified.
+        // Unless the *entire* read gets trimmed
+        if (aln.sequence().size() == 0) {
+            keep = false;
+            ++counts.counts[Counts::FilterName::defray_all];
+        }
+    }
+    if ((keep || verbose) && downsample_probability != 1.0 && !sample_read(aln)) {
+        ++counts.counts[Counts::FilterName::random];
+        keep = false;
+    }
+    if (!keep) {
+        ++counts.counts[Counts::FilterName::filtered];
+    }
+    
+    return counts;
+}
 
-        // offset in count tuples
-        int co = aln.is_secondary() ? 1 : 0;
-        
-        ++counts.read[co];
-        bool keep = true;
-        // filter (current) alignment
-        if (!name_prefixes.empty()) {
-            // Make sure we match at least one name prefix
-            
-            bool found = false;
-            
-            // Do a binary search for the closest prefix and see if all of any prefix exists.
-            // We assume the prefixes are sorted.
-            size_t left_bound = 0;
-            size_t left_match = 0;
-            while (left_match < name_prefixes[left_bound].size() &&
-                left_match < aln.name().size() &&
-                name_prefixes[left_bound][left_match] == aln.name()[left_match]) {
-                // Scan all the matches at the start
-                left_match++;
-            }
-            
-            size_t right_bound = name_prefixes.size() - 1;
-            size_t right_match = 0;
-            while (right_match < name_prefixes[right_bound].size() &&
-                right_match < aln.name().size() &&
-                name_prefixes[right_bound][right_match] == aln.name()[right_match]) {
-                // Scan all the matches at the end
-                right_match++;
-            }
-            
-            if (left_match == name_prefixes[left_bound].size() || right_match == name_prefixes[right_bound].size()) {
-                // We found a match already
-                found = true;
-            } else {
-                while (left_bound + 1 < right_bound) {
-                    // Until we run out of unexamined prefixes, do binary search
-                    size_t center = (left_bound + right_bound) / 2;
-                    // No need to re-check any common prefix
-                    size_t center_match = min(left_match, right_match);
-                    
-                    while (center_match < name_prefixes[center].size() &&
-                        center_match < aln.name().size() &&
-                        name_prefixes[center][center_match] == aln.name()[center_match]) {
-                        // Scan all the matches here
-                        center_match++;
-                    }
-                    
-                    if (center_match == name_prefixes[center].size()) {
-                        // We found a hit!
-                        found = true;
-                        break;
-                    }
-                    
-                    if (center_match < name_prefixes[center].size() && center_match < aln.name().size()) {
-                        // There's a character that differs
-                        if (name_prefixes[center][center_match] < aln.name()[center_match]) {
-                            // The match, if it exists, must be after us.
-                            left_bound = center;
-                            left_match = center_match;
-                        } else {
-                            // The match, if it exists, must be before us
-                            right_bound = center;
-                            right_match = center_match;
-                        }
-                    }
-                }
-            }
-            
-            if (!found) {
-                // There are prefixes and we don't match any, so drop the read.
-                ++counts.wrong_name[co];
-                keep = false;
-            }
-        }
-        if ((keep || verbose) && !excluded_refpos_contigs.empty() && aln.refpos_size() != 0) {
-            // We have refpos exclusion filters and a refpos is set.
-            // We need to bang every refpos anme against every filter.
-            
-            bool found_match = false;
-            for (auto& expression : excluded_refpos_contigs) {
-                for (auto& refpos : aln.refpos()) {
-                    if (regex_search(refpos.name(), expression)) {
-                        // We don't want this read because of this match
-                        found_match = true;
-                        break;
-                    }
-                }
-                if (found_match) {
-                    break;
-                }
-            }
-            
-            if (found_match) {
-                ++counts.wrong_refpos[co];
-                keep = false;    
-            }
-        }
-        if ((keep || verbose) && ((aln.is_secondary() && score < min_secondary) ||
-            (!aln.is_secondary() && score < min_primary))) {
-            ++counts.min_score[co];
-            keep = false;
-        }
-        if ((keep || verbose) && overhang > max_overhang) {
-            ++counts.max_overhang[co];
-            keep = false;
-        }
-        if ((keep || verbose) && end_matches < min_end_matches) {
-            ++counts.min_end_matches[co];
-            keep = false;
-        }
-        if ((keep || verbose) && aln.mapping_quality() < min_mapq) {
-            ++counts.min_mapq[co];
-            keep = false;
-        }
-        
-        if ((keep || verbose) && drop_split && is_split(xindex, aln)) {
-            ++counts.split[co];
-            keep = false;
-        }
-        if ((keep || verbose) && has_repeat(aln, repeat_size)) {
-            ++counts.repeat[co];
-            keep = false;
-        }
-        if ((keep || verbose) && defray_length && trim_ambiguous_ends(xindex, aln, defray_length)) {
-            ++counts.defray[co];
-            // We keep these, because the alignments get modified.
-            // Unless the *entire* read gets trimmed
-            if (aln.sequence().size() == 0) {
-                keep = false;
-                ++counts.defray_all[co];
-            }
-        }
-        if ((keep || verbose) && downsample_probability != 1.0 && !sample_read(aln)) {
-            ++counts.random[co];
-            keep = false;
-        }
-        if (!keep) {
-            ++counts.filtered[co];
-        }
+int ReadFilter::filter(istream* alignment_stream) {
 
-        // add to write buffer
-        if (keep && write_output) {
+    if(defray_length > 0 && xindex == nullptr) {
+        cerr << "xg index required for end de-fraying" << endl;
+        return 1;
+    }
+
+    // output buffers
+    vector<vector<Alignment> > output_buffer(threads);
+    
+    // keep counts of what's filtered to report (in verbose mode)
+    vector<Counts> counts_vec(threads);
+
+    auto output_alignment = [&](Alignment& aln) {
+        auto& output_buf = output_buffer[omp_get_thread_num()];
+        output_buf.emplace_back(move(aln));
+        stream::write_buffered(cout, output_buf, buffer_size);
+    };
+
+    auto flush_buffer = [&output_buffer]() {
+        for (auto& output_buf : output_buffer) {
+            stream::write_buffered(cout, output_buf, 0);
+        }
+        cout.flush();
+    };
+    
+    function<void(Alignment&)> lambda = [&](Alignment& aln) {
+#ifdef debug
+        cerr << "Encountered read named \"" << aln.name() << "\" with " << aln.sequence().size()
+            << " bp sequence and " << aln.quality().size() << " quality values" << endl;
+#endif    
+        Counts aln_counts = filter_alignment(aln);
+        counts_vec[omp_get_thread_num()] += aln_counts;
+        if (aln_counts.keep() && write_output) {
             output_alignment(aln);
         }
     };
-    stream::for_each_parallel(*alignment_stream, lambda);
+
+    function<void(Alignment&, Alignment&)> pair_lambda = [&](Alignment& aln1, Alignment& aln2) {
+        Counts aln_counts = filter_alignment(aln1);
+        aln_counts += filter_alignment(aln2);
+        // when running interleaved, if we filter out one end for any reason, we filter out the other as well
+        aln_counts.set_paired();
+        counts_vec[omp_get_thread_num()] += aln_counts;
+        if (aln_counts.keep() && write_output) {
+            output_alignment(aln1);
+            output_alignment(aln2);
+        }
+    };
+    
+    if (interleaved) {
+        stream::for_each_interleaved_pair_parallel(*alignment_stream, pair_lambda);
+    } else {
+        stream::for_each_parallel(*alignment_stream, lambda);
+    }
     if (write_output) {
         flush_buffer();
     }
@@ -759,39 +792,28 @@ int ReadFilter::filter(istream* alignment_stream, xg::XG* xindex) {
         for (int i = 1; i < counts_vec.size(); ++i) {
             counts += counts_vec[i];
         }
-        size_t tot_reads = counts.read[0] + counts.read[1];
-        size_t tot_filtered = counts.filtered[0] + counts.filtered[1];
-        cerr << "Total Filtered (primary):          " << counts.filtered[0] << " / "
-             << counts.read[0] << endl
-             << "Total Filtered (secondary):        " << counts.filtered[1] << " / "
-             << counts.read[1] << endl
-             << "Read Name Filter (primary):        " << counts.wrong_name[0] << endl
-             << "Read Name Filter (secondary):      " << counts.wrong_name[1] << endl
-             << "refpos Contig Filter (primary):    " << counts.wrong_refpos[0] << endl
-             << "refpos Contig Filter (secondary):  " << counts.wrong_refpos[1] << endl
-             << "Min Identity Filter (primary):     " << counts.min_score[0] << endl
-             << "Min Identity Filter (secondary):   " << counts.min_score[1] << endl
-             << "Max Overhang Filter (primary):     " << counts.max_overhang[0] << endl
-             << "Max Overhang Filter (secondary):   " << counts.max_overhang[1] << endl
-             << "Min End Match Filter (primary):    " << counts.min_end_matches[0] << endl
-             << "Min End Match Filter (secondary):  " << counts.min_end_matches[1] << endl            
-             << "Split Read Filter (primary):       " << counts.split[0] << endl
-             << "Split Read Filter (secondary):     " << counts.split[1] << endl
-             << "Repeat Ends Filter (primary):      " << counts.repeat[0] << endl
-             << "Repeat Ends Filter (secondary):    " << counts.repeat[1] << endl
-             << "All Defrayed Filter (primary):     " << counts.defray_all[0] << endl
-             << "All Defrayed Filter (secondary):   " << counts.defray_all[1] << endl
-             << "Min Quality Filter (primary):      " << counts.min_mapq[0] << endl
-             << "Min Quality Filter (secondary):    " << counts.min_mapq[1] << endl
-             << "Random Filter (primary):           " << counts.random[0] << endl
-             << "Random Filter (secondary):         " << counts.random[1] << endl
-                        
-            
-             << endl;
-    }
-    
+        cerr << counts;
+    }    
     return 0;
+}
 
+ostream& operator<<(ostream& os, const ReadFilter::Counts& counts) {
+    os << "Total Filtered:                " << counts.counts[ReadFilter::Counts::FilterName::filtered] << " / "
+       << counts.counts[ReadFilter::Counts::FilterName::read] << endl
+       << "Read Name Filter:              " << counts.counts[ReadFilter::Counts::FilterName::wrong_name] << endl
+       << "refpos Contig Filter:          " << counts.counts[ReadFilter::Counts::FilterName::wrong_refpos] << endl
+       << "Min Identity Filter:           " << counts.counts[ReadFilter::Counts::FilterName::min_score] << endl
+       << "Min Secondary Identity Filter: " << counts.counts[ReadFilter::Counts::FilterName::min_sec_score] << endl
+       << "Max Overhang Filter:           " << counts.counts[ReadFilter::Counts::FilterName::max_overhang] << endl
+       << "Min End Match Filter:          " << counts.counts[ReadFilter::Counts::FilterName::min_end_matches] << endl
+       << "Split Read Filter:             " << counts.counts[ReadFilter::Counts::FilterName::split] << endl
+       << "Repeat Ends Filter:            " << counts.counts[ReadFilter::Counts::FilterName::repeat] << endl
+       << "All Defrayed Filter:           " << counts.counts[ReadFilter::Counts::FilterName::defray_all] << endl
+       << "Min Quality Filter:            " << counts.counts[ReadFilter::Counts::FilterName::min_mapq] << endl
+       << "Min Base Quality Filter:       " << counts.counts[ReadFilter::Counts::FilterName::min_base_qual] << endl
+       << "Random Filter:                 " << counts.counts[ReadFilter::Counts::FilterName::random] << endl
+       << endl;
+    return os;
 }
 
 }

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -38,7 +38,6 @@ public:
     bool sub_score = false;
     int max_overhang = 99999;
     int min_end_matches = 0;
-    int context_size = 0;
     bool verbose = false;
     double min_mapq = 0.;
     int repeat_size = 0;
@@ -61,59 +60,55 @@ public:
     // Sometimes we only want a report, and not a filtered gam.  toggling off output
     // speeds things up considerably.
     bool write_output = true;
-
+    // An XG index is required for some filters (Note: ReadFilter doesn't own/free this)
+    xg::XG* xindex = nullptr;
+    // Interleaved input
+    bool interleaved = false;
+    // minimum base quality as PHRED score
+    int min_base_quality = 0;
+    // minimum fraction of bases in reads that must have quality at least <min_base_quality>
+    double min_base_quality_fraction = 0.0;
+                     
     // Keep some basic counts for when verbose mode is enabled
     struct Counts {
-        vector<size_t> read;
-        vector<size_t> filtered;
-        vector<size_t> wrong_name;
-        vector<size_t> wrong_refpos;
-        vector<size_t> min_score;
-        vector<size_t> max_overhang;
-        vector<size_t> min_end_matches;
-        vector<size_t> min_mapq;
-        vector<size_t> split;
-        vector<size_t> repeat;
-        vector<size_t> defray;
-        vector<size_t> defray_all;
-        vector<size_t> random;
-        Counts() : read(2, 0), filtered(2, 0), wrong_name(2, 0), wrong_refpos(2, 0),
-                   min_score(2, 0), max_overhang(2, 0), min_end_matches(2, 0),
-                   min_mapq(2, 0), split(2, 0), repeat(2, 0), defray(2, 0),
-                   defray_all(2, 0), random(2, 0) {}
+        enum FilterName { read = 0, wrong_name, wrong_refpos, min_score, min_sec_score, max_overhang, min_end_matches,
+                          min_mapq, split, repeat, defray, defray_all, random, filtered, min_base_qual, last };
+        vector<size_t> counts;
+        Counts () : counts(FilterName::last, 0) {}
         Counts& operator+=(const Counts& other) {
-            for (int i = 0; i < 2; ++i) {
-                read[i] += other.read[i];
-                filtered[i] += other.filtered[i];
-                wrong_name[i] += other.wrong_name[i];
-                wrong_refpos[i] += other.wrong_refpos[i];
-                min_score[i] += other.min_score[i];
-                max_overhang[i] += other.max_overhang[i];
-                min_end_matches[i] += other.min_end_matches[i];
-                min_mapq[i] += other.min_mapq[i];
-                split[i] += other.split[i];
-                repeat[i] += other.repeat[i];
-                defray[i] += other.defray[i];
-                defray_all[i] += other.defray_all[i];
-                random[i] += other.random[i];
+            for (int i = 0; i < FilterName::last; ++i) {
+                counts[i] += other.counts[i];
             }
             return *this;
+        }
+        Counts& set_paired() {
+            for (int i = 0; i < FilterName::last; ++i) {
+                counts[i] = counts[i] == 1 ? 2 : counts[i];
+            }
+            return *this;
+        }
+        void reset() {
+            std::fill(counts.begin(), counts.end(), 0);
+        }
+        bool keep() {
+            return counts[FilterName::filtered] == 0;
         }
     };
     
     bool append_regions = false;
+
+    /**
+     * Run all the filters on an alignment. The alignment may get modified in-place by the defray filter
+     */
+    Counts filter_alignment(Alignment& aln);
     
     /**
      * Filter the alignments available from the given stream, placing them on
      * standard output or in the appropriate file. Returns 0 on success, exit
      * code to use on error.
      *
-     * If an XG index is required, use the specified one. If one is required and
-     * not provided, the function will complain and return nonzero.
-     *
-     * TODO: Refactor to be less CLI-aware and more modular-y.
      */
-    int filter(istream* alignment_stream, xg::XG* xindex = nullptr);
+    int filter(istream* alignment_stream);
     
     /**
      * Look at either end of the given alignment, up to k bases in from the end.
@@ -164,6 +159,7 @@ private:
     bool sample_read(const Alignment& read); 
     
 };
+ostream& operator<<(ostream& os, const ReadFilter::Counts& counts);
 }
 
 #endif

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -39,7 +39,6 @@ void help_filter(char** argv) {
          << "    -S, --drop-split           remove split reads taking nonexistent edges" << endl
          << "    -x, --xg-name FILE         use this xg index (required for -S and -D)" << endl
          << "    -A, --append-regions       append to alignments created with -RB" << endl
-         << "    -c, --context STEPS        expand the context of the subgraph this many steps when looking up chunks" << endl
          << "    -v, --verbose              print out statistics on numbers of reads filtered by what." << endl
          << "    -V, --no-output            print out statistics (as above) but do not write out filtered GAM." << endl
          << "    -q, --min-mapq N           filter alignments with mapping quality < N" << endl
@@ -47,6 +46,8 @@ void help_filter(char** argv) {
          << "    -D, --defray-ends N        clip back the ends of reads that are ambiguously aligned, up to N bases" << endl
          << "    -C, --defray-count N       stop defraying after N nodes visited (used to keep runtime in check) [default=99999]" << endl
          << "    -d, --downsample S.P       filter out all but the given portion 0.P of the reads. S may be an integer seed as in SAMtools" << endl
+         << "    -i, --interleaved          assume interleaved input.  both ends will be filtered out if either fails filter" << endl
+         << "    -b, --min-base-quality Q:F filter reads with where fewer than fraction F bases have base quality >= PHRED score Q." << endl
          << "    -t, --threads N            number of threads [1]" << endl;
 }
 
@@ -84,19 +85,20 @@ int main_filter(int argc, char** argv) {
                 {"drop-split",  no_argument, 0, 'S'},
                 {"xg-name", required_argument, 0, 'x'},
                 {"append-regions", no_argument, 0, 'A'},
-                {"context",  required_argument, 0, 'c'},
                 {"verbose",  no_argument, 0, 'v'},
                 {"min-mapq", required_argument, 0, 'q'},
                 {"repeat-ends", required_argument, 0, 'E'},
                 {"defray-ends", required_argument, 0, 'D'},
                 {"defray-count", required_argument, 0, 'C'},
                 {"downsample", required_argument, 0, 'd'},
+                {"interleaved", required_argument, 0, 'i'},
+                {"min-base-quality", required_argument, 0, 'b'},
                 {"threads", required_argument, 0, 't'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "n:N:X:s:r:Od:e:fauo:m:Sx:Ac:vVq:E:D:C:d:t:",
+        c = getopt_long (argc, argv, "n:N:X:s:r:Od:e:fauo:m:Sx:AvVq:E:D:C:d:ib:t:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -152,9 +154,6 @@ int main_filter(int argc, char** argv) {
             break;
         case 'A':
             filter.append_regions = true;
-            break;
-        case 'c':
-            filter.context_size = parse<int>(optarg);
             break;
         case 'q':
             filter.min_mapq = parse<double>(optarg);
@@ -213,6 +212,24 @@ int main_filter(int argc, char** argv) {
                 }
             }
             break;
+        case 'i':
+            filter.interleaved = true;
+            break;
+        case 'b':
+            {
+                vector<string> parts = split_delims(string(optarg), ":");
+                if (!parts.size() == 2) {
+                    cerr << "[vg filter] Error: -b expects value in form of <INT>:<FLOAT>" << endl;
+                    return 1;
+                }
+                filter.min_base_quality = parse<int>(parts[0]);
+                filter.min_base_quality_fraction = parse<double>(parts[1]);
+                if (filter.min_base_quality_fraction < 0 || filter.min_base_quality_fraction > 1) {
+                    cerr << "[vg filter] Error: second part of -b input must be between 0 and 1" << endl;
+                    return 1;
+                }
+            }
+            break;
         case 't':
             omp_set_num_threads(parse<int>(optarg));
             break;
@@ -248,13 +265,15 @@ int main_filter(int argc, char** argv) {
         // read the xg index
         xindex = stream::VPKG::load_one<xg::XG>(xg_name);
     }
+    filter.xindex = xindex.get();
     
+    // Read in the alignments and filter them.
     get_input_file(optind, argc, argv, [&](istream& in) {
         // Open up the alignment stream
         
         // Read in the alignments and filter them.
-        error_code = filter.filter(&in, xindex.get());
-    });
+        error_code = filter.filter(&in);
+      });
 
     return error_code;
 }

--- a/test/t/21_vg_filter.t
+++ b/test/t/21_vg_filter.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 10
+plan tests 6
 
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg  x.vg
@@ -13,22 +13,6 @@ vg sim -x x.xg -l 100 -n 5000 -e 0.01 -i 0.001 -a > x.gam
 
 # sanity check: does passing no options preserve input
 is $(vg filter x.gam | vg view -a - | jq . | grep mapping | wc -l) 5000 "vg filter with no options preserves input."
-
-# basic chunking tests
-printf "x\t2\t8\nx\t8\t20\ny\t0\t1\nx\t150\t500\nx\t0\t100000000\n" > chunks.bed
-vg filter -x x.xg -R chunks.bed -B filter_chunk x.gam
-
-# right number of chunks
-is $(ls -l filter_chunk-*.gam | wc -l) 5 "vg filter makes right number of chunks."
-
-# is chunk 0 (2-3) comprised of nodes 1,2,4? 
-is $(vg view -a filter_chunk-0.gam | jq -c '.path.mapping[].position' | jq 'select ((.node_id == "1") or (.node_id == "2") or (.node_id == "4"))' | grep node | sed s/,// | sort | uniq | wc -l) 3 "vg filter left chunk has all left nodes"
-
-# check that chunk 4 is off to the right a bit
-is $(vg view -a filter_chunk-3.gam | jq -c '.path.mapping[].position' | jq 'select (((.node_id | tonumber) < 4))' | wc -l) 0 "vg filter right chunk has no left nodes"
-
-# check that chunk 5 is everything
-is $(vg view -a filter_chunk-4.gam | jq . | grep mapping | wc -l) 5000 "vg filter big chunk has everything"
 
 # Downsampling works
 SAMPLED_COUNT=$(vg filter x.gam --downsample 0.5 | vg view -a - | jq . | grep mapping | wc -l)


### PR DESCRIPTION
* Remove some old chunking stuff that's better done with `vg chunk`
* Add interleaved support `-i` (both ends filtered if at least one end fails a filter)
* Add base quality filter.  Ex `-b 20:0.7` will filter an alignment unless at least 70% of the read's bases have qual >= 20
* Add `-V` option to print stats without writing filtered GAM, for when just using `vg filter` to count stuff.  This can easily run an order of magnitude faster than when writing is enabled.  