### PR TITLE
Reuse gbwt states

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -15,11 +15,6 @@
 #include <algorithm>
 #include <cmath>
 
-// Set this to track provenance of intermediate results
-//#define TRACK_PROVENANCE
-// With TRACK_PROVENANCE on, set this to track correctness, which requires some expensive XG queries
-//#define TRACK_CORRECTNESS
-
 namespace vg {
 
 using namespace std;
@@ -49,10 +44,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         aln.set_read_group(read_group);
     }
    
-#ifdef TRACK_PROVENANCE
-    // Start the minimizer finding stage
-    funnel.stage("minimizer");
-#endif
+    if (track_provenance) {
+        // Start the minimizer finding stage
+        funnel.stage("minimizer");
+    }
     
     // We will find all the seed hits
     vector<pos_t> seeds;
@@ -65,13 +60,13 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     // Find minimizers in the query
     minimizers = minimizer_index->minimizers(aln.sequence());
     
-#ifdef TRACK_PROVENANCE
-    // Record how many we found, as new lines.
-    funnel.introduce(minimizers.size());
-    
-    // Start the minimizer locating stage
-    funnel.stage("seed");
-#endif
+    if (track_provenance) {
+        // Record how many we found, as new lines.
+        funnel.introduce(minimizers.size());
+        
+        // Start the minimizer locating stage
+        funnel.stage("seed");
+    }
 
     // Compute minimizer scores for all minimizers as 1 + ln(hard_hit_cap) - ln(hits).
     std::vector<double> minimizer_score(minimizers.size(), 0.0);
@@ -104,10 +99,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     for (size_t i = 0; i < minimizers.size(); i++) {
         size_t minimizer_num = minimizers_in_order[i];
 
-#ifdef TRACK_PROVENANCE
-        // Say we're working on it
-        funnel.processing_input(minimizer_num);
-#endif
+        if (track_provenance) {
+            // Say we're working on it
+            funnel.processing_input(minimizer_num);
+        }
 
         // Select the minimizer if it is informative enough or if the total score
         // of the selected minimizers is not high enough.
@@ -127,66 +122,64 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
             }
             selected_score += minimizer_score[minimizer_num];
             
-#ifdef TRACK_PROVENANCE
-            // Record in the funnel that this minimizer gave rise to these seeds.
-            funnel.expand(minimizer_num, hits);
-#endif
+            if (track_provenance) {
+                // Record in the funnel that this minimizer gave rise to these seeds.
+                funnel.expand(minimizer_num, hits);
+            }
         } else {
             rejected_count++;
             
-#ifdef TRACK_PROVENANCE
-            // Record in the funnel thast we rejected it
-            funnel.kill(minimizer_num);
-#endif
+            if (track_provenance) {
+                // Record in the funnel thast we rejected it
+                funnel.kill(minimizer_num);
+            }
         }
         
-#ifdef TRACK_PROVENANCE
-        // Say we're done with this input item
-        funnel.processed_input();
-#endif
+        if (track_provenance) {
+            // Say we're done with this input item
+            funnel.processed_input();
+        }
     }
 
 
-#ifdef TRACK_PROVENANCE
-#ifdef TRACK_CORRECTNESS
-    // Tag seeds with correctness based on proximity along paths to the input read's refpos
-    funnel.substage("correct");
-    
-    if (aln.refpos_size() != 0) {
-        // Take the first refpos as the true position.
-        auto& true_pos = aln.refpos(0);
+    if (track_provenance && track_correctness) {
+        // Tag seeds with correctness based on proximity along paths to the input read's refpos
+        funnel.substage("correct");
         
-        for (size_t i = 0; i < seeds.size(); i++) {
-            // Find every seed's reference positions. This maps from path name to pairs of offset and orientation.
-            auto offsets = algorithms::nearest_offsets_in_paths(xg_index, seeds[i], 100);
-            for (auto& hit_pos : offsets[true_pos.name()]) {
-                // Look at all the ones on the path the read's true position is on.
-                if (abs((int64_t)hit_pos.first - (int64_t) true_pos.offset()) < 200) {
-                    // Call this seed hit close enough to be correct
-                    funnel.tag_correct(i);
+        if (aln.refpos_size() != 0) {
+            // Take the first refpos as the true position.
+            auto& true_pos = aln.refpos(0);
+            
+            for (size_t i = 0; i < seeds.size(); i++) {
+                // Find every seed's reference positions. This maps from path name to pairs of offset and orientation.
+                auto offsets = algorithms::nearest_offsets_in_paths(xg_index, seeds[i], 100);
+                for (auto& hit_pos : offsets[xg_index->get_path_handle(true_pos.name())]) {
+                    // Look at all the ones on the path the read's true position is on.
+                    if (abs((int64_t)hit_pos.first - (int64_t) true_pos.offset()) < 200) {
+                        // Call this seed hit close enough to be correct
+                        funnel.tag_correct(i);
+                    }
                 }
             }
         }
     }
-#endif
-#endif
         
 #ifdef debug
     cerr << "Read " << aln.name() << ": " << aln.sequence() << endl;
     cerr << "Found " << seeds.size() << " seeds from " << (minimizers.size() - rejected_count) << " minimizers, rejected " << rejected_count << endl;
 #endif
 
-#ifdef TRACK_PROVENANCE
-    // Begin the clustering stage
-    funnel.stage("cluster");
-#endif
+    if (track_provenance) {
+        // Begin the clustering stage
+        funnel.stage("cluster");
+    }
         
     // Cluster the seeds. Get sets of input seed indexes that go together.
     vector<vector<size_t>> clusters = clusterer.cluster_seeds(seeds, distance_limit);
     
-#ifdef TRACK_PROVENANCE
-    funnel.substage("score");
-#endif
+    if (track_provenance) {
+        funnel.substage("score");
+    }
 
     // Cluster score is the sum of minimizer scores.
     std::vector<double> cluster_score(clusters.size(), 0.0);
@@ -197,10 +190,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         // For each cluster
         auto& cluster = clusters[i];
         
-#ifdef TRACK_PROVENANCE
-        // Say we're making it
-        funnel.producing_output(i);
-#endif
+        if (track_provenance) {
+            // Say we're making it
+            funnel.producing_output(i);
+        }
 
         // Which minimizers are present in the cluster.
         vector<bool> present(minimizers.size(), false);
@@ -215,15 +208,14 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
             }
         }
         
-#ifdef TRACK_PROVENANCE
-        // Record the cluster in the funnel as a group of the size of the number of items.
-        funnel.merge_group(cluster.begin(), cluster.end());
-        funnel.score(funnel.latest(), cluster_score[i]);
-        
-        // Say we made it.
-        funnel.produced_output();
-#endif
-
+        if (track_provenance) {
+            // Record the cluster in the funnel as a group of the size of the number of items.
+            funnel.merge_group(cluster.begin(), cluster.end());
+            funnel.score(funnel.latest(), cluster_score[i]);
+            
+            // Say we made it.
+            funnel.produced_output();
+        }
 
         //TODO:
         //Get the cluster coverage
@@ -280,10 +272,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     double cluster_score_cutoff = cluster_score.size() == 0 ? 0 :
                     *std::max_element(cluster_score.begin(), cluster_score.end()) - cluster_score_threshold;
     
-#ifdef TRACK_PROVENANCE
-    // Now we go from clusters to gapless extensions
-    funnel.stage("extend");
-#endif
+    if (track_provenance) {
+        // Now we go from clusters to gapless extensions
+        funnel.stage("extend");
+    }
     
     // These are the GaplessExtensions for all the clusters, in cluster_indexes_in_order order.
     vector<vector<GaplessExtension>> cluster_extensions;
@@ -300,9 +292,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         }
         num_extensions ++;
         
-#ifdef TRACK_PROVENANCE
-        funnel.processing_input(cluster_num);
-#endif
+        if (track_provenance) {
+            funnel.processing_input(cluster_num);
+        }
 
         vector<size_t>& cluster = clusters[cluster_num];
 
@@ -339,19 +331,19 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         }
         cluster_extensions.emplace_back(std::move(filtered_extensions));
         
-#ifdef TRACK_PROVENANCE
-        // Record with the funnel that the previous group became a group of this size.
-        // Don't bother recording the seed to extension matching...
-        funnel.project_group(cluster_num, cluster_extensions.back().size());
-        
-        // Say we finished with this cluster, for now.
-        funnel.processed_input();
-#endif
+        if (track_provenance) {
+            // Record with the funnel that the previous group became a group of this size.
+            // Don't bother recording the seed to extension matching...
+            funnel.project_group(cluster_num, cluster_extensions.back().size());
+            
+            // Say we finished with this cluster, for now.
+            funnel.processed_input();
+        }
     }
     
-#ifdef TRACK_PROVENANCE
-    funnel.substage("score");
-#endif
+    if (track_provenance) {
+        funnel.substage("score");
+    }
 
     // We now estimate the best possible alignment score for each cluster.
     vector<int> cluster_extension_scores;
@@ -359,19 +351,19 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     for (size_t i = 0; i < cluster_extensions.size(); i++) {
         // For each group of GaplessExtensions
         
-#ifdef TRACK_PROVENANCE
-        funnel.producing_output(i);
-#endif
+        if (track_provenance) {
+            funnel.producing_output(i);
+        }
         
         auto& extensions = cluster_extensions[i];
         // Count the matches suggested by the group and use that as a score.
         cluster_extension_scores.push_back(estimate_extension_group_score(aln, extensions));
         
-#ifdef TRACK_PROVENANCE
-        // Record the score with the funnel
-        funnel.score(i, cluster_extension_scores.back());
-        funnel.produced_output();
-#endif
+        if (track_provenance) {
+            // Record the score with the funnel
+            funnel.score(i, cluster_extension_scores.back());
+            funnel.produced_output();
+        }
     }
     
     // Now sort them by score
@@ -393,9 +385,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
                               cluster_extension_scores[extension_indexes_in_order[0]]
                                     - extension_set_score_threshold;
     
-#ifdef TRACK_PROVENANCE
-    funnel.stage("align");
-#endif
+    if (track_provenance) {
+        funnel.stage("align");
+    }
     
     // Now start the alignment step. Everything has to become an alignment.
 
@@ -418,9 +410,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         // Find the extension group we are talking about
         size_t& extension_num = extension_indexes_in_order[i];
         
-#ifdef TRACK_PROVENANCE
-        funnel.processing_input(extension_num);
-#endif
+        if (track_provenance) {
+            funnel.processing_input(extension_num);
+        }
 
         auto& extensions = cluster_extensions[extension_num];
         
@@ -435,9 +427,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
             if (extensions.size() == 1 && extensions[0].full()) {
                 // We got a full-length extension, so directly convert to an Alignment.
                 
-#ifdef TRACK_PROVENANCE
-                funnel.substage("direct");
-#endif
+                if (track_provenance) {
+                    funnel.substage("direct");
+                }
 
                 *out.mutable_path() = extensions.front().to_path(gbwt_graph, out.sequence());
                 
@@ -452,38 +444,37 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
                 out.set_score(alignment_score);
                 out.set_identity(identity);
                 
-#ifdef TRACK_PROVENANCE
-                // Stop the current substage
-                funnel.substage_stop();
-#endif
+                if (track_provenance) {
+                    // Stop the current substage
+                    funnel.substage_stop();
+                }
             } else if (do_chaining) {
                 // We need to do chaining.
                 
-#ifdef TRACK_PROVENANCE
-                funnel.substage("chain");
-#endif
+                if (track_provenance) {
+                    funnel.substage("chain");
+                }
                 
                 // Do the chaining and compute an alignment into out.
                 bool chain_success = chain_extended_seeds(aln, extensions, out);
                 
-#ifdef TRACK_PROVENANCE
-                // We're done chaining. Next alignment may not go through this substage.
-                funnel.substage_stop();
-#endif
+                if (track_provenance) {
+                    // We're done chaining. Next alignment may not go through this substage.
+                    funnel.substage_stop();
+                }
 
                 if (!chain_success) {
                     // We thought chaining would be too hard. Fall back on context extraction
                     
-#ifdef TRACK_PROVENANCE
-                    funnel.substage("context");
-#endif
+                    if (track_provenance) {
+                        funnel.substage("context");
+                    }
 
                     align_to_local_haplotypes(aln, extensions, out);
                  
-#ifdef TRACK_PROVENANCE
-                    funnel.substage_stop();
-#endif
-                
+                    if (track_provenance) {
+                        funnel.substage_stop();
+                    }
                 }
             } else {
                 // We would do chaining but it is disabled.
@@ -491,22 +482,22 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
             }
             
             
-#ifdef TRACK_PROVENANCE
-            // Record the Alignment and its score with the funnel
-            funnel.project(extension_num);
-            funnel.score(i, out.score());
-            
-            // We're done with this input item
-            funnel.processed_input();
-#endif
+            if (track_provenance) {
+                // Record the Alignment and its score with the funnel
+                funnel.project(extension_num);
+                funnel.score(i, out.score());
+                
+                // We're done with this input item
+                funnel.processed_input();
+            }
         } else {
             // If this score is insignificant, nothing past here is significant.
             // Don't do any more.
             
-#ifdef TRACK_PROVENANCE
-            funnel.kill_all(extension_indexes_in_order.begin() + i, extension_indexes_in_order.end());
-            funnel.processed_input();
-#endif
+            if (track_provenance) {
+                funnel.kill_all(extension_indexes_in_order.begin() + i, extension_indexes_in_order.end());
+                funnel.processed_input();
+            }
             
             break;
         }
@@ -516,10 +507,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         // Produce an unaligned Alignment
         alignments.emplace_back(aln);
         
-#ifdef TRACK_PROVENANCE
-        // Say it came from nowhere
-        funnel.introduce();
-#endif
+        if (track_provenance) {
+            // Say it came from nowhere
+            funnel.introduce();
+        }
     }
     
     // Order the Alignments by score
@@ -535,10 +526,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         return alignments[a].score() > alignments[b].score();
     });
     
-#ifdef TRACK_PROVENANCE
-    // Now say we are finding the winner(s)
-    funnel.stage("winner");
-#endif
+    if (track_provenance) {
+        // Now say we are finding the winner(s)
+        funnel.stage("winner");
+    }
     
     vector<Alignment> mappings;
     mappings.reserve(min(alignments_in_order.size(), max_multimaps));
@@ -547,21 +538,21 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         size_t& alignment_num = alignments_in_order[i];
         mappings.emplace_back(std::move(alignments[alignment_num]));
         
-#ifdef TRACK_PROVENANCE
-        // Tell the funnel
-        funnel.project(alignment_num);
-        funnel.score(alignment_num, mappings.back().score());
-#endif
+        if (track_provenance) {
+            // Tell the funnel
+            funnel.project(alignment_num);
+            funnel.score(alignment_num, mappings.back().score());
+        }
     }
 
-#ifdef TRACK_PROVENANCE
-    if (max_multimaps < alignments_in_order.size()) {
-        // Some things stop here
-        funnel.kill_all(alignments_in_order.begin() + max_multimaps, alignments_in_order.end());
+    if (track_provenance) {
+        if (max_multimaps < alignments_in_order.size()) {
+            // Some things stop here
+            funnel.kill_all(alignments_in_order.begin() + max_multimaps, alignments_in_order.end());
+        }
+        
+        funnel.substage("mapq");
     }
-    
-    funnel.substage("mapq");
-#endif
     
     // Grab all the scores for MAPQ computation.
     vector<double> scores;
@@ -590,9 +581,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     // Make sure to clamp 0-60.
     mappings.front().set_mapping_quality(max(min(mapq, 60.0), 0.0));
     
-#ifdef TRACK_PROVENANCE
-    funnel.substage_stop();
-#endif
+    if (track_provenance) {
+        funnel.substage_stop();
+    }
     
     for (size_t i = 0; i < mappings.size(); i++) {
         // For each output alignment in score order
@@ -605,18 +596,18 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     // Stop this alignment
     funnel.stop();
     
-#ifdef TRACK_PROVENANCE
+    if (track_provenance) {
     
-    // And with the number of results in play at each stage
-    funnel.for_each_stage([&](const string& stage, size_t result_count) {
-        set_annotation(mappings[0], "stage_" + stage + "_results", (double)result_count);
-    });
+        // And with the number of results in play at each stage
+        funnel.for_each_stage([&](const string& stage, size_t result_count) {
+            set_annotation(mappings[0], "stage_" + stage + "_results", (double)result_count);
+        });
 
-#ifdef TRACK_CORRECTNESS
-    // And with the last stage at which we had any descendants of the correct seed hit locations
-    set_annotation(mappings[0], "last_correct_stage", funnel.last_correct_stage());
-#endif
-#endif
+        if (track_correctness) {
+            // And with the last stage at which we had any descendants of the correct seed hit locations
+            set_annotation(mappings[0], "last_correct_stage", funnel.last_correct_stage());
+        }
+    }
     
     // Ship out all the aligned alignments
     alignment_emitter.emit_mapped_single(std::move(mappings));

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -462,25 +462,11 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
                 }
                 
                 // Do the chaining and compute an alignment into out.
-                bool chain_success = chain_extended_seeds(aln, extensions, out);
+                chain_extended_seeds(aln, extensions, out);
                 
                 if (track_provenance) {
                     // We're done chaining. Next alignment may not go through this substage.
                     funnel.substage_stop();
-                }
-
-                if (!chain_success) {
-                    // We thought chaining would be too hard. Fall back on context extraction
-                    
-                    if (track_provenance) {
-                        funnel.substage("context");
-                    }
-
-                    align_to_local_haplotypes(aln, extensions, out);
-                 
-                    if (track_provenance) {
-                        funnel.substage_stop();
-                    }
                 }
             } else {
                 // We would do chaining but it is disabled.
@@ -778,7 +764,7 @@ bool MinimizerMapper::score_is_significant(int score_estimate, int best_score, i
     return false;
 }
 
-bool MinimizerMapper::chain_extended_seeds(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, Alignment& out) const {
+void MinimizerMapper::chain_extended_seeds(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, Alignment& out) const {
 
 #ifdef debug
     cerr << "Trying again to chain " << extended_seeds.size() << " extended seeds" << endl;
@@ -833,10 +819,6 @@ bool MinimizerMapper::chain_extended_seeds(const Alignment& aln, const vector<Ga
     
     assert(!source_extensions.empty());
     assert(!sink_extensions.empty());
-   
-    if (source_extensions.size() + sink_extensions.size() > max_tails) {
-        return false;
-    }
    
     // We're going to record source and sink path count distributions, for debugging
     vector<double> tail_path_counts;
@@ -1128,8 +1110,6 @@ bool MinimizerMapper::chain_extended_seeds(const Alignment& aln, const vector<Ga
     // Save all the tail alignment debugging statistics
     set_annotation(out, "tail_path_counts", tail_path_counts);
     set_annotation(out, "tail_lengths", tail_lengths);
-    
-    return true;
 }
 
 pair<Path, size_t> MinimizerMapper::get_best_alignment_against_any_path(const vector<Path>& paths,
@@ -1387,263 +1367,6 @@ pair<Path, size_t> MinimizerMapper::get_best_alignment_against_any_tree(const ve
     }
 
     return make_pair(best_path, best_score);
-}
-
-void MinimizerMapper::align_to_local_haplotypes(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, Alignment& out) const {
-    
-#ifdef debug
-    cerr << "Aligning to haplotypes" << endl;
-#endif
-    
-    // Find all the handles/nodes that are relevant.
-    // This holds handles on the strand visited by each relevant extension.
-    unordered_set<handle_t> start_points;
-    for (auto& extension : extended_seeds) {
-        for (auto& core_handle : extension.path) {
-            // Collect together all the handles that extensions touch
-            start_points.insert(core_handle);
-        }
-    }
-    
-    // Walk a stranded Dijkstra traversal the appropriate distance from all the starting points, both upstream and downstream. 
-    size_t distance_limit = aln.sequence().size() * 2;
-    
-#ifdef debug
-    cerr << "Search out " << distance_limit << " bp from " << start_points.size() << " handles" << endl;
-    for (auto& start : start_points) {
-        cerr << "\t" << gbwt_graph.get_id(start) << " " << gbwt_graph.get_is_reverse(start) << endl;
-    }
-#endif
-    
-    // We track the handles we get from the search.
-    unordered_set<handle_t> context;
-    
-    // When we reach something going left or right, mark it in the
-    // single-direction context and its ID in the total context.
-    auto reached_callback = [&](const handle_t& reached, size_t distance) -> bool {
-        if (distance > distance_limit) {
-            // We hit the limit, so stop the search.
-            return false;
-        }
-#ifdef debug
-        cerr << "\tAdd " << gbwt_graph.get_id(reached) << " " << gbwt_graph.get_is_reverse(reached) << " to context" << endl;
-#endif
-        context.insert(reached);
-        return true;
-    };
-    
-    // Do the right pass
-    algorithms::dijkstra(&gbwt_graph, start_points, reached_callback, false);
-    
-#ifdef debug
-    cerr << "Got right context of " << context.size() << endl;
-#endif
-    
-    // Pull out all the boundary nodes of the right-walking context graph that
-    // have contact with the outside world, or that have no edges.
-    // When looking for haplotypes, we have to walk left from them.
-    unordered_set<handle_t> right_boundaries;
-    for (auto& handle : context) {
-        // See if each handle has anything to its right that is not the context.
-        // If so, we stop early, and the handle is a boundary in the context graph.
-        bool is_enterable = false;
-        bool is_tip = true;
-        gbwt_graph.follow_edges(handle, false, [&](const handle_t& neighbor) {
-            is_tip = false;
-            if (!context.count(neighbor)) {
-                is_enterable = true;
-                return false;
-            }
-            return true;
-        });
-        
-        if (is_tip || is_enterable) {
-            right_boundaries.insert(handle);
-        }
-    }
-    context.clear();
-    
-#ifdef debug
-    cerr << "Got " << right_boundaries.size() << " right boundaries" << endl;
-    for (auto& boundary : right_boundaries) {
-        cerr << "\t" << gbwt_graph.get_id(boundary) << " " << gbwt_graph.get_is_reverse(boundary) << endl;
-    }
-#endif
-    
-    // And the left pass
-    algorithms::dijkstra(&gbwt_graph, start_points, reached_callback, true);
-
-#ifdef debug
-    cerr << "Got left context of " << context.size() << endl;
-#endif
-    
-    // Pull out all the boundary nodes of the left-walking context graph.
-    // When looking for haplotypes, we have to walk right from them.
-    unordered_set<handle_t> left_boundaries;
-    for (auto& handle : context) {
-        bool is_enterable = false;
-        bool is_tip = true;
-        gbwt_graph.follow_edges(handle, true, [&](const handle_t& neighbor) {
-            is_tip = false;
-            if (!context.count(neighbor)) {
-                is_enterable = true;
-                return false;
-            }
-            return true;
-        });
-        
-        if (is_tip || is_enterable) {
-            left_boundaries.insert(handle);
-        }
-    }
-    context.clear();
-    
-#ifdef debug
-    cerr << "Got " << left_boundaries.size() << " left boundaries" << endl;
-    for (auto& boundary : left_boundaries) {
-        cerr << "\t" << gbwt_graph.get_id(boundary) << " " << gbwt_graph.get_is_reverse(boundary) << endl;
-    }
-#endif
-    
-    // Now we have the left and right boundaries, so we can find the haplotypes.
-    vector<Path> haplotypes;
-    
-    for (auto& left_boundary : left_boundaries) {
-        // For each left boundary
-        
-        // Explore the GBWT forward until we hit a right boundary.
-        // We want to go until we hit the opposing boundary or run out of paths.
-        Position boundary_start = make_position(gbwt_graph.get_id(left_boundary), gbwt_graph.get_is_reverse(left_boundary), 0);
-        explore_gbwt(boundary_start, nullptr, numeric_limits<size_t>::max(), [&](const ImmutablePath& path_to, const handle_t& here) -> bool {
-            // When we actually touch something
-            
-#ifdef debug
-            cerr << "Visit " << gbwt_graph.get_id(here) << " " << gbwt_graph.get_is_reverse(here) << endl;
-#endif
-            
-            if (right_boundaries.count(here)) {
-                // This is a right boundary.
-                
-#ifdef debug
-                cerr << "\tReached right boundary" << endl;
-#endif
-                
-                // Complete the path
-                Mapping m;
-                m.mutable_position()->set_node_id(gbwt_graph.get_id(here));
-                m.mutable_position()->set_is_reverse(gbwt_graph.get_is_reverse(here));
-                Edit* e = m.add_edit();
-                e->set_from_length(gbwt_graph.get_length(here));
-                e->set_to_length(gbwt_graph.get_length(here));
-                
-                ImmutablePath path_through = path_to.push_front(m);
-                
-                // Convert to a Path and save
-                haplotypes.emplace_back(to_path(path_through));
-                
-                // Don't go past here
-                return false;
-                
-            } else {
-                // Keep going
-                return true;
-            }
-        }, [&](const ImmutablePath&) {
-            // When we hit the length limit or a dead end, do nothing.
-            
-#ifdef debug
-            cerr << "Ran out of distance or hit a dead end" << endl;
-#endif
-            
-        });
-        
-        // If we actually reach a boundary, that's a Path, so keep it
-    }
-    
-#ifdef debug
-    cerr << "Got " << haplotypes.size() << " haplotypes" << endl;
-#endif
-        
-    // Then if there are any remaining right boundaries, we don't actually care, because they aren't in haplotypes with any left boundaries.
-    // Nor do we care about left boundaries that couldn't get anywhere.
-    // Because they are boundaries, boundaries must be on some haplotype that exits the local graph region through them.
-    
-    // Align to each haplotype path we found
-    
-    // Track how much DP is done when operating on haplotypes
-    vector<double> haplotype_dp_areas;
-    
-    // Now look for the best alignment to any path.
-    // We set thid to ~-inf because we even want results with 0 score.
-    int64_t best_score = numeric_limits<int64_t>::min();
-    // we will store the winner in out's path, so set the rest of out's parameters.
-
-    for (auto& path : haplotypes) {
-        // For each path, make sure it isn't empty.
-        assert(path.mapping_size() > 0);
-
-        // Make a subgraph.
-        // TODO: don't copy the path
-        PathSubgraph subgraph(&gbwt_graph, path);
-        
-        // Do global alignment to the path subgraph
-        Alignment path_alignment;
-        path_alignment.set_sequence(aln.sequence());
-
-#ifdef debug
-        cerr << "Align " << pb2json(path_alignment) << " local";
-
-#ifdef debug_dump_graph
-        cerr << " vs:" << endl;
-        cerr << "Defining path: " << pb2json(path) << endl;
-        subgraph.for_each_handle([&](const handle_t& here) {
-            cerr << subgraph.get_id(here) << " len " << subgraph.get_length(here)
-                << " (" << subgraph.get_sequence(here) << "): " << endl;
-            subgraph.follow_edges(here, true, [&](const handle_t& there) {
-                cerr << "\t" << subgraph.get_id(there) << " len " << subgraph.get_length(there)
-                    << " (" << subgraph.get_sequence(there) << ") ->" << endl;
-            });
-            subgraph.follow_edges(here, false, [&](const handle_t& there) {
-                cerr << "\t-> " << subgraph.get_id(there) << " len " << subgraph.get_length(there)
-                    << " (" << subgraph.get_sequence(there) << ")" << endl;
-            });
-        });
-#else
-        cerr << endl;
-#endif
-#endif
-
-        // Do a local alignment with traceback but no score matrix printing.
-        get_regular_aligner()->align(path_alignment, subgraph, true, false);
-        
-#ifdef debug
-        cerr << "\tScore: " << path_alignment.score() << endl;
-#endif
-
-        if (path_alignment.score() > best_score) {
-            // This is a new best alignment. Translate from subgraph into base graph and keep it
-            *out.mutable_path() = subgraph.translate_down(path_alignment.path());
-            
-            // Preserve the identity and score too.
-            out.set_identity(path_alignment.identity());
-            out.set_score(path_alignment.score());
-#ifdef debug
-            cerr << "\tNew best: " << pb2json(path_alignment) << endl;
-#endif
-            
-            best_score = path_alignment.score();
-        }
-        
-        // Record how much DP we did.
-        haplotype_dp_areas.push_back(path_alignment.sequence().size() * path_from_length(path));
-    }
-    
-    // Now the best alignment from any path is in out.
-    
-    // Annotate it with how many paths we had to align it against.
-    set_annotation(out, "haplotype_alignment_paths", (double)haplotypes.size());
-    // And how much area we did
-    set_annotation(out, "haplotype_dp_areas", haplotype_dp_areas);
 }
 
 unordered_map<size_t, unordered_map<size_t, vector<Path>>>

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -82,7 +82,16 @@ public:
     bool linear_tails = false;
     string sample_name;
     string read_group;
+    
+    /// Track which internal work items came from which others during each
+    /// stage of the mapping algorithm.
+    bool track_provenance = false;
 
+
+    /// Guess which seed hits are correct by location in the linear reference
+    /// and track if/when their descendants make it through stages of the
+    /// algorithm. Only works if track_provenance is true.
+    bool track_correctness = false;
 
 protected:
     // These are our indexes

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -78,7 +78,7 @@ public:
     size_t max_multimaps = 1;
     size_t distance_limit = 1000;
     bool do_chaining = true;
-    bool use_xdrop_for_tails = false;
+    bool use_xdrop_for_tails = true;
     bool linear_tails = false;
     /// Use GBWT states from extensions to seed connectivity and tail searches.
     bool reuse_gbwt_states = false;

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -81,6 +81,8 @@ public:
     size_t max_tails = numeric_limits<size_t>::max();
     bool use_xdrop_for_tails = false;
     bool linear_tails = false;
+    /// Use GBWT states from extensions to seed connectivity and tail searches.
+    bool reuse_gbwt_states = false;
     string sample_name;
     string read_group;
     
@@ -88,12 +90,11 @@ public:
     /// stage of the mapping algorithm.
     bool track_provenance = false;
 
-
     /// Guess which seed hits are correct by location in the linear reference
     /// and track if/when their descendants make it through stages of the
     /// algorithm. Only works if track_provenance is true.
     bool track_correctness = false;
-
+    
 protected:
     // These are our indexes
     const XG* xg_index; // Can be nullptr; only needed for correctness tracking.
@@ -248,6 +249,10 @@ protected:
      * Given a Position, explore the GBWT graph out to the given maximum walk
      * distance.
      *
+     * If from_state is not null, uses that starting GBWT search state, which
+     * must be on the node that from is on and facking in the same orientation
+     * as from.
+     *
      * Calls the visit callback with the list of Mappings being extended (in
      * reverse order) and the handle it is being extended with.
      *
@@ -262,7 +267,8 @@ protected:
      * hit, calls the limit callback with the list of Mappings (in reverse
      * order) that passed the limit or hit the dead end.
      */
-    void explore_gbwt(const Position& from, size_t walk_distance, 
+    void explore_gbwt(const Position& from, const gbwt::SearchState* from_state, 
+        size_t walk_distance, 
         const function<bool(const ImmutablePath&, const handle_t&)>& visit_callback,
         const function<void(const ImmutablePath&)>& limit_callback) const;
         
@@ -270,7 +276,8 @@ protected:
      * The same as explore_gbwt on a Position, but takes a handle in the
      * backing gbwt_graph and an offset from the start of the handle instead.
      */
-    void explore_gbwt(handle_t from_handle, size_t from_offset, size_t walk_distance,
+    void explore_gbwt(handle_t from_handle, size_t from_offset, const gbwt::SearchState* from_state,
+        size_t walk_distance,
         const function<bool(const ImmutablePath&, const handle_t&)>& visit_callback,
         const function<void(const ImmutablePath&)>& limit_callback) const;
     

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -78,7 +78,6 @@ public:
     size_t max_multimaps = 1;
     size_t distance_limit = 1000;
     bool do_chaining = true;
-    size_t max_tails = numeric_limits<size_t>::max();
     bool use_xdrop_for_tails = false;
     bool linear_tails = false;
     /// Use GBWT states from extensions to seed connectivity and tail searches.
@@ -128,18 +127,8 @@ protected:
      * Operating on the given input alignment, chain together the given
      * extended perfect-match seeds and produce an alignment into the given
      * output Alignment object.
-     *
-     * Returns true if successful, or false if too much DP work would be
-     * involved and a fallback approach should be used.
      */
-    bool chain_extended_seeds(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, Alignment& out) const; 
-    
-    /**
-     * Operating on the given input alignment, extract the haplotypes around
-     * the given extended perfect-match seeds and produce the best
-     * haplotype-consistent alignment into the given output Alignment object.
-     */
-    void align_to_local_haplotypes(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, Alignment& out) const;
+    void chain_extended_seeds(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, Alignment& out) const; 
     
     /**
      * Find for each pair of extended seeds all the haplotype-consistent graph

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -81,7 +81,7 @@ public:
     bool use_xdrop_for_tails = true;
     bool linear_tails = false;
     /// Use GBWT states from extensions to seed connectivity and tail searches.
-    bool reuse_gbwt_states = false;
+    bool reuse_gbwt_states = true;
     string sample_name;
     string read_group;
     

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -63,10 +63,10 @@ void help_gaffe(char** argv) {
     << "  -s, --cluster-score INT       only extend clusters if they are within cluster-score of the best score" << endl
     << "  -u, --cluster-coverage FLOAT  only extend clusters if they are within cluster-coverage of the best read coverage" << endl
     << "  -v, --extension-score INT     only align extensions if their score is within extension-score of the best score" << endl
-    << "  -w, --extension-set INT     only align extension sets if their score is within extension-set of the best score" << endl
+    << "  -w, --extension-set INT       only align extension sets if their score is within extension-set of the best score" << endl
     << "  -O, --no-chaining             disable seed chaining and all gapped alignment" << endl
     << "  -l, --linear-tails            align tails as individual linear alignments instead of POA trees" << endl
-    << "  -X, --xdrop                   use xdrop alignment for tails" << endl
+    << "  -S, --gssw                    use GSSW alignment for tails instead of xdrop" << endl
     << "  --reuse-gbwt-states           use GBWT search states from gapless extensions to seed conenctivity and tail searches" << endl
     << "  --track-provenance            track how internal intermediate alignment candidates were arrived at" << endl
     << "  --track-correctness           track if internal intermediate alignment candidates are correct (implies --track-provenance)" << endl
@@ -102,7 +102,7 @@ int main_gaffe(int argc, char** argv) {
     // Should we do individual linear tail alignments instead of tree-shaped ones?
     bool linear_tails = false;
     // Should we use the xdrop aligner for aligning tails?
-    bool use_xdrop_for_tails = false;
+    bool use_xdrop_for_tails = true;
     // Should we re-use GBWT search states?
     bool reuse_gbwt_states = false;
     // What GAMs should we realign?
@@ -166,7 +166,7 @@ int main_gaffe(int argc, char** argv) {
             {"score-fraction", required_argument, 0, 'F'},
             {"no-chaining", no_argument, 0, 'O'},
             {"linear-tails", no_argument, 0, 'l'},
-            {"xdrop", no_argument, 0, 'X'},
+            {"gssw", no_argument, 0, 'S'},
             {"reuse-gbwt-states", no_argument, 0, OPT_REUSE_GBWT_STATES},
             {"track-provenance", no_argument, 0, OPT_TRACK_PROVENANCE},
             {"track-correctness", no_argument, 0, OPT_TRACK_CORRECTNESS},
@@ -175,7 +175,7 @@ int main_gaffe(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:H:m:s:d:pG:f:M:N:R:nc:C:F:e:a:s:u:v:w:OlXt:",
+        c = getopt_long (argc, argv, "hx:g:H:m:s:d:pG:f:M:N:R:nc:C:F:e:a:s:u:v:w:OlSt:",
                          long_options, &option_index);
 
 
@@ -350,8 +350,8 @@ int main_gaffe(int argc, char** argv) {
                 linear_tails = true;
                 break;
                 
-            case 'X':
-                use_xdrop_for_tails = true;
+            case 'S':
+                use_xdrop_for_tails = false;
                 break;
                 
             case OPT_REUSE_GBWT_STATES:
@@ -525,8 +525,8 @@ int main_gaffe(int argc, char** argv) {
     }
     minimizer_mapper.linear_tails = linear_tails;
     
-    if (progress && use_xdrop_for_tails) {
-        cerr << "--xdrop " << endl;
+    if (progress && !use_xdrop_for_tails) {
+        cerr << "--gssw " << endl;
     }
     minimizer_mapper.use_xdrop_for_tails = use_xdrop_for_tails;
     

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -65,7 +65,6 @@ void help_gaffe(char** argv) {
     << "  -v, --extension-score INT     only align extensions if their score is within extension-score of the best score" << endl
     << "  -w, --extension-set INT     only align extension sets if their score is within extension-set of the best score" << endl
     << "  -O, --no-chaining             disable seed chaining and all gapped alignment" << endl
-    << "  -T, --max-tails INT           fall back on alignment to haplotypes when there are more than INT tails" << endl
     << "  -l, --linear-tails            align tails as individual linear alignments instead of POA trees" << endl
     << "  -X, --xdrop                   use xdrop alignment for tails" << endl
     << "  --reuse-gbwt-states           use GBWT search states from gapless extensions to seed conenctivity and tail searches" << endl
@@ -100,8 +99,6 @@ int main_gaffe(int argc, char** argv) {
     bool progress = false;
     // Should we try chaining or just give up if we can't find a full length gapless alignment?
     bool do_chaining = true;
-    // How many tails should we tolerate
-    size_t max_tails = numeric_limits<size_t>::max();
     // Should we do individual linear tail alignments instead of tree-shaped ones?
     bool linear_tails = false;
     // Should we use the xdrop aligner for aligning tails?
@@ -168,7 +165,6 @@ int main_gaffe(int argc, char** argv) {
             {"extension-set", required_argument, 0, 'w'},
             {"score-fraction", required_argument, 0, 'F'},
             {"no-chaining", no_argument, 0, 'O'},
-            {"max-tails", required_argument, 0, 'T'},
             {"linear-tails", no_argument, 0, 'l'},
             {"xdrop", no_argument, 0, 'X'},
             {"reuse-gbwt-states", no_argument, 0, OPT_REUSE_GBWT_STATES},
@@ -179,7 +175,7 @@ int main_gaffe(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:H:m:s:d:pG:f:M:N:R:nc:C:F:e:a:s:u:v:w:OT:lXt:",
+        c = getopt_long (argc, argv, "hx:g:H:m:s:d:pG:f:M:N:R:nc:C:F:e:a:s:u:v:w:OlXt:",
                          long_options, &option_index);
 
 
@@ -348,10 +344,6 @@ int main_gaffe(int argc, char** argv) {
                 break;
             case 'O':
                 do_chaining = false;
-                break;
-                
-            case 'T':
-                max_tails = parse<size_t>(optarg);
                 break;
                 
             case 'l':
@@ -527,11 +519,6 @@ int main_gaffe(int argc, char** argv) {
         cerr << "--distance-limit " << distance_limit << endl;
     }
     minimizer_mapper.distance_limit = distance_limit;
-    
-    if (progress) {
-        cerr << "--max-tails " << max_tails << endl;
-    }
-    minimizer_mapper.max_tails = max_tails;
     
     if (progress && linear_tails) {
         cerr << "--linear-tails " << endl;

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -68,6 +68,7 @@ void help_gaffe(char** argv) {
     << "  -T, --max-tails INT           fall back on alignment to haplotypes when there are more than INT tails" << endl
     << "  -l, --linear-tails            align tails as individual linear alignments instead of POA trees" << endl
     << "  -X, --xdrop                   use xdrop alignment for tails" << endl
+    << "  --reuse-gbwt-states           use GBWT search states from gapless extensions to seed conenctivity and tail searches" << endl
     << "  --track-provenance            track how internal intermediate alignment candidates were arrived at" << endl
     << "  --track-correctness           track if internal intermediate alignment candidates are correct (implies --track-provenance)" << endl
     << "  -t, --threads INT             number of compute threads to use" << endl;
@@ -82,8 +83,9 @@ int main_gaffe(int argc, char** argv) {
         return 1;
     }
 
-    #define OPT_TRACK_PROVENANCE 1000
-    #define OPT_TRACK_CORRECTNESS 1001
+    #define OPT_REUSE_GBWT_STATES 1000
+    #define OPT_TRACK_PROVENANCE 1001
+    #define OPT_TRACK_CORRECTNESS 1002
 
     // initialize parameters with their default options
     string xg_name;
@@ -102,8 +104,10 @@ int main_gaffe(int argc, char** argv) {
     size_t max_tails = numeric_limits<size_t>::max();
     // Should we do individual linear tail alignments instead of tree-shaped ones?
     bool linear_tails = false;
-    // Whould we use the xdrop aligner for aligning tails?
+    // Should we use the xdrop aligner for aligning tails?
     bool use_xdrop_for_tails = false;
+    // Should we re-use GBWT search states?
+    bool reuse_gbwt_states = false;
     // What GAMs should we realign?
     vector<string> gam_filenames;
     // What FASTQs should we align.
@@ -167,6 +171,7 @@ int main_gaffe(int argc, char** argv) {
             {"max-tails", required_argument, 0, 'T'},
             {"linear-tails", no_argument, 0, 'l'},
             {"xdrop", no_argument, 0, 'X'},
+            {"reuse-gbwt-states", no_argument, 0, OPT_REUSE_GBWT_STATES},
             {"track-provenance", no_argument, 0, OPT_TRACK_PROVENANCE},
             {"track-correctness", no_argument, 0, OPT_TRACK_CORRECTNESS},
             {"threads", required_argument, 0, 't'},
@@ -357,6 +362,10 @@ int main_gaffe(int argc, char** argv) {
                 use_xdrop_for_tails = true;
                 break;
                 
+            case OPT_REUSE_GBWT_STATES:
+                reuse_gbwt_states = true;
+                break;
+                
             case OPT_TRACK_PROVENANCE:
                 track_provenance = true;
                 break;
@@ -533,6 +542,11 @@ int main_gaffe(int argc, char** argv) {
         cerr << "--xdrop " << endl;
     }
     minimizer_mapper.use_xdrop_for_tails = use_xdrop_for_tails;
+    
+    if (progress && reuse_gbwt_states) {
+        cerr << "--reuse-gbwt-states" << endl;
+    }
+    minimizer_mapper.reuse_gbwt_states = reuse_gbwt_states;
 
     if (progress && track_provenance) {
         cerr << "--track-provenance " << endl;

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -67,7 +67,7 @@ void help_gaffe(char** argv) {
     << "  -O, --no-chaining             disable seed chaining and all gapped alignment" << endl
     << "  -l, --linear-tails            align tails as individual linear alignments instead of POA trees" << endl
     << "  -S, --gssw                    use GSSW alignment for tails instead of xdrop" << endl
-    << "  --reuse-gbwt-states           use GBWT search states from gapless extensions to seed conenctivity and tail searches" << endl
+    << "  --discard-gbwt-states         rebuild fresh GBWT search states for conenctivity and tail searches" << endl
     << "  --track-provenance            track how internal intermediate alignment candidates were arrived at" << endl
     << "  --track-correctness           track if internal intermediate alignment candidates are correct (implies --track-provenance)" << endl
     << "  -t, --threads INT             number of compute threads to use" << endl;
@@ -82,7 +82,7 @@ int main_gaffe(int argc, char** argv) {
         return 1;
     }
 
-    #define OPT_REUSE_GBWT_STATES 1000
+    #define OPT_DISCARD_GBWT_STATES 1000
     #define OPT_TRACK_PROVENANCE 1001
     #define OPT_TRACK_CORRECTNESS 1002
 
@@ -103,8 +103,8 @@ int main_gaffe(int argc, char** argv) {
     bool linear_tails = false;
     // Should we use the xdrop aligner for aligning tails?
     bool use_xdrop_for_tails = true;
-    // Should we re-use GBWT search states?
-    bool reuse_gbwt_states = false;
+    // Should we discard GBWT search states?
+    bool discard_gbwt_states = false;
     // What GAMs should we realign?
     vector<string> gam_filenames;
     // What FASTQs should we align.
@@ -167,7 +167,7 @@ int main_gaffe(int argc, char** argv) {
             {"no-chaining", no_argument, 0, 'O'},
             {"linear-tails", no_argument, 0, 'l'},
             {"gssw", no_argument, 0, 'S'},
-            {"reuse-gbwt-states", no_argument, 0, OPT_REUSE_GBWT_STATES},
+            {"discard-gbwt-states", no_argument, 0, OPT_DISCARD_GBWT_STATES},
             {"track-provenance", no_argument, 0, OPT_TRACK_PROVENANCE},
             {"track-correctness", no_argument, 0, OPT_TRACK_CORRECTNESS},
             {"threads", required_argument, 0, 't'},
@@ -354,8 +354,8 @@ int main_gaffe(int argc, char** argv) {
                 use_xdrop_for_tails = false;
                 break;
                 
-            case OPT_REUSE_GBWT_STATES:
-                reuse_gbwt_states = true;
+            case OPT_DISCARD_GBWT_STATES:
+                discard_gbwt_states = true;
                 break;
                 
             case OPT_TRACK_PROVENANCE:
@@ -530,10 +530,10 @@ int main_gaffe(int argc, char** argv) {
     }
     minimizer_mapper.use_xdrop_for_tails = use_xdrop_for_tails;
     
-    if (progress && reuse_gbwt_states) {
-        cerr << "--reuse-gbwt-states" << endl;
+    if (progress && discard_gbwt_states) {
+        cerr << "--discard-gbwt-states" << endl;
     }
-    minimizer_mapper.reuse_gbwt_states = reuse_gbwt_states;
+    minimizer_mapper.reuse_gbwt_states = !discard_gbwt_states;
 
     if (progress && track_provenance) {
         cerr << "--track-provenance " << endl;

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -392,6 +392,11 @@ int main_gaffe(int argc, char** argv) {
         exit(1);
     }
     
+    if (track_correctness && xg_name.empty()) {
+        cerr << "error:[vg gaffe] Tracking correctness requires and XG index (-x)" << endl;
+        exit(1);
+    }
+    
     if (gbwt_name.empty()) {
         cerr << "error:[vg gaffe] Mapping requires a GBWT index (-H)" << endl;
         exit(1);

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -67,6 +67,8 @@ void help_gaffe(char** argv) {
     << "  -T, --max-tails INT           fall back on alignment to haplotypes when there are more than INT tails" << endl
     << "  -l, --linear-tails            align tails as individual linear alignments instead of POA trees" << endl
     << "  -X, --xdrop                   use xdrop alignment for tails" << endl
+    << "  --track-provenance            track how internal intermediate alignment candidates were arrived at" << endl
+    << "  --track-correctness           track if internal intermediate alignment candidates are correct (implies --track-provenance)" << endl
     << "  -t, --threads INT             number of compute threads to use" << endl;
 }
 
@@ -76,6 +78,9 @@ int main_gaffe(int argc, char** argv) {
         help_gaffe(argv);
         return 1;
     }
+
+    #define OPT_TRACK_PROVENANCE 1000
+    #define OPT_TRACK_CORRECTNESS 1001
 
     // initialize parameters with their default options
     string xg_name;
@@ -120,6 +125,10 @@ int main_gaffe(int argc, char** argv) {
     string read_group;
     // Should we throw out our alignments instead of outputting them?
     bool discard_alignments = false;
+    // Should we track candidate provenance?
+    bool track_provenance = false;
+    // Should we track candidate correctness?
+    bool track_correctness = false;
     
     vector<size_t> threads_to_run;
     
@@ -153,6 +162,8 @@ int main_gaffe(int argc, char** argv) {
             {"max-tails", required_argument, 0, 'T'},
             {"linear-tails", no_argument, 0, 'l'},
             {"xdrop", no_argument, 0, 'X'},
+            {"track-provenance", no_argument, 0, OPT_TRACK_PROVENANCE},
+            {"track-correctness", no_argument, 0, OPT_TRACK_CORRECTNESS},
             {"threads", required_argument, 0, 't'},
             {0, 0, 0, 0}
         };
@@ -333,6 +344,15 @@ int main_gaffe(int argc, char** argv) {
                 use_xdrop_for_tails = true;
                 break;
                 
+            case OPT_TRACK_PROVENANCE:
+                track_provenance = true;
+                break;
+            
+            case OPT_TRACK_CORRECTNESS:
+                track_provenance = true;
+                track_correctness = true;
+                break;
+                
             case 't':
             {
                 int num_threads = parse<int>(optarg);
@@ -481,6 +501,16 @@ int main_gaffe(int argc, char** argv) {
         cerr << "--xdrop " << use_xdrop_for_tails << endl;
     }
     minimizer_mapper.use_xdrop_for_tails = use_xdrop_for_tails;
+
+    if (progress) {
+        cerr << "--track-provenance " << track_provenance << endl;
+    }
+    minimizer_mapper.track_provenance = track_provenance;
+    
+    if (progress) {
+        cerr << "--track-correctness " << track_correctness << endl;
+    }
+    minimizer_mapper.track_correctness = track_correctness;
 
     minimizer_mapper.sample_name = sample_name;
     minimizer_mapper.read_group = read_group;

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -472,8 +472,8 @@ int main_gaffe(int argc, char** argv) {
     }
     minimizer_mapper.extension_set_score_threshold = extension_set;
 
-    if (progress) {
-        cerr << "--no-chaining " << (!do_chaining) << endl;
+    if (progress && !do_chaining) {
+        cerr << "--no-chaining " << endl;
     }
     minimizer_mapper.do_chaining = do_chaining;
 
@@ -492,23 +492,23 @@ int main_gaffe(int argc, char** argv) {
     }
     minimizer_mapper.max_tails = max_tails;
     
-    if (progress) {
-        cerr << "--linear-tails " << linear_tails << endl;
+    if (progress && linear_tails) {
+        cerr << "--linear-tails " << endl;
     }
     minimizer_mapper.linear_tails = linear_tails;
     
-    if (progress) {
-        cerr << "--xdrop " << use_xdrop_for_tails << endl;
+    if (progress && use_xdrop_for_tails) {
+        cerr << "--xdrop " << endl;
     }
     minimizer_mapper.use_xdrop_for_tails = use_xdrop_for_tails;
 
-    if (progress) {
-        cerr << "--track-provenance " << track_provenance << endl;
+    if (progress && track_provenance) {
+        cerr << "--track-provenance " << endl;
     }
     minimizer_mapper.track_provenance = track_provenance;
     
-    if (progress) {
-        cerr << "--track-correctness " << track_correctness << endl;
+    if (progress && track_correctness) {
+        cerr << "--track-correctness " << endl;
     }
     minimizer_mapper.track_correctness = track_correctness;
 


### PR DESCRIPTION
This gives us an ~10% performance boost on top of using xdrop and @xchang1's parameter set, by re-using the GBWT search states from the gapless extensions when computing the connecting and tail paths. I have seen no change in accuracy.

This makes xdrop and GBWT search state re-use the default parameters.

Also, I am ripping out the fallback linear alignment to local haplotypes system, because it never seemed to be a net benefit to use.

This is based on top of #2351.