### PR TITLE
Fix race condition in Packer class

### DIFF
--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -68,7 +68,11 @@ Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t coverage_bins, 
     if (bin_size) {
         n_bins = num_bases_dynamic / bin_size + 1;
     }
-    tmpfstream_locks = new std::mutex[n_bins];
+    if (record_edits) { 
+        tmpfstream_locks = new std::mutex[n_bins];
+        // open tmpfile if needed
+        ensure_edit_tmpfiles_open();
+    }
 
     // speed up quality computation if necessary
     for (size_t i = 0; i < get_thread_count(); ++i) {
@@ -385,8 +389,6 @@ void Packer::add(const Alignment& aln, int min_mapq, int min_baseq , bool qual_a
     if (aln.mapping_quality() < min_mapq) {
         return;
     }
-    // open tmpfile if needed
-    ensure_edit_tmpfiles_open();
     // count the nodes, edges, and edits
     Mapping prev_mapping;
     bool has_prev_mapping = false;

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -63,6 +63,7 @@ Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t coverage_bins, 
     // mutexes for coverage
     base_locks = new std::mutex[coverage_dynamic.size()];
     edge_locks = new std::mutex[edge_coverage_dynamic.size()];
+    tmpfstream_locks = nullptr;
     
     // count the bins if binning
     if (bin_size) {


### PR DESCRIPTION
This was a problem I introduced when making Packer multithreaded.  Writing to the tmpfiles for edits got put behind a mutex, but creation of the tmpfiles wasn't. 