### PR TITLE
Revert "option to construct alt paths from vcf ids"

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -536,7 +536,7 @@ namespace vg {
 
                     // Name the variant and place it in the order that we'll
                     // actually construct nodes in (see utility.hpp)
-                    string variant_name = alt_names_from_vcf_id ? variant->id : make_variant_id(*variant);
+                    string variant_name = make_variant_id(*variant);
                     if (variants_by_name.count(variant_name)) {
                         // Some VCFs may include multiple variants at the same
                         // position with the same ref and alt. We will only take the
@@ -715,7 +715,7 @@ namespace vg {
                         // Declare its ref path straight away.
                         // We fill in the ref paths after we make all the nodes for the edits.
                         variant_ref_paths[variant] = to_return.graph.add_path();
-                        variant_ref_paths[variant]->set_name(alt_path_prefix + variant_name + "_0");
+                        variant_ref_paths[variant]->set_name("_alt_" + variant_name + "_0");
                     }
 
                     for (size_t alt_index = 0; alt_index < parsed_clump[variant].size(); alt_index++) {                
@@ -723,7 +723,7 @@ namespace vg {
 
                         // Name the alt after the number that this allele has.
                         // We have to bump the allele index because the first alt is 0.
-                        string alt_name = alt_path_prefix + variant_name + "_" + to_string(alt_index + 1);
+                        string alt_name = "_alt_" + variant_name + "_" + to_string(alt_index + 1);
 
                         // There should be a path named after it.
                         Path* alt_path = nullptr;

--- a/src/constructor.hpp
+++ b/src/constructor.hpp
@@ -69,19 +69,11 @@ public:
     // Should alts be interpreted as flat (false) or aligned back to the
     // reference by vcflib (true)?
     bool flat = false;
-
-    // Prefix alt paths with this string. Paths beginning with _alt_ are required
-    // for making the GBWT
-    string alt_path_prefix = "_alt_";
     
     // Should we add paths for the different alts of variants, like
     // _alt_6079b4a76d0ddd6b4b44aeb14d738509e266961c_0 and
     // _alt_6079b4a76d0ddd6b4b44aeb14d738509e266961c_1?
     bool alt_paths = false;
-
-    // When writing alt paths, just take the name from the VCF ID field (but add _0, _1 etc.)
-    // like above.  
-    bool alt_names_from_vcf_id = false;
 
     // Should we handle structural variants in the VCF file,
     // or at least the ones we know how to?

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -24,7 +24,6 @@ void help_construct(char** argv) {
          << "    -v, --vcf FILE         input VCF (may repeat)" << endl
          << "    -n, --rename V=F       rename contig V in the VCFs to contig F in the FASTAs (may repeat)" << endl
          << "    -a, --alt-paths        save paths for alts of variants by variant ID" << endl
-         << "    -N, --alt-named-paths  use VCF IDs instead of _alt_+hashes for alt paths. results *not* indexed as GBWT threads" << endl
          << "    -R, --region REGION    specify a particular chromosome or 1-based inclusive region" << endl
          << "    -C, --region-is-chrom  don't attempt to parse the region (use when the reference" << endl
          << "                           sequence name could be inadvertently parsed as a region)" << endl
@@ -83,7 +82,6 @@ int main_construct(int argc, char** argv) {
                 {"drop-msa-paths", no_argument, 0, 'd'},
                 {"rename", required_argument, 0, 'n'},
                 {"alt-paths", no_argument, 0, 'a'},
-                {"alt-named-paths", no_argument, 0, 'N'},
                 {"handle-sv", no_argument, 0, 'S'},
                 {"insertions", required_argument, 0, 'I'},
                 {"progress",  no_argument, 0, 'p'},
@@ -98,7 +96,7 @@ int main_construct(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "v:r:n:ph?z:t:R:m:aNs:CfSI:M:dF:i",
+        c = getopt_long (argc, argv, "v:r:n:ph?z:t:R:m:as:CfSI:M:dF:i",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -161,12 +159,6 @@ int main_construct(int argc, char** argv) {
             constructor.alt_paths = true;
             break;
 
-        case 'N':
-            constructor.alt_paths = true;
-            constructor.alt_names_from_vcf_id = true;
-            constructor.alt_path_prefix = "";
-            break;
-            
         case 'p':
             show_progress = true;
             break;


### PR DESCRIPTION
This reverts commit 9c5e8aa1c2b40130910b7c77ce3e7133e7ac8910.

Just noticed that this (harmless, but not useful) hackathon commit I never meant to merge made it into Master. 