### PR TITLE
Hack in support for empty files

### DIFF
--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -72,9 +72,13 @@ DistanceIndex::DistanceIndex(const HandleGraph* vg, const SnarlManager* snarlMan
     setSnarlManager(snarlManager);
 }
 
-DistanceIndex::DistanceIndex (istream& in) : graph(nullptr), sm(nullptr) {
+DistanceIndex::DistanceIndex (istream& in) : DistanceIndex() {
     // Load the index
     load(in);
+}
+
+DistanceIndex::DistanceIndex () : graph(nullptr), sm(nullptr) {
+    // Nothing to do
 }
 
 void DistanceIndex::setGraph(const HandleGraph* new_graph) {

--- a/src/distance.hpp
+++ b/src/distance.hpp
@@ -25,6 +25,9 @@ class DistanceIndex {
     //User must call setGraph and setSnarlManager before using the index.
     DistanceIndex (istream& in);
     
+    //Default constructor; load() must be called next.
+    DistanceIndex ();
+    
     //Associate the DistanceIndex with the given graph. Graph must not be null.
     void setGraph(const HandleGraph* new_graph);
     

--- a/src/stream/message_emitter.cpp
+++ b/src/stream/message_emitter.cpp
@@ -5,8 +5,6 @@
 
 #include "message_emitter.hpp"
 
-#define debug
-
 namespace vg {
 
 namespace stream {

--- a/src/stream/message_emitter.hpp
+++ b/src/stream/message_emitter.hpp
@@ -71,6 +71,11 @@ public:
     MessageEmitter(MessageEmitter&& other) = default;
     MessageEmitter& operator=(MessageEmitter&& other) = default;
     
+    /// Ensure that a (possibly empty) group is emitted for the given tag.
+    /// Will coalesce with previous or subsequent write calls for the same tag.
+    /// Note that empty tags are prohibited.
+    void write(const string& tag);
+    
     /// Emit the given message with the given type tag.
     void write(const string& tag, string&& message);
     
@@ -96,6 +101,7 @@ public:
 private:
 
     // This is our internal tag string for what is in our buffer.
+    // If it is empty, no group is buffered, because empty tags are prohibited.
     string group_tag;
     // This is our internal buffer
     vector<string> group;

--- a/src/stream/message_iterator.cpp
+++ b/src/stream/message_iterator.cpp
@@ -6,6 +6,8 @@
 #include "message_iterator.hpp"
 #include "registry.hpp"
 
+#define debug
+
 namespace vg {
 
 namespace stream {
@@ -18,7 +20,7 @@ MessageIterator::MessageIterator(istream& in) : MessageIterator(unique_ptr<Block
 
 MessageIterator::MessageIterator(unique_ptr<BlockedGzipInputStream>&& bgzf) :
     value(),
-    backup_tag(),
+    previous_tag(),
     group_count(0),
     group_idx(0),
     group_vo(-1),
@@ -38,9 +40,9 @@ auto MessageIterator::operator*() -> TaggedMessage& {
 
 
 auto MessageIterator::operator++() -> const MessageIterator& {
-    if (group_count == group_idx) {
+    while (group_count == group_idx) {
         // We have made it to the end of the group we are reading. We will
-        // start a new group now.
+        // start a new group now (and skip through empty groups).
         
         // Determine exactly where we are positioned, if possible, before
         // creating the CodedInputStream to read the group's item count
@@ -124,14 +126,14 @@ auto MessageIterator::operator++() -> const MessageIterator& {
         // Work out if this really is a tag.
         bool is_tag = false;
         
-        if (!backup_tag.empty() && backup_tag == value.first) {
+        if (!previous_tag.empty() && previous_tag == value.first) {
 #ifdef debug
-            cerr << "Tag is the same as the last tag of \"" << backup_tag << "\"" << endl;
+            cerr << "Tag is the same as the last tag of \"" << previous_tag << "\"" << endl;
 #endif
             is_tag = true;
         } else {
 #ifdef debug
-            cerr << "Tag does not match cached backup tag or there is no cached backup tag" << endl;
+            cerr << "Tag does not match cached previous tag or there is no cached previous tag" << endl;
 #endif
         }
     
@@ -151,7 +153,7 @@ auto MessageIterator::operator++() -> const MessageIterator& {
             // Assume it is actually a message, and make the group's tag ""
             swap(value.first, value.second);
             value.first.clear();
-            backup_tag.clear();
+            previous_tag.clear();
             
 #ifdef debug
             cerr << "Tag is actually a message probably." << endl;
@@ -167,7 +169,7 @@ auto MessageIterator::operator++() -> const MessageIterator& {
         
         // Otherwise this is a real tag.
         // Back up its value in case our pair gets moved away.
-        backup_tag = value.first;
+        previous_tag = value.first;
         
         // We continue and read the real first message into the message half of our pair.
     }
@@ -207,9 +209,9 @@ auto MessageIterator::operator++() -> const MessageIterator& {
         handle(coded_in.ReadString(&value.second, msgSize));
     }
     
-    // Fill in the tag from the backup to make sure our value pair actually has it.
+    // Fill in the tag from the previous to make sure our value pair actually has it.
     // It may have been moved away.
-    value.first = backup_tag;
+    value.first = previous_tag;
     
 #ifdef debug
     cerr << "Found message " << group_idx << " size " << msgSize << " with tag \"" << value.first << "\"" << endl;

--- a/src/stream/message_iterator.cpp
+++ b/src/stream/message_iterator.cpp
@@ -6,8 +6,6 @@
 #include "message_iterator.hpp"
 #include "registry.hpp"
 
-#define debug
-
 namespace vg {
 
 namespace stream {

--- a/src/stream/message_iterator.hpp
+++ b/src/stream/message_iterator.hpp
@@ -119,9 +119,9 @@ private:
     /// May get moved away.
     TaggedMessage value;
     
-    /// Because the whole value pair may get moved away, we keep a backup copy of the tag and replace it.
+    /// Because the whole value pair may get moved away, we keep a previous copy of the tag and replace it.
     /// TODO: This is a bit of a hack.
-    string backup_tag;
+    string previous_tag;
     
     /// This holds the number of messages that exist in the current group.
     /// Counts the tag, if present.

--- a/src/stream/protobuf_emitter.hpp
+++ b/src/stream/protobuf_emitter.hpp
@@ -134,8 +134,11 @@ std::function<void(const Item&)> emit_to(ostream& out);
 template<typename T>
 ProtobufEmitter<T>::ProtobufEmitter(std::ostream& out, size_t max_group_size) : message_emitter(out, max_group_size),
     tag(Registry::get_protobuf_tag<T>()) {
-    
-    // Nothing to do!
+    // Make sure to write at least the tag to the file, to represent 0
+    // instances of our type. When trying to load a list of our type from a
+    // file, it's comforting for the loader code to see that as opposed to
+    // nothing mentioning the type it is looking for.
+    message_emitter.write(tag);
 }
 
 template<typename T>

--- a/src/stream/vpkg.hpp
+++ b/src/stream/vpkg.hpp
@@ -23,6 +23,8 @@ namespace stream {
 
 using namespace std;
 
+#define debug
+
 /**
  * Interface for reading/writing type-tagged files.
  *
@@ -480,5 +482,7 @@ private:
 }
 
 }
+
+#undef debug
 
 #endif

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -6,12 +6,15 @@
 
 #include <stdio.h>
 #include <iostream>
+#include <sstream>
 #include <set>
 #include "json2pb.h"
 #include "vg.pb.h"
 #include "catch.hpp"
 #include "snarls.hpp"
 #include "genotypekit.hpp"
+#include "../stream/protobuf_emitter.hpp"
+#include "../stream/vpkg.hpp"
 
 //#define debug
 
@@ -3558,6 +3561,28 @@ namespace vg {
             
              
         } 
+        
+        TEST_CASE( "SnarlManager IO works correctly",
+                  "[sites][snarls]" ) {
+            
+            SECTION( "SnarlManager can be loaded from an empty snarls file") {
+                
+                stringstream buff;
+                
+                {
+                    // Make an emitter
+                    stream::ProtobufEmitter<Snarl> emitter(buff);
+                    // Emit nothing
+                }
+                
+                // Now load it back
+                unique_ptr<SnarlManager> manager = stream::VPKG::try_load_one<SnarlManager>(buff);
+                
+                REQUIRE(manager.get() != nullptr);
+                
+            }
+            
+        }
         
     }
 }


### PR DESCRIPTION
This PR lets empty VPKG files with no messages be interpretable as any type via `load_one` and the type's default constructor. This works around the problem @jeizenga was having with empty snarls files.

This won't work when trying to load multiple things from the same VPKG file, but no subcommands actually do that yet.

I've also included code that will emit empty, tagged groups from the ProtobufEmitter when writing files. In the future I want to rewrite loading a bit so that an empty, tagged group is required to load something empty from a VPKG, to bring back better type safety. However, empty groups are invisible in the MessageIterator's current API, so it will take a while to implement.