### PR TITLE
More augment tweaks

### DIFF
--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -11,9 +11,13 @@ namespace vg {
 using namespace std;
 
 // The correct way to edit the graph
-vector<Translation> augment(MutablePathMutableHandleGraph* graph, istream& gam_stream,
-                            ostream* gam_out_stream, function<void(Path&)> save_path_fn,
-                            bool break_at_ends, bool remove_softclips) {
+void augment(MutablePathMutableHandleGraph* graph,
+             istream& gam_stream,
+             vector<Translation>* out_translations,
+             ostream* gam_out_stream,
+             function<void(Path&)> save_path_fn,
+             bool break_at_ends,
+             bool remove_softclips) {
     // Collect the breakpoints
     unordered_map<id_t, set<pos_t>> breakpoints;
 
@@ -140,7 +144,9 @@ vector<Translation> augment(MutablePathMutableHandleGraph* graph, istream& gam_s
         });
 
     // make the translation
-    return make_translation(graph, node_translation, added_nodes, orig_node_sizes);
+    if (out_translations != nullptr) {
+        *out_translations = make_translation(graph, node_translation, added_nodes, orig_node_sizes);
+    }
 }
 
 

--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -806,7 +806,7 @@ vector<Translation> make_translation(const HandleGraph* graph,
                   }
               });
     // append the reverse complement of the translation
-    vector<Translation> reverse_translation;
+    translation.reserve(translation.size() * 2);
     auto get_curr_node_length = [&](id_t id) {
         return graph->get_length(graph->get_handle(id));
     };
@@ -819,12 +819,11 @@ vector<Translation> make_translation(const HandleGraph* graph,
         return f->second;
     };
     for (auto& trans : translation) {
-        reverse_translation.emplace_back();
-        auto& rev_trans = reverse_translation.back();
+        translation.emplace_back();
+        auto& rev_trans = translation.back();
         *rev_trans.mutable_to() = simplify(reverse_complement_path(trans.to(), get_curr_node_length));
         *rev_trans.mutable_from() = simplify(reverse_complement_path(trans.from(), get_orig_node_length));
     }
-    translation.insert(translation.end(), reverse_translation.begin(), reverse_translation.end());
     return translation;
 }
 

--- a/src/augment.hpp
+++ b/src/augment.hpp
@@ -15,14 +15,15 @@ namespace vg {
 using namespace std;
 
 /// %Edit the graph to include all the sequence and edges added by the given
-/// paths. Can handle paths that visit nodes in any orientation. Returns a
-/// vector of Translations, one per node existing after the edit, describing
-/// how each new or conserved node is embedded in the old graph. Note that
+/// paths. Can handle paths that visit nodes in any orientation. Note that
 /// this method sorts the graph and rebuilds the path index, so it should
 /// not be called in a loop.
 ///
 /// If gam_out_stream is not null, the paths will be modified to reflect their
 /// embedding in the modified graph and written to the stream.
+/// If out_translation is not null, a list of translations, one per node existing
+/// after the edit, describing
+/// how each new or conserved node is embedded in the old graph. 
 /// if save_path_fn is not null, this function will be run on each modified path
 /// in order to add it back to the graph.
 /// If break_at_ends is true, nodes will be broken at
@@ -30,12 +31,13 @@ using namespace std;
 /// be added to the vg graph's paths object.
 /// If soft_clip is true, soft clips will be removed from the input paths
 /// before processing, and the dangling ends won't end up in the graph
-vector<Translation> augment(MutablePathMutableHandleGraph* graph,
-                            istream& gam_stream,
-                            ostream* gam_out_stream = nullptr,
-                            function<void(Path&)> save_path_fn = nullptr,
-                            bool break_at_ends = false,
-                            bool remove_soft_clips = false);
+void augment(MutablePathMutableHandleGraph* graph,
+             istream& gam_stream,
+             vector<Translation>* out_translation = nullptr,
+             ostream* gam_out_stream = nullptr,
+             function<void(Path&)> save_path_fn = nullptr,
+             bool break_at_ends = false,
+             bool remove_soft_clips = false);
 
 /// Find all the points at which a Path enters or leaves nodes in the graph. Adds
 /// them to the given map by node ID of sets of bases in the node that will need

--- a/src/genotypekit.cpp
+++ b/src/genotypekit.cpp
@@ -228,7 +228,8 @@ void AugmentedGraph::augment_from_alignment_edits(vector<Alignment>& alignments,
     
         // Run them through vg::edit() to modify the graph, but don't embed them
         // as paths. Update the paths in place, and save the translations.
-        vector<Translation> augmentation_translations = graph.edit(paths, false, true, false);
+        vector<Translation> augmentation_translations;
+        graph.edit(paths, &augmentation_translations, false, true, false);
         
         for (size_t i = 0; i < paths.size(); i++) {
             // Copy all the modified paths back.

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -393,7 +393,11 @@ int main_augment(int argc, char** argv) {
                     reads.push_back(aln);
                     *reads.back().mutable_path() = Path();
                 });
-            translation = graph->edit(read_paths, include_paths, !gam_out_file_name.empty(), false);
+            graph->edit(read_paths,
+                        !translation_file_name.empty() ? &translation : nullptr,
+                        include_paths,
+                        !gam_out_file_name.empty(),
+                        false);
             if (!gam_out_file_name.empty()) {
                 ofstream gam_out_file(gam_out_file_name);
                 vector<Alignment> gam_buffer;
@@ -418,9 +422,11 @@ int main_augment(int argc, char** argv) {
             if (!gam_out_file_name.empty()) {
                 gam_out_file.open(gam_out_file_name);
             }
-            translation = graph->edit(gam_in_file, include_paths,
-                                      !gam_out_file_name.empty() ? &gam_out_file : nullptr,
-                                      false, !include_softclips);
+            graph->edit(gam_in_file,
+                        !translation_file_name.empty() ? &translation : nullptr,
+                        include_paths,
+                        !gam_out_file_name.empty() ? &gam_out_file : nullptr,
+                        false, !include_softclips);
         }
         
         // Write the augmented graph
@@ -550,7 +556,8 @@ int main_augment(int argc, char** argv) {
         }
         // execute the edits and produce the translation if requested.
         // Make sure to break at node ends, but don't add any paths because they're just loci alleles and not real paths.
-        auto translation = graph->edit(paths, false, false, true);
+        vector<Translation> translation;
+        graph->edit(paths, &translation, false, false, true);
         if (!translation_file_name.empty()) {
             ofstream out(translation_file_name);
             vg::io::write_buffered(out, translation, 0);

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -736,7 +736,7 @@ int main_msga(int argc, char** argv) {
             if (debug) cerr << name << ": editing graph" << endl;
             //graph->serialize_to_file(name + "-pre-edit.vg");
             // Modify graph and embed paths
-            graph->edit(paths, true);
+            graph->edit(paths, nullptr, true);
             //if (!graph->is_valid()) cerr << "invalid after edit" << endl;
             //graph->serialize_to_file(name + "-immed-post-edit.vg");
             if (normalize) graph->normalize(10, debug);

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -752,7 +752,7 @@ void Transcriptome::add_junctions_to_graph() {
 
     // Edit graph with transcript paths and update path traversals
     // to match the augmented graph. 
-    graph->edit(_transcriptome, false, true, true);
+    graph->edit(_transcriptome, nullptr, false, true, true);
 }
 
 void Transcriptome::remove_non_transcribed(const bool keep_reference) {

--- a/src/unittest/vg.cpp
+++ b/src/unittest/vg.cpp
@@ -1682,7 +1682,7 @@ TEST_CASE("edit() should not get confused even under very confusing circumstance
     vector<Path> paths{path};
        
     SECTION("edit() can add the path without modifying it") {
-        graph.edit(paths, false, false, false);
+        graph.edit(paths, nullptr, false, false, false);
         
         REQUIRE(pb2json(paths.front()) == pb2json(path));
         
@@ -1692,7 +1692,7 @@ TEST_CASE("edit() should not get confused even under very confusing circumstance
     }
     
     SECTION("edit() can add the path with modification only") {
-        graph.edit(paths, false, true, false);
+        graph.edit(paths, nullptr, false, true, false);
         
         for (const auto& mapping : paths.front().mapping()) {
             // Make sure all the mappings are perfect matches
@@ -1705,7 +1705,7 @@ TEST_CASE("edit() should not get confused even under very confusing circumstance
     }
     
     SECTION("edit() can add the path with end breaking only") {
-        graph.edit(paths, false, false, true);
+        graph.edit(paths, nullptr, false, false, true);
         
         REQUIRE(pb2json(paths.front()) == pb2json(path));
         

--- a/src/variant_recall.cpp
+++ b/src/variant_recall.cpp
@@ -66,7 +66,7 @@ void genotype_svs(VG* graph,
     vg::io::for_each_interleaved_pair_parallel(gamstream, readfunc);
     vector<Translation> transls;
     if (refpath != ""){
-        transls = graph->edit(direct_ins); // TODO could maybe use edit_fast??
+        graph->edit(direct_ins, &transls); // TODO could maybe use edit_fast??
                
         Deconstructor decon;
         decon.deconstruct(refpath, graph);

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -645,10 +645,11 @@ public:
     void include(const Path& path);
 
     /// %Edit the graph to include all the sequence and edges added by the given
-    /// paths. Can handle paths that visit nodes in any orientation. Returns a
-    /// vector of Translations, one per node existing after the edit, describing
-    /// how each new or conserved node is embedded in the old graph. Note that
-    /// this method sorts the graph and rebuilds the path index, so it should
+    /// paths. Can handle paths that visit nodes in any orientation.
+    /// If out_translations is given, a vector of Translations will be written to it,
+    /// one per node existing after the edit, describing
+    /// how each new or conserved node is embedded in the old graph.
+    /// Note that this method sorts the graph and rebuilds the path index, so it should
     /// not be called in a loop.
     ///
     /// If update_paths is true, the paths will be modified to reflect their
@@ -657,17 +658,23 @@ public:
     /// break_at_ends is true (or save_paths is true), nodes will be broken at
     /// the ends of paths that start/end woth perfect matches, so the paths can
     /// be added to the vg graph's paths object.
-    vector<Translation> edit(vector<Path>& paths_to_add, bool save_paths = false,
-                             bool update_paths = false, bool break_at_ends = false);
+    void edit(vector<Path>& paths_to_add,
+              vector<Translation>* out_translations = nullptr,
+              bool save_paths = false,
+              bool update_paths = false,
+              bool break_at_ends = false);
 
     /// Streaming version of above.  Instead of reading a list of paths into memory
     /// all at once, a stream is used to go one-by-one.  Instead of an option to
     /// updtate the in-memory list, an optional output stream is used
     ///
     /// todo: duplicate less code between the two versions. 
-    vector<Translation> edit(istream& paths_to_add, bool save_paths = false,
-                             ostream* out_path_stream = nullptr, bool break_at_ends = false,
-                             bool remove_softclips = false);
+    void edit(istream& paths_to_add,
+              vector<Translation>* out_translations = nullptr,
+              bool save_paths = false,
+              ostream* out_path_stream = nullptr,
+              bool break_at_ends = false,
+              bool remove_softclips = false);
     
     /// %Edit the graph to include all the sequences and edges added by the
     /// given path. Returns a vector of Translations, one per original-node


### PR DESCRIPTION
Change up the `edit` function to only make translations when wanted, as they take a lot of memory.   (If translations are needed, streaming them out instead of buffering them all, along with moving away from protobuf, can also fix this.) 

This finally gets the memory in check.  Augmenting a 1.5M node chr21 graph into a 12M node graph using 10M illumina reads goes from over 150G to 4.5G RAM:

* Embed each read in the graph (old `mod -i` logic): `>150G` / `hours`
* and augment graph, but put paths in augmented GAM:  `63G`
* and  don't buffer entire input GAM in memory: `30G` / `17m`
* and don't make translations: `13G` / `12m`
* and use HashGraph instead of VG: `8G` / `9m`
* or use PackedGraph instead of VG: `4.5G` / `11m`
