### PR TITLE
Set compression defaults

### DIFF
--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -217,7 +217,8 @@ int main_construct(int argc, char** argv) {
 
         // Make an emitter that serializes the actual Graph objects, with buffering.
         // But just serialize one graph at a time in each group.
-        vg::io::ProtobufEmitter<Graph> emitter(cout, false, 1);
+        // Make sure to compress the output.
+        vg::io::ProtobufEmitter<Graph> emitter(cout, true, 1);
 
         // We need a callback to handle pieces of graph as they are produced.
         auto callback = [&](Graph& big_chunk) {


### PR DESCRIPTION
This should make all the Protobuf-based formats be output as compressed VPKG, while all the succinct formats are output as uncompressed VPKG.

The only thing I had to change was the output of vg construct, which wasn't being compressed. 