### PR TITLE
Pull the HandleGraph code back into Doxygen

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -758,7 +758,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src src/subcommand src/unittest/driver.cpp src/unittest/driver.hpp
+INPUT                  = src src/subcommand src/unittest/driver.cpp src/unittest/driver.hpp deps/libhandlegraph/src deps/libhandlegraph/src/include/handlegraph
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Moving the HandleGraph code out of vg proper makes it have no docs. Rather than set up another Doxygen and hosting for it, I'm just generating docs for it as part of the vg docs build.