### PR TITLE
Giraffe Facts

### DIFF
--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+
+
+"""
+giraffe-facts.py: process a GAM file from the new minimizer-based mapper (vg
+gaffe AKA giraffe) and report runtime statistics by pipeline stage.
+"""
+
+import argparse
+import os
+import sys
+import time
+import subprocess
+import collections
+import json
+
+# We depend on our local histogram.py
+import histogram
+
+# Define a constant list of all the stages, in order.
+STAGES = ['minimizer', 'seed', 'cluster', 'extend', 'align', 'winner']
+    
+def parse_args(args):
+    """
+    Takes in the command-line arguments list (args), and returns a nice argparse
+    result with fields for all the options.
+    
+    Borrows heavily from the argparse documentation examples:
+    <http://docs.python.org/library/argparse.html>
+    """
+    
+    # Construct the parser (which is stored in parser)
+    # Module docstring lives in __doc__
+    # See http://python-forum.com/pythonforum/viewtopic.php?f=3&t=36847
+    # And a formatter class so our examples in the docstring look good. Isn't it
+    # convenient how we already wrapped it to 80 characters?
+    # See http://docs.python.org/library/argparse.html#formatter-class
+    parser = argparse.ArgumentParser(description=__doc__, 
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    
+    parser.add_argument("--input", type=argparse.FileType('r'), default=sys.stdin,
+                        help="line-oriented JSON GAM to process")
+    parser.add_argument("outdir",
+                        help="directory to place output in")
+    
+    # The command line arguments start with the program name, which we don't
+    # want to treat as an argument for argparse. So we remove it.
+    args = args[1:]
+        
+    return parser.parse_args(args)
+
+def accumulate_read_times(reads, stages=STAGES):
+    """
+    Given an iterator that emits parsed JSON reads dicts, yield one list of
+    cumulative runtimes, in stages order, for each read. Each list also ends
+    with the total runtime, after all the stages.
+    """
+    
+    for read in reads:
+        # For every read
+        
+        # We make a list of cumulative times
+        cumulative_times = []
+        # And we track the time we are summing up
+        time_counter = 0.0
+        
+        for stage in stages:
+            # For each stage in order
+            
+            # Grab its runtime from the read
+            stage_time = read.get('annotation', {}).get('stage_' + stage + '_seconds', 0.0)
+            
+            # Sum it in
+            time_counter += stage_time
+            
+            # Record the cumulative sum through this stage
+            cumulative_times.append(time_counter)
+            
+        # Now do the total time
+        cumulative_times.append(read.get('annotation', {}).get('map_seconds', 0.0))
+        
+        yield cumulative_times
+            
+def read_line_oriented_json(lines):
+    """
+    For each line in the given stream, yield it as a parsed JSON object.
+    """
+    
+    for line in lines:
+        yield json.loads(line)
+
+
+def main(args):
+    """
+    Parses command line arguments and do the work of the program.
+    "args" specifies the program arguments, with args[0] being the executable
+    name. The return value should be used as the program's exit code.
+    """
+    
+    options = parse_args(args) # This holds the nicely-parsed options object
+    
+    print("Thank you for subscribing to Giraffe Facts")
+    
+    # Make the output directory if it doesn't exist
+    os.makedirs(options.outdir, exist_ok=True)
+    
+    # Open a TSV file to draw a histogram from
+    tsv_path = os.path.join(options.outdir, 'times.tsv')
+    tsv = open(tsv_path, 'w')
+    
+    # Make a place to total up times by stage and cumulative time
+    time_totals = [0.0 for _ in STAGES] + [0.0]
+    
+    # Count all the reads
+    read_count = 0
+    
+    for times in accumulate_read_times(read_line_oriented_json(options.input)):
+        # For the cumulative runtimes for each read, ending with total time
+        
+        for stage, cumulative_time in zip(STAGES, times):
+            # Dump cumulative times to the TSV we will plot a histogram from
+            tsv.write('{}\t{}\n'.format(stage, cumulative_time))
+        
+        # Also include total time
+        tsv.write('total\t{}\n'.format(times[-1]))
+        
+        # Sum up all times in accumulator
+        for i, time in enumerate(times):
+            time_totals[i] += time
+            
+        # Count the read
+        read_count += 1
+    
+    # After processing all the reads
+    
+    # Close the TSV
+    tsv.close()
+    
+    # Plot the histogram
+    svg_path = os.path.join(options.outdir, 'times.svg')
+    histogram.main(['histogram.py', tsv_path, '--save', svg_path,
+        '--title', 'Runtime Histogram',
+        '--x_label',  'Time (seconds)',
+        '--line',
+        '--bins', '100',
+        '--log',
+        '--cumulative',
+        '--y_label', 'Cumulative Count',
+        '--legend_overlay', 'lower right',
+        '--categories', 'total'] + STAGES)
+   
+   
+    # Now do a table
+    
+    # How long is the longest stage name
+    stage_width = max((len(x) for x in STAGES))
+    # Leave room for the header
+    stage_header = "Stage"
+    stage_width = max(stage_width, len(stage_header))
+    # And for the "Overall" entry
+    stage_overall = "Overall"
+    stage_width = max(stage_width, len(stage_overall))
+    
+    # How about the reads per second column
+    rps_header = "Reads per Second"
+    rps_header2 = "(cumulative)"
+    rps_width = max(len(rps_header), len(rps_header2))
+    
+    print("┌{}┬{}┐".format('─' * stage_width, '─' * rps_width))
+    print("│{}│{}│".format(stage_header.rjust(stage_width), rps_header.rjust(rps_width)))
+    print("│{}│{}│".format(' ' * stage_width, rps_header2.rjust(rps_width)))
+    print("├{}┼{}┤".format('─' * stage_width, '─' * rps_width))
+    
+    for stage, total_cumulative_time in zip(STAGES, time_totals):
+        # Compute cumulative reads per second values
+        reads_per_second = read_count / total_cumulative_time if total_cumulative_time != 0 else float('NaN')
+        
+        # Justify right with spaces in a field of the correct width.
+        print(("│{}│{:>" + str(rps_width) + ".2f}│").format(stage.rjust(stage_width), reads_per_second))
+    
+    # And do overall reads per second, after a divider
+    print("├{}┼{}┤".format('─' * stage_width, '─' * rps_width))
+    reads_per_second_overall = read_count / time_totals[-1] if time_totals[-1] != 0 else float('NaN')
+    print(("│{}│{:>" + str(rps_width) + ".2f}│").format(stage_overall.rjust(stage_width), reads_per_second_overall))
+    
+    print("└{}┴{}┘".format('─' * stage_width, '─' * len(rps_header)))
+
+def entrypoint():
+    """
+    0-argument entry point for setuptools to call.
+    """
+    
+    # Provide main with its arguments and handle exit codes
+    sys.exit(main(sys.argv))
+    
+if __name__ == "__main__" :
+    entrypoint()
+        
+

--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -15,13 +15,65 @@ import subprocess
 import collections
 import itertools
 import json
+import random
 
 # We depend on our local histogram.py
 import histogram
 
 # Define a constant list of all the stages, in order.
 STAGES = ['minimizer', 'seed', 'cluster', 'extend', 'align', 'winner']
-    
+
+FACTS = ["Giraffes are the tallest living terrestrial animal.",
+         "There are nine subspecies of giraffe, each occupying separate regions of Africa. Some researchers consider some subspecies to be separate species entirely.",
+         "Giraffes' horn-like structures are called 'ossicones'. They consist mostly of ossified cartilage.",
+         "Male giraffes compete for dominance in fights in which they strike each other with their necks.",
+         "There are more than 1600 giraffes in captivity worldwide.",
+         "The name 'giraffe' has roots in the Arabic 'zarafah', meaning 'fast-walker'.",
+         "Before the name 'giraffe' came into standard use, giraffes were commonly called 'camelopards'.",
+         "There are 10 known extinct species of giraffe.",
+         "The closest living relative to the giraffe is the okapi, an endangered hoofed mammal from the Congo.",
+         "Full grown giraffes are usually between 14 and 18 feet tall.",
+         "The tallest recorded giraffe was 19.3 feet tall.",
+         "Adult male giraffes weigh an average of 2628 lbs., whereas females weight 1825 lbs.",
+         "Giraffes have the ability to close their nostrils to protect against sandstorms and ants.",
+         "Giraffes have 18-inch-long prehensile tongues, which they use for grasping foliage and for grooming.",
+         "Male giraffes' spots grow darker as they age.",
+         "Under their fur coat, giraffes have grey skin.",
+         "Female giraffes have hair on their ossicones, whereas males' ossicones are bald.",
+         "Giraffes use the weight of their head to maintain their balance when they gallop.",
+         "Giraffes can run at 37 miles per hour for short distances, and 31 miles per hour for several miles.",
+         "Giraffes sleep for about half an hour a day.",
+         "Giraffes have the same number of vertebrae as most mammals. The length of their neck comes from longer vertebrae (over 10 inches each).",
+         "Giraffes' neck is fairly short at birth, probably to make birthing easier for mothers.",
+         "A giraffe's heart can weigh more than 25 lbs.",
+         "Giraffes have structures like check valves in their necks' veins to prevent blood from rushing to their head when they bend down to drink.",
+         "Giraffes have a four-chambered stomach similar to cattle.",
+         "An adult girafffe can eat 75 lbs. of foliage per day.",
+         "While generally herbivorous, giraffes have been observed eating meat and bone from carcasses.",
+         "The giraffe's gestation period is 14 months.",
+         "Newborn giraffes are about 6 feet tall.",
+         "Giraffes are lions' most common prey.",
+         "Most of giraffes' mounting behavior is between two males, often after a fight for dominance.",
+         "Giraffes allow red-billed oxpeckers (a bird species) to perch on them to feed on ticks.",
+         "Egyptian heiroglyphs use the giraffe as a character, pronounced 'sr'.",
+         "Designers of suits for fighter pilots studied giraffe skin, since figher pilots are also at risk of passing out when blood rushes to the legs.",
+         "The Humr people of Sudan use giraffe liver to create a putatively hallucinogenic drink called 'umm nyolokh'. The drink's psychoactive properties may come from the giraffe's diet of acacia plants.",
+         "The giraffe is the national animal of Tanzania.",
+         "There are around 100,000 giraffes in the wild as of 2016.",
+         "Giraffes only need to drink every few days. Most of their water comes from the vegetation they eat.",
+         "Giraffes give birth standing up, so newborn giraffes fall over 5 feet upon being born.",
+         "Giraffes usually sleep standing upright.",
+         "Male giraffes detect oestrus in females by tasting their urine.",
+         "June 21 is World Giraffe Day.",
+         "Toys R' Us has used Geoffrey the Giraffe as its mascot since 1965, although earlier advertisements in the 1950's used another giraffe: Dr. G. Raffe.",
+         "Giraffe hooves are 1 foot in diameter.",
+         "About 50% of giraffe calves die in their first year, mostly due to predation.",
+         "The giraffe's average walking speed is 10 miles per hour.",
+         "The giraffe's tongue is colored dark blue.",
+         "Some of giraffes' vocalizations are too low to be heard by human ears.",
+         "Giraffes have never been observed swimming.",
+         "Mozambique requires power lines to be 39 feet high so giraffes can safely pass underneath."]
+
 def parse_args(args):
     """
     Takes in the command-line arguments list (args), and returns a nice argparse
@@ -482,6 +534,8 @@ def main(args):
     "args" specifies the program arguments, with args[0] being the executable
     name. The return value should be used as the program's exit code.
     """
+    
+    print(random.choice(FACTS), file = sys.stderr)
     
     options = parse_args(args) # This holds the nicely-parsed options object
     

--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -13,6 +13,7 @@ import sys
 import time
 import subprocess
 import collections
+import itertools
 import json
 
 # We depend on our local histogram.py
@@ -89,6 +90,353 @@ def read_line_oriented_json(lines):
     
     for line in lines:
         yield json.loads(line)
+        
+class Table(object):
+    """
+    Format a table of output nicely in fixed-width text.
+    """
+    
+    # Interface
+    
+    def __init__(self, widths, out=sys.stdout):
+        """
+        Start a table with the given column widths (a list of integers) in
+        characters, printing to the given stream.
+        """
+        
+        # Remember the base widths
+        self.widths = widths
+        
+        # Remember the out stream
+        self.out = out
+        
+        # Remember the previous actual column widths used, if any.
+        # None if no wor has been produced.
+        self.last_widths = None
+        
+        # Remember if we need a dividing line
+        self.need_line = False
+        
+    def line(self):
+        """
+        Say to divide the previous row from the next row.
+        """
+        
+        self.need_line = True
+        
+    def row(self, values, justify='l', merge=None, line_top=False, line_bottom=False):
+        """
+        Given a list of values, one per column, for up to the number of columns
+        in the table, draw a table row.
+        
+        Justify can be 'l', 'r', 'c' or a list/string of those per value.
+        
+        If merge is given, it must be a list of the number of cells to merge
+        horizontally for each value.
+        
+        Different merge values without a line_top separator will look bad.
+        If line_top is set, divide from the previous row.
+        If line_bottom is set, divide from the next row.
+        """
+        
+        # Compute new merged widths
+        merged_widths = self.compute_merges(merge)
+        
+        # Start or continue the table
+        if self.last_widths is None:
+            # Start the table
+            self.start(merged_widths)
+        elif self.need_line or line_top:
+            # Divide from the previous row.
+            self.sep(self.last_widths, merged_widths)
+            
+        # Print the actual row
+        self.cells(values, justify, merged_widths)
+            
+        # Remember this row's widths for next time.
+        self.last_widths = merged_widths
+        
+        # Remember if we need a line
+        self.need_line = line_bottom
+        
+    def close(self):
+        """
+        Close off the table at the bottom.
+        """
+        
+        if self.last_widths is None:
+            self.last_widths = self.widths
+        
+        self.end(self.last_widths)
+        
+        self.last_widths = None
+        
+    # Internal methods
+        
+    def box(self, part):
+        """
+        Return the box-drawing character to draw the given part of a box.
+        Parts are {(t)op, (m)iddle, (b)ottom} crossed with {(l)eft, (m)iddle,
+        (r)ight} as two-character strings, plus (v)ertical and (h)orizontal as one-character strings.
+        """
+        
+        skin = {
+            'tl': '┌',
+            'tm': '┬',
+            'tr': '┐',
+            'bl': '└',
+            'bm': '┴',
+            'br': '┘',
+            'ml': '├',
+            'mm': '┼',
+            'mr': '┤',
+            'v': '│',
+            'h': '─'
+        }
+        
+        return skin[part]
+        
+    def horizontal(self, left, junction, right, column, widths=None):
+        """
+        Print a line across (either top, middle, or bottom).
+        
+        Takes the leftmost, between-column, rightmost, and in-column characters
+        as box() character ID strings.
+        
+        Can use a specified widths list, usually self.widths.
+        """
+        
+        if widths is None:
+            widths = self.widths
+        
+        # Start edge
+        self.out.write(self.box(left))
+        
+        for i, width in enumerate(widths):
+            # For each column
+            # Do its top line
+            self.out.write(self.box(column) * width)
+            if i + 1 != len(widths):
+                # Do the separator
+                self.out.write(self.box(junction))
+                
+        # End edge
+        self.out.write(self.box(right))
+        
+        self.out.write('\n')
+        
+    def start(self, widths_after):
+        """
+        Print an opening line at the top of the table.
+        Needs to know the widths of the cells on the next table line.
+        """
+        
+        self.horizontal('tl', 'tm', 'tr', 'h', widths_after)
+        
+    def end(self, widths_before):
+        """
+        Print a closing line at the bottom of the table.
+        Needs to know the widths of the cells on the previous table line.
+        """
+        
+        self.horizontal('bl', 'bm', 'br', 'h', widths_before)
+        
+    def sep(self, widths_before, widths_after):
+        """
+        Print a middle separator line across the table.
+        Needs to know the widths of the cells on the previous and next table lines.
+        Both sets of widths must describe a table of the same total width.
+        """
+        
+        # Start edge
+        self.out.write(self.box('ml'))
+        
+        # Compute total width (cells and separators), not counting final border
+        total_width = sum(widths_before) + len(widths_before) - 1
+        
+        # Track what cell we are in on top
+        before_cursor = 0
+        # And what column its trailing border is at
+        before_border = widths_before[before_cursor]
+        # Track what cell we are in on the bottom
+        after_cursor = 0
+        # And what column its trailing border is at
+        after_border = widths_after[after_cursor]
+        # Track what column of internal table width we are in.
+        col = 0
+        
+        while col < total_width:
+            if col == before_border:
+                if col == after_border:
+                    # Junction on both sides
+                    char = self.box('mm')
+                    
+                    # Advance after
+                    after_cursor += 1
+                    after_border += widths_after[after_cursor] + 1
+                else:
+                    # Junction on top only
+                    char = self.box('bm')
+                    
+                # Advance before
+                before_cursor += 1
+                before_border += widths_before[before_cursor] + 1
+            elif col == after_border:
+                # Junction on bottom only
+                char = self.box('tm')
+                
+                # Advance after
+                after_cursor += 1
+                after_border += widths_after[after_cursor] + 1
+            else:
+                # No junction
+                char = self.box('h')
+                
+            # Print the character
+            self.out.write(char)
+            
+            # Go to the next column
+            col += 1
+        
+        
+        # End edge
+        self.out.write(self.box('mr'))
+        
+        self.out.write('\n')
+        
+    def compute_merges(self, merges=None):
+        """
+        Given a list of cell counts to merge horizontally, compute new widths from self.widths.
+        
+        If merges is None, use self.widths.
+        """
+        
+        widths = self.widths
+        
+        if merges is not None:
+            new_widths = []
+            width_cursor = 0
+            for merge in merges:
+                # Compute a new column by merging the given number of old columns.
+                merged_width = 0
+                for i in range(merge):
+                    # Take the widths of all cells
+                    merged_width += widths[width_cursor]
+                    width_cursor += 1
+                # Take the separating columns between cells
+                merged_width += merge - 1
+                new_widths.append(merged_width)
+            while width_cursor < len(widths):
+                # Copy any unmerged columns
+                new_widths.append(widths[i])
+                
+            widths = new_widths
+            
+        return widths
+        
+    def cells(self, values, justify, widths):
+        """
+        Given a list of values, one per column, for up to the number of columns
+        in the table, draw a table row.
+        
+        Justify can be 'l', 'r', 'c', or a list/string of those per value.
+        
+        Column count/widths must be passed.
+        """
+       
+        # Start the row
+        self.out.write(self.box('v'))
+        
+        for i, (value, width) in enumerate(itertools.zip_longest(values, widths)):
+            # For each item and its column and width...
+            if width is None:
+                # Too many items
+                raise RuntimeError("Ran out of table widths for {} columns".format(len(values)))
+              
+            # Compute the item string
+            item_string = str(value) if value is not None else ''
+              
+            # Decide on justification for this item
+            if justify == 'l':
+                item_just = 'l'
+            elif justify == 'r':
+                item_just = 'r'
+            if justify == 'c':
+                item_just = 'c'
+            elif i < len(justify):
+                item_just = justify[i]
+            else:
+                item_just = 'l'
+                
+            # Actually justify it in a field of the necessary width
+            if item_just == 'l':
+                justified_item = item_string.ljust(width)
+            elif item_just == 'r':
+                justified_item = item_string.rjust(width)
+            elif item_just == 'c':
+                justified_item = item_string.center(width)
+            else:
+                raise RuntimeError('Invalid justification: {}'.format(item_just))
+                
+            # Output the content
+            self.out.write(justified_item)
+            
+            if (i + 1 != len(widths)):
+                # This isn't the last item. Do a separator.
+                self.out.write(self.box('v'))
+                
+                
+        # End the row
+        # TODO: Same as the separator
+        self.out.write(self.box('v'))
+        
+        self.out.write('\n')
+                
+def print_table(read_count, time_totals, stages=STAGES, out=sys.stdout):
+    """
+    Take the read count, and the cumulative time totals in stage order, with trailing total time.
+    
+    Print a nicely formatted table to the given stream.
+    """
+    
+    # Now do a table
+    
+    # How long is the longest stage name
+    stage_width = max((len(x) for x in STAGES))
+    # Leave room for the header
+    stage_header = "Stage"
+    stage_width = max(stage_width, len(stage_header))
+    # And for the "Overall" entry
+    stage_overall = "Overall"
+    stage_width = max(stage_width, len(stage_overall))
+    
+    # How about the reads per second column
+    rps_header = "Reads per Second"
+    rps_header2 = "(cumulative)"
+    rps_width = max(len(rps_header), len(rps_header2))
+    
+    table = Table([stage_width, rps_width])
+    
+    table.row(["Giraffe Facts"], 'c', merge=[2])
+    table.line()
+    table.row([stage_header, rps_header], 'cc' )
+    table.row(['', rps_header2], 'cc')
+    table.line()
+    
+    for stage, total_cumulative_time in zip(STAGES, time_totals):
+        # Compute cumulative reads per second values
+        reads_per_second = read_count / total_cumulative_time if total_cumulative_time != 0 else float('NaN')
+        
+        table.row([stage, '{:.2f}'.format(reads_per_second)], 'cr')
+        
+    table.line()
+        
+    # And do overall reads per second
+    reads_per_second_overall = read_count / time_totals[-1] if time_totals[-1] != 0 else float('NaN')
+    table.row([stage_overall, '{:.2f}'.format(reads_per_second_overall)], 'cr')
+    
+    # Close off table
+    table.close()
 
 
 def main(args):
@@ -99,8 +447,6 @@ def main(args):
     """
     
     options = parse_args(args) # This holds the nicely-parsed options object
-    
-    print("Thank you for subscribing to Giraffe Facts")
     
     # Make the output directory if it doesn't exist
     os.makedirs(options.outdir, exist_ok=True)
@@ -149,43 +495,10 @@ def main(args):
         '--y_label', 'Cumulative Count',
         '--legend_overlay', 'lower right',
         '--categories', 'total'] + STAGES)
-   
-   
-    # Now do a table
-    
-    # How long is the longest stage name
-    stage_width = max((len(x) for x in STAGES))
-    # Leave room for the header
-    stage_header = "Stage"
-    stage_width = max(stage_width, len(stage_header))
-    # And for the "Overall" entry
-    stage_overall = "Overall"
-    stage_width = max(stage_width, len(stage_overall))
-    
-    # How about the reads per second column
-    rps_header = "Reads per Second"
-    rps_header2 = "(cumulative)"
-    rps_width = max(len(rps_header), len(rps_header2))
-    
-    print("┌{}┬{}┐".format('─' * stage_width, '─' * rps_width))
-    print("│{}│{}│".format(stage_header.rjust(stage_width), rps_header.rjust(rps_width)))
-    print("│{}│{}│".format(' ' * stage_width, rps_header2.rjust(rps_width)))
-    print("├{}┼{}┤".format('─' * stage_width, '─' * rps_width))
-    
-    for stage, total_cumulative_time in zip(STAGES, time_totals):
-        # Compute cumulative reads per second values
-        reads_per_second = read_count / total_cumulative_time if total_cumulative_time != 0 else float('NaN')
         
-        # Justify right with spaces in a field of the correct width.
-        print(("│{}│{:>" + str(rps_width) + ".2f}│").format(stage.rjust(stage_width), reads_per_second))
-    
-    # And do overall reads per second, after a divider
-    print("├{}┼{}┤".format('─' * stage_width, '─' * rps_width))
-    reads_per_second_overall = read_count / time_totals[-1] if time_totals[-1] != 0 else float('NaN')
-    print(("│{}│{:>" + str(rps_width) + ".2f}│").format(stage_overall.rjust(stage_width), reads_per_second_overall))
-    
-    print("└{}┴{}┘".format('─' * stage_width, '─' * len(rps_header)))
-
+    # Print the table
+    print_table(read_count, time_totals)
+   
 def entrypoint():
     """
     0-argument entry point for setuptools to call.

--- a/scripts/histogram.py
+++ b/scripts/histogram.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+"""
+histogram: plot a histogram of a file of numbers. Numbers can be floats, one per
+line. Lines with two numbers are interpreted as pre-counted, with the number of
+repeats of the first being given by the second.
+
+Multiple instances of the same value in a category will be merged by adding
+weights.
+
+Re-uses sample code and documentation from 
+<http://users.soe.ucsc.edu/~karplus/bme205/f12/Scaffold.html>
+"""
+
+import argparse, sys, os, itertools, math, numpy, collections
+import matplotlib, matplotlib.ticker
+
+def intify(x):
+    """
+    Turn an integral float into an int, if applicable.
+    """
+    
+    if isinstance(x, float) and x.is_integer():
+        return int(x)
+    return x
+    
+def draw_labels(bin_counts, bar_patches, size=None):
+    """
+    Put the given count labels on the given bar patches, on the current axes.
+    Takes an optional font size.
+    
+    """
+    
+    from matplotlib import pyplot
+    
+    # Grab the axes
+    axes = pyplot.gca()
+
+    for bin_count, bar_patch in zip(bin_counts, bar_patches):
+        
+        if(bin_count.is_integer()):
+            # Intify if applicable
+            bin_count = int(bin_count)
+        
+        # Label each bar
+        if bin_count == 0:
+            # Except those for empty bins
+            continue
+            
+        # Find the center of the bar
+        bar_center_x = bar_patch.get_x() + bar_patch.get_width() / float(2)
+        # And its height
+        bar_height = bar_patch.get_height()
+        
+        # Label the bar
+        axes.annotate("{:,}".format(bin_count), (bar_center_x, bar_height), 
+            ha="center", va="bottom", rotation=45, xytext=(0, 5), 
+            textcoords="offset points", size=size)
+
+def parse_args(args):
+    """
+    Takes in the command-line arguments list (args), and returns a nice argparse
+    result with fields for all the options.
+    Borrows heavily from the argparse documentation examples:
+    <http://docs.python.org/library/argparse.html>
+    """
+    
+    # The command line arguments start with the program name, which we don't
+    # want to treat as an argument for argparse. So we remove it.
+    args = args[1:]
+    
+    # Construct the parser (which is stored in parser)
+    # Module docstring lives in __doc__
+    # See http://python-forum.com/pythonforum/viewtopic.php?f=3&t=36847
+    # And a formatter class so our examples in the docstring look good. Isn't it
+    # convenient how we already wrapped it to 80 characters?
+    # See http://docs.python.org/library/argparse.html#formatter-class
+    parser = argparse.ArgumentParser(description=__doc__, 
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    
+    # Now add all the options to it
+    parser.add_argument("data", nargs="+",
+        help="the file to read")
+    parser.add_argument("--redPortion", type=float, action="append", default=[],
+        help="portion of each bin to color red")
+    parser.add_argument("--redWeight", type=float, action="append", default=[],
+        help="value to plot in red in each bin")
+    parser.add_argument("--title", default="Histogram",
+        help="the plot title")
+    parser.add_argument("--x_label", default="Value",
+        help="the plot title")
+    parser.add_argument("--y_label", default="Number of Items (count)",
+        help="the plot title")
+    parser.add_argument("--bins", type=int, default=10,
+        help="the number of histogram bins")
+    parser.add_argument("--x_min", "--min", type=float, default=None,
+        help="minimum value allowed")
+    parser.add_argument("--x_max", "--max", type=float, default=None,
+        help="maximum value allowed")
+    parser.add_argument("--y_min", type=float, default=None,
+        help="minimum count on plot")
+    parser.add_argument("--y_max", type=float, default=None,
+        help="maximum count on plot")
+    parser.add_argument("--cutoff", type=float, default=None,
+        help="note portion above and below a value, and draw a vertical line")
+    parser.add_argument("--font_size", type=int, default=12,
+        help="the font size for text")
+    parser.add_argument("--categories", nargs="+", default=None,
+        help="categories to plot, in order")
+    parser.add_argument("--category_labels", "--labels", nargs="+",
+        default=[],
+        help="labels for all categories or data files, in order")
+    parser.add_argument("--colors", nargs="+", default=[],
+        help="use the specified Matplotlib colors per category or file")
+    parser.add_argument("--styles", nargs="+", default=[],
+        help="use the specified line styles per category or file")
+    parser.add_argument("--cumulative", action="store_true",
+        help="plot cumulatively")
+    parser.add_argument("--log", action="store_true",
+        help="take the base-10 logarithm of values before plotting histogram")
+    parser.add_argument("--log_counts", "--logCounts", action="store_true",
+        help="take the logarithm of counts before plotting histogram")
+    parser.add_argument("--fake_zero", action="store_true",
+        help="split lines where points would be 0")
+    parser.add_argument("--split_at_zero", action="store_true",
+        help="split lines between positive and negative")
+    parser.add_argument("--stats", action="store_true",
+        help="print data stats")
+    parser.add_argument("--save",
+        help="save figure to the given filename instead of showing it")
+    parser.add_argument("--dpi", type=int, default=300,
+        help="save the figure with the specified DPI, if applicable")
+    parser.add_argument("--sparse_ticks", action="store_true",
+        help="use sparse tick marks on both axes")
+    parser.add_argument("--sparse_x", action="store_true",
+        help="use sparse tick marks on X axis")
+    parser.add_argument("--sparse_y", action="store_true",
+        help="use sparse tick marks on Y axis")
+    parser.add_argument("--ticks", nargs="+", default=None,
+        help="use particular X tick locations")
+    parser.add_argument("--scientific_x", action="store_true",
+        help="use scientific notation on the X axis")
+    parser.add_argument("--scientific_y", action="store_true",
+        help="use scientific notation on the Y axis")
+    parser.add_argument("--label", action="store_true",
+        help="label bins with counts")
+    parser.add_argument("--label_size", type=float,
+        help="bin count label font size")
+    parser.add_argument("--no_n", dest="show_n", action="store_false",
+        help="don't add n value to title")
+    parser.add_argument("--normalize", action="store_true",
+        help="normalize to total weight of 1")
+    parser.add_argument("--line", action="store_true",
+        help="draw a line instead of a barchart")
+    parser.add_argument("--no_zero_ends", dest="zero_ends", default=True,
+        action="store_false",
+        help="don't force line ends to zero")
+    parser.add_argument("--legend_overlay", default=None,
+        help="display the legend overlayed on the graph at this location")
+    parser.add_argument("--no_legend", action="store_true",
+        help="don't display a legend when one would otherwise be dispalyed")
+    parser.add_argument("--points", action="store_true",
+        help="draw points instead of a barchart")
+    parser.add_argument("--width", type=float, default=8,
+        help="plot width in inches")
+    parser.add_argument("--height", type=float, default=6,
+        help="plot height in inches")
+    
+        
+    return parser.parse_args(args)
+    
+def filter2(criterion, key_list, other_list):
+    """
+    Filter two lists of corresponding items based on some function of the first
+    list.
+    
+    """
+    
+    # Make the output lists
+    out1 = []
+    out2 = []
+    
+    for key_val, other_val in zip(key_list, other_list):
+        # Pair up the items
+        if criterion(key_val):
+            # The key passed the filter, so take both.
+            out1.append(key_val)
+            out2.append(other_val)
+            
+    return out1, out2
+    
+def filter_n(*args):
+    """
+    Filter any number of lists of corresponding items based on some function of
+    the first list.
+    
+    """
+    
+    filter_function = args[0]
+    to_filter = args[1:]
+    
+    to_return = [list() for _ in to_filter]
+    
+    for i in range(len(to_filter[0])):
+        # For each run of entries
+        if filter_function(to_filter[0][i]):
+            # If the key passes the filter
+            for j in range(len(to_filter)):
+                # Keep the whole row
+                if i < len(to_filter[j]):
+                    to_return[j].append(to_filter[j][i])
+            
+            
+    # return all the lists as a tuple, which unpacks as multiple return values
+    return tuple(to_return)
+
+def main(args):
+    """
+    Parses command line arguments, and plots a histogram.
+    "args" specifies the program arguments, with args[0] being the executable
+    name. The return value should be used as the program's exit code.
+    """
+    
+    options = parse_args(args) # This holds the nicely-parsed options object
+    
+    if options.save is not None:
+        # Set up plot for use in headless mode if we just want to save. See
+        # <http://stackoverflow.com/a/2766194/402891>. We need to do this before
+        # we grab pyplot.
+        matplotlib.use('Agg')
+        
+    from matplotlib import pyplot
+    
+    # Make the figure with the appropriate size and DPI.
+    pyplot.figure(figsize=(options.width, options.height), dpi=options.dpi)
+    
+    # This will hold a dict of dicts from data value to weight, by category or
+    # file name. Later gets converted to a dict of lists of (value, weight)
+    # pairs, aggregated by value.
+    all_data = collections.defaultdict(lambda: collections.defaultdict(float))
+    
+    for data_filename in options.data:
+        
+        for line_number, line in enumerate(open(data_filename)):
+            # Split each line
+            parts = line.split()
+            
+            if len(parts) == 1:
+                # This is one instance of a value
+                
+                all_data[data_filename][float(parts[0])] += 1.0
+            elif len(parts) == 2:
+                if len(options.data) > 1:
+                    # This is multiple instances of a value, and we are doing
+                    # categories by filename.
+                    all_data[data_filename][float(parts[0])] += float(parts[1])
+                else:
+                    try:
+                        value = float(parts[0])
+                        # If the first column is a number, this is value, weight
+                        # data.
+                        all_data[data_filename][value] += float(parts[1])
+                    except ValueError:
+                        # This is category, instance data, since first column
+                        # isn't a number.
+                        all_data[parts[0]][float(parts[1])] += 1.0
+            elif len(parts) == 3:
+                # This is category, instance, weight data
+                all_data[parts[0]][float(parts[1])] += float(parts[2])
+            else:
+                raise Exception("Wrong number of fields on {} line {}".format(
+                    data_filename, line_number + 1))
+        
+    for category in all_data.keys():
+        # Strip NaNs and Infs and weight-0 entries, and convert to a dict of
+        # lists of tuples.
+        all_data[category] = [(value, weight) for (value, weight)
+            in all_data[category].items() if 
+            value < float("+inf") and value > float("-inf") and weight > 0]
+        
+        
+    
+    # Calculate our own bins, over all the data. First we need the largest and
+    # smallest observed values. The fors in the comprehension have to be in
+    # normal for loop order and not the other order.
+    bin_min = options.x_min if options.x_min is not None else min((pair[0]
+        for pair_list in all_data.values() for pair in pair_list))
+    bin_max = options.x_max if options.x_max is not None else max((pair[0]
+        for pair_list in all_data.values() for pair in pair_list))
+    
+    if options.log:
+        # Do our bins in log space, so they look evenly spaced on the plot.
+        bin_max = math.log10(bin_max)
+        bin_min = math.log10(bin_min)
+    
+    # Work out what step we should use between bin edges
+    bin_step = (bin_max - bin_min) / float(options.bins)
+    # Work out where the bin edges should be
+    bins = [bin_min + bin_step * i for i in range(options.bins + 1)]
+    # Work out where the bin centers should be
+    bin_centers = [left_edge + bin_step / 2.0 for left_edge in bins[:-1]]    
+    
+    if options.log:
+        # Bring bins back into data space
+        bins = [math.pow(10, x) for x in bins]
+        bin_centers = [math.pow(10, x) for x in bin_centers]
+    
+    if options.categories is not None:
+        # Order data by category order
+        ordered_data = [(category, all_data[category]) for category in
+            options.categories]
+    elif len(options.data) > 1:
+        # Order data by file order
+        ordered_data = [(filename, all_data[filename]) for filename in
+            options.data]
+    else:
+        # Order arbitrarily
+        ordered_data = list(all_data.items())
+        
+    if options.categories is not None and options.category_labels == []:
+        # Label categories with their internal names
+        category_labels = options.categories 
+    else:
+        # Label categories exactly as asked
+        category_labels = options.category_labels
+    
+    for (category, data_and_weights), label, color, line_style, marker in \
+        zip(ordered_data,
+        itertools.chain(category_labels, itertools.repeat(None)),
+        itertools.chain(options.colors, itertools.cycle(
+        ['b', 'g', 'r', 'c', 'm', 'y', 'k'])),
+        itertools.chain(options.styles, itertools.cycle(
+        ['-', '--', ':', '-.'])),
+        itertools.cycle(
+        ['o', 'v', '^', '<', '>', 's', '+', 'x', 'D', '|', '_'])):
+        # For every category and its display properties...
+        
+        if len(data_and_weights) == 0:
+            # Skip categories with no data
+            continue
+
+        # Split out the data and the weights for this category/file
+        data = [pair[0] for pair in data_and_weights]
+        weights = [pair[1] for pair in data_and_weights] 
+        
+        # For each set of data and weights that we want to plot, and the label
+        # it needs (or None)...
+            
+        # We may want to normalize by total weight
+        # We need a float here so we don't get int division later.
+        total_weight_overall = float(0)
+        
+        for value, weight in zip(data, weights):
+            # Sum up the weights overall
+            total_weight_overall += weight
+        
+        if options.normalize and total_weight_overall > 0:
+            # Normalize all the weight to 1.0 total weight.
+            weights = [w / total_weight_overall for w in weights]
+            
+        # Apply the limits after normalization
+        if options.x_min is not None:
+            data, weights = filter2(lambda x: x >= options.x_min, data, weights)
+        if options.x_max is not None:
+            data, weights = filter2(lambda x: x <= options.x_max, data, weights)
+           
+        # Work out how many samples there are left within the chart area
+        samples = intify(sum(weights))
+            
+        if options.stats:
+            # Compute and report some stats
+            data_min = numpy.min(data)
+            data_min_count = weights[numpy.argmin(data)]
+            data_max = numpy.max(data)
+            data_max_count = weights[numpy.argmax(data)]
+            # The mode is the data item with maximal count
+            data_mode = data[numpy.argmax(weights)]
+            data_mode_count = numpy.max(weights)
+            
+            # Intify floats pretending to be ints
+            data_min = intify(data_min)
+            data_min_count = intify(data_min_count)
+            data_max = intify(data_max)
+            data_max_count = intify(data_max_count)
+            data_mode = intify(data_mode)
+            data_mode_count = intify(data_mode_count)
+        
+            # TODO: median, mean
+            
+            print("Min: {} occurs {} times".format(data_min, data_min_count))
+            print("Mode: {} occurs {} times".format(data_mode, data_mode_count))
+            print("Max: {} occurs {} times".format(data_max, data_max_count))
+            
+            if options.cutoff is not None:
+                # Work out how much weight is above and below the cutoff
+                above = 0
+                below = 0
+                
+                for value, weight in zip(data, weights):
+                    if value > options.cutoff:
+                        above += weight
+                    else:
+                        below += weight
+                
+                # Report the results wrt the cutoff.
+                print("{} above {}, {} below".format(
+                    above / total_weight_overall, options.cutoff, 
+                    below / total_weight_overall))
+            
+        if options.line or options.points:
+            # Do histogram binning manually
+            
+            # Do the binning
+            bin_values, _ = numpy.histogram(data, bins=bins, weights=weights)
+            
+            if options.cumulative:
+                # Calculate cumulative weights for each data point
+                bin_values = numpy.cumsum(bin_values)
+                
+            if options.zero_ends:
+                if options.cumulative:
+                    # Pin things to 0 on the low end and max on the high
+                    all_bin_centers = [bins[0]] + list(bin_centers) + [bins[-1]]
+                    all_bin_values = [0] + list(bin_values) + [sum(weights)]
+                else:
+                    # Pin things to 0 on the end
+                    all_bin_centers = [bins[0]] + list(bin_centers) + [bins[-1]]
+                    all_bin_values = [0] + list(bin_values) + [0]
+            else:
+                all_bin_centers = bin_centers
+                all_bin_values = bin_values
+                
+            # Now we make a bunch of deries for each line, potentially. This
+            # holds pairs of (centers, values) lists.
+            series = []
+            
+            if options.fake_zero or options.split_at_zero:
+                # We need to split into multiple series, potentially.
+                # This holds the series we are working on.
+                this_series = ([], [])
+                
+                # What was the last bin we saw?
+                last_bin = 0
+                
+                for center, value in zip(all_bin_centers,
+                    all_bin_values):
+                    # For every point on the line, see if we need to break here
+                    # because it's zero.
+                    
+                    # This logic gets complicated so we do some flags.
+                    # Do we keep this point?
+                    includeSample = True
+                    # Do we split the line?
+                    breakSeries = False
+                    
+                    if options.fake_zero and value == 0:
+                        # We don't want this sample, and we need to break the
+                        # series
+                        includeSample = False
+                        breakSeries = True
+                        
+                    if options.split_at_zero and last_bin < 0 and center > 0:
+                        # We crossed the y axis, or we went down to the x axis.
+                        # We can maybe keep the sample, and we need to break the
+                        # series
+                        breakSeries = True
+                        
+                    if breakSeries and len(this_series[0]) > 0:
+                        # Finish the series and start another
+                        series.append(this_series)
+                        this_series = ([], [])
+                        
+                    if includeSample:
+                        # Stick this point in the series
+                        this_series[0].append(center)
+                        this_series[1].append(value)
+                        
+                    last_bin = center
+                        
+                if len(this_series[0]) > 0:
+                    # Finish the last series
+                    series.append(this_series)
+                
+            else:
+                # Just do one series
+                series.append((all_bin_centers, all_bin_values))
+                
+            # We only want to label the first series in the legend, so we'll
+            # none this out after we use it.
+            label_to_use = label
+                
+            for series_centers, series_values in series: 
+                # Plot every series
+                
+                if options.line and options.points:
+                    # Do the plots as lines with points
+                    pyplot.plot(series_centers, series_values,
+                        label=label_to_use, linestyle=line_style, color=color,
+                        marker=marker)
+                    label_to_use = None
+                elif options.line:
+                    # Do the plots as lines only
+                    pyplot.plot(series_centers, series_values,
+                        label=label_to_use, linestyle=line_style, color=color)
+                    label_to_use= None
+                elif options.points:
+                    # Do the plot as points.   
+                    pyplot.scatter(series_centers, series_values,
+                        label=label_to_use, color=color, marker=marker)
+                    label_to_use = None
+            
+            if options.log_counts:
+                # Log the Y axis
+                pyplot.yscale('log')
+                
+            if options.split_at_zero:
+                # Put a big vertical line.
+                pyplot.axvline(linewidth=2, color="k")
+        
+        else:
+            # Do the plot. Do cumulative, or logarithmic Y axis, optionally.
+            # Keep the bin total counts and the bar patches.
+            bin_counts, _, bar_patches = pyplot.hist(data, bins,
+                cumulative=options.cumulative, log=options.log_counts,
+                weights=weights, alpha=0.5 if len(ordered_data) > 1 else 1.0,
+                label=label)
+                
+        if options.cutoff is not None:
+            # Put a vertical line at the cutoff.
+            pyplot.axvline(x=options.cutoff, color="r")
+                
+            
+    if len(options.redPortion) > 0:
+        # Plot a red histogram over that one, modified by redPortion.
+        
+        red_data = []
+        red_weights = []
+        
+        for item, weight in zip(data, weights):
+            # For each item, what bin is it in?
+            bin_number = int(item / bin_step)
+            
+            if bin_number < len(options.redPortion):
+                # We have a potentially nonzero scaling factor. Apply that.
+                weight *= options.redPortion[bin_number]
+                
+                # Keep this item.
+                red_data.append(item)
+                red_weights.append(weight)
+        
+        # Plot the re-weighted data with the same bins, in red
+        red_counts, _, red_patches = pyplot.hist(red_data, bins,
+            cumulative=options.cumulative, log=options.log_counts,
+            weights=red_weights, color='#FF9696', hatch='/'*6)
+            
+        if options.label:
+            # Label all the red portion-based bars
+            draw_labels(red_counts, red_patches, size=options.label_size)
+            
+        
+            
+    if len(options.redWeight) > 0:
+        # Plot a red histogram over that one, modified by redPortion.
+        
+        # Grab an item in each bin
+        items = bins[0:len(options.redWeight)]
+        
+        # Plot the re-weighted data with the same bins, in red
+        red_counts, _, red_patches = pyplot.hist(items, bins,
+            cumulative=options.cumulative, log=options.log_counts,
+            weights=options.redWeight, color='#FF9696', hatch='/'*6)
+            
+        if options.label:
+            # Label all the red weight-based bars
+            draw_labels(red_counts, red_patches, size=options.label_size)
+            
+        
+        
+    # StackOverflow provides us with font sizing. See
+    # <http://stackoverflow.com/q/3899980/402891>
+    matplotlib.rcParams.update({"font.size": options.font_size})
+    if options.show_n:
+        # Add an n value to the title
+        options.title += " (n = {:,})".format(samples)
+    pyplot.title(options.title)
+    pyplot.xlabel(options.x_label)
+    pyplot.ylabel(options.y_label)
+    
+    if options.log:
+        # Set the X axis to log mode
+        pyplot.xscale('log')
+    
+    if options.x_min is not None:
+        # Set only the lower x limit
+        pyplot.xlim((options.x_min, pyplot.xlim()[1]))
+    if options.x_max is not None:
+        # Set only the upper x limit
+        pyplot.xlim((pyplot.xlim()[0], options.x_max))
+        
+    if options.y_min is not None:
+        # Set only the lower y limit
+        pyplot.ylim((options.y_min, pyplot.ylim()[1]))
+    elif options.log_counts:
+        # Make sure the default lower Y limit is 1 on log plots.
+        pyplot.ylim((1, pyplot.ylim()[1]))
+    if options.y_max is not None:
+        # Set only the upper y limit
+        pyplot.ylim((pyplot.ylim()[0], options.y_max))
+        
+    if options.sparse_ticks or options.sparse_x:
+        # Set up X tickmarks to have only 2 per axis, at the ends
+        pyplot.gca().xaxis.set_major_locator(
+            matplotlib.ticker.FixedLocator(pyplot.xlim()))
+    if options.sparse_ticks or options.sparse_y:
+        # Same for the Y axis
+        pyplot.gca().yaxis.set_major_locator(
+            matplotlib.ticker.FixedLocator(pyplot.ylim()))
+            
+    if options.ticks is not None:
+        # Use these particular X ticks instead
+         pyplot.gca().xaxis.set_major_locator(
+            matplotlib.ticker.FixedLocator(
+            [float(pos) for pos in options.ticks]))
+            
+    # Make sure tick labels don't overlap. See
+    # <http://stackoverflow.com/a/20599129/402891>
+    pyplot.gca().tick_params(axis="x", pad=0.5 * options.font_size)
+    
+    # Make our own scientific notation formatter since set_scientific is not
+    # working
+    sci_formatter = matplotlib.ticker.FormatStrFormatter("%1.2e")
+    if options.scientific_x:
+        # Force scientific notation on X axis
+        pyplot.gca().xaxis.set_major_formatter(sci_formatter)
+    if options.scientific_y:
+        # Force scientific notation on Y axis
+        pyplot.gca().yaxis.set_major_formatter(sci_formatter)
+        
+    if options.label:
+        # Label all the normal bars
+        draw_labels(bin_counts, bar_patches, size=options.label_size)
+    
+    # Make everything fit
+    pyplot.tight_layout()
+    
+    if len(category_labels) > 0 and not options.no_legend:
+        # We need a legend
+        
+        if options.legend_overlay is None:
+            # We want the default legend, off to the right of the plot.
+        
+            # First shrink the plot to make room for it.
+            # TODO: automatically actually work out how big it will be.
+            bounds = pyplot.gca().get_position()
+            pyplot.gca().set_position([bounds.x0, bounds.y0,
+                bounds.width * 0.5, bounds.height])
+                
+            # Make the legend
+            pyplot.legend(loc="center left", bbox_to_anchor=(1.05, 0.5))
+            
+        else:
+            # We want the legend on top of the plot at the user-specified
+            # location, and we want the plot to be full width.
+            pyplot.legend(loc=options.legend_overlay)
+    
+    if options.save is not None:
+        # Save the figure to a file
+        pyplot.savefig(options.save, dpi=options.dpi)
+    else:
+        # Show the figure to the user
+        pyplot.show()
+        
+    return 0
+
+if __name__ == "__main__" :
+    sys.exit(main(sys.argv))
+


### PR DESCRIPTION
I've written a "Giraffe Facts" script that can analyze the output GAMs from `vg gaffe` and produce summary statistics about where time is going.

You use it like this:

```
vg view -aj trash/clustering/mapped.gam | scripts/giraffe-facts.py trash/clustering/outdir
┌───────────────────────────────┐
│         Giraffe Facts         │
├───────────────────────────────┤
│Reads                    200000│
├─────────┬────────────────┬────┤
│  Stage  │Reads per Second│Time│
│         │  (cumulative)  │(%) │
├─────────┼────────────────┼────┤
│minimizer│        26871.79│  1%│
│   seed  │         2026.63│  8%│
│ cluster │          532.04│ 24%│
│  extend │          378.46│ 13%│
│  align  │          176.96│ 53%│
│  winner │          176.28│  0%│
├─────────┼────────────────┼────┤
│ Overall │          175.20│100%│
└─────────┴────────────────┴────┘
```

In the specified output directory, it also makes plots of runtime expended up to each stage, per read.

![image](https://user-images.githubusercontent.com/5062495/56250504-7eb07380-6064-11e9-9b53-38e9f7f960b1.png)

I'm somewhat hackily shipping a python 3-ified version of my `histogram.py` script to enable this.