### PR TITLE
Improve packed graph compression

### DIFF
--- a/src/packed_graph.hpp
+++ b/src/packed_graph.hpp
@@ -74,7 +74,6 @@ public:
     bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
     
     /// Return the number of nodes in the graph
-    /// TODO: can't be node_count because XG has a field named node_count.
     size_t node_size(void) const;
     
     /// Return the smallest ID in the graph, or some smaller number if the
@@ -110,17 +109,6 @@ public:
     
     /// Remove all nodes and edges. Does not update any stored paths.
     void clear(void);
-    
-    /// TODO: swap_handles is actually not yet supported
-    
-    /// Swap the nodes corresponding to the given handles, in the ordering used
-    /// by for_each_handle when looping over the graph. Other handles to the
-    /// nodes being swapped must not be invalidated. If a swap is made while
-    /// for_each_handle is running, it affects the order of the handles
-    /// traversed during the current traversal (so swapping an already seen
-    /// handle to a later handle's position will make the seen handle be visited
-    /// again and the later handle not be visited at all).
-    void swap_handles(const handle_t& a, const handle_t& b);
     
     /// Alter the node that the given handle corresponds to so the orientation
     /// indicated by the handle becomes the node's local forward orientation.
@@ -342,6 +330,8 @@ private:
     PagedVector path_membership_node_iv;
     const static size_t NODE_MEMBER_RECORD_SIZE;
     
+    // TODO: split these up?
+    
     /// Encodes a series of linked lists of the memberships within paths. Consists of
     /// fixed width records of the following form. Path IDs are 0-based indexes, the
     /// other two indexes are 1-based and expressed in units of PATH_RECORD_SIZE and
@@ -357,7 +347,7 @@ private:
      * A struct to package the data associated with a path through the graph.
      */
     struct PackedPath {
-        PackedPath(const string& name, bool is_circular) : name(name), is_circular(is_circular), steps_iv(PAGE_WIDTH) {}
+        PackedPath(const string& name, bool is_circular) : name(name), is_circular(is_circular), steps_iv(PAGE_WIDTH), links_iv(PAGE_WIDTH) {}
         
         /// The path's name
         string name;
@@ -368,11 +358,12 @@ private:
         /// Marks whether this path is circular
         bool is_circular = false;
         
-        // TODO: split up steps_iv into adjacencies and travs separately
-        
         /// Linked list records that encode the oriented nodes of the path. Indexes are
         /// 1-based, with 0 used as a sentinel to indicate none further.
-        /// {ID|orientation (bit-packed), prev step index, next step index}
+        /// {prev index, next index}
+        PagedVector links_iv;
+        /// The traversal value is stored in a separate vector at the matching index.
+        /// {ID|orientation (bit-packed)}
         PagedVector steps_iv;
         
         /// 1-based index of the head of the linked list in steps_iv.
@@ -385,9 +376,10 @@ private:
         uint64_t deleted_step_records = 0;
     };
     const static size_t PATH_RECORD_SIZE;
-    const static size_t PATH_TRAV_OFFSET;
     const static size_t PATH_PREV_OFFSET;
     const static size_t PATH_NEXT_OFFSET;
+    
+    const static size_t STEP_RECORD_SIZE;
     
     /// Map from path names to index in the paths vector.
     string_hash_map<string, int64_t> path_id;
@@ -540,27 +532,27 @@ inline void PackedGraph::set_membership_path(const uint64_t& membership_index, c
 }
 
 inline uint64_t PackedGraph::get_step_trav(const PackedPath& path, const uint64_t& step_index) const {
-    return path.steps_iv.get((step_index - 1) * PATH_RECORD_SIZE + PATH_TRAV_OFFSET);
+    return path.steps_iv.get((step_index - 1) * STEP_RECORD_SIZE);
 }
 
 inline uint64_t PackedGraph::get_step_prev(const PackedPath& path, const uint64_t& step_index) const {
-    return path.steps_iv.get((step_index - 1) * PATH_RECORD_SIZE + PATH_PREV_OFFSET);
+    return path.links_iv.get((step_index - 1) * PATH_RECORD_SIZE + PATH_PREV_OFFSET);
 }
 
 inline uint64_t PackedGraph::get_step_next(const PackedPath& path, const uint64_t& step_index) const {
-    return path.steps_iv.get((step_index - 1) * PATH_RECORD_SIZE + PATH_NEXT_OFFSET);
+    return path.links_iv.get((step_index - 1) * PATH_RECORD_SIZE + PATH_NEXT_OFFSET);
 }
 
 inline void PackedGraph::set_step_trav(PackedPath& path, const uint64_t& step_index, const uint64_t& trav) {
-    path.steps_iv.set((step_index - 1) * PATH_RECORD_SIZE + PATH_TRAV_OFFSET, trav);
+    path.steps_iv.set((step_index - 1) * STEP_RECORD_SIZE, trav);
 }
 
 inline void PackedGraph::set_step_prev(PackedPath& path, const uint64_t& step_index, const uint64_t& prev_index) {
-    path.steps_iv.set((step_index - 1) * PATH_RECORD_SIZE + PATH_PREV_OFFSET, prev_index);
+    path.links_iv.set((step_index - 1) * PATH_RECORD_SIZE + PATH_PREV_OFFSET, prev_index);
 }
 
 inline void PackedGraph::set_step_next(PackedPath& path, const uint64_t& step_index, const uint64_t& next_index) {
-    path.steps_iv.set((step_index - 1) * PATH_RECORD_SIZE + PATH_NEXT_OFFSET, next_index);
+    path.links_iv.set((step_index - 1) * PATH_RECORD_SIZE + PATH_NEXT_OFFSET, next_index);
 }
 
 } // end dankness

--- a/src/unittest/handle.cpp
+++ b/src/unittest/handle.cpp
@@ -2007,6 +2007,9 @@ TEST_CASE("Mutable handle graphs with mutable paths work", "[handle][packed][has
         MutablePathDeletableHandleGraph& graph = *implementation;
         
         auto check_path = [&](const path_handle_t& p, const vector<handle_t>& steps) {
+            
+            REQUIRE(graph.get_step_count(p) == steps.size());
+            
             step_handle_t step = graph.path_begin(p);
             for (int i = 0; i < steps.size(); i++) {
                 

--- a/src/unittest/packed_graph.cpp
+++ b/src/unittest/packed_graph.cpp
@@ -25,6 +25,8 @@ using namespace std;
         
         auto check_path = [&](const path_handle_t& p, const vector<handle_t>& steps) {
             
+            REQUIRE(graph.get_step_count(p) == steps.size());
+            
             step_handle_t step = graph.path_begin(p);
             for (int i = 0; i < steps.size(); i++){
                 
@@ -151,7 +153,6 @@ using namespace std;
             // delete some things, but not enough to trigger defragmentation
             graph.destroy_path(p2);
             graph.destroy_handle(h2);
-            
             // reallocate and compress down to the smaller size
             graph.compactify();
             


### PR DESCRIPTION
I split up some of the vectors in the packed graph so that adjacent values will be more likely to be of similar magnitudes, which helps the PagedVector's compression.