### PR TITLE
Reconstruct deconstruct

### DIFF
--- a/src/cactus.cpp
+++ b/src/cactus.cpp
@@ -289,16 +289,25 @@ pair<stCactusGraph*, stList*> handle_graph_to_cactus(PathHandleGraph& graph, con
     
     // Now we decide on telomere pairs.
     // We need one for each weakly connected component in the graph, so first we break into connected components.
-    vector<unordered_set<id_t>> weak_components = algorithms::weakly_connected_components(&graph);
+    vector<unordered_set<id_t>> weak_components_all = algorithms::weakly_connected_components(&graph);
+
+    // If we feed size 1 components through to Cactus it will apparently crash.
+    bool warned = false;
+    vector<unordered_set<id_t>> weak_components;
+    weak_components.reserve(weak_components_all.size());
+    for (auto& component : weak_components_all) {
+        if (component.size() > 1) {
+            weak_components.push_back(std::move(component));
+        } else if (!warned) {
+            cerr << "Warning: Cactus does not currently support finding snarls in a single-node connected component" << endl;
+            warned = true;
+        }
+    }
+    weak_components_all.clear();
        
     // We also want a map so we can efficiently find which component a node lives in.
     unordered_map<id_t, size_t> node_to_component;
     for (size_t i = 0; i < weak_components.size(); i++) {
-        if (weak_components[i].size() == 1) {
-            // If we feed this through to Cactus it will crash.
-            throw runtime_error("Cactus does not currently support finding snarls in a single-node connected component");
-        }
-    
         for (auto& id : weak_components[i]) {
             node_to_component[id] = i;
         }

--- a/src/cactus.cpp
+++ b/src/cactus.cpp
@@ -304,6 +304,9 @@ pair<stCactusGraph*, stList*> handle_graph_to_cactus(PathHandleGraph& graph, con
         }
     }
     weak_components_all.clear();
+    if (weak_components.empty())  {
+        throw runtime_error("Cactus does not currently support finding snarls in graph of single-node connected components");
+    }
        
     // We also want a map so we can efficiently find which component a node lives in.
     unordered_map<id_t, size_t> node_to_component;

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -110,10 +110,8 @@ void Deconstructor::get_genotypes(vcflib::Variant& v, const vector<string>& name
     map<string, vector<int> > sample_to_traversals;
     for (int i = 0; i < names.size(); ++i) {
         string sample_name;
-        if (path_to_sample) {
-            if (path_to_sample->count(names[i])) {
-                sample_name = path_to_sample->find(names[i])->second;
-            }
+        if (path_to_sample && path_to_sample->count(names[i])) {
+            sample_name = path_to_sample->find(names[i])->second;
         } else {
             sample_name = names[i];
         }
@@ -302,14 +300,13 @@ void Deconstructor::deconstruct(vector<string> ref_paths, vg::VG* graph, SnarlMa
     graph->for_each_path_handle([&](const path_handle_t& path_handle) {
             string path_name = graph->get_path_name(path_handle);
             if (!pindexes.count(path_name)) {
-                if (!path_to_sample) {
+                // rely on the given map.  if a path isn't in it, it'll be ignored
+                if (path_to_sample && path_to_sample->count(path_name)) {
+                    sample_names.insert(path_to_sample->find(path_name)->second);
+                }
+                else {
                     // no name mapping, just use every path as is
                     sample_names.insert(path_name);
-                } else {
-                    // rely on the given map.  if a path isn't in it, it'll be ignored
-                    if (path_to_sample->count(path_name)) {
-                        sample_names.insert(path_to_sample->find(path_name)->second);
-                    }
                 }
             }
         });

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -1,213 +1,367 @@
 #include "deconstructor.hpp"
 #include "traversal_finder.hpp"
 
+#define debug
+
 using namespace std;
 
 
 namespace vg {
-    Deconstructor::Deconstructor(){
+Deconstructor::Deconstructor(){
 
-    }
-    Deconstructor::~Deconstructor(){
-    }
+}
+Deconstructor::~Deconstructor(){
+}
 
-    /**
-    * Takes in a vector of snarltraversals
-    * returns their sequences as a vector<string>
-    * returns a boolean hasRef
-    * if a reference path is present, hasRef is set to true and the first
-    * string in the vector is the reference allele
-    * otherwise, hasRef is set to false and all strings are alt alleles.
-    */
-    pair<bool, vector<string> > Deconstructor::get_alleles(vector<SnarlTraversal> travs, string refpath, vg::VG* graph){
-        vector<string> ret;
-        vector<SnarlTraversal> ordered_traversals;
-        bool hasRef = false;
+/**
+ * Takes in a vector of snarltraversals
+ * returns their sequences as a vector<string>
+ * returns a boolean hasRef
+ * if a reference path is present, hasRef is set to true and the first
+ * string in the vector is the reference allele
+ * otherwise, hasRef is set to false and all strings are alt alleles.
+ */
+vector<int> Deconstructor::get_alleles(vcflib::Variant& v, const vector<SnarlTraversal>& travs, int ref_path_idx,
+                                       char prev_char) {
 
-        bool normalize_indels = false;
+    assert(ref_path_idx >=0 && ref_path_idx < travs.size());
 
-        // Check if we have a PathIndex for this path
-        bool path_indexed = pindexes.find(refpath) != pindexes.end();
-        for (auto t : travs){
-            stringstream t_allele;
+    // map strings to allele numbers
+    // (we are using the traversal finder in such a way that duplicate alleles can get returned
+    // in order to be able to preserve the path names)
+    map<string, int> allele_idx;
+    size_t cur_alt = 1;
 
-            // Get ref path index
-            if (path_indexed){
-                PathIndex* pind = pindexes[refpath];
-                // Check nodes of traversals Visits
-                // if they're all on the ref path,
-                // then this Snarltraversal is the ref allele.
-                bool is_ref = true;
-                
-                // Get the middle of the traversal that doesn't include the
-                // boundary nodes
-                auto iter = t.visit().begin();
-                iter++;
-                auto end = t.visit().end();
-                end--;
-                for (; iter != end; iter++){
-                    auto v = *iter;
-                    if (!pind->path_contains_node(v.node_id())){
-                        is_ref = false;
-                    }
-                    if (v.node_id() == 0){
-                        continue;
-                    }
-                    t_allele << graph->get_node(v.node_id())->sequence();
-                }
+    // go from traversals number (offset in travs) to allele number
+    vector<int> trav_to_allele(travs.size());
 
-                string t_str = t_allele.str();
-                if (t_str == ""){
-                    normalize_indels = true;
-                }
-                if (is_ref){
-                    ret.insert(ret.begin(), t_str);
-                    ordered_traversals.insert(ordered_traversals.begin(), t);
-                    hasRef = true;
-                }
-                else{
-                    ret.push_back(t_str);
-                    ordered_traversals.push_back(t);
-                }
-                
-            }
+    // compute the allele as a string
+    auto trav_to_string = [&](const SnarlTraversal& trav) {
+        string allele;
+        // we skip the snarl endpoints
+        for (int j = 1; j < trav.visit_size() - 1; ++j) {
+            const string& node_sequence = graph->get_sequence(graph->get_handle(trav.visit(j).node_id()));
+            allele += trav.visit(j).backward() ? reverse_complement(node_sequence) : node_sequence;
+        }
+        return toUppercase(allele);
+    };
 
-            else{
-                // All alleles are alt alleles
-                // Just make our strings and push them back.
-                
-                // Get the middle of the traversal that doesn't include the
-                // boundary nodes
-                auto iter = t.visit().begin();
-                iter++;
-                auto end = t.visit().end();
-                end--;
-                for (; iter != end; iter++){
-                    auto v = *iter;
-                    t_allele << graph->get_node(v.node_id())->sequence();
-                }
-                ret.push_back(t_allele.str());
-                ordered_traversals.push_back(t);
+    // set the reference allele
+    string ref_allele = trav_to_string(travs.at(ref_path_idx));
+    allele_idx[ref_allele] = 0;
+    trav_to_allele[ref_path_idx] = 0;
+    bool substitution = true;
+        
+    // set the other alleles (they can end up as 0 alleles too if their strings match the reference)
+    for (int i = 0; i < travs.size(); ++i) {
+        if (i != ref_path_idx) {
+            string allele = trav_to_string(travs[i]);
+            auto ai_it = allele_idx.find(allele);
+            if (ai_it == allele_idx.end()) {
+                // make a new allele for this string
+                allele_idx[allele] = cur_alt;
+                trav_to_allele.at(i) = cur_alt;
+                ++cur_alt;
+                substitution = substitution && allele.size() == ref_allele.size();
+            } else {
+                // allele string has been seen, map this traversal to it
+                trav_to_allele.at(i) = ai_it->second;
             }
         }
-            // If we haev indels to normalize, loop over our alleles
-            // normalize each string to VCF-friendly format (i.e. clip one ref base
-            // on the left side and put it in the ref field and the alt field).
-            if (normalize_indels){
-                for (int i = 0; i < ret.size(); ++i){
-                // Get the reference base to the left of the variant.
-                // If our empty allele is the reference (and we have a reference),
-                // put our new-found ref base in the 0th index of alleles vector.
-                // Then, prepend that base to each allele in our alleles vector.
-                    SnarlTraversal t = ordered_traversals[i];
-                    id_t start_id = t.visit(0).node_id();
-                    id_t end_id = t.visit(t.visit_size() - 1).node_id();
-                    pair<size_t, bool> pos_orientation_start = pindexes[refpath]->by_id[start_id];
-                    pair<size_t, bool> pos_orientation_end = pindexes[refpath]->by_id[end_id];
-                    bool use_start = pos_orientation_start.first < pos_orientation_end.first;
-                    bool rev = use_start ? pos_orientation_start.second : pos_orientation_end.second;
-                    string pre_node_seq = use_start ? graph->get_node(start_id)->sequence() :
-                                            graph->get_node(end_id)->sequence();
-                    string pre_variant_base = rev ? string(1, pre_node_seq[0]) : string(1, pre_node_seq[pre_node_seq.length() - 1]);
-                    ret[i].insert(0, pre_variant_base);
-                }
-            }
-        return make_pair(hasRef, ret);
-
     }
 
-    void Deconstructor::deconstruct(string refpath, vg::VG* graph){
-        
-     
+    // fill in the variant
+    v.alleles.resize(allele_idx.size());
+    assert(allele_idx.size() > 0);
+    v.alt.resize(allele_idx.size() - 1);
 
-        // Create path index for the contig if we don't have one.
+    for (auto ai_pair : allele_idx) {
+        string allele_string = substitution ? ai_pair.first : string(1, prev_char) + ai_pair.first;
+        v.alleles[ai_pair.second] = allele_string;
+        if (ai_pair.second > 0) {
+            v.alt[ai_pair.second - 1] = allele_string;
+        } else {
+            v.ref = allele_string;
+        }
+    }
+
+    // shift our variant back if it's an indel
+    if (!substitution) {
+        --v.position;
+        assert(v.position >= 1);
+    }
+
+    v.updateAlleleIndexes();
+
+    return trav_to_allele;
+}
+
+void Deconstructor::get_genotypes(vcflib::Variant& v, const vector<string>& names,
+                                  const vector<int>& trav_to_allele) {
+    map<string, int> name_to_allele;
+    for (int i = 0; i < names.size(); ++i) {
+        name_to_allele[names[i]] = trav_to_allele[i];
+    }
+    v.format.push_back("GT");
+    for (auto& sample_name : sample_names) {
+        auto na = name_to_allele.find(sample_name);
+        if (na != name_to_allele.end()) {
+            v.samples[sample_name]["GT"] = {std::to_string(na->second)};
+        } else {
+            v.samples[sample_name]["GT"] = {"."};
+        }
+    }
+}
+
+    
+bool Deconstructor::deconstruct_site(const Snarl* snarl) {
+
+    auto contents = snarl_manager->shallow_contents(snarl, *graph, false);
+    if (contents.first.empty()) {
+        // Nothing but the boundary nodes in this snarl
+#ifdef debug
+#pragma omp critical (cerr)
+        cerr << "Skipping empty site " << pb2json(*snarl) << endl;
+#endif
+        return false;
+    }
+
+    // find every traversal that runs through a path in the graph
+    pair<vector<SnarlTraversal>, vector<string>> named_travs;
+    named_travs = path_trav_finder->find_named_traversals(*snarl);
+
+    // pick out the traversal corresponding to a reference path, breaking ties consistently
+    int ref_trav_idx = -1;
+    for (int i = 0; i < named_travs.first.size(); ++i) {
+        if (pindexes.count(named_travs.second.at(i)) &&
+            (ref_trav_idx == -1 || named_travs.second[i] < named_travs.second[ref_trav_idx])) {
+            ref_trav_idx = i;
+        }
+    }
+
+    // there's no reference path through the snarl, so we can't make a variant
+    // (todo: should we try to detect this before computing traversals?)
+    if (ref_trav_idx == -1) {
+#ifdef debug
+#pragma omp critical (cerr)
+        cerr << "Skipping site becuase no reference traversal was found " << pb2json(*snarl) << endl;
+#endif
+        return false;
+    }
+
+    // add in the exhaustive traversals
+    if (!path_restricted) {
+        // exhaustive traversal can't do all snarls
+        if (!snarl->type() == ULTRABUBBLE) {
+            return false;
+        }
+        if (!check_max_nodes(snarl)) {
+#pragma omp critical (cerr)
+            cerr << "Warning: Skipping site because it is too complex for exhaustive traversal enumeration: " << pb2json(*snarl) << endl << "         Consider using -e to traverse embedded paths" << endl;
+            return false;
+        }
+        vector<SnarlTraversal> exhaustive_travs = explicit_exhaustive_traversals(snarl);
+        // happens when there was a nested non-ultrabubble snarl
+        if (exhaustive_travs.empty()) {
+            return false;
+        }
+        named_travs.first.insert(named_travs.first.end(), exhaustive_travs.begin(), exhaustive_travs.end());
+        for (int i = 0; i < exhaustive_travs.size(); ++i) {
+            // dummy names so we can use the same code as the named path traversals above
+            named_travs.second.push_back(" >>" + std::to_string(i));
+        }
+    }
+    
+    // there's not alt path through the snarl, so we can't make an interesting variant
+    if (named_travs.first.size() < 2) {
+#ifdef debug
+#pragma omp critical (cerr)
+        cerr << "Skipping site because to alt traversal was found " << pb2json(*snarl) << endl;
+#endif
+        return false;
+    }
+
+    vcflib::Variant v;
+    v.setVariantCallFile(outvcf);
+    v.quality = 23;
+
+    // write variant's sequenceName (VCF contig)
+    v.sequenceName = named_travs.second.at(ref_trav_idx);
+
+    // Set position based on the lowest position in the snarl.
+    pair<size_t, bool> pos_orientation_start = pindexes[v.sequenceName]->by_id[snarl->start().node_id()];
+    pair<size_t, bool> pos_orientation_end = pindexes[v.sequenceName]->by_id[snarl->end().node_id()];
+    bool use_start = pos_orientation_start.first < pos_orientation_end.first;
+    size_t node_pos = (use_start ? pos_orientation_start.first : pos_orientation_end.first);
+    v.position = node_pos + 1; // shift from 0-based to 1-based
+    if (use_start) {
+        v.position += graph->get_node(snarl->start().node_id())->sequence().length();
+    } else {
+        v.position += graph->get_node(snarl->end().node_id())->sequence().length();
+    }
+
+    // We need to shift back a position for indels.  Get the previous base from the graph:
+    const Visit& prev_visit = use_start ? snarl->start() : snarl->end();
+    int offset = 0;
+    if (use_start != prev_visit.backward()) {
+        offset = graph->get_length(graph->get_handle(prev_visit.node_id())) - 1;
+    }
+    char prev_char = ::toupper(graph->get_sequence(graph->get_handle(prev_visit.node_id()))[offset]);
+
+    // Convert the snarl traversals to strings and add them to the variant
+    vector<int> trav_to_allele = get_alleles(v, named_travs.first, ref_trav_idx, prev_char);
+
+    // Fill in the genotypes
+    if (path_restricted) {
+        get_genotypes(v, named_travs.second, trav_to_allele);
+    }
+    
+#pragma omp critical (cout)
+    {
+        cout << v << endl;
+    }
+
+    return true;
+}
+
+/**
+ * Convenience wrapper function for deconstruction of multiple paths.
+ */
+void Deconstructor::deconstruct(vector<string> ref_paths, vg::VG* graph, SnarlManager* snarl_manager,
+                                bool path_restricted_traversals) {
+
+    this->graph = graph;
+    this->snarl_manager = snarl_manager;
+    this->path_restricted = path_restricted_traversals;
+    
+    // Create path index for the contig if we don't have one.
+    for (auto& refpath : ref_paths) {
         if (pindexes.find(refpath) == pindexes.end()){
             pindexes[refpath] = new PathIndex(*graph, refpath, false);
         }
-
-        // Spit header
-        // Set contig to refpath
-        // Set program field
-        // Set the version and data
-        // Set info field, if needed
-        // Make the header line
-        // open a VCF file
-
-        if (!headered){
-            vcflib::VariantCallFile outvcf;
-            stringstream stream;
-            stream << "##fileformat=VCFv4.2" << endl;
-            stream << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t" << "Sample" << endl;
-            
-            string hstr = stream.str();
-            assert(outvcf.openForOutput(hstr));
-            cout << outvcf.header << endl;
-            this->headered = true;
-        }
-
-        // Find snarls
-        // Snarls are variant sites ("bubbles")
-        SnarlFinder* snarl_finder = new CactusSnarlFinder(*graph, refpath);
-        SnarlManager snarl_manager = snarl_finder->find_snarls();
-        vector<const Snarl*> snarl_roots = snarl_manager.top_level_snarls();
-        TraversalFinder* trav_finder = new ExhaustiveTraversalFinder(*graph, snarl_manager);
-        for (const Snarl* snarl: snarl_roots){
-            // For each top level snarl
-            
-            // Except the trivial ones
-            if (snarl->type() == ULTRABUBBLE) {
-                auto contents = snarl_manager.shallow_contents(snarl, *graph, false);
-                if (contents.first.empty()) {
-                    // Nothing but the boundary nodes in this snarl
-                    continue;
-                }
-            }
-            
-            vcflib::Variant v;
-            // SnarlTraversals are the (possible) alleles of our variant site.
-            vector<SnarlTraversal> travs = trav_finder->find_traversals(*snarl);
-            // write variant's sequenceName (VCF contig)
-            v.sequenceName = refpath;
-            // Set position based on the lowest position in the snarl.
-            pair<size_t, bool> pos_orientation_start = pindexes[refpath]->by_id[snarl->start().node_id()];
-            pair<size_t, bool> pos_orientation_end = pindexes[refpath]->by_id[snarl->end().node_id()];
-            bool use_start = pos_orientation_start.first < pos_orientation_end.first;
-            size_t node_pos = (use_start ? pos_orientation_start.first : pos_orientation_end.first);
-            v.position = node_pos +(use_start ? graph->get_node(snarl->start().node_id())->sequence().length() : graph->get_node(snarl->end().node_id())->sequence().length());
-            std::pair<bool, vector<string> > t_alleles = get_alleles(travs, refpath, graph);
-            if (t_alleles.first){
-                v.alleles.insert(v.alleles.begin(), t_alleles.second[0]);
-                v.ref = t_alleles.second[0];
-                for (int i = 1; i < t_alleles.second.size(); i++){
-                    v.alleles.push_back(t_alleles.second[i]);
-                    v.alt.push_back(t_alleles.second[i]);
-                }
-            }
-            else{
-                cerr << "NO REFERENCE ALLELE FOUND" << endl;
-                v.alleles.insert(v.alleles.begin(), ".");
-                for (int i = 0; i < t_alleles.second.size(); i++){
-                    v.alleles.push_back(t_alleles.second[i]);
-                    v.alt.push_back(t_alleles.second[i]);
-                }
-            }
-            v.updateAlleleIndexes();
-            cout << v << endl;
-
-        }
-        
-
     }
 
-    /**
-    * Convenience wrapper function for deconstruction of multiple paths.
-    */
-    void Deconstructor::deconstruct(vector<string> ref_paths, vg::VG* graph){
-
-        for (auto path : ref_paths){
-            deconstruct(path, graph);
+    // Keep track of the non-reference paths in the graph.  They'll be our sample names
+    sample_names.clear();
+    graph->for_each_path_handle([&](const path_handle_t& path_handle) {
+            string path_name = graph->get_path_name(path_handle);
+            if (!pindexes.count(path_name)) {
+                sample_names.push_back(path_name);
+            }
+        });
+    
+    // print the VCF header
+    stringstream stream;
+    stream << "##fileformat=VCFv4.2" << endl;
+    if (path_restricted) {
+        stream << "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">" << endl;
+    }
+    for(auto& refpath : ref_paths) {
+        size_t path_len = 0;
+        path_handle_t path_handle = graph->get_path_handle(refpath);
+        for (handle_t handle : graph->scan_path(path_handle)) {
+            path_len += graph->get_length(handle);
         }
+        stream << "##contig=<ID=" << refpath << ",length=" << path_len << ">" << endl;
+    }
+    stream << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT";
+    if (path_restricted) {
+        for (auto& sample_name : sample_names) {
+            stream << "\t" << sample_name;
+        }
+    }
+    stream << endl;
+    
+    string hstr = stream.str();
+    assert(outvcf.openForOutput(hstr));
+    cout << outvcf.header << endl;
+
+    // create the traversal finder
+    map<string, const Alignment*> reads_by_name;
+    path_trav_finder = unique_ptr<PathRestrictedTraversalFinder>(new PathRestrictedTraversalFinder(*graph,
+                                                                                                   *snarl_manager,
+                                                                                                   reads_by_name,
+                                                                                                   1,
+                                                                                                   100,
+                                                                                                   true));
+    
+    if (!path_restricted) {
+        trav_finder = unique_ptr<TraversalFinder>(new ExhaustiveTraversalFinder(*graph,
+                                                                                *snarl_manager,
+                                                                                true));
 
     }
+    
+    // Do the top-level snarls in parallel
+    snarl_manager->for_each_top_level_snarl_parallel([&](const Snarl* snarl) {
+            vector<const Snarl*> todo(1, snarl);
+            vector<const Snarl*> next;
+            while (!todo.empty()) {
+                for (auto next_snarl : todo) {
+                    // if we can't make a variant from the snarl due to not finding
+                    // paths through it, we try again on the children
+                    // note: we may want to push the parallelism down a bit 
+                    if (!deconstruct_site(next_snarl)) {
+                        const vector<const Snarl*>& children = snarl_manager->children_of(next_snarl);
+                        next.insert(next.end(), children.begin(), children.end());
+                    }
+                }
+                swap(todo, next);
+                next.clear();
+            }
+        });
+}
+
+bool Deconstructor::check_max_nodes(const Snarl* snarl)  {
+    unordered_set<Node*> nodeset = snarl_manager->deep_contents(snarl, *graph, false).first;
+    int node_count = 0;
+    for (auto node : nodeset) {
+        if (graph->start_degree(node) > 1 || graph->end_degree(node) > 1) {
+            ++node_count;
+            if (node_count > max_nodes_for_exhaustive) {
+                return false;
+            }
+        }
+    }
+    return true;
+};
+
+vector<SnarlTraversal> Deconstructor::explicit_exhaustive_traversals(const Snarl* snarl){
+    vector<SnarlTraversal> out_travs;
+    bool ultra_all_the_way_down = true;
+    function<void(const SnarlTraversal&, const Snarl&)> extend_trav =
+        [&](const SnarlTraversal& trav, const Snarl& nested_snarl) {
+        // exhaustive traversal finder is limited.  if we find something
+        // that's not an ultrabubble, not much we can do
+        if (nested_snarl.type() != ULTRABUBBLE) {
+            ultra_all_the_way_down = false;
+            return;
+        }
+        vector<SnarlTraversal> nested_travs = trav_finder->find_traversals(nested_snarl);
+        for (auto& nested_trav : nested_travs) {
+            SnarlTraversal extended_trav = trav;
+            bool is_explicit = true;
+            for (int i = 0; i < nested_trav.visit_size(); ++i) {
+                if (nested_trav.visit(i).node_id() != 0) {
+                    Visit* visit = extended_trav.add_visit();
+                    *visit = nested_trav.visit(i);
+                } else {
+                    extend_trav(extended_trav, nested_trav.visit(i).snarl());
+                    is_explicit = false;
+                }
+            }
+            if (is_explicit) {
+                out_travs.push_back(extended_trav);
+            }
+        }
+    };
+    SnarlTraversal trav;
+    extend_trav(trav, *snarl);
+    if (!ultra_all_the_way_down) {
+        out_travs.clear();
+    }        
+    return out_travs;
+}
+
 }
 

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -215,10 +215,13 @@ bool Deconstructor::deconstruct_site(const Snarl* snarl) {
     if (path_restricted) {
         get_genotypes(v, named_travs.second, trav_to_allele);
     }
-    
+
+    // we only bother printing out sites with at least 1 non-reference allele
+    if (!std::all_of(trav_to_allele.begin(), trav_to_allele.end(), [](int i) { return i == 0; })) {
 #pragma omp critical (cout)
-    {
+        {
         cout << v << endl;
+        }
     }
 
     return true;

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -1,7 +1,7 @@
 #include "deconstructor.hpp"
 #include "traversal_finder.hpp"
 
-#define debug
+//#define debug
 
 using namespace std;
 

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -37,7 +37,8 @@ public:
 
     // deconstruct the entire graph to cout
     void deconstruct(vector<string> refpaths, vg::VG* graph, SnarlManager* snarl_manager,
-                     bool path_restricted_traversals); 
+                     bool path_restricted_traversals,
+                     const unordered_map<string, string>* path_to_sample = nullptr); 
     
 private:
 
@@ -79,7 +80,10 @@ private:
     unique_ptr<TraversalFinder> trav_finder;
 
     // keep track of the non-ref paths as they will be our samples
-    vector<string> sample_names;
+    set<string> sample_names;
+
+    // map the path name to the sample in the vcf
+    const unordered_map<string, string>* path_to_sample;
 
     // upper limit of degree-2+ nodes for exhaustive traversal
     int max_nodes_for_exhaustive = 100;    

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -11,6 +11,7 @@
 #include "path.hpp"
 #include "vg.hpp"
 #include "genotypekit.hpp"
+#include "traversal_finder.hpp"
 #include <vg/vg.pb.h>
 #include "Fasta.h"
 
@@ -26,20 +27,63 @@
 ** "Linear-Time Superbubble Identification Algorithm for Genome Assembly"
 */
 namespace vg{
-    using namespace std;
-          class Deconstructor{
-        public:
+using namespace std;
 
-            Deconstructor();
-            ~Deconstructor();
-            pair<bool, vector<string> > get_alleles(vector<SnarlTraversal> travs, string refpath, vg::VG* graph);
+class Deconstructor{
+public:
 
-            void deconstruct(string refpath, vg::VG* graph);
-            void deconstruct(vector<string> refpaths, vg::VG* graph); 
-            map<string, PathIndex*> pindexes;
+    Deconstructor();
+    ~Deconstructor();
 
-        private:
-            bool headered = false;
-    };
+    // deconstruct the entire graph to cout
+    void deconstruct(vector<string> refpaths, vg::VG* graph, SnarlManager* snarl_manager,
+                     bool path_restricted_traversals); 
+    
+private:
+
+    // write a vcf record for the given site.  returns true if a record was written
+    // (need to have a path going through the site)
+    bool deconstruct_site(const Snarl* site);
+
+    // convert traversals to strings.  returns mapping of traversal (offset in travs) to allele
+    vector<int> get_alleles(vcflib::Variant& v, const vector<SnarlTraversal>& travs, int ref_path_idx, char prev_char);
+
+    // write traversal path names as genotypes
+    void get_genotypes(vcflib::Variant& v, const vector<string>& names, const vector<int>& trav_to_allele);
+
+    // check to see if a snarl is too big to exhaustively traverse
+    bool check_max_nodes(const Snarl* snarl);
+
+    // get traversals from the exhaustive finder.  if they have nested visits, fill them in (exhaustively)
+    // with node visits
+    vector<SnarlTraversal> explicit_exhaustive_traversals(const Snarl* snarl);
+    
+    // output vcf object
+    vcflib::VariantCallFile outvcf;
+    
+    // in memory path index for every specified reference path.
+    map<string, PathIndex*> pindexes;
+
+    // toggle between exhaustive and path restricted traversal finder
+    bool path_restricted = false;
+
+    // the graph
+    VG* graph;
+
+    // the snarl manager
+    SnarlManager* snarl_manager;
+
+    // the traversal finders. we always use a path traversal finder to get the reference path
+    unique_ptr<PathRestrictedTraversalFinder> path_trav_finder;
+    // we optionally use another (exhaustive for now) traversal finder if we don't want to rely on paths
+    unique_ptr<TraversalFinder> trav_finder;
+
+    // keep track of the non-ref paths as they will be our samples
+    vector<string> sample_names;
+
+    // upper limit of degree-2+ nodes for exhaustive traversal
+    int max_nodes_for_exhaustive = 100;    
+};
+
 }
 #endif

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -14,6 +14,8 @@
 
 #include "../vg.hpp"
 #include "../deconstructor.hpp"
+#include <vg/io/stream.hpp>
+#include <vg/io/vpkg.hpp>
 
 using namespace std;
 using namespace vg;
@@ -23,12 +25,15 @@ void help_deconstruct(char** argv){
     cerr << "usage: " << argv[0] << " deconstruct [options] -p <PATH> <my_graph>.vg" << endl
          << "Outputs VCF records for Snarls present in a graph (relative to a chosen reference path)." << endl
          << "options: " << endl
-         << "--path / -p     REQUIRED: A reference path to deconstruct against." << endl
+         << "    -p, --path NAME        REQUIRED: A reference path to deconstruct against (comma-separated list accepted)." << endl
+         << "    -r, --snarls FILE      Snarls file (from vg snarls) to avoid recomputing." << endl
+         << "    -e, --path-traversals  Only consider traversals that correspond to paths in the grpah." << endl
+         << "    -t, --threads N        Use N threads" << endl
+         << "    -v, --verbose          Print some status messages" << endl
          << endl;
 }
 
 int main_deconstruct(int argc, char** argv){
-    //cerr << "WARNING: EXPERIMENTAL" << endl;
     if (argc <= 2) {
         help_deconstruct(argv);
         return 1;
@@ -36,7 +41,9 @@ int main_deconstruct(int argc, char** argv){
 
     vector<string> refpaths;
     string graphname;
-    string outfile = "";
+    string snarl_file_name;
+    bool path_restricted_traversals = false;
+    bool show_progress = false;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -45,45 +52,86 @@ int main_deconstruct(int argc, char** argv){
             {
                 {"help", no_argument, 0, 'h'},
                 {"path", required_argument, 0, 'p'},
+                {"snarls", required_argument, 0, 'r'},
+                {"path-traversals", no_argument, 0, 'e'},
+                {"threads", required_argument, 0, 't'},
+                {"verbose", no_argument, 0, 'v'},
                 {0, 0, 0, 0}
 
             };
 
-            int option_index = 0;
-            c = getopt_long (argc, argv, "hp:",
-                    long_options, &option_index);
+        int option_index = 0;
+        c = getopt_long (argc, argv, "hp:r:et:v",
+                         long_options, &option_index);
 
-            // Detect the end of the options.
-            if (c == -1)
-                break;
+        // Detect the end of the options.
+        if (c == -1)
+            break;
 
-            switch (c)
-            {
-                case 'p':
-                    refpaths = split(optarg, ",");
-                    break;
-                case '?':
-                case 'h':
-                    help_deconstruct(argv);
-                    return 1;
-                default:
-                    help_deconstruct(argv);
-                    abort();
+        switch (c)
+        {
+        case 'p':
+            refpaths = split(optarg, ",");
+            break;
+        case 'r':
+            snarl_file_name = optarg;
+            break;
+        case 'e':
+            path_restricted_traversals = true;
+            break;
+        case 't':
+            omp_set_num_threads(parse<int>(optarg));
+            break;
+        case 'v':
+            show_progress = true;
+            break;
+        case '?':
+        case 'h':
+            help_deconstruct(argv);
+            return 1;
+        default:
+            help_deconstruct(argv);
+            abort();
+        }
+
+    }
+    
+    string graph_file_name = get_input_file_name(optind, argc, argv);
+
+    vg::VG* graph;
+    get_input_file(graph_file_name, [&](istream& in) {
+            if (show_progress) {
+                cerr << "Loading graph" << endl;
             }
+            graph = new VG(in);
+    });
 
+    // Load or compute the snarls
+    unique_ptr<SnarlManager> snarl_manager;    
+    if (!snarl_file_name.empty()) {
+        ifstream snarl_file(snarl_file_name.c_str());
+        if (!snarl_file) {
+            cerr << "[vg deconstruct]: Unable to load snarls file: " << snarl_file_name << endl;
+            return 1;
         }
-        graphname = argv[optind];
-        vg::VG* graph;
-        if (!graphname.empty()){
-            ifstream gstream(graphname);
-            graph = new vg::VG(gstream);
+        if (show_progress) {
+            cerr << "Loading snarls" << endl;
         }
+        snarl_manager = vg::io::VPKG::load_one<SnarlManager>(snarl_file);
+    } else {
+        CactusSnarlFinder finder(*graph);
+        if (show_progress) {
+            cerr << "Finding snarls" << endl;
+        }
+        snarl_manager = unique_ptr<SnarlManager>(new SnarlManager(std::move(finder.find_snarls())));
+    }
 
-        // load graph
-
-        // Deconstruct
-        Deconstructor dd;
-        dd.deconstruct(refpaths, graph);
+    // Deconstruct
+    Deconstructor dd;
+    if (show_progress) {
+        cerr << "Decsontructing top-level snarls" << endl;
+    }
+    dd.deconstruct(refpaths, graph, snarl_manager.get(), path_restricted_traversals);
     return 0;
 }
 

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -147,12 +147,16 @@ class PathRestrictedTraversalFinder : public TraversalFinder {
     
     // How many nodes max should we walk when checking if a path runs through a superbubble/site
     int max_path_search_steps;
+
+    // Allow multiple traversals with the same sequence
+    bool allow_duplicates;
     
 public:
     PathRestrictedTraversalFinder(VG& graph, SnarlManager& snarl_manager,
                                   map<string, const Alignment*>& reads_by_name,
                                   int min_recurrence = 2,
-                                  int max_path_search_steps = 100);
+                                  int max_path_search_steps = 100,
+                                  bool allow_duplicates = false);
     
     virtual ~PathRestrictedTraversalFinder();
 
@@ -164,6 +168,11 @@ public:
      * while those supported by actual embedded named paths are not.
      */
     virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
+
+   /**
+    * Like above, but return the path name corresponding to each traversal
+    */
+    virtual pair<vector<SnarlTraversal>, vector<string>> find_named_traversals(const Snarl& site);
     
 };
 

--- a/src/variant_recall.cpp
+++ b/src/variant_recall.cpp
@@ -69,7 +69,9 @@ void genotype_svs(VG* graph,
         graph->edit(direct_ins, &transls); // TODO could maybe use edit_fast??
                
         Deconstructor decon;
-        decon.deconstruct(refpath, graph);
+        CactusSnarlFinder finder(*graph);
+        SnarlManager snarl_manager = finder.find_snarls();
+        decon.deconstruct({refpath}, graph, &snarl_manager, false);
     }
     direct_ins.clear();
 

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -10,13 +10,12 @@ plan tests 16
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
 vg deconstruct tiny.vg -p x -t 1 > tiny_decon.vcf
 # we pop out that GC allele because it gets invented by the adjacent snps in the graph
-bcftools norm tiny_decon.vcf -f tiny/tiny.fa -m - | grep -v GC > tiny_decon_norm.vcf
-bcftools view tiny/tiny.vcf.gz | grep -v "#" | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' > tiny_orig.tsv
-bcftools view tiny_decon_norm.vcf | grep -v "#" | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' > tiny_dec.tsv
+gzip -dc tiny/tiny.vcf.gz | tail -3 | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' > tiny_orig.tsv
+cat tiny_decon.vcf | grep -v "#" | grep -v GC | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' > tiny_dec.tsv
 diff tiny_orig.tsv tiny_dec.tsv
 is "$?" 0 "deconstruct retrieved original VCF (modulo adjacent snp allele)"
 
-rm -f tiny.vg tiny_decon.vcf tiny_decon_norm.vcf tiny_orig.tsv tiny_dec.tsv
+rm -f tiny.vg tiny_decon.vcf tiny_orig.tsv tiny_dec.tsv
 
 vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 -k 16 | vg mod -U 10 - | vg mod -c - > hla.vg
 
@@ -34,10 +33,10 @@ diff hla_decon.tsv hla_decon_path.tsv
 is "$?" 0 "path-based and exhaustive decontruction give equivalent sites when expected"
 
 # want to extract a sample, but bcftools -s doesn't seem to work on travis.  so we torture it out with awk
-SAMPLE_COL=$(grep CHROM hla_decon_path.vcf | sed 's/\t/\n/g' | nl | grep "528476637" | awk '{print $1}')
+SAMPLE_COL=$(grep CHROM hla_decon_path.vcf | tr '\t' '\n' | nl | grep "528476637" | awk '{print $1}')
 is $(grep -v "#" hla_decon_path.vcf | awk -v x="$SAMPLE_COL" '{print $x}' | uniq) 1 "path that differs from reference in every alt has correct genotype"
 
-SAMPLE_COL=$(grep CHROM hla_decon_path.vcf | sed 's/\t/\n/g' | nl | grep "568815564" | awk '{print $1}')
+SAMPLE_COL=$(grep CHROM hla_decon_path.vcf | tr '\t' '\n' | nl | grep "568815564" | awk '{print $1}')
 is $(grep -v "#" hla_decon_path.vcf | awk -v x="$SAMPLE_COL" '{print $x}' | uniq) 0 "path that is same as reference in every alt has correct genotype"
 
 is $(grep "#" hla_decon_path.vcf | grep "568815592") "##contig=<ID=gi|568815592:29791752-29792749,length=998>" "reference contig correctly written"

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -5,28 +5,44 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 0
+plan tests 9
 
-## Test VG .to_superbubbles()
-#is $(echo 0) 0 "vg deconstruct produces the expected number of superbubbles in a simple graph."
+vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
+vg deconstruct tiny.vg -p x -t 1 > tiny_decon.vcf
+# we pop out that GC allele because it gets invented by the adjacent snps in the graph
+bcftools norm tiny_decon.vcf -f tiny/tiny.fa -m - | grep -v GC > tiny_decon_norm.vcf
+bcftools view tiny/tiny.vcf.gz | grep -v "#" | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' > tiny_orig.tsv
+bcftools view tiny_decon_norm.vcf | grep -v "#" | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' > tiny_dec.tsv
+diff tiny_orig.tsv tiny_dec.tsv
+is "$?" 0 "deconstruct retrieved original VCF (modulo adjacent snp allele)"
 
-## Make sure deconstruct successfully finds the right nodes in a superbubble of a simple graph.
-#is $(echo 0) 0 "vg deconstruct produces the expected superbubble format and the right bubbles on a small graph."
+rm -f tiny.vg tiny_decon.vcf tiny_decon_norm.vcf tiny_orig.tsv tiny_dec.tsv
 
-## Test a larger graph  - CURRENTLY HAS BAD MD5SUM
-## is $(vg deconstruct -x superbubbles/x.xg superbubbles/x.vg | md5sum | cut -f 1 -d " ") 902350cea10dd772ed321e271b2aa6a7 "vg deconstruct produces correct pseudo vcf on a largeish graph."
+vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 -k 16 | vg mod -U 10 - | vg mod -c - > hla.vg
 
-## Test if deconstruct works on a graph that must be DAGified.
-#is $(vg construct -r COMPLEXGRAPH -v ANOTHERONE -m 50 | vg deconstruct -s - | md5sum) SUPERBUBBLEFILEHASH "deconstruct finds the expected superbubbles in a DAGified graph and uses the IDs from the original graph space."
+vg deconstruct hla.vg -p "gi|157734152:29563108-29564082" > hla_decon.vcf
+is $(grep -v "#" hla_decon.vcf | wc -l) 17 "deconstructed hla vcf has correct number of sites"
+is $(grep -v "#" hla_decon.vcf | grep 822 | awk '{print $4 "-" $5}') "C-CGCGGGCGCCGTGGATGGAGCA" "deconstructed hla vcf has correct insertion"
+vg deconstruct hla.vg -p "gi|568815592:29791752-29792749" > hla_decon.vcf
+is $(grep -v "#" hla_decon.vcf | wc -l) 17 "deconstructed hla vcf with other path has correct number of sites"
+is $(grep -v "#" hla_decon.vcf | grep 824 | awk '{print $4 "-" $5}') "CGCGGGCGCCGTGGATGGAGCA-C" "deconstructed hla vcf has correct deletion"
 
-## Test deconstruction on a specific path
-# is $(vg construct -r multipath/mp.fa -v multipath/mp.vcf.gz | vg deconstruct -p - | md5sum AFJAKJFIJ "deconstruct can deconstruct a specific path."
+vg deconstruct hla.vg -p "gi|568815592:29791752-29792749" -e > hla_decon_path.vcf
+grep -v "#" hla_decon.vcf | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' | sort > hla_decon.tsv
+grep -v "#" hla_decon_path.vcf | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' | sort > hla_decon_path.tsv
+diff hla_decon.tsv hla_decon_path.tsv
+is "$?" 0 "path-based and exhaustive decontruction give equivalent sites when expected"
 
-## Test deconstruction on a set of paths specified in a file
-# is $(vg construct -r multipath/mp.fa -v multipath/mp.vcf.gz | vg deconstruct -P - | md5sum AFJAKJFIJ "deconstruct can deconstruct multiple paths specified in a file."
+is $(bcftools view hla_decon_path.vcf -s "gi|528476637:29761569-29762543" -H | awk '{print $10}' | uniq) 1 "path that differs from reference in every alt has correct genotype"
 
-## Test if the depth filtering for deconstruct works with a small GAM file
-# is $(vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg deconstruct -d 10 -a tiny/alignment.gam - | md5sum) AFKJADK "deconstruct can depth filter using a GAM."
+is $(bcftools view hla_decon_path.vcf -s "gi|568815564:1054403-1055400" -H | awk '{print $10}' | uniq) 0 "path that is same as reference in every alt has correct genotype"
 
-## Test masking a graph with a VCF
-#
+is $(grep "#" hla_decon_path.vcf | grep "gi|568815592:29791752-29792749") "##contig=<ID=gi|568815592:29791752-29792749,length=998>" "reference contig correctly written"
+
+
+rm -f hla_decon.vcf hla_decon_path.vcf  hla_decon.tsv hla_decon_path.tsv
+
+
+
+
+

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 9
+plan tests 10
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
 vg deconstruct tiny.vg -p x -t 1 > tiny_decon.vcf
@@ -44,6 +44,18 @@ is $(grep "#" hla_decon_path.vcf | grep "gi|568815592:29791752-29792749") "##con
 
 
 rm -f hla_decon.vcf hla_decon_path.vcf  hla_decon.tsv hla_decon_path.tsv hla.vg
+
+cp sv/x.inv.gfa inv.gfa
+printf "P\ty\t1+,2-,3+\t9M,20M,21M\n" >> inv.gfa
+vg view -Fv inv.gfa > inv.vg
+vg deconstruct inv.vg -p x -e > inv_decon.vcf
+grep -v "#" inv_decon.vcf | awk '{print $1 "\t" $2 "\t" $4 "\t" $5 "\t" $10}' > inv_decon.tsv
+printf "x\t10\tCTTGGAAATTTTCTGGAGTT\tAACTCCAGAAAATTTCCAAG\t1\n" > inv_truth.tsv
+diff inv_decon.tsv inv_truth.tsv
+is "$?" 0 "deconstruct correctly handles a simple inversion"
+
+rm -f inv.gfa inv.vg inv_decon.vcf inv_decon.tsv inv_truth.tsv
+
 
 
 

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -33,14 +33,17 @@ grep -v "#" hla_decon_path.vcf | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' | sort
 diff hla_decon.tsv hla_decon_path.tsv
 is "$?" 0 "path-based and exhaustive decontruction give equivalent sites when expected"
 
-is $(bcftools view hla_decon_path.vcf -s "gi|528476637:29761569-29762543" -H | awk '{print $10}' | uniq) 1 "path that differs from reference in every alt has correct genotype"
+# want to extract a sample, but bcftools -s doesn't seem to work on travis.  so we torture it out with awk
+SAMPLE_COL=$(grep CHROM hla_decon_path.vcf | sed 's/\t/\n/g' | nl | grep "gi|528476637:29761569-29762543" | awk '{print $1}')
+is $(grep -v "#" hla_decon_path.vcf | awk -v x="$SAMPLE_COL" '{print $x}' | uniq) 1 "path that differs from reference in every alt has correct genotype"
 
-is $(bcftools view hla_decon_path.vcf -s "gi|568815564:1054403-1055400" -H | awk '{print $10}' | uniq) 0 "path that is same as reference in every alt has correct genotype"
+SAMPLE_COL=$(grep CHROM hla_decon_path.vcf | sed 's/\t/\n/g' | nl | grep "gi|568815564:1054403-1055400" | awk '{print $1}')
+is $(grep -v "#" hla_decon_path.vcf | awk -v x="$SAMPLE_COL" '{print $x}' | uniq) 0 "path that is same as reference in every alt has correct genotype"
 
 is $(grep "#" hla_decon_path.vcf | grep "gi|568815592:29791752-29792749") "##contig=<ID=gi|568815592:29791752-29792749,length=998>" "reference contig correctly written"
 
 
-rm -f hla_decon.vcf hla_decon_path.vcf  hla_decon.tsv hla_decon_path.tsv
+rm -f hla_decon.vcf hla_decon_path.vcf  hla_decon.tsv hla_decon_path.tsv hla.vg
 
 
 

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 11
+plan tests 13
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
 vg deconstruct tiny.vg -p x -t 1 > tiny_decon.vcf
@@ -62,11 +62,26 @@ printf "y\t10\tAACTCCAGAAAATTTCCAAG\tCTTGGAAATTTTCTGGAGTT\t1\n" > inv_truth.tsv
 diff inv_decon.tsv inv_truth.tsv
 is "$?" 0 "deconstruct correctly handles a simple inversion when the reference contains the reversing edge"
 
-
 rm -f inv.gfa inv.vg inv_decon.vcf inv_decon.tsv inv_truth.tsv
 
 
+vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa | vg view -g - > cyclic_tiny.gfa
+printf "L\t12\t+\t9\t+\t0M\n" >> cyclic_tiny.gfa
+printf "P\ty\t1+,3+,5+,6+,8+,9+,11+,12+,9+,10+,12+,14+,15+\t8M,1M,1M,3M,1M,19M,1M,4M,19M,1M,4M,1M,11M\n" >> cyclic_tiny.gfa
+vg view -Fv cyclic_tiny.gfa > cyclic_tiny.vg
+vg deconstruct cyclic_tiny.vg -p y -e > cyclic_tiny_decon.vcf
+grep -v "#" cyclic_tiny_decon.vcf | awk '{print $1 "\t" $2 "\t" $4 "\t" $5 "\t" $10}' > cyclic_tiny_decon.tsv
+printf "y\t13\tGGAAATTTTCTGGAGTTCTATTATATAAATTTTCTGGAGTTCTATAATATT\tGGAAATTTTCTGGAGTTCTATTATATT\t1\n" > cyclic_tiny_truth.tsv
+diff cyclic_tiny_decon.tsv cyclic_tiny_truth.tsv
+is "$?" 0 "deconstruct correctly handles a cycle in the reference path"
 
+rm -rf cyclic_tiny_decon.vcf cyclic_tiny_decon.tsv cyclic_tiny_truth.tsv
 
+vg deconstruct cyclic_tiny.vg -p x -e > cyclic_tiny_decon.vcf
+grep -v "#" cyclic_tiny_decon.vcf | awk '{print $1 "\t" $2 "\t" $4 "\t" $5 "\t" $10}' > cyclic_tiny_decon.tsv
+printf "x\t13\tGGAAATTTTCTGGAGTTCTATTATATT\tGGAAATTTTCTGGAGTTCTATTATATAAATTTTCTGGAGTTCTATAATATT\t1\n" > cyclic_tiny_truth.tsv
+diff cyclic_tiny_decon.tsv cyclic_tiny_truth.tsv
+is "$?" 0 "deconstruct correctly handles a cycle in the alt path"
 
+rm -rf cyclic_tiny_decon.vcf cyclic_tiny_decon.tsv cyclic_tiny_truth.tsv cyclic_tiny.gfa cyclic_tiny.vg
 

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 10
+plan tests 11
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
 vg deconstruct tiny.vg -p x -t 1 > tiny_decon.vcf
@@ -53,6 +53,15 @@ grep -v "#" inv_decon.vcf | awk '{print $1 "\t" $2 "\t" $4 "\t" $5 "\t" $10}' > 
 printf "x\t10\tCTTGGAAATTTTCTGGAGTT\tAACTCCAGAAAATTTCCAAG\t1\n" > inv_truth.tsv
 diff inv_decon.tsv inv_truth.tsv
 is "$?" 0 "deconstruct correctly handles a simple inversion"
+
+rm -f inv_decon.vcf inv_decon.tsv inv_truth.tsv
+
+vg deconstruct inv.vg -p y -e > inv_decon.vcf
+grep -v "#" inv_decon.vcf | awk '{print $1 "\t" $2 "\t" $4 "\t" $5 "\t" $10}' > inv_decon.tsv
+printf "y\t10\tAACTCCAGAAAATTTCCAAG\tCTTGGAAATTTTCTGGAGTT\t1\n" > inv_truth.tsv
+diff inv_decon.tsv inv_truth.tsv
+is "$?" 0 "deconstruct correctly handles a simple inversion when the reference contains the reversing edge"
+
 
 rm -f inv.gfa inv.vg inv_decon.vcf inv_decon.tsv inv_truth.tsv
 


### PR DESCRIPTION
The need for a graph-to-vcf converter has come up as we're looking at SV graphs built from whole genome alignments.  `vg deconstruct` fit the bill but didn't work on many inputs.  This PR is an attempt at fixing it up a bit.  It's now running on my various tests, including graphs from cactus and seqwish, but still needs more testing especially on inversions and nested sites, as well as maybe a way of lumping different path names together in the same genome.  

In addition to trying to fix the existing logic, I added an option `-e` to consider only traversals corresponding to embedded paths.  This gets around issues of not being able to enumerate all traversals in complex sites.  And in this mode, each non-reference path in the graph is listed as a sample in the VCF, and the genotype field is used to link vcf alleles back to their path names in the graph.  