### PR TITLE
Prototype for extending "interval" type annotations from GFF to subgraphs

### DIFF
--- a/src/gff_reader.cpp
+++ b/src/gff_reader.cpp
@@ -1,0 +1,118 @@
+#include "gff_reader.hpp"
+
+namespace vg {
+    
+    map<string, string> GFFRecord::parse_attributes() {
+        
+        map<string, string> parsed_attributes;
+        stringstream attr_stream(attributes);
+        
+        string buffer;
+        while (attr_stream.good()) {
+            getline(attr_stream, buffer, ';');
+            
+            stringstream split_stream(buffer);
+            
+            string attr_type;
+            string attr_value;
+            
+            getline(split_stream, attr_type, '=');
+            getline(split_stream, attr_value, '\0');
+            
+            parsed_attributes[attr_type] = attr_value;
+            
+            buffer.clear();
+        }
+        
+        return parsed_attributes;
+    }
+    
+    GFFReader::GFFReader(istream& in) : in(in) {
+        
+    }
+    
+    void GFFReader::for_each_gff_record(function<void(const GFFRecord&)>& lambda) {
+        
+        while (in.good()) {
+            // skip header lines
+            if (in.peek() == '#') {
+                in.ignore(numeric_limits<streamsize>::max(), '\n');
+                continue;
+            }
+            
+            GFFRecord record;
+            
+            string buffer;
+            char* ignored;
+            
+            // parse sequence ID
+            getline(in, buffer, '\t');
+            if (buffer.empty()) {
+                continue;
+            }
+            else if (buffer != ".") {
+                record.sequence_id = move(buffer);
+            }
+            buffer.clear();
+            
+            // parse data source
+            getline(in, buffer, '\t');
+            if (buffer != ".") {
+                record.source = move(buffer);
+            }
+            buffer.clear();
+            
+            // parse type of annotation
+            getline(in, buffer, '\t');
+            if (buffer != ".") {
+                record.type = move(buffer);
+            }
+            buffer.clear();
+            
+            // parse start coordinate
+            getline(in, buffer, '\t');
+            if (buffer != ".") {
+                record.start = strtol(buffer.c_str(), &ignored, 10) - 1;
+            }
+            buffer.clear();
+            
+            // parse end coordinate
+            getline(in, buffer, '\t');
+            if (buffer != ".") {
+                record.end = strtol(buffer.c_str(), &ignored, 10) - 1;
+            }
+            buffer.clear();
+            
+            // parse score
+            getline(in, buffer, '\t');
+            if (buffer != ".") {
+                record.score = strtod(buffer.c_str(), &ignored);
+            }
+            buffer.clear();
+            
+            // parse strand
+            getline(in, buffer, '\t');
+            if (buffer != ".") {
+                record.strand_is_rev = (buffer == "-");
+            }
+            buffer.clear();
+            
+            // parse phase
+            getline(in, buffer, '\t');
+            if (buffer != ".") {
+                record.phase = stoi(buffer);
+            }
+            buffer.clear();
+            
+            // parse annotations (but leave as an unparsed string)
+            getline(in, buffer, '\n');
+            if (buffer != ".") {
+                record.attributes = move(buffer);
+            }
+            
+            // execute the iteratee
+            lambda(record);
+        }
+    }
+        
+}

--- a/src/gff_reader.hpp
+++ b/src/gff_reader.hpp
@@ -1,0 +1,54 @@
+#ifndef VG_GFF_READER_HPP_INCLUDED
+#define VG_GFF_READER_HPP_INCLUDED
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <map>
+
+namespace vg {
+    
+    using namespace std;
+    
+    /**
+     * A package of the information contained in a GFF3 record. The null "." entries in a
+     * a GFF are parsed into empty strings or the default values of the numerical fields
+     * as given below.
+     */
+    struct GFFRecord {
+    public:
+        GFFRecord() = default;
+        ~GFFRecord() = default;
+        
+        string sequence_id;
+        string source;
+        string type;
+        // 0-based indexing, unlike the actual GFF standard
+        int64_t start = -1;
+        // 0-based, inclusive
+        int64_t end = -1;
+        double score = numeric_limits<double>::quiet_NaN();
+        bool strand_is_rev = false;
+        int32_t phase = -1;
+        string attributes;
+        
+        map<string, string> parse_attributes();
+    };
+    
+    /**
+     * A class that can parse and iterate over a GFF3 file.
+     */
+    class GFFReader {
+    public:
+        GFFReader(istream& in);
+        ~GFFReader() = default;
+        
+        void for_each_gff_record(function<void(const GFFRecord&)>& lambda);
+        
+    private:
+        istream& in;
+    };
+
+}
+
+#endif

--- a/src/gff_reader.hpp
+++ b/src/gff_reader.hpp
@@ -5,6 +5,8 @@
 #include <sstream>
 #include <string>
 #include <map>
+#include <limits>
+#include <functional>
 
 namespace vg {
     

--- a/src/region_expander.cpp
+++ b/src/region_expander.cpp
@@ -1,0 +1,137 @@
+#include "region_expander.hpp"
+
+namespace vg {
+
+    RegionExpander::RegionExpander(xg::XG* xg_index, const SnarlManager* snarl_manager) :
+        xg_index(xg_index), snarl_manager(snarl_manager)
+    {
+        // Nothing to do
+    }
+
+    map<pair<id_t, bool>, pair<uint64_t,uint64_t >> RegionExpander::expanded_subgraph(const GFFRecord& gff_record) {
+        
+        map<pair<id_t, bool>, pair<uint64_t, uint64_t>> return_val;
+
+        vector<pair<id_t, bool>> interval_subpath;
+        
+        assert(gff_record.start != -1 && gff_record.end != -1 && gff_record.start <= gff_record.end);
+        
+        const xg::XGPath& path = xg_index->get_path(gff_record.sequence_id);
+        
+        size_t offset = path.offset_at_position(gff_record.start);
+        id_t node_id = path.node(offset);
+        bool is_rev = path.directions[offset];
+        size_t node_length = xg_index->node_length(node_id);
+        
+        size_t at_pos = path.positions[offset];
+        
+        interval_subpath.emplace_back(node_id, is_rev);
+        return_val[make_pair(node_id, is_rev)] = pair<uint64_t, uint64_t>(gff_record.start - at_pos,
+                                                                          node_length);
+        at_pos += node_length;
+        while (at_pos <= gff_record.end) {
+            offset++;
+            node_id = path.node(offset);
+            is_rev = path.directions[offset];
+            node_length = xg_index->node_length(node_id);
+            
+            interval_subpath.emplace_back(node_id, is_rev);
+            return_val[make_pair(node_id, is_rev)] = pair<uint64_t, uint64_t>(0, node_length);
+            
+            at_pos += node_length;
+        }
+        
+        return_val[make_pair(node_id, is_rev)].second = gff_record.end - (at_pos - node_length) + 1;
+        
+        unordered_set<const Snarl*> entered_snarls;
+        unordered_set<const Snarl*> completed_snarls;
+        
+        // walk along the path and identify snarls that have both ends on the path
+        for (size_t i = 0; i + 1 < interval_subpath.size(); i++) {
+            const Snarl* snarl_out = snarl_manager->into_which_snarl(interval_subpath[i].first,
+                                                                     !interval_subpath[i].second);
+            
+            if (snarl_out) {
+                if (entered_snarls.count(snarl_out)) {
+                    completed_snarls.insert(snarl_out);
+                }
+            }
+            
+            const Snarl* snarl_in = snarl_manager->into_which_snarl(interval_subpath[i].first,
+                                                                    interval_subpath[i].second);
+            
+            if (snarl_in) {
+                entered_snarls.insert(snarl_in);
+            }
+        }
+        
+        // TODO: in order to handle inversions correctly we actually want to include redundant
+        // children and do a shallow contents algorithm
+        
+        // which of these snarls are the children of other snarls we've identified?
+        vector<const Snarl*> redundant_child_snarls;
+        for (const Snarl* snarl : completed_snarls) {
+            const Snarl* parent = snarl_manager->parent_of(snarl);
+            if (parent) {
+                if (completed_snarls.count(parent)) {
+                    redundant_child_snarls.push_back(snarl);
+                }
+            }
+        }
+        
+        // remove the redundant snarls from the set of snarls we're looking at
+        for (const Snarl* snarl : redundant_child_snarls) {
+            completed_snarls.erase(snarl);
+        }
+        
+        // traverse the subgraph in each snarl and add it to the annotation
+        for (const Snarl* snarl : completed_snarls) {
+            // orient the snarl to match the orientation of the annotation
+            handle_t oriented_start, oriented_end;
+            if (return_val.count(pair<id_t, bool>(snarl->start().node_id(),
+                                                  snarl->start().backward()))) {
+                
+                oriented_start = xg_index->get_handle(snarl->start().node_id(),
+                                                      snarl->start().backward());
+                
+                oriented_end = xg_index->get_handle(snarl->end().node_id(),
+                                                    snarl->end().backward());
+                
+            }
+            else {
+                
+                oriented_start = xg_index->get_handle(snarl->end().node_id(),
+                                                      !snarl->end().backward());
+                
+                oriented_end = xg_index->get_handle(snarl->start().node_id(),
+                                                    !snarl->start().backward());
+            }
+            
+            // mark all the exits and the entry point as untraversable
+            unordered_set<handle_t> stacked{oriented_start, oriented_end, xg_index->flip(oriented_start)};
+            vector<handle_t> stack{oriented_start};
+            
+            // traverse the subgraph and add it to the return value
+            while (!stack.empty()) {
+                handle_t handle = stack.back();
+                stack.pop_back();
+                
+                pair<id_t, bool> trav = make_pair(xg_index->get_id(handle),
+                                                  xg_index->get_is_reverse(handle));
+                
+                if (!return_val.count(trav)) {
+                    return_val[trav] = pair<uint64_t, uint64_t>(0, xg_index->get_length(handle));
+                }
+                
+                xg_index->follow_edges(handle, false, [&](const handle_t& next) {
+                    if (!stacked.count(next)) {
+                        stack.push_back(next);
+                        stacked.insert(next);
+                    }
+                });
+            }
+        }
+        
+        return return_val;
+    }
+}

--- a/src/region_expander.hpp
+++ b/src/region_expander.hpp
@@ -1,0 +1,27 @@
+#ifndef VG_REGION_EXPANDER_HPP_INCLUDED
+#define VG_REGION_EXPANDER_HPP_INCLUDED
+
+#include "xg.hpp"
+#include "snarls.hpp"
+#include "gff_reader.hpp"
+
+namespace vg {
+
+    class RegionExpander {
+        
+    public:
+        RegionExpander(xg::XG* xg_index, const SnarlManager* snarl_manager);
+        ~RegionExpander() = default;
+        
+        map<pair<id_t, bool>, pair<uint64_t,uint64_t >> expanded_subgraph(const GFFRecord& gff_record);
+        
+    private:
+        
+        xg::XG* xg_index = nullptr;
+        const SnarlManager* snarl_manager = nullptr;
+        
+    };
+
+}
+
+#endif

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -759,7 +759,7 @@ void Transcriptome::write_fasta_sequences(ostream * fasta_ostream, VG & graph) c
         *fasta_ostream << graph.path_sequence(path) << endl;
     }
 }
-
+    
 }
 
 


### PR DESCRIPTION
Prepared as part of the Pangenomics Hackathon at UCSC in March 2019. Defines a simple generalization of the GFF3 format, which we're calling GGFF. Also includes an algorithm that can expand intervals into subgraphs using the snarls of a graph. 