### PR TITLE
Giraffe improvements

### DIFF
--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -80,6 +80,7 @@ FACTS = ["Giraffes are the tallest living terrestrial animal.",
          "Toys R' Us has used Geoffrey the Giraffe as its mascot since 1965, although earlier advertisements in the 1950's used another giraffe: Dr. G. Raffe.",
          "Giraffe hooves are 1 foot in diameter.",
          "About 50% of giraffe calves die in their first year, mostly due to predation.",
+         "Kirahvi sanoo öri öri öri öri öri öri.",
          "The giraffe's average walking speed is 10 miles per hour.",
          "The giraffe's tongue is colored dark blue.",
          "Some of giraffes' vocalizations are too low to be heard by human ears.",
@@ -166,6 +167,9 @@ def make_stats(read, stages=STAGES):
         stage_dict['correct_stop'] = 0
         if annot.get('last_correct_stage', None) == stage:
             # Unless one does
+            stage_dict['correct_stop'] += 1
+        elif stage == 'minimizer' and annot.get('last_correct_stage', None) == 'none':
+            # Reads that do not have correct seeds end at the minimizer stage
             stage_dict['correct_stop'] += 1
         
         # Set up substage times

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -71,6 +71,7 @@ public:
      * 1. Call extend_seeds(). If there is a full-length alignment, return the result.
      * 2. Call maximal_extensions().
      * 3. Call extend_flanks() with max_mismatches / 2 mismatches.
+     * The extensions are sorted by (core_interval.first, core_interval.second).
      */
     std::vector<GaplessExtension> extend(cluster_type& cluster, const std::string& sequence, size_t max_mismatches = MAX_MISMATCHES) const;
 

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -152,6 +152,18 @@ std::string GBWTGraph::get_sequence(const handle_t& handle) const {
     return std::string(this->sequences.begin() + this->offsets[offset], this->sequences.begin() + this->offsets[offset + 1]);
 }
 
+char GBWTGraph::get_base(const handle_t& handle, size_t index) const {
+    size_t offset = this->node_offset(handle);
+    return this->sequences[this->offsets[offset] + index];
+}
+
+std::string GBWTGraph::get_subsequence(const handle_t& handle, size_t index, size_t size) const {
+    size_t offset = this->node_offset(handle);
+    size_t start = std::min(static_cast<size_t>(this->offsets[offset] + index), static_cast<size_t>(this->offsets[offset + 1]));
+    size = std::min(size, static_cast<size_t>(this->offsets[offset + 1] - start));
+    return std::string(this->sequences.begin() + start, this->sequences.begin() + start + size);
+}
+
 size_t GBWTGraph::node_size() const {
     return total_nodes;
 }

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -1,8 +1,11 @@
 #include "gbwt_helper.hpp"
+#include "utility.hpp"
 
 #include <queue>
 #include <sstream>
 #include <stack>
+
+#include <omp.h>
 
 namespace vg {
 
@@ -45,21 +48,41 @@ GBWTGraph::GBWTGraph(const gbwt::GBWT& gbwt_index, const HandleGraph& sequence_s
     // Sanity checks for the GBWT index.
     assert(this->index.bidirectional());
 
-    // Determine the number of real nodes and the total length of the sequences.
+    // Determine the real nodes and cache the handles.
     // Node n is real, if real_nodes[node_offset(n) / 2] is true.
-    size_t total_length = 0, potential_nodes = this->index.sigma() - this->index.firstNode();
-    this->real_nodes = std::vector<bool>(potential_nodes / 2, false);
-    std::vector<handle_t> handle_cache(potential_nodes); // Getting handles from XG is slow.
-    for (gbwt::node_type node = this->index.firstNode(); node < this->index.sigma(); node += 2) {
-        if (this->index.empty(node)) {
-            continue;
+    size_t potential_nodes = this->index.sigma() - this->index.firstNode();
+    this->real_nodes = sdsl::bit_vector(potential_nodes / 2, 0);
+    std::vector<handle_t> handle_cache(potential_nodes / 2); // Getting handles from XG is slow.
+    #pragma omp parallel
+    {
+        #pragma omp single
+        {
+            #pragma omp task
+            {
+                for (gbwt::node_type node = this->index.firstNode(); node < this->index.sigma(); node += 2) {
+                    if (!(this->index.empty(node))) {
+                        this->real_nodes[this->node_offset(node) / 2] = 1;
+                        this->total_nodes++;
+                    }
+                }
+            }
+            #pragma omp task
+            {
+                for (gbwt::node_type node = this->index.firstNode(); node < this->index.sigma(); node += 2) {
+                    handle_t source_handle = sequence_source.get_handle(gbwt::Node::id(node), false);
+                    handle_cache[this->node_offset(node) / 2] = source_handle;
+                }
+            }
         }
-        size_t offset = this->node_offset(node);
-        this->real_nodes[offset / 2] = true;
-        this->total_nodes++;
-        handle_t source_handle = sequence_source.get_handle(gbwt::Node::id(node), false);
-        total_length += sequence_source.get_length(source_handle);
-        handle_cache[offset] = source_handle;
+    }
+
+    // Determine the total length of the sequences.
+    size_t total_length = 0;
+    for (gbwt::node_type node = this->index.firstNode(); node < this->index.sigma(); node += 2) {
+        size_t offset = this->node_offset(node) / 2;
+        if (this->real_nodes[offset]) {
+            total_length += sequence_source.get_length(handle_cache[offset]);
+        }
     }
     this->sequences.reserve(2 * total_length);
     this->offsets = sdsl::int_vector<0>(potential_nodes + 1, 0, gbwt::bit_length(this->sequences.capacity()));
@@ -70,11 +93,11 @@ GBWTGraph::GBWTGraph(const gbwt::GBWT& gbwt_index, const HandleGraph& sequence_s
         std::string seq;
         size_t offset = this->node_offset(node);
         if (this->real_nodes[offset / 2]) {
-            seq = sequence_source.get_sequence(handle_cache[offset]);
+            seq = sequence_source.get_sequence(handle_cache[offset / 2]);
         }
         this->sequences.insert(this->sequences.end(), seq.begin(), seq.end());
         this->offsets[offset + 1] = this->sequences.size();
-        seq = reverse_complement(seq);
+        reverse_complement_in_place(seq);
         this->sequences.insert(this->sequences.end(), seq.begin(), seq.end());
         this->offsets[offset + 2] = this->sequences.size();
     }

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -79,7 +79,7 @@ public:
     const gbwt::GBWT&   index;
     std::vector<char>   sequences;
     sdsl::int_vector<0> offsets;
-    std::vector<bool>   real_nodes;
+    sdsl::bit_vector    real_nodes;
     size_t              total_nodes;
 
     constexpr static size_t CHUNK_SIZE = 1024; // For parallel for_each_handle().

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -111,6 +111,15 @@ public:
     /// orientation.
     virtual std::string get_sequence(const handle_t& handle) const;
 
+    /// Returns one base of a handle's sequence, in the orientation of the
+    /// handle.
+    virtual char get_base(const handle_t& handle, size_t index) const;
+    
+    /// Returns a substring of a handle's sequence, in the orientation of the
+    /// handle. If the indicated substring would extend beyond the end of the
+    /// handle's sequence, the return value is truncated to the sequence's end.
+    virtual std::string get_subsequence(const handle_t& handle, size_t index, size_t size) const;
+
     /// Return the number of nodes in the graph.
     virtual size_t node_size() const;
 

--- a/src/minimizer.hpp
+++ b/src/minimizer.hpp
@@ -83,12 +83,12 @@ public:
     struct Header {
         std::uint32_t tag, version;
         std::uint64_t flags;
-        size_t        k, w;
-        size_t        keys, capacity, max_keys;
-        size_t        values;
-        size_t        unused1; // This used to be max_occs.
-        size_t        unique;
-        size_t        unused2; // This used to be frequent.
+        std::uint64_t k, w;
+        std::uint64_t keys, capacity, max_keys;
+        std::uint64_t values;
+        std::uint64_t unused1; // This used to be max_occs.
+        std::uint64_t unique;
+        std::uint64_t unused2; // This used to be frequent.
 
         constexpr static std::uint32_t TAG = 0x31513151;
         constexpr static std::uint32_t VERSION = 3;

--- a/src/minimizer.hpp
+++ b/src/minimizer.hpp
@@ -23,8 +23,6 @@ namespace vg {
  * We encode kmers using 2 bits/character and take wang_hash_64() of the encoding. A minimizer
  * is the kmer with the smallest hash in a window of w consecutive kmers and their reverse
  * complements.
- * There is an option to specify an upper bound for the number of occurrences of each
- * minimizer. If the actual number is higher, the occurrences will not be stored.
  *
  * Index versions:
  *
@@ -33,6 +31,8 @@ namespace vg {
  *   2  Minimizer selection is based on hashes instead of lexicographic order. A sequence and
  *      its reverse complement have the same minimizers, reducing index size by 50%. Not
  *      compatible with version 1.
+ *
+ *   3  Construction-time hit cap is no longer used. Compatible with version 2.
  */
 class MinimizerIndex {
 public:
@@ -47,7 +47,6 @@ public:
     constexpr static size_t    KMER_MAX_LENGTH  = 31;
     constexpr static size_t    INITIAL_CAPACITY = 1024;
     constexpr static double    MAX_LOAD_FACTOR  = 0.77;
-    constexpr static size_t    MAX_OCCS         = std::numeric_limits<size_t>::max();
     constexpr static key_type  NO_KEY           = std::numeric_limits<key_type>::max();
     constexpr static code_type NO_VALUE         = 0;
 
@@ -86,15 +85,17 @@ public:
         std::uint64_t flags;
         size_t        k, w;
         size_t        keys, capacity, max_keys;
-        size_t        values, max_occs;
-        size_t        unique, frequent;
+        size_t        values;
+        size_t        unused1; // This used to be max_occs.
+        size_t        unique;
+        size_t        unused2; // This used to be frequent.
 
         constexpr static std::uint32_t TAG = 0x31513151;
-        constexpr static std::uint32_t VERSION = 2;
+        constexpr static std::uint32_t VERSION = 3;
         constexpr static std::uint32_t MIN_VERSION = 2;
 
         Header();
-        Header(size_t kmer_length, size_t window_length, size_t max_occs_per_key);
+        Header(size_t kmer_length, size_t window_length);
         void sanitize();
         bool check() const;
 
@@ -108,7 +109,7 @@ public:
     MinimizerIndex();
 
     /// Constructs an index with the specified parameter values.
-    MinimizerIndex(size_t kmer_length, size_t window_length, size_t max_occs_per_key = MAX_OCCS);
+    MinimizerIndex(size_t kmer_length, size_t window_length);
 
     /// Copy constructor.
     MinimizerIndex(const MinimizerIndex& source);
@@ -167,15 +168,13 @@ public:
     /// starting from the position should have the minimizer as its prefix.
     void insert(const minimizer_type& minimizer, const pos_t& pos);
 
-    /// Returns the sorted set of occurrences of the minimizer. If the occurrence limit
-    /// has been exceeded, returns a vector containing an empty position.
+    /// Returns the sorted set of occurrences of the minimizer.
     /// Use minimizer() or minimizers() to get the minimizer.
     /// If the minimizer is in reverse orientation, use reverse_base_pos() to reverse
     /// the reported occurrences.
     std::vector<pos_t> find(const minimizer_type& minimizer) const;
 
-    /// Returns the occurrence count of the minimizer. If the occurrence limit has been
-    /// exceeded, returns 0.
+    /// Returns the occurrence count of the minimizer.
     /// Use minimizer() or minimizers() to get the minimizer.
     size_t count(const minimizer_type& minimizer) const;
 
@@ -207,9 +206,6 @@ public:
 
     /// Number of minimizers with a single occurrence.
     size_t unique_keys() const { return this->header.unique; }
-
-    /// Number of minimizers with too many occurrences.
-    size_t frequent_keys() const { return this->header.frequent; }
 
 //------------------------------------------------------------------------------
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -623,16 +623,14 @@ int MinimizerMapper::estimate_extension_group_score(const Alignment& aln, vector
     if (extended_seeds.empty()) {
         // TODO: We should never see an empty group of extensions
         return 0;
-    } else if (extended_seeds.size() == 1 && extended_seeds[0].full()) {
+    } else if (extended_seeds.size() == 1 && extended_seeds.front().full()) {
         // This is a full length match. Compute exact score.
-        
-        // Compute a score using the Aligner, which handles all the full length bonuses and so on.
-        // To do that we make a fake copy Alignment.
-        Alignment temp = aln;
-        *temp.mutable_path() = extended_seeds[0].path;
-        // TODO: have an implementation of this that takes a Path and a string and/or quality.
-        // TODO: Just do this based on mismatch count and match count but with aligner score parameters.
-        return get_regular_aligner()->score_ungapped_alignment(temp);
+        // TODO: Should we use the aligner instead of computing the score here?
+
+        const Aligner* aligner = get_regular_aligner();
+        return (aln.sequence().length() - extended_seeds.front().mismatches()) * aligner->match +
+               extended_seeds.front().mismatches() * aligner->mismatch +
+               2 * aligner->full_length_bonus;
     } else {
         // This is a collection of one or more non-full-length extended seeds.
         

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -14,9 +14,9 @@
 #include <cmath>
 
 // Set this to track provenance of intermediate results
-#define TRACK_PROVENANCE
+//#define TRACK_PROVENANCE
 // With TRACK_PROVENANCE on, set this to track correctness, which requires some expensive XG queries
-#define TRACK_CORRECTNESS
+//#define TRACK_CORRECTNESS
 
 namespace vg {
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -15,9 +15,9 @@
 #include <sdsl/int_vector.hpp>
 
 // Set this to track provenance of intermediate results
-//#define TRACK_PROVENANCE
+#define TRACK_PROVENANCE
 // With TRACK_PROVENANCE on, set this to track correctness, which requires some expensive XG queries
-//#define TRACK_CORRECTNESS
+#define TRACK_CORRECTNESS
 
 namespace vg {
 
@@ -234,7 +234,7 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     vector<vector<GaplessExtension>> cluster_extensions;
     cluster_extensions.reserve(cluster_indexes_in_order.size());
     
-    for (size_t i = 0; i < clusters.size(); i++) {
+    for (size_t i = 0; i < clusters.size() && i < max_extensions; i++) {
         // For each cluster, in sorted order
         size_t& cluster_num = cluster_indexes_in_order[i];
         

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -434,14 +434,6 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
                 funnel.substage("chain");
 #endif
                 
-                // Sort the extended seeds by read start position.
-                // TODO: Score estimation may have sorted them already.
-                std::sort(extensions.begin(), extensions.end(), [&](const GaplessExtension& a, const GaplessExtension& b) -> bool {
-                    // Return true if a needs to come before b.
-                    // This will happen if a is earlier in the read than b.
-                    return a.core_interval.first < b.core_interval.first;
-                });
-                
                 // Do the chaining and compute an alignment into out.
                 chain_extended_seeds(aln, extensions, out);
                 
@@ -648,13 +640,6 @@ int MinimizerMapper::estimate_extension_group_score(const Alignment& aln, vector
             // No score here
             return 0;
         }
-        
-        // Sort them in read order.
-        std::sort(extended_seeds.begin(), extended_seeds.end(), [&](const GaplessExtension& a, const GaplessExtension& b) -> bool {
-            // Return true if a needs to come before b.
-            // This will happen if a is earlier in the read than b.
-            return a.core_interval.first < b.core_interval.first;
-        });
         
         // Now we compute an estimate of the score: match count for all the
         // flank bases that aren't universal mismatches, mismatch count for

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -628,7 +628,7 @@ int MinimizerMapper::estimate_extension_group_score(const Alignment& aln, vector
         // TODO: Should we use the aligner instead of computing the score here?
 
         const Aligner* aligner = get_regular_aligner();
-        return (aln.sequence().length() - extended_seeds.front().mismatches()) * aligner->match +
+        return (aln.sequence().length() - extended_seeds.front().mismatches()) * aligner->match -
                extended_seeds.front().mismatches() * aligner->mismatch +
                2 * aligner->full_length_bonus;
     } else {

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -39,12 +39,23 @@ public:
     // Mapping settings.
     // TODO: document each
 
+    /// Use all minimizers with at most hit_cap hits
+    size_t hit_cap = 10;
+
+    /// Ignore all minimizers with more than hard_hit_cap hits
+    size_t hard_hit_cap = 300;
+
+    /// Take minimizers between hit_cap and hard_hit_cap hits until this fraction
+    /// of total score
+    double minimizer_score_fraction = 0.6;
+
     /// How many clusters should we align?
     size_t max_extensions = 48;
+
     /// How many extended clusters should we align, max?
-    size_t max_alignments = 48;
+    size_t max_alignments = 8;
+
     size_t max_multimaps = 1;
-    size_t hit_cap = 10;
     size_t distance_limit = 1000;
     bool do_chaining = true;
     bool use_xdrop_for_tails = false;

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -39,6 +39,8 @@ public:
     // Mapping settings.
     // TODO: document each
 
+    /// How many clusters should we align?
+    size_t max_extensions = 48;
     /// How many extended clusters should we align, max?
     size_t max_alignments = 48;
     size_t max_multimaps = 1;

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -203,7 +203,7 @@ int main_gaffe(int argc, char** argv) {
                 do_chaining = false;
                 break;
 
-            case 'E':
+            case 'e':
                 {
                     size_t extensions = parse<size_t>(optarg);
                     if (extensions <= 0) {

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -56,6 +56,7 @@ void help_gaffe(char** argv) {
     << "computational parameters:" << endl
     << "  -C, --no-chaining             disable seed chaining and all gapped alignment" << endl
     << "  -e, --max-extensions INT      extend up to INT clusters [48]" << endl
+    << "  -a, --max-alignments INT      align up to INT extensions [48]" << endl
     << "  -X, --xdrop                   use xdrop alignment for tails" << endl
     << "  -t, --threads INT             number of compute threads to use" << endl;
 }
@@ -88,8 +89,10 @@ int main_gaffe(int argc, char** argv) {
     vector<string> fastq_filenames;
     // How many mappings per read can we emit?
     size_t max_multimaps = 1;
-    // How many extended clusters should we align, max?
+    // How many clusters should we extend?
     size_t max_extensions = 48;
+    // How many extended clusters should we align, max?
+    size_t max_alignments = 48;
     // What sample name if any should we apply?
     string sample_name;
     // What read group if any should we apply?
@@ -115,13 +118,14 @@ int main_gaffe(int argc, char** argv) {
             {"read-group", required_argument, 0, 'R'},
             {"no-chaining", no_argument, 0, 'C'},
             {"max-extensions", required_argument, 0, 'e'},
+            {"max-alignments", required_argument, 0, 'a'},
             {"xdrop", no_argument, 0, 'X'},
             {"threads", required_argument, 0, 't'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:H:m:s:d:c:pG:f:M:Ce:Xt:",
+        c = getopt_long (argc, argv, "hx:H:m:s:d:c:pG:f:M:Ce:a:Xt:",
                          long_options, &option_index);
 
 
@@ -211,6 +215,17 @@ int main_gaffe(int argc, char** argv) {
                         exit(1);
                     }
                     max_extensions = extensions;
+                }
+                break;
+
+            case 'a':
+                {
+                    size_t alignments = parse<size_t>(optarg);
+                    if (alignments <= 0) {
+                        cerr << "error: [vg gaffe] Number of alignments (" << alignments << ") must be a positive integer" << endl;
+                        exit(1);
+                    }
+                    max_alignments = alignments;
                 }
                 break;
                 
@@ -303,7 +318,12 @@ int main_gaffe(int argc, char** argv) {
     if (progress) {
         cerr << "--max-extensions " << max_extensions << endl;
     }
-    minimizer_mapper.max_alignments = max_extensions;
+    minimizer_mapper.max_extensions = max_extensions;
+
+    if (progress) {
+        cerr << "--max-alignments " << max_alignments << endl;
+    }
+    minimizer_mapper.max_alignments = max_alignments;
 
     if (progress) {
         cerr << "--max-multipmaps " << max_multimaps << endl;

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -44,7 +44,6 @@ void help_gaffe(char** argv) {
     << "  -m, --minimizer-name FILE     use this minimizer index (required)" << endl
     << "  -s, --snarls FILE             cluster using these snarls (required)" << endl
     << "  -d, --dist-name FILE          cluster using this distance index (required)" << endl
-    << "  -c, --hit-cap INT             ignore minimizers with more than this many locations [10]" << endl
     << "  -p, --progress                show progress" << endl
     << "input options:" << endl
     << "  -G, --gam-in FILE             read and realign GAM-format reads from FILE (may repeat)" << endl
@@ -54,9 +53,12 @@ void help_gaffe(char** argv) {
     << "  -N, --sample NAME             add this sample name" << endl
     << "  -R, --read-group NAME         add this read group" << endl
     << "computational parameters:" << endl
-    << "  -C, --no-chaining             disable seed chaining and all gapped alignment" << endl
+    << "  -c, --hit-cap INT             use all minimizers with at most INT hits [10]" << endl
+    << "  -C, --hard-hit-cap INT        ignore all minimizers with more than INT hits [300]" << endl
+    << "  -F, --score-fraction FLOAT    select minimizers between hit caps until score is FLOAT of total [0.6]" << endl
     << "  -e, --max-extensions INT      extend up to INT clusters [48]" << endl
-    << "  -a, --max-alignments INT      align up to INT extensions [48]" << endl
+    << "  -a, --max-alignments INT      align up to INT extensions [8]" << endl
+    << "  -O, --no-chaining             disable seed chaining and all gapped alignment" << endl
     << "  -X, --xdrop                   use xdrop alignment for tails" << endl
     << "  -t, --threads INT             number of compute threads to use" << endl;
 }
@@ -76,7 +78,8 @@ int main_gaffe(int argc, char** argv) {
     string distance_name;
     // How close should two hits be to be in the same cluster?
     size_t distance_limit = 1000;
-    size_t hit_cap = 30;
+    size_t hit_cap = 10, hard_hit_cap = 300;
+    double minimizer_score_fraction = 0.6;
     bool progress = false;
     // Should we try chaining or just give up if we can't find a full length gapless alignment?
     bool do_chaining = true;
@@ -92,7 +95,7 @@ int main_gaffe(int argc, char** argv) {
     // How many clusters should we extend?
     size_t max_extensions = 48;
     // How many extended clusters should we align, max?
-    size_t max_alignments = 48;
+    size_t max_alignments = 8;
     // What sample name if any should we apply?
     string sample_name;
     // What read group if any should we apply?
@@ -109,23 +112,25 @@ int main_gaffe(int argc, char** argv) {
             {"minimizer-name", required_argument, 0, 'm'},
             {"snarls", required_argument, 0, 's'},
             {"dist-name", required_argument, 0, 'd'},
-            {"hit-cap", required_argument, 0, 'c'},
             {"progress", no_argument, 0, 'p'},
             {"gam-in", required_argument, 0, 'G'},
             {"fastq-in", required_argument, 0, 'f'},
             {"max-multimaps", required_argument, 0, 'M'},
             {"sample", required_argument, 0, 'N'},
             {"read-group", required_argument, 0, 'R'},
-            {"no-chaining", no_argument, 0, 'C'},
+            {"hit-cap", required_argument, 0, 'c'},
+            {"hard-hit-cap", required_argument, 0, 'C'},
             {"max-extensions", required_argument, 0, 'e'},
             {"max-alignments", required_argument, 0, 'a'},
+            {"score-fraction", required_argument, 0, 'F'},
+            {"no-chaining", no_argument, 0, 'O'},
             {"xdrop", no_argument, 0, 'X'},
             {"threads", required_argument, 0, 't'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:H:m:s:d:c:pG:f:M:Ce:a:Xt:",
+        c = getopt_long (argc, argv, "hx:H:m:s:d:pG:f:M:c:C:F:e:a:OXt:",
                          long_options, &option_index);
 
 
@@ -174,10 +179,6 @@ int main_gaffe(int argc, char** argv) {
                     exit(1);
                 }
                 break;
-            
-            case 'c':
-                hit_cap = parse<size_t>(optarg);
-                break;
 
             case 'p':
                 progress = true;
@@ -202,9 +203,31 @@ int main_gaffe(int argc, char** argv) {
             case 'R':
                 read_group = optarg;
                 break;
-                
+
+            case 'c':
+                {
+                    size_t cap = parse<size_t>(optarg);
+                    if (cap <= 0) {
+                        cerr << "error: [vg gaffe] Hit cap (" << cap << ") must be a positive integer" << endl;
+                        exit(1);
+                    }
+                    hit_cap = cap;
+                }
+                break;
+
             case 'C':
-                do_chaining = false;
+                {
+                    size_t cap = parse<size_t>(optarg);
+                    if (cap <= 0) {
+                        cerr << "error: [vg gaffe] Hard hit cap (" << cap << ") must be a positive integer" << endl;
+                        exit(1);
+                    }
+                    hard_hit_cap = cap;
+                }
+                break;
+
+            case 'F':
+                minimizer_score_fraction = parse<double>(optarg);
                 break;
 
             case 'e':
@@ -227,6 +250,10 @@ int main_gaffe(int argc, char** argv) {
                     }
                     max_alignments = alignments;
                 }
+                break;
+
+            case 'O':
+                do_chaining = false;
                 break;
                 
             case 'X':
@@ -315,6 +342,22 @@ int main_gaffe(int argc, char** argv) {
     }
     MinimizerMapper minimizer_mapper(xg_index.get(), gbwt_index.get(), minimizer_index.get(), snarl_manager.get(), distance_index.get());
 
+
+    if (progress) {
+        cerr << "--hit-cap " << hit_cap << endl;
+    }
+    minimizer_mapper.hit_cap = hit_cap;
+
+    if (progress) {
+        cerr << "--hard-hit-cap " << hard_hit_cap << endl;
+    }
+    minimizer_mapper.hard_hit_cap = hard_hit_cap;
+
+    if (progress) {
+        cerr << "--score-fraction " << minimizer_score_fraction << endl;
+    }
+    minimizer_mapper.minimizer_score_fraction = minimizer_score_fraction;
+
     if (progress) {
         cerr << "--max-extensions " << max_extensions << endl;
     }
@@ -326,24 +369,19 @@ int main_gaffe(int argc, char** argv) {
     minimizer_mapper.max_alignments = max_alignments;
 
     if (progress) {
+        cerr << "--no-chaining " << (!do_chaining) << endl;
+    }
+    minimizer_mapper.do_chaining = do_chaining;
+
+    if (progress) {
         cerr << "--max-multipmaps " << max_multimaps << endl;
     }
     minimizer_mapper.max_multimaps = max_multimaps;
 
     if (progress) {
-        cerr << "--hit-cap " << hit_cap << endl;
-    }
-    minimizer_mapper.hit_cap = hit_cap;
-
-    if (progress) {
         cerr << "--distance-limit " << distance_limit << endl;
     }
     minimizer_mapper.distance_limit = distance_limit;
-
-    if (progress) {
-        cerr << "--no-chaining " << (!do_chaining) << endl;
-    }
-    minimizer_mapper.do_chaining = do_chaining;
 
     if (progress) {
         cerr << "--xdrop " << use_xdrop_for_tails << endl;
@@ -354,14 +392,7 @@ int main_gaffe(int argc, char** argv) {
     minimizer_mapper.read_group = read_group;
     
     // Work out the number of threads we will have
-    size_t thread_count = 0;
-    #pragma omp parallel
-    {
-        #pragma omp single
-        {
-            thread_count = omp_get_num_threads();
-        }
-    }
+    size_t thread_count = omp_get_max_threads();
 
     // Set up counters per-thread for total reads mapped
     vector<size_t> reads_mapped_by_thread(thread_count, 0);

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -32,11 +32,7 @@
 #include <vg/io/vpkg.hpp>
 #include <vg/io/stream.hpp>
 
-#include <gcsa/gcsa.h>
-#include <gcsa/lcp.h>
-
 #include <iostream>
-#include <limits>
 #include <vector>
 
 #include <getopt.h>
@@ -57,18 +53,7 @@ void help_minimizer(char** argv) {
     std::cerr << "    -g, --gbwt-name X      index only haplotype-consistent kmers using the GBWT index in file X" << std::endl;
     std::cerr << "    -p, --progress         show progress information" << std::endl;
     std::cerr << "    -t, --threads N        use N threads for index construction (default: " << omp_get_max_threads() << ")" << std::endl;
-    std::cerr << "benchmark options:" << std::endl;
-    std::cerr << "    -b, --benchmark X      query performance benchmarks with the sequences in file X" << std::endl;
-    std::cerr << "    -i, --index-name X     benchmark the minimizer index in file X (required)" << std::endl;
-    std::cerr << "    -G, --gcsa-name X      also benchmark the GCSA2 index in file X" << std::endl;
-    std::cerr << "    -L, --locate           locate the minimizer/MEM occurrences" << std::endl;
-    std::cerr << "    -m, --max-occs N       do not locate minimizers with more than N occurrences" << std::endl;
-    std::cerr << "    -e, --extend N         try gapless extension of unique hits with up to N mismatches (requires -g, -L)" << std::endl;
-    std::cerr << "    -g, --gbwt-name X      extend using the GBWT index in file X" << std::endl;
-    std::cerr << "    -M, --min-hits N       only extend reads with at least N minimizer hits" << std::endl;
 }
-
-int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::unique_ptr<GBWTGraph>& gbwt_graph, const std::string& reads_name, const std::string& gcsa_name, bool locate, size_t max_occs, bool gapless_extend, size_t max_errors, size_t min_hits, bool progress);
 
 int main_minimizer(int argc, char** argv) {
 
@@ -80,10 +65,8 @@ int main_minimizer(int argc, char** argv) {
     // Command-line options.
     size_t kmer_length = MinimizerIndex::KMER_LENGTH;
     size_t window_length = MinimizerIndex::WINDOW_LENGTH;
-    size_t max_occs = std::numeric_limits<size_t>::max();
-    size_t max_errors = 0, min_hits = 1;
-    std::string index_name, load_index, gbwt_name, xg_name, reads_name, gcsa_name;
-    bool progress = false, locate = false, gapless_extend = false;
+    std::string index_name, load_index, gbwt_name, xg_name;
+    bool progress = false;
     int threads = omp_get_max_threads();
 
     int c;
@@ -98,17 +81,11 @@ int main_minimizer(int argc, char** argv) {
             { "gbwt-name", required_argument, 0, 'g' },
             { "progress", no_argument, 0, 'p' },
             { "threads", required_argument, 0, 't' },
-            { "benchmark", required_argument, 0, 'b' },
-            { "max-occs", required_argument, 0, 'm' },
-            { "gcsa-name", required_argument, 0, 'G' },
-            { "locate", no_argument, 0, 'L' },
-            { "extend", required_argument, 0, 'e' },
-            { "min-hits", required_argument, 0, 'M' },
             { 0, 0, 0, 0 }
         };
 
         int option_index = 0;
-        c = getopt_long(argc, argv, "k:w:i:l:g:pt:hb:m:G:Le:M:", long_options, &option_index);
+        c = getopt_long(argc, argv, "k:w:i:l:g:pt:h", long_options, &option_index);
         if (c == -1) { break; } // End of options.
 
         switch (c)
@@ -137,25 +114,6 @@ int main_minimizer(int argc, char** argv) {
             threads = std::max(threads, 1);
             omp_set_num_threads(threads);
             break;
-        case 'b':
-            reads_name = optarg;
-            break;
-        case 'm':
-            max_occs = parse<size_t>(optarg);
-            break;
-        case 'G':
-            gcsa_name = optarg;
-            break;
-        case 'L':
-            locate = true;
-            break;
-        case 'e':
-            max_errors = parse<size_t>(optarg);
-            gapless_extend = true;
-            break;
-        case 'M':
-            min_hits = std::max(static_cast<size_t>(1), parse<size_t>(optarg));
-            break;
 
         case 'h':
         case '?':
@@ -168,13 +126,6 @@ int main_minimizer(int argc, char** argv) {
     if (index_name.empty()) {
         std::cerr << "[vg minimizer]: option --index-name is required" << std::endl;
         return 1;
-    }
-    if (gapless_extend && (!locate || gbwt_name.empty())) {
-        std::cerr << "[vg minimizer]: option --extend requires --gbwt-name and --locate" << std::endl;
-        return 1;
-    }
-    if (!reads_name.empty()) {
-        load_index = index_name;
     }
     if (optind + 1 != argc) {
         help_minimizer(argv);
@@ -213,11 +164,6 @@ int main_minimizer(int argc, char** argv) {
         }
         gbwt_graph.reset(new GBWTGraph(*gbwt_index, *xg_index));
         xg_index.reset(nullptr); // The XG index is no longer needed.
-    }
-
-    // Run the benchmarks and return.
-    if (!reads_name.empty()) {
-        return query_benchmarks(index, gbwt_graph, reads_name, gcsa_name, locate, max_occs, gapless_extend, max_errors, min_hits, progress);
     }
 
     // Minimizer caching.
@@ -310,210 +256,6 @@ int main_minimizer(int argc, char** argv) {
         std::cerr << "Time usage: " << seconds << " seconds" << std::endl;
         std::cerr << "Memory usage: " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
     }
-
-    return 0;
-}
-
-int query_benchmarks(const std::unique_ptr<MinimizerIndex>& index, const std::unique_ptr<GBWTGraph>& gbwt_graph, const std::string& reads_name, const std::string& gcsa_name, bool locate, size_t max_occs, bool gapless_extend, size_t max_errors, size_t min_hits, bool progress) {
-
-    double start = gbwt::readTimer();
-
-    // Load the GCSA index.
-    bool benchmark_gcsa = !(gcsa_name.empty());
-    std::unique_ptr<gcsa::GCSA> gcsa_index;
-    std::unique_ptr<gcsa::LCPArray> lcp_index;
-    if (benchmark_gcsa) {
-        if (progress) {
-            std::cerr << "Loading GCSA index " << gcsa_name << std::endl;
-        }
-        gcsa_index = vg::io::VPKG::load_one<gcsa::GCSA>(gcsa_name);
-        std::string lcp_name = gcsa_name + gcsa::LCPArray::EXTENSION;
-        lcp_index = vg::io::VPKG::load_one<gcsa::LCPArray>(lcp_name);
-    }
-
-    // Load the reads.
-    std::vector<std::string> reads;
-    if (progress) {
-        std::cerr << "Loading the reads from " << reads_name << std::endl;
-    }
-    size_t total_size = gcsa::readRows(reads_name, reads, true);
-    if (progress) {
-        std::cerr << reads.size() << " reads of total length " << total_size << std::endl;
-    }
-    if (reads.empty()) {
-        return 0;
-    }
-
-    size_t threads = omp_get_max_threads();
-    if (progress) {
-        std::cerr << "Query threads: " << threads << std::endl;
-        std::cerr << std::endl;
-    }
-
-    // Minimizers.
-    {
-        double phase_start = gbwt::readTimer();
-
-        GaplessExtender extender;
-        if (gapless_extend) {
-            extender = GaplessExtender(*gbwt_graph);
-        }
-        std::vector<size_t> min_counts(threads, 0);
-        std::vector<size_t> occ_counts(threads, 0);
-        std::vector<size_t> extend_counts(threads, 0);
-        std::vector<size_t> seed_counts(threads, 0);
-        std::vector<size_t> success_counts(threads, 0);
-        std::vector<size_t> success_seed_counts(threads, 0);
-        std::vector<size_t> partial_match_counts(threads, 0);
-        std::vector<size_t> core_lengths(threads, 0);
-        std::vector<size_t> flanked_lengths(threads, 0);
-        #pragma omp parallel for schedule(static)
-        for (size_t i = 0; i < reads.size(); i++) {
-            size_t thread = omp_get_thread_num();
-            std::vector<MinimizerIndex::minimizer_type> result = index->minimizers(reads[i]);
-            min_counts[thread] += result.size();
-            if (locate) {
-                std::vector<std::pair<size_t, pos_t>> hits; // (read offset, pos) for unique hits.
-                for (auto& minimizer : result) {
-                    if (index->count(minimizer) <= max_occs) {
-                        std::vector<pos_t> occs = index->find(minimizer);
-                        if (occs.size() != 1 || !vg::is_empty(occs.front())) {
-                            for (pos_t& occ : occs) {
-                                if (minimizer.is_reverse) {
-                                    size_t node_length = gbwt_graph->get_length(gbwt_graph->get_handle(id(occ)));
-                                    occ = reverse_base_pos(occ, node_length);
-                                }
-                                hits.emplace_back(minimizer.offset, occ);
-                            }
-                        }
-                    }
-                }
-                occ_counts[thread] += hits.size();
-                if (gapless_extend && hits.size() >= min_hits) {
-                    extend_counts[thread]++;
-                    seed_counts[thread] += hits.size();
-                    auto result = extender.extend_seeds(hits, reads[i], max_errors);
-                    if (result.full()) {
-                        success_counts[thread]++;
-                        success_seed_counts[thread] += hits.size();
-                    } else {
-                        auto partial_matches = extender.maximal_extensions(hits, reads[i]);
-                        extender.extend_flanks(partial_matches, reads[i], max_errors / 2);
-                        partial_match_counts[thread] += partial_matches.size();
-                        for (GaplessExtension& extension : partial_matches) {
-                            core_lengths[thread] += extension.core_length();
-                            flanked_lengths[thread] += extension.flanked_length();
-                        }
-                    }
-                }
-            } else {
-                for (auto minimizer : result) {
-                    occ_counts[thread] += index->count(minimizer);
-                }
-            }
-        }
-        size_t min_count = 0, occ_count = 0;
-        size_t extend_count = 0, seed_count = 0, success_count = 0, success_seed_count = 0, partial_match_count = 0;
-        size_t core_length = 0, flanked_length = 0;
-        for (size_t i = 0; i < threads; i++) {
-            min_count += min_counts[i];
-            occ_count += occ_counts[i];
-            extend_count += extend_counts[i];
-            seed_count += seed_counts[i];
-            success_count += success_counts[i];
-            success_seed_count += success_seed_counts[i];
-            partial_match_count += partial_match_counts[i];
-            core_length += core_lengths[i];
-            flanked_length += flanked_lengths[i];
-        }
-
-        double phase_seconds = gbwt::readTimer() - phase_start;
-        std::string query_type = "count";
-        if (locate) { 
-            query_type = "locate";
-        }
-        if (gapless_extend) {
-            query_type = "extend";
-        }
-        std::cerr << "Minimizers (" << query_type << "): " << phase_seconds << " seconds (" << (reads.size() / phase_seconds) << " reads/second)" << std::endl;
-        std::cerr << min_count << " minimizers with " << occ_count << " occurrences" << std::endl;
-        if (gapless_extend) {
-            std::cerr << extend_count << " reads with " << seed_count << " seeds: " << success_count << " full-length alignments with up to " << max_errors << " mismatches" << std::endl;
-            size_t partial_count = extend_count - success_count, partial_seed_count = seed_count - success_seed_count;
-            std::cerr << partial_count << " reads with " << partial_seed_count << " seeds: " << partial_match_count << " partial alignments (core " << (core_length / static_cast<double>(partial_count)) << " bp, flanked " << (flanked_length / static_cast<double>(partial_count)) << " bp/read)" << std::endl;
-        }
-        std::cerr << std::endl;
-    }
-
-    // Count MEMs.
-    if (benchmark_gcsa) {
-        double phase_start = gbwt::readTimer();
-
-        std::vector<size_t> mem_counts(threads, 0);
-        std::vector<size_t> mem_lengths(threads, 0);
-        #pragma omp parallel for schedule(static)
-        for (size_t i = 0; i < reads.size(); i++) {
-            size_t thread = omp_get_thread_num();
-            const std::string& read = reads[i];
-            auto iter = read.rbegin();
-            gcsa::range_type full(0, gcsa_index->size() - 1);
-            gcsa::range_type curr = full;
-            std::vector<gcsa::node_type> occurrences;
-            while (iter != read.rend()) {
-                gcsa::range_type prev = curr;
-                curr = gcsa_index->LF(curr, gcsa_index->alpha.char2comp[*iter]);
-                if (gcsa::Range::empty(curr)) {
-                    if (prev != full) {
-                        mem_counts[thread]++;
-                        if (locate) {
-                            if (gcsa::Range::length(prev) <= max_occs) {
-                                gcsa_index->locate(prev, occurrences);
-                                mem_lengths[thread] += occurrences.size();
-                            }
-                        } else {
-                            mem_lengths[thread] += gcsa::Range::length(prev);
-                        }
-                        gcsa::STNode parent = lcp_index->parent(prev);
-                        curr = parent.range();
-                    } else {
-                        curr = full;
-                    }
-                } else if (iter + 1 == read.rend()) {
-                    if (prev != full) {
-                        mem_counts[thread]++;
-                        if (locate) {
-                            if (gcsa::Range::length(prev) <= max_occs) {
-                                gcsa_index->locate(prev, occurrences);
-                                mem_lengths[thread] += occurrences.size();
-                            }
-                        } else {
-                            mem_lengths[thread] += gcsa::Range::length(prev);
-                        }
-                    }
-                }
-                ++iter;
-            }
-        }
-        size_t mem_count = 0, mem_length = 0;
-        for (size_t i = 0; i < threads; i++) {
-            mem_count += mem_counts[i];
-            mem_length += mem_lengths[i];
-        }
-
-        double phase_seconds = gbwt::readTimer() - phase_start;
-        std::string query_type = (locate ? "locate" : "count");
-        std::cerr << "MEMs (" << query_type << "): " << phase_seconds << " seconds (" << (reads.size() / phase_seconds) << " reads/second)" << std::endl;
-        std::cerr << mem_count << " MEMs with " << mem_length << " occurrences" << std::endl;
-        std::cerr << std::endl;
-    }
-
-
-    // Locate minimizers
-    // Locate MEMs
-
-    double seconds = gbwt::readTimer() - start;
-    std::cerr << "Benchmarks completed in " << seconds << " seconds" << std::endl;
-    std::cerr << "Memory usage: " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
 
     return 0;
 }

--- a/src/unittest/gbwt_helper.cpp
+++ b/src/unittest/gbwt_helper.cpp
@@ -156,6 +156,23 @@ TEST_CASE("GBWTGraph works correctly", "[gbwt_helper]") {
         }
     }
 
+    // Substrings and characters.
+    SECTION("access to partial sequence") {
+        for (id_t id : correct_nodes) {
+            handle_t fw = gbwt_graph.get_handle(id, false);
+            handle_t rev = gbwt_graph.get_handle(id, true);
+            std::string fw_str = gbwt_graph.get_sequence(fw);
+            std::string rev_str = gbwt_graph.get_sequence(rev);
+            REQUIRE(fw_str.length() == rev_str.length());
+            for (size_t i = 0; i < fw_str.length(); i++) {
+                REQUIRE(gbwt_graph.get_base(fw, i) == fw_str[i]);
+                REQUIRE(gbwt_graph.get_base(rev, i) == rev_str[i]);
+                REQUIRE(gbwt_graph.get_subsequence(fw, i, 2) == fw_str.substr(i, 2));
+                REQUIRE(gbwt_graph.get_subsequence(rev, i, 2) == rev_str.substr(i, 2));
+            }
+        }
+    }
+
     // get_sequence_view() and starts_with() / ends_with().
     SECTION("direct access to the sequence") {
         for (id_t id : correct_nodes) {

--- a/test/t/46_vg_minimizer.t
+++ b/test/t/46_vg_minimizer.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 12
+plan tests 10
 
 
 # Indexing a single graph
@@ -19,22 +19,17 @@ is $? 0 "default parameters"
 # Single-threaded
 vg minimizer -t 1 -i x.mi x.xg
 is $? 0 "single-threaded construction"
-is $(md5sum x.mi | cut -f 1 -d\ ) 859da428d4f90d10247cf3a0c8f6cafb "construction is deterministic"
+is $(md5sum x.mi | cut -f 1 -d\ ) 5e32f24011133d89da496fbc9a2f7b29 "construction is deterministic"
 
 # Minimizer parameters
 vg minimizer -t 1 -k 7 -w 3 -i x.mi x.xg
 is $? 0 "minimizer parameters"
-is $(md5sum x.mi | cut -f 1 -d\ ) 08756cda9cd89b923ff4c8bf018f3257 "setting -k -w works correctly"
-
-# Max occs (-k 7 -w 3 -m 2)
-vg minimizer -t 1 -k 7 -w 3 -m 2 -i x.mi x.xg
-is $? 0 "max occurrences"
-is $(md5sum x.mi | cut -f 1 -d\ ) e917beec607f67269322107679c7d415 "frequent minimizers can be excluded"
+is $(md5sum x.mi | cut -f 1 -d\ ) 1a5b8ab49a403adb3cadcd83833e1798 "setting -k -w works correctly"
 
 # Haplotype-consistent minimizers
 vg minimizer -t 1 -g x.gbwt -i x.mi x.xg
 is $? 0 "haplotype-consistent minimizers"
-is $(md5sum x.mi | cut -f 1 -d\ ) b53302959d910faa8b13b1a9e627e1d8 "construction is deterministic"
+is $(md5sum x.mi | cut -f 1 -d\ ) 6bedb0d725cfcab531a7938cdc8120a6 "construction is deterministic"
 
 rm -f x.vg x.xg x.gbwt x.mi
 
@@ -51,7 +46,7 @@ vg minimizer -t 1 -i x.mi x.xg
 is $? 0 "multiple graphs: first"
 vg minimizer -t 1 -l x.mi -i xy.mi y.xg
 is $? 0 "multiple graphs: second"
-is $(md5sum xy.mi | cut -f 1 -d\ ) 45ccf9727fb3147b6133da12de2019f9 "construction is deterministic"
+is $(md5sum xy.mi | cut -f 1 -d\ ) 6597a86c79bdd63bc344c262267c3f7e "construction is deterministic"
 
 rm -f x.vg y.vg
 rm -f x.xg y.xg


### PR DESCRIPTION
* Separate bounds for the number of clusters to extend and the number of extensions to align.
* Adaptive minimizer hit cap: first take all minimizers below the soft cap, and then select additional minimizers below the hard cap until the total score is sufficiently high.
* Faster minimizer index without a construction-time hit cap.
* Various minor optimizations.

The score of a minimizer with k hits is 1 + log (hard_cap / k). In a certain sense, the score tells how informative this minimizer is, with an arbitrary additive constant. This scoring scheme is good for selecting the minimizers to use as seeds. It does not work so well for selecting the clusters to extend.