### PR TITLE
Add TLEN computation and a stricter definition of proper pairing in SAM/BAM output

### DIFF
--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -69,7 +69,9 @@ Alignment bam_to_alignment(const bam1_t *b, map<string, string>& rg_sample);
  * refpos must be -1. Otherwise, refpos must be the position on the reference
  * sequence to which the alignment is aligned. Similarly, refseq must be the
  * sequence aligned to, or "" if unaligned. The mateseq and matepos fields must
- * be set similarly for the mate. Note that mateseq must not be "=".
+ * be set similarly for the mate. Note that mateseq must not be "=". If
+ * tlen_max is given, it is a limit on the magnitude of tlen to consider the
+ * read properly paired.
  *
  * Remember to clean up with bam_destroy1(b);
  */
@@ -82,7 +84,8 @@ bam1_t* alignment_to_bam(const string& sam_header,
                          const string& mateseq,
                          const int32_t matepos,
                          bool materev,
-                         const int32_t tlen);
+                         const int32_t tlen,
+                         const int32_t tlen_max = 0);
                          
 /**
  * Convert an unpaired Alignment to a BAM record. If the alignment is unmapped,
@@ -104,7 +107,9 @@ bam1_t* alignment_to_bam(const string& sam_header,
  * refpos must be -1. Otherwise, refpos must be the position on the reference
  * sequence to which the alignment is aligned. Similarly, refseq must be the
  * sequence aligned to, or "" if unaligned. The mateseq and matepos fields must
- * be set similarly for the mate. Note that mateseq must not be "=".
+ * be set similarly for the mate. Note that mateseq must not be "=". If
+ * tlen_max is given, it is a limit on the magnitude of tlen to consider the
+ * read properly paired.
  */
 string alignment_to_sam(const Alignment& alignment,
                         const string& refseq,
@@ -114,7 +119,8 @@ string alignment_to_sam(const Alignment& alignment,
                         const string& mateseq,
                         const int32_t matepos,
                         bool materev,
-                        const int32_t tlen);
+                        const int32_t tlen,
+                        const int32_t tlen_max = 0);
                         
 /**
  * Convert an unpaired Alignment to a SAM record. If the alignment is unmapped,

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -56,7 +56,7 @@ bam_hdr_t* hts_string_header(string& header,
 void write_alignment_to_file(const Alignment& aln, const string& filename);
 
 void mapping_cigar(const Mapping& mapping, vector<pair<int, char> >& cigar);
-string cigar_string(vector<pair<int, char> >& cigar);
+string cigar_string(const vector<pair<int, char> >& cigar);
 string mapping_string(const string& source, const Mapping& mapping);
 
 void cigar_mapping(const bam1_t *b, Mapping& mapping, xg::XG* xgindex);
@@ -78,7 +78,7 @@ bam1_t* alignment_to_bam(const string& sam_header,
                          const string& refseq,
                          const int32_t refpos,
                          const bool refrev,
-                         const string& cigar,
+                         const vector<pair<int, char>>& cigar,
                          const string& mateseq,
                          const int32_t matepos,
                          bool materev,
@@ -97,7 +97,7 @@ bam1_t* alignment_to_bam(const string& sam_header,
                         const string& refseq,
                         const int32_t refpos,
                         const bool refrev,
-                        const string& cigar);
+                        const vector<pair<int, char>>& cigar);
                          
 /**
  * Convert a paired Alignment to a SAM record. If the alignment is unmapped,
@@ -110,7 +110,7 @@ string alignment_to_sam(const Alignment& alignment,
                         const string& refseq,
                         const int32_t refpos,
                         const bool refrev,
-                        const string& cigar,
+                        const vector<pair<int, char>>& cigar,
                         const string& mateseq,
                         const int32_t matepos,
                         bool materev,
@@ -126,12 +126,18 @@ string alignment_to_sam(const Alignment& alignment,
                         const string& refseq,
                         const int32_t refpos,
                         const bool refrev,
-                        const string& cigar);
+                        const vector<pair<int, char>>& cigar);
                         
 
 
-string cigar_against_path(const Alignment& alignment, bool on_reverse_strand, int64_t& pos, size_t path_len, size_t softclip_suppress);
+vector<pair<int, char>> cigar_against_path(const Alignment& alignment, bool on_reverse_strand, int64_t& pos, size_t path_len, size_t softclip_suppress);
 void mapping_against_path(Alignment& alignment, const bam1_t *b, xg::XG* xgindex, bool on_reverse_strand);
+
+/// Work out the TLEN values for two reads. The magnitude is the distance
+/// between the outermost aligned bases, and the sign is positive for the
+/// leftmost read and negative for the rightmost.
+pair<int32_t, int32_t> compute_template_lengths(const int64_t& pos1, const vector<pair<int, char>>& cigar1,
+    const int64_t& pos2, const vector<pair<int, char>>& cigar2);
 
 int32_t sam_flag(const Alignment& alignment, bool on_reverse_strand, bool paired);
 short quality_char_to_short(char c);

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -790,7 +790,7 @@ int main_map(int argc, char** argv) {
                 if (path_name != "") {
                     path_len = xgidx->path_length(path_name);
                 }
-                string cigar = cigar_against_path(surj, path_reverse, path_pos, path_len, 0);
+                vector<pair<int, char>> cigar = cigar_against_path(surj, path_reverse, path_pos, path_len, 0);
                 bam1_t* b = alignment_to_bam(sam_header,
                                              surj,
                                              path_name,
@@ -833,12 +833,11 @@ int main_map(int argc, char** argv) {
                 if (path_name2 != "") {
                     path_len2 = xgidx->path_length(path_name2);
                 }
-                string cigar1 = cigar_against_path(surj1, path_reverse1, path_pos1, path_len1, 0);
-                string cigar2 = cigar_against_path(surj2, path_reverse2, path_pos2, path_len2, 0);
+                vector<pair<int, char>> cigar1 = cigar_against_path(surj1, path_reverse1, path_pos1, path_len1, 0);
+                vector<pair<int, char>> cigar2 = cigar_against_path(surj2, path_reverse2, path_pos2, path_len2, 0);
                 
-                // TODO: compute template length based on
-                // pair distance and alignment content.
-                int template_length = 0;
+                // Determine the TLEN for each read.
+                auto tlens = compute_template_lengths(path_pos1, cigar1, path_pos2, cigar2);
                 
                 // Make BAM records
                 bam1_t* b1 = alignment_to_bam(sam_header,
@@ -850,7 +849,7 @@ int main_map(int argc, char** argv) {
                                               path_name2,
                                               path_pos2,
                                               path_reverse2,
-                                              template_length);
+                                              tlens.first);
                 bam1_t* b2 = alignment_to_bam(sam_header,
                                               surj2,
                                               path_name2,
@@ -860,7 +859,7 @@ int main_map(int argc, char** argv) {
                                               path_name1,
                                               path_pos1,
                                               path_reverse1,
-                                              template_length);
+                                              tlens.second);
                 
                 // Write the records
                 int r = 0;

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -36,6 +36,7 @@ void help_surject(char** argv) {
          << "    -s, --sam-output        write SAM to stdout" << endl
          << "    -N, --sample NAME       set this sample name for all reads" << endl
          << "    -R, --read-group NAME   set this read group for all reads" << endl
+         << "    -f, --max-frag-len N    reads with fragment lengths greater than N will not be marked properly paired in SAM/BAM/CRAM" << endl
          << "    -C, --compression N     level for compression [0-9]" << endl;
 }
 
@@ -54,6 +55,7 @@ int main_surject(int argc, char** argv) {
     bool interleaved = false;
     string sample_name;
     string read_group;
+    int32_t max_frag_len = 0;
     int compress_level = 9;
     bool subpath_global = true; // force full length alignments in mpmap resolution
 
@@ -74,12 +76,13 @@ int main_surject(int argc, char** argv) {
             {"sam-output", no_argument, 0, 's'},
             {"sample", required_argument, 0, 'N'},
             {"read-group", required_argument, 0, 'R'},
+            {"max-frag-len", required_argument, 0, 'f'},
             {"compress", required_argument, 0, 'C'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:p:F:licbsN:R:C:t:",
+        c = getopt_long (argc, argv, "hx:p:F:licbsN:R:f:C:t:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -128,6 +131,10 @@ int main_surject(int argc, char** argv) {
             
         case 'R':
             read_group = optarg;
+            break;
+            
+        case 'f':
+            max_frag_len = parse<int32_t>(optarg);
             break;
 
         case 'C':
@@ -394,9 +401,9 @@ int main_surject(int argc, char** argv) {
                                     
                                     // Create and write paired BAM records referencing each other
                                     write_bam_record(alignment_to_bam(header, surj1, name1, pos1, reverse1, cigar1,
-                                        name2, pos2, reverse2, tlens.first));
+                                        name2, pos2, reverse2, tlens.first, max_frag_len));
                                     write_bam_record(alignment_to_bam(header, surj2, name2, pos2, reverse2, cigar2,
-                                        name1, pos1, reverse1, tlens.second));
+                                        name1, pos1, reverse1, tlens.second, max_frag_len));
                                 
                                 }
                                 

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -378,8 +378,8 @@ int main_surject(int argc, char** argv) {
                                     auto& reverse2 = get<2>(surjected_pair.second);
                                     auto& surj2 = get<3>(surjected_pair.second);
                                     
-                                    // Compute CIGAR strings if actually surjected
-                                    string cigar1 = "", cigar2 = "";
+                                    // Compute CIGARs if actually surjected
+                                    vector<pair<int, char>> cigar1, cigar2;
                                     if (name1 != "") {
                                         size_t path_len1 = xgidx->path_length(name1);
                                         cigar1 = cigar_against_path(surj1, reverse1, pos1, path_len1, 0);
@@ -389,15 +389,14 @@ int main_surject(int argc, char** argv) {
                                         cigar2 = cigar_against_path(surj2, reverse2, pos2, path_len2, 0);
                                     }
                                     
-                                    // TODO: compute template length based on
-                                    // pair distance and alignment content.
-                                    int template_length = 0;
+                                    // Determine the TLEN for each read.
+                                    auto tlens = compute_template_lengths(pos1, cigar1, pos2, cigar2);
                                     
                                     // Create and write paired BAM records referencing each other
                                     write_bam_record(alignment_to_bam(header, surj1, name1, pos1, reverse1, cigar1,
-                                        name2, pos2, reverse2, template_length));
+                                        name2, pos2, reverse2, tlens.first));
                                     write_bam_record(alignment_to_bam(header, surj2, name2, pos2, reverse2, cigar2,
-                                        name1, pos1, reverse1, template_length));
+                                        name1, pos1, reverse1, tlens.second));
                                 
                                 }
                                 
@@ -498,7 +497,7 @@ int main_surject(int argc, char** argv) {
                                 auto& surj = get<3>(s);
                                 
                                 // Generate a CIGAR string for it
-                                string cigar = "";
+                                vector<pair<int, char>> cigar;
                                 if (name != "") {
                                     size_t path_len = xgidx->path_length(name);
                                     cigar = cigar_against_path(surj, reverse, pos, path_len, 0);


### PR DESCRIPTION
This should fully fix #2123. There's now logic to compute TLEN values, and the properly paired flag now requires reads to be facing inwards and within a user-specified threshold TLEN distance (for surject) or 6 standard deviations above the average fragment length (for map).

Note that we still don't mark things as improperly paired if the TLEN is too *short*. @cmarkello will that be a problem?