### PR TITLE
Surject refactor part 1

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1660,18 +1660,18 @@ AlignerClient::AlignerClient(double gc_content_estimate) :
                          default_gap_extension, default_full_length_bonus, default_xdrop_max_gap_length);
 }
 
-GSSWAligner* AlignerClient::get_aligner(bool have_qualities) const {
+const GSSWAligner* AlignerClient::get_aligner(bool have_qualities) const {
     return (have_qualities && adjust_alignments_for_base_quality) ?
         (GSSWAligner*) get_qual_adj_aligner() :
         (GSSWAligner*) get_regular_aligner();
 }
 
-QualAdjAligner* AlignerClient::get_qual_adj_aligner() const {
+const QualAdjAligner* AlignerClient::get_qual_adj_aligner() const {
     assert(qual_adj_aligner.get() != nullptr);
     return qual_adj_aligner.get();
 }
 
-Aligner* AlignerClient::get_regular_aligner() const {
+const Aligner* AlignerClient::get_regular_aligner() const {
     assert(regular_aligner.get() != nullptr);
     return regular_aligner.get();
 }
@@ -1695,8 +1695,8 @@ void AlignerClient::set_alignment_scores(int8_t match, int8_t mismatch, int8_t g
 void AlignerClient::load_scoring_matrix(std::ifstream& matrix_stream){
     matrix_stream.clear();
     matrix_stream.seekg(0);
-    if(regular_aligner) get_regular_aligner()->load_scoring_matrix(matrix_stream);
+    if(regular_aligner) regular_aligner->load_scoring_matrix(matrix_stream);
     matrix_stream.clear();
     matrix_stream.seekg(0);
-    if(qual_adj_aligner) get_qual_adj_aligner()->load_scoring_matrix(matrix_stream);
+    if(qual_adj_aligner) qual_adj_aligner->load_scoring_matrix(matrix_stream);
 }

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1,4 +1,4 @@
-#include "gssw_aligner.hpp"
+#include "aligner.hpp"
 #include "xdrop_aligner.hpp"
 #include "json2pb.h"
 

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1654,3 +1654,52 @@ int32_t QualAdjAligner::score_partial_alignment(const Alignment& alignment, cons
     }
     return score;
 }
+
+AlignerClient::AlignerClient(double gc_content_estimate) :
+    gc_content_estimate(gc_content_estimate) {
+    
+    // Adopt the default scoring parameters and make the aligners
+    set_alignment_scores(default_match, default_mismatch, default_gap_open,
+                         default_gap_extension, default_full_length_bonus, default_xdrop_max_gap_length);
+}
+
+GSSWAligner* AlignerClient::get_aligner(bool have_qualities) const {
+    return (have_qualities && adjust_alignments_for_base_quality) ?
+        (GSSWAligner*) get_qual_adj_aligner() :
+        (GSSWAligner*) get_regular_aligner();
+}
+
+QualAdjAligner* AlignerClient::get_qual_adj_aligner() const {
+    assert(qual_adj_aligner.get() != nullptr);
+    return qual_adj_aligner.get();
+}
+
+Aligner* AlignerClient::get_regular_aligner() const {
+    assert(regular_aligner.get() != nullptr);
+    return regular_aligner.get();
+}
+
+void AlignerClient::set_alignment_scores(int8_t match, int8_t mismatch, int8_t gap_open, int8_t gap_extend, 
+                                         int8_t full_length_bonus, uint32_t xdrop_max_gap_length) {
+    
+    // hacky, find max score so that scaling doesn't change score
+    int8_t max_score = match;
+    if (mismatch > max_score) max_score = mismatch;
+    if (gap_open > max_score) max_score = gap_open;
+    if (gap_extend > max_score) max_score = gap_extend;
+    
+    qual_adj_aligner = unique_ptr<QualAdjAligner>(new QualAdjAligner(match, mismatch, gap_open, gap_extend,
+                                                                     full_length_bonus, max_score, 255, gc_content_estimate));
+    regular_aligner = unique_ptr<Aligner>(new Aligner(match, mismatch, gap_open, gap_extend,
+                                                      full_length_bonus, gc_content_estimate, xdrop_max_gap_length));
+                  
+}
+
+void AlignerClient::load_scoring_matrix(std::ifstream& matrix_stream){
+    matrix_stream.clear();
+    matrix_stream.seekg(0);
+    if(regular_aligner) get_regular_aligner()->load_scoring_matrix(matrix_stream);
+    matrix_stream.clear();
+    matrix_stream.seekg(0);
+    if(qual_adj_aligner) get_qual_adj_aligner()->load_scoring_matrix(matrix_stream);
+}

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -806,7 +806,7 @@ Aligner::Aligner(int8_t _match,
                  int8_t _gap_extension,
                  int8_t _full_length_bonus,
                  double gc_content)
-    : Aligner(_match, _mismatch, _gap_open, _gap_extension, _full_length_bonus, gc_content, default_max_gap_length)
+    : Aligner(_match, _mismatch, _gap_open, _gap_extension, _full_length_bonus, gc_content, default_xdrop_max_gap_length)
 {
 }
 
@@ -816,8 +816,8 @@ Aligner::Aligner(int8_t _match,
                  int8_t _gap_extension,
                  int8_t _full_length_bonus,
                  double gc_content,
-                 uint32_t _max_gap_length)
-    : xdrop(_match, _mismatch, _gap_open, _gap_extension, _full_length_bonus, _max_gap_length)
+                 uint32_t _xdrop_max_gap_length)
+    : xdrop(_match, _mismatch, _gap_open, _gap_extension, _full_length_bonus, _xdrop_max_gap_length)
 {
     match = _match;
     mismatch = _mismatch;

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -274,7 +274,8 @@ void GSSWAligner::unreverse_graph_mapping(gssw_graph_mapping* gm) const {
     }
 }
 
-string GSSWAligner::graph_cigar(gssw_graph_mapping* gm) {
+string GSSWAligner::graph_cigar(gssw_graph_mapping* gm) const {
+
     stringstream s;
     gssw_graph_cigar* gc = &gm->cigar;
     gssw_node_cigar* nc = gc->elements;
@@ -303,7 +304,7 @@ void GSSWAligner::init_mapping_quality(double gc_content) {
     log_base = gssw_dna_recover_log_base(match, mismatch, gc_content, 1e-12);
 }
 
-int32_t GSSWAligner::score_gap(size_t gap_length) {
+int32_t GSSWAligner::score_gap(size_t gap_length) const {
     return gap_length ? -gap_open - (gap_length - 1) * gap_extension : 0;
 }
 
@@ -429,7 +430,7 @@ double GSSWAligner::maximum_mapping_quality_approx(vector<double>& scaled_scores
     return max(0.0, quality_scale_factor * (max_score - next_score - (next_count > 1 ? log(next_count) : 0.0)));
 }
 
-double GSSWAligner::group_mapping_quality_exact(vector<double>& scaled_scores, vector<size_t>& group) {
+double GSSWAligner::group_mapping_quality_exact(vector<double>& scaled_scores, vector<size_t>& group) const {
     
     // if necessary, assume a null alignment of 0.0 for comparison since this is local
     if (scaled_scores.size() == 1) {
@@ -464,7 +465,7 @@ void GSSWAligner::compute_mapping_quality(vector<Alignment>& alignments,
                                           int overlap_count,
                                           double mq_estimate,
                                           double maybe_mq_threshold,
-                                          double identity_weight) {
+                                          double identity_weight) const {
     
     if (log_base <= 0.0) {
         cerr << "error:[Aligner] must call init_mapping_quality before computing mapping qualities" << endl;
@@ -523,7 +524,7 @@ void GSSWAligner::compute_mapping_quality(vector<Alignment>& alignments,
     }
 }
 
-int32_t GSSWAligner::compute_mapping_quality(vector<double>& scores, bool fast_approximation) {
+int32_t GSSWAligner::compute_mapping_quality(vector<double>& scores, bool fast_approximation) const {
     
     vector<double> scaled_scores(scores.size(), 0.0);
     for (size_t i = 0; i < scores.size(); i++) {
@@ -534,7 +535,7 @@ int32_t GSSWAligner::compute_mapping_quality(vector<double>& scores, bool fast_a
                                          : maximum_mapping_quality_exact(scaled_scores, &idx));
 }
 
-int32_t GSSWAligner::compute_group_mapping_quality(vector<double>& scores, vector<size_t>& group) {
+int32_t GSSWAligner::compute_group_mapping_quality(vector<double>& scores, vector<size_t>& group) const {
     
     // ensure that group is in sorted order as following function expects
     if (!is_sorted(group.begin(), group.end())) {
@@ -560,7 +561,7 @@ void GSSWAligner::compute_paired_mapping_quality(pair<vector<Alignment>, vector<
                                                  double mq_estimate1,
                                                  double mq_estimate2,
                                                  double maybe_mq_threshold,
-                                                 double identity_weight) {
+                                                 double identity_weight) const {
     
     if (log_base <= 0.0) {
         cerr << "error:[Aligner] must call init_mapping_quality before computing mapping qualities" << endl;
@@ -660,18 +661,18 @@ double GSSWAligner::mapping_quality_score_diff(double mapping_quality) const {
     return mapping_quality / (quality_scale_factor * log_base);
 }
 
-double GSSWAligner::estimate_next_best_score(int length, double min_diffs) {
+double GSSWAligner::estimate_next_best_score(int length, double min_diffs) const {
     return ((length - min_diffs) * match - min_diffs * mismatch);
 }
 
-double GSSWAligner::max_possible_mapping_quality(int length) {
+double GSSWAligner::max_possible_mapping_quality(int length) const {
     double max_score = log_base * length * match;
     vector<double> v = { max_score };
     size_t max_idx;
     return maximum_mapping_quality_approx(v, &max_idx);
 }
 
-double GSSWAligner::estimate_max_possible_mapping_quality(int length, double min_diffs, double next_min_diffs) {
+double GSSWAligner::estimate_max_possible_mapping_quality(int length, double min_diffs, double next_min_diffs) const {
     double max_score = log_base * ((length - min_diffs) * match - min_diffs * mismatch);
     double next_max_score = log_base * ((length - next_min_diffs) * match - next_min_diffs * mismatch);
     vector<double> v = { max_score, next_max_score };
@@ -679,7 +680,7 @@ double GSSWAligner::estimate_max_possible_mapping_quality(int length, double min
     return maximum_mapping_quality_approx(v, &max_idx);
 }
 
-double GSSWAligner::score_to_unnormalized_likelihood_ln(double score) {
+double GSSWAligner::score_to_unnormalized_likelihood_ln(double score) const {
     // Log base needs to be set, or this can't work. It's set by default in
     // QualAdjAligner but needs to be set up manually in the normal Aligner.
     assert(log_base != 0);
@@ -1016,29 +1017,29 @@ void Aligner::align_internal(Alignment& alignment, vector<Alignment>* multi_alig
     // bench_end(bench);
 }
 
-void Aligner::align(Alignment& alignment, const HandleGraph& g, bool traceback_aln, bool print_score_matrices) {
+void Aligner::align(Alignment& alignment, const HandleGraph& g, bool traceback_aln, bool print_score_matrices) const {
     
     align_internal(alignment, nullptr, g, nullptr, false, false, 1, traceback_aln, print_score_matrices);
 }
 
 void Aligner::align(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order,
-                    bool traceback_aln, bool print_score_matrices) {
+                    bool traceback_aln, bool print_score_matrices) const {
     
     align_internal(alignment, nullptr, g, &topological_order, false, false, 1, traceback_aln, print_score_matrices);
 }
 
-void Aligner::align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left) {
+void Aligner::align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left) const {
     
     align_internal(alignment, nullptr, g, nullptr, true, pin_left, 1, true, false);
 }
 
-void Aligner::align_pinned(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order, bool pin_left) {
+void Aligner::align_pinned(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order, bool pin_left) const {
     
     align_internal(alignment, nullptr, g, &topological_order, true, pin_left, 1, true, false);
 }
 
 void Aligner::align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                 bool pin_left, int32_t max_alt_alns) {
+                                 bool pin_left, int32_t max_alt_alns) const {
     
     if (alt_alignments.size() != 0) {
         cerr << "error:[Aligner::align_pinned_multi] output vector must be empty for pinned multi-aligning" << endl;
@@ -1049,7 +1050,7 @@ void Aligner::align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_al
 }
 
 void Aligner::align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                 const vector<handle_t>& topological_order, bool pin_left, int32_t max_alt_alns) {
+                                 const vector<handle_t>& topological_order, bool pin_left, int32_t max_alt_alns) const {
     
     if (alt_alignments.size() != 0) {
         cerr << "error:[Aligner::align_pinned_multi] output vector must be empty for pinned multi-aligning" << endl;
@@ -1060,7 +1061,7 @@ void Aligner::align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_al
 }
 
 void Aligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
-                                  int32_t band_padding, bool permissive_banding) {
+                                  int32_t band_padding, bool permissive_banding) const {
     
     // We need to figure out what size ints we need to use.
     // Get upper and lower bounds on the scores. TODO: if these overflow int64 we're out of luck
@@ -1114,7 +1115,7 @@ void Aligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
 }
 
 void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                        int32_t max_alt_alns, int32_t band_padding, bool permissive_banding) {
+                                        int32_t max_alt_alns, int32_t band_padding, bool permissive_banding) const {
                                         
     // We need to figure out what size ints we need to use.
     // Get upper and lower bounds on the scores. TODO: if these overflow int64 we're out of luck
@@ -1173,18 +1174,14 @@ void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>&
 }
 
 // X-drop aligner
-void Aligner::align_xdrop(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, bool multithreaded)
+void Aligner::align_xdrop(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented) const
 {
-    // cerr << "X-drop aligner" << endl;
-    if (multithreaded) {
-        auto xdrop_copy = xdrop; // make thread safe
-        xdrop_copy.align(alignment, g, mems, reverse_complemented);
-    } else {
-        xdrop.align(alignment, g, mems, reverse_complemented);
-    }
+    // Make a single-problem aligner, so we don't modify ourselves and are thread-safe.
+    auto xdrop_copy = xdrop;
+    xdrop_copy.align(alignment, g, mems, reverse_complemented);
 }
 
-void Aligner::align_xdrop_multi(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, int32_t max_alt_alns)
+void Aligner::align_xdrop_multi(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, int32_t max_alt_alns) const
 {
 }
 
@@ -1213,7 +1210,7 @@ int32_t Aligner::score_exact_match(string::const_iterator seq_begin, string::con
 }
 
 int32_t Aligner::score_partial_alignment(const Alignment& alignment, const HandleGraph& graph, const Path& path,
-                                         string::const_iterator seq_begin) const{
+                                         string::const_iterator seq_begin) const {
     
     int32_t score = 0;
     string::const_iterator read_pos = seq_begin;
@@ -1297,7 +1294,7 @@ QualAdjAligner::QualAdjAligner(int8_t _match,
 
 void QualAdjAligner::align_internal(Alignment& alignment, vector<Alignment>* multi_alignments, const HandleGraph& g,
                                     const vector<handle_t>* topological_order, bool pinned, bool pin_left,
-                                    int32_t max_alt_alns, bool traceback_aln, bool print_score_matrices) {
+                                    int32_t max_alt_alns, bool traceback_aln, bool print_score_matrices) const {
     
     // check input integrity
     if (pin_left && !pinned) {
@@ -1489,41 +1486,41 @@ void QualAdjAligner::align_internal(Alignment& alignment, vector<Alignment>* mul
     
 }
 
-void QualAdjAligner::align(Alignment& alignment, const HandleGraph& g, bool traceback_aln, bool print_score_matrices) {
+void QualAdjAligner::align(Alignment& alignment, const HandleGraph& g, bool traceback_aln, bool print_score_matrices) const {
     
     align_internal(alignment, nullptr, g, nullptr, false, false, 1, traceback_aln, print_score_matrices);
 }
 
 void QualAdjAligner::align(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order,
-                           bool traceback_aln, bool print_score_matrices) {
+                           bool traceback_aln, bool print_score_matrices) const {
     
     align_internal(alignment, nullptr, g, &topological_order, false, false, 1, traceback_aln, print_score_matrices);
 }
 
-void QualAdjAligner::align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left) {
+void QualAdjAligner::align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left) const {
 
     align_internal(alignment, nullptr, g, nullptr, true, pin_left, 1, true, false);
 
 }
 
-void QualAdjAligner::align_pinned(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order, bool pin_left) {
+void QualAdjAligner::align_pinned(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order, bool pin_left) const {
     
     align_internal(alignment, nullptr, g, &topological_order, true, pin_left, 1, true, false);
     
 }
 
 void QualAdjAligner::align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                        bool pin_left, int32_t max_alt_alns) {
+                                        bool pin_left, int32_t max_alt_alns) const {
     align_internal(alignment, &alt_alignments, g, nullptr, true, pin_left, max_alt_alns, true, false);
 }
 
 void QualAdjAligner::align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                        const vector<handle_t>& topological_order, bool pin_left, int32_t max_alt_alns) {
+                                        const vector<handle_t>& topological_order, bool pin_left, int32_t max_alt_alns) const {
     align_internal(alignment, &alt_alignments, g, &topological_order, true, pin_left, max_alt_alns, true, false);
 }
 
 void QualAdjAligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
-                                         int32_t band_padding, bool permissive_banding) {
+                                         int32_t band_padding, bool permissive_banding) const {
     
     BandedGlobalAligner<int16_t> band_graph = BandedGlobalAligner<int16_t>(alignment,
                                                                            g,
@@ -1535,7 +1532,7 @@ void QualAdjAligner::align_global_banded(Alignment& alignment, const HandleGraph
 }
 
 void QualAdjAligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                               int32_t max_alt_alns, int32_t band_padding, bool permissive_banding) {
+                                               int32_t max_alt_alns, int32_t band_padding, bool permissive_banding) const {
     
     BandedGlobalAligner<int16_t> band_graph = BandedGlobalAligner<int16_t>(alignment,
                                                                            g,
@@ -1549,14 +1546,14 @@ void QualAdjAligner::align_global_banded_multi(Alignment& alignment, vector<Alig
 }
 
 // X-drop aligner
-void QualAdjAligner::align_xdrop(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, bool multithreaded)
+void QualAdjAligner::align_xdrop(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented) const
 {
     // TODO: implement?
     cerr << "error::[QualAdjAligner] quality-adjusted, X-drop alignment is not implemented" << endl;
     exit(1);
 }
 
-void QualAdjAligner::align_xdrop_multi(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, int32_t max_alt_alns)
+void QualAdjAligner::align_xdrop_multi(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, int32_t max_alt_alns) const
 {
     // TODO: implement?
     cerr << "error::[QualAdjAligner] quality-adjusted, X-drop alignment is not implemented" << endl;
@@ -1599,7 +1596,7 @@ int32_t QualAdjAligner::score_exact_match(string::const_iterator seq_begin, stri
 }
 
 int32_t QualAdjAligner::score_partial_alignment(const Alignment& alignment, const HandleGraph& graph, const Path& path,
-                                                string::const_iterator seq_begin) const{
+                                                string::const_iterator seq_begin) const {
     
     int32_t score = 0;
     string::const_iterator read_pos = seq_begin;

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -13,11 +13,11 @@ GSSWAligner::~GSSWAligner(void) {
     free(score_matrix);
 }
 
-gssw_graph* GSSWAligner::create_gssw_graph(const HandleGraph& g) {
+gssw_graph* GSSWAligner::create_gssw_graph(const HandleGraph& g) const {
     return create_gssw_graph(g, algorithms::lazier_topological_order(&g));
 }
 
-gssw_graph* GSSWAligner::create_gssw_graph(const HandleGraph& g, const vector<handle_t>& topological_order) {
+gssw_graph* GSSWAligner::create_gssw_graph(const HandleGraph& g, const vector<handle_t>& topological_order) const {
     
     gssw_graph* graph = gssw_graph_create(g.node_size());
     unordered_map<int64_t, gssw_node*> nodes;
@@ -95,7 +95,7 @@ void GSSWAligner::gssw_mapping_to_alignment(gssw_graph* graph,
                                             Alignment& alignment,
                                             bool pinned,
                                             bool pin_left,
-                                            bool print_score_matrices) {    
+                                            bool print_score_matrices) const {    
     alignment.clear_path();
     alignment.set_score(gm->score);
     alignment.set_query_position(0);
@@ -215,7 +215,7 @@ void GSSWAligner::gssw_mapping_to_alignment(gssw_graph* graph,
     alignment.set_identity(identity(alignment.path()));
 }
 
-void GSSWAligner::unreverse_graph(gssw_graph* graph) {
+void GSSWAligner::unreverse_graph(gssw_graph* graph) const {
     // this is only for getting correct reference-relative edits, so we can get away with only
     // reversing the sequences and not paying attention to the edges
     
@@ -227,7 +227,7 @@ void GSSWAligner::unreverse_graph(gssw_graph* graph) {
     }
 }
 
-void GSSWAligner::unreverse_graph_mapping(gssw_graph_mapping* gm) {
+void GSSWAligner::unreverse_graph_mapping(gssw_graph_mapping* gm) const {
     
     gssw_graph_cigar* graph_cigar = &(gm->cigar);
     gssw_node_cigar* node_cigars = graph_cigar->elements;
@@ -840,7 +840,7 @@ Aligner::~Aligner()
 
 void Aligner::align_internal(Alignment& alignment, vector<Alignment>* multi_alignments, const HandleGraph& g,
                              const vector<handle_t>* topological_order, bool pinned, bool pin_left,
-                             int32_t max_alt_alns, bool traceback_aln, bool print_score_matrices) {
+                             int32_t max_alt_alns, bool traceback_aln, bool print_score_matrices) const {
     // bench_start(bench);
     // check input integrity
     if (pin_left && !pinned) {

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -63,14 +63,14 @@ namespace vg {
         
         // for construction
         // needed when constructing an alignable graph from the nodes
-        gssw_graph* create_gssw_graph(const HandleGraph& g);
+        gssw_graph* create_gssw_graph(const HandleGraph& g) const;
         // for constructing an alignable graph when the topological order is already known
-        gssw_graph* create_gssw_graph(const HandleGraph& g, const vector<handle_t>& topological_order);
+        gssw_graph* create_gssw_graph(const HandleGraph& g, const vector<handle_t>& topological_order) const;
         
         // convert graph mapping back into unreversed node positions
-        void unreverse_graph_mapping(gssw_graph_mapping* gm);
+        void unreverse_graph_mapping(gssw_graph_mapping* gm) const;
         // convert from graph sequences back into unrereversed form
-        void unreverse_graph(gssw_graph* graph);
+        void unreverse_graph(gssw_graph* graph) const;
         
         // alignment functions
         void gssw_mapping_to_alignment(gssw_graph* graph,
@@ -78,7 +78,7 @@ namespace vg {
                                        Alignment& alignment,
                                        bool pinned,
                                        bool pin_left,
-                                       bool print_score_matrices = false);
+                                       bool print_score_matrices = false) const;
         string graph_cigar(gssw_graph_mapping* gm);
         
     public:
@@ -270,7 +270,7 @@ namespace vg {
                             const vector<handle_t>* topological_order,
                             bool pinned, bool pin_left, int32_t max_alt_alns,
                             bool traceback_aln,
-                            bool print_score_matrices);
+                            bool print_score_matrices) const;
 
         // members
         XdropAligner xdrop;

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -429,12 +429,12 @@ namespace vg {
         /// adjust_alignments_for_base_quality. By setting have_qualities to false,
         /// you can force the non-quality-adjusted aligner, for reads that lack
         /// quality scores.
-        GSSWAligner* get_aligner(bool have_qualities = true) const;
+        const GSSWAligner* get_aligner(bool have_qualities = true) const;
         
         // Sometimes you really do need the two kinds of aligners, to pass to code
         // that expects one or the other.
-        QualAdjAligner* get_qual_adj_aligner() const;
-        Aligner* get_regular_aligner() const;
+        const QualAdjAligner* get_qual_adj_aligner() const;
+        const Aligner* get_regular_aligner() const;
         
     public:
         /// Set all the aligner scoring parameters and create the stored aligner instances.

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -411,6 +411,50 @@ namespace vg {
         
 
     };
+    
+    
+    /**
+     * Holds a set of alignment scores, and has methods to produce aligners of various types on demand, using those scores.
+     * Provides a get_aligner() method to get ahold of a useful, possibly quality-adjusted Aligner.
+     * Base functionality that is shared between alignment and surjections
+     */
+    class AlignerClient {
+    protected:
+
+        /// Create an AlignerClient, which creates the default aligner instances,
+        /// which can depend on a GC content estimate.
+        AlignerClient(double gc_content_estimate = vg::default_gc_content);
+        
+        /// Get the appropriate aligner to use, based on
+        /// adjust_alignments_for_base_quality. By setting have_qualities to false,
+        /// you can force the non-quality-adjusted aligner, for reads that lack
+        /// quality scores.
+        GSSWAligner* get_aligner(bool have_qualities = true) const;
+        
+        // Sometimes you really do need the two kinds of aligners, to pass to code
+        // that expects one or the other.
+        QualAdjAligner* get_qual_adj_aligner() const;
+        Aligner* get_regular_aligner() const;
+        
+    public:
+        /// Set all the aligner scoring parameters and create the stored aligner instances.
+        void set_alignment_scores(int8_t match, int8_t mismatch, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus,
+                                  uint32_t xdrop_max_gap_length = default_xdrop_max_gap_length);
+                                  
+        /// Load a scoring amtrix from a file to set scores
+        void load_scoring_matrix(std::ifstream& matrix_stream);
+        
+        bool adjust_alignments_for_base_quality = false; // use base quality adjusted alignments
+
+    private:
+        // GSSW aligners
+        unique_ptr<QualAdjAligner> qual_adj_aligner;
+        unique_ptr<Aligner> regular_aligner;
+        
+        // GC content estimate that we need for building the aligners.
+        double gc_content_estimate;
+    };
+    
 } // end namespace vg
 
 #endif

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -32,7 +32,7 @@ namespace vg {
     static const int8_t default_max_scaled_score = 32;
     static const uint8_t default_max_qual_score = 255;
     static const double default_gc_content = 0.5;
-    static const uint32_t default_max_gap_length = 40;
+    static const uint32_t default_xdrop_max_gap_length = 40;
 
     
     class VG; // forward declaration
@@ -289,7 +289,7 @@ namespace vg {
                 int8_t _gap_extension,
                 int8_t _full_length_bonus,
                 double _gc_content,
-                uint32_t _max_gap_length);
+                uint32_t _xdrop_max_gap_length);
         ~Aligner(void) = default;
         
         /// Store optimal local alignment against a graph in the Alignment object.

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -45,11 +45,11 @@ namespace vg {
         
         /// Store optimal local alignment against a graph in the Alignment object.
         /// Gives the full length bonus separately on each end of the alignment.
-        virtual void align(Alignment& alignment, const HandleGraph& g, bool traceback_aln, bool print_score_matrices) = 0;
+        virtual void align(Alignment& alignment, const HandleGraph& g, bool traceback_aln, bool print_score_matrices) const = 0;
         
         /// Same as previous, but takes advantage of a pre-computed topological order
         virtual void align(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order,
-                           bool traceback_aln, bool print_score_matrices) = 0;
+                           bool traceback_aln, bool print_score_matrices) const = 0;
         
     };
 
@@ -79,22 +79,22 @@ namespace vg {
                                        bool pinned,
                                        bool pin_left,
                                        bool print_score_matrices = false) const;
-        string graph_cigar(gssw_graph_mapping* gm);
+        string graph_cigar(gssw_graph_mapping* gm) const;
         
     public:
         /// Given a nonempty vector of nonnegative scaled alignment scores,
         /// compute the mapping quality of the maximal score in the vector.
         /// Sets max_idx_out to the index of that score in the vector. May
         /// modify the input vector.
-        static double maximum_mapping_quality_exact(vector<double>& scaled_scores, size_t* max_idx_out);
+        static double maximum_mapping_quality_exact(vector<double>& scaled_scores, size_t* max_idx_out); 
         /// Given a nonempty vector of nonnegative scaled alignment scores,
         /// approximate the mapping quality of the maximal score in the vector.
         /// Sets max_idx_out to the index of that score in the vector. May
         /// modify the input vector.
         static double maximum_mapping_quality_approx(vector<double>& scaled_scores, size_t* max_idx_out);
     protected:
-        double group_mapping_quality_exact(vector<double>& scaled_scores, vector<size_t>& group);
-        double estimate_next_best_score(int length, double min_diffs);
+        double group_mapping_quality_exact(vector<double>& scaled_scores, vector<size_t>& group) const;
+        double estimate_next_best_score(int length, double min_diffs) const;
         
         // must be called before querying mapping_quality
         void init_mapping_quality(double gc_content);
@@ -104,8 +104,8 @@ namespace vg {
         
     public:
 
-        double max_possible_mapping_quality(int length);
-        double estimate_max_possible_mapping_quality(int length, double min_diffs, double next_min_diffs);
+        double max_possible_mapping_quality(int length) const;
+        double estimate_max_possible_mapping_quality(int length, double min_diffs, double next_min_diffs) const;
         
         // store optimal alignment against a graph in the Alignment object with one end of the sequence
         // guaranteed to align to a source/sink node
@@ -117,11 +117,11 @@ namespace vg {
         // Gives the full length bonus only on the non-pinned end of the alignment.
         //
         // assumes that graph is topologically sorted by node index
-        virtual void align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left) = 0;
+        virtual void align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left) const = 0;
         
         /// Same as previous, but takes advantage of a pre-computed topological order
         virtual void align_pinned(Alignment& alignment, const HandleGraph& g,
-                                  const vector<handle_t>& topological_order, bool pin_left) = 0;
+                                  const vector<handle_t>& topological_order, bool pin_left) const = 0;
         
         // store the top scoring pinned alignments in the vector in descending score order up to a maximum
         // number of alignments (including the optimal one). if there are fewer than the maximum number in
@@ -130,18 +130,18 @@ namespace vg {
         //
         // assumes that graph is topologically sorted by node index
         virtual void align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                        bool pin_left, int32_t max_alt_alns) = 0;
+                                        bool pin_left, int32_t max_alt_alns) const = 0;
         
         
         /// Same as previous, but takes advantage of a pre-computed topological order
         virtual void align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                        const vector<handle_t>& topological_order, bool pin_left, int32_t max_alt_alns) = 0;
+                                        const vector<handle_t>& topological_order, bool pin_left, int32_t max_alt_alns) const = 0;
         
         // store optimal global alignment against a graph within a specified band in the Alignment object
         // permissive banding auto detects the width of band needed so that paths can travel
         // through every node in the graph
         virtual void align_global_banded(Alignment& alignment, const HandleGraph& g,
-                                         int32_t band_padding = 0, bool permissive_banding = true) = 0;
+                                         int32_t band_padding = 0, bool permissive_banding = true) const = 0;
         
         // store top scoring global alignments in the vector in descending score order up to a maximum number
         // of alternate alignments (including the optimal alignment). if there are fewer than the maximum
@@ -149,10 +149,10 @@ namespace vg {
         // optimal alignment will be stored in both the vector and the original alignment object
         virtual void align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments,
                                                const HandleGraph& g, int32_t max_alt_alns, int32_t band_padding = 0,
-                                               bool permissive_banding = true) = 0;
+                                               bool permissive_banding = true) const = 0;
         // xdrop aligner
-        virtual void align_xdrop(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, bool multithreaded) = 0;
-        virtual void align_xdrop_multi(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, int32_t max_alt_alns) = 0;
+        virtual void align_xdrop(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented) const = 0;
+        virtual void align_xdrop_multi(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, int32_t max_alt_alns) const = 0;
 
         /// Compute the score of an exact match in the given alignment, from the
         /// given offset, of the given length.
@@ -169,7 +169,7 @@ namespace vg {
                                                 string::const_iterator seq_begin) const = 0;
         
         /// Returns the score of an insert or deletion of the given length
-        int32_t score_gap(size_t gap_length);
+        int32_t score_gap(size_t gap_length) const;
         
         /// stores -10 * log_10(P_err) in alignment mapping_quality field where P_err is the
         /// probability that the alignment is not the correct one (assuming that one of the alignments
@@ -183,7 +183,7 @@ namespace vg {
                                      int overlap_count,
                                      double mq_estimate,
                                      double maybe_mq_threshold,
-                                     double identity_weight);
+                                     double identity_weight) const;
         /// same function for paired reads, mapping qualities are stored in both alignments in the pair
         void compute_paired_mapping_quality(pair<vector<Alignment>, vector<Alignment>>& alignment_pairs,
                                             const vector<double>& frag_weights,
@@ -197,13 +197,13 @@ namespace vg {
                                             double mq_estimate1,
                                             double mq_estimate2,
                                             double maybe_mq_threshold,
-                                            double identity_weight);
+                                            double identity_weight) const;
         
         /// Computes mapping quality for the optimal score in a vector of scores
-        int32_t compute_mapping_quality(vector<double>& scores, bool fast_approximation);
+        int32_t compute_mapping_quality(vector<double>& scores, bool fast_approximation) const;
         
         /// Computes mapping quality for a group of scores in a vector of scores (group given by indexes)
-        int32_t compute_group_mapping_quality(vector<double>& scores, vector<size_t>& group);
+        int32_t compute_group_mapping_quality(vector<double>& scores, vector<size_t>& group) const;
         
         /// Returns the  difference between an optimal and second-best alignment scores that would
         /// result in this mapping quality using the fast mapping quality approximation
@@ -211,7 +211,7 @@ namespace vg {
         
         /// Convert a score to an unnormalized log likelihood for the sequence.
         /// Requires log_base to have been set.
-        double score_to_unnormalized_likelihood_ln(double score);
+        double score_to_unnormalized_likelihood_ln(double score) const;
         
         /// The longest gap detectable from a read position without soft-clipping
         size_t longest_detectable_gap(const Alignment& alignment, const string::const_iterator& read_pos) const;
@@ -295,9 +295,9 @@ namespace vg {
         /// Store optimal local alignment against a graph in the Alignment object.
         /// Gives the full length bonus separately on each end of the alignment.
         /// Assumes that graph is topologically sorted by node index.
-        void align(Alignment& alignment, const HandleGraph& g, bool traceback_aln, bool print_score_matrices);
+        void align(Alignment& alignment, const HandleGraph& g, bool traceback_aln, bool print_score_matrices) const;
         void align(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order,
-                   bool traceback_aln, bool print_score_matrices);
+                   bool traceback_aln, bool print_score_matrices) const;
         
         // store optimal alignment against a graph in the Alignment object with one end of the sequence
         // guaranteed to align to a source/sink node
@@ -309,9 +309,9 @@ namespace vg {
         // Gives the full length bonus only on the non-pinned end of the alignment.
         //
         // assumes that graph is topologically sorted by node index
-        void align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left);
+        void align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left) const;
         void align_pinned(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order,
-                          bool pin_left);
+                          bool pin_left) const;
                 
         // store the top scoring pinned alignments in the vector in descending score order up to a maximum
         // number of alignments (including the optimal one). if there are fewer than the maximum number in
@@ -320,26 +320,26 @@ namespace vg {
         //
         // assumes that graph is topologically sorted by node index
         void align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                bool pin_left, int32_t max_alt_alns);
+                                bool pin_left, int32_t max_alt_alns) const;
         void align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                const vector<handle_t>& topological_order, bool pin_left, int32_t max_alt_alns);
+                                const vector<handle_t>& topological_order, bool pin_left, int32_t max_alt_alns) const;
         
         // store optimal global alignment against a graph within a specified band in the Alignment object
         // permissive banding auto detects the width of band needed so that paths can travel
         // through every node in the graph
         void align_global_banded(Alignment& alignment, const HandleGraph& g,
-                                 int32_t band_padding = 0, bool permissive_banding = true);
+                                 int32_t band_padding = 0, bool permissive_banding = true) const;
         
         // store top scoring global alignments in the vector in descending score order up to a maximum number
         // of alternate alignments (including the optimal alignment). if there are fewer than the maximum
         // number of alignments in the return value, then the vector contains all possible alignments. the
         // optimal alignment will be stored in both the vector and the original alignment object
         void align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                       int32_t max_alt_alns, int32_t band_padding = 0, bool permissive_banding = true);
+                                       int32_t max_alt_alns, int32_t band_padding = 0, bool permissive_banding = true) const;
 
         // xdrop aligner
-        void align_xdrop(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, bool multithreaded);
-        void align_xdrop_multi(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, int32_t max_alt_alns);
+        void align_xdrop(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented) const;
+        void align_xdrop_multi(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, int32_t max_alt_alns) const;
 
         int32_t score_exact_match(const Alignment& aln, size_t read_offset, size_t length) const;
         int32_t score_exact_match(const string& sequence, const string& base_quality) const;
@@ -370,23 +370,23 @@ namespace vg {
         ~QualAdjAligner(void) = default;
 
         // base quality adjusted counterparts to functions of same name from Aligner
-        void align(Alignment& alignment, const HandleGraph& g, bool traceback_aln, bool print_score_matrices);
+        void align(Alignment& alignment, const HandleGraph& g, bool traceback_aln, bool print_score_matrices) const;
         void align(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order,
-                   bool traceback_aln, bool print_score_matrices);
+                   bool traceback_aln, bool print_score_matrices) const;
         void align_global_banded(Alignment& alignment, const HandleGraph& g,
-                                 int32_t band_padding = 0, bool permissive_banding = true);
-        void align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left);
+                                 int32_t band_padding = 0, bool permissive_banding = true) const;
+        void align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left) const;
         void align_pinned(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order,
-                          bool pin_left);
+                          bool pin_left) const;
         void align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                       int32_t max_alt_alns, int32_t band_padding = 0, bool permissive_banding = true);
+                                       int32_t max_alt_alns, int32_t band_padding = 0, bool permissive_banding = true) const;
         void align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                bool pin_left, int32_t max_alt_alns);
+                                bool pin_left, int32_t max_alt_alns) const;
         void align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                const vector<handle_t>& topological_order, bool pin_left, int32_t max_alt_alns);
+                                const vector<handle_t>& topological_order, bool pin_left, int32_t max_alt_alns) const;
         // xdrop aligner
-        void align_xdrop(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, bool multithreaded);
-        void align_xdrop_multi(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, int32_t max_alt_alns);
+        void align_xdrop(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented) const;
+        void align_xdrop_multi(Alignment& alignment, Graph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, int32_t max_alt_alns) const;
 
         void init_mapping_quality(double gc_content);
         
@@ -407,7 +407,7 @@ namespace vg {
                             const vector<handle_t>* topological_order,
                             bool pinned, bool pin_left, int32_t max_alt_alns,
                             bool traceback_aln,
-                            bool print_score_matrices);
+                            bool print_score_matrices) const;
         
 
     };

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -1,5 +1,5 @@
-#ifndef VG_GSSW_ALIGNER_HPP_INCLUDED
-#define VG_GSSW_ALIGNER_HPP_INCLUDED
+#ifndef VG_ALIGNER_HPP_INCLUDED
+#define VG_ALIGNER_HPP_INCLUDED
 
 #include <algorithm>
 #include <utility>

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -392,7 +392,7 @@ bool ShuffledPairs::iterator::operator!=(const iterator& other) const {
 }
     
 int32_t MEMClusterer::estimate_edge_score(const MaximalExactMatch* mem_1, const MaximalExactMatch* mem_2,
-                                          int64_t graph_dist, GSSWAligner* aligner) const {
+                                          int64_t graph_dist, const GSSWAligner* aligner) const {
     
     // the length of the sequence in between the MEMs (can be negative if they overlap)
     int64_t between_length = mem_2->begin - mem_1->end;
@@ -469,7 +469,7 @@ void MEMClusterer::deduplicate_cluster_pairs(vector<pair<pair<size_t, size_t>, i
 #endif
 }
     
-MEMClusterer::HitGraph::HitGraph(const vector<MaximalExactMatch>& mems, const Alignment& alignment, GSSWAligner* aligner,
+MEMClusterer::HitGraph::HitGraph(const vector<MaximalExactMatch>& mems, const Alignment& alignment, const GSSWAligner* aligner,
                                  size_t min_mem_length) {
     // there generally will be at least as many nodes as MEMs, so we can speed up the reallocation
     nodes.reserve(mems.size());
@@ -1015,7 +1015,7 @@ void MEMClusterer::HitGraph::identify_sources_and_sinks(vector<size_t>& sources_
 }
 
 vector<MEMClusterer::cluster_t> MEMClusterer::HitGraph::clusters(const Alignment& alignment,
-                                                                 GSSWAligner* aligner,
+                                                                 const GSSWAligner* aligner,
                                                                  int32_t max_qual_score,
                                                                  int32_t log_likelihood_approx_factor,
                                                                  size_t min_median_mem_coverage_for_split,
@@ -1193,7 +1193,7 @@ vector<MEMClusterer::cluster_t> MEMClusterer::HitGraph::clusters(const Alignment
     
 vector<MEMClusterer::cluster_t> MEMClusterer::clusters(const Alignment& alignment,
                                                        const vector<MaximalExactMatch>& mems,
-                                                       GSSWAligner* aligner,
+                                                       const GSSWAligner* aligner,
                                                        size_t min_mem_length ,
                                                        int32_t max_qual_score,
                                                        int32_t log_likelihood_approx_factor,
@@ -1537,7 +1537,7 @@ vector<pair<size_t, size_t>> SnarlOrientedDistanceMeasurer::exclude_merges(vecto
     
     
 MEMClusterer::HitGraph OrientedDistanceClusterer::make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems,
-                                                                 GSSWAligner* aligner, size_t min_mem_length) {
+                                                                 const GSSWAligner* aligner, size_t min_mem_length) {
     
     HitGraph hit_graph(mems, alignment, aligner, min_mem_length);
     
@@ -3008,7 +3008,7 @@ TVSClusterer::TVSClusterer(const HandleGraph* handle_graph, DistanceIndex* dista
 }
     
 MEMClusterer::HitGraph TVSClusterer::make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems,
-                                                    GSSWAligner* aligner, size_t min_mem_length) {
+                                                    const GSSWAligner* aligner, size_t min_mem_length) {
     
     
     // intialize with nodes

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -392,7 +392,7 @@ bool ShuffledPairs::iterator::operator!=(const iterator& other) const {
 }
     
 int32_t MEMClusterer::estimate_edge_score(const MaximalExactMatch* mem_1, const MaximalExactMatch* mem_2,
-                                          int64_t graph_dist, BaseAligner* aligner) const {
+                                          int64_t graph_dist, GSSWAligner* aligner) const {
     
     // the length of the sequence in between the MEMs (can be negative if they overlap)
     int64_t between_length = mem_2->begin - mem_1->end;
@@ -469,7 +469,7 @@ void MEMClusterer::deduplicate_cluster_pairs(vector<pair<pair<size_t, size_t>, i
 #endif
 }
     
-MEMClusterer::HitGraph::HitGraph(const vector<MaximalExactMatch>& mems, const Alignment& alignment, BaseAligner* aligner,
+MEMClusterer::HitGraph::HitGraph(const vector<MaximalExactMatch>& mems, const Alignment& alignment, GSSWAligner* aligner,
                                  size_t min_mem_length) {
     // there generally will be at least as many nodes as MEMs, so we can speed up the reallocation
     nodes.reserve(mems.size());
@@ -1015,7 +1015,7 @@ void MEMClusterer::HitGraph::identify_sources_and_sinks(vector<size_t>& sources_
 }
 
 vector<MEMClusterer::cluster_t> MEMClusterer::HitGraph::clusters(const Alignment& alignment,
-                                                                 BaseAligner* aligner,
+                                                                 GSSWAligner* aligner,
                                                                  int32_t max_qual_score,
                                                                  int32_t log_likelihood_approx_factor,
                                                                  size_t min_median_mem_coverage_for_split,
@@ -1193,7 +1193,7 @@ vector<MEMClusterer::cluster_t> MEMClusterer::HitGraph::clusters(const Alignment
     
 vector<MEMClusterer::cluster_t> MEMClusterer::clusters(const Alignment& alignment,
                                                        const vector<MaximalExactMatch>& mems,
-                                                       BaseAligner* aligner,
+                                                       GSSWAligner* aligner,
                                                        size_t min_mem_length ,
                                                        int32_t max_qual_score,
                                                        int32_t log_likelihood_approx_factor,
@@ -1537,7 +1537,7 @@ vector<pair<size_t, size_t>> SnarlOrientedDistanceMeasurer::exclude_merges(vecto
     
     
 MEMClusterer::HitGraph OrientedDistanceClusterer::make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems,
-                                                                 BaseAligner* aligner, size_t min_mem_length) {
+                                                                 GSSWAligner* aligner, size_t min_mem_length) {
     
     HitGraph hit_graph(mems, alignment, aligner, min_mem_length);
     
@@ -3008,7 +3008,7 @@ TVSClusterer::TVSClusterer(const HandleGraph* handle_graph, DistanceIndex* dista
 }
     
 MEMClusterer::HitGraph TVSClusterer::make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems,
-                                                    BaseAligner* aligner, size_t min_mem_length) {
+                                                    GSSWAligner* aligner, size_t min_mem_length) {
     
     
     // intialize with nodes

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -170,7 +170,7 @@ public:
     /// contains a pointer to the original MEM and the position of that particular hit in the graph.
     vector<cluster_t> clusters(const Alignment& alignment,
                                const vector<MaximalExactMatch>& mems,
-                               BaseAligner* Aligner,
+                               GSSWAligner* Aligner,
                                size_t min_mem_length = 1,
                                int32_t max_qual_score = 60,
                                int32_t log_likelihood_approx_factor = 0,
@@ -205,12 +205,12 @@ protected:
     /// Initializes a hit graph and adds edges to it, this must be implemented by any inheriting
     /// class
     virtual HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems,
-                                    BaseAligner* aligner, size_t min_mem_length) = 0;
+                                    GSSWAligner* aligner, size_t min_mem_length) = 0;
     
     /// Once the distance between two hits has been estimated, estimate the score of the hit graph edge
     /// connecting them
     int32_t estimate_edge_score(const MaximalExactMatch* mem_1, const MaximalExactMatch* mem_2, int64_t graph_dist,
-                                BaseAligner* aligner) const;
+                                GSSWAligner* aligner) const;
     
     /// Sorts cluster pairs and removes copies of the same cluster pair, choosing only the one whose distance
     /// is closest to the optimal separation
@@ -221,7 +221,7 @@ class MEMClusterer::HitGraph {
 public:
     
     /// Initializes nodes in the hit graph, but does not add edges
-    HitGraph(const vector<MaximalExactMatch>& mems, const Alignment& alignment, BaseAligner* aligner,
+    HitGraph(const vector<MaximalExactMatch>& mems, const Alignment& alignment, GSSWAligner* aligner,
              size_t min_mem_length = 1);
     
     /// Add an edge
@@ -229,7 +229,7 @@ public:
     
     /// Returns the top scoring connected components
     vector<cluster_t> clusters(const Alignment& alignment,
-                               BaseAligner* aligner,
+                               GSSWAligner* aligner,
                                int32_t max_qual_score,
                                int32_t log_likelihood_approx_factor,
                                size_t min_median_mem_coverage_for_split,
@@ -521,7 +521,7 @@ private:
                                                            const vector<MaximalExactMatch>& mems);
     
     /// Concrete implementation of virtual method from MEMClusterer
-    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, BaseAligner* aligner,
+    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, GSSWAligner* aligner,
                             size_t min_mem_length);
     
     OrientedDistanceMeasurer& distance_measurer;
@@ -623,7 +623,7 @@ public:
 private:
     
     /// Concrete implementation of virtual method from MEMClusterer
-    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, BaseAligner* aligner,
+    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, GSSWAligner* aligner,
                             size_t min_mem_length);
     
     TargetValueSearch tvs;

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -170,7 +170,7 @@ public:
     /// contains a pointer to the original MEM and the position of that particular hit in the graph.
     vector<cluster_t> clusters(const Alignment& alignment,
                                const vector<MaximalExactMatch>& mems,
-                               GSSWAligner* Aligner,
+                               const GSSWAligner* Aligner,
                                size_t min_mem_length = 1,
                                int32_t max_qual_score = 60,
                                int32_t log_likelihood_approx_factor = 0,
@@ -205,12 +205,12 @@ protected:
     /// Initializes a hit graph and adds edges to it, this must be implemented by any inheriting
     /// class
     virtual HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems,
-                                    GSSWAligner* aligner, size_t min_mem_length) = 0;
+                                    const GSSWAligner* aligner, size_t min_mem_length) = 0;
     
     /// Once the distance between two hits has been estimated, estimate the score of the hit graph edge
     /// connecting them
     int32_t estimate_edge_score(const MaximalExactMatch* mem_1, const MaximalExactMatch* mem_2, int64_t graph_dist,
-                                GSSWAligner* aligner) const;
+                                const GSSWAligner* aligner) const;
     
     /// Sorts cluster pairs and removes copies of the same cluster pair, choosing only the one whose distance
     /// is closest to the optimal separation
@@ -221,7 +221,7 @@ class MEMClusterer::HitGraph {
 public:
     
     /// Initializes nodes in the hit graph, but does not add edges
-    HitGraph(const vector<MaximalExactMatch>& mems, const Alignment& alignment, GSSWAligner* aligner,
+    HitGraph(const vector<MaximalExactMatch>& mems, const Alignment& alignment, const GSSWAligner* aligner,
              size_t min_mem_length = 1);
     
     /// Add an edge
@@ -229,7 +229,7 @@ public:
     
     /// Returns the top scoring connected components
     vector<cluster_t> clusters(const Alignment& alignment,
-                               GSSWAligner* aligner,
+                               const GSSWAligner* aligner,
                                int32_t max_qual_score,
                                int32_t log_likelihood_approx_factor,
                                size_t min_median_mem_coverage_for_split,
@@ -521,7 +521,7 @@ private:
                                                            const vector<MaximalExactMatch>& mems);
     
     /// Concrete implementation of virtual method from MEMClusterer
-    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, GSSWAligner* aligner,
+    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, const GSSWAligner* aligner,
                             size_t min_mem_length);
     
     OrientedDistanceMeasurer& distance_measurer;
@@ -623,7 +623,7 @@ public:
 private:
     
     /// Concrete implementation of virtual method from MEMClusterer
-    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, GSSWAligner* aligner,
+    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, const GSSWAligner* aligner,
                             size_t min_mem_length);
     
     TargetValueSearch tvs;

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -5,7 +5,7 @@
 #include <gcsa/lcp.h>
 #include <structures/union_find.hpp>
 #include "position.hpp"
-#include "gssw_aligner.hpp"
+#include "aligner.hpp"
 #include "utility.hpp"
 #include "mem.hpp"
 #include "xg.hpp"

--- a/src/flow_sort.cpp
+++ b/src/flow_sort.cpp
@@ -1,6 +1,6 @@
 #include "vg.hpp"
 #include "stream/stream.hpp"
-#include "gssw_aligner.hpp"
+#include "aligner.hpp"
 #include "vg.pb.h"
 #include "flow_sort.hpp"
 #include <raptor2/raptor2.h>

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1592,10 +1592,10 @@ void BaseMapper::force_fragment_length_distr(double mean, double stddev) {
     fragment_length_distr.force_parameters(mean, stddev);
 }
     
-BaseAligner* BaseMapper::get_aligner(bool have_qualities) const {
+GSSWAligner* BaseMapper::get_aligner(bool have_qualities) const {
     return (have_qualities && adjust_alignments_for_base_quality) ?
-        (BaseAligner*) qual_adj_aligner :
-        (BaseAligner*) regular_aligner;
+        (GSSWAligner*) qual_adj_aligner :
+        (GSSWAligner*) regular_aligner;
 }
 
 QualAdjAligner* BaseMapper::get_qual_adj_aligner() const {
@@ -3517,7 +3517,7 @@ VG Mapper::cluster_subgraph_strict(const Alignment& aln, const vector<MaximalExa
     backward_max_dist.reserve(mems.size());
     
     // What aligner are we using?
-    BaseAligner* aligner = get_aligner();
+    GSSWAligner* aligner = get_aligner();
     
     for (const auto& mem : mems) {
         // get the start position of the MEM
@@ -4113,7 +4113,7 @@ bool Mapper::adjacent_positions(const Position& pos1, const Position& pos2) {
 void Mapper::compute_mapping_qualities(vector<Alignment>& alns, double cluster_mq, double mq_estimate, double mq_cap) {
     if (alns.empty()) return;
     double max_mq = min(mq_cap, (double)max_mapping_quality);
-    BaseAligner* aligner = get_aligner();
+    GSSWAligner* aligner = get_aligner();
     int sub_overlaps = sub_overlaps_of_first_aln(alns, mq_overlap);
     switch (mapping_quality_method) {
         case Approx:
@@ -4131,7 +4131,7 @@ void Mapper::compute_mapping_qualities(pair<vector<Alignment>, vector<Alignment>
     if (pair_alns.first.empty() || pair_alns.second.empty()) return;
     double max_mq1 = min(mq_cap1, (double)max_mapping_quality);
     double max_mq2 = min(mq_cap2, (double)max_mapping_quality);
-    BaseAligner* aligner = get_aligner();
+    GSSWAligner* aligner = get_aligner();
     int sub_overlaps1 = sub_overlaps_of_first_aln(pair_alns.first, mq_overlap);
     int sub_overlaps2 = sub_overlaps_of_first_aln(pair_alns.second, mq_overlap);
     vector<double> frag_weights;
@@ -4843,7 +4843,7 @@ void Mapper::remove_full_length_bonuses(Alignment& aln) {
 int32_t Mapper::score_alignment(const Alignment& aln, bool use_approx_distance) {
 
     // Find the right aligner to score with
-    BaseAligner* aligner = get_aligner();
+    GSSWAligner* aligner = get_aligner();
     
     if (use_approx_distance) {
         // Use an approximation

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -3457,7 +3457,7 @@ VG Mapper::cluster_subgraph_strict(const Alignment& aln, const vector<MaximalExa
     backward_max_dist.reserve(mems.size());
     
     // What aligner are we using?
-    GSSWAligner* aligner = get_aligner();
+    const GSSWAligner* aligner = get_aligner();
     
     for (const auto& mem : mems) {
         // get the start position of the MEM
@@ -4053,7 +4053,7 @@ bool Mapper::adjacent_positions(const Position& pos1, const Position& pos2) {
 void Mapper::compute_mapping_qualities(vector<Alignment>& alns, double cluster_mq, double mq_estimate, double mq_cap) {
     if (alns.empty()) return;
     double max_mq = min(mq_cap, (double)max_mapping_quality);
-    GSSWAligner* aligner = get_aligner();
+    const GSSWAligner* aligner = get_aligner();
     int sub_overlaps = sub_overlaps_of_first_aln(alns, mq_overlap);
     switch (mapping_quality_method) {
         case Approx:
@@ -4071,7 +4071,7 @@ void Mapper::compute_mapping_qualities(pair<vector<Alignment>, vector<Alignment>
     if (pair_alns.first.empty() || pair_alns.second.empty()) return;
     double max_mq1 = min(mq_cap1, (double)max_mapping_quality);
     double max_mq2 = min(mq_cap2, (double)max_mapping_quality);
-    GSSWAligner* aligner = get_aligner();
+    const GSSWAligner* aligner = get_aligner();
     int sub_overlaps1 = sub_overlaps_of_first_aln(pair_alns.first, mq_overlap);
     int sub_overlaps2 = sub_overlaps_of_first_aln(pair_alns.second, mq_overlap);
     vector<double> frag_weights;
@@ -4783,7 +4783,7 @@ void Mapper::remove_full_length_bonuses(Alignment& aln) {
 int32_t Mapper::score_alignment(const Alignment& aln, bool use_approx_distance) {
 
     // Find the right aligner to score with
-    GSSWAligner* aligner = get_aligner();
+    const GSSWAligner* aligner = get_aligner();
     
     if (use_approx_distance) {
         // Use an approximation

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1896,7 +1896,7 @@ Alignment Mapper::align_to_graph(const Alignment& aln,
             
             // directly call alignment function without node translation
             // cerr << "X-drop alignment, (" << xdrop_alignment << "), rev(" << ((xdrop_alignment == 1) ? false : true) << ")" << endl;
-            get_aligner(!aln.quality().empty())->align_xdrop(aligned, graph, mems, (xdrop_alignment == 1) ? false : true, alignment_threads > 1);
+            get_aligner(!aln.quality().empty())->align_xdrop(aligned, graph, mems, (xdrop_alignment == 1) ? false : true);
         } else {
             // local alignment is based on gssw, which takes a HandleGraph, but only uses it for sorting and
             // for constructing its own graph representation. we can improve efficiency by taking advantage of

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -180,10 +180,6 @@ public:
     void set_alignment_scores(int8_t match, int8_t mismatch, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus,
                               uint32_t xdrop_max_gap_length = default_xdrop_max_gap_length, double haplotype_consistency_exponent = 1);
     
-    /// Set the alignment thread count, updating internal data structures that
-    /// are per thread. Note that this resets aligner scores to their default values!
-    void set_alignment_threads(int new_thread_count);
-    
     void set_cache_size(int new_cache_size);
     
     /// Returns true if fragment length distribution has been fixed
@@ -324,8 +320,6 @@ protected:
     // Algorithm for choosing an adaptive reseed length based on the length of the parent MEM
     size_t get_adaptive_min_reseed_length(size_t parent_mem_length);
     
-    int alignment_threads; // how many threads will *this* mapper use. Should not be set directly.
-
     /// Score all of the alignments in the vector for haplotype consistency. If
     /// all of them can be scored (i.e. none of them visit nodes/edges with no
     /// haplotypes), adjust all of their scores to reflect haplotype

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -149,50 +149,6 @@ private:
 };
 
 /**
- * Holds a set of alignment scores, and has methods to produce aligners of various types on demand, using those scores.
- * Provides a get_aligner() method to get ahold of a useful, possibly quality-adjusted Aligner.
- * Base functionality that is shared between alignment and surjections
- */
-class AlignerClient {
-protected:
-
-    /// Create an AlignerClient, which creates the default aligner instances,
-    /// which can depend on a GC content estimate.
-    AlignerClient(double gc_content_estimate = vg::default_gc_content);
-    
-    /// Get the appropriate aligner to use, based on
-    /// adjust_alignments_for_base_quality. By setting have_qualities to false,
-    /// you can force the non-quality-adjusted aligner, for reads that lack
-    /// quality scores.
-    GSSWAligner* get_aligner(bool have_qualities = true) const;
-    
-    // Sometimes you really do need the two kinds of aligners, to pass to code
-    // that expects one or the other.
-    QualAdjAligner* get_qual_adj_aligner() const;
-    Aligner* get_regular_aligner() const;
-    
-public:
-    /// Set all the aligner scoring parameters and create the stored aligner instances.
-    void set_alignment_scores(int8_t match, int8_t mismatch, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus,
-                              uint32_t xdrop_max_gap_length = default_xdrop_max_gap_length);
-                              
-    /// Load a scoring amtrix from a file to set scores
-    void load_scoring_matrix(std::ifstream& matrix_stream);
-    
-    bool adjust_alignments_for_base_quality = false; // use base quality adjusted alignments
-
-private:
-    // GSSW aligners
-    unique_ptr<QualAdjAligner> qual_adj_aligner;
-    unique_ptr<Aligner> regular_aligner;
-    
-    // GC content estimate that we need for building the aligners.
-    double gc_content_estimate;
-    
-
-};
-    
-/**
  * Base class for basic mapping functionality shared between the Mapper, MultipathMapper, etc.
  * Handles holding on to the random access and text indexes needed for mapping operations.
  */

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -148,12 +148,21 @@ private:
     void estimate_distribution();
 };
     
-class BaseMapper : public Progressive {
+/**
+ * Base class for basic mapping functionality shared between the Mapper, MultipathMapper, Surjector, etc.
+ * Handles holding on to the random access and text indexes needed for mapping operations.
+ * Provides a get_aligner() method to get ahold of a useful, possibly quality-adjusted Aligner.
+ */
+class BaseMapper {
     
 public:
-    // Make a Mapper that pulls from an XG succinct graph and a GCSA2 kmer
-    // index + LCP array, and which can score reads against haplotypes using
-    // the given ScoreProvider.
+    /**
+     * Make a BaseMapper that pulls from an XG succinct graph and a GCSA2 kmer
+     * index + LCP array, and which can score reads against haplotypes using
+     * the given ScoreProvider.
+     *
+     * If the GCSA and LCPArray are null, cannot do search, only alignment.
+     */
     BaseMapper(xg::XG* xidex, gcsa::GCSA* g, gcsa::LCPArray* a, haplo::ScoreProvider* haplo_score_provider = nullptr);
     BaseMapper(void);
     ~BaseMapper(void);

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -19,7 +19,7 @@
 #include "lru_cache.h"
 #include "json2pb.h"
 #include "entropy.hpp"
-#include "gssw_aligner.hpp"
+#include "aligner.hpp"
 #include "mem.hpp"
 #include "cluster.hpp"
 #include "graph.hpp"

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -360,7 +360,7 @@ protected:
     /// adjust_alignments_for_base_quality. By setting have_qualities to false,
     /// you can force the non-quality-adjusted aligner, for reads that lack
     /// quality scores.
-    BaseAligner* get_aligner(bool have_qualities = true) const;
+    GSSWAligner* get_aligner(bool have_qualities = true) const;
     
     // Sometimes you really do need the two kinds of aligners, to pass to code
     // that expects one or the other.

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1357,7 +1357,7 @@ namespace vg {
         }
     }
    
-    void MultipathAlignmentGraph::synthesize_tail_anchors(const Alignment& alignment, const HandleGraph& align_graph, BaseAligner* aligner,
+    void MultipathAlignmentGraph::synthesize_tail_anchors(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner,
                                                           size_t max_alt_alns, bool dynamic_alt_alns) {
     
         
@@ -2914,7 +2914,7 @@ namespace vg {
         
     }
     
-    void MultipathAlignmentGraph::prune_to_high_scoring_paths(const Alignment& alignment, const BaseAligner* aligner,
+    void MultipathAlignmentGraph::prune_to_high_scoring_paths(const Alignment& alignment, const GSSWAligner* aligner,
                                                               double max_suboptimal_score_ratio, const vector<size_t>& topological_order) {
         
         // Can only prune when edges exist.
@@ -3052,7 +3052,7 @@ namespace vg {
 #endif
     }
     
-    void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGraph& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
+    void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner, bool score_anchors_as_matches,
                                         size_t max_alt_alns, bool dynamic_alt_alns, size_t band_padding, MultipathAlignment& multipath_aln_out, const bool allow_negative_scores) {
         
         // don't dynamically choose band padding, shim constant value into a function type
@@ -3062,7 +3062,7 @@ namespace vg {
         align(alignment, align_graph, aligner, score_anchors_as_matches, max_alt_alns, dynamic_alt_alns, constant_padding, multipath_aln_out, allow_negative_scores);
     }
     
-    void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGraph& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
+    void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner, bool score_anchors_as_matches,
                                         size_t max_alt_alns, bool dynamic_alt_alns,
                                         function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,
                                         MultipathAlignment& multipath_aln_out, const bool allow_negative_scores) {
@@ -3387,7 +3387,7 @@ namespace vg {
     
     unordered_map<bool, unordered_map<size_t, vector<Alignment>>>
     MultipathAlignmentGraph::align_tails(const Alignment& alignment, const HandleGraph& align_graph,
-                                         BaseAligner* aligner, size_t max_alt_alns,
+                                         GSSWAligner* aligner, size_t max_alt_alns,
                                          bool dynamic_alt_alns, unordered_set<size_t>* sources) {
         
 #ifdef debug_multipath_alignment

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1357,8 +1357,8 @@ namespace vg {
         }
     }
    
-    void MultipathAlignmentGraph::synthesize_tail_anchors(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner,
-                                                          size_t max_alt_alns, bool dynamic_alt_alns) {
+    void MultipathAlignmentGraph::synthesize_tail_anchors(const Alignment& alignment, const HandleGraph& align_graph,
+                                                          const GSSWAligner* aligner, size_t max_alt_alns, bool dynamic_alt_alns) {
     
         
         // Align the tails, not collecting a set of source subpaths.
@@ -3052,7 +3052,7 @@ namespace vg {
 #endif
     }
     
-    void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner, bool score_anchors_as_matches,
+    void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner, bool score_anchors_as_matches,
                                         size_t max_alt_alns, bool dynamic_alt_alns, size_t band_padding, MultipathAlignment& multipath_aln_out, const bool allow_negative_scores) {
         
         // don't dynamically choose band padding, shim constant value into a function type
@@ -3062,7 +3062,7 @@ namespace vg {
         align(alignment, align_graph, aligner, score_anchors_as_matches, max_alt_alns, dynamic_alt_alns, constant_padding, multipath_aln_out, allow_negative_scores);
     }
     
-    void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner, bool score_anchors_as_matches,
+    void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner, bool score_anchors_as_matches,
                                         size_t max_alt_alns, bool dynamic_alt_alns,
                                         function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,
                                         MultipathAlignment& multipath_aln_out, const bool allow_negative_scores) {
@@ -3387,7 +3387,7 @@ namespace vg {
     
     unordered_map<bool, unordered_map<size_t, vector<Alignment>>>
     MultipathAlignmentGraph::align_tails(const Alignment& alignment, const HandleGraph& align_graph,
-                                         GSSWAligner* aligner, size_t max_alt_alns,
+                                         const GSSWAligner* aligner, size_t max_alt_alns,
                                          bool dynamic_alt_alns, unordered_set<size_t>* sources) {
         
 #ifdef debug_multipath_alignment

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -100,7 +100,7 @@ namespace vg {
         
         /// Removes nodes and edges that are not part of any path that has an estimated score
         /// within some amount of the highest scoring path. Reachability edges must be present.
-        void prune_to_high_scoring_paths(const Alignment& alignment, const BaseAligner* aligner,
+        void prune_to_high_scoring_paths(const Alignment& alignment, const GSSWAligner* aligner,
                                          double max_suboptimal_score_ratio, const vector<size_t>& topological_order);
         
         /// Clear reachability edges, so that add_reachability_edges can be run
@@ -127,7 +127,7 @@ namespace vg {
         /// Alignment that owns the sequence into which iterators were passed
         /// when the MultipathAlignmentGraph was constructed! TODO: Shouldn't
         /// the class hold a reference to the Alignment then?
-        void synthesize_tail_anchors(const Alignment& alignment, const HandleGraph& align_graph, BaseAligner* aligner,
+        void synthesize_tail_anchors(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner,
                                      size_t max_alt_alns, bool dynamic_alt_alns);
         
         /// Add edges between reachable nodes and split nodes at overlaps
@@ -145,7 +145,7 @@ namespace vg {
         /// Note that the output alignment may NOT be in topologically-sorted
         /// order, even if this MultipathAlignmentGraph is. You MUST sort it
         /// with topologically_order_subpaths() before trying to run DP on it.
-        void align(const Alignment& alignment, const HandleGraph& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
+        void align(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t band_padding, MultipathAlignment& multipath_aln_out, const bool allow_negative_scores = false);
         
         /// Do intervening and tail alignments between the anchoring paths and
@@ -160,7 +160,7 @@ namespace vg {
         /// Note that the output alignment may NOT be in topologically-sorted
         /// order, even if this MultipathAlignmentGraph is. You MUST sort it
         /// with topologically_order_subpaths() before trying to run DP on it.
-        void align(const Alignment& alignment, const HandleGraph& align_graph, BaseAligner* aligner, bool score_anchors_as_matches,
+        void align(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns,
                    function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,
                    MultipathAlignment& multipath_aln_out, const bool allow_negative_scores = false);
@@ -227,7 +227,7 @@ namespace vg {
         /// source subpaths and adds their numbers to the given set if not
         /// null.
         unordered_map<bool, unordered_map<size_t, vector<Alignment>>>
-        align_tails(const Alignment& alignment, const HandleGraph& align_graph, BaseAligner* aligner,
+        align_tails(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner,
                     size_t max_alt_alns, bool dynamic_alt_alns, unordered_set<size_t>* sources = nullptr);
     };
 }

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -127,7 +127,7 @@ namespace vg {
         /// Alignment that owns the sequence into which iterators were passed
         /// when the MultipathAlignmentGraph was constructed! TODO: Shouldn't
         /// the class hold a reference to the Alignment then?
-        void synthesize_tail_anchors(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner,
+        void synthesize_tail_anchors(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner,
                                      size_t max_alt_alns, bool dynamic_alt_alns);
         
         /// Add edges between reachable nodes and split nodes at overlaps
@@ -145,7 +145,7 @@ namespace vg {
         /// Note that the output alignment may NOT be in topologically-sorted
         /// order, even if this MultipathAlignmentGraph is. You MUST sort it
         /// with topologically_order_subpaths() before trying to run DP on it.
-        void align(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner, bool score_anchors_as_matches,
+        void align(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t band_padding, MultipathAlignment& multipath_aln_out, const bool allow_negative_scores = false);
         
         /// Do intervening and tail alignments between the anchoring paths and
@@ -160,7 +160,7 @@ namespace vg {
         /// Note that the output alignment may NOT be in topologically-sorted
         /// order, even if this MultipathAlignmentGraph is. You MUST sort it
         /// with topologically_order_subpaths() before trying to run DP on it.
-        void align(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner, bool score_anchors_as_matches,
+        void align(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns,
                    function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,
                    MultipathAlignment& multipath_aln_out, const bool allow_negative_scores = false);
@@ -227,7 +227,7 @@ namespace vg {
         /// source subpaths and adds their numbers to the given set if not
         /// null.
         unordered_map<bool, unordered_map<size_t, vector<Alignment>>>
-        align_tails(const Alignment& alignment, const HandleGraph& align_graph, GSSWAligner* aligner,
+        align_tails(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner,
                     size_t max_alt_alns, bool dynamic_alt_alns, unordered_set<size_t>* sources = nullptr);
     };
 }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2538,7 +2538,7 @@ namespace vg {
                                                const vector<memcluster_t>& clusters) -> vector<clustergraph_t> {
         
         // Figure out the aligner to use
-        BaseAligner* aligner = get_aligner();
+        GSSWAligner* aligner = get_aligner();
         
         // We populate this with all the cluster graphs.
         vector<clustergraph_t> cluster_graphs_out;
@@ -3143,9 +3143,9 @@ namespace vg {
         // We should never actually compute a MAPQ with the None method. If we try, it means something has gonbe wrong.
         assert(mapq_method != None);
    
-        // TODO: BaseAligner's mapping quality computation insists on sometimes appending a 0 to your score list.
+        // TODO: GSSWAligner's mapping quality computation insists on sometimes appending a 0 to your score list.
         // We don't want to take a mutable score list, so we copy it here.
-        // This can be removed when BaseAligner is fixed to take const score lists.
+        // This can be removed when GSSWAligner is fixed to take const score lists.
         vector<double> mutable_scores(scores.begin(), scores.end());
    
         int32_t raw_mapq;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2538,7 +2538,7 @@ namespace vg {
                                                const vector<memcluster_t>& clusters) -> vector<clustergraph_t> {
         
         // Figure out the aligner to use
-        GSSWAligner* aligner = get_aligner();
+        const GSSWAligner* aligner = get_aligner();
         
         // We populate this with all the cluster graphs.
         vector<clustergraph_t> cluster_graphs_out;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -9,7 +9,7 @@
 
 #include "hash_map.hpp"
 #include "mapper.hpp"
-#include "gssw_aligner.hpp"
+#include "aligner.hpp"
 #include "types.hpp"
 #include "multipath_alignment.hpp"
 #include "xg.hpp"

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -506,7 +506,7 @@ ReadFilter::Counts ReadFilter::filter_alignment(Alignment& aln) {
     } else if (rescore == true) {
         // We need to recalculate the score with the base aligner always
         const static Aligner unadjusted;
-        BaseAligner* aligner = (BaseAligner*)&unadjusted;
+        GSSWAligner* aligner = (GSSWAligner*)&unadjusted;
             
         // Rescore and assign the score
         aln.set_score(aligner->score_ungapped_alignment(aln));

--- a/src/subcommand/align_main.cpp
+++ b/src/subcommand/align_main.cpp
@@ -201,7 +201,7 @@ int main_align(int argc, char** argv) {
         Aligner aligner = Aligner(match, mismatch, gap_open, gap_extend, full_length_bonus, vg::default_gc_content, seq.size());
         if(matrix_stream.is_open()) aligner.load_scoring_matrix(matrix_stream);
         alignment = graph->align(seq, &aligner, true, false, 0, pinned_alignment, pin_left,
-                                 banded_global, 0, 0, 0, 0, 0, debug);
+                                 banded_global, 0, 0, 0, 0, debug);
     }
 
     if (!seq_name.empty()) {

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -971,7 +971,7 @@ int main_map(int argc, char** argv) {
         m->fast_reseed = use_fast_reseed;
         m->max_sub_mem_recursion_depth = max_sub_mem_recursion_depth;
         m->max_target_factor = max_target_factor;
-        m->set_alignment_scores(match, mismatch, gap_open, gap_extend, full_length_bonus, haplotype_consistency_exponent, max_gap_length);
+        m->set_alignment_scores(match, mismatch, gap_open, gap_extend, full_length_bonus, max_gap_length, haplotype_consistency_exponent);
         if(matrix_stream.is_open()) m->load_scoring_matrix(matrix_stream);
         m->strip_bonuses = strip_bonuses;
         m->adjust_alignments_for_base_quality = qual_adjust_alignments;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1017,9 +1017,8 @@ int main_mpmap(int argc, char** argv) {
         multipath_mapper.calibrate_mismapping_detection(num_calibration_simulations, calibration_read_length);
     }
     
-    // set computational paramters
+    // Count our threads 
     int thread_count = get_thread_count();
-    multipath_mapper.set_alignment_threads(thread_count);
     
     // Establish a watchdog to find reads that take too long to map.
     // If we see any, we will issue a warning.

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -135,7 +135,6 @@ int main_msga(int argc, char** argv) {
     int maybe_mq_threshold = 0;
     int min_banded_mq = 0;
     bool use_fast_reseed = true;
-    bool show_align_progress = false;
     bool bigger_first = true;
     bool patch_alignments = true;
     int max_sub_mem_recursion_depth = 2;
@@ -190,7 +189,6 @@ int main_msga(int argc, char** argv) {
                 {"try-up-to", required_argument, 0, 'u'},
                 {"try-at-least", required_argument, 0, 'l'},
                 {"drop-chain", required_argument, 0, 'C'},
-                {"align-progress", no_argument, 0, 'S'},
                 {"bigger-first", no_argument, 0, 'a'},
                 {"no-patch-aln", no_argument, 0, '8'},
                 {"max-gap-length", required_argument, 0, 1},
@@ -199,7 +197,7 @@ int main_msga(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:w:DAc:P:E:Q:NY:H:t:m:M:q:O:I:i:o:y:ZW:z:k:L:e:r:u:l:C:F:SJ:B:a8R:T:",
+        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:w:DAc:P:E:Q:NY:H:t:m:M:q:O:I:i:o:y:ZW:z:k:L:e:r:u:l:C:F:J:B:a8R:T:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -292,10 +290,6 @@ int main_msga(int argc, char** argv) {
 
         case 'A':
             debug_align = true;
-            break;
-
-        case 'S':
-            show_align_progress = true;
             break;
 
         case 'X':
@@ -673,7 +667,6 @@ int main_msga(int argc, char** argv) {
             mapper->max_mapping_quality = max_mapping_quality;
             // set up the multi-threaded alignment interface
             mapper->set_alignment_threads(alignment_threads);
-            mapper->show_progress = show_align_progress;
             mapper->patch_alignments = patch_alignments;
         }
     };

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -108,7 +108,6 @@ int main_msga(int argc, char** argv) {
     bool debug = false;
     bool debug_align = false;
     size_t node_max = 0;
-    int alignment_threads = get_thread_count();
     int edge_max = 3;
     int subgraph_prune = 0;
     bool normalize = false;
@@ -330,7 +329,6 @@ int main_msga(int argc, char** argv) {
 
         case 't':
             omp_set_num_threads(parse<int>(optarg));
-            alignment_threads = parse<int>(optarg);
             break;
 
         case 'Q':
@@ -665,8 +663,6 @@ int main_msga(int argc, char** argv) {
             mapper->extra_multimaps = extra_multimaps;
             mapper->mapping_quality_method = mapping_quality_method;
             mapper->max_mapping_quality = max_mapping_quality;
-            // set up the multi-threaded alignment interface
-            mapper->set_alignment_threads(alignment_threads);
             mapper->patch_alignments = patch_alignments;
         }
     };

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -245,8 +245,6 @@ int main_surject(int argc, char** argv) {
                 strcat(out_mode, tmp);
             }
             
-            int thread_count = get_thread_count();
-            
             // bam/sam/cram output
             
             // Define a string to hold the SAM header, to be generated later.

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -195,14 +195,11 @@ int main_surject(int argc, char** argv) {
         path_length[name] = xgidx->path_length(name);
     }
     
-    // Make Surjectors for all the threads. TODO: There's no good reason to
-    // need one of these per thread. They and BaseAligner ought to be made
-    // thread safe.
+    // Make a single therad-safe Surjector.
+    Surjector surjector(xgidx.get());
+   
+    // Count out threads
     int thread_count = get_thread_count();
-    vector<Surjector*> surjectors(thread_count);
-    for (int i = 0; i < surjectors.size(); i++) {
-        surjectors[i] = new Surjector(xgidx.get());
-    }
 
     if (input_type == "gam") {
         if (output_type == "gam") {
@@ -220,12 +217,12 @@ int main_surject(int argc, char** argv) {
                 string path_name;
                 int64_t path_pos;
                 bool path_reverse;
-                buffer[tid].push_back(surjectors[omp_get_thread_num()]->surject(src,
-                                                                                path_names,
-                                                                                path_name,
-                                                                                path_pos,
-                                                                                path_reverse,
-                                                                                subpath_global));
+                buffer[tid].push_back(surjector.surject(src,
+                                                        path_names,
+                                                        path_name,
+                                                        path_pos,
+                                                        path_reverse,
+                                                        subpath_global));
                 stream::write_buffered(cout, buffer[tid], 100);
             };
             get_input_file(file_name, [&](istream& in) {
@@ -288,12 +285,12 @@ int main_surject(int argc, char** argv) {
                 // reads need to come out with a 0 1-based position.
                 int64_t path_pos = -1; 
                 bool path_reverse = false;
-                auto surj = surjectors[omp_get_thread_num()]->surject(src,
-                                                                      path_names,
-                                                                      path_name,
-                                                                      path_pos,
-                                                                      path_reverse,
-                                                                      subpath_global);
+                auto surj = surjector.surject(src,
+                                              path_names,
+                                              path_name,
+                                              path_pos,
+                                              path_reverse,
+                                              subpath_global);
                 // Always use the surjected alignment, even if it surjects to unmapped.
                 
                 // Set sample metadata after surjection, since input read is const.
@@ -549,10 +546,6 @@ int main_surject(int argc, char** argv) {
     }
     cout.flush();
     
-    for (Surjector* surjector : surjectors) {
-        delete surjector;
-    }
-
     return 0;
 }
 

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -21,7 +21,7 @@ using namespace std;
     
     Alignment Surjector::surject(const Alignment& source, const set<string>& path_names,
                                  string& path_name_out, int64_t& path_pos_out, bool& path_rev_out,
-                                 bool allow_negative_scores) {
+                                 bool allow_negative_scores) const {
         
 #ifdef debug_anchored_surject
         cerr << "surjecting alignment: " << pb2json(source) << " onto paths ";
@@ -183,7 +183,7 @@ using namespace std;
     unordered_map<size_t, vector<Surjector::path_chunk_t>>
     Surjector::extract_overlapping_paths(const Alignment& source, const unordered_map<size_t, string>& path_rank_to_name,
                                          unordered_map<int64_t, vector<size_t>>* paths_of_node_memo,
-                                         unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo) {
+                                         unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo) const {
         
         
         unordered_map<size_t, vector<path_chunk_t>> to_return;
@@ -297,7 +297,7 @@ using namespace std;
     
     pair<size_t, size_t>
     Surjector::compute_path_interval(const Alignment& source, size_t path_rank, const xg::XGPath& xpath, const vector<path_chunk_t>& path_chunks,
-                                     unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo) {
+                                     unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo) const {
         
         pair<size_t, size_t> interval(numeric_limits<size_t>::max(), numeric_limits<size_t>::min());
         
@@ -358,7 +358,7 @@ using namespace std;
     }
     
     VG Surjector::extract_linearized_path_graph(size_t first, size_t last, const xg::XGPath& xpath,
-                                                unordered_map<id_t, pair<id_t, bool>>& node_trans) {
+                                                unordered_map<id_t, pair<id_t, bool>>& node_trans) const {
         
 #ifdef debug_anchored_surject
         cerr << "extracting path graph for position interval " << first << ":" << last << " in path of length " << xpath.positions[xpath.positions.size() - 1] + xindex->node_length(xpath.node(xpath.ids.size() - 1)) << endl;
@@ -397,7 +397,7 @@ using namespace std;
     
     void Surjector::set_path_position(const Alignment& surjected, size_t best_path_rank, const xg::XGPath& xpath,
                                       string& path_name_out, int64_t& path_pos_out, bool& path_rev_out,
-                                      unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo) {
+                                      unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo) const {
         
         const Path& path = surjected.path();
         

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -13,14 +13,10 @@ namespace vg {
 
 using namespace std;
     
-    Surjector::Surjector(xg::XG* xg_index) : BaseMapper(xg_index, nullptr, nullptr) {
+    Surjector::Surjector(const xg::XG* xg_index) : xindex(xg_index) {
         if (!xindex) {
             cerr << "error:[Surjector] Failed to provide an XG index to the Surjector" << endl;
         }
-    }
-    
-    Surjector::~Surjector() {
-        
     }
     
     Alignment Surjector::surject(const Alignment& source, const set<string>& path_names,

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -41,7 +41,7 @@ using namespace std;
                           string& path_name_out,
                           int64_t& path_pos_out,
                           bool& path_rev_out,
-                          bool allow_negative_scores = false);
+                          bool allow_negative_scores = false) const;
         
         /// a local type that represents a read interval matched to a portion of the alignment path
         using path_chunk_t = pair<pair<string::const_iterator, string::const_iterator>, Path>;
@@ -52,25 +52,25 @@ using namespace std;
         unordered_map<size_t, vector<path_chunk_t>>
         extract_overlapping_paths(const Alignment& source, const unordered_map<size_t, string>& path_rank_to_name,
                                   unordered_map<int64_t, vector<size_t>>* paths_of_node_memo = nullptr,
-                                  unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo = nullptr);
+                                  unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo = nullptr) const;
         
         /// compute the widest interval of path positions that the realigned sequence could align to
         pair<size_t, size_t>
         compute_path_interval(const Alignment& source, size_t path_rank, const xg::XGPath& xpath, const vector<path_chunk_t>& path_chunks,
-                              unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo = nullptr);
+                              unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo = nullptr) const;
         
         /// make a linear graph that corresponds to a path interval, possibly duplicating nodes in case of cycles
         VG extract_linearized_path_graph(size_t first, size_t last, const xg::XGPath& xpath,
-                                         unordered_map<id_t, pair<id_t, bool>>& node_trans);
+                                         unordered_map<id_t, pair<id_t, bool>>& node_trans) const;
         
         
         /// associate a path position and strand to a surjected alignment against this path
         void set_path_position(const Alignment& surjected, size_t best_path_rank, const xg::XGPath& xpath,
                                string& path_name_out, int64_t& path_pos_out, bool& path_rev_out,
-                               unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo = nullptr);
+                               unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo = nullptr) const;
         
         // make a sentinel meant to indicate an unmapped read
-        Alignment make_null_alignment(const Alignment& source);
+        static Alignment make_null_alignment(const Alignment& source);
         
         const xg::XG* xindex;
     };

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -9,7 +9,7 @@
 #include <set>
 
 #include "alignment.hpp"
-#include "mapper.hpp"
+#include "aligner.hpp"
 #include "xg.hpp"
 #include "vg.hpp"
 #include "translator.hpp"
@@ -23,11 +23,10 @@ namespace vg {
 
 using namespace std;
 
-    class Surjector : BaseMapper {
+    class Surjector : AlignerClient {
     public:
         
-        Surjector(xg::XG* xg_index);
-        ~Surjector();
+        Surjector(const xg::XG* xg_index);
         
         /// Extract the portions of an alignment that are on a chosen set of paths and try to
         /// align realign the portions that are off of the chosen paths to the intervening
@@ -72,6 +71,8 @@ using namespace std;
         
         // make a sentinel meant to indicate an unmapped read
         Alignment make_null_alignment(const Alignment& source);
+        
+        const xg::XG* xindex;
     };
 }
 

--- a/src/unittest/aligner.cpp
+++ b/src/unittest/aligner.cpp
@@ -8,7 +8,7 @@
 #include <string>
 #include "../json2pb.h"
 #include "../vg.pb.h"
-#include "../gssw_aligner.hpp"
+#include "../aligner.hpp"
 #include "catch.hpp"
 
 namespace vg {

--- a/src/unittest/aligner.cpp
+++ b/src/unittest/aligner.cpp
@@ -316,7 +316,7 @@ TEST_CASE("Full-length bonus is applied to both ends by rescoring", "[aligner][a
     REQUIRE(aligner1.score_ungapped_alignment(aln) == 139);
 }
 
-TEST_CASE("BaseAligner mapping quality estimation is robust", "[aligner][alignment][mapping][mapq]") {
+TEST_CASE("GSSWAligner mapping quality estimation is robust", "[aligner][alignment][mapping][mapq]") {
     
     vector<double> scaled_scores;
     size_t max_idx;
@@ -327,25 +327,25 @@ TEST_CASE("BaseAligner mapping quality estimation is robust", "[aligner][alignme
         
         SECTION("a 1-element positive vector has its element chosen") {
             scaled_scores = {10};
-            BaseAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            GSSWAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a 1-element zero vector has its element chosen") {
             scaled_scores = {0};
-            BaseAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            GSSWAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a 1-element negative vector has its element chosen") {
             scaled_scores = {-10};
-            BaseAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            GSSWAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a multi-element vector has a maximal element chosen") {
             scaled_scores = {1, 5, 2, 5, 4};
-            BaseAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
+            GSSWAligner::maximum_mapping_quality_exact(scaled_scores, &max_idx);
             REQUIRE(max_idx >= 1);
             REQUIRE(max_idx != 2);
             REQUIRE(max_idx <= 3);
@@ -358,25 +358,25 @@ TEST_CASE("BaseAligner mapping quality estimation is robust", "[aligner][alignme
 
         SECTION("a 1-element positive vector has its element chosen") {
             scaled_scores = {10};
-            BaseAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            GSSWAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a 1-element zero vector has its element chosen") {
             scaled_scores = {0};
-            BaseAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            GSSWAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a 1-element negative vector has its element chosen") {
             scaled_scores = {-10};
-            BaseAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            GSSWAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
             REQUIRE(max_idx == 0);
         }
         
         SECTION("a multi-element vector has a maximal element chosen") {
             scaled_scores = {1, 5, 2, 5, 4};
-            BaseAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
+            GSSWAligner::maximum_mapping_quality_approx(scaled_scores, &max_idx);
             REQUIRE(max_idx >= 1);
             REQUIRE(max_idx != 2);
             REQUIRE(max_idx <= 3);

--- a/src/unittest/banded_global_aligner.cpp
+++ b/src/unittest/banded_global_aligner.cpp
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include "catch.hpp"
-#include "gssw_aligner.hpp"
+#include "aligner.hpp"
 #include "vg.hpp"
 #include "path.hpp"
 #include "banded_global_aligner.hpp"

--- a/src/unittest/pinned_alignment.cpp
+++ b/src/unittest/pinned_alignment.cpp
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <unordered_set>
 #include "alignment.hpp"
-#include "gssw_aligner.hpp"
+#include "aligner.hpp"
 #include "vg.hpp"
 #include "path.hpp"
 #include "catch.hpp"

--- a/src/variant_adder.cpp
+++ b/src/variant_adder.cpp
@@ -714,7 +714,7 @@ Alignment VariantAdder::smart_align(vg::VG& graph, pair<NodeSide, NodeSide> endp
             
                 // Otherwise, it's unsafe to try the tight banded alignment
                 // (because our bands might get too big). Try a Mapper-based
-                // fake-banded alignment, and trturn its alignment if it finds a
+                // fake-banded alignment, and return its alignment if it finds a
                 // good one.
                 
                 // Generate an XG index
@@ -744,10 +744,9 @@ Alignment VariantAdder::smart_align(vg::VG& graph, pair<NodeSide, NodeSide> endp
                         
                 // Make the Mapper
                 Mapper mapper(&xg_index, gcsa_index, lcp_index);
-                // Set up the threads
-                mapper.set_alignment_threads(omp_get_num_threads());
                 // Copy over alignment scores
-                mapper.set_alignment_scores(aligner.match, aligner.mismatch, aligner.gap_open, aligner.gap_extension, aligner.full_length_bonus);
+                mapper.set_alignment_scores(aligner.match, aligner.mismatch, aligner.gap_open, aligner.gap_extension,
+                                            aligner.full_length_bonus);
                 
                 // Map. Will invoke the banded aligner if the read is long, and
                 // the normal index-based aligner otherwise.

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -6737,8 +6737,8 @@ unordered_map<id_t, pair<id_t, bool> > VG::overlay_node_translations(const unord
 }
 
 Alignment VG::align(const Alignment& alignment,
-                    Aligner* aligner,
-                    QualAdjAligner* qual_adj_aligner,
+                    const Aligner* aligner,
+                    const QualAdjAligner* qual_adj_aligner,
                     const vector<MaximalExactMatch>& mems,
                     bool traceback,
                     bool acyclic_and_sorted,
@@ -6898,7 +6898,7 @@ Alignment VG::align(const Alignment& alignment,
 }
 
 Alignment VG::align(const Alignment& alignment,
-                    Aligner* aligner,
+                    const Aligner* aligner,
                     const vector<MaximalExactMatch>& mems,
                     bool traceback,
                     bool acyclic_and_sorted,
@@ -6917,7 +6917,7 @@ Alignment VG::align(const Alignment& alignment,
 }
 
 Alignment VG::align(const Alignment& alignment,
-                    Aligner* aligner,
+                    const Aligner* aligner,
                     bool traceback,
                     bool acyclic_and_sorted,
                     size_t max_query_graph_ratio,
@@ -6936,7 +6936,7 @@ Alignment VG::align(const Alignment& alignment,
 }
 
 Alignment VG::align(const string& sequence,
-                    Aligner* aligner,
+                    const Aligner* aligner,
                     bool traceback,
                     bool acyclic_and_sorted,
                     size_t max_query_graph_ratio,
@@ -6994,7 +6994,7 @@ Alignment VG::align(const string& sequence,
 
 
 Alignment VG::align_qual_adjusted(const Alignment& alignment,
-                                  QualAdjAligner* qual_adj_aligner,
+                                  const QualAdjAligner* qual_adj_aligner,
                                   const vector<MaximalExactMatch>& mems,
                                   bool traceback,
                                   bool acyclic_and_sorted,
@@ -7013,7 +7013,7 @@ Alignment VG::align_qual_adjusted(const Alignment& alignment,
 }
 
 Alignment VG::align_qual_adjusted(const Alignment& alignment,
-                                  QualAdjAligner* qual_adj_aligner,
+                                  const QualAdjAligner* qual_adj_aligner,
                                   bool traceback,
                                   bool acyclic_and_sorted,
                                   size_t max_query_graph_ratio,
@@ -7032,7 +7032,7 @@ Alignment VG::align_qual_adjusted(const Alignment& alignment,
 }
 
 Alignment VG::align_qual_adjusted(const string& sequence,
-                                  QualAdjAligner* qual_adj_aligner,
+                                  const QualAdjAligner* qual_adj_aligner,
                                   bool traceback,
                                   bool acyclic_and_sorted,
                                   size_t max_query_graph_ratio,

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -1,6 +1,6 @@
 #include "vg.hpp"
 #include "stream/stream.hpp"
-#include "gssw_aligner.hpp"
+#include "aligner.hpp"
 // We need to use ultrabubbles for dot output
 #include "genotypekit.hpp"
 #include "algorithms/topological_sort.hpp"

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -6750,7 +6750,6 @@ Alignment VG::align(const Alignment& alignment,
                     size_t max_span,
                     size_t unroll_length,
                     int xdrop_alignment,
-                    bool multithreaded_xdrop,
                     bool print_score_matrices) {
 
     auto aln = alignment;
@@ -6807,7 +6806,7 @@ Alignment VG::align(const Alignment& alignment,
         } else if(xdrop_alignment) {
             // cerr << "X-drop alignment, (" << xdrop_alignment << ")" << endl;
             if (aligner && !qual_adj_aligner) {
-                aligner->align_xdrop(aln, g.graph, (translated_mems.size()? translated_mems : mems), (xdrop_alignment == 1) ? false : true, multithreaded_xdrop);
+                aligner->align_xdrop(aln, g.graph, (translated_mems.size()? translated_mems : mems), (xdrop_alignment == 1) ? false : true);
             } else {
                 /* qual_adj_aligner is not yet implemented, fallback */
                 qual_adj_aligner->align/*_xdrop*/(aln, g, traceback, print_score_matrices);
@@ -6911,11 +6910,10 @@ Alignment VG::align(const Alignment& alignment,
                     size_t max_span,
                     size_t unroll_length,
                     int xdrop_alignment,
-                    bool multithreaded_xdrop,
                     bool print_score_matrices) {
     return align(alignment, aligner, nullptr, mems, traceback, acyclic_and_sorted, max_query_graph_ratio,
                  pinned_alignment, pin_left, banded_global, band_padding_override,
-                 max_span, unroll_length, xdrop_alignment, multithreaded_xdrop, print_score_matrices);
+                 max_span, unroll_length, xdrop_alignment, print_score_matrices);
 }
 
 Alignment VG::align(const Alignment& alignment,
@@ -6930,12 +6928,11 @@ Alignment VG::align(const Alignment& alignment,
                     size_t max_span,
                     size_t unroll_length,
                     int xdrop_alignment,
-                    bool multithreaded_xdrop,
                     bool print_score_matrices) {
     const vector<MaximalExactMatch> mems;
     return align(alignment, aligner, nullptr, mems, traceback, acyclic_and_sorted, max_query_graph_ratio,
                  pinned_alignment, pin_left, banded_global, band_padding_override,
-                 max_span, unroll_length, xdrop_alignment, multithreaded_xdrop, print_score_matrices);
+                 max_span, unroll_length, xdrop_alignment, print_score_matrices);
 }
 
 Alignment VG::align(const string& sequence,
@@ -6950,13 +6947,12 @@ Alignment VG::align(const string& sequence,
                     size_t max_span,
                     size_t unroll_length,
                     int xdrop_alignment,
-                    bool multithreaded_xdrop,
                     bool print_score_matrices) {
     Alignment alignment;
     alignment.set_sequence(sequence);
     return align(alignment, aligner, traceback, acyclic_and_sorted, max_query_graph_ratio,
                  pinned_alignment, pin_left, banded_global, band_padding_override,
-                 max_span, unroll_length, xdrop_alignment, multithreaded_xdrop, print_score_matrices);
+                 max_span, unroll_length, xdrop_alignment, print_score_matrices);
 }
 
 Alignment VG::align(const Alignment& alignment,
@@ -6970,12 +6966,11 @@ Alignment VG::align(const Alignment& alignment,
                     size_t max_span,
                     size_t unroll_length,
                     int xdrop_alignment,
-                    bool multithreaded_xdrop,
                     bool print_score_matrices) {
     Aligner default_aligner = Aligner();
     return align(alignment, &default_aligner, traceback, acyclic_and_sorted, max_query_graph_ratio,
                  pinned_alignment, pin_left, banded_global, band_padding_override,
-                 max_span, unroll_length, xdrop_alignment, multithreaded_xdrop, print_score_matrices);
+                 max_span, unroll_length, xdrop_alignment, print_score_matrices);
 }
 
 Alignment VG::align(const string& sequence,
@@ -6989,13 +6984,12 @@ Alignment VG::align(const string& sequence,
                     size_t max_span,
                     size_t unroll_length,
                     int xdrop_alignment,
-                    bool multithreaded_xdrop,
                     bool print_score_matrices) {
     Alignment alignment;
     alignment.set_sequence(sequence);
     return align(alignment, traceback, acyclic_and_sorted, max_query_graph_ratio,
                  pinned_alignment, pin_left, banded_global, band_padding_override,
-                 max_span, unroll_length, xdrop_alignment, multithreaded_xdrop, print_score_matrices);
+                 max_span, unroll_length, xdrop_alignment, print_score_matrices);
 }
 
 
@@ -7012,11 +7006,10 @@ Alignment VG::align_qual_adjusted(const Alignment& alignment,
                                   size_t max_span,
                                   size_t unroll_length,
                                   int xdrop_alignment,
-                                  bool multithreaded_xdrop,
                                   bool print_score_matrices) {
     return align(alignment, nullptr, qual_adj_aligner, mems, traceback, acyclic_and_sorted, max_query_graph_ratio,
                  pinned_alignment, pin_left, banded_global, band_padding_override,
-                 max_span, unroll_length, xdrop_alignment, multithreaded_xdrop, print_score_matrices);
+                 max_span, unroll_length, xdrop_alignment, print_score_matrices);
 }
 
 Alignment VG::align_qual_adjusted(const Alignment& alignment,
@@ -7031,12 +7024,11 @@ Alignment VG::align_qual_adjusted(const Alignment& alignment,
                                   size_t max_span,
                                   size_t unroll_length,
                                   int xdrop_alignment,
-                                  bool multithreaded_xdrop,
                                   bool print_score_matrices) {
     const vector<MaximalExactMatch> mems;
     return align(alignment, nullptr, qual_adj_aligner, mems, traceback, acyclic_and_sorted, max_query_graph_ratio,
                  pinned_alignment, pin_left, banded_global, band_padding_override,
-                 max_span, unroll_length, xdrop_alignment, multithreaded_xdrop, print_score_matrices);
+                 max_span, unroll_length, xdrop_alignment, print_score_matrices);
 }
 
 Alignment VG::align_qual_adjusted(const string& sequence,
@@ -7051,13 +7043,12 @@ Alignment VG::align_qual_adjusted(const string& sequence,
                                   size_t max_span,
                                   size_t unroll_length,
                                   int xdrop_alignment,
-                                  bool multithreaded_xdrop,
                                   bool print_score_matrices) {
     Alignment alignment;
     alignment.set_sequence(sequence);
     return align_qual_adjusted(alignment, qual_adj_aligner, traceback, acyclic_and_sorted, max_query_graph_ratio,
                                pinned_alignment, pin_left, banded_global, band_padding_override,
-                               max_span, unroll_length, xdrop_alignment, multithreaded_xdrop, print_score_matrices);
+                               max_span, unroll_length, xdrop_alignment, print_score_matrices);
 }
 
 const string VG::hash(void) {

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -1031,7 +1031,7 @@ public:
     /// May modify the graph by re-ordering the nodes.
     /// May add nodes to the graph, but cleans them up afterward.
     Alignment align(const string& sequence,
-                    Aligner* aligner,
+                    const Aligner* aligner,
                     bool traceback = true,
                     bool acyclic_and_sorted = false,
                     size_t max_query_graph_ratio = 0,
@@ -1048,7 +1048,7 @@ public:
     /// May modify the graph by re-ordering the nodes.
     /// May add nodes to the graph, but cleans them up afterward.
     Alignment align(const Alignment& alignment,
-                    Aligner* aligner,
+                    const Aligner* aligner,
                     const vector<MaximalExactMatch>& mems,
                     bool traceback = true,
                     bool acyclic_and_sorted = false,
@@ -1062,7 +1062,7 @@ public:
                     int xdrop_alignment = 0,                // 1 for forward, >1 for reverse
                     bool print_score_matrices = false);
     Alignment align(const Alignment& alignment,
-                    Aligner* aligner,
+                    const Aligner* aligner,
                     bool traceback = true,
                     bool acyclic_and_sorted = false,
                     size_t max_query_graph_ratio = 0,
@@ -1113,7 +1113,7 @@ public:
     /// May modify the graph by re-ordering the nodes.
     /// May add nodes to the graph, but cleans them up afterward.
     Alignment align_qual_adjusted(const Alignment& alignment,
-                                  QualAdjAligner* qual_adj_aligner,
+                                  const QualAdjAligner* qual_adj_aligner,
                                   const vector<MaximalExactMatch>& mems,
                                   bool traceback = true,
                                   bool acyclic_and_sorted = false,
@@ -1127,7 +1127,7 @@ public:
                                   int xdrop_alignment = 0,              // 1 for forward, >1 for reverse
                                   bool print_score_matrices = false);
     Alignment align_qual_adjusted(const Alignment& alignment,
-                                  QualAdjAligner* qual_adj_aligner,
+                                  const QualAdjAligner* qual_adj_aligner,
                                   bool traceback = true,
                                   bool acyclic_and_sorted = false,
                                   size_t max_query_graph_ratio = 0,
@@ -1144,7 +1144,7 @@ public:
     /// May modify the graph by re-ordering the nodes.
     /// May add nodes to the graph, but cleans them up afterward.
     Alignment align_qual_adjusted(const string& sequence,
-                                  QualAdjAligner* qual_adj_aligner,
+                                  const QualAdjAligner* qual_adj_aligner,
                                   bool traceback = true,
                                   bool acyclic_and_sorted = false,
                                   size_t max_query_graph_ratio = 0,
@@ -1262,8 +1262,8 @@ private:
     /// padding is provided. If the band padding override is not provided, the
     /// max span is used as the band padding and permissive banding is enabled.
     Alignment align(const Alignment& alignment,
-                    Aligner* aligner,
-                    QualAdjAligner* qual_adj_aligner,
+                    const Aligner* aligner,
+                    const QualAdjAligner* qual_adj_aligner,
                     const vector<MaximalExactMatch>& mems,
                     bool traceback = true,
                     bool acyclic_and_sorted = false,

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -17,7 +17,7 @@
 #include "gssw.h"
 #include <gcsa/gcsa.h>
 #include <gcsa/lcp.h>
-#include "gssw_aligner.hpp"
+#include "aligner.hpp"
 #include "ssw_aligner.hpp"
 #include "region.hpp"
 #include "path.hpp"

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -1042,7 +1042,6 @@ public:
                     size_t max_span = 0,
                     size_t unroll_length = 0,
                     int xdrop_alignment = 0,                // 1 for forward, >1 for reverse, see constructor for the X-drop threshold
-                    bool multithreaded_xdrop = false,
                     bool print_score_matrices = false);
     /// Align without base quality adjusted scores.
     /// Align to the graph.
@@ -1061,7 +1060,6 @@ public:
                     size_t max_span = 0,
                     size_t unroll_length = 0,
                     int xdrop_alignment = 0,                // 1 for forward, >1 for reverse
-                    bool multithreaded_xdrop = false,
                     bool print_score_matrices = false);
     Alignment align(const Alignment& alignment,
                     Aligner* aligner,
@@ -1075,7 +1073,6 @@ public:
                     size_t max_span = 0,
                     size_t unroll_length = 0,
                     int xdrop_alignment = 0,                // 1 for forward, >1 for reverse
-                    bool multithreaded_xdrop = false,
                     bool print_score_matrices = false);
     
     /// Align with default Aligner.
@@ -1093,7 +1090,6 @@ public:
                     size_t max_span = 0,
                     size_t unroll_length = 0,
                     int xdrop_alignment = 0,                // 1 for forward, >1 for reverse
-                    bool multithreaded_xdrop = false,
                     bool print_score_matrices = false);
     /// Align with default Aligner.
     /// Align to the graph.
@@ -1110,7 +1106,6 @@ public:
                     size_t max_span = 0,
                     size_t unroll_length = 0,
                     int xdrop_alignment = 0,                // 1 for forward, >1 for reverse
-                    bool multithreaded_xdrop = false,
                     bool print_score_matrices = false);
     
     /// Align with base quality adjusted scores.
@@ -1130,7 +1125,6 @@ public:
                                   size_t max_span = 0,
                                   size_t unroll_length = 0,
                                   int xdrop_alignment = 0,              // 1 for forward, >1 for reverse
-                                  bool multithreaded_xdrop = false,
                                   bool print_score_matrices = false);
     Alignment align_qual_adjusted(const Alignment& alignment,
                                   QualAdjAligner* qual_adj_aligner,
@@ -1144,7 +1138,6 @@ public:
                                   size_t max_span = 0,
                                   size_t unroll_length = 0,
                                   int xdrop_alignment = 0,              // 1 for forward, >1 for reverse
-                                  bool multithreaded_xdrop = false,
                                   bool print_score_matrices = false);
     /// Align with base quality adjusted scores.
     /// Align to the graph.
@@ -1162,7 +1155,6 @@ public:
                                   size_t max_span = 0,
                                   size_t unroll_length = 0,
                                   int xdrop_alignment = 0,              // 1 for forward, >1 for reverse
-                                  bool multithreaded_xdrop = false,
                                   bool print_score_matrices = false);
     
     
@@ -1283,7 +1275,6 @@ private:
                     size_t max_span = 0,
                     size_t unroll_length = 0,
                     int xdrop_alignment = 0,                // 1 for forward, >1 for reverse
-                    bool multithreaded_xdrop = false,
                     bool print_score_matrices = false);
 
 

--- a/src/xdrop_aligner.cpp
+++ b/src/xdrop_aligner.cpp
@@ -380,7 +380,7 @@ size_t XdropAligner::push_edit(
 	char const *alt,
 	size_t len)
 {
-	/* see gssw_aligner.cpp:gssw_mapping_to_alignment */
+	/* see aligner.cpp:gssw_mapping_to_alignment */
 	#define _add_edit(_from_len, _to_len, _subseq) { \
 		Edit *e = mapping->add_edit(); \
 		e->set_from_length((_from_len)); \

--- a/src/xdrop_aligner.hpp
+++ b/src/xdrop_aligner.hpp
@@ -31,6 +31,7 @@ namespace vg {
 		uint32_t ref_offset, query_offset;
 	};
 
+    /// Non-thread-safe alignment problem, to be solved using the x-drop algorithm.
 	class XdropAligner {
 	private:
 		// context (contains memory arena and constants) and working buffers

--- a/src/xdrop_aligner.hpp
+++ b/src/xdrop_aligner.hpp
@@ -69,7 +69,7 @@ namespace vg {
 		// bench_t bench;
 
 	public:
-		// default_* defined in vg::, see gssw_aligner.hpp
+		// default_* defined in vg::, see aligner.hpp
 		XdropAligner();
 		XdropAligner(XdropAligner const &);
 		XdropAligner& operator=(XdropAligner const &);
@@ -88,7 +88,7 @@ namespace vg {
 			uint32_t _max_gap_length);
 		~XdropAligner(void);
 
-		// copied from gssw_aligner.hpp
+		// copied from aligner.hpp
 		void align(Alignment &alignment, Graph const &graph, const vector<MaximalExactMatch> &mems, bool reverse_complemented);
 	};
 } // end of namespace vg


### PR DESCRIPTION
This is the start of my attempt to refactor surjection. I haven't actually unified the duplicated map/surject driver code yet.

What I have done is made the `Surjector` no longer a `BaseMapper`. Instead there's an `AlignerClient` base class that includes `get_aligner()` and the score setting functionality, without dragging all the indexes and the MEM finding machinery along.

I've made the BaseMapper not have progress bar functionality, since it never seemed to be actually used to draw a progress bar.

I've also gone through and const-ified the Aligners.  I've also removed the concept of a thread count inside the mappers, since it didn't really do anything, especially with const, thread-safe Aligners. To pull this off I removed the notion of non-multithreaded Xdrop alignment in the Aligner; the XdropAligner is now always cloned. I want to change that whole system later, anyway, so I think it is fine to do for now. Note that `map` is still making loads of Mappers, because each one has its own paired end distribution stats that don't appear to be thread safe. I want to const-ify all the Mapper methods to the extent that I can, and/or just make the paired end distribution manager nicely thread-safe with internal locks.

I've renamed `BaseAligner` to `GSSWAligner`, since it has a bunch of GSSW-specific things. But I changed the cpp/hpp to just `aligner`, and created a new `BaseAligner` class that I eventually want to be the base interface for the GSSW and Xdrop-based aligners.

Right now the Xdrop alignment is implemented by having the `Aligner` have an `XdropAligner` inside it, and have some xdrop-specific methods on it. I want to change that to xdrop being another kind of aligner that can come out of the `get_aligner()` system. This should alleviate the weird cloning it does to be thread safe right now.

The problem is that the Xdrop aligner needs seeds, and the other Aligners don't, so they can't really implement the same interface. I'm still thinking about how to solve that. Also, the XdropAligner still uses a `Graph`, while the other aligners have been ported over to `HandleGraph`, but that's more straightforward to solve.