### PR TITLE
Add functionality for rewriting sections of paths to the HandleGraph implementations

### DIFF
--- a/src/hash_graph.cpp
+++ b/src/hash_graph.cpp
@@ -481,7 +481,7 @@ namespace vg {
         
         path_t& path_list = paths[as_integers(segment_begin)[0]];
         
-        for (path_mapping_t* mapping = begin; mapping != end; mapping = mapping->next) {
+        for (path_mapping_t* mapping = begin; mapping != end;) {
             
             // remove this occurrence of the mapping from the occurrences index
             auto& node_occurrences = occurrences[get_id(mapping->handle)];
@@ -493,8 +493,12 @@ namespace vg {
                 }
             }
             
+            path_mapping_t* next = mapping->next;
+            
             // remove the step from the path
             path_list.remove(mapping);
+            
+            mapping = next;
         }
         
         // init the new range for the return value

--- a/src/hash_graph.hpp
+++ b/src/hash_graph.hpp
@@ -28,58 +28,58 @@ public:
     HashGraph(istream& in);
     
     /// Method to check if a node exists by ID
-    virtual bool has_node(id_t node_id) const;
+    bool has_node(id_t node_id) const;
     
     /// Look up the handle for the node with the given ID in the given orientation
-    virtual handle_t get_handle(const id_t& node_id, bool is_reverse = false) const;
+    handle_t get_handle(const id_t& node_id, bool is_reverse = false) const;
     
     /// Get the ID from a handle
-    virtual id_t get_id(const handle_t& handle) const;
+    id_t get_id(const handle_t& handle) const;
     
     /// Get the orientation of a handle
-    virtual bool get_is_reverse(const handle_t& handle) const;
+    bool get_is_reverse(const handle_t& handle) const;
     
     /// Invert the orientation of a handle (potentially without getting its ID)
-    virtual handle_t flip(const handle_t& handle) const;
+    handle_t flip(const handle_t& handle) const;
     
     /// Get the length of a node
-    virtual size_t get_length(const handle_t& handle) const;
+    size_t get_length(const handle_t& handle) const;
     
     /// Get the sequence of a node, presented in the handle's local forward orientation.
-    virtual string get_sequence(const handle_t& handle) const;
+    string get_sequence(const handle_t& handle) const;
     
     /// Loop over all the handles to next/previous (right/left) nodes. Passes
     /// them to a callback which returns false to stop iterating and true to
     /// continue. Returns true if we finished and false if we stopped early.
-    virtual bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
+    bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
     
     /// Loop over all the nodes in the graph in their local forward
     /// orientations, in their internal stored order. Stop if the iteratee
     /// returns false. Can be told to run in parallel, in which case stopping
     /// after a false return value is on a best-effort basis and iteration
     /// order is not defined.
-    virtual bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+    bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
     
     /// Return the number of nodes in the graph
     /// TODO: can't be node_count because XG has a field named node_count.
-    virtual size_t node_size(void) const;
+    size_t node_size(void) const;
     
     /// Return the smallest ID in the graph, or some smaller number if the
     /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
-    virtual id_t min_node_id(void) const;
+    id_t min_node_id(void) const;
     
     /// Return the largest ID in the graph, or some larger number if the
     /// largest ID is unavailable. Return value is unspecified if the graph is empty.
-    virtual id_t max_node_id(void) const;
+    id_t max_node_id(void) const;
     
     /// Efficiently get the number of edges attached to one side of a handle.
-    virtual size_t get_degree(const handle_t& handle, bool go_left) const;
+    size_t get_degree(const handle_t& handle, bool go_left) const;
 
     /// Create a new node with the given sequence and return the handle.
-    virtual handle_t create_handle(const std::string& sequence);
+    handle_t create_handle(const std::string& sequence);
 
     /// Create a new node with the given id and sequence, then return the handle.
-    virtual handle_t create_handle(const std::string& sequence, const id_t& id);
+    handle_t create_handle(const std::string& sequence, const id_t& id);
     
     /// Remove the node belonging to the given handle and all of its edges.
     /// Does not update any stored paths.
@@ -87,19 +87,19 @@ public:
     /// May be called during serial for_each_handle iteration **ONLY** on the node being iterated.
     /// May **NOT** be called during parallel for_each_handle iteration.
     /// May **NOT** be called on the node from which edges are being followed during follow_edges.
-    virtual void destroy_handle(const handle_t& handle);
+    void destroy_handle(const handle_t& handle);
     
     /// Create an edge connecting the given handles in the given order and orientations.
     /// Ignores existing edges.
-    virtual void create_edge(const handle_t& left, const handle_t& right);
+    void create_edge(const handle_t& left, const handle_t& right);
     
     /// Remove the edge connecting the given handles in the given order and orientations.
     /// Ignores nonexistent edges.
     /// Does not update any stored paths.
-    virtual void destroy_edge(const handle_t& left, const handle_t& right);
+    void destroy_edge(const handle_t& left, const handle_t& right);
     
     /// Remove all nodes and edges. Does not update any stored paths.
-    virtual void clear(void);
+    void clear(void);
     
     /// Alter the node that the given handle corresponds to so the orientation
     /// indicated by the handle becomes the node's local forward orientation.
@@ -109,7 +109,7 @@ public:
     /// orientation. Note that it is possible for the node's ID to change.
     /// Does not update any stored paths. May change the ordering of the underlying
     /// graph.
-    virtual handle_t apply_orientation(const handle_t& handle);
+    handle_t apply_orientation(const handle_t& handle);
     
     /// Split a handle's underlying node at the given offsets in the handle's
     /// orientation. Returns all of the handles to the parts. Other handles to
@@ -118,46 +118,46 @@ public:
     /// handles come in the order and orientation appropriate for the handle
     /// passed in.
     /// Updates stored paths.
-    virtual vector<handle_t> divide_handle(const handle_t& handle, const std::vector<size_t>& offsets);
+    vector<handle_t> divide_handle(const handle_t& handle, const std::vector<size_t>& offsets);
     
     ////////////////////////////////////////////////////////////////////////////
     // Path handle interface
     ////////////////////////////////////////////////////////////////////////////
     
     /// Returns the number of paths stored in the graph
-    virtual size_t get_path_count() const;
+    size_t get_path_count() const;
 
     /// Determine if a path name exists and is legal to get a path handle for.
-    virtual bool has_path(const std::string& path_name) const;
+    bool has_path(const std::string& path_name) const;
 
     /// Look up the path handle for the given path name.
     /// The path with that name must exist.
-    virtual path_handle_t get_path_handle(const std::string& path_name) const;
+    path_handle_t get_path_handle(const std::string& path_name) const;
 
     /// Look up the name of a path from a handle to it
-    virtual string get_path_name(const path_handle_t& path_handle) const;
+    string get_path_name(const path_handle_t& path_handle) const;
     
     /// Look up whether a path is circular
-    virtual bool get_is_circular(const path_handle_t& path_handle) const;
+    bool get_is_circular(const path_handle_t& path_handle) const;
 
     /// Returns the number of node steps in the path
-    virtual size_t get_step_count(const path_handle_t& path_handle) const;
+    size_t get_step_count(const path_handle_t& path_handle) const;
 
     /// Get a node handle (node ID and orientation) from a handle to a step on a path
-    virtual handle_t get_handle_of_step(const step_handle_t& step_handle) const;
+    handle_t get_handle_of_step(const step_handle_t& step_handle) const;
 
     /// Returns a handle to the path that a step is on
-    virtual path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
+    path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
     
     /// Get a handle to the first step, or in a circular path to an arbitrary step
     /// considered "first". If the path is empty, returns the past-the-last step
     /// returned by path_end.
-    virtual step_handle_t path_begin(const path_handle_t& path_handle) const;
+    step_handle_t path_begin(const path_handle_t& path_handle) const;
     
     /// Get a handle to a fictitious position past the end of a path. This position is
     /// return by get_next_step for the final step in a path in a non-circular path.
     /// Note that get_next_step will *NEVER* return this value for a circular path.
-    virtual step_handle_t path_end(const path_handle_t& path_handle) const;
+    step_handle_t path_end(const path_handle_t& path_handle) const;
     
     /// Returns a handle to the next step on the path. If the given step is the final step
     /// of a non-circular path, returns the past-the-last step that is also returned by
@@ -165,7 +165,7 @@ public:
     /// the one returned by path_begin).
     /// Note: to iterate over each step one time, even in a circular path, consider
     /// for_each_step_in_path.
-    virtual step_handle_t get_next_step(const step_handle_t& step_handle) const;
+    step_handle_t get_next_step(const step_handle_t& step_handle) const;
     
     /// Returns a handle to the previous step on the path. If the given step is the first
     /// step of a non-circular path, this method has undefined behavior. In a circular path,
@@ -173,19 +173,19 @@ public:
     /// the "last" step.
     /// Note: to iterate over each step one time, even in a circular path, consider
     /// for_each_step_in_path.
-    virtual step_handle_t get_previous_step(const step_handle_t& step_handle) const;
+    step_handle_t get_previous_step(const step_handle_t& step_handle) const;
     
     /// Execute a function on each path in the graph
-    virtual bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
+    bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
     
     /// Calls a function with all steps of a node on paths.
-    virtual bool for_each_step_on_handle_impl(const handle_t& handle,
-                                              const function<bool(const step_handle_t&)>& iteratee) const;
+    bool for_each_step_on_handle_impl(const handle_t& handle,
+                                      const function<bool(const step_handle_t&)>& iteratee) const;
     
     /**
      * Destroy the given path. Invalidates handles to the path and its node steps.
      */
-    virtual void destroy_path(const path_handle_t& path);
+    void destroy_path(const path_handle_t& path);
 
     /**
      * Create a path with the given name. The caller must ensure that no path
@@ -193,7 +193,7 @@ public:
      * Returns a handle to the created empty path. Handles to other paths must
      * remain valid.
      */
-    virtual path_handle_t create_path_handle(const string& name, bool is_circular = false);
+    path_handle_t create_path_handle(const string& name, bool is_circular = false);
 
     /**
      * Append a visit to a node to the given path. Returns a handle to the new
@@ -202,8 +202,27 @@ public:
      * method path_begin. Handles to prior steps on the path, and to other paths,
      * must remain valid.
      */
-    virtual step_handle_t append_step(const path_handle_t& path, const handle_t& to_append);
+    step_handle_t append_step(const path_handle_t& path, const handle_t& to_append);
 
+    /**
+     * Prepend a visit to a node to the given path. Returns a handle to the new
+     * first step on the path which is appended. If the path is cirular, the new
+     * step is placed between the steps considered "last" and "first" by the
+     * method path_begin. Handles to later steps on the path, and to other paths,
+     * must remain valid.
+     */
+    step_handle_t prepend_step(const path_handle_t& path, const handle_t& to_prepend);
+    
+    /**
+     * Delete a segment of a path and rewrite it as some other sequence of steps. Returns a pair
+     * of step_handle_t's that indicate the range of the new segment in the path. The segment to
+     * delete should be designated by the first and the past-the-last step handle.  If the step
+     * that is returned by path_begin is deleted, path_begin will now return the first step from
+     * the new segment or, in the case that the new segment is empty, segment_end.
+     */
+    pair<step_handle_t, step_handle_t> rewrite_segment(const step_handle_t& segment_begin,
+                                                       const step_handle_t& segment_end,
+                                                       const std::vector<handle_t>& new_segment);
     
     /**
      * Make a path circular or non-circular. If the path is becoming circular, the
@@ -211,7 +230,7 @@ public:
      * step considered "last" is unjoined from the step considered "first" according
      * to the method path_begin.
      */
-    virtual void set_circularity(const path_handle_t& path, bool circular);
+    void set_circularity(const path_handle_t& path, bool circular);
     
     ////////////////////////////////////////////////////////////////////////////
     // Non-handle methods
@@ -282,9 +301,9 @@ private:
         /// Remove the mapping from the path and free its memory
         void remove(path_mapping_t* mapping);
         
-        /// Insert a new node into the middle of the path. If the the profvided node
-        /// is null, inserts at the beginning.
-        path_mapping_t* insert_after(const handle_t& handle, path_mapping_t* mapping);
+        /// Insert a new node into the middle of the path. If the the provided node
+        /// is null, inserts at the end.
+        path_mapping_t* insert_before(const handle_t& handle, path_mapping_t* mapping);
         
         void serialize(ostream& out) const;
         

--- a/src/io/register_libvg_io.hpp
+++ b/src/io/register_libvg_io.hpp
@@ -1,5 +1,5 @@
 #ifndef VG_IO_REGISTER_LIBVG_IO_HPP_INCLUDED
-#define VG_IO_REGISTER_LIBVG_IO_HPP_HPP_INCLUDED
+#define VG_IO_REGISTER_LIBVG_IO_HPP_INCLUDED
 
 /**
  * \file register_libvg_io.hpp

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1334,8 +1334,7 @@ namespace vg {
         
         // find and erase the record of this node's membership on the path
         for (size_t step_offset = as_integers(segment_begin)[1];
-             step_offset != as_integers(segment_end)[1];
-             step_offset = get_step_next(packed_path, step_offset)) {
+             step_offset != as_integers(segment_end)[1]; ) {
             
             size_t g_iv_idx = graph_iv_index(decode_traversal(get_step_trav(packed_path, step_offset)));
             size_t node_member_idx = graph_index_to_node_member_index(g_iv_idx);
@@ -1391,6 +1390,8 @@ namespace vg {
             
             // maybe reallocate to address fragmentation within the path
             //defragment_path(packed_path);
+            
+            step_offset = next_offset;
         }
         
         pair<step_handle_t, step_handle_t> new_segment_range(segment_end, segment_end);

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -57,6 +57,7 @@ namespace vg {
             sdsl::write_member(path.is_circular, out);
             sdsl::write_member(path.head, out);
             sdsl::write_member(path.tail, out);
+            sdsl::write_member(path.deleted_step_records, out);
             path.steps_iv.serialize(out);
         }
         // note: path_id can be reconstructed from the paths
@@ -84,12 +85,13 @@ namespace vg {
         for (size_t i = 0; i < num_paths; i++) {
             string name;
             sdsl::read_member(name, in);
-            paths.emplace_back(name, false); // dummy circularity for now
+            paths.emplace_back(name, false); // dummy circularity for now, set real one in a few lines
             PackedPath& path = paths.back();
             sdsl::read_member(path.is_deleted, in);
             sdsl::read_member(path.is_circular, in);
             sdsl::read_member(path.head, in);
             sdsl::read_member(path.tail, in);
+            sdsl::read_member(path.deleted_step_records, in);
             path.steps_iv.deserialize(in);
         }
         
@@ -603,7 +605,7 @@ namespace vg {
             
             // we don't actually bother removing the reference, but we will also consider
             // the edge on the deleting node to be deleted and hence count it up here
-            deleted_edge_records++;
+            ++deleted_edge_records;
             return true;
         });
         follow_edges(handle, true, [&](const handle_t& prev) {
@@ -612,7 +614,7 @@ namespace vg {
             
             // we don't actually bother removing the reference, but we will also consider
             // the edge on the deleting node to be deleted and hence count it up here
-            deleted_edge_records++;
+            ++deleted_edge_records;
             return true;
         });
         
@@ -622,7 +624,7 @@ namespace vg {
         // remove the reference to the node
         id_to_graph_iv.set(get_id(handle) - min_id, 0);
         
-        deleted_node_records++;
+        ++deleted_node_records;
         
         // maybe reallocate to address fragmentation
         defragment();
@@ -655,7 +657,7 @@ namespace vg {
             edge_lists_iv.set((prev_edge_list_idx - 1) * EDGE_RECORD_SIZE + EDGE_NEXT_OFFSET,
                               get_next_edge_index(edge_list_idx));
         }
-        deleted_edge_records++;
+        ++deleted_edge_records;
     }
     
     void PackedGraph::destroy_edge(const handle_t& left, const handle_t& right) {
@@ -664,9 +666,177 @@ namespace vg {
         defragment();
     }
     
+    void PackedGraph::defragment_path(PackedPath& path, bool force) {
+        
+        // we don't want to defrag deleted paths since they have already been cleared
+        if (path.is_deleted) {
+            return;
+        }
+        
+        // have we either deleted a lot of steps or forced a defrag?
+        if (path.deleted_step_records > defrag_factor * (path.steps_iv.size() / PATH_RECORD_SIZE) || force) {
+            
+            if (path.head != 0) {
+                // the path is non-empty, so we need to straighten it out and reallocate it
+                PagedVector new_steps_iv(PAGE_WIDTH);
+                
+                // we will need to record the translation between path steps so we can update memberships later
+                PagedVector offset_translator(PAGE_WIDTH);
+                offset_translator.resize(path.steps_iv.size() / PATH_RECORD_SIZE + 1);
+                
+                new_steps_iv.reserve(path.steps_iv.size() - path.deleted_step_records);
+                bool first_iter = true;
+                size_t copying_from = path.head;
+                size_t prev = 0;
+                while (copying_from != 0 && (first_iter || copying_from != path.head)) {
+                    
+                    // make a new record
+                    new_steps_iv.append(get_step_trav(path, copying_from));
+                    new_steps_iv.append(prev);
+                    new_steps_iv.append(0);
+                    
+                    size_t here = new_steps_iv.size() / PATH_RECORD_SIZE;
+                    
+                    // record the correspondance between the old
+                    offset_translator.set(copying_from, here);
+                    
+                    // update the point on the previous node
+                    if (prev != 0) {
+                        new_steps_iv.set(new_steps_iv.size() - 2 * PATH_RECORD_SIZE + PATH_NEXT_OFFSET, here);
+                    }
+                    
+                    prev = here;
+                    
+                    copying_from = get_step_next(path, copying_from);
+                    first_iter = false;
+                }
+                
+                // add the looping connection if this is a circular path
+                if (path.is_circular) {
+                    new_steps_iv.set(new_steps_iv.size() - PATH_RECORD_SIZE + PATH_NEXT_OFFSET, 1);
+                    new_steps_iv.set(PATH_PREV_OFFSET, new_steps_iv.size() / PATH_RECORD_SIZE);
+                }
+                
+                path.steps_iv = move(new_steps_iv);
+                
+                // update the head and tail of the newly allocated path
+                path.head = 1;
+                path.tail = prev;
+                
+                // retrieve the ID of this path so we can match it to membership records
+                int64_t path_id_here = path_id.at(path.name);
+                
+                // now we need to iterate over each node on the path exactly one time to update its membership
+                // records (even if the node occurs multiple times on this path), so we will use a bit deque
+                // indexed by node_id - min_id to flag nodes as either translated or untranslated
+                PackedDeque id_translated;
+                id_translated.append_back(0);
+                id_t min_translated_id = get_id(decode_traversal(get_step_trav(path, path.head)));
+                
+                first_iter = true;
+                for (size_t here = path.head; here != 0 && (here != path.head || first_iter); here = get_step_next(path, here)) {
+                    
+                    handle_t handle = decode_traversal(get_step_trav(path, here));
+                    id_t step_node_id = get_id(handle);
+                    
+                    // expand the bounds of the deque as necessary to be able to index by ID
+                    if (step_node_id < min_translated_id) {
+                        for (id_t i = step_node_id; i < min_translated_id; ++i) {
+                            id_translated.append_front(0);
+                        }
+                        min_translated_id = step_node_id;
+                    }
+                    else if (step_node_id >= min_translated_id + id_translated.size()) {
+                        for (id_t i = min_translated_id + id_translated.size(); i <= step_node_id; ++i) {
+                            id_translated.append_back(0);
+                        }
+                    }
+                    
+                    // have we already translated the membership records for the path on this node?
+                    // (we need to check this to avoid falsely translating pointers that we have actually
+                    // already translated)
+                    if (id_translated.get(step_node_id - min_translated_id) != 1) {
+                        
+                        size_t member_idx = path_membership_node_iv.get(graph_index_to_node_member_index(graph_iv_index(handle)));
+                        while (member_idx) {
+                            
+                            // update the offsets for membership records on this path
+                            if (get_membership_path(member_idx) == path_id_here) {
+                                set_membership_step(member_idx, offset_translator.get(get_membership_step(member_idx)));
+                            }
+                            
+                            // move to the next membership record
+                            member_idx = get_next_membership(member_idx);
+                        }
+                        
+                        // mark this node as updated so we don't re-update the offsets
+                        id_translated.set(step_node_id - min_translated_id, 1);
+                    }
+                    
+                    first_iter = false;
+                }
+            }
+            else {
+                // the path is empty, so let's make sure it's not holding onto any capacity it doesn't need
+                path.steps_iv = PagedVector(PAGE_WIDTH);
+            }
+            
+            path.deleted_step_records = 0;
+        }
+    }
+    
+    void PackedGraph::eject_deleted_paths() {
+        
+        uint64_t num_paths_deleted = 0;
+        vector<uint64_t> paths_deleted_before(paths.size(), 0);
+        for (size_t i = 0; i < paths.size(); i++) {
+            
+            paths_deleted_before[i] = num_paths_deleted;
+            
+            if (paths[i].is_deleted) {
+                num_paths_deleted++;
+                continue;
+            }
+            
+            // move non-deleted paths into the front of the vector
+            if (num_paths_deleted > 0) {
+                paths[i - num_paths_deleted] = std::move(paths[i]);
+            }
+        }
+        
+        // eliminate the empty spots we left at the end of the vector
+        if (num_paths_deleted > 0) {
+            for (size_t i = 0; i < num_paths_deleted; ++i) {
+                // we use pop back instead of resize because it doesn't require a default constructor
+                paths.pop_back();
+            }
+            paths.shrink_to_fit();
+            
+            // update the path IDs
+            for (size_t i = 0; i < paths.size(); ++i) {
+                path_id[paths[i].name] = i;
+            }
+            
+            // update the path IDs in the membership records
+            for (size_t i = 0; i < path_membership_value_iv.size(); i += MEMBERSHIP_RECORD_SIZE) {
+                uint64_t current_path = path_membership_value_iv.get(i + MEMBERSHIP_PATH_OFFSET);
+                path_membership_value_iv.set(i + MEMBERSHIP_PATH_OFFSET, current_path - paths_deleted_before[current_path]);
+            }
+        }
+    }
+    
     void PackedGraph::compactify() {
         
-        // force the data structures to reallocate in ID order and eject deleted material
+        // remove deleted paths and force them to eject deleted material
+        for (size_t i = 0; i < paths.size(); i++) {
+            // force the path to defragment
+            defragment_path(paths[i], true);
+        }
+        
+        // push any paths we deleted out of the path vector
+        eject_deleted_paths();
+        
+        // force the graph structures to reallocate in ID order and eject deleted material
         defragment(true);
         
         // make a new id_to_graph_iv of exactly the right size
@@ -704,49 +874,6 @@ namespace vg {
         }
         // replace the old seq iv
         seq_iv = std::move(new_seq_iv);
-        
-        size_t num_paths_deleted_so_far = 0;
-        for (size_t i = 0; i < paths.size(); i++) {
-            
-            if (paths[i].is_deleted) {
-                num_paths_deleted_so_far++;
-                continue;
-            }
-            
-            if (num_paths_deleted_so_far > 0) {
-                paths[i - num_paths_deleted_so_far] = std::move(paths[i]);
-            }
-            
-            PackedPath& path = paths[i - num_paths_deleted_so_far];
-            
-            if (path.head != 0) {
-                PagedVector new_steps_iv(PAGE_WIDTH);
-                // TODO: if we add deletes for paths then this won't be a compact capacity
-                new_steps_iv.reserve(path.steps_iv.size());
-                size_t copying_from = path.head;
-                size_t prev = 0;
-                while (copying_from != 0) {
-                    
-                    // make a new record
-                    new_steps_iv.append(get_step_trav(path, copying_from));
-                    new_steps_iv.append(prev);
-                    new_steps_iv.append(0);
-                    
-                    size_t here = new_steps_iv.size() / PATH_RECORD_SIZE;
-                    
-                    // update the point on the previous node
-                    if (prev != 0) {
-                        new_steps_iv.set(new_steps_iv.size() - 2 * PATH_RECORD_SIZE + PATH_NEXT_OFFSET, here);
-                    }
-                    
-                    prev = here;
-                    
-                    copying_from = get_step_next(path, copying_from);
-                }
-                
-                path.steps_iv = move(new_steps_iv);
-            }
-        }
     }
     
     void PackedGraph::defragment(bool force) {
@@ -932,7 +1059,7 @@ namespace vg {
     size_t PackedGraph::get_step_count(const path_handle_t& path_handle) const {
         // TODO: if we every allow step deletes, this will need to be adjusted
         const PackedPath& path = paths.at(as_integer(path_handle));
-        return path.steps_iv.size() / PATH_RECORD_SIZE;
+        return path.steps_iv.size() / PATH_RECORD_SIZE - path.deleted_step_records;
     }
     
     size_t PackedGraph::get_path_count() const {
@@ -1023,8 +1150,12 @@ namespace vg {
         PackedPath& packed_path = paths.at(as_integer(path));
         
         // remove node membership records corresponding to this path
-        for (size_t i = 0; i < packed_path.steps_iv.size(); i += PATH_RECORD_SIZE) {
-            uint64_t trav = packed_path.steps_iv.get(i + PATH_TRAV_OFFSET);
+        bool first_iter = true;
+        for (uint64_t step_offset = packed_path.head;
+             step_offset != 0 && (step_offset != packed_path.head || first_iter);
+             step_offset = get_step_next(packed_path, step_offset)) {
+            
+            uint64_t trav = get_step_trav(packed_path, step_offset);
             size_t node_member_idx = graph_index_to_node_member_index(graph_iv_index(decode_traversal(trav)));
             
             // find a membership record for this path
@@ -1047,7 +1178,9 @@ namespace vg {
                 set_next_membership(prev, get_next_membership(here));
             }
             
-            deleted_membership_records++;
+            ++deleted_membership_records;
+            
+            first_iter = false;
         }
         
         path_id.erase(packed_path.name);
@@ -1113,14 +1246,193 @@ namespace vg {
         return step;
     }
     
-    void PackedGraph::set_circularity(const path_handle_t& path, bool circular) {
-        PackedPath& packed_path = paths[as_integer(path)];
-        // set the looping connection as appropriate
-        if (circular && !packed_path.steps_iv.empty()) {
+    step_handle_t PackedGraph::prepend_step(const path_handle_t& path, const handle_t& to_prepend) {
+        
+        PackedPath& packed_path = paths.at(as_integer(path));
+        
+        // create a new path record
+        packed_path.steps_iv.append(as_integer(to_prepend));
+        packed_path.steps_iv.append(0);
+        packed_path.steps_iv.append(packed_path.head);
+        
+        // the offset associated with the new record
+        size_t step_offset = packed_path.steps_iv.size() / PATH_RECORD_SIZE;
+        
+        // update the pointer from the current head
+        if (packed_path.head != 0) {
+            set_step_prev(packed_path, packed_path.head, step_offset);
+        }
+        
+        // update the head and tail of the list
+        packed_path.head = step_offset;
+        if (packed_path.tail == 0) {
+            packed_path.tail = step_offset;
+        }
+        
+        // update the looping connection if this is a circular path
+        if (packed_path.is_circular) {
             set_step_prev(packed_path, packed_path.head, packed_path.tail);
             set_step_next(packed_path, packed_path.tail, packed_path.head);
         }
-        else if (!circular && !packed_path.steps_iv.empty()) {
+        
+        // record the membership of this node in this path
+        size_t node_member_idx = graph_index_to_node_member_index(graph_iv_index(to_prepend));
+        path_membership_value_iv.append(as_integer(path));
+        path_membership_value_iv.append(step_offset);
+        path_membership_value_iv.append(path_membership_node_iv.get(node_member_idx));
+        
+        // make this new membership record the head of the linked list
+        path_membership_node_iv.set(node_member_idx, path_membership_value_iv.size() / MEMBERSHIP_RECORD_SIZE);
+        
+        // make and return an step handle
+        step_handle_t step;
+        as_integers(step)[0] = as_integer(path);
+        as_integers(step)[1] = step_offset;
+        return step;
+    }
+    
+    pair<step_handle_t, step_handle_t> PackedGraph::rewrite_segment(const step_handle_t& segment_begin,
+                                                                    const step_handle_t& segment_end,
+                                                                    const vector<handle_t>& new_segment) {
+        
+        if (get_path_handle_of_step(segment_begin) != get_path_handle_of_step(segment_end)) {
+            cerr << "error:[PackedGraph] attempted to rewrite a path segment delimited by steps on two different paths" << endl;
+            exit(1);
+        }
+        
+        PackedPath& packed_path =  paths.at(as_integers(segment_begin)[0]);
+        
+        // TODO: somewhat repetitive with a routine in destroy_path
+        
+        // find and erase the record of this node's membership on the path
+        for (size_t step_offset = as_integers(segment_begin)[1];
+             step_offset != as_integers(segment_end)[1];
+             step_offset = get_step_next(packed_path, step_offset)) {
+            
+            size_t g_iv_idx = graph_iv_index(decode_traversal(get_step_trav(packed_path, step_offset)));
+            size_t node_member_idx = graph_index_to_node_member_index(g_iv_idx);
+            
+            // find the membership record that corresponds to this step
+            size_t prev = 0;
+            size_t here = path_membership_node_iv.get(node_member_idx);
+            while (get_membership_path(here) != as_integers(segment_end)[0] ||
+                   get_membership_step(here) != step_offset) {
+                prev = here;
+                here = get_next_membership(here);
+            }
+            
+            if (prev == 0) {
+                // this was the first record, set following one to be the head
+                path_membership_node_iv.set(node_member_idx, get_next_membership(here));
+            }
+            else {
+                // make the link from the previous record skip over the current one
+                set_next_membership(prev, get_next_membership(here));
+            }
+            
+            ++deleted_membership_records;
+            
+            // get the adjacent nodes in the path
+            size_t prev_offset = get_step_prev(packed_path, step_offset);
+            size_t next_offset = get_step_next(packed_path,step_offset);
+            
+            // make their links skip over this node
+            if (prev_offset != 0) {
+                set_step_next(packed_path, prev_offset, next_offset);
+            }
+            if (next_offset != 0) {
+                set_step_prev(packed_path, next_offset, prev_offset);
+            }
+            
+            // update the head and tail of the path if necessary
+            if (step_offset == packed_path.head && step_offset == packed_path.tail) {
+                // this is the last node in the path, set the head and tail to null
+                packed_path.head = packed_path.tail = 0;
+            }
+            else if (step_offset == packed_path.head) {
+                packed_path.head = next_offset;
+            }
+            else if (step_offset == packed_path.tail) {
+                packed_path.tail = prev_offset;
+            }
+            
+            packed_path.deleted_step_records++;
+            
+            // TODO: reallocating paths invalidates pointers, so we can't really do it here because
+            // we need to return the range. might also be confusing to users
+            
+            // maybe reallocate to address fragmentation within the path
+            //defragment_path(packed_path);
+        }
+        
+        pair<step_handle_t, step_handle_t> new_segment_range(segment_end, segment_end);
+        
+        // now add in the new segment
+        bool first_iter = true;
+        uint64_t anchor_offset = as_integers(segment_end)[1];
+        for (const handle_t& handle : new_segment) {
+            
+            // create a new step record
+            packed_path.steps_iv.append(encode_traversal(handle));
+            packed_path.steps_iv.append(0);
+            packed_path.steps_iv.append(0);
+            
+            uint64_t step_offset = packed_path.steps_iv.size() / PATH_RECORD_SIZE;
+            
+            if (anchor_offset != 0) {
+                
+                // insert before
+                uint64_t anchor_prev = get_step_prev(packed_path, anchor_offset);
+                set_step_prev(packed_path, step_offset, get_step_prev(packed_path, anchor_offset));
+                if (anchor_prev != 0) {
+                    set_step_next(packed_path, anchor_prev, step_offset);
+                }
+                
+                set_step_next(packed_path, step_offset, anchor_offset);
+                set_step_prev(packed_path, anchor_offset, step_offset);
+            }
+            else {
+                // place after the tail, since we're not putting it before anything
+                if (packed_path.tail != 0) {
+                    // attach to the tail
+                    uint64_t tail_next = get_step_next(packed_path, packed_path.tail);
+                    set_step_next(packed_path, packed_path.tail, step_offset);
+                    set_step_prev(packed_path, step_offset, packed_path.tail);
+                    
+                    // handle the potential looping connection
+                    if (tail_next != 0) {
+                        set_step_next(packed_path, step_offset, tail_next);
+                        set_step_prev(packed_path, tail_next, step_offset);
+                    }
+                }
+                
+                // we're placing at the end, so this is the new tail
+                packed_path.tail = step_offset;
+            }
+            
+            if (anchor_offset == packed_path.head) {
+                // we're placing before the head (or the head is null), so this is new head
+                packed_path.head = step_offset;
+            }
+            
+            if (first_iter) {
+                // record the start of the new range
+                as_integers(new_segment_range.first)[1] = step_offset;
+                first_iter = false;
+            }
+        }
+        
+        return new_segment_range;
+    }
+    
+    void PackedGraph::set_circularity(const path_handle_t& path, bool circular) {
+        PackedPath& packed_path = paths[as_integer(path)];
+        // set the looping connection as appropriate
+        if (circular && packed_path.head != 0) {
+            set_step_prev(packed_path, packed_path.head, packed_path.tail);
+            set_step_next(packed_path, packed_path.tail, packed_path.head);
+        }
+        else if (!circular && packed_path.head != 0) {
             set_step_prev(packed_path, packed_path.head, 0);
             set_step_next(packed_path, packed_path.tail, 0);
         }

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -12,6 +12,7 @@ namespace vg {
     using namespace handlegraph;
     
     /// Define all of the static class variables
+    
     const double PackedGraph::defrag_factor = .2;
     
     const size_t PackedGraph::PAGE_WIDTH = 128;
@@ -1441,6 +1442,13 @@ namespace vg {
                 // we're placing before the head (or the head is null), so this is new head
                 packed_path.head = step_offset;
             }
+            
+            // put a membership record for this occurrence at the front of the membership list
+            size_t node_member_idx = graph_index_to_node_member_index(graph_iv_index(handle));
+            path_membership_value_iv.append(as_integers(segment_end)[0]);
+            path_membership_value_iv.append(step_offset);
+            path_membership_value_iv.append(path_membership_node_iv.get(node_member_idx));
+            path_membership_node_iv.set(node_member_idx, path_membership_value_iv.size() / MEMBERSHIP_RECORD_SIZE);
             
             if (first_iter) {
                 // record the start of the new range

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1,5 +1,5 @@
 //
-//  dgraph.cpp
+//  packed_graph.cpp
 //
 
 #include "packed_graph.hpp"
@@ -11,7 +11,34 @@ namespace vg {
 
     using namespace handlegraph;
     
+    /// Define all of the static class variables
     const double PackedGraph::defrag_factor = .2;
+    
+    const size_t PackedGraph::PAGE_WIDTH = 128;
+    
+    const size_t PackedGraph::GRAPH_RECORD_SIZE = 2;
+    const size_t PackedGraph::GRAPH_START_EDGES_OFFSET = 0;
+    const size_t PackedGraph::GRAPH_END_EDGES_OFFSET = 1;
+    
+    const size_t PackedGraph::SEQ_START_RECORD_SIZE = 1;
+    
+    const size_t PackedGraph::SEQ_LENGTH_RECORD_SIZE = 1;
+    
+    const size_t PackedGraph::EDGE_RECORD_SIZE = 2;
+    const size_t PackedGraph::EDGE_TRAV_OFFSET = 0;
+    const size_t PackedGraph::EDGE_NEXT_OFFSET = 1;
+    
+    const size_t PackedGraph::NODE_MEMBER_RECORD_SIZE = 1;
+    
+    const size_t PackedGraph::MEMBERSHIP_RECORD_SIZE = 3;
+    const size_t PackedGraph::MEMBERSHIP_PATH_OFFSET = 0;
+    const size_t PackedGraph::MEMBERSHIP_STEP_OFFSET = 1;
+    const size_t PackedGraph::MEMBERSHIP_NEXT_OFFSET = 2;
+    
+    const size_t PackedGraph::PATH_RECORD_SIZE = 3;
+    const size_t PackedGraph::PATH_TRAV_OFFSET = 0;
+    const size_t PackedGraph::PATH_PREV_OFFSET = 1;
+    const size_t PackedGraph::PATH_NEXT_OFFSET = 2;
     
     PackedGraph::PackedGraph() :
         graph_iv(PAGE_WIDTH),

--- a/src/packed_graph.hpp
+++ b/src/packed_graph.hpp
@@ -295,7 +295,7 @@ private:
     const static double defrag_factor;
     
     /// We use a standard page width for all page-compressed vectors
-    const static size_t PAGE_WIDTH = 128;
+    const static size_t PAGE_WIDTH;
     
     // TODO: some of these offsets are a little silly and only are around as legacy.
     // They could be removed once the factoring stabilizes, but optimization will also
@@ -305,24 +305,24 @@ private:
     /// offsets in edge_lists_iv.
     /// {start edge list index, end edge list index}
     PagedVector graph_iv;
-    const static size_t GRAPH_RECORD_SIZE = 2;
-    const static size_t GRAPH_START_EDGES_OFFSET = 0;
-    const static size_t GRAPH_END_EDGES_OFFSET = 1;
+    const static size_t GRAPH_RECORD_SIZE;
+    const static size_t GRAPH_START_EDGES_OFFSET;
+    const static size_t GRAPH_END_EDGES_OFFSET;
     
     /// Encodes the start of a node's sequence in seq_iv. Matches the order of graph_iv.
     PagedVector seq_start_iv;
-    const static size_t SEQ_START_RECORD_SIZE = 1;
+    const static size_t SEQ_START_RECORD_SIZE;
     
     /// Encodes the length of a node's sequence in seq_iv. Matches the order of graph_iv.
     PackedVector seq_length_iv;
-    const static size_t SEQ_LENGTH_RECORD_SIZE = 1;
+    const static size_t SEQ_LENGTH_RECORD_SIZE;
 
     /// Encodes a series of edges lists of nodes.
     /// {ID|orientation (bit-packed), next edge index}
     PagedVector edge_lists_iv;
-    const static size_t EDGE_RECORD_SIZE = 2;
-    const static size_t EDGE_TRAV_OFFSET = 0;
-    const static size_t EDGE_NEXT_OFFSET = 1;
+    const static size_t EDGE_RECORD_SIZE;
+    const static size_t EDGE_TRAV_OFFSET;
+    const static size_t EDGE_NEXT_OFFSET;
     
     // TODO: template out the deque and back id_to_graph_iv with a paged vector? might
     // provide better compression now that it can handle 0's gracefully. unsure how the
@@ -340,7 +340,7 @@ private:
     /// Consists of 1-based offset to the corresponding heads of linked lists in
     /// path_membership_value_iv, which contains the actual pointers into the paths.
     PagedVector path_membership_node_iv;
-    const static size_t NODE_MEMBER_RECORD_SIZE = 1;
+    const static size_t NODE_MEMBER_RECORD_SIZE;
     
     /// Encodes a series of linked lists of the memberships within paths. Consists of
     /// fixed width records of the following form. Path IDs are 0-based indexes, the
@@ -348,10 +348,10 @@ private:
     /// MEMBERSHIP_RECORD_SIZE respectively.
     /// {path ID, index in path, next membership record index}
     PagedVector path_membership_value_iv;
-    const static size_t MEMBERSHIP_RECORD_SIZE = 3;
-    const static size_t MEMBERSHIP_PATH_OFFSET = 0;
-    const static size_t MEMBERSHIP_STEP_OFFSET = 1;
-    const static size_t MEMBERSHIP_NEXT_OFFSET = 2;
+    const static size_t MEMBERSHIP_RECORD_SIZE;
+    const static size_t MEMBERSHIP_PATH_OFFSET;
+    const static size_t MEMBERSHIP_STEP_OFFSET;
+    const static size_t MEMBERSHIP_NEXT_OFFSET;
     
     /*
      * A struct to package the data associated with a path through the graph.
@@ -384,10 +384,10 @@ private:
         /// The number of steps that have been deleted from the path
         uint64_t deleted_step_records = 0;
     };
-    const static size_t PATH_RECORD_SIZE = 3;
-    const static size_t PATH_TRAV_OFFSET = 0;
-    const static size_t PATH_PREV_OFFSET = 1;
-    const static size_t PATH_NEXT_OFFSET = 2;
+    const static size_t PATH_RECORD_SIZE;
+    const static size_t PATH_TRAV_OFFSET;
+    const static size_t PATH_PREV_OFFSET;
+    const static size_t PATH_NEXT_OFFSET;
     
     /// Map from path names to index in the paths vector.
     string_hash_map<string, int64_t> path_id;

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -260,8 +260,12 @@ Path& append_path(Path& a, const Path& b) {
     return a;
 }
 
-bool Paths::has_mapping(const string& name, size_t rank) {
-    return mappings_by_rank.count(name) && mappings_by_rank[name].count(rank);
+bool Paths::has_mapping(const string& name, int32_t rank) {
+    auto iter = mappings_by_rank.find(name);
+    if (iter != mappings_by_rank.end()) {
+        return iter->second.count(rank);
+    }
+    return false;
 }
 
 void Paths::append_mapping(const string& name, const mapping_t& m, bool warn_on_duplicates) {
@@ -367,16 +371,29 @@ void Paths::prepend_mapping(const string& name, const Mapping& m, bool warn_on_d
     // get or create the path with this name
     list<mapping_t>& pt = get_create_path(name);
    
-    // TODO: Implement dealing with no rank.
-    // We can't prepend a mapping that doesn't have a rank set. We would like to
-    // generate ranks, but we can't keep decrementing the first rank
-    // indefinitely, and that might not be correct. Also, what rank would we use
-    // for the only mapping in a path?
-    assert(m.rank());
+    // TODO: I'm not sure if this is the best way for handling ranks, but the ranks
+    // are really a chunked serialization thing, not an in-memory construct. Moreover,
+    // we're ideally going to move away from using the VG graph in the future, so I don't
+    // expect this will even come up. Mostly just trying to meet the HandleGraph interface
+    // in the interim.
+    int32_t rank = m.rank();
+    if (rank == 0) {
+        // no given rank, decrement the first rank, skipping over 0 to preserve it as
+        // a sentinel
+        if (pt.empty()) {
+            rank = 1;
+        }
+        else if (pt.front().rank != 1) {
+            rank = pt.front().rank - 1;
+        }
+        else {
+            rank = -1;
+        }
+    }
     
     // now if we haven't already supplied a mapping
     // add it
-    if (!has_mapping(name, m.rank())) {
+    if (!has_mapping(name, rank)) {
         // If we don't have a rank set or we don't have a mapping in this path
         // with that rank, we need to add the mapping.
         
@@ -394,7 +411,7 @@ void Paths::prepend_mapping(const string& name, const Mapping& m, bool warn_on_d
     } else if (warn_on_duplicates) {
         // This mapping duplicates the rank of an existing mapping.
         // We're not going to keep it, so we should complain.
-        cerr << "[vg] warning: path " << name << " rank " << m.rank() << " appears multiple times. Skipping." << endl;
+        cerr << "[vg] warning: path " << name << " rank " << rank << " appears multiple times. Skipping." << endl;
     }
 }
 

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -104,7 +104,7 @@ public:
     // We need this in order to make sure we aren't adding duplicate mappings
     // with the same rank in the same path. Maps from path name and rank to
     // Mapping pointer.
-    map<string, hash_map<size_t, mapping_t*>> mappings_by_rank;
+    map<string, hash_map<int32_t, mapping_t*>> mappings_by_rank;
     // This maps from node ID, then path name, then rank and orientation, to
     // Mapping pointers for the mappings on that path to that node.
     hash_map<id_t, map<int64_t, set<mapping_t*>>> node_mapping;
@@ -152,7 +152,7 @@ public:
     // Does the given path have a mapping meeting the given criteria?
     // Is there a mapping in the given path with the given assigned rank? Note
     // that the rank passed may not be 0.
-    bool has_mapping(const string& name, size_t rank);
+    bool has_mapping(const string& name, int32_t rank);
     // We used to be able to search for a Mapping by value, but that's not
     // efficient if the Mappings don't have ranks, and it never checked the
     // edits for equality anyway.
@@ -215,7 +215,7 @@ public:
     void append_mapping(const string& name, id_t id, bool is_reverse, size_t length, size_t rank = 0, bool warn_on_duplicates = false);
     // TODO: Adapt this to use mapping_t instead.
     void prepend_mapping(const string& name, const Mapping& m, bool warn_on_duplicates = false);
-    void prepend_mapping(const string& name, id_t id, bool is_reverse, size_t length, size_t rank, bool warn_on_duplicates = false);
+    void prepend_mapping(const string& name, id_t id, bool is_reverse, size_t length, size_t rank = 0, bool warn_on_duplicates = false);
     size_t get_next_rank(const string& name);
     void append(const Paths& paths, bool warn_on_duplicates = false, bool rebuild_indexes = true);
     void append(const Graph& g, bool warn_on_duplicates = false, bool rebuild_indexes = true);

--- a/src/unittest/handle.cpp
+++ b/src/unittest/handle.cpp
@@ -1682,63 +1682,62 @@ TEST_CASE("VG and XG path handle implementations are correct", "[handle][vg][xg]
         REQUIRE(xg_index.get_path_count() == 3);
     }
     
-    SECTION("Handles can traverse paths") {
+    // check that a path is correctly accessible and traversible
+    auto check_path_traversal = [&](const PathHandleGraph& graph, const Path& path) {
         
-        // check that a path is correctly accessible and traversible
-        auto check_path_traversal = [&](const PathHandleGraph& graph, const Path& path) {
+        path_handle_t path_handle = graph.get_path_handle(path.name());
+        
+        REQUIRE(graph.get_step_count(path_handle) == path.mapping_size());
+        
+        // check that steps is pointing to the same index along the path
+        auto check_step = [&](const step_handle_t& step_handle,
+                              int mapping_idx) {
+            REQUIRE(graph.get_path_handle_of_step(step_handle) == path_handle);
             
-            path_handle_t path_handle = graph.get_path_handle(path.name());
+            const Mapping& mapping = path.mapping(mapping_idx);
             
-            REQUIRE(graph.get_step_count(path_handle) == path.mapping_size());
+            handle_t handle = graph.get_handle_of_step(step_handle);
             
-            // check that steps is pointing to the same index along the path
-            auto check_step = [&](const step_handle_t& step_handle,
-                                  int mapping_idx) {
-                REQUIRE(graph.get_path_handle_of_step(step_handle) == path_handle);
-                
-                const Mapping& mapping = path.mapping(mapping_idx);
-                
-                handle_t handle = graph.get_handle_of_step(step_handle);
-                
-                REQUIRE(graph.get_id(handle) == mapping.position().node_id());
-                REQUIRE(graph.get_is_reverse(handle) == mapping.position().is_reverse());
-            };
-            
-            step_handle_t step_handle = graph.path_begin(path_handle);
-            
-            // iterate front to back
-            for (int i = 0; i < path.mapping_size(); i++) {
-                
-                if (i > 0) {
-                    step_handle_t previous = graph.get_previous_step(step_handle);
-                    check_step(previous, i - 1);
-                }
-                else if (path.is_circular()) {
-                    step_handle_t previous = graph.get_previous_step(step_handle);
-                    check_step(previous, path.mapping_size() - 1);
-                }
-                
-                check_step(step_handle, i);
-                step_handle = graph.get_next_step(step_handle);
-            }
-            
-            if (path.is_circular() && path.mapping_size() > 0) {
-                REQUIRE(step_handle == graph.path_begin(path_handle));
-            }
-            else {
-                REQUIRE(step_handle == graph.path_end(path_handle));
-            }
-
-            // iterate front to back with the iteration function
-            {
-                int i = 0;
-                graph.for_each_step_in_path(path_handle, [&i, &check_step](const step_handle_t& step_handle) {
-                    check_step(step_handle, i);
-                    i++;
-                });
-                REQUIRE(i == path.mapping_size());
-            }
+            REQUIRE(graph.get_id(handle) == mapping.position().node_id());
+            REQUIRE(graph.get_is_reverse(handle) == mapping.position().is_reverse());
         };
+        
+        step_handle_t step_handle = graph.path_begin(path_handle);
+        
+        // iterate front to back
+        for (int i = 0; i < path.mapping_size(); i++) {
+            if (i > 0) {
+                step_handle_t previous = graph.get_previous_step(step_handle);
+                check_step(previous, i - 1);
+            }
+            else if (path.is_circular()) {
+                step_handle_t previous = graph.get_previous_step(step_handle);
+                check_step(previous, path.mapping_size() - 1);
+            }
+            
+            check_step(step_handle, i);
+            step_handle = graph.get_next_step(step_handle);
+        }
+        
+        if (path.is_circular() && path.mapping_size() > 0) {
+            REQUIRE(step_handle == graph.path_begin(path_handle));
+        }
+        else {
+            REQUIRE(step_handle == graph.path_end(path_handle));
+        }
+        
+        // iterate front to back with the iteration function
+        {
+            int i = 0;
+            graph.for_each_step_in_path(path_handle, [&i, &check_step](const step_handle_t& step_handle) {
+                check_step(step_handle, i);
+                i++;
+            });
+            REQUIRE(i == path.mapping_size());
+        }
+    };
+    
+    SECTION("Handles can traverse paths") {
         
         check_path_traversal(vg, path1);
         check_path_traversal(vg, path2);
@@ -1746,6 +1745,47 @@ TEST_CASE("VG and XG path handle implementations are correct", "[handle][vg][xg]
         check_path_traversal(xg_index, path1);
         check_path_traversal(xg_index, path2);
         check_path_traversal(xg_index, path3);
+    }
+    
+    SECTION("VG can rewrite a segment of a path") {
+        
+        // get the segments we want to replace
+        
+        path_handle_t path_handle_1 = vg.get_path_handle("1");
+        step_handle_t segment_begin_1 = vg.get_next_step(vg.get_next_step(vg.path_begin(path_handle_1)));
+        step_handle_t segment_end_1 = vg.get_next_step(vg.get_next_step(segment_begin_1));
+        
+        path_handle_t path_handle_2 = vg.get_path_handle("2");
+        step_handle_t segment_begin_2 = vg.path_begin(path_handle_2);
+        step_handle_t segment_end_2 = vg.get_next_step(segment_begin_2);
+        
+        path_handle_t path_handle_3 = vg.get_path_handle("3");
+        step_handle_t segment_end_3 = vg.path_end(path_handle_3);
+        step_handle_t segment_begin_3 = vg.get_previous_step(vg.get_previous_step(segment_end_3));
+        
+        // replace them
+        auto new_segment_1 = vg.rewrite_segment(segment_begin_1, segment_end_1, {vg.get_handle(n2->id()), vg.get_handle(n3->id())});
+        auto new_segment_2 = vg.rewrite_segment(segment_begin_2, segment_end_2, {vg.get_handle(n4->id())});
+        auto new_segment_3 = vg.rewrite_segment(segment_begin_3, segment_end_3, {vg.get_handle(n6->id(), true), vg.get_handle(n5->id(), true), vg.get_handle(n4->id(), true)});
+        
+        // update the Path objects to match our edits
+        path1.mutable_mapping(3)->mutable_position()->set_node_id(n3->id());
+        
+        path2.mutable_mapping(0)->mutable_position()->set_node_id(n4->id());
+        
+        path3.mutable_mapping(1)->mutable_position()->set_node_id(n6->id());
+        path3.mutable_mapping(2)->mutable_position()->set_node_id(n5->id());
+        Mapping* mapping = path3.add_mapping();
+        Position* position = mapping->mutable_position();
+        position->set_node_id(n4->id());
+        position->set_is_reverse(true);
+        
+        // check to make sure the handle backings are correct
+        check_path_traversal(vg, path1);
+        check_path_traversal(vg, path2);
+        check_path_traversal(vg, path3);
+        
+        // TODO: check the replaced segments' handles
     }
 }
     
@@ -1967,9 +2007,8 @@ TEST_CASE("Mutable handle graphs with mutable paths work", "[handle][packed][has
         MutablePathDeletableHandleGraph& graph = *implementation;
         
         auto check_path = [&](const path_handle_t& p, const vector<handle_t>& steps) {
-            
             step_handle_t step = graph.path_begin(p);
-            for (int i = 0; i < steps.size(); i++){
+            for (int i = 0; i < steps.size(); i++) {
                 
                 REQUIRE(graph.get_path_handle_of_step(step) == p);
                 REQUIRE(graph.get_handle_of_step(step) == steps[i]);
@@ -1986,7 +2025,7 @@ TEST_CASE("Mutable handle graphs with mutable paths work", "[handle][packed][has
             
             step = graph.get_previous_step(step);
             
-            for (int i = steps.size() - 1; i >= 0; i--){
+            for (int i = steps.size() - 1; i >= 0; i--) {
                 
                 REQUIRE(graph.get_path_handle_of_step(step) == p);
                 REQUIRE(graph.get_handle_of_step(step) == steps[i]);
@@ -2228,6 +2267,57 @@ TEST_CASE("Mutable handle graphs with mutable paths work", "[handle][packed][has
         
         // check flips to see if membership records are still functional
         check_flips(p2, {h1, graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0]), h3});
+        
+        // make a path to rewrite
+        path_handle_t p4 = graph.create_path_handle("4");
+        graph.prepend_step(p4, h3);
+        graph.prepend_step(p4, segments[2]);
+        graph.prepend_step(p4, segments[1]);
+        graph.prepend_step(p4, segments[0]);
+        graph.prepend_step(p4, h1);
+        
+        check_flips(p4, {h1, segments[0], segments[1], segments[2], h3});
+        
+        auto check_rewritten_segment = [&](const pair<step_handle_t, step_handle_t>& new_segment,
+                                           const vector<handle_t>& steps) {
+            int i = 0;
+            for (auto step = new_segment.first; step != new_segment.second; step = graph.get_next_step(step)) {
+                REQUIRE(graph.get_handle_of_step(step) == steps[i]);
+                i++;
+            }
+            REQUIRE(i == steps.size());
+        };
+        
+        // rewrite the middle portion of a path
+        
+        step_handle_t s1 = graph.get_next_step(graph.path_begin(p4));
+        step_handle_t s2 = graph.get_next_step(graph.get_next_step(graph.get_next_step(s1)));
+        
+        auto new_segment = graph.rewrite_segment(s1, s2, {graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0])});
+        
+        check_flips(p4, {h1, graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0]), h3});
+        check_rewritten_segment(new_segment, {graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0])});
+        
+        // rewrite around the end of a circular path to delete
+        
+        graph.create_edge(h3, h1);
+        graph.create_edge(segments[2], segments[0]);
+        graph.set_circularity(p4, true);
+        
+        s1 = graph.get_previous_step(graph.path_begin(p4));
+        s2 = graph.get_next_step(graph.path_begin(p4));
+        
+        new_segment = graph.rewrite_segment(s1, s2, vector<handle_t>());
+        
+        check_flips(p4, {graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0])});
+        check_rewritten_segment(new_segment, vector<handle_t>());
+        
+        // add into an empty slot
+        
+        new_segment = graph.rewrite_segment(new_segment.first, new_segment.second, {graph.flip(h1), graph.flip(h3)});
+        
+        check_flips(p4, {graph.flip(h1), graph.flip(h3), graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0])});
+        check_rewritten_segment(new_segment, {graph.flip(h1), graph.flip(h3)});
         
     }
     

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -593,8 +593,10 @@ pair<step_handle_t, step_handle_t> VG::rewrite_segment(const step_handle_t& segm
     vector<mapping_t*> to_erase;
     
     auto& path_list = paths._paths.at(paths.get_path_name(as_integer(get_path_handle_of_step(segment_begin))));
-    for (step_handle_t step = segment_begin; step != segment_end; step = get_next_step(step)) {
+    for (step_handle_t step = segment_begin; step != segment_end; ) {
+        step_handle_t next = get_next_step(step);
         path_list.erase(paths.mapping_itr.at(reinterpret_cast<mapping_t*>(as_integers(step)[1])).first);
+        step = next;
     }
     
     for (mapping_t* mapping : to_erase) {

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -250,6 +250,16 @@ public:
     /// Append a visit to a node to the given path
     virtual step_handle_t append_step(const path_handle_t& path, const handle_t& to_append);
     
+    /// Append a visit to a node to the given path
+    virtual step_handle_t prepend_step(const path_handle_t& path, const handle_t& to_prepend);
+    
+    
+    /// Delete a segment of a path and rewrite it as some other sequence of steps. Returns a pair
+    ///  of step_handle_t's that indicate the range of the new segment in the path.
+    virtual pair<step_handle_t, step_handle_t> rewrite_segment(const step_handle_t& segment_begin,
+                                                               const step_handle_t& segment_end,
+                                                               const vector<handle_t>& new_segment);
+    
     /// Make a path circular or non-circular. If the path is becoming circular, the
     /// last step is joined to the first step. If the path is becoming linear, the
     /// step considered "last" is unjoined from the step considered "first" according
@@ -1372,7 +1382,10 @@ private:
     /// Placeholder for functions that sometimes need to be passed an empty vector
     vector<pair<id_t, bool>> empty_edge_ends;
 
+    bool warned_about_rewrites = false;
 };
+
+
 
 } // end namespace vg
 


### PR DESCRIPTION
I switched to the most up-to-date libhandlegraph, which includes the path modification methods I added. This PR mostly consists of implementations for those methods in HashGraph, PackedGraph, and VG.