### PR TITLE
Speed up vg filter, set up for speed testing

### DIFF
--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -1,6 +1,7 @@
 #include "readfilter.hpp"
 #include "IntervalTree.h"
 #include "annotation.hpp"
+#include "alignment_emitter.hpp"
 #include <vg/io/stream.hpp>
 
 #include <fstream>
@@ -749,25 +750,16 @@ int ReadFilter::filter(istream* alignment_stream) {
         return 1;
     }
 
-    // output buffers
-    vector<vector<Alignment> > output_buffer(threads);
+    // Keep an AlignmentEmitter to multiplex output from multiple threads.
+    unique_ptr<AlignmentEmitter> emitter;
     
+    if (write_output) {
+        emitter = get_alignment_emitter("-", "GAM",  map<string, int64_t>(), get_thread_count());
+    }
+
     // keep counts of what's filtered to report (in verbose mode)
     vector<Counts> counts_vec(threads);
 
-    auto output_alignment = [&](Alignment& aln) {
-        auto& output_buf = output_buffer[omp_get_thread_num()];
-        output_buf.emplace_back(move(aln));
-        vg::io::write_buffered(cout, output_buf, buffer_size);
-    };
-
-    auto flush_buffer = [&output_buffer]() {
-        for (auto& output_buf : output_buffer) {
-            vg::io::write_buffered(cout, output_buf, 0);
-        }
-        cout.flush();
-    };
-    
     function<void(Alignment&)> lambda = [&](Alignment& aln) {
 #ifdef debug
         cerr << "Encountered read named \"" << aln.name() << "\" with " << aln.sequence().size()
@@ -776,7 +768,7 @@ int ReadFilter::filter(istream* alignment_stream) {
         Counts aln_counts = filter_alignment(aln);
         counts_vec[omp_get_thread_num()] += aln_counts;
         if ((aln_counts.keep() != complement_filter) && write_output) {
-            output_alignment(aln);
+            emitter->emit_single(std::move(aln));
         }
     };
 
@@ -793,8 +785,7 @@ int ReadFilter::filter(istream* alignment_stream) {
         }
         counts_vec[omp_get_thread_num()] += aln_counts;
         if ((aln_counts.keep() != complement_filter) && write_output) {
-            output_alignment(aln1);
-            output_alignment(aln2);
+            emitter->emit_pair(std::move(aln1), std::move(aln2));
         }
         
     };
@@ -803,9 +794,6 @@ int ReadFilter::filter(istream* alignment_stream) {
         vg::io::for_each_interleaved_pair_parallel(*alignment_stream, pair_lambda);
     } else {
         vg::io::for_each_parallel(*alignment_stream, lambda);
-    }
-    if (write_output) {
-        flush_buffer();
     }
 
     if (verbose) {

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -186,8 +186,7 @@ private:
      * kept. Returns true if the read should stay, and false if it should be
      * removed. Always accepts or rejects paired reads together.
      */
-    bool sample_read(const Alignment& read); 
-    
+    bool sample_read(const Alignment& read);
 };
 ostream& operator<<(ostream& os, const ReadFilter::Counts& counts);
 }


### PR DESCRIPTION
I've set vg filter to use the AlignmentEmitter. This makes it much faster.

Unfortunately, it also gives it the issue that @xchang1 has identified: throwing more threads at the process wastes more CPU time:

```
time vg filter trash/big.gam -t64 > trash/clustering/multiplex.bam

real	0m8.132s
user	3m27.102s
sys	0m3.755s

time vg filter trash/big.gam -t32 > trash/clustering/multiplex.bam

real	0m6.662s
user	2m46.286s
sys	0m3.518s
```

I have modified vg filter mostly so I can try profiling it with gperftools' sampling profiler. I tried it on Giraffe, but turning it on resulted in a bad_alloc during XG load. I can't find anything online about gperftools profiling being supposed to cause bad_alloc when on, so either we're doing something very bad during XG load, or there's a gperftools bug I need to work around.

I think I can profile the new vg filter at different thread counts with gperftools' sampling profiler, and then compare the profiles to see what parts of the program take more time as thread count increases.