### PR TITLE
Longer minimizers

### DIFF
--- a/src/io/register_loader_saver_minimizer.cpp
+++ b/src/io/register_loader_saver_minimizer.cpp
@@ -16,15 +16,15 @@ using namespace std;
 using namespace vg::io;
 
 void register_loader_saver_minimizer() {
-    Registry::register_bare_loader_saver<gbwtgraph::MinimizerIndex>("MinimizerIndex", [](istream& input) -> void* {
-        gbwtgraph::MinimizerIndex* index = new gbwtgraph::MinimizerIndex();
+    Registry::register_bare_loader_saver<gbwtgraph::DefaultMinimizerIndex>("MinimizerIndex", [](istream& input) -> void* {
+        gbwtgraph::DefaultMinimizerIndex* index = new gbwtgraph::DefaultMinimizerIndex();
         index->deserialize(input);
         
         // Return the index so the caller owns it.
         return static_cast<void*>(index);
     }, [](const void* index_void, ostream& output) {
         assert(index_void != nullptr);
-        static_cast<const gbwtgraph::MinimizerIndex*>(index_void)->serialize(output);
+        static_cast<const gbwtgraph::DefaultMinimizerIndex*>(index_void)->serialize(output);
     });
 }
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -20,7 +20,7 @@ namespace vg {
 
 using namespace std;
 
-MinimizerMapper::MinimizerMapper(const gbwtgraph::GBWTGraph& graph, const gbwtgraph::MinimizerIndex& minimizer_index,
+MinimizerMapper::MinimizerMapper(const gbwtgraph::GBWTGraph& graph, const gbwtgraph::DefaultMinimizerIndex& minimizer_index,
     MinimumDistanceIndex& distance_index, const PathPositionHandleGraph* path_graph) :
     path_graph(path_graph), minimizer_index(minimizer_index),
     distance_index(distance_index), gbwt_graph(graph),
@@ -54,7 +54,7 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     vector<pos_t> seeds;
     
     // This will hold all the minimizers in the query
-    vector<gbwtgraph::MinimizerIndex::minimizer_type> minimizers;
+    vector<gbwtgraph::DefaultMinimizerIndex::minimizer_type> minimizers;
     // And either way this will map from seed to minimizer that generated it
     vector<size_t> seed_to_source;
     

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -30,7 +30,7 @@ public:
      * as we only use it for correctness tracking.
      */
 
-    MinimizerMapper(const gbwtgraph::GBWTGraph& graph, const gbwtgraph::MinimizerIndex& minimizer_index,
+    MinimizerMapper(const gbwtgraph::GBWTGraph& graph, const gbwtgraph::DefaultMinimizerIndex& minimizer_index,
          MinimumDistanceIndex& distance_index, const PathPositionHandleGraph* path_graph = nullptr);
 
     /**
@@ -95,7 +95,7 @@ public:
 protected:
     // These are our indexes
     const PathPositionHandleGraph* path_graph; // Can be nullptr; only needed for correctness tracking.
-    const gbwtgraph::MinimizerIndex& minimizer_index;
+    const gbwtgraph::DefaultMinimizerIndex& minimizer_index;
     MinimumDistanceIndex& distance_index;
 
     /// This is our primary graph.

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -186,9 +186,9 @@ int main_cluster(int argc, char** argv) {
         gcsa_index = vg::io::VPKG::load_one<gcsa::GCSA>(gcsa_name);
         lcp_index = vg::io::VPKG::load_one<gcsa::LCPArray>(gcsa_name + ".lcp");
     }
-    unique_ptr<gbwtgraph::MinimizerIndex> minimizer_index;
+    unique_ptr<gbwtgraph::DefaultMinimizerIndex> minimizer_index;
     if (!minimizer_name.empty()) {
-        minimizer_index = vg::io::VPKG::load_one<gbwtgraph::MinimizerIndex>(minimizer_name);
+        minimizer_index = vg::io::VPKG::load_one<gbwtgraph::DefaultMinimizerIndex>(minimizer_name);
     }
     unique_ptr<SnarlManager> snarl_manager = vg::io::VPKG::load_one<SnarlManager>(snarls_name);
     unique_ptr<MinimumDistanceIndex> distance_index = vg::io::VPKG::load_one<MinimumDistanceIndex>(distance_name);
@@ -224,7 +224,7 @@ int main_cluster(int argc, char** argv) {
             // If working with MEMs, this will hold all the MEMs
             vector<MaximalExactMatch> mems;
             // If working with minimizers, this will hold all the minimizers in the query
-            vector<gbwtgraph::MinimizerIndex::minimizer_type> minimizers;
+            vector<gbwtgraph::DefaultMinimizerIndex::minimizer_type> minimizers;
             // And either way this will map from seed to MEM or minimizer that generated it
             vector<size_t> seed_to_source;
             

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -694,7 +694,7 @@ int main_gaffe(int argc, char** argv) {
     if (progress) {
         cerr << "Loading minimizer index " << minimizer_name << endl;
     }
-    unique_ptr<gbwtgraph::MinimizerIndex> minimizer_index = vg::io::VPKG::load_one<gbwtgraph::MinimizerIndex>(minimizer_name);
+    unique_ptr<gbwtgraph::DefaultMinimizerIndex> minimizer_index = vg::io::VPKG::load_one<gbwtgraph::DefaultMinimizerIndex>(minimizer_name);
 
     if (progress) {
         cerr << "Loading distance index " << distance_name << endl;

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -7,13 +7,9 @@
  * successive kmers and their reverse complements. If the kmer contains
  * characters other than A, C, G, and T, it will not be indexed.
  *
- * By default, the index contains all minimizers in the graph. Option
- * --max-occs can be used to specify the maximum number of occurrences for
- * a kmer. Kmers more frequent than that will be removed from the index.
- *
- * The index contains either all haplotype-consistent minimizers. Indexing al
- *  minimizers from complex graph regions can take a long time (e.g. 65 hours
- * vs 30 minutes for 1000GP), because many windows have the same minimizer.
+ * The index contains either all or haplotype-consistent minimizers. Indexing all
+ * minimizers from complex graph regions can take a long time (e.g. 65 hours
+ * vs 10 minutes for 1000GP), because many windows have the same minimizer.
  * As the total number of minimizers is manageable (e.g. 2.1 billion vs.
  * 1.4 billion for 1000GP), it should be possible to develop a better
  * algorithm for finding the minimizers.

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -34,8 +34,7 @@
 #include <getopt.h>
 #include <omp.h>
 
-#include <gbwtgraph/gbwtgraph.h>
-#include <gbwtgraph/minimizer.h>
+#include <gbwtgraph/index.h>
 
 #include "../handle.hpp"
 #include "../utility.hpp"
@@ -53,8 +52,8 @@ void help_minimizer(char** argv) {
     std::cerr << "    -i, --index-name X     store the index to file X" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Minimizer options:" << std::endl;
-    std::cerr << "    -k, --kmer-length N    length of the kmers in the index (default: " << gbwtgraph::MinimizerIndex::KMER_LENGTH << ")" << std::endl;
-    std::cerr << "    -w, --window-length N  index the smallest kmer in a window of N kmers (default: " << gbwtgraph::MinimizerIndex::WINDOW_LENGTH << ")" << std::endl;
+    std::cerr << "    -k, --kmer-length N    length of the kmers in the index (default: " << gbwtgraph::DefaultMinimizerIndex::key_type::KMER_LENGTH << ")" << std::endl;
+    std::cerr << "    -w, --window-length N  index the smallest kmer in a window of N kmers (default: " << gbwtgraph::DefaultMinimizerIndex::key_type::WINDOW_LENGTH << ")" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
     std::cerr << "    -l, --load-index X     load the index from file X and insert the new kmers into it" << std::endl;
@@ -73,8 +72,8 @@ int main_minimizer(int argc, char** argv) {
     }
 
     // Command-line options.
-    size_t kmer_length = gbwtgraph::MinimizerIndex::KMER_LENGTH;
-    size_t window_length = gbwtgraph::MinimizerIndex::WINDOW_LENGTH;
+    size_t kmer_length = gbwtgraph::DefaultMinimizerIndex::key_type::KMER_LENGTH;
+    size_t window_length = gbwtgraph::DefaultMinimizerIndex::key_type::WINDOW_LENGTH;
     std::string index_name, load_index, gbwt_name, graph_name;
     bool is_gbwt_graph = false;
     bool progress = false;
@@ -176,12 +175,12 @@ int main_minimizer(int argc, char** argv) {
     }
 
     // Minimizer index.
-    std::unique_ptr<gbwtgraph::MinimizerIndex> index(new gbwtgraph::MinimizerIndex(kmer_length, window_length));
+    std::unique_ptr<gbwtgraph::DefaultMinimizerIndex> index(new gbwtgraph::DefaultMinimizerIndex(kmer_length, window_length));
     if (!load_index.empty()) {
         if (progress) {
             std::cerr << "Loading MinimizerIndex " << load_index << std::endl;
         }
-        index = vg::io::VPKG::load_one<gbwtgraph::MinimizerIndex>(load_index);
+        index = vg::io::VPKG::load_one<gbwtgraph::DefaultMinimizerIndex>(load_index);
     }
 
     // Build the index.

--- a/test/t/46_vg_minimizer.t
+++ b/test/t/46_vg_minimizer.t
@@ -20,13 +20,13 @@ is $? 0 "default parameters"
 vg minimizer -t 1 -i x.mi -g x.gbwt x.xg
 is $? 0 "single-threaded construction"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 6d173d906b6eead5074f1d7a26464e7c "construction is deterministic"
+is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 6c85e2438939fcadb332cb46899c8e79 "construction is deterministic"
 
 # Minimizer parameters
 vg minimizer -t 1 -k 7 -w 3 -i x.mi -g x.gbwt x.xg
 is $? 0 "minimizer parameters"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) fd3cea04319fe9ff7eb623788be4b31e "setting -k -w works correctly"
+is $(md5sum x.extracted.mi | cut -f 1 -d\ ) fef89fc3b7783932f9568960bb512c56 "setting -k -w works correctly"
 # FIXME
 
 # Construction from GBWTGraph
@@ -34,7 +34,7 @@ vg gbwt -x x.xg -g x.gg x.gbwt
 vg minimizer -t 1 -g x.gbwt -G -i x.mi x.gg
 is $? 0 "construction from GBWTGraph"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 6d173d906b6eead5074f1d7a26464e7c "construction is deterministic"
+is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 6c85e2438939fcadb332cb46899c8e79 "construction is deterministic"
 
 rm -f x.vg x.xg x.gbwt x.mi x.extracted.mi x.gg
 
@@ -52,7 +52,7 @@ is $? 0 "multiple graphs: first"
 vg minimizer -t 1 -l x.mi -i xy.mi -g y.gbwt y.xg
 is $? 0 "multiple graphs: second"
 vg view --extract-tag MinimizerIndex xy.mi > xy.extracted.mi
-is $(md5sum xy.extracted.mi | cut -f 1 -d\ ) f64285d9aeca03551c1a8a48e4c3f654 "construction is deterministic"
+is $(md5sum xy.extracted.mi | cut -f 1 -d\ ) fa4dc8d8e8f7c2f754916e46a227ad7e "construction is deterministic"
 
 rm -f x.vg y.vg
 rm -f x.xg y.xg


### PR DESCRIPTION
Update the minimizer index to a version that supports up to 63 bp minimizers. This increases index sizes by 40-50%. Set (39, 15) as the new default. Old minimizer indexes are no longer compatible.