### PR TITLE
augment -s option to ignore alignments that map outside graph

### DIFF
--- a/src/augment.hpp
+++ b/src/augment.hpp
@@ -31,13 +31,16 @@ using namespace std;
 /// be added to the vg graph's paths object.
 /// If soft_clip is true, soft clips will be removed from the input paths
 /// before processing, and the dangling ends won't end up in the graph
+/// If filter_out_of_graph_alignments is true, some extra time will be taken to check if
+/// all nodes in the alignment are in the graph.  If they aren't, then it will be ignored
 void augment(MutablePathMutableHandleGraph* graph,
              istream& gam_stream,
              vector<Translation>* out_translation = nullptr,
              ostream* gam_out_stream = nullptr,
              bool embed_paths = false,
              bool break_at_ends = false,
-             bool remove_soft_clips = false);
+             bool remove_soft_clips = false,
+             bool filter_out_of_graph_alignments = false);
 
 /// Like above, but operates on a vector of Alignments, instead of a stream
 /// (Note: It is best to use stream interface for large numbers of alignments to save memory)
@@ -47,7 +50,8 @@ void augment(MutablePathMutableHandleGraph* graph,
              ostream* gam_out_stream = nullptr,
              bool embed_paths = false,
              bool break_at_ends = false,
-             bool remove_soft_clips = false);
+             bool remove_soft_clips = false,
+             bool filter_out_of_graph_alignments = false);
 
 /// Generic version used to implement the above two methods.  
 void augment_impl(MutablePathMutableHandleGraph* graph,
@@ -56,7 +60,8 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
                   ostream* gam_out_stream,
                   bool embed_paths,
                   bool break_at_ends,
-                  bool remove_soft_clips);
+                  bool remove_soft_clips,
+                  bool filter_out_of_graph_alignments);
 
 /// Add a path to the graph.  This is like VG::extend, and expects
 /// a path with no edits, and for all the nodes and edges in the path

--- a/test/t/17_vg_augment.t
+++ b/test/t/17_vg_augment.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 14
+plan tests 15
 
 vg view -J -v pileup/tiny.json > tiny.vg
 
@@ -53,7 +53,11 @@ vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa >t.vg
 vg align -s GGGGGGGAAATTTTCTGGAGTTCTATTATATTCCAAAAAAAAAA t.vg >t.gam
 is $(vg augment -i t.vg t.gam | vg view - | grep ^S | grep $(vg augment -i t.vg t.gam | vg stats  -H - | awk '{ print $3}') | cut -f 3) GGGGG "a soft clip at read start becomes a new head of the graph"
 is $(vg augment -i t.vg t.gam | vg view - | grep ^S | grep $(vg augment -i t.vg t.gam | vg stats  -T - | awk '{ print $3}') | cut -f 3) AAAAAAAA "a soft clip at read end becomes a new tail of the graph"
-rm -rf t.vg t.gam
+vg align -s AAATTTTCTGGAGTTCTAT t.vg >> t.gam
+vg find -x t.vg -n 9 -c 1 > n9.vg
+vg augment n9.vg t.gam -s -A n9_aug.gam > /dev/null
+is $(vg view -a n9_aug.gam | wc -l) "1" "augment -s works as desired"
+rm -rf t.vg t.gam n9.vg n9_aug.gam
 
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 16 x.vg


### PR DESCRIPTION
`vg augment` currently crashes an assertion error if the GAM contains a node that's not in the graph.  Here we add the `-s` option to safely ignore alignments to nodes outside the graph, under the assumption that the given graph is a subgraph of the graph used to make the GAM.

This is to help with running augment whole-genome as discussed in #2502.   

```
vg augment chr1.vg whole-genome.gam -s > chr1_aug.vg
vg augment chr2.vg whole-genome.gam -s > chr2_aug.vg
etc

vg ids -j chr1_aug.vg chr2_aug.vg etc
```
will now be sufficient to make a whole-genome augmented graph.  The problem is that it will not work with the augmented gams (`augment -A`) as their ids won't be in sync after `vg ids -j`.  So still some work to be done there....


