### PR TITLE
GAFFE improvements

### DIFF
--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -363,7 +363,7 @@ Path maximal_match_to_path(const MaximalGBWTMatch& match, const GBWTGraph& graph
     return result;
 }
 
-std::vector<Path> GaplessExtender::seeds_to_mems(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const {
+std::vector<std::pair<Path, size_t>> GaplessExtender::seeds_to_mems(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const {
 
     // Process the seeds in sorted order.
     handle_t prev_handle = GBWTGraph::node_to_handle(gbwt::ENDMARKER);
@@ -489,9 +489,10 @@ std::vector<Path> GaplessExtender::seeds_to_mems(std::vector<std::pair<size_t, p
         }
     }
 
-    std::vector<Path> result;
+    // FIXME this would be a good place to filter MEMs contained in other MEMs
+    std::vector<std::pair<Path, size_t>> result;
     for(const MaximalGBWTMatch& match : mems) {
-        result.emplace_back(maximal_match_to_path(match, *(this->graph), sequence));
+        result.emplace_back(maximal_match_to_path(match, *(this->graph), sequence), match.start);
     }
     return result;
 }

--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -20,6 +20,7 @@ GaplessExtender::GaplessExtender(const GBWTGraph& graph) :
 
 //------------------------------------------------------------------------------
 
+// FIXME seq_start, seq_limit, node_start, node_limit
 struct GaplessMatch {
     size_t score;
     size_t start, limit; // In the sequence.
@@ -271,228 +272,204 @@ std::pair<Path, size_t> GaplessExtender::extend_seeds(std::vector<std::pair<size
 //------------------------------------------------------------------------------
 
 struct MaximalGBWTMatch {
-    size_t start, limit; // In the sequence.
-    size_t offset; // In the initial node of the path.
+    size_t seq_start, seq_limit; // Sequence range.
+    size_t node_start, node_limit; // In the initial/final nodes of the path.
     gbwt::BidirectionalState state;
 
     std::vector<handle_t> path;
 
-    size_t length() const { return this->limit - this->start; }
+    size_t length() const { return this->seq_limit - this->seq_start; }
     bool empty() const { return (this->length() == 0); }
 
-    // Two matches are considered equivalent, if the substrings and search states are identical.
+    // Compare sequence ranges, start/end nodes, and node offsets.
     bool operator<(const MaximalGBWTMatch& another) const {
-        if (this->start != another.start) {
-            return (this->start < another.start);
+        if (this->seq_start != another.seq_start) {
+            return (this->seq_start < another.seq_start);
         }
-        if (this->limit != another.limit) {
-            return (this->limit < another.limit);
-        }
-        if (this->state.forward.node != another.state.forward.node) {
-            return (this->state.forward.node < another.state.forward.node);
+        if (this->seq_limit != another.seq_limit) {
+            return (this->seq_limit < another.seq_limit);
         }
         if (this->state.backward.node != another.state.backward.node) {
             return (this->state.backward.node < another.state.backward.node);
         }
-        if (this->state.forward.range.first != another.state.forward.range.first) {
-            return (this->state.forward.range.first < another.state.forward.range.first);
+        if (this->node_start != another.node_start) {
+            return (this->node_start < another.node_start);
         }
-        if (this->state.forward.range.second != another.state.forward.range.second) {
-            return (this->state.forward.range.second < another.state.forward.range.second);
+        if (this->state.forward.node != another.state.forward.node) {
+            return (this->state.forward.node < another.state.forward.node);
+        }
+        if (this->node_limit != another.node_limit) {
+            return (this->node_limit < another.node_limit);
         }
         return false;
     }
 };
 
-// Match forward, starting from the given target offset.
-// Returns the number of successfully matched characters.
-size_t match_forward(const std::string& seq, std::pair<const char*, size_t> target, size_t target_offset,
-                   MaximalGBWTMatch& match) {
-    size_t initial_offset = target_offset;
-    while (match.limit < seq.length() && target_offset < target.second) {
-        if (seq[match.limit] != target.first[target_offset]) {
+// Match forward as long as the characters match,
+void match_forward(const std::string& seq, std::pair<const char*, size_t> target, MaximalGBWTMatch& match) {
+    while (match.seq_limit < seq.length() && match.node_limit < target.second) {
+        if (seq[match.seq_limit] != target.first[match.node_limit]) {
             break;
         }
-        match.limit++;
-        target_offset++;
+        match.seq_limit++;
+        match.node_limit++;
     }
-    return target_offset - initial_offset;
 }
 
-// Match backward, starting from the end of the target and updating match offset.
-// Returns the number of successfully matched characters.
-size_t match_backward(const std::string& seq, std::pair<const char*, size_t> target, MaximalGBWTMatch& match) {
-    match.offset = target.second;
-    while (match.start > 0 && match.offset > 0) {
-        match.start--;
-        match.offset--;
-        if (seq[match.start] != target.first[match.offset]) {
-            return target.second - match.offset - 1;
+// Match backward as long as the characters match.
+void match_backward(const std::string& seq, std::pair<const char*, size_t> target, MaximalGBWTMatch& match) {
+    while (match.seq_start > 0 && match.node_start > 0) {
+        if (seq[match.seq_start - 1] != target.first[match.node_start - 1]) {
+            break;
         }
+        match.seq_start--;
+        match.node_start--;
     }
-    return target.second - match.offset;
 }
 
 // Convert the exact match to a path.
-Path maximal_match_to_path(const MaximalGBWTMatch& match, const GBWTGraph& graph, const std::string& sequence) {
+Path maximal_match_to_path(const MaximalGBWTMatch& match, const GBWTGraph& graph) {
 
     Path result;
     if (match.empty()) {
         return result;
     }
 
-    size_t sequence_offset = match.start; // Start of the unmapped part in the sequence.
-    size_t node_offset = match.offset; // Start of the alignment in the current node.
     for (size_t i = 0; i < match.path.size(); i++) {
-        size_t limit = std::min(sequence_offset + graph.get_length(match.path[i]) - node_offset, match.limit);
+        size_t start = (i == 0 ? match.node_start : 0);
+        size_t limit = (i + 1 == match.path.size() ? match.node_limit : graph.get_length(match.path[i]));
 
         Mapping& mapping = *(result.add_mapping());
         mapping.mutable_position()->set_node_id(graph.get_id(match.path[i]));
-        mapping.mutable_position()->set_offset(node_offset);
+        mapping.mutable_position()->set_offset(start);
         mapping.mutable_position()->set_is_reverse(graph.get_is_reverse(match.path[i]));
 
         Edit& exact_match = *(mapping.add_edit());
-        exact_match.set_from_length(limit - sequence_offset);
-        exact_match.set_to_length(limit - sequence_offset);
-        sequence_offset = limit;
+        exact_match.set_from_length(limit - start);
+        exact_match.set_to_length(limit - start);
 
         mapping.set_rank(i + 1);
-        node_offset = 0;
     }
 
     return result;
 }
 
-std::vector<std::pair<Path, size_t>> GaplessExtender::seeds_to_mems(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const {
+std::vector<std::pair<Path, size_t>> GaplessExtender::maximal_extensions(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const {
 
     // Process the seeds in sorted order.
-    handle_t prev_handle = GBWTGraph::node_to_handle(gbwt::ENDMARKER);
-    size_t prev_start = 0, prev_limit = 0;
+    std::pair<size_t, pos_t> prev(0, make_pos_t(0, false, 0));
+    size_t prev_limit = 0; // Limit in the initial node.
     std::sort(cluster.begin(), cluster.end());
-    std::set<MaximalGBWTMatch> mems;
+    std::set<MaximalGBWTMatch> matches;
     for (size_t i = 0; i < cluster.size(); i++) {
 
         // Skip redundant seeds.
-        std::pair<size_t, pos_t> hit = cluster[i];
-        handle_t handle = GBWTGraph::node_to_handle(pos_to_gbwt(hit.second));
-        size_t adjustment = std::min(static_cast<size_t>(offset(hit.second)), hit.first);
-        if (handle == prev_handle && offset(hit.second) - adjustment == prev_start && offset(hit.second) < prev_limit) {
+        std::pair<size_t, pos_t> normalized = cluster[i];
+        size_t adjustment = std::min(static_cast<size_t>(offset(normalized.second)), normalized.first);
+        normalized.first -= adjustment;
+        get_offset(normalized.second) -= adjustment;
+        if (normalized == prev && offset(cluster[i].second) < prev_limit) {
             continue;
         }
-        prev_handle = handle;
-        prev_start = offset(hit.second) - adjustment;
-        // prev_limit is updated later
+        prev = normalized;
+        // prev_limit is updated later when we match the first node.
 
         // Match the initial node.
-        std::stack<MaximalGBWTMatch> forward, backward;
-        {
-            // Maximal match within the initial node.
-            MaximalGBWTMatch match {
-                hit.first, hit.first,
-                static_cast<size_t>(offset(hit.second)),
-                this->graph->get_bd_state(handle),
-                { handle }            
-            };
-            std::pair<const char*, size_t> node_view = this->graph->get_sequence_view(handle);
-            match_forward(sequence, node_view, match.offset, match);
-            prev_limit = match.offset + match.length();
-            match_backward(sequence, node_view, match);
-            if (match.limit >= sequence.length()) {
-                if (match.start == 0) {
-                    mems.insert(match);
-                } else if (match.offset == 0) {
-                    backward.push(match);
-                }
-            } else if (prev_limit >= node_view.second) {
-                forward.push(match);
-            }
-        }
+        handle_t handle = GBWTGraph::node_to_handle(pos_to_gbwt(cluster[i].second));
+        MaximalGBWTMatch match {
+            cluster[i].first, cluster[i].first,
+            static_cast<size_t>(offset(cluster[i].second)), static_cast<size_t>(offset(cluster[i].second)),
+            this->graph->get_bd_state(handle),
+            { handle }            
+        };
+        std::pair<const char*, size_t> node_view = this->graph->get_sequence_view(handle);
+        match_forward(sequence, node_view, match);
+        prev_limit = match.node_limit;
+        match_backward(sequence, node_view, match);
 
-        // Match forward over all paths.
-        while (!forward.empty()) {
-            MaximalGBWTMatch curr = forward.top();
-            forward.pop();
-            size_t extend_total = 0; // Number of paths in successful extensions.
-            this->graph->follow_paths(curr.state, false, [&](const gbwt::BidirectionalState& next_state) -> bool {
+        // Match forward.
+        while (match.node_limit >= node_view.second && match.seq_limit < sequence.length()) {
+            bool extension = false, ambiguous = false;
+            gbwt::BidirectionalState successor;
+            this->graph->follow_paths(match.state, false, [&](const gbwt::BidirectionalState& next_state) -> bool {
+                if (ambiguous) {
+                    return false;
+                }
                 if (next_state.empty()) {
                     return true;
                 }
-                handle_t handle = GBWTGraph::node_to_handle(next_state.forward.node);
-                MaximalGBWTMatch next {
-                    curr.start, curr.limit,
-                    curr.offset,
-                    next_state,
-                    { }
-                };
-                std::pair<const char*, size_t> node_view = this->graph->get_sequence_view(handle);
-                size_t matching_chars = match_forward(sequence, node_view, 0, next);
-                if (matching_chars == 0) {
-                    return true;
-                }
-                extend_total += next_state.size();
-                next.path.reserve(curr.path.size() + 1);
-                next.path.insert(next.path.end(), curr.path.begin(), curr.path.end());
-                next.path.push_back(handle);
-                if (next.limit >= sequence.length()) {
-                    if (next.start == 0) {
-                        mems.insert(next);
-                    } else if (next.offset == 0) {
-                        backward.push(next);
+                handle_t next_handle = GBWTGraph::node_to_handle(next_state.forward.node);
+                if (this->graph->starts_with(next_handle, sequence[match.seq_limit])) {
+                    if (extension) {
+                        ambiguous = true;
+                        return false;
+                    } else {
+                        extension = true;
+                        successor = next_state;
+                        handle = next_handle;
+                        return true;
                     }
-                } else if (matching_chars >= node_view.second) {
-                    forward.push(next);
                 }
                 return true;
             });
-            // We could not extend all paths, so some MEMs end at curr.
-            if (extend_total < curr.state.size() && curr.offset == 0) {
-                backward.push(curr);
+            if (extension && !ambiguous) {
+                node_view = this->graph->get_sequence_view(handle);
+                match.seq_limit++;
+                match.node_limit = 1;
+                match.state = successor;
+                match.path.push_back(handle);
+                match_forward(sequence, node_view, match);
+            } else {
+                break;
             }
         }
 
-        // Match backward over all paths.
-        while (!backward.empty()) {
-            MaximalGBWTMatch curr = backward.top();
-            backward.pop();
-            size_t extend_total = 0; // Number of paths in successful extensions.
-            this->graph->follow_paths(curr.state, true, [&](const gbwt::BidirectionalState& next_state) -> bool {
+        // Match backward.
+        while (match.node_start == 0 && match.seq_start > 0) {
+            bool extension = false, ambiguous = false;
+            gbwt::BidirectionalState successor;
+            this->graph->follow_paths(match.state, true, [&](const gbwt::BidirectionalState& next_state) -> bool {
+                if (ambiguous) {
+                    return false;
+                }
                 if (next_state.empty()) {
                     return true;
                 }
-                handle_t handle = GBWTGraph::node_to_handle(gbwt::Node::reverse(next_state.backward.node));
-                MaximalGBWTMatch next {
-                    curr.start, curr.limit,
-                    curr.offset, // This will be replaced in match_backward().
-                    next_state,
-                    { }
-                };
-                std::pair<const char*, size_t> node_view = this->graph->get_sequence_view(handle);
-                size_t matching_chars = match_backward(sequence, node_view, next);
-                if (matching_chars == 0) {
-                    return true;
-                }
-                extend_total += next_state.size();
-                next.path.reserve(curr.path.size() + 1);
-                next.path.push_back(handle);
-                next.path.insert(next.path.end(), curr.path.begin(), curr.path.end());
-                if (next.start == 0) {
-                    mems.insert(next);
-                } else if (next.offset == 0) {
-                    backward.push(next);
+                handle_t next_handle = GBWTGraph::node_to_handle(gbwt::Node::reverse(next_state.backward.node));
+                if (this->graph->ends_with(next_handle, sequence[match.seq_start - 1])) {
+                    if (extension) {
+                        ambiguous = true;
+                        return false;
+                    } else {
+                        extension = true;
+                        successor = next_state;
+                        handle = next_handle;
+                        return true;
+                    }
                 }
                 return true;
             });
-            // We could not extend all paths, so some MEMs start at curr.
-            if (extend_total < curr.state.size()) {
-                mems.insert(curr);
+            if (extension && !ambiguous) {
+                node_view = this->graph->get_sequence_view(handle);
+                match.seq_start--;
+                match.node_start = node_view.second - 1;
+                match.state = successor;
+                match.path.insert(match.path.begin(), handle);
+                match_backward(sequence, node_view, match);
+            } else {
+                break;
             }
+        }
+
+        if (!match.empty()) {
+            matches.insert(match);
         }
     }
 
-    // FIXME this would be a good place to filter MEMs contained in other MEMs
+    // Convert the matches to Path objects.
     std::vector<std::pair<Path, size_t>> result;
-    for(const MaximalGBWTMatch& match : mems) {
-        result.emplace_back(maximal_match_to_path(match, *(this->graph), sequence), match.start);
+    for(const MaximalGBWTMatch& match : matches) {
+        result.emplace_back(maximal_match_to_path(match, *(this->graph)), match.seq_start);
     }
     return result;
 }

--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -93,34 +93,30 @@ std::pair<Path, size_t> gapless_match_to_path(GaplessMatch& match, const GBWTGra
     size_t node_offset = match.offset; // Start of the alignment in the current node.
     for (size_t i = 0; i < match.path.size(); i++) {
         size_t limit = sequence_offset + graph.get_length(match.path[i]) - node_offset;
-        Mapping mapping;
+        Mapping& mapping = *(result.first.add_mapping());
         mapping.mutable_position()->set_node_id(graph.get_id(match.path[i]));
         mapping.mutable_position()->set_offset(node_offset);
         mapping.mutable_position()->set_is_reverse(graph.get_is_reverse(match.path[i]));
         while (mismatch_offset < match.mismatches.size() && match.mismatches[mismatch_offset] < limit) {
             if (sequence_offset < match.mismatches[mismatch_offset]) {
-                Edit exact_match;
+                Edit& exact_match = *(mapping.add_edit());
                 exact_match.set_from_length(match.mismatches[mismatch_offset] - sequence_offset);
                 exact_match.set_to_length(match.mismatches[mismatch_offset] - sequence_offset);
-                *(mapping.add_edit()) = exact_match;
             }
-            Edit mismatch;
+            Edit& mismatch = *(mapping.add_edit());
             mismatch.set_from_length(1);
             mismatch.set_to_length(1);
             mismatch.set_sequence(std::string(1, sequence[match.mismatches[mismatch_offset]]));
-            *(mapping.add_edit()) = mismatch;
             sequence_offset = match.mismatches[mismatch_offset] + 1;
             mismatch_offset++;
         }
         if (sequence_offset < limit) {
-            Edit exact_match;
+            Edit& exact_match = *(mapping.add_edit());
             exact_match.set_from_length(limit - sequence_offset);
             exact_match.set_to_length(limit - sequence_offset);
-            *(mapping.add_edit()) = exact_match;
             sequence_offset = limit;
         }
         mapping.set_rank(i + 1);
-        *(result.first.add_mapping()) = mapping;
         node_offset = 0;
     }
 

--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -20,7 +20,6 @@ GaplessExtender::GaplessExtender(const GBWTGraph& graph) :
 
 //------------------------------------------------------------------------------
 
-// FIXME seq_start, seq_limit, node_start, node_limit
 struct GaplessMatch {
     size_t score;
     size_t start, limit; // In the sequence.

--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -1,6 +1,7 @@
 #include "gapless_extender.hpp"
 
 #include <queue>
+#include <set>
 #include <stack>
 
 namespace vg {
@@ -79,10 +80,10 @@ void match_backward(const std::string& seq, std::pair<const char*, size_t> targe
     }
 }
 
-// Convert the gapless match to a path and a mismatch count.
-std::pair<Path, size_t> gapless_match_to_path(GaplessMatch& match, const GBWTGraph& graph, const std::string& sequence) {
+// Convert the gapless match to a path.
+Path gapless_match_to_path(GaplessMatch& match, const GBWTGraph& graph, const std::string& sequence) {
 
-    std::pair<Path, size_t> result(Path(), match.score);
+    Path result;
     if (match.empty()) {
         return result;
     }
@@ -92,8 +93,8 @@ std::pair<Path, size_t> gapless_match_to_path(GaplessMatch& match, const GBWTGra
     size_t mismatch_offset = 0; // In match.mismatches.
     size_t node_offset = match.offset; // Start of the alignment in the current node.
     for (size_t i = 0; i < match.path.size(); i++) {
-        size_t limit = sequence_offset + graph.get_length(match.path[i]) - node_offset;
-        Mapping& mapping = *(result.first.add_mapping());
+        size_t limit = std::min(sequence_offset + graph.get_length(match.path[i]) - node_offset, match.limit);
+        Mapping& mapping = *(result.add_mapping());
         mapping.mutable_position()->set_node_id(graph.get_id(match.path[i]));
         mapping.mutable_position()->set_offset(node_offset);
         mapping.mutable_position()->set_is_reverse(graph.get_is_reverse(match.path[i]));
@@ -123,7 +124,7 @@ std::pair<Path, size_t> gapless_match_to_path(GaplessMatch& match, const GBWTGra
     return result;
 }
 
-std::pair<Path, size_t> GaplessExtender::extend_seeds(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence, size_t max_mismatches) {
+std::pair<Path, size_t> GaplessExtender::extend_seeds(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence, size_t max_mismatches) const {
 
     GaplessMatch best_match {
         max_mismatches + 1,
@@ -133,7 +134,7 @@ std::pair<Path, size_t> GaplessExtender::extend_seeds(std::vector<std::pair<size
         { }
     };
     if (this->graph == nullptr) {
-        return gapless_match_to_path(best_match, *(this->graph), sequence);
+        return std::make_pair(gapless_match_to_path(best_match, *(this->graph), sequence), best_match.score);
     }
 
     // Process the seeds in sorted order.
@@ -179,7 +180,7 @@ std::pair<Path, size_t> GaplessExtender::extend_seeds(std::vector<std::pair<size
                 forward.push(match);
             }
             if (best_match.score == 0) {
-                return gapless_match_to_path(best_match, *(this->graph), sequence);
+                return std::make_pair(gapless_match_to_path(best_match, *(this->graph), sequence), best_match.score);
             }
         }
 
@@ -221,7 +222,7 @@ std::pair<Path, size_t> GaplessExtender::extend_seeds(std::vector<std::pair<size
                 return true;
             });
             if (best_match.score == 0) {
-                return gapless_match_to_path(best_match, *(this->graph), sequence);
+                return std::make_pair(gapless_match_to_path(best_match, *(this->graph), sequence), best_match.score);
             }
         }
 
@@ -259,12 +260,240 @@ std::pair<Path, size_t> GaplessExtender::extend_seeds(std::vector<std::pair<size
                 return true;
             });
             if (best_match.score == 0) {
-                return gapless_match_to_path(best_match, *(this->graph), sequence);
+                return std::make_pair(gapless_match_to_path(best_match, *(this->graph), sequence), best_match.score);
             }
         }
     }
 
-    return gapless_match_to_path(best_match, *(this->graph), sequence);
+    return std::make_pair(gapless_match_to_path(best_match, *(this->graph), sequence), best_match.score);
+}
+
+//------------------------------------------------------------------------------
+
+struct MaximalGBWTMatch {
+    size_t start, limit; // In the sequence.
+    size_t offset; // In the initial node of the path.
+    gbwt::BidirectionalState state;
+
+    std::vector<handle_t> path;
+
+    size_t length() const { return this->limit - this->start; }
+    bool empty() const { return (this->length() == 0); }
+
+    // Two matches are considered equivalent, if the substrings and search states are identical.
+    bool operator<(const MaximalGBWTMatch& another) const {
+        if (this->start != another.start) {
+            return (this->start < another.start);
+        }
+        if (this->limit != another.limit) {
+            return (this->limit < another.limit);
+        }
+        if (this->state.forward.node != another.state.forward.node) {
+            return (this->state.forward.node < another.state.forward.node);
+        }
+        if (this->state.backward.node != another.state.backward.node) {
+            return (this->state.backward.node < another.state.backward.node);
+        }
+        if (this->state.forward.range.first != another.state.forward.range.first) {
+            return (this->state.forward.range.first < another.state.forward.range.first);
+        }
+        if (this->state.forward.range.second != another.state.forward.range.second) {
+            return (this->state.forward.range.second < another.state.forward.range.second);
+        }
+        return false;
+    }
+};
+
+// Match forward, starting from the given target offset.
+// Returns the number of successfully matched characters.
+size_t match_forward(const std::string& seq, std::pair<const char*, size_t> target, size_t target_offset,
+                   MaximalGBWTMatch& match) {
+    size_t initial_offset = target_offset;
+    while (match.limit < seq.length() && target_offset < target.second) {
+        if (seq[match.limit] != target.first[target_offset]) {
+            break;
+        }
+        match.limit++;
+        target_offset++;
+    }
+    return target_offset - initial_offset;
+}
+
+// Match backward, starting from the end of the target and updating match offset.
+// Returns the number of successfully matched characters.
+size_t match_backward(const std::string& seq, std::pair<const char*, size_t> target, MaximalGBWTMatch& match) {
+    match.offset = target.second;
+    while (match.start > 0 && match.offset > 0) {
+        match.start--;
+        match.offset--;
+        if (seq[match.start] != target.first[match.offset]) {
+            return target.second - match.offset - 1;
+        }
+    }
+    return target.second - match.offset;
+}
+
+// Convert the exact match to a path.
+Path maximal_match_to_path(const MaximalGBWTMatch& match, const GBWTGraph& graph, const std::string& sequence) {
+
+    Path result;
+    if (match.empty()) {
+        return result;
+    }
+
+    size_t sequence_offset = match.start; // Start of the unmapped part in the sequence.
+    size_t node_offset = match.offset; // Start of the alignment in the current node.
+    for (size_t i = 0; i < match.path.size(); i++) {
+        size_t limit = std::min(sequence_offset + graph.get_length(match.path[i]) - node_offset, match.limit);
+
+        Mapping& mapping = *(result.add_mapping());
+        mapping.mutable_position()->set_node_id(graph.get_id(match.path[i]));
+        mapping.mutable_position()->set_offset(node_offset);
+        mapping.mutable_position()->set_is_reverse(graph.get_is_reverse(match.path[i]));
+
+        Edit& exact_match = *(mapping.add_edit());
+        exact_match.set_from_length(limit - sequence_offset);
+        exact_match.set_to_length(limit - sequence_offset);
+        sequence_offset = limit;
+
+        mapping.set_rank(i + 1);
+        node_offset = 0;
+    }
+
+    return result;
+}
+
+std::vector<Path> GaplessExtender::seeds_to_mems(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const {
+
+    // Process the seeds in sorted order.
+    handle_t prev_handle = GBWTGraph::node_to_handle(gbwt::ENDMARKER);
+    size_t prev_start = 0, prev_limit = 0;
+    std::sort(cluster.begin(), cluster.end());
+    std::set<MaximalGBWTMatch> mems;
+    for (size_t i = 0; i < cluster.size(); i++) {
+
+        // Skip redundant seeds.
+        std::pair<size_t, pos_t> hit = cluster[i];
+        handle_t handle = GBWTGraph::node_to_handle(pos_to_gbwt(hit.second));
+        size_t adjustment = std::min(static_cast<size_t>(offset(hit.second)), hit.first);
+        if (handle == prev_handle && offset(hit.second) - adjustment == prev_start && offset(hit.second) < prev_limit) {
+            continue;
+        }
+        prev_handle = handle;
+        prev_start = offset(hit.second) - adjustment;
+        // prev_limit is updated later
+
+        // Match the initial node.
+        std::stack<MaximalGBWTMatch> forward, backward;
+        {
+            // Maximal match within the initial node.
+            MaximalGBWTMatch match {
+                hit.first, hit.first,
+                static_cast<size_t>(offset(hit.second)),
+                this->graph->get_bd_state(handle),
+                { handle }            
+            };
+            std::pair<const char*, size_t> node_view = this->graph->get_sequence_view(handle);
+            match_forward(sequence, node_view, match.offset, match);
+            prev_limit = match.offset + match.length();
+            match_backward(sequence, node_view, match);
+            if (match.limit >= sequence.length()) {
+                if (match.start == 0) {
+                    mems.insert(match);
+                } else if (match.offset == 0) {
+                    backward.push(match);
+                }
+            } else if (prev_limit >= node_view.second) {
+                forward.push(match);
+            }
+        }
+
+        // Match forward over all paths.
+        while (!forward.empty()) {
+            MaximalGBWTMatch curr = forward.top();
+            forward.pop();
+            size_t extend_total = 0; // Number of paths in successful extensions.
+            this->graph->follow_paths(curr.state, false, [&](const gbwt::BidirectionalState& next_state) -> bool {
+                if (next_state.empty()) {
+                    return true;
+                }
+                handle_t handle = GBWTGraph::node_to_handle(next_state.forward.node);
+                MaximalGBWTMatch next {
+                    curr.start, curr.limit,
+                    curr.offset,
+                    next_state,
+                    { }
+                };
+                std::pair<const char*, size_t> node_view = this->graph->get_sequence_view(handle);
+                size_t matching_chars = match_forward(sequence, node_view, 0, next);
+                if (matching_chars == 0) {
+                    return true;
+                }
+                extend_total += next_state.size();
+                next.path.reserve(curr.path.size() + 1);
+                next.path.insert(next.path.end(), curr.path.begin(), curr.path.end());
+                next.path.push_back(handle);
+                if (next.limit >= sequence.length()) {
+                    if (next.start == 0) {
+                        mems.insert(next);
+                    } else if (next.offset == 0) {
+                        backward.push(next);
+                    }
+                } else if (matching_chars >= node_view.second) {
+                    forward.push(next);
+                }
+                return true;
+            });
+            // We could not extend all paths, so some MEMs end at curr.
+            if (extend_total < curr.state.size() && curr.offset == 0) {
+                backward.push(curr);
+            }
+        }
+
+        // Match backward over all paths.
+        while (!backward.empty()) {
+            MaximalGBWTMatch curr = backward.top();
+            backward.pop();
+            size_t extend_total = 0; // Number of paths in successful extensions.
+            this->graph->follow_paths(curr.state, true, [&](const gbwt::BidirectionalState& next_state) -> bool {
+                if (next_state.empty()) {
+                    return true;
+                }
+                handle_t handle = GBWTGraph::node_to_handle(gbwt::Node::reverse(next_state.backward.node));
+                MaximalGBWTMatch next {
+                    curr.start, curr.limit,
+                    curr.offset, // This will be replaced in match_backward().
+                    next_state,
+                    { }
+                };
+                std::pair<const char*, size_t> node_view = this->graph->get_sequence_view(handle);
+                size_t matching_chars = match_backward(sequence, node_view, next);
+                if (matching_chars == 0) {
+                    return true;
+                }
+                extend_total += next_state.size();
+                next.path.reserve(curr.path.size() + 1);
+                next.path.push_back(handle);
+                next.path.insert(next.path.end(), curr.path.begin(), curr.path.end());
+                if (next.start == 0) {
+                    mems.insert(next);
+                } else if (next.offset == 0) {
+                    backward.push(next);
+                }
+                return true;
+            });
+            // We could not extend all paths, so some MEMs start at curr.
+            if (extend_total < curr.state.size()) {
+                mems.insert(curr);
+            }
+        }
+    }
+
+    std::vector<Path> result;
+    for(const MaximalGBWTMatch& match : mems) {
+        result.emplace_back(maximal_match_to_path(match, *(this->graph), sequence));
+    }
+    return result;
 }
 
 //------------------------------------------------------------------------------

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -41,12 +41,13 @@ public:
 
     /**
     * Extend the pairs of matching sequence/graph position into maximal exact matches and
-    * return the corresponding distinct paths as Path objects.
+    * return the corresponding distinct paths as Path objects and their starting offsets in
+    * the read.
     * The cluster can be in an arbitrary order, but it will be sorted during the call. Each
     * pair in the cluster consists of matching sequence/graph positions. Some positions may
     * occur multiple times, and the matches in the cluster may agree or conflict.
     */
-    std::vector<Path> seeds_to_mems(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const;
+    std::vector<std::pair<Path, size_t>> seeds_to_mems(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const;
 
     const GBWTGraph* graph;
 };

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -37,7 +37,16 @@ public:
     * pair in the cluster consists of matching sequence/graph positions. Some positions may
     * occur multiple times, and the matches in the cluster may agree or conflict.
     */
-    std::pair<Path, size_t> extend_seeds(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence, size_t max_mismatches = MAX_MISMATCHES);
+    std::pair<Path, size_t> extend_seeds(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence, size_t max_mismatches = MAX_MISMATCHES) const;
+
+    /**
+    * Extend the pairs of matching sequence/graph position into maximal exact matches and
+    * return the corresponding distinct paths as Path objects.
+    * The cluster can be in an arbitrary order, but it will be sorted during the call. Each
+    * pair in the cluster consists of matching sequence/graph positions. Some positions may
+    * occur multiple times, and the matches in the cluster may agree or conflict.
+    */
+    std::vector<Path> seeds_to_mems(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const;
 
     const GBWTGraph* graph;
 };

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -40,14 +40,14 @@ public:
     std::pair<Path, size_t> extend_seeds(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence, size_t max_mismatches = MAX_MISMATCHES) const;
 
     /**
-    * Extend the pairs of matching sequence/graph position into maximal exact matches and
-    * return the corresponding distinct paths as Path objects and their starting offsets in
-    * the read.
+    * Find maximal unambiguous extensions of each seed in the cluster. The extension ends
+    * with the first mismatch or when there are multiple successor nodes with the same
+    * character.
     * The cluster can be in an arbitrary order, but it will be sorted during the call. Each
     * pair in the cluster consists of matching sequence/graph positions. Some positions may
     * occur multiple times, and the matches in the cluster may agree or conflict.
     */
-    std::vector<std::pair<Path, size_t>> seeds_to_mems(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const;
+    std::vector<std::pair<Path, size_t>> maximal_extensions(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const;
 
     const GBWTGraph* graph;
 };

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -170,6 +170,22 @@ std::pair<const char*, size_t> GBWTGraph::get_sequence_view(const handle_t& hand
     return std::make_pair(this->sequences.data() + this->offsets[offset], this->offsets[offset + 1] - this->offsets[offset]);
 }
 
+bool GBWTGraph::starts_with(const handle_t& handle, char c) const {
+    size_t offset = this->node_offset(handle);
+    if (this->offsets[offset + 1] <= this->offsets[offset]) {
+        return false;
+    }
+    return (this->sequences[this->offsets[offset]] == c);
+}
+
+bool GBWTGraph::ends_with(const handle_t& handle, char c) const {
+    size_t offset = this->node_offset(handle);
+    if (this->offsets[offset + 1] <= this->offsets[offset]) {
+        return false;
+    }
+    return (this->sequences[this->offsets[offset + 1] - 1] == c);
+}
+
 // Using undocumented parts of the GBWT interface. --Jouni
 bool GBWTGraph::follow_paths(gbwt::SearchState state, const std::function<bool(const gbwt::SearchState&)>& iteratee) const {
     gbwt::CompressedRecord record = this->index.record(state.node);

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -149,6 +149,12 @@ public:
     /// Get node sequence as a pointer and length.
     std::pair<const char*, size_t> get_sequence_view(const handle_t& handle) const;
 
+    /// Determine if the node sequence starts with the given character.
+    bool starts_with(const handle_t& handle, char c) const;
+
+    /// Determine if the node sequence ends with the given character.
+    bool ends_with(const handle_t& handle, char c) const;
+
     /// Convert handle_t to gbwt::SearchState.
     gbwt::SearchState get_state(const handle_t& handle) const { return this->index.find(handle_to_node(handle)); }
 

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -349,6 +349,8 @@ int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::un
         std::vector<size_t> extend_counts(threads, 0);
         std::vector<size_t> seed_counts(threads, 0);
         std::vector<size_t> success_counts(threads, 0);
+        std::vector<size_t> success_seed_counts(threads, 0);
+        std::vector<size_t> partial_match_counts(threads, 0);
         #pragma omp parallel for schedule(static)
         for (size_t i = 0; i < reads.size(); i++) {
             size_t thread = omp_get_thread_num();
@@ -375,6 +377,10 @@ int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::un
                     auto result = extender.extend_seeds(hits, reads[i], max_errors);
                     if (result.second <= max_errors) {
                         success_counts[thread]++;
+                        success_seed_counts[thread] += hits.size();
+                    } else {
+                        auto partial_matches = extender.maximal_extensions(hits, reads[i]);
+                        partial_match_counts[thread] += partial_matches.size();
                     }
                 }
             } else {
@@ -384,13 +390,15 @@ int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::un
             }
         }
         size_t min_count = 0, occ_count = 0;
-        size_t extend_count = 0, seed_count = 0, success_count = 0;
+        size_t extend_count = 0, seed_count = 0, success_count = 0, success_seed_count = 0, partial_match_count = 0;
         for (size_t i = 0; i < threads; i++) {
             min_count += min_counts[i];
             occ_count += occ_counts[i];
             extend_count += extend_counts[i];
             seed_count += seed_counts[i];
             success_count += success_counts[i];
+            success_seed_count += success_seed_counts[i];
+            partial_match_count += partial_match_counts[i];
         }
 
         double phase_seconds = gbwt::readTimer() - phase_start;
@@ -405,6 +413,7 @@ int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::un
         std::cerr << min_count << " minimizers with " << occ_count << " occurrences" << std::endl;
         if (gapless_extend) {
             std::cerr << extend_count << " reads with " << seed_count << " seeds, " << success_count << " extended with up to " << max_errors << " mismatches" << std::endl;
+            std::cerr << "Extended " << (extend_count - success_count) << " reads with " << (seed_count - success_seed_count) << " seeds into " << partial_match_count << " partial matches" << std::endl;
         }
         std::cerr << std::endl;
     }

--- a/src/unittest/gapless_extender.cpp
+++ b/src/unittest/gapless_extender.cpp
@@ -122,7 +122,7 @@ TEST_CASE("Haplotype-aware gapless extension works correctly", "[gapless_extende
     // And finally wrap it in a GaplessExtender.
     GaplessExtender extender(gbwt_graph);
 
-    SECTION("read matches exactly") {
+    SECTION("read starting in the middle of a node matches exactly") {
         std::string read = "GTACA";
         std::vector<std::pair<pos_t, std::string>> correct_alignment {
             { make_pos_t(4, false, 2), "1" },
@@ -177,18 +177,17 @@ TEST_CASE("Haplotype-aware gapless extension works correctly", "[gapless_extende
         alignment_matches(result, correct_alignment, error_bound);
     }
 
-    SECTION("read matches reverse complement") {
-        std::string read = "GTACTCC";
+    SECTION("read matches reverse complement and ends within a node") {
+        std::string read = "GTACT";
         std::vector<std::pair<pos_t, std::string>> correct_alignment {
             { make_pos_t(7, true, 0), "1" },
             { make_pos_t(6, true, 0), "1" },
             { make_pos_t(5, true, 0), "1" },
-            { make_pos_t(4, true, 0), "1T1" },
-            { make_pos_t(1, true, 0), "1" }
+            { make_pos_t(4, true, 0), "1T" }
         };
         std::vector<std::pair<size_t, pos_t>> cluster {
             { 2, make_pos_t(5, true, 0) },
-            { 5, make_pos_t(4, true, 2) }
+            { 1, make_pos_t(6, true, 0) }
         };
         size_t error_bound = 1;
         auto result = extender.extend_seeds(cluster, read, error_bound);

--- a/src/unittest/gapless_extender.cpp
+++ b/src/unittest/gapless_extender.cpp
@@ -123,17 +123,17 @@ TEST_CASE("Haplotype-aware gapless extension works correctly", "[gapless_extende
     GaplessExtender extender(gbwt_graph);
 
     SECTION("read matches exactly") {
-        std::string read = "GGTACA";
+        std::string read = "GTACA";
         std::vector<std::pair<pos_t, std::string>> correct_alignment {
-            { make_pos_t(4, false, 1), "2" },
+            { make_pos_t(4, false, 2), "1" },
             { make_pos_t(5, false, 0), "1" },
             { make_pos_t(6, false, 0), "1" },
             { make_pos_t(7, false, 0), "1" },
             { make_pos_t(9, false, 0), "1" }
         };
         std::vector<std::pair<size_t, pos_t>> cluster {
-            { 1, make_pos_t(4, false, 2) },
-            { 3, make_pos_t(6, false, 0) }
+            { 0, make_pos_t(4, false, 2) },
+            { 2, make_pos_t(6, false, 0) }
         };
         size_t error_bound = 0;
         auto result = extender.extend_seeds(cluster, read, error_bound);

--- a/src/unittest/gbwt_helper.cpp
+++ b/src/unittest/gbwt_helper.cpp
@@ -156,6 +156,23 @@ TEST_CASE("GBWTGraph works correctly", "[gbwt_helper]") {
         }
     }
 
+    // get_sequence_view() and starts_with() / ends_with().
+    SECTION("direct access to the sequence") {
+        for (id_t id : correct_nodes) {
+            for (bool orientation : { false, true }) {
+                handle_t handle = gbwt_graph.get_handle(id, orientation);
+                std::string sequence = gbwt_graph.get_sequence(handle);
+                std::pair<const char*, size_t> view = gbwt_graph.get_sequence_view(handle);
+                std::string view_sequence(view.first, view.second);
+                REQUIRE(sequence == view_sequence);
+                REQUIRE(gbwt_graph.starts_with(handle, sequence.front()));
+                REQUIRE(!gbwt_graph.starts_with(handle, 'x'));
+                REQUIRE(gbwt_graph.ends_with(handle, sequence.back()));
+                REQUIRE(!gbwt_graph.ends_with(handle, 'x'));
+            }
+        }
+    }
+
     // Verify edges.
     typedef std::pair<gbwt::node_type, gbwt::node_type> gbwt_edge;
     std::set<gbwt_edge> correct_edges {


### PR DESCRIPTION
* Faster minimizer extraction from a sequence.
* Optimizations and bug fixes in `GaplessExtender`.
* Extend seeds to maximal unambiguous exact matches using `GaplessExtender::maximal_extensions()`.
* `GBWTGraph::starts_with(handle, c)` and `ends_with(handle, c)` for determining whether the node sequence starts/ends with the given character.