### PR TITLE
Fix multipath alignment validation failures in vg gaffe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ $(OBJ_DIR)/Fasta.o: $(FASTAHACK_DIR)/*.h $(FASTAHACK_DIR)/*.cpp
 $(LIB_DIR)/libvgio.a: $(LIB_DIR)/libhts.a $(LIB_DIR)/pkgconfig/htslib.pc $(LIB_DIR)/libprotobuf.a $(LIBVGIO_DIR)/CMakeLists.txt $(LIBVGIO_DIR)/src/*.cpp $(LIBVGIO_DIR)/include/vg/io/*.hpp
 	+rm -f $(CWD)/$(INC_DIR)/vg.pb.h $(CWD)/$(INC_DIR)/vg/vg.pb.h
 	+rm -Rf $(CWD)/$(INC_DIR)/vg/io/
-	+. ./source_me.sh && cd $(LIBVGIO_DIR) && PKG_CONFIG_PATH=$(CWD)/$(LIB_DIR)/pkgconfig:$(PKG_CONFIG_PATH) cmake -DCMAKE_PREFIX_PATH=$(CWD) -DCMAKE_LIBRARY_PATH=$(CWD)/$(LIB_DIR) -DCMAKE_INSTALL_PREFIX=$(CWD) -DCMAKE_INSTALL_LIBDIR=lib . $(FILTER) && $(MAKE) $(FILTER) && $(MAKE) install && rm -f $(CWD)/$(LIB_DIR)/libvgio.so
+	+. ./source_me.sh && cd $(LIBVGIO_DIR) && PKG_CONFIG_PATH=$(CWD)/$(LIB_DIR)/pkgconfig:$(PKG_CONFIG_PATH) cmake -DCMAKE_PREFIX_PATH=$(CWD) -DCMAKE_LIBRARY_PATH=$(CWD)/$(LIB_DIR) -DCMAKE_INSTALL_PREFIX=$(CWD) -DCMAKE_INSTALL_LIBDIR=lib . $(FILTER) && $(MAKE) clean && $(MAKE) $(FILTER) && $(MAKE) install && rm -f $(CWD)/$(LIB_DIR)/libvgio.so
 
 $(LIB_DIR)/libhandlegraph.a: $(LIBHANDLEGRAPH_DIR)/src/include/handlegraph/*.hpp $(LIBHANDLEGRAPH_DIR)/src/*.cpp
 	+. ./source_me.sh && cd $(LIBHANDLEGRAPH_DIR) && cmake . && $(MAKE) $(FILTER) && cp libhandlegraph.a $(CWD)/$(LIB_DIR) && cp -r src/include/handlegraph $(CWD)/$(INC_DIR)

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -1031,7 +1031,13 @@ void MinimizerMapper::chain_extended_seeds(const Alignment& aln, const vector<Ga
                             tail_dp_areas.push_back(trailing_sequence.size() * path_from_length(path));
 
                             if (after_alignment.score() > best_score) {
-                                // This is a new best alignment. Translate from subgraph into base graph and keep it
+                                // This is a new best alignment.
+                                
+#ifdef debug
+                                cerr << "\t\tNew best, beating previous best of " << best_score << endl;
+#endif
+                                
+                                // Translate from subgraph into base graph and keep it.
                                 best_path = subgraph.translate_down(after_alignment.path());
                                 best_score = after_alignment.score();
                             }
@@ -1242,7 +1248,8 @@ MinimizerMapper::find_connecting_paths(const vector<GaplessExtension>& extended_
 
 #ifdef debug
         cerr << "Extended seed " << i << " starts on node " << pos.node_id() << " " << pos.is_reverse()
-            << " at offset " << pos.offset() << endl;
+            << " at offset " << pos.offset() << " corresponding to read "
+            << extended_seeds[i].core_interval.first << " - " << extended_seeds[i].core_interval.second << endl;
 #endif
     }
 
@@ -1267,7 +1274,7 @@ MinimizerMapper::find_connecting_paths(const vector<GaplessExtension>& extended_
 
 #ifdef debug
         cerr << "Extended seed " << i << ": cut after on node " << cut_pos_graph.node_id() << " " << cut_pos_graph.is_reverse()
-            << " at point " << cut_pos_graph.offset() << endl;
+            << " at point " << cut_pos_graph.offset() << " corresponding to read base " << cut_pos_read << endl;
 #endif
 
         // Get a handle in the GBWTGraph
@@ -1413,6 +1420,10 @@ MinimizerMapper::find_connecting_paths(const vector<GaplessExtension>& extended_
             }
         }
     }
+
+#ifdef debug
+    cerr << "After rightward extensions, have " << sources.size() << " sources" << endl;
+#endif
 
     // Now we need the paths *from* numeric_limits<size_t>::max() to sources.
     // Luckily we know the sources.

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -20,8 +20,6 @@
 // With TRACK_PROVENANCE on, set this to track correctness, which requires some expensive XG queries
 //#define TRACK_CORRECTNESS
 
-#define debug
-
 namespace vg {
 
 using namespace std;


### PR DESCRIPTION
Previously the multipath validation logic did not handle going from the end of a handle back to the start around a self loop. I have adjusted it to allow that to happen.