### PR TITLE
Tolerate alt path mappings on the last nodes of constructed chunks

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -2,8 +2,7 @@
  * \file
  * constructor.cpp: contains implementations for vg construction functions.
  */
-
-
+ 
 #include "vg.hpp"
 #include "constructor.hpp"
 
@@ -1548,7 +1547,7 @@ namespace vg {
         // Modifies the chunk in place.
         auto wire_and_emit = [&](ConstructedChunk& chunk) {
             // When each chunk comes back:
-
+            
             if (chunk.left_ends.size() == 1 && last_node_buffer.id() != 0) {
                 // We have a last node from the last chunk that we want to glom onto
                 // this chunk.
@@ -1644,8 +1643,7 @@ namespace vg {
 
                 // We know it's the last node in the graph
                 last_node_buffer = chunk.graph.node(chunk.graph.node_size() - 1);
-
-
+                
                 assert(chunk.right_ends.count(last_node_buffer.id()));
 
                 // Remove it
@@ -1661,6 +1659,10 @@ namespace vg {
 
                 // Update its ID separately, since it's no longer in the graph.
                 last_node_buffer.set_id(last_node_buffer.id() + max_id);
+                
+#ifdef debug
+                cerr << "Buffered final node becomes: " << last_node_buffer.id() << endl;
+#endif
             }
 
             // Up all the IDs in the graph

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -236,16 +236,15 @@ int main_construct(int argc, char** argv) {
                 return a.id() < b.id();
             });
         
-            // Wrap the chunk in a vg object that can properly divide it into
-            // reasonably sized serialized chunks.
-            VG* g = new VG(big_chunk, false, true);
+            // We don't validate the chunk because its end node may be held
+            // back for the next chunk, while edges and path mappings for it
+            // still live in this chunk. Also, we no longer create a VG to
+            // re-chunk the chunk (because we can now handle chunks up to about
+            // 1 GB serialized), and the VG class has the validator.
             
-            // Check our work. Never output an invalid graph.
-            // But allow for edges where one node isn't there, because we need those to connect segments.
-            assert(g->is_valid(true, false, true, true));
             // One thread at a time can write to the emitter and the output stream
 #pragma omp critical (emitter)
-            g->serialize_to_emitter(emitter);
+            emitter.write_copy(big_chunk); 
         };
         
         // Copy shared parameters into the constructor

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -6056,8 +6056,20 @@ bool VG::is_valid(bool check_nodes,
                 //       to sort by rank, but I'm not sure if any of this is by design or not...
 
                 auto& p1 = m1.position();
+                if (!has_node(p1.node_id())) {
+                    cerr << "graph path '" << path.name() << "' has invalid mapping " << pb2json(m1)
+                    << ": node does not exist" << endl;
+                    paths_ok = false;
+                    return;
+                }
                 auto& n1 = *get_node(p1.node_id());
                 auto& p2 = m2.position();
+                if (!has_node(p2.node_id())) {
+                    cerr << "graph path '" << path.name() << "' has invalid mapping " << pb2json(m2)
+                    << ": node does not exist" << endl;
+                    paths_ok = false;
+                    return;
+                }
                 auto& n2 = *get_node(p2.node_id());
                 // count up how many bases of the node m1 covers.
                 id_t m1_edit_length = m1.edit_size() == 0 ? n1.sequence().length() : 0;


### PR DESCRIPTION
This should fix #2251, which arose because we couldn't handle alt path mappings on the final reference node of a constructed chunk, because we were removing that node and putting it in the next chunk.

It's a somewhat dramatic change to accomplish that; I'm removing the VG-class-based rechunking (because I don't think it will work correctly if the chunk has mappings to a node that doesn't show up until later), and I'm removing the per-chunk validation (because it depends on having a VG instance, and because if we remove the last node, the chunk on its own won't have valid edges *or* paths, leaving the validation more or less nothing to check).

We're now going to lean a bit harder on the high maximum message sizes in libvgio, without the constructed chunk rechunking. I noticed they might not have been working right, so I've fixed them.

If we find users trying to do a vg construct that makes chunks over 1 GB in size (which might happen if way too many SVs overlap and a whole chromosome condenses down to one chunk), we'll have to revisit re-chunking. We should be able to do it with something much simpler than the VG class, if we don't try to guarantee that nodes and edges and path mappings for the same IDs all stay together like the VG class does.