### PR TITLE
Weights for edge supports in call

### DIFF
--- a/src/support_caller.cpp
+++ b/src/support_caller.cpp
@@ -351,7 +351,7 @@ const string& SupportCaller::PrimaryPath::get_name() const {
     return name;
 }
 
-map<string, SupportCaller::PrimaryPath>::iterator SupportCaller::find_path(const Snarl& site, map<string, PrimaryPath>& primary_paths) {
+map<string, SupportCaller::PrimaryPath>::iterator SupportCaller::find_path(const Snarl& site) {
     for(auto i = primary_paths.begin(); i != primary_paths.end(); ++i) {
         // Scan the whole map with an iterator
         
@@ -364,6 +364,38 @@ map<string, SupportCaller::PrimaryPath>::iterator SupportCaller::find_path(const
     // Otherwise we hit the end and found no path that this site can be strung
     // on.
     return primary_paths.end();
+}
+
+size_t SupportCaller::get_deletion_length(const NodeSide& end1, const NodeSide& end2,
+                                          SupportAugmentedGraph& augmented) {
+    
+    for(auto i = primary_paths.begin(); i != primary_paths.end(); ++i) {
+        // Scan the whole map with an iterator
+
+        map<int64_t, pair<size_t, bool>>& idx = i->second.get_index().by_id;
+        map<int64_t, pair<size_t, bool>>::iterator idx_it1 = idx.find(end1.node);
+        map<int64_t, pair<size_t, bool>>::iterator  idx_it2 = idx_it1 != idx.end() ? idx.find(end2.node) : idx.end();
+        
+        if (idx_it1 != idx.end() && idx_it2 != idx.end()) {
+
+            // find the positions of our nodesides in the path.
+            size_t pos1 = idx_it1->second.first;
+            if (end1.is_end != idx_it1->second.second) {
+                pos1 += augmented.graph.get_length(augmented.graph.get_handle(idx_it1->first));
+            }
+            size_t pos2 = idx_it2->second.first;
+            if (end2.is_end != idx_it2->second.second) {
+                pos2 += augmented.graph.get_length(augmented.graph.get_handle(idx_it2->first));
+            }
+
+            if (pos1 > pos2) {
+                std::swap(pos1, pos2);
+            }
+            return pos2 - pos1;
+        }
+    }
+    
+    return 0;
 }
 
 /**
@@ -415,13 +447,13 @@ void trace_traversal(const SnarlTraversal& traversal, const Snarl& site, functio
 
 /**
  * Get the min support, total support, bp size (to divide total by for average
- * support), and min likelihood for a traversal, optionally special-casing the
+ * support), and fraction of unsupported edges for a traversal, optionally special-casing the
  * material used by another traversal. Material used by another traversal only
  * makes half its coverage available to this traversal.
  */
-tuple<Support, Support, size_t> get_traversal_support(SupportAugmentedGraph& augmented,
+tuple<Support, Support, size_t, double> SupportCaller::get_traversal_support(SupportAugmentedGraph& augmented,
     SnarlManager& snarl_manager, const Snarl& site, const SnarlTraversal& traversal,
-    const SnarlTraversal* already_used = nullptr) {
+    const SnarlTraversal* already_used) {
 
 #ifdef debug
     cerr << "Evaluate traversal: " << endl;
@@ -463,6 +495,10 @@ tuple<Support, Support, size_t> get_traversal_support(SupportAugmentedGraph& aug
     vector<Support> total_supports(record_count, Support());
     // And the bp size of each visit
     vector<size_t> visit_sizes(record_count, 0);
+    // Number of visited edges
+    size_t total_edges = 0;
+    // Number of supported edges
+    size_t supported_edges = 0;
     
     // Don't count nodes shared between child snarls more than once.
     set<Node*> coverage_counted;
@@ -496,10 +532,14 @@ tuple<Support, Support, size_t> get_traversal_support(SupportAugmentedGraph& aug
         // This is an edge
         Edge* edge = augmented.graph.get_edge(end1, end2);
         assert(edge != nullptr);
-        
+
+        // edges between adjacent nodes or ones that go off primary path count for size 1
+        // otherwise, they count as the number of deleted bases on the primary path
+        size_t edge_size = max(1UL, get_deletion_length(end1, end2, augmented));
+
         // Count as 1 base worth for the total/average support
         // Make sure to only use half the support if the edge is shared
-        auto got_support = augmented.get_support(edge) * (shared_edges.count(edge) ? 0.5 : 1.0);
+        auto got_support = (double)edge_size * augmented.get_support(edge) * (shared_edges.count(edge) ? 0.5 : 1.0);
         
         if (end1.node > end2.node || (end1.node == end2.node && !end1.is_end)) {
             // We follow the edge backward, from high ID to low ID, or backward around a normal self loop.
@@ -515,10 +555,15 @@ tuple<Support, Support, size_t> get_traversal_support(SupportAugmentedGraph& aug
 
         total_supports[i] += got_support;
         
-        visit_sizes[i] += 1;
+        visit_sizes[i] += edge_size;
         
         // Min in its support
         min_supports[i] = support_min(min_supports[i], augmented.get_support(edge) * (shared_edges.count(edge) ? 0.5 : 1.0));
+        // Edges don't contribute much to total support.  We keep a separate tally to make sure we don't
+        // have too many unsupported edges in any called traversals. 
+        total_edges += 1;
+        supported_edges += total(augmented.get_support(edge)) > 0. ? 1 : 0;
+        
     }, [&](size_t i, Snarl child, bool is_reverse) {
         // This is a child snarl, so get its max support.
         
@@ -596,14 +641,18 @@ tuple<Support, Support, size_t> get_traversal_support(SupportAugmentedGraph& aug
         // If we have actually no material, say we have actually no support
         min_support = Support();
     }
+
+    double frac_supported_edges = (double)supported_edges / (double)total_edges;
         
     // Spit out the supports, the size in bases observed.
-    return tie(min_support, total_support, total_size);
+    return tie(min_support, total_support, total_size, frac_supported_edges);
         
 }
 
 /** Get the support for each traversal in a list, using average_support_switch_threshold
-    to decide if we use the minimum or average */
+    to decide if we use the minimum or average.  Apply the min_supported_edges cutoff
+    to set support to 0 if not enough edges were supported.
+*/
 tuple<vector<Support>, vector<size_t> > SupportCaller::get_traversal_supports_and_sizes(
     SupportAugmentedGraph& augmented, SnarlManager& snarl_manager, const Snarl& site,
     const vector<SnarlTraversal>& traversals, const SnarlTraversal* minus_traversal) {
@@ -628,14 +677,26 @@ tuple<vector<Support>, vector<size_t> > SupportCaller::get_traversal_supports_an
         size_t total_size;
         // And the min support?
         Support min_support;
+        // And the supported edges
+        double frac_supported_edges;
         // Trace the traversal and get its support
-        tie(min_support, total_support, total_size) = get_traversal_support(
+        tie(min_support, total_support, total_size, frac_supported_edges) = get_traversal_support(
             augmented, snarl_manager, site, traversal, minus_traversal);
             
         // Add average and min supports to vectors. Note that average support
         // ignores edges.
         min_supports.push_back(min_support);
-        average_supports.push_back(total_size != 0 ? total_support / total_size : Support());
+
+        Support avg_support;
+        if (total_size != 0 && frac_supported_edges >= min_edge_support_frac) {
+            // When using average support to call larger variants, we may be okay with a
+            // few patches of 0-support.  But this can lead to calling a deletion with no edge
+            // support just because some of the flanking nodes in the snarl are supported.
+            // the min_edge_support_frac is a heuristic cutoff to avoid this, though it may be
+            // better to try weigting edges by the bases they delete in a primary path
+            avg_support = total_support / total_size;
+        }
+        average_supports.push_back(avg_support);
         
 #ifdef debug
         cerr << "Min: " << min_support << " Total: " << total_support << " Average: " << average_supports.back() << endl;
@@ -1130,7 +1191,7 @@ void SupportCaller::call(
     
     // We'll fill this in with a PrimaryPath for every primary reference path
     // that is specified or detected.
-    map<string, PrimaryPath> primary_paths;
+    primary_paths.clear();
     for (auto& name : primary_path_names) {
         // Make a PrimaryPath for every primary path we have.
         // Index the primary path and compute the binned supports.   
@@ -1252,7 +1313,7 @@ void SupportCaller::call(
         // corresponding PrimaryPath object. Otherwise, leave this null.
         PrimaryPath* primary_path = nullptr;
         {
-            auto found = find_path(*site, primary_paths);
+            auto found = find_path(*site);
             if (found != primary_paths.end()) {
                 primary_path = &found->second;
             }
@@ -1334,7 +1395,7 @@ void SupportCaller::call(
                                                    [&] (const Snarl& site) -> PathIndex* {
         
         // When the TraversalFinder needs a primary path index for a site, it can look it up with this function.
-        auto found = find_path(site, primary_paths);
+        auto found = find_path(site);
         if (found != primary_paths.end()) {
             // It's on a path
             return &found->second.get_index();
@@ -1360,7 +1421,7 @@ void SupportCaller::call(
         // For every site, we're going to make a bunch of Locus objects
         
         // See if the site is on a primary path, so we can use binned support.
-        map<string, PrimaryPath>::iterator found_path = find_path(*site, primary_paths);
+        map<string, PrimaryPath>::iterator found_path = find_path(*site);
         
         // We need to figure out how much support a site ought to have.
         // Within its local bin?
@@ -1823,7 +1884,7 @@ void SupportCaller::call(
         
         // Recursively type the site, using that support and an assumption of a diploid sample.
         find_best_traversals(augmented, site_manager, &traversal_finder, *site, baseline_support, 2,
-            [&locus_buffer, &emit_variant, &site_manager, &called_loci, &primary_paths, &augmented,
+            [&locus_buffer, &emit_variant, &site_manager, &called_loci, &augmented,
             &covered_nodes, &covered_edges, this](const Locus& locus, const Snarl* site) {
             
             // Now we have the Locus with call information, and the site (either
@@ -1834,7 +1895,7 @@ void SupportCaller::call(
                 // We want to emit VCF
                 
                 // Look up the path this child site lives on. (TODO: just capture and use the path the parent lives on?)
-                auto found_path = find_path(*site, primary_paths);
+                auto found_path = find_path(*site);
                 if(found_path != primary_paths.end()) {
                     // And this site is on a primary path
                     

--- a/src/support_caller.cpp
+++ b/src/support_caller.cpp
@@ -562,7 +562,7 @@ tuple<Support, Support, size_t, double> SupportCaller::get_traversal_support(Sup
         // Edges don't contribute much to total support.  We keep a separate tally to make sure we don't
         // have too many unsupported edges in any called traversals. 
         total_edges += 1;
-        supported_edges += total(augmented.get_support(edge)) > 0. ? 1 : 0;
+        supported_edges += support_val(augmented.get_support(edge)) > 0. ? 1 : 0;
         
     }, [&](size_t i, Snarl child, bool is_reverse) {
         // This is a child snarl, so get its max support.
@@ -695,6 +695,8 @@ tuple<vector<Support>, vector<size_t> > SupportCaller::get_traversal_supports_an
             // the min_edge_support_frac is a heuristic cutoff to avoid this, though it may be
             // better to try weigting edges by the bases they delete in a primary path
             avg_support = total_support / total_size;
+        } else {
+            avg_support = min_support;
         }
         average_supports.push_back(avg_support);
         


### PR DESCRIPTION
Right now, `vg call` scales node supports by the number of bases, but all edges count for 1.  This generally works fine when using a minimum support cutoff, but using average support (as needed for SVs) can lead to trouble.  If a traversal has lots of node support, but runs through a giant unsupported deletion edge, the deletion can still be called.  So here we
* scale edges supports by the number of reference bases they delete
* add cutoff of fraction of unsupported edges in a traversal

