### PR TITLE
Be more careful with dot alts

### DIFF
--- a/src/constructor.hpp
+++ b/src/constructor.hpp
@@ -227,6 +227,14 @@ private:
      * bound before their start, because the anchoring base isn't included.
      */
     static pair<int64_t, int64_t> get_symbolic_bounds(vcflib::Variant var);
+
+
+    /**
+     * Remove some illegal alts from a variant. Variant edited in place,
+     * false returned if all alts removed. 
+     */
+    static bool remove_illegal_alts(vcflib::Variant& var);
+    
     /// What sequences have we warned about containing lowercase characters?
     mutable unordered_set<string> warned_sequences;
     /// Have we given a warning yet about lowercase alt alleles?

--- a/src/support_caller.cpp
+++ b/src/support_caller.cpp
@@ -2037,7 +2037,8 @@ void SupportCaller::call(
             // Don't bother with trivial calls
             if (write_trivial_calls ||
                 (genotype_vector.back() != "./." && genotype_vector.back() != ".|." &&
-                 genotype_vector.back() != "0/0" && genotype_vector.back() != "0|0")) {
+                 genotype_vector.back() != "0/0" && genotype_vector.back() != "0|0" &&
+                 genotype_vector.back() != "." && genotype_vector.back() != "0")) {
             
                 if(can_write_alleles(variant)) {
                     // No need to check for collisions because we assume sites are correctly found.


### PR DESCRIPTION
Warn about and don't construct non-DNA alts.  Don't include haploid reference calls in vg call output by default. 
Should fix #2148