### PR TITLE
Yet Another Path Traversal Finder

### DIFF
--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -816,10 +816,10 @@ PathTraversalFinder::PathTraversalFinder(const PathHandleGraph& graph, SnarlMana
 }
 
 vector<SnarlTraversal> PathTraversalFinder::find_traversals(const Snarl& site) {
-    return find_named_traversals(site).first;
+    return find_path_traversals(site).first;
 }
 
-pair<vector<SnarlTraversal>, vector<string> > PathTraversalFinder::find_named_traversals(const Snarl& site) {
+pair<vector<SnarlTraversal>, vector<pair<step_handle_t, step_handle_t> > > PathTraversalFinder::find_path_traversals(const Snarl& site) {
 
     handle_t start_handle = graph.get_handle(site.start().node_id(), site.start().backward());
     handle_t end_handle = graph.get_handle(site.end().node_id(), site.end().backward());
@@ -842,7 +842,7 @@ pair<vector<SnarlTraversal>, vector<string> > PathTraversalFinder::find_named_tr
 #endif
 
     vector<SnarlTraversal> out_travs;
-    vector<string> out_names; //todo: change to step 
+    vector<pair<step_handle_t, step_handle_t> > out_steps;
 
     for (const step_handle_t& start_step : start_steps) {
         path_handle_t start_path_handle = graph.get_path_handle_of_step(start_step);
@@ -893,13 +893,6 @@ pair<vector<SnarlTraversal>, vector<string> > PathTraversalFinder::find_named_tr
                     start_visit->set_node_id(graph.get_id(handle));
                     start_visit->set_backward(graph.get_is_reverse(handle));
 
-                    auto print_edge = [&](const edge_t& e) -> string{
-                        stringstream ss;
-                        ss << graph.get_id(e.first) << ":" << graph.get_is_reverse(e.first) << "->"
-                        << graph.get_id(e.second) << ":" << graph.get_is_reverse(e.second);
-                        return ss.str();
-                    };
-                        
                     can_continue = false;
                     if (graph.has_previous_step(step) && handle != end_handle) {
                         step_handle_t prev_step = graph.get_previous_step(step);
@@ -913,19 +906,14 @@ pair<vector<SnarlTraversal>, vector<string> > PathTraversalFinder::find_named_tr
                     }
                 }
             }
-                auto print_handle = [&](const handle_t& h) -> string{
-                    stringstream ss;
-                    ss << graph.get_id(h) << ":" << graph.get_is_reverse(h) ;
-                    return ss.str();
-                };
             if (graph.get_handle_of_step(step) == end_check) {
                 out_travs.push_back(trav);
-                out_names.push_back(graph.get_path_name(start_path_handle));
+                out_steps.push_back(make_pair(start_step, step));
             } 
         }
     }
     
-    return make_pair(out_travs, out_names);
+    return make_pair(out_travs, out_steps);
 }
  
 

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -129,6 +129,8 @@ public:
  * I'm not sure what PathBasedTraversalFinder (see below) does, but it does not work
  * as a drop-in replacement for this class, so keep the two implementations at least 
  * for now.    
+ *
+ * DEPRECATED: Use PathTraversalFinder instead
  */
 class PathRestrictedTraversalFinder : public TraversalFinder {
 
@@ -185,6 +187,34 @@ class PathBasedTraversalFinder : public TraversalFinder{
     virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
 
 };
+
+/** This is a Handle Graph replacement for PathRestrictedTraversalFinder
+ * that uses the PathHandleGraph interface instead of the VG-based 
+ * path index.  It returns all traversals through a snarl that are contained
+ * within paths in the graph.  It can also return a mapping from the traversals
+ * to their paths*/
+class PathTraversalFinder : public TraversalFinder {
+    
+protected:
+    // our graph with indexed path positions
+    const PathHandleGraph& graph;
+    
+    SnarlManager& snarl_manager;
+    
+public:
+    PathTraversalFinder(const PathHandleGraph& graph, SnarlManager& snarl_manager);
+
+    /**
+     * Return all traversals through the site that are sub-paths of embedded paths in the graph
+     */
+    virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
+
+   /**
+    * Like above, but return the path name corresponding to each traversal
+    */
+    virtual pair<vector<SnarlTraversal>, vector<string> > find_named_traversals(const Snarl& site);
+};    
+    
 
 /**
  * This traversal finder finds one or more traversals through leaf sites with

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -171,10 +171,10 @@ public:
      */
     virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
 
-   /**
+    /**
     * Like above, but return the path name corresponding to each traversal
     */
-    virtual pair<vector<SnarlTraversal>, vector<string>> find_named_traversals(const Snarl& site);
+    virtual pair<vector<SnarlTraversal>, vector<string> > find_named_traversals(const Snarl& site);
     
 };
 
@@ -209,10 +209,11 @@ public:
      */
     virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
 
-   /**
-    * Like above, but return the path name corresponding to each traversal
+    /**
+    * Like above, but return the path steps for the for the traversal endpoints
     */
-    virtual pair<vector<SnarlTraversal>, vector<string> > find_named_traversals(const Snarl& site);
+    virtual pair<vector<SnarlTraversal>, vector<pair<step_handle_t, step_handle_t> > > find_path_traversals(const Snarl& site);
+
 };    
     
 

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -13,6 +13,7 @@
 #include "catch.hpp"
 #include "snarls.hpp"
 #include "genotypekit.hpp"
+#include "traversal_finder.hpp"
 #include <vg/io/protobuf_emitter.hpp>
 #include <vg/io/vpkg.hpp>
 
@@ -3600,5 +3601,262 @@ namespace vg {
             }
             
         }
+
+    TEST_CASE( "PathTraversalFinder works correctly",
+               "[sites][snarls]" ) {
+
+
+        // Build a toy graph
+        const string graph_json = R"(
+        
+            {
+                "node": [
+                    {"id": 1, "sequence": "G"},
+                    {"id": 2, "sequence": "A"},
+                    {"id": 3, "sequence": "G"},
+                    {"id": 4, "sequence": "A"},
+                    {"id": 5, "sequence": "G"},
+                    {"id": 6, "sequence": "A"},
+                    {"id": 7, "sequence": "G"},
+                    {"id": 8, "sequence": "A"},
+                    {"id": 9, "sequence": "A"},
+                    {"id": 10, "sequence": "G"},
+                    {"id": 11, "sequence": "A"}
+                ],
+                "edge": [
+                    {"from": 1, "to": 2},
+                    {"from": 2, "to": 3},
+                    {"from": 2, "to": 4},
+                    {"from": 3, "to": 5},
+                    {"from": 3, "to": 6},
+                    {"from": 4, "to": 5},
+                    {"from": 4, "to": 6},
+                    {"from": 5, "to": 7},
+                    {"from": 6, "to": 7},
+                    {"from": 7, "to": 8},
+                    {"from": 8, "to": 9},
+                    {"from": 8, "to": 10, "to_end": "true"},
+                    {"from": 9, "to": 10},
+                    {"from": 9, "to": 10, "from_start": "true"},
+                    {"from": 9, "to": 11, "to_end": "true"},
+                    {"from": 9, "to": 11, "from_start": "true", "to_end": "true"},
+                    {"from": 10, "to": 11, "to_end": "true"}
+                ],
+                "path": [
+                    {"name": "ref", "mapping": [
+                        {"position": {"node_id": 1}, "rank" : 1 },
+                        {"position": {"node_id": 2}, "rank" : 2 },
+                        {"position": {"node_id": 4}, "rank" : 3 },
+                        {"position": {"node_id": 6}, "rank" : 4 },
+                        {"position": {"node_id": 7}, "rank" : 5 },
+                        {"position": {"node_id": 8}, "rank" : 6 },
+                        {"position": {"node_id": 9}, "rank" : 7 },
+                        {"position": {"node_id": 10}, "rank" : 8 },
+                        {"position": {"node_id": 11, "is_reverse" : "true"}, "rank" : 9 }
+                    ]},
+                    {"name": "alt1", "mapping": [
+                        {"position": {"node_id": 1}, "rank" : 1 },
+                        {"position": {"node_id": 2}, "rank" : 2 },
+                        {"position": {"node_id": 3}, "rank" : 3 },
+                        {"position": {"node_id": 5}, "rank" : 4 },
+                        {"position": {"node_id": 7}, "rank" : 5 },
+                        {"position": {"node_id": 8}, "rank" : 6 },
+                        {"position": {"node_id": 10, "is_reverse" : "true"}, "rank" : 7 },
+                        {"position": {"node_id": 9}, "rank" : 8 },
+                        {"position": {"node_id": 11, "is_reverse" : "true"}, "rank" : 9 }
+                    ]},
+                    {"name": "alt1a", "mapping": [
+                        {"position": {"node_id": 2}, "rank" : 2 },
+                        {"position": {"node_id": 3}, "rank" : 3 },
+                        {"position": {"node_id": 5}, "rank" : 4 },
+                        {"position": {"node_id": 7}, "rank" : 5 }
+                    ]},
+                    {"name": "alt2", "mapping": [
+                        {"position": {"node_id": 8, "is_reverse" : "true"}, "rank" : 1 },
+                        {"position": {"node_id": 7, "is_reverse" : "true"}, "rank" : 2 },
+                        {"position": {"node_id": 6, "is_reverse" : "true"}, "rank" : 3 },
+                        {"position": {"node_id": 3, "is_reverse" : "true"}, "rank" : 4 },
+                        {"position": {"node_id": 2, "is_reverse" : "true"}, "rank" : 5 },
+                        {"position": {"node_id": 1, "is_reverse" : "true"}, "rank" : 6 }
+                    ]},
+                    {"name": "shorty", "mapping": [
+                        {"position": {"node_id": 1}, "rank" : 1 },
+                        {"position": {"node_id": 2}, "rank" : 2 },
+                        {"position": {"node_id": 3}, "rank" : 3 },
+                        {"position": {"node_id": 6}, "rank" : 4 }
+                    ]},
+                    {"name": "alt3", "mapping": [
+                        {"position": {"node_id": 11}, "rank" : 1 },
+                        {"position": {"node_id": 9}, "rank" : 2 },
+                        {"position": {"node_id": 10}, "rank" : 3 },
+                        {"position": {"node_id": 8, "is_reverse" : "true"}, "rank" : 4 },
+                        {"position": {"node_id": 7, "is_reverse" : "true"}, "rank" : 5 }
+                    ]},
+                    {"name": "alt4", "mapping": [
+                        {"position": {"node_id": 11}, "rank" : 1 },
+                        {"position": {"node_id": 10, "is_reverse" : "true"}, "rank" : 2 },
+                        {"position": {"node_id": 9, "is_reverse" : "true"}, "rank" : 3 },
+                        {"position": {"node_id": 8, "is_reverse" : "true"}, "rank" : 4 },
+                        {"position": {"node_id": 7, "is_reverse" : "true"}, "rank" : 5 }
+                    ]}
+                ]
+            }            
+            )";
+            
+        // Make an actual graph
+        VG graph;
+        Graph chunk;
+        json2pb(chunk, graph_json.c_str(), graph_json.size());
+        graph.extend(chunk);
+        assert(graph.is_valid());
+        
+        SECTION( "PathTraversalFinder can find simple forward traversals") {
+
+            CactusSnarlFinder snarl_finder(graph);
+            SnarlManager snarl_manager = snarl_finder.find_snarls();
+            PathTraversalFinder trav_finder(graph, snarl_manager);
+
+            Snarl snarl;
+            snarl.mutable_start()->set_node_id(2);
+            snarl.mutable_end()->set_node_id(7);
+
+            auto trav_results = trav_finder.find_named_traversals(snarl);
+
+            // get a path for ref, atl1, alt1a and alt2
+            REQUIRE(trav_results.first.size() == 4);
+
+            set<string> correct_names = {"ref", "alt1", "alt1a", "alt2"};
+            set<string> found_names(trav_results.second.begin(), trav_results.second.end());
+            bool correct_equals_found = correct_names == found_names;
+            REQUIRE(correct_equals_found);
+
+            map<string, string> true_trav_strings = {
+                {"ref", R"({"visit":[{"node_id":"2"},{"node_id":"4"},{"node_id":"6"},{"node_id":"7"}]})"},
+                {"alt1", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"5"},{"node_id":"7"}]})"},
+                {"alt1a", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"5"},{"node_id":"7"}]})"},
+                {"alt2", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"6"},{"node_id":"7"}]})"}
+            };
+            for (int i = 0; i < trav_results.first.size(); ++i) {
+                REQUIRE(true_trav_strings.count(trav_results.second[i]));
+                SnarlTraversal true_trav;
+                json2pb(true_trav, true_trav_strings[trav_results.second[i]]);
+                bool trav_is_correct = trav_results.first[i] == true_trav;
+                REQUIRE(trav_is_correct);
+            }
+        }
+
+        SECTION( "PathTraversalFinder can find simple traversals when snarl is backward") {
+
+            CactusSnarlFinder snarl_finder(graph);
+            SnarlManager snarl_manager = snarl_finder.find_snarls();
+            PathTraversalFinder trav_finder(graph, snarl_manager);
+
+            Snarl snarl;
+            snarl.mutable_start()->set_node_id(7);
+            snarl.mutable_start()->set_backward(true);
+            snarl.mutable_end()->set_node_id(2);
+            snarl.mutable_end()->set_backward(true);
+            
+            auto trav_results = trav_finder.find_named_traversals(snarl);
+
+            // get a path for ref, atl1, alt1a and alt2
+            REQUIRE(trav_results.first.size() == 4);
+
+            set<string> correct_names = {"ref", "alt1", "alt1a", "alt2"};
+            set<string> found_names(trav_results.second.begin(), trav_results.second.end());
+            bool correct_equals_found = correct_names == found_names;
+            REQUIRE(correct_equals_found);
+
+            map<string, string> true_trav_strings = {
+                {"ref", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"6","backward":true},{"node_id":"4","backward":true},{"node_id":"2","backward":true}]})"},
+                {"alt1", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"5","backward":true},{"node_id":"3","backward":true},{"node_id":"2","backward":true}]})"},
+                {"alt1a", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"5","backward":true},{"node_id":"3","backward":true},{"node_id":"2","backward":true}]})"},
+                {"alt2", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"6","backward":true},{"node_id":"3","backward":true},{"node_id":"2","backward":true}]})"}
+            };
+            for (int i = 0; i < trav_results.first.size(); ++i) {
+                REQUIRE(true_trav_strings.count(trav_results.second[i]));
+                SnarlTraversal true_trav;
+                json2pb(true_trav, true_trav_strings[trav_results.second[i]]);
+                bool trav_is_correct = trav_results.first[i] == true_trav;
+                REQUIRE(trav_is_correct);
+            }
+        }
+
+        SECTION( "PathTraversalFinder can find forward traversals in snarl with inversion") {
+
+            CactusSnarlFinder snarl_finder(graph);
+            SnarlManager snarl_manager = snarl_finder.find_snarls();
+            PathTraversalFinder trav_finder(graph, snarl_manager);
+
+            Snarl snarl;
+            snarl.mutable_start()->set_node_id(8);
+            snarl.mutable_end()->set_node_id(11);
+            snarl.mutable_end()->set_backward(true);
+            
+            auto trav_results = trav_finder.find_named_traversals(snarl);
+
+            // get a path for ref, atl1, alt1a and alt2
+            REQUIRE(trav_results.first.size() == 4);
+
+            set<string> correct_names = {"ref", "alt1", "alt3", "alt4"};
+            set<string> found_names(trav_results.second.begin(), trav_results.second.end());
+            bool correct_equals_found = correct_names == found_names;
+            REQUIRE(correct_equals_found);
+
+            map<string, string> true_trav_strings = {
+                {"ref", R"({"visit":[{"node_id":"8"},{"node_id":"9"},{"node_id":"10"},{"node_id":"11","backward":true}]})"},
+                {"alt1", R"({"visit":[{"node_id":"8"},{"node_id":"10","backward":true},{"node_id":"9"},{"node_id":"11","backward":true}]})"},
+                {"alt3", R"({"visit":[{"node_id":"8"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"11","backward":true}]})"},
+                {"alt4", R"({"visit":[{"node_id":"8"},{"node_id":"9"},{"node_id":"10"},{"node_id":"11","backward":true}]})"}
+            };
+            for (int i = 0; i < trav_results.first.size(); ++i) {
+                REQUIRE(true_trav_strings.count(trav_results.second[i]));
+                SnarlTraversal true_trav;
+                json2pb(true_trav, true_trav_strings[trav_results.second[i]]);
+                bool trav_is_correct = trav_results.first[i] == true_trav;
+                REQUIRE(trav_is_correct);
+            }
+        }
+
+        SECTION( "PathTraversalFinder can find traversals in backward snarl with inversion") {
+
+            CactusSnarlFinder snarl_finder(graph);
+            SnarlManager snarl_manager = snarl_finder.find_snarls();
+            PathTraversalFinder trav_finder(graph, snarl_manager);
+
+            Snarl snarl;
+            snarl.mutable_start()->set_node_id(11);
+            snarl.mutable_end()->set_node_id(8);
+            snarl.mutable_end()->set_backward(true);
+            
+            auto trav_results = trav_finder.find_named_traversals(snarl);
+
+            // get a path for ref, atl1, alt1a and alt2
+            REQUIRE(trav_results.first.size() == 4);
+
+            set<string> correct_names = {"ref", "alt1", "alt3", "alt4"};
+            set<string> found_names(trav_results.second.begin(), trav_results.second.end());
+            bool correct_equals_found = correct_names == found_names;
+            REQUIRE(correct_equals_found);
+
+            map<string, string> true_trav_strings = {
+                {"ref", R"({"visit":[{"node_id":"11"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"8","backward":true}]})"},
+                {"alt1", R"({"visit":[{"node_id":"11"},{"node_id":"9","backward":true},{"node_id":"10"},{"node_id":"8","backward":true}]})"},
+                {"alt3", R"({"visit":[{"node_id":"11"},{"node_id":"9"},{"node_id":"10"},{"node_id":"8","backward":true}]})"},
+                {"alt4", R"({"visit":[{"node_id":"11"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"8","backward":true}]})"}
+            };
+            for (int i = 0; i < trav_results.first.size(); ++i) {
+                REQUIRE(true_trav_strings.count(trav_results.second[i]));
+                SnarlTraversal true_trav;
+                json2pb(true_trav, true_trav_strings[trav_results.second[i]]);
+                bool trav_is_correct = trav_results.first[i] == true_trav;
+                REQUIRE(trav_is_correct);
+            }
+        }
+
+        
+            
+    }
+
    }
 }

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -3720,16 +3720,19 @@ namespace vg {
             snarl.mutable_start()->set_node_id(2);
             snarl.mutable_end()->set_node_id(7);
 
-            auto trav_results = trav_finder.find_named_traversals(snarl);
+            auto trav_results = trav_finder.find_path_traversals(snarl);
 
             // get a path for ref, atl1, alt1a and alt2
             REQUIRE(trav_results.first.size() == 4);
 
             set<string> correct_names = {"ref", "alt1", "alt1a", "alt2"};
-            set<string> found_names(trav_results.second.begin(), trav_results.second.end());
-            bool correct_equals_found = correct_names == found_names;
-            REQUIRE(correct_equals_found);
-
+            for (auto step_pair : trav_results.second) {
+                string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
+                string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
+                REQUIRE(name1 == name2);
+                REQUIRE(correct_names.count(name1));
+            }
+            
             map<string, string> true_trav_strings = {
                 {"ref", R"({"visit":[{"node_id":"2"},{"node_id":"4"},{"node_id":"6"},{"node_id":"7"}]})"},
                 {"alt1", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"5"},{"node_id":"7"}]})"},
@@ -3737,9 +3740,10 @@ namespace vg {
                 {"alt2", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"6"},{"node_id":"7"}]})"}
             };
             for (int i = 0; i < trav_results.first.size(); ++i) {
-                REQUIRE(true_trav_strings.count(trav_results.second[i]));
+                string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));
+                REQUIRE(true_trav_strings.count(name));
                 SnarlTraversal true_trav;
-                json2pb(true_trav, true_trav_strings[trav_results.second[i]]);
+                json2pb(true_trav, true_trav_strings[name]);
                 bool trav_is_correct = trav_results.first[i] == true_trav;
                 REQUIRE(trav_is_correct);
             }
@@ -3757,15 +3761,18 @@ namespace vg {
             snarl.mutable_end()->set_node_id(2);
             snarl.mutable_end()->set_backward(true);
             
-            auto trav_results = trav_finder.find_named_traversals(snarl);
+            auto trav_results = trav_finder.find_path_traversals(snarl);
 
             // get a path for ref, atl1, alt1a and alt2
             REQUIRE(trav_results.first.size() == 4);
 
             set<string> correct_names = {"ref", "alt1", "alt1a", "alt2"};
-            set<string> found_names(trav_results.second.begin(), trav_results.second.end());
-            bool correct_equals_found = correct_names == found_names;
-            REQUIRE(correct_equals_found);
+            for (auto step_pair : trav_results.second) {
+                string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
+                string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
+                REQUIRE(name1 == name2);
+                REQUIRE(correct_names.count(name1));
+            }
 
             map<string, string> true_trav_strings = {
                 {"ref", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"6","backward":true},{"node_id":"4","backward":true},{"node_id":"2","backward":true}]})"},
@@ -3774,9 +3781,10 @@ namespace vg {
                 {"alt2", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"6","backward":true},{"node_id":"3","backward":true},{"node_id":"2","backward":true}]})"}
             };
             for (int i = 0; i < trav_results.first.size(); ++i) {
-                REQUIRE(true_trav_strings.count(trav_results.second[i]));
+                string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));                
+                REQUIRE(true_trav_strings.count(name));
                 SnarlTraversal true_trav;
-                json2pb(true_trav, true_trav_strings[trav_results.second[i]]);
+                json2pb(true_trav, true_trav_strings[name]);
                 bool trav_is_correct = trav_results.first[i] == true_trav;
                 REQUIRE(trav_is_correct);
             }
@@ -3793,15 +3801,18 @@ namespace vg {
             snarl.mutable_end()->set_node_id(11);
             snarl.mutable_end()->set_backward(true);
             
-            auto trav_results = trav_finder.find_named_traversals(snarl);
+            auto trav_results = trav_finder.find_path_traversals(snarl);
 
             // get a path for ref, atl1, alt1a and alt2
             REQUIRE(trav_results.first.size() == 4);
 
             set<string> correct_names = {"ref", "alt1", "alt3", "alt4"};
-            set<string> found_names(trav_results.second.begin(), trav_results.second.end());
-            bool correct_equals_found = correct_names == found_names;
-            REQUIRE(correct_equals_found);
+            for (auto step_pair : trav_results.second) {
+                string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
+                string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
+                REQUIRE(name1 == name2);
+                REQUIRE(correct_names.count(name1));
+            }
 
             map<string, string> true_trav_strings = {
                 {"ref", R"({"visit":[{"node_id":"8"},{"node_id":"9"},{"node_id":"10"},{"node_id":"11","backward":true}]})"},
@@ -3810,9 +3821,10 @@ namespace vg {
                 {"alt4", R"({"visit":[{"node_id":"8"},{"node_id":"9"},{"node_id":"10"},{"node_id":"11","backward":true}]})"}
             };
             for (int i = 0; i < trav_results.first.size(); ++i) {
-                REQUIRE(true_trav_strings.count(trav_results.second[i]));
+                string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));                
+                REQUIRE(true_trav_strings.count(name));
                 SnarlTraversal true_trav;
-                json2pb(true_trav, true_trav_strings[trav_results.second[i]]);
+                json2pb(true_trav, true_trav_strings[name]);
                 bool trav_is_correct = trav_results.first[i] == true_trav;
                 REQUIRE(trav_is_correct);
             }
@@ -3829,16 +3841,19 @@ namespace vg {
             snarl.mutable_end()->set_node_id(8);
             snarl.mutable_end()->set_backward(true);
             
-            auto trav_results = trav_finder.find_named_traversals(snarl);
+            auto trav_results = trav_finder.find_path_traversals(snarl);
 
             // get a path for ref, atl1, alt1a and alt2
             REQUIRE(trav_results.first.size() == 4);
 
             set<string> correct_names = {"ref", "alt1", "alt3", "alt4"};
-            set<string> found_names(trav_results.second.begin(), trav_results.second.end());
-            bool correct_equals_found = correct_names == found_names;
-            REQUIRE(correct_equals_found);
-
+            for (auto step_pair : trav_results.second) {
+                string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
+                string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
+                REQUIRE(name1 == name2);
+                REQUIRE(correct_names.count(name1));
+            }
+                
             map<string, string> true_trav_strings = {
                 {"ref", R"({"visit":[{"node_id":"11"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"8","backward":true}]})"},
                 {"alt1", R"({"visit":[{"node_id":"11"},{"node_id":"9","backward":true},{"node_id":"10"},{"node_id":"8","backward":true}]})"},
@@ -3846,9 +3861,10 @@ namespace vg {
                 {"alt4", R"({"visit":[{"node_id":"11"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"8","backward":true}]})"}
             };
             for (int i = 0; i < trav_results.first.size(); ++i) {
-                REQUIRE(true_trav_strings.count(trav_results.second[i]));
+                string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));                                
+                REQUIRE(true_trav_strings.count(name));
                 SnarlTraversal true_trav;
-                json2pb(true_trav, true_trav_strings[trav_results.second[i]]);
+                json2pb(true_trav, true_trav_strings[name]);
                 bool trav_is_correct = trav_results.first[i] == true_trav;
                 REQUIRE(trav_is_correct);
             }


### PR DESCRIPTION
Added `PathTraversalFinder`, which returns a SnarlTraversal for every embedded path that spans the snarl.   It can optionally return some steps to link the traversal back to its position in the path.  `PathTraversalFinder` is similar in functionality to `PathRestrictedTraversalFinder`, except it operates on any PathHandelGraph.  Cyclic paths are better supported.  Neither are to be confused with `PathBasedTraversalFinder` which identifies alt paths within a snarl (but does not guarantee valid traversals).

I intend to use this to fix a bug in deconstruct where cyclic references aren't properly supported, as well as to let it directly operate on xg. 
 