### PR TITLE
Try to bind to NUMA nodes and use BWA batch info for BWA RPS

### DIFF
--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -46,12 +46,28 @@ shift
 
 # Define the Giraffe parameters
 GIRAFFE_OPTS=(-s75 -u 0.1 -v 25 -w 5 -C 600)
-# And the thread count for everyone
-THREAD_COUNT=32
+# And the thread count for everyone.
+# Should fit on a NUMA node
+THREAD_COUNT=24
 
 # Define a work directory
 # TODO: this requires GNU mptemp
 WORK="$(mktemp -d)"
+
+# Check for NUMA. If we have NUMA and no numactl results may be unreliable
+NUMA_COUNT="$(lscpu | grep "NUMA node(s)" | cut -f3- -d' ' | tr -d ' ')"
+NUMA_PREFIX=""
+NUMA_WARNING=0
+
+if [[ "${NUMA_COUNT}" -gt "1" ]] ; then
+    if which numactl >/dev/null 2>&1 ; then
+        # Run everything on one NUMA node
+        NUMA_PREFIX="numactl --cpunodebind=0 --membind=0"
+    else
+        # We should warn in the report that NUMA may confound the results
+        NUMA_WARNING=1
+    fi
+fi
 
 if which perf >/dev/null 2>&1 ; then
     # Record profile.
@@ -61,17 +77,17 @@ if which perf >/dev/null 2>&1 ; then
     # script makes take forever because the binary is huge
     strip bin/vg
     
-    perf record -F 100 --call-graph dwarf -o "${WORK}/perf.data"  vg gaffe -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -f "${REAL_FASTQ}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/perf.gam"
+    ${NUMA_PREFIX} perf record -F 100 --call-graph dwarf -o "${WORK}/perf.data"  vg gaffe -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -f "${REAL_FASTQ}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/perf.gam"
     perf script -i "${WORK}/perf.data" >"${WORK}/out.perf"
     deps/FlameGraph/stackcollapse-perf.pl "${WORK}/out.perf" >"${WORK}/out.folded"
     deps/FlameGraph/flamegraph.pl "${WORK}/out.folded" > "${WORK}/profile.svg"
 fi
 
 # Run simulated reads, with stats
-vg gaffe --track-correctness -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -G "${SIM_GAM}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/mapped.gam"
+${NUMA_PREFIX} vg gaffe --track-correctness -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -G "${SIM_GAM}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/mapped.gam"
 
 # And map to compare with them
-vg map -x "${XG_INDEX}" -g "${GCSA_INDEX}" -G "${SIM_GAM}" -t "${THREAD_COUNT}" >"${WORK}/mapped-map.gam"
+${NUMA_PREFIX} vg map -x "${XG_INDEX}" -g "${GCSA_INDEX}" -G "${SIM_GAM}" -t "${THREAD_COUNT}" >"${WORK}/mapped-map.gam"
 
 # Annotate and compare against truth
 vg annotate -p -x "${XG_INDEX}" -a "${WORK}/mapped.gam" >"${WORK}/annotated.gam"
@@ -91,7 +107,7 @@ vg view -aj "${WORK}/mapped.gam" | scripts/giraffe-facts.py "${WORK}/facts" >"${
 # Now do the real reads
 
 # Get RPS
-vg gaffe -p -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -f "${REAL_FASTQ}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/real.gam" 2>"${WORK}/log.txt"
+${NUMA_PREFIX} vg gaffe -p -x "${XG_INDEX}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -f "${REAL_FASTQ}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/real.gam" 2>"${WORK}/log.txt"
 
 GIRAFFE_RPS="$(cat "${WORK}/log.txt" | grep "reads per second" | sed 's/[^0-9.]//g')"
 
@@ -99,17 +115,19 @@ GIRAFFE_RPS="$(cat "${WORK}/log.txt" | grep "reads per second" | sed 's/[^0-9.]/
 REAL_READ_COUNT="$(cat "${REAL_FASTQ}" | wc -l)"
 ((REAL_READ_COUNT /= 4))
 
-bwa mem -t "${THREAD_COUNT}" "${FASTA}" "${REAL_FASTQ}" >"${WORK}/mapped.bam" 2>"${WORK}/bwa-log.txt"
-cat "${REAL_FASTQ}" "${REAL_FASTQ}" >"${WORK}/double.fq"
-bwa mem -t "${THREAD_COUNT}" "${FASTA}" "${WORK}/double.fq" >"${WORK}/mapped-double.bam" 2>"${WORK}/bwa-log-double.txt"
+${NUMA_PREFIX} bwa mem -t "${THREAD_COUNT}" "${FASTA}" "${REAL_FASTQ}" >"${WORK}/mapped.bam" 2>"${WORK}/bwa-log.txt"
 
-BWA_TIME="$(cat "${WORK}/bwa-log.txt" | grep "Real time:" | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')"
-BWA_DOUBLE_TIME="$(cat "${WORK}/bwa-log-double.txt" | grep "Real time:" | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')"
+# Now we get all the batch times from BWA and use those to compute RPS values.
+# This is optimistic but hopefully consistent.
+BWA_RPS_ALL_THREADS="$(cat "${WORK}/bwa-log.txt" | grep "Processed" | sed 's/[^0-9]*\([0-9]*\) reads in .* CPU sec, \([0-9]*\.[0-9]*\) real sec/\1 \2/g' | tr ' ' '\t' | awk '{sum1+=$1; sum2+=$2} END {print sum1/sum2}')"
 
-BWA_RPS="$(echo "${REAL_READ_COUNT} / (${BWA_DOUBLE_TIME} - ${BWA_TIME}) / ${THREAD_COUNT}" | bc -l)"
-
+BWA_RPS="$(echo "${BWA_RPS_ALL_THREADS} / ${THREAD_COUNT}" | bc -l)"
 
 echo "==== Giraffe Wrangler Report for vg $(vg version -s) ===="
+
+if [[ "${NUMA_WARNING}" == "1" ]] ; then
+    echo "WARNING! Unable to restrict to a single NUMA node! Results may have high variance!"
+fi
 
 if which perf >/dev/null 2>&1 ; then
     # Output perf stuff


### PR DESCRIPTION
This makes the output of Giraffe Wrangler much more consistent (and also raises the measured mapping speeds) by keeping all the threads and allocated memory for a given mapper run on one NUMA node, when `numactl` is available and the system has multiple NUMA nodes. You need to make sure that your NUMA nodes are big enough for the hardcoded thread count still.

I ran three runs and had ~0.2% deviation between the slowest and fastest, for both BWA and Giraffe.

I'm also using the BWA batch times and sizes for computing BWA mapping speed, instead of running two BWA runs and subtracting their overall wall clock times. This is going to overestimate BWA's speed, since I think it may not be counting IO, but it should be much more consistent.