### PR TITLE
Merge nodes and add size info for simple view

### DIFF
--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -1,4 +1,5 @@
 #include "packer.hpp"
+#include "../vg.hpp"
 
 namespace vg {
 
@@ -383,9 +384,10 @@ vector<Edit> Packer::edits_at_position(size_t i) const {
     return edits;
 }
 
-ostream& Packer::as_table(ostream& out, bool show_edits) {
+ostream& Packer::as_table(ostream& out, bool show_edits, vector<vg::id_t> node_ids) {
 #ifdef debug
-    cerr << "Packer table of " << coverage_civ.size() << " rows:" << endl;
+    cerr << "Packer table of " << coverage_civ.size() << " rows:" << 
+        l;
 #endif
 
     out << "seq.pos" << "\t"
@@ -397,6 +399,9 @@ ostream& Packer::as_table(ostream& out, bool show_edits) {
     // write the coverage as a vector
     for (size_t i = 0; i < coverage_civ.size(); ++i) {
         id_t node_id = xgidx->node_at_seq_pos(i+1);
+        if (!node_ids.empty() && find(node_ids.begin(), node_ids.end(), node_id) == node_ids.end()) {
+            continue;
+        }
         size_t offset = i - xgidx->node_start(node_id);
         out << i << "\t" << node_id << "\t" << offset << "\t" << coverage_civ[i];
         if (show_edits) {

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -44,7 +44,7 @@ public:
     vector<Edit> edits_at_position(size_t i) const;
     size_t coverage_at_position(size_t i) const;
     void collect_coverage(const Packer& c);
-    ostream& as_table(ostream& out, bool show_edits = true);
+    ostream& as_table(ostream& out, bool show_edits, vector<vg::id_t> node_ids);
     ostream& show_structure(ostream& out); // debugging
     void write_edits(vector<ofstream*>& out) const; // for merge
     void write_edits(ostream& out, size_t bin) const; // for merge

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -21,6 +21,8 @@ void help_pack(char** argv) {
          << "    -d, --as-table         write table on stdout representing packs" << endl
          << "    -e, --with-edits       record and write edits rather than only recording graph-matching coverage" << endl
          << "    -b, --bin-size N       number of sequence bases per CSA bin [default: inf]" << endl
+         << "    -n, --node ID          write table for only specified node(s)" << endl
+         << "    -N, --node-list FILE   a white space or line delimited list of nodes to collect" << endl
          << "    -t, --threads N        use N threads (defaults to numCPUs)" << endl;
 }
 
@@ -34,6 +36,8 @@ int main_pack(int argc, char** argv) {
     int thread_count = 1;
     bool record_edits = false;
     size_t bin_size = 0;
+    vector<vg::id_t> node_ids;
+    string node_list_file;
 
     if (argc == 2) {
         help_pack(argv);
@@ -53,12 +57,14 @@ int main_pack(int argc, char** argv) {
             {"as-table", no_argument, 0, 'd'},
             {"threads", required_argument, 0, 't'},
             {"with-edits", no_argument, 0, 'e'},
+            {"node", required_argument, 0, 'n'},
+            {"node-list", required_argument, 0, 'N'},
             {"bin-size", required_argument, 0, 'b'},
             {0, 0, 0, 0}
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:o:i:g:dt:eb:",
+        c = getopt_long (argc, argv, "hx:o:i:g:dt:eb:n:N:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -96,6 +102,12 @@ int main_pack(int argc, char** argv) {
         case 't':
             thread_count = parse<int>(optarg);
             break;
+        case 'n':
+            node_ids.push_back(parse<int>(optarg));
+            break;
+        case 'N':
+            node_list_file = optarg;
+            break;
 
         default:
             abort();
@@ -110,6 +122,23 @@ int main_pack(int argc, char** argv) {
         exit(1);
     } else {
         xgidx = stream::VPKG::load_one<xg::XG>(xg_name);
+    }
+
+    // process input node list
+    if (!node_list_file.empty()) {
+        ifstream nli;
+        nli.open(node_list_file);
+        if (!nli.good()){
+            cerr << "[vg pack] error, unable to open the node list input file." << endl;
+            exit(1);
+        }
+        string line;
+        while (getline(nli, line)){
+            for (auto& idstr : split_delims(line, " \t")) {
+                node_ids.push_back(parse<int64_t>(idstr.c_str()));
+            }
+        }
+        nli.close();
     }
 
     // todo one packer per thread and merge
@@ -156,7 +185,7 @@ int main_pack(int argc, char** argv) {
     }
     if (write_table) {
         packer.make_compact();
-        packer.as_table(cout, record_edits);
+        packer.as_table(cout, record_edits, node_ids);
     }
 
     return 0;

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -5964,7 +5964,7 @@ void VG::to_dot(ostream& out,
     //out << "    splines=line;" << endl;
     //out << "    splines=true;" << endl;
     //out << "    smoothType=spring;" << endl;
-
+    
     //map<id_t, vector<
     map<id_t, set<pair<string, string>>> symbols_for_node;
     if (ultrabubble_labeling) {
@@ -6016,7 +6016,7 @@ void VG::to_dot(ostream& out,
             inner_label << "</TD>";
         } else if (simple_mode) {
             //inner_label << "<TD ROWSPAN=\"3\" BORDER=\"2\" CELLPADDING=\"5\">";
-            inner_label << n->id();
+	    inner_label << n->id() << "\\n" << n->sequence().size() << " bp";
             //inner_label << "</TD>";
         } else {
             inner_label << "<TD ROWSPAN=\"3\" BORDER=\"2\" CELLPADDING=\"5\">";

--- a/test/t/34_vg_pack.t
+++ b/test/t/34_vg_pack.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 6
+plan tests 8
 
 vg construct -m 1000 -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
@@ -30,6 +30,14 @@ x=$(vg pack -x flat.xg -di 2snp.gam.cx | wc -c )
 vg pack -x flat.xg -o 2snp.gam.cx -b 10 -g 2snp.gam
 y=$(vg pack -x flat.xg -di 2snp.gam.cx | wc -c )
 is $x $y "binned edit accumulation does not affect the result"
+
+x=$(vg pack -x flat.xg -di 2snp.gam.cx -n 1 | wc -c)
+y=$(vg pack -x flat.xg -di 2snp.gam.cx | wc -c)
+is $x $y "pack records are filtered by node id"
+
+x=$(vg pack -x flat.xg -di 2snp.gam.cx -n 1 | cut -f 2 | grep -v "1" | wc -c)
+y=$(vg pack -x flat.xg -di 2snp.gam.cx | cut -f 2 | head -n 1 | wc -c)
+is $x $y "pack records are filtered by node id"
 
 vg pack -x flat.xg -o 2snp.gam.cx -g 2snp.gam
 vg pack -x flat.xg -o 2snp.gam.cx.3x -i 2snp.gam.cx -i 2snp.gam.cx -i 2snp.gam.cx


### PR DESCRIPTION
What about we merge nodes as much as possible in the simple DOT mode of vg view and add information about the node size? 

That would be useful for me when looking at SVs. For example a large deletion looked like this:

![simple view](https://user-images.githubusercontent.com/5704457/55267297-a028f700-523e-11e9-8dca-8e7259c07e88.png)

With the new version it's easier to see here the 1 kbp deletion in the middle:

![simple view 2](https://user-images.githubusercontent.com/5704457/55267316-b59e2100-523e-11e9-95fa-cdbb76801f62.png)

If someone prefers to keep the current `-S` behavior, I can add a new argument for it.
 