### PR TITLE
Plumbing for SV evaluation of Giraffe

### DIFF
--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -662,6 +662,9 @@ def main(args):
     # Close the TSV
     tsv.close()
     
+    # Print the table now in case histogram plotting fails
+    print_table(read_count, stats_total)
+    
     # Plot the histogram
     svg_path = os.path.join(options.outdir, 'times.svg')
     histogram.main(['histogram.py', tsv_path, '--save', svg_path,
@@ -675,8 +678,7 @@ def main(args):
         '--legend_overlay', 'lower right',
         '--categories', 'total'] + STAGES)
         
-    # Print the table
-    print_table(read_count, stats_total)
+    
    
 def entrypoint():
     """

--- a/scripts/histogram.py
+++ b/scripts/histogram.py
@@ -282,10 +282,11 @@ def main(args):
     # Calculate our own bins, over all the data. First we need the largest and
     # smallest observed values. The fors in the comprehension have to be in
     # normal for loop order and not the other order.
+    # Make sure to filter out 0s from bounds determination if using log space.
     bin_min = options.x_min if options.x_min is not None else min((pair[0]
-        for pair_list in all_data.values() for pair in pair_list))
+        for pair_list in all_data.values() for pair in pair_list if (not options.log or pair[0] != 0)))
     bin_max = options.x_max if options.x_max is not None else max((pair[0]
-        for pair_list in all_data.values() for pair in pair_list))
+        for pair_list in all_data.values() for pair in pair_list if (not options.log or pair[0] != 0)))
     
     if options.log:
         # Do our bins in log space, so they look evenly spaced on the plot.

--- a/src/algorithms/dijkstra.cpp
+++ b/src/algorithms/dijkstra.cpp
@@ -1,0 +1,94 @@
+/**
+ * \file dijkstra.cpp
+ *
+ * Implementation of Dijkstra's Algorithm over the bidirected graph.
+ */
+ 
+#include "find_shortest_paths.hpp"
+#include <structures/updateable_priority_queue.hpp>
+
+namespace vg {
+namespace algorithms {
+
+using namespace structures;
+
+bool dijkstra(const HandleGraph* g, handle_t start,
+              function<bool(const handle_t&, size_t)> reached_callback,
+              bool traverse_leftward) {
+
+    // We keep a priority queue so we can visit the handle with the shortest
+    // distance next. We put handles in here whenever we see them with shorter
+    // distances (since STL priority queue can't update), so we also need to
+    // make sure nodes coming out haven't been visited already.
+    using Record = pair<size_t, handle_t>;
+    
+    // We filter out handles that have already been visited.
+    unordered_set<handle_t> visited;
+    
+    // We need a custom ordering for the queue
+    struct IsFirstGreater {
+        inline bool operator()(const Record& a, const Record& b) {
+            return a.first > b.first;
+        }
+    };
+    
+    // We use a filtered priority queue for auto-Dijkstra
+    UpdateablePriorityQueue<Record, handle_t, vector<Record>, IsFirstGreater> queue([](const Record& item) {
+        return item.second;
+    });
+    
+    // We keep a current handle
+    handle_t current = start;
+    size_t distance = 0;
+    queue.push(make_pair(distance, start));
+    
+    while (!queue.empty()) {
+        // While there are things in the queue, get the first.
+        tie(distance, current) = queue.top();
+        queue.pop();
+        
+#ifdef debug_vg_algorithms
+        cerr << "Visit " << g->get_id(current) << " " << g->get_is_reverse(current) << " at distance " << distance << endl;
+#endif    
+
+
+        // Emit the handle as being at the given distance
+        if (!reached_callback(current, distance)) {
+            // The user told us to stop. Return that we stopped early.
+            return false;
+        }
+        
+        // Remember that we made it here.
+        visited.emplace(current);
+        
+        if (current != start) {
+            // Up the distance with the node's length. We don't do this for the
+            // start handle because we want to count distance from the *end* of
+            // the start handle unless directed otherwise.
+            distance += g->get_length(current);
+        }
+            
+        g->follow_edges(current, traverse_leftward, [&](const handle_t& next) {
+            // For each handle to the right of here
+            
+            if (!visited.count(next)) {
+                // New shortest distance. Will never happen after the handle comes out of the queue because of Dijkstra.
+                queue.push(make_pair(distance, next));
+                
+#ifdef debug_vg_algorithms
+                cerr << "\tNew best path to " << g->get_id(next) << " " << g->get_is_reverse(next)
+                    << " at distance " << distance << endl;
+#endif
+                
+            }
+        });
+    }
+
+    // If we made it here, we finished the entire graph.
+    return true;
+
+}
+
+    
+}
+}

--- a/src/algorithms/dijkstra.hpp
+++ b/src/algorithms/dijkstra.hpp
@@ -1,0 +1,42 @@
+#ifndef VG_ALGORITHMS_DIJKSTRA_HPP_INCLUDED
+#define VG_ALGORITHMS_DIJKSTRA_HPP_INCLUDED
+
+/**
+ * \file dijkstra.hpp
+ *
+ * Definitions of Dijkstra's Algorithm utilities for traversing the graph closest-first.
+ */
+
+#include <unordered_map>
+#include <vg/vg.pb.h>
+
+#include "../position.hpp"
+#include "../hash_map.hpp"
+#include "../handle.hpp"
+
+namespace vg {
+namespace algorithms {
+    
+    /// Walk out from the given handle and visit all reachable handles
+    /// (including the start) in the graph once, in closest-first order,
+    /// accounting for sequence lengths. Walks right unless traverse_leftward
+    /// is specified, in which case it walks left. Distances are measured
+    /// between the outgoing side of the start node and the incoming side of
+    /// the target.
+    ///
+    /// When the shortest distance to a handle has been determined, calls
+    /// reached_callback with that handle and the distance to it. Calls to
+    /// reached_callback will occur in ascending order of distance. The
+    /// reached_callback function must return true to continue the search, and
+    /// false to abort it early.
+    ///
+    /// Returns true if the search terminated normally, and false if it was
+    /// aborted.
+    bool dijkstra(const HandleGraph* g, handle_t start,
+                  function<bool(const handle_t&, size_t)> reached_callback,
+                  bool traverse_leftward = false);
+                                                      
+}
+}
+
+#endif

--- a/src/algorithms/find_shortest_paths.cpp
+++ b/src/algorithms/find_shortest_paths.cpp
@@ -5,6 +5,7 @@
  */
  
 #include "find_shortest_paths.hpp"
+#include "dijkstra.hpp"
 #include <structures/updateable_priority_queue.hpp>
 
 namespace vg {
@@ -18,64 +19,14 @@ unordered_map<handle_t, size_t>  find_shortest_paths(const HandleGraph* g, handl
     // This is the minimum distance to each handle
     unordered_map<handle_t, size_t> distances;
     
-    // We keep a priority queue so we can visit the handle with the shortest
-    // distance next. We put handles in here whenever we see them with shorter
-    // distances (since STL priority queue can't update), so we also need to
-    // make sure nodes coming out haven't been visited already.
-    using Record = pair<size_t, handle_t>;
-    
-    // We need a custom ordering for the queue
-    struct IsFirstGreater {
-        inline bool operator()(const Record& a, const Record& b) {
-            return a.first > b.first;
-        }
-    };
-    
-    // We use a filtered priority queue for auto-Dijkstra
-    UpdateablePriorityQueue<Record, handle_t, vector<Record>, IsFirstGreater> queue([](const Record& item) {
-        return item.second;
-    });
-    
-    // We keep a current handle
-    handle_t current = start;
-    size_t distance = 0;
-    queue.push(make_pair(distance, start));
-    
-    while (!queue.empty()) {
-        // While there are things in the queue, get the first.
-        tie(distance, current) = queue.top();
-        queue.pop();
-        
-#ifdef debug_vg_algorithms
-        cerr << "Visit " << g->get_id(current) << " " << g->get_is_reverse(current) << " at distance " << distance << endl;
-#endif    
-
+    dijkstra(g, start, [&](const handle_t& current, size_t distance) {
         // Record handle's distance
         distances[current] = distance;
         
-        if (current != start) {
-            // Up the distance with the node's length. We don't do this for the
-            // start handle because we want to count distance from the *end* of
-            // the start handle unless directed otherwise.
-            distance += g->get_length(current);
-        }
-            
-        g->follow_edges(current, traverse_leftward, [&](const handle_t& next) {
-            // For each handle to the right of here
-            
-            if (!distances.count(next)) {
-                // New shortest distance. Will never happen after the handle comes out of the queue because of Dijkstra.
-                queue.push(make_pair(distance, next));
-                
-#ifdef debug_vg_algorithms
-                cerr << "\tNew best path to " << g->get_id(next) << " " << g->get_is_reverse(next)
-                    << " at distance " << distance << endl;
-#endif
-                
-            }
-        });
-    }
-
+        // Always keep going
+        return true;
+    }, traverse_leftward);
+    
     return distances;
 
 }

--- a/src/colors.hpp
+++ b/src/colors.hpp
@@ -1,6 +1,12 @@
 #ifndef VG_COLORS_HPP_INCLUDED
 #define VG_COLORS_HPP_INCLUDED
 
+/**
+ * \file colors.hpp
+ * Includes facilities for generating random GraphViz colors seeded by strings.
+ * Used for colorizing paths in visualizations.
+ */
+
 #include <vector>
 #include <random>
 
@@ -8,6 +14,10 @@ namespace vg {
 
 using namespace std;
 
+/**
+ * Generates random GraphViz colors seeded by strings.
+ * Used for colorizing paths in visualizations.
+ */
 class Colors {
     mt19937 rng;
 public:

--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -269,10 +269,6 @@ void Funnel::to_dot(ostream& out) {
     out << "}" << endl;
 }
 
-Funnel::Timepoint Funnel::now() const {
-    return chrono::high_resolution_clock::now();
-}
-
 Funnel::Item& Funnel::get_item(size_t index) {
     assert(!stages.empty());
     if (index >= stages.back().items.size()) {

--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -13,23 +13,17 @@ void Funnel::start(const string& name) {
     assert(!name.empty());
 
     // (Re)start the funnel.
-    funnel_start_time = now();
     funnel_name = name;
     
     // Clear out old data
     stage_name.clear();
     substage_name.clear();
-    stage_durations.clear();
-    substage_durations.clear();
     stages.clear();
 }
 
 void Funnel::stop() {
-    // Stop any lingering stage (which takes care of substages and processing/producing timers)
+    // Stop any lingering stage (which takes care of substages)
     stage_stop();
-    
-    // Record the ultimate duration.
-    funnel_duration = now() - funnel_start_time;
 }
 
 void Funnel::stage(const string& name) {
@@ -43,9 +37,8 @@ void Funnel::stage(const string& name) {
     stages.emplace_back();
     stages.back().name = name;
     
-    // Save the name and start time
+    // Save the name
     stage_name = name;
-    stage_start_time = now();
 }
 
 void Funnel::stage_stop() {
@@ -54,14 +47,9 @@ void Funnel::stage_stop() {
         
         // Stop any substage.
         substage_stop();
-        // Stop any process/produce timers
+        // Stop any process/produce 
         processed_input();
         produced_output();
-        
-        // Get the elapsed stage time
-        Duration stage_duration = now() - stage_start_time;
-        // Save it, coalescing by name
-        stage_durations[stage_name] += stage_duration;
         
         // Say the stage is stopped 
         stage_name.clear();
@@ -76,23 +64,17 @@ void Funnel::substage(const string& name) {
     // Stop previous substage if any.
     substage_stop();
     
-    // Substages don't bound produce/process timers.
+    // Substages don't bound produce/process.
     
-    // Save the name and start time
+    // Save the name 
     substage_name = name;
-    substage_start_time = now();
 }
     
 void Funnel::substage_stop() {
     if (!substage_name.empty()) {
         // A substage was running.
         
-        // Substages don't bound produce/process timers.
-        
-        // Get the elapsed substage time
-        Duration substage_duration = now() - substage_start_time;
-        // Save it, coalescing by name
-        substage_durations[stage_name][substage_name] += substage_duration;
+        // Substages don't bound produce/process.
         
         // Say the stage is stopped 
         substage_name.clear();
@@ -106,22 +88,16 @@ void Funnel::processing_input(size_t prev_stage_item) {
     assert(prev_stage_item != numeric_limits<size_t>::max());
     assert(stages[stages.size() - 2].items.size() > prev_stage_item);
 
-    // Stop any previous input processing timer
+    // Stop any previous input processing
     processed_input();
     
     // Start this one
     input_in_progress = prev_stage_item;
-    input_start_time = now();
 }
 
 void Funnel::processed_input() {
     if (input_in_progress != numeric_limits<size_t>::max()) {
         // We were processing an input
-        
-        // Work out how long it took
-        Duration input_duration = now() - input_start_time;
-        // Add it in
-        stages[stages.size() - 2].items[input_in_progress].process_duration += input_duration;
         
         // Say we're done with the input.
         input_in_progress = numeric_limits<size_t>::max();
@@ -134,22 +110,16 @@ void Funnel::producing_output(size_t item) {
     assert(!stages.empty());
     assert(item != numeric_limits<size_t>::max());
     
-    // Stop any previous input processing timer
+    // Stop any previous input processing
     produced_output();
     
     // Start this one
     output_in_progress = item;
-    output_start_time = now();
 }
 
 void Funnel::produced_output() {
     if (output_in_progress != numeric_limits<size_t>::max()) {
         // We were producing an output
-        
-        // Work out how long it took
-        Duration output_duration = now() - output_start_time;
-        // Add it in
-        get_item(output_in_progress).produce_duration += output_duration;
         
         // Say we're done with the output.
         output_in_progress = numeric_limits<size_t>::max();
@@ -226,31 +196,6 @@ size_t Funnel::latest() const {
     return stages.back().items.size() - 1;
 }
 
-double Funnel::to_seconds(const Duration& time) const {
-    return chrono::duration_cast<chrono::duration<double>>(time).count();
-}
-
-double Funnel::total_seconds() const {
-    return to_seconds(funnel_duration);
-}
-
-void Funnel::for_each_time(const function<void(const string&, const string&, double)>& callback) const {
-    // Handle overall
-    callback("", "", total_seconds());
-
-    for (auto& kv : stage_durations) {
-        // Handle each stage
-        callback(kv.first, "", to_seconds(kv.second));
-    }
-
-    for (auto& kv : substage_durations) {
-        for (auto& kv2 : kv.second) {
-            // Handle each substage
-            callback(kv.first, kv2.first, to_seconds(kv2.second));
-        }
-    }
-}
-
 void Funnel::for_each_stage(const function<void(const string&, size_t)>& callback) const {
     for (auto& stage : stages) {
         // Report the name and item count of each stage.
@@ -261,9 +206,6 @@ void Funnel::for_each_stage(const function<void(const string&, size_t)>& callbac
 void Funnel::to_dot(ostream& out) {
     out << "digraph graphname {" << endl;
     out << "rankdir=\"TB\";" << endl;
-
-    // Get total time
-    double total_time = total_seconds();
 
     for (size_t s = 0; s < stages.size(); s++) {
         // For each stage in order
@@ -319,47 +261,6 @@ void Funnel::to_dot(ostream& out) {
                 }
             }
 
-            // Assign generation time
-            double item_time = to_seconds(item.produce_duration);
-            if (item_time > 0 && total_time > 0) {
-                // We can have a time node attached to this item
-                double item_portion = item_time / total_time;
-
-                // Make an ID for the time node
-                string time_id = item_id + "t1";
-                
-                // Make the time node like a little bar chart
-                out << time_id << "[shape=box style=filled label=\"\" color=red fixedsize=true width=\"0.5\" height=\""
-                    << item_portion << "\" tooltip=\"" << item_time << " seconds" << "\"];" << endl;
-
-                // Attach it to the item
-                out << item_id << "->" << time_id << "[dir=none style=dashed constraint=false];" << endl;
-            }
-
-        }
-
-        if (s > 1) {
-            // Make time nodes in this stage for processing things from the previous stage
-            for (size_t prev_stage_item = 0; prev_stage_item < stages[s - 1].items.size(); prev_stage_item++) {
-                auto& item = stages[s - 1].items[prev_stage_item];
-
-                double item_time = to_seconds(item.process_duration);
-                if (item_time > 0 && total_time > 0) {
-                    // We can have a time node attached to this item
-                    double item_portion = item_time / total_time;
-
-                    // Make an ID for the time node
-                    string item_id = "s" + to_string(s - 1) + "i" + to_string(prev_stage_item);
-                    string time_id = item_id + "t2";
-                    
-                    // Make the time node like a little bar chart
-                    out << time_id << "[shape=box style=filled label=\"\" color=red fixedsize=true width=\"0.5\" height=\""
-                        << item_portion << "\" tooltip=\"" << item_time << " seconds" << "\"];" << endl;
-
-                    // Attach it to the item
-                    out << item_id << "->" << time_id << "[dir=none style=dashed];" << endl;
-                }
-            }
         }
 
         out << "}" << endl;

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -111,9 +111,6 @@ public:
     /// Get the index of the most recent item created in the current stage.
     size_t latest() const;
     
-    /// Get the total number of seconds elapsed between start() and stop()
-    double total_seconds() const;
-
     /// Call the given callback with stage name and number of results at that stage, for each stage.
     void for_each_stage(const function<void(const string&, size_t)>& callback) const;
 

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <functional>
 #include <iostream>
+#include <limits>
 
 /** 
  * \file funnel.hpp

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -1,7 +1,6 @@
 #ifndef VG_FUNNEL_HPP_INCLUDED
 #define VG_FUNNEL_HPP_INCLUDED
 
-#include <chrono>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -22,32 +21,26 @@ using namespace std;
  * Represents a record of an invocation of a pipeline for an input.
  *
  * Tracks the history of "lines" of data "item" provenance through a series of
- * timed "stages".
+ * "stages".
  *
  * Lines are "introduced", and "project" from earlier stages to later stages,
  * possibly "expanding" or "merging", until they are "killed" or reach the
  * final stage. At each stage, items occur in a linear order and are identified
  * by index.
  *
- * Each stage has its runtime recorded, and the runtime for substages of the
- * stage are recorded as well.
- *
  * An item may be a "group", with a certain size.
- *
- * We can also allocate time to processing input items from the previous stage,
- * or ourput items of the current stage.
  *
  * We also can assign scores to items at a stage.
  */
 class Funnel {
 
 public:
-    /// Start the timer for processing the given named input.
+    /// Start processing the given named input.
     /// Name must not be empty.
     /// No stage or substage will be active.
     void start(const string& name);
     
-    /// Stop the timer for processing the given named input.
+    /// Stop processing the given named input.
     /// All stages and substages are stopped.
     void stop();
     
@@ -56,7 +49,7 @@ public:
     /// Multiple stages with the same name will be coalesced.
     void stage(const string& name);
     
-    /// Stop counting time against the current stage.
+    /// Stop the current stage.
     void stage_stop();
     
     /// Start the given substage, nested insude the current stage. End all previous substages.
@@ -64,19 +57,19 @@ public:
     /// Name must not be empty.
     void substage(const string& name);
     
-    /// Stop counting time against the current substage.
+    /// Stop the current substage.
     void substage_stop();
     
-    /// Start a clock assigning runtime to processing the given item coming from the previous stage.
+    /// Start processing the given item coming from the previous stage.
     void processing_input(size_t prev_stage_item);
     
-    /// Stop the clock assigning runtime to processing an item from the previous stage.
+    /// Stop processing an item from the previous stage.
     void processed_input();
     
-    /// Start a clock assigning time to producing the given output item, whether it has been projected yet or not. 
+    /// Start producing the given output item, whether it has been projected yet or not. 
     void producing_output(size_t item);
     
-    /// Stop the clock assigning time to producing an output item.
+    /// Stop producing an output item.
     void produced_output();
     
     /// Introduce the given number of new items, starting their own lines of provenance (default 1).
@@ -121,64 +114,31 @@ public:
     /// Get the total number of seconds elapsed between start() and stop()
     double total_seconds() const;
 
-    /// Call the given callback with stage name (or ""), substage name (or ""), and
-    /// time in seconds overall, for each stage, and for each substage in a stage.
-    void for_each_time(const function<void(const string&, const string&, double)>& callback) const;
-    
     /// Call the given callback with stage name and number of results at that stage, for each stage.
     void for_each_stage(const function<void(const string&, size_t)>& callback) const;
 
     /// Dump information from the Funnel as a dot-format Graphviz graph to the given stream.
-    /// Illustrates stages, provenance, and runtime assignment.
+    /// Illustrates stages and provenance.
     void to_dot(ostream& out);
     
 protected:
     
-    /// How do we record durations internally?
-    using Duration = chrono::nanoseconds;
-    /// How do we record timepoints internally?
-    using Timepoint = chrono::time_point<chrono::high_resolution_clock>;
-    
-    // Members we need for time tracking
-    
     /// What's the name of the funnel we start()-ed. Will be empty if nothing is running.
     string funnel_name;
-    /// When did we start it the funnel?
-    Timepoint funnel_start_time;
-    /// If we finished the funnel, how long did it last?
-    Duration funnel_duration;
     
     /// What's the name of the current stage? Will be empty if no stage is running.
     string stage_name;
-    /// When did we start the stage?
-    Timepoint stage_start_time;
-    /// Records total duration of all stages by name.
-    unordered_map<string, Duration> stage_durations;
     
     /// What's the name of the current substage? Will be empty if no substage is running.
     string substage_name;
-    /// When did we start the substage?
-    Timepoint substage_start_time;
-    /// Records total duration of all substages by substage name and stage name.
-    unordered_map<string, unordered_map<string, Duration>> substage_durations;
     
     /// What's the current prev-stage input we are processing?
     /// Will be numeric_limits<size_t>::max() if none.
     size_t input_in_progress = numeric_limits<size_t>::max();
-    /// When did we start processing that input?
-    Timepoint input_start_time;
     
     /// what's the current current-stage output we are generating?
     /// Will be numeric_limits<size_t>::max() if none.
     size_t output_in_progress = numeric_limits<size_t>::max();
-    /// When did we start processing that input?
-    Timepoint output_start_time;
-    
-    /// Produce the current time
-    Timepoint now() const;
-
-    /// Convert a Duration to fractional seconds
-    double to_seconds(const Duration& time) const;
     
     // Now members we need for provenance tracking
     
@@ -190,10 +150,6 @@ protected:
         bool correct = false;
         /// What previous stage items were combined to make this one, if any?
         vector<size_t> prev_stage_items = {};
-        /// How long did it take to produce this item, in total?
-        Duration produce_duration{0};
-        /// How long was spent processing this item as an input, in total?
-        Duration process_duration{0};
     };
     
     /// Represents a Stage which is a series of Items, which track their own provenance.
@@ -201,7 +157,7 @@ protected:
         string name;
         vector<Item> items;
         /// How many of the items were actually projected?
-        /// Needed because items may need to expand to hold production times for items that have not been projected yet.
+        /// Needed because items may need to expand to hold information for items that have not been projected yet.
         size_t projected_count = 0;
         /// Does this stage contain any items tagged as correct?
         bool has_correct = false;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1972,7 +1972,7 @@ pos_t Mapper::likely_mate_position(const Alignment& aln, bool is_first_mate) {
 }
 
 map<string, vector<pair<size_t, bool> > > Mapper::alignment_path_offsets(const Alignment& aln, bool just_min, bool nearby) const {
-    return xg_alignment_path_offsets(aln, just_min, nearby, xindex);
+    return xg_alignment_path_offsets(xindex, aln, just_min, nearby);
 }
 
 vector<pos_t> Mapper::likely_mate_positions(const Alignment& aln, bool is_first_mate) {
@@ -2956,12 +2956,12 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
 
 }
 
-void Mapper::annotate_with_initial_path_positions(vector<Alignment>& alns) const {
-    for (auto& aln : alns) annotate_with_initial_path_positions(aln);
+void Mapper::annotate_with_initial_path_positions(vector<Alignment>& alns, size_t search_limit) const {
+    for (auto& aln : alns) annotate_with_initial_path_positions(aln, search_limit);
 }
 
-void Mapper::annotate_with_initial_path_positions(Alignment& aln) const {
-    xg_annotate_with_initial_path_positions(aln, xindex);
+void Mapper::annotate_with_initial_path_positions(Alignment& aln, size_t search_limit) const {
+    xg_annotate_with_initial_path_positions(xindex, aln, search_limit);
 }
 
 double Mapper::compute_cluster_mapping_quality(const vector<vector<MaximalExactMatch> >& clusters,

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -480,10 +480,20 @@ public:
 
     double graph_entropy(void);
 
-    /// Use the xg index we hold to annotate an Alignment with the first position it touches on each reference path. Thread safe.
-    void annotate_with_initial_path_positions(Alignment& aln) const;
-    /// Use the xg index we hold to annotate Alignments with the first position they touch on each reference path. Thread safe.
-    void annotate_with_initial_path_positions(vector<Alignment>& alns) const;
+    /// Use the xg index we hold to annotate an Alignment with the first
+    /// position it touches on each reference path. Thread safe.
+    ///
+    /// search_limit gives the maximum distance to search for a path if the
+    /// alignment does not actually touch any paths. If 0, the alignment's
+    /// sequence length is used.
+    void annotate_with_initial_path_positions(Alignment& aln, size_t search_limit = 0) const;
+    /// Use the xg index we hold to annotate Alignments with the first position
+    /// they touch on each reference path. Thread safe.
+    ///
+    /// search_limit gives the maximum distance to search for a path if the
+    /// alignment does not actually touch any paths. If 0, the alignment's
+    /// sequence length is used.
+    void annotate_with_initial_path_positions(vector<Alignment>& alns, size_t search_limit = 0) const;
 
     // Return true of the two alignments are consistent for paired reads, and false otherwise
     bool alignments_consistent(const map<string, double>& pos1,

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -12,11 +12,9 @@
 #include <iostream>
 #include <algorithm>
 
-// We define this to turn on the detailed funnel instrumentation and correctness tracking.
-// Without this we just track per-read time.
-#define INSTRUMENT_MAPPING
-// With INSTRUMENT_MAPPING on, set this to track provenance of intermediate results
-#define TRACK_PROVENANCE
+
+// Set this to track provenance of intermediate results
+//#define TRACK_PROVENANCE
 // With TRACK_PROVENANCE on, set this to track correctness, which requires some expensive XG queries
 //#define TRACK_CORRECTNESS
 
@@ -38,7 +36,7 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         
     // Make a new funnel instrumenter to watch us map this read.
     Funnel funnel;
-    // Start timing
+    // Start this alignment 
     funnel.start(aln.name());
     
     // Annotate the original read with metadata
@@ -429,7 +427,7 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
                 out.set_identity(identity);
                 
 #ifdef INSTRUMENT_MAPPING
-                // Stop the timer on the current substage
+                // Stop the current substage
                 funnel.substage_stop();
 #endif
             } else if (do_chaining) {
@@ -588,26 +586,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         out.set_is_secondary(i > 0);
     }
     
-    // Stop timing with the funnel
+    // Stop this alignment
     funnel.stop();
     
-    // Annotate with total, stage, and substage runtimes.
-    // If we didn't record stages, we just get the total.
-    funnel.for_each_time([&](const string& stage, const string& substage, double seconds) {
-        if (stage == "") {
-            // Overall runtime
-            set_annotation(mappings[0], "map_seconds", seconds);
-        } else {
-            if (substage == "") {
-                // Overall time for this stage
-                set_annotation(mappings[0], "stage_" + stage + "_seconds", seconds);
-            } else {
-                // Time for just this substage
-                set_annotation(mappings[0], "stage_" + stage + "_" + substage + "_seconds", seconds);
-            }
-        }
-    });
-
 #ifdef INSTRUMENT_MAPPING
 #ifdef TRACK_PROVENANCE
     

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -296,7 +296,7 @@ Alignment Sampler::mutate(const Alignment& aln,
     mutaln.set_sequence(alignment_seq(mutaln));
     mutaln.set_name(aln.name());
     mutaln.clear_refpos();
-    xg_annotate_with_initial_path_positions(mutaln, xgidx);
+    xg_annotate_with_initial_path_positions(xgidx, mutaln);
     return mutaln;
 }
 
@@ -421,7 +421,7 @@ Alignment Sampler::alignment_to_path(const string& source_path, size_t length) {
     // And set its identity
     aln.set_identity(identity(aln.path()));
     aln.clear_refpos();
-    xg_annotate_with_initial_path_positions(aln, xgidx);
+    xg_annotate_with_initial_path_positions(xgidx, aln);
     return aln;
 }
 
@@ -473,7 +473,7 @@ Alignment Sampler::alignment_to_graph(size_t length) {
     }
     // And set its identity
     aln.set_identity(identity(aln.path()));
-    xg_annotate_with_initial_path_positions(aln, xgidx);
+    xg_annotate_with_initial_path_positions(xgidx, aln);
     return aln;
 }
 
@@ -516,7 +516,7 @@ Alignment Sampler::alignment_with_error(size_t length,
     
     // Check the alignment to make sure we didn't mess it up
     assert(is_valid(aln));
-    xg_annotate_with_initial_path_positions(aln, xgidx);
+    xg_annotate_with_initial_path_positions(xgidx, aln);
     return aln;
 }
 
@@ -767,7 +767,7 @@ Alignment NGSSimulator::sample_read() {
     apply_N_mask(*aln.mutable_sequence(), qual_and_masks.second);
     
     aln.set_name(get_read_name());
-    xg_annotate_with_initial_path_positions(aln, &xg_index);
+    xg_annotate_with_initial_path_positions(&xg_index, aln);
     return aln;
 }
 
@@ -873,8 +873,8 @@ pair<Alignment, Alignment> NGSSimulator::sample_read_pair() {
     string name = get_read_name();
     aln_pair.first.set_name(name + "_1");
     aln_pair.second.set_name(name + "_2");
-    xg_annotate_with_initial_path_positions(aln_pair.first, &xg_index);
-    xg_annotate_with_initial_path_positions(aln_pair.second, &xg_index);
+    xg_annotate_with_initial_path_positions(&xg_index, aln_pair.first);
+    xg_annotate_with_initial_path_positions(&xg_index, aln_pair.second);
     return aln_pair;
 }
 

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -27,6 +27,7 @@ void help_annotate(char** argv) {
          << "    -a, --gam FILE         file of Alignments to annotate (required)" << endl
          << "    -x, --xg-name FILE     xg index of the graph against which the Alignments are aligned (required)" << endl
          << "    -p, --positions        annotate alignments with reference positions" << endl
+         << "    -l, --search-limit N   when annotating with positions, search this far for paths (default: read length)" << endl
          << "    -b, --bed-name FILE    annotate alignments with overlapping region names from this BED. May repeat." << endl
          << "    -n, --novelty          output TSV table with header describing how much of each Alignment is novel" << endl
          << "    -t, --threads          use the specified number of threads" << endl;
@@ -88,6 +89,7 @@ int main_annotate(int argc, char** argv) {
     vector<string> gff_names;
     string gam_name;
     bool add_positions = false;
+    size_t search_limit = 0;
     bool novelty = false;
     bool output_ggff = false;
     string snarls_name;
@@ -99,6 +101,7 @@ int main_annotate(int argc, char** argv) {
         {
             {"gam", required_argument, 0, 'a'},
             {"positions", no_argument, 0, 'p'},
+            {"search-limit", required_argument, 0, 'l'},
             {"xg-name", required_argument, 0, 'x'},
             {"bed-name", required_argument, 0, 'b'},
             {"gff-name", required_argument, 0, 'f'},
@@ -111,7 +114,7 @@ int main_annotate(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:a:pb:f:gs:nt:h",
+        c = getopt_long (argc, argv, "hx:a:pl:b:f:gs:nt:h",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -146,6 +149,10 @@ int main_annotate(int argc, char** argv) {
 
         case 'p':
             add_positions = true;
+            break;
+            
+        case 'l':
+            search_limit = parse<size_t>(optarg);
             break;
             
         case 'n':
@@ -301,7 +308,7 @@ int main_annotate(int argc, char** argv) {
                     if (add_positions) {
                         // Annotate it with its initial position on each path it touches
                         aln.clear_refpos();
-                        mapper.annotate_with_initial_path_positions(aln);
+                        mapper.annotate_with_initial_path_positions(aln, search_limit);
                     }
                     
                     if (!features_on_node.empty()) {

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -73,7 +73,7 @@ int main_gaffe(int argc, char** argv) {
     string distance_name;
     // How close should two hits be to be in the same cluster?
     size_t distance_limit = 1000;
-    size_t hit_cap = 10;
+    size_t hit_cap = 30;
     // Should we try chaining or just give up if we can't find a full length gapless alignment?
     bool do_chaining = true;
     // Whould we use the xdrop aligner for aligning tails?

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -850,7 +850,6 @@ int main_map(int argc, char** argv) {
             unaligned.set_quality(qual);
         }
         
-        std::chrono::time_point<std::chrono::system_clock> start = std::chrono::system_clock::now();
         vector<Alignment> alignments = mapper[tid]->align_multi(unaligned,
                                                                 kmer_size,
                                                                 kmer_stride,
@@ -858,12 +857,6 @@ int main_map(int argc, char** argv) {
                                                                 band_width,
                                                                 band_overlap,
                                                                 xdrop_alignment);
-        std::chrono::time_point<std::chrono::system_clock> end = std::chrono::system_clock::now();
-        std::chrono::duration<double> elapsed_seconds = end-start;
-        if (!alignments.empty()) {
-            // Record runtime as an annotation
-            set_annotation(alignments[0], "map_seconds", elapsed_seconds.count());
-        }
 
         if(alignments.size() == 0 && !exclude_unaligned) {
             // If we didn't have any alignments, report the unaligned alignment
@@ -898,7 +891,6 @@ int main_map(int argc, char** argv) {
                     // Make an alignment
                     Alignment unaligned;
                     unaligned.set_sequence(line);
-                    std::chrono::time_point<std::chrono::system_clock> start = std::chrono::system_clock::now();
                     vector<Alignment> alignments = mapper[tid]->align_multi(unaligned,
                                                                             kmer_size,
                                                                             kmer_stride,
@@ -906,12 +898,6 @@ int main_map(int argc, char** argv) {
                                                                             band_width,
                                                                             band_overlap,
                                                                             xdrop_alignment);
-                    std::chrono::time_point<std::chrono::system_clock> end = std::chrono::system_clock::now();
-                    std::chrono::duration<double> elapsed_seconds = end-start;
-                    if (!alignments.empty()) {
-                        // Record runtime as an annotation
-                        set_annotation(alignments[0], "map_seconds", elapsed_seconds.count());
-                    }
                     
 
                     for(auto& alignment : alignments) {
@@ -938,7 +924,6 @@ int main_map(int argc, char** argv) {
                 unaligned.set_sequence(seq);
                 unaligned.set_name(name);
                 int tid = omp_get_thread_num();
-                std::chrono::time_point<std::chrono::system_clock> start = std::chrono::system_clock::now();
                 vector<Alignment> alignments = mapper[tid]->align_multi(unaligned,
                                                                         kmer_size,
                                                                         kmer_stride,
@@ -946,12 +931,6 @@ int main_map(int argc, char** argv) {
                                                                         band_width,
                                                                         band_overlap,
                                                                         xdrop_alignment);
-                std::chrono::time_point<std::chrono::system_clock> end = std::chrono::system_clock::now();
-                std::chrono::duration<double> elapsed_seconds = end-start;
-                if (!alignments.empty()) {
-                    // Record runtime as an annotation
-                    set_annotation(alignments[0], "map_seconds", elapsed_seconds.count());
-                }
                 
                 for(auto& alignment : alignments) {
                     // Set the alignment metadata
@@ -978,7 +957,6 @@ int main_map(int argc, char** argv) {
             }
 
             int tid = omp_get_thread_num();
-            std::chrono::time_point<std::chrono::system_clock> start = std::chrono::system_clock::now();
             vector<Alignment> alignments = mapper[tid]->align_multi(alignment,
                                                                     kmer_size,
                                                                     kmer_stride,
@@ -986,12 +964,6 @@ int main_map(int argc, char** argv) {
                                                                     band_width,
                                                                     band_overlap,
                                                                     xdrop_alignment);
-            std::chrono::time_point<std::chrono::system_clock> end = std::chrono::system_clock::now();
-            std::chrono::duration<double> elapsed_seconds = end-start;
-            if (!alignments.empty()) {
-                // Record runtime as an annotation
-                set_annotation(alignments[0], "map_seconds", elapsed_seconds.count());
-            }
                                                                     
             for(auto& alignment : alignments) {
                 // Set the alignment metadata
@@ -1070,7 +1042,6 @@ int main_map(int argc, char** argv) {
             // single
             function<void(Alignment&)> lambda = [&](Alignment& alignment) {
                         int tid = omp_get_thread_num();
-                        std::chrono::time_point<std::chrono::system_clock> start = std::chrono::system_clock::now();
                         vector<Alignment> alignments = mapper[tid]->align_multi(alignment,
                                                                                 kmer_size,
                                                                                 kmer_stride,
@@ -1078,12 +1049,6 @@ int main_map(int argc, char** argv) {
                                                                                 band_width,
                                                                                 band_overlap,
                                                                                 xdrop_alignment);
-                        std::chrono::time_point<std::chrono::system_clock> end = std::chrono::system_clock::now();
-                        std::chrono::duration<double> elapsed_seconds = end-start;
-                        if (!alignments.empty()) {
-                            // Record runtime as an annotation
-                            set_annotation(alignments[0], "map_seconds", elapsed_seconds.count());
-                        }
                         //cerr << "This is just before output_alignments" << alignment.DebugString() << endl;
                         output_alignments(alignments, empty_alns);
                     };
@@ -1218,7 +1183,6 @@ int main_map(int argc, char** argv) {
             // Processing single-end GAM input
             function<void(Alignment&)> lambda = [&](Alignment& alignment) {
                 int tid = omp_get_thread_num();
-                std::chrono::time_point<std::chrono::system_clock> start = std::chrono::system_clock::now();
                 vector<Alignment> alignments = mapper[tid]->align_multi(alignment,
                                                                         kmer_size,
                                                                         kmer_stride,
@@ -1226,16 +1190,10 @@ int main_map(int argc, char** argv) {
                                                                         band_width,
                                                                         band_overlap,
                                                                         xdrop_alignment);
-                std::chrono::time_point<std::chrono::system_clock> end = std::chrono::system_clock::now();
-                std::chrono::duration<double> elapsed_seconds = end-start;
                 if (compare_gam) {
                     // Compare against true input at mapping time
                     alignments.front().set_correct(overlap(alignment.path(), alignments.front().path()));
                     alignment_set_distance_to_correct(alignments.front(), alignment);
-                }
-                if (!alignments.empty()) {
-                    // Record runtime as an annotation
-                    set_annotation(alignments[0], "map_seconds", elapsed_seconds.count());
                 }
                 output_alignments(alignments, empty_alns);
             };

--- a/src/unittest/xg.cpp
+++ b/src/unittest/xg.cpp
@@ -744,20 +744,52 @@ TEST_CASE("next_path_position can search out for several nodes", "[xg]") {
     
     SECTION("nothing is found when searching a slightly too-short distance") {
         pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, false, 0), 5);
+        REQUIRE(id(result.first) == 0);
+    }
+    
+    SECTION("something is found at the right distance when searching an exactly sufficiently long distance") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, false, 0), 6);
+        
+        REQUIRE(id(result.first) == 7);
+        REQUIRE(result.second == 6);
+    }
+    
+    SECTION("something is found at the rigth distance when searching an overly-long distance") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, false, 0), 100);
+        
+        REQUIRE(id(result.first) == 7);
+        REQUIRE(result.second == 6);
+    }
+    
+    SECTION("nothing is found when searching a zero distance in reverse") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, true, 1), 0);
         
         REQUIRE(id(result.first) == 0);
     }
     
-    SECTION("something is found when searching an exactly sufficiently long distance") {
-        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, false, 0), 6);
+    SECTION("nothing is found when searching a too-short distance in reverse") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, true, 1), 2);
         
-        REQUIRE(id(result.first) == 7);
+        REQUIRE(id(result.first) == 0);
     }
     
-    SECTION("something is found when searching an overly-long distance") {
-        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, false, 0), 100);
+    SECTION("nothing is found when searching a slightly too-short distance in reverse") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, true, 1), 5);
+        REQUIRE(id(result.first) == 0);
+    }
+    
+    SECTION("something is found at the right distance when searching an exactly sufficiently long distance in reverse") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, true, 1), 6);
         
         REQUIRE(id(result.first) == 7);
+        REQUIRE(result.second == 6);
+    }
+    
+    SECTION("something is found at the rigth distance when searching an overly-long distance in reverse") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, true, 1), 100);
+        
+        REQUIRE(id(result.first) == 7);
+        REQUIRE(result.second == 6);
     }
 }
 

--- a/src/unittest/xg.cpp
+++ b/src/unittest/xg.cpp
@@ -704,5 +704,62 @@ TEST_CASE("Looping over XG handles in parallel works", "[xg]") {
 
 }
 
+TEST_CASE("next_path_position can search out for several nodes", "[xg]") {
+
+    string graph_json = R"(
+    {"node":[{"id":1,"sequence":"G"},
+    {"id":2,"sequence":"A"},
+    {"id":3,"sequence":"T"},
+    {"id":4,"sequence":"T"},
+    {"id":5,"sequence":"A"},
+    {"id":6,"sequence":"C"},
+    {"id":7,"sequence":"A"}],
+    "edge":[{"from":1,"to":2},
+    {"from":2,"to":3},
+    {"from":3,"to":4},
+    {"from":4,"to":5},
+    {"from":5,"to":6},
+    {"from":6,"to":7}],
+    "path":[{"name":"x","mapping":[{"position":{"node_id":7}, "edit":[{"from_length":1,"to_length":1}]}]}]}
+    )";
+    
+    // Load the JSON
+    Graph proto_graph;
+    json2pb(proto_graph, graph_json.c_str(), graph_json.size());
+    
+    // Build the xg index
+    xg::XG xg_index(proto_graph);
+    
+    SECTION("nothing is found when searching a zero distance") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, false, 0), 0);
+        
+        REQUIRE(id(result.first) == 0);
+    }
+    
+    SECTION("nothing is found when searching a too-short distance") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, false, 0), 2);
+        
+        REQUIRE(id(result.first) == 0);
+    }
+    
+    SECTION("nothing is found when searching a slightly too-short distance") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, false, 0), 5);
+        
+        REQUIRE(id(result.first) == 0);
+    }
+    
+    SECTION("something is found when searching an exactly sufficiently long distance") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, false, 0), 6);
+        
+        REQUIRE(id(result.first) == 7);
+    }
+    
+    SECTION("something is found when searching an overly-long distance") {
+        pair<pos_t, int64_t> result = xg_index.next_path_position(make_pos_t(1, false, 0), 100);
+        
+        REQUIRE(id(result.first) == 7);
+    }
+}
+
 }
 }

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2690,37 +2690,33 @@ bool XG::path_is_circular(size_t rank) const {
 }
 
 pair<pos_t, int64_t> XG::next_path_position(pos_t pos, int64_t max_search) const {
+    // We need the closest on-a-path position to the passed in position, and the approximate rightward offset to it.
+    // Offset will be negative if you have to go left instead.
+    
+    // Get a handle to where we start
     handle_t h_fwd = get_handle(id(pos), is_rev(pos));
-    handle_t h_rev = get_handle(id(pos), !is_rev(pos));
-    int64_t fwd_seen = offset(pos);
-    int64_t rev_seen = node_length(id(pos)) - offset(pos);
-    pair<pos_t, int64_t> fwd_next = make_pair(make_pos_t(0,false,0), numeric_limits<int64_t>::max());
-    pair<pos_t, int64_t> rev_next = make_pair(make_pos_t(0,false,0), numeric_limits<int64_t>::max());
-    follow_edges(h_fwd, false, [&](const handle_t& n) {
-            id_t id = get_id(n);
-            if (!paths_of_node(id).empty()) {
-                fwd_next = make_pair(make_pos_t(id, get_is_reverse(n), 0), fwd_seen);
-                return false;
-            } else {
-                fwd_seen += node_length(id);
-                return fwd_seen < max_search;
-            }
-        });
-    follow_edges(h_rev, false, [&](const handle_t& n) {
-            id_t id = get_id(n);
-            if (!paths_of_node(id).empty()) {
-                rev_next = make_pair(make_pos_t(id, !get_is_reverse(n), 0), rev_seen);
-                return false;
-            } else {
-                rev_seen += node_length(id);
-                return rev_seen < max_search;
-            }
-        });
-    if (fwd_next.second <= rev_next.second) {
-        return fwd_next;
+    
+    // Record offsets to its ends
+    int64_t rev_seen = offset(pos);
+    int64_t fwd_seen = node_length(id(pos)) - offset(pos);
+    
+    // Find the closest on-a-path node, accounting for offsets to start/end of this node.
+    vector<tuple<handle_t, size_t, bool>> closest = find_closest_with_paths(h_fwd, max_search, fwd_seen, rev_seen);
+    
+    if (!closest.empty()) {
+        // We found something.
+        // Unpack it.
+        auto& found = get<0>(closest.front());
+        auto& dist = get<1>(closest.front());
+        auto& arrived_at_end = get<2>(closest.front());
+        
+        // Output the position. Make sure to get the offset we end up at in the
+        // node's forward strand for the end of the node we arrive at.
+        return make_pair(make_pos_t(get_id(found), get_is_reverse(found),
+            (arrived_at_end != get_is_reverse(found)) ? (get_length(found) - 1) : 0), dist);
     } else {
-        rev_next.second = -rev_next.second;
-        return rev_next;
+        // We aren't connected to anything on a path within the requested distance limit
+        return make_pair(make_pos_t(0,false,0), numeric_limits<int64_t>::max());
     }
 }
 
@@ -3319,6 +3315,109 @@ int64_t XG::closest_shared_path_oriented_distance(int64_t id1, size_t offset1, b
     
     return (on_reverse_strand && forward_strand) ? -approx_dist : approx_dist;
 }
+
+vector<tuple<handle_t, size_t, bool>> XG::find_closest_with_paths(handle_t start, size_t max_search_dist,
+    size_t right_extra_dist, size_t left_extra_dist,
+    unordered_map<int64_t, vector<size_t>>* paths_of_node_memo,
+    unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo) const {
+    
+    // Holds all the handles with paths, their unsigned distances from the start handle, and whether they were found going left.
+    vector<tuple<handle_t, size_t, bool>> to_return;
+    
+    // a local struct for traversals that are ordered by search distance and keep
+    // track of whether we're searching to the left or right
+    struct Traversal {
+        Traversal() {}
+        Traversal(int64_t dist, handle_t handle, bool search_left) :
+        dist(dist), handle(handle), search_left(search_left) {}
+        handle_t handle;
+        int64_t dist;
+        bool search_left;
+        inline bool operator<(const Traversal& other) const {
+            return dist > other.dist; // opposite order so priority queue selects minimum
+        }
+    };
+    
+    // Check if the node for the given handle occurs on any paths.
+    // Remember we reached it at the given distance, and whether we reached it searching left or not.
+    // Record the handle and its signed distance if it has paths.
+    // Return true if any paths touching the handle were found.
+    function<bool(handle_t,int64_t,bool)> look_for_paths = [&](handle_t handle, int64_t search_dist, bool search_left) {
+        
+        bool found_path = false;
+        
+        int64_t trav_id = get_id(handle);
+        bool trav_is_rev = get_is_reverse(handle);
+        
+#ifdef debug_algorithms
+        cerr << "[XG] checking for paths for " << trav_id << (trav_is_rev ? "-" : "+") << " at search dist "
+            << search_dist << " from searching " << (search_left ? "leftwards" : "rightwards") << endl;
+#endif
+        
+        for (pair<size_t, vector<pair<size_t, bool>>>& oriented_occurrences : memoized_oriented_paths_of_node(trav_id,
+            paths_of_node_memo, oriented_occurrences_memo)) {
+            
+            // For each path this node occurs on
+            
+            const XGPath& path = *paths[oriented_occurrences.first - 1];
+            
+            if (!oriented_occurrences.second.empty()) {
+                // The node has some occurrences on this path. Record that fact.
+                to_return.emplace_back(handle, search_dist, search_left);
+                return true;
+            }
+        }
+        
+        return false;
+    };
+    
+    // TODO: This is *NOT* a Dijkstra traversal! We should maybe use a UpdateablePriorityQueue.
+    priority_queue<Traversal> queue;
+    unordered_set<handle_t> traversed;
+    
+    handle_t handle = start; 
+    
+    // add in the initial traversals in both directions from the start position
+    queue.emplace(left_extra_dist, handle, true);
+    queue.emplace(right_extra_dist, handle, false);
+    
+    // Start by checking the start node
+    traversed.insert(handle);
+    bool found_path = look_for_paths(handle, 0, false);
+    
+    while (!queue.empty() && !found_path) {
+        // get the queue that has the next shortest path
+        
+        Traversal trav = queue.top();
+        queue.pop();
+        
+#ifdef debug_algorithms
+        cerr << "[XG] traversing " << get_id(trav.handle) << (get_is_reverse(trav.handle) ? "-" : "+") << " in " << (trav.search_left ? "leftward" : "rightward") << " direction at distance " << trav.dist << endl;
+#endif
+        
+        function<bool(const handle_t& next)> check_next = [&](const handle_t& next) {
+#ifdef debug_algorithms
+            cerr << "\tfollowing edge to " << get_id(next) << (get_is_reverse(next) ? "-" : "+") << " at dist " << trav.dist << endl;
+#endif
+            
+            if (!traversed.count(next)) {
+                found_path = look_for_paths(next, trav.dist, trav.search_left);
+                
+                int64_t dist_thru = trav.dist + get_length(next);
+                
+                if (dist_thru <= (int64_t) max_search_dist) {
+                    queue.emplace(dist_thru, next, trav.search_left);
+                }
+                traversed.emplace(next);
+            }
+            return !found_path;
+        };
+        
+        follow_edges(trav.handle, trav.search_left, check_next);
+    }
+    
+    return std::move(to_return);
+}
     
 vector<tuple<int64_t, bool, size_t>> XG::jump_along_closest_path(int64_t id, bool is_rev, size_t offset, int64_t jump_dist, size_t max_search_dist,
                                                                  unordered_map<int64_t, vector<size_t>>* paths_of_node_memo,
@@ -3792,7 +3891,7 @@ map<string, vector<pair<size_t, bool> > > XG::nearest_offsets_in_paths(pos_t pos
     auto& path_pos = pz.first;
     auto& diff = pz.second;
     if (id(path_pos)) {
-        // TODO apply approximate offset, second in pair returned by next_path_position
+        // Now apply approximate offset, second in pair returned by next_path_position
         auto offsets = offsets_in_paths(path_pos);
         for (auto& o : offsets) {
             for (auto& p : o.second) {

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -466,6 +466,24 @@ public:
                                                   unordered_map<int64_t, vector<size_t>>* paths_of_node_memo = nullptr,
                                                   unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo = nullptr,
                                                   unordered_map<pair<int64_t, bool>, handle_t>* handle_memo = nullptr) const;
+                                                  
+    /// Return a vector of pairs of handles that occur on the same relative
+    /// strand as the start handle, the distance from the right or left end
+    /// of the start handle needed to reach them, and whether they were reached
+    /// going right (true) or left (false) from the start. The handles are the
+    /// closest one(s) to the start handle that touch any paths.
+    ///
+    /// Distances are always positive. If specified, right_extra_dist and
+    /// left_extra_dist are added to the search distances, to allow for
+    /// searching from a particular point on the starting node. 
+    ///
+    /// Search does not exceed max_search_dist bases.
+    ///
+    /// Will only ever return an empty vector or a 1-element vector.
+    vector<tuple<handle_t, size_t, bool>> find_closest_with_paths(handle_t start, size_t max_search_dist,
+                                                                  size_t right_extra_dist = 0, size_t left_extra_dist = 0,
+                                                                  unordered_map<int64_t, vector<size_t>>* paths_of_node_memo = nullptr,
+                                                                  unordered_map<pair<int64_t, size_t>, vector<pair<size_t, bool>>>* oriented_occurrences_memo = nullptr) const;
     
     /// returns a vector of (node id, is reverse, offset) tuples that are found by jumping a fixed oriented distance
     /// along path(s) from the given position. if the position is not on a path, searches from the position to a path

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -409,7 +409,8 @@ public:
     // nearest node (in steps) that is in a path, and the paths
     pair<int64_t, vector<size_t> > nearest_path_node(int64_t id, int max_steps = 16) const;
     int64_t min_approx_path_distance(int64_t id1, int64_t id2) const;
-    /// nearest position that is in a path and the distance between it and the current position
+    /// nearest position that is in a path and the distance between it and the current position is <= max_search.
+    /// Will search over multiple nodes.
     pair<pos_t, int64_t> next_path_position(pos_t pos, int64_t max_search) const;
     
     /// returns true if the paths are on the same connected component of the graph (constant time)

--- a/src/xg_position.cpp
+++ b/src/xg_position.cpp
@@ -212,8 +212,24 @@ set<pos_t> xg_positions_bp_from(pos_t pos, int64_t distance, bool rev, const xg:
     }
 }
 
+#define debug
 map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const xg::XG* xgidx, const Alignment& aln, bool just_min,
     bool nearby, size_t search_limit) {
+    
+    if (nearby && search_limit == 0) {
+        // Fill in the search limit
+        search_limit = aln.sequence().size();
+    }
+    
+#ifdef debug
+    cerr << "Searching for path positions for " << aln.name();
+    if (nearby) {
+        cerr << " within " << search_limit << " bp";
+    } else {
+        cerr << " that are actually touched";
+    }
+    cerr << endl;
+#endif
     
     map<string, vector<pair<size_t, bool> > > offsets;
     for (auto& mapping : aln.path().mapping()) {
@@ -252,7 +268,7 @@ map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const xg::XG
        
             // Find the positions for this end of this Mapping
             auto pos_offs = (nearby ?
-                             xgidx->nearest_offsets_in_paths(mapping_pos, search_limit == 0 ? aln.sequence().size() : search_limit)
+                             xgidx->nearest_offsets_in_paths(mapping_pos, search_limit)
                              : xgidx->offsets_in_paths(mapping_pos));
             for (auto& p : pos_offs) {
                 // For each path, splice the list of path positions for this
@@ -262,6 +278,10 @@ map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const xg::XG
                 auto& y = p.second;
                 v.reserve(v.size() + distance(y.begin(),y.end()));
                 v.insert(v.end(),y.begin(),y.end());
+                
+#ifdef debug
+                cerr << "\tFound hit on path " << p.first << endl; 
+#endif
             }
         }
     }

--- a/src/xg_position.cpp
+++ b/src/xg_position.cpp
@@ -212,7 +212,6 @@ set<pos_t> xg_positions_bp_from(pos_t pos, int64_t distance, bool rev, const xg:
     }
 }
 
-#define debug
 map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const xg::XG* xgidx, const Alignment& aln, bool just_min,
     bool nearby, size_t search_limit) {
     

--- a/src/xg_position.hpp
+++ b/src/xg_position.hpp
@@ -46,14 +46,19 @@ vector<Edge> xg_edges_on_end(id_t id, const xg::XG* xgidx);
 /// *touched* by the Alignment (could be a Mapping start *or* end). Otherwise,
 /// produces one position per occurrence on the path of the position of each
 /// Mapping in the Alignment, which will be the position at which the Mapping
-/// *starts*. 
-map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const Alignment& aln, bool just_min, bool nearby, const xg::XG* xgidx);
+/// *starts*.
+///
+/// During the search for nearby positions, walk up to search_limit bases, or
+/// the length of the Alignment's sequence if search_limit is 0.
+map<string, vector<pair<size_t, bool> > > xg_alignment_path_offsets(const xg::XG* xgidx, const Alignment& aln,
+    bool just_min, bool nearby, size_t search_limit = 0);
 
 /// Annotate the given Alignment in place with the earliest touched positions,
 /// as produced by xg_alignment_path_offsets, as refpos values. Always uses min
 /// positions. Only resorts to nearby positions if no positions on a path are
-/// touched.
-void xg_annotate_with_initial_path_positions(Alignment& aln, const xg::XG* xgidx);
+/// touched. During the search for nearby positions, walk up to search_limit
+/// bases, or the length of the Alignment's sequence if search_limit is 0.
+void xg_annotate_with_initial_path_positions(const xg::XG* xgidx, Alignment& aln, size_t search_limit = 0);
 
 }
 


### PR DESCRIPTION
To run and evaluate Giraffe on SV graphs, I needed to get `vg annotate` to search much further for path hits.

To do this, I had to change the functions it was using internally; it looks like `XG::next_path_position` never really did what it was supposed to. It now uses a double-ended Dijkstra-ish search like a lot of Jordan's XG functions, instead of just checking immediately adjacent nodes (and accumulating the lengths of the ones that don't have paths). There is also now a test for it.

I also refactored single-ended Dijkstra out into its own HandleGraph algorithm, even though I turned out not to need it.