### PR TITLE
Transition to HandleGraphs in alignment code

### DIFF
--- a/src/algorithms/extract_containing_graph.cpp
+++ b/src/algorithms/extract_containing_graph.cpp
@@ -125,15 +125,15 @@ void extract_containing_graph(const HandleGraph* source,
 void extract_containing_graph(const HandleGraph* source, MutableHandleGraph* into, const vector<pos_t>& positions,
                               size_t max_dist, size_t reversing_walk_length) {
     
-    return extract_containing_graph(source, into, positions, vector<size_t>(positions.size(), max_dist),
-                                    reversing_walk_length);
+    extract_containing_graph(source, into, positions, vector<size_t>(positions.size(), max_dist),
+                             reversing_walk_length);
 }
 
 void extract_containing_graph(const HandleGraph* source, MutableHandleGraph* into, const vector<pos_t>& positions,
                               const vector<size_t>& position_max_dist, size_t reversing_walk_length) {
     
-    return extract_containing_graph(source, into, positions, position_max_dist, position_max_dist,
-                                    reversing_walk_length);
+    extract_containing_graph(source, into, positions, position_max_dist, position_max_dist,
+                             reversing_walk_length);
 }
 
 }

--- a/src/backwards_graph.cpp
+++ b/src/backwards_graph.cpp
@@ -1,0 +1,71 @@
+/**
+ * \file backwards_graph.cpp: contains the implementation of BackwardsGraph
+ */
+
+
+#include "backwards_graph.hpp"
+
+
+namespace vg {
+
+using namespace std;
+
+    BackwardsGraph::BackwardsGraph(const HandleGraph* forward_graph) : forward_graph(forward_graph) {
+        // nothing to do
+    }
+    
+    bool BackwardsGraph::has_node(id_t node_id) const {
+        return forward_graph->has_node(node_id);
+    }
+    
+    handle_t BackwardsGraph::get_handle(const id_t& node_id, bool is_reverse) const {
+        return forward_graph->get_handle(node_id, is_reverse);
+    }
+    
+    id_t BackwardsGraph::get_id(const handle_t& handle) const {
+        return forward_graph->get_id(handle);
+    }
+    
+    bool BackwardsGraph::get_is_reverse(const handle_t& handle) const {
+        return forward_graph->get_is_reverse(handle);
+    }
+    
+    handle_t BackwardsGraph::flip(const handle_t& handle) const {
+        return forward_graph->flip(handle);
+    }
+    
+    size_t BackwardsGraph::get_length(const handle_t& handle) const {
+        return forward_graph->get_length(handle);
+    }
+    
+    string BackwardsGraph::get_sequence(const handle_t& handle) const {
+        // reverse (non-complementing) the sequence
+        string sequence = forward_graph->get_sequence(handle);
+        reverse(sequence.begin(), sequence.end());
+        return sequence;
+    }
+    
+    bool BackwardsGraph::follow_edges(const handle_t& handle, bool go_left,
+                                      const function<bool(const handle_t&)>& iteratee) const {
+        // the left and right side have been switched, so reverse the direction
+        return forward_graph->follow_edges(handle, !go_left, iteratee);
+    }
+    
+    void BackwardsGraph::for_each_handle(const function<bool(const handle_t&)>& iteratee, bool parallel) const {
+        forward_graph->for_each_handle(iteratee);
+    }
+    
+    size_t BackwardsGraph::node_size() const {
+        return forward_graph->node_size();
+    }
+    
+    id_t BackwardsGraph::min_node_id() const {
+        return forward_graph->min_node_id();
+    }
+    
+    id_t BackwardsGraph::max_node_id() const {
+        return forward_graph->max_node_id();
+    }
+
+}
+

--- a/src/backwards_graph.hpp
+++ b/src/backwards_graph.hpp
@@ -1,0 +1,88 @@
+#ifndef VG_BACKWARDS_GRAPH_HPP_INCLUDED
+#define VG_BACKWARDS_GRAPH_HPP_INCLUDED
+
+/** \file
+ * backwards_graph.hpp: defines a handle graph implementation that reverses the sequences
+ * of some other graph
+ */
+
+#include <unordered_map>
+#include "handle.hpp"
+
+namespace vg {
+
+using namespace std;
+
+    /**
+     * A HandleGraph implementation that wraps some other handle graph and reverses
+     * but does *NOT* complement the sequences.
+     */
+    class BackwardsGraph : public HandleGraph {
+    public:
+        
+        /// Initialize as the backwards version of another graph
+        BackwardsGraph(const HandleGraph* forward_graph);
+        
+        /// Default constructor -- not actually functional
+        BackwardsGraph() = default;
+        
+        /// Default destructor
+        ~BackwardsGraph() = default;
+        
+        //////////////////////////
+        /// HandleGraph interface
+        //////////////////////////
+        
+        // Method to check if a node exists by ID
+        virtual bool has_node(id_t node_id) const;
+        
+        /// Look up the handle for the node with the given ID in the given orientation
+        virtual handle_t get_handle(const id_t& node_id, bool is_reverse = false) const;
+        
+        /// Get the ID from a handle
+        virtual id_t get_id(const handle_t& handle) const;
+        
+        /// Get the orientation of a handle
+        virtual bool get_is_reverse(const handle_t& handle) const;
+        
+        /// Invert the orientation of a handle (potentially without getting its ID)
+        virtual handle_t flip(const handle_t& handle) const;
+        
+        /// Get the length of a node
+        virtual size_t get_length(const handle_t& handle) const;
+        
+        /// Get the sequence of a node, presented in the handle's local forward
+        /// orientation.
+        virtual string get_sequence(const handle_t& handle) const;
+        
+        /// Loop over all the handles to next/previous (right/left) nodes. Passes
+        /// them to a callback which returns false to stop iterating and true to
+        /// continue. Returns true if we finished and false if we stopped early.
+        virtual bool follow_edges(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const;
+        
+        /// Loop over all the nodes in the graph in their local forward
+        /// orientations, in their internal stored order. Stop if the iteratee
+        /// returns false. Can be told to run in parallel, in which case stopping
+        /// after a false return value is on a best-effort basis and iteration
+        /// order is not defined.
+        virtual void for_each_handle(const function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+        
+        /// Return the number of nodes in the graph
+        /// TODO: can't be node_count because XG has a field named node_count.
+        virtual size_t node_size() const;
+        
+        /// Return the smallest ID in the graph, or some smaller number if the
+        /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
+        virtual id_t min_node_id() const;
+        
+        /// Return the largest ID in the graph, or some larger number if the
+        /// largest ID is unavailable. Return value is unspecified if the graph is empty.
+        virtual id_t max_node_id() const;
+        
+    private:
+        /// The forward version of the graph we're making backwards
+        const HandleGraph* forward_graph = nullptr;
+    };
+}
+
+#endif

--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -34,22 +34,23 @@ BandedGlobalAligner<IntType>::BABuilder::~BABuilder() {
 }
 
 template<class IntType>
-void BandedGlobalAligner<IntType>::BABuilder::update_state(matrix_t matrix, Node* node,
-                                                           int64_t read_idx, int64_t node_idx,
+void BandedGlobalAligner<IntType>::BABuilder::update_state(const HandleGraph& graph, matrix_t matrix,
+                                                           const handle_t& node, int64_t read_idx, int64_t node_idx,
                                                            bool empty_node_seq) {
 #ifdef debug_banded_aligner_traceback
     cerr << "[BABuilder::update_state] beginning " << (empty_node_seq ? "" : "non-") << "empty state update for read index " << read_idx << ", node seq index " << node_idx << endl;
 #endif
-    if (node != current_node) {
+    if (graph.get_id(node) != current_node_id) {
 #ifdef debug_banded_aligner_traceback
-        cerr << "[BABuilder::update_state] at new node " << (node ? node->id() : -1) << " previously " << (current_node ? current_node->id() : -1) << endl;
+        cerr << "[BABuilder::update_state] at new node " << graph.get_id(node) << " previously " << current_node_id << endl;
 #endif
         // conclude current mapping and proceed to next node
         finish_current_node();
-        current_node = node;
+        current_node_id = graph.get_id(node);
+        current_node_sequence = graph.get_sequence(node);
         matrix_state = matrix;
         if (matrix_state == Match) {
-            matching = (alignment.sequence()[read_idx] == current_node->sequence()[node_idx]);
+            matching = (alignment.sequence()[read_idx] == current_node_sequence[node_idx]);
         }
         edit_length = !empty_node_seq;
         edit_read_end_idx = read_idx;
@@ -64,13 +65,13 @@ void BandedGlobalAligner<IntType>::BABuilder::update_state(matrix_t matrix, Node
         }
         matrix_state = matrix;
         if (matrix_state == Match) {
-            matching = (alignment.sequence()[read_idx] == current_node->sequence()[node_idx]);
+            matching = (alignment.sequence()[read_idx] == current_node_sequence[node_idx]);
         }
         edit_length = 1;
         edit_read_end_idx = read_idx;
     }
     else if (matrix == Match &&
-             (alignment.sequence()[read_idx] == current_node->sequence()[node_idx]) != matching) {
+             (alignment.sequence()[read_idx] == current_node_sequence[node_idx]) != matching) {
 #ifdef debug_banded_aligner_traceback
         cerr << "[BABuilder::update_state] switching between match and mismatch" << endl;
 #endif
@@ -86,7 +87,7 @@ void BandedGlobalAligner<IntType>::BABuilder::update_state(matrix_t matrix, Node
     }
     
 #ifdef debug_banded_aligner_traceback
-    cerr << "[BABuilder::update_state] finished updating state, matrix is " << (matrix_state == Match ? "match" : (matrix_state == InsertRow ? "insert row" : "insert column" )) << ", is matching? " << (matching ? "yes" : "no") << ", edit length " << edit_length << ", edit end index (on read) " << edit_read_end_idx << ", current node " << current_node->id() << endl;
+    cerr << "[BABuilder::update_state] finished updating state, matrix is " << (matrix_state == Match ? "match" : (matrix_state == InsertRow ? "insert row" : "insert column" )) << ", is matching? " << (matching ? "yes" : "no") << ", edit length " << edit_length << ", edit end index (on read) " << edit_read_end_idx << ", current node " << current_node_id << endl;
 #endif
 }
 
@@ -137,7 +138,7 @@ template <class IntType>
 void BandedGlobalAligner<IntType>::BABuilder::finish_current_node() {
 
     // sentinel for first iteration
-    if (current_node == nullptr) {
+    if (current_node_id == 0) {
 #ifdef debug_banded_aligner_traceback
         cerr << "[BABuilder::finish_current_node] at beginning of traceback, not creating a mapping" << endl;
 #endif
@@ -147,7 +148,7 @@ void BandedGlobalAligner<IntType>::BABuilder::finish_current_node() {
     finish_current_edit();
     
 #ifdef debug_banded_aligner_traceback
-    cerr << "[BABuilder::finish_current_node] finishing mapping for node " << current_node->id() << endl;
+    cerr << "[BABuilder::finish_current_node] finishing mapping for node " << current_node_id << endl;
 #endif
     
     node_mappings.emplace_front();
@@ -161,7 +162,7 @@ void BandedGlobalAligner<IntType>::BABuilder::finish_current_node() {
     
     mapping_edits.clear();
     
-    (*(node_mappings.front().mutable_position())).set_node_id(current_node->id());
+    (*(node_mappings.front().mutable_position())).set_node_id(current_node_id);
     // note: global alignment always starts at beginning of node, default offset 0 is correct
 }
 
@@ -202,15 +203,13 @@ void BandedGlobalAligner<IntType>::BABuilder::finalize_alignment(const list<int6
 }
 
 template <class IntType>
-BandedGlobalAligner<IntType>::BAMatrix::BAMatrix(Alignment& alignment, Node* node, int64_t top_diag,
-                                                 int64_t bottom_diag, BAMatrix** seeds, int64_t num_seeds,
-                                                 int64_t cumulative_seq_len) :
+BandedGlobalAligner<IntType>::BAMatrix::BAMatrix(Alignment& alignment, handle_t node, int64_t top_diag, int64_t bottom_diag,
+                                                 const vector<BAMatrix*>& seeds, int64_t cumulative_seq_len) :
                                                  node(node),
                                                  top_diag(top_diag),
                                                  bottom_diag(bottom_diag),
                                                  seeds(seeds),
                                                  alignment(alignment),
-                                                 num_seeds(num_seeds),
                                                  cumulative_seq_len(cumulative_seq_len),
                                                  match(nullptr),
                                                  insert_col(nullptr),
@@ -218,7 +217,7 @@ BandedGlobalAligner<IntType>::BAMatrix::BAMatrix(Alignment& alignment, Node* nod
 {
     // nothing to do
 #ifdef debug_banded_aligner_objects
-    cerr << "[BAMatrix]: constructor for node " << node->id() << " with sequence " << node->sequence() << " and band from " << top_diag << " to " << bottom_diag << endl;;
+    cerr << "[BAMatrix]: constructor for node " << as_integer(node) << " and band from " << top_diag << " to " << bottom_diag << endl;;
 #endif
 }
 
@@ -226,7 +225,7 @@ template <class IntType>
 BandedGlobalAligner<IntType>::BAMatrix::~BAMatrix() {
 #ifdef debug_banded_aligner_objects
     if (node != nullptr) {
-        cerr << "[BAMatrix::~BAMatrix] destructing matrix for node " << node->id() << endl;
+        cerr << "[BAMatrix::~BAMatrix] destructing matrix for node " << as_integer(node) << endl;
     }
     else {
         cerr << "[BAMatrix::~BAMatrix] destructing null matrix" << endl;
@@ -239,23 +238,23 @@ BandedGlobalAligner<IntType>::BAMatrix::~BAMatrix() {
 }
 
 template <class IntType>
-void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(int8_t* score_mat, int8_t* nt_table, int8_t gap_open,
-                                                         int8_t gap_extend, bool qual_adjusted, IntType min_inf) {
+void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(const HandleGraph& graph, int8_t* score_mat, int8_t* nt_table,
+                                                         int8_t gap_open, int8_t gap_extend, bool qual_adjusted, IntType min_inf) {
     
 #ifdef debug_banded_aligner_fill_matrix
-    cerr << "[BAMatrix::fill_matrix] beginning DP on matrix for node " << node->id() << endl;;
+    cerr << "[BAMatrix::fill_matrix] beginning DP on matrix for node " << as_integer(node) << endl;;
 #endif
     
     // note: bottom has the higher index
     int64_t band_height = bottom_diag - top_diag + 1;
-    int64_t ncols = node->sequence().length();
+    int64_t ncols = graph.get_length(node);
     int64_t band_size = band_height * ncols;
     
 #ifdef debug_banded_aligner_fill_matrix
     cerr << "[BAMatrix::fill_matrix]: allocating matrices of height " << band_height << " and width " << ncols << " for a total cell count of " << band_size << endl;
 #endif
     
-    const string& node_seq = node->sequence();
+    string node_seq = graph.get_sequence(node);
     const string& read = alignment.sequence();
     const string& base_quality = alignment.quality();
     
@@ -310,14 +309,12 @@ void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(int8_t* score_mat, int8
     // is connected to a source node by a length 0 path (which we will check later)
     bool treat_as_source = (num_seeds == 0);
     
-    list<BAMatrix*> seed_queue;
-    for (int64_t seed_num = 0; seed_num < num_seeds; seed_num++) {
-        seed_queue.push_back(seeds[seed_num]);
-    }
+    // initialize the queue with all of the predecessors
+    vector<BAMatrix*> seed_queue = seeds;
     
     while (!seed_queue.empty()) {
-        BAMatrix* seed = seed_queue.front();
-        seed_queue.pop_front();
+        BAMatrix* seed = seed_queue.back();
+        seed_queue.pop_back();
         
         if (seed == nullptr) {
 #ifdef debug_banded_aligner_fill_matrix
@@ -327,20 +324,20 @@ void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(int8_t* score_mat, int8
         }
         
 #ifdef debug_banded_aligner_fill_matrix
-        cerr << "[BAMatrix::fill_matrix]: doing POA across boundary from seed node " << seed->node->id() << " to node " << node->id() << endl;
+        cerr << "[BAMatrix::fill_matrix]: doing POA across boundary from seed node " << graph.get_id(seed->node) << " to node " << graph.get_id(node) << endl;
 #endif
         
-        int64_t seed_node_seq_len = seed->node->sequence().length();
+        int64_t seed_node_seq_len = graph.get_length(seed->node);
         
         if (seed_node_seq_len == 0) {
 #ifdef debug_banded_aligner_fill_matrix
-            cerr << "[BAMatrix::fill_matrix]: seed node " << seed->node->id() << " has no sequence, adding its predecessors as seed nodes" << endl;
+            cerr << "[BAMatrix::fill_matrix]: seed node " << graph.get_id(seed->node) << " has no sequence, adding its predecessors as seed nodes" << endl;
 #endif
             // this is a length 0 node, so let this seed's predecessors seed into this one or
             // identify this node as a "source"
-            treat_as_source = treat_as_source || (seed->num_seeds == 0);
-            for (int64_t seed_num = 0; seed_num < seed->num_seeds; seed_num++) {
-                seed_queue.push_back(seed->seeds[seed_num]);
+            treat_as_source = treat_as_source || seed->seeds.empty();
+            for (auto& seed_of_seed : seed->seeds) {
+                seed_queue.push_back(seed_of_seed);
             }
             continue;
         }
@@ -571,12 +568,12 @@ void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(int8_t* score_mat, int8
     for (int64_t j = 1; j < ncols; j++) {
         
         // are we clipping any diagonals because they are outside the range of the matrix in this column?
-        bool bottom_diag_outside = bottom_diag + j >= (int64_t) read.length();
+        bool bottom_diag_outside = bottom_diag + j >= int64_t(read.size());
         bool top_diag_outside = top_diag + j < 0;
         bool top_diag_abutting = top_diag + j == 0;
         
         int64_t iter_start = top_diag_outside ? -(top_diag + j) : 0;
-        int64_t iter_stop = bottom_diag_outside ? band_height + (int64_t) read.length() - bottom_diag - j - 1 : band_height;
+        int64_t iter_stop = bottom_diag_outside ? band_height + int64_t(read.size()) - bottom_diag - j - 1 : band_height;
         
         idx = iter_start * ncols + j;
         
@@ -683,49 +680,50 @@ void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(int8_t* score_mat, int8
     }
     
 #ifdef debug_banded_aligner_print_matrices
-    print_full_matrices();
-    print_rectangularized_bands();
+    print_full_matrices(graph);
+    print_rectangularized_bands(graph);
 #endif
 }
 
 template <class IntType>
-void BandedGlobalAligner<IntType>::BAMatrix::traceback(BABuilder& builder, AltTracebackStack& traceback_stack, matrix_t start_mat,
-                                                       int8_t* score_mat, int8_t* nt_table, int8_t gap_open, int8_t gap_extend,
-                                                       bool qual_adjusted, IntType min_inf) {
+void BandedGlobalAligner<IntType>::BAMatrix::traceback(const HandleGraph& graph, BABuilder& builder, AltTracebackStack& traceback_stack,
+                                                       matrix_t start_mat, int8_t* score_mat, int8_t* nt_table, int8_t gap_open,
+                                                       int8_t gap_extend, bool qual_adjusted, IntType min_inf) {
     
     // get coordinates of bottom right corner
     const string& read = alignment.sequence();
-    int64_t ncols = node->sequence().length();
+    int64_t ncols = graph.get_length(node);
     int64_t row = bottom_diag + ncols > (int64_t) read.length() ? (int64_t) read.length() - top_diag - ncols : bottom_diag - top_diag;
     int64_t col = ncols - 1;
     
     
 #ifdef debug_banded_aligner_traceback
-    cerr << "[BAMatrix::traceback] beginning traceback in matrices for node " << node->id() << " starting matrix is " << (start_mat == Match ? "match" : (start_mat == InsertCol ? "insert column" : "insert row")) << endl;
+    cerr << "[BAMatrix::traceback] beginning traceback in matrices for node " << graph.get_id(node) << " starting matrix is " << (start_mat == Match ? "match" : (start_mat == InsertCol ? "insert column" : "insert row")) << endl;
 #endif
     
-    traceback_internal(builder, traceback_stack, row, col, start_mat, alignment.sequence().empty(), score_mat, nt_table, gap_open, gap_extend,
-                       qual_adjusted, min_inf);
+    traceback_internal(graph, builder, traceback_stack, row, col, start_mat, alignment.sequence().empty(), score_mat, nt_table,
+                       gap_open, gap_extend, qual_adjusted, min_inf);
 }
 
 template <class IntType>
-void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& builder, AltTracebackStack& traceback_stack,
+void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(const HandleGraph& graph, BABuilder& builder,
+                                                                AltTracebackStack& traceback_stack,
                                                                 int64_t start_row, int64_t start_col, matrix_t start_mat,
                                                                 bool in_lead_gap, int8_t* score_mat, int8_t* nt_table,
                                                                 int8_t gap_open, int8_t gap_extend, bool qual_adjusted,
                                                                 IntType min_inf) {
     
 #ifdef debug_banded_aligner_traceback
-    cerr << "[BAMatrix::traceback_internal] starting traceback back through node " << node->id() << " from rectangular coordinates (" << start_row << ", " << start_col << "), currently " << (in_lead_gap ? "" : "not ") << "in a lead gap" << endl;
+    cerr << "[BAMatrix::traceback_internal] starting traceback back through node " << graph.get_id(node) << " from rectangular coordinates (" << start_row << ", " << start_col << "), currently " << (in_lead_gap ? "" : "not ") << "in a lead gap" << endl;
 #endif
     
     const string& read = alignment.sequence();
     const string& base_quality = alignment.quality();
     
     int64_t band_height = bottom_diag - top_diag + 1;
-    const char* node_seq = node->sequence().c_str();
-    int64_t ncols = node->sequence().length();
-    int64_t node_id = node->id();
+    string node_seq = graph.get_sequence(node);
+    int64_t ncols = node_seq.size();
+    int64_t node_id = graph.get_id(node);
     
     int64_t idx, next_idx;
     int64_t i = start_row, j = start_col;
@@ -745,7 +743,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
 #endif
         
         // add traceback step to alignment
-        builder.update_state(curr_mat, node, i + top_diag + j, j);
+        builder.update_state(graph, curr_mat, node, i + top_diag + j, j);
         
         // check for a deflection
         if (traceback_stack.at_next_deflection(node_id, i, j)) {
@@ -1013,7 +1011,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
         // add lead column gaps until reaching edge of node
         curr_mat = InsertCol;
         while (j > 0) {
-            builder.update_state(curr_mat, node, -1, j);
+            builder.update_state(graph, curr_mat, node, -1, j);
             j--;
             i++;
         }
@@ -1023,9 +1021,9 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
     
     bool treat_as_source = false;
     unordered_set<int64_t> traceback_source_nodes;
-    if (num_seeds == 0) {
+    if (seeds.empty()) {
         treat_as_source = true;
-        traceback_source_nodes.insert(node->id());
+        traceback_source_nodes.insert(graph.get_id(node));
     }
     
     BAMatrix* traceback_seed = nullptr;
@@ -1040,17 +1038,17 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
         cerr << "[BAMatrix::traceback_internal] at boundary, taking a deflection" << endl;
 #endif
         
-        builder.update_state(curr_mat, node, curr_diag, 0);
+        builder.update_state(graph, curr_mat, node, curr_diag, 0);
         
         // where to deflect to?
         int64_t deflect_node_id;
         matrix_t deflect_matrix = traceback_stack.deflect_to_matrix(deflect_node_id);
         
         // find which seed matrix to deflect to (don't have a better way of looking this up right now)
-        list<BAMatrix*> seed_path;
-        for (int64_t k = 0; k < num_seeds; k++) {
+        vector<BAMatrix*> seed_path;
+        for (auto initial_seed : seeds) {
             
-            list<BAMatrix*> seed_stack{seeds[k]};
+            vector<BAMatrix*> seed_stack{initial_seed};
             
             while (!seed_stack.empty()) {
                 BAMatrix* seed = seed_stack.back();
@@ -1060,18 +1058,18 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
                     // pop off the path if we hit the stack marker
                     seed_path.pop_back();
                 }
-                else if (seed->node->id() == deflect_node_id) {
+                else if (graph.get_id(seed->node) == deflect_node_id) {
                     // we found the traceback node
                     seed_path.push_back(seed);
                     break;
                 }
-                else if (seed->node->sequence().length() == 0) {
+                else if (graph.get_length(seed->node) == 0) {
                     // this is not the traceback node, but it is an empty node so the traceback
                     // might be on the other side of it
                     seed_path.push_back(seed);
                     seed_stack.push_back(nullptr);
-                    for (int64_t l = 0; l < seed->num_seeds; l++) {
-                        seed_stack.push_back(seed->seeds[l]);
+                    for (auto seed_of_seed : seed->seeds) {
+                        seed_stack.push_back(seed_of_seed);
                     }
                 }
             }
@@ -1092,13 +1090,13 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
             auto end = seed_path.end();
             end--;
             for (auto iter = seed_path.begin(); iter != end; iter++) {
-                builder.update_state(curr_mat, (*iter)->node, i, 0, true);
+                builder.update_state(graph, curr_mat, (*iter)->node, i, 0, true);
             }
         }
         
         BAMatrix* seed = seed_path.back();
         
-        int64_t seed_ncols = seed->node->sequence().length();
+        int64_t seed_ncols = graph.get_length(seed->node);
         traceback_seed_row = curr_diag - seed->top_diag - seed_ncols + (curr_mat == InsertCol);
         traceback_seed_col = seed_ncols - 1;
         // check whether we're crossing into a lead gap
@@ -1109,7 +1107,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
 #endif
         
         // continue traceback in the next node
-        seed->traceback_internal(builder, traceback_stack, traceback_seed_row, traceback_seed_col, deflect_matrix,
+        seed->traceback_internal(graph, builder, traceback_stack, traceback_seed_row, traceback_seed_col, deflect_matrix,
                                  in_lead_gap, score_mat, nt_table, gap_open, gap_extend, qual_adjusted, min_inf);
         return;
     }
@@ -1120,9 +1118,9 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
     vector<BAMatrix*> empty_source_path;
     
     // a queue of seeds and their empty predecessors
-    list<pair<BAMatrix*, vector<BAMatrix*>>> seed_queue;
-    for (int64_t k = 0; k < num_seeds; k++) {
-        seed_queue.emplace_back(seeds[k], vector<BAMatrix*>());
+    vector<pair<BAMatrix*, vector<BAMatrix*>>> seed_queue;
+    for (auto seed : seeds) {
+        seed_queue.emplace_back(seed, vector<BAMatrix*>());
     }
     
     if (in_lead_gap) {
@@ -1133,13 +1131,13 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
         // take the shortest path back to the origin of the global alignment
         
         // add final read deletion of node
-        builder.update_state(curr_mat, node, -1, j);
+        builder.update_state(graph, curr_mat, node, -1, j);
         
         while (!seed_queue.empty()) {
             
-            auto seed_record = seed_queue.front();
+            auto seed_record = seed_queue.back();
             BAMatrix* seed = seed_record.first;
-            seed_queue.pop_front();
+            seed_queue.pop_back();
             
             // is seed masked?
             if (seed == nullptr) {
@@ -1147,35 +1145,35 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
             }
             
 #ifdef debug_banded_aligner_traceback
-            cerr << "[BAMatrix::traceback_internal] checking seed node " << seed->node->id() << endl;
+            cerr << "[BAMatrix::traceback_internal] checking seed node " << graph.get_id(seed->node) << endl;
 #endif
             
             // if this node is empty, add its predecessors to the queue
-            if (seed->node->sequence().length() == 0) {
+            if (graph.get_length(seed->node) == 0) {
 #ifdef debug_banded_aligner_traceback
-                cerr << "[BAMatrix::traceback_internal] seed node " << seed->node->id() << " is empty, checking predecessors" << endl;
+                cerr << "[BAMatrix::traceback_internal] seed node " << graph.get_id(seed->node) << " is empty, checking predecessors" << endl;
 #endif
                 // record that this seed comes before its predecessors in the traceback
                 seed_record.second.push_back(seed);
-                if (seed->num_seeds == 0) {
+                if (seed->seeds.empty()) {
 #ifdef debug_banded_aligner_traceback
-                    cerr << "[BAMatrix::traceback_internal] empty seed node " << seed->node->id() << " is a source" << endl;
+                    cerr << "[BAMatrix::traceback_internal] empty seed node " << graph.get_id(seed->node) << " is a source" << endl;
 #endif
                     treat_as_source = true;
-                    traceback_source_nodes.insert(seed->node->id());
+                    traceback_source_nodes.insert(graph.get_id(seed->node));
                     empty_source_path = seed_record.second;
                 }
                 
-                for (int64_t seed_num = 0; seed_num < seed->num_seeds; seed_num++) {
-                    seed_queue.push_back(make_pair(seed->seeds[seed_num], seed_record.second));
+                for (auto seed_of_seed : seed->seeds) {
+                    seed_queue.push_back(make_pair(seed_of_seed, seed_record.second));
                 }
                 continue;
             }
             
-            score_diff = gap_extend * (seed->cumulative_seq_len + seed->node->sequence().length() - cumulative_seq_len);
+            score_diff = gap_extend * (seed->cumulative_seq_len + graph.get_length(seed->node) - cumulative_seq_len);
             if (score_diff == 0 && !found_trace) {
 #ifdef debug_banded_aligner_traceback
-                cerr << "[BAMatrix::traceback_internal] found a lead gap traceback to node " << seed->node->id() << endl;
+                cerr << "[BAMatrix::traceback_internal] found a lead gap traceback to node " << graph.get_id(seed->node) << endl;
 #endif
                 traceback_seed = seed;
                 empty_intermediate_nodes = seed_record.second;
@@ -1183,13 +1181,13 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
             }
             else {
                 alt_score = curr_traceback_score - score_diff;
-                traceback_stack.propose_deflection(alt_score, node_id, i, j, seed->node->id(), InsertCol);
+                traceback_stack.propose_deflection(alt_score, node_id, i, j, graph.get_id(seed->node), InsertCol);
             }
         }
         
         if (traceback_seed) {
             // where in the matrix is this?
-            int64_t seed_ncols = traceback_seed->node->sequence().length();
+            int64_t seed_ncols = graph.get_length(traceback_seed->node);
             int64_t seed_extended_top_diag = traceback_seed->top_diag + seed_ncols;
             traceback_seed_row = top_diag - seed_extended_top_diag + i + 1;
             traceback_seed_col = seed_ncols - 1;
@@ -1197,7 +1195,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
     }
     else {
         
-        builder.update_state(curr_mat, node, curr_diag, 0);
+        builder.update_state(graph, curr_mat, node, curr_diag, 0);
         
         IntType match_score;
         switch (curr_mat) {
@@ -1235,7 +1233,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
         }
         
 #ifdef debug_banded_aligner_traceback
-        cerr << "[BAMatrix::traceback_internal] at boundary, in node " << node->id() << " following seed backward from " << (curr_mat == Match ? "match" : "insert column") << " matrix with score " << (int) curr_score << endl;
+        cerr << "[BAMatrix::traceback_internal] at boundary, in node " << graph.get_id(node) << " following seed backward from " << (curr_mat == Match ? "match" : "insert column") << " matrix with score " << (int) curr_score << endl;
 #endif
         
         // matches stay on same diagonal, column insertions move over one diagonal
@@ -1243,9 +1241,9 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
         
         // check traceback goes to each seed matrix
         while (!seed_queue.empty()) {
-            auto seed_record = seed_queue.front();
+            auto seed_record = seed_queue.back();
             BAMatrix* seed = seed_record.first;
-            seed_queue.pop_front();
+            seed_queue.pop_back();
             
             // is the matrix masked?
             if (seed == nullptr) {
@@ -1255,14 +1253,14 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
                 continue;
             }
             
-            if (seed->node->sequence().length() == 0) {
+            if (graph.get_length(seed->node) == 0) {
                 
-                for (int64_t seed_num = 0; seed_num < seed->num_seeds; seed_num++) {
-                    seed_queue.push_back(make_pair(seed->seeds[seed_num], seed_record.second));
+                for (auto seed_of_seed : seed->seeds) {
+                    seed_queue.push_back(make_pair(seed_of_seed, seed_record.second));
                     seed_queue.back().second.push_back(seed);
                 }
                 
-                if (seed->num_seeds == 0) {
+                if (seed->seeds.empty()) {
                     treat_as_source = true;
                     // keep track of the path through empty nodes to a source
                     empty_source_path = seed_record.second;
@@ -1273,11 +1271,11 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
             
             
 #ifdef debug_banded_aligner_traceback
-            cerr << "[BAMatrix::traceback_internal] checking seed node " << seed->node->id() << endl;
+            cerr << "[BAMatrix::traceback_internal] checking seed node " << graph.get_id(seed->node) << endl;
 #endif
             
-            int64_t seed_node_id = seed->node->id();
-            int64_t seed_ncols = seed->node->sequence().length();
+            int64_t seed_node_id = graph.get_id(seed->node);
+            int64_t seed_ncols = graph.get_length(seed->node);
             
             // the diagonals in the current matrix that this seed extends to
             int64_t seed_extended_top_diag = seed->top_diag + seed_ncols;
@@ -1572,7 +1570,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
     if (found_source_trace) {
         // if we traversed any empty nodes before finding the traceback, add empty updates for them
         for (BAMatrix* seed_path_node : empty_source_path) {
-            builder.update_state(InsertCol, seed_path_node->node, i + top_diag, 0, true);
+            builder.update_state(graph, InsertCol, seed_path_node->node, i + top_diag, 0, true);
         }
         
         // add any lead row gaps necessary
@@ -1581,8 +1579,8 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
             cerr << "[BAMatrix::traceback_internal] initial row gaps are present, adding read char " << top_diag + i - 1 << ": " << read[top_diag + i - 1] << endl;
 #endif
             i--;
-            Node* end_node = empty_source_path.empty() ? node : empty_source_path.back()->node;
-            builder.update_state(InsertRow, end_node, i + top_diag, -1, end_node->sequence().empty());
+            const handle_t& end_node = empty_source_path.empty() ? node : empty_source_path.back()->node;
+            builder.update_state(graph, InsertRow, end_node, i + top_diag, -1, graph.get_length(end_node) == 0);
         }
         return;
     }
@@ -1592,7 +1590,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
 #endif
         // if we traversed any empty nodes before finding the traceback, add empty updates for them
         for (BAMatrix* intermediate_node : empty_intermediate_nodes) {
-            builder.update_state(curr_mat, intermediate_node->node, i + top_diag, 0, true);
+            builder.update_state(graph, curr_mat, intermediate_node->node, i + top_diag, 0, true);
         }
         
     }
@@ -1603,44 +1601,44 @@ void BandedGlobalAligner<IntType>::BAMatrix::traceback_internal(BABuilder& build
     }
     
     // continue traceback in the next node
-    traceback_seed->traceback_internal(builder, traceback_stack, traceback_seed_row, traceback_seed_col, traceback_mat,
+    traceback_seed->traceback_internal(graph, builder, traceback_stack, traceback_seed_row, traceback_seed_col, traceback_mat,
                                        in_lead_gap, score_mat, nt_table, gap_open, gap_extend, qual_adjusted, min_inf);
 }
 
 template <class IntType>
-void BandedGlobalAligner<IntType>::BAMatrix::print_full_matrices() {
+void BandedGlobalAligner<IntType>::BAMatrix::print_full_matrices(const HandleGraph& graph) {
     if (match == nullptr) {
         cerr << "error:[BandedGlobalAligner] cannot print matrix before performing dynamic programming" << endl;
         assert(0);
     }
     
-    cerr << "matrices for node " << node->id() << ":" << endl;
+    cerr << "matrices for node " << graph.get_id(node) << ":" << endl;
     
     for (matrix_t mat : {Match, InsertRow, InsertCol}) {
-        print_matrix(mat);
+        print_matrix(graph, mat);
     }
 
 }
 
 template <class IntType>
-void BandedGlobalAligner<IntType>::BAMatrix::print_rectangularized_bands() {
+void BandedGlobalAligner<IntType>::BAMatrix::print_rectangularized_bands(const HandleGraph& graph) {
     if (match == nullptr) {
         cerr << "error:[BandedGlobalAligner] cannot print band before performing dynamic programming" << endl;
         assert(0);
     }
     
-    cerr << "rectangularized bands for node " << node->id() << ":" << endl;
+    cerr << "rectangularized bands for node " << graph.get_id(node) << ":" << endl;
     
     for (matrix_t mat : {Match, InsertRow, InsertCol}) {
-        print_band(mat);
+        print_band(graph, mat);
     }
 }
 
 template <class IntType>
-void BandedGlobalAligner<IntType>::BAMatrix::print_matrix(matrix_t which_mat) {
+void BandedGlobalAligner<IntType>::BAMatrix::print_matrix(const HandleGraph& graph, matrix_t which_mat) {
 
     const string& read = alignment.sequence();
-    const string& node_seq = node->sequence();
+    string node_seq = graph.get_sequence(node);
     
     IntType* band_rect;
     switch (which_mat) {
@@ -1688,10 +1686,10 @@ void BandedGlobalAligner<IntType>::BAMatrix::print_matrix(matrix_t which_mat) {
 }
 
 template <class IntType>
-void BandedGlobalAligner<IntType>::BAMatrix::print_band(matrix_t which_mat) {
+void BandedGlobalAligner<IntType>::BAMatrix::print_band(const HandleGraph& graph, matrix_t which_mat) {
     
     const string& read = alignment.sequence();
-    const string& node_seq = node->sequence();
+    string node_seq = graph.get_sequence(node);
     
     IntType* band_rect;
     switch (which_mat) {
@@ -1749,7 +1747,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::print_band(matrix_t which_mat) {
 }
 
 template <class IntType>
-BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g,
+BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, const HandleGraph& g,
                                                   int64_t band_padding, bool permissive_banding,
                                                   bool adjust_for_base_quality) :
                                                   BandedGlobalAligner(alignment, g,
@@ -1762,7 +1760,7 @@ BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g
 }
 
 template <class IntType>
-BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g,
+BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, const HandleGraph& g,
                                                   vector<Alignment>& alt_alignments,
                                                   int64_t max_multi_alns, int64_t band_padding,
                                                   bool permissive_banding,
@@ -1782,16 +1780,21 @@ BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g
 }
 
 template <class IntType>
-BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g,
+BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, const HandleGraph& g,
                                                   vector<Alignment>* alt_alignments,
                                                   int64_t max_multi_alns,
                                                   int64_t band_padding,
                                                   bool permissive_banding,
                                                   bool adjust_for_base_quality) :
+                                                  graph(g),
                                                   alignment(alignment),
                                                   alt_alignments(alt_alignments),
                                                   max_multi_alns(max_multi_alns),
-                                                  adjust_for_base_quality(adjust_for_base_quality)
+                                                  adjust_for_base_quality(adjust_for_base_quality),
+                                                  // compute some graph features we will be frequently reusing
+                                                  topological_order(algorithms::lazier_topological_order(&g)),
+                                                  source_nodes(algorithms::head_nodes(&g)),
+                                                  sink_nodes(algorithms::tail_nodes(&g))
 {
 #ifdef debug_banded_aligner_objects
     cerr << "[BandedGlobalAligner]: constructing BandedBlobalAligner with " << band_padding << " padding, " << permissive_banding << " permissive, " << adjust_for_base_quality << " quality adjusted" << endl;
@@ -1803,6 +1806,10 @@ BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g
         }
     }
     
+    if (topological_order.size() < graph.node_size()) {
+        cerr << "error:[BandedGlobalAligner] alignment graph must be a DAG" << endl;
+    }
+    
     // TODO: this can waste memory, but reallocating the vector seems to throw an error in protobuf and
     // we won't know if there are fewer alignments than the max until the cycle is over
     if (alt_alignments) {
@@ -1810,50 +1817,12 @@ BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g
     }
     
     // map node ids to indices
-    for (int64_t i = 0; i < g.node_size(); i++) {
-        node_id_to_idx[g.node(i).id()] = i;
-    }
-    
-#ifdef debug_banded_aligner_objects
-    cerr << "[BandedGlobalAligner]: constructing edge lists by node" << endl;
-#endif
-    
-    // convert the graph into adjacency list representation
-    vector<vector<int64_t>> node_edges_in;
-    vector<vector<int64_t>> node_edges_out;
-    graph_edge_lists(g, true, node_edges_out);
-    graph_edge_lists(g, false, node_edges_in);
-    
-#ifdef debug_banded_aligner_objects
-    cerr << "[BandedGlobalAligner]: performing topological sort" << endl;
-#endif
-    
-    // compute topological ordering
-    topological_sort(g, node_edges_out, topological_order);
-    
-#ifdef debug_banded_aligner_objects
-    cerr << "[BandedGlobalAligner]: identifying source and sink nodes" << endl;
-#endif
-    
-    // identify source and sink nodes in the graph
-    for (int64_t i = 0; i < g.node_size(); i++) {
-        if (node_edges_in[i].empty()) {
-            source_nodes.insert(g.mutable_node(i));
-        }
-        if (node_edges_out[i].empty()) {
-            sink_nodes.insert(g.mutable_node(i));
-        }
-    }
-    
-    if (source_nodes.empty() || sink_nodes.empty()) {
-        cerr << "error:[BandedGlobalAligner] alignment graph must be a DAG" << endl;
+    for (int64_t i = 0; i < topological_order.size(); i++) {
+        node_id_to_idx[graph.get_id(topological_order[i])] = i;
     }
     
 #ifdef debug_banded_aligner_objects
     cerr << "[BandedGlobalAligner]: " << source_nodes.size() << " sources and " << sink_nodes.size() << " sinks" << endl;
-#endif
-    
-#ifdef debug_banded_aligner_objects
     cerr << "[BandedGlobalAligner]: computing node bands" << endl;
 #endif
     
@@ -1861,7 +1830,7 @@ BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g
     // global alignment within the band
     vector<bool> node_masked;
     vector<pair<int64_t, int64_t>> band_ends;
-    find_banded_paths(alignment.sequence(), permissive_banding, node_edges_in, node_edges_out, band_padding, node_masked, band_ends);
+    find_banded_paths(permissive_banding, band_padding, node_masked, band_ends);
     
 #ifdef debug_banded_aligner_objects
     cerr << "[BandedGlobalAligner]: identifying shortest paths" << endl;
@@ -1870,69 +1839,52 @@ BandedGlobalAligner<IntType>::BandedGlobalAligner(Alignment& alignment, Graph& g
     // find the shortest sequence leading to each node so we can infer the length
     // of lead deletions
     vector<int64_t> shortest_seqs;
-    shortest_seq_paths(node_edges_out, source_nodes, shortest_seqs);
+    shortest_seq_paths(shortest_seqs);
     
 #ifdef debug_banded_aligner_objects
     cerr << "[BandedGlobalAligner]: constructing banded matrix objects" << endl;
 #endif
     
     // initialize DP matrices for each node
-    banded_matrices.resize(g.node_size());
-    for (int64_t i = 0; i < g.node_size(); i++) {
+    banded_matrices.resize(graph.node_size(), nullptr);
+    for (int64_t i = 0; i < topological_order.size(); i++) {
         
 #ifdef debug_banded_aligner_objects
-        cerr << "[BandedGlobalAligner]: creating matrix object for node " << topological_order[i]->id() << " at index " << i << endl;
+        cerr << "[BandedGlobalAligner]: creating matrix object for node " << graph.get_id(topological_order[i]) << " at index " << i << endl;
 #endif
-        Node* node = topological_order[i];
-        int64_t node_idx = node_id_to_idx[node->id()];
         
-        if (node_masked[node_idx]) {
-#ifdef debug_banded_aligner_objects
-            cerr << "[BandedGlobalAligner]: node is masked, creating dummy matrix object" << endl;
-#endif
+        if (!node_masked[i])  {
             
-            banded_matrices[node_idx] = nullptr;
-        }
-        else {
-            int64_t node_seq_len = node->sequence().length();
+            const handle_t& node = topological_order[i];
+            
+            int64_t node_seq_len = graph.get_length(node);
             
 #ifdef debug_banded_aligner_objects
-            cerr << "[BandedGlobalAligner]: establishing seed list for node " << node->id() << " at index " << i << endl;
+            cerr << "[BandedGlobalAligner]: establishing seed list for node " << graph.get_id(node) << " at index " << i << endl;
 #endif
             
             // POA predecessor matrices
-            BAMatrix** seeds;
-            vector<int64_t>& edges_in = node_edges_in[node_idx];
-            if (edges_in.empty()) {
-                
-#ifdef debug_banded_aligner_objects
-                cerr << "[BandedGlobalAligner]: no seeds, setting array to null" << endl;
-#endif
-                
-                seeds = nullptr;
-            }
-            else {
-                seeds = (BAMatrix**) malloc(sizeof(BAMatrix**) * edges_in.size());
-                for (int64_t j = 0; j < edges_in.size(); j++) {
-                    seeds[j] = banded_matrices[edges_in[j]];
-                }
-            }
+            vector<BAMatrix*> seeds;
+            graph.follow_edges(node, true, [&](const handle_t& prev) {
+                seeds.push_back(banded_matrices[node_id_to_idx[graph.get_id(prev)]]);
+            });
             
             banded_matrices[node_idx] = new BAMatrix(alignment,
                                                      node,
                                                      band_ends[node_idx].first,
                                                      band_ends[node_idx].second,
-                                                     seeds,
-                                                     edges_in.size(),
+                                                     std::move(seeds),
                                                      shortest_seqs[node_idx]);
             
         }
     }
     
+    // check to see if we chose a banding that is too restrictive for making an
+    // an alignment
     if (!permissive_banding) {
         bool sinks_masked = true;
-        for (Node* node : sink_nodes) {
-            if (banded_matrices[node_id_to_idx[node->id()]] != nullptr) {
+        for (const handle_t& node : sink_nodes) {
+            if (banded_matrices[node_id_to_idx[graph.get_id(node)]] != nullptr) {
                 sinks_masked = false;
                 break;
             }
@@ -1956,220 +1908,131 @@ BandedGlobalAligner<IntType>::~BandedGlobalAligner() {
     }
 }
 
-// fills a vector with vectors ids that have edges to/from each node
 template <class IntType>
-void BandedGlobalAligner<IntType>::graph_edge_lists(Graph& g, bool outgoing_edges, vector<vector<int64_t>>& out_edge_list) {
-    out_edge_list = vector<vector<int64_t>>(g.node_size());
-    for (int64_t i = 0; i < g.edge_size(); i++) {
-        // Find the connected nodes
-        const Edge& edge = g.edge(i);
-        id_t from = edge.from();
-        id_t to = edge.to();
-        // We know the edge can't be reversing (since we align to DAGs), but it might be doubly reversing.
-        if (edge.from_start() && edge.to_end()) {
-            std::swap(from, to);
-        }
-        
-        if (outgoing_edges) {
-            // We want to store destinations by sources
-            out_edge_list[node_id_to_idx.at(from)].push_back(node_id_to_idx.at(to));
-        } else {
-            // We want to store sources by destinations
-            out_edge_list[node_id_to_idx.at(to)].push_back(node_id_to_idx.at(from));
-        }
-    }
-    
-}
-
-// standard DFS-based topological sort algorithm
-// NOTE: this is only valid if the Graph g has been dag-ified first and there are no from_start
-// or to_end edges.
-template <class IntType>
-void BandedGlobalAligner<IntType>::topological_sort(Graph& g, vector<vector<int64_t>>& node_edges_out,
-                                                    vector<Node*>& out_topological_order) {
-    if (g.node_size() == 0) {
-        cerr << "warning:[BandedGlobalAligner] attempted to perform topological sort on empty graph" << endl;
-        return;
-    }
-    
-    // initialize return value
-    out_topological_order = vector<Node*>(g.node_size());
-    size_t order_index = g.node_size() - 1;
-    
-    // initialize iteration structures
-    vector<bool> enqueued = vector<bool>(g.node_size());
-    vector<int> edge_index = vector<int>(g.node_size());
-    vector<int64_t> stack;
-    
-    // iterate through starting nodes
-    for (int64_t init_node_id = 0; init_node_id < g.node_size(); init_node_id++) {
-        if (enqueued[init_node_id]) {
-            continue;
-        }
-        // navigate through graph with DFS
-        stack.push_back(init_node_id);
-        enqueued[init_node_id] = true;
-        while (!stack.empty()) {
-            int64_t node_id = stack[stack.size() - 1];
-            if (edge_index[node_id] < node_edges_out[node_id].size()) {
-                int64_t target_id = node_edges_out[node_id][edge_index[node_id]];
-                if (enqueued[target_id]) {
-                    edge_index[node_id]++;
-                }
-                else {
-                    stack.push_back(target_id);
-                    enqueued[target_id] = true;
-                }
-            }
-            else {
-                // add to topological order in reverse finishing order
-                stack.pop_back();
-                out_topological_order[order_index] = g.mutable_node(node_id);
-                order_index--;
-            }
-        }
-    }
-}
-
-template <class IntType>
-void BandedGlobalAligner<IntType>::path_lengths_to_sinks(const string& read, vector<vector<int64_t>>& node_edges_in,
-                                                         vector<int64_t>& shortest_path_to_sink,
+void BandedGlobalAligner<IntType>::path_lengths_to_sinks(vector<int64_t>& shortest_path_to_sink,
                                                          vector<int64_t>& longest_path_to_sink) {
 #ifdef debug_banded_aligner_graph_processing
     cerr << "[BandedGlobalAligner::path_lengths_to_sinks]: finding longest and shortest paths to sink node" << endl;
 #endif
     
     // find the longest path from the right side of each matrix to the end of the graph
-    longest_path_to_sink = vector<int64_t>(topological_order.size());
-    shortest_path_to_sink = vector<int64_t>(topological_order.size());
     
-    // set initial values -- 0 default value is sufficient for longest path
-    for (int64_t& initial_path_length :  shortest_path_to_sink) {
-        initial_path_length = numeric_limits<int64_t>::max();
-    }
+    // set initial values
+    longest_path_to_sink.resize(topological_order.size(), 0);
+    shortest_path_to_sink.resize(topological_order.size(), numeric_limits<int64_t>::max());
+    
     // set base case (longest path already set to 0)
-    for (Node* node : sink_nodes) {
-        shortest_path_to_sink[node_id_to_idx.at(node->id())] = 0;
+    for (const handle_t& handle : sink_nodes) {
+        shortest_path_to_sink[node_id_to_idx.at(graph.get_id(handle))] = 0;
     }
     
     // iterate in reverse order
-    for (auto iter = topological_order.rbegin(); iter != topological_order.rend(); iter++) {
-        Node* node = *iter;
-        int64_t node_seq_len = node->sequence().length();
-        int64_t node_idx = node_id_to_idx.at(node->id());
+    for (int64_t i = topological_order.size() - 1; i >= 0; i--) {
+        
+        int64_t node_seq_len = graph.get_length(topological_order[i]);
         // compute longest path through this node to right side of incoming matrices
-        int64_t longest_path_length = longest_path_to_sink[node_idx] + node_seq_len;
-        int64_t shortest_path_length = shortest_path_to_sink[node_idx] + node_seq_len;
+        int64_t longest_path_length = longest_path_to_sink[i] + node_seq_len;
+        int64_t shortest_path_length = shortest_path_to_sink[i] + node_seq_len;
         
-#ifdef debug_banded_aligner_graph_processing
-        cerr << "[BandedGlobalAligner::path_lengths_to_sinks]: processing node " << node->id() << " at index " << node_idx << " with longest/shortest distance to sink " << longest_path_to_sink[node_idx] << "/" << shortest_path_to_sink[node_idx] << " and sequence " << node->sequence() << " for total path length of " << longest_path_length << "/" << shortest_path_length << endl;
-#endif
-        
-        for (int64_t node_in_idx : node_edges_in[node_idx] ) {
-            if (longest_path_to_sink[node_in_idx] < longest_path_length) {
-                
-#ifdef debug_banded_aligner_graph_processing
-                cerr << "[BandedGlobalAligner::path_lengths_to_sinks]: path through " << node->id() << " of length " << longest_path_length << " to node at index " << node_in_idx << " is longer than current longest path " << longest_path_to_sink[node_in_idx] << ", updating it now" << endl;
-#endif
-                
-                longest_path_to_sink[node_in_idx] = longest_path_length;
-            }
+        graph.follow_edges(topological_order[i], true, [&](const handle_t& prev) {
             
-            if (shortest_path_to_sink[node_in_idx] > shortest_path_length) {
+            int64_t prev_idx = node_id_to_idx.at(graph.get_id(prev));
+            
+            if (longest_path_to_sink[prev_idx] < longest_path_length) {
                 
 #ifdef debug_banded_aligner_graph_processing
-                cerr << "[BandedGlobalAligner::path_lengths_to_sinks]: path through " << node->id() << " of length " << shortest_path_length << " to node at index " << node_in_idx << " is shorter than current shortest path " << shortest_path_to_sink[node_in_idx] << ", updating it now" << endl;
+                cerr << "[BandedGlobalAligner::path_lengths_to_sinks]: path through " << graph.get_id(prev) << " of length " << longest_path_length << " to node at index " << prev_idx << " is longer than current longest path " << longest_path_to_sink[prev_idx] << ", updating it now" << endl;
 #endif
                 
-                shortest_path_to_sink[node_in_idx] = shortest_path_length;
+                longest_path_to_sink[prev_idx] = longest_path_length;
             }
-        }
+            if (shortest_path_to_sink[prev_idx] > shortest_path_length) {
+                
+#ifdef debug_banded_aligner_graph_processing
+                cerr << "[BandedGlobalAligner::path_lengths_to_sinks]: path through " << graph.get_id(prev) << " of length " << shortest_path_length << " to node at index " << prev_idx << " is shorter than current shortest path " << shortest_path_to_sink[prev_idx] << ", updating it now" << endl;
+#endif
+                
+                shortest_path_to_sink[prev_idx] = shortest_path_length;
+            }
+        });
     }
 }
 
 
 // fills vectors with whether nodes are masked by the band width, and the band ends of each node
 template <class IntType>
-void BandedGlobalAligner<IntType>::find_banded_paths(const string& read, bool permissive_banding,
-                                                     vector<vector<int64_t>>& node_edges_in,
-                                                     vector<vector<int64_t>>& node_edges_out,
-                                                     int64_t band_padding, vector<bool>& node_masked,
+void BandedGlobalAligner<IntType>::find_banded_paths(bool permissive_banding, int64_t band_padding,
+                                                     vector<bool>& node_masked,
                                                      vector<pair<int64_t, int64_t>>& band_ends) {
+    
+    // keeps track of which nodes cannot reach the bottom corner within the band
+    node_masked.resize(topological_order.size(), false);
+    
+    // the bottom and top indices of the band in the rightmost column of each node's matrix
+    band_ends.resize(topological_order.size(), make_pair(numeric_limits<int64_t>::max(),
+                                                         numeric_limits<int64_t>::min()));
     
     // find the longest and shortest path from each node to any sink
     vector<int64_t> shortest_path_to_sink;
     vector<int64_t> longest_path_to_sink;
-    path_lengths_to_sinks(read, node_edges_in, shortest_path_to_sink, longest_path_to_sink);
-    
-    // keeps track of which nodes cannot reach the bottom corner within the band
-    node_masked = vector<bool>(topological_order.size());
-    
-    // the bottom and top indices of the band in the rightmost column of each node's matrix
-    band_ends = vector<pair<int64_t, int64_t>>(topological_order.size());
-    
-    // set band ends to identities of max / min functions
-    for (int64_t i = 0; i < topological_order.size(); i++) {
-        band_ends[i].first = numeric_limits<int64_t>::max();
-        band_ends[i].second = numeric_limits<int64_t>::min();
-    }
-    
+    path_lengths_to_sinks(shortest_path_to_sink, longest_path_to_sink);
     
     if (permissive_banding) {
         // initialize with wide enough bands that every source can hit every connected sink
-        for (Node* init_node : source_nodes) {
-            int64_t init_node_idx = node_id_to_idx.at(init_node->id());
-            int64_t init_node_seq_len = init_node->sequence().length();
+        for (const handle_t& init_node : source_nodes) {
+            int64_t init_node_idx = node_id_to_idx.at(graph.get_id(init_node));
+            int64_t init_node_seq_len = graph.get_length(init_node);
             band_ends[init_node_idx].first = min(-band_padding,
-                                                 (int64_t) read.length() - (init_node_seq_len + longest_path_to_sink[init_node_idx]) - band_padding);
+                                                 int64_t(alignment.sequence().size())
+                                                 - (init_node_seq_len + longest_path_to_sink[init_node_idx]) - band_padding);
             band_ends[init_node_idx].second = max(band_padding,
-                                                  (int64_t) read.length() - (init_node_seq_len + shortest_path_to_sink[init_node_idx]) + band_padding);
+                                                  int64_t(alignment.sequence().size())
+                                                  - (init_node_seq_len + shortest_path_to_sink[init_node_idx]) + band_padding);
 #ifdef debug_banded_aligner_graph_processing
-            cerr << "[BandedGlobalAligner::find_banded_paths]: initializing band path end at node " << init_node->id() << " at index " << init_node_idx << " to top " << band_ends[init_node_idx].first << ", and bottom " << band_ends[init_node_idx].second << " from shortest and longest paths of length " << shortest_path_to_sink[init_node_idx] << " and " << longest_path_to_sink[init_node_idx] << " compared to read length " << read.length() << " with padding " << band_padding << endl;
+            cerr << "[BandedGlobalAligner::find_banded_paths]: initializing band path end at node " << graph.get_id(init_node) << " at index " << init_node_idx << " to top " << band_ends[init_node_idx].first << ", and bottom " << band_ends[init_node_idx].second << " from shortest and longest paths of length " << shortest_path_to_sink[init_node_idx] << " and " << longest_path_to_sink[init_node_idx] << " compared to read length " << alignment.sequence().size() << " with padding " << band_padding << endl;
 #endif
         }
         
     }
     else {
         // initialize with band ends beginning with source nodes
-        for (Node* init_node : source_nodes) {
-            int64_t init_node_idx = node_id_to_idx.at(init_node->id());
-            int64_t init_node_seq_len = init_node->sequence().length();
+        for (const handle_t& handle : source_nodes) {
+            int64_t init_node_idx = node_id_to_idx.at(graph.get_id(init_node));
+            int64_t init_node_seq_len = graph.get_length(init_node);
             band_ends[init_node_idx].first = -band_padding;
             band_ends[init_node_idx].second = band_padding;
 #ifdef debug_banded_aligner_graph_processing
-            cerr << "[BandedGlobalAligner::find_banded_paths]: initializing band path end at node " << init_node->id() << " at index " << init_node_idx << " to top " << band_ends[init_node_idx].first << ", and bottom " << band_ends[init_node_idx].second << endl;
+            cerr << "[BandedGlobalAligner::find_banded_paths]: initializing band path end at node " << graph.get_id(init_node) << " at index " << init_node_idx << " to top " << band_ends[init_node_idx].first << ", and bottom " << band_ends[init_node_idx].second << endl;
 #endif
         }
     }
     
     // iterate through the rest of the nodes in topological order
     for (int64_t i = 0; i < topological_order.size(); i++) {
-        Node* node = topological_order[i];
-        int64_t node_idx = node_id_to_idx.at(node->id());
-        int64_t node_seq_len = node->sequence().length();
-        vector<int64_t>& edges_out = node_edges_out[node_idx];
+        const handle_t& node = topological_order[i];
+        int64_t node_seq_len = graph.get_length(node);
         
-        int64_t extended_band_top = band_ends[node_idx].first + node_seq_len;
-        int64_t extended_band_bottom = band_ends[node_idx].second + node_seq_len;
+        int64_t extended_band_top = band_ends[i].first + node_seq_len;
+        int64_t extended_band_bottom = band_ends[i].second + node_seq_len;
         
 #ifdef debug_banded_aligner_graph_processing
-        cerr << "[BandedGlobalAligner::find_banded_paths]: following edges out of node " << node->id() << " at index " << node_idx << " with sequence " << node->sequence() << ", band of " << band_ends[node_idx].first << ", " << band_ends[node_idx].second << " extending to " << extended_band_top << ", " << extended_band_bottom << endl;
+        cerr << "[BandedGlobalAligner::find_banded_paths]: following edges out of node " << graph.get_id(node) << " at index " << i << " with sequence " << graph.get_sequence(node) << ", band of " << band_ends[i].first << ", " << band_ends[i].second << " extending to " << extended_band_top << ", " << extended_band_bottom << endl;
 #endif
         // can alignments from this node reach the bottom right corner within the band?
-        if (extended_band_top + shortest_path_to_sink[node_idx] > (int64_t) read.length()
-            || extended_band_bottom + longest_path_to_sink[node_idx] < (int64_t) read.length()) {
+        if (extended_band_top + shortest_path_to_sink[node_idx] > int64_t(alignment.sequence().size())
+            || extended_band_bottom + longest_path_to_sink[node_idx] < int64_t(alignment.sequence().size())) {
             
-            node_masked[node_idx] = true;
+            node_masked[i] = true;
             
 #ifdef debug_banded_aligner_graph_processing
-            cerr << "[BandedGlobalAligner::find_banded_paths]: cannot complete alignment to read of length " << read.length() << " along shortest path " << shortest_path_to_sink[node_idx] << " or longest path " << longest_path_to_sink[node_idx] << ", which reach range " << extended_band_top + shortest_path_to_sink[node_idx] << ", " << extended_band_bottom + longest_path_to_sink[node_idx] << endl;
+            cerr << "[BandedGlobalAligner::find_banded_paths]: cannot complete alignment to read of length " << alignment.sequence().size() << " along shortest path " << shortest_path_to_sink[i] << " or longest path " << longest_path_to_sink[i] << ", which reach range " << extended_band_top + shortest_path_to_sink[i] << ", " << extended_band_bottom + longest_path_to_sink[i] << endl;
 #endif
             continue;
         }
         
-        // check if each edge out requires expanding the bands
-        for (int64_t j = 0; j < edges_out.size(); j++) {
-            int64_t node_out_idx = edges_out[j];
+        graph.follow_edges(node, false, [&](const handle_t& next) {
+            
+            int64_t node_out_idx = node_id_to_idx.at(graph.get_id(next));
             
 #ifdef debug_banded_aligner_graph_processing
             cerr << "[BandedGlobalAligner::find_banded_paths]: extending band to node at index " << node_out_idx << endl;
@@ -2188,37 +2051,34 @@ void BandedGlobalAligner<IntType>::find_banded_paths(const string& read, bool pe
 #endif
                 band_ends[node_out_idx].second = extended_band_bottom;
             }
-        }
+        });
     }
 }
 
 
 // returns the shortest sequence from any source node to each node
 template <class IntType>
-void BandedGlobalAligner<IntType>::shortest_seq_paths(vector<vector<int64_t>>& node_edges_out,
-                                                      unordered_set<Node*>& source_nodes,
-                                                      vector<int64_t>& seq_lens_out) {
+void BandedGlobalAligner<IntType>::shortest_seq_paths(vector<int64_t>& seq_lens_out) {
     
     // initialize vector with min identity to store sequence lengths
-    seq_lens_out = vector<int64_t>(topological_order.size(), numeric_limits<int64_t>::max());
+    seq_lens_out.resize(topological_order.size(), numeric_limits<int64_t>::max());
     
     // base cases
-    for (Node* node : source_nodes) {
-        seq_lens_out[node_id_to_idx[node->id()]] = 0;
+    for (const handle_t& handle : source_nodes) {
+        seq_lens_out[node_id_to_idx[graph.get_id(handle)]] = 0;
     }
     
     // dynamic programming to calculate sequence lengths for rest of nodes
-    for (auto iter = topological_order.begin(); iter != topological_order.end(); iter++) {
-        Node* node = *iter;
-        int64_t node_idx = node_id_to_idx.at(node->id());
-        int64_t seq_len = node->sequence().length() + seq_lens_out[node_idx];
+    for (size_t i = 0; i < topological_order.size(); i++) {
+        int64_t seq_len = graph.get_length(topological_order[i]) + seq_lens_out[i];
 
-        for (int64_t target_idx : node_edges_out[node_idx]) {
+        graph.follow_edges(topological_order[i], false, [&](const handle_t& handle) {
+            int64_t target_idx = node_id_to_idx(graph.get_id(handle));
             // find the shortest sequence that can reach the top left corner of the matrix
             if (seq_len < seq_lens_out[target_idx]) {
                 seq_lens_out[target_idx] = seq_len;
             }
-        }
+        });
     }
 }
 
@@ -2234,28 +2094,25 @@ void BandedGlobalAligner<IntType>::align(int8_t* score_mat, int8_t* nt_table, in
     
     
     // fill each nodes matrix in topological order
-    for (int64_t i = 0; i < topological_order.size(); i++) {
-        Node* node = topological_order[i];
-        int64_t node_idx = node_id_to_idx.at(node->id());
-        BAMatrix* band_matrix = banded_matrices[node_idx];
-#ifdef debug_banded_aligner_fill_matrix
-        cerr << "[BandedGlobalAligner::align] checking node " << node->id() << " at index " << node_idx << " with sequence " << node->sequence() << " and topological position " << i << endl;
-#endif
+    for (int64_t i = 0; i < banded_matrices.size(); i++) {
+        BAMatrix* band_matrix = banded_matrices[i];
         
         // skip masked nodes
         if (band_matrix == nullptr) {
 #ifdef debug_banded_aligner_fill_matrix
-            cerr << "[BandedGlobalAligner::align] node is masked, skipping" << endl;
+            cerr << "[BandedGlobalAligner::align] node " << graph.get_id(topological_order[i]) << " is masked, skipping" << endl;
 #endif
             continue;
         }
+        
 #ifdef debug_banded_aligner_fill_matrix
+        cerr << "[BandedGlobalAligner::align] at node " << graph.get_id(band_matrix->node) << " at index " << i << " with sequence " << graph.get_id(band_matrix->node) << endl;
         cerr << "[BandedGlobalAligner::align] node is not masked, filling matrix" << endl;
 #endif
-        band_matrix->fill_matrix(score_mat, nt_table, gap_open, gap_extend, adjust_for_base_quality, min_inf);
+        band_matrix->fill_matrix(graph, score_mat, nt_table, gap_open, gap_extend, adjust_for_base_quality, min_inf);
     }
     
-    traceback(score_mat, nt_table, gap_open, gap_extend, min_inf);
+    traceback(graph, score_mat, nt_table, gap_open, gap_extend, min_inf);
 }
 
 template <class IntType>
@@ -2264,11 +2121,11 @@ void BandedGlobalAligner<IntType>::traceback(int8_t* score_mat, int8_t* nt_table
     // get the sink and source node matrices for alignment stack
     unordered_set<BAMatrix*> sink_node_matrices;
     unordered_set<BAMatrix*> source_node_matrices;
-    for (Node* node : sink_nodes) {
-        sink_node_matrices.insert(banded_matrices[node_id_to_idx[node->id()]]);
+    for (const handle_t& node : sink_nodes) {
+        sink_node_matrices.insert(banded_matrices[node_id_to_idx[graph.get_id(node)]]);
     }
-    for (Node* node : source_nodes) {
-        source_node_matrices.insert(banded_matrices[node_id_to_idx[node->id()]]);
+    for (const handle_t& node : source_nodes) {
+        source_node_matrices.insert(banded_matrices[node_id_to_idx[graph.get_id(node)]]);
     }
     
     int64_t read_length = alignment.sequence().length();
@@ -2371,12 +2228,12 @@ BandedGlobalAligner<IntType>::AltTracebackStack::AltTracebackStack(int64_t max_m
                 continue;
             }
             
-            if (band_matrix->node->sequence().length() == 0) {
-                path.push_front(band_matrix->node->id());
+            if (graph.get_length(band_matrix->node) == 0) {
+                path.push_front(graph.get_id(band_matrix->node));
                 band_stack.push_back(nullptr);
                 
 #ifdef debug_banded_aligner_traceback
-                cerr << "[BandedGlobalAligner::traceback] traversing initial empty path on " << band_matrix->node->id() << endl;
+                cerr << "[BandedGlobalAligner::traceback] traversing initial empty path on " << graph.get_id(band_matrix->node) << endl;
 #endif
                 
                 // we went all the way from a source to a sink using only nodes with
@@ -2397,11 +2254,11 @@ BandedGlobalAligner<IntType>::AltTracebackStack::AltTracebackStack(int64_t max_m
             else {
 
                 // get the coordinates of the bottom right corner
-                Node* node = band_matrix->node;
-                int64_t node_id = node->id();
+                const handle_t& node = band_matrix->node;
+                int64_t node_id = graph.get_id(node);
                 
                 int64_t read_length = band_matrix->alignment.sequence().length();
-                int64_t ncols = node->sequence().length();
+                int64_t ncols = graph.get_length(node);
                 
                 int64_t final_col = ncols - 1;
                 int64_t final_row = band_matrix->bottom_diag + ncols > read_length ? read_length - band_matrix->top_diag - ncols : band_matrix->bottom_diag - band_matrix->top_diag;
@@ -2410,7 +2267,7 @@ BandedGlobalAligner<IntType>::AltTracebackStack::AltTracebackStack(int64_t max_m
                 
                 if (band_matrix->alignment.sequence().empty()) {
                     // if the read sequence is empty then we can only insert relative to the graph
-                    size_t graph_length = band_matrix->cumulative_seq_len + band_matrix->node->sequence().size();
+                    size_t graph_length = band_matrix->cumulative_seq_len + graph.get_length(band_matrix->node);
                     IntType insert_score = graph_length ? (graph_length - 1) * (-gap_extend) - gap_open : 0;
                     insert_traceback(null_prefix, insert_score, node_id, final_row, final_col, node_id, InsertCol, path);
                 }

--- a/src/banded_global_aligner.hpp
+++ b/src/banded_global_aligner.hpp
@@ -53,7 +53,7 @@ namespace vg {
         ///  permissive_banding          expand band, not necessarily symmetrically, to allow all node paths
         ///  adjust_for_base_quality     perform base quality adjusted alignment (see QualAdjAligner)
         ///
-        BandedGlobalAligner(Alignment& alignment, Graph& g,
+        BandedGlobalAligner(Alignment& alignment, const HandleGraph& g,
                             int64_t band_padding, bool permissive_banding = false,
                             bool adjust_for_base_quality = false);
         
@@ -70,7 +70,7 @@ namespace vg {
         ///  band_padding                width to expand band by
         ///  permissive_banding          expand band, not necessarily symmetrically, to allow all node paths
         ///  adjust_for_base_quality     perform base quality adjusted alignment (see QualAdjAligner)
-        BandedGlobalAligner(Alignment& alignment, Graph& g,
+        BandedGlobalAligner(Alignment& alignment, const HandleGraph& g,
                             vector<Alignment>& alt_alignments, int64_t max_multi_alns,
                             int64_t band_padding, bool permissive_banding = false,
                             bool adjust_for_base_quality = false);
@@ -102,6 +102,7 @@ namespace vg {
         /// Matrices used in Smith-Waterman-Gotoh alignment algorithm
         enum matrix_t {Match, InsertCol, InsertRow};
         
+        const HandleGraph& graph;
         /// The primary alignment
         Alignment& alignment;
         /// Vector for alternate alignments, or null if not making any
@@ -117,11 +118,11 @@ namespace vg {
         /// Map from node IDs to the index used in internal vectors
         unordered_map<int64_t, int64_t> node_id_to_idx;
         /// A topological ordering of the nodes
-        vector<Node*> topological_order;
+        vector<handle_t> topological_order;
         /// Source nodes in the graph
-        unordered_set<Node*> source_nodes;
+        vector<handle_t> source_nodes;
         /// Sink nodes in the graph
-        unordered_set<Node*> sink_nodes;
+        vector<handle_t> sink_nodes;
         
         /// Internal constructor that the public constructors funnel into
         BandedGlobalAligner(Alignment& alignment, Graph& g,
@@ -132,17 +133,12 @@ namespace vg {
         /// Traceback through dynamic programming matrices to compute alignment
         void traceback(int8_t* score_mat, int8_t* nt_table, int8_t gap_open, int8_t gap_extend, IntType min_inf);
         
-        /// Constructor helper function: converts Graph object into adjacency list representation
-        void graph_edge_lists(Graph& g, bool outgoing_edges, vector<vector<int64_t>>& out_edge_list);
-        /// Constructor helper function: compute topoligical ordering
-        void topological_sort(Graph& g, vector<vector<int64_t>>& node_edges_out, vector<Node*>& out_topological_order);
         /// Constructor helper function: compute the longest and shortest path to a sink for each node
         void path_lengths_to_sinks(const string& read, vector<vector<int64_t>>& node_edges_in,
                                    vector<int64_t>& shortest_path_to_sink, vector<int64_t>& longest_path_to_sink);
         /// Constructor helper function: compute which diagonals the bands cover on each node's matrix
-        void find_banded_paths(const string& read, bool permissive_banding, vector<vector<int64_t>>& node_edges_in,
-                               vector<vector<int64_t>>& node_edges_out, int64_t band_padding,
-                               vector<bool>& node_masked, vector<pair<int64_t, int64_t>>& band_ends);
+        void find_banded_paths(int64_t band_padding, vector<bool>& node_masked,
+                               vector<pair<int64_t, int64_t>>& band_ends);
         /// Constructor helper function: compute the shortest path from a source to each node
         void shortest_seq_paths(vector<vector<int64_t>>& node_edges_out, unordered_set<Node*>& source_nodes,
                                 vector<int64_t>& seq_lens_out);
@@ -156,22 +152,23 @@ namespace vg {
     class BandedGlobalAligner<IntType>::BAMatrix {
         
     public:
-        BAMatrix(Alignment& alignment, Node* node, int64_t top_diag, int64_t bottom_diag,
-                 BAMatrix** seeds, int64_t num_seeds, int64_t cumulative_seq_len);
+        BAMatrix(Alignment& alignment, handle_t node, int64_t top_diag, int64_t bottom_diag,
+                 const vector<BAMatrix*>& seeds, int64_t cumulative_seq_len);
         ~BAMatrix();
         
         /// Use DP to fill the band with alignment scores
-        void fill_matrix(int8_t* score_mat, int8_t* nt_table, int8_t gap_open, int8_t gap_extend, bool qual_adjusted,
-                         IntType min_inf);
+        void fill_matrix(const HandleGraph& graph, int8_t* score_mat, int8_t* nt_table, int8_t gap_open,
+                         int8_t gap_extend, bool qual_adjusted, IntType min_inf);
         
         /// Traceback through the band after using DP to fill it
-        void traceback(BABuilder& builder, AltTracebackStack& traceback_stack, matrix_t start_mat, int8_t* score_mat,
-                       int8_t* nt_table, int8_t gap_open, int8_t gap_extend, bool qual_adjusted, IntType min_inf);
+        void traceback(const HandleGraph& graph, BABuilder& builder, AltTracebackStack& traceback_stack,
+                       matrix_t start_mat, int8_t* score_mat, int8_t* nt_table, int8_t gap_open,
+                       int8_t gap_extend, bool qual_adjusted, IntType min_inf);
         
         /// Debugging function
-        void print_full_matrices();
+        void print_full_matrices(const HandleGraph& graph);
         /// Debugging function
-        void print_rectangularized_bands();
+        void print_rectangularized_bands(const HandleGraph& graph);
         
     private:
 
@@ -179,7 +176,7 @@ namespace vg {
         int64_t top_diag;
         int64_t bottom_diag;
         
-        Node* node;
+        handle_t node;
         
         Alignment& alignment;
         
@@ -187,8 +184,7 @@ namespace vg {
         int64_t cumulative_seq_len;
         
         /// Matrices for nodes with edges into this node
-        BAMatrix** seeds;
-        int64_t num_seeds;
+        vector<BAMatrix*> seeds;
         
         /// DP matrix
         IntType* match;
@@ -197,15 +193,15 @@ namespace vg {
         /// DP matrix
         IntType* insert_row;
         
-        void traceback_internal(BABuilder& builder, AltTracebackStack& traceback_stack, int64_t start_row,
-                                int64_t start_col, matrix_t start_mat, bool in_lead_gap, int8_t* score_mat,
-                                int8_t* nt_table, int8_t gap_open, int8_t gap_extend, bool qual_adjusted,
-                                IntType min_inf);
+        void traceback_internal(const HandleGraph& graph, BABuilder& builder, AltTracebackStack& traceback_stack,
+                                int64_t start_row, int64_t start_col, matrix_t start_mat, bool in_lead_gap,
+                                int8_t* score_mat, int8_t* nt_table, int8_t gap_open, int8_t gap_extend,
+                                bool qual_adjusted, IntType min_inf);
         
         /// Debugging function
-        void print_matrix(matrix_t which_mat);
+        void print_matrix(const HandleGraph& graph, matrix_t which_mat);
         /// Debugging function
-        void print_band(matrix_t which_mat);
+        void print_band(const HandleGraph& graph, matrix_t which_mat);
         
         friend class BABuilder;
         friend class AltTracebackStack; // not a fan of this one, but constructor ugly without it
@@ -321,8 +317,8 @@ namespace vg {
         ~BABuilder();
         
         /// Add next step in traceback
-        void update_state(matrix_t matrix, Node* node, int64_t read_idx, int64_t node_idx,
-                          bool empty_node_seq = false);
+        void update_state(const HandleGraph& graph, matrix_t matrix, const handle_t& node, int64_t read_idx,
+                          int64_t node_idx, bool empty_node_seq = false);
         /// Call after concluding traceback to finish adding edits to alignment
         void finalize_alignment(const list<int64_t>& empty_prefix);
         
@@ -334,12 +330,13 @@ namespace vg {
         
         matrix_t matrix_state;
         bool matching = false;
-        Node* current_node = nullptr;
+        id_t current_node_id = 0;
+        string current_node_sequence = "";
         int64_t edit_length = 0;
         int64_t edit_read_end_idx = 0;
         
         void finish_current_edit();
-        void finish_current_node();
+        void finish_current_node(const HandleGraph& graph);
     };
 
 }

--- a/src/gssw_aligner.hpp
+++ b/src/gssw_aligner.hpp
@@ -52,8 +52,9 @@ namespace vg {
         gssw_graph* create_gssw_graph(const HandleGraph& g, const vector<handle_t>& topological_order);
         
         // convert graph mapping back into unreversed node positions
-        // convert graph mapping back into unreversed node positions
         void unreverse_graph_mapping(gssw_graph_mapping* gm);
+        // convert from graph sequences back into unrereversed form
+        void unreverse_graph(gssw_graph* graph);
         
         // alignment functions
         void gssw_mapping_to_alignment(gssw_graph* graph,

--- a/src/gssw_aligner.hpp
+++ b/src/gssw_aligner.hpp
@@ -52,10 +52,11 @@ namespace vg {
                         set<gssw_node*>& unmarked_nodes,
                         set<gssw_node*>& temporary_marks);
         
-        // create a reversed graph for left-pinned alignment
+        // create a reversed (not complemented) graph for left-pinned alignment
         void reverse_graph(Graph& g, Graph& reversed_graph_out);
         // reverse all node sequences (other aspects of graph object not unreversed)
         void unreverse_graph(Graph& graph);
+        // convert graph mapping back into unreversed node positions
         // convert graph mapping back into unreversed node positions
         void unreverse_graph_mapping(gssw_graph_mapping* gm);
         

--- a/src/gssw_aligner.hpp
+++ b/src/gssw_aligner.hpp
@@ -47,10 +47,6 @@ namespace vg {
         // for construction
         // needed when constructing an alignable graph from the nodes
         gssw_graph* create_gssw_graph(Graph& g);
-        void visit_node(gssw_node* node,
-                        list<gssw_node*>& sorted_nodes,
-                        set<gssw_node*>& unmarked_nodes,
-                        set<gssw_node*>& temporary_marks);
         
         // create a reversed (not complemented) graph for left-pinned alignment
         void reverse_graph(Graph& g, Graph& reversed_graph_out);

--- a/src/hash_graph.cpp
+++ b/src/hash_graph.cpp
@@ -106,6 +106,12 @@ namespace vg {
         return max_id;
     }
     
+    size_t HashGraph::get_degree(const handle_t& handle, bool go_left) const {
+        auto& edge_list = get_is_reverse(handle) != go_left ? graph.at(get_id(handle)).left_edges
+                                                            : graph.at(get_id(handle)).right_edges;
+        return edge_list.size();
+    }
+    
     void HashGraph::for_each_handle(const std::function<bool(const handle_t&)>& iteratee,
                                     bool parallel) const {
         

--- a/src/hash_graph.hpp
+++ b/src/hash_graph.hpp
@@ -67,6 +67,9 @@ public:
     /// Return the largest ID in the graph, or some larger number if the
     /// largest ID is unavailable. Return value is unspecified if the graph is empty.
     virtual id_t max_node_id(void) const;
+    
+    /// Efficiently get the number of edges attached to one side of a handle.
+    virtual size_t get_degree(const handle_t& handle, bool go_left) const;
 
     /// Create a new node with the given sequence and return the handle.
     virtual handle_t create_handle(const std::string& sequence);

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1923,22 +1923,51 @@ Alignment Mapper::align_to_graph(const Alignment& aln,
                                              // xdrop_alignment*/);
         }
     } else {
-        // we've got an id-sortable graph and we can directly align with gssw
+        // we've got an id-sortable graph so we can avoid recomputing the topological order
+        // later because we know that we called sort_by_id_dedup_and_clean, which put it in
+        // topological order by ID
+        
         aligned = aln;
         if (banded_global) {
+            // the banded global alignment no longer constructs an internal representation of the graph
+            // for topological sorting, etc., instead counting on the HandleGraph to do that itself. accordingly
+            // we need a more serious/performant implementation of a graph here
+            VG align_graph(graph);
+            
             size_t max_span = aln.sequence().size();
             size_t band_padding_override = 0;
             bool permissive_banding = (band_padding_override == 0);
             size_t band_padding = permissive_banding ? max(max_span, (size_t) 1) : band_padding_override;
-            get_aligner(!aln.quality().empty())->align_global_banded(aligned, graph, band_padding, false);
+            get_aligner(!aln.quality().empty())->align_global_banded(aligned, align_graph, band_padding, false);
         } else if (pinned_alignment) {
-            get_aligner(!aln.quality().empty())->align_pinned(aligned, graph, pin_left);
+            // pinned alignment is based on gssw, which takes a HandleGraph, but only uses it for sorting and
+            // for constructing its own graph representation. we can improve efficiency by taking advantage of
+            // the internal sort order and a thin shim into the HandleGraph interface
+            ProtoHandleGraph proto_handle_graph(&graph);
+            // construct a topological order manually using the internal sort order
+            vector<handle_t> topological_order(graph.node_size());
+            for (size_t i = 0; i < graph.node_size(); i++) {
+                topological_order[i] = proto_handle_graph.get_handle_by_index(i);
+            }
+            get_aligner(!aln.quality().empty())->align_pinned(aligned, proto_handle_graph, pin_left);
         } else if (xdrop_alignment) {
+            // we'll still use the Protobuf graph for the X-drop aligner, which hasn't been transitioned
+            // to HandleGraphs yet
+            
             // directly call alignment function without node translation
             // cerr << "X-drop alignment, (" << xdrop_alignment << "), rev(" << ((xdrop_alignment == 1) ? false : true) << ")" << endl;
             get_aligner(!aln.quality().empty())->align_xdrop(aligned, graph, mems, (xdrop_alignment == 1) ? false : true, alignment_threads > 1);
         } else {
-            get_aligner(!aln.quality().empty())->align(aligned, graph, traceback, false);
+            // local alignment is based on gssw, which takes a HandleGraph, but only uses it for sorting and
+            // for constructing its own graph representation. we can improve efficiency by taking advantage of
+            // the internal sort order and a thin shim into the HandleGraph interface
+            ProtoHandleGraph proto_handle_graph(&graph);
+            // construct a topological order manually using the internal sort order
+            vector<handle_t> topological_order(graph.node_size());
+            for (size_t i = 0; i < graph.node_size(); i++) {
+                topological_order[i] = proto_handle_graph.get_handle_by_index(i);
+            }
+            get_aligner(!aln.quality().empty())->align(aligned, proto_handle_graph, traceback, false);
         }
     }
     if (traceback && !keep_bonuses && aligned.score()) {

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1949,7 +1949,7 @@ Alignment Mapper::align_to_graph(const Alignment& aln,
             for (size_t i = 0; i < graph.node_size(); i++) {
                 topological_order[i] = proto_handle_graph.get_handle_by_index(i);
             }
-            get_aligner(!aln.quality().empty())->align_pinned(aligned, proto_handle_graph, pin_left);
+            get_aligner(!aln.quality().empty())->align_pinned(aligned, proto_handle_graph, topological_order, pin_left);
         } else if (xdrop_alignment) {
             // we'll still use the Protobuf graph for the X-drop aligner, which hasn't been transitioned
             // to HandleGraphs yet
@@ -1967,7 +1967,7 @@ Alignment Mapper::align_to_graph(const Alignment& aln,
             for (size_t i = 0; i < graph.node_size(); i++) {
                 topological_order[i] = proto_handle_graph.get_handle_by_index(i);
             }
-            get_aligner(!aln.quality().empty())->align(aligned, proto_handle_graph, traceback, false);
+            get_aligner(!aln.quality().empty())->align(aligned, proto_handle_graph, topological_order, traceback, false);
         }
     }
     if (traceback && !keep_bonuses && aligned.score()) {

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -23,10 +23,10 @@
 #include "mem.hpp"
 #include "cluster.hpp"
 #include "graph.hpp"
+#include "proto_handle_graph.hpp"
 #include "translator.hpp"
 // TODO: pull out ScoreProvider into its own file
 #include "haplotypes.hpp"
-#include "algorithms/topological_sort.hpp"
 
 // #define BENCH
 // #include "bench.h"

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3151,7 +3151,7 @@ namespace vg {
 #endif
                 
                 // extract the graph between the matches
-                VG connecting_graph;
+                HashGraph connecting_graph;
                 unordered_map<id_t, id_t> connect_trans = algorithms::extract_connecting_graph(&align_graph,      // DAG with split strands
                                                                                                &connecting_graph, // graph to extract into
                                                                                                max_dist,          // longest distance necessary
@@ -3194,7 +3194,7 @@ namespace vg {
                                                                                     dest_path_node.begin - src_path_node.end));
                     }
                 
-                    aligner->align_global_banded_multi(intervening_sequence, alt_alignments, connecting_graph.graph, num_alt_alns,
+                    aligner->align_global_banded_multi(intervening_sequence, alt_alignments, connecting_graph, num_alt_alns,
                                                        band_padding_function(intervening_sequence, connecting_graph), true);
                 }
                 
@@ -3423,23 +3423,18 @@ namespace vg {
                     // want past-the-last instead of last index here
                     get_offset(end_pos)++;
                     
-                    VG tail_graph_extractor;
+                    HashGraph tail_graph;
                     unordered_map<id_t, id_t> tail_trans = algorithms::extract_extending_graph(&align_graph,
-                                                                                               &tail_graph_extractor,
+                                                                                               &tail_graph,
                                                                                                target_length,
                                                                                                end_pos,
                                                                                                false,         // search forward
                                                                                                false);        // no need to preserve cycles (in a DAG)
                     
-                    size_t num_alt_alns = dynamic_alt_alns ? min(max_alt_alns, algorithms::count_walks(&tail_graph_extractor)) :
+                    size_t num_alt_alns = dynamic_alt_alns ? min(max_alt_alns, algorithms::count_walks(&tail_graph)) :
                                                              max_alt_alns;
                     
                     if (num_alt_alns > 0) {
-                    
-                        Graph& tail_graph = tail_graph_extractor.graph;
-                        
-                        // ensure invariants that gssw-based alignment expects
-                        groom_graph_for_gssw(tail_graph);
                         
                         // get the sequence remaining in the right tail
                         Alignment right_tail_sequence;
@@ -3536,22 +3531,18 @@ namespace vg {
                     pos_t begin_pos = initial_position(path_node.path);
                     
                     
-                    VG tail_graph_extractor;
+                    HashGraph tail_graph;
                     unordered_map<id_t, id_t> tail_trans = algorithms::extract_extending_graph(&align_graph,
-                                                                                               &tail_graph_extractor,
+                                                                                               &tail_graph,
                                                                                                target_length,
                                                                                                begin_pos,
                                                                                                true,          // search backward
                                                                                                false);        // no need to preserve cycles (in a DAG)
                     
-                    size_t num_alt_alns = dynamic_alt_alns ? min(max_alt_alns, algorithms::count_walks(&tail_graph_extractor)) : 
+                    size_t num_alt_alns = dynamic_alt_alns ? min(max_alt_alns, algorithms::count_walks(&tail_graph)) :
                                                              max_alt_alns;
                             
                     if (num_alt_alns > 0) {
-                    
-                        Graph& tail_graph = tail_graph_extractor.graph;
-                        // ensure invariants that gssw-based alignment expects
-                        groom_graph_for_gssw(tail_graph);
                         
                         Alignment left_tail_sequence;
                         left_tail_sequence.set_sequence(alignment.sequence().substr(0, path_node.begin - alignment.sequence().begin()));

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3186,7 +3186,7 @@ namespace vg {
                                                                                   dest_path_node.begin - src_path_node.end));
                     
 #ifdef debug_multipath_alignment
-                    cerr << "making " << num_alt_alns << " alignments of sequence " << intervening_sequence.sequence() << " to connecting graph: " << pb2json(connecting_graph.graph) << endl;
+                    cerr << "making " << num_alt_alns << " alignments of sequence " << intervening_sequence.sequence() << " to connecting graph" << endl;
 #endif
                     
                     if (!alignment.quality().empty()) {
@@ -3431,6 +3431,9 @@ namespace vg {
                                                                                                false,         // search forward
                                                                                                false);        // no need to preserve cycles (in a DAG)
                     
+                    // remove the empty anchoring nodes that this algorithm sometimes creates
+                    groom_graph_for_gssw(tail_graph);
+                    
                     size_t num_alt_alns = dynamic_alt_alns ? min(max_alt_alns, algorithms::count_walks(&tail_graph)) :
                                                              max_alt_alns;
                     
@@ -3446,7 +3449,7 @@ namespace vg {
                         }
                         
 #ifdef debug_multipath_alignment
-                        cerr << "making " << num_alt_alns << " alignments of sequence: " << right_tail_sequence.sequence() << endl << "to right tail graph: " << pb2json(tail_graph) << endl;
+                        cerr << "making " << num_alt_alns << " alignments of sequence: " << right_tail_sequence.sequence() << endl << "to right tail graph" << endl;
 #endif
                         
                         auto& alt_alignments = right_alignments[j];
@@ -3539,6 +3542,9 @@ namespace vg {
                                                                                                true,          // search backward
                                                                                                false);        // no need to preserve cycles (in a DAG)
                     
+                    // remove the empty anchoring nodes that this algorithm sometimes creates
+                    groom_graph_for_gssw(tail_graph);
+                    
                     size_t num_alt_alns = dynamic_alt_alns ? min(max_alt_alns, algorithms::count_walks(&tail_graph)) :
                                                              max_alt_alns;
                             
@@ -3552,7 +3558,7 @@ namespace vg {
                         
                         
 #ifdef debug_multipath_alignment
-                        cerr << "making " << num_alt_alns << " alignments of sequence: " << left_tail_sequence.sequence() << endl << "to left tail graph: " << pb2json(tail_graph) << endl;
+                        cerr << "making " << num_alt_alns << " alignments of sequence: " << left_tail_sequence.sequence() << endl << "to left tail graph" << endl;
 #endif
                         
                         auto& alt_alignments = left_alignments[j];
@@ -3610,106 +3616,18 @@ namespace vg {
         return to_return;
     }
     
-    void MultipathAlignmentGraph::groom_graph_for_gssw(Graph& graph) {
+    void MultipathAlignmentGraph::groom_graph_for_gssw(DeletableHandleGraph& graph) {
         
-        // remove empty nodes
-        size_t end = graph.node_size();
-        size_t idx = 0;
-        unordered_set<id_t> removed_nodes;
-        while (idx < end) {
-            if (graph.node(idx).sequence().empty()) {
-                end--;
-                removed_nodes.insert(graph.node(idx).id());
-                std::swap(*graph.mutable_node(idx), *graph.mutable_node(end));
+        // collect all of the empty node IDs without doing any edits
+        vector<id_t> empty_nodes;
+        graph.for_each_handle([&](const handle_t& handle) {
+            if (graph.get_length(handle) == 0) {
+                empty_nodes.push_back(graph.get_id(handle));
             }
-            else {
-                idx++;
-            }
-        }
-        if (end != graph.node_size()) {
-            graph.mutable_node()->DeleteSubrange(end, graph.node_size() - end);
-            
-            // look for any edges connecting them and remove these too
-            end = graph.edge_size();
-            idx = 0;
-            while (idx < end) {
-                Edge* edge = graph.mutable_edge(idx);
-                if (removed_nodes.count(edge->from()) || removed_nodes.count(edge->to())) {
-                    end--;
-                    std::swap(*edge, *graph.mutable_edge(end));
-                }
-                else {
-                    idx++;
-                }
-            }
-            graph.mutable_edge()->DeleteSubrange(end, graph.edge_size() - end);
-        }
-        
-        // flip doubly reversing edges
-        for (size_t i = 0; i < graph.edge_size(); i++) {
-            Edge* edge = graph.mutable_edge(i);
-            if (edge->from_start() && edge->to_end()) {
-                id_t tmp = edge->from();
-                edge->set_from(edge->to());
-                edge->set_to(tmp);
-                edge->set_from_start(false);
-                edge->set_to_end(false);
-            }
-        }
-        
-        // associate node ids with their index
-        unordered_map<id_t, size_t> node_idx;
-        for (size_t i = 0; i < graph.node_size(); i++) {
-            node_idx[graph.node(i).id()] = i;
-        }
-        
-        // construct adjacency list and compute in degrees
-        vector<size_t> in_degree(graph.node_size(), 0);
-        vector<vector<size_t>> adj_list(graph.node_size());
-        for (size_t i = 0; i < graph.edge_size(); i++) {
-            const Edge& edge = graph.edge(i);
-            size_t to_idx = node_idx[edge.to()];
-            adj_list[node_idx[edge.from()]].push_back(to_idx);
-            in_degree[to_idx]++;
-        }
-        
-        // get the topological ordering of the graph (Kahn's algorithm)
-        vector<size_t> source_stack;
-        for (size_t i = 0; i < graph.node_size(); i++) {
-            if (in_degree[i] == 0) {
-                source_stack.push_back(i);
-            }
-        }
-        
-        vector<id_t> order(graph.node_size());
-        size_t next = 0;
-        while (!source_stack.empty()) {
-            size_t src = source_stack.back();
-            source_stack.pop_back();
-            
-            for (size_t dest : adj_list[src]) {
-                in_degree[dest]--;
-                if (in_degree[dest] == 0) {
-                    source_stack.push_back(dest);
-                }
-            }
-            
-            order[next] = src;
-            next++;
-        }
-        
-        // identify the index that we want each node to end up at
-        vector<size_t> index(order.size());
-        for (size_t i = 0; i < order.size(); i++) {
-            index[order[i]] = i;
-        }
-        
-        // in place permutation according to the topological order
-        for (size_t i = 0; i < graph.node_size(); i++) {
-            while (index[i] != i) {
-                std::swap(*graph.mutable_node(i), *graph.mutable_node(index[i]));
-                std::swap(index[i], index[index[i]]);
-            }
+        });
+        // go through and delete them now that we're done iterating
+        for (const id_t& node_id : empty_nodes) {
+            graph.destroy_handle(graph.get_handle(node_id));
         }
     }
     

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -215,10 +215,9 @@ namespace vg {
         /// ordering of their target nodes
         void reorder_adjacency_lists(const vector<size_t>& order);
         
-        /// Reorders the nodes of a Protobuf graph in topological order, flips doubly reversing edges,
-        /// and removes empty sequence nodes (invariants required for gssw alignment)
-        /// TODO: this is duplicative with VG::lazy_sort, but I don't want to construct a VG here
-        void groom_graph_for_gssw(Graph& graph);
+        /// Removes the empty anchoring nodes that are sometimes created by the graph extraction
+        /// algorithms, which is how gssw likes it
+        void groom_graph_for_gssw(DeletableHandleGraph& graph);
         
         /// Generate alignments of the tails of the query sequence, beyond the
         /// sources and sinks. The Alignment passed *must* be the one that owns

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -451,12 +451,12 @@ namespace vg {
         size_t target_length = other_aln.sequence().size() + get_aligner()->longest_detectable_gap(other_aln);
         
         // convert from bidirected to directed
-        VG align_graph;
+        HashGraph align_graph;
         unordered_map<id_t, pair<id_t, bool> > node_trans = algorithms::split_strands(&rescue_graph, &align_graph);
         // if necessary, convert from cyclic to acylic
         if (!algorithms::is_directed_acyclic(&rescue_graph)) {
             // make a dagified graph and translation
-            VG dagified;
+            HashGraph dagified;
             unordered_map<id_t,id_t> dagify_trans = algorithms::dagify(&align_graph, &dagified, target_length);
             
             // replace the original with the dagified ones
@@ -464,15 +464,12 @@ namespace vg {
             node_trans = overlay_node_translations(dagify_trans, node_trans);
         }
         
-        // gssw is going to want a topologically ordered Protobuf graph from us
-        algorithms::lazier_topological_sort(&align_graph);
-        
         // put local alignment here
         Alignment aln = other_aln;
         // in case we're realigning a GAM, get rid of the path
         aln.clear_path();
         
-        get_aligner()->align(aln, align_graph.graph, true, false);
+        get_aligner()->align(aln, align_graph, true, false);
         
         // get the IDs back into the space of the reference graph
         translate_oriented_node_ids(*aln.mutable_path(), node_trans);
@@ -3030,7 +3027,7 @@ namespace vg {
 #endif
     }
             
-    void MultipathMapper::make_nontrivial_multipath_alignment(const Alignment& alignment, VG& subgraph,
+    void MultipathMapper::make_nontrivial_multipath_alignment(const Alignment& alignment, const HandleGraph& subgraph,
                                                               unordered_map<id_t, pair<id_t, bool>>& translator,
                                                               SnarlManager& snarl_manager, MultipathAlignment& multipath_aln_out) const {
         

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -438,7 +438,7 @@ namespace vg {
         vector<size_t> backward_dist(jump_positions.size(), 6 * fragment_length_distr.stdev());
         vector<size_t> forward_dist(jump_positions.size(), 6 * fragment_length_distr.stdev() + other_aln.sequence().size());
         algorithms::extract_containing_graph(xindex, &rescue_graph, jump_positions, backward_dist, forward_dist,
-                                             reversing_walk_length);
+                                             num_alt_alns > 1 ? reversing_walk_length : 0);
         
 #ifdef debug_multipath_mapper
         cerr << "got rescue graph" << endl;
@@ -2594,8 +2594,8 @@ namespace vg {
             // extract the subgraph within the search distance
             
             HashGraph* cluster_graph = new HashGraph();
-            algorithms::extract_containing_graph(xindex, cluster_graph, positions, forward_max_dist,
-                                                 backward_max_dist, reversing_walk_length);
+            algorithms::extract_containing_graph(xindex, cluster_graph, positions, forward_max_dist, backward_max_dist,
+                                                 num_alt_alns > 1 ? reversing_walk_length : 0);
                                                  
             // check if this subgraph overlaps with any previous subgraph (indicates a probable clustering failure where
             // one cluster was split into multiple clusters)

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -295,7 +295,7 @@ namespace vg {
         /// Removes the sections of an Alignment's path within snarls and re-aligns them with multiple traceback
         /// to create a multipath alignment with non-trivial topology.
         /// Guarantees that the resulting MultipathAlignment is in topological order.
-        void make_nontrivial_multipath_alignment(const Alignment& alignment, VG& subgraph,
+        void make_nontrivial_multipath_alignment(const Alignment& alignment, const HandleGraph& subgraph,
                                                  unordered_map<id_t, pair<id_t, bool>>& translator,
                                                  SnarlManager& snarl_manager, MultipathAlignment& multipath_aln_out) const;
         

--- a/src/proto_handle_graph.cpp
+++ b/src/proto_handle_graph.cpp
@@ -1,0 +1,124 @@
+/**
+ * \file proto_handle_graph.hpp: implementation of the ProtoHandleGraph
+ */
+
+
+#include "proto_handle_graph.hpp"
+
+
+namespace vg {
+
+using namespace std;
+
+    ProtoHandleGraph::ProtoHandleGraph(const Graph* graph) : graph(graph) {
+        // nothing to do
+    }
+    
+    handle_t ProtoHandleGraph::get_handle_by_index(const size_t& i) const {
+        return EasyHandlePacking::pack(i, false);
+    }
+    
+    size_t ProtoHandleGraph::edge_size() const {
+        return graph->edge_size();
+    }
+    
+    edge_t ProtoHandleGraph::get_edge_by_index(const size_t& i) const {
+        const Edge& edge = graph->edge(i);
+        return edge_handle(get_handle(edge.from(), edge.from_start()),
+                           get_handle(edge.to(), edge.to_end()));
+    }
+    
+    bool ProtoHandleGraph::has_node(id_t node_id) const {
+        bool found = false;
+        for (size_t i = 0; i < graph->node_size() && !found; i++) {
+            found = graph->node(i).id() == node_id;
+        }
+        return found;
+    }
+    
+    handle_t ProtoHandleGraph::get_handle(const id_t& node_id, bool is_reverse) const {
+        for (size_t i = 0; i < graph->node_size(); i++) {
+            if (graph->node(i).id() == node_id) {
+                return EasyHandlePacking::pack(i, is_reverse);
+            }
+        }
+        // tried to find a handle for a node that doesn't exist
+        cerr << "error::[ProtoHandleGraph] requested handle for a node that does not exist: " << node_id << endl;
+        return as_handle(-1);
+    }
+    
+    id_t ProtoHandleGraph::get_id(const handle_t& handle) const {
+        return graph->node(EasyHandlePacking::unpack_number(handle)).id();
+    }
+    
+    bool ProtoHandleGraph::get_is_reverse(const handle_t& handle) const {
+        return EasyHandlePacking::unpack_bit(handle);
+    }
+    
+    handle_t ProtoHandleGraph::flip(const handle_t& handle) const {
+        return EasyHandlePacking::toggle_bit(handle);
+    }
+    
+    size_t ProtoHandleGraph::get_length(const handle_t& handle) const {
+        return graph->node(EasyHandlePacking::unpack_number(handle)).sequence().size();
+    }
+    
+    string ProtoHandleGraph::get_sequence(const handle_t& handle) const {
+        return graph->node(EasyHandlePacking::unpack_number(handle)).sequence();
+    }
+    
+    bool ProtoHandleGraph::follow_edges(const handle_t& handle, bool go_left,
+                                      const function<bool(const handle_t&)>& iteratee) const {
+        bool keep_going = true;
+        bool leftward = (go_left != get_is_reverse(handle));
+        for (size_t i = 0; i < graph->edge_size() && keep_going; i++) {
+            const Edge& edge = graph->edge(i);
+            if (edge.from() == get_id(handle) && leftward == edge.from_start()) {
+                keep_going = iteratee(get_handle(edge.to(), go_left != edge.to_end()));
+            }
+            else if (edge.to() == get_id(handle) && leftward != edge.to_end()) {
+                keep_going = iteratee(get_handle(edge.from(), go_left == edge.from_start()));
+            }
+        }
+        return keep_going;
+    }
+    
+    void ProtoHandleGraph::for_each_handle(const function<bool(const handle_t&)>& iteratee, bool parallel) const {
+        if (parallel) {
+            size_t num_nodes = graph->node_size();
+#pragma omp parallel shared(num_nodes)
+            for (size_t i = 0; i < num_nodes; i++) {
+                // ignore stopping early in parallel mode
+                iteratee(EasyHandlePacking::pack(i, false));
+            }
+        }
+        else {
+            bool keep_going = true;
+            for (size_t i = 0; i < graph->node_size() && keep_going; i++) {
+                keep_going = iteratee(EasyHandlePacking::pack(i, false));
+            }
+        }
+    }
+    
+    size_t ProtoHandleGraph::node_size() const {
+        return graph->node_size();
+    }
+    
+    id_t ProtoHandleGraph::min_node_id() const {
+        id_t min_id = numeric_limits<id_t>::max();
+        for (size_t i = 0; i < graph->node_size(); i++) {
+            min_id = min(min_id, graph->node(i).id());
+        }
+        return min_id;
+    }
+    
+    id_t ProtoHandleGraph::max_node_id() const {
+        id_t max_id = numeric_limits<id_t>::min();
+        for (size_t i = 0; i < graph->node_size(); i++) {
+            max_id = max(max_id, graph->node(i).id());
+        }
+        return max_id;
+    }
+
+}
+

--- a/src/proto_handle_graph.hpp
+++ b/src/proto_handle_graph.hpp
@@ -1,0 +1,103 @@
+#ifndef VG_PROTO_GRAPH_HPP_INCLUDED
+#define VG_PROTO_GRAPH_HPP_INCLUDED
+
+/** \file
+ * proto_handle_graph.hpp: a handle graph wrapper for an unindexed Protobuf graph
+ */
+
+#include "handle.hpp"
+
+namespace vg {
+
+using namespace std;
+
+    /**
+     * THIS IS NOT AN EFFICIENT GRAPH IMPLMENTATION. It is a HandleGraph wrapper for an
+     * unindexed Protobuf graph, which is primarily intended to provide a shim that eases
+     * the transition away from using Protobuf. In particular, it does not maintain
+     * adjacency lists, so edge and node lookup are O(N). However, it does provide the
+     * ability to look up nodes and edges by ordinal index in addition to the standard
+     * HandleGraph interface.
+     */
+    class ProtoHandleGraph : public HandleGraph {
+    public:
+        
+        /// Initialize as a wrapper for a Protobuf graph
+        ProtoHandleGraph(const Graph* graph);
+        
+        /// Default constructor -- not actually functional
+        ProtoHandleGraph() = default;
+        
+        /// Default destructor
+        ~ProtoHandleGraph() = default;
+        
+        //////////////////////////////////////////
+        /// Non-HandleGraph methods from Protobuf
+        //////////////////////////////////////////
+
+        /// Get a handle to the i-th node
+        handle_t get_handle_by_index(const size_t& i) const;
+        
+        /// Returns the number of edges in the graph
+        size_t edge_size() const;
+        
+        /// Get a handle to the i-th edge
+        edge_t get_edge_by_index(const size_t& i) const;
+        
+        //////////////////////////
+        /// HandleGraph interface
+        //////////////////////////
+        
+        /// Method to check if a node exists by ID
+        virtual bool has_node(id_t node_id) const;
+        
+        /// Look up the handle for the node with the given ID in the given orientation
+        virtual handle_t get_handle(const id_t& node_id, bool is_reverse = false) const;
+        
+        /// Get the ID from a handle
+        virtual id_t get_id(const handle_t& handle) const;
+        
+        /// Get the orientation of a handle
+        virtual bool get_is_reverse(const handle_t& handle) const;
+        
+        /// Invert the orientation of a handle (potentially without getting its ID)
+        virtual handle_t flip(const handle_t& handle) const;
+        
+        /// Get the length of a node
+        virtual size_t get_length(const handle_t& handle) const;
+        
+        /// Get the sequence of a node, presented in the handle's local forward
+        /// orientation.
+        virtual string get_sequence(const handle_t& handle) const;
+        
+        /// Loop over all the handles to next/previous (right/left) nodes. Passes
+        /// them to a callback which returns false to stop iterating and true to
+        /// continue. Returns true if we finished and false if we stopped early.
+        virtual bool follow_edges(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const;
+        
+        /// Loop over all the nodes in the graph in their local forward
+        /// orientations, in their internal stored order. Stop if the iteratee
+        /// returns false. Can be told to run in parallel, in which case stopping
+        /// after a false return value is on a best-effort basis and iteration
+        /// order is not defined.
+        virtual void for_each_handle(const function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+        
+        /// Return the number of nodes in the graph
+        /// TODO: can't be node_count because XG has a field named node_count.
+        virtual size_t node_size() const;
+        
+        /// Return the smallest ID in the graph, or some smaller number if the
+        /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
+        virtual id_t min_node_id() const;
+        
+        /// Return the largest ID in the graph, or some larger number if the
+        /// largest ID is unavailable. Return value is unspecified if the graph is empty.
+        virtual id_t max_node_id() const;
+        
+    private:
+        /// The Protobuf graph we're wrapping
+        const Graph* graph = nullptr;
+    };
+}
+
+#endif

--- a/src/unittest/aligner.cpp
+++ b/src/unittest/aligner.cpp
@@ -37,8 +37,8 @@ TEST_CASE("Aligner respects the full length bonus at both ends", "[aligner][alig
     aln1.set_sequence(read);
     aln2.set_sequence(read);
     
-    aligner_1.align(aln1, graph.graph, true, false);
-    aligner_2.align(aln2, graph.graph, true, false);
+    aligner_1.align(aln1, graph, true, false);
+    aligner_2.align(aln2, graph, true, false);
     
     SECTION("bonus is collected at both ends") {
         REQUIRE(aln2.score() == aln1.score() + 20);
@@ -68,8 +68,8 @@ TEST_CASE("Aligner respects the full length bonus for a single base read", "[ali
     aln1.set_sequence(read);
     aln2.set_sequence(read);
     
-    aligner_1.align(aln1, graph.graph, true, false);
-    aligner_2.align(aln2, graph.graph, true, false);
+    aligner_1.align(aln1, graph, true, false);
+    aligner_2.align(aln2, graph, true, false);
     
     SECTION("bonus is collected twice even though both ends are one match") {
         REQUIRE(aln2.score() == aln1.score() + 20);
@@ -99,8 +99,8 @@ TEST_CASE("Aligner works when end bonus is granted to a match at the start of a 
     aln2.set_sequence(read);
     
     // Make sure aligner runs
-    aligner_1.align(aln1, graph.graph, true, false);
-    aligner_2.align(aln2, graph.graph, true, false);
+    aligner_1.align(aln1, graph, true, false);
+    aligner_2.align(aln2, graph, true, false);
     
     SECTION("bonus is collected twice") {
         REQUIRE(aln2.score() == aln1.score() + 20);
@@ -120,8 +120,8 @@ TEST_CASE("Full-length bonus can hold down the left end", "[aligner][alignment][
     aln1.set_sequence(read);
     aln2.set_sequence(read);
     
-    aligner_1.align(aln1, graph.graph, true, false);
-    aligner_2.align(aln2, graph.graph, true, false);
+    aligner_1.align(aln1, graph, true, false);
+    aligner_2.align(aln2, graph, true, false);
     
     SECTION("left end is detatched without bonus") {
         REQUIRE(aln1.path().mapping_size() == 1);
@@ -155,8 +155,8 @@ TEST_CASE("Full-length bonus can hold down the right end", "[aligner][alignment]
     aln1.set_sequence(read);
     aln2.set_sequence(read);
     
-    aligner_1.align(aln1, graph.graph, true, false);
-    aligner_2.align(aln2, graph.graph, true, false);
+    aligner_1.align(aln1, graph, true, false);
+    aligner_2.align(aln2, graph, true, false);
     
     SECTION("right end is detatched without bonus") {
         REQUIRE(aln1.path().mapping_size() == 1);
@@ -200,8 +200,8 @@ TEST_CASE("Full-length bonus can attach Ns", "[aligner][alignment][mapping]") {
     aln1.set_sequence(read);
     aln2.set_sequence(read);
     
-    aligner_1.align(aln1, graph.graph, true, false);
-    aligner_2.align(aln2, graph.graph, true, false);
+    aligner_1.align(aln1, graph, true, false);
+    aligner_2.align(aln2, graph, true, false);
     
     SECTION("bonused alignment ends in full-length match/mismatches") {
         REQUIRE(aln2.path().mapping_size() == 3);
@@ -239,8 +239,8 @@ TEST_CASE("Full-length bonus can attach to Ns", "[aligner][alignment][mapping]")
     aln1.set_sequence(read);
     aln2.set_sequence(read);
     
-    aligner_1.align(aln1, graph.graph, true, false);
-    aligner_2.align(aln2, graph.graph, true, false);
+    aligner_1.align(aln1, graph, true, false);
+    aligner_2.align(aln2, graph, true, false);
     
     SECTION("bonused alignment ends in full-length match/mismatches") {
         REQUIRE(aln2.path().mapping_size() == 3);
@@ -278,8 +278,8 @@ TEST_CASE("Full-length bonus can attach Ns to Ns", "[aligner][alignment][mapping
     aln1.set_sequence(read);
     aln2.set_sequence(read);
     
-    aligner_1.align(aln1, graph.graph, true, false);
-    aligner_2.align(aln2, graph.graph, true, false);
+    aligner_1.align(aln1, graph, true, false);
+    aligner_2.align(aln2, graph, true, false);
     
     SECTION("bonused alignment ends in full-length match/mismatches") {
         REQUIRE(aln2.path().mapping_size() == 3);

--- a/src/unittest/banded_global_aligner.cpp
+++ b/src/unittest/banded_global_aligner.cpp
@@ -2447,7 +2447,7 @@ namespace vg {
                 REQUIRE(aln.path().mapping(2).edit(0).sequence().empty());
                 
                 aln.Clear();
-                read = "TGA";
+                read = "AGA";
                 qual = "HHH";
                 
                 aln.set_sequence(read);
@@ -2462,7 +2462,7 @@ namespace vg {
                 
                 // follows correct path
                 REQUIRE(aln.path().mapping(0).position().node_id() == n0->id());
-                REQUIRE(aln.path().mapping(1).position().node_id() == n1->id());
+                REQUIRE(aln.path().mapping(1).position().node_id() == n2->id());
                 REQUIRE(aln.path().mapping(2).position().node_id() == n3->id());
                 
                 // has corrects edits

--- a/src/unittest/banded_global_aligner.cpp
+++ b/src/unittest/banded_global_aligner.cpp
@@ -42,7 +42,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -91,7 +91,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -140,7 +140,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = true;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                                 
                 const Path& path = aln.path();
                 
@@ -193,7 +193,7 @@ namespace vg {
                 
                 int band_width = 2;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -250,7 +250,7 @@ namespace vg {
                 
                 int band_width = 2;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);;
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);;
                 
                 const Path& path = aln.path();
                 
@@ -307,7 +307,7 @@ namespace vg {
                 
                 int band_width = 2;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -364,7 +364,7 @@ namespace vg {
                 
                 int band_width = 2;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -421,7 +421,7 @@ namespace vg {
                 
                 int band_width = 2;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -479,7 +479,7 @@ namespace vg {
                 
                 int band_width = 2;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -534,7 +534,7 @@ namespace vg {
                 
                 int band_width = 2;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -587,7 +587,7 @@ namespace vg {
                 
                 int band_width = 2;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);;
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);;
                 
                 const Path& path = aln.path();
                 
@@ -640,7 +640,7 @@ namespace vg {
                 
                 int band_width = 2;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);;
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);;
                 
                 const Path& path = aln.path();
                 
@@ -693,7 +693,7 @@ namespace vg {
                 
                 int band_width = 3;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -742,7 +742,7 @@ namespace vg {
                 
                 int band_padding = 1;
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding);
+                aligner.align_global_banded(aln, graph, band_padding);
                 
                 const Path& path = aln.path();
                 
@@ -783,7 +783,7 @@ namespace vg {
                 
                 int band_padding = 1;
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding);
+                aligner.align_global_banded(aln, graph, band_padding);
                 
                 const Path& path = aln.path();
                 
@@ -832,7 +832,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -873,7 +873,7 @@ namespace vg {
                 
                 int band_padding = 1;
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding);
+                aligner.align_global_banded(aln, graph, band_padding);
                 
                 const Path& path = aln.path();
                 
@@ -914,7 +914,7 @@ namespace vg {
                 
                 int band_padding = 1;
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding);
+                aligner.align_global_banded(aln, graph, band_padding);
                 
                 const Path& path = aln.path();
                                 
@@ -963,7 +963,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1009,7 +1009,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1050,7 +1050,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1095,7 +1095,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1142,7 +1142,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1191,7 +1191,7 @@ namespace vg {
                 
                 int band_width = 20;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1240,7 +1240,7 @@ namespace vg {
                 
                 int band_width = 0;
                 bool permissive_banding = false;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1292,7 +1292,7 @@ namespace vg {
                 aln.set_sequence(read);
                 
                 int band_padding = 1;
-                aligner.align_global_banded(aln, graph.graph, band_padding);
+                aligner.align_global_banded(aln, graph, band_padding);
                 
                 const Path& path = aln.path();
                 
@@ -1332,7 +1332,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = true;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1381,7 +1381,7 @@ namespace vg {
                 
                 int band_width = 0;
                 bool permissive_banding = true;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1445,7 +1445,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = true;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1497,7 +1497,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = true;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 const Path& path = aln.path();
                 
@@ -1548,8 +1548,8 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = true;
-                aligner.align_global_banded(aln_full, graph.graph, band_width, permissive_banding);
-                aligner.align_global_banded(aln_reduced, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln_full, graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln_reduced, graph, band_width, permissive_banding);
                 
                 const Path& path_full = aln_full.path();
                 const Path& path_reduced = aln_reduced.path();
@@ -1626,7 +1626,7 @@ namespace vg {
                 bool permissive_banding = true;
                 vector<Alignment> multi_alns;
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 const Path& path = aln.path();
@@ -1671,7 +1671,7 @@ namespace vg {
                 bool permissive_banding = true;
                 vector<Alignment> multi_alns;
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 REQUIRE(aln.sequence() == multi_alns[0].sequence());
@@ -1715,7 +1715,7 @@ namespace vg {
                 bool permissive_banding = true;
                 vector<Alignment> multi_alns;
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 bool found_first_opt = false;
@@ -1811,7 +1811,7 @@ namespace vg {
                 bool permissive_banding = true;
                 vector<Alignment> multi_alns;
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 bool took_alternate_path = false;
@@ -1863,7 +1863,7 @@ namespace vg {
                 bool permissive_banding = true;
                 vector<Alignment> multi_alns;
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 bool found_first_opt = false;
@@ -1970,7 +1970,7 @@ namespace vg {
                 bool permissive_banding = true;
                 vector<Alignment> multi_alns;
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 bool found_first_opt = false;
@@ -2073,7 +2073,7 @@ namespace vg {
                 bool permissive_banding = true;
                 vector<Alignment> multi_alns;
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 bool found_first_opt = false;
@@ -2191,7 +2191,7 @@ namespace vg {
                 bool permissive_banding = true;
                 vector<Alignment> multi_alns;
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 bool found_first_opt = false;
@@ -2274,7 +2274,7 @@ namespace vg {
                 bool permissive_banding = true;
                 vector<Alignment> multi_alns;
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 unordered_set<string> alns_seen;
@@ -2311,7 +2311,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = true;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 SECTION("alignment ends in full-length matches/mismatches") {
                     REQUIRE(aln.path().mapping_size() == 3);
@@ -2345,7 +2345,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = true;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 SECTION("alignment ends in full-length matches/mismatches") {
                     REQUIRE(aln.path().mapping_size() == 3);
@@ -2379,7 +2379,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = true;
-                aligner.align_global_banded(aln, graph.graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
                 
                 SECTION("alignment ends in full-length matches/mismatches") {
                     REQUIRE(aln.path().mapping_size() == 3);
@@ -2422,7 +2422,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2454,7 +2454,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2511,7 +2511,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2562,7 +2562,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2617,7 +2617,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2670,7 +2670,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2712,7 +2712,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2745,7 +2745,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2798,7 +2798,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2846,7 +2846,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2883,7 +2883,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2926,7 +2926,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2955,7 +2955,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -2996,7 +2996,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 bool found_first_opt = false;
@@ -3072,7 +3072,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 REQUIRE(multi_alns.size() <= 3);
@@ -3156,7 +3156,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -3209,7 +3209,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -3267,7 +3267,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -3323,7 +3323,7 @@ namespace vg {
                 aln.set_quality(qual);
                 alignment_quality_char_to_short(aln);
                 
-                aligner.align_global_banded(aln, graph.graph, band_padding, permissive_banding);
+                aligner.align_global_banded(aln, graph, band_padding, permissive_banding);
                 
                 // is a global alignment
                 REQUIRE(aln.path().mapping(0).position().offset() == 0);
@@ -3369,7 +3369,7 @@ namespace vg {
                 alignment_quality_char_to_short(aln);
                 
                 vector<Alignment> multi_alns;
-                aligner.align_global_banded_multi(aln, multi_alns, graph.graph, max_multi_alns,
+                aligner.align_global_banded_multi(aln, multi_alns, graph, max_multi_alns,
                                                   band_padding, permissive_banding);
                 
                 bool found_first_opt = false, found_second_opt = false;
@@ -3416,6 +3416,7 @@ namespace vg {
                 
                 Graph graph;
                 json2pb(graph, graph_json.c_str(), graph_json.size());
+                VG vg_graph(graph);
                 
                 Aligner aligner;
                 
@@ -3425,7 +3426,7 @@ namespace vg {
                 
                 int band_width = 1;
                 bool permissive_banding = true;
-                aligner.align_global_banded(aln, graph, band_width, permissive_banding);
+                aligner.align_global_banded(aln, vg_graph, band_width, permissive_banding);
                 
                 const Path& p = aln.path();
                 for (int i = 0; i < p.mapping_size();i++) {

--- a/src/unittest/pinned_alignment.cpp
+++ b/src/unittest/pinned_alignment.cpp
@@ -43,7 +43,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -99,7 +99,7 @@ namespace vg {
                 bool pin_left = true;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -155,7 +155,7 @@ namespace vg {
                 
                 Aligner aligner(1, 4, 6, 1, 0);
                 
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -215,7 +215,7 @@ namespace vg {
                 bool pin_left = true;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -273,7 +273,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -332,7 +332,7 @@ namespace vg {
                 bool pin_left = true;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -391,7 +391,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -445,7 +445,7 @@ namespace vg {
                 bool pin_left = true;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -498,7 +498,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -557,7 +557,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -620,7 +620,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -683,7 +683,7 @@ namespace vg {
                 bool pin_left = true;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -746,7 +746,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -797,7 +797,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -827,7 +827,7 @@ namespace vg {
                 bool pin_left = true;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -869,7 +869,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -928,7 +928,7 @@ namespace vg {
                 bool pin_left = true;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -987,7 +987,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1036,7 +1036,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1096,7 +1096,7 @@ namespace vg {
                 bool pin_left = true;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1145,7 +1145,7 @@ namespace vg {
                 bool pin_left = true;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1205,7 +1205,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1273,7 +1273,7 @@ namespace vg {
                 bool pin_left = true;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1339,7 +1339,7 @@ namespace vg {
                 bool pin_left = false;
                 
                 Aligner aligner;
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1394,7 +1394,7 @@ namespace vg {
                 int8_t full_length_bonus = 3;
                 
                 Aligner aligner(1, 4, 6, 1, full_length_bonus);
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1461,7 +1461,7 @@ namespace vg {
                 int8_t full_length_bonus = 3;
                 
                 Aligner aligner(1, 4, 6, 1, full_length_bonus);
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1528,7 +1528,7 @@ namespace vg {
                 int8_t full_length_bonus = 5;
                 
                 Aligner aligner(1, 4, 6, 1, full_length_bonus);
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                                 
                 const Path& path = aln.path();
                 
@@ -1591,7 +1591,7 @@ namespace vg {
                 int8_t full_length_bonus = 2;
                 
                 Aligner aligner(1, 4, 6, 1, full_length_bonus);
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1662,7 +1662,7 @@ namespace vg {
                 int8_t full_length_bonus = 5;
                 
                 QualAdjAligner aligner(1, 4, 6, 1, full_length_bonus, 6);
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1726,7 +1726,7 @@ namespace vg {
                 int8_t full_length_bonus = 5;
                 
                 QualAdjAligner aligner(1, 4, 6, 1, full_length_bonus, 6);
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1789,7 +1789,7 @@ namespace vg {
                 int8_t full_length_bonus = 5;
                 
                 QualAdjAligner aligner(1, 4, 6, 1, full_length_bonus, 6);
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1853,7 +1853,7 @@ namespace vg {
                 
                 
                 QualAdjAligner aligner(1, 4, 6, 1, full_length_bonus, 64);
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1916,7 +1916,7 @@ namespace vg {
                 int8_t full_length_bonus = 3;
                 
                 QualAdjAligner aligner(1, 4, 6, 1, full_length_bonus, 64);
-                aligner.align_pinned(aln, graph.graph, pin_left);
+                aligner.align_pinned(aln, graph, pin_left);
                 
                 const Path& path = aln.path();
                 
@@ -1985,7 +1985,7 @@ namespace vg {
                 
                 Aligner aligner;
                 vector<Alignment> multi_alns;
-                aligner.align_pinned_multi(aln, multi_alns, graph.graph, pin_left, max_multi_alns);
+                aligner.align_pinned_multi(aln, multi_alns, graph, pin_left, max_multi_alns);
                 
                 int64_t prev_score = numeric_limits<int64_t>::max();
                 for (Alignment& alt_aln : multi_alns) {
@@ -2031,7 +2031,7 @@ namespace vg {
                 
                 Aligner aligner;
                 vector<Alignment> multi_alns;
-                aligner.align_pinned_multi(aln, multi_alns, graph.graph, pin_left, max_multi_alns);
+                aligner.align_pinned_multi(aln, multi_alns, graph, pin_left, max_multi_alns);
                 
                 REQUIRE(aln.sequence() == multi_alns[0].sequence());
                 REQUIRE(aln.score() == multi_alns[0].score());
@@ -2073,7 +2073,7 @@ namespace vg {
                 
                 Aligner aligner;
                 vector<Alignment> multi_alns;
-                aligner.align_pinned_multi(aln, multi_alns, graph.graph, pin_left, max_multi_alns);
+                aligner.align_pinned_multi(aln, multi_alns, graph, pin_left, max_multi_alns);
                 
                 bool found_first_opt = false;
                 bool found_second_opt = false;
@@ -2173,7 +2173,7 @@ namespace vg {
                 
                 Aligner aligner;
                 vector<Alignment> multi_alns;
-                aligner.align_pinned_multi(aln, multi_alns, graph.graph, pin_left, max_multi_alns);
+                aligner.align_pinned_multi(aln, multi_alns, graph, pin_left, max_multi_alns);
                 
                 bool took_alternate_path = false;
                 for (Alignment& alt_aln : multi_alns) {
@@ -2214,7 +2214,7 @@ namespace vg {
                 
                 Aligner aligner;
                 vector<Alignment> multi_alns;
-                aligner.align_pinned_multi(aln, multi_alns, graph.graph, pin_left, max_multi_alns);
+                aligner.align_pinned_multi(aln, multi_alns, graph, pin_left, max_multi_alns);
                 
                 REQUIRE(multi_alns.size() == 1);
             }
@@ -2250,7 +2250,7 @@ namespace vg {
                 
                 Aligner aligner;
                 vector<Alignment> multi_alns;
-                aligner.align_pinned_multi(aln, multi_alns, graph.graph, pin_left, max_multi_alns);
+                aligner.align_pinned_multi(aln, multi_alns, graph, pin_left, max_multi_alns);
                 
                 bool found_first_opt = false;
                 bool found_second_opt = false;
@@ -2359,7 +2359,7 @@ namespace vg {
                 
                 Aligner aligner;
                 vector<Alignment> multi_alns;
-                aligner.align_pinned_multi(aln, multi_alns, graph.graph, pin_left, max_multi_alns);
+                aligner.align_pinned_multi(aln, multi_alns, graph, pin_left, max_multi_alns);
                 
                 bool found_first_opt = false;
                 bool found_second_opt = false;
@@ -2485,7 +2485,7 @@ namespace vg {
                 
                 QualAdjAligner aligner(1, 4, 6, 1, 5, 6);
                 vector<Alignment> multi_alns;
-                aligner.align_pinned_multi(aln, multi_alns, graph.graph, pin_left, max_multi_alns);
+                aligner.align_pinned_multi(aln, multi_alns, graph, pin_left, max_multi_alns);
                 
                 for (Alignment& alt_aln : multi_alns) {
                     for (size_t i = 0; i < alt_aln.path().mapping_size(); i++) {
@@ -2522,7 +2522,7 @@ namespace vg {
                 int max_multi_alns = 5000;
                 
                 vector<Alignment> multi_alns;
-                aligner.align_pinned_multi(aln, multi_alns, graph.graph, pin_left, max_multi_alns);
+                aligner.align_pinned_multi(aln, multi_alns, graph, pin_left, max_multi_alns);
                 
                 unordered_set<string> alns_seen;
                 for (Alignment& alt_aln : multi_alns) {

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -6757,7 +6757,7 @@ Alignment VG::align(const Alignment& alignment,
     vector<MaximalExactMatch> translated_mems;
     
     // trans is only required in the X-drop aligner; can be nullptr
-    auto do_align = [&](Graph& g) {
+    auto do_align = [&](VG& g) {
 #ifdef debug
         write_alignment_to_file(alignment, hash_alignment(alignment) + ".gam");
         serialize_to_file(hash_alignment(alignment) + ".vg");
@@ -6793,7 +6793,7 @@ Alignment VG::align(const Alignment& alignment,
         } else if(xdrop_alignment) {
             // cerr << "X-drop alignment, (" << xdrop_alignment << ")" << endl;
             if (aligner && !qual_adj_aligner) {
-                aligner->align_xdrop(aln, g, (translated_mems.size()? translated_mems : mems), (xdrop_alignment == 1) ? false : true, multithreaded_xdrop);
+                aligner->align_xdrop(aln, g.graph, (translated_mems.size()? translated_mems : mems), (xdrop_alignment == 1) ? false : true, multithreaded_xdrop);
             } else {
                 /* qual_adj_aligner is not yet implemented, fallback */
                 qual_adj_aligner->align/*_xdrop*/(aln, g, traceback, print_score_matrices);
@@ -6815,7 +6815,7 @@ Alignment VG::align(const Alignment& alignment,
         cerr << "Graph is a non-inverting DAG, so just sort and align" << endl;
 #endif
         // run the alignment without id translation
-        do_align(this->graph);
+        do_align(*this);
     } else {
 #ifdef debug
         cerr << "Graph is complex, so dagify and unfold before alignment" << endl;
@@ -6847,7 +6847,7 @@ Alignment VG::align(const Alignment& alignment,
         algorithms::topological_sort(&dag);
         
         // run the alignment with id translation table
-        do_align(dag.graph);
+        do_align(dag);
 
 #ifdef debug
         auto check_aln = [&](VG& graph, const Alignment& a) {


### PR DESCRIPTION
This switches (most of) the alignment code away from Protobuf Graphs to HandleGraphs. I haven't touched the X-drop code, mostly because of lack of familiarity. Switching to HandleGraphs allows us to move away from Protobuf-backed implementations (cough cough VG cough) in the alignment-adjacent code, to other potentially better performing implementations.

This factoring also lets us offload some of the graph processing that we had reimplemented multiple places (e.g. sorting) to the HandleGraph algorithms namespace. In turn, this let me easily move the graph processing closer to where it's actually needed in the alignment algorithms. This is a better separation of responsibilities; it makes the alignment methods more self-contained. 

To maintain some of the optimizations in the Mapper, I did have to write one hack into this PR. There's now a thin overlay on an unindexed Protobuf graph that will let you shim it into the new Aligner interfaces. It is not performant, and not really meant to be used for any other purpose than this. However, I think it will help ease the transition to other graph implementations until we do a more substantial refactoring.