### PR TITLE
Minimizer index node size limit

### DIFF
--- a/src/minimizer.hpp
+++ b/src/minimizer.hpp
@@ -130,8 +130,10 @@ public:
     }
 
     /// Inserts the minimizer encoded in the key at the given position into the index.
-    /// Minimizers with key NO_KEY or a position encoded as NO_VALUE are not inserted.
-    /// Use minimizer() or minimizers() to get the key.
+    /// Minimizers with key NO_KEY or a position encoded as NO_VALUE (node id 0) are
+    /// not inserted. The offset will be truncated to fit in REV_OFFSET bits.
+    /// Use minimizer() or minimizers() to get the key and valid_offset() to check if
+    /// the offset fits in the available space.
     void insert(key_type key, pos_t pos);
 
     /// Returns the sorted set of occurrences of the kmer encoded in the key.
@@ -201,6 +203,11 @@ public:
     constexpr static size_t    REV_OFFSET = 10;
     constexpr static code_type REV_MASK   = 0x400;
     constexpr static code_type OFF_MASK   = 0x3FF;
+
+    /// Is the offset small enough to fit in the low-order bits of the encoding?
+    static bool valid_offset(pos_t pos) {
+        return (std::get<2>(pos) <= OFF_MASK);
+    }
 
     /// Encode pos_t as code_type.
     static code_type encode(pos_t pos) {

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -258,6 +258,13 @@ int main_minimizer(int argc, char** argv) {
                 node_length = graph.get_length(*iter);
             }
             pos_t pos { graph.get_id(*iter), graph.get_is_reverse(*iter), minimizer.second - node_start };
+            if (!MinimizerIndex::valid_offset(pos)) {
+                #pragma omp critical (cerr)
+                {
+                    std::cerr << "error: [vg minimizer] node offset " << offset(pos) << " is too large" << std::endl;
+                }
+                std::exit(EXIT_FAILURE);
+            }
             cache[thread_id].emplace_back(minimizer.first, pos);
         }
         if (cache[thread_id].size() >= MINIMIZER_CACHE_SIZE) {


### PR DESCRIPTION
The minimizer index has the same 1024 bp node size limit as GCSA2. After this PR, `vg minimizer` will abort index construction when node offsets are too large.