### PR TITLE
Pack faster

### DIFF
--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -175,17 +175,21 @@ void Packer::collect_coverage(const vector<Packer*>& packers) {
         if (record_bases) {
             size_t base_offset = i * coverage_dynamic[0].size();
             for (size_t j = 0; j < coverage_dynamic[i].size(); ++j) {
+                size_t inc_cov = 0;
                 for (size_t k = 0; k < packers.size(); ++k) {
-                    increment_coverage(j + base_offset, packers[k]->coverage_at_position(j + base_offset));
+                    inc_cov += packers[k]->coverage_at_position(j + base_offset);
                 }
+                increment_coverage(j + base_offset, inc_cov);
             }
         }
         if (record_edges) {
             size_t edge_base_offset = i * edge_coverage_dynamic[0].size();
             for (size_t j = 0; j < edge_coverage_dynamic[i].size(); ++j) {
+                size_t inc_edge_cov = 0;
                 for (size_t k = 0; k < packers.size(); ++k) {
-                    increment_edge_coverage(j + edge_base_offset, packers[k]->edge_coverage(j + edge_base_offset));
+                    inc_edge_cov += packers[k]->edge_coverage(j + edge_base_offset);
                 }
+                increment_edge_coverage(j + edge_base_offset, inc_edge_cov);
             }
         }
     }

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -495,14 +495,14 @@ size_t Packer::edge_vector_size(void) const{
 }
 
 pair<size_t, size_t> Packer::coverage_bin_offset(size_t i) const {
-    size_t bin = min(i / coverage_dynamic[0].size(), coverage_dynamic.size() - 1);
+    size_t bin = min((size_t)(i / coverage_dynamic[0].size()), (size_t)(coverage_dynamic.size() - 1));
     // last bin can have different size so we don't use mod
     size_t offset = i - bin * coverage_dynamic[0].size();
     return make_pair(bin, offset);
 }
 
 pair<size_t, size_t> Packer::edge_coverage_bin_offset(size_t i) const {
-    size_t bin = min(i / edge_coverage_dynamic[0].size(), edge_coverage_dynamic.size() - 1);
+    size_t bin = min((size_t)(i / edge_coverage_dynamic[0].size()), (size_t)(edge_coverage_dynamic.size() - 1));
     // last bin can have different size so we don't use mod
     size_t offset = i - bin * edge_coverage_dynamic[0].size();
     return make_pair(bin, offset);
@@ -689,7 +689,7 @@ int Packer::combine_qualities(int map_quality, int base_quality) const {
             double p_err = logprob_invert(logprob_invert(phred_to_logprob(base_quality)) +
                                           logprob_invert(phred_to_logprob(map_quality)));
             // clamp our quality to 60
-            int qual = min((int)logprob_to_phred(p_err), maximum_quality);
+            int qual = min((int)logprob_to_phred(p_err), (int)maximum_quality);
             // update the cache
             quality_cache->put(make_pair(map_quality, base_quality), qual);
             return qual;

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -28,7 +28,7 @@ Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t coverage_bins, 
     }
 
     // only bin if we need to
-    if (num_edges_dynamic <= coverage_bins || num_bases_dynamic <= coverage_bins) {
+    if (coverage_bins < 1 || num_edges_dynamic <= coverage_bins || num_bases_dynamic <= coverage_bins) {
         coverage_bins = 1;
     }
     assert(coverage_bins > 0);

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -38,9 +38,9 @@ Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t coverage_bins, 
     // initialize a coverage counter for each bin (totally independent from the edit coverage bins)
     for (size_t i = 0; i < coverage_bins; ++i) {
         size_t cov_bin_size = num_bases_dynamic / coverage_bins + (i == coverage_bins - 1 ? num_bases_dynamic % coverage_bins : 0);
-        coverage_dynamic.push_back(gcsa::CounterArray(cov_bin_size, data_width));
+        coverage_dynamic.emplace_back(cov_bin_size, data_width);
         size_t edge_bin_size = num_edges_dynamic / coverage_bins + (i == coverage_bins - 1 ? num_edges_dynamic % coverage_bins : 0);
-        edge_coverage_dynamic.push_back(gcsa::CounterArray(edge_bin_size, data_width));
+        edge_coverage_dynamic.emplace_back(edge_bin_size, data_width);
     }
 
     // count the bins if binning

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -28,7 +28,7 @@ Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t coverage_bins, 
     }
 
     // only bin if we need to
-    if (coverage_bins < 1 || num_edges_dynamic <= coverage_bins || num_bases_dynamic <= coverage_bins) {
+    if (num_edges_dynamic <= coverage_bins || num_bases_dynamic <= coverage_bins) {
         coverage_bins = 1;
     }
     assert(coverage_bins > 0);

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -1,35 +1,51 @@
 #include "packer.hpp"
 #include "../vg.hpp"
 
+//#define debug
+
 namespace vg {
 
 const int Packer::maximum_quality = 60;
 const int Packer::lru_cache_size = 50;
 
-Packer::Packer(void) : graph(nullptr), quality_cache(nullptr) { }
+Packer::Packer(void) : graph(nullptr), num_bases_dynamic(0), num_edges_dynamic(0), quality_cache(nullptr) { }
 
-Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t data_width, bool record_bases, bool record_edges, bool record_edits) :
+Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t coverage_bins, size_t data_width, bool record_bases, bool record_edges, bool record_edits) :
     graph(graph), bin_size(bin_size), record_bases(record_bases), record_edges(record_edges), record_edits(record_edits) {
-    // initialize the base coverage counter
-    size_t seq_length = 0;
+    // get the size of the base coverage counter
+    num_bases_dynamic = 0;
     if (record_bases) {
-        graph->for_each_handle([&](const handle_t& handle) { seq_length += graph->get_length(handle); });
+        graph->for_each_handle([&](const handle_t& handle) { num_bases_dynamic += graph->get_length(handle); });
     }
-    coverage_dynamic = gcsa::CounterArray(seq_length, data_width);
-
-    // initialize the edge coverage counter
-    size_t max_edge_index = 0;
+    // get the size of the edge coverage counter
+    num_edges_dynamic = 0;
     if (record_edges) {
         graph->for_each_edge([&](const edge_t& edge) {
-                max_edge_index = std::max(max_edge_index,
+                num_edges_dynamic = std::max(num_edges_dynamic,
                                           dynamic_cast<const VectorizableHandleGraph*>(graph)->edge_index(edge));
             });
+        ++num_edges_dynamic; // add one so our size is greater than the max element
     }
-    edge_coverage_dynamic = gcsa::CounterArray(max_edge_index+1, data_width);
+
+    // only bin if we need to
+    if (num_edges_dynamic <= coverage_bins || num_bases_dynamic <= coverage_bins) {
+        coverage_bins = 1;
+    }
+    assert(coverage_bins > 0);
+    coverage_dynamic.reserve(coverage_bins);
+    edge_coverage_dynamic.reserve(coverage_bins);
+
+    // initialize a coverage counter for each bin (totally independent from the edit coverage bins)
+    for (size_t i = 0; i < coverage_bins; ++i) {
+        size_t cov_bin_size = num_bases_dynamic / coverage_bins + (i == coverage_bins - 1 ? num_bases_dynamic % coverage_bins : 0);
+        coverage_dynamic.push_back(gcsa::CounterArray(cov_bin_size, data_width));
+        size_t edge_bin_size = num_edges_dynamic / coverage_bins + (i == coverage_bins - 1 ? num_edges_dynamic % coverage_bins : 0);
+        edge_coverage_dynamic.push_back(gcsa::CounterArray(edge_bin_size, data_width));
+    }
 
     // count the bins if binning
     if (bin_size) {
-        n_bins = seq_length / bin_size + 1;
+        n_bins = num_bases_dynamic / bin_size + 1;
     }
 
     // speed up quality computation if necessary
@@ -154,25 +170,18 @@ void Packer::write_edits(ostream& out, size_t bin) const {
 void Packer::collect_coverage(const Packer& c) {
     // assume the same basis vector
     assert(!is_compacted);
-#pragma omp parallel
-    {
-#pragma omp single
-        {
-#pragma omp task
-            {
-                if (record_bases) {
-                    for (size_t i = 0; i < c.graph_length(); ++i) {
-                        increment_coverage(i, c.coverage_at_position(i));
-                    }
-                }
+#pragma omp parallel for
+    for (size_t i = 0; i < coverage_dynamic.size(); ++i) {
+        if (record_bases) {
+            size_t base_offset = i * coverage_dynamic[0].size();
+            for (size_t j = 0; j < coverage_dynamic[i].size(); ++j) {
+                increment_coverage(j + base_offset, c.coverage_at_position(j + base_offset));
             }
-#pragma omp task
-            {
-                if (record_edges) {
-                    for (size_t i = 0; i < c.edge_vector_size(); ++i){
-                        increment_edge_coverage(i, c.edge_coverage(i));
-                    }
-                }
+        }
+        if (record_edges) {
+            size_t edge_base_offset = i * edge_coverage_dynamic[0].size();
+            for (size_t j = 0; j < edge_coverage_dynamic[i].size(); ++j) {
+                increment_edge_coverage(j + edge_base_offset, c.edge_coverage(j + edge_base_offset));
             }
         }
     }
@@ -459,11 +468,12 @@ string Packer::unescape_delim(const string& s, char d) const {
     return unescaped;
 }
 
-size_t Packer::graph_length(void) const {
-    if (is_compacted) {
+size_t Packer::coverage_size(void) {
+    if (is_compacted){
         return coverage_civ.size();
-    } else {
-        return coverage_dynamic.size();
+    }
+    else{
+        return num_bases_dynamic;
     }
 }
 
@@ -472,24 +482,50 @@ size_t Packer::edge_vector_size(void) const{
         return edge_coverage_civ.size();
     }
     else{
-        return edge_coverage_dynamic.size();
+        return num_edges_dynamic;
     }
 }
 
+pair<size_t, size_t> Packer::coverage_bin_offset(size_t i) const {
+    size_t bin = min(i / coverage_dynamic[0].size(), coverage_dynamic.size() - 1);
+    // last bin can have different size so we don't use mod
+    size_t offset = i - bin * coverage_dynamic[0].size();
+    return make_pair(bin, offset);
+}
+
+pair<size_t, size_t> Packer::edge_coverage_bin_offset(size_t i) const {
+    size_t bin = min(i / edge_coverage_dynamic[0].size(), edge_coverage_dynamic.size() - 1);
+    // last bin can have different size so we don't use mod
+    size_t offset = i - bin * edge_coverage_dynamic[0].size();
+    return make_pair(bin, offset);
+}
+
+void Packer::increment_coverage(size_t i) {
+    pair<size_t, size_t> bin_offset = coverage_bin_offset(i);
+    coverage_dynamic.at(bin_offset.first).increment(bin_offset.second);
+}
+
+void Packer::increment_coverage(size_t i, size_t v) {
+    pair<size_t, size_t> bin_offset = coverage_bin_offset(i);
+    coverage_dynamic.at(bin_offset.first).increment(bin_offset.second, v);
+}
+
 void Packer::increment_edge_coverage(size_t i) {
-    edge_coverage_dynamic.increment(i);
+    pair<size_t, size_t> bin_offset = edge_coverage_bin_offset(i);
+    edge_coverage_dynamic.at(bin_offset.first).increment(bin_offset.second);
 }
 
 void Packer::increment_edge_coverage(size_t i, size_t v) {
-    edge_coverage_dynamic.increment(i, v);
+    pair<size_t, size_t> bin_offset = edge_coverage_bin_offset(i);
+    edge_coverage_dynamic.at(bin_offset.first).increment(bin_offset.second, v);
 }
-
 
 size_t Packer::coverage_at_position(size_t i) const {
     if (is_compacted) {
         return coverage_civ[i];
     } else {
-        return coverage_dynamic[i];
+        pair<size_t, size_t> bin_offset = coverage_bin_offset(i);
+        return coverage_dynamic.at(bin_offset.first)[bin_offset.second];
     }
 }
 
@@ -498,7 +534,8 @@ size_t Packer::edge_coverage(size_t i) const {
         return edge_coverage_civ[i];
     }
     else{
-        return edge_coverage_dynamic[i];
+        pair<size_t, size_t> bin_offset = edge_coverage_bin_offset(i);
+        return edge_coverage_dynamic.at(bin_offset.first)[bin_offset.second];
     }
 }
 
@@ -547,8 +584,7 @@ size_t Packer::edge_index(const Edge& e) const {
 
 ostream& Packer::as_table(ostream& out, bool show_edits, vector<vg::id_t> node_ids) {
 #ifdef debug
-    cerr << "Packer table of " << coverage_civ.size() << " rows:" << 
-        l;
+    cerr << "Packer table of " << coverage_civ.size() << " rows:" << endl;
 #endif
 
     out << "seq.pos" << "\t"
@@ -576,8 +612,7 @@ ostream& Packer::as_table(ostream& out, bool show_edits, vector<vg::id_t> node_i
 
 ostream& Packer::as_edge_table(ostream& out, vector<vg::id_t> node_ids) {
 #ifdef debug
-    cerr << "Packer edge table of " << edge_coverage_civ.size() << " rows:" << 
-        l;
+    cerr << "Packer edge table of " << edge_coverage_civ.size() << " rows:" << endl;
 #endif
 
     out << "from.id" << "\t"
@@ -616,23 +651,6 @@ ostream& Packer::show_structure(ostream& out) {
     //out << " i SA ISA PSI LF BWT    T[SA[i]..SA[i]-1]" << endl;
     //csXprintf(cout, "%2I %2S %3s %3P %2p %3B   %:3T", edit_csa);
     return out;
-}
-
-size_t Packer::coverage_size(void) {
-    if (is_compacted){
-        return coverage_civ.size();
-    }
-    else{
-        return coverage_dynamic.size();
-    }
-}
-
-void Packer::increment_coverage(size_t i) {
-    coverage_dynamic.increment(i);
-}
-
-void Packer::increment_coverage(size_t i, size_t v) {
-    coverage_dynamic.increment(i, v);
 }
 
 int Packer::compute_quality(const Alignment& aln, size_t position_in_read) const {

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -55,11 +55,15 @@ public:
     size_t get_n_bins(void) const;
     bool is_dynamic(void);
     size_t coverage_size(void);
+    void increment_coverage(size_t i);
+    void increment_coverage(size_t i, size_t v);
 
     size_t edge_coverage(Edge& e) const;
     size_t edge_coverage(size_t i) const;
     size_t edge_vector_size(void) const;
     size_t edge_index(const Edge& e) const;
+    void increment_edge_coverage(size_t i);
+    void increment_edge_coverage(size_t i, size_t v);
 private:
     void ensure_edit_tmpfiles_open(void);
     void close_edit_tmpfiles(void);

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -21,13 +21,32 @@ namespace vg {
 
 using namespace sdsl;
 
+/// Packer collects coverage of a GAM using compressed indexes
+/// Any combination of these 3 types of information can be stored
+/// - base coverage : number of reads aligning to a given base (offset in node) in the graph
+/// - edge coverage : number of reads aligning to a given edge in the graph
+/// - edits : a list of edits at a given base in the graph
+/// In memory, the coverages are stored in SDSL int vectors (dynamic) and on disk they are compressed int vectors
 class Packer {
 public:
     Packer(void);
-    // graph must also implement VectorizableHandleGraph
-    Packer(const HandleGraph* graph, size_t bin_size = 0, bool qual_adjust = false, int min_mapq = 0, int min_baseq = 0);
+    /// Create a Packer
+    /// graph : Must implement the VectorizableHandleGraph interface
+    /// bin_size : Bin coverage into bins
+    /// data_width : Number of bits per entry in the dynamic coverage vector.  Higher values get stored in a map
+    /// record_bases : Store the base coverage
+    /// record_edges : Store the edge coverage
+    /// record_edits : Store the edits
+    Packer(const HandleGraph* graph, size_t bin_size = 0, size_t data_width = 8, bool record_bases = true, bool record_edges = true, bool record_edits = true);
     ~Packer(void);
-    const HandleGraph* graph;
+
+    /// Add coverage from given alignment to the indexes
+    /// aln : given alignemnt
+    /// min_mapq : ignore alignments with mapping_quality below this value
+    /// min_baseq : ignore bases in the alignment if their read quality is below this value
+    /// qual_adjust : instead of incrementing the coverage by 1, increment it by the quality (mapq and baseq combined)
+    void add(const Alignment& aln, int min_mapq = 0, int min_baseq = 0, bool qual_adjust = false);
+
     void merge_from_files(const vector<string>& file_names);
     void merge_from_dynamic(vector<Packer*>& packers);
     void load_from_file(const string& file_name);
@@ -38,7 +57,6 @@ public:
                      std::string name = "");
     void make_compact(void);
     void make_dynamic(void);
-    void add(const Alignment& aln, bool record_edits = true);
     size_t graph_length(void) const;
     size_t position_in_basis(const Position& pos) const;
     string pos_key(size_t i) const;
@@ -53,7 +71,8 @@ public:
     void write_edits(ostream& out, size_t bin) const; // for merge
     size_t get_bin_size(void) const;
     size_t get_n_bins(void) const;
-    bool is_dynamic(void);
+    bool is_dynamic(void) const;
+    const HandleGraph* get_graph() const;
     size_t coverage_size(void);
     void increment_coverage(size_t i);
     void increment_coverage(size_t i, size_t v);
@@ -69,6 +88,10 @@ private:
     void close_edit_tmpfiles(void);
     void remove_edit_tmpfiles(void);
     bool is_compacted = false;
+    
+    // base graph
+    const HandleGraph* graph;
+
     // dynamic model
     gcsa::CounterArray coverage_dynamic;
     gcsa::CounterArray edge_coverage_dynamic;
@@ -82,7 +105,7 @@ private:
     size_t edit_count = 0;
     dac_vector<> coverage_civ; // graph coverage (compacted coverage_dynamic)
     vlc_vector<> edge_coverage_civ; // edge coverage (compacted edge_coverage_dynamic)
-    //
+    // edits
     vector<csa_sada<enc_vector<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, succinct_byte_alphabet<> > > edit_csas;
     // make separators that are somewhat unusual, as we escape these
     char delim1 = '\xff';
@@ -94,12 +117,10 @@ private:
     string unescape_delim(const string& s, char d) const;
     string unescape_delims(const string& s) const;
 
-    // toggle quality adjusted mode
-    bool qual_adjust = false;
-
-    // quality thresholds;
-    int min_mapq = 0;
-    int min_baseq = 0;
+    // toggles:
+    bool record_bases;
+    bool record_edges;
+    bool record_edits;
     
     // Combine the MAPQ and base quality (if available) for a given position in the read
     int compute_quality(const Alignment& aln, size_t position_in_read) const;

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -63,7 +63,7 @@ public:
     string edit_value(const Edit& edit, bool revcomp) const;
     vector<Edit> edits_at_position(size_t i) const;
     size_t coverage_at_position(size_t i) const;
-    void collect_coverage(const Packer& c);
+    void collect_coverage(const vector<Packer*>& packers);
     ostream& as_table(ostream& out, bool show_edits, vector<vg::id_t> node_ids);
     ostream& as_edge_table(ostream& out, vector<vg::id_t> node_ids);
     ostream& show_structure(ostream& out); // debugging

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -672,7 +672,7 @@ unordered_map<id_t, size_t> SupportBasedSnarlCaller::get_ref_offsets(const Snarl
 }
 
 PackedSupportSnarlCaller::PackedSupportSnarlCaller(const Packer& packer, SnarlManager& snarl_manager) :
-    SupportBasedSnarlCaller(*dynamic_cast<const PathHandleGraph*>(packer.graph), snarl_manager),
+    SupportBasedSnarlCaller(*dynamic_cast<const PathHandleGraph*>(packer.get_graph()), snarl_manager),
     packer(packer) {
 }
 

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -23,7 +23,7 @@ void help_convert(char** argv) {
          << "    -a, --hash-out         output in HashGraph format" << endl
          << "    -p, --packed-out       output in PackedGraph format" << endl
          << "    -x, --xg-out           output in XG format" << endl
-         << "    -o, --odgi-out           output in ODGI format" << endl;
+         << "    -o, --odgi-out         output in ODGI format" << endl;
 }
 
 int main_convert(int argc, char** argv) {

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -192,7 +192,7 @@ int main_pack(int argc, char** argv) {
     vector<Packer*> packers(num_packers, nullptr);
 #pragma omp parallel for
     for (int i = 0; i < packers.size(); ++i) {
-        packers[i] = new Packer(graph, bin_size, data_width, max(1, thread_count - 1), true, true, record_edits);
+        packers[i] = new Packer(graph, bin_size, data_width, thread_count, true, true, record_edits);
     }
 
     Packer& packer = *packers[0];

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -188,7 +188,7 @@ int main_pack(int argc, char** argv) {
     size_t data_width = std::ceil(std::log2(2 * expected_coverage));
 
     // todo one packer per thread and merge
-    vg::Packer packer(graph, bin_size, data_width, true, true, record_edits);
+    vg::Packer packer(graph, bin_size, data_width, thread_count, true, true, record_edits);
     if (packs_in.size() == 1) {
         packer.load_from_file(packs_in.front());
     } else if (packs_in.size() > 1) {
@@ -201,7 +201,7 @@ int main_pack(int argc, char** argv) {
             packers.push_back(&packer);
         } else {
             for (size_t i = 0; i < thread_count; ++i) {
-                packers.push_back(new Packer(graph, bin_size, data_width, true, true, record_edits));
+                packers.push_back(new Packer(graph, bin_size, thread_count, data_width, true, true, record_edits));
             }
         }
         std::function<void(Alignment&)> lambda = [&packer,&min_mapq,&min_baseq,&qual_adjust,&packers](Alignment& aln) {

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -192,7 +192,7 @@ int main_pack(int argc, char** argv) {
     vector<Packer*> packers(num_packers, nullptr);
 #pragma omp parallel for
     for (int i = 0; i < packers.size(); ++i) {
-        packers[i] = new Packer(graph, bin_size, data_width, thread_count, true, true, record_edits);
+        packers[i] = new Packer(graph, bin_size, data_width, max(1, thread_count - 1), true, true, record_edits);
     }
 
     Packer& packer = *packers[0];

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -192,7 +192,7 @@ int main_pack(int argc, char** argv) {
     vector<Packer*> packers(num_packers, nullptr);
 #pragma omp parallel for
     for (int i = 0; i < packers.size(); ++i) {
-        packers[i] = new Packer(graph, bin_size, data_width, thread_count, true, true, record_edits);
+        packers[i] = new Packer(graph, bin_size, thread_count, data_width, true, true, record_edits);
     }
 
     Packer& packer = *packers[0];

--- a/test/t/34_vg_pack.t
+++ b/test/t/34_vg_pack.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 15
+plan tests 17
 
 vg construct -m 1000 -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
@@ -85,7 +85,7 @@ vg construct -r small/x.fa -v small/x.vcf.gz > x.vg
 vg index -x x.xg x.vg
 vg sim -s 1 -n 1000 -l 150 -x x.xg -a > sim.gam
 vg pack -x x.xg -g sim.gam -o x.xg.cx
-vg pack -x x.vg -g sim.gam -o x.vg.cx
+vg pack -x x.vg -g sim.gam -o x.vg.cx -t 1
 vg pack -x x.xg -i x.xg.cx -d | awk '!($1="")' | sort > node-table.xg.tsv
 vg pack -x x.vg -i x.vg.cx -d | awk '!($1="")' | sort > node-table.vg.tsv
 diff node-table.xg.tsv node-table.vg.tsv
@@ -96,4 +96,12 @@ vg pack -x x.vg -i x.vg.cx -D | sort > edge-table.vg.tsv
 diff edge-table.xg.tsv edge-table.vg.tsv
 is "$?" 0 "edge packs on vg same as xg"
 
-rm -f x.vg x.xg sim.gam x.xg.cx x.vg.cx node-table.vg.tsv node-table.xg.tsv edge-table.vg.tsv edge-table.xg.tsv
+vg pack -x x.vg -g sim.gam -d -t 3 | awk '!($1="")' | sort > node-table.vg.t3.tsv
+diff node-table.vg.tsv node-table.vg.t3.tsv
+is "$?" 0 "node packs same on vg when using 3 threads as when using 1"
+
+vg pack -x x.vg -g sim.gam -D -t 2 | sort > edge-table.vg.t3.tsv
+diff edge-table.vg.tsv edge-table.vg.t3.tsv
+is "$?" 0 "edge packs same on vg when using 2 threads as when using 1"
+
+rm -f x.vg x.xg sim.gam x.xg.cx x.vg.cx node-table.vg.tsv node-table.xg.tsv edge-table.vg.tsv edge-table.xg.tsv edge-table.vg.t3.tsv node-table.vg.t3.tsv


### PR DESCRIPTION
Using more threads in `vg pack` makes more `Packer` objects, which are used to process the GAM in parallel.  The problem is that creating the Packers at the beginning, and merging them together at the end is sequential.  So in practice after about 5 threads, adding more slows the wall time down.

This PR parallelizes packer construction and merging.  On my (whole-genome SV graph with 30X GAM) test, this lets it use up to about 16 threads before slowing down, and reduces the best wall time from about 80 minutes to under 30.  

Memory usage still scales up linearly with the number of threads, though.  