### PR TITLE
Obliterate sglib

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -3505,7 +3505,7 @@ vector<pair<gcsa::node_type, size_t> > mem_node_start_positions(const HandleGrap
     return positions;
 }
 
-sglib::HashGraph cluster_subgraph_containing(const HandleGraph& base, const Alignment& aln, const vector<vg::MaximalExactMatch>& cluster, const GSSWAligner* aligner) {
+bdsg::HashGraph cluster_subgraph_containing(const HandleGraph& base, const Alignment& aln, const vector<vg::MaximalExactMatch>& cluster, const GSSWAligner* aligner) {
     vector<pos_t> positions;
     vector<size_t> forward_max_dist;
     vector<size_t> backward_max_dist;
@@ -3521,12 +3521,12 @@ sglib::HashGraph cluster_subgraph_containing(const HandleGraph& base, const Alig
         backward_max_dist.push_back(aligner->longest_detectable_gap(aln, mem.begin)
                                     + (mem.begin - aln.sequence().begin()));
     }
-    auto cluster_graph = new sglib::HashGraph();
+    auto cluster_graph = new bdsg::HashGraph();
     algorithms::extract_containing_graph(&base, cluster_graph, positions, forward_max_dist, backward_max_dist);
     return *cluster_graph;
 }
 
-sglib::HashGraph cluster_subgraph_walk(const HandleGraph& base, const Alignment& aln, const vector<vg::MaximalExactMatch>& mems, double expansion) {
+bdsg::HashGraph cluster_subgraph_walk(const HandleGraph& base, const Alignment& aln, const vector<vg::MaximalExactMatch>& mems, double expansion) {
     assert(mems.size());
     auto& start_mem = mems.front();
     auto start_pos = make_pos_t(start_mem.nodes.front());
@@ -3534,7 +3534,7 @@ sglib::HashGraph cluster_subgraph_walk(const HandleGraph& base, const Alignment&
     // Even if the MEM is right up against the start of the read, it may not be
     // part of the best alignment. Make sure to have some padding.
     // TODO: how much padding?
-    sglib::HashGraph graph;
+    bdsg::HashGraph graph;
     int inside_padding = max(1, (int)aln.sequence().size()/16);
     int end_padding = max(8, (int)aln.sequence().size()/8);
     int get_before = end_padding + (int)(expansion * (int)(start_mem.begin - aln.sequence().begin()));

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -11,7 +11,7 @@
 #include "handle.hpp"
 #include "min_distance.hpp"
 #include "path_component_index.hpp"
-#include "sglib/hash_graph.hpp"
+#include "bdsg/hash_graph.hpp"
 #include "algorithms/subgraph.hpp"
 #include "algorithms/extract_containing_graph.hpp"
 
@@ -674,10 +674,10 @@ private:
 /// get the handles that a mem covers
 vector<pair<gcsa::node_type, size_t> > mem_node_start_positions(const HandleGraph& graph, const vg::MaximalExactMatch& mem);
 /// return a containing subgraph connecting the mems
-sglib::HashGraph cluster_subgraph_containing(const HandleGraph& base, const Alignment& aln, const vector<vg::MaximalExactMatch>& cluster, const GSSWAligner* aligner);
+bdsg::HashGraph cluster_subgraph_containing(const HandleGraph& base, const Alignment& aln, const vector<vg::MaximalExactMatch>& cluster, const GSSWAligner* aligner);
 /// return a subgraph form an xg for a cluster of MEMs from the given alignment
 /// use walking to get the hits
-sglib::HashGraph cluster_subgraph_walk(const HandleGraph& base, const Alignment& aln, const vector<vg::MaximalExactMatch>& mems, double expansion);
+bdsg::HashGraph cluster_subgraph_walk(const HandleGraph& base, const Alignment& aln, const vector<vg::MaximalExactMatch>& mems, double expansion);
 
 }
 

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1610,7 +1610,7 @@ Alignment Mapper::align_to_graph(const Alignment& aln,
 
     // convert from bidirected to directed
     unordered_map<id_t, pair<id_t, bool> > node_trans;
-    sglib::HashGraph align_graph;
+    bdsg::HashGraph align_graph;
         
     // check if we can get away with using only one strand of the graph
     bool use_single_stranded = algorithms::is_single_stranded(&graph);
@@ -1667,7 +1667,7 @@ Alignment Mapper::align_to_graph(const Alignment& aln,
     // if necessary, convert from cyclic to acylic
     if (!algorithms::is_directed_acyclic(&align_graph)) {
         // make a dagified graph and translation
-        sglib::HashGraph dagified;
+        bdsg::HashGraph dagified;
         unordered_map<id_t,id_t> dagify_trans = algorithms::dagify(&align_graph, &dagified, target_length);
         // replace the original with the dagified ones
         align_graph = move(dagified);
@@ -1839,7 +1839,7 @@ pair<bool, bool> Mapper::pair_rescue(Alignment& mate1, Alignment& mate2,
         return make_pair(false, false);
     }
     if (mate_positions.empty()) return make_pair(false, false); // can't rescue because the selected mate is unaligned
-    sglib::HashGraph graph;
+    bdsg::HashGraph graph;
     set<bool> orientations;
 #ifdef debug_rescue
     if (debug) cerr << "got " << mate_positions.size() << " mate positions" << endl;
@@ -3082,7 +3082,7 @@ double Mapper::compute_uniqueness(const Alignment& aln, const vector<MaximalExac
 }
 
 Alignment Mapper::align_cluster(const Alignment& aln, const vector<MaximalExactMatch>& mems, bool traceback, bool xdrop_alignment) {
-    sglib::HashGraph graph = cluster_subgraph_containing(*xindex, aln, mems, get_aligner());
+    bdsg::HashGraph graph = cluster_subgraph_containing(*xindex, aln, mems, get_aligner());
     Alignment aligned = align_maybe_flip(aln, graph, mems, false, traceback, false, xdrop_alignment);
     return aligned;
 }
@@ -3266,7 +3266,7 @@ bool Mapper::check_alignment(const Alignment& aln) {
     // assert that this == the alignment
     if (aln.path().mapping_size()) {
         // get the graph corresponding to the alignment path
-        sglib::HashGraph sub;
+        bdsg::HashGraph sub;
         for (int i = 0; i < aln.path().mapping_size(); ++ i) {
             auto& m = aln.path().mapping(i);
             if (m.has_position() && m.position().node_id()) {
@@ -3878,7 +3878,7 @@ Alignment Mapper::patch_alignment(const Alignment& aln, int max_patch_length, bo
                         int max_score = -std::numeric_limits<int>::max();
                         for (auto& pos : band_ref_pos) {
                             //cerr << "trying position " << pos << endl;
-                            sglib::HashGraph graph;
+                            bdsg::HashGraph graph;
                             algorithms::extract_context(*xindex, graph, xindex->get_handle(id(pos), is_rev(pos)), offset(pos),
                                                         band.sequence().size()*extend_fwd, true, false);
                             algorithms::extract_context(*xindex, graph, xindex->get_handle(id(pos), is_rev(pos)), offset(pos),
@@ -3896,7 +3896,7 @@ Alignment Mapper::patch_alignment(const Alignment& aln, int max_patch_length, bo
                         int max_score = -std::numeric_limits<int>::max();
                         for (auto& pos : band_ref_pos) {
                             //cerr << "trying position " << pos << endl;
-                            sglib::HashGraph graph;
+                            bdsg::HashGraph graph;
                             algorithms::extract_context(*xindex, graph, xindex->get_handle(id(pos), is_rev(pos)), offset(pos),
                                                         band.sequence().size()*extend_fwd, true, false);
                             algorithms::extract_context(*xindex, graph, xindex->get_handle(id(pos), is_rev(pos)), offset(pos),
@@ -3910,7 +3910,7 @@ Alignment Mapper::patch_alignment(const Alignment& aln, int max_patch_length, bo
                         int max_score = -std::numeric_limits<int>::max();
                         for (auto& pos : band_ref_pos) {
                             //cerr << "trying position " << pos << endl;
-                            sglib::HashGraph graph;
+                            bdsg::HashGraph graph;
                             algorithms::extract_context(*xindex, graph, xindex->get_handle(id(pos), is_rev(pos)), offset(pos),
                                                         band.sequence().size()*extend_fwd, true, false);
                             algorithms::extract_context(*xindex, graph, xindex->get_handle(id(pos), is_rev(pos)), offset(pos),

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -8,7 +8,7 @@
 #include "omp.h"
 #include "vg.hpp"
 #include "index.hpp"
-#include "sglib/hash_graph.hpp"
+#include "bdsg/hash_graph.hpp"
 #include <gcsa/gcsa.h>
 #include <gcsa/lcp.h>
 #include <gbwt/gbwt.h>


### PR DESCRIPTION
Some bits of sglib survived #2361, presumably because the removed headers and submodules stayed cached on our CI somehow? Master didn't build when I updated to it. This should excise all references to "sglib" from cpp and hpp files and make master build for other people.