### PR TITLE
specify the cairo directory when including

### DIFF
--- a/src/viz.hpp
+++ b/src/viz.hpp
@@ -2,8 +2,8 @@
 #define VG_VIZ_HPP_INCLUDED
 
 #include <vector>
-#include <cairo.h>
-#include <cairo-svg.h>
+#include <cairo/cairo.h>
+#include <cairo/cairo-svg.h>
 #include <iostream>
 #include <chrono>
 #include <ctime>


### PR DESCRIPTION
On some systems, it seems that we need to specify that cairo is within /usr/include/cairo.

Here I do that by writing `#include <cairo/cairo.h>`.

It's not clear to me why this is needed, or if we should make this change. It does fix my build problems though. If testing is fine then we might as well set it up like this to avoid future problems.