### PR TITLE
Giraffe wrangler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -107,3 +107,6 @@
 	path = deps/sglib
 	url = https://github.com/vgteam/sglib.git
 	branch = master
+[submodule "deps/FlameGraph"]
+	path = deps/FlameGraph
+	url = https://github.com/brendangregg/FlameGraph

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -85,9 +85,18 @@ BWA_DOUBLE_TIME="$(cat "${WORK}/bwa-log-double.txt" | grep "Real time:" | sed 's
 
 BWA_RPS="$(echo "${REAL_READ_COUNT} / (${BWA_DOUBLE_TIME} - ${BWA_TIME})" | bc -l)"
 
+if which perf 2>/dev/null ; then
+    # Record profile
+    perf record -F 100 --call-graph dwarf -o "${WORK}/perf.data"  vg gaffe -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -f "${REAL_FASTQ}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/perf.gam"
+    mv "${WORK}/perf.data" ./pref.data
+    echo "Profiling information saved as ./perf.data"
+fi
+
 # Print the report
 echo "Giraffe got ${CORRECT_COUNT} simulated reads correct with ${MEAN_IDENTITY} average identity"
 echo "Giraffe aligned real reads at ${GIRAFFE_RPS} reads/second vs. bwa-mem's ${BWA_RPS} reads/second"
+
+
 
 rm -Rf "${WORK}"
 

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -88,8 +88,13 @@ BWA_RPS="$(echo "${REAL_READ_COUNT} / (${BWA_DOUBLE_TIME} - ${BWA_TIME})" | bc -
 if which perf 2>/dev/null ; then
     # Record profile
     perf record -F 100 --call-graph dwarf -o "${WORK}/perf.data"  vg gaffe -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -f "${REAL_FASTQ}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/perf.gam"
+    perf script -i "${WORK}/perf.data" >"${WORK}/out.perf"
+    deps/FlameGraph/stackcollapse-perf.pl "${WORK}/out.perf" >"${WORK}/out.folded"
+    deps/FlameGraph/flamegraph.pl "${WORK}/out.folded" > "${WORK}/profile.svg"
     mv "${WORK}/perf.data" ./pref.data
+    mv "${WORK}/profile.svg" ./profile.svg
     echo "Profiling information saved as ./perf.data"
+    echo "Interactive flame graph saved as ./profile.svg"
 fi
 
 # Print the report

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# giraffe-wrangler.sh: Run and profile vg gaffe and analyze the results.
+
+set -e
+
+usage() {
+    # Print usage to stderr
+    exec 1>&2
+    printf "Usage: $0 [Options] FASTA XG_INDEX GBWT_INDEX MINIMIZER_INDEX DISTANCE_INDEX SIM_GAM REAL_FASTQ \n"
+    printf "Options:\n\n"
+    exit 1
+}
+
+while getopts "" o; do
+    case "${o}" in
+        *)
+            usage
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+if [[ "$#" -lt "7" ]]; then
+    # Too few arguments
+    usage
+fi
+
+FASTA="${1}"
+shift
+XG_INDEX="${1}"
+shift
+GBWT_INDEX="${1}"
+shift
+MINIMIZER_INDEX="${1}"
+shift
+DISTANCE_INDEX="${1}"
+shift
+SIM_GAM="${1}"
+shift
+REAL_FASTQ="${1}"
+shift
+
+# Define the Giraffe parameters
+GIRAFFE_OPTS=(-s75 -u 0.1 -v 25 -w 5 -C 600)
+# And the thread count for everyone
+THREAD_COUNT=32
+
+# Define a work directory
+# TODO: this requires GNU mptemp
+WORK="$(mktemp -d)"
+
+# Run simulated reads
+vg gaffe -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -G "${SIM_GAM}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/mapped.gam"
+
+# Annotate and compare against truth
+vg annotate -p -x "${XG_INDEX}" -a "${WORK}/mapped.gam" >"${WORK}/annotated.gam"
+
+# GAM compare against truth. Use gamcompare to count correct reads to save a JSON scan.
+CORRECT_COUNT="$(vg gamcompare -r 100 "${WORK}/annotated.gam" "${SIM_GAM}" 2>&1 >/dev/null | sed 's/[^0-9]//g')"
+
+# Compute identity
+MEAN_IDENTITY="$(vg view -aj "${WORK}/mapped.gam" | jq -c '.identity' | awk '{x+=$1} END {print x/NR}')"
+
+# TODO: Compute loss stages
+
+# Now do the real reads
+
+# Get RPS
+vg gaffe -p -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -f "${REAL_FASTQ}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/real.gam" 2>"${WORK}/log.txt"
+
+GIRAFFE_RPS="$(cat "${WORK}/log.txt" | grep "reads per second" | sed 's/[^0-9.]//g')"
+
+# Get RPS for bwa-mem
+REAL_READ_COUNT="$(cat "${REAL_FASTQ}" | wc -l)"
+((REAL_READ_COUNT /= 4))
+
+bwa mem -t "${THREAD_COUNT}" "${FASTA}" "${REAL_FASTQ}" >"${WORK}/mapped.bam" 2>"${WORK}/bwa-log.txt"
+cat "${REAL_FASTQ}" "${REAL_FASTQ}" >"${WORK}/double.fq"
+bwa mem -t "${THREAD_COUNT}" "${FASTA}" "${WORK}/double.fq" >"${WORK}/mapped-double.bam" 2>"${WORK}/bwa-log-double.txt"
+
+BWA_TIME="$(cat "${WORK}/bwa-log.txt" | grep "Real time:" | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')"
+BWA_DOUBLE_TIME="$(cat "${WORK}/bwa-log-double.txt" | grep "Real time:" | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')"
+
+BWA_RPS="$(echo "${REAL_READ_COUNT} / (${BWA_DOUBLE_TIME} - ${BWA_TIME})" | bc -l)"
+
+# Print the report
+echo "Giraffe got ${CORRECT_COUNT} simulated reads correct with ${MEAN_IDENTITY} average identity"
+echo "Giraffe aligned real reads at ${GIRAFFE_RPS} reads/second vs. bwa-mem's ${BWA_RPS} reads/second"
+
+rm -Rf "${WORK}"
+
+
+
+

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -41,7 +41,7 @@ void help_gaffe(char** argv) {
     << endl
     << "basic options:" << endl
     << "  -x, --xg-name FILE            use this xg index (required if -g not specified)" << endl
-    << "  -g, --graph-name FILE         use this GBWTGraph (required if -x not specified)"
+    << "  -g, --graph-name FILE         use this GBWTGraph (required if -x not specified)" << endl
     << "  -H, --gbwt-name FILE          use this GBWT index (required)" << endl
     << "  -m, --minimizer-name FILE     use this minimizer index (required)" << endl
     << "  -d, --dist-name FILE          cluster using this distance index (required)" << endl


### PR DESCRIPTION
This adds a script in `scripts/giraffe-wrangler.sh` which can automatically profile the Giraffe mapper, measure its accuracy and identity, and compare its speed to BWA.

You can test it with something like the following:

```
vg construct -a -r test/small/x.fa -v test/small/x.vcf.gz > x.vg
vg snarls -t x.vg > x.trivial.snarls
vg index -x x.xg -G x.gbwt -v  test/small/x.vcf.gz -s x.trivial.snarls -j x.dist x.vg
vg minimizer -i x.min -g x.gbwt x.xg
vg sim -i 0.001 -e 0.01 -l 100 -p 100 -v 20 -x x.xg -n 100000 -s 100 -a >x.gam 
vg view -X x.gam > x.fastq
bwa index test/small/x.fa

scripts/giraffe-wrangler.sh test/small/x.fa x.xg x.gbwt x.min x.dist x.gam x.fastq
```

It will spit out some statistics, and generate an interactive profile SVG that you can explore in your browser, using [these cool scripts](https://github.com/brendangregg/FlameGraph).

![image](https://user-images.githubusercontent.com/5062495/61570672-21510780-aa43-11e9-88e0-9fef34d69e96.png)

I've also modified `vg gamcompare` to count correct reads itself to support this script, saving a jq pass.

I still need to run this on *real* real reads and get real figures, but I can do that simply now, and hopefully eventually automate it.
