### PR TITLE
WIP: Faster augment via coverage threshold

### DIFF
--- a/src/augment.hpp
+++ b/src/augment.hpp
@@ -119,8 +119,8 @@ map<pos_t, id_t> ensure_breakpoints(MutableHandleGraph* graph,
 
 /// Remove edits in our graph that don't correspond to breakpoints (ie were effectively filtered
 /// out due to insufficient coverage.  This way, subsequent logic in add_nodes_and_edges
-/// can be run correctly
-void simplify_filtered_edits(HandleGraph* graph, Path& path, const map<pos_t, id_t>& node_translation,
+/// can be run correctly.  Returns true if at least one edit survived the filter.
+bool simplify_filtered_edits(HandleGraph* graph, Path& path, const map<pos_t, id_t>& node_translation,
                              const unordered_map<id_t, size_t>& orig_node_sizes);
 
 /// Given a path on nodes that may or may not exist, and a map from start

--- a/src/augment.hpp
+++ b/src/augment.hpp
@@ -117,6 +117,12 @@ unordered_map<id_t, set<pos_t>> filter_breakpoints_by_coverage(const Packer& pac
 map<pos_t, id_t> ensure_breakpoints(MutableHandleGraph* graph,
                                     const unordered_map<id_t, set<pos_t>>& breakpoints);
 
+/// Remove edits in our graph that don't correspond to breakpoints (ie were effectively filtered
+/// out due to insufficient coverage.  This way, subsequent logic in add_nodes_and_edges
+/// can be run correctly
+void simplify_filtered_edits(HandleGraph* graph, Path& path, const map<pos_t, id_t>& node_translation,
+                             const unordered_map<id_t, size_t>& orig_node_sizes);
+
 /// Given a path on nodes that may or may not exist, and a map from start
 /// position in the old graph to a node in the current graph, add all the
 /// new sequence and edges required by the path. The given path must not

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -9,6 +9,22 @@ namespace vg {
 const int Packer::maximum_quality = 60;
 const int Packer::lru_cache_size = 4096;
 
+size_t Packer::estimate_data_width(size_t expected_coverage) {
+    return std::ceil(std::log2(2 * expected_coverage));
+}
+
+size_t Packer::estimate_batch_size(size_t num_threads) {
+    size_t batch_size = max((size_t)128, (size_t)(pow(2, 14 - log2(num_threads))));
+    if (batch_size % 2 != 0) {
+        ++batch_size;
+    }
+    return batch_size;
+}
+
+size_t Packer::estimate_bin_count(size_t num_threads) {
+    return pow(2, log2(num_threads) + 14);
+}
+
 Packer::Packer(void) : graph(nullptr), data_width(8), cov_bin_size(0), edge_cov_bin_size(0), num_bases_dynamic(0), base_locks(nullptr), num_edges_dynamic(0), edge_locks(nullptr), tmpfstream_locks(nullptr) { }
 
 Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t coverage_bins, size_t data_width, bool record_bases, bool record_edges, bool record_edits) :
@@ -527,7 +543,7 @@ string Packer::unescape_delim(const string& s, char d) const {
     return unescaped;
 }
 
-size_t Packer::coverage_size(void) {
+size_t Packer::coverage_size(void) const {
     if (is_compacted){
         return coverage_civ.size();
     }

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -76,21 +76,31 @@ Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t coverage_bins, 
     }
 }
 
-Packer::~Packer(void) {
-    for (auto counter : coverage_dynamic) {
+void Packer::clear() {
+    for (auto& counter : coverage_dynamic) {
         delete counter;
+        counter = nullptr;
     }
-    for (auto counter : edge_coverage_dynamic) {
+    for (auto& counter : edge_coverage_dynamic) {
         delete counter;
+        counter = nullptr;
     }
     delete [] base_locks;
+    base_locks = nullptr;
     delete [] edge_locks;
+    edge_locks = nullptr;
     delete [] tmpfstream_locks;
+    tmpfstream_locks = nullptr;
     close_edit_tmpfiles();
     remove_edit_tmpfiles();
-    for (auto lru_cache : quality_cache) {
+    for (auto& lru_cache : quality_cache) {
         delete lru_cache;
+        lru_cache = nullptr;
     }
+}
+
+Packer::~Packer() {
+    clear();
 }
 
 void Packer::load_from_file(const string& file_name) {

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -47,7 +47,8 @@ public:
     /// record_edges : Store the edge coverage
     /// record_edits : Store the edits
     Packer(const HandleGraph* graph, size_t bin_size = 0, size_t coverage_bins = 1, size_t data_width = 8, bool record_bases = true, bool record_edges = true, bool record_edits = true);
-    ~Packer(void);
+    ~Packer();
+    void clear();
 
     /// Add coverage from given alignment to the indexes
     /// aln : given alignemnt

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -30,6 +30,12 @@ using namespace sdsl;
 /// In memory, the coverages are stored in SDSL int vectors (dynamic) and on disk they are compressed int vectors
 class Packer {
 public:
+    
+    /// Some helper functions to heuristically estimate input parameters for constructor
+    static size_t estimate_data_width(size_t expected_coverage);
+    static size_t estimate_batch_size(size_t num_threads);
+    static size_t estimate_bin_count(size_t num_threads);
+    
     Packer(void);
     /// Create a Packer
     /// graph : Must implement the VectorizableHandleGraph interface
@@ -75,7 +81,7 @@ public:
     size_t get_n_bins(void) const;
     bool is_dynamic(void) const;
     const HandleGraph* get_graph() const;
-    size_t coverage_size(void);
+    size_t coverage_size(void) const ;
     void increment_coverage(size_t i);
     void increment_coverage(size_t i, size_t v);
 
@@ -84,7 +90,8 @@ public:
     size_t edge_vector_size(void) const;
     size_t edge_index(const Edge& e) const;
     void increment_edge_coverage(size_t i);
-    void increment_edge_coverage(size_t i, size_t v);
+    void increment_edge_coverage(size_t i, size_t v);    
+   
 private:
     /// map from absolute postion to positions in the binned arrays
     pair<size_t, size_t> coverage_bin_offset(size_t i) const;

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -25,12 +25,14 @@
 #include "../xg.hpp"
 #include "../vg.hpp"
 #include "../augment.hpp"
+#include "../packer.hpp"
 #include <vg/io/stream.hpp>
 #include <vg/io/vpkg.hpp>
 #include <handlegraph/mutable_path_mutable_handle_graph.hpp>
 #include "bdsg/packed_graph.hpp"
 #include "bdsg/hash_graph.hpp"
 #include "bdsg/odgi.hpp"
+#include <bdsg/overlay_helper.hpp>
 
 using namespace std;
 using namespace vg;
@@ -47,6 +49,8 @@ void help_augment(char** argv, ConfigurableParser& parser) {
          << "    -Z, --translation FILE      save translations from augmented back to base graph to FILE" << endl
          << "    -A, --alignment-out FILE    save augmented GAM reads to FILE" << endl
          << "    -s, --subgraph              graph is a subgraph of the one used to create GAM. ignore alignments with missing nodes" << endl
+         << "    -m, --min-coverage N        minimum coverage of a breakpoint required for it to be added to the graph" << endl
+         << "    -c, --expected-cov N        expected coverage.  used only for memory tuning [default : 128]" << endl
          << "    -h, --help                  print this help message" << endl
          << "    -p, --progress              show progress" << endl
          << "    -v, --verbose               print information and warnings about vcf generation" << endl
@@ -89,14 +93,18 @@ int main_augment(int argc, char** argv) {
     // fail when nodes are missing
     bool is_subgraph = false;
 
+    // Min coverage for graph to be broken at a breakpoint
+    // Whene non-zero, the Packer will be used to collect breakpoints
+    size_t min_coverage = 0;
+
+    // Used to set data_width for Packer
+    size_t expected_coverage = 128;
+
     // Print some progress messages to screen
     bool show_progress = false;
 
     // Print verbose message
     bool verbose = false;
-
-    // Number of threads to use (will default to all if not specified)
-    int thread_count = 0;
 
     static const struct option long_options[] = {
         // Deprecated Options
@@ -108,6 +116,8 @@ int main_augment(int argc, char** argv) {
         {"cut-softclips", no_argument, 0, 'C'},
         {"label-paths", no_argument, 0, 'B'},
         {"subgraph", no_argument, 0, 's'},
+        {"min-coverage", required_argument, 0, 'm'},
+        {"expected-cov", required_argument, 0, 'c'},        
         {"help", no_argument, 0, 'h'},
         {"progress", required_argument, 0, 'p'},
         {"verbose", no_argument, 0, 'v'},
@@ -117,7 +127,7 @@ int main_augment(int argc, char** argv) {
         {"include-gt", required_argument, 0, 'L'},
         {0, 0, 0, 0}
     };
-    static const char* short_options = "a:Z:A:iCBhpvt:l:L:s";
+    static const char* short_options = "a:Z:A:iCBhpvt:l:L:sm:c:";
     optind = 2; // force optind past command positional arguments
 
     // This is our command-line parser
@@ -148,6 +158,12 @@ int main_augment(int argc, char** argv) {
         case 's':
             is_subgraph = true;
             break;
+        case 'm':
+            min_coverage = parse<size_t>(optarg);
+            break;
+        case 'c':
+            expected_coverage = parse<size_t>(optarg);
+            break;            
         case 'h':
         case '?':
             /* getopt_long already printed an error message. */
@@ -159,12 +175,18 @@ int main_augment(int argc, char** argv) {
             break;
         case 'v':
             verbose = true;
-            break;            
-        case 't':
-            thread_count = parse<int>(optarg);
             break;
-
-            // Loci Options
+        case 't':
+        {
+            int num_threads = parse<int>(optarg);
+            if (num_threads <= 0) {
+                cerr << "error:[vg call] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                exit(1);
+            }
+            omp_set_num_threads(num_threads);
+            break;
+        }            
+        // Loci Options
         case 'l':
             loci_file = optarg;
             break;
@@ -180,12 +202,6 @@ int main_augment(int argc, char** argv) {
 
     // Parse the command line options, updating optind.
     parser.parse(argc, argv);
-
-    if (thread_count != 0) {
-        // Use a non-default number of threads
-        omp_set_num_threads(thread_count);
-    }
-    thread_count = get_thread_count();
 
     // Parse the two positional arguments
     if (optind + 1 > argc) {
@@ -227,6 +243,15 @@ int main_augment(int argc, char** argv) {
             graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(in);
         });
     VG* vg_graph = dynamic_cast<VG*>(graph.get());
+    HandleGraph* vectorizable_graph = nullptr;
+    unique_ptr<Packer> packer;
+    bdsg::VectorizableOverlayHelper overlay_helper;
+    if (min_coverage > 0) {
+        vectorizable_graph = dynamic_cast<HandleGraph*>(overlay_helper.apply(graph.get()));
+        size_t data_width = Packer::estimate_data_width(expected_coverage);
+        size_t bin_count = Packer::estimate_bin_count(get_thread_count());
+        packer = make_unique<Packer>(vectorizable_graph, 0, bin_count, data_width, true, false, false);
+    }
     
     if (label_paths) {
         // Just add path names with extend()
@@ -302,7 +327,9 @@ int main_augment(int argc, char** argv) {
                     include_paths,
                     include_paths,
                     !include_softclips,
-                    is_subgraph);
+                    is_subgraph,
+                    packer.get(),
+                    min_coverage);
         } else {
             // much better to stream from a file so we can do two passes without storing in memory
             get_input_file(gam_in_file_name, [&](istream& alignment_stream) {
@@ -313,7 +340,9 @@ int main_augment(int argc, char** argv) {
                             include_paths,
                             include_paths,
                             !include_softclips,
-                            is_subgraph);
+                            is_subgraph,
+                            packer.get(),
+                            min_coverage);
                 });
         }
 

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -189,17 +189,14 @@ int main_pack(int argc, char** argv) {
 
     // get a data width from our expected coverage, using simple heuristic of counting
     // bits needed to store double the coverage
-    size_t data_width = std::ceil(std::log2(2 * expected_coverage));
+    size_t data_width = Packer::estimate_data_width(expected_coverage);
 
     // use some naive heuristics to come up with bin count and batch size based on thread count
     // more bins: finer grained parallelism at cost of more mutexes and allocations
     // bigger batch size: more robustness to sorted input at cost of less parallelism
     size_t num_threads = get_thread_count();
-    size_t batch_size = max((size_t)128, (size_t)(pow(2, 14 - log2(num_threads))));
-    if (batch_size % 2 != 0) {
-        ++batch_size;
-    }
-    size_t bin_count = pow(2, log2(num_threads) + 14);
+    size_t batch_size = Packer::estimate_batch_size(num_threads);
+    size_t bin_count = Packer::estimate_bin_count(num_threads);
 
     // create our packer
     Packer packer(graph, bin_size, bin_count, data_width, true, true, record_edits);


### PR DESCRIPTION
`augment` works in three phases:

1. Find all the breakpoints implied by the GAM
2. Chop of the graph at each breakpoint
3. Add new stuff to the graph

Breakpoints due to read errors saturate the graph (and memory. and running time) for larger inputs.  This PR explores adding a coverage threshold for breakpoints: only those breakpoints with at least `M` support (from command line) will get passed to step 2.  

Read errors can still get into the graph if they occur on the same breakpoints as legitimate stuff.  Getting around this is tough.  Perhaps a re-imagining of Packer's edit index would be needed.  For now, I'm hoping that these are (relatively) rare enough to not blow up memory and/or cause trouble with downstream analysis.

Determining the coverage threshold from the data should be possible, but that may go into a later PR. 