### PR TITLE
Fix VPKG backward compatibility and improve errors

### DIFF
--- a/src/stream/registry.hpp
+++ b/src/stream/registry.hpp
@@ -366,7 +366,7 @@ void Registry::register_loader_saver(const vector<string>& tags, load_function_t
     
     for (size_t i = 1; i < tags.size(); i++) {
         // Other tags just get loaders
-        register_loader<Handled>(tags.front(), loader);
+        register_loader<Handled>(tags[i], loader);
     }
 }
 

--- a/src/stream/vpkg.hpp
+++ b/src/stream/vpkg.hpp
@@ -263,24 +263,45 @@ public:
             exit(1);
         }
         
-        // Open the file
-        ifstream in(filename);
+        // We branch into two completely different flows here for better error reporting.
         
-        if (!in) {
-            // We can't even open the file
-            cerr << "error[VPKG::load_one]: Could not open " << filename << " while loading " << describe<Wanted>() << endl;
-            exit(1);
+        if (filename == "-") {
+            // Load from cin
+            if (!cin) {
+                cerr << "error[VPKG::load_one]: Could not access standard input while loading " << describe<Wanted>() << endl;
+                exit(1);
+            }
+            
+            // Read the stream.
+            auto result = try_load_one<Wanted>(cin);
+            
+            if (result.get() == nullptr) {
+                cerr << "error[VPKG::load_one]: Correct input type not found in standard input while loading " << describe<Wanted>() << endl;
+                exit(1);
+            }
+            
+            return result;
+            
+        } else {
+            // Load from a real file
+            ifstream in(filename);
+            
+            if (!in) {
+                // We can't even open the file
+                cerr << "error[VPKG::load_one]: Could not open " << filename << " while loading " << describe<Wanted>() << endl;
+                exit(1);
+            }
+            
+            // Read the file.
+            auto result = try_load_one<Wanted>(in);
+            
+            if (result.get() == nullptr) {
+                cerr << "error[VPKG::load_one]: Correct input type not found in " << filename << " while loading " << describe<Wanted>() << endl;
+                exit(1);
+            }
+            
+            return result;
         }
-        
-        // Read the file.
-        auto result = try_load_one<Wanted>(in);
-        
-        if (result.get() == nullptr) {
-            cerr << "error[VPKG::load_one]: Correct input type not found in " << filename << " while loading " << describe<Wanted>() << endl;
-            exit(1);
-        }
-        
-        return result;
     }
     
     


### PR DESCRIPTION
Turns out I wasn't registering the loader for VG files for the old
untagged file format.

Also, I've improved error reporting. There should be better file
not found messages, and the types we are trying to load are now
demangled for people who don't enjoy reading mangled C++ type
names.

This should fix #2120.