### PR TITLE
Fixed linking snappy

### DIFF
--- a/source_me.sh
+++ b/source_me.sh
@@ -6,6 +6,8 @@ export LD_INCLUDE_PATH=`pwd`/include:$LD_INCLUDE_PATH
 # automatically get them demoted to the end of the search list even if a -I
 # option is passed to try and bump them up earlier, before other -I options.
 # We leave the Makefile in charge of finding all the include directories.
+export CFLAGS="-I $(pwd)/include ${CFLAGS}"
+export CXXFLAGS="-I $(pwd)/include ${CXXFLAGS}"
 export PATH=`pwd`/bin:`pwd`/scripts:$PATH
 export CC=$(which gcc)
 export CXX=$(which g++)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -107,6 +107,7 @@ void Index::open(const std::string& dir, bool read_only) {
         s = rocksdb::DB::Open(db_options, name, &db);
     }
     if (!s.ok()) {
+        cerr << s.ToString();
         if (db) {
             delete db;
         }


### PR DESCRIPTION
rocksdb wasn't building because it couldn't find snappy. Now it can find snappy