### PR TITLE
Make mpmap not crazy slow

### DIFF
--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -128,7 +128,7 @@ namespace vg {
         /// when the MultipathAlignmentGraph was constructed! TODO: Shouldn't
         /// the class hold a reference to the Alignment then?
         void synthesize_tail_anchors(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner,
-                                     size_t max_alt_alns, bool dynamic_alt_alns);
+                                     size_t min_anchor_size, size_t max_alt_alns, bool dynamic_alt_alns);
         
         /// Add edges between reachable nodes and split nodes at overlaps
         void add_reachability_edges(const HandleGraph& vg,

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3009,7 +3009,7 @@ namespace vg {
 #endif
 
                 // Make fake anchor paths to cut the snarls out of in the tails
-                multi_aln_graph.synthesize_tail_anchors(alignment, align_graph, get_aligner(), num_alt_alns, dynamic_max_alt_alns);
+                multi_aln_graph.synthesize_tail_anchors(alignment, align_graph, get_aligner(), min_tail_anchor_length, 1, false);
                 
             }
        

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -97,6 +97,7 @@ namespace vg {
         size_t max_branch_trim_length = 1;
         int64_t max_snarl_cut_size = 5;
         bool suppress_tail_anchors = false;
+        size_t min_tail_anchor_length = 3;
         double band_padding_multiplier = 1.0;
         size_t max_expected_dist_approx_error = 8;
         int32_t num_alt_alns = 4;

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -88,7 +88,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         SECTION("Tries multiple traversals of snarls in tails") {
         
             // Generate 2 fake tail anchors
-            mpg.synthesize_tail_anchors(query, vg, &aligner, 2, false);
+            mpg.synthesize_tail_anchors(query, vg, &aligner, 1, 2, false);
             
             // Cut new anchors on snarls
             mpg.resect_snarls_from_paths(&snarl_manager, identity, 5);
@@ -184,7 +184,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         SECTION("Tries multiple traversals of snarls in tails") {
         
             // Generate 2 fake tail anchors
-            mpg.synthesize_tail_anchors(query, vg, &aligner, 2, false);
+            mpg.synthesize_tail_anchors(query, vg, &aligner, 1, 2, false);
             
             // Cut new anchors on snarls
             mpg.resect_snarls_from_paths(&snarl_manager, identity, 5);
@@ -278,7 +278,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         SECTION("Tries multiple traversals of snarls in tails") {
         
             // Generate 2 fake tail anchors
-            mpg.synthesize_tail_anchors(query, vg, &aligner, 2, false);
+            mpg.synthesize_tail_anchors(query, vg, &aligner, 1, 2, false);
             
             // Cut new anchors on snarls
             mpg.resect_snarls_from_paths(&snarl_manager, identity, 5);


### PR DESCRIPTION
Some recent development I did on mpmap made it crazy slow with default parameters when used with the GBWT. I believe I tracked the problem down to the method of synthesizing tail anchors, which was now performing 10 alternate tracebacks much of the time, leading to an explosion of mostly redundant alternate paths that interacted poorly with the haplotype-consistent traceback code. I've modified it to only perform 1 traceback when looking for synthetic anchors and also to enforce a minimum anchor length on the tails to reduce the chance of being fooled by microhomologies.