### PR TITLE
Reuse GBWT search states when finding tree tails

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -1148,20 +1148,28 @@ unordered_map<size_t, vector<TreeSubgraph>> MinimizerMapper::get_tail_forests(co
 #endif
 
         // TODO: Come up with a better way to do this with more accessors on the extension and less get_handle
-        // Get the Position reading out of the extnsion on the appropriate tail
+        // Get the Position reading out of the extension on the appropriate tail
         Position from;
         // And the length of that tail
         size_t tail_length;
+        // And the GBWT search state we want to start with
+        const gbwt::SearchState* base_state = nullptr;
         if (left_tails) {
             // Look right from start 
             from = extended_seeds[extension_number].starting_position(gbwt_graph);
             // And then flip to look the other way at the prev base
             from = reverse(from, gbwt_graph.get_length(gbwt_graph.get_handle(from.node_id(), false)));
-            
+           
+            // Use the search state going backward
+            base_state = &extended_seeds[extension_number].state.backward;
+           
             tail_length = extended_seeds[extension_number].read_interval.first;
         } else {
             // Look right from end
             from = extended_seeds[extension_number].tail_position(gbwt_graph);
+            
+            // Use the search state going forward
+            base_state = &extended_seeds[extension_number].state.forward;
             
             tail_length = read_length - extended_seeds[extension_number].read_interval.second;
         }
@@ -1181,6 +1189,7 @@ unordered_map<size_t, vector<TreeSubgraph>> MinimizerMapper::get_tail_forests(co
         list<int64_t> parent_stack;
         
         // Get the handle we are starting from
+        // TODO: is it cheaper to get this out of base_state? 
         handle_t start_handle = gbwt_graph.get_handle(from.node_id(), from.is_reverse());
         
         // Decide if the start node will end up included in the tree, or if we cut it all off with the offset.
@@ -1190,7 +1199,7 @@ unordered_map<size_t, vector<TreeSubgraph>> MinimizerMapper::get_tail_forests(co
         size_t search_limit = get_regular_aligner()->longest_detectable_gap(tail_length, read_length) + tail_length;
         
         // Do a DFS over the haplotypes in the GBWT out to that distance.
-        dfs_gbwt(start_handle, from.offset(), search_limit, [&](const handle_t& entered) {
+        dfs_gbwt(*base_state, from.offset(), search_limit, [&](const handle_t& entered) {
             // Enter a new handle.
             
             if (parent_stack.empty()) {
@@ -1274,17 +1283,26 @@ void MinimizerMapper::dfs_gbwt(const Position& from, size_t walk_distance,
 void MinimizerMapper::dfs_gbwt(handle_t from_handle, size_t from_offset, size_t walk_distance,
     const function<void(const handle_t&)>& enter_handle, const function<void(void)> exit_handle) const {
     
+    // Turn from_handle into a SearchState for everything on it.
+    gbwt::SearchState start_state = gbwt_graph.get_state(from_handle);
+    
+    // Delegate to the state-based version
+    dfs_gbwt(start_state, from_offset,walk_distance, exit_handle);
+}
+    
+void MinimizerMapper::dfs_gbwt(const gbwt::SearchState& start_state, size_t from_offset, size_t walk_distance,
+    const function<void(const handle_t&)>& enter_handle, const function<void(void)> exit_handle) const {
+    
     // Holds the gbwt::SearchState we are at, and the distance we have consumed
     using traversal_state_t = pair<gbwt::SearchState, size_t>;
-
-    // Turn from_handle into a SearchState.
-    // TODO: Let a search state come in.
-    gbwt::SearchState start_state = gbwt_graph.get_state(from_handle);
     
     if (start_state.empty()) {
         // No haplotypes even visit the first node. Stop.
         return;
     }
+    
+    // Get the handle we are starting on
+    handle_t from_handle = gbwt_graph.node_to_handle(start_state.node);
 
     // The search state represents searching through the end of the node, so we have to consume that much search limit.
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -1287,7 +1287,7 @@ void MinimizerMapper::dfs_gbwt(handle_t from_handle, size_t from_offset, size_t 
     gbwt::SearchState start_state = gbwt_graph.get_state(from_handle);
     
     // Delegate to the state-based version
-    dfs_gbwt(start_state, from_offset,walk_distance, exit_handle);
+    dfs_gbwt(start_state, from_offset, walk_distance, enter_handle, exit_handle);
 }
     
 void MinimizerMapper::dfs_gbwt(const gbwt::SearchState& start_state, size_t from_offset, size_t walk_distance,

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -241,6 +241,14 @@ protected:
      */ 
     void dfs_gbwt(handle_t from_handle, size_t from_offset, size_t walk_distance,
         const function<void(const handle_t&)>& enter_handle, const function<void(void)> exit_handle) const;
+        
+    /**
+     * The same as dfs_gbwt on a handle and an offset, but takes a
+     * gbwt::SearchState that defines only some haplotypes on a handle to start
+     * with.
+     */ 
+    void dfs_gbwt(const gbwt::SearchState& start_state, size_t from_offset, size_t walk_distance,
+        const function<void(const handle_t&)>& enter_handle, const function<void(void)> exit_handle) const;
      
 };
 


### PR DESCRIPTION
This re-uses the GBWT search states when finding the trees to align tails against. I had implemented this for linear tail finding, but not for tree tail finding.

Here's a report for the master commit this is based on:

```
TMPDIR=/mnt/scratch scripts/giraffe-wrangler.sh ~/data/hs37d5.fa ~/graphs/whole_genome_graph/whole_genome.xg ~/graphs/whole_genome_graph/whole_genome.gcsa ~/indexes/all_full.gbwt ~/graphs/whole_genome_graph/whole_genome.min ~/graphs/whole_genome_graph/whole_genome.dist ~/reads/sim_trained_100K_HG002-p570-v65-i0.0002-HS37D5.gam ~/graphs/whole_genome_graph/real_148_4000000.fastq

==== Giraffe Wrangler Report for vg v1.17.0-245-g55aa2b950 ====
Giraffe got 196350 simulated reads correct with 0.99442 average identity
Map got 197001 simulated reads correct with 0.997138 average identity
Giraffe aligned real reads at 2169.18 reads/second vs. bwa-mem's 3022.60911618909442630878 reads/second on 32 threads
Male giraffes detect oestrus in females by tasting their urine.
┌────────────────────────────┐
│       Giraffe Facts        │
├────────────────────────────┤
│Reads                 200000│
├─────────┬──────────┬───────┤
│  Stage  │Candidates│Correct│
│         │  (Avg.)  │  Lost │
├─────────┼──────────┼───────┤
│minimizer│     20.62│    767│
│   seed  │     57.25│      0│
│ cluster │     31.81│    689│
│  extend │      1.56│     77│
│  align  │      1.07│   2089│
│  winner │      1.00│      -│
├─────────┼──────────┼───────┤
│ Overall │          │   3622│
└─────────┴──────────┴───────┘
```

And here's one for this branch:

```
TMPDIR=/mnt/scratch scripts/giraffe-wrangler.sh ~/data/hs37d5.fa ~/graphs/whole_genome_graph/whole_genome.xg ~/graphs/whole_genome_graph/whole_genome.gcsa ~/indexes/all_full.gbwt ~/graphs/whole_genome_graph/whole_genome.min ~/graphs/whole_genome_graph/whole_genome.dist ~/reads/sim_trained_100K_HG002-p570-v65-i0.0002-HS37D5.gam ~/graphs/whole_genome_graph/real_148_4000000.fastq
        
        
==== Giraffe Wrangler Report for vg v1.17.0-247-g24d1baf5a ====
Giraffe got 196350 simulated reads correct with 0.994412 average identity
Map got 197001 simulated reads correct with 0.997138 average identity
Giraffe aligned real reads at 2563.02 reads/second vs. bwa-mem's 3185.93092901745890149101 reads/second on 32 threads
Giraffes use the weight of their head to maintain their balance when they gallop.
┌────────────────────────────┐
│       Giraffe Facts        │
├────────────────────────────┤
│Reads                 200000│
├─────────┬──────────┬───────┤
│  Stage  │Candidates│Correct│
│         │  (Avg.)  │  Lost │
├─────────┼──────────┼───────┤
│minimizer│     20.62│    767│
│   seed  │     57.25│      0│
│ cluster │     31.81│    689│
│  extend │      1.56│     77│
│  align  │      1.07│   2089│
│  winner │      1.00│      -│
├─────────┼──────────┼───────┤
│ Overall │          │   3622│
└─────────┴──────────┴───────┘
```

Giraffe got ~18% faster, and BWA randomly got 5% faster between runs. There's a tiny decrease in identity (since we are prohibiting some paths due to haplotype inconsistency), but no change in accuracy. So I think this is a fairly clear improvement.