### PR TITLE
WIP: Packer improvements

### DIFF
--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -87,6 +87,12 @@ private:
     /// map from absolute postion to positions in the binned arrays
     pair<size_t, size_t> coverage_bin_offset(size_t i) const;
     pair<size_t, size_t> edge_coverage_bin_offset(size_t i) const;
+    /// get the size of a bin
+    size_t coverage_bin_size(size_t i) const;
+    size_t edge_coverage_bin_size(size_t i) const;
+    /// initialize coverage bins on demand
+    void init_coverage_bin(size_t i);
+    void init_edge_coverage_bin(size_t i);
     
     void ensure_edit_tmpfiles_open(void);
     void close_edit_tmpfiles(void);
@@ -96,13 +102,19 @@ private:
     // base graph
     const HandleGraph* graph;
 
+    // data with for counter arrays
+    size_t data_width;
+    // bin sizes (last bins may be a bit bicker)
+    size_t cov_bin_size;
+    size_t edge_cov_bin_size;
+
     // dynamic model
     // base coverage.  we bin to make merging faster
-    vector<gcsa::CounterArray> coverage_dynamic;
+    vector<gcsa::CounterArray*> coverage_dynamic;
     // total length of above vectors
     size_t num_bases_dynamic;
     // edge coverage.  we bin to make merging faster
-    vector<gcsa::CounterArray> edge_coverage_dynamic;
+    vector<gcsa::CounterArray*> edge_coverage_dynamic;
     // total length of above
     size_t num_edges_dynamic;
     vector<string> edit_tmpfile_names;

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -187,15 +187,8 @@ int main_pack(int argc, char** argv) {
     // bits needed to store double the coverage
     size_t data_width = std::ceil(std::log2(2 * expected_coverage));
 
-    // create our packers
-    size_t num_packers = !gam_in.empty() ? thread_count : 1;
-    vector<Packer*> packers(num_packers, nullptr);
-#pragma omp parallel for
-    for (int i = 0; i < packers.size(); ++i) {
-        packers[i] = new Packer(graph, bin_size, thread_count, data_width, true, true, record_edits);
-    }
-
-    Packer& packer = *packers[0];
+    // create our packer
+    Packer packer(graph, bin_size, 65536, data_width, true, true, record_edits);
     
     // todo one packer per thread and merge
     if (packs_in.size() == 1) {
@@ -205,8 +198,8 @@ int main_pack(int argc, char** argv) {
     }
 
     if (!gam_in.empty()) {
-        std::function<void(Alignment&)> lambda = [&packer,&min_mapq,&min_baseq,&qual_adjust,&packers](Alignment& aln) {
-            packers[omp_get_thread_num()]->add(aln, min_mapq, min_baseq, qual_adjust);
+        std::function<void(Alignment&)> lambda = [&packer,&min_mapq,&min_baseq,&qual_adjust](Alignment& aln) {
+            packer.add(aln, min_mapq, min_baseq, qual_adjust);
         };
         if (gam_in == "-") {
             vg::io::for_each_parallel(std::cin, lambda);
@@ -218,14 +211,6 @@ int main_pack(int argc, char** argv) {
             }
             vg::io::for_each_parallel(gam_stream, lambda);
             gam_stream.close();
-        }
-        if (packers.size() > 1) {
-            vector<Packer*> others(packers.begin() + 1, packers.end());
-            packer.merge_from_dynamic(others);
-            for (auto other : others) {
-                delete other;
-            }
-            packers.resize(1);
         }
     }
 
@@ -242,11 +227,6 @@ int main_pack(int argc, char** argv) {
         }
     }
 
-    for (int i = 0; i < packers.size(); ++i) {
-        delete packers[i];
-    }        
-    packers.clear();
-    
     return 0;
 }
 


### PR DESCRIPTION
* Allocate counter bins as-needed to better support sparse use cases. 
* Make Packer objects multithreaded by locking counter bins to avoid costly merges, and to be more easily re-usable in other code. 