### PR TITLE
More traversals with vg snarls -r

### DIFF
--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -30,7 +30,7 @@ void help_snarl(char** argv) {
          << "    -l, --leaf-only        restrict traversals to leaf ultrabubbles." << endl
          << "    -o, --top-level        restrict traversals to top level ultrabubbles" << endl
          << "    -a, --any-snarl-type   compute traversals for any snarl type (not limiting to ultrabubbles)" << endl
-         << "    -m, --max-nodes N      only compute traversals for snarls with <= N nodes [10]" << endl
+         << "    -m, --max-nodes N      only compute traversals for snarls with <= N nodes (with degree > 1) [10]" << endl
          << "    -t, --include-trivial  report snarls that consist of a single edge" << endl
          << "    -s, --sort-snarls      return snarls in sorted order by node ID (for topologically ordered graphs)" << endl
          << "    -v, --vcf FILE         use vcf-based instead of exhaustive traversal finder with -r" << endl
@@ -303,12 +303,25 @@ int main_snarl(int argc, char** argv) {
             snarl_buffer.push_back(*snarl);
             stream::write_buffered(cout, snarl_buffer, buffer_size);
 
+            auto check_max_nodes = [&graph, &max_nodes](const unordered_set<Node*>& nodeset)  {
+                int node_count = 0;
+                for (auto node : nodeset) {
+                    if (graph->start_degree(node) > 1 || graph->end_degree(node) > 1) {
+                        ++node_count;
+                        if (node_count > max_nodes) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            };
+
             // Optionally write our traversals
             if (!traversal_file.empty() &&
                 (!ultrabubble_only || snarl->type() == ULTRABUBBLE) &&
                 (!leaf_only || snarl_manager.is_leaf(snarl)) &&
                 (!top_level_only || snarl_manager.is_root(snarl)) &&
-                (snarl_manager.deep_contents(snarl, *graph, true).first.size() <= max_nodes)) {
+                (check_max_nodes(snarl_manager.deep_contents(snarl, *graph, true).first))) { 
                 
 #ifdef debug
                 cerr << "Look for traversals of " << pb2json(*snarl) << endl;

--- a/src/support_caller.cpp
+++ b/src/support_caller.cpp
@@ -1389,13 +1389,15 @@ void SupportCaller::recall_locus(Locus& locus, const Snarl& site, vector<SnarlTr
 
         // convert the allele we called from our traversal list into the corresponding
         // allele for this variant in the VCF
-        for (int i = 0; i < locus.genotype(0).allele_size(); ++i) {
-            int called_allele = locus.genotype(0).allele(i);
-            int vcf_allele = trav_alleles[called_allele][var_idx];
-            vcf_genotype.add_allele(vcf_allele);
-            // make absolutely sure we're using the right support for our called alleles
-            // the support is in terms of the entire snarl, and not the vcf variant
-            *vcf_locus.mutable_support(vcf_allele) = locus.support(called_allele);
+        if (locus.genotype_size() > 0) {
+            for (int i = 0; i < locus.genotype(0).allele_size(); ++i) {
+                int called_allele = locus.genotype(0).allele(i);
+                int vcf_allele = trav_alleles[called_allele][var_idx];
+                vcf_genotype.add_allele(vcf_allele);
+                // make absolutely sure we're using the right support for our called alleles
+                // the support is in terms of the entire snarl, and not the vcf variant
+                *vcf_locus.mutable_support(vcf_allele) = locus.support(called_allele);
+            }
         }
         
         *vcf_locus.mutable_overall_support() = locus.overall_support();

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3017,8 +3017,6 @@ pair<int, int> VCFTraversalFinder::scan_for_deletion(vcflib::Variant* var, int a
         }
     }
 
-    assert(best_pos_delta != std::numeric_limits<int>::max());
-
     first_path_it = best_start;
     last_path_it = best_end;
 

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -2835,6 +2835,11 @@ VCFTraversalFinder::get_haplotype_alt_contents(
 
         // get the alt path information out of the graph
         pair<SnarlTraversal, bool> alt_path_info = get_alt_path(var, haplotype[allele], path_index);
+        if (alt_path_info.first.visit_size() == 0) {
+            assert(alt_path_info.second == true);
+            // skip deletion alt path where we can't find the deletion edge in the graph
+            continue;
+        }
         SnarlTraversal& alt_traversal = alt_path_info.first;
         bool is_deletion = alt_path_info.second;
 
@@ -2904,10 +2909,18 @@ pair<SnarlTraversal, bool> VCFTraversalFinder::get_alt_path(vcflib::Variant* var
                 if (allele != 0) {
                     // alt paths don't always line up with deletion edges, so we hunt for
                     // our deletion edge using the path_index here.
-                    bool del_len_found = scan_for_deletion(var, allele, path_index, first_path_it, last_path_it);
-                    if (!del_len_found) {
+                    pair<int, int> scan_deltas = scan_for_deletion(var, allele, path_index,
+                                                                   first_path_it, last_path_it);
+                    if (scan_deltas.first != 0 || scan_deltas.second != 0) {
                         cerr << "[VCFTraversalFinder] Warning: Could not find deletion edge that matches allele "
-                             << allele << " of\n" << *var << "\nUsing approximate match" << endl;
+                             << allele << " of\n" << *var << "\naround alt path" << alt_path_name << ":";
+                        if (scan_deltas.first != 0) {
+                            cerr << " Ignoring allele" << endl;
+                            return make_pair(alt_path, is_deletion);
+                        } else {
+                            cerr << " Using approximate match with size-delta " << scan_deltas.first << " and position delta "
+                                 << scan_deltas.second << " nodes" << endl;
+                        }
                     }
                 }
                 handle_t left = graph.get_handle(first_path_it->second.node);
@@ -2928,14 +2941,14 @@ pair<SnarlTraversal, bool> VCFTraversalFinder::get_alt_path(vcflib::Variant* var
     return make_pair(alt_path, is_deletion);
 }
 
-bool VCFTraversalFinder::scan_for_deletion(vcflib::Variant* var, int allele, PathIndex* path_index,
-                                           PathIndex::iterator& first_path_it, PathIndex::iterator& last_path_it) {
+pair<int, int> VCFTraversalFinder::scan_for_deletion(vcflib::Variant* var, int allele, PathIndex* path_index,
+                                                     PathIndex::iterator& first_path_it, PathIndex::iterator& last_path_it) {
     assert(allele > 0);
 
     // if our path matches an edge, we don't need to do anything
     if (graph.has_edge(graph.get_handle(first_path_it->second.node),
                        graph.get_handle(last_path_it->second.node))) {
-        return true;
+        return make_pair(0, 0);
     }
 
     // we're doing everything via length comparison, so keep track of the length we're
@@ -3009,7 +3022,7 @@ bool VCFTraversalFinder::scan_for_deletion(vcflib::Variant* var, int allele, Pat
     first_path_it = best_start;
     last_path_it = best_end;
 
-    return best_pos_delta == 0;
+    return make_pair(best_size_delta, best_pos_delta);
 }
 
 

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -376,7 +376,7 @@ protected:
     bool include_endpoints = true;
 
     /// How far to scan when looking for deletions
-    size_t max_deletion_scan_nodes = 200;
+    size_t max_deletion_scan_nodes = 100;
 
 public:
 
@@ -468,10 +468,12 @@ protected:
      * returns true if the exact size is found.  
      * Todo: check the sequence as well
      * Also todo: It'd be really nice if construct -fa would make the deletion-edge easily inferrable 
-     * from the alte path
+     * from the alt path.  It really shouldn't be necessary to hunt around. 
+     * Returns: <size delta between returned deletion and vcf allele,
+     *           position delta between returned deletion and alt path>
      */
-    bool scan_for_deletion(vcflib::Variant* var, int allele, PathIndex* path_index,
-                           PathIndex::iterator& first_path_it, PathIndex::iterator& last_path_it);
+    pair<int, int> scan_for_deletion(vcflib::Variant* var, int allele, PathIndex* path_index,
+                                     PathIndex::iterator& first_path_it, PathIndex::iterator& last_path_it);
 
     /**
      * Prune our search space using the skip_alt method.  Will return a list of pruned VCF alleles/


### PR DESCRIPTION
The snarl size limit (`vg snarls -m` default=10) for computing traversals with `vg snarls` is there because the exhaustive traversal finder is used, and it can take forever on larger snarls. 

Talking to @shilpagarg about phasing SV graphs with whatshap made me realize that this limit is going to hit SV graphs pretty hard.   Even simple sites with, say, one big indel are going to be skipped. 

I think the best way to resolve this is by using information from a GAM to prune out unsupported traversals.  VCFTraversalFinder can do this for graphs made from VCF, and I want to add a more general version soon. 

In the meantime, this PR just changes the node size limit from counting all nodes in the snarl, to counting nodes with a side of degree > 1.  It about doubles the amount of snarls processed on a (complicated) test SV graph.

(also including some lingering fixes for vg call)  

