### PR TITLE
Handle graphify vg snarls

### DIFF
--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -14,6 +14,7 @@
 #include <vg/vg.pb.h>
 #include "../traversal_finder.hpp"
 #include <vg/io/stream.hpp>
+#include <vg/io/vpkg.hpp>
 
 //#define debug
 
@@ -22,7 +23,7 @@ using namespace vg;
 using namespace vg::subcommand;
 
 void help_snarl(char** argv) {
-    cerr << "usage: " << argv[0] << " snarls [options] graph.vg > snarls.pb" << endl
+    cerr << "usage: " << argv[0] << " snarls [options] graph > snarls.pb" << endl
          << "       By default, a list of protobuf Snarls is written" << endl
          << "options:" << endl
          << "    -p, --pathnames        output variant paths as SnarlTraversals to STDOUT" << endl
@@ -155,16 +156,15 @@ int main_snarl(int argc, char** argv) {
     }
 
     // Read the graph
-    VG* graph;
+    VG* vg_graph = nullptr;
+    unique_ptr<PathHandleGraph> graph;
     get_input_file(optind, argc, argv, [&](istream& in) {
-            graph = new VG(in);
+            graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
         });
-    
-    if (graph == nullptr) {
-        cerr << "error:[vg snarl]: Could not load graph" << endl;
-        exit(1);
-    }
 
+    // this is hopefully temporary, pending traversal finder support
+    vg_graph = dynamic_cast<VG*>(graph.get());
+    
     // The only implemented snarl finder:
     SnarlFinder* snarl_finder = new CactusSnarlFinder(*graph);
 
@@ -177,6 +177,10 @@ int main_snarl(int argc, char** argv) {
     map<string, PathIndex*> path_index;
     
     if (!vcf_filename.empty()) {
+        if (vg_graph == nullptr) {
+            cerr << "error: [vg snarls] -v requires .vg graph input" << endl;
+            return 1;
+        }
         variant_file.parseSamples = false;
         variant_file.open(vcf_filename);
         if (!variant_file.is_open()) {
@@ -185,9 +189,9 @@ int main_snarl(int argc, char** argv) {
         }
 
         // load every reference path into the index
-        graph->paths.for_each_name([&] (const string& path_name) {
+        vg_graph->paths.for_each_name([&] (const string& path_name) {
                 if (!Paths::is_alt(path_name)) {
-                    path_index[path_name] = new PathIndex(*graph, path_name);
+                    path_index[path_name] = new PathIndex(*vg_graph, path_name);
                 }
             });
 
@@ -220,7 +224,11 @@ int main_snarl(int argc, char** argv) {
     SnarlManager snarl_manager = snarl_finder->find_snarls();
     vector<const Snarl*> snarl_roots = snarl_manager.top_level_snarls();
     if (fill_path_names){
-      trav_finder = new PathBasedTraversalFinder(*graph, snarl_manager);
+        if (vg_graph == nullptr) {
+            cerr << "error: [vg snarls] -p requires .vg graph input" << endl;
+            return 1;
+        }
+        trav_finder = new PathBasedTraversalFinder(*vg_graph, snarl_manager);
         for (const Snarl* snarl : snarl_roots ){
             if (filter_trivial_snarls) {
                 auto contents = snarl_manager.shallow_contents(snarl, *graph, false);
@@ -235,7 +243,6 @@ int main_snarl(int argc, char** argv) {
 
         delete trav_finder;
         delete snarl_finder;
-        delete graph;
         delete_path_index();
 
         exit(0);
@@ -248,7 +255,7 @@ int main_snarl(int argc, char** argv) {
         // for testing purposes.  The VCFTraversalFinder differs from Exhaustive in that
         // it's easier to limit traversals using read support, and it takes care of
         // mapping back to the VCF via the alt paths. 
-        trav_finder = new VCFTraversalFinder(*graph, snarl_manager, variant_file, get_path_index,
+        trav_finder = new VCFTraversalFinder(*vg_graph, snarl_manager, variant_file, get_path_index,
                                              ref_fasta.get(), ins_fasta.get());
     }
     
@@ -363,7 +370,6 @@ int main_snarl(int argc, char** argv) {
     
     delete snarl_finder;
     delete trav_finder;
-    delete graph;
     delete_path_index();
 
     return 0;

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -47,12 +47,12 @@ public:
 
 class ExhaustiveTraversalFinder : public TraversalFinder {
     
-    VG& graph;
+    const HandleGraph& graph;
     SnarlManager& snarl_manager;
     bool include_reversing_traversals;
     
 public:
-    ExhaustiveTraversalFinder(VG& graph, SnarlManager& snarl_manager,
+    ExhaustiveTraversalFinder(const HandleGraph& graph, SnarlManager& snarl_manager,
                               bool include_reversing_traversals = false);
     
     virtual ~ExhaustiveTraversalFinder();
@@ -64,10 +64,10 @@ public:
     virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
     
 protected:
-    void stack_up_valid_walks(NodeTraversal walk_head, vector<NodeTraversal>& stack);
-    virtual bool visit_next_node(const Node*, const Edge*) { return true; }
-    void add_traversals(vector<SnarlTraversal>& traversals, NodeTraversal traversal_start,
-                        set<NodeTraversal>& stop_at, set<NodeTraversal>& yield_at);
+    void stack_up_valid_walks(handle_t walk_head, vector<Visit>& stack);
+    virtual bool visit_next_node(handle_t handle) { return true; }
+    void add_traversals(vector<SnarlTraversal>& traversals, handle_t traversal_start,
+                        unordered_set<handle_t>& stop_at, unordered_set<handle_t>& yield_at);
 };
 
 /** Does exhaustive traversal, but restricting to nodes and edges that meet 

--- a/test/t/32_vg_snarls.t
+++ b/test/t/32_vg_snarls.t
@@ -5,13 +5,19 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 5
+plan tests 7
 
 vg view -J -v snarls/snarls.json > snarls.vg
 is $(vg snarls snarls.vg -r st.pb | vg view -R - | wc -l) 3 "vg snarls made right number of protobuf Snarls"
 is $(vg view -E st.pb | wc -l) 6 "vg snarls made right number of protobuf SnarlTraversals"
 
-rm -f snarls.vg st.pb 
+rm -f st.pb
+
+vg index snarls.vg -x snarls.xg
+is $(vg snarls snarls.xg -r st.pb | vg view -R - | wc -l) 3 "vg snarls on xg made right number of protobuf Snarls"
+is $(vg view -E st.pb | wc -l) 6 "vg snarls on xg made right number of protobuf SnarlTraversals"
+
+rm -f snarls.vg snarls.xg st.pb
 
 # vcf alt traversals in tiny graph
 vg construct -Saf -v tiny/tiny.vcf.gz -r tiny/tiny.fa > tiny.vg


### PR DESCRIPTION
`vg snarls` changed to read input via the generic handle graph interface (when not using `-p` or `-v`).  This means it will seamlessly work on vg/xg input now, and the various other formats soon once they get hooked in.    