### PR TITLE
Pruning improvements

### DIFF
--- a/src/prune.cpp
+++ b/src/prune.cpp
@@ -2,35 +2,92 @@
 
 namespace vg {
 
-vector<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, size_t edge_max) {
+constexpr size_t PRUNE_THREAD_BUFFER_SIZE = 128 * 1024;
+
+pair_hash_set<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, size_t edge_max) {
+
+    // Each thread collects edges to be deleted into a separate buffer. When the buffer grows
+    // large enough, flush it into a shared hash set.
+    pair_hash_set<edge_t> result;
+    auto flush_buffer = [&result](std::vector<edge_t>& buffer) {
+        #pragma omp critical (prune_flush)
+        {
+            for (const edge_t& edge : buffer) {
+                result.insert(edge);
+            }
+        }
+        buffer.clear();
+    };
+
     // for each position on the forward and reverse of the graph
-    //unordered_set<edge_t> edges_to_prune;
-    vector<vector<edge_t> > edges_to_prune;
-    edges_to_prune.resize(get_thread_count());
+    std::vector<std::vector<edge_t>> buffers(get_thread_count());
     graph.for_each_handle([&](const handle_t& h) {
-            // for the forward and reverse of this handle
-            // walk k bases from the end, so that any kmer starting on the node will be represented in the tree we build
-            for (auto handle_is_rev : { false, true }) {
-                //cerr << "###########################################" << endl;
-                handle_t handle = handle_is_rev ? graph.flip(h) : h;
-                list<walk_t> walks;
-                // for each position in the node, set up a kmer with that start position and the node end or kmer length as the end position
-                // determine next positions
-                id_t handle_id = graph.get_id(handle);
-                size_t handle_length = graph.get_length(handle);
-                string handle_seq = graph.get_sequence(handle);
-                for (size_t i = 0; i < handle_length;  ++i) {
-                    pos_t begin = make_pos_t(handle_id, handle_is_rev, handle_length);
-                    pos_t end = make_pos_t(handle_id, handle_is_rev, min(handle_length, i+k));
-                    walk_t walk = walk_t(offset(end)-offset(begin), begin, end, handle, 0);
-                    if (walk.length < k) {
-                        // are we branching over more than one edge?
-                        size_t next_count = 0;
-                        graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; });
-                        graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
+        // for the forward and reverse of this handle
+        // walk k bases from the end, so that any kmer starting on the node will be represented in the tree we build
+        for (auto handle_is_rev : { false, true }) {
+            //cerr << "###########################################" << endl;
+            handle_t handle = handle_is_rev ? graph.flip(h) : h;
+            list<walk_t> walks;
+            // for each position in the node, set up a kmer with that start position and the node end or kmer length as the end position
+            // determine next positions
+            id_t handle_id = graph.get_id(handle);
+            size_t handle_length = graph.get_length(handle);
+            string handle_seq = graph.get_sequence(handle);
+            for (size_t i = 0; i < handle_length;  ++i) {
+                pos_t begin = make_pos_t(handle_id, handle_is_rev, handle_length);
+                pos_t end = make_pos_t(handle_id, handle_is_rev, min(handle_length, i+k));
+                walk_t walk = walk_t(offset(end)-offset(begin), begin, end, handle, 0);
+                if (walk.length < k) {
+                    // are we branching over more than one edge?
+                    size_t next_count = 0;
+                    graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; });
+                    graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
+                            if (next_count > 1 && edge_max == walk.forks) { // our next step takes us over the max
+                                int tid = omp_get_thread_num();
+                                buffers[tid].push_back(graph.edge_handle(walk.curr, next));
+                                if (buffers[tid].size() >= PRUNE_THREAD_BUFFER_SIZE) {
+                                    flush_buffer(buffers[tid]);
+                                }
+                            } else {
+                                walks.push_back(walk);
+                                auto& todo = walks.back();
+                                todo.curr = next;
+                                if (next_count > 1) {
+                                    ++todo.forks;
+                                }
+                            }
+                        });
+                } else {
+                    walks.push_back(walk);
+                }
+            }
+            // now expand the kmers until they reach k
+            while (!walks.empty()) {
+                // first we check which ones have reached length k in the current handle; for each of these we run lambda and remove them from our list
+                auto walks_end = walks.end();
+                for (list<walk_t>::iterator q = walks.begin(); q != walks_end; ++q) {
+                    auto& walk = *q;
+                    // did we reach our target length?
+                    if (walk.length >= k) {
+                        q = walks.erase(q);
+                    } else {
+                        id_t curr_id = graph.get_id(walk.curr);
+                        size_t curr_length = graph.get_length(walk.curr);
+                        bool curr_is_rev = graph.get_is_reverse(walk.curr);
+                        size_t take = min(curr_length, k-walk.length);
+                        walk.end = make_pos_t(curr_id, curr_is_rev, take);
+                        walk.length += take;
+                        if (walk.length < k) {
+                            // if not, we need to expand through the node then follow on
+                            size_t next_count = 0;
+                            graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; });
+                            graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
                                 if (next_count > 1 && edge_max == walk.forks) { // our next step takes us over the max
                                     int tid = omp_get_thread_num();
-                                    edges_to_prune[tid].push_back(graph.edge_handle(walk.curr, next));
+                                    buffers[tid].push_back(graph.edge_handle(walk.curr, next));
+                                    if (buffers[tid].size() >= PRUNE_THREAD_BUFFER_SIZE) {
+                                        flush_buffer(buffers[tid]);
+                                    }
                                 } else {
                                     walks.push_back(walk);
                                     auto& todo = walks.back();
@@ -40,60 +97,21 @@ vector<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, size_t ed
                                     }
                                 }
                             });
-                    } else {
-                        walks.push_back(walk);
-                    }
-                }
-                // now expand the kmers until they reach k
-                while (!walks.empty()) {
-                    // first we check which ones have reached length k in the current handle; for each of these we run lambda and remove them from our list
-                    auto walks_end = walks.end();
-                    for (list<walk_t>::iterator q = walks.begin(); q != walks_end; ++q) {
-                        auto& walk = *q;
-                        // did we reach our target length?
-                        if (walk.length >= k) {
                             q = walks.erase(q);
                         } else {
-                            id_t curr_id = graph.get_id(walk.curr);
-                            size_t curr_length = graph.get_length(walk.curr);
-                            bool curr_is_rev = graph.get_is_reverse(walk.curr);
-                            size_t take = min(curr_length, k-walk.length);
-                            walk.end = make_pos_t(curr_id, curr_is_rev, take);
-                            walk.length += take;
-                            if (walk.length < k) {
-                                // if not, we need to expand through the node then follow on
-                                size_t next_count = 0;
-                                graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; });
-                                graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
-                                        if (next_count > 1 && edge_max == walk.forks) { // our next step takes us over the max
-                                            int tid = omp_get_thread_num();
-                                            edges_to_prune[tid].push_back(graph.edge_handle(walk.curr, next));
-                                        } else {
-                                            walks.push_back(walk);
-                                            auto& todo = walks.back();
-                                            todo.curr = next;
-                                            if (next_count > 1) {
-                                                ++todo.forks;
-                                            }
-                                        }
-                                    });
-                                q = walks.erase(q);
-                            } else {
-                                // nothing, we'll remove it next time around
-                            }
+                            // nothing, we'll remove it next time around
                         }
                     }
                 }
             }
-        }, true);
-    uint64_t total_edges = 0;
-    for (auto& v : edges_to_prune) total_edges += v.size();
-    vector<edge_t> merged; merged.reserve(total_edges);
-    for (auto& v : edges_to_prune) {
-        merged.insert(merged.end(), v.begin(), v.end());
+        }
+    }, true);
+
+    // Flush the buffers and return the result.
+    for (std::vector<edge_t>& buffer : buffers) {
+        flush_buffer(buffer);
     }
-    // duplicates are assumed to be dealt with externally
-    return merged;
+    return result;
 }
 
 

--- a/src/prune.cpp
+++ b/src/prune.cpp
@@ -1,5 +1,7 @@
 #include "prune.hpp"
 
+#include <stack>
+
 namespace vg {
 
 constexpr size_t PRUNE_THREAD_BUFFER_SIZE = 128 * 1024;
@@ -25,83 +27,69 @@ pair_hash_set<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, si
         // for the forward and reverse of this handle
         // walk k bases from the end, so that any kmer starting on the node will be represented in the tree we build
         for (auto handle_is_rev : { false, true }) {
-            //cerr << "###########################################" << endl;
             handle_t handle = handle_is_rev ? graph.flip(h) : h;
-            list<walk_t> walks;
+            std::stack<walk_t> walks;
             // for each position in the node, set up a kmer with that start position and the node end or kmer length as the end position
             // determine next positions
             id_t handle_id = graph.get_id(handle);
             size_t handle_length = graph.get_length(handle);
-            string handle_seq = graph.get_sequence(handle);
-            for (size_t i = 0; i < handle_length;  ++i) {
+            for (size_t i = 0; i < handle_length; i++) {
                 pos_t begin = make_pos_t(handle_id, handle_is_rev, handle_length);
-                pos_t end = make_pos_t(handle_id, handle_is_rev, min(handle_length, i+k));
-                walk_t walk = walk_t(offset(end)-offset(begin), begin, end, handle, 0);
-                if (walk.length < k) {
-                    // are we branching over more than one edge?
-                    size_t next_count = 0;
-                    graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; });
-                    graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
-                            if (next_count > 1 && edge_max == walk.forks) { // our next step takes us over the max
-                                int tid = omp_get_thread_num();
-                                buffers[tid].insert(graph.edge_handle(walk.curr, next));
-                                if (buffers[tid].size() >= PRUNE_THREAD_BUFFER_SIZE) {
-                                    flush_buffer(buffers[tid]);
-                                }
-                            } else {
-                                walks.push_back(walk);
-                                auto& todo = walks.back();
-                                todo.curr = next;
-                                if (next_count > 1) {
-                                    ++todo.forks;
-                                }
+                pos_t end = make_pos_t(handle_id, handle_is_rev, std::min(handle_length, i + k));
+                // We are only interested in walks that did not reach length k in the initial node.
+                if (offset(end) - offset(begin) < k) {
+                    size_t outdegree = graph.get_degree(handle, false);
+                    graph.follow_edges(handle, false, [&](const handle_t& next) {
+                        if (outdegree > 1 && edge_max == 0) { // our next step takes us over the max
+                            int tid = omp_get_thread_num();
+                            buffers[tid].insert(graph.edge_handle(handle, next));
+                            if (buffers[tid].size() >= PRUNE_THREAD_BUFFER_SIZE) {
+                                flush_buffer(buffers[tid]);
                             }
-                        });
-                } else {
-                    walks.push_back(walk);
+                        } else {
+                            walk_t walk(offset(end) - offset(begin), begin, end, next, 0);
+                            if (outdegree > 1) {
+                                walk.forks++;
+                            }
+                            walks.push(walk);
+                        }
+                    });
                 }
             }
-            // now expand the kmers until they reach k
+
+            // Now expand the kmers until they reach k.
             while (!walks.empty()) {
-                // first we check which ones have reached length k in the current handle; for each of these we run lambda and remove them from our list
-                auto walks_end = walks.end();
-                for (list<walk_t>::iterator q = walks.begin(); q != walks_end; ++q) {
-                    auto& walk = *q;
-                    // did we reach our target length?
-                    if (walk.length >= k) {
-                        q = walks.erase(q);
-                    } else {
-                        id_t curr_id = graph.get_id(walk.curr);
-                        size_t curr_length = graph.get_length(walk.curr);
-                        bool curr_is_rev = graph.get_is_reverse(walk.curr);
-                        size_t take = min(curr_length, k-walk.length);
-                        walk.end = make_pos_t(curr_id, curr_is_rev, take);
-                        walk.length += take;
-                        if (walk.length < k) {
-                            // if not, we need to expand through the node then follow on
-                            size_t next_count = 0;
-                            graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; });
-                            graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
-                                if (next_count > 1 && edge_max == walk.forks) { // our next step takes us over the max
-                                    int tid = omp_get_thread_num();
-                                    buffers[tid].insert(graph.edge_handle(walk.curr, next));
-                                    if (buffers[tid].size() >= PRUNE_THREAD_BUFFER_SIZE) {
-                                        flush_buffer(buffers[tid]);
-                                    }
-                                } else {
-                                    walks.push_back(walk);
-                                    auto& todo = walks.back();
-                                    todo.curr = next;
-                                    if (next_count > 1) {
-                                        ++todo.forks;
-                                    }
-                                }
-                            });
-                            q = walks.erase(q);
+                walk_t walk = walks.top();
+                walks.pop();
+                // Did we reach our target length?
+                if (walk.length >= k) {
+                    continue;
+                }
+                id_t curr_id = graph.get_id(walk.curr);
+                size_t curr_length = graph.get_length(walk.curr);
+                bool curr_is_rev = graph.get_is_reverse(walk.curr);
+                size_t take = min(curr_length, k - walk.length);
+                walk.end = make_pos_t(curr_id, curr_is_rev, take);
+                walk.length += take;
+                // Do we need to continue to the successor nodes?
+                if (walk.length < k) {
+                    size_t outdegree = graph.get_degree(walk.curr, false);
+                    graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
+                        if (outdegree > 1 && edge_max == walk.forks) { // our next step takes us over the max
+                            int tid = omp_get_thread_num();
+                            buffers[tid].insert(graph.edge_handle(walk.curr, next));
+                            if (buffers[tid].size() >= PRUNE_THREAD_BUFFER_SIZE) {
+                                flush_buffer(buffers[tid]);
+                            }
                         } else {
-                            // nothing, we'll remove it next time around
+                            walk_t next_walk = walk;
+                            next_walk.curr = next;
+                            if (outdegree > 1) {
+                                next_walk.forks++;
+                            }
+                            walks.push(next_walk);
                         }
-                    }
+                    });
                 }
             }
         }

--- a/src/prune.cpp
+++ b/src/prune.cpp
@@ -4,7 +4,7 @@
 
 namespace vg {
 
-constexpr size_t PRUNE_THREAD_BUFFER_SIZE = 128 * 1024;
+constexpr size_t PRUNE_THREAD_BUFFER_SIZE = 1024 * 1024;
 
 pair_hash_set<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, size_t edge_max) {
 

--- a/src/prune.cpp
+++ b/src/prune.cpp
@@ -9,7 +9,7 @@ pair_hash_set<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, si
     // Each thread collects edges to be deleted into a separate buffer. When the buffer grows
     // large enough, flush it into a shared hash set.
     pair_hash_set<edge_t> result;
-    auto flush_buffer = [&result](std::vector<edge_t>& buffer) {
+    auto flush_buffer = [&result](pair_hash_set<edge_t>& buffer) {
         #pragma omp critical (prune_flush)
         {
             for (const edge_t& edge : buffer) {
@@ -20,7 +20,7 @@ pair_hash_set<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, si
     };
 
     // for each position on the forward and reverse of the graph
-    std::vector<std::vector<edge_t>> buffers(get_thread_count());
+    std::vector<pair_hash_set<edge_t>> buffers(get_thread_count());
     graph.for_each_handle([&](const handle_t& h) {
         // for the forward and reverse of this handle
         // walk k bases from the end, so that any kmer starting on the node will be represented in the tree we build
@@ -44,7 +44,7 @@ pair_hash_set<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, si
                     graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
                             if (next_count > 1 && edge_max == walk.forks) { // our next step takes us over the max
                                 int tid = omp_get_thread_num();
-                                buffers[tid].push_back(graph.edge_handle(walk.curr, next));
+                                buffers[tid].insert(graph.edge_handle(walk.curr, next));
                                 if (buffers[tid].size() >= PRUNE_THREAD_BUFFER_SIZE) {
                                     flush_buffer(buffers[tid]);
                                 }
@@ -84,7 +84,7 @@ pair_hash_set<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, si
                             graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
                                 if (next_count > 1 && edge_max == walk.forks) { // our next step takes us over the max
                                     int tid = omp_get_thread_num();
-                                    buffers[tid].push_back(graph.edge_handle(walk.curr, next));
+                                    buffers[tid].insert(graph.edge_handle(walk.curr, next));
                                     if (buffers[tid].size() >= PRUNE_THREAD_BUFFER_SIZE) {
                                         flush_buffer(buffers[tid]);
                                     }
@@ -108,7 +108,7 @@ pair_hash_set<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, si
     }, true);
 
     // Flush the buffers and return the result.
-    for (std::vector<edge_t>& buffer : buffers) {
+    for (pair_hash_set<edge_t>& buffer : buffers) {
         flush_buffer(buffer);
     }
     return result;

--- a/src/prune.hpp
+++ b/src/prune.hpp
@@ -2,9 +2,8 @@
 #define VG_PRUNE_HPP_INCLUDED
 
 #include <vg/vg.pb.h>
-#include <iostream>
-#include "json2pb.h"
 #include "handle.hpp"
+#include "hash_map.hpp"
 #include "position.hpp"
 
 /** \file 
@@ -32,7 +31,7 @@ struct walk_t {
 };
 
 /// Iterate over all the walks up to length k, adding edges which 
-vector<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, size_t edge_max);
+pair_hash_set<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, size_t edge_max);
 
 }
 

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -99,29 +99,31 @@ void print_defaults(const std::map<PruningMode, ValueType>& defaults) {
 
 void help_prune(char** argv) {
     std::cerr << "usage: " << argv[0] << " prune [options] <graph.vg> >[output.vg]" << std::endl;
+    std::cerr << std::endl;
     std::cerr << "Prunes the complex regions of the graph for GCSA2 indexing. Pruning the graph" << std::endl;
     std::cerr << "removes embedded paths." << std::endl;
-    std::cerr << "pruning parameters:" << std::endl;
+    std::cerr << std::endl;
+    std::cerr << "Pruning parameters:" << std::endl;
     std::cerr << "    -k, --kmer-length N    kmer length used for pruning" << std::endl;
     std::cerr << "                           "; print_defaults(PruningParameters::kmer_length);
     std::cerr << "    -e, --edge-max N       remove the edges on kmers making > N edge choices" << std::endl;
     std::cerr << "                           "; print_defaults(PruningParameters::edge_max);
     std::cerr << "    -s, --subgraph-min N   remove subgraphs of < N bases" << std::endl;
     std::cerr << "                           "; print_defaults(PruningParameters::subgraph_min);
-    std::cerr << "pruning modes (-P, -r, and -u are mutually exclusive):" << std::endl;
+    std::cerr << "Pruning modes (-P, -r, and -u are mutually exclusive):" << std::endl;
     std::cerr << "    -P, --prune            simply prune the graph (default)" << std::endl;
     std::cerr << "    -r, --restore-paths    restore the edges on non-alt paths" << std::endl;
     std::cerr << "    -u, --unfold-paths     unfold non-alt paths and GBWT threads" << std::endl;
     std::cerr << "    -v, --verify-paths     verify that the paths exist after pruning" << std::endl;
     std::cerr << "                           (potentially very slow)" << std::endl;
-    std::cerr << "unfolding options:" << std::endl;
+    std::cerr << "Unfolding options:" << std::endl;
     std::cerr << "    -g, --gbwt-name FILE   unfold the threads from this GBWT index" << std::endl;
-    std::cerr << "    -m, --mapping FILE     store the node mapping for duplicates in this file" << std::endl;
-    std::cerr << "    -a, --append-mapping   append to the existing node mapping (requires -m)" << std::endl;
-    std::cerr << "other options:" << std::endl;
+    std::cerr << "    -m, --mapping FILE     store the node mapping for duplicates in this file (required with -u)" << std::endl;
+    std::cerr << "    -a, --append-mapping   append to the existing node mapping" << std::endl;
+    std::cerr << "Other options:" << std::endl;
     std::cerr << "    -p, --progress         show progress" << std::endl;
     std::cerr << "    -t, --threads N        use N threads (default: " << omp_get_max_threads() << ")" << std::endl;
-    std::cerr << "    -d, --dry-run          determine the validity of the parameter combination" << std::endl;
+    std::cerr << "    -d, --dry-run          determine the validity of the combination of options" << std::endl;
 }
 
 int main_prune(int argc, char** argv) {
@@ -243,10 +245,6 @@ int main_prune(int argc, char** argv) {
         std::cerr << "error: [vg prune] --kmer-length and --edge-max must be positive" << std::endl;
         return 1;
     }
-    if (append_mapping && mapping_name.empty()) {
-        std::cerr << "error: [vg prune] parameter --append-mapping requires --mapping" << std::endl;
-        return 1;
-    }
 
     // Mode-specific checks.
     if (mode == mode_prune) {
@@ -266,7 +264,10 @@ int main_prune(int argc, char** argv) {
         }
     }
     if (mode == mode_unfold) {
-        // Nothing here
+        if (mapping_name.empty()) {
+            std::cerr << "error: [vg prune] mode --unfold requires a node mapping file specified with --mapping" << std::endl;
+            return 1;
+        }
     }
 
     // Dry run.

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -6,6 +6,7 @@
 #include "algorithms/topological_sort.hpp"
 #include "algorithms/id_sort.hpp"
 #include "augment.hpp"
+#include "prune.hpp"
 #include <raptor2/raptor2.h>
 #include <stPinchGraphs.h>
 
@@ -6929,7 +6930,7 @@ void VG::prune_complex_with_head_tail(int path_length, int edge_max) {
     // Duplicate code from prune_complex(). If pruning leaves many loose nodes
     // (that will usually be deleted in the next step), attaching them to the
     // head/tail nodes is unnecessary and potentially expensive.
-    vector<edge_t> to_destroy = find_edges_to_prune(*this, path_length, edge_max);
+    pair_hash_set<edge_t> to_destroy = find_edges_to_prune(*this, path_length, edge_max);
     for (auto& e : to_destroy) {
         destroy_edge(e.first, e.second);
     }
@@ -6940,7 +6941,7 @@ void VG::prune_complex_with_head_tail(int path_length, int edge_max) {
 
 void VG::prune_complex(int path_length, int edge_max, Node* head_node, Node* tail_node) {
 
-    vector<edge_t> to_destroy = find_edges_to_prune(*this, path_length, edge_max);
+    pair_hash_set<edge_t> to_destroy = find_edges_to_prune(*this, path_length, edge_max);
     for (auto& e : to_destroy) {
         destroy_edge(e.first, e.second);
     }

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -23,7 +23,6 @@
 #include "path.hpp"
 #include "utility.hpp"
 #include "alignment.hpp"
-#include "prune.hpp"
 #include "mem.hpp"
 
 #include <vg/vg.pb.h>

--- a/test/t/38_vg_prune.t
+++ b/test/t/38_vg_prune.t
@@ -27,18 +27,18 @@ is $(vg stats -E y.vg) 48 "pruning with path restoring leaves the correct number
 rm -f y.vg
 
 # Unfold paths and threads: 1 component, 60 nodes, 72 edges
-vg prune -u -g x.gbwt -e 1 x.vg > y.vg
+vg prune -u -m x.mapping -g x.gbwt -e 1 x.vg > y.vg
 is $(vg stats -s y.vg | wc -l) 1 "pruning with path/thread unfolding produces the correct number of components"
 is $(vg stats -N y.vg) 60 "pruning with path/thread unfolding produces the correct number of nodes"
 is $(vg stats -E y.vg) 72 "pruning with path/thread unfolding produces the correct number of edges"
-rm -f y.vg
+rm -f x.mapping y.vg
 
 # Unfold only paths: 1 component, 44 nodes, 48 edges
-vg prune -u -e 1 x.vg > y.vg
+vg prune -u -m x.mapping -e 1 x.vg > y.vg
 is $(vg stats -s y.vg | wc -l) 1 "pruning with path unfolding produces the correct number of components"
 is $(vg stats -N y.vg) 44 "pruning with path unfolding produces the correct number of nodes"
 is $(vg stats -E y.vg) 48 "pruning with path unfolding produces the correct number of edges"
-rm -f y.vg
+rm -f x.mapping y.vg
 
 rm -f x.vg x.gbwt
 


### PR DESCRIPTION
Improve the `vg prune` subcommand in several ways.

* When searching for edges to prune, each thread uses a hash set as a buffer. When the buffer gets full, it is flushed into a shared hash set. This reduces the memory usage significantly with complex graphs. (See #2480 for discussion.)
* Replace breadth-first search with DFS. This further reduces the memory usage with complex graphs. (See #2480 for discussion.)
* Some graphs are so complex that enumerating all 24 bp windows is going to take too long. In such cases, it is better to remove high-degree nodes before pruning. This can be achieved with option `-M`. (See #2480 for discussion.)
* Haplotype unfolding (`vg prune -u`) now always requires a node mapping. Without the mapping, information on the original identifiers of duplicated nodes would be lost.
* Fix `PhaseUnfolder`. After recent changes, the unfolding code sometimes added invalid edges and failed to add the correct edges to the complement graph.
* Update GBWTGraph to deal with errors with some compiler versions. (See #2434 for discussion.)

Note that haplotype verification (`vg prune -u -v`) will still sometimes fail, because graph construction and GBWT construction interpret overlapping variants in different ways. One example is path 1966 (sample 983, phase 0) of 1000GP chromosome 10 with chromosome-length haplotypes, where the haplotype ends up taking a nonexistent edge from a node to itself. (See #1774 for an example.)