### PR TITLE
Fix bug in split strand overlay

### DIFF
--- a/src/algorithms/dfs.cpp
+++ b/src/algorithms/dfs.cpp
@@ -1,5 +1,7 @@
 #include "dfs.hpp"
 
+//#define debug
+
 namespace vg {
 namespace algorithms {
 

--- a/src/algorithms/is_acyclic.cpp
+++ b/src/algorithms/is_acyclic.cpp
@@ -28,15 +28,8 @@ bool is_directed_acyclic(const HandleGraph* graph) {
     // And also the stack of tips to start at
     vector<handle_t> stack;
     graph->for_each_handle([&](const handle_t& here) {
-        size_t start_degree = 0;
-        graph->follow_edges(here, true, [&](const handle_t& ignored) {
-            start_degree++;
-        });
-        
-        size_t end_degree = 0;
-        graph->follow_edges(here, false, [&](const handle_t& ignored) {
-            end_degree++;
-        });
+        size_t start_degree = graph->get_degree(here, true);
+        size_t end_degree = graph->get_degree(here, false);
     
         degrees[graph->get_id(here)] = make_pair(start_degree, end_degree);
         
@@ -50,7 +43,6 @@ bool is_directed_acyclic(const HandleGraph* graph) {
         }
         
     });
-    
     
     while (!stack.empty()) {
         handle_t here = stack.back();

--- a/src/algorithms/strongly_connected_components.cpp
+++ b/src/algorithms/strongly_connected_components.cpp
@@ -1,5 +1,7 @@
 #include "strongly_connected_components.hpp"
 
+//#define debug
+
 namespace vg {
 namespace algorithms {
 

--- a/src/split_strand_graph.cpp
+++ b/src/split_strand_graph.cpp
@@ -39,7 +39,7 @@ using namespace std;
     }
     
     string StrandSplitGraph::get_sequence(const handle_t& handle) const {
-        return  graph->get_sequence(get_underlying_handle(handle));
+        return graph->get_sequence(get_underlying_handle(handle));
     }
     
     bool StrandSplitGraph::follow_edges_impl(const handle_t& handle, bool go_left,
@@ -47,7 +47,7 @@ using namespace std;
         
         return graph->follow_edges(get_underlying_handle(handle), go_left,
                                    [&] (const handle_t& next) {
-            return iteratee(get_handle((graph->get_id(next) << 1) + graph->get_is_reverse(next),
+            return iteratee(get_handle((graph->get_id(next) << 1) + (graph->get_is_reverse(next) != get_is_reverse(handle)),
                                        get_is_reverse(handle)));
         });
     }

--- a/src/unittest/dagify.cpp
+++ b/src/unittest/dagify.cpp
@@ -1,13 +1,17 @@
-/// \file mem.cpp
+/// \file dagify.cpp
 ///  
-/// unit tests for MEMs and their clustering algorithms
+/// unit tests for the handle based dagify algorithm
 ///
 
 #include <iostream>
 #include "json2pb.h"
 #include "../vg.hpp"
+#include "../hash_graph.hpp"
+#include "../split_strand_graph.hpp"
 #include "../algorithms/dagify.hpp"
 #include "../algorithms/is_acyclic.hpp"
+#include "../algorithms/split_strands.hpp"
+#include "random_graph.hpp"
 #include "catch.hpp"
 
 namespace vg {
@@ -387,6 +391,33 @@ namespace unittest {
                 
                 REQUIRE(found);
             }
+        }
+    }
+    
+    TEST_CASE("Dagify algorithm produces expected results random test cases using both methods of making single stranded graphs", "[algorithms][dagify]") {
+        
+        size_t preserved_length = 15;
+        size_t seq_size = 50;
+        size_t variant_len = 5;
+        size_t variant_count = 8;
+        
+        size_t num_trials = 1000;
+        for (size_t i = 0; i < num_trials; ++i) {
+            HashGraph graph;
+            random_graph(seq_size, variant_len, variant_count, &graph);
+            
+            HashGraph direct_split;
+            algorithms::split_strands(&graph, &direct_split);
+            HashGraph direct_dagified;
+            algorithms::dagify(&direct_split, &direct_dagified, preserved_length);
+
+            StrandSplitGraph split(&graph);
+            
+            HashGraph dagified;
+            algorithms::dagify(&split, &dagified, preserved_length);
+            
+            REQUIRE(algorithms::is_acyclic(&direct_dagified));
+            REQUIRE(algorithms::is_acyclic(&dagified));
         }
     }
 }

--- a/src/unittest/overlays.cpp
+++ b/src/unittest/overlays.cpp
@@ -14,6 +14,10 @@
 
 #include "algorithms/is_single_stranded.hpp"
 
+#include "../vg.hpp"
+#include "algorithms/dagify.hpp"
+#include "algorithms/is_acyclic.hpp"
+
 #include "catch.hpp"
 
 
@@ -21,7 +25,7 @@ namespace vg {
 namespace unittest {
 using namespace std;
 
-    TEST_CASE("SplitStrandGraph overlay produces graphs that are single stranded", "[overlay][handle]") {
+    TEST_CASE("StrandSplitGraph overlay produces graphs that are single stranded", "[overlay][handle]") {
         
         int num_tests = 100;
         int seq_size = 500;
@@ -73,8 +77,6 @@ using namespace std;
             
             REQUIRE(split_edge_trav_count == 2 * graph_edge_trav_count);
         }
-        
-        
     }
 }
 }


### PR DESCRIPTION
Resolves a bug that @xchang1 found in the strand splitting overlay, which affected some edge traversals.