### PR TITLE
Optimize after augment

### DIFF
--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -147,6 +147,9 @@ void augment(MutablePathMutableHandleGraph* graph,
     if (out_translations != nullptr) {
         *out_translations = make_translation(graph, node_translation, added_nodes, orig_node_sizes);
     }
+
+    // optimize the graph.  VG will use this to rebuild its in-memory path index which is important. 
+    graph->optimize();
 }
 
 

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -727,7 +727,11 @@ vector<handle_t> VG::divide_handle(const handle_t& handle, const vector<size_t>&
 }
 
 void VG::optimize(bool allow_id_reassignment) {
-    // no-op for now, but should we implement something?
+    // Rebuild path ranks, aux mapping, etc. by compacting the path ranks
+    paths.compact_ranks();
+
+    // execute a semi partial order sort on the nodes
+    sort();
 }
     
 
@@ -5242,12 +5246,6 @@ void VG::edit(istream& paths_to_add,
     augment(this, paths_to_add, out_translations, out_gam_stream, save_fn,
             break_at_ends, remove_softclips);
         
-    // Rebuild path ranks, aux mapping, etc. by compacting the path ranks
-    // Todo: can we just do this once?
-    paths.compact_ranks();
-
-    // execute a semi partial order sort on the nodes
-    sort();
 }
     
 // The not quite as robust (TODO: how?) but actually efficient way to edit the graph.


### PR DESCRIPTION
Move that path-reindexing and sorting from the end of VG::edit to VG::optimize, and call the latter from augment.  This should let augment() be a better drop-in replacement when dealing with a VG back end. 

