### PR TITLE
Sync paths correctly in VG::expand_context

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -269,6 +269,7 @@ bool Paths::has_mapping(const string& name, int32_t rank) {
 }
 
 void Paths::append_mapping(const string& name, const mapping_t& m, bool warn_on_duplicates) {
+
     // get or create the path with this name
     list<mapping_t>& pt = get_create_path(name);
     // now if we haven't already supplied a mapping

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -1968,7 +1968,11 @@ void VG::expand_context_by_steps(VG& g, size_t steps, bool add_paths) {
                     }
                 }
             });
-        g.sync_paths();
+        g.paths.sort_by_mapping_rank();
+        g.paths.rebuild_mapping_aux();
+
+        // store paths in graph
+        g.paths.to_graph(g.graph);
     }
 }
 


### PR DESCRIPTION
Another example of the pain-in-the-ass sync'ing issues with the `VG` and `Paths`, which is in turn another example of why we should switch to our newer better implementations.

Resolves https://github.com/vgteam/vg/issues/2364, although it's strange to me that it ever worked...