### PR TITLE
Fix mpmap anchoring bug

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -2276,7 +2276,7 @@ namespace vg {
 #endif
                         }
                         
-                        for (const pair<size_t, size_t>& start_next : reachable_starts_from_start[start_here.second]) {
+                        for (const pair<size_t, size_t>& start_next : reachable_starts_from_start[start_here.first]) {
                             start_queue.push_or_reprioritize(start_next.first, start_here.second + start_next.second);
                         }
                     }


### PR DESCRIPTION
Another small bug in mpmap that can occasionally produce an incorrect mapping, this time in the reachability computation between anchors.