### PR TITLE
Update a few mpmap default parameters

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1083,13 +1083,13 @@ namespace vg {
             if (prefix_idx > 0 || suffix_idx + 1 < path_node.path.mapping_size()) {
                 
                 // compute the amount of read we're trimming off from each end
-                int64_t trimmed_prefix_from_length = 0;
-                int64_t trimmed_suffix_from_length = 0;
+                int64_t trimmed_prefix_to_length = 0;
+                int64_t trimmed_suffix_to_length = 0;
                 for (int64_t i = 0; i < prefix_idx; i++) {
-                    trimmed_prefix_from_length += mapping_from_length(path_node.path.mapping(i));
+                    trimmed_prefix_to_length += mapping_to_length(path_node.path.mapping(i));
                 }
                 for (int64_t i = suffix_idx + 1; i < path_node.path.mapping_size(); i++) {
-                    trimmed_suffix_from_length += mapping_from_length(path_node.path.mapping(i));
+                    trimmed_suffix_to_length += mapping_to_length(path_node.path.mapping(i));
                 }
                 
                 // replace the path with the portion that we didn't trim
@@ -1106,8 +1106,8 @@ namespace vg {
                 cerr << "trimmed path: " << pb2json(path_node.path) << endl;
 #endif
                 // update the read interval
-                path_node.begin += trimmed_prefix_from_length;
-                path_node.end -= trimmed_suffix_from_length;
+                path_node.begin += trimmed_prefix_to_length;
+                path_node.end -= trimmed_suffix_to_length;
             }
         }
     }

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -56,7 +56,7 @@ void help_mpmap(char** argv) {
     << "algorithm:" << endl
     << "  -v, --tvs-clusterer           use the target value search based clusterer (requies a distance index from -d)" << endl
     << "  -X, --snarl-max-cut INT       do not align to alternate paths in a snarl if an exact match is at least this long (0 for no limit) [5]" << endl
-    << "  -a, --alt-paths INT           align to (up to) this many alternate paths in between MEMs or in snarls [4]" << endl
+    << "  -a, --alt-paths INT           align to (up to) this many alternate paths in between MEMs or in snarls [10]" << endl
     << "      --suppress-tail-anchors   don't produce extra anchors when aligning to alternate paths in snarls" << endl
     << "  -n, --unstranded              use lazy strand consistency when clustering MEMs" << endl
     << "  -b, --frag-sample INT         look for this many unambiguous mappings to estimate the fragment length distribution [1000]" << endl
@@ -128,7 +128,7 @@ int main_mpmap(int argc, char** argv) {
     int full_length_bonus = default_full_length_bonus;
     bool interleaved_input = false;
     int snarl_cut_size = 5;
-    int max_branch_trim_length = 1;
+    int max_branch_trim_length = 4;
     bool suppress_tail_anchors = false;
     int max_paired_end_map_attempts = 24;
     int max_single_end_mappings_for_rescue = 64;
@@ -155,7 +155,7 @@ int main_mpmap(int argc, char** argv) {
     MappingQualityMethod mapq_method = Adaptive;
     double band_padding_multiplier = 1.0;
     int max_dist_error = 12;
-    int num_alt_alns = 4;
+    int num_alt_alns = 10;
     double suboptimal_path_exponent = 1.25;
     double likelihood_approx_exp = 10.0;
     double recombination_penalty = 20.7;


### PR DESCRIPTION
The way `mpmap` works has changed a bit and some of the default parameters are now unnecessarily conservative. This update chooses more appropriate defaults and fixes a small bug.