### PR TITLE
Filter reads based on feature tags

### DIFF
--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -620,14 +620,14 @@ ReadFilter::Counts ReadFilter::filter_alignment(Alignment& aln) {
             keep = false;    
         }
     }
-    if ((keep || verbose) && !banned_features.empty()) {
+    if ((keep || verbose) && !excluded_features.empty()) {
         // Get all the feature tags on the read
         vector<string> features(get_annotation<vector<string>>(aln, "features"));
         
         for (auto& feature : features) {
-            if (banned_features.count(feature)) {
+            if (excluded_features.count(feature)) {
                 // If the read has any banned features, fail it.
-                ++counts.counts[Counts::FilterName::banned_feature];
+                ++counts.counts[Counts::FilterName::excluded_feature];
                 keep = false;
                 break;
             }
@@ -783,13 +783,20 @@ int ReadFilter::filter(istream* alignment_stream) {
     function<void(Alignment&, Alignment&)> pair_lambda = [&](Alignment& aln1, Alignment& aln2) {
         Counts aln_counts = filter_alignment(aln1);
         aln_counts += filter_alignment(aln2);
-        // when running interleaved, if we filter out one end for any reason, we filter out the other as well
-        aln_counts.set_paired();
+        if (filter_on_all) {
+            // Unless both reads were filtered out (total filtered count == 2), keep the read.
+            aln_counts.set_paired_all();
+        } else {
+            // Either read failing is sufficient to scuttle the pair.
+            // So if we filter out one end for any reason, we filter out the other as well.
+            aln_counts.set_paired_any();
+        }
         counts_vec[omp_get_thread_num()] += aln_counts;
         if ((aln_counts.keep() != complement_filter) && write_output) {
             output_alignment(aln1);
             output_alignment(aln2);
         }
+        
     };
     
     if (interleaved) {
@@ -816,6 +823,7 @@ ostream& operator<<(ostream& os, const ReadFilter::Counts& counts) {
        << counts.counts[ReadFilter::Counts::FilterName::read] << endl
        << "Read Name Filter:              " << counts.counts[ReadFilter::Counts::FilterName::wrong_name] << endl
        << "refpos Contig Filter:          " << counts.counts[ReadFilter::Counts::FilterName::wrong_refpos] << endl
+       << "Feature Filter:                " << counts.counts[ReadFilter::Counts::FilterName::excluded_feature] << endl
        << "Min Identity Filter:           " << counts.counts[ReadFilter::Counts::FilterName::min_score] << endl
        << "Min Secondary Identity Filter: " << counts.counts[ReadFilter::Counts::FilterName::min_sec_score] << endl
        << "Max Overhang Filter:           " << counts.counts[ReadFilter::Counts::FilterName::max_overhang] << endl

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -32,6 +32,9 @@ public:
     vector<string> name_prefixes;
     /// Read must not have a refpos set with a contig name containing a match to any of these
     vector<regex> excluded_refpos_contigs;
+    /// If a read has one of the features in this set as annotations, the read
+    /// is filtered out.
+    unordered_set<string> banned_features;
     double min_secondary = 0.;
     double min_primary = 0.;
     // Should we rescore each alignment with default parameters and no e.g.
@@ -74,8 +77,9 @@ public:
                      
     // Keep some basic counts for when verbose mode is enabled
     struct Counts {
-        enum FilterName { read = 0, wrong_name, wrong_refpos, min_score, min_sec_score, max_overhang, min_end_matches,
-                          min_mapq, split, repeat, defray, defray_all, random, filtered, min_base_qual, last };
+        enum FilterName { read = 0, wrong_name, wrong_refpos, banned_feature, min_score, min_sec_score, max_overhang,
+                          min_end_matches, min_mapq, split, repeat, defray, defray_all, random, filtered, min_base_qual,
+                          last };
         vector<size_t> counts;
         Counts () : counts(FilterName::last, 0) {}
         Counts& operator+=(const Counts& other) {

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -34,11 +34,11 @@ public:
     vector<regex> excluded_refpos_contigs;
     /// If a read has one of the features in this set as annotations, the read
     /// is filtered out.
-    unordered_set<string> banned_features;
+    unordered_set<string> excluded_features;
     double min_secondary = 0.;
     double min_primary = 0.;
-    // Should we rescore each alignment with default parameters and no e.g.
-    // haplotype info?
+    /// Should we rescore each alignment with default parameters and no e.g.
+    /// haplotype info?
     bool rescore = false;
     bool frac_score = false;
     bool sub_score = false;
@@ -47,29 +47,36 @@ public:
     bool verbose = false;
     double min_mapq = 0.;
     int repeat_size = 0;
-    // How far in from the end should we look for ambiguous end alignment to
-    // clip off?
-    int defray_length = 0;
-    // Limit defray recursion to visit this many nodes
-    int defray_count = 99999;
-    // Should we drop split reads that follow edges not in the graph?
+    /// Should we drop split reads that follow edges not in the graph?
     bool drop_split = false;
-    // We can also pseudorandomly drop reads. What's the probability that we keep a read?
+    
+    /// We can also pseudorandomly drop reads. What's the probability that we keep a read?
     double downsample_probability = 1.0;
-    // Samtools-compatible internal seed mask, for deciding which read pairs to keep.
-    // To be generated with rand() after srand() from the user-visible seed.
+    /// Samtools-compatible internal seed mask, for deciding which read pairs to keep.
+    /// To be generated with rand() after srand() from the user-visible seed.
     uint32_t downsample_seed_mask = 0;
-    // number of threads from omp
+    
+    /// How far in from the end should we look for ambiguous end alignment to
+    /// clip off?
+    int defray_length = 0;
+    /// Limit defray recursion to visit this many nodes
+    int defray_count = 99999;
+    
+    /// Number of threads from omp
     int threads = -1;
-    // GAM output buffer size
+    /// GAM output buffer size
     int buffer_size = 512;
-    // Sometimes we only want a report, and not a filtered gam.  toggling off output
-    // speeds things up considerably.
+    /// Sometimes we only want a report, and not a filtered gam.  toggling off output
+    /// speeds things up considerably.
     bool write_output = true;
-    // An XG index is required for some filters (Note: ReadFilter doesn't own/free this)
+    /// An XG index is required for some filters (Note: ReadFilter doesn't own/free this)
     xg::XG* xindex = nullptr;
-    // Interleaved input
+    /// Interleaved input
     bool interleaved = false;
+    /// When outputting paired reads, fail the pair only if both (all) reads
+    /// fail (true) instead of if either (any) read fails (false)
+    bool filter_on_all = false;
+    
     // minimum base quality as PHRED score
     int min_base_quality = 0;
     // minimum fraction of bases in reads that must have quality at least <min_base_quality>
@@ -77,8 +84,8 @@ public:
                      
     // Keep some basic counts for when verbose mode is enabled
     struct Counts {
-        enum FilterName { read = 0, wrong_name, wrong_refpos, banned_feature, min_score, min_sec_score, max_overhang,
-                          min_end_matches, min_mapq, split, repeat, defray, defray_all, random, filtered, min_base_qual,
+        enum FilterName { read = 0, wrong_name, wrong_refpos, excluded_feature, min_score, min_sec_score, max_overhang,
+                          min_end_matches, min_mapq, split, repeat, defray, defray_all, random, min_base_qual, filtered,
                           last };
         vector<size_t> counts;
         Counts () : counts(FilterName::last, 0) {}
@@ -88,10 +95,26 @@ public:
             }
             return *this;
         }
-        Counts& set_paired() {
+        /// If any read was filtered, count the other read as filtered
+        Counts& set_paired_any() {
             for (int i = 0; i < FilterName::last; ++i) {
                 counts[i] = counts[i] == 1 ? 2 : counts[i];
             }
+            return *this;
+        }
+        /// If not all reads were filtered, count filtered ones as unfiltered.
+        Counts& set_paired_all() {
+            // We know that the pair as a whole was filtered out if counts[FilterName::filtered] == 2, and that it was kept otherwise.
+            if (counts[FilterName::filtered] != 2) {
+                // The read pair was not discarded, so clear out all the fail counts (including FilterName::filtered).
+                for (int i = 0; i < FilterName::last; ++i) {
+                    counts[i] = 0;
+                }
+            }
+            // Otherwise the read pair was discarded, so leave all the
+            // counts alone. There is at least one fail on each side to be
+            // responsible for it (and if not verbose, only one fail on
+            // each side).
             return *this;
         }
         void reset() {

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -29,6 +29,7 @@ void help_filter(char** argv) {
          << "    -n, --name-prefix NAME     keep only reads with this prefix in their names [default='']" << endl
          << "    -N, --name-prefixes FILE   keep reads with names with one of many prefixes, one per nonempty line" << endl
          << "    -X, --exclude-contig REGEX drop reads with refpos annotations on contigs matching the given regex (may repeat)" << endl
+         << "    -F, --exclude-feature NAME drop reads with the given feature in the \"features\" annotation (may repeat)" << endl
          << "    -s, --min-secondary N      minimum score to keep secondary alignment [default=0]" << endl
          << "    -r, --min-primary N        minimum score to keep primary alignment [default=0]" << endl
          << "    -O, --rescore              re-score reads using default parameters and only alignment information" << endl
@@ -46,7 +47,8 @@ void help_filter(char** argv) {
          << "    -D, --defray-ends N        clip back the ends of reads that are ambiguously aligned, up to N bases" << endl
          << "    -C, --defray-count N       stop defraying after N nodes visited (used to keep runtime in check) [default=99999]" << endl
          << "    -d, --downsample S.P       filter out all but the given portion 0.P of the reads. S may be an integer seed as in SAMtools" << endl
-         << "    -i, --interleaved          assume interleaved input.  both ends will be filtered out if either fails filter" << endl
+         << "    -i, --interleaved          assume interleaved input. both ends will be filtered out if either fails filter" << endl
+         << "    -I, --interleaved-all      assume interleaved input. both ends will be filtered out if *both* fail filters" << endl
          << "    -b, --min-base-quality Q:F filter reads with where fewer than fraction F bases have base quality >= PHRED score Q." << endl
          << "    -U, --complement           apply the complement of the filter implied by the other arguments." << endl
          << "    -t, --threads N            number of threads [1]" << endl;
@@ -76,6 +78,7 @@ int main_filter(int argc, char** argv) {
                 {"name-prefix", required_argument, 0, 'n'},
                 {"name-prefixes", required_argument, 0, 'N'},
                 {"exclude-contig", required_argument, 0, 'X'},
+                {"exclude-feature", required_argument, 0, 'F'},
                 {"min-secondary", required_argument, 0, 's'},
                 {"min-primary", required_argument, 0, 'r'},
                 {"rescore", no_argument, 0, 'O'},
@@ -92,7 +95,8 @@ int main_filter(int argc, char** argv) {
                 {"defray-ends", required_argument, 0, 'D'},
                 {"defray-count", required_argument, 0, 'C'},
                 {"downsample", required_argument, 0, 'd'},
-                {"interleaved", required_argument, 0, 'i'},
+                {"interleaved", no_argument, 0, 'i'},
+                {"interleaved-all", no_argument, 0, 'I'},
                 {"min-base-quality", required_argument, 0, 'b'},
                 {"complement", no_argument, 0, 'U'},
                 {"threads", required_argument, 0, 't'},
@@ -100,7 +104,7 @@ int main_filter(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "n:N:X:s:r:Od:e:fauo:m:Sx:AvVq:E:D:C:d:ib:Ut:",
+        c = getopt_long (argc, argv, "n:N:X:F:s:r:Od:e:fauo:m:Sx:AvVq:E:D:C:d:iIb:Ut:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -127,6 +131,9 @@ int main_filter(int argc, char** argv) {
             break;
         case 'X':
             filter.excluded_refpos_contigs.push_back(parse<std::regex>(optarg));
+            break;
+        case 'F':
+            filter.excluded_features.insert(optarg);
             break;
         case 's':
             filter.min_secondary = parse<double>(optarg);
@@ -216,6 +223,10 @@ int main_filter(int argc, char** argv) {
             break;
         case 'i':
             filter.interleaved = true;
+            break;
+        case 'I':
+            filter.interleaved = true;
+            filter.filter_on_all = true;
             break;
         case 'b':
             {

--- a/test/t/21_vg_filter.t
+++ b/test/t/21_vg_filter.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 8
+plan tests 10
 
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg  x.vg
@@ -64,6 +64,9 @@ is "$(vg filter -X "[w-z]" paired.annotated.gam | vg view -aj - | wc -l)" "0" "r
 is "$(vg filter -U x.gam | vg view -aj - | wc -l)" "0" "negating a non-filter results in no reads"
 
 is "$(cat <(vg filter -U -d 123.5 -t 10 paired.gam | vg view -aj -) <(vg filter -d 123.5 -t 10 paired.gam | vg view -aj -)  | wc -l)" "$(vg view -aj paired.gam | wc -l)" "a filter and its complement should form the entire file"
+
+is "$(echo '{"sequence": "GATTACA", "name": "read1", "annotation": {"features": ["test"]}, "fragment_next": {"name": "read2"}}{"sequence": "CATTAG", "name": "read2", "fragment_prev":{"name": "read1"}}' | vg view -JGa - | vg filter -F "test" -i - | vg view -aj - | wc -l)" "0" "read pairs can be tropped by feature"
+is "$(echo '{"sequence": "GATTACA", "name": "read1", "annotation": {"features": ["test"]}, "fragment_next": {"name": "read2"}}{"sequence": "CATTAG", "name": "read2", "fragment_prev":{"name": "read1"}}' | vg view -JGa - | vg filter -F "test" -I - | vg view -aj - | wc -l)" "2" "read pairs can be kept if only one read fails"
 
 rm -f x.gam filter_chunk*.gam chunks.bed
 rm -f x.vg x.xg paired.gam paired.sam paired.annotated.gam single.gam single.sam filtered.gam filtered.sam


### PR DESCRIPTION
This fixes #2163 by adding a way for `vg filter` to filter on tags in the `.annotation.features` field.

To let you filter out the pair only if *both* reads have a tag, I have also added a `-I` option, which means that the input is interleaved and also that read pairs should only be removed if both ends fail filters.

So to drop read pairs where both ends are tagged `centromere`, @jeizenga can do `vg filter -I -F centromere input.gam >output.gam`.