### PR TITLE
Faster xg context expansion

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -27,6 +27,10 @@ side_t make_side(id_t id, bool is_end) {
     return !is_end ? id : -1 * id;
 }
 
+pair<side_t, side_t> make_side_pair(side_t s1, side_t s2) {
+    return s1 < s2 ? make_pair(s1, s2) : make_pair(s2, s1);
+}
+
 id_t trav_id(const trav_t& trav) {
     return abs(trav.first);
 }
@@ -2319,8 +2323,8 @@ void XG::expand_context_by_steps(Graph& g, size_t steps, bool add_paths,
         auto& edge = g.edge(i);
         to_visit.insert(edge.from());
         to_visit.insert(edge.to());
-        edges[make_pair(make_side(edge.from(), edge.from_start()),
-                        make_side(edge.to(), edge.to_end()))] = g.mutable_edge(i);
+        edges[make_side_pair(make_side(edge.from(), edge.from_start()),
+                             make_side(edge.to(), edge.to_end()))] = g.mutable_edge(i);
     }
     // and expand
     for (size_t i = 0; i < steps; ++i) {
@@ -2345,8 +2349,8 @@ void XG::expand_context_by_steps(Graph& g, size_t steps, bool add_paths,
                 exit(1);
             }
             for (auto& edge : edges_todo) {
-                auto sides = make_pair(make_side(edge.from(), edge.from_start()),
-                                       make_side(edge.to(), edge.to_end()));
+                auto sides = make_side_pair(make_side(edge.from(), edge.from_start()),
+                                            make_side(edge.to(), edge.to_end()));
                 if (edges.find(sides) == edges.end()) {
                     Edge* ep = g.add_edge(); *ep = edge;
                     edges[sides] = ep;
@@ -2397,8 +2401,8 @@ void XG::expand_context_by_steps(Graph& g, size_t steps, bool add_paths,
                 
                 // Determine if it's been seen already (somehow).
                 // TODO: it probably shouldn't have been, unless it's a self loop or something.
-                auto sides = make_pair(make_side(edge.from(), edge.from_start()),
-                                       make_side(edge.to(), edge.to_end()));
+                auto sides = make_side_pair(make_side(edge.from(), edge.from_start()),
+                                            make_side(edge.to(), edge.to_end()));
                 if (edges.find(sides) == edges.end()) {
                     // If it isn't there already, add it to the graph
                     Edge* ep = g.add_edge(); *ep = edge;
@@ -2439,8 +2443,8 @@ void XG::expand_context_by_length(Graph& g, size_t length, bool add_paths,
     // add starting edges
     for (size_t i = 0; i < g.edge_size(); ++i) {
         auto& edge = g.edge(i);
-        edges[make_pair(make_side(edge.from(), edge.from_start()),
-                        make_side(edge.to(), edge.to_end()))] = g.mutable_edge(i);
+        edges[make_side_pair(make_side(edge.from(), edge.from_start()),
+                             make_side(edge.to(), edge.to_end()))] = g.mutable_edge(i);
     }
 
     // expand outward breadth-first
@@ -2492,10 +2496,10 @@ void XG::expand_context_by_length(Graph& g, size_t length, bool add_paths,
                         }
                         // create all links back to graph, so as not to break paths
                         for (auto& other_edge : edges_of(other)) {
-                            auto sides = make_pair(make_side(other_edge.from(),
-                                                             other_edge.from_start()),
-                                                   make_side(other_edge.to(),
-                                                             other_edge.to_end()));
+                            auto sides = make_side_pair(make_side(other_edge.from(),
+                                                                  other_edge.from_start()),
+                                                        make_side(other_edge.to(),
+                                                                  other_edge.to_end()));
                             int64_t other_from = other_edge.from() == other ? other_edge.to() :
                                 other_edge.from();
                             if (nodes.find(other_from) != nodes.end() &&

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -338,7 +338,7 @@ public:
     vector<size_t> paths_of_node(int64_t id) const;
     map<string, vector<Mapping>> node_mappings(int64_t id) const;
     bool path_contains_node(const string& name, int64_t id) const;
-    void add_paths_to_graph(map<int64_t, Node*>& nodes, Graph& g) const;
+    void add_paths_to_graph(unordered_map<int64_t, Node*>& nodes, Graph& g) const;
     size_t node_occs_in_path(int64_t id, const string& name) const;
     size_t node_occs_in_path(int64_t id, size_t rank) const;
     vector<size_t> node_ranks_in_path(int64_t id, const string& name) const;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -45,6 +45,8 @@ typedef int64_t side_t;
 id_t side_id(const side_t& side);
 bool side_is_end(const side_t& side);
 side_t make_side(id_t id, bool is_end);
+pair<side_t, side_t> make_side_pair(side_t s1, side_t s2);
+    
 // node traversals
 typedef pair<int64_t, int32_t> trav_t; // meant to encode pos+side or pos+strand
 id_t trav_id(const trav_t& trav);


### PR DESCRIPTION
Fixing up some low-haning STL stuff gives a decent speedup on some test data.

old
```
time vg chunk -x component0.xg -p S288C.chrI -c 100 > /dev/null 
real	0m47.752s
user	0m47.260s
sys	0m0.484s
```
new
```
time vg chunk -x component0.xg -p S288C.chrI -c 100 > /dev/null 
real	0m18.226s
user	0m17.788s
sys	0m0.420s
```