### PR TITLE
Fix handling of dots in VCF

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1767,7 +1767,7 @@ namespace vg {
                     // TODO: handle remaining alts.
                     if (alt == ".") {
                         variant_acceptable = false;
-                        if (vvar->alt.size() > 0) {
+                        if (vvar->alt.size() > 1) {
                             // Warn if there are more alts we will miss because of skipping
                             #pragma omp critical (cerr)
                             cerr << "warning:[vg::Constructor] Variant with '.' among multiple alts being skipped: "

--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -437,9 +437,7 @@ namespace vg {
 
             // Group variants into clumps of overlapping variants.
             if (clump.empty() || 
-
                 (next_variant != variants.end() && clump_end > next_variant->zeroBasedPosition() - chunk_offset)) {
-
 
                 // Either there are no variants in the clump, or this variant
                 // overlaps the clump. It belongs in the clump
@@ -1760,68 +1758,90 @@ namespace vg {
             // We need to decide if we want to use this variant. By default we will use all variants.
             bool variant_acceptable = true;
             
-            if (vvar->isSymbolicSV()) {
-                // We have a symbolic not-all-filled-in alt.
-                // We need to be processed as a symbolic SV
-            
-                if (this->do_svs) {
-                    // We are actually going to try to handle this SV.
-                    
-                    // Canonicalize the variant and see if that disqualifies it.
-                    // This also takes care of setting the variant's alt sequences.
-                    variant_acceptable = vvar->canonicalize(reference, insertions, true);
-     
-                    if (variant_acceptable) {
-                        // Worth checking for multiple alts.
-                        if (vvar->alt.size() > 1) {
-                            // We can't handle multiallelic SVs yet.
+            if (vvar->alt.empty()) {
+                // Variants with no alts are unimportant
+                variant_acceptable = false;
+            } else {
+                for (string& alt : vvar->alt) {
+                    // Variants with "." alts can't be processsed.
+                    // TODO: handle remaining alts.
+                    if (alt == ".") {
+                        variant_acceptable = false;
+                        if (vvar->alt.size() > 0) {
+                            // Warn if there are more alts we will miss because of skipping
                             #pragma omp critical (cerr)
-                            cerr << "warning:[vg::Constructor] Unsupported multiallelic SV being skipped: " << *vvar << endl;
-                            variant_acceptable = false;
-                        }
-                    }
-                        
-                    if (variant_acceptable) {
-                        // Worth checking for bounds problems.
-                        // We have seen VCFs where the variant positions are on GRCh38 but the END INFO tags are on GRCh37.
-                        // But for inserts the bounds will have the end right before the start, so we have to allow for those.
-                        auto bounds = get_symbolic_bounds(*vvar);
-                        if (bounds.second + 1 < bounds.first) {
-                            #pragma omp critical (cerr)
-                            cerr << "warning:[vg::Constructor] SV with end position " << bounds.second
-                                << " significantly before start " << bounds.first << " being skipped (check liftover?): "
+                            cerr << "warning:[vg::Constructor] Variant with '.' among multiple alts being skipped: "
                                 << *vvar << endl;
-                            variant_acceptable = false;
                         }
+                        break;
                     }
-                } else {
-                    // SV handling is off.
-                    variant_acceptable = false;
-                    
-                    // Figure out exactly what to complain about.
-                    
-                    for (string& alt : vvar->alt) {
-                        // Validate each alt of the variant
+                }
+            }
+            
+            if (variant_acceptable) {
+                if (vvar->isSymbolicSV()) {
+                    // We have a symbolic not-all-filled-in alt.
+                    // We need to be processed as a symbolic SV
+                
+                    if (this->do_svs) {
+                        // We are actually going to try to handle this SV.
+                        
+                        // Canonicalize the variant and see if that disqualifies it.
+                        // This also takes care of setting the variant's alt sequences.
+                        variant_acceptable = vvar->canonicalize(reference, insertions, true);
+         
+                        if (variant_acceptable) {
+                            // Worth checking for multiple alts.
+                            if (vvar->alt.size() > 1) {
+                                // We can't handle multiallelic SVs yet.
+                                #pragma omp critical (cerr)
+                                cerr << "warning:[vg::Constructor] Unsupported multiallelic SV being skipped: " << *vvar << endl;
+                                variant_acceptable = false;
+                            }
+                        }
+                            
+                        if (variant_acceptable) {
+                            // Worth checking for bounds problems.
+                            // We have seen VCFs where the variant positions are on GRCh38 but the END INFO tags are on GRCh37.
+                            // But for inserts the bounds will have the end right before the start, so we have to allow for those.
+                            auto bounds = get_symbolic_bounds(*vvar);
+                            if (bounds.second + 1 < bounds.first) {
+                                #pragma omp critical (cerr)
+                                cerr << "warning:[vg::Constructor] SV with end position " << bounds.second
+                                    << " significantly before start " << bounds.first << " being skipped (check liftover?): "
+                                    << *vvar << endl;
+                                variant_acceptable = false;
+                            }
+                        }
+                    } else {
+                        // SV handling is off.
+                        variant_acceptable = false;
+                        
+                        // Figure out exactly what to complain about.
+                        
+                        for (string& alt : vvar->alt) {
+                            // Validate each alt of the variant
 
-                        if(!allATGCN(alt)) {
-                            // This is our problem alt here.
-                            // Either it's a symbolic alt or it is somehow lower case or something.
-                            #pragma omp critical (cerr)
-                            {
-                                bool warn = true;
-                                if (!alt.empty() && alt[0] == '<' && alt[alt.size()-1] == '>') {
-                                    if (symbolic_allele_warnings.find(alt) != symbolic_allele_warnings.end()) {
-                                        warn = false;
-                                    } else {
-                                        symbolic_allele_warnings.insert(alt);
+                            if(!allATGCN(alt)) {
+                                // This is our problem alt here.
+                                // Either it's a symbolic alt or it is somehow lower case or something.
+                                #pragma omp critical (cerr)
+                                {
+                                    bool warn = true;
+                                    if (!alt.empty() && alt[0] == '<' && alt[alt.size()-1] == '>') {
+                                        if (symbolic_allele_warnings.find(alt) != symbolic_allele_warnings.end()) {
+                                            warn = false;
+                                        } else {
+                                            symbolic_allele_warnings.insert(alt);
+                                        }
+                                    }
+                                    if (warn) {
+                                        cerr << "warning:[vg::Constructor] Unsupported variant allele \""
+                                            << alt << "\"; Skipping variant(s) " << *vvar <<" !" << endl;
                                     }
                                 }
-                                if (warn) {
-                                    cerr << "warning:[vg::Constructor] Unsupported variant allele \""
-                                        << alt << "\"; Skipping variant(s) " << *vvar <<" !" << endl;
-                                }
+                                break;
                             }
-                            break;
                         }
                     }
                 }

--- a/src/support_caller.cpp
+++ b/src/support_caller.cpp
@@ -2037,7 +2037,8 @@ void SupportCaller::call(
             // Don't bother with trivial calls
             if (write_trivial_calls ||
                 (genotype_vector.back() != "./." && genotype_vector.back() != ".|." &&
-                 genotype_vector.back() != "0/0" && genotype_vector.back() != "0|0")) {
+                 genotype_vector.back() != "0/0" && genotype_vector.back() != "0|0" &&
+                 genotype_vector.back() != "." && genotype_vector.back() != "0")) {
             
                 if(can_write_alleles(variant)) {
                     // No need to check for collisions because we assume sites are correctly found.

--- a/test/t/02_vg_construct.t
+++ b/test/t/02_vg_construct.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order 
 
-plan tests 24
+plan tests 25
 
 is $(vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz | vg stats -z - | grep nodes | cut -f 2) 210 "construction produces the right number of nodes"
 
@@ -102,4 +102,7 @@ is $short_enough 1 "vg construct respects node size limit"
 
 is $(vg construct -CR 'gi|568815592:29791752-29792749' -r GRCh38_alts/FASTA/HLA/V-352962.fa | vg view - | grep TCTAGAAGAGTCCACGGGGACAGGTAAG | wc -l) 1 "--region can be interpreted to be a reference sequence (and not parsed as a region spec)"
 
-is "$(vg construct -r sv/x.fa -v sv/x.inv.vcf -S | vg view - | sort | md5sum | cut -f 1 -d\ )" "$(cat sv/x.inv.gfa | sort | md5sum | cut -f1 -d\ )" "vg constructs the correct graph for inversions."
+is "$(vg construct -r sv/x.fa -v sv/x.inv.vcf -S | vg view - | sort | md5sum | cut -f 1 -d\ )" "$(cat sv/x.inv.gfa | sort | md5sum | cut -f1 -d\ )" "vg constructs the correct graph for inversions"
+
+is "$(vg construct -r tiny/tiny.fa -v tiny/dots.vcf | vg mod -u - | vg stats -z - | grep nodes | cut -f2)" "1" "vg construct skips variants with . ALTs"
+

--- a/test/tiny/dots.vcf
+++ b/test/tiny/dots.vcf
@@ -1,0 +1,20 @@
+##fileformat=VCFv4.1
+##fileDate=20141110
+##source=mutatrix population genome simulator
+##seed=1415643582
+##reference=x.fa
+##phasing=true
+##commandline=mutatrix --dry-run -s 0.05 -i 0.01 -p 2 x.fa
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Alternate allele count">
+##INFO=<ID=TYPE,Number=A,Type=String,Description="Type of each allele (snp, ins, del, mnp, complex)">
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of samples at the site">
+##INFO=<ID=NA,Number=1,Type=Integer,Description="Number of alternate alleles">
+##INFO=<ID=LEN,Number=A,Type=Integer,Description="Length of each alternate allele">
+##INFO=<ID=MICROSAT,Number=0,Type=Flag,Description="Generated at a sequence repeat loci">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	1
+x	9	.	G	.	99	.	AC=0;LEN=1;NA=1;NS=1;TYPE=snp	GT	0|0
+x	10	.	C	.	99	.	AC=0;LEN=1;NA=1;NS=1;TYPE=snp	GT	0|0
+x	14	.	G	.	99	.	AC=0;LEN=1;NA=1;NS=1;TYPE=snp	GT	0|0
+x	34	.	T	.	99	.	AC=0;LEN=1;NA=1;NS=1;TYPE=snp	GT	0|0
+x	39	.	T	.	99	.	AC=0;LEN=1;NA=1;NS=1;TYPE=snp	GT	0|0


### PR DESCRIPTION
This should fix #2148 by both preventing vg call from generating calls with '.' as the alt without `-i` having been passed, and by preventing vg construct from trying to operate on them.

If any alt in a variant is '.', I'm skipping the whole variant. If there's more than one alt in that variant, I'm printing a warning.