### PR TITLE
Giraffe Funnel

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1295,6 +1295,10 @@ int32_t Aligner::score_exact_match(string::const_iterator seq_begin, string::con
     return score_exact_match(seq_begin, seq_end);
 }
 
+int32_t Aligner::score_mismatch(size_t length) const {
+    return -match * length;
+}
+
 int32_t Aligner::score_partial_alignment(const Alignment& alignment, const HandleGraph& graph, const Path& path,
                                          string::const_iterator seq_begin) const {
     

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -170,6 +170,9 @@ namespace vg {
         /// Qualities may be ignored by some implementations.
         virtual int32_t score_exact_match(string::const_iterator seq_begin, string::const_iterator seq_end,
                                           string::const_iterator base_qual_begin) const = 0;
+      
+        // TODO: Provide a generic way to score a mismatch.
+        
         /// Compute the score of a path against the given range of subsequence with the given qualities.
         virtual int32_t score_partial_alignment(const Alignment& alignment, const HandleGraph& graph, const Path& path,
                                                 string::const_iterator seq_begin) const = 0;
@@ -356,6 +359,9 @@ namespace vg {
                                   string::const_iterator base_qual_begin) const;
         int32_t score_exact_match(const string& sequence) const;
         int32_t score_exact_match(string::const_iterator seq_begin, string::const_iterator seq_end) const;
+        
+        /// Score a mismatch given just the length. Only possible since we ignore qualities.
+        int32_t score_mismatch(size_t length) const;
 
         int32_t score_partial_alignment(const Alignment& alignment, const HandleGraph& graph, const Path& path,
                                         string::const_iterator seq_begin) const;
@@ -403,7 +409,7 @@ namespace vg {
         int32_t score_exact_match(const string& sequence, const string& base_quality) const;
         int32_t score_exact_match(string::const_iterator seq_begin, string::const_iterator seq_end,
                                   string::const_iterator base_qual_begin) const;
-        
+                                  
         int32_t score_partial_alignment(const Alignment& alignment, const HandleGraph& graph, const Path& path,
                                         string::const_iterator seq_begin) const;
         

--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -1,5 +1,7 @@
 #include "funnel.hpp"
 
+#include <cassert>
+
 /**
  * \file funnel.hpp: implementation of the Funnel class
  */
@@ -38,7 +40,8 @@ void Funnel::stage(const string& name) {
     stage_stop();
 
     // Allocate new stage structures.
-    stages.emplace_back(name);
+    stages.emplace_back();
+    stages.back().name = name;
     
     // Save the name and start time
     stage_name = name;
@@ -199,7 +202,7 @@ double Funnel::total_seconds() const {
 }
 
 Funnel::Timepoint Funnel::now() const {
-    return chrono::high_resolution_clock::now()
+    return chrono::high_resolution_clock::now();
 }
 
 Funnel::Item& Funnel::get_item(size_t index) {

--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -171,8 +171,20 @@ void Funnel::expand(size_t prev_stage_item, size_t count) {
 }
 
 void Funnel::project(size_t prev_stage_item) {
-    // Expand to just one new item
-    get_item(create_item()).prev_stage_items.push_back(prev_stage_item);
+    // There must be a prev stage to project from
+    assert(stages.size() > 1);
+    auto& prev_stage = stages[stages.size() - 2];
+
+    // Make one new item
+    size_t index = create_item();
+
+    // Record the ancestry
+    get_item(index).prev_stage_items.push_back(prev_stage_item);
+
+    if (prev_stage.items[prev_stage_item].correct) {
+        // Tag the new item correct if it came from something correct
+        tag_correct(index);
+    }
 }
 
 void Funnel::project_group(size_t prev_stage_item, size_t group_size) {
@@ -189,6 +201,23 @@ void Funnel::kill(size_t prev_stage_item) {
 
 void Funnel::score(size_t item, double score) {
     get_item(item).score = score;
+}
+
+void Funnel::tag_correct(size_t item) {
+    // Say the item is correct
+    get_item(item).correct = true;
+    // Say the stage has something correct.
+    stages.back().has_correct = true;
+}
+
+string Funnel::last_correct_stage() const {
+    // Just do a linear scan backward through stages
+    for (auto it = stages.rbegin(); it != stages.rend(); ++it) {
+        if (it->has_correct) {
+            return it->name;
+        }
+    }
+    return "none";
 }
 
 size_t Funnel::latest() const {

--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -1,0 +1,172 @@
+#include "funnel.hpp"
+
+/**
+ * \file funnel.hpp: implementation of the Funnel class
+ */
+ 
+namespace vg {
+using namespace std;
+
+void Funnel::start(const string& name) {
+    assert(!name.empty());
+
+    // (Re)start the funnel.
+    funnel_start_time = now();
+    funnel_name = name;
+    
+    // Clear out old data
+    stage_name.clear();
+    substage_name.clear();
+    stage_durations.clear();
+    substage_durations.clear();
+    stages.clear();
+}
+
+void Funnel::stop() {
+    // Stop any lingering stage (which takes care of substages and processing/producing timers)
+    stage_stop();
+    
+    // Record the ultimate duration.
+    funnel_duration = now() - funnel_start_time;
+}
+
+void Funnel::stage(const string& name) {
+    assert(!funnel_name.empty());
+    assert(!name.empty());
+    
+    // Stop the previous stage if any.
+    stage_stop();
+
+    // Allocate new stage structures.
+    stages.emplace_back(name);
+    
+    // Save the name and start time
+    stage_name = name;
+    stage_start_time = now();
+}
+
+void Funnel::stage_stop() {
+    if (!stage_name.empty()) {
+        // A stage was running.
+        
+        // Stop any substage.
+        substage_stop();
+        // Stop any process/produce timers
+        processed_input();
+        produced_output();
+        
+        // Get the elapsed stage time
+        Duration stage_duration = now() - stage_start_time;
+        // Save it, coalescing by name
+        stage_durations[stage_name] += stage_duration;
+        
+        // Say the stage is stopped 
+        stage_name.clear();
+    }
+}
+
+void Funnel::substage(const string& name) {
+    assert(!funnel_name.empty());
+    assert(!stage_name.empty());
+    assert(!name.empty());
+
+    // Stop previous substage if any.
+    substage_stop();
+    
+    // Substages don't bound produce/process timers.
+    
+    // Save the name and start time
+    substage_name = name;
+    substage_start_time = now();
+}
+    
+void Funnel::substage_stop() {
+    if (!substage_name.empty()) {
+        // A substage was running.
+        
+        // Substages don't bound produce/process timers.
+        
+        // Get the elapsed substage time
+        Duration substage_duration = now() - substage_start_time;
+        // Save it, coalescing by name
+        substage_durations[stage_name][substage_name] += substage_duration;
+        
+        // Say the stage is stopped 
+        substage_name.clear();
+    }
+}
+
+void Funnel::processing_input(size_t prev_stage_item) {
+    // We can only take input from previous stages, in a stage
+    assert(!stage_name.empty());
+    assert(stages.size() > 1);
+    assert(prev_stage_item != numeric_limits<size_t>::max());
+    assert(stages[stages.size() - 2].items.size() > prev_stage_item);
+
+    // Stop any previous input processing timer
+    processed_input();
+    
+    // Start this one
+    input_in_progress = prev_stage_item;
+    input_start_time = now();
+}
+
+void Funnel::processed_input() {
+    if (input_in_progress != numeric_limits<size_t>::max()) {
+        // We were processing an input
+        
+        // Work out how long it took
+        Duration input_duration = now() - input_start_time;
+        // Add it in
+        stages[stages.size() - 2].items[input_in_progress].process_duration += input_duration;
+        
+        // Say we're done with the input.
+        input_in_progress = numeric_limits<size_t>::max();
+    }
+}
+
+void Funnel::producing_output(size_t item) {
+    // We can only produce output in a stage
+    assert(!stage_name.empty());
+    assert(!stages.empty());
+    assert(item != numeric_limits<size_t>::max());
+    
+    // Stop any previous input processing timer
+    produced_output();
+    
+    // Start this one
+    output_in_progress = item;
+    output_start_time = now();
+}
+
+void Funnel::produced_output() {
+    if (output_in_progress != numeric_limits<size_t>::max()) {
+        // We were producing an output
+        
+        // Work out how long it took
+        Duration output_duration = now() - output_start_time;
+        // Add it in
+        get_item(output_in_progress).produce_duration += output_duration;
+        
+        // Say we're done with the output.
+        output_in_progress = numeric_limits<size_t>::max();
+    }
+}
+    
+
+
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -230,6 +230,23 @@ double Funnel::total_seconds() const {
     return chrono::duration_cast<chrono::duration<double>>(funnel_duration).count();
 }
 
+void Funnel::for_each_time(const function<void(const string&, const string&, double)>& callback) {
+    // Handle overall
+    callback("", "", total_seconds());
+
+    for (auto& kv : stage_durations) {
+        // Handle each stage
+        callback(kv.first, "", chrono::duration_cast<chrono::duration<double>>(kv.second).count());
+    }
+
+    for (auto& kv : substage_durations) {
+        for (auto& kv2 : kv.second) {
+            // Handle each substage
+            callback(kv.first, kv2.first, chrono::duration_cast<chrono::duration<double>>(kv2.second).count());
+        }
+    }
+}
+
 Funnel::Timepoint Funnel::now() const {
     return chrono::high_resolution_clock::now();
 }

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <cassert>
 #include <functional>
+#include <iostream>
 
 /** 
  * \file funnel.hpp
@@ -123,6 +124,10 @@ public:
     /// Call the given callback with stage name (or ""), substage name (or ""), and
     /// time in seconds overasll, for each stage, and for each substage in a stage.
     void for_each_time(const function<void(const string&, const string&, double)>& callback);
+
+    /// Dump information from the Funnel as a dot-format Graphviz graph to the given stream.
+    /// Illustrates stages, provenance, and runtime assignment.
+    void to_dot(ostream& out);
     
 protected:
     
@@ -168,6 +173,9 @@ protected:
     
     /// Produce the current time
     Timepoint now() const;
+
+    /// Convert a Duration to fractional seconds
+    double to_seconds(const Duration& time) const;
     
     // Now members we need for provenance tracking
     

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <cassert>
 
 /** 
  * \file funnel.hpp
@@ -164,9 +165,9 @@ protected:
         /// What previous stage items were combined to make this one, if any?
         vector<size_t> prev_stage_items = {};
         /// How long did it take to produce this item, in total?
-        Duration produce_duration = 0;
+        Duration produce_duration{0};
         /// How long was spent processing this item as an input, in total?
-        Duration process_duration = 0;
+        Duration process_duration{0};
     };
     
     /// Represents a Stage which is a series of Items, which track their own provenance.

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <unordered_map>
 #include <cassert>
+#include <functional>
 
 /** 
  * \file funnel.hpp
@@ -118,6 +119,10 @@ public:
     
     /// Get the total number of seconds elapsed between start() and stop()
     double total_seconds() const;
+
+    /// Call the given callback with stage name (or ""), substage name (or ""), and
+    /// time in seconds overasll, for each stage, and for each substage in a stage.
+    void for_each_time(const function<void(const string&, const string&, double)>& callback);
     
 protected:
     

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -93,7 +93,8 @@ public:
     /// Project a single item from the previous stage to a new group item at the current stage, with the given size.
     void project_group(size_t prev_stage_item, size_t group_size);
     
-    /// Kill the given item from the previous stage and do not project it through to this stage
+    /// Kill the given item from the previous stage and do not project it through to this stage.
+    /// Items which are not killed must be projected to something.
     void kill(size_t prev_stage_item);
     
     /// Gill all the given items from the previous stage.
@@ -114,7 +115,7 @@ protected:
     /// How do we record durations internally?
     using Duration = chrono::nanoseconds;
     /// How do we record timepoints internally?
-    using Timepoint = chrono::time_point<chrono::system_clock>;
+    using Timepoint = chrono::time_point<chrono::high_resolution_clock>;
     
     // Members we need for time tracking
     
@@ -180,11 +181,12 @@ protected:
     /// Ensure an item with the given index exists in the current stage and return a reference to it.
     /// We need to do it this way because we might save a production duration before an item is really projected.
     /// The items of the current stage should only be modified through this.
+    /// Note that you do *not* need to create an item in order to get it.
     Item& get_item(size_t index);
     
-    /// Project a new item in the current stage and get its index.
+    /// Create a new item in the current stage and get its index.
     /// Advances the projected count counter.
-    size_t project_item();
+    size_t create_item();
     
     /// Rercord all the stages, including their names and item provenance.
     /// Handles repeated stages.
@@ -195,7 +197,7 @@ template<typename Iterator>
 void Funnel::merge_group(Iterator prev_stage_items_begin, Iterator prev_stage_items_end) {
     assert(!stages.empty());
     // Make a new item holding all the given items.
-    size_t index = project_item();
+    size_t index = create_item();
     std::copy(prev_stage_items_begin, prev_stage_items_end, std::back_inserter(get_item(index).prev_stage_items));
     // Update its size
     get_item(index).group_size = get_item(index).prev_stage_items.size();

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -1,0 +1,215 @@
+#ifndef VG_FUNNEL_HPP_INCLUDED
+#define VG_FUNNEL_HPP_INCLUDED
+
+#include <chrono>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+/** 
+ * \file funnel.hpp
+ * Contains the Funnel class, for recording the history of complex multi-stage transformations of sets of results.
+ */
+ 
+namespace vg {
+
+using namespace std;
+
+/**
+ * Represents a record of an invocation of a pipeline for an input.
+ *
+ * Tracks the history of "lines" of data "item" provenance through a series of
+ * timed "stages".
+ *
+ * Lines are "introduced", and "project" from earlier stages to later stages,
+ * possibly "expanding" or "merging", until they are "killed" or reach the
+ * final stage. At each stage, items occur in a linear order and are identified
+ * by index.
+ *
+ * Each stage has its runtime recorded, and the runtime for substages of the
+ * stage are recorded as well.
+ *
+ * An item may be a "group", with a certain size.
+ *
+ * We can also allocate time to processing input items from the previous stage,
+ * or ourput items of the current stage.
+ *
+ * We also can assign scores to items at a stage.
+ */
+class Funnel {
+
+public:
+    /// Start the timer for processing the given named input.
+    /// Name must not be empty.
+    /// No stage or substage will be active.
+    void start(const string& name);
+    
+    /// Stop the timer for processing the given named input.
+    /// All stages and substages are stopped.
+    void stop();
+    
+    /// Start the given stage, and end all previous stages and substages.
+    /// Name must not be empty.
+    /// Multiple stages with the same name will be coalesced.
+    void stage(const string& name);
+    
+    /// Stop counting time against the current stage.
+    void stage_stop();
+    
+    /// Start the given substage, nested insude the current stage. End all previous substages.
+    /// Substages within a stage may repeat and are coalesced.
+    /// Name must not be empty.
+    void substage(const string& name);
+    
+    /// Stop counting time against the current substage.
+    void substage_stop();
+    
+    /// Start a clock assigning runtime to processing the given item coming from the previous stage.
+    void processing_input(size_t prev_stage_item);
+    
+    /// Stop the clock assigning runtime to processing an item from the previous stage.
+    void processed_input();
+    
+    /// Start a clock assigning time to producing the given output item, whether it has been projected yet or not. 
+    void producing_output(size_t item);
+    
+    /// Stop the clock assigning time to producing an output item.
+    void produced_output();
+    
+    /// Introduce the given number of new items, starting their own lines of provenance (default 1).
+    void introduce(size_t count = 1);
+    
+    /// Expand the given item from the previous stage into the given number of new items at this stage.
+    void expand(size_t prev_stage_item, size_t count);
+    
+    /// Merge all the given item indexes from the previous stage into a new item at this stage.
+    /// The new item will be a group, sized according to the number of previous items merged.
+    template<typename Iterator>
+    void merge_group(Iterator prev_stage_items_begin, Iterator prev_stage_items_end);
+    
+    /// Project a single item from the previous stage to a single non-group item at this stage.
+    void project(size_t prev_stage_item);
+    
+    /// Project a single item from the previous stage to a new group item at the current stage, with the given size.
+    void project_group(size_t prev_stage_item, size_t group_size);
+    
+    /// Kill the given item from the previous stage and do not project it through to this stage
+    void kill(size_t prev_stage_item);
+    
+    /// Gill all the given items from the previous stage.
+    template<typename Iterator>
+    void kill_all(Iterator prev_stage_items_begin, Iterator prev_stage_items_end);
+    
+    /// Assign the given score to the given item at the current stage.
+    void score(size_t item, double score);
+    
+    /// Get the index of the most recent item created in the current stage.
+    size_t latest() const;
+    
+    /// Get the total number of seconds elapsed between start() and stop()
+    double total_seconds() const;
+    
+protected:
+    
+    /// How do we record durations internally?
+    using Duration = chrono::nanoseconds;
+    /// How do we record timepoints internally?
+    using Timepoint = chrono::time_point<chrono::system_clock>;
+    
+    // Members we need for time tracking
+    
+    /// What's the name of the funnel we start()-ed. Will be empty if nothing is running.
+    string funnel_name;
+    /// When did we start it the funnel?
+    Timepoint funnel_start_time;
+    /// If we finished the funnel, how long did it last?
+    Duration funnel_duration;
+    
+    /// What's the name of the current stage? Will be empty if no stage is running.
+    string stage_name;
+    /// When did we start the stage?
+    Timepoint stage_start_time;
+    /// Records total duration of all stages by name.
+    unordered_map<string, Duration> stage_durations;
+    
+    /// What's the name of the current substage? Will be empty if no substage is running.
+    string substage_name;
+    /// When did we start the substage?
+    Timepoint substage_start_time;
+    /// Records total duration of all substages by substage name and stage name.
+    unordered_map<string, unordered_map<string, Duration>> substage_durations;
+    
+    /// What's the current prev-stage input we are processing?
+    /// Will be numeric_limits<size_t>::max() if none.
+    size_t input_in_progress = numeric_limits<size_t>::max();
+    /// When did we start processing that input?
+    Timepoint input_start_time;
+    
+    /// what's the current current-stage output we are generating?
+    /// Will be numeric_limits<size_t>::max() if none.
+    size_t output_in_progress = numeric_limits<size_t>::max();
+    /// When did we start processing that input?
+    Timepoint output_start_time;
+    
+    /// Produce the current time
+    Timepoint now() const;
+    
+    // Now members we need for provenance tracking
+    
+    /// Represents an Item whose provenance we track
+    struct Item {
+        size_t group_size = 0;
+        double score = 0;
+        /// What previous stage items were combined to make this one, if any?
+        vector<size_t> prev_stage_items = {};
+        /// How long did it take to produce this item, in total?
+        Duration produce_duration = 0;
+        /// How long was spent processing this item as an input, in total?
+        Duration process_duration = 0;
+    };
+    
+    /// Represents a Stage which is a series of Items, which track their own provenance.
+    struct Stage {
+        string name;
+        vector<Item> items;
+        /// How many of the items were actually projected?
+        /// Needed because items may need to expand to hold production times for items that have not been projected yet.
+        size_t projected_count = 0;
+    };
+    
+    /// Ensure an item with the given index exists in the current stage and return a reference to it.
+    /// We need to do it this way because we might save a production duration before an item is really projected.
+    /// The items of the current stage should only be modified through this.
+    Item& get_item(size_t index);
+    
+    /// Project a new item in the current stage and get its index.
+    /// Advances the projected count counter.
+    size_t project_item();
+    
+    /// Rercord all the stages, including their names and item provenance.
+    /// Handles repeated stages.
+    vector<Stage> stages;
+};
+
+template<typename Iterator>
+void Funnel::merge_group(Iterator prev_stage_items_begin, Iterator prev_stage_items_end) {
+    assert(!stages.empty());
+    // Make a new item holding all the given items.
+    size_t index = project_item();
+    std::copy(prev_stage_items_begin, prev_stage_items_end, std::back_inserter(get_item(index).prev_stage_items));
+    // Update its size
+    get_item(index).group_size = get_item(index).prev_stage_items.size();
+}
+
+template<typename Iterator>
+void Funnel::kill_all(Iterator prev_stage_items_begin, Iterator prev_stage_items_end) {
+    for (; prev_stage_items_begin != prev_stage_items_end; ++prev_stage_items_begin) {
+        // Kill each thing between begin and end
+        kill(*prev_stage_items_begin);
+    }
+}
+
+
+}
+
+#endif

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -42,7 +42,7 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     }
     
     // Start the minimizer finding stage
-    funnel.stage("minimizers");
+    funnel.stage("minimizer");
     
     // We will find all the seed hits
     vector<pos_t> seeds;
@@ -382,6 +382,7 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         
         // Tell the funnel
         funnel.project(alignment_num);
+        funnel.score(alignment_num, mappings.back().score());
     }
     if (max_multimaps < alignments_in_order.size()) {
         // Some things stop here
@@ -451,6 +452,11 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     
     // Ship out all the aligned alignments
     alignment_emitter.emit_mapped_single(std::move(mappings));
+
+#ifdef debug
+    // Dump the funnel info graph.
+    funnel.to_dot(cerr);
+#endif
 }
 
 int MinimizerMapper::estimate_extension_group_score(const Alignment& aln, vector<GaplessExtension>& extended_seeds) const {

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -355,7 +355,7 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     
     vector<Alignment> mappings;
     mappings.reserve(min(alignments_in_order.size(), max_multimaps));
-    for (size_t i = 0; i < alignments_in_order.size() && i <= max_multimaps; i++) {
+    for (size_t i = 0; i < alignments_in_order.size() && i < max_multimaps; i++) {
         // For each output slot, fill it with the alignment at that rank if available.
         size_t& alignment_num = alignments_in_order[i];
         mappings.emplace_back(std::move(alignments[alignment_num]));

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -253,7 +253,7 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     // Keep track of best and second best scores.
     int best_score = 0;
     int second_best_score = 0;
-    for (size_t i = 0; i < extension_indexes_in_order.size(); i++) {
+    for (size_t i = 0; i < extension_indexes_in_order.size() && i < max_alignments; i++) {
         // Find the extension group we are talking about
         size_t& extension_num = extension_indexes_in_order[i];
         funnel.processing_input(extension_num);
@@ -575,9 +575,11 @@ int MinimizerMapper::estimate_extension_group_score(const Alignment& aln, vector
 }
 
 bool MinimizerMapper::score_is_significant(int score_estimate, int best_score, int second_best_score) const {
-    // TODO: Find Jordan's method and apply that.
-    // For now just use a magic relative cutoff.
-    if (score_estimate + 10 >= second_best_score) {
+    // mpmap uses a heuristic of if the read coverage of the cluster is less than half the best cluster's read coverage, stop.
+    // We do something similar, but with scores. And we make sure to get at least one second best score.
+    // If it's not more than half the best score, it doesn't matter if it beats the second best score; both secondaries are sufficiently bad.
+    // TODO: real scores from full-length gapless extensions aren't quite directly comparable with estimates.
+    if (score_estimate * 2 >= best_score || second_best_score < 1) {
         return true;
     }
     return false;

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -68,7 +68,7 @@ protected:
      * extended perfect-match seeds and produce an alignment into the given
      * output Alignment object.
      */
-    void chain_extended_seeds(const Alignment& aln, const vector<pair<Path, size_t>>& extended_seeds, Alignment& out); 
+    void chain_extended_seeds(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, Alignment& out); 
     
     /**
      * Find for each pair of extended seeds all the haplotype-consistent graph

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -33,7 +33,7 @@ public:
     /**
      * Map the given read, and send output to the given AlignmentEmitter. May be run from any thread.
      */
-    void map(Alignment& aln, AlignmentEmitter& alignment_emitter);
+    void map(Alignment& aln, AlignmentEmitter& alignment_emitter) const;
 
     // Mapping settings.
     // TODO: document each
@@ -64,11 +64,24 @@ protected:
     SnarlSeedClusterer clusterer;
     
     /**
+     * Estimate the maximum score it may be possible to achieve using the given group of GaplessExtensions.
+     * Supports single full-length extensions and groups that need chaining.
+     * May reorder the input extended_seeds vector if it is not sorted in read space.
+     */
+    int estimate_extension_group_score(const Alignment& aln, vector<GaplessExtension>& extended_seeds) const;
+    
+    /**
+     * Determine if a score estimate is significant enough to justify computing the real Alignment.
+     * Returns true if it might win or affect mapping quality, and false otherwise.
+     */
+    bool score_is_significant(int score_estimate, int best_score, int second_best_score) const; 
+    
+    /**
      * Operating on the given input alignment, chain together the given
      * extended perfect-match seeds and produce an alignment into the given
      * output Alignment object.
      */
-    void chain_extended_seeds(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, Alignment& out); 
+    void chain_extended_seeds(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, Alignment& out) const; 
     
     /**
      * Find for each pair of extended seeds all the haplotype-consistent graph

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -64,9 +64,10 @@ protected:
     SnarlSeedClusterer clusterer;
     
     /**
-     * Estimate the maximum score it may be possible to achieve using the given group of GaplessExtensions.
+     * Estimate the score it may be possible to achieve using the given group of GaplessExtensions.
      * Supports single full-length extensions and groups that need chaining.
      * May reorder the input extended_seeds vector if it is not sorted in read space.
+     * Is not always an overestimate of the actual score.
      */
     int estimate_extension_group_score(const Alignment& aln, vector<GaplessExtension>& extended_seeds) const;
     

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -38,7 +38,9 @@ public:
 
     // Mapping settings.
     // TODO: document each
-    size_t max_alignments = 10;
+
+    /// How many extended clusters should we align, max?
+    size_t max_alignments = 48;
     size_t max_multimaps = 1;
     size_t hit_cap = 10;
     size_t distance_limit = 1000;

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -32,8 +32,9 @@ public:
 
     /**
      * Map the given read, and send output to the given AlignmentEmitter. May be run from any thread.
+     * TODO: Can't be const because the clusterer's cluster_seeds isn't const.
      */
-    void map(Alignment& aln, AlignmentEmitter& alignment_emitter) const;
+    void map(Alignment& aln, AlignmentEmitter& alignment_emitter);
 
     // Mapping settings.
     // TODO: document each

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -62,7 +62,14 @@ protected:
     
     /// We have a clusterer
     SnarlSeedClusterer clusterer;
-
+    
+    /**
+     * Operating on the given input alignment, chain together the given
+     * extended perfect-match seeds and produce an alignment into the given
+     * output Alignment object.
+     */
+    void chain_extended_seeds(const Alignment& aln, const vector<pair<Path, size_t>>& extended_seeds, Alignment& out); 
+    
     /**
      * Find for each pair of extended seeds all the haplotype-consistent graph
      * paths against which the intervening read sequence needs to be aligned.

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -82,8 +82,8 @@ int main_gaffe(int argc, char** argv) {
     vector<string> fastq_filenames;
     // How many mappings per read can we emit?
     size_t max_multimaps = 1;
-    // How many clusters per read should we examine/extend?
-    size_t max_alignments = 10;
+    // How many extended clusters should we align, max?
+    size_t max_alignments = 48;
     // What sample name if any should we apply?
     string sample_name;
     // What read group if any should we apply?


### PR DESCRIPTION
This adds my "funnel" system for instrumenting the new mapper. It can produce funnel diagrams like this, if you `#define debug`.

<img width="1223" alt="Screen Shot 2019-04-10 at 4 07 38 PM" src="https://user-images.githubusercontent.com/5062495/55919440-e40aed00-5baa-11e9-8f2c-79f4baa165f3.png">

The red rectangles represent time consumed processing inputs or producing outputs at various stages of the pipeline. Hits are colored green if they are deemed "correct" relative to the refpos set on the input alignment, and correctness is propagated to all descendant clusters and alignments.

The annotations also include some useful information:

```
[anovak@courtyard vg]$ vg view -aj mapped.gam | jq '.annotation'
{
  "tail_lengths": [
    63,
    82,
    25
  ],
  "last_correct_stage": "winner",
  "stage_minimizer_seconds": 7.142e-05,
  "stage_seed_seconds": 0.003497916,
  "map_seconds": 0.005868578,
  "tail_dp_areas": [
    9891,
    21074,
    4975
  ],
  "stage_winner_seconds": 2.2366e-05,
  "stage_align_chain_seconds": 0.001235153,
  "stage_cluster_seconds": 0.000711311,
  "stage_seed_correct_seconds": 0.00199597,
  "stage_extend_score_seconds": 2.1441e-05,
  "stage_cluster_score_seconds": 1.9753e-05,
  "features": [
    "LINE"
  ],
  "tail_path_counts": [
    1,
    1,
    1
  ],
  "stage_winner_mapq_seconds": 1.8649e-05,
  "stage_extend_seconds": 0.000220082,
  "stage_align_seconds": 0.001314661
}
```

For each stage, we have a total runtime, and for each substage of that stage we also have a runtime. Also, we have the `last_correct_stage`; if a read is not mapped correctly, you can look at `last_correct_stage` to find at what stage in the pipeline the correct mapping was lost.

@jltsiren @xchang1 I think after this PR we are ready to investigate individual slow reads and incorrect alignments. Is this PR enough for you to continue improving your bits independently?

I've been testing using the files in /public/home/anovak/build/vg/trash/clustering, from /public/home/anovak/build/vg:

```
vg gaffe -x trash/clustering/snp1kg-CHR21_filter.xg -m trash/clustering/snp1kg-CHR21_filter.min -d trash/clustering/snp1kg-CHR21_filter.dist -s trash/clustering/snp1kg-CHR21_filter.snarls -H trash/clustering/snp1kg-CHR21_filter.gbwt -G trash/clustering/reads/sim.gam > trash/clustering/mapped.gam

vg view -aj trash/clustering/mapped.gam | jq -r '.annotation.last_correct_stage' | sort | uniq -c

vg annotate -x trash/clustering/snp1kg-CHR21_filter.xg -p -a trash/clustering/mapped.gam > trash/clustering/annotated.gam
vg gamcompare trash/clustering/annotated.gam trash/clustering/reads/sim.gam -r 100 > trash/clustering/compared.gam

vg view -aj trash/clustering/compared.gam | jq -c 'select(.correctly_mapped)' | wc -l

vg view -aj trash/clustering/compared.gam | jq -r '.annotation.map_seconds' > trash/clustering/times.tsv
histogram.py trash/clustering/times.tsv --save trash/clustering/times.svg --title "GAFFE Runtime Histogram" --x_label "Time (seconds)" --line --bins 100 --log --cumulative --y_label "Cumulative Count"

cat trash/clustering/times.tsv | sum.sh
```

The `histogram.py` and `sum.sh` scripts I use are in `~anovak/bin`.

Currently I am getting 190113/200000 alignments correct, in 1141.57 seconds total alignment time, for an overall speed of about 175 alignments per second. `MinimizerMapper::score_is_significant()` is maybe one place to start trying to tune the heuristic that controls the trade-off between accuracy and alignment time. I'm working with scores, and I tried to port over @jeizenga's >=50%-of-the-MEM-coverage-of-the-top-alignment heuristic from mpmap into score space, but it probably could be improved.

Correct alignments are lost at the following stages:

```
    9375 align
      3 extend
    476 none (i.e. no correct seed hit ever located)
 190146 winner (i.e. never lost)
```

(There are more reads marked as having the correct mapping make it through to the end than there are reads correctly mapped. I think this is because sometimes the cluster that contains seed hits at the correct position doesn't always produce a winning alignment at the correct position, especially if the cluster is wide and in a locally repetitive region. You can find reads like that with `vg view -aj trash/clustering/compared.gam | jq 'select(.correctly_mapped | not) | select(.annotation.last_correct_stage == "winner") | .name'`)

Here's my read runtime histogram.

<img width="792" alt="Screen Shot 2019-04-10 at 4 25 35 PM" src="https://user-images.githubusercontent.com/5062495/55920086-4b29a100-5bad-11e9-8faf-c9e275f40d80.png">



