### PR TITLE
Tolerate tcmalloc refusing instructions

### DIFF
--- a/src/tcmalloc_configuration.cpp
+++ b/src/tcmalloc_configuration.cpp
@@ -28,7 +28,9 @@ public:
         // Allow 16 MB of memory per core (i.e. per default OMP thread) for tcmalloc thread caches.
         // The default is 16 MB total, which is way too small.
         size_t tcmalloc_thread_cache_bytes = get_thread_count() * 16 * 1024 * 1024;
-        //assert(MallocExtension::instance()->SetNumericProperty("tcmalloc.max_total_thread_cache_bytes", tcmalloc_thread_cache_bytes));
+        // Ask tcmalloc to up our thread cache size.
+        // Don't stop if this fails; it doesn't work under callgrind for example.
+        MallocExtension::instance()->SetNumericProperty("tcmalloc.max_total_thread_cache_bytes", tcmalloc_thread_cache_bytes);
     }
 };
 

--- a/src/tcmalloc_configuration.cpp
+++ b/src/tcmalloc_configuration.cpp
@@ -28,7 +28,7 @@ public:
         // Allow 16 MB of memory per core (i.e. per default OMP thread) for tcmalloc thread caches.
         // The default is 16 MB total, which is way too small.
         size_t tcmalloc_thread_cache_bytes = get_thread_count() * 16 * 1024 * 1024;
-        assert(MallocExtension::instance()->SetNumericProperty("tcmalloc.max_total_thread_cache_bytes", tcmalloc_thread_cache_bytes));
+        //assert(MallocExtension::instance()->SetNumericProperty("tcmalloc.max_total_thread_cache_bytes", tcmalloc_thread_cache_bytes));
     }
 };
 


### PR DESCRIPTION
We can't successfully adjust tcmalloc under callgrind, apparently.