### PR TITLE
Cloud profiling

### DIFF
--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -14,8 +14,8 @@ RUN apt-get -qq -y update && \
     apt-get -qq -y upgrade && \
     apt-get -qq -y install \
     numactl \
-    python-matplotlib \
-    python-numpy \
+    python3-matplotlib \
+    python3-numpy \
     awscli \
     bwa \
     jq \

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -21,6 +21,7 @@ RUN apt-get -qq -y update && \
     jq \
     bc \
     linux-tools-common \
+    perl \
     && apt-get -qq -y clean
 
 COPY scripts /vg/scripts

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -9,6 +9,10 @@ ENV PATH /vg/bin:$PATH
 
 ENTRYPOINT /vg/bin/vg
 
+# Prevent dpkg from trying to ask any questions, ever
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+
 # Install dependencies for scripts
 RUN apt-get -qq -y update && \
     apt-get -qq -y upgrade && \

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -9,6 +9,16 @@ ENV PATH /vg/bin:$PATH
 
 ENTRYPOINT /vg/bin/vg
 
+# Install dependencies for scripts
+RUN apt-get -qq -y update && \
+    apt-get -qq -y upgrade && \
+    apt-get -qq -y install \
+    numactl \
+    python-matplotlib \
+    awscli \
+    bwa \
+    && apt-get -qq -y clean
+
 COPY scripts /vg/scripts
 COPY bin/vg /vg/bin/vg
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -15,8 +15,10 @@ RUN apt-get -qq -y update && \
     apt-get -qq -y install \
     numactl \
     python-matplotlib \
+    python-numpy \
     awscli \
     bwa \
+    jq \
     && apt-get -qq -y clean
 
 COPY scripts /vg/scripts

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -20,6 +20,7 @@ RUN apt-get -qq -y update && \
     bwa \
     jq \
     bc \
+    linux-tools-common \
     && apt-get -qq -y clean
 
 COPY scripts /vg/scripts

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -33,4 +33,3 @@ RUN apt-get -qq -y update && \
 COPY deps/FlameGraph /vg/deps/FlameGraph
 COPY scripts /vg/scripts
 COPY bin/vg /vg/bin/vg
-

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -25,10 +25,12 @@ RUN apt-get -qq -y update && \
     jq \
     bc \
     linux-tools-common \
+    linux-tools-generic \
     binutils \
     perl \
     && apt-get -qq -y clean
 
+COPY deps/FlameGraph /vg/deps/FlameGraph
 COPY scripts /vg/scripts
 COPY bin/vg /vg/bin/vg
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -25,6 +25,7 @@ RUN apt-get -qq -y update && \
     jq \
     bc \
     linux-tools-common \
+    binutils \
     perl \
     && apt-get -qq -y clean
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -19,6 +19,7 @@ RUN apt-get -qq -y update && \
     awscli \
     bwa \
     jq \
+    bc \
     && apt-get -qq -y clean
 
 COPY scripts /vg/scripts

--- a/Makefile
+++ b/Makefile
@@ -305,8 +305,10 @@ $(LIB_DIR)/vg_is_static: $(INC_DIR)/vg_environment_version.hpp $(OBJ_DIR)/main.o
 # For now we link dynamically and then link statically, if we actually need to rebuild anything.
 static: $(LIB_DIR)/vg_is_static
 
+# Make sure to strip out the symbols that make the binary 300 MB, but leave the
+# symbols perf needs for profiling.
 static-docker: static scripts/*
-	strip $(BIN_DIR)/$(EXE)
+	strip -d $(BIN_DIR)/$(EXE)
 	DOCKER_BUILDKIT=1 docker build . -f Dockerfile.static -t vg
 
 $(LIB_DIR)/libvg.a: $(OBJ) $(ALGORITHMS_OBJ) $(IO_OBJ) $(DEP_OBJ) $(DEPS)

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,11 @@ endif
 $(BIN_DIR)/vg: $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
 	. ./source_me.sh && $(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/vg $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
-static: $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
+# We don't want to always rebuild the static vg if no files have changed.
+# But we do need to rebuild it if files have changed.
+# TODO: is there a way to query the mtimes of all the files and rebuild if they changed *or* vg isn't static?
+# For now we link dynamically and then link statically, if we actually need to rebuild anything.
+static: $(BIN_DIR)/vg
 	([ -x $(BIN_DIR)/vg ] && file $(BIN_DIR)/vg | grep "statically linked") || $(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/vg $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(STATIC_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS) 
 
 static-docker: static scripts/*

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ $(BIN_DIR)/$(EXE): $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOM
 
 # We keep a file that we touch on the last static build.
 # If the vg linkables are newer than the last static build, we do a build
-$(LIB_DIR)/vg_is_static: .pre-build .check-environment .check-git $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
+$(LIB_DIR)/vg_is_static: $(INC_DIR)/vg_environment_version.hpp $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
 	$(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(STATIC_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 	-touch $(LIB_DIR)/vg_is_static
 

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ $(BIN_DIR)/$(EXE): $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOM
 
 # We keep a file that we touch on the last static build.
 # If the vg linkables are newer than the last static build, we do a build
-$(LIB_DIR)/vg_is_static: $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
+$(LIB_DIR)/vg_is_static: .pre-build .check-environment .check-git $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
 	$(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(STATIC_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 	-touch $(LIB_DIR)/vg_is_static
 

--- a/Makefile
+++ b/Makefile
@@ -288,18 +288,18 @@ endif
 
 .PHONY: clean get-deps deps test set-path static static-docker docs .pre-build .check-environment .check-git .no-git
 
-$(BIN_DIR)/vg: $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
-	. ./source_me.sh && $(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/vg $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
+$(BIN_DIR)/$(EXE): $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) $(DEPS) $(LINK_DEPS)
+	. ./source_me.sh && $(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS)
 
 # We don't want to always rebuild the static vg if no files have changed.
 # But we do need to rebuild it if files have changed.
 # TODO: is there a way to query the mtimes of all the files and rebuild if they changed *or* vg isn't static?
 # For now we link dynamically and then link statically, if we actually need to rebuild anything.
-static: $(BIN_DIR)/vg
-	([ -x $(BIN_DIR)/vg ] && file $(BIN_DIR)/vg | grep "statically linked") || $(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/vg $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(STATIC_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS) 
+static: $(BIN_DIR)/$(EXE)
+	([ -x $(BIN_DIR)/$(EXE) ] && file $(BIN_DIR)/$(EXE) | grep "statically linked") || $(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIGURATION_OBJ) -lvg $(STATIC_FLAGS) $(LD_LIB_FLAGS) $(ROCKSDB_LDFLAGS) 
 
 static-docker: static scripts/*
-	strip bin/vg
+	strip $(BIN_DIR)/$(EXE)
 	DOCKER_BUILDKIT=1 docker build . -f Dockerfile.static -t vg
 
 $(LIB_DIR)/libvg.a: $(OBJ) $(ALGORITHMS_OBJ) $(IO_OBJ) $(DEP_OBJ) $(DEPS)
@@ -313,7 +313,7 @@ get-deps:
 # And we have submodule deps to build
 deps: $(DEPS)
 
-test: $(BIN_DIR)/vg $(LIB_DIR)/libvg.a test/build_graph $(BIN_DIR)/shuf $(VCFLIB_DIR)/bin/vcf2tsv $(FASTAHACK_DIR)/fastahack $(BIN_DIR)/rapper
+test: $(BIN_DIR)/$(EXE) $(LIB_DIR)/libvg.a test/build_graph $(BIN_DIR)/shuf $(VCFLIB_DIR)/bin/vcf2tsv $(FASTAHACK_DIR)/fastahack $(BIN_DIR)/rapper
 	. ./source_me.sh && cd test && prove -v t
 
 docs: $(SRC_DIR)/*.cpp $(SRC_DIR)/*.hpp $(SUBCOMMAND_SRC_DIR)/*.cpp $(SUBCOMMAND_SRC_DIR)/*.hpp $(UNITTEST_SRC_DIR)/*.cpp $(UNITTEST_SRC_DIR)/*.hpp
@@ -687,7 +687,7 @@ $(UNITTEST_OBJ_DIR)/%.d: ;
 
 # for rebuilding just vg
 clean-vg:
-	$(RM) -r $(BIN_DIR)/vg
+	$(RM) -r $(BIN_DIR)/$(EXE)
 	$(RM) -r $(UNITTEST_OBJ_DIR)/*.o $(UNITTEST_OBJ_DIR)/*.d
 	$(RM) -r $(SUBCOMMAND_OBJ_DIR)/*.o $(SUBCOMMAND_OBJ_DIR)/*.d
 	$(RM) -r $(OBJ_DIR)/*.o $(OBJ_DIR)/*.d

--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -19,6 +19,13 @@ import json
 import random
 import math
 
+# Force output to UTF-8. Eventually we can use reconfigure() if we drop 3.6
+# and earlier.
+# We need to do this before these streams get picked as any argument default
+# values.
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf8')
+sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf8')
+
 # We depend on our local histogram.py
 import histogram
 
@@ -844,11 +851,6 @@ def main(args):
     "args" specifies the program arguments, with args[0] being the executable
     name. The return value should be used as the program's exit code.
     """
-   
-    # Force output to UTF-8. Eventually we can use reconfigure() if we drop 3.6
-    # and earlier.
-    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf8')
-    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf8')
    
     print(random.choice(FACTS), file = sys.stderr)
     

--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -13,6 +13,7 @@ import sys
 import time
 import subprocess
 import collections
+import io
 import itertools
 import json
 import random
@@ -843,7 +844,12 @@ def main(args):
     "args" specifies the program arguments, with args[0] being the executable
     name. The return value should be used as the program's exit code.
     """
-    
+   
+    # Force output to UTF-8. Eventually we can use reconfigure() if we drop 3.6
+    # and earlier.
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf8')
+    sys.stderr = io.TextIOWrapper(sys.sterr.buffer, encoding='utf8')
+   
     print(random.choice(FACTS), file = sys.stderr)
     
     options = parse_args(args) # This holds the nicely-parsed options object

--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -848,7 +848,7 @@ def main(args):
     # Force output to UTF-8. Eventually we can use reconfigure() if we drop 3.6
     # and earlier.
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf8')
-    sys.stderr = io.TextIOWrapper(sys.sterr.buffer, encoding='utf8')
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf8')
    
     print(random.choice(FACTS), file = sys.stderr)
     

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -4,6 +4,8 @@
 
 echo "Wrangling giraffes..."
 
+scripts/giraffe-facts.py || true
+
 set -ex
 
 usage() {
@@ -141,7 +143,8 @@ MEAN_IDENTITY="$(vg view -aj "${WORK}/mapped.gam" | jq -c 'select(.path) | .iden
 MEAN_IDENTITY_MAP="$(vg view -aj "${WORK}/mapped-map.gam" | jq -c 'select(.path) | .identity' | awk '{x+=$1} END {print x/NR}')"
 
 # Compute loss stages
-vg view -aj "${WORK}/mapped.gam" | scripts/giraffe-facts.py "${WORK}/facts" >"${WORK}/facts.txt" 2>&1
+# Let giraffe facts errors out
+vg view -aj "${WORK}/mapped.gam" | scripts/giraffe-facts.py "${WORK}/facts" >"${WORK}/facts.txt"
 
 # Now do the real reads
 

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -2,7 +2,7 @@
 
 # giraffe-wrangler.sh: Run and profile vg gaffe and analyze the results.
 
-set -e
+set -ex
 
 usage() {
     # Print usage to stderr

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -2,11 +2,7 @@
 
 # giraffe-wrangler.sh: Run and profile vg gaffe and analyze the results.
 
-echo "Wrangling giraffes..."
-
-scripts/giraffe-facts.py || true
-
-set -ex
+set -e
 
 usage() {
     # Print usage to stderr

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -27,24 +27,41 @@ if [[ "$#" -lt "8" ]]; then
     usage
 fi
 
-FASTA="${1}"
+fetch_input() {
+    # Download the specified file, if not a file already.
+    # Dumps all files into the current directory as their basenames
+    # Output the new filename
+    if [[ "${1}" == s3://* ]] ; then
+        aws s3 cp --quiet "${1}" "$(basename "${1}")"
+        basename "${1}"
+    else
+        echo "${1}"
+    fi
+}
+
+FASTA="$(fetch_input "${1}")"
+for EXT in amb ann bwt fai pac sa ; do
+    # Make sure we have all the indexes adjacent to the FASTA
+    fetch_input "${1}.${EXT}" >/dev/null
 shift
-XG_INDEX="${1}"
+XG_INDEX="$(fetch_input "${1}")"
+# Make sure we have the GBWTGraph pre-made
+GBWT_GRAPH="$(fetch_input "${1%.xg}.gg")"
 shift
-GCSA_INDEX="${1}"
+GCSA_INDEX="$(fetch_input "${1}")"
+LCP_INDEX="$(fetch_input "${1}.lcp")"
 shift
-GBWT_INDEX="${1}"
+GBWT_INDEX="$(fetch_input "${1}")"
 shift
-MINIMIZER_INDEX="${1}"
+MINIMIZER_INDEX="$(fetch_input "${1}")"
 shift
-DISTANCE_INDEX="${1}"
+DISTANCE_INDEX="$(fetch_input "${1}")"
 shift
-SIM_GAM="${1}"
+SIM_GAM="$(fetch_input "${1}")"
 shift
-REAL_FASTQ="${1}"
+REAL_FASTQ="$(fetch_input "${1}")"
 shift
 
-GBWT_GRAPH=${XG_INDEX%.xg}.gg
 if [ -f "$GBWT_GRAPH" ]; then
     GIRAFFE_GRAPH=(-g "${GBWT_GRAPH}")
 else

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -2,7 +2,7 @@
 
 # giraffe-wrangler.sh: Run and profile vg gaffe and analyze the results.
 
-set -ex
+set -e
 
 usage() {
     # Print usage to stderr

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -2,7 +2,9 @@
 
 # giraffe-wrangler.sh: Run and profile vg gaffe and analyze the results.
 
-set -e
+echo "Wrangling giraffes..."
+
+set -ex
 
 usage() {
     # Print usage to stderr
@@ -32,7 +34,7 @@ fetch_input() {
     # Dumps all files into the current directory as their basenames
     # Output the new filename
     if [[ "${1}" == s3://* ]] ; then
-        aws s3 cp --quiet "${1}" "$(basename "${1}")"
+        aws s3 --quiet cp "${1}" "$(basename "${1}")"
         basename "${1}"
     else
         echo "${1}"
@@ -43,6 +45,7 @@ FASTA="$(fetch_input "${1}")"
 for EXT in amb ann bwt fai pac sa ; do
     # Make sure we have all the indexes adjacent to the FASTA
     fetch_input "${1}.${EXT}" >/dev/null
+done
 shift
 XG_INDEX="$(fetch_input "${1}")"
 # Make sure we have the GBWTGraph pre-made
@@ -67,6 +70,17 @@ if [ -f "$GBWT_GRAPH" ]; then
 else
     GIRAFFE_GRAPH=(-x "${XG_INDEX}")
 fi
+
+echo "Indexes:"
+echo "${XG_INDEX}"
+echo "${GBWT_GRAPH}"
+echo "${GCSA_INDEX}"
+echo "${LCP_INDEX}"
+echo "${GBWT_INDEX}"
+echo "${MINIMIZER_INDEX}"
+echo "${DISTANCE_INDEX}"
+echo "${SIM_GAM}"
+echo "${REAL_FASTQ}"
 
 # Define the Giraffe parameters
 GIRAFFE_OPTS=(-s75 -u 0.1 -v 1 -w 5 -C 600)

--- a/scripts/giraffe-wrangler.sh
+++ b/scripts/giraffe-wrangler.sh
@@ -112,7 +112,7 @@ if which perf >/dev/null 2>&1 ; then
     
     # If we don't strip bin/vg to make it small, the addr2line calls that perf
     # script makes take forever because the binary is huge
-    strip bin/vg
+    strip -d bin/vg
     
     ${NUMA_PREFIX} perf record -F 100 --call-graph dwarf -o "${WORK}/perf.data"  vg gaffe "${GIRAFFE_GRAPH[@]}" -m "${MINIMIZER_INDEX}" -H "${GBWT_INDEX}" -d "${DISTANCE_INDEX}" -f "${REAL_FASTQ}" -t "${THREAD_COUNT}" "${GIRAFFE_OPTS[@]}" >"${WORK}/perf.gam"
     perf script -i "${WORK}/perf.data" >"${WORK}/out.perf"

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -104,8 +104,6 @@ struct Range {
     
     /// Check the range for usefulness
     inline bool is_valid() {
-        cerr << "Validating range " << start << ":" << end << ":" << step << endl;
-    
         if (start != end && step == 0) {
             // We'll never make it
             cerr << "Invalid range (no movement): " << start << " to " << end << " step " << step << endl;


### PR DESCRIPTION
This PR modifies Giraffe Wrangler to work well on Kubernes in AWS. It can now take S3 URLs for input files, and knows how to download them along with the files that are supposed to sit next to them  .gcsa.lcp, .fa.bwt, etc.).

I've been running it on our Kubernetes cluster like this:

```
make static-docker && docker tag vg:latest quay.io/adamnovak/vg:test && docker push quay.io/adamnovak/vg:test && (kubectl delete job adamnovak-giraffe-wrangler || true) && kubectl apply -f - <<'EOF'
apiVersion: batch/v1
kind: Job
metadata:
  name: adamnovak-giraffe-wrangler
spec:
  ttlSecondsAfterFinished: 86400
  template:
    spec:
      containers:
      - name: wrangler
        imagePullPolicy: Always
        image: quay.io/adamnovak/vg:test
        command:
        - /bin/bash
        - -c
        - |
          cp /usr/lib/linux-tools/*/perf /usr/bin/perf
          "/vg/scripts/giraffe-wrangler.sh" "s3://vg-k8s/profiling/data/hs37d5.fa" "s3://vg-k8s/profiling/graphs/whole_genome_graph/whole_genome.xg" "s3://vg-k8s/profiling/graphs/whole_genome_graph/whole_genome.gcsa" "s3://vg-k8s/profiling/indexes/all_full.gbwt" "s3://vg-k8s/profiling/graphs/whole_genome_graph/whole_genome.v5.min" "s3://vg-k8s/profiling/graphs/whole_genome_graph/whole_genome.dist" "s3://vg-k8s/profiling/reads/sim_trained_100K_HG002-p570-v65-i0.0002-HS37D5.gam" "s3://vg-k8s/profiling/reads/real_148_4000000.fastq"
        volumeMounts:
        - mountPath: /tmp
          name: scratch-volume
        - mountPath: /root/.aws
          name: s3-credentials
        resources:
          requests:
            cpu: 24
            memory: "100Gi"
            ephemeral-storage: "200Gi"
          limits:
            cpu: 24
            memory: "100Gi"
            ephemeral-storage: "200Gi"
      restartPolicy: Never
      volumes:
      - name: scratch-volume
        emptyDir: {}
      - name: s3-credentials
        secret:
          secretName: shared-s3-credentials
  backoffLimit: 0
EOF
```