### PR TITLE
WIP vg depth

### DIFF
--- a/src/algorithms/coverage_depth.cpp
+++ b/src/algorithms/coverage_depth.cpp
@@ -23,7 +23,9 @@ void packed_depths(const Packer& packer, const string& path_name, size_t min_cov
         for (size_t i = 0; i < cur_len; ++i) {
             cur_pos.set_offset(i);
             size_t pos_coverage = packer.coverage_at_position(packer.position_in_basis(cur_pos));
-            out_stream << path_name << "\t" << path_offset << "\t" << pos_coverage << "\n";
+            if (pos_coverage >= min_coverage) {
+                out_stream << path_name << "\t" << path_offset << "\t" << pos_coverage << "\n";
+            }
             ++path_offset;
         }
     }

--- a/src/algorithms/coverage_depth.cpp
+++ b/src/algorithms/coverage_depth.cpp
@@ -1,0 +1,207 @@
+#include "coverage_depth.hpp"
+#include <bdsg/hash_graph.hpp>
+#include "algorithms/subgraph.hpp"
+#include <vg/io/stream.hpp>
+#include "../path.hpp"
+
+namespace vg {
+namespace algorithms {
+
+/// Estimate the depth of coverage of a given (sub) graph using the packer
+/// Coverage is computed relative to the given path
+double packed_depth(const PathHandleGraph& graph, const Packer& packer, const string& ref_path) {
+
+    // get the path length
+    path_handle_t path_handle = graph.get_path_handle(ref_path);
+    size_t path_len = 0;
+    for (handle_t handle : graph.scan_path(path_handle)) {
+        path_len += graph.get_length(handle);
+    }
+    if (path_len == 0) {
+        return 0;
+    }
+
+    // sum up the coverage
+    size_t tot_base_coverage = 0;
+    graph.for_each_handle([&] (handle_t handle) {
+            Position pos;
+            pos.set_node_id(graph.get_id(handle));
+            size_t packer_pos = packer.position_in_basis(pos);
+            size_t node_len = graph.get_length(handle);
+            for (size_t offset = 0; offset < node_len; ++offset) {
+                tot_base_coverage += packer.coverage_at_position(packer_pos + offset);
+            }
+        });
+
+    // return average (over the path)
+    return (double)tot_base_coverage / (double)path_len;
+}
+
+
+/// Estimate the binned coverage along a path
+map<size_t, double> binned_packed_depth(const PathHandleGraph& graph, const Packer& packer, const string& ref_path,
+                                        size_t step, size_t context, size_t threads) {
+
+    // move forward along path (note: this can be sped up if we're given a PathPositionHandleGraph but I don't think
+    // it matters for a couple of scans. 
+    function<size_t(step_handle_t&, size_t)> advance = [&] (step_handle_t& step_handle, size_t distance) {
+        size_t went = 0;
+        for (; graph.has_next_step(step_handle) && went < distance; step_handle = graph.get_next_step(step_handle)) {
+            went += graph.get_length(graph.get_handle_of_step(step_handle));
+        }
+        return went;
+    };
+
+    path_handle_t path_handle = graph.get_path_handle(ref_path);
+    step_handle_t step_handle = graph.path_begin(path_handle);
+
+    // hop along the graph, grabbing a step handle every "step" bases (or thereabouts)
+    vector<pair<size_t, step_handle_t>> bin_centers;
+    size_t pos = advance(step_handle, step / 2);
+    if (pos >= step / 2) {
+        size_t went;
+        do {
+            if (bin_centers.empty() || step_handle != bin_centers.back().second) {
+                bin_centers.push_back(make_pair(pos, step_handle));
+            }
+            went = advance(step_handle, step);
+            pos += went;
+        } while (went >= step);
+    }
+
+    // our graph's too small to do any stepping, just use the first handle
+    if (bin_centers.empty()) {
+        bin_centers.push_back(make_pair(0, graph.path_begin(path_handle)));
+    }
+
+    // visit every bin center and make a subgraph to collect coverage from
+    if (threads == 0) {
+        threads = get_thread_count();
+    }
+    map<size_t, double> binned_depths;
+#pragma omp parallel for num_threads(threads)
+    for (size_t i = 0; i < bin_centers.size(); ++i) {
+        // extract the subgraph
+        bdsg::HashGraph subgraph;
+        step_handle_t bin_step = bin_centers[i].second;
+        handle_t bin_handle = graph.get_handle_of_step(bin_step);
+        assert(graph.get_is_reverse(bin_handle) == false);
+        subgraph.create_handle(graph.get_sequence(bin_handle), graph.get_id(bin_handle));
+        expand_subgraph_by_steps(graph, subgraph, context);
+
+        // sum up the coverage on the subgraph
+        size_t tot_base_coverage = 0;
+        size_t tot_ref_len = 0;
+        subgraph.for_each_handle([&] (handle_t sub_handle) {
+                // go back into the original graph because we don't have any
+                // path information in the subgraph because we are unable
+                // to get it without requiring the path position interface
+                handle_t orig_handle = graph.get_handle(subgraph.get_id(sub_handle));
+                Position pos;
+                pos.set_node_id(graph.get_id(orig_handle));
+                size_t packer_pos = packer.position_in_basis(pos);
+                size_t node_len = graph.get_length(orig_handle);
+                for (size_t offset = 0; offset < node_len; ++offset) {
+                    tot_base_coverage += packer.coverage_at_position(packer_pos + offset);
+                }
+                // we manually test if each handle is on our reference path (again, to
+                // not require path position interface)
+                vector<step_handle_t> step_path_handles = graph.steps_of_handle(orig_handle);
+                bool on_ref = false;
+                for (size_t j = 0; j < step_path_handles.size() && !on_ref; ++j) {
+                    on_ref = graph.get_path_handle_of_step(step_path_handles[j]) == path_handle;
+                }
+                if (on_ref) {
+                    tot_ref_len += node_len;
+                }
+            });
+        
+        assert(tot_ref_len > 0);
+        double avg_base_coverage = tot_base_coverage / tot_ref_len;
+        
+#pragma omp critical (update_binned_depth)
+        binned_depths[bin_centers[i].first] = avg_base_coverage;
+    }
+
+    return binned_depths;
+
+}
+
+// draw (roughly) max_nodes nodes from the graph using the random seed
+static unordered_map<nid_t, size_t> sample_nodes(const HandleGraph& graph, size_t max_nodes, size_t random_seed) {
+    default_random_engine generator(random_seed);
+    uniform_real_distribution<double> distribution(0, 1);
+    double cutoff = std::min((double)1.0, (double)(max_nodes / graph.get_node_count()));
+    unordered_map<nid_t, size_t> sampled_nodes;
+    graph.for_each_handle([&](handle_t handle) {
+        if (cutoff == 1 || cutoff < distribution(generator)) {
+            sampled_nodes[graph.get_id(handle)] = 0;
+        }
+      });
+    return sampled_nodes;
+}
+
+// update the coverage from an alignment.  only count nodes that are in the map already
+static void update_sample_gam_depth(const Alignment& aln, unordered_map<nid_t, size_t>& node_coverage) {
+    const Path& path = aln.path();
+    for (int i = 0; i < path.mapping_size(); ++i) {
+        const Mapping& mapping = path.mapping(i);
+        nid_t node_id = mapping.position().node_id();
+        if (node_coverage.count(node_id)) {
+            ++node_coverage[node_id];
+        } 
+    }
+}
+
+// sum up the results from the different threads and return the average.
+// if a min_coverage is given, nodes with less coverage are ignored
+static double combine_and_average_node_coverages(vector<unordered_map<nid_t, size_t>>& node_coverages, size_t min_coverage) {
+    for (int i = 1; i < node_coverages.size(); ++i) {
+        for (const auto& node_cov : node_coverages[i]) {
+            node_coverages[0][node_cov.first] += node_cov.second;
+        }
+    }
+    size_t tot_coverage = 0;
+    size_t tot_count = 0;
+    for (const auto & node_cov : node_coverages[0]) {
+        if (node_cov.second >= min_coverage) {
+            tot_coverage += node_cov.second;
+            ++tot_count;
+        }
+    }
+
+    return tot_count > 0 ? (double)tot_coverage / (double)tot_count : 0;
+}
+
+
+double sample_gam_depth(const HandleGraph& graph, istream& gam_stream, size_t max_nodes, size_t random_seed, size_t min_coverage) {
+    // one node counter per thread
+    vector<unordered_map<nid_t, size_t>> node_coverages(get_thread_count(), sample_nodes(graph, max_nodes, random_seed));
+
+    function<void(Alignment& aln)> aln_callback = [&](Alignment& aln) {
+        update_sample_gam_depth(aln, node_coverages[omp_get_thread_num()]);
+    };
+    vg::io::for_each_parallel(gam_stream, aln_callback);
+    return combine_and_average_node_coverages(node_coverages, min_coverage);
+}
+
+double sample_gam_depth(const HandleGraph& graph, const vector<Alignment>& alignments, size_t max_nodes, size_t random_seed, size_t min_coverage) {
+    // one node counter per thread
+    vector<unordered_map<nid_t, size_t>> node_coverages(get_thread_count(), sample_nodes(graph, max_nodes, random_seed));
+
+#pragma omp parallel for
+    for (size_t i = 0; i < alignments.size(); ++i) {
+        update_sample_gam_depth(alignments[i], node_coverages[omp_get_thread_num()]);
+    }
+    return combine_and_average_node_coverages(node_coverages, min_coverage);
+}
+
+
+
+}
+
+
+
+
+}
+

--- a/src/algorithms/coverage_depth.cpp
+++ b/src/algorithms/coverage_depth.cpp
@@ -7,134 +7,136 @@
 namespace vg {
 namespace algorithms {
 
-/// Estimate the depth of coverage of a given (sub) graph using the packer
-/// Coverage is computed relative to the given path
-double packed_depth(const PathHandleGraph& graph, const Packer& packer, const string& ref_path) {
-
-    // get the path length
-    path_handle_t path_handle = graph.get_path_handle(ref_path);
-    size_t path_len = 0;
-    for (handle_t handle : graph.scan_path(path_handle)) {
-        path_len += graph.get_length(handle);
+void packed_depths(const Packer& packer, const string& path_name, size_t min_coverage, ostream& out_stream) {
+    const PathHandleGraph& graph = dynamic_cast<const PathHandleGraph&>(*packer.get_graph());
+    path_handle_t path_handle = graph.get_path_handle(path_name);
+    step_handle_t start_step = graph.path_begin(path_handle);
+    step_handle_t end_step = graph.path_end(path_handle);
+    Position cur_pos;
+    size_t path_offset = 1;
+    for (step_handle_t cur_step = start_step; cur_step != end_step; cur_step = graph.get_next_step(cur_step)) {
+        handle_t cur_handle = graph.get_handle_of_step(cur_step);
+        nid_t cur_id = graph.get_id(cur_handle);
+        size_t cur_len = graph.get_length(cur_handle);
+        cur_pos.set_node_id(cur_id);
+        cur_pos.set_is_reverse(graph.get_is_reverse(cur_handle));
+        for (size_t i = 0; i < cur_len; ++i) {
+            cur_pos.set_offset(i);
+            size_t pos_coverage = packer.coverage_at_position(packer.position_in_basis(cur_pos));
+            out_stream << path_name << "\t" << path_offset << "\t" << pos_coverage << "\n";
+            ++path_offset;
+        }
     }
-    if (path_len == 0) {
-        return 0;
-    }
-
-    // sum up the coverage
-    size_t tot_base_coverage = 0;
-    graph.for_each_handle([&] (handle_t handle) {
-            Position pos;
-            pos.set_node_id(graph.get_id(handle));
-            size_t packer_pos = packer.position_in_basis(pos);
-            size_t node_len = graph.get_length(handle);
-            for (size_t offset = 0; offset < node_len; ++offset) {
-                tot_base_coverage += packer.coverage_at_position(packer_pos + offset);
-            }
-        });
-
-    // return average (over the path)
-    return (double)tot_base_coverage / (double)path_len;
 }
 
+pair<double, double> packed_depth_of_bin(const Packer& packer,
+                                         step_handle_t start_step, step_handle_t end_plus_one_step,
+                                         size_t min_coverage, bool include_deletions) {
 
-/// Estimate the binned coverage along a path
-map<size_t, double> binned_packed_depth(const PathHandleGraph& graph, const Packer& packer, const string& ref_path,
-                                        size_t step, size_t context, size_t threads) {
+    const PathHandleGraph& graph = dynamic_cast<const PathHandleGraph&>(*packer.get_graph());
 
-    // move forward along path (note: this can be sped up if we're given a PathPositionHandleGraph but I don't think
-    // it matters for a couple of scans. 
-    function<size_t(step_handle_t&, size_t)> advance = [&] (step_handle_t& step_handle, size_t distance) {
-        size_t went = 0;
-        for (; graph.has_next_step(step_handle) && went < distance; step_handle = graph.get_next_step(step_handle)) {
-            went += graph.get_length(graph.get_handle_of_step(step_handle));
+    // coverage of each node via deletion (that's contained in the bin)
+    unordered_map<nid_t, size_t> deletion_coverages;
+    if (include_deletions) {
+        const VectorizableHandleGraph* vec_graph = dynamic_cast<const VectorizableHandleGraph*>(packer.get_graph());
+        unordered_map<handle_t, step_handle_t> deletion_candidates;
+        handle_t prev_handle;
+        for (step_handle_t cur_step = start_step; cur_step != end_plus_one_step; cur_step = graph.get_next_step(cur_step)) {
+            handle_t cur_handle = graph.get_handle_of_step(cur_step);
+            graph.follow_edges(cur_handle, true, [&] (handle_t other) {
+                    if (!deletion_candidates.empty() && other!= prev_handle && deletion_candidates.count(other)) {
+                        edge_t edge = graph.edge_handle(other, cur_handle);
+                        size_t edge_pos = vec_graph->edge_index(edge);
+                        size_t deletion_coverage = packer.edge_coverage(edge_pos);
+                        // quadratic alert.  if this is too slow, can use interval tree or something
+                        for (step_handle_t del_step = graph.get_next_step(deletion_candidates[other]);
+                             del_step != cur_step;
+                             del_step = graph.get_next_step(del_step)) {
+                            handle_t del_handle = graph.get_handle_of_step(del_step);
+                            nid_t del_id = graph.get_id(del_handle);
+                            if (!deletion_coverages.count(del_id)) {
+                                deletion_coverages[del_id] = deletion_coverage;
+                            } else {
+                                deletion_coverages[del_id] += deletion_coverage;
+                            }
+                        }
+                    }
+                });
+            prev_handle = cur_handle;
+            deletion_candidates[cur_handle] = cur_step;
         }
-        return went;
-    };
+    }
 
-    path_handle_t path_handle = graph.get_path_handle(ref_path);
-    step_handle_t step_handle = graph.path_begin(path_handle);
+    // compute the mean and variance of our base coverage across the bin
+    size_t bin_length = 0;
+    double mean = 0.0;
+    double M2 = 0.0;
 
-    // hop along the graph, grabbing a step handle every "step" bases (or thereabouts)
-    vector<pair<size_t, step_handle_t>> bin_centers;
-    size_t pos = advance(step_handle, step / 2);
-    if (pos >= step / 2) {
-        size_t went;
-        do {
-            if (bin_centers.empty() || step_handle != bin_centers.back().second) {
-                bin_centers.push_back(make_pair(pos, step_handle));
+    for (step_handle_t cur_step = start_step; cur_step != end_plus_one_step; cur_step = graph.get_next_step(cur_step)) {
+        handle_t cur_handle = graph.get_handle_of_step(cur_step);
+        nid_t cur_id = graph.get_id(cur_handle);
+        size_t cur_len = graph.get_length(cur_handle);
+        size_t del_coverage = !include_deletions or !deletion_coverages.count(cur_id) ? 0 : deletion_coverages[cur_id];
+        Position cur_pos;
+        cur_pos.set_node_id(cur_id);
+        cur_pos.set_is_reverse(graph.get_is_reverse(cur_handle));
+        for (size_t i = 0; i < cur_len; ++i) {
+            cur_pos.set_offset(i);
+            size_t pos_coverage = packer.coverage_at_position(packer.position_in_basis(cur_pos)) + del_coverage;
+            if (pos_coverage >= min_coverage) {
+                wellford_update(bin_length, mean, M2, pos_coverage);
             }
-            went = advance(step_handle, step);
-            pos += went;
-        } while (went >= step);
+        }
+    }
+    return wellford_mean_var(bin_length, mean, M2, true);
+}
+
+vector<tuple<size_t, size_t, double, double>> binned_packed_depth(const Packer& packer, const string& path_name, size_t bin_size,
+                                                                  size_t min_coverage, bool include_deletions) {
+
+    const PathHandleGraph& graph = dynamic_cast<const PathHandleGraph&>(*packer.get_graph());
+    path_handle_t path_handle = graph.get_path_handle(path_name);
+    
+    // one scan of our path to collect the bins
+    step_handle_t start_step = graph.path_begin(path_handle);
+    step_handle_t end_step = graph.path_end(path_handle);
+    vector<pair<size_t, step_handle_t>> bins; // start offset / start step of each bin
+    size_t offset = 0;
+    size_t cur_bin_size = bin_size;
+    for (step_handle_t cur_step = start_step; cur_step != end_step; cur_step = graph.get_next_step(cur_step)) {
+        if (cur_bin_size >= bin_size) {
+            bins.push_back(make_pair(offset, cur_step));
+            cur_bin_size = 0;
+        }
+        size_t node_len = graph.get_length(graph.get_handle_of_step(cur_step));
+        offset += node_len;
+        cur_bin_size += node_len;
     }
 
-    // our graph's too small to do any stepping, just use the first handle
-    if (bin_centers.empty()) {
-        bin_centers.push_back(make_pair(0, graph.path_begin(path_handle)));
-    }
-
-    // visit every bin center and make a subgraph to collect coverage from
-    if (threads == 0) {
-        threads = get_thread_count();
-    }
-    map<size_t, double> binned_depths;
-#pragma omp parallel for num_threads(threads)
-    for (size_t i = 0; i < bin_centers.size(); ++i) {
-        // extract the subgraph
-        bdsg::HashGraph subgraph;
-        step_handle_t bin_step = bin_centers[i].second;
-        handle_t bin_handle = graph.get_handle_of_step(bin_step);
-        assert(graph.get_is_reverse(bin_handle) == false);
-        subgraph.create_handle(graph.get_sequence(bin_handle), graph.get_id(bin_handle));
-        expand_subgraph_by_steps(graph, subgraph, context);
-
-        // sum up the coverage on the subgraph
-        size_t tot_base_coverage = 0;
-        size_t tot_ref_len = 0;
-        subgraph.for_each_handle([&] (handle_t sub_handle) {
-                // go back into the original graph because we don't have any
-                // path information in the subgraph because we are unable
-                // to get it without requiring the path position interface
-                handle_t orig_handle = graph.get_handle(subgraph.get_id(sub_handle));
-                Position pos;
-                pos.set_node_id(graph.get_id(orig_handle));
-                size_t packer_pos = packer.position_in_basis(pos);
-                size_t node_len = graph.get_length(orig_handle);
-                for (size_t offset = 0; offset < node_len; ++offset) {
-                    tot_base_coverage += packer.coverage_at_position(packer_pos + offset);
-                }
-                // we manually test if each handle is on our reference path (again, to
-                // not require path position interface)
-                vector<step_handle_t> step_path_handles = graph.steps_of_handle(orig_handle);
-                bool on_ref = false;
-                for (size_t j = 0; j < step_path_handles.size() && !on_ref; ++j) {
-                    on_ref = graph.get_path_handle_of_step(step_path_handles[j]) == path_handle;
-                }
-                if (on_ref) {
-                    tot_ref_len += node_len;
-                }
-            });
-        
-        assert(tot_ref_len > 0);
-        double avg_base_coverage = tot_base_coverage / tot_ref_len;
-        
-#pragma omp critical (update_binned_depth)
-        binned_depths[bin_centers[i].first] = avg_base_coverage;
+    // parallel scan to compute the coverages
+    vector<tuple<size_t, size_t, double, double>> binned_depths(bins.size());
+#pragma omp parallel for
+    for (size_t i = 0; i < bins.size(); ++i) {
+        step_handle_t bin_start_step = bins[i].second;
+        step_handle_t bin_end_step = i < bins.size() - 1 ? bins[i+1].second : end_step;
+        size_t bin_start = bins[i].first;
+        size_t bin_end = i < bins.size() - 1 ? bins[i+1].first : offset;
+        pair<double, double> coverage = packed_depth_of_bin(packer, bin_start_step, bin_end_step, min_coverage, include_deletions);
+        binned_depths[i] = make_tuple(bin_start, bin_end, coverage.first, coverage.second);
     }
 
     return binned_depths;
-
 }
+
 
 // draw (roughly) max_nodes nodes from the graph using the random seed
 static unordered_map<nid_t, size_t> sample_nodes(const HandleGraph& graph, size_t max_nodes, size_t random_seed) {
     default_random_engine generator(random_seed);
     uniform_real_distribution<double> distribution(0, 1);
-    double cutoff = std::min((double)1.0, (double)(max_nodes / graph.get_node_count()));
+    double cutoff = std::min((double)1.0, (double)max_nodes / (double)graph.get_node_count());
     unordered_map<nid_t, size_t> sampled_nodes;
     graph.for_each_handle([&](handle_t handle) {
-        if (cutoff == 1 || cutoff < distribution(generator)) {
+        if (cutoff == 1. || cutoff <= distribution(generator)) {
             sampled_nodes[graph.get_id(handle)] = 0;
         }
       });
@@ -148,52 +150,59 @@ static void update_sample_gam_depth(const Alignment& aln, unordered_map<nid_t, s
         const Mapping& mapping = path.mapping(i);
         nid_t node_id = mapping.position().node_id();
         if (node_coverage.count(node_id)) {
-            ++node_coverage[node_id];
+            // we add the number of bases covered
+            node_coverage[node_id] += mapping_from_length(mapping);
         } 
     }
 }
 
 // sum up the results from the different threads and return the average.
 // if a min_coverage is given, nodes with less coverage are ignored
-static double combine_and_average_node_coverages(vector<unordered_map<nid_t, size_t>>& node_coverages, size_t min_coverage) {
+static pair<double, double> combine_and_average_node_coverages(const HandleGraph& graph, vector<unordered_map<nid_t, size_t>>& node_coverages, size_t min_coverage) {
     for (int i = 1; i < node_coverages.size(); ++i) {
         for (const auto& node_cov : node_coverages[i]) {
             node_coverages[0][node_cov.first] += node_cov.second;
         }
     }
-    size_t tot_coverage = 0;
-    size_t tot_count = 0;
+    size_t count = 0;
+    double mean = 0.;
+    double M2 = 0.;
     for (const auto & node_cov : node_coverages[0]) {
         if (node_cov.second >= min_coverage) {
-            tot_coverage += node_cov.second;
-            ++tot_count;
+            // we normalize the bases covered by the node length as we sum
+            double node_len = graph.get_length(graph.get_handle(node_cov.first));
+            wellford_update(count, mean, M2, (double)node_cov.second / node_len);
         }
     }
 
-    return tot_count > 0 ? (double)tot_coverage / (double)tot_count : 0;
+    return wellford_mean_var(count, mean, M2, count < graph.get_node_count());
 }
 
 
-double sample_gam_depth(const HandleGraph& graph, istream& gam_stream, size_t max_nodes, size_t random_seed, size_t min_coverage) {
+pair<double, double> sample_gam_depth(const HandleGraph& graph, istream& gam_stream, size_t max_nodes, size_t random_seed, size_t min_coverage, size_t min_mapq) {
     // one node counter per thread
     vector<unordered_map<nid_t, size_t>> node_coverages(get_thread_count(), sample_nodes(graph, max_nodes, random_seed));
 
     function<void(Alignment& aln)> aln_callback = [&](Alignment& aln) {
-        update_sample_gam_depth(aln, node_coverages[omp_get_thread_num()]);
+        if (aln.mapping_quality() >= min_mapq) {
+            update_sample_gam_depth(aln, node_coverages[omp_get_thread_num()]);
+        }
     };
     vg::io::for_each_parallel(gam_stream, aln_callback);
-    return combine_and_average_node_coverages(node_coverages, min_coverage);
+    return combine_and_average_node_coverages(graph, node_coverages, min_coverage);
 }
 
-double sample_gam_depth(const HandleGraph& graph, const vector<Alignment>& alignments, size_t max_nodes, size_t random_seed, size_t min_coverage) {
+pair<double, double> sample_gam_depth(const HandleGraph& graph, const vector<Alignment>& alignments, size_t max_nodes, size_t random_seed, size_t min_coverage, size_t min_mapq) {
     // one node counter per thread
     vector<unordered_map<nid_t, size_t>> node_coverages(get_thread_count(), sample_nodes(graph, max_nodes, random_seed));
 
 #pragma omp parallel for
     for (size_t i = 0; i < alignments.size(); ++i) {
-        update_sample_gam_depth(alignments[i], node_coverages[omp_get_thread_num()]);
+        if (alignments[i].mapping_quality() >= min_mapq) {
+            update_sample_gam_depth(alignments[i], node_coverages[omp_get_thread_num()]);
+        }
     }
-    return combine_and_average_node_coverages(node_coverages, min_coverage);
+    return combine_and_average_node_coverages(graph, node_coverages, min_coverage);
 }
 
 

--- a/src/algorithms/coverage_depth.hpp
+++ b/src/algorithms/coverage_depth.hpp
@@ -1,0 +1,48 @@
+#ifndef VG_DEPTH_HPP_INCLUDED
+#define VG_DEPTH_HPP_INCLUDED
+
+#include <iostream>
+#include <algorithm>
+#include <functional>
+#include <cmath>
+#include <limits>
+#include <unordered_set>
+#include <tuple>
+#include "handle.hpp"
+#include "packer.hpp"
+
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+/// Estimate the depth of coverage of a given (sub) graph using the packer
+/// Coverage is computed relative to the given path
+double packed_depth(const PathHandleGraph& graph, const Packer& packer, const string& ref_path);
+
+/// Estimate the binned coverage along a path using the packer
+/// ref_path is scanned, and every "step" bases as subgraph is extracted using the given number of context steps
+/// If threads is 0, all the threads are used
+map<size_t, double> binned_packed_depth(const PathHandleGraph& graph, const Packer& packer, const string& ref_path,
+                                        size_t step, size_t context, size_t threads = 0);
+
+
+/// Get the depth of a bin
+/// the "k_nearest" closest bins to the given position are used
+/// bins with coverage below min_coverage are ignored
+double get_binned_depth(const unordered_map<size_t, double>& binned_depths, size_t pos, size_t k_nearest = 3, double min_coverage = 1.0);
+
+/// Return the average depth of coverage of randomly sampled nodes from a GAM
+/// Nodes with less than min_coverage are ignored
+/// The stream is scanned in parallel with all threads
+/// max_nodes is used to keep memory down
+double sample_gam_depth(const HandleGraph& graph, istream& gam_stream, size_t max_nodes, size_t random_seed, size_t min_coverage = 1.0);
+
+/// As above, but read a vector instead of a stream
+double sample_gam_depth(const HandleGraph& graph, const vector<Alignment>& alignments, size_t max_nodes, size_t random_seed, size_t min_coverage = 1.0);
+
+}
+}
+
+#endif

--- a/src/algorithms/coverage_depth.hpp
+++ b/src/algorithms/coverage_depth.hpp
@@ -27,6 +27,8 @@ void packed_depths(const Packer& packer, const string& path_name, size_t min_cov
 /// (which is contained in the bin) will get the deletion edge's coverage counted.
 /// Other types of events (such as SNPs) can throw off coverage in similar ways but deletions tend to be bigger
 /// (and easier to find), so we hope that counting them is enough.
+/// If one wants to infer deletions from the coverage, obviously this should be false, but if looking for
+/// a background coverage for genotyping, then setting it to true may be helpful
 pair<double, double> packed_depth_of_bin(const Packer& packer, step_handle_t start_step, step_handle_t end_plus_one_step,
                                          size_t min_coverage, bool include_deletions);
 

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -1,0 +1,200 @@
+/** \file depth_main.cpp
+ *
+ * Estimate sequencing depth from a (packed) alignment.
+ */
+
+
+#include <omp.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <algorithm>
+#include <iostream>
+
+#include "subcommand.hpp"
+
+#include <vg/io/vpkg.hpp>
+#include <vg/io/stream.hpp>
+#include "../handle.hpp"
+#include <bdsg/overlay_helper.hpp>
+#include "../utility.hpp"
+#include "../packer.hpp"
+#include "algorithms/coverage_depth.hpp"
+
+using namespace std;
+using namespace vg;
+using namespace vg::subcommand;
+
+void help_depth(char** argv) {
+    cerr << "usage: " << argv[0] << " depth [options] <graph>" << endl
+         << "options:" << endl
+         << "  packed coverage depth:" << endl
+         << "    -k, --pack FILE       Supports created from vg pack for given input graph" << endl
+         << "    -p, --ref-path NAME   Reference path to call on (multipile allowed.  defaults to all paths)" << endl
+         << "    -c, --context-size N  Context size (steps) for expanding bin subgraphs [50]" << endl
+         << "    -b, --bin-size N      Bin size (in bases) [10000000]" << endl
+         << "  GAM coverage depth:" << endl
+         << "    -g, --gam FILE        read alignments from this file (could be '-' for stdin)" << endl
+         << "    -n, --max-nodes N     maximum nodes to consider [1000000]" << endl
+         << "    -s, --random-seed N   random seed for sampling nodes to consider" << endl
+         << "  common options:" << endl
+         << "    -m, --min-coverage N  ignore nodes with less than N coverage [1]" << endl
+         << "    -t, --threads N       Number of threads to use [all available]" << endl;
+}
+
+int main_depth(int argc, char** argv) {
+
+    if (argc == 2) {
+        help_depth(argv);
+        return 1;
+    }
+
+    string pack_filename;
+    vector<string> ref_paths;
+    size_t context_steps = 50;
+    size_t bin_size = 10000000;
+    
+    string gam_filename;
+    size_t max_nodes = 1000000;
+    int random_seed = time(NULL);
+
+    size_t min_coverage = 1;
+
+    int c;
+    optind = 2; // force optind past command positional argument
+    while (true) {
+
+        static const struct option long_options[] = {
+            {"pack", required_argument, 0, 'k'},            
+            {"ref-path", required_argument, 0, 'p'},
+            {"context-size", required_argument, 0, 'c'},
+            {"bin-size", required_argument, 0, 'b'},
+            {"gam", required_argument, 0, 'g'},
+            {"max-nodes", required_argument, 0, 'n'},
+            {"random-seed", required_argument, 0, 's'},
+            {"min-coverage", required_argument, 0, 'm'},
+            {"threads", required_argument, 0, 't'},
+            {"help", no_argument, 0, 'h'},
+            {0, 0, 0, 0}
+        };
+
+        int option_index = 0;
+        c = getopt_long (argc, argv, "hk:p:c:b:g:n:s:m:t:",
+                long_options, &option_index);
+
+        // Detect the end of the options.
+        if (c == -1)
+            break;
+
+        switch (c)
+        {
+        case 'k':
+            pack_filename = optarg;
+            break;
+        case 'p':
+            ref_paths.push_back(optarg);
+            break;            
+        case 'c':
+            context_steps = parse<size_t>(optarg);
+            break;
+        case 'b':
+            bin_size = parse<size_t>(optarg);
+            break;
+        case 'g':
+            gam_filename = optarg;
+            break;
+        case 'n':
+            max_nodes = parse<size_t>(optarg);
+            break;
+        case 's':
+            random_seed = parse<size_t>(optarg);
+            break;
+        case 'm':
+            min_coverage = parse<size_t>(optarg);
+            break;
+        case 't':
+        {
+            int num_threads = parse<int>(optarg);
+            if (num_threads <= 0) {
+                cerr << "error:[vg depth] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                exit(1);
+            }
+            omp_set_num_threads(num_threads);
+            break;
+        }
+        case 'h':
+        case '?':
+            /* getopt_long already printed an error message. */
+            help_depth(argv);
+            exit(1);
+            break;
+        default:
+            abort ();
+        }
+    }
+
+    if (argc <= 2) {
+        help_depth(argv);
+        return 1;
+    }
+
+    if (pack_filename.empty() == gam_filename.empty() ) {
+        cerr << "error:[vg depth] Either a pack file (-k) or a gam file (-g) must be given" << endl;
+        exit(1);
+    }
+
+    // Read the graph
+    unique_ptr<PathHandleGraph> path_handle_graph;
+    get_input_file(optind, argc, argv, [&](istream& in) {
+            path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
+        });
+    PathHandleGraph* graph = path_handle_graph.get();
+    
+    // Apply the overlay if necessary
+    bdsg::PathVectorizableOverlayHelper overlay_helper;
+    if (!pack_filename.empty()) {
+        graph = dynamic_cast<PathHandleGraph*>(overlay_helper.apply(path_handle_graph.get()));
+        assert(graph != nullptr);
+    }
+
+    // Process the pack
+    unique_ptr<Packer> packer;
+    if (!pack_filename.empty()) {        
+        // Load our packed supports (they must have come from vg pack on graph)
+        packer = unique_ptr<Packer>(new Packer(graph));
+        packer->load_from_file(pack_filename);
+
+        // All paths if none given
+        if (ref_paths.empty()) {
+            graph->for_each_path_handle([&](path_handle_t path_handle) {
+                    string path_name = graph->get_path_name(path_handle);
+                    if (!Paths::is_alt(path_name)) {
+                        ref_paths.push_back(path_name);
+                    }
+                });
+        }
+
+        for (const string& ref_path : ref_paths) {
+            map<size_t, double> binned_depth = algorithms::binned_packed_depth(*graph, *packer, ref_path, bin_size, get_thread_count());
+            for (auto& bin_cov : binned_depth) {
+                cerr << ref_path << "\t" << bin_cov.first << "\t" << bin_cov.second << endl;
+            }
+        }
+    }
+
+    // Process the gam
+    if (!gam_filename.empty()) {
+        double gam_cov;
+        get_input_file(gam_filename, [&] (istream& gam_stream) {
+                gam_cov = algorithms::sample_gam_depth(*graph, gam_stream, max_nodes, random_seed, min_coverage);
+            });
+        cerr << "gam-coverage\t" << gam_cov << endl;
+    }
+
+    return 0;
+
+}
+
+// Register subcommand
+static Subcommand vg_depth("depth", "estimate sequencing depth", main_depth);
+

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -29,18 +29,18 @@ void help_depth(char** argv) {
     cerr << "usage: " << argv[0] << " depth [options] <graph>" << endl
          << "options:" << endl
          << "  packed coverage depth (print positional depths along path):" << endl
-         << "    -k, --pack FILE        Supports created from vg pack for given input graph" << endl
-         << "    -p, --ref-path NAME    Reference path to call on (multipile allowed.  defaults to all paths)" << endl
-         << "    -b, --bin-size N       Bin size (in bases) [1] (2 extra columns printed when N>1: bin-end-pos and stddev)" << endl
-         << "    -d, --count-dels       Count deletion edges within the bin as covering reference positions" << endl
+         << "    -k, --pack FILE        supports created from vg pack for given input graph" << endl
+         << "    -p, --ref-path NAME    reference path to call on (multipile allowed.  defaults to all paths)" << endl
+         << "    -b, --bin-size N       bin size (in bases) [1] (2 extra columns printed when N>1: bin-end-pos and stddev)" << endl
+         << "    -d, --count-dels       count deletion edges within the bin as covering reference positions" << endl
          << "  GAM coverage depth (print <mean> <stddev> for depth):" << endl
          << "    -g, --gam FILE         read alignments from this file (could be '-' for stdin)" << endl
          << "    -n, --max-nodes N      maximum nodes to consider [1000000]" << endl
          << "    -s, --random-seed N    random seed for sampling nodes to consider" << endl
-         << "    -Q, --min-mapq N      ignore alignments with mapping quality < N" << endl
+         << "    -Q, --min-mapq N       ignore alignments with mapping quality < N [0]" << endl
          << "  common options:" << endl
-         << "    -m, --min-coverage N  ignore nodes with less than N coverage [1]" << endl
-         << "    -t, --threads N       Number of threads to use [all available]" << endl;
+         << "    -m, --min-coverage N   ignore nodes with less than N coverage [1]" << endl
+         << "    -t, --threads N        number of threads to use [all available]" << endl;
 }
 
 int main_depth(int argc, char** argv) {
@@ -192,8 +192,11 @@ int main_depth(int argc, char** argv) {
                 vector<tuple<size_t, size_t, double, double>> binned_depth =
                     algorithms::binned_packed_depth(*packer, ref_path, bin_size, min_coverage, count_dels);
                 for (auto& bin_cov : binned_depth) {
-                    cout << ref_path << "\t" << (get<0>(bin_cov) + 1)<< "\t" << (get<1>(bin_cov) + 1) << "\t" << get<2>(bin_cov)
-                         << "\t" << sqrt(get<3>(bin_cov)) << endl;
+                    // bins can ben nan if min_coverage filters everything out.  just skip
+                    if (!isnan(get<3>(bin_cov))) {
+                        cout << ref_path << "\t" << (get<0>(bin_cov) + 1)<< "\t" << (get<1>(bin_cov) + 1) << "\t" << get<2>(bin_cov)
+                             << "\t" << sqrt(get<3>(bin_cov)) << endl;
+                    }
                 }
             } else {
                 algorithms::packed_depths(*packer, ref_path, min_coverage, cout);

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -336,6 +336,24 @@ double median(std::vector<int> &v) {
         return 0.5*(vn+v[n-1]);
     }
 }
+
+// from Python exmaple here:
+// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
+void wellford_update(size_t& count, double& mean, double& M2, double new_val) {
+    ++count;
+    double delta = new_val - mean;
+    mean += delta / (double)count;
+    double delta2 = new_val - mean;
+    M2 += delta * delta2;
+}
+
+pair<double, double> wellford_mean_var(size_t count, double mean, double M2, bool sample_variance) {
+    if (count == 0 || (sample_variance && count == 1)) {
+        return make_pair(nan(""), nan(""));
+    } else {
+        return make_pair(mean, M2 / (double)(sample_variance ? count - 1 : count));
+    }
+}
     
 vector<size_t> range_vector(size_t begin, size_t end) {
     size_t len = end - begin;

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -51,6 +51,9 @@ string nonATGCNtoN(const string& s);
 string toUppercase(const string& s);
 double median(std::vector<int> &v);
 double stdev(const std::vector<double>& v);
+// Online mean-variance computation with wellfords algorithm (pass 0's to 1st 3 params to start)
+void wellford_update(size_t& count, double& mean, double& M2, double new_val);
+pair<double, double> wellford_mean_var(size_t count, double mean, double M2, bool sample_variance = false);
 
 // write a fasta sqeuence
 void write_fasta_sequence(const std::string& name, const std::string& sequence, ostream& os, size_t width=80);

--- a/test/t/49_vg_depth.t
+++ b/test/t/49_vg_depth.t
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 3
+
+vg construct -m 10 -r tiny/tiny.fa >flat.vg
+vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
+vg sim -l 30 -x 2snp.vg -n 30 -a >2snp.sim
+vg index -x flat.xg -g flat.gcsa -k 16 flat.vg
+vg map -g flat.gcsa -x flat.xg -G 2snp.sim -k 8 >2snp.gam
+vg pack -x flat.xg -o 2snp.gam.cx -g 2snp.gam
+# total read bases (30 * 30) / total graph bases 50 = 18
+is $(vg depth flat.vg -g 2snp.gam | awk '{print $1}') 18 "vg depth gets correct depth from gam"
+is $(vg depth flat.xg -k 2snp.gam.cx -b 100000 | awk '{print $4}') 18 "vg depth gets correct depth from pack"
+is $(vg depth flat.xg -k 2snp.gam.cx -b 10 | wc -l) 5 "vg depth gets correct number of bins"
+
+rm -f flat.vg flat.gcsa flat.xg 2snp.vg 2snp.sim 2snp.gam 2snp.gam.cx

--- a/test/t/49_vg_depth.t
+++ b/test/t/49_vg_depth.t
@@ -9,13 +9,13 @@ plan tests 3
 
 vg construct -m 10 -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
-vg sim -l 30 -x 2snp.vg -n 30 -a >2snp.sim
+vg sim -l 30 -x 2snp.vg -n 30 -a -s 1 >2snp.sim
 vg index -x flat.xg -g flat.gcsa -k 16 flat.vg
 vg map -g flat.gcsa -x flat.xg -G 2snp.sim -k 8 >2snp.gam
 vg pack -x flat.xg -o 2snp.gam.cx -g 2snp.gam
 # total read bases (30 * 30) / total graph bases 50 = 18
 is $(vg depth flat.vg -g 2snp.gam | awk '{print $1}') 18 "vg depth gets correct depth from gam"
-is $(vg depth flat.xg -k 2snp.gam.cx -b 100000 | awk '{print $4}') 18 "vg depth gets correct depth from pack"
+is $(vg depth flat.xg -k 2snp.gam.cx -b 100000 | awk '{print int($4)}') 18 "vg depth gets correct depth from pack"
 is $(vg depth flat.xg -k 2snp.gam.cx -b 10 | wc -l) 5 "vg depth gets correct number of bins"
 
 rm -f flat.vg flat.gcsa flat.xg 2snp.vg 2snp.sim 2snp.gam 2snp.gam.cx


### PR DESCRIPTION
API for estimate depth of coverage from a `vg pack` file or a GAM, as well as new subcommand `vg depth`. 

Starting with
* binned coverage from `vg pack` using sampled subgraphs along reference path(s).  will use to make `vg calls` genotyping algorithm probablistic. 
* overall depth from a gam file using sampling to be as fast as possible.  hoping to use in `vg pack` and `vg augment` to estimate the number of bits for the coverage vector (to replace `-c` in both).    Could also use to make coverage threshold (`augment -m`) more adaptive (by, for example, using z-score instead of absolute cutoff)

Finally, would like to get the CLI printing some kind of histogram that's useful in and of itself. 

resolves #2511