### PR TITLE
Normalize alignments to handle N's in a consistent manner

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1547,9 +1547,10 @@ void normalize_alignment(Alignment& alignment) {
                 auto begin = seq.begin() + cumul_to_length;
                 auto end = begin + edit.to_length();
                 
-                edit_type_t type =  edit.sequence().empty() ? Mismatch : Match;
-                
                 auto first_N = find(begin, end, 'N');
+                
+                edit_type_t type =  edit.sequence().empty() ? Match : Mismatch;
+                
                 if (prev == type || first_N != end || doing_normalization) {
                     // we have to do some normalization here
                     ensure_init_normalized_path(i, j);
@@ -1618,7 +1619,7 @@ void normalize_alignment(Alignment& alignment) {
     if (doing_normalization) {
         // we found things we needed to normalize away, so we must have built the normalized
         // path, now replace the original with it
-        *alignment.mutable_path() = normalized;
+        *alignment.mutable_path() = move(normalized);
     }
 }
 

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1453,6 +1453,165 @@ Alignment simplify(const Alignment& a, bool trim_internal_deletions) {
     }
     return aln;
 }
+    
+void normalize_alignment(Alignment& alignment) {
+    
+    enum edit_type_t {None, Match, Mismatch, Insert, Delete, N};
+    
+    size_t cumul_to_length = 0;
+    
+    // we only build the normalized path if we find things we need to normalize
+    // (this makes the whole algorithm a little fucky, but it should be less overhead)
+    bool doing_normalization = false;
+    Path normalized;
+    
+    const Path& path = alignment.path();
+    const string& seq = alignment.sequence();
+    
+    auto ensure_init_normalized_path = [&](size_t i, size_t j) {
+        // we won't copy the already normalized prefix unless we have to
+        if (!doing_normalization) {
+            for (size_t k = 0; k < i; k++) {
+                *normalized.add_mapping() = path.mapping(k);
+            }
+            Mapping* mapping = normalized.add_mapping();
+            *mapping->mutable_position() = path.mapping(i).position();
+            mapping->set_rank(path.mapping_size());
+            for (size_t k = 0; k < j; k++) {
+                *mapping->add_edit() = path.mapping(i).edit(k);
+            }
+        }
+        doing_normalization = true;
+    };
+    
+    edit_type_t prev = None;
+    
+    auto walk_non_gap_edit = [&](const edit_type_t& type,
+                                 string::const_iterator begin,
+                                 string::const_iterator end) {
+        
+        
+    };
+    
+    for (size_t i = 0; i < path.mapping_size(); ++i) {
+        
+        const Mapping& mapping = path.mapping(i);
+        prev = None;
+        
+        if (doing_normalization) {
+            // we're maintaining the normalized path, so we need to add mappings
+            // as we go
+            Mapping* norm_mapping = normalized.add_mapping();
+            *norm_mapping->mutable_position() = mapping.position();
+            norm_mapping->set_rank(normalized.mapping_size());
+        }
+        
+        for (size_t j = 0; j < mapping.edit_size(); ++j) {
+            
+            const Edit& edit = mapping.edit(j);
+            
+            if (edit.from_length() > 0 && edit.to_length() == 0) {
+                
+                if (prev == Delete || doing_normalization) {
+                    // we need to modify the normalized path this round
+                    ensure_init_normalized_path(i, j);
+                    Mapping* norm_mapping = normalized.mutable_mapping(normalized.mapping_size() - 1);
+                    if (prev == Delete) {
+                        // merge with the previous
+                        Edit* norm_edit = norm_mapping->mutable_edit(norm_mapping->edit_size() - 1);
+                        norm_edit->set_from_length(norm_edit->from_length() + edit.from_length());
+                    }
+                    else {
+                        // just copy
+                        *norm_mapping->add_edit() = edit;
+                    }
+                }
+                
+                prev = Delete;
+            }
+            else if (edit.from_length() == 0 && edit.to_length() > 0) {
+                
+                if (prev == Insert || doing_normalization) {
+                    // we need to modify the normalized path this round
+                    ensure_init_normalized_path(i, j);
+                    Mapping* norm_mapping = normalized.mutable_mapping(normalized.mapping_size() - 1);
+                    if (prev == Insert) {
+                        // merge with the previous
+                        Edit* norm_edit = norm_mapping->mutable_edit(norm_mapping->edit_size() - 1);
+                        norm_edit->set_to_length(norm_edit->to_length() + edit.to_length());
+                    }
+                    else {
+                        // just copy
+                        *norm_mapping->add_edit() = edit;
+                    }
+                }
+                
+                cumul_to_length += edit.to_length();
+                prev = Insert;
+            }
+            else {
+                auto begin = seq.begin() + cumul_to_length;
+                auto end = begin + edit.to_length();
+                edit_type_t type =  edit.sequence().empty() ? Mismatch : Match;
+                
+                auto next_pos = find(begin, end, 'N');
+                if (prev == type || next_pos != end || doing_normalization) {
+                    // we have to do some normalization here
+                    ensure_init_normalized_path(i, j);
+                    
+                    Mapping* norm_mapping = normalized.mutable_mapping(normalized.mapping_size() - 1);
+                    if (next_pos == end && prev != type) {
+                        // just need to copy, no fancy normalization
+                        *norm_mapping->add_edit() = edit;
+                    }
+                    else {
+                        bool on_Ns = next_pos == begin;
+                        // iterate until we've handled the whole edit sequence
+                        while (next_pos != end) {
+                            // find the next place where we switch from N to non-N or the reverse
+                            auto next_end = find_if(next_pos, end, [&](char c) {
+                                return c == 'N' != on_Ns;
+                            });
+                            
+                            if ((prev == N && on_Ns) || (prev == type && !on_Ns)) {
+                                // we need to merge with the previous edit
+                                Edit* norm_edit = norm_mapping->mutable_edit(norm_mapping->edit_size() - 1);
+                                norm_edit->set_from_length(norm_edit->from_length() + edit.from_length());
+                                norm_edit->set_to_length(norm_edit->to_length() + edit.to_length());
+                                
+                                // we copy sequence for Ns and for mismatches only
+                                if ((prev == N && on_Ns) || (prev == type && !on_Ns && type == Mismatch)) {
+                                    norm_edit->mutable_sequence()->insert(norm_edit->sequence().end(),
+                                                                          next_pos, next_end);
+                                }
+                            }
+                            else {
+                                // we can just copy
+                                *norm_mapping->add_edit() = edit;
+                            }
+                            
+                            next_pos = next_end;
+                            prev = on_Ns ? N : type;
+                            on_Ns = !on_Ns;
+                        }
+                    }
+                }
+                else {
+                    // no normalization yet
+                    prev = type;
+                }
+                
+                cumul_to_length += edit.to_length();
+            }
+        }
+    }
+    
+    if (doing_normalization) {
+        // we found things we needed to normalize away, so we must have built the normalized
+        // path, now replace the original with it
+        *alignment.mutable_path() = normalized;
+    }
+}
 
 map<id_t, int> alignment_quality_per_node(const Alignment& aln) {
     map<id_t, int> quals;

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -206,6 +206,9 @@ void flip_nodes(Alignment& a, const set<int64_t>& ids, const std::function<size_
 /// the start and end of Mappings, so code that handles simplified Alignments
 /// needs to handle offsets on internal Mappings.
 Alignment simplify(const Alignment& a, bool trim_internal_deletions = true);
+    
+/// Merge adjacent edits of the same type and convert all N matches to mismatches.
+void normalize_alignment(Alignment& alignment);
 
 // quality information; a kind of poor man's pileup
 map<id_t, int> alignment_quality_per_node(const Alignment& aln);

--- a/src/endianness.hpp
+++ b/src/endianness.hpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstdlib>
+#include <type_traits>
 
 namespace vg {
 
@@ -18,20 +19,23 @@ namespace vg {
         
         /// Converts from an integer in the native representation in the machine
         /// architecture to a big-endian representation
-        static IntType to_big_endian(IntType value);
+        static inline IntType to_big_endian(IntType value);
         
         /// Converts from a big-endian integer to the native representation in
         /// the machine architecture
-        static IntType from_big_endian(IntType value);
+        static inline IntType from_big_endian(IntType value);
         
     private:
         
         /// Returns the integer in the opposite endianness representation it currently
         /// has
-        static IntType swap_endianness(IntType value);
+        static inline IntType swap_endianness(IntType value);
         
         /// Returns true if the architecture is big-endian, otherwise false
-        static bool arch_is_big_endian();
+        static inline bool arch_is_big_endian();
+        
+        static_assert(std::is_integral<IntType>::value,
+                      "Endianness only applies to integer data types");
     };
     
     ////////////////////////////
@@ -40,19 +44,19 @@ namespace vg {
     
     
     template <class IntType>
-    IntType endianness<IntType>::to_big_endian(IntType value) {
+    inline IntType endianness<IntType>::to_big_endian(IntType value) {
         return arch_is_big_endian() ? value : swap_endianness(value);
     }
     
     template <class IntType>
-    IntType endianness<IntType>::from_big_endian(IntType value) {
+    inline IntType endianness<IntType>::from_big_endian(IntType value) {
         // these turn out to be identical functions, but having both aliases still
         // seems cognitively useful
         return to_big_endian(value);
     }
     
     template <class IntType>
-    IntType endianness<IntType>::swap_endianness(IntType value) {
+    inline IntType endianness<IntType>::swap_endianness(IntType value) {
         
         IntType swapped;
         
@@ -69,7 +73,7 @@ namespace vg {
     // TODO: this method will not detect endianness correctly on 1-byte
     // integers, but endianness is irrelevant for them anyway...
     template <class IntType>
-    bool endianness<IntType>::arch_is_big_endian() {
+    inline bool endianness<IntType>::arch_is_big_endian() {
         
         // mark volatile so the compiler won't optimize it away
         volatile IntType val = 1;

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1880,7 +1880,7 @@ namespace vg {
                     bool is_Ns = find_if(edit.sequence().begin(), edit.sequence().end(), [](char c) {return c != 'N';}) == edit.sequence().end();
                     for (size_t j = 0; j < edit.from_length(); j++, node_idx++, seq_idx++) {
                         // we will also let N's be marked as mismatches even if the node sequence is also Ns
-                        if ((mapping.position().is_reverse() ? rev_node_seq[node_idx] : node_seq[node_idx]) == subseq[seq_idx] || is_Ns) {
+                        if ((mapping.position().is_reverse() ? rev_node_seq[node_idx] : node_seq[node_idx]) == subseq[seq_idx] && !is_Ns) {
 #ifdef debug_verbose_validation
                             cerr << "validation failure on mismatch that matches" << endl;
                             cerr << pb2json(mapping) << ", " << subseq << endl;

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1877,8 +1877,10 @@ namespace vg {
                     }
                 }
                 else if (edit_is_sub(edit)) {
+                    bool is_Ns = find_if(edit.sequence().begin(), edit.sequence().end(), [](char c) {return c != 'N';}) == edit.sequence().end();
                     for (size_t j = 0; j < edit.from_length(); j++, node_idx++, seq_idx++) {
-                        if ((mapping.position().is_reverse() ? rev_node_seq[node_idx] : node_seq[node_idx]) == subseq[seq_idx]) {
+                        // we will also let N's be marked as mismatches even if the node sequence is also Ns
+                        if ((mapping.position().is_reverse() ? rev_node_seq[node_idx] : node_seq[node_idx]) == subseq[seq_idx] || is_Ns) {
 #ifdef debug_verbose_validation
                             cerr << "validation failure on mismatch that matches" << endl;
                             cerr << pb2json(mapping) << ", " << subseq << endl;

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3377,11 +3377,11 @@ namespace vg {
                     cerr << "making " << num_alt_alns << " alignments of sequence " << intervening_sequence.sequence() << " to connecting graph" << endl;
                     connecting_graph.for_each_handle([&](const handle_t& handle) {
                         cerr << connecting_graph.get_id(handle) << " " << connecting_graph.get_sequence(handle) << endl;
+                        connecting_graph.follow_edges(handle, true, [&](const handle_t& prev) {
+                            cerr << "\t" << connecting_graph.get_id(prev) << " <-" << endl;
+                        });
                         connecting_graph.follow_edges(handle, false, [&](const handle_t& next) {
                             cerr << "\t-> " << connecting_graph.get_id(next) << endl;
-                        });
-                        connecting_graph.follow_edges(handle, false, [&](const handle_t& prev) {
-                            cerr << "\t" << connecting_graph.get_id(prev) << " <-" << endl;
                         });
                     });
 #endif
@@ -3653,11 +3653,11 @@ namespace vg {
                         cerr << "making " << num_alt_alns << " alignments of sequence: " << right_tail_sequence.sequence() << endl << "to right tail graph" << endl;
                         tail_graph.for_each_handle([&](const handle_t& handle) {
                             cerr << tail_graph.get_id(handle) << " " << tail_graph.get_sequence(handle) << endl;
-                            tail_graph.follow_edges(handle, false, [&](const handle_t& next) {
-                                cerr << "\t-> " << tail_graph.get_id(next) << endl;
-                            });
                             tail_graph.follow_edges(handle, false, [&](const handle_t& prev) {
                                 cerr << "\t" << tail_graph.get_id(prev) << " <-" << endl;
+                            });
+                            tail_graph.follow_edges(handle, false, [&](const handle_t& next) {
+                                cerr << "\t-> " << tail_graph.get_id(next) << endl;
                             });
                         });
 #endif
@@ -3741,7 +3741,7 @@ namespace vg {
                             tail_graph.follow_edges(handle, false, [&](const handle_t& next) {
                                 cerr << "\t-> " << tail_graph.get_id(next) << endl;
                             });
-                            tail_graph.follow_edges(handle, false, [&](const handle_t& prev) {
+                            tail_graph.follow_edges(handle, true, [&](const handle_t& prev) {
                                 cerr << "\t" << tail_graph.get_id(prev) << " <-" << endl;
                             });
                         });

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1375,6 +1375,7 @@ namespace vg {
                 // And all the alignments off of there
                 auto& alns = kv.second;
 
+                
 #ifdef debug_multipath_alignment
                 cerr << "Handling " << (handling_right_tail ? "right" : "left") << " tail off of PathNode "
                     << attached_path_node_index << " with path " << pb2json(path_nodes.at(attached_path_node_index).path) << endl;
@@ -1384,6 +1385,7 @@ namespace vg {
 #ifdef debug_multipath_alignment
                     cerr << "Tail alignment: " << pb2json(aln) << endl;
 #endif
+                    normalize_alignment(aln);
                     
                     auto seq_begin = alignment.sequence().begin() + (handling_right_tail ? (alignment.sequence().size() - aln.sequence().size()) : 0);
                     
@@ -1440,6 +1442,7 @@ namespace vg {
                         // on the final mapping we don't need to pay special attention to the initial position, but
                         // we can't copy over the whole mapping since there might be more edits after the match
                         if (i > match_start_mapping_idx && j > 0) {
+                            // This condition is broken because N matches get split into separate edits
                             assert(j == 1);
                             new_mapping = synth_path_node.path.add_mapping();
                             *new_mapping->mutable_position() = path.mapping(i).position();

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1382,10 +1382,10 @@ namespace vg {
 #endif
                 
                 for (auto& aln : alns) {
+                    
 #ifdef debug_multipath_alignment
                     cerr << "Tail alignment: " << pb2json(aln) << endl;
 #endif
-                    normalize_alignment(aln);
                     
                     auto seq_begin = alignment.sequence().begin() + (handling_right_tail ? (alignment.sequence().size() - aln.sequence().size()) : 0);
                     
@@ -3768,6 +3768,17 @@ namespace vg {
                 }
             }
         }
+        
+        // GSSW does some weird things with N's that we want to normalize away
+         if (find(alignment.sequence().begin(), alignment.sequence().end(), 'N') != alignment.sequence().end()) {
+             for (bool side : {true, false}) {
+                 for (pair<const size_t, vector<Alignment>>& tail_alignments : to_return[side]) {
+                     for (Alignment& aln : tail_alignments.second) {
+                         normalize_alignment(aln);
+                     }
+                 }
+             }
+         }
         
 #ifdef debug_multipath_alignment
         cerr << "made alignments for " << to_return[false].size() << " source PathNodes and " << to_return[true].size() << " sink PathNodes" << endl;

--- a/src/unittest/alignment.cpp
+++ b/src/unittest/alignment.cpp
@@ -109,6 +109,33 @@ TEST_CASE("Alignment trimming works even on unaligned reads", "[alignment]") {
     REQUIRE(a.sequence().size() - 100 == aln.sequence().size());
     
 }
+    
+TEST_CASE("Alignment normalization behaves as expected","[alignment]") {
+    string alignment_string = R"(
+    {"sequence":"ATNNNNANCT","path":{"mapping":[{"position":{"node_id":"1"},"edit":[{"from_length":"1","to_length":"1"},{"from_length":"1","to_length":"1"},{"from_length":"1","to_length":"1","sequence":"N"},{"from_length":"1","to_length":"1"},{"from_length":"2","to_length":"2","sequence":"NN"},{"from_length":"2","to_length":"2","sequence":"AN"},{"to_length":"1","sequence":"C"},{"to_length":"1","sequence":"T"},{"from_length":"1"},{"from_length":"1"}]}]}}
+    )";
+    
+    string normalized_string = R"(
+    {"sequence":"ATNNNNANCT","path":{"mapping":[{"position":{"node_id":"1"},"edit":[{"from_length":"2","to_length":"2"},{"from_length":"4","to_length":"4","sequence":"NNNN"},{"from_length":"1","to_length":"1","sequence":"A"},{"from_length":"1","to_length":"1","sequence":"N"},{"to_length":"2","sequence":"CT"},{"from_length":"2"}]}]}}
+    )";
+    
+    Alignment aln;
+    json2pb(aln, alignment_string.c_str(), alignment_string.size());
+    Alignment target;
+    json2pb(target, normalized_string.c_str(), normalized_string.size());
+    
+    normalize_alignment(aln);
+    
+    REQUIRE(aln.path().mapping_size() == target.path().mapping_size());
+    for (size_t i = 0; i < aln.path().mapping_size(); i++) {
+        REQUIRE(aln.path().mapping(i).edit_size() == target.path().mapping(i).edit_size());
+        for (size_t j = 0; j < target.path().mapping(i).edit_size(); j++) {
+            REQUIRE(aln.path().mapping(i).edit(j).from_length() == target.path().mapping(i).edit(j).from_length());
+            REQUIRE(aln.path().mapping(i).edit(j).to_length() == target.path().mapping(i).edit(j).to_length());
+            REQUIRE(aln.path().mapping(i).edit(j).sequence() == target.path().mapping(i).edit(j).sequence());
+        }
+    }
+}
 
 }
 }


### PR DESCRIPTION
Fixes https://github.com/vgteam/vg/issues/2202

We had a crash, which was triggered by an assert about the form that it thought alignments should take. Turns out that form would be violated by alignments of reads that have Ns to regions of the graph that also have Ns. I've introduced a normalization step that should fix this.