### PR TITLE
Option to weight support by quality in vg pack

### DIFF
--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -253,7 +253,6 @@ void Packer::add(const Alignment& aln, bool record_edits, bool qual_adjust) {
     for (size_t mi = 0; mi < aln.path().mapping_size(); ++mi) {
         auto& mapping = aln.path().mapping(mi);
         int mapping_quality = aln.mapping_quality();
-        bool has_base_quality = !aln.quality().empty();
         if (!mapping.has_position()) {
 #ifdef debug
             cerr << "Mapping has no position" << endl;
@@ -298,7 +297,7 @@ void Packer::add(const Alignment& aln, bool record_edits, bool qual_adjust) {
                 i += edit.from_length();
             }
             if (!edit_is_match(edit)) {
-                position_in_read += edit.from_length();
+                position_in_read += edit.to_length();
             }
         }
 

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -248,9 +248,6 @@ void Packer::add(const Alignment& aln, bool record_edits) {
     int prev_bq_total = 0;
     int prev_bq_count = 0;
     size_t position_in_read = 0;
-    if (qual_adjust && quality_cache == nullptr) {
-        quality_cache = new LRUCache<pair<int, int>, int>(lru_cache_size);
-    }
     for (size_t mi = 0; mi < aln.path().mapping_size(); ++mi) {
         auto& mapping = aln.path().mapping(mi);
         int mapping_quality = aln.mapping_quality();

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -24,7 +24,7 @@ using namespace sdsl;
 class Packer {
 public:
     Packer(void);
-    Packer(xg::XG* xidx, size_t bin_size = 0);
+    Packer(xg::XG* xidx, size_t bin_size = 0, bool qual_adjust = false);
     ~Packer(void);
     xg::XG* xgidx;
     void merge_from_files(const vector<string>& file_names);
@@ -37,7 +37,7 @@ public:
                      std::string name = "");
     void make_compact(void);
     void make_dynamic(void);
-    void add(const Alignment& aln, bool record_edits = true, bool qual_adjust = false);
+    void add(const Alignment& aln, bool record_edits = true);
     size_t graph_length(void) const;
     size_t position_in_basis(const Position& pos) const;
     string pos_key(size_t i) const;
@@ -89,6 +89,9 @@ private:
     string unescape_delim(const string& s, char d) const;
     string unescape_delims(const string& s) const;
 
+    // toggle quality adjusted mode
+    bool qual_adjust;
+    
     // Combine the MAPQ and base quality (if available) for a given position in the read
     int compute_quality(const Alignment& aln, size_t position_in_read) const;
     int combine_qualities(int map_quality, int base_quality) const;

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <ctime>
 #include "omp.h"
+#include "lru_cache.h"
 #include "xg.hpp"
 #include "alignment.hpp"
 #include "path.hpp"
@@ -36,7 +37,7 @@ public:
                      std::string name = "");
     void make_compact(void);
     void make_dynamic(void);
-    void add(const Alignment& aln, bool record_edits = true);
+    void add(const Alignment& aln, bool record_edits = true, bool qual_adjust = false);
     size_t graph_length(void) const;
     size_t position_in_basis(const Position& pos) const;
     string pos_key(size_t i) const;
@@ -88,7 +89,14 @@ private:
     string unescape_delim(const string& s, char d) const;
     string unescape_delims(const string& s) const;
 
-    Edge edge_from_mappings(const Mapping& m, const Mapping& n);
+    // Combine the MAPQ and base quality (if available) for a given position in the read
+    int compute_quality(const Alignment& aln, size_t position_in_read) const;
+    int combine_qualities(int map_quality, int base_quality) const;
+    
+    // Avoid recomputing qualities in above
+    mutable LRUCache<pair<int, int>, int>* quality_cache;
+    static const int maximum_quality;
+    static const int lru_cache_size;
     
 };
 

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -169,11 +169,11 @@ int main_pack(int argc, char** argv) {
             packers.push_back(&packer);
         } else {
             for (size_t i = 0; i < thread_count; ++i) {
-                packers.push_back(new Packer(xgidx.get(), bin_size));
+                packers.push_back(new Packer(xgidx.get(), bin_size, qual_adjust));
             }
         }
         std::function<void(Alignment&)> lambda = [&packer,&record_edits,&packers,&qual_adjust](Alignment& aln) {
-            packers[omp_get_thread_num()]->add(aln, record_edits, qual_adjust);
+            packers[omp_get_thread_num()]->add(aln, record_edits);
         };
         if (gam_in == "-") {
             vg::io::for_each_parallel(std::cin, lambda);

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -156,7 +156,7 @@ int main_pack(int argc, char** argv) {
 
     // todo one packer per thread and merge
 
-    vg::Packer packer(xgidx.get(), bin_size);
+    vg::Packer packer(xgidx.get(), bin_size, qual_adjust);
     if (packs_in.size() == 1) {
         packer.load_from_file(packs_in.front());
     } else if (packs_in.size() > 1) {
@@ -172,7 +172,7 @@ int main_pack(int argc, char** argv) {
                 packers.push_back(new Packer(xgidx.get(), bin_size, qual_adjust));
             }
         }
-        std::function<void(Alignment&)> lambda = [&packer,&record_edits,&packers,&qual_adjust](Alignment& aln) {
+        std::function<void(Alignment&)> lambda = [&packer,&record_edits,&packers](Alignment& aln) {
             packers[omp_get_thread_num()]->add(aln, record_edits);
         };
         if (gam_in == "-") {

--- a/test/t/34_vg_pack.t
+++ b/test/t/34_vg_pack.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 11
+plan tests 13
 
 vg construct -m 1000 -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
@@ -69,3 +69,11 @@ is $x $y "pack stores the correct edge pileup to disk"
 
 rm -f tiny.vg tiny.xg tiny.gam tiny.vgpu tiny.pack
 
+vg construct -m 20 -r tiny/tiny.fa >flat.vg
+printf '@forward\nCAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG\n+\n<B<BBB!BBBB<BBBBBBBBBBBBBBBBBBB<BBBBBBBBBBBBB<B7BB\n' > reads.fq
+printf '@reverses\nCAGAGAGTTGGAATATAATAGAACTCCAGAAAATTTCCAAGCCTTATTTG\n+\nBB7B<BBBBBBBBBBBBB<BBBBBBBBBBBBBBBBBBB<BBBB!BBB<B<\n' >> reads.fq
+vg index -x flat.xg -g flat.gcsa -k 16 flat.vg
+vg map -g flat.gcsa -x flat.xg -f reads.fq -k 8 > reads.gam
+vg pack -x flat.xg -o reads.gam.cx -g reads.gam -q
+is $(vg pack -x flat.xg -di reads.gam.cx | tail -n+2 | cut -f 4 | grep ^0$ | wc -l) 1 "qual-adjust packing detects 1 base with 0 quality"
+is $(vg pack -x flat.xg -Di reads.gam.cx | tail | cut -f 5 | grep ^59$ | wc -l) 1 "qual-adjust packing gets correct edge support"

--- a/test/t/34_vg_pack.t
+++ b/test/t/34_vg_pack.t
@@ -77,3 +77,5 @@ vg map -g flat.gcsa -x flat.xg -f reads.fq -k 8 > reads.gam
 vg pack -x flat.xg -o reads.gam.cx -g reads.gam -q
 is $(vg pack -x flat.xg -di reads.gam.cx | tail -n+2 | cut -f 4 | grep ^0$ | wc -l) 1 "qual-adjust packing detects 1 base with 0 quality"
 is $(vg pack -x flat.xg -Di reads.gam.cx | tail | cut -f 5 | grep ^59$ | wc -l) 1 "qual-adjust packing gets correct edge support"
+
+rm -f flat.vg flat.xg flat.gcsa reads.fq reads.gam reads.gam.cx


### PR DESCRIPTION
If a position in the graph is covered by two reads in the GAM, one with MAPQ=60 and the other with MAPQ=30, it will get a coverage of 2 in the pack.   This PR adds the `-q` option for quality-scaling which would instead give it 90.  The idea is to use this as a very simple heuristic to downweight coverage from low quality alignments.  When a base quality is available, it gets combined with the MAPQ.  For edges, the average base quality of its two incident Mappings is used.  

A variant caller may want to have access to both the scaled and unscaled support at the same time (in addition to some strand information), but we can worry about that later. 