### PR TITLE
Specify regions in msga

### DIFF
--- a/src/region.cpp
+++ b/src/region.cpp
@@ -26,7 +26,8 @@ void parse_region(const string& target, string& name, int64_t& start, int64_t& e
 }
 
 void parse_bed_regions(const string& bed_path,
-                       vector<Region>& out_regions) {
+                       vector<Region>& out_regions,
+                       vector<string>* out_names) {
     out_regions.clear();
     ifstream bedstream(bed_path);
     if (!bedstream) {
@@ -36,6 +37,7 @@ void parse_bed_regions(const string& bed_path,
     string row;
     string sbuf;
     string ebuf;
+    string nbuf;
     for (int line = 1; getline(bedstream, row); ++line) {
         Region region;
         if (row.size() < 2 || row[0] == '#') {
@@ -44,7 +46,8 @@ void parse_bed_regions(const string& bed_path,
         istringstream ss(row);
         if (!getline(ss, region.seq, '\t') ||
             !getline(ss, sbuf, '\t') ||
-            !getline(ss, ebuf, '\t')) {
+            !getline(ss, ebuf, '\t') ||
+            (out_names != nullptr && !getline(ss, nbuf, '\t'))) {
             cerr << "Error parsing bed line " << line << ": " << row << endl;
         } else {
             region.start = std::stoi(sbuf);
@@ -55,6 +58,10 @@ void parse_bed_regions(const string& bed_path,
             region.end -= 1;
 
             out_regions.push_back(region);
+            
+            if (out_names != nullptr) {
+                out_names->push_back(nbuf);
+            }
         }
     }
 }

--- a/src/region.hpp
+++ b/src/region.hpp
@@ -37,7 +37,8 @@ inline void parse_region(string& region,
 // So bedline "chr1   5   10" will return start=5 stop=9
 void parse_bed_regions(
     const string& bed_path,
-    vector<Region>& out_regions);
+    vector<Region>& out_regions,
+    vector<string>* out_names = nullptr);
     
 }    
 

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -583,8 +583,15 @@ int main_msga(int argc, char** argv) {
         // the GCSA index.
         VG* region_graph = nullptr;
         if (name_idx < names_in_order.size() && position_hints.count(names_in_order[name_idx])) {
-            region_graph = new VG();
             Region region = position_hints[names_in_order[name_idx]];
+            if (!xgidx->has_path(region.seq) || xgidx->get_path_length(xgidx->get_path_handle(region.seq)) <=
+                region.end) {
+                stringstream err_msg;
+                err_msg << "[vg msga] Error: Target region for \"" << names_in_order[name_idx] << "\" ("
+                     << region.seq << ":" << region.start << "-" << region.end << ") not found in graph." << endl;
+                throw runtime_error(err_msg.str());
+            }
+            region_graph = new VG();
             Region out_region;
             PathChunker chunker(xgidx);
             if (debug) cerr << "Subsetting graph to " << region.seq << ":" << region.start << "-" << region.end

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -154,7 +154,7 @@ int main_msga(int argc, char** argv) {
                 {"seq", required_argument, 0, 's'},
                 {"graph", required_argument, 0, 'g'},
                 {"fasta-order", no_argument, 0, 'a'},
-                {"positon-bed", required_argument, 0, 'R'},
+                {"position-bed", required_argument, 0, 'R'},
                 {"context", required_argument, 0, 'T'},
                 {"base", required_argument, 0, 'b'},
                 {"idx-kmer-size", required_argument, 0, 'K'},

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -6,6 +6,7 @@
 #include "../kmer.hpp"
 #include "../build_index.hpp"
 #include "../algorithms/topological_sort.hpp"
+#include "../chunker.hpp"
 
 #include <unistd.h>
 #include <getopt.h>
@@ -28,6 +29,8 @@ void help_msga(char** argv) {
          << "    -s, --seq SEQUENCE      literally include this sequence" << endl
          << "    -g, --graph FILE        include this graph" << endl
          << "    -a, --fasta-order       build the graph in the order the sequences are seen in the FASTA (default: bigger first)" << endl
+         << "    -R, --position-bed FILE BED file mapping sequence names (col 4) to positions on reference path (cols 1-3)" << endl
+         << "    -T, --context STEPS     expand context around BED regions (-R) by this many steps [50]" << endl
          << "alignment:" << endl
          << "    -k, --min-mem INT       minimum MEM length (if 0 estimate via -e) [0]" << endl
          << "    -e, --mem-chance FLOAT  set {-k} such that this fraction of {-k} length hits will by chance [5e-4]" << endl
@@ -89,6 +92,8 @@ int main_msga(int argc, char** argv) {
     vector<string> sequences;
     vector<string> graph_files;
     string base_seq_name;
+    string position_bed_file;
+    int context_steps = 50;
     int idx_kmer_size = 16;
     int hit_max = 2048;
     // if we set this above 1, we use a dynamic programming process to determine the
@@ -148,6 +153,9 @@ int main_msga(int argc, char** argv) {
                 {"name", required_argument, 0, 'n'},
                 {"seq", required_argument, 0, 's'},
                 {"graph", required_argument, 0, 'g'},
+                {"fasta-order", no_argument, 0, 'a'},
+                {"positon-bed", required_argument, 0, 'R'},
+                {"context", required_argument, 0, 'T'},
                 {"base", required_argument, 0, 'b'},
                 {"idx-kmer-size", required_argument, 0, 'K'},
                 {"idx-doublings", required_argument, 0, 'X'},
@@ -191,7 +199,7 @@ int main_msga(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:w:DAc:P:E:Q:NY:H:t:m:M:q:O:I:i:o:y:ZW:z:k:L:e:r:u:l:C:F:SJ:B:a8",
+        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:w:DAc:P:E:Q:NY:H:t:m:M:q:O:I:i:o:y:ZW:z:k:L:e:r:u:l:C:F:SJ:B:a8R:T:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -363,6 +371,14 @@ int main_msga(int argc, char** argv) {
             bigger_first = false;
             break;
 
+        case 'R':
+            position_bed_file = optarg;
+            break;
+
+        case 'T':
+            context_steps = parse<int>(optarg);
+            break;
+            
         case '8':
             patch_alignments = false;
             break;
@@ -445,6 +461,17 @@ int main_msga(int argc, char** argv) {
         }
     }
 
+    // read in our bed file of positions for the input sequences    
+    unordered_map<string, Region> position_hints;
+    if (!position_bed_file.empty()) {
+        vector<Region> regions;
+        vector<string> region_names;
+        parse_bed_regions(position_bed_file, regions, &region_names);
+        for (size_t i = 0; i < regions.size(); ++i) {
+            position_hints[region_names[i]] = regions[i];
+        }
+    }
+
     // give a label to sequences passed on the command line
     // use the sha1sum, take the head
     // collision avoidance with nonce ensures we get the same names for the same sequences across multiple runs
@@ -520,11 +547,15 @@ int main_msga(int argc, char** argv) {
     // Configure GCSA temp directory to the system temp directory
     gcsa::TempFile::setDirectory(temp_file::get_dir());
 
-    auto rebuild = [&](VG* graph) {
-        if (mapper) delete mapper;
-        if (xgidx) delete xgidx;
-        if (gcsaidx) delete gcsaidx;
-        if (lcpidx) delete lcpidx;
+    auto rebuild = [&](VG* graph, int name_idx) {
+        delete mapper;
+        mapper = nullptr;
+        delete xgidx;
+        xgidx = nullptr;
+        delete gcsaidx;
+        gcsaidx = nullptr;
+        delete lcpidx;
+        lcpidx = nullptr;
     
         //stringstream s; s << iter++ << ".vg";
         algorithms::topological_sort(graph);
@@ -532,6 +563,11 @@ int main_msga(int argc, char** argv) {
         graph->graph.clear_path();
         graph->paths.to_graph(graph->graph);
         graph->rebuild_indexes();
+
+        if (name_idx >= names_in_order.size()) {
+            // nothing to align to next, so don't bother making mapping indexes
+            return;
+        }
 
         if (debug) cerr << "building xg index" << endl;
         xgidx = new xg::XG(graph->graph);
@@ -542,6 +578,21 @@ int main_msga(int argc, char** argv) {
         
         // Configure its temp directory to the system temp directory
         gcsa::TempFile::setDirectory(temp_file::get_dir());
+
+        // Replace "graph" with a subsetted graph, and use it below when creating
+        // the GCSA index.
+        VG* region_graph = nullptr;
+        if (name_idx < names_in_order.size() && position_hints.count(names_in_order[name_idx])) {
+            region_graph = new VG();
+            Region region = position_hints[names_in_order[name_idx]];
+            Region out_region;
+            PathChunker chunker(xgidx);
+            if (debug) cerr << "Subsetting graph to " << region.seq << ":" << region.start << "-" << region.end
+                            << " for sequence " << names_in_order[name_idx] << " using " << context_steps
+                            << " context steps." << endl;
+            chunker.extract_subgraph(region, context_steps, 0, false, *region_graph, out_region);
+            graph = region_graph;
+        }
 
         if (idx_path_only) {
             // make the index from only the kmers in the embedded paths
@@ -580,6 +631,10 @@ int main_msga(int argc, char** argv) {
             // if no complexity reduction is requested, just build the index
             build_gcsa_lcp(*graph, gcsaidx, lcpidx, idx_kmer_size, doubling_steps);
         }
+        
+        delete region_graph;
+        graph = nullptr;
+        
         mapper = new Mapper(xgidx, gcsaidx, lcpidx);
         { // set mapper variables
             mapper->hit_max = hit_max;
@@ -617,7 +672,7 @@ int main_msga(int argc, char** argv) {
     };
 
     // set up the graph for mapping
-    rebuild(graph);
+    rebuild(graph, 0);
 
     // todo restructure so that we are trying to map everything
     // add alignment score/bp bounds to catch when we get a good alignment
@@ -712,7 +767,7 @@ int main_msga(int argc, char** argv) {
             graph->graph.clear_path();
             graph->paths.to_graph(graph->graph);
             // and rebuild the indexes
-            rebuild(graph);
+            rebuild(graph, i);
             //graph->serialize_to_file(convert(i) + "-" + name + "-post.vg");
 
             // verfy validity of path
@@ -738,6 +793,11 @@ int main_msga(int argc, char** argv) {
             exit(1);
         }
     }
+
+    delete mapper;
+    delete xgidx;
+    delete gcsaidx;
+    delete lcpidx;    
 
     // auto include_paths = [&mapper,
     //      kmer_size,

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -303,12 +303,6 @@ int main_paths(int argc, char** argv) {
                 }
                 cout << endl;
             }
-        } else if (extract_as_gam) {
-            auto alns = xg_index->paths_as_alignments();
-            stream::ProtobufEmitter<Alignment> emitter(cout);
-            for (auto& aln : alns) {
-                emitter.write(std::move(aln));
-            }
         } else if (!path_prefix.empty()) {
             vector<Path> got = xg_index->paths_by_prefix(path_prefix);
             if (extract_as_gam) {
@@ -323,6 +317,12 @@ int main_paths(int argc, char** argv) {
                     vector<Graph> gb = { g };
                     stream::write_buffered(cout, gb, 0);
                 }
+            }            
+        } else if (extract_as_gam) {
+            auto alns = xg_index->paths_as_alignments();
+            stream::ProtobufEmitter<Alignment> emitter(cout);
+            for (auto& aln : alns) {
+                emitter.write(std::move(aln));
             }
         } else {
             cerr << "[vg paths] Error: specify an operation to perform" << endl;

--- a/test/t/16_vg_msga.t
+++ b/test/t/16_vg_msga.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 13
+plan tests 14
 
 #is $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 4 -k 16 | vg mod -U 10 - | vg mod -c - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) $(vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 -k 16 | vg mod -U 10 - | vg mod -c - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) "graph for GRCh38 HLA-V is unaffected by the number of alignment threads"
 
@@ -28,6 +28,7 @@ vg msga -f msgas/s.fa -w 16 | vg mod -U 10 - | vg mod -c - | vg view -j -
 vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa >t.vg
 is $(vg msga -g t.vg -s CAAATTTTCTGGAGTTCTAT -k 8 -N | vg stats -s - | wc -l) 1 "soft clips at node boundaries (start) are included correctly"
 is $(vg msga -g t.vg -s TTCTATAATATG -k 8 -N | vg stats -s - | wc -l) 1 "soft clips at node boundaries (end) are included correctly"
+is $(vg msga -g t.vg -f msgas/t.fa -k 8 -N | vg mod -U 10 - | vg mod -c - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) $(vg msga -g t.vg -f msgas/t.fa -R msgas/t.bed -T 1 -k 8 -N | vg mod -U 10 - | vg mod -c - | vg view - | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) "region hints (-p) produce same graph" 
 rm t.vg
 
 vg msga -f msgas/s.fa -b s1 -w 20 | vg mod -U 10 - | vg mod -c - >s.vg

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -25,7 +25,7 @@ is $(vg gbwt -S x.gbwt) 1 "chromosome x: 1 sample"
 is $(vg paths -x x.xg -g x.gbwt -X -T | vg view -a -  | wc -l) 2 "vg paths may be used to extract threads"
 
 # Query test
-is $(vg paths -x x.xg -g x.gbwt -X -Q _thread_1_x_0 | vg view -a -  | wc -l) 1 "vg paths can extract one thread by name prefix"
+is $(vg paths -x x.xg -g x.gbwt -X -q _thread_1_x_0 | vg view -a -  | wc -l) 1 "vg paths can extract one thread by name prefix"
 
 # Chromosome Y
 vg index -G y.gbwt -v small/xy2.vcf.gz y.vg


### PR DESCRIPTION
`-R` option added to accept 4-column BED file mapping fasta sequence names to intervals on reference paths.  When some location information is known a priori, this can be used to speed up alignment as well as force sequences to be aligned about where you expect.    