### PR TITLE
Fixed logic in pinned alignment

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -88,7 +88,7 @@ unordered_set<vg::id_t> GSSWAligner::identify_pinning_points(const HandleGraph& 
             handle_t here =  stack.back();
             stack.pop_back();
             
-            if (graph.get_degree(here, false) == 0) {
+            if (graph.get_length(here) > 0) {
                 return_val.insert(graph.get_id(here));
             }
             else {

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -7,6 +7,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include "gssw.h"
 #include "vg.pb.h"
 #include "vg.hpp"
@@ -18,6 +19,8 @@
 #include "xdrop_aligner.hpp"
 #include "handle.hpp"
 #include "backwards_graph.hpp"
+#include "null_masking_graph.hpp"
+#include "algorithms/distance_to_tail.hpp"
 
 // #define BENCH
 // #include "bench.h"
@@ -50,7 +53,6 @@ namespace vg {
         /// Same as previous, but takes advantage of a pre-computed topological order
         virtual void align(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& topological_order,
                            bool traceback_aln, bool print_score_matrices) const = 0;
-        
     };
 
     /**
@@ -66,6 +68,10 @@ namespace vg {
         gssw_graph* create_gssw_graph(const HandleGraph& g) const;
         // for constructing an alignable graph when the topological order is already known
         gssw_graph* create_gssw_graph(const HandleGraph& g, const vector<handle_t>& topological_order) const;
+        
+        // identify the IDs of nodes that should be used as pinning points in GSSW for pinned
+        // alignment ((i.e. non-empty nodes as close as possible to sinks))
+        unordered_set<id_t> identify_pinning_points(const HandleGraph& graph) const;
         
         // convert graph mapping back into unreversed node positions
         void unreverse_graph_mapping(gssw_graph_mapping* gm) const;

--- a/src/backwards_graph.cpp
+++ b/src/backwards_graph.cpp
@@ -52,7 +52,7 @@ using namespace std;
     }
     
     bool BackwardsGraph::for_each_handle_impl(const function<bool(const handle_t&)>& iteratee, bool parallel) const {
-        return forward_graph->for_each_handle(iteratee);
+        return forward_graph->for_each_handle(iteratee, parallel);
     }
     
     size_t BackwardsGraph::node_size() const {

--- a/src/haplotypes.cpp
+++ b/src/haplotypes.cpp
@@ -319,7 +319,7 @@ void haplo_DP_column::update_score_vector(haploMath::RRMemo& memo) {
       i = 1;
     }
     if(length == 1) {
-      for(i; i < entries.size(); i++) {
+      for(; i < entries.size(); i++) {
         assert(entries[i].get() != nullptr);
         double logLHS = memo.logT_base +
                         previous_R(i) +
@@ -327,7 +327,7 @@ void haplo_DP_column::update_score_vector(haploMath::RRMemo& memo) {
         entries[i]->R = haploMath::logsum(logLHS, logpS1S2RRS);
       }
     } else {
-      for(i; i < entries.size(); i++) {
+      for(; i < entries.size(); i++) {
         assert(entries[i].get() != nullptr);
         double logLHS = memo.logT_base +
                         haploMath::logsum(logS1RRD, previous_R(i) + memo.logT(length));

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3364,6 +3364,15 @@ namespace vg {
                     
 #ifdef debug_multipath_alignment
                     cerr << "making " << num_alt_alns << " alignments of sequence " << intervening_sequence.sequence() << " to connecting graph" << endl;
+                    connecting_graph.for_each_handle([&](const handle_t& handle) {
+                        cerr << connecting_graph.get_id(handle) << " " << connecting_graph.get_sequence(handle) << endl;
+                        connecting_graph.follow_edges(handle, false, [&](const handle_t& next) {
+                            cerr << "\t-> " << connecting_graph.get_id(next) << endl;
+                        });
+                        connecting_graph.follow_edges(handle, false, [&](const handle_t& prev) {
+                            cerr << "\t" << connecting_graph.get_id(prev) << " <-" << endl;
+                        });
+                    });
 #endif
                     
                     if (!alignment.quality().empty()) {
@@ -3635,6 +3644,15 @@ namespace vg {
                         
 #ifdef debug_multipath_alignment
                         cerr << "making " << num_alt_alns << " alignments of sequence: " << right_tail_sequence.sequence() << endl << "to right tail graph" << endl;
+                        tail_graph.for_each_handle([&](const handle_t& handle) {
+                            cerr << tail_graph.get_id(handle) << " " << tail_graph.get_sequence(handle) << endl;
+                            tail_graph.follow_edges(handle, false, [&](const handle_t& next) {
+                                cerr << "\t-> " << tail_graph.get_id(next) << endl;
+                            });
+                            tail_graph.follow_edges(handle, false, [&](const handle_t& prev) {
+                                cerr << "\t" << tail_graph.get_id(prev) << " <-" << endl;
+                            });
+                        });
 #endif
                         
                         auto& alt_alignments = right_alignments[j];
@@ -3744,6 +3762,15 @@ namespace vg {
                         
 #ifdef debug_multipath_alignment
                         cerr << "making " << num_alt_alns << " alignments of sequence: " << left_tail_sequence.sequence() << endl << "to left tail graph" << endl;
+                        tail_graph.for_each_handle([&](const handle_t& handle) {
+                            cerr << tail_graph.get_id(handle) << " " << tail_graph.get_sequence(handle) << endl;
+                            tail_graph.follow_edges(handle, false, [&](const handle_t& next) {
+                                cerr << "\t-> " << tail_graph.get_id(next) << endl;
+                            });
+                            tail_graph.follow_edges(handle, false, [&](const handle_t& prev) {
+                                cerr << "\t" << tail_graph.get_id(prev) << " <-" << endl;
+                            });
+                        });
 #endif
                         
                         auto& alt_alignments = left_alignments[j];

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3505,7 +3505,6 @@ namespace vg {
             // want past-the-last instead of last index here
             get_offset(end_pos)++;
             
-                    
             for (const Alignment& tail_alignment : alt_alignments) {
                 
                 sink_subpath->add_next(multipath_aln_out.subpath_size());
@@ -3652,38 +3651,9 @@ namespace vg {
                         });
 #endif
                         
+                        // align against the graph
                         auto& alt_alignments = right_alignments[j];
-                        if (tail_graph.node_size() == 0) {
-                            // edge case for when a read keeps going past the end of a graph
-                            alt_alignments.emplace_back();
-                            Alignment& tail_alignment = alt_alignments.back();
-                            tail_alignment.set_score(aligner->score_gap(right_tail_sequence.sequence().size()));
-                            Mapping* insert_mapping = tail_alignment.mutable_path()->add_mapping();
-                            
-                            // add a soft clip
-                            Edit* edit = insert_mapping->add_edit();
-                            edit->set_to_length(right_tail_sequence.sequence().size());
-                            edit->set_sequence(right_tail_sequence.sequence());
-                            
-                            // make it at the correct position
-                            const Path& anchoring_path = path_nodes.at(j).path;
-                            const Mapping& anchoring_mapping = anchoring_path.mapping(anchoring_path.mapping_size() - 1);
-                            Position* anchoring_position = insert_mapping->mutable_position();
-                            anchoring_position->set_node_id(anchoring_mapping.position().node_id());
-                            anchoring_position->set_is_reverse(anchoring_mapping.position().is_reverse());
-                            anchoring_position->set_offset(anchoring_mapping.position().offset() + mapping_from_length(anchoring_mapping));
-#ifdef debug_multipath_alignment
-                            cerr << "read overhangs end of graph, manually added softclip: " << pb2json(tail_alignment) << endl;
-#endif
-                            // the ID translator is empty, so add this ID here so it doesn't give an out of index error
-                            id_t node_id = insert_mapping->position().node_id();
-                            tail_trans[node_id] = node_id;
-                        }
-                        else {
-                            // align against the graph
-                            
-                            aligner->align_pinned_multi(right_tail_sequence, alt_alignments, tail_graph, true, num_alt_alns);
-                        }
+                        aligner->align_pinned_multi(right_tail_sequence, alt_alignments, tail_graph, true, num_alt_alns);
                         
                         // Translate back into non-extracted graph.
                         // Make sure to account for having removed the left end of the cut node relative to end_pos
@@ -3753,7 +3723,6 @@ namespace vg {
                             left_tail_sequence.set_quality(alignment.quality().substr(0, path_node.begin - alignment.sequence().begin()));
                         }
                         
-                        
 #ifdef debug_multipath_alignment
                         cerr << "making " << num_alt_alns << " alignments of sequence: " << left_tail_sequence.sequence() << endl << "to left tail graph" << endl;
                         tail_graph.for_each_handle([&](const handle_t& handle) {
@@ -3767,31 +3736,9 @@ namespace vg {
                         });
 #endif
                         
+                        // align against the graph
                         auto& alt_alignments = left_alignments[j];
-                        if (tail_graph.node_size() == 0) {
-                            // edge case for when a read keeps going past the end of a graph
-                            alt_alignments.emplace_back();
-                            Alignment& tail_alignment = alt_alignments.back();
-                            tail_alignment.set_score(aligner->score_gap(left_tail_sequence.sequence().size()));
-                            Mapping* insert_mapping = tail_alignment.mutable_path()->add_mapping();
-                            
-                            // add a soft clip
-                            Edit* edit = insert_mapping->add_edit();
-                            edit->set_to_length(left_tail_sequence.sequence().size());
-                            edit->set_sequence(left_tail_sequence.sequence());
-                            
-                            // make it at the correct position
-                            *insert_mapping->mutable_position() = path_nodes.at(j).path.mapping(0).position();
-#ifdef debug_multipath_alignment
-                            cerr << "read overhangs end of graph, manually added softclip: " << pb2json(tail_alignment) << endl;
-#endif
-                            // the ID translator is empty, so add this ID here so it doesn't give an out of index error
-                            id_t node_id = insert_mapping->position().node_id();
-                            tail_trans[node_id] = node_id;
-                        }
-                        else {
-                            aligner->align_pinned_multi(left_tail_sequence, alt_alignments, tail_graph, false, num_alt_alns);
-                        }
+                        aligner->align_pinned_multi(left_tail_sequence, alt_alignments, tail_graph, false, num_alt_alns);
                         
                         // Translate back into non-extracted graph.
                         // Make sure to account for having removed the right end of the cut node relative to begin_pos

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3625,9 +3625,6 @@ namespace vg {
                                                                                                false,         // search forward
                                                                                                false);        // no need to preserve cycles (in a DAG)
                     
-                    // remove the empty anchoring nodes that this algorithm sometimes creates
-                    groom_graph_for_gssw(tail_graph);
-                    
                     size_t num_alt_alns = dynamic_alt_alns ? min(max_alt_alns, algorithms::count_walks(&tail_graph)) :
                                                              max_alt_alns;
                     
@@ -3745,9 +3742,6 @@ namespace vg {
                                                                                                true,          // search backward
                                                                                                false);        // no need to preserve cycles (in a DAG)
                     
-                    // remove the empty anchoring nodes that this algorithm sometimes creates
-                    groom_graph_for_gssw(tail_graph);
-                    
                     size_t num_alt_alns = dynamic_alt_alns ? min(max_alt_alns, algorithms::count_walks(&tail_graph)) :
                                                              max_alt_alns;
                             
@@ -3826,21 +3820,6 @@ namespace vg {
         
         // Return all the alignments, organized by tail and subpath
         return to_return;
-    }
-    
-    void MultipathAlignmentGraph::groom_graph_for_gssw(DeletableHandleGraph& graph) {
-        
-        // collect all of the empty node IDs without doing any edits
-        vector<id_t> empty_nodes;
-        graph.for_each_handle([&](const handle_t& handle) {
-            if (graph.get_length(handle) == 0) {
-                empty_nodes.push_back(graph.get_id(handle));
-            }
-        });
-        // go through and delete them now that we're done iterating
-        for (const id_t& node_id : empty_nodes) {
-            graph.destroy_handle(graph.get_handle(node_id));
-        }
     }
     
     bool MultipathAlignmentGraph::empty() {

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -215,10 +215,6 @@ namespace vg {
         /// ordering of their target nodes
         void reorder_adjacency_lists(const vector<size_t>& order);
         
-        /// Removes the empty anchoring nodes that are sometimes created by the graph extraction
-        /// algorithms, which is how gssw likes it
-        void groom_graph_for_gssw(DeletableHandleGraph& graph);
-        
         /// Generate alignments of the tails of the query sequence, beyond the
         /// sources and sinks. The Alignment passed *must* be the one that owns
         /// the sequence we are working on. Returns a map from tail

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3491,6 +3491,16 @@ namespace vg {
         // the scores of the optimal alignments and fragments, ignoring population
         vector<double> base_scores(multipath_aln_pairs.size(), 0.0);
         
+#ifdef debug_multipath_mapper
+        // trackers that let us keep track of the alignment and population components separately
+        vector<pair<double, double>> chosen_align_score(multipath_aln_pairs.size(),
+                                                        make_pair(numeric_limits<double>::quiet_NaN(),
+                                                                  numeric_limits<double>::quiet_NaN()));
+        vector<pair<double, double>> chosen_population_score(multipath_aln_pairs.size(),
+                                                             make_pair(numeric_limits<double>::quiet_NaN(),
+                                                                       numeric_limits<double>::quiet_NaN()));
+#endif
+        
         // the scores of the optimal alignments and fragments, accounting for population
         vector<double> pop_adjusted_scores;
         if (include_population_component) {
@@ -3633,6 +3643,16 @@ namespace vg {
                                 best_total_score[end] = total_score;
                                 best_pop_score[end] = pop_score.first / log_base;
                                 have_best_linearization[end] = true;
+#ifdef debug_multipath_mapper
+                                if (end == 0) {
+                                    chosen_align_score[i].first = alignments[end][j].score();
+                                    chosen_population_score[i].first = pop_score.first / log_base;
+                                }
+                                else {
+                                    chosen_align_score[i].second = alignments[end][j].score();
+                                    chosen_population_score[i].second = pop_score.first / log_base;
+                                }
+#endif
                             }
                             
                         }
@@ -3744,7 +3764,7 @@ namespace vg {
                 << " align:" << optimal_alignment_score(multipath_aln_pairs[i].first) + optimal_alignment_score(multipath_aln_pairs[i].second)
             << ", length: " << cluster_pairs[i].second;
             if (include_population_component && all_multipaths_pop_consistent) {
-                cerr << ", pop: " << scores[i] - base_scores[i];
+                cerr << ", pop adjusted aligns: " << chosen_align_score[i].first << " " << chosen_align_score[i].second << ", population: " << chosen_population_score[i].first << " " << chosen_population_score[i].second;
             }
             cerr << ", combined: " << scores[i] << endl;
         }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3746,6 +3746,10 @@ namespace vg {
                 std::swap(scores[index[i]], scores[i]);
                 std::swap(cluster_pairs[index[i]], cluster_pairs[i]);
                 std::swap(multipath_aln_pairs[index[i]], multipath_aln_pairs[i]);
+#ifdef debug_multipath_mapper
+                std::swap(chosen_align_score[index[i]], chosen_align_score[i]);
+                std::swap(chosen_population_score[index[i]], chosen_population_score[i]);
+#endif
                 std::swap(index[index[i]], index[i]);
                 
             }

--- a/src/null_masking_graph.cpp
+++ b/src/null_masking_graph.cpp
@@ -1,0 +1,91 @@
+/**
+ * \file null_masking_graph.cpp: contains the implementation of NullMaskingGraph
+ */
+
+
+#include "null_masking_graph.hpp"
+
+
+namespace vg {
+
+using namespace std;
+
+    NullMaskingGraph::NullMaskingGraph(const HandleGraph* graph) : graph(graph) {
+        graph->for_each_handle([&](const handle_t& handle) {
+            if (graph->get_length(handle) == 0) {
+                num_null_nodes++;
+            }
+        });
+    }
+    
+    bool NullMaskingGraph::has_node(id_t node_id) const {
+        bool found_node = false;
+        if (graph->has_node(node_id)) {
+            if (graph->get_length(graph->get_handle(node_id)) > 0) {
+                found_node = true;
+            }
+        }
+        return found_node;
+    }
+    
+    handle_t NullMaskingGraph::get_handle(const id_t& node_id, bool is_reverse) const {
+        // TODO: should we throw an assert that it's non-empty?
+        return graph->get_handle(node_id, is_reverse);
+    }
+    
+    id_t NullMaskingGraph::get_id(const handle_t& handle) const {
+        return graph->get_id(handle);
+    }
+    
+    bool NullMaskingGraph::get_is_reverse(const handle_t& handle) const {
+        return graph->get_is_reverse(handle);
+    }
+    
+    handle_t NullMaskingGraph::flip(const handle_t& handle) const {
+        return graph->flip(handle);
+    }
+    
+    size_t NullMaskingGraph::get_length(const handle_t& handle) const {
+        return graph->get_length(handle);
+    }
+    
+    string NullMaskingGraph::get_sequence(const handle_t& handle) const {
+        return graph->get_sequence(handle);
+    }
+    
+    bool NullMaskingGraph::follow_edges_impl(const handle_t& handle, bool go_left,
+                                           const function<bool(const handle_t&)>& iteratee) const {
+        
+        return graph->follow_edges(handle, go_left, [&](const handle_t& next) {
+            bool keep_going = true;
+            if (graph->get_length(next) > 0) {
+                keep_going = iteratee(next);
+            }
+            return keep_going;
+        });
+    }
+    
+    bool NullMaskingGraph::for_each_handle_impl(const function<bool(const handle_t&)>& iteratee, bool parallel) const {
+        return graph->for_each_handle([&](const handle_t& handle) {
+            bool keep_going = true;
+            if (graph->get_length(handle) > 0) {
+                keep_going = iteratee(handle);
+            }
+            return keep_going;
+        }, parallel);
+    }
+    
+    size_t NullMaskingGraph::node_size() const {
+        return graph->node_size() - num_null_nodes;
+    }
+    
+    id_t NullMaskingGraph::min_node_id() const {
+        return graph->min_node_id();
+    }
+    
+    id_t NullMaskingGraph::max_node_id() const {
+        return graph->max_node_id();
+    }
+
+}
+

--- a/src/null_masking_graph.hpp
+++ b/src/null_masking_graph.hpp
@@ -1,0 +1,91 @@
+#ifndef VG_NULL_MASKING_GRAPH_HPP_INCLUDED
+#define VG_NULL_MASKING_GRAPH_HPP_INCLUDED
+
+/** \file
+ * null_masking_graph.hpp: defines a handle graph implementation that hides nodes
+ * that have no sequence in another graph
+ */
+
+#include "handle.hpp"
+
+namespace vg {
+
+using namespace std;
+
+    /**
+     * A HandleGraph implementation that wraps some other handle graph and hides any
+     * nodes that have no sequence associated with them.
+     */
+    class NullMaskingGraph : public HandleGraph {
+    public:
+        
+        /// Initialize as the backwards version of another graph
+        NullMaskingGraph(const HandleGraph* graph);
+        
+        /// Default constructor -- not actually functional
+        NullMaskingGraph() = default;
+        
+        /// Default destructor
+        ~NullMaskingGraph() = default;
+        
+        //////////////////////////
+        /// HandleGraph interface
+        //////////////////////////
+        
+        // Method to check if a node exists by ID
+        virtual bool has_node(id_t node_id) const;
+        
+        /// Look up the handle for the node with the given ID in the given orientation
+        virtual handle_t get_handle(const id_t& node_id, bool is_reverse = false) const;
+        
+        /// Get the ID from a handle
+        virtual id_t get_id(const handle_t& handle) const;
+        
+        /// Get the orientation of a handle
+        virtual bool get_is_reverse(const handle_t& handle) const;
+        
+        /// Invert the orientation of a handle (potentially without getting its ID)
+        virtual handle_t flip(const handle_t& handle) const;
+        
+        /// Get the length of a node
+        virtual size_t get_length(const handle_t& handle) const;
+        
+        /// Get the sequence of a node, presented in the handle's local forward
+        /// orientation.
+        virtual string get_sequence(const handle_t& handle) const;
+        
+        /// Loop over all the handles to next/previous (right/left) nodes. Passes
+        /// them to a callback which returns false to stop iterating and true to
+        /// continue. Returns true if we finished and false if we stopped early.
+        virtual bool follow_edges_impl(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const;
+        
+        /// Loop over all the nodes in the graph in their local forward
+        /// orientations, in their internal stored order. Stop if the iteratee
+        /// returns false. Can be told to run in parallel, in which case stopping
+        /// after a false return value is on a best-effort basis and iteration
+        /// order is not defined.
+        virtual bool for_each_handle_impl(const function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+        
+        /// Return the number of nodes in the graph.
+        /// *WARNING* This method's implementation is O(N) in the size of the graph, unlike
+        /// for most HandleGraphs.
+        virtual size_t node_size() const;
+        
+        /// Return the smallest ID in the graph, or some smaller number if the
+        /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
+        virtual id_t min_node_id() const;
+        
+        /// Return the largest ID in the graph, or some larger number if the
+        /// largest ID is unavailable. Return value is unspecified if the graph is empty.
+        virtual id_t max_node_id() const;
+        
+    private:
+        /// The graph we're masking empty nodes in
+        const HandleGraph* graph = nullptr;
+        
+        /// The total number of null nodes
+        size_t num_null_nodes = 0;
+    };
+}
+
+#endif

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1309,7 +1309,7 @@ Path simplify(const Path& p, bool trim_internal_deletions) {
         auto& m = r.mapping(i);
         int curr_to_length = mapping_to_length(m);
         // skip bits at the beginning and end
-        if (!seen_to_length && !curr_to_length
+        if ((!seen_to_length && !curr_to_length)
             || seen_to_length == total_to_length) continue;
         Mapping n;
         *n.mutable_position() = m.position();

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -220,7 +220,7 @@ int main_filter(int argc, char** argv) {
         case 'b':
             {
                 vector<string> parts = split_delims(string(optarg), ":");
-                if (!parts.size() == 2) {
+                if (parts.size() != 2) {
                     cerr << "[vg filter] Error: -b expects value in form of <INT>:<FLOAT>" << endl;
                     return 1;
                 }


### PR DESCRIPTION
I had some alignment bugs pop up in the multipath alignment code that revealed a bug in the pinning logic. As part of the fix, I pushed some of the ugliness of shimming between HandleGraphs with empty nodes as anchors  and GSSW graphs into the Aligner. I also replaced a specialized graph algorithm in this shim with an overlay. There's a small update to GSSW that accompanies this change. 