### PR TITLE
Fix empty sv alt paths

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -580,7 +580,8 @@ namespace vg {
                     // Note: we still want bounds for SVs, we just have to get them differently
                     std::pair<int64_t, int64_t> bounds;
                     
-                    if (!variant->hasSVTags()){
+                    if (!variant->canonical){
+                        // The variant did not have to be canonicalized.
                         // We will process the variant as a normal variant, based on its ref and alt sequences.
                         
                         for (auto &kv : alternates) {

--- a/src/unittest/constructor.cpp
+++ b/src/unittest/constructor.cpp
@@ -2304,14 +2304,14 @@ CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG
         unordered_map<size_t, string> expected;
         expected.insert({1, "CAAATAAGGC"});
 		expected.insert({2, "T"});
-        expected.insert({3, "TTTCTTTCTT"});
-        expected.insert({4, "TCTTTCTTTC"});
-        expected.insert({5, "TTTCTTTCTT"});
-        expected.insert({6, "TCTTTC"});
+        expected.insert({3, "TTCTTTCTTT"});
+        expected.insert({4, "CTTTCTTTCT"});
+        expected.insert({5, "TTCTTTCTTT"});
+        expected.insert({6, "CTTTC"});
         expected.insert({7, "TGGAAATTTT"});
-        expected.insert({8, "TCTGGAGTTC"});
-        expected.insert({9, "TATTATATTC"});
-        expected.insert({10, "CAACTCTCTG"});
+        expected.insert({8, "CTGGAGTTCT"});
+        expected.insert({9, "ATTATATTCC"});
+        expected.insert({10, "AACTCTCTG"});
 
         for (size_t i = 0; i < result.node_size(); i++) {
             auto& node = result.node(i);

--- a/src/unittest/constructor.cpp
+++ b/src/unittest/constructor.cpp
@@ -2274,6 +2274,75 @@ CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG
 
 }
 
+TEST_CASE( "SVs that are fully base specified are constructed correctly" , "[constructor]") {
+
+    auto vcf_data = R"(##fileformat=VCFv4.2
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=1000GenomesPilot-NCBI36
+##phasing=partial
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
+x	11	sv1	T	TTTCTTTCTTTCTTTCTTTCTTTCTTTCTTTCTTTC	11	PASS	END=10;SVLEN=35;SVTYPE=INS	GT)";
+
+    auto fasta_data = R"(>x
+CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG
+)";
+
+    // Build the graph
+    auto result = construct_test_graph(fasta_data, vcf_data, 10, true, false);
+    
+#ifdef debug
+    std::cerr << pb2json(result) << std::endl;
+#endif
+
+	SECTION("nodes are as expected") {
+        // Look at each node
+
+        unordered_map<size_t, string> expected;
+        expected.insert({1, "CAAATAAGGC"});
+		expected.insert({2, "T"});
+        expected.insert({3, "TTTCTTTCTT"});
+        expected.insert({4, "TCTTTCTTTC"});
+        expected.insert({5, "TTTCTTTCTT"});
+        expected.insert({6, "TCTTTC"});
+        expected.insert({7, "TGGAAATTTT"});
+        expected.insert({8, "TCTGGAGTTC"});
+        expected.insert({9, "TATTATATTC"});
+        expected.insert({10, "CAACTCTCTG"});
+
+        for (size_t i = 0; i < result.node_size(); i++) {
+            auto& node = result.node(i);
+            REQUIRE(node.sequence()==expected[node.id()]);
+        }
+    }
+    
+    SECTION("edges are as expected") {
+        unordered_set<tuple<id_t, bool, id_t, bool>> edges_wanted;
+        edges_wanted.emplace(1, false, 2, false);
+        edges_wanted.emplace(2, false, 3, false);
+        edges_wanted.emplace(3, false, 4, false);
+        edges_wanted.emplace(4, false, 5, false);
+        edges_wanted.emplace(5, false, 6, false);
+        edges_wanted.emplace(6, false, 7, false);
+        edges_wanted.emplace(7, false, 8, false);
+        edges_wanted.emplace(8, false, 9, false);
+        edges_wanted.emplace(9, false, 10, false);
+        edges_wanted.emplace(2, false, 7, false);
+        
+        // We should have the right number of edges
+        REQUIRE(result.edge_size() == edges_wanted.size());
+        
+        for (auto& edge : result.edge()) {
+            // The edge should be expected
+            REQUIRE(edges_wanted.count(make_tuple(edge.from(), edge.from_start(), edge.to(), edge.to_end())));
+        }
+    }
+
+}
+
 
 
 

--- a/vgci/Dockerfile.vgci
+++ b/vgci/Dockerfile.vgci
@@ -22,7 +22,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
     rs \
     libffi-dev
 
-ADD http://mirrors.edge.kernel.org/ubuntu/pool/universe/b/bwa/bwa_0.7.17-3_amd64.deb /tmp/bwa.deb
+ADD https://github.com/vgteam/vg_docker/raw/master/deps/bwa_0.7.15-5_amd64.deb /tmp/bwa.deb
 RUN dpkg -i /tmp/bwa.deb
 
 # copy over current directory to docker

--- a/vgci/Dockerfile.vgci
+++ b/vgci/Dockerfile.vgci
@@ -22,7 +22,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
     rs \
     libffi-dev
 
-ADD http://mirrors.kernel.org/ubuntu/pool/universe/b/bwa/bwa_0.7.15-5_amd64.deb /tmp/bwa.deb
+ADD http://mirrors.edge.kernel.org/ubuntu/pool/universe/b/bwa/bwa_0.7.17-3_amd64.deb /tmp/bwa.deb
 RUN dpkg -i /tmp/bwa.deb
 
 # copy over current directory to docker


### PR DESCRIPTION
This should fix #2251. We were not consistently treating the variant as either an SV or not.

This should treat anything that went through canonicalization as an SV, and anything that didn't as not an SV.