### PR TITLE
Handlify vg paths

### DIFF
--- a/src/path.hpp
+++ b/src/path.hpp
@@ -259,6 +259,8 @@ bool path_is_simple_match(const Path& p);
 // convert the mapping to the particular node into the sequence implied by the mapping
 const string mapping_sequence(const Mapping& m, const string& node_seq);
 const string mapping_sequence(const Mapping& m, const Node& n);
+// convert the path to a sequence
+string path_sequence(const HandleGraph& graph, const Path& path);
 // Reverse-complement a Mapping and all the Edits in it. A function to get node
 // lengths is needed, because the mapping will need to count its position from
 // the other end of the node.
@@ -348,6 +350,11 @@ Path path_from_node_traversals(const list<NodeTraversal>& traversals);
 // Store them in the list unless it is nullptr.
 void remove_paths(Graph& graph, const function<bool(const string&)>& paths_to_take, std::list<Path>* matching);
 
+// Get a Path from a handle graph
+Path path_from_path_handle(const PathHandleGraph& graph, path_handle_t path_handle);
+
+// Wrap a Path in an Alignment
+Alignment alignment_from_path(const HandleGraph& graph, const Path& path);
 }
 
 #endif

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -652,14 +652,7 @@ int main_find(int argc, char** argv) {
                         if (pattern.length() <= path_name.length() && path_name.compare(0, pattern.length(), pattern) == 0) {
                             // We need a Graph for serialization purposes.
                             Graph g;
-                            Path* path = g.add_path();
-                            path->set_name(path_name);
-                            for (handle_t handle : xindex->scan_path(path_handle)) {
-                                Mapping* mapping = path->add_mapping();
-                                Position* position = mapping->mutable_position();
-                                position->set_node_id(xindex->get_id(handle));
-                                position->set_is_reverse(xindex->get_is_reverse(handle));
-                            }
+                            *g.add_path() = path_from_path_handle(*xindex, path_handle);
                             // Dump the graph with its mappings. TODO: can we restrict these to
                             vector<Graph> gb = { g };
                             vg::io::write_buffered(cout, gb, 0);

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -328,6 +328,7 @@ int main_paths(int argc, char** argv) {
                             }
                             cout << "\t" << path_length;
                         }
+                        cout << endl;
                     } else {
                         Path path = path_from_path_handle(*graph, path_handle);
                         if (extract_as_gam) {

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -30,15 +30,15 @@ void help_paths(char** argv) {
          << "    -v, --vg FILE         use the paths in this vg FILE" << endl
          << "    -x, --xg FILE         use the paths in the XG index FILE" << endl
          << "    -g, --gbwt FILE       use the threads in the GBWT index in FILE" << endl
-         << "                          (XG index is required for most output options; -g takes priority over -x)" << endl
+         << "                          (XG index or vg graph required for most output options; -g takes priority over -x)" << endl
          << "  output:" << endl
          << "    -X, --extract-gam     print (as GAM alignments) the stored paths in the graph" << endl
-         << "    -V, --extract-vg      print (as path-only .vg) the queried paths (requires -x -g and -q or -Q)" << endl
+         << "    -V, --extract-vg      print (as path-only .vg) the queried paths" << endl
          << "    -L, --list            print (as a list of names, one per line) the path (or thread) names" << endl
          << "    -E, --lengths         print a list of path names (as with -L) but paired with their lengths" << endl
          << "    -F, --extract-fasta   print the paths in FASTA format" << endl
          << "  path selection:" << endl
-         << "    -Q, --paths-by STR    select the paths with the given name prefix (XG, GBWT)" << endl
+         << "    -Q, --paths-by STR    select the paths with the given name prefix" << endl
          << "    -S, --sample STR      select the threads for this sample (GBWT)" << endl;
 }
 
@@ -170,16 +170,16 @@ int main_paths(int argc, char** argv) {
         std::exit(EXIT_FAILURE);
     }
     if (!gbwt_file.empty()) {
-        bool need_xg = (extract_as_gam || extract_as_vg || list_lengths || extract_as_fasta);
-        if (need_xg && xg_file.empty()) {
-            std::cerr << "error: [vg paths] an XG index is needed for extracting threads in -X, -V, -E or -F format" << std::endl;
+        bool need_graph = (extract_as_gam || extract_as_vg || list_lengths || extract_as_fasta);
+        if (need_graph && xg_file.empty() && vg_file.empty()) {
+            std::cerr << "error: [vg paths] an XG index or vg graph needed for extracting threads in -X, -V, -E or -F format" << std::endl;
             std::exit(EXIT_FAILURE);
         }
-        if (!need_xg && !xg_file.empty()) {
+        if (!need_graph && (!xg_file.empty() || !vg_file.empty())) {
             // TODO: This should be an error, but we display a warning instead for backward compatibility.
             //std::cerr << "error: [vg paths] cannot read input from multiple sources" << std::endl;
             //std::exit(EXIT_FAILURE);
-            std::cerr << "warning: [vg paths] XG index is unnecessary for listing GBWT threads" << std::endl;
+            std::cerr << "warning: [vg paths] XG index and/or vg graph  unnecessary for listing GBWT threads" << std::endl;
         }
     }
     if (output_formats != 1) {
@@ -196,23 +196,15 @@ int main_paths(int argc, char** argv) {
     }
     
     // Load whatever indexes we were given
-    unique_ptr<VG> graph;
-    if (!vg_file.empty()) {
-        // We want a vg
-        graph = unique_ptr<VG>(new VG());
-        // Load the vg
-        get_input_file(vg_file, [&](istream& in) {
-            graph->from_istream(in);
-        });
-    }
-    unique_ptr<XG> xg_index;
-    if (!xg_file.empty()) {
-        // We want an xg
-        xg_index = unique_ptr<XG>();
-        // Load the xg
-        get_input_file(xg_file, [&](istream& in) {
-            xg_index = vg::io::VPKG::load_one<XG>(in);
-        });
+    // Note: during handlifiction, distinction between -v and -x options disappeared.
+    unique_ptr<PathHandleGraph> graph;
+    if (!vg_file.empty() || !xg_file.empty()) {
+        assert(vg_file.empty() || xg_file.empty());
+        const string& graph_file = vg_file.empty() ? xg_file : vg_file;
+        // Load the vg or xg
+        get_input_file(graph_file, [&](istream& in) {
+                graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
+            });
     }
     unique_ptr<gbwt::GBWT> gbwt_index;
     if (!gbwt_file.empty()) {
@@ -227,7 +219,18 @@ int main_paths(int argc, char** argv) {
           exit(1);
         }
     }
-    
+
+    // We may need to emit a stream of Alignemnts
+    unique_ptr<vg::io::ProtobufEmitter<Alignment>> gam_emitter;
+    // Or we might need to emit a stream of VG Graph objects
+    unique_ptr<vg::io::ProtobufEmitter<Graph>> graph_emitter;
+    if (extract_as_gam) {
+        // Open up a GAM output stream
+        gam_emitter = unique_ptr<vg::io::ProtobufEmitter<Alignment>>(new vg::io::ProtobufEmitter<Alignment>(cout));
+    } else if (extract_as_vg) {
+        // Open up a VG Graph chunk output stream
+        graph_emitter = unique_ptr<vg::io::ProtobufEmitter<Graph>>(new vg::io::ProtobufEmitter<Graph>(cout));
+    }
     
     if (gbwt_index.get() != nullptr) {
 
@@ -261,18 +264,6 @@ int main_paths(int argc, char** argv) {
             }
         }
         
-        // We may need to emit a stream of Alignemnts
-        unique_ptr<vg::io::ProtobufEmitter<Alignment>> gam_emitter;
-        // Or we might need to emit a stream of VG Graph objects
-        unique_ptr<vg::io::ProtobufEmitter<Graph>> graph_emitter;
-        if (extract_as_gam) {
-            // Open up a GAM output stream
-            gam_emitter = unique_ptr<vg::io::ProtobufEmitter<Alignment>>(new vg::io::ProtobufEmitter<Alignment>(cout));
-        } else if (extract_as_vg) {
-            // Open up a VG Graph chunk output stream
-            graph_emitter = unique_ptr<vg::io::ProtobufEmitter<Graph>>(new vg::io::ProtobufEmitter<Graph>(cout));
-        }
-
         // Process the threads.
         for (gbwt::size_type id : thread_ids) {
             std::string name = thread_name(*gbwt_index, id);        
@@ -295,21 +286,21 @@ int main_paths(int argc, char** argv) {
                 p->set_node_id(gbwt::Node::id(node));
                 p->set_is_reverse(gbwt::Node::is_reverse(node));
                 Edit* e = m->add_edit();
-                size_t len = xg_index->node_length(p->node_id());
+                size_t len = graph->get_length(graph->get_handle(p->node_id()));
                 e->set_to_length(len);
                 e->set_from_length(len);
                 m->set_rank(rank++);
             }
             if (extract_as_gam) {
                 // Write as an Alignment
-                gam_emitter->write(xg_index->path_as_alignment(path));
+                gam_emitter->write(alignment_from_path(*graph, path));
             } else if (extract_as_vg) {
                 // Write as a Path in a VG
                 Graph g;
                 *(g.add_path()) = path;
                 graph_emitter->write(std::move(g));
             } else if (extract_as_fasta) {
-                write_fasta_sequence(name, xg_index->path_string(path), cout);
+                write_fasta_sequence(name, path_sequence(*graph, path), cout);
             }
             if (list_lengths) {
                 cout << path.name() << "\t" << path_to_length(path) << endl;
@@ -324,90 +315,34 @@ int main_paths(int argc, char** argv) {
             std::mismatch(name.begin(), name.end(),
                           path_prefix.begin(), path_prefix.end()).second == path_prefix.end();
         };
-        
-        if (list_names) {
-            graph->paths.for_each([&list_lengths, &check_prefix, &graph](const Path& path) {
-                  if (check_prefix(path.name())) {
-                      cout << path.name();
-                      if (list_lengths) {
-                          size_t path_length = 0;
-                          for (const auto& m : path.mapping()) {
-                              if (m.edit_size() > 0) {
-                                  path_length += mapping_to_length(m);
-                              } else {
-                                  path_length += graph->get_length(graph->get_handle(m.position().node_id()));
-                              }
-                          }
-                          cout << "\t" << path_length;
-                      }
-                      cout << endl;
-                  }
-              });
-        } else if (extract_as_gam) {
-            vector<Alignment> alns = graph->paths_as_alignments();
-            vg::io::ProtobufEmitter<Alignment> emitter(cout);
-            for (auto& aln : alns) {
-                if (check_prefix(aln.name())) {
-                    emitter.write(std::move(aln));
-                }
-            }
-        } else if (extract_as_vg) {
-            cerr << "error: [vg paths] vg extraction is only defined for prefix queries against a XG/GBWT index pair" << endl;
-            exit(1);
-        } else if (extract_as_fasta) {
-            graph->paths.for_each([&check_prefix, &graph](const Path& path) {
-                    if (check_prefix(path.name())) {
-                        write_fasta_sequence(path.name(), graph->path_string(path), cout);
+
+        graph->for_each_path_handle([&](path_handle_t path_handle) {
+                string path_name = graph->get_path_name(path_handle);
+                if (check_prefix(path_name)) {
+                    if (list_names) {
+                        cout << path_name;
+                        if (list_lengths) {
+                            size_t path_length = 0;
+                            for (handle_t handle : graph->scan_path(path_handle)) {
+                                path_length += graph->get_length(handle);
+                            }
+                            cout << "\t" << path_length;
+                        }
+                    } else {
+                        Path path = path_from_path_handle(*graph, path_handle);
+                        if (extract_as_gam) {
+                            gam_emitter->write(alignment_from_path(*graph, path));
+                        } else if (extract_as_vg) {
+                            Graph g;
+                            *(g.add_path()) = path;
+                            graph_emitter->write(std::move(g));
+                        } else if (extract_as_fasta) {
+                            write_fasta_sequence(path_name, path_sequence(*graph, path), cout);
+                        }
                     }
-                });
-        }
-    } else if (xg_index.get() != nullptr) {
-        // Handle non-thread queries from xg
-        if (list_names) {
-            // We aren't looking for threads, but we are looking for names.
-            size_t max_path = xg_index->max_path_rank();
-            for (size_t i = 1; i <= max_path; ++i) {
-                cout << xg_index->path_name(i);
-                if (list_lengths) {
-                    cout << "\t" << xg_index->path_length(i);
                 }
-                cout << endl;
-            }
-        } else if (!path_prefix.empty()) {
-            vector<Path> got = xg_index->paths_by_prefix(path_prefix);
-            if (extract_as_gam) {
-                vg::io::ProtobufEmitter<Alignment> emitter(cout);
-                for (auto& path : got) {
-                    emitter.write(xg_index->path_as_alignment(path));
-                }
-            } else if (extract_as_vg) {
-                for(auto& path : got) {
-                    Graph g;
-                    *(g.add_path()) = xg_index->path(path.name());
-                    vector<Graph> gb = { g };
-                    vg::io::write_buffered(cout, gb, 0);
-                }
-            } else if (extract_as_fasta) {
-                for (auto& path : got) {
-                    write_fasta_sequence(path.name(), xg_index->path_string(path), cout);
-                }
-            }
-        } else if (extract_as_gam) {
-            auto alns = xg_index->paths_as_alignments();
-            vg::io::ProtobufEmitter<Alignment> emitter(cout);
-            for (auto& aln : alns) {
-                emitter.write(std::move(aln));
-            }
-        } else if (extract_as_fasta) {
-            size_t max_path = xg_index->max_path_rank();
-            for (size_t i = 1; i <= max_path; ++i) {
-                write_fasta_sequence(xg_index->path_name(i),
-                                     xg_index->path_string(xg_index->path(xg_index->path_name(i))),
-                                     cout);
-            }
-        }
+            });
     }
-    
     return 0;
 
 }


### PR DESCRIPTION
I left the command line interface alone, but `-x` and `-v` are treated identically now. 