### PR TITLE
Pack input for vg call

### DIFF
--- a/src/genotypekit.hpp
+++ b/src/genotypekit.hpp
@@ -24,6 +24,7 @@
 #include "distributions.hpp"
 #include "snarls.hpp"
 #include "path_index.hpp"
+#include "packer.hpp"
 
 namespace vg {
 
@@ -296,6 +297,12 @@ struct SupportAugmentedGraph : public AugmentedGraph {
     * Read the supports from protobuf.
     */
     void load_supports(istream& in_file);
+
+    /**
+     * Read the suppors from output of vg pack
+     * Everything put in forward support, average used for nodes
+     */
+    void load_pack_as_supports(const string& pack_file_name, xg::XG* xg);
 
     /**
      * Write the supports to protobuf

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -18,6 +18,11 @@ Packer::~Packer(void) {
 
 void Packer::load_from_file(const string& file_name) {
     ifstream in(file_name);
+    if (!in) {
+        stringstream ss;
+        ss << "Error [Packer]: unable to read pack file: \"" << file_name << "\"" << endl;
+        throw runtime_error(ss.str());
+    }
     load(in);
 }
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -16,6 +16,8 @@
 
 #include "../vg.hpp"
 #include "../support_caller.hpp"
+#include <vg/io/stream.hpp>
+#include <vg/io/vpkg.hpp>
 
 
 
@@ -122,12 +124,14 @@ int main_call(int argc, char** argv) {
     }
     string graph_file_name = get_input_file_name(optind, argc, argv);
 
-    if (string(support_caller.support_file_name).empty()) {
-        cerr << "[vg call]: Support file must be specified with -s" << endl;
+    if (string(support_caller.support_file_name).empty() ==
+        string(support_caller.pack_file_name).empty()) {
+        cerr << "[vg call]: Support file must be specified with either -s (or -P)" << endl;
         return 1;
     }
+    
 
-    if (translation_file_name.empty()) {
+    if (string(support_caller.pack_file_name).empty() && translation_file_name.empty()) {
         cerr << "[vg call]: Translation file must be specified with -Z" << endl;
         return 1;
     }
@@ -182,21 +186,36 @@ int main_call(int argc, char** argv) {
     delete graph;
 
     // Load the supports
-    ifstream support_file(support_caller.support_file_name);
-    if (!support_file) {
-        cerr << "[vg call]: Unable to load supports file: "
-             << string(support_caller.support_file_name) << endl;
-        return 1;
-    }
-    augmented_graph.load_supports(support_file);
+    if (!string(support_caller.support_file_name).empty()) {
+        ifstream support_file(support_caller.support_file_name);
+        if (!support_file) {
+            cerr << "[vg call]: Unable to load supports file: "
+                 << string(support_caller.support_file_name) << endl;
+            return 1;
+        }
+        augmented_graph.load_supports(support_file);
+    } else {
+        assert(!string(support_caller.pack_file_name).empty());
+        if (string(support_caller.xg_file_name).empty()) {
+            cerr << "[vg call]: pack support (-P) requires xg index (-x)" << endl;
+            return 1;
+        }
+        unique_ptr<xg::XG> xgidx = vg::io::VPKG::load_one<xg::XG>(support_caller.xg_file_name);
+        augmented_graph.load_pack_as_supports(support_caller.pack_file_name, xgidx.get());
+        // make sure we're ignoring quality, as it's not read from the pack
+        bool& usc = support_caller.use_support_count;
+        usc = true;
+    }        
 
     // Load the translations
-    ifstream translation_file(translation_file_name.c_str());
-    if (!translation_file) {
-        cerr << "[vg call]: Unable to load translations file: " << translation_file_name << endl;
-        return 1;
+    if (!translation_file_name.empty()) {
+        ifstream translation_file(translation_file_name.c_str());
+        if (!translation_file) {
+            cerr << "[vg call]: Unable to load translations file: " << translation_file_name << endl;
+            return 1;
+        }
+        augmented_graph.load_translations(translation_file);
     }
-    augmented_graph.load_translations(translation_file);
     
     if (show_progress) {
         cerr << "Calling variants with support caller" << endl;

--- a/src/support_caller.hpp
+++ b/src/support_caller.hpp
@@ -423,6 +423,13 @@ public:
     Option<string> recall_ins_fasta_filename{this, "insertion-fasta", "Z", "",
             "Insertion FASTA required for --recall-vcf in the presence of symbolic insertions"};
 
+    /// Path of pack file generated from vg pack
+    Option<string> pack_file_name{this, "pack-file", "P", {}, 
+            "path of pack file from vg pack"};
+
+    Option<string> xg_file_name{this, "xg-file", "x", {},
+            "path of xg file (required to read pack file with -P)"};
+
     /// structures to hold the recall vcf and fastas
     vcflib::VariantCallFile variant_file;
     unique_ptr<FastaReference> ref_fasta;


### PR DESCRIPTION
Option for vg call to take a pack file input instead of the old support format.  It only needed some minor additions to the command line interface.  

It seems to work fine for chrom 21 SV genotyping, so I'll try whole-genome.  It takes about 2 minutes: 1 for pack, 1 for (single threaded) call.  The old way wasted about 3 minutes on gamsort, 11 minutes on vg chunk (with the huge context expansion) and 3 on everything else.  

