### PR TITLE
Make Giraffe spit out MAPQ 0 for unmapped reads

### DIFF
--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -81,9 +81,9 @@ vg annotate -p -x "${XG_INDEX}" -a "${WORK}/mapped-map.gam" >"${WORK}/annotated-
 CORRECT_COUNT="$(vg gamcompare -r 100 "${WORK}/annotated.gam" "${SIM_GAM}" 2>&1 >/dev/null | sed 's/[^0-9]//g')"
 CORRECT_COUNT_MAP="$(vg gamcompare -r 100 "${WORK}/annotated-map.gam" "${SIM_GAM}" 2>&1 >/dev/null | sed 's/[^0-9]//g')"
 
-# Compute identity
-MEAN_IDENTITY="$(vg view -aj "${WORK}/mapped.gam" | jq -c '.identity' | awk '{x+=$1} END {print x/NR}')"
-MEAN_IDENTITY_MAP="$(vg view -aj "${WORK}/mapped-map.gam" | jq -c '.identity' | awk '{x+=$1} END {print x/NR}')"
+# Compute identity of mapped reads
+MEAN_IDENTITY="$(vg view -aj "${WORK}/mapped.gam" | jq -c 'select(.path) | .identity' | awk '{x+=$1} END {print x/NR}')"
+MEAN_IDENTITY_MAP="$(vg view -aj "${WORK}/mapped-map.gam" | jq -c 'select(.path) | .identity' | awk '{x+=$1} END {print x/NR}')"
 
 # Compute loss stages
 vg view -aj "${WORK}/mapped.gam" | scripts/giraffe-facts.py "${WORK}/facts" >"${WORK}/facts.txt" 2>&1
@@ -120,8 +120,8 @@ if which perf 2>/dev/null ; then
 fi
 
 # Print the report
-echo "Giraffe got ${CORRECT_COUNT} simulated reads correct with ${MEAN_IDENTITY} average identity"
-echo "Map got ${CORRECT_COUNT_MAP} simulated reads correct with ${MEAN_IDENTITY_MAP} average identity"
+echo "Giraffe got ${CORRECT_COUNT} simulated reads correct with ${MEAN_IDENTITY} average identity per mapped base"
+echo "Map got ${CORRECT_COUNT_MAP} simulated reads correct with ${MEAN_IDENTITY_MAP} average identity per mapped base"
 echo "Giraffe aligned real reads at ${GIRAFFE_RPS} reads/second vs. bwa-mem's ${BWA_RPS} reads/second on ${THREAD_COUNT} threads"
 
 cat "${WORK}/facts.txt"

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -53,7 +53,7 @@ THREAD_COUNT=32
 # TODO: this requires GNU mptemp
 WORK="$(mktemp -d)"
 
-if which perf 2>/dev/null ; then
+if which perf >/dev/null 2>&1 ; then
     # Record profile.
     # Do this first because perf is likely to be misconfigured and we want to fail fast.
     
@@ -111,7 +111,7 @@ BWA_RPS="$(echo "${REAL_READ_COUNT} / (${BWA_DOUBLE_TIME} - ${BWA_TIME}) / ${THR
 
 echo "==== Giraffe Wrangler Report for vg $(vg version -s) ===="
 
-if which perf 2>/dev/null ; then
+if which perf >/dev/null 2>&1 ; then
     # Output perf stuff
     mv "${WORK}/perf.data" ./perf.data
     mv "${WORK}/profile.svg" ./profile.svg

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -564,7 +564,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
 #endif
 
     size_t winning_index;
-    double mapq = get_regular_aligner()->maximum_mapping_quality_exact(scores, &winning_index);
+    // Compute MAPQ if not unmapped. Otherwise use 0 instead of the 50% this would give us.
+    double mapq = (mappings.empty() || mappings.front().path().mapping_size() == 0) ? 0 : 
+        get_regular_aligner()->maximum_mapping_quality_exact(scores, &winning_index);
     
 #ifdef debug
     cerr << "MAPQ is " << mapq << endl;


### PR DESCRIPTION
Giraffe has been giving a MAPQ of 3 for unmapped reads. I think it just throws a single 0 score into the MAPQ computation, which is equal to the implicit 0 of leaving the read unmapped that the MAPQ logic uses, giving a probability of 50% that the 0-score alignment is the right one, and a MAPQ of 3.

This PR changes Giraffe to not invoke the MAPQ logic unless it actually has an aligned alignment with a path. If not, it will use a MAPQ of 0.