### PR TITLE
Add an easy way to build and tag a statically linked vg development Docker

### DIFF
--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,0 +1,13 @@
+# Dockerfile for shipping just the vg binary you have
+# Run with bin as the context so you don't ship the whole build tree.
+FROM ubuntu:18.04
+MAINTAINER vgteam
+
+WORKDIR /vg
+
+ENV PATH /vg/bin:$PATH
+
+ENTRYPOINT /vg/bin/vg
+
+COPY vg /vg/bin/vg
+

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,5 +1,5 @@
 # Dockerfile for shipping just the vg binary you have
-# Run with bin as the context so you don't ship the whole build tree.
+# Run with DOCKER_BUILDKIT=1 to avoid shipping the whole vg directory as context
 FROM ubuntu:18.04
 MAINTAINER vgteam
 
@@ -9,5 +9,6 @@ ENV PATH /vg/bin:$PATH
 
 ENTRYPOINT /vg/bin/vg
 
-COPY vg /vg/bin/vg
+COPY scripts /vg/scripts
+COPY bin/vg /vg/bin/vg
 

--- a/Makefile
+++ b/Makefile
@@ -286,13 +286,17 @@ ifneq ($(shell uname -s),Darwin)
 	LD_LIB_FLAGS += -ljemalloc
 endif
 
-.PHONY: clean get-deps deps test set-path static docs .pre-build .check-environment .check-git .no-git
+.PHONY: clean get-deps deps test set-path static static-docker docs .pre-build .check-environment .check-git .no-git
 
 $(BIN_DIR)/vg: $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
 	. ./source_me.sh && $(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/vg $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
 static: $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
-	$(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/vg $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(STATIC_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS) 
+	([ -x $(BIN_DIR)/vg ] && file $(BIN_DIR)/vg | grep "statically linked") || $(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/vg $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(STATIC_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS) 
+
+static-docker: static
+	strip bin/vg
+	docker build bin -f Dockerfile.static -t vg
 
 $(LIB_DIR)/libvg.a: $(OBJ) $(ALGORITHMS_OBJ) $(IO_OBJ) $(DEP_OBJ) $(DEPS)
 	rm -f $@

--- a/Makefile
+++ b/Makefile
@@ -294,9 +294,9 @@ $(BIN_DIR)/vg: $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND
 static: $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
 	([ -x $(BIN_DIR)/vg ] && file $(BIN_DIR)/vg | grep "statically linked") || $(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/vg $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(STATIC_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS) 
 
-static-docker: static
+static-docker: static scripts/*
 	strip bin/vg
-	docker build bin -f Dockerfile.static -t vg
+	DOCKER_BUILDKIT=1 docker build . -f Dockerfile.static -t vg
 
 $(LIB_DIR)/libvg.a: $(OBJ) $(ALGORITHMS_OBJ) $(IO_OBJ) $(DEP_OBJ) $(DEPS)
 	rm -f $@


### PR DESCRIPTION
This lets you `make static-docker` to automatically get a Docker image `vg:latest`, with a static vg binary in it, assuming you have Docker and can build a static vg binary on your system.

You can thus get a Docker with a new version of vg in a few seconds, instead of waiting an hour for Quay or the vg_docker repo to build one from scratch. Unfortunately, it doesn't ship supporting tools (jq), just vg and the scripts. It used the new `DOCKER_BUILDKIT` setting to avoid sending a giant context to the daemon.

This should help us get going on UCSC's new Kubernetes setup.