### PR TITLE
Make Giraffe Stats be about filters

### DIFF
--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -711,14 +711,21 @@ def plot_filter_statistic_histograms(out_dir, stats_total):
         tsv_path = os.path.join(out_dir, 'stat_{}.tsv'.format(filter_name))
         tsv = open(tsv_path, 'w')
         
+        # Some stages don't have correctness annotation. So we track if we saw
+        # correct and noncorrect things to identify them.
+        have_correct = False
+        have_noncorrect = False
+        
         if isinstance(correct_counter, dict) and len(correct_counter) > 0:
             # We have correct item stats.
+            have_correct = True
             for value, count in correct_counter.items():
                 # Output format: label, value, repeats
                 tsv.write('correct\t{}\t{}\n'.format(value, count))
                 
         if isinstance(noncorrect_counter, dict) and len(noncorrect_counter) > 0:
             # We have noncorrect item stats.
+            have_noncorrect = True
             for value, count in noncorrect_counter.items():
                 # Output format: label, value, repeats
                 tsv.write('noncorrect\t{}\t{}\n'.format(value, count))
@@ -727,13 +734,19 @@ def plot_filter_statistic_histograms(out_dir, stats_total):
         
         # Now make the plot
         svg_path = os.path.join(out_dir, 'stat_{}.svg'.format(filter_name))
-        histogram.main(['histogram.py', tsv_path, '--save', svg_path,
+        
+        args = ['histogram.py', tsv_path, '--save', svg_path,
             '--title', '{} Statistic Histogram'.format(filter_name),
             '--x_label',  'Statistic Value',
             '--bins', '20',
-            '--y_label', 'Frequency',
-            '--legend_overlay', 'upper right',
-            '--categories', 'correct', 'noncorrect'])
+            '--y_label', 'Frequency']
+        if have_correct and have_noncorrect:
+            args.append('--legend_overlay')
+            args.append('best')
+            args.append('--categories')
+            args.append('correct')
+            args.append('noncorrect')
+        histogram.main(args)
                 
             
 

--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -564,7 +564,7 @@ def print_table(read_count, stats_total, out=sys.stdout):
     
     # And the incorrect result rejected count header
     rejected_header = "Incorrect"
-    rejected_header2 = "Rejected"
+    rejected_header2 = "Removed"
     # How big a number will we need to hold?
     # Look at the reads rejected at all filters
     rejected_reads = [(stats_total[filter_name]['failed_count_total'] - stats_total[filter_name]['failed_count_correct'])

--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -621,7 +621,7 @@ def print_table(read_count, stats_total, out=sys.stdout):
     row = [filter_overall]
     align = 'c'
     # Add the provenance columns
-    row += ['', overall_lost, overall_rejected]
+    row += ['', '', overall_lost, overall_rejected]
     align += 'rr'
     
     table.row(row, align)

--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -708,7 +708,7 @@ def plot_filter_statistic_histograms(out_dir, stats_total):
             continue
         
         # Open a TSV file to draw a histogram from
-        tsv_path = os.path.join(options.outdir, 'stat_{}.tsv'.format(filter_name))
+        tsv_path = os.path.join(out_dir, 'stat_{}.tsv'.format(filter_name))
         tsv = open(tsv_path, 'w')
         
         if isinstance(correct_counter, dict) and len(correct_counter) > 0:
@@ -726,7 +726,7 @@ def plot_filter_statistic_histograms(out_dir, stats_total):
         tsv.close()
         
         # Now make the plot
-        svg_path = os.path.join(options.outdir, 'stat_{}.svg'.format(filter_name))
+        svg_path = os.path.join(out_dir, 'stat_{}.svg'.format(filter_name))
         histogram.main(['histogram.py', tsv_path, '--save', svg_path,
             '--title', '{} Statistic Histogram'.format(filter_name),
             '--x_label',  'Statistic Value',

--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -165,22 +165,24 @@ void Funnel::project_group(size_t prev_stage_item, size_t group_size) {
     get_item(latest()).group_size = group_size;
 }
 
-void Funnel::fail(const char* filter, size_t prev_stage_item) {
+void Funnel::fail(const char* filter, size_t prev_stage_item, double statistic) {
     // There must be a prev stage to project from
     assert(stages.size() > 1);
     auto& prev_stage = stages[stages.size() - 2];
 
     // Record the item as having failed this filter
     prev_stage.items[prev_stage_item].failed_filter = filter;
+    prev_stage.items[prev_stage_item].failed_statistic = statistic;
 }
 
-void Funnel::pass(const char* filter, size_t prev_stage_item) {
+void Funnel::pass(const char* filter, size_t prev_stage_item, double statistic) {
     // There must be a prev stage to project from
     assert(stages.size() > 1);
     auto& prev_stage = stages[stages.size() - 2];
 
     // Record the item as having passed this filter
     prev_stage.items[prev_stage_item].passed_filters.emplace_back(filter);
+    prev_stage.items[prev_stage_item].passed_statistics.emplace_back(statistic);
 }
 
 void Funnel::score(size_t item, double score) {
@@ -224,13 +226,15 @@ void Funnel::for_each_stage(const function<void(const string&, const vector<size
 }
 
 void Funnel::for_each_filter(const function<void(const string&, const string&,
-    const FilterPerformance&, const FilterPerformance&)>& callback) const {
+    const FilterPerformance&, const FilterPerformance&, const vector<double>&, const vector<double>&)>& callback) const {
     
     for (auto& stage : stages) {
         // Hold the names of all filters encountered
         vector<const char*> filter_names;
         // And the by-item and by-size performance stats.
         vector<pair<FilterPerformance, FilterPerformance>> filter_performances;
+        // And the correct and not-known-correct filter statistic values
+        vector<pair<vector<double>, vector<double>>> filter_statistics;
         
         for (auto& item : stage.items) {
             // For each item
@@ -245,6 +249,7 @@ void Funnel::for_each_filter(const function<void(const string&, const string&,
                     
                     // And give it an empty report
                     filter_performances.emplace_back();
+                    filter_statistics.emplace_back();
                 } else {
                     // Make sure the name is correct
                     // TODO: can we justy match on pointer value and not string value?
@@ -257,6 +262,14 @@ void Funnel::for_each_filter(const function<void(const string&, const string&,
                 
                 filter_performances[filter_index].second.passing += item.group_size;
                 filter_performances[filter_index].second.passing_correct += item.correct ? item.group_size : 0;
+                
+                if (item.correct) {
+                    // Record this statistic value as belonging to a correct item
+                    filter_statistics[filter_index].first.push_back(item.passed_statistics[filter_index]);
+                } else {
+                    // Record this statistic value as belonging to a not necessarily correct item
+                    filter_statistics[filter_index].second.push_back(item.passed_statistics[filter_index]);
+                }
             }
             
             if (item.failed_filter != nullptr) {
@@ -270,6 +283,7 @@ void Funnel::for_each_filter(const function<void(const string&, const string&,
                     
                     // And give it an empty report
                     filter_performances.emplace_back();
+                    filter_statistics.emplace_back();
                 } else {
                     // Make sure the name is correct
                     // TODO: can we justy match on pointer value and not string value?
@@ -282,15 +296,26 @@ void Funnel::for_each_filter(const function<void(const string&, const string&,
                 
                 filter_performances[filter_index].second.failing += item.group_size;
                 filter_performances[filter_index].second.failing_correct += item.correct ? item.group_size : 0;
+                
+                if (item.correct) {
+                    // Record this statistic value as belonging to a correct item
+                    filter_statistics[filter_index].first.push_back(item.failed_statistic);
+                } else {
+                    // Record this statistic value as belonging to a not necessarily correct item
+                    filter_statistics[filter_index].second.push_back(item.failed_statistic);
+                }
             }
         }
         
         // Now we have gone through the filters for this stage for every item.
         
         for (size_t i = 0; i < filter_names.size(); i++) {
-            // Report the results by filter.
+            // For each filter
+            
+            // Report the results tabulated across items.
             callback(stage.name, filter_names[i],
-                filter_performances[i].first, filter_performances[i].second);
+                filter_performances[i].first, filter_performances[i].second,
+                filter_statistics[i].first, filter_statistics[i].second);
         }
     }
 }

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -93,13 +93,13 @@ public:
     /// Fail the given item from the previous stage on the given filter and do not project it through to this stage.
     /// Items which do not fail a filter must pass the filter and be projected to something.
     /// The filter name must survive the funnel, because a pointer to it will be stored.
-    void fail(const string& filter, size_t prev_stage_item);
+    void fail(const char* filter, size_t prev_stage_item);
     
     /// Pass the given item from the previous stage through the given filter at this stage.
     /// Items which do not pass a filter must fail it.
     /// All items which pass filters must do so in the same order.
     /// The filter name must survive the funnel, because a pointer to it will be stored.
-    void pass(const string& filter, size_t prev_stage_item);
+    void pass(const char* filter, size_t prev_stage_item);
     
     /// Assign the given score to the given item at the current stage.
     void score(size_t item, double score);
@@ -168,9 +168,9 @@ protected:
         /// What previous stage items were combined to make this one, if any?
         vector<size_t> prev_stage_items = {};
         /// What filters did the item pass at this stage, if any?
-        vector<const string*> passed_filters = {};
+        vector<const char*> passed_filters = {};
         /// What filter did the item finallt fail at at this stage, if any?
-        const string* failed_filter = nullptr;
+        const char* failed_filter = nullptr;
     };
     
     /// Represents a Stage which is a series of Items, which track their own provenance.

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -584,15 +584,15 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
             string filter_id = to_string(filter_num) + "_" + filter + "_" + stage;
             
             // Save the stats
-            set_annotation(mappings[0], "filter_" + filter_id + "_passed", (double) by_count.passing);
-            set_annotation(mappings[0], "filter_" + filter_id + "_failed", (double) by_count.failing);
+            set_annotation(mappings[0], "filter_" + filter_id + "_passed_count_total", (double) by_count.passing);
+            set_annotation(mappings[0], "filter_" + filter_id + "_failed_count_total", (double) by_count.failing);
             
-            set_annotation(mappings[0], "filter_" + filter_id + "_passed_size", (double) by_size.passing);
-            set_annotation(mappings[0], "filter_" + filter_id + "_failed_size", (double) by_size.failing);
+            set_annotation(mappings[0], "filter_" + filter_id + "_passed_size_total", (double) by_size.passing);
+            set_annotation(mappings[0], "filter_" + filter_id + "_failed_size_total", (double) by_size.failing);
             
             if (track_correctness) {
-                set_annotation(mappings[0], "filter_" + filter_id + "_passed_correct", (double) by_count.passing_correct);
-                set_annotation(mappings[0], "filter_" + filter_id + "_failed_correct", (double) by_count.failing_correct);
+                set_annotation(mappings[0], "filter_" + filter_id + "_passed_count_correct", (double) by_count.passing_correct);
+                set_annotation(mappings[0], "filter_" + filter_id + "_failed_count_correct", (double) by_count.failing_correct);
                 
                 set_annotation(mappings[0], "filter_" + filter_id + "_passed_size_correct", (double) by_size.passing_correct);
                 set_annotation(mappings[0], "filter_" + filter_id + "_failed_size_correct", (double) by_size.failing_correct);

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -618,6 +618,17 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
             
             filter_num++;
         });
+        
+        // Annotate with parameters used for the filters.
+        set_annotation(mappings[0], "param_hit-cap", (double) hit_cap);
+        set_annotation(mappings[0], "param_hard-hit-cap", (double) hard_hit_cap);
+        set_annotation(mappings[0], "param_score-fraction", (double) minimizer_score_fraction);
+        set_annotation(mappings[0], "param_max-extensions", (double) max_extensions);
+        set_annotation(mappings[0], "param_max-alignments", (double) max_alignments);
+        set_annotation(mappings[0], "param_cluster-score", (double) cluster_score_threshold);
+        set_annotation(mappings[0], "param_cluster-coverage", (double) cluster_coverage_threshold);
+        set_annotation(mappings[0], "param_extension-set", (double) extension_set_score_threshold);
+        set_annotation(mappings[0], "param_max-multimaps", (double) max_multimaps);
     }
     
     // Ship out all the aligned alignments

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -607,7 +607,8 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         // We need to track filter number
         size_t filter_num = 0;
         funnel.for_each_filter([&](const string& stage, const string& filter,
-            const Funnel::FilterPerformance& by_count, const Funnel::FilterPerformance& by_size) {
+            const Funnel::FilterPerformance& by_count, const Funnel::FilterPerformance& by_size,
+            const vector<double>& filter_statistics_correct, const vector<double>& filter_statistics_non_correct) {
             
             string filter_id = to_string(filter_num) + "_" + filter + "_" + stage;
             
@@ -625,6 +626,11 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
                 set_annotation(mappings[0], "filter_" + filter_id + "_passed_size_correct", (double) by_size.passing_correct);
                 set_annotation(mappings[0], "filter_" + filter_id + "_failed_size_correct", (double) by_size.failing_correct);
             }
+            
+            // Save the correct and non-correct filter statistics, even if
+            // everything is non-correct because correctness isn't computed
+            set_annotation(mappings[0], "filterstats_" + filter_id + "_correct", filter_statistics_correct);
+            set_annotation(mappings[0], "filterstats_" + filter_id + "_noncorrect", filter_statistics_non_correct);
             
             filter_num++;
         });

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -298,7 +298,7 @@ void MinimizerMapper::process_until_threshold(const vector<Item>& items, const f
         // Find the item we are talking about
         size_t& item_num = indexes_in_order[i];
         
-        if (threshold != 0 && get_score(item) <= cutoff) {
+        if (threshold != 0 && get_score(item_num) <= cutoff) {
             // Item would fail the score threshold
             
             if (unskipped < min_count) {


### PR DESCRIPTION
This changes the Giraffe Stats script to describe filters instead of stages. It also changes Giraffe to report filter info when using `--track-provenance`.

For each filter, I am recording the number and size of correct and all items that are passed and failed by the filter. I can't usefully show all that in the report, so right now the reports look like this (on a chr21 test graph):


```
┌─────────────────────────────────────────────────────────────┐
│                        Giraffe Facts                        │
├─────────────────────────────────────────────────────────────┤
│Reads                                                  200000│
├───────────────────────┬──────────┬──────────┬───────┬───────┤
│         Filter        │ Passing  │ Failing  │Correct│ Total │
│                       │(Per Read)│(Per Read)│  Lost │Removed│
├───────────────────────┼──────────┼──────────┼───────┼───────┤
│      hard-hit-cap     │     20.44│      0.17│    N/A│  34666│
│hit-cap||score-fraction│     19.47│      0.97│    N/A│ 194296│
│    cluster-coverage   │      1.21│      5.92│     52│1183528│
│     max-extensions    │      1.21│      0.00│      0│    402│
│     cluster-score     │      1.21│      0.00│      0│      3│
│     extension-set     │      1.18│      0.03│     17│   5594│
│     max-alignments    │      1.18│      0.00│     30│    524│
│     max-multimaps     │      1.00│      0.18│   9649│  35615│
├───────────────────────┼──────────┼──────────┼───────┼───────┤
│        Overall        │          │          │9748   │1454628│
└───────────────────────┴──────────┴──────────┴───────┴───────┘
```

I've tried to name the filters according to the command-line options that control them, though in the hard cap/normal cap/score fraction logic used to choose minimizers that isn't quite possible, since it's not really a series of filters AND-ed together.

I'm also recording filter "statistic" values, like the score fraction achieved for the score fraction filter, or the coverage of each cluster for the cluster-coverage filter. I can stratify these by correct/noncorrect status for the filters that happen after that determination is made, and I plot histograms that might be useful for picking optimal filter cutoffs.

Are there any other columns that you (@xchang1 and @jltsiren) want to see in the table to help you pick filter values? Maybe something like the total passed and number of noncorrect items passed, to let you calculate precision? Or should I just put the precision and recall floats for each filter?
