### PR TITLE
Remove gPBWT, make GBWT the only haplotype database

### DIFF
--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -28,11 +28,6 @@ inline pos_t gbwt_to_pos(gbwt::node_type node, size_t offset) {
     return make_pos_t(gbwt::Node::id(node), gbwt::Node::is_reverse(node), offset);
 }
 
-/// Convert gbwt::node_type to XG:ThreadMapping.
-inline XG::ThreadMapping gbwt_to_thread_mapping(gbwt::node_type node) {
-    return { static_cast<int64_t>(gbwt::Node::id(node)), gbwt::Node::is_reverse(node) };
-}
-
 /// Convert handle_t to gbwt::node_type.
 inline gbwt::node_type handle_to_gbwt(const HandleGraph& graph, handle_t handle) {
     return gbwt::Node::encode(graph.get_id(handle), graph.get_is_reverse(handle));

--- a/src/haplotype_extracter.cpp
+++ b/src/haplotype_extracter.cpp
@@ -8,24 +8,25 @@ namespace vg {
 
 using namespace std;
 
-void trace_haplotypes_and_paths(vg::XG& index, const gbwt::GBWT* haplotype_database,
+void trace_haplotypes_and_paths(vg::XG& index, const gbwt::GBWT& haplotype_database,
                                 vg::id_t start_node, int extend_distance,
                                 Graph& out_graph,
                                 map<string, int>& out_thread_frequencies,
                                 bool expand_graph) {
   // get our haplotypes
-  XG::ThreadMapping n = {start_node, false};
-  vector<pair<thread_t,int> > haplotypes = haplotype_database ?
-    list_haplotypes(index, *haplotype_database, n, extend_distance) :
-    list_haplotypes(index, n, extend_distance);
+  gbwt::node_type n = gbwt::Node::encode(start_node, false);
+  vector<pair<thread_t,int> > haplotypes = list_haplotypes(index, haplotype_database, n, extend_distance);
 
 #ifdef debug
-  cerr << "Haplotype database " << haplotype_database << " produced " << haplotypes.size() << " haplotypes" << endl;
+  cerr << "Haplotype database " << &haplotype_database << " produced " << haplotypes.size() << " haplotypes" << endl;
 #endif
 
   if (expand_graph) {
     // get our subgraph and "regular" paths by expanding forward
-    *out_graph.add_node() = index.node(start_node);
+    handle_t handle = index.get_handle(start_node);
+    Node* node = out_graph.add_node();
+    node->set_sequence(index.get_sequence(handle));
+    node->set_id(start_node);
     index.expand_context(out_graph, extend_distance, true, true, true, false);
   }
 
@@ -45,7 +46,7 @@ void trace_haplotypes_and_paths(vg::XG& index, const gbwt::GBWT* haplotype_datab
 
 
 void output_haplotype_counts(ostream& annotation_ostream,
-            vector<pair<thread_t,int>>& haplotype_list, vg::XG& index) {
+            vector<pair<thread_t,int>>& haplotype_list) {
   for(int i = 0; i < haplotype_list.size(); i++) {
     annotation_ostream << i << "\t" << haplotype_list[i].second << endl;
   }
@@ -84,15 +85,18 @@ void output_graph_with_embedded_paths(ostream& subgraph_ostream,
 void thread_to_graph_spanned(thread_t& t, Graph& g, vg::XG& index) {
   set<int64_t> nodes;
   set<pair<int,int> > edges;
-  nodes.insert(t[0].node_id);
+  nodes.insert(gbwt::Node::id(t[0]));
   for(int i = 1; i < t.size(); i++) {
-    nodes.insert(t[i].node_id);
-    edges.insert(make_pair(make_side(t[i-1].node_id,t[i-1].is_reverse),
-              make_side(t[i].node_id,t[i].is_reverse)));
-	}
- 	for (auto& n : nodes) {
-    *g.add_node() = index.node(n);
- 	}
+    nodes.insert(gbwt::Node::id(t[i]));
+    edges.insert(make_pair(make_side(gbwt::Node::id(t[i-1]),gbwt::Node::is_reverse(t[i-1])),
+              make_side(gbwt::Node::id(t[i]),gbwt::Node::is_reverse(t[i]))));
+  }
+  for (auto& n : nodes) {
+    handle_t handle = index.get_handle(n);
+    Node* node = g.add_node();
+    node->set_sequence(index.get_sequence(handle));
+    node->set_id(n);
+  }
   for (auto& e : edges) {
     Edge edge;
     edge.set_from(side_id(e.first));
@@ -105,22 +109,25 @@ void thread_to_graph_spanned(thread_t& t, Graph& g, vg::XG& index) {
 
 void add_thread_nodes_to_set(thread_t& t, set<int64_t>& nodes) {
   for(int i = 0; i < t.size(); i++) {
-    nodes.insert(t[i].node_id);
+    nodes.insert(gbwt::Node::id(t[i]));
   }
 }
 
 void add_thread_edges_to_set(thread_t& t, set<pair<int,int> >& edges) {
   for(int i = 1; i < t.size(); i++) {
-    edges.insert(make_pair(make_side(t[i-1].node_id,t[i-1].is_reverse),
-              make_side(t[i].node_id,t[i].is_reverse)));
+    edges.insert(make_pair(make_side(gbwt::Node::id(t[i-1]),gbwt::Node::is_reverse(t[i-1])),
+              make_side(gbwt::Node::id(t[i]),gbwt::Node::is_reverse(t[i]))));
   }
 }
 
 void construct_graph_from_nodes_and_edges(Graph& g, vg::XG& index,
             set<int64_t>& nodes, set<pair<int,int> >& edges) {
   for (auto& n : nodes) {
-	   *g.add_node() = index.node(n);
- 	}
+    handle_t handle = index.get_handle(n);
+    Node* node = g.add_node();
+    node->set_sequence(index.get_sequence(handle));
+    node->set_id(n);
+  }
   for (auto& e : edges) {
     Edge edge;
     edge.set_from(side_id(e.first));
@@ -138,12 +145,12 @@ Path path_from_thread_t(thread_t& t, vg::XG& index) {
 		Mapping* mapping = toReturn.add_mapping();
 
         // Set up the position
-        mapping->mutable_position()->set_node_id(t[i].node_id);
-        mapping->mutable_position()->set_is_reverse(t[i].is_reverse);
+        mapping->mutable_position()->set_node_id(gbwt::Node::id(t[i]));
+        mapping->mutable_position()->set_is_reverse(gbwt::Node::is_reverse(t[i]));
 
         // Set up the edits
         Edit* e = mapping->add_edit();
-        size_t l = index.node_length(t[i].node_id);
+        size_t l = index.get_length(index.get_handle(gbwt::Node::id(t[i])));
         e->set_from_length(l);
         e->set_to_length(l);
 
@@ -154,149 +161,80 @@ Path path_from_thread_t(thread_t& t, vg::XG& index) {
     return toReturn;
 }
 
-vector<pair<thread_t,int> > list_haplotypes(vg::XG& index,
-            XG::ThreadMapping start_node, int extend_distance) {
-  vector<pair<thread_t,XG::ThreadSearchState> > search_intermediates;
-  vector<pair<thread_t,int> > search_results;
-  thread_t first_thread = {start_node};
-  XG::ThreadSearchState first_state;
-  index.extend_search(first_state,first_thread);
-  vector<Edge> edges = start_node.is_reverse ?
-            index.edges_on_start(start_node.node_id) :
-            index.edges_on_end(start_node.node_id);
-  for(int i = 0; i < edges.size(); i++) {
-    XG::ThreadMapping next_node;
-    next_node.node_id = edges[i].to();
-    next_node.is_reverse = edges[i].to_end();
-    XG::ThreadSearchState new_state = first_state;
-    thread_t t = {next_node};
-    index.extend_search(new_state, t);
-    thread_t new_thread = first_thread;
-    new_thread.push_back(next_node);
-    if(!new_state.is_empty()) {
-      search_intermediates.push_back(make_pair(new_thread,new_state));
-    }
-  }
-  while(search_intermediates.size() > 0) {
-    pair<thread_t,XG::ThreadSearchState> last = search_intermediates.back();
-    search_intermediates.pop_back();
-    int check_size = search_intermediates.size();
-    vector<Edge> edges = last.first.back().is_reverse ?
-              index.edges_on_start(last.first.back().node_id) :
-              index.edges_on_end(last.first.back().node_id);
-    if(edges.size() == 0) {
-      search_results.push_back(make_pair(last.first,last.second.count()));
-    } else {
-      for(int i = 0; i < edges.size(); i++) {
-        XG::ThreadMapping next_node;
-        next_node.node_id = edges[i].to();
-        next_node.is_reverse = edges[i].to_end();
-        XG::ThreadSearchState new_state = last.second;
-        thread_t next_thread = {next_node};
-        index.extend_search(new_state,next_thread);
-        thread_t new_thread = last.first;
-        new_thread.push_back(next_node);
-        if(!new_state.is_empty()) {
-          if(new_thread.size() >= extend_distance) {
-            search_results.push_back(make_pair(new_thread,new_state.count()));
-          } else {
-            search_intermediates.push_back(make_pair(new_thread,new_state));
-          }
-        }
-      }
-      if(check_size == search_intermediates.size() &&
-                last.first.size() < extend_distance - 1) {
-        search_results.push_back(make_pair(last.first,last.second.count()));
-      }
-    }
-  }
-  return search_results;
-}
-
 vector<pair<thread_t,int> > list_haplotypes(vg::XG& index, const gbwt::GBWT& haplotype_database,
-            XG::ThreadMapping start_node, int extend_distance) {
+            gbwt::node_type start_node, int extend_distance) {
 
 #ifdef debug
-  cerr << "Extracting haplotypes from GBWT" << endl;
+    cerr << "Extracting haplotypes from GBWT" << endl;
 #endif
 
-  vector<pair<thread_t,gbwt::SearchState> > search_intermediates;
-  vector<pair<thread_t,int> > search_results;
-  // We still keep our data as thread_ts full of xg ThreadMappings and convert on the fly.
-  thread_t first_thread = {start_node};
-  auto first_node = gbwt::Node::encode(start_node.node_id, start_node.is_reverse);
-  gbwt::SearchState first_state = haplotype_database.find(first_node);
+    vector<pair<thread_t,gbwt::SearchState> > search_intermediates;
+    vector<pair<thread_t,int> > search_results;
+    thread_t first_thread = {start_node};
+    gbwt::SearchState first_state = haplotype_database.find(start_node);
 #ifdef debug
-  cerr << "Start with state " << first_state << " for node " << gbwt::Node::id(first_node) << endl;
+    cerr << "Start with state " << first_state << " for node " << gbwt::Node::id(start_node) << endl;
 #endif
-  vector<Edge> edges = start_node.is_reverse ?
-            index.edges_on_start(start_node.node_id) :
-            index.edges_on_end(start_node.node_id);
-
-  // TODO: this is just most of the loop body repeated!
-  for(int i = 0; i < edges.size(); i++) {
-    XG::ThreadMapping next_node;
-    next_node.node_id = edges[i].to();
-    next_node.is_reverse = edges[i].to_end();
-    auto extend_node = gbwt::Node::encode(next_node.node_id, next_node.is_reverse);
-    auto new_state = haplotype_database.extend(first_state, extend_node);
+    
+    index.follow_edges(gbwt_to_handle(index, start_node), false, [&](const handle_t& next) {
+        auto extend_node = handle_to_gbwt(index, next);
+        auto new_state = haplotype_database.extend(first_state, extend_node);
 #ifdef debug
-    cerr << "Extend state " << first_state << " to " << new_state << " with " << gbwt::Node::id(extend_node) << endl;
+        cerr << "Extend state " << first_state << " to " << new_state << " with " << gbwt::Node::id(extend_node) << endl;
 #endif
-    thread_t new_thread = first_thread;
-    new_thread.push_back(next_node);
-    if(!new_state.empty()) {
-#ifdef debug
-      cerr << "\tGot " << new_state.size() << " results; extending more" << endl;
-#endif
-      search_intermediates.push_back(make_pair(new_thread,new_state));
-    }
-  }
-  while(search_intermediates.size() > 0) {
-    pair<thread_t,gbwt::SearchState> last = search_intermediates.back();
-    search_intermediates.pop_back();
-    int check_size = search_intermediates.size();
-    vector<Edge> edges = last.first.back().is_reverse ?
-              index.edges_on_start(last.first.back().node_id) :
-              index.edges_on_end(last.first.back().node_id);
-    if(edges.size() == 0) {
-#ifdef debug
-      cerr << "Hit end of graph on state " << last.second << endl;
-#endif
-      search_results.push_back(make_pair(last.first,last.second.size()));
-    } else {
-      for(int i = 0; i < edges.size(); i++) {
-        XG::ThreadMapping next_node;
-        next_node.node_id = edges[i].to();
-        next_node.is_reverse = edges[i].to_end();
-        auto extend_node = gbwt::Node::encode(next_node.node_id, next_node.is_reverse);
-        auto new_state = haplotype_database.extend(last.second, extend_node);
-#ifdef debug
-        cerr << "Extend state " << last.second << " to " << new_state << " with " << gbwt::Node::id(extend_node) << endl;
-#endif
-        thread_t new_thread = last.first;
-        new_thread.push_back(next_node);
+        thread_t new_thread = first_thread;
+        new_thread.push_back(extend_node);
         if(!new_state.empty()) {
-          if(new_thread.size() >= extend_distance) {
-#ifdef debug
-            cerr << "\tGot " << new_state.size() << " results at limit; emitting" << endl;
-#endif
-            search_results.push_back(make_pair(new_thread,new_state.size()));
-          } else {
 #ifdef debug
             cerr << "\tGot " << new_state.size() << " results; extending more" << endl;
 #endif
             search_intermediates.push_back(make_pair(new_thread,new_state));
-          }
         }
-      }
-      if(check_size == search_intermediates.size() &&
-                last.first.size() < extend_distance - 1) {
-        search_results.push_back(make_pair(last.first,last.second.size()));
-      }
+    });
+    
+    while(search_intermediates.size() > 0) {
+        auto last = search_intermediates.back();
+        search_intermediates.pop_back();
+        
+        int check_size = search_intermediates.size();
+        bool any_edges = false;
+        index.follow_edges(gbwt_to_handle(index, last.first.back()), false, [&](const handle_t& next) {
+            any_edges = true;
+            auto extend_node = handle_to_gbwt(index, next);
+            auto new_state = haplotype_database.extend(last.second, extend_node);
+#ifdef debug
+            cerr << "Extend state " << last.second << " to " << new_state << " with " << gbwt::Node::id(extend_node) << endl;
+#endif
+            thread_t new_thread = last.first;
+            new_thread.push_back(extend_node);
+            if(!new_state.empty()) {
+                if(new_thread.size() >= extend_distance) {
+#ifdef debug
+                    cerr << "\tGot " << new_state.size() << " results at limit; emitting" << endl;
+#endif
+                    search_results.push_back(make_pair(new_thread,new_state.size()));
+                }
+                else {
+#ifdef debug
+                    cerr << "\tGot " << new_state.size() << " results; extending more" << endl;
+#endif
+                    search_intermediates.push_back(make_pair(new_thread,new_state));
+                }
+            }
+        });
+        if (!any_edges) {
+#ifdef debug
+            cerr << "Hit end of graph on state " << last.second << endl;
+#endif
+            search_results.push_back(make_pair(last.first,last.second.size()));
+        }
+        else if (check_size == search_intermediates.size() &&
+                 last.first.size() < extend_distance - 1) {
+            search_results.push_back(make_pair(last.first,last.second.size()));
+        }
     }
-  }
-  return search_results;
+    
+    return search_results;
 }
 
 }

--- a/src/haplotype_extracter.hpp
+++ b/src/haplotype_extracter.hpp
@@ -10,20 +10,20 @@
 
 #include <vg/vg.pb.h>
 #include "xg.hpp"
+#include "gbwt_helper.hpp"
 
 namespace vg {
 
 using namespace std;
 
-using thread_t = vector<vg::XG::ThreadMapping>;
-
+using thread_t = vector<gbwt::node_type>;
+    
 // Walk forward from a node, collecting all haplotypes.  Also do a regular
 // subgraph search for all the paths too.  Haplotype thread i will be embedded
 // as Paths a path with name thread_i.  Each path name (including threads) is
 // mapped to a frequency in out_thread_frequencies.  Haplotypes will be pulled
-// from the xg index's gPBWT if haplotype_database is null, and from the given
-// GBWT index otherwise.
-void trace_haplotypes_and_paths(vg::XG& index, const gbwt::GBWT* haplotype_database,
+// from the GBWT index.
+void trace_haplotypes_and_paths(vg::XG& index, const gbwt::GBWT& haplotype_database,
                                 vg::id_t start_node, int extend_distance,
                                 Graph& out_graph,
                                 map<string, int>& out_thread_frequencies,
@@ -32,19 +32,12 @@ void trace_haplotypes_and_paths(vg::XG& index, const gbwt::GBWT* haplotype_datab
 // Turns an (xg-based) thread_t into a (vg-based) Path
 Path path_from_thread_t(thread_t& t, vg::XG& index);
 
-// Lists all the sub-haplotypes of length extend_distance nodes starting at node
-// start_node from the set of haplotypes embedded as thread_t's in xg index.
-// Records, for each thread_t t the number of haplotypes of which t is a
-// subhaplotype
-vector<pair<thread_t,int> > list_haplotypes(vg::XG& index,
-            vg::XG::ThreadMapping start_node, int extend_distance);
-
 // Lists all the sub-haplotypes of length extend_distance nodes starting at
 // node start_node from the set of haplotypes embedded in the geven GBWT
 // haplotype database.  Records, for each thread_t t the number of haplotypes
 // of which t is a subhaplotype
 vector<pair<thread_t,int> > list_haplotypes(vg::XG& index, const gbwt::GBWT& haplotype_database,
-            vg::XG::ThreadMapping start_node, int extend_distance);
+            gbwt::node_type start_node, int extend_distance);
 
 // writes to subgraph_ostream the subgraph covered by
 // the haplotypes in haplotype_list, as well as these haplotypes embedded as
@@ -57,7 +50,7 @@ Graph output_graph_with_embedded_paths(vector<pair<thread_t,int>>& haplotype_lis
 // writes to annotation_ostream the list of counts of identical subhaplotypes
 // using the same ordering as the Paths from output_graph_with_embedded_paths
 void output_haplotype_counts(ostream& annotation_ostream,
-            vector<pair<thread_t,int>>& haplotype_list, vg::XG& index);
+            vector<pair<thread_t,int>>& haplotype_list);
 
 // Adds to a Graph the nodes and edges touched by a thread_t
 void thread_to_graph_spanned(thread_t& t, Graph& graph, vg::XG& index);

--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -24,9 +24,8 @@ using namespace std;
 // 
 // A. Construct the following shared objects
 //    1. An index, either a
-//        i.   XG index
-//        ii.  gbwt::GBWT
-//        iii. gbwt::DynamicGBWT
+//        i.  gbwt::GBWT
+//        ii. gbwt::DynamicGBWT
 //    2. An appropriate ScoreProvider implementation that will use the index.
 //       It is also responsible for determining the population size from its index, if able.
 //       It can also implement incremental haplotype search, because we need that
@@ -52,11 +51,9 @@ using namespace std;
 //    which takes in inputs
 //        i.   const vg::Path& Path
 //        ii.  indexType& index where indexType is one of
-//             a. XG
-//             b. gbwt::GBWT
-//             c. gbwt::DynamicGBWT
+//             a. gbwt::GBWT
+//             b. gbwt::DynamicGBWT
 //        iii. haploMath::RRMemo
-
 //
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -64,8 +61,6 @@ namespace haplo {
 
 // If this global is set, warn the user when scoring fails
 extern bool warn_on_score_fail;
- 
-using thread_t = vector<vg::XG::ThreadMapping>;
 
 namespace haploMath{
   double logsum(double a, double b);
@@ -119,55 +114,6 @@ struct int_itvl_t{
   // NB that the set of int_itvl_t's is closed under intersections but not under
   // unions or differences
   static int_itvl_t intersection(const int_itvl_t& A, const int_itvl_t& B);
-};
-
-// -----------------------------------------------------------------------------
-
-struct haplo_DP_edge_memo {
-private:  
-  vector<vg::Edge> in;
-  vector<vg::Edge> out;
-public:
-  haplo_DP_edge_memo();                      // for constructing null edge_memos
-  haplo_DP_edge_memo(vg::XG& graph,
-                     vg::XG::ThreadMapping last_node,
-                     vg::XG::ThreadMapping node);
-  const vector<vg::Edge>& edges_in() const;
-  const vector<vg::Edge>& edges_out() const;
-  bool is_null() const;
-  static bool has_edge(vg::XG& graph, vg::XG::ThreadMapping old_node, vg::XG::ThreadMapping new_node);
-};
-
-// -----------------------------------------------------------------------------
-
-class hDP_graph_accessor {
-public:
-  const vg::XG::ThreadMapping old_node;
-  const vg::XG::ThreadMapping new_node;
-  const haplo_DP_edge_memo edges;
-  const vg::XG& graph;
-  haploMath::RRMemo& memo;
-  
-  // accessor for noninitial nodes in a haplotype
-  hDP_graph_accessor(vg::XG& graph,
-                     vg::XG::ThreadMapping old_node,
-                     vg::XG::ThreadMapping new_node,
-                     haploMath::RRMemo& memo);
-  // accessor for initial node in a haplotype                   
-  // old_node and edge-vectors are null; do not use to extend nonempty states
-  hDP_graph_accessor(vg::XG& graph,
-                     vg::XG::ThreadMapping new_node,
-                     haploMath::RRMemo& memo);
-                     
-  int64_t new_side() const;
-  int64_t new_height() const;
-  int64_t old_height() const;
-  int64_t new_length() const;
-  
-  bool has_edge() const;
-  bool inclusive_interval() const { return false; }
-  
-  void print(ostream& output_stream) const;
 };
 
 // -----------------------------------------------------------------------------
@@ -238,7 +184,6 @@ public:
   haplo_DP_rectangle(bool inclusive_interval);
   double R;
   void set_offset(int offset);
-  void extend(hDP_graph_accessor& ga);
   template<class accessorType>
   void false_extend(accessorType& ga, int_itvl_t delta);
   template<class GBWTType>
@@ -284,8 +229,6 @@ public:
   bool is_empty() const;
 };
 
-thread_t path_to_thread_t(const vg::Path& path);
-
 //------------------------------------------------------------------------------
 // Outward-facing
 //------------------------------------------------------------------------------
@@ -302,7 +245,6 @@ private:
 public:
 //------------------------------------------------------------------------------
 // API functions
-  static haplo_score_type score(const vg::Path& path, vg::XG& graph, haploMath::RRMemo& memo);
   template<class GBWTType>
   static haplo_score_type score(const vg::Path& path, GBWTType& graph, haploMath::RRMemo& memo);
 //------------------------------------------------------------------------------
@@ -311,7 +253,6 @@ public:
   template<class accessorType>
   haplo_DP(accessorType& ga);
   haplo_DP_column* get_current_column();
-  static haplo_score_type score(const thread_t& thread, vg::XG& graph, haploMath::RRMemo& memo);
   template<class GBWTType>
   static haplo_score_type score(const gbwt_thread_t& thread, GBWTType& graph, haploMath::RRMemo& memo);
 };
@@ -388,7 +329,7 @@ public:
 using IncrementalSearchState = gbwt::SearchState;
 
 /// Interface abstracting over the various ways of generating haplotype scores.
-/// You probably want the implementations: XGScoreProvider, GBWTScoreProvider, LinearScoreProvider
+/// You probably want the implementations: GBWTScoreProvider, LinearScoreProvider
 /// TODO: Const-ify the indexes used
 class ScoreProvider {
 public:
@@ -417,16 +358,6 @@ public:
   virtual IncrementalSearchState incremental_extend(const IncrementalSearchState& state, const vg::Position& pos) const;
   
   virtual ~ScoreProvider() = default;
-};
-
-/// Score haplotypes using the gPBWT haplotype data stored in an XG index
-class XGScoreProvider : public ScoreProvider {
-public:
-  XGScoreProvider(vg::XG& index);
-  pair<double, bool> score(const vg::Path&, haploMath::RRMemo& memo);
-  int64_t get_haplotype_count() const;
-private:
-  vg::XG& index;
 };
 
 /// Score haplotypes using a GBWT haplotype database (normal or dynamic)

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -536,7 +536,7 @@ int main_chunk(int argc, char** argv) {
             }
             int64_t trace_steps = trace_end - trace_start;
             Graph g;
-            trace_haplotypes_and_paths(*xindex, gbwt_index.get(), trace_start, trace_steps,
+            trace_haplotypes_and_paths(*xindex, *gbwt_index.get(), trace_start, trace_steps,
                                        g, trace_thread_frequencies, false);
             subgraph->paths.for_each([&trace_thread_frequencies](const Path& path) {
                     trace_thread_frequencies[path.name()] = 1;});            

--- a/src/subcommand/trace_main.cpp
+++ b/src/subcommand/trace_main.cpp
@@ -13,7 +13,7 @@ using namespace vg;
 using namespace std;
 using namespace vg::subcommand;
 
-using thread_t = vector<XG::ThreadMapping>;
+using thread_t = vector<gbwt::node_type>;
 
 void help_trace(char** argv) {
     cerr << "usage: " << argv[0] << " trace [options]" << endl
@@ -141,7 +141,7 @@ int main_trace(int argc, char** argv) {
   // trace out our graph and paths from the start node
   Graph trace_graph;
   map<string, int> haplotype_frequences;
-  trace_haplotypes_and_paths(xindex, gbwt_index.get(), start_node, extend_distance,
+  trace_haplotypes_and_paths(xindex, *gbwt_index.get(), start_node, extend_distance,
                              trace_graph, haplotype_frequences);
 
   // dump our graph to stdout

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -73,9 +73,6 @@ char revdna3bit(int i) {
     }
 }
 
-const XG::destination_t XG::BS_SEPARATOR = 1;
-const XG::destination_t XG::BS_NULL = 0;
-
 XG::XG(istream& in) {
     load(in);
 }
@@ -157,11 +154,12 @@ void XG::load(istream& in) {
         case 8:
         case 9:
         case 10:
+        case 11:
             cerr << "warning:[XG] Loading an out-of-date XG format. In-memory conversion between versions can be time-consuming. "
                  << "For better performance over repeated loads, consider recreating this XG with 'vg index' "
                  << "or upgrading it with 'vg xg'." << endl;
             // Fall through
-        case 11:
+        case 12:
             {
                 sdsl::read_member(seq_length, in);
                 sdsl::read_member(node_count, in);
@@ -189,22 +187,45 @@ void XG::load(istream& in) {
                 s_bv_rank.load(in, &s_bv);
                 s_bv_select.load(in, &s_bv);
 
-                // Load thread names
-                tn_csa.load(in);
-                tn_cbv.load(in);
-                tn_cbv_rank.load(in, &tn_cbv);
-                tn_cbv_select.load(in, &tn_cbv);
+                if (file_version <= 11) {
+                    // Skip over gPBWT thread names
+                    {
+                        csa_bitcompressed<> tn_csa;
+                        tn_csa.load(in);
+                    }
+                    {
+                        sd_vector<> tn_cbv;
+                        tn_cbv.load(in);
+                        sd_vector<>::rank_1_type tn_cbv_rank;
+                        tn_cbv_rank.load(in, &tn_cbv);
+                        sd_vector<>::select_1_type tn_cbv_select;
+                        tn_cbv_select.load(in, &tn_cbv);
+                    }
+                }
                 
-                if (file_version >= 7) {
+                if (file_version >= 7 && file_version <= 11) {
                     // There is a single haplotype count here for all components
+                    // We ignore this part of the gPBWT
+                    size_t haplotype_count;
                     sdsl::read_member(haplotype_count, in);
                 }
                 // Otherwise we will calculate it at the end
                 
-                // Load thread positions in gPBWT
-                tin_civ.load(in);
-                tio_civ.load(in);
-                side_thread_wt.load(in);
+                if (file_version <= 11) {
+                    // Skip thread positions in gPBWT
+                    {
+                        vlc_vector<> tin_civ;
+                        tin_civ.load(in);
+                    }
+                    {
+                        vlc_vector<> tio_civ;
+                        tio_civ.load(in);
+                    }
+                    {
+                        wt_int<> side_thread_wt;
+                        side_thread_wt.load(in);
+                    }
+                }
                 
                 pn_iv.load(in);
                 pn_csa.load(in);
@@ -237,16 +258,22 @@ void XG::load(istream& in) {
                     path_ranks_bv.load(in);
                 }
                 
-                h_civ.load(in);
-                ts_civ.load(in);
-
-                // Load all the B_s arrays for sides.
-                // Baking required before serialization.
-                deserialize_rsiv(bs_single_array, in);
-                
-                if (file_version < 7) {
-                    // No haplotype count; one needs to be genenrated by hackily parsing the thread names.
-                    count_haplotypes();
+                if (file_version <= 11) {
+                    // load and ignore the gPBWT entity vectors
+                    {
+                        vlc_vector<> h_civ;
+                        h_civ.load(in);
+                    }
+                    // and the thread starts
+                    {
+                        vlc_vector<> ts_civ;
+                        ts_civ.load(in);
+                    }
+                    // and the B arrays
+                    {
+                        sdsl::wt_rlmn<sdsl::sd_vector<>> bs_single_array;
+                        bs_single_array.load(in);
+                    }
                 }
             }
             break;
@@ -523,18 +550,6 @@ size_t XG::serialize_and_measure(ostream& out, sdsl::structure_tree_node* s, std
     written += s_bv_rank.serialize(out, child, "seq_node_starts_rank");
     written += s_bv_select.serialize(out, child, "seq_node_starts_select");
 
-    // save the thread name index and haplotype database
-    written += tn_csa.serialize(out, child, "thread_name_csa");
-    written += tn_cbv.serialize(out, child, "thread_name_cbv");
-    written += tn_cbv_rank.serialize(out, child, "thread_name_cbv_rank");
-    written += tn_cbv_select.serialize(out, child, "thread_name_cbv_select");
-    written += sdsl::write_member(haplotype_count, out, child, "haplotype_count");
-    
-    // and the thread to GBWT mapping (which may not be in use)
-    written += tin_civ.serialize(out, child, "thread_start_node_civ");
-    written += tio_civ.serialize(out, child, "thread_start_offset_civ");
-    written += side_thread_wt.serialize(out, child, "side_thread_wt");
-
     // Treat the paths as their own node
     size_t paths_written = 0;
     auto paths_child = sdsl::structure_tree::add_child(child, "paths", sdsl::util::class_name(*this));
@@ -561,46 +576,31 @@ size_t XG::serialize_and_measure(ostream& out, sdsl::structure_tree_node* s, std
     sdsl::structure_tree::add_size(paths_child, paths_written);
     written += paths_written;
 
-    // Treat the threads as their own node.
-    // This will mess up any sort of average size stats, but it will also be useful.
-    auto threads_child = sdsl::structure_tree::add_child(child, "threads", sdsl::util::class_name(*this));
-    
-    size_t threads_written = 0;
-    threads_written += h_civ.serialize(out, threads_child, "thread_usage_count");
-    threads_written += ts_civ.serialize(out, threads_child, "thread_start_count");
-    // Stick all the B_s arrays in together. Must be baked.
-    threads_written += serialize_vector(bs_single_array, out, threads_child, "bs_single_array");
-    
-    sdsl::structure_tree::add_size(threads_child, threads_written);
-    written += threads_written;
-
     sdsl::structure_tree::add_size(child, written);
     return written;
     
 }
 
-void XG::from_stream(istream& in, bool validate_graph, bool print_graph,
-    bool store_threads, bool is_sorted_dag) {
+void XG::from_stream(istream& in, bool validate_graph, bool print_graph) {
 
     from_callback([&](function<void(Graph&)> handle_chunk) {
         // TODO: should I be bandying about function references instead of
         // function objects here?
         vg::io::for_each(in, handle_chunk);
-    }, validate_graph, print_graph, store_threads, is_sorted_dag);
+    }, validate_graph, print_graph);
 }
 
-void XG::from_graph(Graph& graph, bool validate_graph, bool print_graph,
-    bool store_threads, bool is_sorted_dag) {
+void XG::from_graph(Graph& graph, bool validate_graph, bool print_graph) {
 
     from_callback([&](function<void(Graph&)> handle_chunk) {
         // There's only one chunk in this case.
         handle_chunk(graph);
-    }, validate_graph, print_graph, store_threads, is_sorted_dag);
+    }, validate_graph, print_graph);
 
 }
 
 void XG::from_callback(function<void(function<void(Graph&)>)> get_chunks, 
-    bool validate_graph, bool print_graph, bool store_threads, bool is_sorted_dag) {
+    bool validate_graph, bool print_graph) {
 
     // temporaries for construction
     vector<pair<id_t, string> > node_label;
@@ -711,7 +711,7 @@ void XG::from_callback(function<void(function<void(Graph&)>)> get_chunks,
     }
 
     build(node_label, from_to, to_from, path_nodes, circular_paths, validate_graph,
-        print_graph, store_threads, is_sorted_dag);
+        print_graph);
     
 }
 
@@ -721,9 +721,7 @@ void XG::build(vector<pair<id_t, string> >& node_label,
                map<string, vector<trav_t> >& path_nodes,
                unordered_set<string>& circular_paths,
                bool validate_graph,
-               bool print_graph,
-               bool store_threads,
-               bool is_sorted_dag) {
+               bool print_graph) {
 
     size_t entity_count = node_count + edge_count;
 
@@ -850,12 +848,6 @@ void XG::build(vector<pair<id_t, string> >& node_label,
     sdsl::util::clear(i_iv);
     util::bit_compress(g_iv);
 
-#if GPBWT_MODE == MODE_SDSL
-    // We have one B_s array for every side, but the first 2 numbers for sides
-    // are unused. But max node rank is inclusive, so it evens out...
-    bs_arrays.resize(max_node_rank() * 2);
-#endif
-
 #ifdef VERBOSE_DEBUG
     cerr << "storing paths" << endl;
 #endif
@@ -915,63 +907,6 @@ void XG::build(vector<pair<id_t, string> >& node_label,
     util::assign(np_bv_rank, rank_support_v<1>(&np_bv));
     util::assign(np_bv_select, bit_vector::select_1_type(&np_bv));
     
-    if(store_threads) {
-
-// Prepare empty vectors for path indexing
-#ifdef VERBOSE_DEBUG
-        cerr << "creating empty succinct thread store" << endl;
-#endif
-
-        util::assign(h_iv, int_vector<>(g_iv.size() * 2, 0));
-        util::assign(ts_iv, int_vector<>((node_count + 1) * 2, 0));
-        
-#ifdef VERBOSE_DEBUG
-        cerr << "storing threads" << endl;
-#endif
-    
-        // If we're a sorted DAG we'll batch up the paths and use a batch
-        // insert.
-        vector<thread_t> batch;
-        vector<string> batch_names;
-    
-        // Just store all the paths that are all perfect mappings as threads.
-        // We end up converting *back* into thread_t objects.
-        for (auto& pathpair : path_nodes) {
-            thread_t reconstructed;
-            
-            // Grab the trav_ts, which are now sorted by rank
-            for (auto& m : pathpair.second) {
-                // Convert the mapping to a ThreadMapping
-                // trav_ts are already rank sorted and deduplicated.
-                ThreadMapping mapping = {trav_id(m), trav_is_rev(m)};
-                reconstructed.push_back(mapping);
-            }
-            
-#if GPBWT_MODE == MODE_SDSL
-            if(is_sorted_dag) {
-                // Save for a batch insert
-                batch.push_back(reconstructed);
-                batch_names.push_back(pathpair.first);
-            }
-            // TODO: else case!
-#elif GPBWT_MODE == MODE_DYNAMIC
-            // Insert the thread right now
-            insert_thread(reconstructed, pathpair.first);
-#endif
-            
-        }
-        
-#if GPBWT_MODE == MODE_SDSL
-        if(is_sorted_dag) {
-            // Do the batch insert
-            insert_threads_into_dag(batch, batch_names);
-        }
-        // TODO: else case!
-#endif
-        util::assign(h_civ, h_iv);
-        util::assign(ts_civ, ts_iv);
-    }
-    
 #ifdef DEBUG_CONSTRUCTION
     cerr << "|g_iv| = " << size_in_mega_bytes(g_iv) << endl;
     cerr << "|g_bv| = " << size_in_mega_bytes(g_bv) << endl;
@@ -980,9 +915,6 @@ void XG::build(vector<pair<id_t, string> >& node_label,
     //cerr << "|i_wt| = " << size_in_mega_bytes(i_wt) << endl;
 
     cerr << "|s_bv| = " << size_in_mega_bytes(s_bv) << endl;
-    
-    cerr << "|h_civ| = " << size_in_mega_bytes(h_civ) << endl;
-    cerr << "|ts_civ| = " << size_in_mega_bytes(ts_civ) << endl;
 
     long double paths_mb_size = 0;
     cerr << "|pn_iv| = " << size_in_mega_bytes(pn_iv) << endl;
@@ -1112,66 +1044,6 @@ void XG::build(vector<pair<id_t, string> >& node_label,
             }
         }
         node_label.clear();
-        
-#if GPBWT_MODE == MODE_SDSL
-        if(store_threads && is_sorted_dag) {
-#elif GPBWT_MODE == MODE_DYNAMIC
-        if(store_threads) {
-#endif
-        
-            cerr << "validating threads" << endl;
-            
-            // How many thread orientations are in the index?
-            size_t threads_found = 0;
-            // And how many shoukd we have inserted?
-            size_t threads_expected = 0;
-            list<thread_t> threads;
-            for (auto& t : extract_threads(false)) {
-                for (auto& k : t.second) threads.push_back(k);
-            }
-            for (auto& t : extract_threads(true)) {
-                for (auto& k : t.second) threads.push_back(k);
-            }
-            for(auto thread : threads) {
-#ifdef VERBOSE_DEBUG
-                cerr << "Thread: ";
-                for(size_t i = 0; i < thread.size(); i++) {
-                    ThreadMapping mapping = thread[i];
-                    cerr << mapping.node_id * 2 + mapping.is_reverse << "; ";
-                }
-                cerr << endl;
-#endif
-                // Make sure we can search all the threads we find present in the index
-                assert(count_matches(thread) > 0);
-                
-                // Flip the thread around
-                reverse(thread.begin(), thread.end());
-                for(auto& mapping : thread) {
-                    mapping.is_reverse = !mapping.is_reverse;
-                }
-                
-                // We need to be able to find it backwards as well
-                assert(count_matches(thread) > 0);
-                
-                threads_found++;
-            }
-            
-            for (auto& pathpair : path_nodes) {
-                Path reconstructed;
-                
-                // Grab the name
-                reconstructed.set_name(pathpair.first);
-                
-                // This path should have been inserted. Look for it.
-                assert(count_matches(reconstructed) > 0);
-                
-                threads_expected += 2;
-                
-            }
-            
-            // Make sure we have the right number of threads.
-            assert(threads_found == threads_expected);
-        }
 
         cerr << "graph ok" << endl;
     }
@@ -2792,1332 +2664,6 @@ void to_text(ostream& out, Graph& graph) {
             << edge.to() << "\t"
             << (edge.to_end() ? "-" : "+") << endl;
     }
-}
-
-int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_side) const {
-    // Given that we were at visit_offset on the current side, where will we be
-    // on the new side? 
-    
-    // Work out where we're going as a node and orientation
-    int64_t new_node_id = rank_to_id(new_side / 2);
-    bool new_node_is_reverse = new_side % 2;
-    
-    // Work out what node and orientation we came from
-    int64_t old_node_id = rank_to_id(current_side / 2);
-    bool old_node_is_reverse = current_side % 2;
-    
-    // Work out what edges are going into the place we're going into.
-    vector<Edge> edges = new_node_is_reverse ? edges_on_end(new_node_id) : edges_on_start(new_node_id);
-    
-    // Look at the edges we could have taken next
-    vector<Edge> edges_out = old_node_is_reverse ? edges_on_start(old_node_id) : edges_on_end(old_node_id);
-    
-    return where_to(current_side, visit_offset, new_side, edges, edges_out);
-}
-
-int64_t XG::node_height(XG::ThreadMapping node) const {
-  return h_civ[node_graph_idx(node.node_id) * 2 + node.is_reverse];
-}
-
-int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_side, const vector<Edge>& edges_into_new, const vector<Edge>& edges_out_of_old) const {
-    // Given that we were at visit_offset on the current side, where will we be
-    // on the new side?
-
-    // What will the new visit offset be?
-    int64_t new_visit_offset = 0;
-
-    // Work out where we're going as a node and orientation
-    int64_t new_node_id = rank_to_id(new_side / 2);
-    bool new_node_is_reverse = new_side % 2;
-
-    // Work out what edges are going into the place we're going into.
-
-    // Work out what node and orientation we came from
-    int64_t old_node_id = rank_to_id(current_side / 2);
-    bool old_node_is_reverse = current_side % 2;
-
-    // What edge are we following
-    Edge edge_taken = make_edge(old_node_id, old_node_is_reverse, new_node_id, new_node_is_reverse);
-
-    // Make sure we find it
-    bool edge_found = false;
-
-    for(auto& edge : edges_into_new) {
-        // Look at every edge in order.
-
-        if(edges_equivalent(edge, edge_taken)) {
-            // If we found the edge we're taking, break.
-            edge_found = true;
-            break;
-        }
-
-        // Otherwise add in the threads on this edge to the offset
-
-        // Get the orientation number for this edge (which is *not* the edge we
-        // are following and so doesn't involve old_node_anything). We only
-        // treat it as reverse if the reverse direction is the only direction we
-        // can take to get here.
-        int64_t edge_orientation_number = (edge_graph_idx(edge) * 2) + arrive_by_reverse(edge, new_node_id, new_node_is_reverse);
-
-        int64_t contribution = h_civ[edge_orientation_number];
-#ifdef VERBOSE_DEBUG
-        cerr << contribution << " (from prev edge " << edge.from() << (edge.from_start() ? "L" : "R") << "-" << edge.to() << (edge.to_end() ? "R" : "L") << " at " << edge_orientation_number << ") + ";
-#endif
-        new_visit_offset += contribution;
-    }
-
-    assert(edge_found);
-
-    // What edge out of all the edges we can take are we taking?
-    int64_t edge_taken_index = -1;
-
-    // Look at the edges we could have taken next
-
-    for(int64_t i = 0; i < edges_out_of_old.size(); i++) {
-        if(edges_equivalent(edges_out_of_old[i], edge_taken)) {
-            // i is the index of the edge we took, of the edges available to us.
-            edge_taken_index = i;
-            break;
-        }
-    }
-
-    assert(edge_taken_index != -1);
-
-    // Get the rank in B_s[] for our current side of our visit offset among
-    // B_s[] entries pointing to the new node and add that in. Make sure to +2
-    // to account for the nulls and separators.
-    int64_t contribution = bs_rank(current_side, visit_offset, edge_taken_index + 2);
-#ifdef VERBOSE_DEBUG
-    cerr << contribution << " (via this edge) + ";
-#endif
-    new_visit_offset += contribution;
-
-    // Get the number of threads starting at the new side and add that in.
-    contribution = ts_civ[new_side];
-#ifdef VERBOSE_DEBUG
-    cerr << contribution << " (starting here) = ";
-#endif
-    new_visit_offset += contribution;
-#ifdef VERBOSE_DEBUG
-    cerr << new_visit_offset << endl;
-#endif
-
-    // Now we know where it actually ends up: after all the threads that start,
-    // all the threads that come in via earlier edges, and all the previous
-    // threads going there that come via this edge.
-    return new_visit_offset;
-}
-
-XG::thread_t XG::extract_thread(XG::ThreadMapping node, int64_t offset = 0, int64_t max_length = 0) {
-  thread_t path;
-  int64_t side = (node.node_id)*2 + node.is_reverse;
-  bool continue_search = true;
-  while(continue_search) {
-    XG::ThreadMapping m = {rank_to_id(side / 2), (bool) (side % 2)};
-    path.push_back(m);
-    // Work out where we go:
-    // What edge of the available edges do we take?
-    int64_t edge_index = bs_get(side, offset);
-    assert(edge_index != BS_SEPARATOR);
-    if(edge_index == BS_NULL) {
-        // Path ends here.
-        break;
-    } else {
-        // If we've got an edge, convert to an actual edge index
-        edge_index -= 2;
-    }
-    // We also should not have negative edges.
-    assert(edge_index >= 0);
-    // Look at the edges we could have taken next
-    vector<Edge> edges_out = side % 2 ? edges_on_start(rank_to_id(side / 2)) :
-          edges_on_end(rank_to_id(side / 2));
-    assert(edge_index < edges_out.size());
-    Edge& taken = edges_out[edge_index];
-    // Follow the edge
-    int64_t other_node = taken.from() == rank_to_id(side / 2) ? taken.to() :
-          taken.from();
-    bool other_orientation = (side % 2) != taken.from_start() != taken.to_end();
-    // Get the side
-    int64_t other_side = id_to_rank(other_node) * 2 + other_orientation;
-    // Go there with where_to
-    offset = where_to(side, offset, other_side);
-    side = other_side;
-    // Continue the process from this new side
-    if(max_length != 0) {
-      if(path.size() >= max_length) {
-        continue_search = false;
-      }
-    }
-  }
-  return path;
-}
-
-void XG::set_thread_names(const vector<string>& names) {
-    size_t total_length = 0;
-    for(auto& name : names) { total_length += name.length(); }
-    names_str.clear(); names_str.reserve(total_length);
-
-    for (auto& name : names) {
-        names_str.append("$" + name);
-    }
-#ifdef VERBOSE_DEBUG
-    cerr << "Compressing thread names..." << endl;
-#endif
-    tn_bake();
-    
-}
-
-void XG::insert_threads_into_dag(const vector<thread_t>& t, const vector<string>& names) {
-
-    util::assign(h_iv, int_vector<>(g_iv.size() * 2, 0));
-    util::assign(ts_iv, int_vector<>((node_count + 1) * 2, 0));
-
-    set_thread_names(names);
-
-    // store the sides in order of their addition to the threads
-    int_vector<> sides_ordered_by_thread_id(t.size()*2); // fwd and reverse
-
-    // store the start+offset for each thread and its reverse complement
-    int_vector<> tin_iv(t.size()*2+2);
-    int_vector<> tio_iv(t.size()*2+2);
-    int thread_count = 0;
-    
-    auto emit_destinations = [&](int64_t node_id, bool is_reverse, vector<size_t> destinations) {
-        // We have to take this destination vector and store it in whatever B_s
-        // storage we are using.
-        
-        int64_t node_side = id_to_rank(node_id) * 2 + is_reverse;
-        
-        // Copy all the destinations into the succinct B_s storage
-        bs_set(node_side, destinations);
-        
-        // Set the number of total visits to this side.
-        h_iv[node_graph_idx(node_id) * 2 + is_reverse] = destinations.size();
-    
-#ifdef VERBOSE_DEBUG
-        cerr << "Found " << destinations.size() << " visits total to node " << node_id << (is_reverse ? "-" : "+") << endl;
-#endif
-    };
-    
-    auto emit_edge_traversal = [&](int64_t node_id, bool from_start, int64_t next_node_id, bool to_end) {
-        // We have to store the fact that we traversed this edge in the specified direction in our succinct storage. 
-        
-        // Find the edge as it actually appears in the graph.
-        Edge canonical = canonicalize(make_edge(node_id, from_start, next_node_id, to_end));
-        
-        // We're departing along this edge, so our orientation cares about
-        // whether we have to take the edge forward or backward when departing.
-        auto edge_idx = edge_graph_idx(canonical);
-        assert(edge_idx != numeric_limits<size_t>::max()); // We must actually have the edge
-        int64_t edge_orientation_number = edge_idx * 2 +
-            depart_by_reverse(canonical, node_id, from_start);
-
-#ifdef VERBOSE_DEBUG
-        cerr << "We need to add 1 to the traversals of oriented edge " << edge_orientation_number << endl;
-#endif
-                
-        // Increment the count for the edge
-        h_iv[edge_orientation_number]++; 
-    };
-    
-    auto emit_thread_start = [&](int64_t node_id, bool is_reverse) {
-        // Record that an (orientation of) a thread starts at this node in this
-        // orientation. We have to update our thread start succinct data
-        // structure.
-        
-        int64_t node_side = id_rev_to_side(node_id, is_reverse);
-        
-        // Say we start one more thread on this side.
-        ts_iv[node_side]++;
-        // Record the side
-        sides_ordered_by_thread_id[thread_count] = node_side;
-        // Sum the number of threads
-        thread_count++;
-
-#ifdef VERBOSE_DEBUG
-        cerr << "A thread starts at " << node_side << " for " <<  node_id << (is_reverse ? "-" : "+") << endl;
-#endif
-        
-    };
-
-    // We want to go through and insert running forward through the DAG, and
-    // then again backward through the DAG.
-    auto insert_in_direction = [&](bool insert_reverse) {
-
-        // First sort out the thread numbers by the node they start at.
-        // We know all the threads go the same direction through each node.
-        map<int64_t, list<size_t>> thread_numbers_by_start_node;
-        
-        for(size_t i = 0; i < t.size(); i++) {
-            if(t[i].size() > 0) {
-                // Do we start with the first or last mapping in the thread?
-                size_t thread_start = insert_reverse ? t[i].size() - 1 : 0;
-                auto& mapping = t[i][thread_start];
-                thread_numbers_by_start_node[mapping.node_id].push_back(i);
-                // we know the mapping node id and rank
-                // so we can construct the start position for this entity
-                int k = 2*(i+1) + insert_reverse;
-                tin_iv[k] = mapping.node_id;
-                // nb: the rank of this thread among those starting at this side
-                tio_iv[k] = thread_numbers_by_start_node[mapping.node_id].size()-1;
-                // Say a thread starts here, going in the orientation determined
-                // by how the node is visited and how we're traversing the path.
-                emit_thread_start(mapping.node_id, mapping.is_reverse != insert_reverse);
-            }
-        }
-        
-        // We have this message-passing architecture, where we send groups of
-        // threads along edges to destination nodes. This records, by edge rank of
-        // the traversed edge (with 0 meaning starting there), the group of threads
-        // coming in along that edge, and the offset in each thread that the visit
-        // to the node is at. These are messages passed along the edge from the
-        // earlier node to the later node (since we know threads follow a DAG).
-        map<size_t, list<pair<size_t, size_t>>> edge_to_ordered_threads;
-        
-        for(size_t node_rank = (insert_reverse ? max_node_rank() : 1);
-            node_rank != (insert_reverse ? 0 : max_node_rank() + 1);
-            node_rank += (insert_reverse ? -1 : 1)) {
-            // Then we start at the first node in the DAG
-            
-            int64_t node_id = rank_to_id(node_rank);
-            
-#ifdef VERBOSE_DEBUG
-            if(node_id % 10000 == 1) {
-                cerr << "Processing node " << node_id << endl;
-            }
-#endif
-            
-            // We order the thread visits starting there, and then all the threads
-            // coming in from other places, ordered by edge traversed.
-            // Stores a pair of thread number and mapping index in the thread.
-            list<pair<size_t, size_t>> threads_visiting;
-            
-            if(thread_numbers_by_start_node.count(node_id)) {
-                // Grab the threads starting here
-                for(size_t thread_number : thread_numbers_by_start_node.at(node_id)) {
-                    // For every thread that starts here, say it visits here
-                    // with its first mapping (0 for forward inserts, last one
-                    // for reverse inserts).
-                    threads_visiting.emplace_back(thread_number, insert_reverse ? t[thread_number].size() - 1 : 0);
-                }
-                thread_numbers_by_start_node.erase(node_id);
-            }
-            
-            
-            for(Edge& in_edge : edges_of(node_id)) {
-                // Look at all the edges on the node. Messages will only exist on
-                // the incoming ones.
-                auto edge_idx = edge_graph_idx(in_edge);
-                if(edge_to_ordered_threads.count(edge_idx)) {
-                    // We have messages coming along this edge on our start
-                    
-                    // These threads come in next. Splice them in because they
-                    // already have the right mapping indices.
-                    threads_visiting.splice(threads_visiting.end(), edge_to_ordered_threads[edge_idx]);
-                    edge_to_ordered_threads.erase(edge_idx);
-                }
-            }
-            
-            if(threads_visiting.empty()) {
-                // Nothing visits here, so there's no cool succinct data structures
-                // to generate.
-                continue;
-            }
-            
-            
-            // Some threads visit here! Determine our orientation from the first
-            // and assume it applies to all threads visiting us.
-            auto& first_visit = threads_visiting.front();
-            bool node_is_reverse = t[first_visit.first][first_visit.second].is_reverse;
-            // When we're inserting threads backwards, we need to treat forward
-            // nodes as reverse and visa versa, to leave the correct side.
-            node_is_reverse = node_is_reverse != insert_reverse;
-            
-            // Now we have all the threads coming through this node, and we know
-            // which way they are going.
-
-            // Make a map from outgoing edge rank to the B_s array number (0 for
-            // stop here, 1 reserved as a separator, and 2 through n corresponding
-            // to outgoing edges in order) for this node's outgoing side.
-            map<size_t, size_t> edge_idx_to_local_edge_number;
-            auto outgoing_edges = node_is_reverse ? edges_on_start(node_id) : edges_on_end(node_id);
-            for(size_t i = 0; i < outgoing_edges.size(); i++) {
-                size_t edge_idx = edge_graph_idx(outgoing_edges[i]);
-                edge_idx_to_local_edge_number[edge_idx] = i + 2;
-            }
-            
-            // Make a vector we'll fill in with all the B array values (0 for stop,
-            // 2 + edge number for outgoing edge)
-            vector<size_t> destinations;
-            
-            for(auto& visit : threads_visiting) {
-                // Now go through all the path visits, fill in the edge numbers (or 0
-                // for stop) they go to, and stick visits to the next mappings in the
-                // correct message lists.
-                if(insert_reverse ? (visit.second != 0) : (visit.second + 1 < t[visit.first].size())) {
-                    // This visit continues on from here
-                    
-                    // Make a visit to the next mapping on the path
-                    auto next_visit = visit;
-                    next_visit.second += insert_reverse ? -1 : 1;
-                    
-                    // Work out what node that is, and what orientation
-                    auto& next_mapping = t[next_visit.first][next_visit.second];
-                    int64_t next_node_id = next_mapping.node_id;
-                    bool next_is_reverse = next_mapping.is_reverse != insert_reverse;
-                    
-                    // Figure out the rank of the edge we need to take to get
-                    // there. Note that we need to make sure we can handle going
-                    // forward and backward over edges.
-                    Edge canonical = canonicalize(make_edge(node_id, node_is_reverse, next_node_id, next_is_reverse));
-                    size_t next_edge_idx = edge_graph_idx(canonical);
-                    
-                    // Look up what local edge number that edge gets and say we follow it.
-                    destinations.push_back(edge_idx_to_local_edge_number.at(next_edge_idx));
-                    
-                    // Send the new mapping along the edge after all the other ones
-                    // we've sent along the edge
-                    edge_to_ordered_threads[next_edge_idx].push_back(next_visit);
-                    
-                    // Say we traverse an edge going from this node in this
-                    // orientation to that node in that orientation.
-                    emit_edge_traversal(node_id, node_is_reverse, next_node_id, next_is_reverse);
-                    
-                } else {
-                    // This visit ends here
-#ifdef VERBOSE_DEBUG
-                    if(insert_reverse) {
-                        cerr << "A thread ends here because " << visit.second << " is 0 " << endl;
-                    } else {
-                        cerr << "A thread ends here because " << visit.second + 1 << " is >= " << t[visit.first].size() << endl;
-                    }
-#endif
-                    destinations.push_back(BS_NULL);
-                }
-            }
-            
-            // Emit the destinations array for the node. Store it in whatever
-            // sort of succinct storage we are using...
-            // We need to send along the side (false for left, true for right)
-            emit_destinations(node_id, node_is_reverse, destinations);
-            
-            // We repeat through all nodes until done.
-        }
-    
-        // OK now we have gone through the whole set of everything and inserted
-        // in this direction.
-    };
-    
-    // Actually call the inserts
-#ifdef VERBOSE_DEBUG
-    cerr << "Inserting threads forwards..." << endl;
-#endif
-    insert_in_direction(false);
-#ifdef VERBOSE_DEBUG
-    cerr << "Inserting threads backwards..." << endl;
-#endif
-    insert_in_direction(true);
-    
-    // Actually build the B_s arrays for rank and select.
-#ifdef VERBOSE_DEBUG
-    cerr << "Creating final compressed array..." << endl;
-#endif
-    bs_bake();
-    // compress the visit counts
-    util::assign(h_civ, h_iv);
-    util::assign(ts_civ, ts_iv);
-    // compress the starts for the threads
-    util::assign(tin_civ, int_vector<>(tin_iv));
-    util::assign(tio_civ, int_vector<>(tio_iv));
-    util::bit_compress(sides_ordered_by_thread_id);
-    // and build up the side wt
-    construct_im(side_thread_wt, sides_ordered_by_thread_id);
-}
-
-void XG::insert_thread(const thread_t& t, const string& name) {
-    // We're going to insert this thread
-    
-    auto insert_thread_forward = [&](const thread_t& thread) {
-    
-#ifdef VERBOSE_DEBUG
-        cerr << "Inserting thread with " << thread.size() << " mappings" << endl;
-#endif
-        // Where does the current visit fall on its node? On the first node we
-        // arbitrarily decide to be first of all the threads starting there.
-        // TODO: Make sure that we actually end up ordering starts based on path
-        // name or something later.
-        int64_t visit_offset = 0;
-        for(size_t i = 0; i < thread.size(); i++) {
-            // For each visit to a node...
-        
-            // What side are we visiting?
-            int64_t node_id = thread[i].node_id;
-            bool node_is_reverse = thread[i].is_reverse;
-            int64_t node_side = id_to_rank(node_id) * 2 + node_is_reverse;
-            
-#ifdef VERBOSE_DEBUG
-            cerr << "Visit side " << node_side << endl;
-#endif
-
-            // Where are we going next?
-            
-            if(i == thread.size() - 1) {
-                // This is the last visit. Send us off to null
-                
-#ifdef VERBOSE_DEBUG
-                cerr << "End the thread." << endl;
-#endif
-                // Stick a new entry in the B array at the place where it belongs.
-                bs_insert(node_side, visit_offset, BS_NULL);
-            } else {
-                // This is not the last visit. Send us off to the next place, and update the count on the edge.
-                
-                // Work out where we're actually going next
-                int64_t next_id = thread[i + 1].node_id;
-                bool next_is_reverse = thread[i + 1].is_reverse;
-                int64_t next_side = id_to_rank(next_id) * 2 + next_is_reverse;
-
-                // What edge do we take to get there? We're going to search for
-                // the actual edge articulated in the official orientation.
-                Edge edge_wanted = make_edge(node_id, node_is_reverse, next_id, next_is_reverse);
-                
-                // And what is its index in the edges we can take?
-                int64_t edge_taken_index = -1;
-                
-                // Look at the edges we could have taken
-                vector<Edge> edges_out = node_is_reverse ? edges_on_start(node_id) : edges_on_end(node_id);
-                for(int64_t j = 0; j < edges_out.size(); j++) {
-                    if(edge_taken_index == -1 && edges_equivalent(edges_out[j], edge_wanted)) {
-                        // i is the index of the edge we took, of the edges available to us.
-                        edge_taken_index = j;
-                    }
-#ifdef VERBOSE_DEBUG
-                    cerr << "Edge #" << j << ": "  << edges_out[j].from() << (edges_out[j].from_start() ? "L" : "R") << "-" << edges_out[j].to() << (edges_out[j].to_end() ? "R" : "L") << endl;
-                    
-                    // Work out what its number is for the orientation it goes
-                    // out in. We know we have this edge, so we just see if we
-                    // have to depart in reveres and if so take the edge in
-                    // reverse.
-                    int64_t edge_orientation_number = edge_graph_idx(edges_out[j]) * 2 + depart_by_reverse(edges_out[j], node_id, node_is_reverse);
-                    
-                    cerr << "\tOrientation rank: " << edge_orientation_number << endl;
-#endif
-                }
-                
-                if(edge_taken_index == -1) {
-                    cerr << "[xg] error: step " << i << " of thread: "
-                        << edge_wanted.from() << (edge_wanted.from_start() ? "L" : "R") << "-" 
-                        << edge_wanted.to() << (edge_wanted.to_end() ? "R" : "L") << " does not exist" << endl;
-                    cerr << "[xg] error: Possibilities: ";
-                    for(Edge& edge_out : edges_out) {
-                        cerr << edge_out.from() << (edge_out.from_start() ? "L" : "R") << "-" 
-                            << edge_out.to() << (edge_out.to_end() ? "R" : "L") << " ";
-                    }
-                    cerr << endl;
-                    cerr << "[xg] error: On start: ";
-                    for(Edge& edge_out : edges_on_start(node_id)) {
-                        cerr << edge_out.from() << (edge_out.from_start() ? "L" : "R") << "-" 
-                            << edge_out.to() << (edge_out.to_end() ? "R" : "L") << " ";
-                    }
-                    cerr << endl;
-                    cerr << "[xg] error: On end: ";
-                    for(Edge& edge_out : edges_on_end(node_id)) {
-                        cerr << edge_out.from() << (edge_out.from_start() ? "L" : "R") << "-" 
-                            << edge_out.to() << (edge_out.to_end() ? "R" : "L") << " ";
-                    }
-                    cerr << endl;
-                    cerr << "[xg] error: Both: ";
-                    for(Edge& edge_out : edges_of(node_id)) {
-                        cerr << edge_out.from() << (edge_out.from_start() ? "L" : "R") << "-" 
-                            << edge_out.to() << (edge_out.to_end() ? "R" : "L") << " ";
-                    }
-                    cerr << endl;
-                    cerr << "[xg] error: has_edge: " << has_edge(edge_wanted.from(), edge_wanted.from_start(), edge_wanted.to(), edge_wanted.to_end()) << endl;
-                    assert(false);
-                }
-                
-                assert(edge_taken_index != -1);
-
-#ifdef VERBOSE_DEBUG
-                cerr << "Proceed to " << next_side << " via edge #" << edge_taken_index << "/" << edges_out.size() << endl;
-#endif
-            
-                // Make a nice reference to the edge we're taking in its real orientation.
-                auto& edge_taken = edges_out[edge_taken_index];
-            
-                // Stick a new entry in the B array at the place where it belongs.
-                // Make sure to +2 to leave room in the number space for the separators and null destinations.
-                bs_insert(node_side, visit_offset, edge_taken_index + 2);
-                
-                // Update the usage count for the edge going form here to the next node
-                // Make sure that edge storage direction is correct.
-                // Which orientation of an edge are we crossing?
-                int64_t edge_orientation_number = edge_graph_idx(edge_taken) * 2 + depart_by_reverse(edge_taken, node_id, node_is_reverse);
-                
-#ifdef VERBOSE_DEBUG
-                cerr << "We need to add 1 to the traversals of oriented edge " << edge_orientation_number << endl;
-#endif
-                
-                // Increment the count for the edge
-                h_iv[edge_orientation_number]++;
-                
-#ifdef VERBOSE_DEBUG
-                cerr << "h = [";
-                for(int64_t k = 0; k < h_iv.size(); k++) {
-                    cerr << h_iv[k] << ", ";
-                }
-                cerr << "]" << endl;
-#endif
-                
-                // Now where do we go to on the next visit?
-                visit_offset = where_to(node_side, visit_offset, next_side);
-                
-#ifdef VERBOSE_DEBUG
-
-                cerr << "Offset " << visit_offset << " at side " << next_side << endl;
-#endif
-                
-            }
-            
-#ifdef VERBOSE_DEBUG
-            
-            cerr << "Node " << node_id << " orientation " << node_is_reverse <<
-                " has rank " <<
-                (node_graph_idx(node_id) * 2 + node_is_reverse) <<
-                " of " << h_civ.size() << endl;
-#endif
-            
-            // Increment the usage count of the node in this orientation
-            h_iv[node_graph_idx(node_id) * 2 + node_is_reverse]++;
-            
-            if(i == 0) {
-                // The thread starts here
-                ts_iv[node_side]++;
-            }
-        }
-        
-    };
-    
-    // We need a simple reverse that works only for perfect match paths
-    auto simple_reverse = [&](const thread_t& thread) {
-        // Make a reversed version
-        thread_t reversed;
-        
-        // TODO: give it a reversed name or something
-        
-        for(size_t i = thread.size(); i != (size_t) -1; i--) { 
-            // Copy the mappings from back to front, flipping the is_reverse on their positions.
-            ThreadMapping reversing = thread[thread.size() - 1 - i];
-            reversing.is_reverse = !reversing.is_reverse;
-            reversed.push_back(reversing);
-        }
-        
-        return reversed;        
-    };
-    
-    // Insert forward
-    insert_thread_forward(t);
-    
-    // Insert reverse
-    insert_thread_forward(simple_reverse(t));
-    
-    // Save the name
-    names_str.append("$" + name);
-}
-
-auto XG::extract_threads_matching(const string& pattern, bool reverse) const -> map<string, list<thread_t>> {
-
-    map<string, list<thread_t> > found;
-
-    // get the set of threads that match the given pattern
-    // for each thread, get its start position
-    vector<int64_t> threads = threads_named_starting(pattern);
-    for (auto& id : threads) {
-        // For every thread starting there
-        // make a new thread
-        thread_t path;
-
-        // Get the name of this thread
-        string path_name = thread_name(id);
-
-        // Start the side at i and the offset at j
-        auto p = thread_start(id, reverse);
-        int64_t side = id_rev_to_side(p.first, reverse);
-        int64_t offset = p.second;
-
-        while(true) {
-                
-            // Unpack the side into a node traversal
-            ThreadMapping m = {rank_to_id(side/2), (bool) (side % 2)};
-
-            // Add the mapping to the thread
-            path.push_back(m);
-                
-            // Work out where we go
-                
-            // What edge of the available edges do we take?
-            int64_t edge_index = bs_get(side, offset);
-                
-            // If we find a separator, we're very broken.
-            assert(edge_index != BS_SEPARATOR);
-                
-            if(edge_index == BS_NULL) {
-                // Path ends here.
-                break;
-            } else {
-                // Convert to an actual edge index
-                edge_index -= 2;
-            }
-                
-            // We also should not have negative edges.
-            assert(edge_index >= 0);
-                
-            // Look at the edges we could have taken next
-            vector<Edge> edges_out = side % 2 ? edges_on_start(rank_to_id(side / 2)) : edges_on_end(rank_to_id(side / 2));
-                
-            assert(edge_index < edges_out.size());
-                
-            Edge& taken = edges_out[edge_index];
-                
-            // Follow the edge
-            int64_t other_node = taken.from() == rank_to_id(side / 2) ? taken.to() : taken.from();
-            bool other_orientation = (side % 2) != taken.from_start() != taken.to_end();
-                
-            // Get the side 
-            int64_t other_side = id_to_rank(other_node) * 2 + other_orientation;
-                
-            // Go there with where_to
-            offset = where_to(side, offset, other_side);
-            side = other_side;
-    
-        }
-            
-        found[path_name].push_back(path);
-            
-    }
-    
-    return found;
-    
-}
-
-auto XG::extract_threads(bool extract_reverse) const -> map<string, list<thread_t>> {
-
-    // Fill in a map of lists of paths found by name
-    map<string, list<thread_t> > found;
-
-#ifdef VERBOSE_DEBUG
-    cerr << "Extracting threads" << endl;
-#endif
-    // We consider "reverse" threads to be those that start on the higher-
-    // numbered sides of their nodes.
-    // We know sides 0 and 1 are unused, so the smallest side is 2.
-    int64_t begin = !extract_reverse ? 2 : 3;
-    int64_t end = !extract_reverse ? ts_civ.size()-1 : ts_civ.size();
-    for(int64_t i = begin; i < end; i+=2) {
-        // For every other real side
-    
-#ifdef VERBOSE_DEBUG
-        cerr << ts_civ[i] << " threads start at side " << i << endl;
-#endif
-        // For each side
-        if(ts_civ[i] == 0) {
-            // Skip it if no threads start at it
-            continue;
-        }
-
-        for(int64_t j = 0; j < ts_civ[i]; j++) {
-            // For every thread starting there
-      
-#ifdef debug    
-            cerr << "Extracting thread " << j << endl;
-#endif
-            
-            // make a new thread
-            thread_t path;
-            
-            // Start the side at i and the offset at j
-            int64_t side = i;
-            int64_t offset = j;
-
-            // Get the name of this thread
-            string path_name = thread_name(thread_starting_at(side, offset));
-
-            while(true) {
-                
-                // Unpack the side into a node traversal
-                ThreadMapping m = {rank_to_id(side / 2), (bool) (side % 2)};
-                
-                // Add the mapping to the thread
-                path.push_back(m);
-                
-#ifdef VERBOSE_DEBUG
-                cerr << "At side " << side << endl;
-                
-#endif
-                // Work out where we go
-                
-                // What edge of the available edges do we take?
-                int64_t edge_index = bs_get(side, offset);
-                
-                // If we find a separator, we're very broken.
-                assert(edge_index != BS_SEPARATOR);
-                
-                if(edge_index == BS_NULL) {
-                    // Path ends here.
-                    break;
-                } else {
-                    // Convert to an actual edge index
-                    edge_index -= 2;
-                }
-                
-#ifdef VERBOSE_DEBUG
-                cerr << "Taking edge #" << edge_index << " from " << side << endl;
-#endif
-
-                // We also should not have negative edges.
-                assert(edge_index >= 0);
-                
-                // Look at the edges we could have taken next
-                vector<Edge> edges_out = side % 2 ? edges_on_start(rank_to_id(side / 2)) : edges_on_end(rank_to_id(side / 2));
-                
-                assert(edge_index < edges_out.size());
-                
-                Edge& taken = edges_out[edge_index];
-                
-#ifdef VERBOSE_DEBUG
-                cerr << edges_out.size() << " edges possible." << endl;
-#endif
-                // Follow the edge
-                int64_t other_node = taken.from() == rank_to_id(side / 2) ? taken.to() : taken.from();
-                bool other_orientation = (side % 2) != taken.from_start() != taken.to_end();
-                
-                // Get the side 
-                int64_t other_side = id_to_rank(other_node) * 2 + other_orientation;
-                
-#ifdef VERBOSE_DEBUG
-                cerr << "Go to side " << other_side << endl;
-#endif
-                
-                // Go there with where_to
-                offset = where_to(side, offset, other_side);
-                side = other_side;
-    
-            }
-            
-            found[path_name].push_back(path);
-            
-        }
-    }
-    
-    return found;
-}
-
-XG::destination_t XG::bs_get(int64_t side, int64_t offset) const {
-#if GPBWT_MODE == MODE_SDSL
-    if(!bs_arrays.empty()) {
-        // We still have per-side arrays
-        return bs_arrays.at(side - 2)[offset];
-    } else {
-        // We have a single big array
-#ifdef VERBOSE_DEBUG
-        cerr << "Range " << side << " has its separator at " << bs_single_array.select(side, BS_SEPARATOR) << endl;
-        cerr << "Offset " << offset << " puts us at " << bs_single_array.select(side, BS_SEPARATOR) + 1 + offset << endl;
-#endif
-        return bs_single_array[bs_single_array.select(side, BS_SEPARATOR) + 1 + offset];
-    }
-#elif GPBWT_MODE == MODE_DYNAMIC
-    // Start after the separator for the side and go offset from there.
-    
-    auto& bs_single_array = const_cast<rank_select_int_vector&>(this->bs_single_array);
-    
-    return bs_single_array.at(bs_single_array.select(side - 2, BS_SEPARATOR) + 1 + offset);
-#endif
-    
-}
-
-size_t XG::bs_rank(int64_t side, int64_t offset, destination_t value) const {
-#if GPBWT_MODE == MODE_SDSL
-    if(!bs_arrays.empty()) {
-        throw runtime_error("No rank support until bs_bake() is called!");
-    } else {
-        size_t range_start = bs_single_array.select(side, BS_SEPARATOR) + 1;
-        return bs_single_array.rank(range_start + offset, value) - bs_single_array.rank(range_start, value);
-    }
-#elif GPBWT_MODE == MODE_DYNAMIC
-
-    auto& bs_single_array = const_cast<rank_select_int_vector&>(this->bs_single_array);
-
-    // Where does the B_s[] range for the side we're interested in start?
-    int64_t bs_start = bs_single_array.select(side - 2, BS_SEPARATOR) + 1;
-    
-    // Get the rank difference between the start and the start plus the offset.
-    return bs_single_array.rank(bs_start + offset, value) - bs_single_array.rank(bs_start, value);
-#endif
-}
-
-void XG::bs_set(int64_t side, vector<destination_t> new_array) {
-#if GPBWT_MODE == MODE_SDSL
-    // We always know bs_arrays will be big enough.
-    
-    // Turn the new array into a string of bytes.
-    // TODO: none of the destinations can be 255 or greater!
-    bs_arrays.at(side - 2) = string(new_array.size(), 0);
-    copy(new_array.begin(), new_array.end(), bs_arrays.at(side - 2).begin());
-    
-#ifdef VERBOSE_DEBUG
-    cerr << "B_s for " << side << ": ";
-    for(auto entry : bs_arrays.at(side - 2)) { 
-        cerr << to_string(entry);
-    }
-    cerr << endl;
-#endif
-#elif GPBWT_MODE == MODE_DYNAMIC
-    auto current_separators = bs_single_array.rank(bs_single_array.size(), BS_SEPARATOR);
-    while(current_separators <= side - 2) {
-        // Tack on separators until we have enough
-        bs_single_array.insert(bs_single_array.size(), BS_SEPARATOR);
-        current_separators++;
-    }
-
-    // Where does the block we want start?
-    size_t this_range_start = bs_single_array.select(side - 2, BS_SEPARATOR) + 1;
-    
-    // Where is the first spot not in the range for this side?
-    int64_t this_range_past_end = (side - 2 == bs_single_array.rank(bs_single_array.size(), BS_SEPARATOR) - 1 ?
-        bs_single_array.size() : bs_single_array.select(side - 2 + 1, BS_SEPARATOR));
-    
-    if(this_range_start != this_range_past_end) {
-        // We can't overwrite! Just explode.
-        throw runtime_error("B_s overwrite not supported");
-    }
-    
-    size_t bs_insert_index = this_range_start;
-    
-    for(auto destination : new_array) {
-        // Blit everything into the B_s array
-        bs_single_array.insert(bs_insert_index, destination);
-        bs_insert_index++;
-    }
-#endif
-}
-
-void XG::bs_insert(int64_t side, int64_t offset, destination_t value) {
-#if GPBWT_MODE == MODE_SDSL
-    // This is a pretty slow insert. Use set instead.
-
-    auto& array_to_expand = bs_arrays.at(side - 2);
-    
-    // Stick one copy of the new entry in at the right position.
-    array_to_expand.insert(offset, 1, value);
-#elif GPBWT_MODE == MODE_DYNAMIC
-     // Find the place to put it in the correct side's B_s and insert
-     bs_single_array.insert(bs_single_array.select(side - 2, BS_SEPARATOR) + 1 + offset, value);
-#endif
-}
-
-void XG::bs_bake() {
-#if GPBWT_MODE == MODE_SDSL
-    // First pass: determine required size
-    size_t total_visits = 1;
-    for(auto& bs_array : bs_arrays) {
-        total_visits += 1; // For the separator
-        total_visits += bs_array.size();
-    }
-
-#ifdef VERBOSE_DEBUG
-    cerr << "Allocating giant B_s array of " << total_visits << " bytes..." << endl;
-#endif
-    // Move over to a single array which is big enough to start out with.
-    string all_bs_arrays(total_visits, 0);
-    
-    // Where are we writing to?
-    size_t pos = 0;
-    
-    // Start with a separator for sides 0 and 1.
-    // We don't start at run 0 because we can't select(0, BS_SEPARATOR).
-    all_bs_arrays[pos++] = BS_SEPARATOR;
-    
-#ifdef VERBOSE_DEBUG
-    cerr << "Baking " << bs_arrays.size() << " sides' arrays..." << endl;
-#endif
-    
-    for(auto& bs_array : bs_arrays) {
-        // Stick everything together with a separator at the front of every
-        // range.
-        all_bs_arrays[pos++] = BS_SEPARATOR;
-        for(size_t i = 0; i < bs_array.size(); i++) {
-            all_bs_arrays[pos++] = bs_array[i];
-        }
-        bs_array.clear();
-    }
-    
-#ifdef VERBOSE_DEBUG
-    cerr << "B_s: ";
-    for(auto entry : all_bs_arrays) { 
-        cerr << to_string(entry);
-    }
-    cerr << endl;
-#endif
-    
-    // Rebuild based on the entire concatenated string.
-    construct_im(bs_single_array, all_bs_arrays, 1);
-    
-    bs_arrays.clear();
-#endif
-}
-
-void XG::tn_bake() {
-    names_str.append("$"); // tail marker to avoid edge case
-    construct_im(tn_csa, names_str, 1);
-    // build the bv
-    bit_vector tn_bv(names_str.size());
-    int i = 0;
-    for (auto c : names_str) {
-        if (c == '$') tn_bv[i] = 1;
-        ++i;
-    }
-    names_str.clear();
-    
-    // make a compressed version and its supports
-    util::assign(tn_cbv, sd_vector<>(tn_bv));
-    util::assign(tn_cbv_rank, sd_vector<>::rank_1_type(&tn_cbv));
-    util::assign(tn_cbv_select, sd_vector<>::select_1_type(&tn_cbv));
-}
-
-
-void XG::bs_dump(ostream& out) const {
-#if GPBWT_MODE == MODE_SDSL
-    if(!bs_arrays.empty()) {
-        // We still have per-side arrays
-        
-        for(auto& array : bs_arrays) {
-            // For each side in order
-            out << "---SEP---" << endl;
-            for(auto& entry : array) {
-                if(entry == BS_NULL) {
-                    // Mark nulls
-                    out << "**NULL**" << endl;
-                } else {
-                    // Output adjusted, actual edge numbers
-                    out << entry - 2 << endl;
-                }
-            }
-        }
-    } else {
-        // We have a single big array
-        
-        for(size_t i = 0; i < bs_single_array.size(); i++) {
-            auto entry = bs_single_array[i];
-            if(entry == BS_SEPARATOR) {
-                /// Mark separators
-                out << "---SEP---" << endl;
-            } else if(entry == BS_NULL) {
-                // Mark nulls
-                out << "**NULL**" << endl;
-            } else {
-                // Output adjusted, actual edge numbers
-                out << entry - 2 << endl;
-            }
-        }
-        
-        // Now dump the wavelet tree to a string
-        stringstream wt_dump;
-        bs_single_array.serialize(wt_dump, nullptr, "");
-        
-        out << endl << "++++Serialized Bits++++" << endl;
-        
-        // Turn all the bytes into binary representations
-        for(auto& letter : wt_dump.str()) {
-            // Make each into a bitset
-            bitset<8> bits(letter);
-            out << bits << endl;
-        }
-        
-    }
-#elif GPBWT_MODE == MODE_DYNAMIC
-    auto& bs_single_array = const_cast<rank_select_int_vector&>(this->bs_single_array);
-    
-    for(size_t i = 0; i < bs_single_array.size(); i++) {
-        auto entry = bs_single_array.at(i);
-        if(entry == BS_SEPARATOR) {
-            /// Mark separators
-            out << "---SEP---" << endl;
-        } else if(entry == BS_NULL) {
-            // Mark nulls
-            out << "**NULL**" << endl;
-        } else {
-            // Output adjusted, actual edge numbers
-            out << entry - 2 << endl;
-        }
-    }
-#endif
-    
-}
-
-size_t XG::count_matches(const thread_t& t) const {
-    // This is just a really simple wrapper that does a single extend
-    ThreadSearchState state;
-    extend_search(state, t);
-    return state.count();
-}
-
-size_t XG::count_matches(const Path& t) const {
-    // We assume the path is a thread and convert.
-    thread_t thread;
-    for(size_t i = 0; i < t.mapping_size(); i++) {
-        // Convert the mapping
-        ThreadMapping m = {t.mapping(i).position().node_id(), t.mapping(i).position().is_reverse()};
-        
-        thread.push_back(m);
-    }
-    
-    // Count matches to the converted thread
-    return count_matches(thread);
-}
-
-void XG::extend_search(ThreadSearchState& state, const thread_t& t) const {
-    
-#ifdef VERBOSE_DEBUG
-    cerr << "Looking for path: ";
-    for(int64_t i = 0; i < t.size(); i++) {
-        // For each item in the path
-        const ThreadMapping& mapping = t[i];
-        int64_t next_id = mapping.node_id;
-        bool next_is_reverse = mapping.is_reverse;
-        int64_t next_side = id_to_rank(next_id) * 2 + next_is_reverse;
-        cerr << next_side << "; ";
-    }
-    cerr << endl;
-#endif
-    
-    
-    for(int64_t i = 0; i < t.size(); i++) {
-        // For each item in the path
-        const ThreadMapping& mapping = t[i];
-        
-        if(state.is_empty()) {
-            // Don't bother trying to extend empty things.
-            
-#ifdef VERBOSE_DEBUG
-            cerr << "Nothing selected!" << endl;
-#endif
-            
-            break;
-        }
-        
-        // TODO: make this mapping to side thing a function
-        int64_t next_id = mapping.node_id;
-        bool next_is_reverse = mapping.is_reverse;
-        int64_t next_side = id_to_rank(next_id) * 2 + next_is_reverse;
-        
-#ifdef VERBOSE_DEBUG
-        cerr << "Extend mapping to " << state.current_side << " range " << state.range_start << " to " << state.range_end << " with " << next_side << endl;
-#endif
-        
-        if(state.current_side == 0) {
-            // If the state is a start state, just select the whole node using
-            // the node usage count in this orientation. TODO: orientation not
-            // really important unless we're going to search during a path
-            // addition.
-            state.range_start = 0;
-            state.range_end = h_civ.size() ? h_civ[node_graph_idx(next_id) * 2 + next_is_reverse] : 0;
-            
-#ifdef VERBOSE_DEBUG
-            cerr << "\tFound " << state.range_end << " threads present here." << endl;
-            
-            int64_t here = node_graph_idx(next_id) * 2 + next_is_reverse;
-            cerr << here << endl;
-            for(int64_t i = here - 5; i < here + 5; i++) {
-                if(i >= 0) {
-                    cerr << "\t\t" << (i == here ? "*" : " ") << "h_civ[" << i << "] = " << h_civ[i] << endl;
-                }
-            }
-            
-#endif
-            
-        } else {
-            // Else, look at where the path goes to and apply the where_to function to shrink the range down.
-            state.range_start = where_to(state.current_side, state.range_start, next_side);
-            state.range_end = where_to(state.current_side, state.range_end, next_side);
-            
-#ifdef VERBOSE_DEBUG
-            cerr << "\tFound " << state.range_start << " to " << state.range_end << " threads continuing through." << endl;
-#endif
-            
-        }
-        
-        // Update the side that the state is on
-        state.current_side = next_side;
-    }
-}
-
-void XG::extend_search(ThreadSearchState& state, const ThreadMapping& t) const {
-    // Just make it into a temporary vector
-    extend_search(state, thread_t{t});
-}
-
-int64_t XG::threads_starting_on_side(int64_t side) const {
-    return side_thread_wt.rank(side_thread_wt.size(), side);
-}
-
-int64_t XG::thread_starting_at(int64_t side, int64_t offset) const {
-    return side_thread_wt.select(offset+1, side)+1;
-}
-
-pair<int64_t, int64_t> XG::thread_start(int64_t thread_id, bool is_rev) const {
-    int64_t idx = thread_id*2 + is_rev;
-    return make_pair(tin_civ[idx], tio_civ[idx]);
-}
-
-string XG::thread_name(int64_t thread_id) const {
-    // How many forward threads are there?
-    // Don't use side_thread_wt since it is only filled in if the gPBWT is used.
-    //size_t thread_count = tn_cbv_rank(tn_cbv.size()) - 1;
-
-    // convert to forward thread
-    /*
-    if (thread_id > thread_count) {
-        thread_id -= thread_count;
-    }
-    */
-    //thread_id -= (thread_id+1) % 2;
-    return extract(tn_csa,
-                   tn_cbv_select(thread_id)+1, // skip delimiter
-                   tn_cbv_select(thread_id+1)-1); // to next-1
-}
-
-vector<int64_t> XG::threads_named_starting(const string& pattern) const {
-    vector<int64_t> results;
-    // threads named starting with this, so add the sep character so our occs give us thread ids
-    auto occs = locate(tn_csa, "$" + pattern);
-    // for each occurrance get the thread id
-    for (size_t i = 0; i < occs.size(); ++i) {
-        results.push_back(tn_cbv_rank(occs[i])+1);
-    }
-    return results;
-}
-
-void XG::count_haplotypes() {
-    // Go through the thread names, which we assume are like _thread_<sample>_<contig>_<phase>_<chunk>.
-    // Count the total unique samples and assume diploid.
-    
-    // We will just count unique sample names
-    unordered_set<string> sample_names;
-    auto thread_ids = threads_named_starting("_thread_");
-    for (auto thread_id : thread_ids) {
-        // For each thread, get its full name.
-        auto name = thread_name(thread_id);
-        
-        // Find where the sample name should start
-        size_t sample_start = strlen("_thread_");
-        if (name.size() <= sample_start) {
-            // Too short!
-            continue;
-        }
-        auto sample_end = name.find('_', sample_start);
-        if (sample_end == string::npos) {
-            // Can't find the end of the sample name
-            continue;
-        }
-        
-        // Extract the name of the sample
-        auto sample_name = name.substr(sample_start, sample_end - sample_start);
-        // Put it in the set
-        sample_names.insert(sample_name);
-    }
-    
-    // Now we have a count
-    // TODO: this assumes diploid
-    set_haplotype_count(sample_names.size() * 2);
-}
-
-void XG::set_haplotype_count(size_t count) {
-    haplotype_count = count;
-}
-
-size_t XG::get_haplotype_count() const {
-    return haplotype_count;
-}
-
-XG::ThreadSearchState XG::select_starting(const ThreadMapping& start) const {
-    // We need to select just the threads starting at this node with this
-    // mapping, rather than those coming in from elsewhere.
-    
-    // Make a search state with nothing searched
-    ThreadSearchState state;
-    
-    // Say we've searched this ThreadMapping's side.    
-    state.current_side = id_rev_to_side(start.node_id, start.is_reverse);
-    
-    // Threads starting at a node come first, so select from 0 to the number of
-    // threads that start there.
-    state.range_start = 0;
-    state.range_end = ts_civ[state.current_side];
-    
-    return state;
-}
-
-int64_t XG::id_rev_to_side(int64_t id, bool is_rev) const {
-    return id_to_rank(id) * 2 + is_rev;
-}
-
-pair<int64_t, bool> XG::side_to_id_rev(int64_t side) const {
-    return make_pair(side / 2, side % 2);
-}
-
-XG::ThreadSearchState XG::select_continuing(const ThreadMapping& start) const {
-    // We need to select just the threads coming in from elsewhere, and not
-    // those starting here.
-    
-    // Make a search state with nothing searched
-    ThreadSearchState state;
-    
-    // Say we've searched this ThreadMapping's side.
-    state.current_side = id_rev_to_side(start.node_id, start.is_reverse);
-    
-    // Threads starting at a node come first, so select from past them to the
-    // number of threads total on the node.
-    state.range_start = ts_civ[state.current_side];
-    state.range_end = h_civ[state.current_side];
-    
-    return state;
-}
-
-
-size_t serialize_vector(const XG::rank_select_int_vector& to_serialize, ostream& out,
-    sdsl::structure_tree_node* parent, const std::string name) {
-#if GPBWT_MODE == MODE_SDSL
-    // Just delegate to the SDSL code
-    return to_serialize.serialize(out, parent, name);
-
-#elif GPBWT_MODE == MODE_DYNAMIC
-    // We need to check to make sure we're actually writing the correct numbers of bytes.
-    size_t start = out.tellp();
-    
-    // We just use the DYNAMIC serialization.  
-    size_t written = to_serialize.serialize(out);
-    
-    // TODO: when https://github.com/nicolaprezza/DYNAMIC/issues/4 is closed,
-    // trust the sizes that DYNAMIC reports. For now, second-guess it and just
-    // look at how far the stream has actually moved.
-    written = (size_t) out.tellp() - start;
-    
-    // And then do the structure tree stuff
-    sdsl::structure_tree_node* child = structure_tree::add_child(parent, name, sdsl::util::class_name(to_serialize));
-    sdsl::structure_tree::add_size(child, written);
-    
-    return written;
-#endif
-}
-
-void deserialize_rsiv(XG::rank_select_int_vector& target, istream& in) {
-#if GPBWT_MODE == MODE_SDSL
-    // We just load using the SDSL deserialization code
-    target.load(in);
-#elif GPBWT_MODE == MODE_DYNAMIC
-    // The DYNAMIC code has the same API
-    target.load(in);
-#endif
 }
 
 bool edges_equivalent(const Edge& e1, const Edge& e2) {

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -91,19 +91,13 @@ public:
     XG& operator=(XG&& other) = delete;
     
     void from_stream(istream& in, bool validate_graph = false,
-        bool print_graph = false, bool store_threads = false,
-        bool is_sorted_dag = false);
+        bool print_graph = false);
     void from_graph(Graph& graph, bool validate_graph = false,
-        bool print_graph = false, bool store_threads = false,
-        bool is_sorted_dag = false);
+        bool print_graph = false);
     // Load the graph by calling a function that calls us back with graph chunks.
     // The function passed in here is responsible for looping.
-    // If is_sorted_dag is true and store_threads is true, we store the threads
-    // with an algorithm that only works on topologically sorted DAGs, but which
-    // is faster.
     void from_callback(function<void(function<void(Graph&)>)> get_chunks,
-        bool validate_graph = false, bool print_graph = false,
-        bool store_threads = false, bool is_sorted_dag = false);
+        bool validate_graph = false, bool print_graph = false);
         
     /// Actually build the graph
     /// Note that path_nodes is a map to make the output deterministic in path order.
@@ -113,14 +107,12 @@ public:
                map<string, vector<trav_t> >& path_nodes,
                unordered_set<string>& circular_paths,
                bool validate_graph,
-               bool print_graph,
-               bool store_threads,
-               bool is_sorted_dag);
+               bool print_graph);
                
     // What's the maximum XG version number we can read with this code?
-    const static uint32_t MAX_INPUT_VERSION = 11;
+    const static uint32_t MAX_INPUT_VERSION = 12;
     // What's the version we serialize?
-    const static uint32_t OUTPUT_VERSION = 11;
+    const static uint32_t OUTPUT_VERSION = 12;
                
     // Load this XG index from a stream. Throw an XGFormatError if the stream
     // does not produce a valid XG file.
@@ -433,173 +425,6 @@ public:
     /// and the orientation of the occurrences. false indicates that the traversal occurs in the same
     /// orientation as in the path, true indicates.
     vector<pair<size_t, vector<pair<size_t, bool>>>> oriented_paths_of_node(int64_t id) const;
-                                                  
-    ////////////////////////////////////////////////////////////////////////////
-    // Sample database API
-    ////////////////////////////////////////////////////////////////////////////
-    
-    // Can be used either with the gPBWT or an external index of threads.
-    
-    /// Replace the existing thread names (if any) with the new names. Each name
-    /// must be unique. Each name corresponds to a pair of embedded oriented
-    /// threads, which comprise a single thread.
-    void set_thread_names(const vector<string>& names);
-    
-    /// Given a thread id, return its name. Thread IDs are all threads as given
-    /// in names in order, and then the reverse versions of all those oriented
-    /// threads in the same order.
-    string thread_name(int64_t thread_id) const;
-    
-    /// Store the number of haplotypes that gave rise to the indexed threads. A
-    /// single haplotype may be represented by multiple threads. If the index
-    /// spans multiple contigs, threads from the same VCF phase on different
-    /// contigs from the same sample will be considered to be part of the same
-    /// haplotype for counting purposes.
-    void set_haplotype_count(size_t count);
-    
-    /// Get the number of haplotypes that gave rise to threads stored in the
-    /// thread index. TODO: needs to account for graph component or contig, as
-    /// different components may have different numbers of haplotypes on them.
-    size_t get_haplotype_count() const;
-    
-    
-    
-    ////////////////////////////////////////////////////////////////////////////
-    // gPBWT API
-    ////////////////////////////////////////////////////////////////////////////
-    
-#if GPBWT_MODE == MODE_SDSL
-    // We keep our strings in instances of this cool run-length-compressed wavelet tree.
-    using rank_select_int_vector = sdsl::wt_rlmn<sdsl::sd_vector<>>;
-#elif GPBWT_MODE == MODE_DYNAMIC
-    using rank_select_int_vector = dyn::rle_str;
-#endif
-
-    // We need the w function, which we call the "where_to" function. It tells
-    // you, from a given visit at a given side, what visit offset if you go to
-    // another side.
-    int64_t where_to(int64_t current_side, int64_t visit_offset, int64_t new_side) const;
-    
-    // This is another version of the where_to function which requires that you
-    // supply two vectors of edges.
-    // edges_into_new -> edges going into new_side
-    // edges_out_of_old -> edges coming out of current_side
-    // this is to save the overhead of re-extracting these edge-vectors in cases
-    // where you're calling where_to between the same two sides (but with 
-    // different offsets) many times. Otherwise use version above
-    int64_t where_to(int64_t current_side, int64_t visit_offset, int64_t new_side,
-      const vector<Edge>& edges_into_new, const vector<Edge>& edges_out_of_old) const;
-    
-    // We define a thread visit that's much smaller than a Protobuf Mapping.
-    // Note that the fields are not initialized, so the default-constructed ThreadMapping will be garbage.
-    struct ThreadMapping {
-        int64_t node_id;
-        bool is_reverse;
-        /// We need comparison for deduplication in sets and canonically orienting threads
-        bool operator<(const ThreadMapping& other) const {
-            return tie(node_id, is_reverse) < tie(other.node_id, other.is_reverse);
-        }
-    };
-    
-    // we have a public function for querying the contents of the h_iv vector
-    int64_t node_height(ThreadMapping node) const;
-    
-    // We define a thread as just a vector of these things, instead of a bulky
-    // Path.
-    using thread_t = vector<ThreadMapping>;
-    
-    /// Insert a thread. Name must be unique or empty.
-    /// bs_bake() and tn_bake() need to be called before queries.
-    void insert_thread(const thread_t& t, const string& name);
-    /// Insert a whole group of threads. Names should be unique or empty (though
-    /// they aren't used yet). The indexed graph must be a DAG, at least in the
-    /// subset traversed by the threads. (Reversing edges are fine, but the
-    /// threads in a node must all run in the same direction.) This uses a
-    /// special efficient batch insert algorithm for DAGs that lets us just scan
-    /// the graph and generate nodes' B_s arrays independently. This must be
-    /// called only once, and no threads can have been inserted previously.
-    /// Otherwise the gPBWT data structures will be left in an inconsistent
-    /// state.
-    void insert_threads_into_dag(const vector<thread_t>& t, const vector<string>& names);
-    /// Read all the threads embedded in the graph.
-    map<string, list<thread_t> > extract_threads(bool extract_reverse) const;
-    /// Extract a particular thread by name. Name may not be empty.
-    thread_t extract_thread(const string& name) const;
-    /// Extract a set of threads matching a pattern.
-    map<string, list<thread_t> > extract_threads_matching(const string& pattern, bool reverse) const;
-    /// Extract a particular thread, referring to it by its offset at node; step
-    /// it out to a maximum of max_length
-    thread_t extract_thread(XG::ThreadMapping node, int64_t offset, int64_t max_length);
-    /// Count matches to a subthread among embedded threads
-    size_t count_matches(const thread_t& t) const;
-    size_t count_matches(const Path& t) const;
-    
-    /**
-     * Represents the search state for the graph PBWT, so that you can continue
-     * a search with more of a thread, or backtrack.
-     *
-     * By default, represents an un-started search (with no first visited side)
-     * that can be extended to the whole collection of visits to a side.
-     */
-    struct ThreadSearchState {
-        // What side have we just arrived at in the search?
-        int64_t current_side = 0;
-        // What is the first visit at that side that is selected?
-        int64_t range_start = 0;
-        // And what is the past-the-last visit that is selected?
-        int64_t range_end = numeric_limits<int64_t>::max();
-        
-        // How many visits are selected?
-        inline int64_t count() {
-            return range_end - range_start;
-        }
-        
-        // Return true if the range has nothing selected.
-        inline bool is_empty() {
-            return range_end <= range_start;
-        }
-    };
-    
-    // Extend a search with the given section of a thread.
-    void extend_search(ThreadSearchState& state, const thread_t& t) const;
-
-    /// Extend a search with the given single ThreadMapping.
-    void extend_search(ThreadSearchState& state, const ThreadMapping& t) const;
-    
-    /// Select only the threads (if any) starting with a particular
-    /// ThreadMapping, and not those continuing through it.
-    ThreadSearchState select_starting(const ThreadMapping& start) const;
-
-    /// Take a node id and side and return the side id
-    int64_t id_rev_to_side(int64_t id, bool is_rev) const;
-
-    /// Take a side and give a node id / rev pair
-    pair<int64_t, bool> side_to_id_rev(int64_t side) const;
-
-    /// The number of threads starting at this side
-    int64_t threads_starting_on_side(int64_t side) const;
-    
-    /// Given a side and offset, return the id of the thread starting there (or 0 if none)
-    int64_t thread_starting_at(int64_t side, int64_t offset) const;
-
-    /// Given a thread id and the reverse state get the starting side and offset
-    pair<int64_t, int64_t> thread_start(int64_t thread_id) const;
-
-    /// Gives the thread start for the given thread
-    pair<int64_t, int64_t> thread_start(int64_t thread_id, bool is_rev) const;
-
-    /// Gives the thread ids of those whose names start with this pattern
-    vector<int64_t> threads_named_starting(const string& pattern) const;
-    
-    /// Select only the threads (if any) continuing through a particular
-    /// ThreadMapping, and not those starting there.
-    ThreadSearchState select_continuing(const ThreadMapping& start) const;
-
-    // Dump the whole B_s array to the given output stream as a report.
-    void bs_dump(ostream& out) const;
-    
-    char start_marker = '#';
-    char end_marker = '$';
     
 private:
 
@@ -698,120 +523,9 @@ private:
     bit_vector np_bv; // entity delimiters in ep_iv
     rank_support_v<1> np_bv_rank;
     bit_vector::select_1_type np_bv_select;
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Thread haplotype/sample database
-    ////////////////////////////////////////////////////////////////////////////
     
-    // thread name storage
-    // CSA that lets us look up names efficiently, build from ordered null-delimited names
-    // thread ids are taken to be the rank in the source text for tn_csa
-    csa_bitcompressed<> tn_csa;
-    // allows us to go from positions in the CSA to thread ids
-    // rank(i) gives us our thread index for a position in tn_csa's source
-    // select(i) gives us the thread name start for a given thread id
-    sd_vector<> tn_cbv;
-    sd_vector<>::rank_1_type tn_cbv_rank;
-    sd_vector<>::select_1_type tn_cbv_select;
-    
-    // Stores the number of haplotypes per contig that gave rise to the threads in the database
-    size_t haplotype_count = 0;
-    
-    /// Back-calculate haplotype_count from the thread names for upgrading old XGs.
-    void count_haplotypes();
-    
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Succinct thread storage (the gPBWT)
-    ////////////////////////////////////////////////////////////////////////////
-    
-    // Threads are haplotype paths in the graph with no edits allowed, starting
-    // and stopping at node boundaries.
-    
-    // TODO: Explain the whole graph PBWT extension here
-    
-    // Basically we keep usage counts for every element in the graph, and and
-    // array of next-node-start sides for each side in the graph. We number
-    // sides as 2 * xg internal node ID, +1 if it's a right side. This leaves us
-    // 0 and 1 free for representing the null destination side and to use as a
-    // per-side array run separator, respectively.
-    
-    // This holds, for each node and edge, in each direction (with indexes as in
-    // the entity vector g_iv, *2, and +1 for reverse), the usage count (i.e.
-    // the number of times it is visited by encoded threads). This doesn't have
-    // to be dynamic since the length will never change. Remember that entity
-    // ranks are 1-based, so if you have an entity rank you have to subtract 1
-    // to get its position here. We have to track separately for both directions
-    // because, even though when everything is inserted the usage counts in both
-    // directions are the same, while we're inserting a thread in one direction
-    // and not (yet) the other, the usage counts in both directions will be
-    // different.
-    int_vector<> h_iv;  // only used in construction
-    vlc_vector<> h_civ;
-
-    // This (as an extension to the algorithm described in the paper) holds the
-    // number of threads beginning at each node. This isn't any extra
-    // information relative to what's in the usage count array, but it's cheaper
-    // (probably) to maintain this rather than to scan through all the edges on
-    // a side every time.
-    // ts stands for "thread start"
-    int_vector<> ts_iv;  // only used in construction
-    vlc_vector<> ts_civ;
-    
-#if GPBWT_MODE == MODE_SDSL
-    // We use this for creating the sub-parts of the uncompressed B_s arrays.
-    // We don't really support rank and select on this.
-    vector<string> bs_arrays;
-#endif
-    
-    // This holds the concatenated Benedict arrays, with BS_SEPARATOR separating
-    // them, and BS_NULL noting the null side (i.e. the thread ends at this
-    // node). Instead of holding destination sides, we actually hold the index
-    // of the edge that gets taken to the destination side, out of all edges we
-    // could take leaving the node. We offset all the values up by 2, to make
-    // room for the null sentinel and the separator. Currently the separator
-    // isn't used; we just place these by side.
-    rank_select_int_vector bs_single_array;
-
-    // Glue to connect thread names and IDs to their locations in the gPBWT
-    // allows us to go from thread ids to thread start positions, enabling named queries of the graph
-    vlc_vector<> tin_civ; // from thread id to side id / reverse thread id to side id
-    vlc_vector<> tio_civ; // from thread id to offset / reverse thread id to offset
-    // thread starts ordered by their identifiers so we can map from sides into thread ids
-    wt_int<> side_thread_wt;
-    
-    // Holds the names of threads while they are being inserted, before the
-    // succinct name representation is built.
-    string names_str;
-    
-    // A "destination" is either a local edge number + 2, BS_NULL for stopping,
-    // or possibly BS_SEPARATOR for cramming multiple Benedict arrays into one.
-    using destination_t = size_t;
-    
-    // Constants used as sentinels in bs_iv above.
-    const static destination_t BS_SEPARATOR;
-    const static destination_t BS_NULL;
-    
-    // We access this only through these wrapper methods, because we're going to
-    // swap out functionality.
-    // Sides are from 1-based node ranks, so start at 2.
-    // Get the item in a B_s array for a side at an offset.
-    destination_t bs_get(int64_t side, int64_t offset) const;
-    // Get the rank of a position among positions pointing to a certain
-    // destination from a side.
-    size_t bs_rank(int64_t side, int64_t offset, destination_t value) const;
-    // Set the whole B_s array for a size. May throw an error if B_s for that
-    // side has already been set (as overwrite is not necessarily possible).
-    void bs_set(int64_t side, vector<destination_t> new_array);
-    // Insert into the B_s array for a side
-    void bs_insert(int64_t side, int64_t offset, destination_t value);
-    
-    // Prepare the B_s array data structures for query. After you call this, you
-    // shouldn't call bset or bs_insert.
-    void bs_bake();
-    
-    // Prepare the succinct thread name representation for queries
-    void tn_bake();
+    char start_marker = '#';
+    char end_marker = '$';
 };
 
 class XGPath {
@@ -864,13 +578,6 @@ public:
 
 Mapping new_mapping(const string& name, int64_t id, size_t rank, bool is_reverse);
 void to_text(ostream& out, Graph& graph);
-
-// Serialize a rank_select_int_vector in an SDSL serialization compatible way. Returns the number of bytes written.
-size_t serialize_vector(const XG::rank_select_int_vector& to_serialize, ostream& out,
-    sdsl::structure_tree_node* parent, const std::string name);
-
-// Deserialize a rank_select_int_vector in an SDSL serialization compatible way.
-void deserialize_rsiv(XG::rank_select_int_vector& target, istream& in);
 
 // Determine if two edges are equivalent (the same or one is the reverse of the other)
 bool edges_equivalent(const Edge& e1, const Edge& e2);


### PR DESCRIPTION
I removed the gPBWT from the XG index. Recognizing the fact that the GBWT has essentially replaced it in all of our work, I did not replace the gPBWT implementation. The GBWT will now be our only haplotype database. I've also removed all command line access to the gPBWT.