### PR TITLE
Add back vector interface for augment()

### DIFF
--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -18,11 +18,61 @@ void augment(MutablePathMutableHandleGraph* graph,
              function<void(Path&)> save_path_fn,
              bool break_at_ends,
              bool remove_softclips) {
+
+    function<void(function<void(Alignment&)>, bool)> iterate_gam =
+        [&gam_stream] (function<void(Alignment&)> aln_callback, bool reset_stream) {
+        if (reset_stream) {
+            gam_stream.clear();
+            gam_stream.seekg(0, ios_base::beg);
+        }
+        vg::io::for_each(gam_stream, aln_callback);
+    };
+
+    augment_impl(graph,
+                 iterate_gam,
+                 out_translations,
+                 gam_out_stream,
+                 save_path_fn,
+                 break_at_ends,
+                 remove_softclips);
+}
+
+void augment(MutablePathMutableHandleGraph* graph,
+             vector<Alignment>& gam_vector,
+             vector<Translation>* out_translations,
+             ostream* gam_out_stream,
+             function<void(Path&)> save_path_fn,
+             bool break_at_ends,
+             bool remove_softclips) {
+    
+    function<void(function<void(Alignment&)>, bool)> iterate_gam =
+        [&gam_vector] (function<void(Alignment&)> aln_callback, bool reset_stream) {
+        for (Alignment& aln : gam_vector) {
+            aln_callback(aln);
+        }
+    };
+
+    augment_impl(graph,
+                 iterate_gam,
+                 out_translations,
+                 gam_out_stream,
+                 save_path_fn,
+                 break_at_ends,
+                 remove_softclips);
+}
+
+void augment_impl(MutablePathMutableHandleGraph* graph,
+                  function<void(function<void(Alignment&)>, bool)> iterate_gam,
+                  vector<Translation>* out_translations,
+                  ostream* gam_out_stream,
+                  function<void(Path&)> save_path_fn,
+                  bool break_at_ends,
+                  bool remove_softclips) {
     // Collect the breakpoints
     unordered_map<id_t, set<pos_t>> breakpoints;
 
     // First pass: find the breakpoints
-    vg::io::for_each(gam_stream, (function<void(Alignment&)>)[&](Alignment& aln) {
+    iterate_gam((function<void(Alignment&)>)[&](Alignment& aln) {
 #ifdef debug
             cerr << pb2json(aln.path()) << endl;
 #endif
@@ -39,7 +89,7 @@ void augment(MutablePathMutableHandleGraph* graph,
             // Add in breakpoints from each path
             find_breakpoints(simplified_path, breakpoints, break_at_ends);
 
-        });
+        }, false);
 
     // Invert the breakpoints that are on the reverse strand
     breakpoints = forwardize_breakpoints(graph, breakpoints);
@@ -65,9 +115,7 @@ void augment(MutablePathMutableHandleGraph* graph,
     vector<Alignment> gam_buffer;
 
     // Second pass: add the nodes and edges
-    gam_stream.clear();
-    gam_stream.seekg(0, ios_base::beg);
-    vg::io::for_each(gam_stream, (function<void(Alignment&)>)[&](Alignment& aln) {
+    iterate_gam((function<void(Alignment&)>)[&](Alignment& aln) {
             if (remove_softclips) {
                 softclip_trim(aln);
             }
@@ -114,7 +162,7 @@ void augment(MutablePathMutableHandleGraph* graph,
                 gam_buffer.push_back(aln);
                 vg::io::write_buffered(*gam_out_stream, gam_buffer, 100);
             }
-        });
+    }, true);
     if (gam_out_stream != nullptr) {
         // Flush the buffer
         vg::io::write_buffered(*gam_out_stream, gam_buffer, 0);

--- a/src/augment.hpp
+++ b/src/augment.hpp
@@ -39,6 +39,26 @@ void augment(MutablePathMutableHandleGraph* graph,
              bool break_at_ends = false,
              bool remove_soft_clips = false);
 
+/// Like above, but operates on a vector of Alignments, instead of a stream
+/// (Note: It is best to use stream interface for large numbers of alignments to save memory)
+void augment(MutablePathMutableHandleGraph* graph,
+             vector<Alignment>& gam_vector,
+             vector<Translation>* out_translation = nullptr,
+             ostream* gam_out_stream = nullptr,
+             function<void(Path&)> save_path_fn = nullptr,
+             bool break_at_ends = false,
+             bool remove_soft_clips = false);
+
+/// Generic version used to implement the above two methods.  
+void augment_impl(MutablePathMutableHandleGraph* graph,
+                  function<void(function<void(Alignment&)>, bool)> iterate_gam,
+                  vector<Translation>* out_translation,
+                  ostream* gam_out_stream,
+                  function<void(Path&)> save_path_fn,
+                  bool break_at_ends,
+                  bool remove_soft_clips);
+
+
 /// Find all the points at which a Path enters or leaves nodes in the graph. Adds
 /// them to the given map by node ID of sets of bases in the node that will need
 /// to become the starts of new nodes.


### PR DESCRIPTION
This is to help with replacing VG::edit() during handle-graphification.  The stream interface is still to be preferred when possible as it uses less memory.