### PR TITLE
Handlify haplotype extracter and expand context

### DIFF
--- a/src/algorithms/are_equivalent.cpp
+++ b/src/algorithms/are_equivalent.cpp
@@ -87,7 +87,7 @@ namespace algorithms {
         if (!are_equivalent(graph_1, graph_2, verbose)) {
             return false;
         }
-        
+                
         if (graph_1->get_path_count() != graph_2->get_path_count()) {
             if (verbose) {
                 cerr << "graphs have different numbers of paths: " << graph_1->get_path_count() << " and " << graph_2->get_path_count() << endl;

--- a/src/algorithms/expand_context.cpp
+++ b/src/algorithms/expand_context.cpp
@@ -187,11 +187,14 @@ using namespace std;
             step_handle_t segment_seed = *seen_steps.begin();
             path_handle_t path_handle = source->get_path_handle_of_step(segment_seed);
             
+            
             // walk backwards until we're out of the subgraph or we loop around to
             // the same step
             auto step = segment_seed;
+            step_handle_t prev;
             bool first_iter = true;
             while (seen_steps.count(step) && (first_iter || step != segment_seed)) {
+                prev = step;
                 step = source->get_previous_step(step);
                 first_iter = false;
             }
@@ -227,7 +230,7 @@ using namespace std;
                 // make a new path for this segment
                 path_handle_t segment_handle = subgraph->create_path_handle(path_name);
                 
-                for (step = source->get_next_step(step);   // walk back onto the subgraph
+                for (step = prev;                          // start back on the subgraph
                      seen_steps.count(step);               // stop once we leave the subgraph
                      step = source->get_next_step(step)) {
                     

--- a/src/algorithms/expand_context.cpp
+++ b/src/algorithms/expand_context.cpp
@@ -112,7 +112,7 @@ using namespace std;
                 // cross the node (traverse the sequence length)
                 int64_t dist_across = here.second + source->get_length(here.first.first);
                 if (dist_across <= dist) {
-                    dijk_queue.push_or_reprioritize(make_pair(here.first.first, false), dist_across);
+                    dijk_queue.push_or_reprioritize(make_pair(here.first.first, !here.first.second), dist_across);
                 }
             }
             if ((here.first.second && expand_backward)

--- a/src/algorithms/expand_context.cpp
+++ b/src/algorithms/expand_context.cpp
@@ -1,0 +1,254 @@
+#include "expand_context.hpp"
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+    void expand_context_by_steps(const HandleGraph* source, MutableHandleGraph* subgraph,
+                                 int64_t dist, bool expand_forward, bool expand_backward) {
+        
+        // let's make an O(1) lookup for the current edges in case the implementation doesn't provide
+        // one (avoids O(N^2) behavior using has_edge)
+        unordered_set<edge_t> already_included_edges;
+        subgraph->for_each_edge([&](const edge_t& edge) {
+            already_included_edges.insert(edge);
+        });
+        
+        // a fifo queue for BFS
+        queue<pair<handle_t, int64_t>> bfs_queue;
+        // all the edges we encounter along the way
+        unordered_set<edge_t> seen_edges;
+        
+        // initialize the queue with the current subgraph
+        subgraph->for_each_handle([&](const handle_t& handle) {
+            bfs_queue.emplace(source->get_handle(subgraph->get_id(handle)), 0);
+        });
+        
+        // BFS outward
+        while (!bfs_queue.empty()) {
+            pair<handle_t, int64_t> here = bfs_queue.front();
+            bfs_queue.pop();
+            
+            int64_t dist_thru = here.second + 1;
+            
+            if (dist_thru <= dist) {
+                if (expand_forward) {
+                    source->follow_edges(here.first, false, [&](const handle_t& next) {
+                        seen_edges.insert(source->edge_handle(here.first, next));
+                        if (!subgraph->has_node(source->get_id(next))) {
+                            subgraph->create_handle(source->get_sequence(source->forward(next)),
+                                                    source->get_id(next));
+                            bfs_queue.emplace(next, dist_thru);
+                        }
+                    });
+                }
+                
+                if (expand_backward) {
+                    source->follow_edges(here.first, true, [&](const handle_t& prev) {
+                        seen_edges.insert(source->edge_handle(prev, here.first));
+                        if (!subgraph->has_node(source->get_id(prev))) {
+                            subgraph->create_handle(source->get_sequence(source->forward(prev)),
+                                                    source->get_id(prev));
+                            bfs_queue.emplace(prev, dist_thru);
+                        }
+                    });
+                }
+            }
+        }
+        
+        // add in the edges we saw
+        for (const edge_t& edge : seen_edges) {
+            edge_t insertable = subgraph->edge_handle(subgraph->get_handle(source->get_id(edge.first),
+                                                                           source->get_is_reverse(edge.first)),
+                                                      subgraph->get_handle(source->get_id(edge.second),
+                                                                           source->get_is_reverse(edge.second)));
+            if (!already_included_edges.count(insertable)) {
+                subgraph->create_edge(insertable);
+            }
+        }
+    }
+    
+    void expand_context_by_length(const HandleGraph* source, MutableHandleGraph* subgraph,
+                                  int64_t dist, bool expand_forward, bool expand_backward) {
+        
+        // let's make an O(1) lookup for the current edges in case the implementation doesn't provide
+        // one (avoids O(N^2) behavior using has_edge)
+        unordered_set<edge_t> already_included_edges;
+        subgraph->for_each_edge([&](const edge_t& edge) {
+            already_included_edges.insert(edge);
+        });
+        
+        // extra bool indicates whether the position indicated is at the
+        // beginning of the node (beginning = true, end = false)
+        structures::RankPairingHeap<pair<handle_t, bool>, int64_t, greater<int64_t>> dijk_queue;
+        // all the edges we encounter along the way
+        unordered_set<edge_t> seen_edges;
+        
+        // initialize the queue at the ends pointing out of the node in the direction
+        // of our search
+        subgraph->for_each_handle([&](const handle_t& handle) {
+            handle_t src_handle = source->get_handle(subgraph->get_id(handle));
+            if (expand_forward) {
+                dijk_queue.push_or_reprioritize(make_pair(src_handle, false), 0);
+            }
+            if (expand_backward) {
+                dijk_queue.push_or_reprioritize(make_pair(src_handle, true), 0);
+            }
+        });
+        
+        
+        while (!dijk_queue.empty()) {
+            // the next closest untraversed node end
+            pair<pair<handle_t, bool>, int64_t> here = dijk_queue.top();
+            dijk_queue.pop();
+            
+            if (here.first.second) {
+                // we're at the beginning of the node
+                if (expand_forward) {
+                    // cross the node (traverse the sequence length)
+                    int64_t dist_across = here.second + source->get_length(here.first.first);
+                    if (dist_across <= dist) {
+                        dijk_queue.push_or_reprioritize(make_pair(here.first.first, false), dist_across);
+                    }
+                    
+                }
+                if (expand_backward) {
+                    // cross a join (no added distance)
+                    source->follow_edges(here.first.first, true, [&](const handle_t& prev) {
+                        dijk_queue.push_or_reprioritize(make_pair(prev, false), here.second);
+                        seen_edges.insert(source->edge_handle(prev, here.first.first));
+                        if (!subgraph->has_node(source->get_id(prev))) {
+                            subgraph->create_handle(source->get_sequence(source->forward(prev)),
+                                                    source->get_id(prev));
+                        }
+                    });
+                }
+            }
+            else {
+                // we're at the end of the node
+                if (expand_forward) {
+                    // cross a join (no added distance)
+                    source->follow_edges(here.first.first, false, [&](const handle_t& next) {
+                        dijk_queue.push_or_reprioritize(make_pair(next, true), here.second);
+                        seen_edges.insert(source->edge_handle(here.first.first, next));
+                        if (!subgraph->has_node(source->get_id(next))) {
+                            subgraph->create_handle(source->get_sequence(source->forward(next)),
+                                                    source->get_id(next));
+                        }
+                    });
+                }
+                if (expand_backward) {
+                    // cross the node (traverse the sequence length)
+                    int64_t dist_across = here.second + source->get_length(here.first.first);
+                    if (dist_across <= dist) {
+                        dijk_queue.push_or_reprioritize(make_pair(here.first.first, true), dist_across);
+                    }
+                }
+            }
+        }
+        
+        // add in the edges we saw
+        for (const edge_t& edge : seen_edges) {
+            edge_t insertable = subgraph->edge_handle(subgraph->get_handle(source->get_id(edge.first),
+                                                                           source->get_is_reverse(edge.first)),
+                                                      subgraph->get_handle(source->get_id(edge.second),
+                                                                           source->get_is_reverse(edge.second)));
+            if (!already_included_edges.count(insertable)) {
+                subgraph->create_edge(insertable);
+            }
+        }
+    }
+    
+    void expand_context(const HandleGraph* source, MutableHandleGraph* subgraph,
+                        int64_t dist, bool use_steps, bool expand_forward,
+                        bool expand_backward) {
+        
+        if (use_steps) {
+            expand_context_by_steps(source, subgraph, dist, expand_forward, expand_backward);
+        }
+        else {
+            expand_context_by_length(source, subgraph, dist, expand_forward, expand_backward);
+        }
+    }
+    
+    void expand_context_with_paths(const PathHandleGraph* source,
+                                   MutablePathMutableHandleGraph* subgraph,
+                                   int64_t dist, bool use_steps, bool expand_forward,
+                                   bool expand_backward) {
+        
+        // get the topology of the subgraph we want
+        expand_context(source, subgraph, dist, use_steps, expand_forward, expand_backward);
+        
+        // find all steps on all nodes
+        unordered_set<step_handle_t> seen_steps;
+        subgraph->for_each_handle([&](const handle_t& handle) {
+            handle_t src_handle = source->get_handle(subgraph->get_id(handle));
+            source->for_each_step_on_handle(src_handle, [&](const step_handle_t& step) {
+                seen_steps.insert(step);
+            });
+        });
+        
+        // keep track of how many segments we've added for each path
+        unordered_map<path_handle_t, int> segment_count;
+        
+        while (!seen_steps.empty()) {
+            // choose a segment arbitrarily
+            step_handle_t segment_seed = *seen_steps.begin();
+            path_handle_t path_handle = source->get_path_handle_of_step(segment_seed);
+            
+            // walk backwards until we're out of the subgraph or we loop around to
+            // the same step
+            auto step = segment_seed;
+            bool first_iter = true;
+            while (seen_steps.count(step) && (first_iter || step != segment_seed)) {
+                step = source->get_previous_step(step);
+                first_iter = false;
+            }
+            
+            if (step == segment_seed) {
+                // we walked all the way around a circular path
+                assert(source->get_is_circular(path_handle));
+                
+                // copy the whole path, making the same step the "first"
+                path_handle_t segment_handle = subgraph->create_path_handle(source->get_path_name(path_handle), true);
+                source->for_each_step_in_path(path_handle, [&](const step_handle_t& step) {
+                    handle_t handle = source->get_handle_of_step(step);
+                    subgraph->append_step(segment_handle,
+                                          subgraph->get_handle(source->get_id(handle),
+                                                               source->get_is_reverse(handle)));
+                    seen_steps.erase(step);
+                });
+            }
+            else {
+                // we walked off the subgraph, so this is the start of a segment
+                
+                // get the path name (and possibly disambiguate segments from the same path)
+                string path_name = source->get_path_name(path_handle);
+                if (segment_count[path_handle]) {
+                    path_name += "-" + to_string(segment_count[path_handle]);
+                }
+                
+                // make a new path for this segment
+                path_handle_t segment_handle = subgraph->create_path_handle(path_name);
+                
+                for (step = source->get_next_step(step);   // walk back onto the subgraph
+                     seen_steps.count(step);               // stop once we leave the subgraph
+                     step = source->get_next_step(step)) {
+                    
+                    handle_t src_handle = source->get_handle_of_step(step);
+                    subgraph->append_step(segment_handle,
+                                          subgraph->get_handle(source->get_id(src_handle),
+                                                               source->get_is_reverse(src_handle)));
+                    
+                    // keep track of which steps we've already added
+                    seen_steps.erase(step);
+                }
+            }
+            
+            // make note of the fact that we've made a segment from this source path
+            segment_count[path_handle]++;
+        }
+    }
+}
+}

--- a/src/algorithms/expand_context.hpp
+++ b/src/algorithms/expand_context.hpp
@@ -20,13 +20,18 @@ namespace algorithms {
 
 using namespace std;
 
-    // basic method to query regions of the graph
+    // basic method to query regions of the graph. subgraph must have the same
+    // ID and sequence space as source.
     // use_steps flag toggles whether dist refers to steps or length in base pairs
+    // note: neighboring nodes are considered to be length 0 away from each other,
+    // so to do a null expansion by length, use dist < 0.
     void expand_context(const HandleGraph* source, MutableHandleGraph* subgraph,
                         int64_t dist, bool use_steps = true, bool expand_forward = true,
                         bool expand_backward = true);
     
-    // same as above but with (potentially costly, and thread-locking) addition of paths
+    // same as above but with addition of paths
+    // if the subgraph contains disconnected regions of a path, it will attempt to
+    // add both regions as separate paths with a disambiguated name
     void expand_context_with_paths(const PathHandleGraph* source,
                                    MutablePathMutableHandleGraph* subgraph,
                                    int64_t dist, bool use_steps = true, bool expand_forward = true,

--- a/src/algorithms/expand_context.hpp
+++ b/src/algorithms/expand_context.hpp
@@ -1,0 +1,38 @@
+#ifndef VG_ALGORITHMS_EXPAND_CONTEXT_HPP_INCLUDED
+#define VG_ALGORITHMS_EXPAND_CONTEXT_HPP_INCLUDED
+
+/**
+ * \file expand_context.hpp
+ *
+ * Defines algorithm for adding graph material from the context around a subgraph
+ * into the subgraph
+ */
+
+#include "../handle.hpp"
+
+#include "structures/rank_pairing_heap.hpp"
+
+#include <queue>
+#include <unordered_set>
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+    // basic method to query regions of the graph
+    // use_steps flag toggles whether dist refers to steps or length in base pairs
+    void expand_context(const HandleGraph* source, MutableHandleGraph* subgraph,
+                        int64_t dist, bool use_steps = true, bool expand_forward = true,
+                        bool expand_backward = true);
+    
+    // same as above but with (potentially costly, and thread-locking) addition of paths
+    void expand_context_with_paths(const PathHandleGraph* source,
+                                   MutablePathMutableHandleGraph* subgraph,
+                                   int64_t dist, bool use_steps = true, bool expand_forward = true,
+                                   bool expand_backward = true);
+
+}
+}
+
+#endif

--- a/src/haplotype_extracter.cpp
+++ b/src/haplotype_extracter.cpp
@@ -28,6 +28,7 @@ void trace_haplotypes_and_paths(const PathHandleGraph& source, const gbwt::GBWT&
       // TODO: is expanding only forward really the right behavior here?
       algorithms::expand_context_with_paths(&source, &extractor, extend_distance, true, true, false);
       
+      // Convert to Protobuf I guess
       extractor.for_each_handle([&](const handle_t& h) {
           Node* node = out_graph.add_node();
           node->set_id(extractor.get_id(h));

--- a/src/haplotype_extracter.cpp
+++ b/src/haplotype_extracter.cpp
@@ -2,32 +2,58 @@
 #include "vg.hpp"
 #include "haplotype_extracter.hpp"
 #include "json2pb.h"
-#include "xg.hpp"
 
 namespace vg {
 
 using namespace std;
 
-void trace_haplotypes_and_paths(vg::XG& index, const gbwt::GBWT& haplotype_database,
+void trace_haplotypes_and_paths(const PathHandleGraph& source, const gbwt::GBWT& haplotype_database,
                                 vg::id_t start_node, int extend_distance,
                                 Graph& out_graph,
                                 map<string, int>& out_thread_frequencies,
                                 bool expand_graph) {
   // get our haplotypes
   gbwt::node_type n = gbwt::Node::encode(start_node, false);
-  vector<pair<thread_t,int> > haplotypes = list_haplotypes(index, haplotype_database, n, extend_distance);
+  vector<pair<thread_t,int> > haplotypes = list_haplotypes(source, haplotype_database, n, extend_distance);
 
 #ifdef debug
   cerr << "Haplotype database " << &haplotype_database << " produced " << haplotypes.size() << " haplotypes" << endl;
 #endif
 
   if (expand_graph) {
-    // get our subgraph and "regular" paths by expanding forward
-    handle_t handle = index.get_handle(start_node);
-    Node* node = out_graph.add_node();
-    node->set_sequence(index.get_sequence(handle));
-    node->set_id(start_node);
-    index.expand_context(out_graph, extend_distance, true, true, true, false);
+      // get our subgraph and "regular" paths by expanding forward
+      handle_t handle = source.get_handle(start_node);
+      bdsg::HashGraph extractor;
+      extractor.create_handle(source.get_sequence(handle), source.get_id(handle));
+      // TODO: is expanding only forward really the right behavior here?
+      algorithms::expand_context_with_paths(&source, &extractor, extend_distance, true, true, false);
+      
+      extractor.for_each_handle([&](const handle_t& h) {
+          Node* node = out_graph.add_node();
+          node->set_id(extractor.get_id(h));
+          node->set_sequence(extractor.get_sequence(h));
+      });
+      extractor.for_each_edge([&](const edge_t& e) {
+          Edge* edge = out_graph.add_edge();
+          edge->set_from(extractor.get_id(e.first));
+          edge->set_from_start(extractor.get_is_reverse(e.first));
+          edge->set_to(extractor.get_id(e.second));
+          edge->set_to_end(extractor.get_is_reverse(e.second));
+      });
+      extractor.for_each_path_handle([&](const path_handle_t& p) {
+          Path* path = out_graph.add_path();
+          path->set_name(extractor.get_path_name(p));
+          path->set_is_circular(extractor.get_is_circular(p));
+          int64_t rank = 1;
+          for (handle_t step : extractor.scan_path(p)) {
+              Mapping* mapping = path->add_mapping();
+              Position* position = mapping->mutable_position();
+              position->set_node_id(extractor.get_id(step));
+              position->set_is_reverse(extractor.get_is_reverse(step));
+              mapping->set_rank(rank);
+              ++rank;
+          }
+      });
   }
 
   // add a frequency of 1 for each normal path
@@ -37,7 +63,7 @@ void trace_haplotypes_and_paths(vg::XG& index, const gbwt::GBWT& haplotype_datab
 
   // add our haplotypes to the subgraph, naming ith haplotype "thread_i"
   for (int i = 0; i < haplotypes.size(); ++i) {
-    Path p = path_from_thread_t(haplotypes[i].first, index);
+    Path p = path_from_thread_t(haplotypes[i].first, source);
     p.set_name("thread_" + to_string(i));
     out_thread_frequencies[p.name()] = haplotypes[i].second;
     *(out_graph.add_path()) = move(p);
@@ -52,7 +78,7 @@ void output_haplotype_counts(ostream& annotation_ostream,
   }
 }
 
-Graph output_graph_with_embedded_paths(vector<pair<thread_t,int>>& haplotype_list, vg::XG& index) {
+Graph output_graph_with_embedded_paths(vector<pair<thread_t,int>>& haplotype_list, const HandleGraph& source) {
   Graph g;
   set<int64_t> nodes;
   set<pair<int,int> > edges;
@@ -60,9 +86,9 @@ Graph output_graph_with_embedded_paths(vector<pair<thread_t,int>>& haplotype_lis
     add_thread_nodes_to_set(haplotype_list[i].first, nodes);
     add_thread_edges_to_set(haplotype_list[i].first, edges);
   }
-  construct_graph_from_nodes_and_edges(g, index, nodes, edges);
+  construct_graph_from_nodes_and_edges(g, source, nodes, edges);
   for(int i = 0; i < haplotype_list.size(); i++) {
-    Path p = path_from_thread_t(haplotype_list[i].first, index);
+    Path p = path_from_thread_t(haplotype_list[i].first, source);
     p.set_name(to_string(i));
     *(g.add_path()) = move(p);
   }
@@ -70,8 +96,8 @@ Graph output_graph_with_embedded_paths(vector<pair<thread_t,int>>& haplotype_lis
 }
  
 void output_graph_with_embedded_paths(ostream& subgraph_ostream,
-            vector<pair<thread_t,int>>& haplotype_list, vg::XG& index, bool json) {
-  Graph g = output_graph_with_embedded_paths(haplotype_list, index);
+            vector<pair<thread_t,int>>& haplotype_list, const HandleGraph& source, bool json) {
+  Graph g = output_graph_with_embedded_paths(haplotype_list, source);
 
   if (json) {
     subgraph_ostream << pb2json(g);
@@ -82,7 +108,7 @@ void output_graph_with_embedded_paths(ostream& subgraph_ostream,
   }
 }
 
-void thread_to_graph_spanned(thread_t& t, Graph& g, vg::XG& index) {
+void thread_to_graph_spanned(thread_t& t, Graph& g, const HandleGraph& source) {
   set<int64_t> nodes;
   set<pair<int,int> > edges;
   nodes.insert(gbwt::Node::id(t[0]));
@@ -92,9 +118,9 @@ void thread_to_graph_spanned(thread_t& t, Graph& g, vg::XG& index) {
               make_side(gbwt::Node::id(t[i]),gbwt::Node::is_reverse(t[i]))));
   }
   for (auto& n : nodes) {
-    handle_t handle = index.get_handle(n);
+    handle_t handle = source.get_handle(n);
     Node* node = g.add_node();
-    node->set_sequence(index.get_sequence(handle));
+    node->set_sequence(source.get_sequence(handle));
     node->set_id(n);
   }
   for (auto& e : edges) {
@@ -120,12 +146,12 @@ void add_thread_edges_to_set(thread_t& t, set<pair<int,int> >& edges) {
   }
 }
 
-void construct_graph_from_nodes_and_edges(Graph& g, vg::XG& index,
+void construct_graph_from_nodes_and_edges(Graph& g, const HandleGraph& source,
             set<int64_t>& nodes, set<pair<int,int> >& edges) {
   for (auto& n : nodes) {
-    handle_t handle = index.get_handle(n);
+    handle_t handle = source.get_handle(n);
     Node* node = g.add_node();
-    node->set_sequence(index.get_sequence(handle));
+    node->set_sequence(source.get_sequence(handle));
     node->set_id(n);
   }
   for (auto& e : edges) {
@@ -138,7 +164,7 @@ void construct_graph_from_nodes_and_edges(Graph& g, vg::XG& index,
   }
 }
 
-Path path_from_thread_t(thread_t& t, vg::XG& index) {
+Path path_from_thread_t(thread_t& t, const HandleGraph& source) {
 	Path toReturn;
 	int rank = 1;
 	for(int i = 0; i < t.size(); i++) {
@@ -150,7 +176,7 @@ Path path_from_thread_t(thread_t& t, vg::XG& index) {
 
         // Set up the edits
         Edit* e = mapping->add_edit();
-        size_t l = index.get_length(index.get_handle(gbwt::Node::id(t[i])));
+        size_t l = source.get_length(source.get_handle(gbwt::Node::id(t[i])));
         e->set_from_length(l);
         e->set_to_length(l);
 
@@ -161,7 +187,7 @@ Path path_from_thread_t(thread_t& t, vg::XG& index) {
     return toReturn;
 }
 
-vector<pair<thread_t,int> > list_haplotypes(vg::XG& index, const gbwt::GBWT& haplotype_database,
+vector<pair<thread_t,int> > list_haplotypes(const HandleGraph& source, const gbwt::GBWT& haplotype_database,
             gbwt::node_type start_node, int extend_distance) {
 
 #ifdef debug
@@ -176,8 +202,8 @@ vector<pair<thread_t,int> > list_haplotypes(vg::XG& index, const gbwt::GBWT& hap
     cerr << "Start with state " << first_state << " for node " << gbwt::Node::id(start_node) << endl;
 #endif
     
-    index.follow_edges(gbwt_to_handle(index, start_node), false, [&](const handle_t& next) {
-        auto extend_node = handle_to_gbwt(index, next);
+    source.follow_edges(gbwt_to_handle(source, start_node), false, [&](const handle_t& next) {
+        auto extend_node = handle_to_gbwt(source, next);
         auto new_state = haplotype_database.extend(first_state, extend_node);
 #ifdef debug
         cerr << "Extend state " << first_state << " to " << new_state << " with " << gbwt::Node::id(extend_node) << endl;
@@ -198,9 +224,9 @@ vector<pair<thread_t,int> > list_haplotypes(vg::XG& index, const gbwt::GBWT& hap
         
         int check_size = search_intermediates.size();
         bool any_edges = false;
-        index.follow_edges(gbwt_to_handle(index, last.first.back()), false, [&](const handle_t& next) {
+        source.follow_edges(gbwt_to_handle(source, last.first.back()), false, [&](const handle_t& next) {
             any_edges = true;
-            auto extend_node = handle_to_gbwt(index, next);
+            auto extend_node = handle_to_gbwt(source, next);
             auto new_state = haplotype_database.extend(last.second, extend_node);
 #ifdef debug
             cerr << "Extend state " << last.second << " to " << new_state << " with " << gbwt::Node::id(extend_node) << endl;

--- a/src/haplotype_extracter.hpp
+++ b/src/haplotype_extracter.hpp
@@ -7,9 +7,10 @@
 #include <vector>
 
 #include <gbwt/gbwt.h>
-
 #include <vg/vg.pb.h>
-#include "xg.hpp"
+#include "bdsg/hash_graph.hpp"
+
+#include "algorithms/expand_context.hpp"
 #include "gbwt_helper.hpp"
 
 namespace vg {
@@ -23,29 +24,30 @@ using thread_t = vector<gbwt::node_type>;
 // as Paths a path with name thread_i.  Each path name (including threads) is
 // mapped to a frequency in out_thread_frequencies.  Haplotypes will be pulled
 // from the GBWT index.
-void trace_haplotypes_and_paths(vg::XG& index, const gbwt::GBWT& haplotype_database,
+void trace_haplotypes_and_paths(const PathHandleGraph& source,
+                                const gbwt::GBWT& haplotype_database,
                                 vg::id_t start_node, int extend_distance,
                                 Graph& out_graph,
                                 map<string, int>& out_thread_frequencies,
                                 bool expand_graph = true);
 
 // Turns an (xg-based) thread_t into a (vg-based) Path
-Path path_from_thread_t(thread_t& t, vg::XG& index);
+Path path_from_thread_t(thread_t& t, const HandleGraph& source);
 
 // Lists all the sub-haplotypes of length extend_distance nodes starting at
 // node start_node from the set of haplotypes embedded in the geven GBWT
 // haplotype database.  Records, for each thread_t t the number of haplotypes
 // of which t is a subhaplotype
-vector<pair<thread_t,int> > list_haplotypes(vg::XG& index, const gbwt::GBWT& haplotype_database,
+vector<pair<thread_t,int> > list_haplotypes(const HandleGraph& source, const gbwt::GBWT& haplotype_database,
             gbwt::node_type start_node, int extend_distance);
 
 // writes to subgraph_ostream the subgraph covered by
 // the haplotypes in haplotype_list, as well as these haplotypes embedded as
 // Paths.  Will output in JSON format if json set to true and Protobuf otherwise.
 void output_graph_with_embedded_paths(ostream& subgraph_ostream,
-            vector<pair<thread_t,int>>& haplotype_list, vg::XG& index, bool json = true);
+            vector<pair<thread_t,int>>& haplotype_list, const HandleGraph& source, bool json = true);
 // get the graph directly
-Graph output_graph_with_embedded_paths(vector<pair<thread_t,int>>& haplotype_list, vg::XG& index);
+Graph output_graph_with_embedded_paths(vector<pair<thread_t,int>>& haplotype_list, const HandleGraph& source);
 
 // writes to annotation_ostream the list of counts of identical subhaplotypes
 // using the same ordering as the Paths from output_graph_with_embedded_paths
@@ -53,13 +55,13 @@ void output_haplotype_counts(ostream& annotation_ostream,
             vector<pair<thread_t,int>>& haplotype_list);
 
 // Adds to a Graph the nodes and edges touched by a thread_t
-void thread_to_graph_spanned(thread_t& t, Graph& graph, vg::XG& index);
+void thread_to_graph_spanned(thread_t& t, Graph& graph, const HandleGraph& source);
 // Adds to a set of nodes all those touched by thread_t t
 void add_thread_nodes_to_set(thread_t& t, set<int64_t>& nodes);
 // Adds to a set of edges all those touched by thread_t t
 void add_thread_edges_to_set(thread_t& t, set<pair<int,int> >& edges);
 // Turns a set of nodes and a set of edges into a Graph
-void construct_graph_from_nodes_and_edges(Graph& g, vg::XG& index,
+void construct_graph_from_nodes_and_edges(Graph& g, const HandleGraph& source,
             set<int64_t>& nodes, set<pair<int,int> >& edges);
 
 }

--- a/src/unittest/vg_algorithms.cpp
+++ b/src/unittest/vg_algorithms.cpp
@@ -28,6 +28,8 @@
 #include "algorithms/shortest_cycle.hpp"
 #include "algorithms/reverse_complement.hpp"
 #include "algorithms/jump_along_path.hpp"
+#include "algorithms/expand_context.hpp"
+#include "algorithms/are_equivalent.hpp"
 #include "unittest/random_graph.hpp"
 #include "vg.hpp"
 #include "xg.hpp"
@@ -5619,6 +5621,193 @@ namespace vg {
                 REQUIRE(is_rev(jump_pos[0]) == false);
                 REQUIRE(offset(jump_pos[0]) == 1);
             }
+        }
+    }
+    
+    TEST_CASE("expand_context behaves as expected","[algorithms][subgraph][expand_context]") {
+        
+        VG graph;
+        
+        handle_t h1 = graph.create_handle("ACGT");
+        handle_t h2 = graph.create_handle("GGC");
+        handle_t h3 = graph.create_handle("T");
+        handle_t h4 = graph.create_handle("CCAG");
+        handle_t h5 = graph.create_handle("AAA");
+        handle_t h6 = graph.create_handle("C");
+        handle_t h7 = graph.create_handle("TG");
+        
+        graph.create_edge(h1, h3);
+        graph.create_edge(h2, h3);
+        graph.create_edge(h3, h4);
+        graph.create_edge(h3, h5);
+        graph.create_edge(h4, h7);
+        graph.create_edge(h5, h6);
+        
+        VG subgraph;
+        subgraph.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+        
+        SECTION("expand_context can do 0 step extraction") {
+            
+            algorithms::expand_context(&graph, &subgraph, 0, true, true, true);
+            
+            VG compare;
+            handle_t c3 = compare.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+            
+            REQUIRE(algorithms::are_equivalent(&subgraph, &compare));
+        }
+        
+        SECTION("expand_context can do 1 step extraction") {
+            
+            algorithms::expand_context(&graph, &subgraph, 1, true, true, true);
+            
+            VG compare;
+            handle_t c1 = compare.create_handle(graph.get_sequence(h1), graph.get_id(h1));
+            handle_t c2 = compare.create_handle(graph.get_sequence(h2), graph.get_id(h2));
+            handle_t c3 = compare.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+            handle_t c4 = compare.create_handle(graph.get_sequence(h4), graph.get_id(h4));
+            handle_t c5 = compare.create_handle(graph.get_sequence(h5), graph.get_id(h5));
+            
+            compare.create_edge(c1, c3);
+            compare.create_edge(c2, c3);
+            compare.create_edge(c3, c4);
+            compare.create_edge(c3, c5);
+            
+            REQUIRE(algorithms::are_equivalent(&subgraph, &compare));
+        }
+        
+        SECTION("expand_context can do 2 step extraction") {
+            
+            algorithms::expand_context(&graph, &subgraph, 2, true, true, true);
+            
+            VG compare;
+            handle_t c1 = compare.create_handle(graph.get_sequence(h1), graph.get_id(h1));
+            handle_t c2 = compare.create_handle(graph.get_sequence(h2), graph.get_id(h2));
+            handle_t c3 = compare.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+            handle_t c4 = compare.create_handle(graph.get_sequence(h4), graph.get_id(h4));
+            handle_t c5 = compare.create_handle(graph.get_sequence(h5), graph.get_id(h5));
+            handle_t c6 = compare.create_handle(graph.get_sequence(h6), graph.get_id(h6));
+            handle_t c7 = compare.create_handle(graph.get_sequence(h7), graph.get_id(h7));
+            
+            compare.create_edge(c1, c3);
+            compare.create_edge(c2, c3);
+            compare.create_edge(c3, c4);
+            compare.create_edge(c3, c5);
+            compare.create_edge(c4, c7);
+            compare.create_edge(c5, c6);
+            
+            REQUIRE(algorithms::are_equivalent(&subgraph, &compare));
+        }
+        
+        SECTION("expand_context expand by steps only forward") {
+            
+            algorithms::expand_context(&graph, &subgraph, 1, true, true, false);
+            
+            VG compare;
+            handle_t c3 = compare.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+            handle_t c4 = compare.create_handle(graph.get_sequence(h4), graph.get_id(h4));
+            handle_t c5 = compare.create_handle(graph.get_sequence(h5), graph.get_id(h5));
+            
+            compare.create_edge(c3, c4);
+            compare.create_edge(c3, c5);
+            
+            REQUIRE(algorithms::are_equivalent(&subgraph, &compare));
+        }
+        
+        SECTION("expand_context expand by steps only backward") {
+            
+            algorithms::expand_context(&graph, &subgraph, 1, true, false, true);
+            
+            VG compare;
+            handle_t c1 = compare.create_handle(graph.get_sequence(h1), graph.get_id(h1));
+            handle_t c2 = compare.create_handle(graph.get_sequence(h2), graph.get_id(h2));
+            handle_t c3 = compare.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+            
+            compare.create_edge(c1, c3);
+            compare.create_edge(c2, c3);
+            
+            REQUIRE(algorithms::are_equivalent(&subgraph, &compare));
+        }
+        
+        SECTION("expand_context can do null length-based extraction") {
+            
+            algorithms::expand_context(&graph, &subgraph, -1, false, true, true);
+            
+            VG compare;
+            handle_t c3 = compare.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+            
+            REQUIRE(algorithms::are_equivalent(&subgraph, &compare));
+        }
+        
+        SECTION("expand_context can get neighbors by length") {
+            
+            algorithms::expand_context(&graph, &subgraph, 0, false, true, true);
+            
+            VG compare;
+            handle_t c1 = compare.create_handle(graph.get_sequence(h1), graph.get_id(h1));
+            handle_t c2 = compare.create_handle(graph.get_sequence(h2), graph.get_id(h2));
+            handle_t c3 = compare.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+            handle_t c4 = compare.create_handle(graph.get_sequence(h4), graph.get_id(h4));
+            handle_t c5 = compare.create_handle(graph.get_sequence(h5), graph.get_id(h5));
+            
+            compare.create_edge(c1, c3);
+            compare.create_edge(c2, c3);
+            compare.create_edge(c3, c4);
+            compare.create_edge(c3, c5);
+            
+            REQUIRE(algorithms::are_equivalent(&subgraph, &compare));
+        }
+        
+        SECTION("expand_context can get selected neighbors by length") {
+            
+            algorithms::expand_context(&graph, &subgraph, 3, false, true, true);
+            
+            VG compare;
+            handle_t c1 = compare.create_handle(graph.get_sequence(h1), graph.get_id(h1));
+            handle_t c2 = compare.create_handle(graph.get_sequence(h2), graph.get_id(h2));
+            handle_t c3 = compare.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+            handle_t c4 = compare.create_handle(graph.get_sequence(h4), graph.get_id(h4));
+            handle_t c5 = compare.create_handle(graph.get_sequence(h5), graph.get_id(h5));
+            handle_t c6 = compare.create_handle(graph.get_sequence(h6), graph.get_id(h6));
+            
+            compare.create_edge(c1, c3);
+            compare.create_edge(c2, c3);
+            compare.create_edge(c3, c4);
+            compare.create_edge(c3, c5);
+            compare.create_edge(c5, c6);
+            
+            REQUIRE(algorithms::are_equivalent(&subgraph, &compare));
+        }
+        
+        SECTION("expand_context can expand by length going only forward") {
+            
+            algorithms::expand_context(&graph, &subgraph, 3, false, true, false);
+            
+            VG compare;
+            handle_t c3 = compare.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+            handle_t c4 = compare.create_handle(graph.get_sequence(h4), graph.get_id(h4));
+            handle_t c5 = compare.create_handle(graph.get_sequence(h5), graph.get_id(h5));
+            handle_t c6 = compare.create_handle(graph.get_sequence(h6), graph.get_id(h6));
+            
+            compare.create_edge(c3, c4);
+            compare.create_edge(c3, c5);
+            compare.create_edge(c5, c6);
+            
+            REQUIRE(algorithms::are_equivalent(&subgraph, &compare));
+        }
+        
+        SECTION("expand_context can expand by length going only backward") {
+            
+            algorithms::expand_context(&graph, &subgraph, 3, false, false, true);
+            
+            VG compare;
+            handle_t c1 = compare.create_handle(graph.get_sequence(h1), graph.get_id(h1));
+            handle_t c2 = compare.create_handle(graph.get_sequence(h2), graph.get_id(h2));
+            handle_t c3 = compare.create_handle(graph.get_sequence(h3), graph.get_id(h3));
+            
+            compare.create_edge(c1, c3);
+            compare.create_edge(c2, c3);
+            
+            REQUIRE(algorithms::are_equivalent(&subgraph, &compare));
         }
     }
 }


### PR DESCRIPTION
I handlified the `HaplotypeExtracter`. It still has some Protobuf bits that feel dated, but I think that it's the primary interface for SequenceTubeMaps and I don't want to break that. 

Of note, as part of this I wrote a handle-based replacement for `expand_context` that I think could replace the equivalent method in both `XG` and `VG`. However, the semantics are ever-so-slightly different, but in a way that I think makes it more well-defined. Accordingly, I'm not going through to replace calls to the old versions yet.