### PR TITLE
Gapless extension

### DIFF
--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -5,6 +5,8 @@
  * Haplotype-consistent gapless seed extension.
  */
 
+#include <functional>
+
 #include "gbwt_helper.hpp"
 
 namespace vg {
@@ -12,11 +14,44 @@ namespace vg {
 //------------------------------------------------------------------------------
 
 /**
- * A class that supports haplotype-consistent seed extension using GBWTGraph.
- * The extension finds, for a given cluster of matching sequence/graph positions,
- * the best haplotype-consistent gapless alignment starting from any pair of
- * positions in the cluster. The search can be constrained by giving a maximum
- * number of mismatches.
+ * A result of the gapless extension of a seed.
+ * - 'path' covers 'core_interval' of the read.
+ * - The intervals are semi-open [first, second) intervals.
+ * - 'state' is the search state corresponding to 'path'.
+ * - If 'is_full_alignment' is set, the path is a full-length alignment and may contain
+ *   mismatches. Otherwise it is a maximal unambiguous exact extension of a seed.
+ * - If the path is not a full-length alignment, 'flanked_interval' is a read interval
+ *   extending 'core_interval'. The extension may contain mismatches, but it starts and
+ *   ends with a match.
+ * - The mismatching read positions are stored in 'mismatch_positions' in sorted order.
+ */
+struct GaplessExtension
+{
+  Path                      path;
+  gbwt::BidirectionalState  state;
+  std::pair<size_t, size_t> core_interval;
+  bool                      is_full_alignment;
+
+  std::pair<size_t, size_t> flanked_interval;
+  std::vector<size_t>       mismatch_positions;
+
+  size_t core_length() const { return this->core_interval.second - this->core_interval.first; }
+  size_t flanked_length() const { return this->flanked_interval.second - this->flanked_interval.first; }
+  bool empty() const { return (this->core_length() == 0); }
+  bool full() const { return this->is_full_alignment; }
+  bool exact() const { return this->mismatch_positions.empty(); }
+  size_t mismatches() const { return this->mismatch_positions.size(); }
+};
+
+//------------------------------------------------------------------------------
+
+/**
+ * A class that supports haplotype-consistent seed extension using GBWTGraph. Each seed
+ * is a pair of matching read/graph positions and each extension is a gapless alignment
+ * of an interval of the read to a haplotype.
+ * A cluster is a vector of distinct seeds. The cluster may initially be in an arbitrary
+ * order, but it will be sorted during the extension. All seeds in a cluster should
+ * correspond to the same alignment or positions near it.
  */
 class GaplessExtender {
 public:
@@ -30,24 +65,18 @@ public:
     explicit GaplessExtender(const GBWTGraph& graph);
 
     /**
-    * Extend the exact match hits gaplessly against the given input sequence with at most
-    * the given number of mismarches. Return a Path representing the best alignment to the
-    * graph and the number of mismatches.
-    * The cluster can be in an arbitrary order, but it will be sorted during the call. Each
-    * pair in the cluster consists of matching sequence/graph positions. Some positions may
-    * occur multiple times, and the matches in the cluster may agree or conflict.
-    */
-    std::pair<Path, size_t> extend_seeds(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence, size_t max_mismatches = MAX_MISMATCHES) const;
+     * Find a full-length extension of the seeds with up to 'max_mismatches' mismatches.
+     * Return an alignment with the fewest number of mismatches or an empty extension if
+     * no full-length alignment exists.
+     */
+    GaplessExtension extend_seeds(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence, size_t max_mismatches = MAX_MISMATCHES) const;
 
     /**
-    * Find maximal unambiguous extensions of each seed in the cluster. The extension ends
-    * with the first mismatch or when there are multiple successor nodes with the same
-    * character.
-    * The cluster can be in an arbitrary order, but it will be sorted during the call. Each
-    * pair in the cluster consists of matching sequence/graph positions. Some positions may
-    * occur multiple times, and the matches in the cluster may agree or conflict.
-    */
-    std::vector<std::pair<Path, size_t>> maximal_extensions(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const;
+     * Find the maximal unambiguous extension for each seed. Returns the set of distinct
+     * extensions. A maximal unambiguous extension ends when further extensions either
+     * contain mismatches or branch with the same character.
+     */
+    std::vector<GaplessExtension> maximal_extensions(std::vector<std::pair<size_t, pos_t>>& cluster, const std::string& sequence) const;
 
     const GBWTGraph* graph;
 };

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -72,7 +72,7 @@ public:
      * 2. Call maximal_extensions().
      * 3. Call extend_flanks() with max_mismatches / 2 mismatches.
      */
-    std::vector<GaplessExtension> gapless_extension(cluster_type& cluster, const std::string& sequence, size_t max_mismatches = MAX_MISMATCHES) const;
+    std::vector<GaplessExtension> extend(cluster_type& cluster, const std::string& sequence, size_t max_mismatches = MAX_MISMATCHES) const;
 
     /**
      * Find a full-length extension of the seeds with up to 'max_mismatches' mismatches.

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -79,7 +79,7 @@ protected:
      * seeds) and starting after sinks (which cannot reach any other extended
      * seeds). Only sources and sinks have these "tail" paths.
      */
-    unordered_map<size_t, unordered_map<size_t, vector<Path>>> find_connecting_paths(const vector<pair<Path, size_t>>& extended_seeds,
+    unordered_map<size_t, unordered_map<size_t, vector<Path>>> find_connecting_paths(const vector<GaplessExtension>& extended_seeds,
         size_t read_length) const;
         
     /// We define a type for shared-tail lists of Mappings, to avoid constantly

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -375,7 +375,7 @@ int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::un
                     extend_counts[thread]++;
                     seed_counts[thread] += hits.size();
                     auto result = extender.extend_seeds(hits, reads[i], max_errors);
-                    if (result.second <= max_errors) {
+                    if (result.mismatches() <= max_errors) {
                         success_counts[thread]++;
                         success_seed_counts[thread] += hits.size();
                     } else {

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -351,6 +351,8 @@ int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::un
         std::vector<size_t> success_counts(threads, 0);
         std::vector<size_t> success_seed_counts(threads, 0);
         std::vector<size_t> partial_match_counts(threads, 0);
+        std::vector<size_t> core_lengths(threads, 0);
+        std::vector<size_t> flanked_lengths(threads, 0);
         #pragma omp parallel for schedule(static)
         for (size_t i = 0; i < reads.size(); i++) {
             size_t thread = omp_get_thread_num();
@@ -375,12 +377,17 @@ int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::un
                     extend_counts[thread]++;
                     seed_counts[thread] += hits.size();
                     auto result = extender.extend_seeds(hits, reads[i], max_errors);
-                    if (result.mismatches() <= max_errors) {
+                    if (result.full()) {
                         success_counts[thread]++;
                         success_seed_counts[thread] += hits.size();
                     } else {
                         auto partial_matches = extender.maximal_extensions(hits, reads[i]);
+                        extender.extend_flanks(partial_matches, reads[i], max_errors / 2);
                         partial_match_counts[thread] += partial_matches.size();
+                        for (GaplessExtension& extension : partial_matches) {
+                            core_lengths[thread] += extension.core_length();
+                            flanked_lengths[thread] += extension.flanked_length();
+                        }
                     }
                 }
             } else {
@@ -391,6 +398,7 @@ int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::un
         }
         size_t min_count = 0, occ_count = 0;
         size_t extend_count = 0, seed_count = 0, success_count = 0, success_seed_count = 0, partial_match_count = 0;
+        size_t core_length = 0, flanked_length = 0;
         for (size_t i = 0; i < threads; i++) {
             min_count += min_counts[i];
             occ_count += occ_counts[i];
@@ -399,6 +407,8 @@ int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::un
             success_count += success_counts[i];
             success_seed_count += success_seed_counts[i];
             partial_match_count += partial_match_counts[i];
+            core_length += core_lengths[i];
+            flanked_length += flanked_lengths[i];
         }
 
         double phase_seconds = gbwt::readTimer() - phase_start;
@@ -412,8 +422,9 @@ int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::un
         std::cerr << "Minimizers (" << query_type << "): " << phase_seconds << " seconds (" << (reads.size() / phase_seconds) << " reads/second)" << std::endl;
         std::cerr << min_count << " minimizers with " << occ_count << " occurrences" << std::endl;
         if (gapless_extend) {
-            std::cerr << extend_count << " reads with " << seed_count << " seeds, " << success_count << " extended with up to " << max_errors << " mismatches" << std::endl;
-            std::cerr << "Extended " << (extend_count - success_count) << " reads with " << (seed_count - success_seed_count) << " seeds into " << partial_match_count << " partial matches" << std::endl;
+            std::cerr << extend_count << " reads with " << seed_count << " seeds: " << success_count << " full-length alignments with up to " << max_errors << " mismatches" << std::endl;
+            size_t partial_count = extend_count - success_count, partial_seed_count = seed_count - success_seed_count;
+            std::cerr << partial_count << " reads with " << partial_seed_count << " seeds: " << partial_match_count << " partial alignments (core " << (core_length / static_cast<double>(partial_count)) << " bp, flanked " << (flanked_length / static_cast<double>(partial_count)) << " bp/read)" << std::endl;
         }
         std::cerr << std::endl;
     }

--- a/src/unittest/gapless_extender.cpp
+++ b/src/unittest/gapless_extender.cpp
@@ -142,8 +142,10 @@ TEST_CASE("Haplotype-aware gapless extension works correctly", "[gapless_extende
         };
         size_t error_bound = 0;
         auto result = extender.extend_seeds(cluster, read, error_bound);
-        REQUIRE(result.second <= error_bound);
-        alignment_matches(result.first, correct_alignment);
+        REQUIRE(!result.empty());
+        REQUIRE(result.full());
+        REQUIRE(result.mismatches() <= error_bound);
+        alignment_matches(result.path, correct_alignment);
     }
 
     SECTION("read matches with errors") {
@@ -161,8 +163,10 @@ TEST_CASE("Haplotype-aware gapless extension works correctly", "[gapless_extende
         };
         size_t error_bound = 1;
         auto result = extender.extend_seeds(cluster, read, error_bound);
-        REQUIRE(result.second <= error_bound);
-        alignment_matches(result.first, correct_alignment);
+        REQUIRE(!result.empty());
+        REQUIRE(result.full());
+        REQUIRE(result.mismatches() <= error_bound);
+        alignment_matches(result.path, correct_alignment);
     }
 
     SECTION("false seeds do not matter") {
@@ -181,8 +185,10 @@ TEST_CASE("Haplotype-aware gapless extension works correctly", "[gapless_extende
         };
         size_t error_bound = 1;
         auto result = extender.extend_seeds(cluster, read, error_bound);
-        REQUIRE(result.second <= error_bound);
-        alignment_matches(result.first, correct_alignment);
+        REQUIRE(!result.empty());
+        REQUIRE(result.full());
+        REQUIRE(result.mismatches() <= error_bound);
+        alignment_matches(result.path, correct_alignment);
     }
 
     SECTION("read matches reverse complement and ends within a node") {
@@ -199,8 +205,10 @@ TEST_CASE("Haplotype-aware gapless extension works correctly", "[gapless_extende
         };
         size_t error_bound = 1;
         auto result = extender.extend_seeds(cluster, read, error_bound);
-        REQUIRE(result.second <= error_bound);
-        alignment_matches(result.first, correct_alignment);
+        REQUIRE(!result.empty());
+        REQUIRE(result.full());
+        REQUIRE(result.mismatches() <= error_bound);
+        alignment_matches(result.path, correct_alignment);
     }
 
     SECTION("a non-matching read cannot be extended") {
@@ -211,7 +219,8 @@ TEST_CASE("Haplotype-aware gapless extension works correctly", "[gapless_extende
         };
         size_t error_bound = 1;
         auto result = extender.extend_seeds(cluster, read, error_bound);
-        REQUIRE(result.second > error_bound);
+        REQUIRE(result.empty());
+        REQUIRE(!result.full());
     }
 }
 
@@ -253,8 +262,9 @@ TEST_CASE("Haplotype-aware maximal extension works correctly", "[gapless_extende
         auto result = extender.maximal_extensions(cluster, read);
         REQUIRE(result.size() == correct_extensions.size());
         for (size_t i = 0; i < result.size(); i++) {
-            alignment_matches(result[i].first, correct_extensions[i]);
-            REQUIRE(result[i].second == correct_offsets[i]);
+            REQUIRE(!(result[i].empty()));
+            REQUIRE(result[i].core_interval.first == correct_offsets[i]);
+            alignment_matches(result[i].path, correct_extensions[i]);
         }
     }
 
@@ -288,8 +298,9 @@ TEST_CASE("Haplotype-aware maximal extension works correctly", "[gapless_extende
         auto result = extender.maximal_extensions(cluster, read);
         REQUIRE(result.size() == correct_extensions.size());
         for (size_t i = 0; i < result.size(); i++) {
-            alignment_matches(result[i].first, correct_extensions[i]);
-            REQUIRE(result[i].second == correct_offsets[i]);
+            REQUIRE(!(result[i].empty()));
+            REQUIRE(result[i].core_interval.first == correct_offsets[i]);
+            alignment_matches(result[i].path, correct_extensions[i]);
         }
     }
 
@@ -330,8 +341,9 @@ TEST_CASE("Haplotype-aware maximal extension works correctly", "[gapless_extende
         auto result = extender.maximal_extensions(cluster, read);
         REQUIRE(result.size() == correct_extensions.size());
         for (size_t i = 0; i < result.size(); i++) {
-            alignment_matches(result[i].first, correct_extensions[i]);
-            REQUIRE(result[i].second == correct_offsets[i]);
+            REQUIRE(!(result[i].empty()));
+            REQUIRE(result[i].core_interval.first == correct_offsets[i]);
+            alignment_matches(result[i].path, correct_extensions[i]);
         }
     }
 
@@ -357,8 +369,9 @@ TEST_CASE("Haplotype-aware maximal extension works correctly", "[gapless_extende
         auto result = extender.maximal_extensions(cluster, read);
         REQUIRE(result.size() == correct_extensions.size());
         for (size_t i = 0; i < result.size(); i++) {
-            alignment_matches(result[i].first, correct_extensions[i]);
-            REQUIRE(result[i].second == correct_offsets[i]);
+            REQUIRE(!(result[i].empty()));
+            REQUIRE(result[i].core_interval.first == correct_offsets[i]);
+            alignment_matches(result[i].path, correct_extensions[i]);
         }
     }
 }

--- a/src/unittest/gapless_extender.cpp
+++ b/src/unittest/gapless_extender.cpp
@@ -472,8 +472,8 @@ TEST_CASE("Haplotype-aware flank extension works correctly", "[gapless_extender]
     SECTION("trim flanking mismatches") {
         std::string read = "GATTxAATC";
         std::vector<std::pair<size_t, pos_t>> cluster {
-            { 0, make_pos_t(1, false, 0) }, // Ambiguous right extension.
-            { 8, make_pos_t(1, true, 0) }   // Ambiguous left extension.
+            { 0, make_pos_t(1, false, 0) },
+            { 8, make_pos_t(1, true, 0) }
         };
         size_t error_bound = 1;
         std::vector<std::pair<size_t, size_t>> core_ranges {
@@ -501,8 +501,8 @@ TEST_CASE("Haplotype-aware flank extension works correctly", "[gapless_extender]
     SECTION("extend with mismatches") {
         std::string read = "GTCTxAGAC";
         std::vector<std::pair<size_t, pos_t>> cluster {
-            { 0, make_pos_t(1, false, 0) }, // Ambiguous right extension.
-            { 8, make_pos_t(1, true, 0) }   // Ambiguous left extension.
+            { 0, make_pos_t(1, false, 0) },
+            { 8, make_pos_t(1, true, 0) }
         };
         size_t error_bound = 1;
         std::vector<std::pair<size_t, size_t>> core_ranges {
@@ -516,6 +516,31 @@ TEST_CASE("Haplotype-aware flank extension works correctly", "[gapless_extender]
         std::vector<std::vector<size_t>> mismatches {
             { static_cast<size_t>(1) },
             { static_cast<size_t>(7) }
+        };
+        auto result = extender.maximal_extensions(cluster, read);
+        extender.extend_flanks(result, read, error_bound);
+        REQUIRE(result.size() == core_ranges.size());
+        for (size_t i = 0; i < result.size(); i++) {
+            REQUIRE(!(result[i].empty()));
+            REQUIRE(!(result[i].full()));
+            flanks_match(result[i], core_ranges[i], flanked_ranges[i], mismatches[i]);
+        }
+    }
+
+    SECTION("mismatches in both directions") {
+        std::string read = "GAGGTTCA";
+        std::vector<std::pair<size_t, pos_t>> cluster {
+            { 3, make_pos_t(4, false, 2) }
+        };
+        size_t error_bound = 2;
+        std::vector<std::pair<size_t, size_t>> core_ranges {
+            { static_cast<size_t>(2), static_cast<size_t>(5) }
+        };
+        std::vector<std::pair<size_t, size_t>> flanked_ranges {
+            { static_cast<size_t>(0), static_cast<size_t>(8) }
+        };
+        std::vector<std::vector<size_t>> mismatches {
+            { static_cast<size_t>(1), static_cast<size_t>(5) }
         };
         auto result = extender.maximal_extensions(cluster, read);
         extender.extend_flanks(result, read, error_bound);


### PR DESCRIPTION
`GaplessExtender` now returns the alignments as `GaplessExtension` objects. The objects have the following interface:

* `Path path`: The core alignment as a path.
* `gbwt::BidirectionalState state`: Search state for the core alignment.
* `std::pair<size_t, size_t> core_interval`: Read interval for the core alignment.
* `std::pair<size_t, size_t> flanked_interval`: Read interval for the extended alignment.
* `std::vector<size_t> mismatch_positions`: Mismatching read positions in the extended alignment, including those in the core alignment.
* `size_t core_length()`: Length of the core alignment.
* `size_t extended_length()`: Length of the extended alignment.
* `bool empty()`: Is the alignment empty?
* `bool full()`: Is the core alignment a full-length alignment?
* `bool exact()`: Is the extended alignment an exact match?
* `size_t mismatches()`: The number of mismatches in the extended alignment.

This interface is basically what I needed for the gapless extension itself. New functions can be added if necessary.

The extension interface is:
```
std::vector<GaplessExtension>
extend(std::vector<std::pair<size_t, size_t>>& cluster,
       const std::string& sequence,
       size_t max_mismatches = 4) const;
```

The extension algorithm consists of three phases:

1. Try to find a full-length core alignment with at most `max_mismatches` mismatches. If successful, return an alignment with the fewest mismatches.
2. Extend all seeds into unambiguous exact core alignments and filter out duplicates.
3. Extend each core alignment into an extended alignment with at most `max_mismatches / 2` mismatches on each flank. Trim mismatches at the start/end of the extended alignment. If multiple extensions are possible, find the longest one (primary) with the fewest mismatches (secondary).

Each of the three phases can also be used separately.