### PR TITLE
resolve memory leaks in mapper (resolves #2421)

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -3521,9 +3521,9 @@ bdsg::HashGraph cluster_subgraph_containing(const HandleGraph& base, const Align
         backward_max_dist.push_back(aligner->longest_detectable_gap(aln, mem.begin)
                                     + (mem.begin - aln.sequence().begin()));
     }
-    auto cluster_graph = new bdsg::HashGraph();
-    algorithms::extract_containing_graph(&base, cluster_graph, positions, forward_max_dist, backward_max_dist);
-    return *cluster_graph;
+    auto cluster_graph = bdsg::HashGraph();
+    algorithms::extract_containing_graph(&base, &cluster_graph, positions, forward_max_dist, backward_max_dist);
+    return cluster_graph;
 }
 
 bdsg::HashGraph cluster_subgraph_walk(const HandleGraph& base, const Alignment& aln, const vector<vg::MaximalExactMatch>& mems, double expansion) {

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -1217,6 +1217,11 @@ int main_map(int argc, char** argv) {
     
     cout.flush();
 
+    // clean up our mappers
+    for (uint64_t i = 0; i < mapper.size(); ++i) {
+        delete mapper[i];
+    }
+
     return 0;
 
 }


### PR DESCRIPTION
This fixes a grave memory leak in the mapper.

I actually have no idea how the mapper was even getting through our CI testing with this leak. I guess it's running on a pretty high-memory system.