### PR TITLE
Use 0-based indexing in BED parsing

### DIFF
--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -95,11 +95,11 @@ void Transcriptome::add_transcripts(istream & transcript_stream, const gbwt::GBW
             continue;
         }
 
-        // Parse start and end exon position and convert to 0-base. 
+        // Parse start and end exon position.
         getline(transcript_stream, pos, '\t');
-        int32_t spos = stoi(pos) - 1;
+        int32_t spos = stoi(pos);
         getline(transcript_stream, pos, '\t');
-        int32_t epos = stoi(pos) - 1;
+        int32_t epos = stoi(pos);
 
         assert(spos <= epos);
 


### PR DESCRIPTION
I think we had a mistake in the BED parsing, where we were assuming that the indexes were 1-based. However, the format standard is pretty explicit about the indexing being 0-based:
https://genome.ucsc.edu/FAQ/FAQformat.html#format1

Some chance this has been biasing the RNA mapping experiments. @jonassibbesen, thoughts?