### PR TITLE
Count reads with no indels in vg stats

### DIFF
--- a/scripts/analyze_indels.py
+++ b/scripts/analyze_indels.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+
+"""
+analyze_indels.py: take GAM JSON as input and produce tables of non-softclip
+indel positions in the read and lengths
+"""
+
+import argparse
+import os
+import sys
+import time
+import subprocess
+import collections
+import json
+
+    
+def parse_args(args):
+    """
+    Takes in the command-line arguments list (args), and returns a nice argparse
+    result with fields for all the options.
+    
+    Borrows heavily from the argparse documentation examples:
+    <http://docs.python.org/library/argparse.html>
+    """
+    
+    # Construct the parser (which is stored in parser)
+    # Module docstring lives in __doc__
+    # See http://python-forum.com/pythonforum/viewtopic.php?f=3&t=36847
+    # And a formatter class so our examples in the docstring look good. Isn't it
+    # convenient how we already wrapped it to 80 characters?
+    # See http://docs.python.org/library/argparse.html#formatter-class
+    parser = argparse.ArgumentParser(description=__doc__, 
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    
+    parser.add_argument("--input", type=argparse.FileType('r'), default=sys.stdin,
+                        help="JSON GAM to process")
+    parser.add_argument("--positions", required=True, type=argparse.FileType('w'),
+                        help="TSV of positions and counts to write")
+    parser.add_argument("--lengths", required=True, type=argparse.FileType('w'),
+                        help="TSV of lengths and counts to write")
+    
+    # The command line arguments start with the program name, which we don't
+    # want to treat as an argument for argparse. So we remove it.
+    args = args[1:]
+        
+    return parser.parse_args(args)
+
+def main(args):
+    """
+    Parses command line arguments and do the work of the program.
+    "args" specifies the program arguments, with args[0] being the executable
+    name. The return value should be used as the program's exit code.
+    """
+    
+    options = parse_args(args) # This holds the nicely-parsed options object
+    
+    # These will track stats over all the indels.
+    
+    # Where does each indel start in read space?
+    indel_starts = collections.Counter()
+    # How long is each indel?
+    indel_lengths = collections.Counter()
+    
+    for line in options.input:
+        # Load each line
+        alignment = json.loads(line)
+        
+        # Parse the alignment using these counters
+        read_offset = 0
+        ref_offset = 0
+        
+        mappings = alignment.get("path", {}).get("mapping", []) 
+        
+        for i, mapping in enumerate(mappings):
+            edits = mapping.get("edit", [])
+            for j, edit in enumerate(edits):
+                # Parse each edit
+                from_length = edit.get("from_length", 0)
+                to_length = edit.get("to_length", 0)
+                
+                # If we're the first or last edit, we're never an indel; we're a softclip instead
+                is_border = (i == 0 and j == 0) or (i == len(mappings) - 1 and j == len(edits) - 1)
+                
+                # If the lengths differ and we aren't on the end of the read we're an indel.
+                is_indel = from_length != to_length and not is_border
+                
+                if is_indel:
+                    # Record this indel
+                    indel_starts[read_offset] += 1
+                    indel_lengths[to_length - from_length] += 1
+                
+                # Advance the position counters
+                read_offset += to_length
+                ref_offset += from_length
+                
+    # Now dump tables for plotting
+    for value, count in indel_starts.iteritems():
+        options.positions.write("{}\t{}\n".format(value, count))
+        
+    for value, count in indel_lengths.iteritems():
+        options.lengths.write("{}\t{}\n".format(value, count))
+
+
+def entrypoint():
+    """
+    0-argument entry point for setuptools to call.
+    """
+    
+    # Provide main with its arguments and handle exit codes
+    sys.exit(main(sys.argv))
+    
+if __name__ == "__main__" :
+    entrypoint()
+        

--- a/src/stream/register_loader_saver_vg.cpp
+++ b/src/stream/register_loader_saver_vg.cpp
@@ -15,7 +15,8 @@ namespace stream {
 using namespace std;
 
 void register_loader_saver_vg() {
-    Registry::register_loader_saver<VG>("VG", [](const message_sender_function_t& for_each_message) -> void* {
+    // We register for "" so we can handle untagged old-style vg files and make them into HandleGraphs
+    Registry::register_loader_saver<VG>(vector<string>{"VG", ""}, [](const message_sender_function_t& for_each_message) -> void* {
         // We have a bit of a control problem.
         // The source function wants to drive; we give it a function of strings, and it calls it with all the strings in turn.
         

--- a/src/stream/vpkg.hpp
+++ b/src/stream/vpkg.hpp
@@ -101,15 +101,19 @@ public:
     /**
      * Allocate and load one or more objects from the given file on a single pass.
      * Returns a tuple of pointers to loaded objects, or null if they could not be found.
-     * Only works on VPKG-formatted files.
+     * Only works on VPKG-formatted files. Supports "-" for standard input.
      */
     template<typename... Wanted>
     static tuple<unique_ptr<Wanted>...> load_all(const string& filename) {
-        // Open the file
-        ifstream open_file(filename.c_str());
-        
-        // Read from it
-        return load_all<Wanted...>(open_file);
+        if (filename == "-") {
+            return load_all<Wanted...>(cin);
+        } else {
+            // Open the file
+            ifstream open_file(filename.c_str());
+            
+            // Read from it
+            return load_all<Wanted...>(open_file);
+        }
     }
     
     /**
@@ -181,7 +185,7 @@ public:
      * Load an object of the given type from a file by name.
      * The stream may be VPKG with the appropriate tag, or a bare non-VPKG stream understood by the loader.
      * Tagged messages that can't be used to load the thing we are looking for are skipped.
-     * Returns null if the object could not be found in the file.
+     * Returns null if the object could not be found in the file. Supports "-" for standard input.
      */
     template<typename Wanted>
     static unique_ptr<Wanted> try_load_one(const string& filename) {
@@ -190,11 +194,15 @@ public:
             return unique_ptr<Wanted>();
         }
         
-        // Open the file
-        ifstream open_file(filename.c_str());
-        
-        // Read from it
-        return try_load_one<Wanted>(open_file);
+        if (filename == "-") {
+            return try_load_one<Wanted>(cin);
+        } else {
+            // Open the file
+            ifstream open_file(filename.c_str());
+            
+            // Read from it
+            return try_load_one<Wanted>(open_file);
+        }
     }
     
     /**
@@ -225,7 +233,7 @@ public:
      * Load an object of the given type from a file by name.
      * The stream may be VPKG with the appropriate tag, or a bare non-VPKG stream understood by the loader.
      * Tagged messages that can't be used to load the thing we are looking for are skipped.
-     * Ends the program with an error if the object could not be found in the file.
+     * Ends the program with an error if the object could not be found in the file. Supports "-" for standard input.
      */
     template<typename Wanted>
     static unique_ptr<Wanted> load_one(const string& filename) {
@@ -234,11 +242,8 @@ public:
             exit(1);
         }
         
-        // Open the file
-        ifstream open_file(filename.c_str());
-        
-        // Read from it
-        auto result = try_load_one<Wanted>(open_file);
+        // Open and read the file.
+        auto result = try_load_one<Wanted>(filename);
         
         if (result.get() == nullptr) {
             cerr << "error[VPKG::load_one]: Could not find correct object " << typeid(Wanted).name() << " in " << filename << endl;
@@ -274,14 +279,19 @@ public:
     
     /*
      * Save an object to the given filename, using the appropriate saver.
+     * Supports "-" for standard output.
      */
     template<typename Have>
     static void save(const Have& have, const string& filename) {
-        // Open the file
-        ofstream open_file(filename.c_str());
-        
-        // Save to it
-        save<Have>(have, open_file);
+        if (filename == "-") {
+            save<Have>(have, cout);
+        } else {
+            // Open the file
+            ofstream open_file(filename.c_str());
+            
+            // Save to it
+            save<Have>(have, open_file);
+        }
     }
     
     /**

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -385,16 +385,6 @@ int main_stats(int argc, char** argv) {
 
         // We need some allele parsing functions
 
-        // This one decided if a path is really an allele path
-        auto path_name_is_allele = [](const string path_name) -> bool {
-            string prefix = "_alt_";
-            // It needs to start with "_alt_" and have another separating
-            // underscore between site name and allele number
-            return(prefix.size() < path_name.size() &&
-                count(path_name.begin(), path_name.end(), '_') >= 3 &&
-                equal(prefix.begin(), prefix.end(), path_name.begin()));
-        };
-
         // This one gets the site name from an allele path name
         auto path_name_to_site = [](const string& path_name) -> string {
             auto last_underscore = path_name.rfind('_');
@@ -442,7 +432,7 @@ int main_stats(int argc, char** argv) {
             string allele_path;
             for(auto& name_and_mappings : graph.paths.get_node_mapping_by_path_name(node)) {
                 // For each path on it
-                if(path_name_is_allele(name_and_mappings.first)) {
+                if(Paths::is_alt(name_and_mappings.first)) {
                     // If it's an allele path
                     if(allele_path.empty()) {
                         // It's the first. Take it.

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -336,6 +336,22 @@ vector<size_t> range_vector(size_t begin, size_t end) {
     return range;
 }
 
+bool have_input_file(int& optind, int argc, char** argv) {
+
+    if (optind >= argc) {
+        // Out of arguments
+        return false;
+    }
+    
+    if (argv[optind][0] == '\0') {
+        // File name is empty
+        return false;
+    }
+    
+    // Otherwise we found one
+    return true;
+}
+
 void get_input_file(int& optind, int argc, char** argv, function<void(istream&)> callback) {
     
     // Just combine the two operations below in the way they're supposed to be used together    

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -546,6 +546,9 @@ unordered_map<id_t, id_t> overlay_node_translations(const unordered_map<id_t, id
                                                     const unordered_map<id_t, id_t>& under);
     
 
+/// Return true if there's a command line argument (i.e. input file name) waiting to be processed. 
+bool have_input_file(int& optind, int argc, char** argv);
+
 /// Get a callback with an istream& to an open file if a file name argument is
 /// present after the parsed options, or print an error message and exit if one
 /// is not. Handles "-" as a filename as indicating standard input. The reference

--- a/test/correct/10_vg_stats/15.txt
+++ b/test/correct/10_vg_stats/15.txt
@@ -2,6 +2,8 @@ Total alignments: 100
 Total primary: 100
 Total secondary: 0
 Total aligned: 100
+Total perfect: 100
+Total gapless (softclips allowed): 100
 Insertions: 0 bp in 0 read events
 Deletions: 0 bp in 0 read events
 Substitutions: 0 bp in 0 read events

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 10
+plan tests 11
 
 vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 #is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
@@ -40,6 +40,8 @@ vg construct -m 1000 -r small/x.fa -a -f -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 16 x.vg
 vg map -x x.xg -g x.gcsa -T small/x-s1337-n100.reads >x.gam
 is "$(vg stats -a x.gam x.vg | md5sum | cut -f 1 -d\ )" "$(md5sum correct/10_vg_stats/15.txt | cut -f 1 -d\ )" "aligned read stats are computed correctly"
+
+is "$(vg stats -a x.gam | grep 'Total alignments')" "Total alignments: 100" "stats can be computed for GAM files without graphs"
 rm -f x.vg x.xg x.gcsa x.gam
 
 vg msga -g <(vg msga -f msgas/cycle.fa -b s1 -w 16 -t 1 | vg mod -D - | vg mod -U 10 -) -f msgas/cycle.fa -t 1 | vg mod -N - | vg mod -U 10 - >c.vg


### PR DESCRIPTION
I'm counting reads that don't have any indels in vg stats now, as well as perfect reads. I'm not counting softclips as indels.

I'm also making the graph file optional for vg stats, so you can do `vg stats -a whatever.gam` and get just stats about the reads, without all the stats about how the reads relate to the graph and the alleles in it. 