### PR TITLE
Grid search for Giraffe parameters

### DIFF
--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -690,4 +690,19 @@ unordered_map<id_t, id_t> overlay_node_translations(const unordered_map<id_t, id
     return overlaid;
 }
 
+template<>
+bool parse(const string& arg, double& dest) {
+    size_t after;
+    dest = std::stod(arg, &after);
+    return(after == arg.size());
+}
+
+template<>
+bool parse(const string& arg, std::regex& dest) {
+    // This throsw std::regex_error if it can't parse.
+    // That contains a kind of useless error code that we can't turn itno a string without switching on all the values.
+    dest = std::regex(arg);
+    return true;
+}
+
 }

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -590,7 +590,7 @@ bool parse(const string& arg, Result& dest);
 // Do one generic implementation for signed integers that fit in a long long.
 // Cram the constraint into the type of the output parameter.
 template<typename Result>
-inline bool parse(const string& arg, typename enable_if<sizeof(Result) <= sizeof(long long) &&
+bool parse(const string& arg, typename enable_if<sizeof(Result) <= sizeof(long long) &&
     is_integral<Result>::value &&
     is_signed<Result>::value, Result>::type& dest) {
     
@@ -607,7 +607,7 @@ inline bool parse(const string& arg, typename enable_if<sizeof(Result) <= sizeof
 
 // Do another generic implementation for unsigned integers
 template<typename Result>
-inline bool parse(const string& arg, typename enable_if<sizeof(Result) <= sizeof(unsigned long long) &&
+bool parse(const string& arg, typename enable_if<sizeof(Result) <= sizeof(unsigned long long) &&
     is_integral<Result>::value &&
     !is_signed<Result>::value, Result>::type& dest) {
     
@@ -622,22 +622,13 @@ inline bool parse(const string& arg, typename enable_if<sizeof(Result) <= sizeof
     return(after == arg.size());    
 }              
 
-// We also have an implementation for doubles
+// We also have an implementation for doubles (defined in the cpp)
 template<>
-inline bool parse(const string& arg, double& dest) {
-    size_t after;
-    dest = std::stod(arg, &after);
-    return(after == arg.size());
-}
+bool parse(const string& arg, double& dest);
 
 // And one for regular expressions
 template<>
-inline bool parse(const string& arg, std::regex& dest) {
-    // This throsw std::regex_error if it can't parse.
-    // That contains a kind of useless error code that we can't turn itno a string without switching on all the values.
-    dest = std::regex(arg);
-    return true;
-}
+bool parse(const string& arg, std::regex& dest);
 
 // Implement the first version in terms of the second, for any type
 template<typename Result>


### PR DESCRIPTION
This enables grid search on numerical parameters for `vg gaffe`. Instead of a single number, you can specify a parameter Pythonically as `start:end` or `start:end:step`, and all values in the range will be tried. If you do this for multiple parameters, all combinations will be tried.

Parameter sets are run one after the other, all in the same process, and all using the same loaded indexes.

You can split up the output into multiple files by specifying a base name with `--output-basename`. Each file will have the parameter settings used and a `.gam` extension added to the base name.

You can get a report of the reads-per-second-per-thread value for each grid search point with `--report-name`. A TSV (with header) of output file name and reads-per-second-per-thread value will be created. (If you don't use an `--output-basename`, all the filenames will be `-` because all the output will have gone to standard out.)