### PR TITLE
Sorting of spliced variation graphs

### DIFF
--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -27,7 +27,7 @@ void help_rna(char** argv) {
          << "    -e, --use-embedded-paths   project transcripts onto embedded graph paths" << endl
          << "    -r, --filter-reference     filter transcripts on reference chromosomes/contigs" << endl
          << "    -c, --do-not-collapse      do not collapse identical transcripts across haplotypes" << endl
-         << "    -d, --remove-non-gene      remove intergenic and intronic regions (includes reference paths)" << endl
+         << "    -d, --remove-non-gene      remove intergenic and intronic regions (removes reference paths if -a)" << endl
          << "    -a, --add-paths            add transcripts as embedded paths in the graph" << endl
          << "    -b, --write-gbwt FILE      write transcripts as threads to GBWT index file" << endl
          << "    -g, --write-gam FILE       write transcripts as alignments to GAM file" << endl
@@ -214,17 +214,16 @@ int32_t main_rna(int32_t argc, char** argv) {
 
     if (remove_non_transcribed) {
 
-        if (show_progress) { cerr << "[vg rna] Remove non-transcribed regions and paths ..." << endl; }
-
-        // Remove non-transcribed nodes and non transcript paths
-        transcriptome.remove_non_transcribed();
+        if (show_progress) { cerr << "[vg rna] Removing non-transcribed regions ..." << endl; }
+        transcriptome.remove_non_transcribed(!add_transcript_paths);
     }
+
+    if (show_progress) { cerr << "[vg rna] Topological sorting and compacting graph ..." << endl; }
+    transcriptome.compact_ordered();
 
     if (add_transcript_paths) {
 
         if (show_progress) { cerr << "[vg rna] Adding transcript paths to graph ..." << endl; }
-
-        // Add transcript as embedded paths in the graph
         transcriptome.add_paths_to_graph();
     }
 

--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -100,11 +100,16 @@ class Transcriptome {
         /// Returns spliced variation graph.
         const VG & splice_graph() const; 
 
+        /// Removes non-transcribed (not in transcript paths) nodes.
+        /// Optionally create new reference paths that only include
+        /// trancribed nodes and edges.
+        void remove_non_transcribed(const bool keep_reference);
+
+        /// Topological sort and compact graph.
+        void compact_ordered();
+
         /// Embeds transcript paths in variation graph.
         void add_paths_to_graph();
-
-        /// Removes non-transcribed (not in transcript paths) nodes
-        void remove_non_transcribed();
 
         /// Add transcript paths as threads in GBWT index.
         void construct_gbwt(gbwt::GBWTBuilder * gbwt_builder) const;

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -3018,6 +3018,10 @@ void VG::include(const Path& path) {
 
 void VG::compact_ids(void) {
     hash_map<id_t, id_t> new_id;
+    compact_ids(new_id);
+}
+
+void VG::compact_ids(hash_map<id_t, id_t> & new_id) {
     id_t id = 1; // start at 1
     for_each_node([&id, &new_id](Node* n) {
             new_id[n->id()] = id++; });

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -556,6 +556,10 @@ public:
 
     /// Squish the node IDs down into as small a space as possible. Fixes up paths itself.
     void compact_ids(void);
+    /// Squish the node IDs down into as small a space as possible. Fixes up paths itself.
+    /// Record translation in provided map.
+    void compact_ids(hash_map<id_t, id_t> & new_id);
+    
     /// Add the given value to all node IDs. Preserves the paths.
     void increment_node_ids(id_t increment);
     /// Subtract the given value from all the node IDs. Must not create a node with 0 or negative IDs. Invalidates the paths.


### PR DESCRIPTION
This PR adds topological sorting of spliced variation graphs to `vg rna`. This generally results in much reduced computation time when creating the xg version of the graphs afterwards. The sorting is done during construction instead of after (using e.g. `vg ids`) in order to make sure that the haplotype-specific transcripts written to the gbwt index are compatible with the sorted graph.

In addition, reference subpaths are now created when non-exonic regions are removed and haplotype-specific transcripts are not added as embedded paths. These subpaths are added to guide the mapping algorithms, when it is not feasible to embed all haplotype-specific transcripts (generally the case for whole genomes). These subpaths only traverses transcribed nodes and edges. Therefore the same gene can contain multiple reference subpaths if there is neighboring exons not connected by splice-junctions.
