### PR TITLE
Fix minimum distance clustering logic in mpmap

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -724,7 +724,7 @@ namespace vg {
 #endif
         
         int64_t dist;
-        if (use_min_dist_clusterer) {
+        if (use_min_dist_clusterer || use_tvs_clusterer) {
             assert(!forward_strand);
             // measure the distance in both directions and choose the minimum (or the only) absolute distance
             int64_t forward_dist = distance_index->minDistance(pos_1, pos_2);

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -146,21 +146,23 @@ namespace vg {
     vector<MultipathMapper::memcluster_t> MultipathMapper::get_clusters(const Alignment& alignment, const vector<MaximalExactMatch>& mems,
                                                                         OrientedDistanceMeasurer* distance_measurer) const {
         
+        vector<MultipathMapper::memcluster_t> return_val;
         if (use_tvs_clusterer) {
             TVSClusterer clusterer(xindex, distance_index);
-            return clusterer.clusters(alignment, mems, get_aligner(), min_clustering_mem_length, max_mapping_quality,
-                                      log_likelihood_approx_factor, min_median_mem_coverage_for_split);
+            return_val = clusterer.clusters(alignment, mems, get_aligner(), min_clustering_mem_length, max_mapping_quality,
+                                            log_likelihood_approx_factor, min_median_mem_coverage_for_split);
         }
         else if (use_min_dist_clusterer) {
             MinDistanceClusterer clusterer(distance_index);
-            return clusterer.clusters(alignment, mems, get_aligner(), min_clustering_mem_length, max_mapping_quality,
-                                      log_likelihood_approx_factor, min_median_mem_coverage_for_split);
+            return_val = clusterer.clusters(alignment, mems, get_aligner(), min_clustering_mem_length, max_mapping_quality,
+                                            log_likelihood_approx_factor, min_median_mem_coverage_for_split);
         }
         else {
             OrientedDistanceClusterer clusterer(*distance_measurer, unstranded_clustering, max_expected_dist_approx_error);
-            return clusterer.clusters(alignment, mems, get_aligner(), min_clustering_mem_length, max_mapping_quality,
-                                      log_likelihood_approx_factor, min_median_mem_coverage_for_split);
+            return_val = clusterer.clusters(alignment, mems, get_aligner(), min_clustering_mem_length, max_mapping_quality,
+                                            log_likelihood_approx_factor, min_median_mem_coverage_for_split);
         }
+        return return_val;
     }
     
     vector<pair<pair<size_t, size_t>, int64_t>> MultipathMapper::get_cluster_pairs(const Alignment& alignment1,
@@ -733,7 +735,7 @@ namespace vg {
                 // unreachable both ways, convert to the sentinel that the client code expects
                 dist = numeric_limits<int64_t>::max();
             }
-            else if (forward_dist == -1 || reverse_dist < forward_dist) {
+            else if (forward_dist == -1 || (reverse_dist < forward_dist && reverse_dist != -1)) {
                 dist = -reverse_dist;
             }
             else {

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1016,6 +1016,7 @@ int main_mpmap(int argc, char** argv) {
     
     // set pruning and clustering parameters
     multipath_mapper.use_tvs_clusterer = use_tvs_clusterer;
+    multipath_mapper.use_min_dist_clusterer = use_min_dist_clusterer;
     multipath_mapper.max_expected_dist_approx_error = max_dist_error;
     multipath_mapper.mem_coverage_min_ratio = cluster_ratio;
     multipath_mapper.log_likelihood_approx_factor = likelihood_approx_exp;

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -95,11 +95,11 @@ void Transcriptome::add_transcripts(istream & transcript_stream, const gbwt::GBW
             continue;
         }
 
-        // Parse start and end exon position.
+        // Parse start and end exon position and convert to 0-base.
         getline(transcript_stream, pos, '\t');
-        int32_t spos = stoi(pos);
+        int32_t spos = stoi(pos) - 1;
         getline(transcript_stream, pos, '\t');
-        int32_t epos = stoi(pos);
+        int32_t epos = stoi(pos) - 1;
 
         assert(spos <= epos);
 

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -95,11 +95,11 @@ void Transcriptome::add_transcripts(istream & transcript_stream, const gbwt::GBW
             continue;
         }
 
-        // Parse start and end exon position and convert to 0-base. 
+        // Parse start and end exon position.
         getline(transcript_stream, pos, '\t');
-        int32_t spos = stoi(pos) - 1;
+        int32_t spos = stoi(pos);
         getline(transcript_stream, pos, '\t');
-        int32_t epos = stoi(pos) - 1;
+        int32_t epos = stoi(pos);
 
         assert(spos <= epos);
 


### PR DESCRIPTION
I'm pretty sure I found the bug that was leading to mis-estimated fragment length distributions on splice graphs.