### PR TITLE
More precise calling of big deletions

### DIFF
--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -387,7 +387,7 @@ int main_chunk(int argc, char** argv) {
             delete range_stream;
         }
     }
-    else {
+    else if (xindex != nullptr) {
         // every path
         size_t max_rank = xindex->max_path_rank();
         for (size_t rank = 1; rank <= max_rank; ++rank) {

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -832,7 +832,11 @@ int main_msga(int argc, char** argv) {
 
     if (normalize) {
         if (debug) cerr << "normalizing graph" << endl;
-        graph->remove_non_path();
+        if (graph_files.empty()) {
+            // shouldn't be any reason to do this, but if we are going to do it,
+            // only try if graph was made entirely of msga'd sequences.
+            graph->remove_non_path();
+        }
         graph->normalize();
         graph->dice_nodes(node_max);
         algorithms::topological_sort(graph);

--- a/src/support_caller.hpp
+++ b/src/support_caller.hpp
@@ -144,7 +144,7 @@ public:
     /** 
      * Get the support and size for each traversal in a list. Discount support
      * of minus_traversal if it's specified.  Use average_support_switch_threshold and
-     * use_average_support to decide whether to return min or avg supports
+     * use_average_support to decide whether to return min or avg supports.
      */
     tuple<vector<Support>, vector<size_t> > get_traversal_supports_and_sizes(
         SupportAugmentedGraph& augmented, SnarlManager& snarl_manager, const Snarl& site,
@@ -153,13 +153,16 @@ public:
 
     /**
      * Get the min support, total support, bp size (to divide total by for average
-     * support), and fraction of unsupported edges for a traversal, optionally special-casing the
-     * material used by another traversal. Material used by another traversal only
-     * makes half its coverage available to this traversal.
+     * support), optionally special-casing the material used by another traversal. 
+     * Material used by another traversal only makes half its coverage available to this traversal.
+     * If ref_traversal specified (and not same as traversal), its contents will be forbidden from
+     * boosting the average support to avoid the actual variation from getting
+     * diluted by shared reference.
      */
-    tuple<Support, Support, size_t, double> get_traversal_support(
+    tuple<Support, Support, size_t> get_traversal_support(
         SupportAugmentedGraph& augmented, SnarlManager& snarl_manager, const Snarl& site,
-        const SnarlTraversal& traversal, const SnarlTraversal* already_used = nullptr);
+        const SnarlTraversal& traversal, const SnarlTraversal* already_used = nullptr,
+        const SnarlTraversal* ref_traversal = nullptr);
 
     /**
      * For the given snarl, find the reference traversal, the best traversal,
@@ -358,11 +361,6 @@ public:
     /// in an output VCF line.  This is mostly for debugging.
     Option<bool> leave_shared_ends{this, "leave-shared-ends", "X", false,
             "don't collapse shared prefix and suffix of alleles in VCF output"};
-
-    /// Don't call a traversal with more than this proportion of unsupported edges.
-    /// Only relevant when using average support with minimum support 0.
-    Option<double> min_edge_support_frac{this, "min-edge-support-frac", "e", 0.8,
-            "Traversal must have at least this proportion of supported edges to be counted"};
 
     /// print warnings etc. to stderr
     bool verbose = false;


### PR DESCRIPTION
* Switch up heuristic for long deletions in caller: make sure they don't get bogged down by high reference support when doing average.
* Get vg chunk -m working again (so toil-vg can realign gams)
* Let msga leave in non-path nodes when normalizing if starting with a graph (which may have non-path nodes we want to keep). 