### PR TITLE
Turn tcmalloc back on

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,8 @@ DEPS += $(INC_DIR)/progress_bar.hpp
 DEPS += $(INC_DIR)/backward.hpp
 
 ifneq ($(shell uname -s),Darwin)
-    #DEPS += $(LIB_DIR)/libtcmalloc_minimal.a
-    #LD_LIB_FLAGS += -ltcmalloc_minimal
+    DEPS += $(LIB_DIR)/libtcmalloc_minimal.a
+    LD_LIB_FLAGS += -ltcmalloc_minimal
 endif
 
 .PHONY: clean get-deps deps test set-path static docs .pre-build .check-environment .check-git .no-git


### PR DESCRIPTION
I accidentally left it commented out, because I needed it off to run valgrind on something.

It would be nice if we could "make debug" to link without it, instead of hand-editing the Makefile.