### PR TITLE
Caller fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,11 @@ vg augment x.vg aln.gam -i > aug_with_paths.vg
 
 ### Variant Calling
 
-The following example shows how to construct a VCF using read support, considering only variants in the graph.  It depends on output from the Mapping and Augmentation examples above.  Small variants and SVs can be called using the same approach.  Currently, it is more accuracte for SVs. 
+#### Calling variants using read support
+
+The following examples show how to generate a VCF with vg using read support.  They depend on output from the Mapping and Augmentation examples above.  Small variants and SVs can be called using the same approach.  Currently, it is more accuracte for SVs.  
+
+Call only variants that are present in the graph:
 
 ```sh
 # Compute the read support from the gam (ignoring mapping and base qualitiy < 15)
@@ -230,7 +234,7 @@ vg pack -x x.xg -g aln.gam -Q 15 -o aln.pack
 vg call x.xg -k aln.pack > graph_calls.vcf
 ```
 
-In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -C -A`)
+In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -C -A`):
 
 ```sh
 # Index our augmented graph
@@ -243,7 +247,7 @@ vg pack -x aug.xg -g aug.gam -Q 15 -o aln_aug.pack
 vg call aug.xg -k aln_aug.pack > calls.vcf
 ```
 
-A similar process can by used to *genotype* known variants from a VCF. To do this, the graph must be constructed from the VCF with `vg construct -a`.
+A similar process can by used to *genotype* known variants from a VCF. To do this, the graph must be constructed from the VCF with `vg construct -a`:
 
 ```sh
 # Re-construct the same graph as before but with `-a`
@@ -256,7 +260,7 @@ vg index xa.vg -x xa.xg -L
 vg pack -x xa.xg -g aln.gam -o aln.pack
 
 # Genotype the VCF
-vg call xa.xg -k aln.pack -v small/x.vcf.gz
+vg call xa.xg -k aln.pack -v small/x.vcf.gz > genotypes.vcf
 ```
 
 Pre-filtering the GAM before computing support can improve precision of SNP calling
@@ -266,6 +270,38 @@ vg filter aln.gam -r 0.90 -fu -s 2 -o 0 -D 999 -x x.xg > aln.filtered.gam
 
 # then compute the support from aln.filtered.gam instead of aln.gam in above etc.
 ```
+
+For larger graphs, it is recommended to compute snarls separately:
+```sh
+vg snarls x.xg > x.snarls
+
+# load snarls from a file instead of computing on the fly
+vg call x.xg -k aln.pack -r x.snarls > calls.vcf
+```
+
+Note: `vg pack`, `vg call` and `vg snarls` can now all be run on directly on any graph format (ex `.vg`, `.xg` or anything output by `vg convert`).  Operating on `.vg` uses the most memory and is not recommended for large graphs.  The output of `vg pack` can only be read in conjunction with the same graph used to create it, so `vg pack x.vg -g aln.gam -o x.pack` then `vg call x.xg -k x.pack` will not work.
+
+#### Calling variants from paths in the graph
+
+Infer variants from from alignments implied by paths in the graph.  This can be used, for example, to call SVs directly from a variation graph that was constructed from a multiple alignment of different assemblies:
+```sh
+# create a graph from a multiple alignment of HLA haplotypes (from vg/test directory)
+vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 -k 16 | vg mod -U 10 - | vg mod -c - > hla.vg
+
+# index it
+vg index hla.vg -x hla.xg
+
+# generate a VCF using gi|568815592:29791752-29792749 as the reference contig.  The other paths will be considered as haploid samples
+vg deconstruct hla.xg -e -p "gi|568815592:29791752-29792749" > hla_variants.vcf
+```
+
+Variants can also be inferred strictly from topology by not using `-e`, though unlike the above example, cycles are not supported.  "Deconstruct" the VCF variants that were used to construct the graph. The output will be similar but identical to `small/x.vcf.gz` as `vg construct` can add edges between adjacent alts and/or do some normalization:
+```sh
+# using the same graph from the `map` example
+vg deconstruct x.xg > x.vcf
+```
+
+As with `vg call`, it is best to compute snarls separately and pass them in with `-r` when working with large graphs.
 
 ### Command line interface
 

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -4,9 +4,8 @@
 namespace vg {
 
 GraphCaller::GraphCaller(SnarlCaller& snarl_caller,
-                         SnarlManager& snarl_manager,
-                         ostream& out_stream) :
-    snarl_caller(snarl_caller), snarl_manager(snarl_manager), out_stream(out_stream) {
+                         SnarlManager& snarl_manager) :
+    snarl_caller(snarl_caller), snarl_manager(snarl_manager) {
 }
 
 GraphCaller::~GraphCaller() {
@@ -44,6 +43,18 @@ void GraphCaller::call_top_level_snarls(bool recurse_on_fail) {
   
 }
 
+void GraphCaller::write_vcf(const PathHandleGraph& graph, const vector<string>& contigs, ostream& out_stream) const {
+    out_stream << vcf_header(graph, contigs);
+
+    std::sort(out_variants.begin(), out_variants.end(), [](const vcflib::Variant& v1, const vcflib::Variant& v2) {
+            return v1.sequenceName < v2.sequenceName || (v1.sequenceName == v2.sequenceName && v1.position < v2.position);
+        });
+
+    for (auto& var : out_variants) {
+        out_stream << var << endl;
+    }
+}
+
 string GraphCaller::vcf_header(const PathHandleGraph& graph, const vector<string>& contigs) const {
     stringstream ss;
     ss << "##fileformat=VCFv4.2" << endl;
@@ -72,9 +83,8 @@ VCFGenotyper::VCFGenotyper(const PathHandleGraph& graph,
                            const string& sample_name,
                            const vector<string>& ref_paths,
                            FastaReference* ref_fasta,
-                           FastaReference* ins_fasta,
-                           ostream& out_stream) :
-    GraphCaller(snarl_caller, snarl_manager, out_stream),
+                           FastaReference* ins_fasta) :
+    GraphCaller(snarl_caller, snarl_manager),
     graph(graph),
     input_vcf(variant_file),
     sample_name(sample_name),
@@ -177,9 +187,9 @@ bool VCFGenotyper::call_snarl(const Snarl& snarl) {
             snarl_caller.update_vcf_info(snarl, vcf_traversals, vcf_alleles, sample_name, out_variant);
 
             // print the variant
-#pragma omp critical(cout)
+#pragma omp critical(out_stream)
             {
-                out_stream << out_variant << endl;
+                out_variants.push_back(out_variant);
             }
         }
         return true;
@@ -235,7 +245,7 @@ LegacyCaller::LegacyCaller(const PathPositionHandleGraph& graph,
                            const vector<string>& ref_paths,
                            const vector<size_t>& ref_path_offsets,
                            const vector<size_t>& ref_path_lengths) :
-    GraphCaller(snarl_caller, snarl_manager, out_stream),
+    GraphCaller(snarl_caller, snarl_manager),
     graph(graph),
     sample_name(sample_name),
     ref_paths(ref_paths) {
@@ -621,9 +631,9 @@ void LegacyCaller::emit_variant(const Snarl& snarl, TraversalFinder& trav_finder
     snarl_caller.update_vcf_info(snarl, site_traversals, site_genotype, sample_name, out_variant);
 
     if (!out_variant.alt.empty()) {
-#pragma omp critical(cout)
+#pragma omp critical(out_stream)
         {
-            cout << out_variant << endl;
+            out_variants.push_back(out_variant);
         }
     }
 }

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -177,7 +177,10 @@ bool VCFGenotyper::call_snarl(const Snarl& snarl) {
             snarl_caller.update_vcf_info(snarl, vcf_traversals, vcf_alleles, sample_name, out_variant);
 
             // print the variant
-            out_stream << out_variant << endl;
+#pragma omp critical(cout)
+            {
+                out_stream << out_variant << endl;
+            }
         }
         return true;
     }

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -103,7 +103,7 @@ VCFGenotyper::VCFGenotyper(const PathHandleGraph& graph,
     VCFOutputCaller(sample_name),
     graph(graph),
     input_vcf(variant_file),
-    traversal_finder(graph, snarl_manager, variant_file, ref_paths, ref_fasta, ins_fasta) {
+    traversal_finder(graph, snarl_manager, variant_file, ref_paths, ref_fasta, ins_fasta, snarl_caller.get_skip_allele_fn()) {
 
     scan_contig_lengths();    
 }
@@ -183,7 +183,6 @@ bool VCFGenotyper::call_snarl(const Snarl& snarl) {
             // create an output variant from the input one
             vcflib::Variant out_variant;
             out_variant.sequenceName = variants[i]->sequenceName;
-            out_variant.quality = 23;
             out_variant.position = variants[i]->position;
             out_variant.id = variants[i]->id;
             out_variant.ref = variants[i]->ref;
@@ -218,7 +217,7 @@ string VCFGenotyper::vcf_header(const PathHandleGraph& graph, const vector<strin
     vector<size_t> vcf_contig_lengths;
     auto length_map = scan_contig_lengths();
     for (int i = 0; i < ref_paths.size(); ++i) {
-        vcf_contig_lengths[i] = length_map[ref_paths[i]];
+        vcf_contig_lengths.push_back(length_map[ref_paths[i]]);
     }
     
     string header = VCFOutputCaller::vcf_header(graph, ref_paths, vcf_contig_lengths);
@@ -624,7 +623,6 @@ void LegacyCaller::emit_variant(const Snarl& snarl, TraversalFinder& trav_finder
 
     // fill out the rest of the variant
     out_variant.sequenceName = ref_path_name;
-    out_variant.quality = 23;
     // +1 to convert to 1-based VCF
     out_variant.position = get_ref_position(snarl, ref_path_name).first + ref_offsets.find(ref_path_name)->second + 1; 
     out_variant.id = ".";

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -24,7 +24,8 @@ using namespace std;
 class GraphCaller {
 public:
     GraphCaller(SnarlCaller& snarl_caller,
-                SnarlManager& snarl_manager);
+                SnarlManager& snarl_manager,
+                ostream& out_stream = cout);
 
     virtual ~GraphCaller();
 
@@ -36,14 +37,9 @@ public:
     /// Call a given snarl, and print the output to out_stream
     virtual bool call_snarl(const Snarl& snarl) = 0;
 
-    /// Write the vcf
-    virtual void write_vcf(const PathHandleGraph& graph, const vector<string>& contigs, ostream& out_stream) const;
-
-protected:
-
     /// Write the vcf header (version and contigs and basic info)
     virtual string vcf_header(const PathHandleGraph& graph, const vector<string>& contigs) const;
-
+   
 protected:
 
     /// Our Genotyper
@@ -52,8 +48,8 @@ protected:
     /// Our snarls
     SnarlManager& snarl_manager;
 
-    /// Buffer needed because we want to print the variants in sorted order
-    mutable vector<vcflib::Variant> out_variants;
+    /// Where all output written
+    ostream& out_stream;
 
     /// keep track of lengths of the reference paths (for overriding VCF output when input is a subpath)
     map<string, size_t> ref_lengths;
@@ -72,7 +68,8 @@ public:
                  const string& sample_name,
                  const vector<string>& ref_paths = {},
                  FastaReference* ref_fasta = nullptr,
-                 FastaReference* ins_fasta = nullptr);
+                 FastaReference* ins_fasta = nullptr,
+                 ostream& out_stream = cout);
 
     virtual ~VCFGenotyper();
 

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -24,8 +24,7 @@ using namespace std;
 class GraphCaller {
 public:
     GraphCaller(SnarlCaller& snarl_caller,
-                SnarlManager& snarl_manager,
-                ostream& out_stream = cout);
+                SnarlManager& snarl_manager);
 
     virtual ~GraphCaller();
 
@@ -37,9 +36,14 @@ public:
     /// Call a given snarl, and print the output to out_stream
     virtual bool call_snarl(const Snarl& snarl) = 0;
 
+    /// Write the vcf
+    virtual void write_vcf(const PathHandleGraph& graph, const vector<string>& contigs, ostream& out_stream) const;
+
+protected:
+
     /// Write the vcf header (version and contigs and basic info)
     virtual string vcf_header(const PathHandleGraph& graph, const vector<string>& contigs) const;
-   
+
 protected:
 
     /// Our Genotyper
@@ -48,8 +52,8 @@ protected:
     /// Our snarls
     SnarlManager& snarl_manager;
 
-    /// Where all output written
-    ostream& out_stream;
+    /// Buffer needed because we want to print the variants in sorted order
+    mutable vector<vcflib::Variant> out_variants;
 
     /// keep track of lengths of the reference paths (for overriding VCF output when input is a subpath)
     map<string, size_t> ref_lengths;
@@ -68,8 +72,7 @@ public:
                  const string& sample_name,
                  const vector<string>& ref_paths = {},
                  FastaReference* ref_fasta = nullptr,
-                 FastaReference* ins_fasta = nullptr,
-                 ostream& out_stream = cout);
+                 FastaReference* ins_fasta = nullptr);
 
     virtual ~VCFGenotyper();
 

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -249,7 +249,8 @@ void SupportBasedSnarlCaller::update_vcf_info(const Snarl& snarl,
 
     if (!allele_supports.empty()) { //only add info if we made a call
         for (int allele = 0; allele < traversals.size(); ++allele) {
-            auto& support = called_allele_set.count(allele) ? allele_supports[allele] : uncalled_supports[allele];
+            bool is_called = called_allele_set.count(allele);
+            auto& support = is_called ? allele_supports[allele] : uncalled_supports[allele];
             
             // Set up allele-specific stats for the allele
             variant.samples[sample_name]["AD"].push_back(std::to_string((int64_t)round(total(support))));
@@ -262,8 +263,10 @@ void SupportBasedSnarlCaller::update_vcf_info(const Snarl& snarl,
                 alt_support += support;
             }
             
-            // Min all the total supports from the alleles called as present    
-            min_site_support = min(min_site_support, total(support));
+            // Min all the total supports from the alleles called as present
+            if (is_called) {
+                min_site_support = min(min_site_support, total(support));
+            }
         }
     }
     

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -89,10 +89,15 @@ public:
 
     /// Get the support of a set of traversals.  Any support overlapping traversals in shared_travs
     /// will have their support split.  If exclusive_only is true, then any split support gets
-    /// rounded down to 0.  if the ref_trav_idx is given, it will be used for computing (deletion) edge lengths
+    /// rounded down to 0 (and ignored when computing mins or averages) .
+    /// exclusive_count is like exclusive only except shared traversals will be counted (as 0)
+    /// when doing average and min support
+    /// if the ref_trav_idx is given, it will be used for computing (deletion) edge lengths
     virtual vector<Support> get_traversal_set_support(const vector<SnarlTraversal>& traversals,
                                                       const vector<int>& shared_travs,
-                                                      bool exclusive_only, int ref_trav_idx = -1) const;
+                                                      bool exclusive_only,
+                                                      bool exclusive_count,
+                                                      int ref_trav_idx = -1) const;
 
     /// Get the total length of all nodes in the traversal
     virtual vector<int> get_traversal_sizes(const vector<SnarlTraversal>& traversals) const;

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -41,6 +41,9 @@ public:
 
     /// Define any header fields needed by the above
     virtual void update_vcf_header(string& header) const = 0;
+
+    /// Optional method used for pruning searches
+    virtual function<bool(const SnarlTraversal&)> get_skip_allele_fn() const;
 };
 
 /**
@@ -82,6 +85,9 @@ public:
 
     /// Define any header fields needed by the above
     virtual void update_vcf_header(string& header) const;
+
+    /// Use min_alt_path_support threshold as cutoff
+    virtual function<bool(const SnarlTraversal&)> get_skip_allele_fn() const;
 
     /// Get the support of a traversal
     /// Child snarls are handled as in the old call code: their maximum support is used
@@ -148,6 +154,8 @@ protected:
     /// Use average instead of minimum support when determining a node's support
     /// its position supports.
     size_t average_node_support_switch_threshold = 50;
+    /// minimum average base support on alt path for it to be considered
+    double min_alt_path_support = 0.2;
 
     const PathHandleGraph& graph;
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -271,17 +271,22 @@ int main_call(int argc, char** argv) {
         LegacyCaller* legacy_caller = new LegacyCaller(*dynamic_cast<PathPositionHandleGraph*>(graph),
                                                        *dynamic_cast<SupportBasedSnarlCaller*>(snarl_caller.get()),
                                                        *snarl_manager,
-                                                       sample_name, ref_paths, ref_path_offsets, ref_path_lengths);
+                                                       sample_name, ref_paths, ref_path_offsets);
         graph_caller = unique_ptr<GraphCaller>(legacy_caller);
     }
 
     // Call the graph
-    cout << graph_caller->vcf_header(*graph, ref_paths) << flush;
     graph_caller->call_top_level_snarls();
+
+    // VCF output is our only supported output
+    VCFOutputCaller* vcf_caller = dynamic_cast<VCFOutputCaller*>(graph_caller.get());
+    assert(vcf_caller != nullptr);
+    cout << vcf_caller->vcf_header(*graph, ref_paths, ref_path_lengths) << flush;
+    vcf_caller->write_variants(cout);
         
     return 0;
 }
 
 // Register subcommand
-static Subcommand vg_call("call", "call variants", PIPELINE, 5, main_call);
+static Subcommand vg_call("call", "call or genotype VCF variants", PIPELINE, 7, main_call);
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -276,13 +276,12 @@ int main_call(int argc, char** argv) {
     }
 
     // Call the graph
+    cout << graph_caller->vcf_header(*graph, ref_paths) << flush;
     graph_caller->call_top_level_snarls();
-    // Print the VCF
-    graph_caller->write_vcf(*graph, ref_paths, cout);
-    
+        
     return 0;
 }
 
 // Register subcommand
-static Subcommand vg_call("call", "call or genotype VCF variants", PIPELINE, 7, main_call);
+static Subcommand vg_call("call", "call variants", PIPELINE, 5, main_call);
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -276,12 +276,13 @@ int main_call(int argc, char** argv) {
     }
 
     // Call the graph
-    cout << graph_caller->vcf_header(*graph, ref_paths) << flush;
     graph_caller->call_top_level_snarls();
-        
+    // Print the VCF
+    graph_caller->write_vcf(*graph, ref_paths, cout);
+    
     return 0;
 }
 
 // Register subcommand
-static Subcommand vg_call("call", "call variants", PIPELINE, 5, main_call);
+static Subcommand vg_call("call", "call or genotype VCF variants", PIPELINE, 7, main_call);
 

--- a/src/subcommand/call_main_old.cpp
+++ b/src/subcommand/call_main_old.cpp
@@ -253,5 +253,5 @@ int main_call_old(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_call_old("call-old", "call variants on an augmented graph [deprecated, soon to be removed]", PIPELINE, 5, main_call_old);
+static Subcommand vg_call_old("call-old", "call variants on an augmented graph [deprecated, soon to be removed]", DEVELOPMENT, main_call_old);
 

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -190,5 +190,5 @@ int main_deconstruct(int argc, char** argv){
 }
 
 // Register subcommand
-static Subcommand vg_deconstruct("deconstruct", "convert a graph into VCF relative to a reference", main_deconstruct);
+static Subcommand vg_deconstruct("deconstruct", "create a VCF from variation in the graph", TOOLKIT, main_deconstruct);
 

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -247,4 +247,4 @@ int main_pack(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_pack("pack", "convert alignments to a compact coverage, edit, and path index", main_pack);
+static Subcommand vg_pack("pack", "convert alignments to a compact coverage index", PIPELINE, 6, main_pack);

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -226,8 +226,15 @@ int main_snarl(int argc, char** argv) {
         // This shuold effectively be the same as above, and is included in this tool
         // for testing purposes.  The VCFTraversalFinder differs from Exhaustive in that
         // it's easier to limit traversals using read support, and it takes care of
-        // mapping back to the VCF via the alt paths. 
-      trav_finder = new VCFTraversalFinder(*vg_graph, snarl_manager, variant_file, {},
+        // mapping back to the VCF via the alt paths.
+      vector<string> ref_paths;
+      vg_graph->for_each_path_handle([&](path_handle_t path_handle) {
+              const string& name = vg_graph->get_path_name(path_handle);
+              if (!Paths::is_alt(name)) {
+                  ref_paths.push_back(name);
+              }
+          });
+      trav_finder = new VCFTraversalFinder(*vg_graph, snarl_manager, variant_file, ref_paths,
                                              ref_fasta.get(), ins_fasta.get());
     }
     

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -354,5 +354,5 @@ int main_snarl(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_snarl("snarls", "compute snarls and their traversals", main_snarl);
+static Subcommand vg_snarl("snarls", "compute snarls and their traversals", TOOLKIT, main_snarl);
 

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -2730,9 +2730,9 @@ void VCFTraversalFinder::brute_force_alt_traversals(
     if (!check_max_trav_cutoff(alt_alleles)) {
         cerr << "[VCFTraversalFinder] Warning: Site " << pb2json(site) << " with " << site_variants.size()
              << " variants contains too many traversals (>" << max_traversal_cutoff 
-             << ") to enumerate so it will be skipped:";
+             << ") to enumerate so it will be skipped:\n";
         for (auto site_var : site_variants) {
-            cerr << "  " << *site_var << endl;
+            cerr << "   " << *site_var << endl;
         }
         output_traversals.clear();
         return;

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3221,10 +3221,12 @@ pair<SnarlTraversal, vector<edge_t>> VCFTraversalFinder::scan_for_deletion(vcfli
         if (i < best_set.size() - 1) {
             step_handle_t next_step = node_to_step[graph.get_id(best_set[i + 1].first)];
             step_handle_t cur_step = node_to_step[graph.get_id(best_set[i].second)];
-            for (cur_step = graph.get_next_step(cur_step); cur_step != next_step; cur_step = graph.get_next_step(cur_step)) {
-                visit = traversal.add_visit();
-                visit->set_node_id(graph.get_id(graph.get_handle_of_step(cur_step)));
-                visit->set_backward(graph.get_is_reverse(graph.get_handle_of_step(cur_step)));
+            if (cur_step != next_step) {
+                for (cur_step = graph.get_next_step(cur_step); cur_step != next_step; cur_step = graph.get_next_step(cur_step)) {
+                    visit = traversal.add_visit();
+                    visit->set_node_id(graph.get_id(graph.get_handle_of_step(cur_step)));
+                    visit->set_backward(graph.get_is_reverse(graph.get_handle_of_step(cur_step)));
+                }
             }
         }
     }

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -1091,9 +1091,9 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
     size_t site_end = index.by_id.at(site.end().node_id()).first;
     
 #ifdef debug
-    cerr << "Site starts with " << to_node_traversal(site.start(), graph)
+    cerr << "Site starts with " << pb2json(site.start())
          << " at " << site_start
-         << " and ends with " << to_node_traversal(site.end(), graph)
+         << " and ends with " << pb2json(site.end())
          << " at " << site_end << endl;
         
     for (id_t node : nodes_left) {
@@ -1159,7 +1159,7 @@ vector<SnarlTraversal> RepresentativeTraversalFinder::find_traversals(const Snar
             id_t here = visited_node;
             do {
 #ifdef debug
-                cerr << "at node " << pb2json(*here) << endl;
+                cerr << "at node " << here << endl;
 #endif
                 // Advance
                 ref_node_start = found->first + graph.get_length(graph.get_handle(here));
@@ -2974,14 +2974,14 @@ VCFTraversalFinder::get_haplotype_alt_contents(
         vcflib::Variant* var = site_variants[allele];
 
         // get the alt path information out of the graph
-        pair<SnarlTraversal, bool> alt_path_info = get_alt_path(var, haplotype[allele], ref_path);
+        pair<SnarlTraversal, vector<edge_t>> alt_path_info = get_alt_path(var, haplotype[allele], ref_path);
         if (alt_path_info.first.visit_size() == 0) {
-            assert(alt_path_info.second == true);
+            assert(!alt_path_info.second.empty());
             // skip deletion alt path where we can't find the deletion edge in the graph
             continue;
         }
         SnarlTraversal& alt_traversal = alt_path_info.first;
-        bool is_deletion = alt_path_info.second;
+        bool is_deletion = !alt_path_info.second.empty();
 
         if (!is_deletion) {
             // fill in the nodes from the path
@@ -2990,24 +2990,21 @@ VCFTraversalFinder::get_haplotype_alt_contents(
                                                   alt_traversal.visit(i).backward()));
             }
         }  else {
-            // add the deletion edge from the path
-            assert(alt_traversal.visit_size() == 2);
-            handle_t left = graph.get_handle(alt_traversal.visit(0).node_id(),
-                                             alt_traversal.visit(0).backward());
-            handle_t right = graph.get_handle(alt_traversal.visit(1).node_id(),
-                                              alt_traversal.visit(1).backward());
-            alt_deletion_edges.insert(graph.edge_handle(left, right));
+            // add the deletion edges from the path
+            for (auto deletion_edge : alt_path_info.second) {
+                alt_deletion_edges.insert(deletion_edge);
+            }
         }
     }
 
     return make_pair(alt_nodes, alt_deletion_edges);
 }
 
-pair<SnarlTraversal, bool> VCFTraversalFinder::get_alt_path(vcflib::Variant* var, int allele,
+pair<SnarlTraversal, vector<edge_t>> VCFTraversalFinder::get_alt_path(vcflib::Variant* var, int allele,
                                                             path_handle_t ref_path) {
 
     SnarlTraversal alt_path;
-    bool is_deletion = false;
+    vector<edge_t> deletion_edges;
     
     string alt_path_name = "_alt_" + make_variant_id(*var) + "_" + to_string(allele);
     if (graph.has_path(alt_path_name) && !graph.is_empty(graph.get_path_handle(alt_path_name))) {
@@ -3024,7 +3021,7 @@ pair<SnarlTraversal, bool> VCFTraversalFinder::get_alt_path(vcflib::Variant* var
         // in this case we use the reference allele path, and try to find an edge that spans
         // it.  this will be our alt edge
         // todo: put an alt path name maker into utility.hpp
-        is_deletion = allele != 0;
+        bool is_deletion = allele != 0;
         alt_path_name = "_alt_" + make_variant_id(*var) + "_0";
         // allele 0 can be empty for an insertion.  we don't complain if it's not in the graph
         assert(allele == 0 || graph.has_path(alt_path_name));
@@ -3043,128 +3040,196 @@ pair<SnarlTraversal, bool> VCFTraversalFinder::get_alt_path(vcflib::Variant* var
                 // todo: logic needed here if want to support non-forward reference paths.
                 first_step = graph.get_previous_step(first_step);
                 last_step = graph.get_next_step(last_step);
-                if (allele != 0) {
+                if (allele == 0) {
+                    handle_t left = graph.get_handle_of_step(first_step);
+                    handle_t right = graph.get_handle_of_step(last_step);
+                    
+                    Visit* visit = alt_path.add_visit();
+                    visit->set_node_id(graph.get_id(left));
+                    visit->set_backward(graph.get_is_reverse(left));
+                    visit = alt_path.add_visit();
+                    visit->set_node_id(graph.get_id(right));
+                    visit->set_backward(graph.get_is_reverse(right));
+                } else {
                     // alt paths don't always line up with deletion edges, so we hunt for
                     // our deletion edge using the path_index here.
-                    pair<int, int> scan_deltas = scan_for_deletion(var, allele, ref_path,
-                                                                   first_step, last_step);
-                    if (scan_deltas.first != 0 || scan_deltas.second != 0) {
+                    pair<SnarlTraversal, vector<edge_t>> scan_deletion = scan_for_deletion(var, allele, ref_path,
+                                                                                           first_step, last_step);
+                    if (scan_deletion.first.visit_size() == 0) {
                         cerr << "[VCFTraversalFinder] Warning: Could not find deletion edge that matches allele "
                              << allele << " of\n" << *var << "\naround alt path" << alt_path_name << ":";
-                        if (scan_deltas.first != 0) {
-                            cerr << " Ignoring allele" << endl;
-                            return make_pair(alt_path, is_deletion);
-                        } else {
-                            cerr << " Using approximate match with size-delta " << scan_deltas.first << " and position delta "
-                                 << scan_deltas.second << " nodes" << endl;
-                        }
                     }
+                    alt_path = std::move(scan_deletion.first);
+                    deletion_edges = std::move(scan_deletion.second);
                 }
-                handle_t left = graph.get_handle_of_step(first_step);
-                handle_t right = graph.get_handle_of_step(last_step);
-
-                Visit* visit = alt_path.add_visit();
-                visit->set_node_id(graph.get_id(left));
-                visit->set_backward(graph.get_is_reverse(left));
-                visit = alt_path.add_visit();
-                visit->set_node_id(graph.get_id(right));
-                visit->set_backward(graph.get_is_reverse(right));
             } else {
                 assert(allele == 0);
             }
         }
     }
 
-    return make_pair(alt_path, is_deletion);
+    return make_pair(alt_path, deletion_edges);
 }
 
-pair<int, int> VCFTraversalFinder::scan_for_deletion(vcflib::Variant* var, int allele, path_handle_t ref_path,
-                                                     step_handle_t& first_path_step, step_handle_t& last_path_step) {
+pair<SnarlTraversal, vector<edge_t>> VCFTraversalFinder::scan_for_deletion(vcflib::Variant* var, int allele, path_handle_t ref_path,
+                                                                           step_handle_t first_path_step, step_handle_t last_path_step) {
     assert(allele > 0);
 
     // if our path matches an edge, we don't need to do anything
-    if (graph.has_edge(graph.get_handle_of_step(first_path_step),
-                       graph.get_handle_of_step(last_path_step))) {
-        return make_pair(0, 0);
+    edge_t spanning_edge = graph.edge_handle(graph.get_handle_of_step(first_path_step),
+                                             graph.get_handle_of_step(last_path_step));
+    if (graph.has_edge(spanning_edge)) {
+        SnarlTraversal traversal;
+        Visit* visit = traversal.add_visit();
+        visit->set_node_id(graph.get_id(graph.get_handle_of_step(first_path_step)));
+        visit->set_backward(graph.get_is_reverse(graph.get_handle_of_step(first_path_step)));
+        visit = traversal.add_visit();
+        visit->set_node_id(graph.get_id(graph.get_handle_of_step(last_path_step)));
+        visit->set_backward(graph.get_is_reverse(graph.get_handle_of_step(last_path_step)));
+        return make_pair(traversal, vector<edge_t>(1, spanning_edge));
     }
 
-    // todo: this function is buggy
-    //       when vg normalizes complex indels, a single deletion in the vcf can
-    //       be broken up into multiple completely separate deletions in the graph.
-    //       this function needs to find every deletion that "crosses" the alt
-    //       path in any way. 
-    
     // we're doing everything via length comparison, so keep track of the length we're
     // looking for (vcf_deletion_length) and the length we have (path_deletion_length)
     int vcf_deletion_length = var->alleles[0].length() - var->alleles[allele].length();
 
-    // zip back a few nodes
-    auto start = first_path_step;
-    for (int i = 0; i < max_deletion_scan_nodes / 2 && graph.has_previous_step(start); ++i) {
-        start = graph.get_previous_step(start);
+    // make our search window by scanning out the ends of our path
+    step_handle_t first_window_step = first_path_step;
+    for (int i = 0; i < max_deletion_scan_nodes && graph.has_previous_step(first_window_step); ++i) {
+        first_window_step = graph.get_previous_step(first_window_step);
     }
-
-#ifdef debug
-    cerr << "Seaching for deletion edge for allele " << allele << " of\n" << *var << endl
-         << "The deletion from the VCF is " << vcf_deletion_length << " bases" << endl;
-#endif
-
-    int best_size_delta = std::numeric_limits<int>::max();
-    int best_pos_delta = std::numeric_limits<int>::max();
-    step_handle_t best_start = graph.path_end(ref_path);
-    step_handle_t best_end = graph.path_end(ref_path);
+    step_handle_t last_window_step = last_path_step;
+    for (int i = 0; i < max_deletion_scan_nodes && graph.has_next_step(last_window_step); ++i) {
+        last_window_step = graph.get_next_step(last_window_step);
+    }
     
-    // measure every deletion edge in quadratic time and find the one that best fits the variant
-    // if only construct would actually put the alt paths through the deletions...
-    auto cur = start;
-    for (int i = 0; i < max_deletion_scan_nodes && graph.has_next_step(cur); ++i, cur = graph.get_next_step(cur)) {
-        if (graph.has_next_step(cur)) {
-            auto next = graph.get_next_step(cur);
-            handle_t node = graph.get_handle_of_step(cur);
-            graph.follow_edges(node, false, [&] (const handle_t& next_node) {
-                    if (graph.get_id(next_node) != graph.get_id(graph.get_handle_of_step(next))) {
-                        auto step_found = step_in_path(next_node, ref_path);
-                        if (step_found.second) {
-                            auto step = step_found.first;
-                            // the edge comes back to the reference path
-                            int length = 0;
-                            auto del_start = cur;
-                            auto del_end = step;
-                            // iterate over the reference path spanned by the edge to count the length
-                            for (graph.get_next_step(del_start); del_start != del_end; graph.get_next_step(del_start)) {
-                                length += graph.get_length(graph.get_handle_of_step(del_start));
-                                if (length > 2 * vcf_deletion_length) {
-                                    length = -1;
-                                    break;
-                                }
-                            }
-                            if (length > 0) {
-                                int delta = std::abs(length - vcf_deletion_length);
-                                int pos_delta = std::abs(i - (int)(max_deletion_scan_nodes / 2));
-                                if (delta < best_size_delta || delta == best_size_delta && pos_delta < best_pos_delta) {
-                                    best_size_delta = delta;
-                                    best_start = cur;
-                                    best_end = del_end;
-                                    best_pos_delta = pos_delta;
-#ifdef debug
-                                    cerr << "found candidate deletion at i=" << i << " from "
-                                         << graph.get_id(graph.get_handle_of_step(best_start)) << "->"
-                                         << graph.get_id(graph.get_handle_of_step(best_end)) 
-                                         << " with length " << length << endl;
-#endif
-
-                                }
-                            }
-                        }
-                    }
-                });
+    // index our reference offsets (assuming forward reference path with no cycles)
+    // needing this logic doesn't happen very often, otherwise would consider
+    // requiring path position interface
+    unordered_map<nid_t, int> ref_offsets;
+    unordered_map<nid_t, step_handle_t> node_to_step;
+    int offset = 0;
+    int first_offset = 0;
+    int last_offset = 0;
+    step_handle_t cur_step = first_window_step;
+    while (true) { // want to iterate last-inclusive
+        handle_t cur_handle = graph.get_handle_of_step(cur_step);
+        assert(graph.get_is_reverse(cur_handle) == false);
+        ref_offsets[graph.get_id(cur_handle)] = offset;
+        node_to_step[graph.get_id(cur_handle)] = cur_step;
+        if (cur_step == first_path_step) {
+            first_offset = offset + graph.get_length(cur_handle);
+        }
+        if (cur_step == last_path_step) {
+            last_offset = offset;
+        }
+        offset += graph.get_length(cur_handle);
+        if (cur_step == last_window_step) {
+            break;
+        } else {
+            cur_step = graph.get_next_step(cur_step);
         }
     }
 
-    first_path_step = best_start;
-    last_path_step = best_end;
+    // find our deletions, and index them by how close they match our given alt path
+    // the delta is the min length of the deletion's two endpoints to the paths enpoints. 
+    multimap<int, edge_t> delta_to_deletion; // index deleions by their distance from ref path ends
+    unordered_map<edge_t, size_t> deletion_to_length; // lookup deletion sizes
+    for (cur_step = first_window_step; cur_step != last_window_step; cur_step = graph.get_next_step(cur_step)) {
+        handle_t cur_handle = graph.get_handle_of_step(cur_step);
+        handle_t next_handle = graph.get_handle_of_step(graph.get_next_step(cur_step));        
+        graph.follow_edges(cur_handle, false, [&] (const handle_t& edge_next_handle) {
+                assert(graph.get_is_reverse(edge_next_handle) == false);
+                if (graph.get_id(next_handle) != graph.get_id(edge_next_handle) &&
+                    ref_offsets.count(graph.get_id(edge_next_handle))) {
+                    // we are in a deletion that's contained in the window
+                    int deletion_start_offset = ref_offsets[graph.get_id(cur_handle)] + graph.get_length(cur_handle);
+                    int deletion_end_offset = ref_offsets[graph.get_id(edge_next_handle)];
+                    int delta = std::min(std::abs(deletion_start_offset - first_offset), std::abs(deletion_end_offset - last_offset));
+                    delta_to_deletion.insert(make_pair(delta, make_pair(cur_handle, edge_next_handle)));
+                    deletion_to_length[make_pair(cur_handle, edge_next_handle)] = deletion_end_offset - deletion_start_offset;
+                }
+            });
+    }
 
-    return make_pair(best_size_delta, best_pos_delta);
+    // our goal is to find a traversal that threads the deletions we find.  in order to do this, our deltions
+    // can't overlap
+    function<bool(edge_t, const vector<edge_t>&)> doesnt_intersect = [&](edge_t edge, const vector<edge_t>& edge_set) {
+        int edge_start = ref_offsets[graph.get_id(edge.first)] + graph.get_length(edge.first);
+        int edge_end = ref_offsets[graph.get_id(edge.second)];
+        // because of previous assumptins, are edges shoudl always be forward alogn the path.
+        // note they are not made wtih graph.edge_handle, and are just oriented in the scan order
+        assert(edge_start <= edge_end);
+        for (edge_t other_edge : edge_set) {
+            int other_start = ref_offsets[graph.get_id(other_edge.first)] + graph.get_length(other_edge.first);
+            int other_end = ref_offsets[graph.get_id(other_edge.second)];
+            if ((other_start >= edge_start && other_start < edge_end) || (other_end > edge_start && other_end <= edge_end) ||
+                (edge_start >= other_start && edge_start < other_end) || (edge_end > other_start && edge_end >= other_end)) {
+                return false;
+            }
+        }
+        return true;
+    };
+    
+    // greedily try to find some deletions that add up to the desired length, and are close to spanning
+    // the alt path
+    int best_delta = numeric_limits<int>::max();
+    vector<edge_t> best_set;
+    for (auto delta_edge : delta_to_deletion) {
+        // can do better than quadratic here, but the sizes should be small enough not to matter
+        vector<edge_t> candidate_set = {delta_edge.second};
+        size_t total_size = deletion_to_length[delta_edge.second];
+        int total_delta = delta_edge.first;
+        for (auto delta_edge2 : delta_to_deletion) {
+            if (delta_edge2 != delta_edge) {
+                if (total_size + deletion_to_length[delta_edge2.second] <= vcf_deletion_length &&
+                    // make that cubic...
+                    doesnt_intersect(delta_edge2.second, candidate_set)) {
+                        total_size += deletion_to_length[delta_edge2.second];
+                        total_delta += delta_edge2.first;
+                        candidate_set.push_back(delta_edge2.second);
+                    }
+            }
+            if (total_size == vcf_deletion_length) {
+                break;
+            }
+        }
+        if (total_delta < best_delta) {
+            best_set = candidate_set;
+            best_delta = total_delta;
+        }
+    }
+
+    // sort the edges along the path
+    std::sort(best_set.begin(), best_set.end(), [&](edge_t e1, edge_t e2) {
+            return ref_offsets[graph.get_id(e1.first)] < ref_offsets[graph.get_id(e2.first)]; });
+
+    SnarlTraversal traversal;
+    Visit* visit;
+    // fill out the traversal
+    for (int i = 0; i < best_set.size(); ++i) {
+        // add a visit for each edge endpoint
+        if (i == 0 || best_set[i].first != best_set[i-1].second) {
+            visit = traversal.add_visit();
+            visit->set_node_id(graph.get_id(best_set[i].first));
+            visit->set_backward(graph.get_is_reverse(best_set[i].first));
+        }
+        visit = traversal.add_visit();
+        visit->set_node_id(graph.get_id(best_set[i].second));
+        visit->set_backward(graph.get_is_reverse(best_set[i].second));
+        // the fill in the reference path to the next edge
+        if (i < best_set.size() - 1) {
+            step_handle_t next_step = node_to_step[graph.get_id(best_set[i + 1].first)];
+            step_handle_t cur_step = node_to_step[graph.get_id(best_set[i].second)];
+            for (cur_step = graph.get_next_step(cur_step); cur_step != next_step; cur_step = graph.get_next_step(cur_step)) {
+                visit = traversal.add_visit();
+                visit->set_node_id(graph.get_id(graph.get_handle_of_step(cur_step)));
+                visit->set_backward(graph.get_is_reverse(graph.get_handle_of_step(cur_step)));
+            }
+        }
+    }
+
+    return make_pair(traversal, best_set);
 }
 
 

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -428,7 +428,7 @@ protected:
     bool include_endpoints = true;
 
     /// How far to scan when looking for deletions
-    size_t max_deletion_scan_nodes = 20;
+    size_t max_deletion_scan_nodes = 50;
 
 public:
 

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -428,7 +428,7 @@ protected:
     bool include_endpoints = true;
 
     /// How far to scan when looking for deletions
-    size_t max_deletion_scan_nodes = 100;
+    size_t max_deletion_scan_nodes = 20;
 
 public:
 
@@ -506,26 +506,26 @@ protected:
                                     const vector<int>& haplotype,
                                     path_handle_t ref_path);
 
-    /** Get one alt-path out of the graph in the form of a snarl traversal.  bool value
-     *  returned is true if allele is a deletion, and returned traversal will be a pair of nodes
-     *  representing the deletion edge.
+    /** Get one alt-path out of the graph in the form of a snarl traversal.  if the path is a deletion,
+     *  the edges corresponding to the deletion are also returned.  note that it is indeed possible
+     *  for one alt path (and therefore one vcf alleles) to correspond to several deletion edges in the 
+     *  graph due to normalization during construction.
      */
-    pair<SnarlTraversal, bool> get_alt_path(vcflib::Variant* site_variant, int allele, path_handle_t ref_path);
+    pair<SnarlTraversal, vector<edge_t>> get_alt_path(vcflib::Variant* site_variant, int allele, path_handle_t ref_path);
 
     /**
      * An alt path for a deletion is the deleted reference path.  But sometimes vg construct doesn't
      * write a deletion edge that exactly jumps over the alt path.  In these cases, we need to 
      * search the graph for one. This does a brute-force check of all deletion edges in the vicinity
-     * for one that's the same size as the one we're looking for.  It picks the nearest one and
-     * returns true if the exact size is found.  
+     * for one that's the same size as the one we're looking for.  
+     * It tries to find a set of nearyby deletions that match the desired length.
      * Todo: check the sequence as well
      * Also todo: It'd be really nice if construct -fa would make the deletion-edge easily inferrable 
      * from the alt path.  It really shouldn't be necessary to hunt around. 
-     * Returns: <size delta between returned deletion and vcf allele,
-     *           position delta between returned deletion and alt path>
+     * Returns: <deletion traversal, list of deletion edges>
      */
-    pair<int, int> scan_for_deletion(vcflib::Variant* var, int allele, path_handle_t ref_path,
-                                     step_handle_t& first_path_step, step_handle_t& last_path_step);
+    pair<SnarlTraversal, vector<edge_t>> scan_for_deletion(vcflib::Variant* var, int allele, path_handle_t ref_path,
+                                                           step_handle_t first_path_step, step_handle_t last_path_step);
 
     /**
      * Prune our search space using the skip_alt method.  Will return a list of pruned VCF alleles/


### PR DESCRIPTION
* `vg construct -a` can make it difficult to match alt paths back to deletion edges (#2259).  patch to use heuristic search that can map one vcf deletion to several graph deletions
* when genotyping a vcf, make sure output not written in parallel
* [WIP] only called alleles get info fields.  change so all alleles in variatn get a field 