### PR TITLE
Giraffe wrangler improvements

### DIFF
--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -78,7 +78,7 @@ CORRECT_COUNT="$(vg gamcompare -r 100 "${WORK}/annotated.gam" "${SIM_GAM}" 2>&1 
 MEAN_IDENTITY="$(vg view -aj "${WORK}/mapped.gam" | jq -c '.identity' | awk '{x+=$1} END {print x/NR}')"
 
 # Compute loss stages
-vg view -aj "${WORK}/mapped.gam" | scripts/giraffe-facts.py "${WORK}/facts" >"${WORK}/facts.txt" 2>"${WORK}/facts.txt"
+vg view -aj "${WORK}/mapped.gam" | scripts/giraffe-facts.py "${WORK}/facts" >"${WORK}/facts.txt" 2>&1
 
 # Now do the real reads
 

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -97,7 +97,7 @@ bwa mem -t "${THREAD_COUNT}" "${FASTA}" "${WORK}/double.fq" >"${WORK}/mapped-dou
 BWA_TIME="$(cat "${WORK}/bwa-log.txt" | grep "Real time:" | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')"
 BWA_DOUBLE_TIME="$(cat "${WORK}/bwa-log-double.txt" | grep "Real time:" | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')"
 
-BWA_RPS="$(echo "${REAL_READ_COUNT} / (${BWA_DOUBLE_TIME} - ${BWA_TIME})" | bc -l)"
+BWA_RPS="$(echo "${REAL_READ_COUNT} / (${BWA_DOUBLE_TIME} - ${BWA_TIME}) / ${THREAD_COUNT}" | bc -l)"
 
 if which perf 2>/dev/null ; then
     # Output perf stuff

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -65,8 +65,8 @@ if which perf 2>/dev/null ; then
     deps/FlameGraph/flamegraph.pl "${WORK}/out.folded" > "${WORK}/profile.svg"
 fi
 
-# Run simulated reads
-vg gaffe -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -G "${SIM_GAM}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/mapped.gam"
+# Run simulated reads, with stats
+vg gaffe --track-correctness -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -G "${SIM_GAM}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/mapped.gam"
 
 # Annotate and compare against truth
 vg annotate -p -x "${XG_INDEX}" -a "${WORK}/mapped.gam" >"${WORK}/annotated.gam"
@@ -77,7 +77,8 @@ CORRECT_COUNT="$(vg gamcompare -r 100 "${WORK}/annotated.gam" "${SIM_GAM}" 2>&1 
 # Compute identity
 MEAN_IDENTITY="$(vg view -aj "${WORK}/mapped.gam" | jq -c '.identity' | awk '{x+=$1} END {print x/NR}')"
 
-# TODO: Compute loss stages
+# Compute loss stages
+vg view -aj "${WORK}/mapped.gam" | scripts/giraffe-facts.py "${WORK}/facts" >"${WORK}/facts.txt" 2>"${WORK}/facts.txt"
 
 # Now do the real reads
 
@@ -109,9 +110,9 @@ fi
 
 # Print the report
 echo "Giraffe got ${CORRECT_COUNT} simulated reads correct with ${MEAN_IDENTITY} average identity"
-echo "Giraffe aligned real reads at ${GIRAFFE_RPS} reads/second vs. bwa-mem's ${BWA_RPS} reads/second"
+echo "Giraffe aligned real reads at ${GIRAFFE_RPS} reads/second vs. bwa-mem's ${BWA_RPS} reads/second on ${THREAD_COUNT} threads"
 
-
+cat "${WORK}/facts.txt"
 
 rm -Rf "${WORK}"
 

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -102,7 +102,7 @@ BWA_RPS="$(echo "${REAL_READ_COUNT} / (${BWA_DOUBLE_TIME} - ${BWA_TIME}) / ${THR
 
 if which perf 2>/dev/null ; then
     # Output perf stuff
-    mv "${WORK}/perf.data" ./pref.data
+    mv "${WORK}/perf.data" ./perf.data
     mv "${WORK}/profile.svg" ./profile.svg
     echo "Profiling information saved as ./perf.data"
     echo "Interactive flame graph (for browsers) saved as ./profile.svg"


### PR DESCRIPTION
This makes the Giraffe Wrangler output Giraffe Facts output, and also properly computes the BWA mapping speed.

```
time scripts/giraffe-wrangler.sh ~/data/hs37d5.fa ~/graphs/whole_genome_graph/whole_genome.xg ~/indexes/all_full.gbwt ~/graphs/whole_genome_graph/whole_genome.min ~/graphs/whole_genome_graph/whole_genome.dist ~/reads/sim_trained_100K_HG002-p570-v65-i0.0002-HS37D5.gam ~/graphs/whole_genome_graph/real_148_4000000.fastq 2>&1 | tee wrangle.txt
        
Profiling information saved as ./perf.data
Interactive flame graph (for browsers) saved as ./profile.svg
Giraffe got 196350 simulated reads correct with 0.99442 average identity
Giraffe aligned real reads at 2055.44 reads/second vs. bwa-mem's 3182.03803171855510017055 reads/second on 32 threads
┌────────────────────────────┐
│       Giraffe Facts        │
├────────────────────────────┤
│Reads                 200000│
├─────────┬──────────┬───────┤
│  Stage  │Candidates│Correct│
│         │  (Avg.)  │  Lost │
├─────────┼──────────┼───────┤
│minimizer│     20.62│    767│
│   seed  │     57.25│      0│
│ cluster │     31.81│    689│
│  extend │      1.56│     77│
│  align  │      1.07│   2089│
│  winner │      1.00│      -│
├─────────┼──────────┼───────┤
│ Overall │          │   3622│
└─────────┴──────────┴───────┘

real    30m41.244s
user    154m4.004s
sys     20m20.208s
```