### PR TITLE
Allow building a distance index from an xg again

### DIFF
--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -507,7 +507,8 @@ int main_index(int argc, char** argv) {
         return 1;
     }
     
-    if (file_names.size() != 1 && build_dist) {
+    if (file_names.size() > 1 && build_dist) {
+        // Allow zero filenames for the index-from-xg mode
         cerr << "error: [vg index] can only create one distance index at a time" << endl;
         return 1;
     }


### PR DESCRIPTION
We should be able to make a distance index from an xg, but vg index acquired a check that refuses to do distance indexing when filenames is empty. This fixes that.