### PR TITLE
Transition to new interface for path handles

### DIFF
--- a/src/algorithms/apply_bulk_modifications.cpp
+++ b/src/algorithms/apply_bulk_modifications.cpp
@@ -19,28 +19,5 @@ using namespace std;
         }
         return flipped;
     }
-    
-    void apply_ordering(MutableHandleGraph* graph, const vector<handle_t>& ordering) {
-        
-        if (graph->node_size() != ordering.size()) {
-            cerr << "error:[algorithms] attempting to sort a graph with an incomplete ordering" << endl;
-            exit(1);
-        }
-        
-        // TODO: we don't check that all nodes are present only once, which might be nice to do
-        
-        size_t index = 0;
-        graph->for_each_handle([&](const handle_t& at_index) {
-            // For each handle in the graph, along with its index
-            
-            // Swap the handle we observe at this index with the handle that we know belongs at this index.
-            // The loop invariant is that all the handles before index are the correct sorted handles in the right order.
-            // Note that this ignores orientation
-            graph->swap_handles(at_index, ordering.at(index));
-            
-            // Now we've written the sorted handles through one more space.
-            index++;
-        });
-    }
 }
 }

--- a/src/algorithms/apply_bulk_modifications.hpp
+++ b/src/algorithms/apply_bulk_modifications.hpp
@@ -22,10 +22,6 @@ using namespace std;
     /// Returns a set of IDs for nodes that were flipped. Invalid if vector contains multiple handles to
     /// the same node. May change the ordering of the underlying graph.
     unordered_set<id_t> apply_orientations(MutableHandleGraph* graph, const vector<handle_t>& orientations);
-    
-    /// Modifies underlying graph so that nodes occur in the same order as in the provided vector. Vector
-    /// must contain exactly one handle for each node.
-    void apply_ordering(MutableHandleGraph* graph, const vector<handle_t>& ordering);
 
 }
 }

--- a/src/algorithms/are_equivalent.cpp
+++ b/src/algorithms/are_equivalent.cpp
@@ -107,43 +107,43 @@ namespace algorithms {
             
             path_handle_t path_handle_2 = graph_2->get_path_handle(graph_1->get_path_name(path_handle_1));
             
-            if (graph_1->get_occurrence_count(path_handle_1) != graph_2->get_occurrence_count(path_handle_2)) {
+            if (graph_1->get_is_circular(path_handle_1) != graph_2->get_is_circular(path_handle_2)) {
+                if (verbose) {
+                    cerr << "path " << graph_1->get_path_name(path_handle_1) << " does not have the same circularity in the two graphs: " << graph_1->get_is_circular(path_handle_1) << " and " << graph_2->get_is_circular(path_handle_2) << endl;
+                }
                 equivalent = false;
                 return false;
             }
             
-            // TODO: if paths are circular, we shouldn't enforce that the start at the same place
-            if (!graph_1->is_empty(path_handle_1)) {
+            if (graph_1->get_step_count(path_handle_1) != graph_2->get_step_count(path_handle_2)) {
+                if (verbose) {
+                    cerr << "path " << graph_1->get_path_name(path_handle_1) << " is not the same length in the two graphs: " << graph_1->get_step_count(path_handle_1) << " and " << graph_2->get_step_count(path_handle_2) << endl;
+                }
+                equivalent = false;
+                return false;
+            }
+            
+            vector<handle_t> handles_1, handles_2;
+            for (handle_t handle : graph_1->scan_path(path_handle_1)) {
+                handles_1.push_back(handle);
+            }
+            for (handle_t handle : graph_2->scan_path(path_handle_2)) {
+                handles_2.push_back(handle);
+            }
+            
+            assert(handles_1.size() == handles_2.size());
+            
+            for (size_t i = 0; i < handles_1.size(); i++) {
+                handle_t handle_1 = handles_1[i];
+                handle_t handle_2 = handles_2[i];
                 
-                auto check_equiv = [&](const occurrence_handle_t& occ_1,
-                                       const occurrence_handle_t& occ_2) {
-                    handle_t handle_1 = graph_1->get_occurrence(occ_1);
-                    handle_t handle_2 = graph_2->get_occurrence(occ_2);
-                    bool match = (graph_1->get_id(handle_1) == graph_2->get_id(handle_2) &&
-                                  graph_1->get_is_reverse(handle_1) == graph_2->get_is_reverse(handle_2));
-                    if (verbose && !match) {
+                if (graph_1->get_id(handle_1) != graph_2->get_id(handle_2) ||
+                    graph_1->get_is_reverse(handle_1) != graph_2->get_is_reverse(handle_2)) {
+                    if (verbose) {
                         cerr << "path " << graph_1->get_path_name(path_handle_1) << " has mismatching occurrences " << graph_1->get_id(handle_1) << (graph_1->get_is_reverse(handle_1) ? "-" : "+") << " and " << graph_2->get_id(handle_2) << (graph_2->get_is_reverse(handle_2) ? "-" : "+") << endl;
                     }
-                    
-                    return match;
-                };
-                
-                occurrence_handle_t occ_1 = graph_1->get_first_occurrence(path_handle_1);
-                occurrence_handle_t occ_2 = graph_2->get_first_occurrence(path_handle_2);
-                
-                if (!check_equiv(occ_1, occ_2)) {
                     equivalent = false;
                     return false;
-                }
-                
-                while (graph_1->has_next_occurrence(occ_1)) {
-                    occ_1 = graph_1->get_next_occurrence(occ_1);
-                    occ_2 = graph_1->get_next_occurrence(occ_2);
-                    
-                    if (!check_equiv(occ_1, occ_2)) {
-                        equivalent = false;
-                        return false;
-                    }
                 }
             }
             

--- a/src/algorithms/id_sort.cpp
+++ b/src/algorithms/id_sort.cpp
@@ -10,7 +10,7 @@ namespace algorithms {
 
 using namespace std;
 
-vector<handle_t> id_order(HandleGraph* g) {
+vector<handle_t> id_order(const HandleGraph* g) {
     // We will fill and sort this
     vector<handle_t> to_return;
     g->for_each_handle([&](const handle_t& handle) {
@@ -24,16 +24,6 @@ vector<handle_t> id_order(HandleGraph* g) {
     });
     
     return to_return;
-}
-
-void id_sort(MutableHandleGraph* g) {
-    if (g->node_size() <= 1) {
-        // A graph with <2 nodes has only one sort.
-        return;
-    }
-    
-    // Order handles by ID and then apply the order to the graph
-    apply_ordering(g, id_order(g));
 }
     
 }

--- a/src/algorithms/id_sort.hpp
+++ b/src/algorithms/id_sort.hpp
@@ -22,12 +22,6 @@ using namespace std;
  * Order all the handles in the graph in ID order. All orientations are forward.
  */
 vector<handle_t> id_order(const HandleGraph* g);
-
-/**
- * Sort the given handle graph by ID, and then apply that sort to re-order the
- * nodes of the graph.
- */
-void id_sort(MutableHandleGraph* g);
                                                       
 }
 }

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -345,25 +345,6 @@ vector<handle_t> lazy_topological_order(const HandleGraph* g) {
 vector<handle_t> lazier_topological_order(const HandleGraph* g) {
     return lazy_topological_order_internal(g, true);
 }
-void topological_sort(MutableHandleGraph* g) {
-    if (g->node_size() <= 1) {
-        // A graph with <2 nodes has only one sort.
-        return;
-    }
-    
-    // No need to modify the graph; topological_sort is guaranteed to be stable.
-    
-    // Topologically sort, which orders and orients all the nodes, and apply the order to the backing graph
-    apply_ordering(g, topological_order(g));
-}
-    
-void lazy_topological_sort(MutableHandleGraph* g) {
-    apply_ordering(g, lazy_topological_order(g));
-}
-
-void lazier_topological_sort(MutableHandleGraph* g) {
-    apply_ordering(g, lazier_topological_order(g));
-}
     
 unordered_set<id_t> orient_nodes_forward(MutableHandleGraph* g) {
     // Topologically sort, which orders and orients all the nodes, and apply the orientations to the backing graph.

--- a/src/algorithms/topological_sort.hpp
+++ b/src/algorithms/topological_sort.hpp
@@ -76,34 +76,7 @@ vector<handle_t> lazy_topological_order(const HandleGraph* g);
  * and algorithms::is_single_stranded().
  */
 vector<handle_t> lazier_topological_order(const HandleGraph* g);
-    
-/**
- * Topologically sort the given handle graph, and then apply that sort to re-
- * order the nodes of the graph. The sort is guaranteed to be stable. This sort is well-defined
- * on graphs that are not DAGs, but instead of finding a topological sort ti does a heuristic
- * sort to minimize a feedback arc set.
- */
-void topological_sort(MutableHandleGraph* g);
-    
-/**
- * Topologically sort the given handle graph, and then apply that sort to re-
- * order the nodes of the graph. The sort is NOT guaranteed to be stable or
- * machine-independent, but it is faster than sort(). This algorithm is invalid 
- * in a graph that has any cycles. For safety, consider checking this property with
- * algorithms::is_acyclic().
- */
-void lazy_topological_sort(MutableHandleGraph* g);
 
-/**
- * Topologically sort the given handle graph, and then apply that sort to re-
- * order the nodes of the graph. The sort is NOT guaranteed to be stable or
- * machine-independent, but it is faster than sort() and somewhat faster than
- * lazy_sort(). This algorithm is invalid in a graph that has any cycles or reversing
- * edges. For safety, consider checking these properties with algorithms::is_single_stranded()
- * and algorithms::is_acyclic().
- */
-void lazier_topological_sort(MutableHandleGraph* g);
-    
 /**
  * Topologically sort the given handle graph, and then apply that sort to orient
  * all the nodes in the global forward direction. May invalidate any paths

--- a/src/convert_handle.cpp
+++ b/src/convert_handle.cpp
@@ -34,7 +34,7 @@ using namespace std;
         });
     }
 
-    void convert_path_handle_graph(const PathHandleGraph* converting, MutablePathDeletableHandleGraph* converted) {
+    void convert_path_handle_graph(const PathHandleGraph* converting, MutablePathMutableHandleGraph* converted) {
         assert(converted->get_path_count() == 0);
         
         // Must convert nodes and edges before converting paths.
@@ -45,18 +45,16 @@ using namespace std;
             // create path
             string path_name = converting->get_path_name(path);
             path_handle_t converted_path = converted->create_path_handle(path_name);
-            // find first occurence in path
-            occurrence_handle_t converting_occurence = converting->get_first_occurrence(path);
-            handle_t converting_handle = converting->get_occurrence(converting_occurence);
-            handle_t converted_handle = converted->get_handle(converting->get_id(converting_handle), converting->get_is_reverse(converting_handle));
-            occurrence_handle_t converted_occurance_handle = converted->append_occurrence(converted_path, converted_handle);
-            // iterate through path and add each handle to converted graph
-            while (converting->has_next_occurrence(converting_occurence)){
-                converting_occurence = converting->get_next_occurrence(converting_occurence);
-                converting_handle = converting->get_occurrence(converting_occurence);
-                converted_handle = converted->get_handle(converting->get_id(converting_handle), converting->get_is_reverse(converting_handle));
-                occurrence_handle_t converted_occurance_handle = converted->append_occurrence(converted_path, converted_handle);
+            
+            // convert steps of path
+            for (handle_t converting_handle : converting->scan_path(path)) {
+                handle_t converted_handle = converted->get_handle(converting->get_id(converting_handle),
+                                                                  converting->get_is_reverse(converting_handle));
+                converted->append_step(converted_path, converted_handle);
             }
+            
+            // set circularity to match
+            converted->set_circularity(converted_path, converting->get_is_circular(path));
         });
     }
 }

--- a/src/convert_handle.hpp
+++ b/src/convert_handle.hpp
@@ -14,7 +14,7 @@ namespace vg {
     void convert_handle_graph(const HandleGraph* converting, MutableHandleGraph* converted);
     
     // Change paths to a mutable path.
-    void convert_path_handle_graph(const PathHandleGraph* converting, MutablePathDeletableHandleGraph* converted);
+    void convert_path_handle_graph(const PathHandleGraph* converting, MutablePathMutableHandleGraph* converted);
 
 }
 

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -25,7 +25,7 @@ using namespace std;
 // Import all the handle stuff into the vg namespace for transition purposes.
 using handle_t = handlegraph::handle_t;
 using path_handle_t = handlegraph::path_handle_t;
-using occurrence_handle_t = handlegraph::occurrence_handle_t;
+using step_handle_t = handlegraph::step_handle_t;
 using edge_t = handlegraph::edge_t;
 
 using HandleGraph = handlegraph::HandleGraph;

--- a/src/hash_graph.cpp
+++ b/src/hash_graph.cpp
@@ -389,7 +389,8 @@ namespace vg {
     step_handle_t HashGraph::get_previous_step(const step_handle_t& step_handle) const {
         step_handle_t prev;
         as_integers(prev)[0] = as_integers(step_handle)[0];
-        as_integers(prev)[1] = intptr_t(((path_mapping_t*) intptr_t(as_integers(step_handle)[1]))->prev);
+        as_integers(prev)[1] = as_integers(step_handle)[1] != intptr_t(nullptr) ? intptr_t(((path_mapping_t*) intptr_t(as_integers(step_handle)[1]))->prev)
+                                                                                : intptr_t(paths.at(as_integers(step_handle)[0]).tail);
         return prev;
     }
     

--- a/src/hash_graph.hpp
+++ b/src/hash_graph.hpp
@@ -100,17 +100,6 @@ public:
     /// Remove all nodes and edges. Does not update any stored paths.
     virtual void clear(void);
     
-    /// TODO: swap_handles is actually not yet supported
-    
-    /// Swap the nodes corresponding to the given handles, in the ordering used
-    /// by for_each_handle when looping over the graph. Other handles to the
-    /// nodes being swapped must not be invalidated. If a swap is made while
-    /// for_each_handle is running, it affects the order of the handles
-    /// traversed during the current traversal (so swapping an already seen
-    /// handle to a later handle's position will make the seen handle be visited
-    /// again and the later handle not be visited at all).
-    virtual void swap_handles(const handle_t& a, const handle_t& b);
-    
     /// Alter the node that the given handle corresponds to so the orientation
     /// indicated by the handle becomes the node's local forward orientation.
     /// Rewrites all edges pointing to the node and the node's sequence to
@@ -133,6 +122,9 @@ public:
     ////////////////////////////////////////////////////////////////////////////
     // Path handle interface
     ////////////////////////////////////////////////////////////////////////////
+    
+    /// Returns the number of paths stored in the graph
+    virtual size_t get_path_count() const;
 
     /// Determine if a path name exists and is legal to get a path handle for.
     virtual bool has_path(const std::string& path_name) const;
@@ -143,48 +135,54 @@ public:
 
     /// Look up the name of a path from a handle to it
     virtual string get_path_name(const path_handle_t& path_handle) const;
+    
+    /// Look up whether a path is circular
+    virtual bool get_is_circular(const path_handle_t& path_handle) const;
 
-    /// Returns the number of node occurrences in the path
-    virtual size_t get_occurrence_count(const path_handle_t& path_handle) const;
+    /// Returns the number of node steps in the path
+    virtual size_t get_step_count(const path_handle_t& path_handle) const;
 
-    /// Returns the number of paths stored in the graph
-    virtual size_t get_path_count() const;
+    /// Get a node handle (node ID and orientation) from a handle to a step on a path
+    virtual handle_t get_handle_of_step(const step_handle_t& step_handle) const;
 
+    /// Returns a handle to the path that a step is on
+    virtual path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
+    
+    /// Get a handle to the first step, or in a circular path to an arbitrary step
+    /// considered "first". If the path is empty, returns the past-the-last step
+    /// returned by path_end.
+    virtual step_handle_t path_begin(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to a fictitious position past the end of a path. This position is
+    /// return by get_next_step for the final step in a path in a non-circular path.
+    /// Note that get_next_step will *NEVER* return this value for a circular path.
+    virtual step_handle_t path_end(const path_handle_t& path_handle) const;
+    
+    /// Returns a handle to the next step on the path. If the given step is the final step
+    /// of a non-circular path, returns the past-the-last step that is also returned by
+    /// path_end. In a circular path, the "last" step will loop around to the "first" (i.e.
+    /// the one returned by path_begin).
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    virtual step_handle_t get_next_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the previous step on the path. If the given step is the first
+    /// step of a non-circular path, this method has undefined behavior. In a circular path,
+    /// it will loop around from the "first" step (i.e. the one returned by path_begin) to
+    /// the "last" step.
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    virtual step_handle_t get_previous_step(const step_handle_t& step_handle) const;
+    
     /// Execute a function on each path in the graph
     virtual bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
-
-    /// Get a node handle (node ID and orientation) from a handle to an occurrence on a path
-    virtual handle_t get_occurrence(const occurrence_handle_t& occurrence_handle) const;
-
-    /// Get a handle to the first occurrence in a path.
-    /// The path MUST be nonempty.
-    virtual occurrence_handle_t get_first_occurrence(const path_handle_t& path_handle) const;
-
-    /// Get a handle to the last occurrence in a path
-    /// The path MUST be nonempty.
-    virtual occurrence_handle_t get_last_occurrence(const path_handle_t& path_handle) const;
-
-    /// Returns true if the occurrence is not the last occurence on the path, else false
-    virtual bool has_next_occurrence(const occurrence_handle_t& occurrence_handle) const;
-
-    /// Returns true if the occurrence is not the first occurence on the path, else false
-    virtual bool has_previous_occurrence(const occurrence_handle_t& occurrence_handle) const;
-
-    /// Returns a handle to the next occurrence on the path
-    virtual occurrence_handle_t get_next_occurrence(const occurrence_handle_t& occurrence_handle) const;
-
-    /// Returns a handle to the previous occurrence on the path
-    virtual occurrence_handle_t get_previous_occurrence(const occurrence_handle_t& occurrence_handle) const;
-
-    /// Returns a handle to the path that an occurrence is on
-    virtual path_handle_t get_path_handle_of_occurrence(const occurrence_handle_t& occurrence_handle) const;
     
-    /// Calls a function with all occurrences of a node on paths.
-    virtual bool for_each_occurrence_on_handle_impl(const handle_t& handle,
-                                                    const function<bool(const occurrence_handle_t&)>& iteratee) const;
+    /// Calls a function with all steps of a node on paths.
+    virtual bool for_each_step_on_handle_impl(const handle_t& handle,
+                                              const function<bool(const step_handle_t&)>& iteratee) const;
     
     /**
-     * Destroy the given path. Invalidates handles to the path and its node occurrences.
+     * Destroy the given path. Invalidates handles to the path and its node steps.
      */
     virtual void destroy_path(const path_handle_t& path);
 
@@ -194,15 +192,25 @@ public:
      * Returns a handle to the created empty path. Handles to other paths must
      * remain valid.
      */
-    virtual path_handle_t create_path_handle(const string& name);
+    virtual path_handle_t create_path_handle(const string& name, bool is_circular = false);
 
     /**
      * Append a visit to a node to the given path. Returns a handle to the new
-     * final occurrence on the path which is appended. Handles to prior
-     * occurrences on the path, and to other paths, must remain valid.
+     * final step on the path which is appended. If the path is cirular, the new
+     * step is placed between the steps considered "last" and "first" by the
+     * method path_begin. Handles to prior steps on the path, and to other paths,
+     * must remain valid.
      */
-    virtual occurrence_handle_t append_occurrence(const path_handle_t& path, const handle_t& to_append);
+    virtual step_handle_t append_step(const path_handle_t& path, const handle_t& to_append);
 
+    
+    /**
+     * Make a path circular or non-circular. If the path is becoming circular, the
+     * last step is joined to the first step. If the path is becoming linear, the
+     * step considered "last" is unjoined from the step considered "first" according
+     * to the method path_begin.
+     */
+    virtual void set_circularity(const path_handle_t& path, bool circular);
     
     ////////////////////////////////////////////////////////////////////////////
     // Non-handle methods
@@ -248,7 +256,7 @@ private:
     public:
         
         path_t();
-        path_t(const string& name, const int64_t& path_id);
+        path_t(const string& name, const int64_t& path_id, bool is_circular = false);
         
         /// Move constructor
         path_t(path_t&& other);
@@ -286,6 +294,7 @@ private:
         size_t count = 0;
         int64_t path_id = 0;
         string name;
+        bool is_circular = false;
     };
     
     /// The maximum ID in the graph

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -3960,8 +3960,8 @@ vector<Alignment> Mapper::align_banded(const Alignment& read, int kmer_size, int
         } else if (!aln1.has_path() && aln2.has_path()) {
             return 0.0;
         }
-        auto aln1_end = make_pos_t(path_end(aln1.path()));
-        auto aln2_begin = make_pos_t(path_start(aln2.path()));
+        auto aln1_end = make_pos_t(path_end_position(aln1.path()));
+        auto aln2_begin = make_pos_t(path_start_position(aln2.path()));
         pair<int64_t, int64_t> distances = min_oriented_distances(pos1, pos2);
         // consider both the forward and inversion case
         // counter[3]++; bench_t b; bench_init(b); bench_start(b);

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -978,8 +978,9 @@ namespace vg {
     step_handle_t PackedGraph::get_previous_step(const step_handle_t& step_handle) const {
         step_handle_t prev;
         as_integers(prev)[0] = as_integers(step_handle)[0];
-        as_integers(prev)[1] = get_step_prev(paths.at(as_integers(step_handle)[0]),
-                                             as_integers(step_handle)[1]);
+        as_integers(prev)[1] = as_integers(step_handle)[1] != 0 ? get_step_prev(paths.at(as_integers(step_handle)[0]),
+                                                                                as_integers(step_handle)[1])
+                                                                : paths.at(as_integers(step_handle)[0]).tail;
         return prev;
     }
     

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -2077,7 +2077,7 @@ bool maps_to_node(const Path& p, id_t id) {
 }
 
 // returns the start position, or an empty position if the path has no mappings with positions
-Position path_start(const Path& path) {
+Position path_start_position(const Path& path) {
     for (size_t i = 0; i < path.mapping_size(); ++i) {
         auto& mapping = path.mapping(i);
         if (mapping.has_position()) return mapping.position();
@@ -2099,7 +2099,7 @@ string path_to_string(Path p){
 }
 
 // determine the path end
-Position path_end(const Path& path) {
+Position path_end_position(const Path& path) {
     Position pos;
     if (!path.mapping_size()) return pos;
     auto& last = path.mapping(path.mapping_size()-1);

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -312,8 +312,8 @@ pair<Path, Path> cut_path(const Path& path, const Position& pos);
 pair<Path, Path> cut_path(const Path& path, size_t offset);
 bool maps_to_node(const Path& p, id_t id);
 // the position that starts just after the path ends
-Position path_start(const Path& path);
-Position path_end(const Path& path);
+Position path_start_position(const Path& path);
+Position path_end_position(const Path& path);
 bool adjacent_mappings(const Mapping& m1, const Mapping& m2);
 // Return true if a mapping is a perfect match (i.e. contains no non-match edits)
 bool mapping_is_match(const Mapping& m);

--- a/src/rare_variant_simplifier.cpp
+++ b/src/rare_variant_simplifier.cpp
@@ -24,11 +24,11 @@ void RareVariantSimplifier::simplify() {
         if (!is_alt_path(graph.get_path_name(path))) {
             // If it isn't an alt path, we want to trace it
 
-            graph.for_each_occurrence_in_path(path, [&](const occurrence_handle_t& occurrence) {
-                // For each occurrence from start to end
-                // Put the ID of the node we are visiting in the to-keep set
-                to_keep.insert(graph.get_id(graph.get_occurrence(occurrence)));
-            });
+            // For each occurrence from start to end
+            // Put the ID of the node we are visiting in the to-keep set
+            for (handle_t handle : graph.scan_path(path)) {
+                to_keep.insert(graph.get_id(handle));
+            }
         }
     });
 
@@ -147,14 +147,12 @@ void RareVariantSimplifier::simplify() {
                     // Skip those that do not exist
                     continue;
                 }
-                
-                path_handle_t path = graph.get_path_handle(path_name);
 
-                graph.for_each_occurrence_in_path(path, [&](const occurrence_handle_t& occurrence) {
-                    // For each occurrence from start to end
-                    // Put the ID of the node we are visiting in the to-keep set
-                    to_keep.insert(graph.get_id(graph.get_occurrence(occurrence)));
-                });
+                // For each occurrence from start to end
+                // Put the ID of the node we are visiting in the to-keep set
+                for (handle_t handle : graph.scan_path(graph.get_path_handle(path_name))) {
+                    to_keep.insert(graph.get_id(handle));
+                }
             }
         } else {
             // Otherwise delete all its alt paths and also its ref path

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -15,7 +15,7 @@ namespace vg {
 CactusSnarlFinder::CactusSnarlFinder(VG& graph) :
     graph(graph) {
     // Make sure the graph is sorted.
-    algorithms::topological_sort(&graph);
+    graph.sort();
 }
 
 CactusSnarlFinder::CactusSnarlFinder(VG& graph, const string& hint_path) :

--- a/src/subcommand/benchmark_main.cpp
+++ b/src/subcommand/benchmark_main.cpp
@@ -131,10 +131,10 @@ int main_benchmark(int argc, char** argv) {
             assert(order.size() == vg.node_size());
         }));
         
-        results.push_back(run_benchmark("vg::algorithms topological_sort", 1000, [&]() {
+        results.push_back(run_benchmark("VG::sort", 1000, [&]() {
             vg_mut = vg;
         }, [&]() {
-            algorithms::topological_sort(&vg_mut);
+            vg_mut.sort();
         }));
         
         results.push_back(run_benchmark("vg::algorithms orient_nodes_forward", 1000, [&]() {

--- a/src/subcommand/ids_main.cpp
+++ b/src/subcommand/ids_main.cpp
@@ -117,7 +117,7 @@ int main_ids(int argc, char** argv) {
 
         if (sort) {
             // Set up the nodes so we go through them in topological order
-            algorithms::topological_sort(graph);
+            graph->sort();
         }
 
         if (compact || sort) {

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -793,7 +793,7 @@ int main_mod(int argc, char** argv) {
 
     // and optionally compact ids
     if (compact_ids) {
-        algorithms::topological_sort(graph);
+        graph->sort();
         graph->compact_ids();
     }
 
@@ -844,7 +844,7 @@ int main_mod(int argc, char** argv) {
 
     if (cactus) {
         // ensure we're sorted
-        algorithms::topological_sort(graph);
+        graph->sort();
         *graph = cactusify(*graph);
         // no paths survive, make sure they are erased
         graph->paths = Paths();

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -499,7 +499,7 @@ int main_msga(int argc, char** argv) {
         auto build_graph = [&graph,&node_max](const string& seq, const string& name) {
             graph->create_node(seq);
             graph->dice_nodes(node_max);
-            algorithms::topological_sort(graph);
+            graph->sort();
             graph->compact_ids();
             // the graph will have a single embedded path in it
             Path& path = *graph->graph.add_path();
@@ -550,7 +550,7 @@ int main_msga(int argc, char** argv) {
         lcpidx = nullptr;
     
         //stringstream s; s << iter++ << ".vg";
-        algorithms::topological_sort(graph);
+        graph->sort();
         graph->sync_paths();
         graph->graph.clear_path();
         graph->paths.to_graph(graph->graph);
@@ -744,7 +744,7 @@ int main_msga(int argc, char** argv) {
             //if (!graph->is_valid()) cerr << "invalid after dice" << endl;
             //graph->serialize_to_file(name + "-post-dice.vg");
             if (debug) cerr << name << ": sorting and compacting ids" << endl;
-            algorithms::topological_sort(graph);
+            graph->sort();
             //if (!graph->is_valid()) cerr << "invalid after sort" << endl;
             graph->compact_ids(); // xg can't work unless IDs are compacted.
             //if (!graph->is_valid()) cerr << "invalid after compact" << endl;
@@ -828,7 +828,7 @@ int main_msga(int argc, char** argv) {
         }
         graph->normalize();
         graph->dice_nodes(node_max);
-        algorithms::topological_sort(graph);
+        graph->sort();
         graph->compact_ids();
         if (!graph->is_valid()) {
             cerr << "[vg msga] warning! graph is not valid after normalization" << endl;

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -160,10 +160,10 @@ int main_sort(int argc, char *argv[]) {
             }
         } else if (algorithm == "id") {
             // Sort by ID
-            algorithms::id_sort(graph.get());
+            graph.get()->id_sort();
         } else if (algorithm == "topo") {
             // Sort topologically
-            algorithms::topological_sort(graph.get());
+            graph.get()->sort();
         } else {
             throw runtime_error("Unimplemented sort algorithm: " + algorithm);
         }

--- a/src/subcommand/xg_main.cpp
+++ b/src/subcommand/xg_main.cpp
@@ -283,22 +283,7 @@ int main_xg(int argc, char** argv) {
         
         VG converted;
         // Convert the xg graph to vg format
-        convert_handle_graph(graph.get(), &converted);
-        
-        // TODO: The converter doesn't copy circular paths yet.
-        // When it does, we can remove all this path copying code.
-
-        // Make a raw Proto Graph to hold Path objects
-        Graph path_graph;
-
-        // Since paths are not copied, copy the paths.
-        for (size_t rank = 1; rank <= graph->max_path_rank(); rank++) {
-            // Extract each path into the path graph
-            *path_graph.add_path() = graph->path(graph->path_name(rank));
-        }
-
-        // Merge in all the paths
-        converted.extend(path_graph);
+        convert_path_handle_graph(graph.get(), &converted);
         
         if (vg_out == "-") {
             converted.serialize_to_ostream(std::cout);

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -119,8 +119,6 @@ using namespace std;
             VG split_path_graph;
             unordered_map<id_t, pair<id_t, bool>> split_trans = algorithms::split_strands(&path_graph, &split_path_graph);
             
-            algorithms::lazier_topological_sort(&split_path_graph);
-            
             auto node_trans = split_path_graph.overlay_node_translations(split_trans, path_trans);
             
 #ifdef debug_anchored_surject

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -2462,10 +2462,10 @@ void VCFTraversalFinder::create_variant_index(vcflib::VariantCallFile& vcf, Fast
             string alt_path_name = "_alt_" + make_variant_id(var) + "_" + to_string(allele);
             if (graph.has_path(alt_path_name)) {
                 path_handle_t path_handle = graph.get_path_handle(alt_path_name);
-                if (graph.get_occurrence_count(path_handle) > 0) {
+                if (!graph.is_empty(path_handle)) {
                     path_found = true;
-                    occurrence_handle_t occurrence_handle = graph.get_first_occurrence(path_handle);
-                    handle_t handle = graph.get_occurrence(occurrence_handle);
+                    step_handle_t step_handle = graph.path_begin(path_handle);
+                    handle_t handle = graph.get_handle_of_step(step_handle);
                     id_t node_id = graph.get_id(handle);
                     // copy our variant just this once, and add its new pointer to our map
                     if (node_to_variant.count(node_id)) {

--- a/src/unittest/convert_handle.cpp
+++ b/src/unittest/convert_handle.cpp
@@ -394,10 +394,10 @@ namespace vg {
             vg.for_each_path_handle([&](const path_handle_t& path) {
                 string path_name = vg.get_path_name(path);
                 if (path_name == "path1"){
-                    REQUIRE(vg.get_occurrence_count(path) == 3);
+                    REQUIRE(vg.get_step_count(path) == 3);
                 }
                 if (path_name == "path2"){
-                    REQUIRE(vg.get_occurrence_count(path) == 4);
+                    REQUIRE(vg.get_step_count(path) == 4);
                 }
             });
         }
@@ -470,10 +470,10 @@ namespace vg {
             pg.for_each_path_handle([&](const path_handle_t& path) {
                 string path_name = pg.get_path_name(path);
                 if (path_name == "path1"){
-                    REQUIRE(pg.get_occurrence_count(path) == 3);
+                    REQUIRE(pg.get_step_count(path) == 3);
                 }
                 if (path_name == "path2"){
-                    REQUIRE(pg.get_occurrence_count(path) == 4);
+                    REQUIRE(pg.get_step_count(path) == 4);
                 }
             });
         }
@@ -546,10 +546,10 @@ namespace vg {
             hg.for_each_path_handle([&](const path_handle_t& path) {
                 string path_name = hg.get_path_name(path);
                 if (path_name == "path1"){
-                    REQUIRE(hg.get_occurrence_count(path) == 3);
+                    REQUIRE(hg.get_step_count(path) == 3);
                 }
                 if (path_name == "path2"){
-                    REQUIRE(hg.get_occurrence_count(path) == 4);
+                    REQUIRE(hg.get_step_count(path) == 4);
                 }
             });
         }

--- a/src/unittest/hash_graph.cpp
+++ b/src/unittest/hash_graph.cpp
@@ -43,7 +43,6 @@ using namespace std;
             graph.serialize(strm);
             strm.seekg(0);
             HashGraph loaded(strm);
-            
             REQUIRE(algorithms::are_equivalent_with_paths(&graph, &loaded));
         }
     }

--- a/src/unittest/indexed_vg.cpp
+++ b/src/unittest/indexed_vg.cpp
@@ -95,7 +95,7 @@ TEST_CASE("IndexedVG works on random graphs", "[handle][indexed-vg]") {
         random_graph(300, 3, 30, &random);
         
         // Sort each by ID
-        algorithms::id_sort(&random);
+        random.id_sort();
         
         string filename = temp_file::create();
         random.serialize_to_file(filename, 10);

--- a/src/unittest/packed_graph.cpp
+++ b/src/unittest/packed_graph.cpp
@@ -23,43 +23,34 @@ using namespace std;
         
         PackedGraph graph;
         
-        auto check_path = [&](const path_handle_t& p, const vector<handle_t>& occs) {
+        auto check_path = [&](const path_handle_t& p, const vector<handle_t>& steps) {
             
-            occurrence_handle_t occ;
-            for (int i = 0; i < occs.size(); i++){
-                if (i == 0) {
-                    occ = graph.get_first_occurrence(p);
-                }
+            step_handle_t step = graph.path_begin(p);
+            for (int i = 0; i < steps.size(); i++){
                 
-                REQUIRE(graph.get_path_handle_of_occurrence(occ) == p);
-                REQUIRE(graph.get_occurrence(occ) == occs[i]);
-                REQUIRE(graph.has_previous_occurrence(occ) == (i > 0));
-                REQUIRE(graph.has_next_occurrence(occ) == (i < occs.size() - 1));
-                
-                if (i != occs.size() - 1) {
-                    occ = graph.get_next_occurrence(occ);
-                }
+                REQUIRE(graph.get_path_handle_of_step(step) == p);
+                REQUIRE(graph.get_handle_of_step(step) == steps[i]);
             }
             
-            for (int i = occs.size() - 1; i >= 0; i--){
-                if (i == occs.size() - 1) {
-                    occ = graph.get_last_occurrence(p);
-                }
+            REQUIRE(step == graph.path_end(p));
+            step = graph.get_previous_step(step);
+            
+            for (int i = steps.size() - 1; i >= 0; i--){
                 
-                REQUIRE(graph.get_path_handle_of_occurrence(occ) == p);
-                REQUIRE(graph.get_occurrence(occ) == occs[i]);
-                REQUIRE(graph.has_previous_occurrence(occ) == (i > 0));
-                REQUIRE(graph.has_next_occurrence(occ) == (i < occs.size() - 1));
+                REQUIRE(graph.get_path_handle_of_step(step) == p);
+                REQUIRE(graph.get_handle_of_step(step) == steps[i]);
                 
                 if (i != 0) {
-                    occ = graph.get_previous_occurrence(occ);
+                    step = graph.get_previous_step(step);
                 }
             }
+            
+            REQUIRE(step == graph.path_begin(p));
         };
         
-        auto check_flips = [&](const path_handle_t& p, const vector<handle_t>& occs) {
-            auto flipped = occs;
-            for (size_t i = 0; i < occs.size(); i++) {
+        auto check_flips = [&](const path_handle_t& p, const vector<handle_t>& steps) {
+            auto flipped = steps;
+            for (size_t i = 0; i < steps.size(); i++) {
                 graph.apply_orientation(graph.flip(graph.forward(flipped[i])));
                 flipped[i] = graph.flip(flipped[i]);
                 check_path(p, flipped);
@@ -88,19 +79,19 @@ using namespace std;
         path_handle_t p2 = graph.create_path_handle("2");
 
         
-        graph.append_occurrence(p0, h3);
-        graph.append_occurrence(p0, h4);
-        graph.append_occurrence(p0, h5);
+        graph.append_step(p0, h3);
+        graph.append_step(p0, h4);
+        graph.append_step(p0, h5);
         
-        graph.append_occurrence(p1, h1);
-        graph.append_occurrence(p1, h3);
-        graph.append_occurrence(p1, h5);
+        graph.append_step(p1, h1);
+        graph.append_step(p1, h3);
+        graph.append_step(p1, h5);
         
-        graph.append_occurrence(p2, h1);
-        graph.append_occurrence(p2, h2);
-        graph.append_occurrence(p2, h3);
-        graph.append_occurrence(p2, h4);
-        graph.append_occurrence(p2, h5);
+        graph.append_step(p2, h1);
+        graph.append_step(p2, h2);
+        graph.append_step(p2, h3);
+        graph.append_step(p2, h4);
+        graph.append_step(p2, h5);
         
         SECTION("Defragmentation during dynamic deletes does not change topology") {
             

--- a/src/unittest/packed_graph.cpp
+++ b/src/unittest/packed_graph.cpp
@@ -30,9 +30,17 @@ using namespace std;
                 
                 REQUIRE(graph.get_path_handle_of_step(step) == p);
                 REQUIRE(graph.get_handle_of_step(step) == steps[i]);
+                
+                step = graph.get_next_step(step);
             }
             
-            REQUIRE(step == graph.path_end(p));
+            if (graph.get_is_circular(p) && !graph.is_empty(p)) {
+                REQUIRE(step == graph.path_begin(p));
+            }
+            else {
+                REQUIRE(step == graph.path_end(p));
+            }
+            
             step = graph.get_previous_step(step);
             
             for (int i = steps.size() - 1; i >= 0; i--){
@@ -40,12 +48,17 @@ using namespace std;
                 REQUIRE(graph.get_path_handle_of_step(step) == p);
                 REQUIRE(graph.get_handle_of_step(step) == steps[i]);
                 
-                if (i != 0) {
+                if (i != 0 || (graph.get_is_circular(p) && !graph.is_empty(p))) {
                     step = graph.get_previous_step(step);
                 }
             }
             
-            REQUIRE(step == graph.path_begin(p));
+            if (graph.get_is_circular(p) && !graph.is_empty(p)) {
+                REQUIRE(graph.get_handle_of_step(step) == steps.back());
+            }
+            else {
+                REQUIRE(step == graph.path_begin(p));
+            }
         };
         
         auto check_flips = [&](const path_handle_t& p, const vector<handle_t>& steps) {

--- a/src/unittest/random_graph.cpp
+++ b/src/unittest/random_graph.cpp
@@ -32,7 +32,7 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
     handle_t h = graph->create_handle(seq);
     
     path_handle_t p = graph->create_path_handle("path");
-    graph->append_occurrence(p, h);
+    graph->append_step(p, h);
     
     index_to_id[0] = graph->get_id(h);
 

--- a/src/unittest/random_graph.cpp
+++ b/src/unittest/random_graph.cpp
@@ -4,7 +4,7 @@ namespace vg {
 namespace unittest {
 
 void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
-                  MutablePathDeletableHandleGraph* graph) {
+                  MutablePathMutableHandleGraph* graph) {
     //Create a random graph for a sequence of length seq_size
     //variant_len is the mean length of a larger variation and variationCount
     //is the number of variations in the graph

--- a/src/unittest/random_graph.hpp
+++ b/src/unittest/random_graph.hpp
@@ -9,7 +9,7 @@ namespace unittest{
 /// variant_len is the mean length of a larger variation and variant_count
 /// is the number of variations added to the graph
 void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
-                  MutablePathDeletableHandleGraph* graph);
+                  MutablePathMutableHandleGraph* graph);
 
 }
 }

--- a/src/unittest/vg_algorithms.cpp
+++ b/src/unittest/vg_algorithms.cpp
@@ -4111,62 +4111,24 @@ namespace vg {
             }
         }
 
-        TEST_CASE("lazy_topological_sort() and lazier_topological_sort() should put a DAG in topological order", "[algorithms][sort]") {
+        TEST_CASE("lazy_topological_order() and lazier_topological_order() should put a DAG in topological order", "[algorithms][sort]") {
             
-            auto is_in_topological_order = [](const Graph& graph) {
+            auto is_in_topological_order = [](const HandleGraph* graph, const vector<handle_t>& order) {
                 
-                unordered_map<id_t, bool> node_orientation;
-                
-                unordered_map<id_t, size_t> id_to_idx;
-                for (size_t i = 0; i < graph.node_size(); i++) {
-                    id_to_idx[graph.node(i).id()] = i;
+                unordered_map<handle_t, size_t> handle_to_idx;
+                for (size_t i = 0; i < order.size(); i++) {
+                    handle_to_idx[order[i]] = i;
                 }
                 
                 bool return_val = true;
-                for (size_t i = 0; i < graph.edge_size() && return_val; i++) {
-                    const Edge& e = graph.edge(i);
-                    
-                    if (id_to_idx[e.from()] < id_to_idx[e.to()]) {
-                        if (node_orientation.count(e.from())) {
-                            return_val = return_val && (e.from_start() == node_orientation[e.from()]);
-                        }
-                        else {
-                            node_orientation[e.from()] = e.from_start();
-                        }
-                        
-                        if (node_orientation.count(e.to())) {
-                            return_val = return_val && (e.to_end() == node_orientation[e.to()]);
-                        }
-                        else {
-                            node_orientation[e.to()] = e.to_end();
-                        }
-                    }
-                    else {
-                        if (node_orientation.count(e.from())) {
-                            return_val = return_val && (e.from_start() != node_orientation[e.from()]);
-                        }
-                        else {
-                            node_orientation[e.from()] = !e.from_start();
-                        }
-                        
-                        if (node_orientation.count(e.to())) {
-                            return_val = return_val && (e.to_end() != node_orientation[e.to()]);
-                        }
-                        else {
-                            node_orientation[e.to()] = !e.to_end();
-                        }
-                    }
-                    
-                    if (e.from() == e.to()) {
-                        return_val = false;
-                    }
-                    else if (id_to_idx[e.from()] < id_to_idx[e.to()]) {
-                        return_val = return_val && (e.from_start() == node_orientation[e.from()] && e.to_end() == node_orientation[e.to()]);
-                    }
-                    else {
-                        return_val = return_val && (e.from_start() != node_orientation[e.from()] && e.to_end() != node_orientation[e.to()]);
-                    }
-                }
+                
+                graph->for_each_handle([&](const handle_t& h) {
+                    handle_t handle = handle_to_idx.count(h) ? h : graph->flip(h);
+                    graph->follow_edges(handle, false, [&](const handle_t& next) {
+                        return_val = return_val && handle_to_idx.count(next) && handle_to_idx[next] > handle_to_idx[handle];
+                    });
+                });
+                
                 return return_val;
             };
             
@@ -4183,11 +4145,11 @@ namespace vg {
                 // make the second graph have some locally stored nodes in the reverse orientation
                 vg2.apply_orientation(vg2.get_handle(n1->id(), true));
                 
-                algorithms::lazier_topological_sort(&vg1);
-                algorithms::lazy_topological_sort(&vg2);
+                auto lazier_order = algorithms::lazier_topological_order(&vg1);
+                auto lazy_order = algorithms::lazy_topological_order(&vg2);
                 
-                REQUIRE(is_in_topological_order(vg1.graph));
-                REQUIRE(is_in_topological_order(vg2.graph));
+                REQUIRE(is_in_topological_order(&vg1, lazier_order));
+                REQUIRE(is_in_topological_order(&vg2, lazy_order));
             }
             
             SECTION("laz[y/ier]_topological_sort() works on a simple graph that's not already in topological order") {
@@ -4203,11 +4165,11 @@ namespace vg {
                 // make the second graph have some locally stored nodes in the reverse orientation
                 vg2.apply_orientation(vg2.get_handle(n1->id(), true));
                 
-                algorithms::lazier_topological_sort(&vg1);
-                algorithms::lazy_topological_sort(&vg2);
+                auto lazier_order = algorithms::lazier_topological_order(&vg1);
+                auto lazy_order = algorithms::lazy_topological_order(&vg2);
                 
-                REQUIRE(is_in_topological_order(vg1.graph));
-                REQUIRE(is_in_topological_order(vg2.graph));
+                REQUIRE(is_in_topological_order(&vg1, lazier_order));
+                REQUIRE(is_in_topological_order(&vg2, lazy_order));
 
             }
             
@@ -4246,15 +4208,15 @@ namespace vg {
                 vg2.apply_orientation(vg2.get_handle(n8->id(), true));
                 vg2.apply_orientation(vg2.get_handle(n6->id(), true));
                 
-                algorithms::lazier_topological_sort(&vg1);
-                algorithms::lazy_topological_sort(&vg2);
+                auto lazier_order = algorithms::lazier_topological_order(&vg1);
+                auto lazy_order = algorithms::lazy_topological_order(&vg2);
                 
-                REQUIRE(is_in_topological_order(vg1.graph));
-                REQUIRE(is_in_topological_order(vg2.graph));
+                REQUIRE(is_in_topological_order(&vg1, lazier_order));
+                REQUIRE(is_in_topological_order(&vg2, lazy_order));
             }
         }
         
-        TEST_CASE("apply_ordering and apply_orientations work as expected", "[algorithms]") {
+        TEST_CASE("apply_orientations works as expected", "[algorithms]") {
             
             VG vg;
             
@@ -4267,31 +4229,6 @@ namespace vg {
             
             random_device rd;
             default_random_engine prng(rd());
-            
-            SECTION("apply_ordering works with random permutations") {
-                
-                for (int i = 0; i < 20; i++) {
-                    
-                    vector<handle_t> order;
-                    vg.for_each_handle([&](const handle_t& handle) {
-                        order.push_back(handle);
-                    });
-                    shuffle(order.begin(), order.end(), prng);
-                    
-                    vector<id_t> id_order;
-                    for (handle_t handle : order){
-                        id_order.push_back(vg.get_id(handle));
-                    }
-                    
-                    algorithms::apply_ordering(&vg, order);
-                    
-                    int idx = 0;
-                    vg.for_each_handle([&](const handle_t& handle) {
-                        REQUIRE(vg.get_id(handle) == id_order[idx]);
-                        idx++;
-                    });
-                }
-            }
             
             SECTION("apply_orientations works with random orientations") {
                 

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -318,7 +318,8 @@ path_handle_t VG::get_path_handle_of_step(const step_handle_t& step_handle) cons
 step_handle_t VG::path_begin(const path_handle_t& path_handle) const {
     step_handle_t step_handle;
     as_integers(step_handle)[0] = as_integer(path_handle);
-    as_integers(step_handle)[1] = reinterpret_cast<int64_t>(&paths._paths.at(paths.get_path_name(as_integer(path_handle))).front());
+    const auto& path_list = paths._paths.at(paths.get_path_name(as_integer(path_handle)));
+    as_integers(step_handle)[1] = reinterpret_cast<int64_t>(path_list.empty() ? nullptr : &path_list.front());
     return step_handle;
 }
 

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -350,8 +350,8 @@ step_handle_t VG::get_next_step(const step_handle_t& step_handle) const {
 
 step_handle_t VG::get_previous_step(const step_handle_t& step_handle) const {
     step_handle_t prev_step_handle;
-    as_integers(prev_step_handle)[0] = as_integers(step_handle)[0]  ;
-    if (reinterpret_cast<void*>(as_integers(prev_step_handle)[1]) == nullptr) {
+    as_integers(prev_step_handle)[0] = as_integers(step_handle)[0];
+    if (reinterpret_cast<mapping_t*>(as_integers(step_handle)[1]) == nullptr) {
         as_integers(prev_step_handle)[1] = reinterpret_cast<int64_t>(&paths._paths.at(paths.get_path_name(as_integer(get_path_handle_of_step(step_handle)))).back());
     }
     else {

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -542,7 +542,20 @@ public:
     /// node. Invalidates the paths. Invalidates any paths containing the node,
     /// since they are not updated.
     void swap_node_id(Node* node, id_t new_id);
-
+    
+    /// Topologically sort the graph, and then apply that sort to re- order the nodes in the backing
+    /// data structure. The sort is guaranteed to be stable. This sort is well-defined  on graphs that
+    /// are not DAGs, but instead of finding a topological sort it does a heuristic sort to minimize
+    /// a feedback arc set.
+    void sort();
+    
+    /// Order the backing graph data structure by node ID
+    void id_sort();
+    
+    /// Modifies underlying graph so that nodes occur in the same order as in the provided vector. Vector
+    /// must contain exactly one handle for each node.
+    void apply_ordering(const vector<handle_t>& ordering);
+    
     /// Iteratively add when nodes and edges are novel. Good when there are very
     /// many overlaps. TODO: If you are using this with warn on duplicates on,
     /// and you know there shouldn't be any duplicates, maybe you should use

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -136,6 +136,9 @@ public:
     // Path handle interface
     ////////////////////////////////////////////////////////////////////////////
     
+    /// Returns the number of paths stored in the graph
+    virtual size_t get_path_count() const;
+    
     /// Determine if a path name exists and is legal to get a path handle for.
     virtual bool has_path(const string& path_name) const;
     
@@ -145,42 +148,50 @@ public:
     /// Look up the name of a path from a handle to it
     virtual string get_path_name(const path_handle_t& path_handle) const;
     
-    /// Returns the number of node occurrences in the path
-    virtual size_t get_occurrence_count(const path_handle_t& path_handle) const;
+    /// Look up whether a path is circular
+    virtual bool get_is_circular(const path_handle_t& path_handle) const;
     
-    /// Returns the number of paths stored in the graph
-    virtual size_t get_path_count() const;
+    /// Returns the number of node steps in the path
+    virtual size_t get_step_count(const path_handle_t& path_handle) const;
+    
+    /// Get a node handle (node ID and orientation) from a handle to an step on a path
+    virtual handle_t get_handle_of_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the path that an step is on
+    virtual path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
+    
+    /// Get a handle to the first step, or in a circular path to an arbitrary step
+    /// considered "first". If the path is empty, returns the past-the-last step
+    /// returned by path_end.
+    virtual step_handle_t path_begin(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to a fictitious position past the end of a path. This position is
+    /// return by get_next_step for the final step in a path in a non-circular path.
+    /// Note that get_next_step will *NEVER* return this value for a circular path.
+    virtual step_handle_t path_end(const path_handle_t& path_handle) const;
+    
+    /// Returns a handle to the next step on the path. If the given step is the final step
+    /// of a non-circular path, returns the past-the-last step that is also returned by
+    /// path_end. In a circular path, the "last" step will loop around to the "first" (i.e.
+    /// the one returned by path_begin).
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    virtual step_handle_t get_next_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the previous step on the path. If the given step is the first
+    /// step of a non-circular path, this method has undefined behavior. In a circular path,
+    /// it will loop around from the "first" step (i.e. the one returned by path_begin) to
+    /// the "last" step.
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    virtual step_handle_t get_previous_step(const step_handle_t& step_handle) const;
     
     /// Execute a function on each path in the graph
     virtual bool for_each_path_handle_impl(const function<bool(const path_handle_t&)>& iteratee) const;
     
-    /// Get a node handle (node ID and orientation) from a handle to an occurrence on a path
-    virtual handle_t get_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    
-    /// Get a handle to the first occurrence in a path
-    virtual occurrence_handle_t get_first_occurrence(const path_handle_t& path_handle) const;
-    
-    /// Get a handle to the last occurrence in a path
-    virtual occurrence_handle_t get_last_occurrence(const path_handle_t& path_handle) const;
-    
-    /// Returns true if the occurrence is not the last occurence on the path, else false
-    virtual bool has_next_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    
-    /// Returns true if the occurrence is not the first occurence on the path, else false
-    virtual bool has_previous_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    
-    /// Returns a handle to the next occurrence on the path
-    virtual occurrence_handle_t get_next_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    
-    /// Returns a handle to the previous occurrence on the path
-    virtual occurrence_handle_t get_previous_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    
-    /// Returns a handle to the path that an occurrence is on
-    virtual path_handle_t get_path_handle_of_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    
-    /// Loop over the occurrences of a handle in paths.
-    virtual bool for_each_occurrence_on_handle_impl(const handle_t& handle,
-                                                    const function<bool(const occurrence_handle_t&)>& iteratee) const;
+    /// Loop over the steps of a handle in paths.
+    virtual bool for_each_step_on_handle_impl(const handle_t& handle,
+                                                    const function<bool(const step_handle_t&)>& iteratee) const;
     
     ////////////////////////////////////////////////////////////////////////////
     // Mutable handle-based interface
@@ -229,14 +240,21 @@ public:
     // Mutable path handle interface
     ////////////////////////////////////////////////////////////////////////////
 
-    /// Destroy the given path. Invalidates handles to the path and its node occurrences.
+    /// Destroy the given path. Invalidates handles to the path and its node steps.
     virtual void destroy_path(const path_handle_t& path);
 
     /// Create a path with the given name.
-    virtual path_handle_t create_path_handle(const string& name);
+    virtual path_handle_t create_path_handle(const string& name,
+                                             bool is_circular = false);
     
     /// Append a visit to a node to the given path
-    virtual occurrence_handle_t append_occurrence(const path_handle_t& path, const handle_t& to_append);
+    virtual step_handle_t append_step(const path_handle_t& path, const handle_t& to_append);
+    
+    /// Make a path circular or non-circular. If the path is becoming circular, the
+    /// last step is joined to the first step. If the path is becoming linear, the
+    /// step considered "last" is unjoined from the step considered "first" according
+    /// to the method path_begin.
+    virtual void set_circularity(const path_handle_t& path, bool circular);
     
 public:
     

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1843,7 +1843,7 @@ string XG::get_path_name(const path_handle_t& path_handle) const {
 }
 
 bool XG::get_is_circular(const path_handle_t& path_handle) const {
-    return paths[as_integer(path_handle) - 1].is_circular;
+    return paths[as_integer(path_handle) - 1]->is_circular;
 }
 
 size_t XG::get_step_count(const path_handle_t& path_handle) const {
@@ -1868,14 +1868,14 @@ step_handle_t XG::path_begin(const path_handle_t& path_handle) const {
     step_handle_t step;
     as_integers(step)[0] = as_integer(path_handle);
     as_integers(step)[1] = 0;
-    return step_handle;
+    return step;
 }
 
 step_handle_t XG::path_end(const path_handle_t& path_handle) const {
     step_handle_t step;
     as_integers(step)[0] = as_integer(path_handle);
     as_integers(step)[1] = get_step_count(path_handle);
-    return step_handle;
+    return step;
 }
 
 step_handle_t XG::get_next_step(const step_handle_t& step_handle) const {

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1826,6 +1826,10 @@ bool XG::for_each_handle_impl(const function<bool(const handle_t&)>& iteratee, b
     return !stop_early;
 }
 
+size_t XG::get_path_count() const {
+    return paths.size();
+}
+
 bool XG::has_path(const string& path_name) const {
     return path_rank(path_name) != 0;
 }
@@ -1837,19 +1841,68 @@ path_handle_t XG::get_path_handle(const string& path_name) const {
 string XG::get_path_name(const path_handle_t& path_handle) const {
     return path_name(as_integer(path_handle));
 }
-    
-size_t XG::get_occurrence_count(const path_handle_t& path_handle) const {
+
+bool XG::get_is_circular(const path_handle_t& path_handle) const {
+    return paths[as_integer(path_handle) - 1].is_circular;
+}
+
+size_t XG::get_step_count(const path_handle_t& path_handle) const {
     return paths[as_integer(path_handle) - 1]->ids.size();
 }
     
 size_t XG::get_path_length(const path_handle_t& path_handle) const {
     return paths[as_integer(path_handle) - 1]->offsets.size();
 }
-    
-size_t XG::get_path_count() const {
-    return paths.size();
+
+handle_t XG::get_handle_of_step(const step_handle_t& step_handle) const {
+    const auto& xgpath = *paths[as_integer(get_path_handle_of_step(step_handle)) - 1];
+    size_t idx = as_integers(step_handle)[1];
+    return get_handle(xgpath.node(idx), xgpath.is_reverse(idx));
 }
-    
+
+path_handle_t XG::get_path_handle_of_step(const step_handle_t& step_handle) const {
+    return as_path_handle(as_integers(step_handle)[0]);
+}
+
+step_handle_t XG::path_begin(const path_handle_t& path_handle) const {
+    step_handle_t step;
+    as_integers(step)[0] = as_integer(path_handle);
+    as_integers(step)[1] = 0;
+    return step_handle;
+}
+
+step_handle_t XG::path_end(const path_handle_t& path_handle) const {
+    step_handle_t step;
+    as_integers(step)[0] = as_integer(path_handle);
+    as_integers(step)[1] = get_step_count(path_handle);
+    return step_handle;
+}
+
+step_handle_t XG::get_next_step(const step_handle_t& step_handle) const {
+    step_handle_t next_step;
+    as_integers(next_step)[0] = as_integers(step_handle)[0];
+    as_integers(next_step)[1] = as_integers(step_handle)[1] + 1;
+    if (get_is_circular(get_path_handle_of_step(step_handle))) {
+        if (as_integers(next_step)[1] == get_step_count(get_path_handle_of_step(step_handle))) {
+            as_integers(next_step)[1] = 0;
+        }
+    }
+    return next_step;
+}
+
+step_handle_t XG::get_previous_step(const step_handle_t& step_handle) const {
+    step_handle_t prev_step;
+    as_integers(prev_step)[0] = as_integers(step_handle)[0];
+    if (get_is_circular(get_path_handle_of_step(step_handle)) && as_integers(step_handle)[1] == 0) {
+        as_integers(prev_step)[1] = get_step_count(get_path_handle_of_step(step_handle)) - 1;
+    }
+    else {
+        as_integers(prev_step)[1] = as_integers(step_handle)[1] - 1;
+    }
+    return prev_step;
+
+}
+
 bool XG::for_each_path_handle_impl(const function<bool(const path_handle_t&)>& iteratee) const {
     for (size_t i = 0; i < paths.size(); i++) {
         // convert to 1-based rank
@@ -1862,62 +1915,16 @@ bool XG::for_each_path_handle_impl(const function<bool(const path_handle_t&)>& i
     return true;
 }
 
-handle_t XG::get_occurrence(const occurrence_handle_t& occurrence_handle) const {
-    const auto& xgpath = *paths[as_integer(get_path_handle_of_occurrence(occurrence_handle)) - 1];
-    size_t idx = as_integers(occurrence_handle)[1];
-    return get_handle(xgpath.node(idx), xgpath.is_reverse(idx));
-}
-
-occurrence_handle_t XG::get_first_occurrence(const path_handle_t& path_handle) const {
-    occurrence_handle_t occurrence_handle;
-    as_integers(occurrence_handle)[0] = as_integer(path_handle);
-    as_integers(occurrence_handle)[1] = 0;
-    return occurrence_handle;
-}
-
-occurrence_handle_t XG::get_last_occurrence(const path_handle_t& path_handle) const {
-    occurrence_handle_t occurrence_handle;
-    as_integers(occurrence_handle)[0] = as_integer(path_handle);
-    as_integers(occurrence_handle)[1] = paths[as_integer(path_handle) - 1]->ids.size() - 1;
-    return occurrence_handle;
-}
-
-bool XG::has_next_occurrence(const occurrence_handle_t& occurrence_handle) const {
-    return as_integers(occurrence_handle)[1] + 1 < paths[as_integers(occurrence_handle)[0] - 1]->ids.size();
-}
-
-bool XG::has_previous_occurrence(const occurrence_handle_t& occurrence_handle) const {
-    return as_integers(occurrence_handle)[1] > 0;
-}
-
-occurrence_handle_t XG::get_next_occurrence(const occurrence_handle_t& occurrence_handle) const {
-    occurrence_handle_t next_occurrence_handle;
-    as_integers(next_occurrence_handle)[0] = as_integers(occurrence_handle)[0];
-    as_integers(next_occurrence_handle)[1] = as_integers(occurrence_handle)[1] + 1;
-    return next_occurrence_handle;
-}
-
-occurrence_handle_t XG::get_previous_occurrence(const occurrence_handle_t& occurrence_handle) const {
-    occurrence_handle_t prev_occurrence_handle;
-    as_integers(prev_occurrence_handle)[0] = as_integers(occurrence_handle)[0];
-    as_integers(prev_occurrence_handle)[1] = as_integers(occurrence_handle)[1] - 1;
-    return prev_occurrence_handle;
-
-}
-
-path_handle_t XG::get_path_handle_of_occurrence(const occurrence_handle_t& occurrence_handle) const {
-    return as_path_handle(as_integers(occurrence_handle)[0]);
-}
-
-bool XG::for_each_occurrence_on_handle_impl(const handle_t& handle, const function<bool(const occurrence_handle_t&)>& iteratee) const {
+bool XG::for_each_step_on_handle_impl(const handle_t& handle, const function<bool(const step_handle_t&)>& iteratee) const {
+    
     vector<pair<size_t, vector<pair<size_t, bool>>>> oriented_paths = oriented_paths_of_node(get_id(handle));
     
     for (const pair<size_t, vector<pair<size_t, bool>>>& path_occs : oriented_paths) {
         for (const pair<size_t, bool>& oriented_occ : path_occs.second) {
-            occurrence_handle_t occurrence_handle;
-            as_integers(occurrence_handle)[0] = path_occs.first;
-            as_integers(occurrence_handle)[1] = oriented_occ.first;
-            if (!iteratee(occurrence_handle)) {
+            step_handle_t step_handle;
+            as_integers(step_handle)[0] = path_occs.first;
+            as_integers(step_handle)[1] = oriented_occ.first;
+            if (!iteratee(step_handle)) {
                 return false;
             }
         }

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -245,38 +245,51 @@ public:
     // Path handle graph API
     ////////////////////////
    
-    /// Determine if a path with a given name exists
-    virtual bool has_path(const string& path_name) const;
-    /// Look up the path handle for the given path name
-    virtual path_handle_t get_path_handle(const string& path_name) const;
-    /// Look up the name of a path from a handle to it
-    virtual string get_path_name(const path_handle_t& path_handle) const;
-    /// Returns the number of node occurrences in the path
-    virtual size_t get_occurrence_count(const path_handle_t& path_handle) const;
-    /// Returns the total length of sequence in the path
-    virtual size_t get_path_length(const path_handle_t& path_handle) const;
     /// Returns the number of paths stored in the graph
-    virtual size_t get_path_count() const;
+    size_t get_path_count() const;
+    /// Determine if a path with a given name exists
+    bool has_path(const string& path_name) const;
+    /// Look up the path handle for the given path name
+    path_handle_t get_path_handle(const string& path_name) const;
+    /// Look up the name of a path from a handle to it
+    string get_path_name(const path_handle_t& path_handle) const;
+    /// Look up whether a path is circular
+    bool get_is_circular(const path_handle_t& path_handle) const;
+    /// Returns the number of node steps in the path
+    size_t get_step_count(const path_handle_t& path_handle) const;
+    /// Returns the total length of sequence in the path
+    size_t get_path_length(const path_handle_t& path_handle) const;
+    /// Get a node handle (node ID and orientation) from a handle to a step on a path
+    handle_t get_handle_of_step(const step_handle_t& step_handle) const;
+    /// Returns a handle to the path that an step is on
+    path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
+    /// Get a handle to the first step, or in a circular path to an arbitrary step
+    /// considered "first". If the path is empty, returns the past-the-last step
+    /// returned by path_end.
+    step_handle_t path_begin(const path_handle_t& path_handle) const;
+    /// Get a handle to a fictitious position past the end of a path. This position is
+    /// return by get_next_step for the final step in a path in a non-circular path.
+    /// Note that get_next_step will *NEVER* return this value for a circular path.
+    step_handle_t path_end(const path_handle_t& path_handle) const;
+    /// Returns a handle to the next step on the path. If the given step is the final step
+    /// of a non-circular path, returns the past-the-last step that is also returned by
+    /// path_end. In a circular path, the "last" step will loop around to the "first" (i.e.
+    /// the one returned by path_begin).
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    step_handle_t get_next_step(const step_handle_t& step_handle) const;
+    /// Returns a handle to the previous step on the path. If the given step is the first
+    /// step of a non-circular path, this method has undefined behavior. In a circular path,
+    /// it will loop around from the "first" step (i.e. the one returned by path_begin) to
+    /// the "last" step.
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    step_handle_t get_previous_step(const step_handle_t& step_handle) const;
+    
     /// Execute a function on each path in the graph
-    virtual bool for_each_path_handle_impl(const function<bool(const path_handle_t&)>& iteratee) const;
-    /// Get a node handle (node ID and orientation) from a handle to an occurrence on a path
-    virtual handle_t get_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    /// Get a handle to the first occurrence in a path
-    virtual occurrence_handle_t get_first_occurrence(const path_handle_t& path_handle) const;
-    /// Get a handle to the last occurrence in a path
-    virtual occurrence_handle_t get_last_occurrence(const path_handle_t& path_handle) const;
-    /// Returns true if the occurrence is not the last occurence on the path, else false
-    virtual bool has_next_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    /// Returns true if the occurrence is not the first occurence on the path, else false
-    virtual bool has_previous_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    /// Returns a handle to the next occurrence on the path
-    virtual occurrence_handle_t get_next_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    /// Returns a handle to the previous occurrence on the path
-    virtual occurrence_handle_t get_previous_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    /// Returns a handle to the path that an occurrence is on
-    virtual path_handle_t get_path_handle_of_occurrence(const occurrence_handle_t& occurrence_handle) const;
-    /// Executes a function on each occurrence of a handle in any path.
-    virtual bool for_each_occurrence_on_handle_impl(const handle_t& handle, const function<bool(const occurrence_handle_t&)>& iteratee) const;
+    bool for_each_path_handle_impl(const function<bool(const path_handle_t&)>& iteratee) const;
+    /// Executes a function on each step of a handle in any path.
+    bool for_each_step_on_handle_impl(const handle_t& handle, const function<bool(const step_handle_t&)>& iteratee) const;
     
     ////////////////////////////////////////////////////////////////////////////
     // Higher-level graph API

--- a/test/t/12_vg_kmers.t
+++ b/test/t/12_vg_kmers.t
@@ -41,5 +41,5 @@ rm -f j.vg
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz| vg kmers -g -k 11 -t 1 -H 1000 -T 1001 - | grep '1000\|1001' | wc -l) 76 "start/stop node IDs can be specified in GCSA2 output"
 
-vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa | vg view - |head -10 | vg view -v - | vg mod -o - | vg kmers -k 16 - >/dev/null
+vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa | vg view - | head -10 | vg view -vF - | vg mod -o - | vg kmers -k 16 - >/dev/null
 is $? 0 "attempting to generate kmers longer than the longest path in a graph correctly yields no kmers"


### PR DESCRIPTION
I switched the HandleGraph code throughout the codebase to the new and improved path interface. This includes removing HandleGraph support for the concept of graph ordering, adding support for circular paths, and retooling iteration along paths. All of the HandleGraph implementations in this repository now implement the new functionality.