### PR TITLE
Force test IO to be in blocking mode

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,8 @@ test-job:
     - docker pull "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"
     - docker tag "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" vgci-docker-vg-local
     - mkdir -p junit
-    - bash vgci/vgci-parallel-wrapper.sh vgci/test-list.txt vgci-docker-vg-local ${CI_NODE_INDEX} ${CI_NODE_TOTAL} ./junit ./test_output
+    # Make sure IO to Gitlab is in blocking mode so we can't swamp it and crash
+    - vgci/blockify.py bash vgci/vgci-parallel-wrapper.sh vgci/test-list.txt vgci-docker-vg-local ${CI_NODE_INDEX} ${CI_NODE_TOTAL} ./junit ./test_output
   artifacts:
     # Let Gitlab see the junit report
     reports:
@@ -67,6 +68,7 @@ report-job:
     # All the test output folder artifacts should automatically merge.
     # Make the report and post it.
     # We still need the Docker for version detection.
-    - bash vgci/vgci.sh -J junit.all.xml -T vgci-docker-vg-local -W test_output
+    # Make sure IO to Gitlab is in blocking mode so we can't swamp it and crash
+    - vgci/blockify.py bash vgci/vgci.sh -J junit.all.xml -T vgci-docker-vg-local -W test_output
    
   

--- a/vgci/blockify.py
+++ b/vgci/blockify.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+blockify.py: make sure input and output FDs are in blocking mode before running a command.
+"""
+
+import os
+import sys
+import fcntl
+
+# Check input
+if len(sys.argv) < 2:
+    raise RuntimeError("A program to execute is required")
+
+# Fix up standard file descriptors (0, 1, 2) by clearing the nonblocking flag.
+# See https://stackoverflow.com/a/30172682
+for fd in range(3):
+    fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) & ~os.O_NONBLOCK)
+
+# Become the first argument running with the rest of the arguments.
+# Make sure to pass along the program name.
+os.execvp(sys.argv[1], sys.argv[1:])


### PR DESCRIPTION
I'm trying to fix the problem of pytest dumping logs too fast and crashing due to failed nonblocking IO, on the theory that it's Gitlab's fault that our IO is nonblocking and we can just fix it before running the main part of our test code.

See https://github.com/vgteam/vg/pull/2079#issuecomment-461120947

The actual underlying test failures will still be a problem, but at least we might be able to actually debug them.

Also still a problem is the Docker daemon on the runner worker disappearing as in https://ucsc-ci.com/vgteam/vg/-/jobs/1958. For that see also https://gitlab.com/gitlab-org/gitlab-runner/issues/3612