### PR TITLE
Allow loading of HandleGraphs from files, with dynamic implementation selection

### DIFF
--- a/src/indexed_vg.cpp
+++ b/src/indexed_vg.cpp
@@ -462,11 +462,11 @@ bool IndexedVG::with_cache_entry(int64_t group_vo, const function<void(const Cac
                 cerr << "error[vg::IndexedVG]: Could not seek from group pos " << pre_seek_group
                     << " to group pos " << group_vo << endl;
                 cerr << "Current position: group " << cursor.tell_group()
-                    << " has_next: " << cursor.has_next() << endl;
+                    << " has_current: " << cursor.has_current() << endl;
                 assert(false);
             }
             
-            if (cursor.has_next()) {
+            if (cursor.has_current()) {
                 // We seeked to a real thing and not EOF
             
                 // Read the group into a cache entry
@@ -500,12 +500,12 @@ IndexedVG::CacheEntry::CacheEntry(cursor_t& cursor) {
     // We want to cache the group we are pointed at
     int64_t group_vo = cursor.tell_group();
     
-    while (cursor.has_next() && cursor.tell_group() == group_vo) {
+    while (cursor.has_current() && cursor.tell_group() == group_vo) {
         // Merge the whole group together
         merged_group.MergeFrom(cursor.take());
     }
 
-    if (!cursor.has_next()) {
+    if (!cursor.has_current()) {
         // We hit EOF
         next_group = numeric_limits<int64_t>::max();
     } else {

--- a/src/io/register_loader_saver_vg.cpp
+++ b/src/io/register_loader_saver_vg.cpp
@@ -17,7 +17,8 @@ using namespace vg::io;
 
 void register_loader_saver_vg() {
     // We register for "" so we can handle untagged old-style vg files and make them into HandleGraphs
-    Registry::register_loader_saver<VG>(vector<string>{"VG", ""}, [](const message_sender_function_t& for_each_message) -> void* {
+    Registry::register_loader_saver<VG, PathHandleGraph, HandleGraph>(vector<string>{"VG", ""},
+        [](const message_sender_function_t& for_each_message) -> void* {
         // We have a bit of a control problem.
         // The source function wants to drive; we give it a function of strings, and it calls it with all the strings in turn.
         

--- a/src/io/register_loader_saver_xg.cpp
+++ b/src/io/register_loader_saver_xg.cpp
@@ -16,7 +16,7 @@ using namespace std;
 using namespace vg::io;
 
 void register_loader_saver_xg() {
-    Registry::register_bare_loader_saver<xg::XG>("XG", [](istream& input) -> void* {
+    Registry::register_bare_loader_saver<xg::XG, PathHandleGraph, HandleGraph>("XG", [](istream& input) -> void* {
         // Allocate an XG
         xg::XG* index = new xg::XG();
         

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -553,7 +553,7 @@ ChainIterator chain_end_from(const Chain& chain, const Snarl* start_snarl, bool 
 
 SnarlManager::SnarlManager(istream& in) : SnarlManager([&in](const function<void(Snarl&)>& consume_snarl) -> void {
     // Find all the snarls in the input stream and use each of them in the callback-based constructor
-    for (vg::io::ProtobufIterator<Snarl> iter(in); iter.has_next(); iter.get_next()) {
+    for (vg::io::ProtobufIterator<Snarl> iter(in); iter.has_current(); iter.advance()) {
         consume_snarl(*iter);
     }
 }) {

--- a/src/stream_index.hpp
+++ b/src/stream_index.hpp
@@ -746,7 +746,7 @@ auto StreamIndex<Message>::find(cursor_t& cursor, const vector<pair<id_t, id_t>>
             // currently looking up.
             int64_t group_vo = cursor.tell_group();
             id_t group_min_id = numeric_limits<id_t>::max();
-            while (cursor.has_next() && cursor.tell_group() < past_end_vo) {
+            while (cursor.has_current() && cursor.tell_group() < past_end_vo) {
                 // Read each message until we find a group that starts out of range
                 
                 // Which group is this message in?
@@ -836,7 +836,7 @@ auto StreamIndex<Message>::find(cursor_t& cursor, const vector<pair<id_t, id_t>>
                 }
                 
                 // Look for the next message
-                cursor.get_next();
+                cursor.advance();
                 
             }
            
@@ -880,7 +880,7 @@ auto StreamIndex<Message>::index(cursor_t& cursor) -> void {
     // We need to have seek support
     assert(group_vo != -1);
     
-    while (cursor.has_next()) {
+    while (cursor.has_current()) {
         // For each message
         
         // Work out what group it is in

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -449,10 +449,10 @@ int main_view(int argc, char** argv) {
         get_input_file(file_name, [&](istream& in) {
             // Iterate over the input as tagged messages.
             vg::io::MessageIterator it(in);
-            while(it.has_next()) {
-                if ((*it).first == extract_tag) {
+            while(it.has_current()) {
+                if ((*it).first == extract_tag && (*it).second.get() != nullptr) {
                     // We match the tag, so dump this message.
-                    cout << (*it).second;
+                    cout << *((*it).second.get());
                 }
                 ++it;
             }

--- a/src/unittest/stream.cpp
+++ b/src/unittest/stream.cpp
@@ -199,6 +199,26 @@ TEST_CASE("ProtobufIterator can read serialized data", "[stream]") {
     }
 }
 
+TEST_CASE("We can read a tag-only GAM file with for_each_parallel", "[stream][gam][empty]") {
+
+    stringstream ss;
+    {
+        // Make an empty GAM by creating and destroying an Alignment ProtobufEmitter
+        vg::io::ProtobufEmitter<Alignment> empty_gam_maker(ss);
+    }
+    
+    // Make sure it wrote something
+    REQUIRE(ss.str().size() != 0);
+    
+    vg::io::for_each_parallel<Alignment>(ss, [&](const Alignment& observed) {
+        // Should never be triggered
+        REQUIRE(false);
+    });
+    
+    // We should complete the test without any errors from the reader code.
+
+}
+
 }
 
 }

--- a/src/unittest/stream.cpp
+++ b/src/unittest/stream.cpp
@@ -153,7 +153,7 @@ TEST_CASE("ProtobufIterator can read serialized data", "[stream]") {
         vg::io::ProtobufIterator<message_t> it(datastream);
         
         size_t index_found = 0;
-        while (it.has_next()) {
+        while (it.has_current()) {
 #ifdef debug
         cerr << "We wrote " << index_found << " at VO " << it.tell_group() << endl;
 #endif
@@ -183,7 +183,7 @@ TEST_CASE("ProtobufIterator can read serialized data", "[stream]") {
     
     SECTION("Data can be iterated back all in a run") {
         size_t index_expected = 0;
-        for (vg::io::ProtobufIterator<message_t> it(datastream); it.has_next(); it.get_next()) {
+        for (vg::io::ProtobufIterator<message_t> it(datastream); it.has_current(); it.advance()) {
             auto vo_parts = unvo(it.tell_group());
 #ifdef debug
             cerr << "Found item " << (*it).node_id() << " at VO " << it.tell_group()

--- a/src/unittest/vpkg.cpp
+++ b/src/unittest/vpkg.cpp
@@ -7,7 +7,9 @@
 
 #include "catch.hpp"
 
+#define debug
 #include <vg/io/vpkg.hpp>
+#undef debug
 #include "../xg.hpp"
 #include "../seed_clusterer.hpp"
 #include "../json2pb.h"
@@ -132,7 +134,7 @@ TEST_CASE("We cannot read a base HandleGraph from an empty file", "[vpkg][handle
     REQUIRE(loaded.get() == nullptr);
 }
 
-TEST_CASE("We can read from a VPKG-wrapped stream as a HandleGraph", "[vpkg][handlegraph][vg]") {
+TEST_CASE("We can read VG from a VPKG-wrapped stream as a HandleGraph", "[vpkg][handlegraph][vg]") {
     string graph_json = R"(
     {"node":[{"id":1,"sequence":"GATT"},
     {"id":2,"sequence":"ACA"}],
@@ -161,6 +163,32 @@ TEST_CASE("We can read from a VPKG-wrapped stream as a HandleGraph", "[vpkg][han
     // Make sure it is the thing we saved
     REQUIRE(loaded->get_node_count() == 2);
     REQUIRE(loaded->get_sequence(loaded->get_handle(1, false)) == "GATT");
+}
+
+TEST_CASE("We can read an empty VG as a HandleGraph", "[vpkg][handlegraph][vg][empty]") {
+    string graph_json = "{}";
+    
+    // Load the JSON
+    Graph proto_graph;
+    json2pb(proto_graph, graph_json.c_str(), graph_json.size());
+    
+    // Build the VG
+    vg::VG vg_graph(proto_graph);
+    
+    // Save it
+    stringstream ss;
+    vg::io::VPKG::save(vg_graph, ss);
+    
+    // There should be some data
+    REQUIRE(ss.str().size() != 0);
+    
+    unique_ptr<HandleGraph> loaded = vg::io::VPKG::load_one<HandleGraph>(ss);
+    
+    // Make sure we got something
+    REQUIRE(loaded.get() != nullptr);
+    
+    // Make sure it is the thing we saved
+    REQUIRE(loaded->get_node_count() == 0);
 }
 
 }

--- a/src/unittest/vpkg.cpp
+++ b/src/unittest/vpkg.cpp
@@ -7,9 +7,7 @@
 
 #include "catch.hpp"
 
-#define debug
 #include <vg/io/vpkg.hpp>
-#undef debug
 #include "../xg.hpp"
 #include "../seed_clusterer.hpp"
 #include "../json2pb.h"


### PR DESCRIPTION
You can now do:

```
unique_ptr<HandleGraph> graph = vg::io::VPKG::load_one<HandleGraph>("file.vg");
```

This works with vg and xg files with a consistent interface, selecting the correct implementation based on what is in the file, and tolerates empty vg files as long as they were written containing a "VG"-tagged empty group (so the loader knows they are vg files). There are unit tests to make sure this keeps working.

(This used to work before I added empty file support. The hacks I made to enable empty file support broke this functionality.)

I've also changed the MessageIterator and ProtobufIterator methods `has_next` and `get_next` to `has_current` and `advance`, which is what they did anyway.

Once this is in, we should work on revising subcommands. Most things that take an xg or vg specifically should be able to just load a HandleGraph or MutableHandleGraph or PathHandleGraph or whatever they actually need. Places where we use different options to select whether to read an xg or a vg should no longer need to do that.

When we register all the other graph implementations (PackedGraph, ODGI) in the libvgio registry, they will magically become supported too.

