### PR TITLE
Reorganize path dropping from graphs

### DIFF
--- a/src/algorithms/copy_graph.cpp
+++ b/src/algorithms/copy_graph.cpp
@@ -1,0 +1,45 @@
+#include "copy_graph.hpp"
+
+namespace vg {
+namespace algorithms {
+
+    void copy_handle_graph(const HandleGraph* from, MutableHandleGraph* into) {
+        
+        // copy nodes
+        from->for_each_handle([&](const handle_t& handle) {
+            into->create_handle(from->get_sequence(handle), from->get_id(handle));
+        });
+        
+        // copy edges
+        from->for_each_edge([&](const edge_t& edge_handle) {
+            into->create_edge(into->get_handle(from->get_id(edge_handle.first),
+                                               from->get_is_reverse(edge_handle.first)),
+                              into->get_handle(from->get_id(edge_handle.second),
+                                               from->get_is_reverse(edge_handle.second)));
+        });
+    }
+    
+    void copy_path_handle_graph(const PathHandleGraph* from, MutablePathMutableHandleGraph* into) {
+        
+        // copy topology
+        copy_handle_graph(from, into);
+        
+        // copy paths
+        from->for_each_path_handle([&](const path_handle_t& path_handle) {
+            copy_path(from, path_handle, into);
+        });
+    }
+    
+    void copy_path(const PathHandleGraph* from, const path_handle_t& path,
+                   MutablePathHandleGraph* into) {
+        
+        // init path
+        path_handle_t copied = into->create_path_handle(from->get_path_name(path), from->get_is_circular(path));
+        
+        // copy steps
+        for (handle_t handle : from->scan_path(path)) {
+            into->append_step(copied, into->get_handle(from->get_id(handle), from->get_is_reverse(handle)));
+        }
+    }
+}
+}

--- a/src/algorithms/copy_graph.hpp
+++ b/src/algorithms/copy_graph.hpp
@@ -1,0 +1,32 @@
+#ifndef VG_ALGORITHMS_COPY_GRAPH_HPP_INCLUDED
+#define VG_ALGORITHMS_COPY_GRAPH_HPP_INCLUDED
+
+/**
+ * \file copy_graph.hpp
+ *
+ * Defines algorithms for copying data between handle graphs
+ */
+
+#include <iostream>
+
+#include "../handle.hpp"
+
+namespace vg {
+namespace algorithms {
+using namespace std;
+
+    /// Copies the nodes and edges from one graph into another.
+    void copy_handle_graph(const HandleGraph* from, MutableHandleGraph* into);
+    
+    /// Copies the nodes, edges, and paths from one graph into another.
+    void copy_path_handle_graph(const PathHandleGraph* from, MutablePathMutableHandleGraph* into);
+    
+    /// Copies a path from one graph to another. Nodes and edges to support
+    /// the path must already exist.
+    void copy_path(const PathHandleGraph* from, const path_handle_t& path,
+                   MutablePathHandleGraph* into);
+
+}
+}
+
+#endif

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -94,7 +94,7 @@ rm -f test.vg test.xg
 
 vg construct -m 1000 -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a 2> /dev/null | vg view -j - | sed s/_alt/alt/g | vg view -Jv - >w.vg
 vg index -x w.xg w.vg
-is $(( cat w.vg | vg mod -D - ; vg find -x w.xg -Q alt ) | vg paths -L -v - | wc -l) 38 "pattern based path extraction works"
+is $(( cat w.vg | vg paths -d -v - ; vg find -x w.xg -Q alt ) | vg paths -L -v - | wc -l) 38 "pattern based path extraction works"
 rm -f w.xg w.vg
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -90,7 +90,7 @@ rm -f giab.vg giab.xg giab.gcsa giab.gcsa.lcp sorting.tmp*
 # I was having a problem when updating an edge due to a flipped end node made it
 # identical to an already existing edge that hadn't yet been updated. This makes
 # sure that that isn't happening.
-vg mod -D cyclic/orient_must_swap_edges.vg >e.vg
+vg paths -d -v cyclic/orient_must_swap_edges.vg > e.vg
 vg index -x e.xg -g e.gcsa -k 10 e.vg
 vg map -s "ACACCTCCCTCCCGGACGGGGCGGCTGGCC" -d e >/dev/null
 is $? 0 "mapping to graphs that can't be oriented without swapping edges works correctly"

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -44,6 +44,6 @@ is "$(vg stats -a x.gam x.vg | md5sum | cut -f 1 -d\ )" "$(md5sum correct/10_vg_
 is "$(vg stats -a x.gam | grep 'Total alignments')" "Total alignments: 100" "stats can be computed for GAM files without graphs"
 rm -f x.vg x.xg x.gcsa x.gam
 
-vg msga -g <(vg msga -f msgas/cycle.fa -b s1 -w 11 -O 10 -k 4 -t 1 | vg mod -D - | vg mod -U 10 -) -f msgas/cycle.fa -t 1 | vg mod -N - | vg mod -U 10 - >c.vg
+vg msga -g <(vg msga -f msgas/cycle.fa -b s1 -w 11 -O 10 -k 4 -t 1 | vg paths -d -v - | vg mod -E - | vg mod -U 10 -) -f msgas/cycle.fa -t 1 | vg mod -N - | vg mod -U 10 - >c.vg
 is $(vg stats -O c.vg | wc -l) 155 "a path overlap description of a cyclic graph built by msga has the expected length"
 rm -f c.vg

--- a/test/t/11_vg_paths.t
+++ b/test/t/11_vg_paths.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order 
 
-plan tests 10
+plan tests 13
 
 vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
 vg construct -r small/x.fa -v small/x.vcf.gz > x2.vg
@@ -35,6 +35,11 @@ diff x_from_vg.fa small/x.fa
 is $? 0 "Fasta extracted from vg is the same as the input fasta"
 is $(vg paths -x x.xg -g x.gbwt -F | wc -l) 28 "Fasta extracted from threads has correct number of lines"
 
+is $(vg msga -w 20 -f msgas/s.fa | vg paths -v - -r -Q s1 | vg view - | grep ^P | cut -f 3 | sort | uniq | wc -l) 1 "a single path may be retained"
+
+is $(vg msga -w 20 -f msgas/s.fa | vg paths -v - -r -Q s1 | vg view - | grep -v ^P | md5sum | cut -f 1 -d\ ) $(vg msga -w 20 -f msgas/s.fa  | vg view - | grep -v ^P | md5sum | cut -f 1 -d\ ) "path filtering does not modify the graph"
+
+is $(vg construct -a -r tiny/tiny.fa -v tiny/tiny.vcf.gz | vg paths -d -a -v - | vg paths -L -v - | wc -l) 1 "alt allele paths can be dropped"
 
 rm -f x.xg x.gbwt x.vg x2.vg x_from_xg.fa x_from_vg.fa
 

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order
 
-plan tests 33
+plan tests 31
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -k x - | vg view - | grep "^P" | cut -f 3 | grep -o "[0-9]\+" |  wc -l) \
     $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -k x - | vg view - | grep "^S" | wc -l) \
@@ -58,10 +58,6 @@ vg mod -u s2.vg >/dev/null
 is $? 0 "mod successfully unchops a difficult graph"
 rm -f s.vg s2.vg
 
-is $(vg msga -w 20 -f msgas/s.fa  | vg mod -r s1 - | vg view - | grep ^P | cut -f 3 | sort | uniq | wc -l) 1 "a single path may be retained"
-
-is $(vg msga -w 20 -f msgas/s.fa | vg mod -r s1 - | vg view - | grep -v ^P | md5sum | cut -f 1 -d\ ) $(vg msga -w 20 -f msgas/s.fa  | vg view - | grep -v ^P | md5sum | cut -f 1 -d\ ) "path filtering does not modify the graph"
-
 vg msga -f msgas/l.fa -b a1 -w 16 | vg mod -X 8 - | vg validate -
 is $? 0 "chopping self-cycling nodes retains the cycle"
 
@@ -88,7 +84,7 @@ is $? 0 "dagify unrolls the un-unrollable graph"
 vg mod -s graphs/not-simple.vg | vg validate -
 is $? 0 "sibling simplification does not disrupt paths"
 
-vg msga -g <(vg msga -f msgas/cycle.fa -b s1 -w 19 -O 18 -k 4 -t 1 | vg mod -D - | vg mod -U 10 -) -f msgas/cycle.fa -t 1 | vg mod -N - | vg mod -D - | vg mod -U 10 - >c.vg
+vg msga -g <(vg msga -f msgas/cycle.fa -b s1 -w 19 -O 18 -k 4 -t 1 | vg paths -d -v - | vg mod -U 10 -) -f msgas/cycle.fa -t 1 | vg mod -N - | vg paths -d -v - | vg mod -U 10 - >c.vg
 is $(cat c.vg | vg mod -w 100 - | vg stats -N -) 4 "dagify correctly calculates the minimum distance through the unrolled component"
 is $(cat c.vg | vg mod -w 100 - | vg stats -l - | cut -f 2) 200 "dagify produces a graph of the correct size"
 rm -f c.vg

--- a/test/t/17_vg_augment.t
+++ b/test/t/17_vg_augment.t
@@ -68,7 +68,7 @@ vg index -x 2snp.xg 2snp.vg
 vg sim -l 30 -x 2snp.xg -n 30 -a >2snp.sim
 vg index -x flat.xg -g flat.gcsa -k 16 flat.vg
 vg map -g flat.gcsa -x flat.xg -G 2snp.sim -k 8 >2snp.gam
-is $(vg augment flat.vg 2snp.gam -i | vg mod -D - | vg mod -n - | vg view - | grep ^S | wc -l) 7 "editing the graph with many SNP-containing alignments does not introduce duplicate identical nodes"
+is $(vg augment flat.vg 2snp.gam -i | vg paths -d -v - | vg mod -n - | vg view - | grep ^S | wc -l) 7 "editing the graph with many SNP-containing alignments does not introduce duplicate identical nodes"
 
 vg augment flat.vg 2snp.gam | vg view - | grep S | awk '{print $3}' | sort > vg_augment.nodes
 vg convert flat.vg -p > flat.pg

--- a/test/t/27_vg_genotype.t
+++ b/test/t/27_vg_genotype.t
@@ -38,8 +38,8 @@ vg map -x flat.xg -g flat.gcsa -G <(cat flat1.sim flat2.sim) >flat.gam
 vg index -d flat.gam.index -N flat.gam
 vg genotype flat.vg flat.gam.index -t 1 >flat.loci
 cat tiny/tiny.fa flat1.fa flat2.fa >flats.fa
-vg msga -f flats.fa -b x | vg mod -D - | vg mod -n - | vg mod -c - >flat_msga.vg
-vg augment flat.vg -L flat.loci | vg mod -D - | vg mod -n - | vg mod -c - >flat_mod.vg
+vg msga -f flats.fa -b x | vg paths -d -v - | vg mod -n - | vg mod -c - >flat_msga.vg
+vg augment flat.vg -L flat.loci | vg paths -d -v - | vg mod -n - | vg mod -c - >flat_mod.vg
 
 is $(vg view flat_mod.vg | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) \
    $(vg view flat_msga.vg | grep ^S | cut -f 3 | sort | md5sum | cut -f 1 -d\ ) \

--- a/test/t/43_vg_simplify.t
+++ b/test/t/43_vg_simplify.t
@@ -13,7 +13,7 @@ vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
 vg simplify --algorithm small x.vg > x.small.vg 2>/dev/null
 is "${?}" "0" "vg simplify runs through when popping small bubbles"
 
-is "$(vg mod --drop-paths x.small.vg | vg mod --unchop - | vg stats -N -)" "1" "simplification pops all the bubbles in a simple graph"
+is "$(vg paths -d -v x.small.vg | vg mod --unchop - | vg stats -N -)" "1" "simplification pops all the bubbles in a simple graph"
 
 vg simplify --algorithm rare --min-count 2 -v small/x.vcf.gz x.vg > x.rare.vg
 is "${?}" "0" "vg simplify runs through when removing rare variants"
@@ -21,7 +21,7 @@ is "${?}" "0" "vg simplify runs through when removing rare variants"
 vg validate x.rare.vg
 is "${?}" "0" "the graph is valid after removing rare variants"
 
-is "$(vg mod --drop-paths x.rare.vg | vg mod --unchop - | vg stats -N -)" "118" "simplification keeps only some variants"
+is "$(vg paths -d -v x.rare.vg | vg mod --unchop - | vg stats -N -)" "118" "simplification keeps only some variants"
 
 rm -f x.vg x.small.vg x.rare.vg
  


### PR DESCRIPTION
I moved the methods to add and drop paths from a graph from `vg mod` into `vg paths`, which has a much better interface for selecting paths. I also expanded the interface to include the catch-all "list of names in a file" option and a convenience filter for the embedded paths added by `vg construct -a`.

@glennhickey Do you think toil-vg will need any updating? 