### PR TITLE
Provenance option

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -15,11 +15,6 @@
 #include <algorithm>
 #include <cmath>
 
-// Set this to track provenance of intermediate results
-//#define TRACK_PROVENANCE
-// With TRACK_PROVENANCE on, set this to track correctness, which requires some expensive XG queries
-//#define TRACK_CORRECTNESS
-
 namespace vg {
 
 using namespace std;
@@ -49,10 +44,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         aln.set_read_group(read_group);
     }
    
-#ifdef TRACK_PROVENANCE
-    // Start the minimizer finding stage
-    funnel.stage("minimizer");
-#endif
+    if (track_provenance) {
+        // Start the minimizer finding stage
+        funnel.stage("minimizer");
+    }
     
     // We will find all the seed hits
     vector<pos_t> seeds;
@@ -65,13 +60,13 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     // Find minimizers in the query
     minimizers = minimizer_index->minimizers(aln.sequence());
     
-#ifdef TRACK_PROVENANCE
-    // Record how many we found, as new lines.
-    funnel.introduce(minimizers.size());
-    
-    // Start the minimizer locating stage
-    funnel.stage("seed");
-#endif
+    if (track_provenance) {
+        // Record how many we found, as new lines.
+        funnel.introduce(minimizers.size());
+        
+        // Start the minimizer locating stage
+        funnel.stage("seed");
+    }
 
     // Compute minimizer scores for all minimizers as 1 + ln(hard_hit_cap) - ln(hits).
     std::vector<double> minimizer_score(minimizers.size(), 0.0);
@@ -104,10 +99,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     for (size_t i = 0; i < minimizers.size(); i++) {
         size_t minimizer_num = minimizers_in_order[i];
 
-#ifdef TRACK_PROVENANCE
-        // Say we're working on it
-        funnel.processing_input(minimizer_num);
-#endif
+        if (track_provenance) {
+            // Say we're working on it
+            funnel.processing_input(minimizer_num);
+        }
 
         // Select the minimizer if it is informative enough or if the total score
         // of the selected minimizers is not high enough.
@@ -127,66 +122,64 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
             }
             selected_score += minimizer_score[minimizer_num];
             
-#ifdef TRACK_PROVENANCE
-            // Record in the funnel that this minimizer gave rise to these seeds.
-            funnel.expand(minimizer_num, hits);
-#endif
+            if (track_provenance) {
+                // Record in the funnel that this minimizer gave rise to these seeds.
+                funnel.expand(minimizer_num, hits);
+            }
         } else {
             rejected_count++;
             
-#ifdef TRACK_PROVENANCE
-            // Record in the funnel thast we rejected it
-            funnel.kill(minimizer_num);
-#endif
+            if (track_provenance) {
+                // Record in the funnel thast we rejected it
+                funnel.kill(minimizer_num);
+            }
         }
         
-#ifdef TRACK_PROVENANCE
-        // Say we're done with this input item
-        funnel.processed_input();
-#endif
+        if (track_provenance) {
+            // Say we're done with this input item
+            funnel.processed_input();
+        }
     }
 
 
-#ifdef TRACK_PROVENANCE
-#ifdef TRACK_CORRECTNESS
-    // Tag seeds with correctness based on proximity along paths to the input read's refpos
-    funnel.substage("correct");
-    
-    if (aln.refpos_size() != 0) {
-        // Take the first refpos as the true position.
-        auto& true_pos = aln.refpos(0);
+    if (track_provenance && track_correctness) {
+        // Tag seeds with correctness based on proximity along paths to the input read's refpos
+        funnel.substage("correct");
         
-        for (size_t i = 0; i < seeds.size(); i++) {
-            // Find every seed's reference positions. This maps from path name to pairs of offset and orientation.
-            auto offsets = algorithms::nearest_offsets_in_paths(xg_index, seeds[i], 100);
-            for (auto& hit_pos : offsets[true_pos.name()]) {
-                // Look at all the ones on the path the read's true position is on.
-                if (abs((int64_t)hit_pos.first - (int64_t) true_pos.offset()) < 200) {
-                    // Call this seed hit close enough to be correct
-                    funnel.tag_correct(i);
+        if (aln.refpos_size() != 0) {
+            // Take the first refpos as the true position.
+            auto& true_pos = aln.refpos(0);
+            
+            for (size_t i = 0; i < seeds.size(); i++) {
+                // Find every seed's reference positions. This maps from path name to pairs of offset and orientation.
+                auto offsets = algorithms::nearest_offsets_in_paths(xg_index, seeds[i], 100);
+                for (auto& hit_pos : offsets[xg_index->get_path_handle(true_pos.name())]) {
+                    // Look at all the ones on the path the read's true position is on.
+                    if (abs((int64_t)hit_pos.first - (int64_t) true_pos.offset()) < 200) {
+                        // Call this seed hit close enough to be correct
+                        funnel.tag_correct(i);
+                    }
                 }
             }
         }
     }
-#endif
-#endif
         
 #ifdef debug
     cerr << "Read " << aln.name() << ": " << aln.sequence() << endl;
     cerr << "Found " << seeds.size() << " seeds from " << (minimizers.size() - rejected_count) << " minimizers, rejected " << rejected_count << endl;
 #endif
 
-#ifdef TRACK_PROVENANCE
-    // Begin the clustering stage
-    funnel.stage("cluster");
-#endif
+    if (track_provenance) {
+        // Begin the clustering stage
+        funnel.stage("cluster");
+    }
         
     // Cluster the seeds. Get sets of input seed indexes that go together.
     vector<vector<size_t>> clusters = clusterer.cluster_seeds(seeds, distance_limit);
     
-#ifdef TRACK_PROVENANCE
-    funnel.substage("score");
-#endif
+    if (track_provenance) {
+        funnel.substage("score");
+    }
 
     // Cluster score is the sum of minimizer scores.
     std::vector<double> cluster_score(clusters.size(), 0.0);
@@ -197,10 +190,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         // For each cluster
         auto& cluster = clusters[i];
         
-#ifdef TRACK_PROVENANCE
-        // Say we're making it
-        funnel.producing_output(i);
-#endif
+        if (track_provenance) {
+            // Say we're making it
+            funnel.producing_output(i);
+        }
 
         // Which minimizers are present in the cluster.
         vector<bool> present(minimizers.size(), false);
@@ -215,15 +208,14 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
             }
         }
         
-#ifdef TRACK_PROVENANCE
-        // Record the cluster in the funnel as a group of the size of the number of items.
-        funnel.merge_group(cluster.begin(), cluster.end());
-        funnel.score(funnel.latest(), cluster_score[i]);
-        
-        // Say we made it.
-        funnel.produced_output();
-#endif
-
+        if (track_provenance) {
+            // Record the cluster in the funnel as a group of the size of the number of items.
+            funnel.merge_group(cluster.begin(), cluster.end());
+            funnel.score(funnel.latest(), cluster_score[i]);
+            
+            // Say we made it.
+            funnel.produced_output();
+        }
 
         //TODO:
         //Get the cluster coverage
@@ -280,10 +272,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     double cluster_score_cutoff = cluster_score.size() == 0 ? 0 :
                     *std::max_element(cluster_score.begin(), cluster_score.end()) - cluster_score_threshold;
     
-#ifdef TRACK_PROVENANCE
-    // Now we go from clusters to gapless extensions
-    funnel.stage("extend");
-#endif
+    if (track_provenance) {
+        // Now we go from clusters to gapless extensions
+        funnel.stage("extend");
+    }
     
     // These are the GaplessExtensions for all the clusters, in cluster_indexes_in_order order.
     vector<vector<GaplessExtension>> cluster_extensions;
@@ -300,9 +292,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         }
         num_extensions ++;
         
-#ifdef TRACK_PROVENANCE
-        funnel.processing_input(cluster_num);
-#endif
+        if (track_provenance) {
+            funnel.processing_input(cluster_num);
+        }
 
         vector<size_t>& cluster = clusters[cluster_num];
 
@@ -339,19 +331,19 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         }
         cluster_extensions.emplace_back(std::move(filtered_extensions));
         
-#ifdef TRACK_PROVENANCE
-        // Record with the funnel that the previous group became a group of this size.
-        // Don't bother recording the seed to extension matching...
-        funnel.project_group(cluster_num, cluster_extensions.back().size());
-        
-        // Say we finished with this cluster, for now.
-        funnel.processed_input();
-#endif
+        if (track_provenance) {
+            // Record with the funnel that the previous group became a group of this size.
+            // Don't bother recording the seed to extension matching...
+            funnel.project_group(cluster_num, cluster_extensions.back().size());
+            
+            // Say we finished with this cluster, for now.
+            funnel.processed_input();
+        }
     }
     
-#ifdef TRACK_PROVENANCE
-    funnel.substage("score");
-#endif
+    if (track_provenance) {
+        funnel.substage("score");
+    }
 
     // We now estimate the best possible alignment score for each cluster.
     vector<int> cluster_extension_scores;
@@ -359,19 +351,19 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     for (size_t i = 0; i < cluster_extensions.size(); i++) {
         // For each group of GaplessExtensions
         
-#ifdef TRACK_PROVENANCE
-        funnel.producing_output(i);
-#endif
+        if (track_provenance) {
+            funnel.producing_output(i);
+        }
         
         auto& extensions = cluster_extensions[i];
         // Count the matches suggested by the group and use that as a score.
         cluster_extension_scores.push_back(estimate_extension_group_score(aln, extensions));
         
-#ifdef TRACK_PROVENANCE
-        // Record the score with the funnel
-        funnel.score(i, cluster_extension_scores.back());
-        funnel.produced_output();
-#endif
+        if (track_provenance) {
+            // Record the score with the funnel
+            funnel.score(i, cluster_extension_scores.back());
+            funnel.produced_output();
+        }
     }
     
     // Now sort them by score
@@ -393,9 +385,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
                               cluster_extension_scores[extension_indexes_in_order[0]]
                                     - extension_set_score_threshold;
     
-#ifdef TRACK_PROVENANCE
-    funnel.stage("align");
-#endif
+    if (track_provenance) {
+        funnel.stage("align");
+    }
     
     // Now start the alignment step. Everything has to become an alignment.
 
@@ -418,9 +410,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         // Find the extension group we are talking about
         size_t& extension_num = extension_indexes_in_order[i];
         
-#ifdef TRACK_PROVENANCE
-        funnel.processing_input(extension_num);
-#endif
+        if (track_provenance) {
+            funnel.processing_input(extension_num);
+        }
 
         auto& extensions = cluster_extensions[extension_num];
         
@@ -435,9 +427,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
             if (extensions.size() == 1 && extensions[0].full()) {
                 // We got a full-length extension, so directly convert to an Alignment.
                 
-#ifdef TRACK_PROVENANCE
-                funnel.substage("direct");
-#endif
+                if (track_provenance) {
+                    funnel.substage("direct");
+                }
 
                 *out.mutable_path() = extensions.front().to_path(gbwt_graph, out.sequence());
                 
@@ -452,38 +444,37 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
                 out.set_score(alignment_score);
                 out.set_identity(identity);
                 
-#ifdef TRACK_PROVENANCE
-                // Stop the current substage
-                funnel.substage_stop();
-#endif
+                if (track_provenance) {
+                    // Stop the current substage
+                    funnel.substage_stop();
+                }
             } else if (do_chaining) {
                 // We need to do chaining.
                 
-#ifdef TRACK_PROVENANCE
-                funnel.substage("chain");
-#endif
+                if (track_provenance) {
+                    funnel.substage("chain");
+                }
                 
                 // Do the chaining and compute an alignment into out.
                 bool chain_success = chain_extended_seeds(aln, extensions, out);
                 
-#ifdef TRACK_PROVENANCE
-                // We're done chaining. Next alignment may not go through this substage.
-                funnel.substage_stop();
-#endif
+                if (track_provenance) {
+                    // We're done chaining. Next alignment may not go through this substage.
+                    funnel.substage_stop();
+                }
 
                 if (!chain_success) {
                     // We thought chaining would be too hard. Fall back on context extraction
                     
-#ifdef TRACK_PROVENANCE
-                    funnel.substage("context");
-#endif
+                    if (track_provenance) {
+                        funnel.substage("context");
+                    }
 
                     align_to_local_haplotypes(aln, extensions, out);
                  
-#ifdef TRACK_PROVENANCE
-                    funnel.substage_stop();
-#endif
-                
+                    if (track_provenance) {
+                        funnel.substage_stop();
+                    }
                 }
             } else {
                 // We would do chaining but it is disabled.
@@ -491,22 +482,22 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
             }
             
             
-#ifdef TRACK_PROVENANCE
-            // Record the Alignment and its score with the funnel
-            funnel.project(extension_num);
-            funnel.score(i, out.score());
-            
-            // We're done with this input item
-            funnel.processed_input();
-#endif
+            if (track_provenance) {
+                // Record the Alignment and its score with the funnel
+                funnel.project(extension_num);
+                funnel.score(i, out.score());
+                
+                // We're done with this input item
+                funnel.processed_input();
+            }
         } else {
             // If this score is insignificant, nothing past here is significant.
             // Don't do any more.
             
-#ifdef TRACK_PROVENANCE
-            funnel.kill_all(extension_indexes_in_order.begin() + i, extension_indexes_in_order.end());
-            funnel.processed_input();
-#endif
+            if (track_provenance) {
+                funnel.kill_all(extension_indexes_in_order.begin() + i, extension_indexes_in_order.end());
+                funnel.processed_input();
+            }
             
             break;
         }
@@ -516,10 +507,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         // Produce an unaligned Alignment
         alignments.emplace_back(aln);
         
-#ifdef TRACK_PROVENANCE
-        // Say it came from nowhere
-        funnel.introduce();
-#endif
+        if (track_provenance) {
+            // Say it came from nowhere
+            funnel.introduce();
+        }
     }
     
     // Order the Alignments by score
@@ -535,10 +526,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         return alignments[a].score() > alignments[b].score();
     });
     
-#ifdef TRACK_PROVENANCE
-    // Now say we are finding the winner(s)
-    funnel.stage("winner");
-#endif
+    if (track_provenance) {
+        // Now say we are finding the winner(s)
+        funnel.stage("winner");
+    }
     
     vector<Alignment> mappings;
     mappings.reserve(min(alignments_in_order.size(), max_multimaps));
@@ -547,21 +538,21 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         size_t& alignment_num = alignments_in_order[i];
         mappings.emplace_back(std::move(alignments[alignment_num]));
         
-#ifdef TRACK_PROVENANCE
-        // Tell the funnel
-        funnel.project(alignment_num);
-        funnel.score(alignment_num, mappings.back().score());
-#endif
+        if (track_provenance) {
+            // Tell the funnel
+            funnel.project(alignment_num);
+            funnel.score(alignment_num, mappings.back().score());
+        }
     }
 
-#ifdef TRACK_PROVENANCE
-    if (max_multimaps < alignments_in_order.size()) {
-        // Some things stop here
-        funnel.kill_all(alignments_in_order.begin() + max_multimaps, alignments_in_order.end());
+    if (track_provenance) {
+        if (max_multimaps < alignments_in_order.size()) {
+            // Some things stop here
+            funnel.kill_all(alignments_in_order.begin() + max_multimaps, alignments_in_order.end());
+        }
+        
+        funnel.substage("mapq");
     }
-    
-    funnel.substage("mapq");
-#endif
     
     // Grab all the scores for MAPQ computation.
     vector<double> scores;
@@ -590,9 +581,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     // Make sure to clamp 0-60.
     mappings.front().set_mapping_quality(max(min(mapq, 60.0), 0.0));
     
-#ifdef TRACK_PROVENANCE
-    funnel.substage_stop();
-#endif
+    if (track_provenance) {
+        funnel.substage_stop();
+    }
     
     for (size_t i = 0; i < mappings.size(); i++) {
         // For each output alignment in score order
@@ -605,18 +596,18 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     // Stop this alignment
     funnel.stop();
     
-#ifdef TRACK_PROVENANCE
+    if (track_provenance) {
     
-    // And with the number of results in play at each stage
-    funnel.for_each_stage([&](const string& stage, size_t result_count) {
-        set_annotation(mappings[0], "stage_" + stage + "_results", (double)result_count);
-    });
+        // And with the number of results in play at each stage
+        funnel.for_each_stage([&](const string& stage, size_t result_count) {
+            set_annotation(mappings[0], "stage_" + stage + "_results", (double)result_count);
+        });
 
-#ifdef TRACK_CORRECTNESS
-    // And with the last stage at which we had any descendants of the correct seed hit locations
-    set_annotation(mappings[0], "last_correct_stage", funnel.last_correct_stage());
-#endif
-#endif
+        if (track_correctness) {
+            // And with the last stage at which we had any descendants of the correct seed hit locations
+            set_annotation(mappings[0], "last_correct_stage", funnel.last_correct_stage());
+        }
+    }
     
     // Ship out all the aligned alignments
     alignment_emitter.emit_mapped_single(std::move(mappings));

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -82,7 +82,16 @@ public:
     bool linear_tails = false;
     string sample_name;
     string read_group;
+    
+    /// Track which internal work items came from which others during each
+    /// stage of the mapping algorithm.
+    bool track_provenance = false;
 
+
+    /// Guess which seed hits are correct by location in the linear reference
+    /// and track if/when their descendants make it through stages of the
+    /// algorithm. Only works if track_provenance is true.
+    bool track_correctness = false;
 
 protected:
     // These are our indexes

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -392,6 +392,11 @@ int main_gaffe(int argc, char** argv) {
         exit(1);
     }
     
+    if (track_correctness && xg_name.empty()) {
+        cerr << "error:[vg gaffe] Tracking correctness requires and XG index (-x)" << endl;
+        exit(1);
+    }
+    
     if (gbwt_name.empty()) {
         cerr << "error:[vg gaffe] Mapping requires a GBWT index (-H)" << endl;
         exit(1);

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -67,6 +67,8 @@ void help_gaffe(char** argv) {
     << "  -T, --max-tails INT           fall back on alignment to haplotypes when there are more than INT tails" << endl
     << "  -l, --linear-tails            align tails as individual linear alignments instead of POA trees" << endl
     << "  -X, --xdrop                   use xdrop alignment for tails" << endl
+    << "  --track-provenance            track how internal intermediate alignment candidates were arrived at" << endl
+    << "  --track-correctness           track if internal intermediate alignment candidates are correct (implies --track-provenance)" << endl
     << "  -t, --threads INT             number of compute threads to use" << endl;
 }
 
@@ -76,6 +78,9 @@ int main_gaffe(int argc, char** argv) {
         help_gaffe(argv);
         return 1;
     }
+
+    #define OPT_TRACK_PROVENANCE 1000
+    #define OPT_TRACK_CORRECTNESS 1001
 
     // initialize parameters with their default options
     string xg_name;
@@ -120,6 +125,10 @@ int main_gaffe(int argc, char** argv) {
     string read_group;
     // Should we throw out our alignments instead of outputting them?
     bool discard_alignments = false;
+    // Should we track candidate provenance?
+    bool track_provenance = false;
+    // Should we track candidate correctness?
+    bool track_correctness = false;
     
     vector<size_t> threads_to_run;
     
@@ -153,6 +162,8 @@ int main_gaffe(int argc, char** argv) {
             {"max-tails", required_argument, 0, 'T'},
             {"linear-tails", no_argument, 0, 'l'},
             {"xdrop", no_argument, 0, 'X'},
+            {"track-provenance", no_argument, 0, OPT_TRACK_PROVENANCE},
+            {"track-correctness", no_argument, 0, OPT_TRACK_CORRECTNESS},
             {"threads", required_argument, 0, 't'},
             {0, 0, 0, 0}
         };
@@ -333,6 +344,15 @@ int main_gaffe(int argc, char** argv) {
                 use_xdrop_for_tails = true;
                 break;
                 
+            case OPT_TRACK_PROVENANCE:
+                track_provenance = true;
+                break;
+            
+            case OPT_TRACK_CORRECTNESS:
+                track_provenance = true;
+                track_correctness = true;
+                break;
+                
             case 't':
             {
                 int num_threads = parse<int>(optarg);
@@ -481,6 +501,16 @@ int main_gaffe(int argc, char** argv) {
         cerr << "--xdrop " << use_xdrop_for_tails << endl;
     }
     minimizer_mapper.use_xdrop_for_tails = use_xdrop_for_tails;
+
+    if (progress) {
+        cerr << "--track-provenance " << track_provenance << endl;
+    }
+    minimizer_mapper.track_provenance = track_provenance;
+    
+    if (progress) {
+        cerr << "--track-correctness " << track_correctness << endl;
+    }
+    minimizer_mapper.track_correctness = track_correctness;
 
     minimizer_mapper.sample_name = sample_name;
     minimizer_mapper.read_group = read_group;

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -472,8 +472,8 @@ int main_gaffe(int argc, char** argv) {
     }
     minimizer_mapper.extension_set_score_threshold = extension_set;
 
-    if (progress) {
-        cerr << "--no-chaining " << (!do_chaining) << endl;
+    if (progress && !do_chaining) {
+        cerr << "--no-chaining " << endl;
     }
     minimizer_mapper.do_chaining = do_chaining;
 
@@ -492,23 +492,23 @@ int main_gaffe(int argc, char** argv) {
     }
     minimizer_mapper.max_tails = max_tails;
     
-    if (progress) {
-        cerr << "--linear-tails " << linear_tails << endl;
+    if (progress && linear_tails) {
+        cerr << "--linear-tails " << endl;
     }
     minimizer_mapper.linear_tails = linear_tails;
     
-    if (progress) {
-        cerr << "--xdrop " << use_xdrop_for_tails << endl;
+    if (progress && use_xdrop_for_tails) {
+        cerr << "--xdrop " << endl;
     }
     minimizer_mapper.use_xdrop_for_tails = use_xdrop_for_tails;
 
-    if (progress) {
-        cerr << "--track-provenance " << track_provenance << endl;
+    if (progress && track_provenance) {
+        cerr << "--track-provenance " << endl;
     }
     minimizer_mapper.track_provenance = track_provenance;
     
-    if (progress) {
-        cerr << "--track-correctness " << track_correctness << endl;
+    if (progress && track_correctness) {
+        cerr << "--track-correctness " << endl;
     }
     minimizer_mapper.track_correctness = track_correctness;
 


### PR DESCRIPTION
This replaces the `TRACK_CORRECTNESS` and `TRACK_PROVENANCE` defines in `minimizer_mapper.cpp` with `--track-correctness` and `--track-provenance` options to `vg gaffe`. Additionally, `--track-correctness` implies `--track-provenance`, so you don't need to specify both.

This should make debugging easier because we no longer have to rebuild to use these features. It should not slow things down too much; these are easily-predicted branches.