### PR TITLE
WIP: Probablistic calling and genotyping with vg call

### DIFF
--- a/src/algorithms/coverage_depth.cpp
+++ b/src/algorithms/coverage_depth.cpp
@@ -90,7 +90,7 @@ pair<double, double> packed_depth_of_bin(const Packer& packer,
             }
         }
     }
-    return wellford_mean_var(bin_length, mean, M2, true);
+    return wellford_mean_var(bin_length, mean, M2);
 }
 
 vector<tuple<size_t, size_t, double, double>> binned_packed_depth(const Packer& packer, const string& path_name, size_t bin_size,
@@ -225,7 +225,7 @@ static pair<double, double> combine_and_average_node_coverages(const HandleGraph
         }
     }
 
-    return wellford_mean_var(count, mean, M2, count < graph.get_node_count());
+    return wellford_mean_var(count, mean, M2);
 }
 
 

--- a/src/algorithms/coverage_depth.cpp
+++ b/src/algorithms/coverage_depth.cpp
@@ -157,7 +157,10 @@ unordered_map<string, map<size_t, pair<double, double>>> binned_packed_depth_ind
 
 const pair<double, double>& get_depth_from_index(const unordered_map<string, map<size_t, pair<double, double>>>& depth_index,
                                           const string& path_name, size_t offset) {
-    return depth_index.at(path_name).lower_bound(offset)->second;
+
+    auto ub = depth_index.at(path_name).upper_bound(offset);
+    --ub;
+    return ub->second;
 }
 
 // draw (roughly) max_nodes nodes from the graph using the random seed

--- a/src/algorithms/coverage_depth.cpp
+++ b/src/algorithms/coverage_depth.cpp
@@ -146,7 +146,7 @@ unordered_map<string, map<size_t, pair<double, double>>> binned_packed_depth_ind
             double var = get<3>(binned_depth);
             // optionally convert variance to standard error
             if (std_err) {
-                var = sqrt(var / (double)(get<1>(binned_depth) - get<2>(binned_depth)));
+                var = sqrt(var / (double)(get<1>(binned_depth) - get<0>(binned_depth)));
             }
             depth_map[get<0>(binned_depth)] = make_pair(get<2>(binned_depth), var);
         }

--- a/src/algorithms/coverage_depth.hpp
+++ b/src/algorithms/coverage_depth.hpp
@@ -11,7 +11,6 @@
 #include "handle.hpp"
 #include "packer.hpp"
 
-
 namespace vg {
 namespace algorithms {
 
@@ -35,7 +34,21 @@ pair<double, double> packed_depth_of_bin(const Packer& packer, step_handle_t sta
 /// Use all available threads to estimate the binned packed coverage of a path using above fucntion
 /// Each element is a bin's 0-based open-ended interval in the path, and its coverage mean,variance. 
 vector<tuple<size_t, size_t, double, double>> binned_packed_depth(const Packer& packer, const string& path_name, size_t bin_size,
-                                                          size_t min_coverage, bool include_deletions);
+                                                                  size_t min_coverage, bool include_deletions);
+
+/// Use the above function to retrieve the binned depths of a list of paths, and store them indexed by start
+/// coordinate.  If std_err is true, store <mean, stderr> instead of <mean, variance>
+using BinnedDepthIndex = unordered_map<string, map<size_t, pair<double, double>>>;
+BinnedDepthIndex binned_packed_depth_index(const Packer& packer,
+                                           const vector<string>& path_names,
+                                           size_t bin_size,
+                                           size_t min_coverage,
+                                           bool include_deletions,
+                                           bool std_err);
+
+/// Query index created above
+/// Todo: optionally smooth over adjacent bins?
+const pair<double, double>& get_depth_from_index(const BinnedDepthIndex& depth_index, const string& path_name, size_t offset);
 
 /// Return the mean and variance of coverage of randomly sampled nodes from a GAM
 /// Nodes with less than min_coverage are ignored

--- a/src/algorithms/coverage_depth.hpp
+++ b/src/algorithms/coverage_depth.hpp
@@ -38,7 +38,7 @@ vector<tuple<size_t, size_t, double, double>> binned_packed_depth(const Packer& 
 
 /// Use the above function to retrieve the binned depths of a list of paths, and store them indexed by start
 /// coordinate.  If std_err is true, store <mean, stderr> instead of <mean, variance>
-using BinnedDepthIndex = unordered_map<string, map<size_t, pair<double, double>>>;
+using BinnedDepthIndex = unordered_map<string, map<size_t, pair<float, float>>>;
 BinnedDepthIndex binned_packed_depth_index(const Packer& packer,
                                            const vector<string>& path_names,
                                            size_t bin_size,
@@ -47,8 +47,8 @@ BinnedDepthIndex binned_packed_depth_index(const Packer& packer,
                                            bool std_err);
 
 /// Query index created above
-/// Todo: optionally smooth over adjacent bins?
-const pair<double, double>& get_depth_from_index(const BinnedDepthIndex& depth_index, const string& path_name, size_t offset);
+const pair<float, float>& get_depth_from_index(const BinnedDepthIndex& depth_index, const string& path_name, size_t offset);
+pair<float, float> get_depth_from_index(const BinnedDepthIndex& depth_index, const string& path_name, size_t start_offset, size_t end_offset);
 
 /// Return the mean and variance of coverage of randomly sampled nodes from a GAM
 /// Nodes with less than min_coverage are ignored

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -241,7 +241,7 @@ tuple<string, size_t, size_t> VCFGenotyper::get_ref_positions(const vector<vcfli
     map<string, pair<size_t, size_t>> path_offsets;
     for (const vcflib::Variant* var : variants) {
         if (path_offsets.count(var->sequenceName)) {
-            pair<size_t, size_t>& record = path_offsets[var->ref];
+            pair<size_t, size_t>& record = path_offsets[var->sequenceName];
             record.first = std::min((size_t)var->position, record.first);
             record.second = std::max((size_t)var->position + var->ref.length(), record.second);
         } else {

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -296,8 +296,8 @@ LegacyCaller::LegacyCaller(const PathPositionHandleGraph& graph,
                                                              0,
                                                              0,
                                                              get_path_index,
-                                                             [&](id_t id) { return snarl_caller.get_min_node_support(id);},
-                                                             [&](edge_t edge) { return snarl_caller.get_edge_support(edge);});
+                                                             [&](id_t id) { return snarl_caller.get_support_finder().get_min_node_support(id);},
+                                                             [&](edge_t edge) { return snarl_caller.get_support_finder().get_edge_support(edge);});
 
     } else {
         // our graph is not in vg format.  we will make graphs for each site as needed and work with those
@@ -364,7 +364,7 @@ bool LegacyCaller::call_snarl(const Snarl& snarl) {
         // determine the support threshold for the traversal finder.  if we're using average
         // support, then we don't use any (set to 0), other wise, use the minimum support for a call
         SupportBasedSnarlCaller& support_caller = dynamic_cast<SupportBasedSnarlCaller&>(snarl_caller);
-        size_t threshold = support_caller.get_average_traversal_support_switch_threshold();
+        size_t threshold = support_caller.get_support_finder().get_average_traversal_support_switch_threshold();
         double support_cutoff = total_snarl_length <= threshold ? support_caller.get_min_total_support_for_call() : 0;
         rep_trav_finder = new RepresentativeTraversalFinder(vg_graph, snarl_manager,
                                                             max_search_depth,
@@ -373,10 +373,10 @@ bool LegacyCaller::call_snarl(const Snarl& snarl) {
                                                             support_cutoff,
                                                             support_cutoff,
                                                             get_path_index,
-                                                            [&](id_t id) { return support_caller.get_min_node_support(id);},
+                                                            [&](id_t id) { return support_caller.get_support_finder().get_min_node_support(id);},
                                                             // note: because our traversal finder and support caller have
                                                             // different graphs, they can't share edge handles
-                                                            [&](edge_t edge) { return support_caller.get_edge_support(
+                                                            [&](edge_t edge) { return support_caller.get_support_finder().get_edge_support(
                                                                     vg_graph.get_id(edge.first), vg_graph.get_is_reverse(edge.first),
                                                                     vg_graph.get_id(edge.second), vg_graph.get_is_reverse(edge.second));});
                                                             

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -102,6 +102,9 @@ public:
 
 protected:
 
+    /// get path positions bounding a set of variants
+    tuple<string, size_t, size_t>  get_ref_positions(const vector<vcflib::Variant*>& variants) const;
+
     /// munge out the contig lengths from the VCF header
     virtual unordered_map<string, size_t> scan_contig_lengths() const;
 
@@ -145,7 +148,8 @@ protected:
 
     /// recursively genotype a snarl
     /// todo: can this be pushed to a more generic class? 
-    pair<vector<SnarlTraversal>, vector<int>> top_down_genotype(const Snarl& snarl, TraversalFinder& trav_finder, int ploidy) const;
+    pair<vector<SnarlTraversal>, vector<int>> top_down_genotype(const Snarl& snarl, TraversalFinder& trav_finder, int ploidy,
+                                                                const string& ref_path_name, pair<size_t, size_t> ref_interval) const;
     
     /// we need the reference traversal for VCF, but if the ref is not called, the above method won't find it. 
     SnarlTraversal get_reference_traversal(const Snarl& snarl, TraversalFinder& trav_finder) const;
@@ -153,10 +157,13 @@ protected:
     /// re-genotype output of top_down_genotype.  it may give slightly different results as
     /// it's working with fully-defined traversals and can exactly determine lengths and supports
     /// it will also make sure the reference traversal is in the beginning of the output
-    pair<vector<SnarlTraversal>, vector<int>> re_genotype(const Snarl& snarl, TraversalFinder& trav_finder,
+    pair<vector<SnarlTraversal>, vector<int>> re_genotype(const Snarl& snarl,
+                                                          TraversalFinder& trav_finder,
                                                           const vector<SnarlTraversal>& in_traversals,
                                                           const vector<int>& in_genotype,
-                                                          int ploidy) const;
+                                                          int ploidy,
+                                                          const string& ref_path_name,
+                                                          pair<size_t, size_t> ref_interval) const;
 
     /// print a vcf variant 
     void emit_variant(const Snarl& snarl, TraversalFinder& trav_finder, const vector<SnarlTraversal>& called_traversals,
@@ -168,9 +175,9 @@ protected:
     /// look up a path index for a site and return its name too
     pair<string, PathIndex*> find_index(const Snarl& snarl, const vector<PathIndex*> path_indexes) const;
 
-    /// get the position of a snarl from our reference path using the PathPositionHandleGraph interface
+    /// get the interval of a snarl from our reference path using the PathPositionHandleGraph interface
     /// the bool is true if the snarl's backward on the path
-    pair<size_t, bool> get_ref_position(const Snarl& snarl, const string& ref_path_name) const;
+    tuple<size_t, size_t, bool> get_ref_interval(const Snarl& snarl, const string& ref_path_name) const;
 
     /// clean up the alleles to not share common prefixes / suffixes
     void flatten_common_allele_ends(vcflib::Variant& variant, bool backward) const;

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -74,8 +74,8 @@ protected:
     /// Sample name
     string sample_name;
 
-    /// output buffer (for sorting)
-    mutable vector<vcflib::Variant> output_variants;
+    /// output buffers (1/thread) (for sorting)
+    mutable vector<vector<vcflib::Variant>> output_variants;
 };
     
 /**

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -512,7 +512,9 @@ vector<int> PoissonSupportSnarlCaller::genotype(const Snarl& snarl,
             // doesn't meet a certain cutoff
             vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, true, false, false, ref_trav_idx);
             for (int j = 0; j < secondary_exclusive_supports.size(); ++j) {
-                if (j != best_allele && support_val(secondary_exclusive_supports[j]) <= min_total_support_for_call) {
+                if (j != best_allele &&
+                    support_val(secondary_exclusive_supports[j]) < min_total_support_for_call &&
+                    support_val(secondary_exclusive_supports[j]) < support_val(supports[j])) {
                     skips.insert(j);
                 }
             }

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -547,8 +547,9 @@ vector<int> PoissonSupportSnarlCaller::genotype(const Snarl& snarl,
     // expected depth from our coverage
     auto depth_info = algorithms::get_depth_from_index(depth_index, ref_path_name, ref_range.first, ref_range.second);
     double exp_depth = depth_info.first;
-    double depth_err = depth_info.second;
-    assert(!isnan(exp_depth) && !isnan(depth_err));
+    assert(!isnan(exp_depth));
+    // variance/std-err can be nan when binsize < 2.  We just clamp it to 0
+    double depth_err = depth_info.second ? !isnan(depth_info.second) : 0.;
 
     // genotype (log) likelihoods
     double best_genotype_likelihood = -numeric_limits<double>::max();
@@ -701,8 +702,9 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
 					       variant.position + variant.ref.length() + padding);
     auto depth_info = algorithms::get_depth_from_index(depth_index, variant.sequenceName, ref_range.first, ref_range.second);
     double exp_depth = depth_info.first;
-    double depth_err = depth_info.second;
-    assert(!isnan(exp_depth) && !isnan(depth_err));
+    assert(!isnan(exp_depth));
+    // variance/std-err can be nan when binsize < 2.  We just clamp it to 0
+    double depth_err = depth_info.second ? !isnan(depth_info.second) : 0.;
 
     // assume ploidy 2
     for (int i = 0; i < traversals.size(); ++i) {

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -13,9 +13,11 @@ function<bool(const SnarlTraversal&)> SnarlCaller::get_skip_allele_fn() const {
     return [](const SnarlTraversal&) { return false; };
 }
 
-SupportBasedSnarlCaller::SupportBasedSnarlCaller(const PathHandleGraph& graph, SnarlManager& snarl_manager) :
+SupportBasedSnarlCaller::SupportBasedSnarlCaller(const PathHandleGraph& graph, SnarlManager& snarl_manager,
+                                                 TraversalSupportFinder& support_finder) :
     graph(graph),
-    snarl_manager(snarl_manager) {
+    snarl_manager(snarl_manager),
+    support_finder(support_finder) {
 }
 
 SupportBasedSnarlCaller::~SupportBasedSnarlCaller() {
@@ -57,10 +59,10 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
 #endif
 
     // get the traversal sizes
-    vector<int> traversal_sizes = get_traversal_sizes(traversals);
+    vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);
 
     // get the supports of each traversal independently
-    vector<Support> supports = get_traversal_set_support(traversals, {}, false, false, ref_trav_idx);
+    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, false, false, ref_trav_idx);
     int best_allele = get_best_support(supports, {});
 
 #ifdef debug
@@ -75,7 +77,7 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
 
     // we prune out traversals whose exclusive support (structure that is not shared with best traversal)
     // doesn't meet a certain cutoff
-    vector<Support> secondary_exclusive_supports = get_traversal_set_support(traversals, {best_allele}, true, false, ref_trav_idx);    
+    vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, true, false, ref_trav_idx);    
     vector<int> skips = {best_allele};
     for (int i = 0; i < secondary_exclusive_supports.size(); ++i) {
         double bias = get_bias(traversal_sizes, i, best_allele, ref_trav_idx);
@@ -88,7 +90,7 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
         }
     }
     // get the supports of each traversal in light of best
-    vector<Support> secondary_supports = get_traversal_set_support(traversals, {best_allele}, false, false, ref_trav_idx);
+    vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, false, false, ref_trav_idx);
     int second_best_allele = get_best_support(secondary_supports, {skips});
 
     // get the supports of each traversal in light of second best
@@ -97,7 +99,7 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
     int third_best_allele = -1;
     if (second_best_allele != -1) {
         // prune out traversals whose exclusive support relative to second best doesn't pass cut
-        vector<Support> tertiary_exclusive_supports = get_traversal_set_support(traversals, {second_best_allele}, true, false, ref_trav_idx);
+        vector<Support> tertiary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {second_best_allele}, true, false, ref_trav_idx);
         skips.push_back(best_allele);
         skips.push_back(second_best_allele);
         for (int i = 0; i < tertiary_exclusive_supports.size(); ++i) {
@@ -106,7 +108,7 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
                 skips.push_back(i);
             }
         }
-        tertiary_supports = get_traversal_set_support(traversals, {second_best_allele}, false, false, ref_trav_idx);
+        tertiary_supports = support_finder.get_traversal_set_support(traversals, {second_best_allele}, false, false, ref_trav_idx);
         third_best_allele = get_best_support(tertiary_supports, skips);
     }
 
@@ -253,11 +255,11 @@ void SupportBasedSnarlCaller::update_vcf_info(const Snarl& snarl,
         shared_travs.push_back(genotype[0]);
     }
     // compute the support of our called alleles
-    vector<Support> allele_supports = get_traversal_set_support(traversals, shared_travs, false, false, 0);
+    vector<Support> allele_supports = support_finder.get_traversal_set_support(traversals, shared_travs, false, false, 0);
 
     // get the support of our uncalled alleles, making sure to not include any called support
     // TODO: handle shared support within this set
-    vector<Support> uncalled_supports = get_traversal_set_support(traversals, genotype, false, true, 0);
+    vector<Support> uncalled_supports = support_finder.get_traversal_set_support(traversals, genotype, false, true, 0);
         
     // Set up the depth format field
     variant.format.push_back("DP");
@@ -366,221 +368,6 @@ void SupportBasedSnarlCaller::update_vcf_header(string& header) const {
         std::to_string(min_site_depth) + "\">\n";    
 }
 
-function<bool(const SnarlTraversal&)> SupportBasedSnarlCaller::get_skip_allele_fn() const {
-    // port over cutoff used in old support caller (there avg support used all the time, here
-    // we use the same toggles as when genotyping)
-    return [&](const SnarlTraversal& trav) -> bool {
-        return support_val(get_traversal_support(trav)) < min_alt_path_support;
-    };
-}
-
-int64_t SupportBasedSnarlCaller::get_edge_length(const edge_t& edge, const unordered_map<id_t, size_t>& ref_offsets) const {
-    int len = -1;
-    // use our reference traversal to try to come up with a deletion length for our edge
-    // idea: if our edge corresponds to a huge deltion, it should be weighted accordingly
-    auto s_it = ref_offsets.find(graph.get_id(edge.first));
-    auto e_it = ref_offsets.find(graph.get_id(edge.second));
-    if (s_it != ref_offsets.end() && e_it != ref_offsets.end()) {
-        size_t start_offset = s_it->second;
-        if (!graph.get_is_reverse(edge.first)) {
-            start_offset += graph.get_length(edge.first);
-        }
-        size_t end_offset = e_it->second;
-        if (graph.get_is_reverse(edge.second)) {
-            end_offset += graph.get_length(edge.second);
-        }
-        if (start_offset > end_offset) {
-            std::swap(start_offset, end_offset);
-        }
-        len = end_offset - start_offset;
-    }
-    return std::max(len, 1);
-}
-
-tuple<Support, Support, int> SupportBasedSnarlCaller::get_child_support(const Snarl& snarl) const {
-    // port over old functionality from support caller
-    // todo: do we need to flag nodes as covered like it does?
-    pair<unordered_set<id_t>, unordered_set<edge_t> > contents = snarl_manager.deep_contents(&snarl, graph, true);
-    Support child_max_support;
-    Support child_total_support;
-    size_t child_size = 0;
-    for (id_t node_id : contents.first) {
-        Support child_support = get_avg_node_support(node_id);
-        child_max_support = support_max(child_max_support, child_support);
-        child_size += graph.get_length(graph.get_handle(node_id));
-        child_total_support += child_support;
-    }
-    Support child_avg_support = child_total_support / child_size;
-    // we always use child_max like the old support_caller.
-    // this is the only way to get top-down recursion to work in many cases
-    // todo: fix to use bottom up, get get support from actual traversals
-    // every time!! 
-    return std::tie(child_max_support, child_max_support, child_size);
-}
-
-
-Support SupportBasedSnarlCaller::get_traversal_support(const SnarlTraversal& traversal) const {
-    return get_traversal_set_support({traversal}, {}, false, false).at(0);
-}
-
-vector<Support> SupportBasedSnarlCaller::get_traversal_set_support(const vector<SnarlTraversal>& traversals,
-                                                                   const vector<int>& shared_travs,
-                                                                   bool exclusive_only,
-                                                                   bool exclusive_count,
-                                                                   int ref_trav_idx) const {
-
-    // pass 1: how many times have we seen a node or edge
-    unordered_map<id_t, int> node_counts;
-    unordered_map<edge_t, int> edge_counts;
-    map<Snarl, int> child_counts;
-
-    for (auto trav_idx : shared_travs) {
-        const SnarlTraversal& trav = traversals[trav_idx];
-        for (int i = 0; i < trav.visit_size(); ++i) {
-            const Visit& visit = trav.visit(i);
-            if (visit.node_id() != 0) {
-                // Count the node once
-                if (node_counts.count(visit.node_id())) {
-                    node_counts[visit.node_id()] += 1;
-                } else {
-                    node_counts[visit.node_id()] = 1;
-                }
-            } else {
-                // Count the child once
-                if (child_counts.count(visit.snarl())) {
-                    child_counts[visit.snarl()] += 1;
-                } else {
-                    child_counts[visit.snarl()] = 1;
-                }
-            }
-            // note: there is no edge between adjacent snarls as they overlap
-            // on their endpoints. 
-            if (i > 0 && (trav.visit(i - 1).node_id() != 0 || trav.visit(i).node_id() != 0)) {
-                edge_t edge = to_edge(graph, trav.visit(i - 1), visit);
-                // Count the edge once
-                if (edge_counts.count(edge)) {
-                    edge_counts[edge] += 1;
-                } else {
-                    edge_counts[edge] = 1;
-                }
-            }
-        }
-    }
-
-    // pass 1.5: get index for looking up deletion edge lengths (so far we aren't dependent
-    // on having anything but a path handle graph, so we index on the fly)
-    unordered_map<id_t, size_t> ref_offsets;
-    if (ref_trav_idx >= 0) {
-        ref_offsets = get_ref_offsets(traversals[ref_trav_idx]);
-    }
-
-    // pass 2: get the supports
-    // we compute the various combinations of min/avg node/trav supports as we don't know which
-    // we will need until all the sizes are known
-    Support max_support;
-    max_support.set_forward(numeric_limits<int>::max());
-    vector<Support> min_supports_min(traversals.size(), max_support); // use min node support
-    vector<Support> min_supports_avg(traversals.size(), max_support); // use avg node support
-    vector<bool> has_support(traversals.size(), false);
-    vector<Support> tot_supports_min(traversals.size()); // weighted by lengths, using min node support
-    vector<Support> tot_supports_avg(traversals.size()); // weighted by lengths, using avg node support
-    vector<int> tot_sizes(traversals.size(), 0); // to compute average from to_supports;
-    vector<int> tot_sizes_all(traversals.size(), 0); // as above, but includes excluded lengths
-    int max_trav_size = 0; // size of longest traversal
-
-    bool count_end_nodes = false; // toggle to include snarl ends
-
-    auto update_support = [&] (int trav_idx, const Support& min_support,
-                               const Support& avg_support, int length, int share_count) {
-        // keep track of overall size of longest traversal
-        tot_sizes_all[trav_idx] += length;
-        max_trav_size = std::max(tot_sizes_all[trav_idx], max_trav_size);
-
-        // apply the scaling
-        double scale_factor = ((exclusive_only || exclusive_count) && share_count > 0) ? 0. : 1. / (1. + share_count);
-        
-        // when looking at exclusive support, we don't normalize by skipped lengths
-        if (scale_factor != 0 || !exclusive_only || exclusive_count) {
-            has_support[trav_idx] = true;
-            Support scaled_support_min = min_support * scale_factor;
-            Support scaled_support_avg = avg_support * scale_factor;
-
-            tot_supports_min[trav_idx] += scaled_support_min;
-            tot_supports_avg[trav_idx] += scaled_support_avg * length;
-            tot_sizes[trav_idx] += length;
-            min_supports_min[trav_idx] = support_min(min_supports_min[trav_idx], scaled_support_min);
-            min_supports_avg[trav_idx] = support_min(min_supports_avg[trav_idx], scaled_support_avg * length);
-        }
-    };
-
-    for (int trav_idx = 0; trav_idx < traversals.size(); ++trav_idx) {
-        const SnarlTraversal& trav = traversals[trav_idx];
-        for (int visit_idx = 0; visit_idx < trav.visit_size(); ++visit_idx) {
-            const Visit& visit = trav.visit(visit_idx);
-            Support min_support;
-            Support avg_support;
-            int64_t length;
-            int share_count = 0;
-
-            if (visit.node_id() != 0) {
-                // get the node support
-                min_support = get_min_node_support(visit.node_id());
-                avg_support = get_avg_node_support(visit.node_id());
-                length = graph.get_length(graph.get_handle(visit.node_id()));
-                if (node_counts.count(visit.node_id())) {
-                    share_count = node_counts[visit.node_id()];
-                }
-            } else {
-                // get the child support
-                tie(min_support, avg_support, length) = get_child_support(visit.snarl());
-                if (child_counts.count(visit.snarl())) {
-                    share_count = child_counts[visit.snarl()];
-                }
-            }
-            if (count_end_nodes || (visit_idx > 0 && visit_idx < trav.visit_size() - 1)) {
-                update_support(trav_idx, min_support, avg_support, length, share_count);
-            }
-            share_count = 0;
-            
-            if (visit_idx > 0 && (trav.visit(visit_idx - 1).node_id() != 0 || trav.visit(visit_idx).node_id() != 0)) {
-                // get the edge support
-                edge_t edge = to_edge(graph, trav.visit(visit_idx - 1), visit);
-                min_support = get_edge_support(edge);
-                length = get_edge_length(edge, ref_offsets);
-                if (edge_counts.count(edge)) {
-                    share_count = edge_counts[edge];
-                }
-                update_support(trav_idx, min_support, min_support, length, share_count);
-            }
-        }
-    }
-
-    // correct for case where no exclusive support found
-    for (int i = 0; i < min_supports_min.size(); ++i) {
-        if (!has_support[i]) {
-            min_supports_min[i] = Support();
-            min_supports_avg[i] = Support();
-        }
-    }
-
-    bool use_avg_trav_support = max_trav_size >= average_traversal_support_switch_threshold;
-    bool use_avg_node_support = max_trav_size >= average_node_support_switch_threshold;
-
-    if (use_avg_trav_support) {
-        vector<Support>& tot_supports = use_avg_node_support ? tot_supports_avg : tot_supports_min;
-        for (int i = 0; i < tot_supports.size(); ++i) {
-            if (tot_sizes[i] > 0) {
-                tot_supports[i] /= (double)tot_sizes[i];
-            } else {
-                tot_supports[i] = Support();
-            }
-        }
-        return tot_supports;
-    } else {
-        return use_avg_node_support ? min_supports_avg : min_supports_min;
-    }
-}   
-
 int SupportBasedSnarlCaller::get_best_support(const vector<Support>& supports, const vector<int>& skips) {
     int best_allele = -1;
     for(size_t i = 0; i < supports.size(); i++) {
@@ -592,34 +379,23 @@ int SupportBasedSnarlCaller::get_best_support(const vector<Support>& supports, c
     return best_allele;
 }
 
-vector<int> SupportBasedSnarlCaller::get_traversal_sizes(const vector<SnarlTraversal>& traversals) const {
-    vector<int> sizes(traversals.size(), 0);
-    for (int i = 0; i < traversals.size(); ++i) {
-        for (int j = 0; j < traversals[i].visit_size(); ++j) {
-            if (traversals[i].visit(j).node_id() != 0) {
-                sizes[i] += graph.get_length(graph.get_handle(traversals[i].visit(j).node_id()));
-            } else {
-                // just summing up the snarl contents, which isn't a great heuristic but will
-                // help in some cases
-                pair<unordered_set<id_t>, unordered_set<edge_t> > contents = snarl_manager.deep_contents(
-                    snarl_manager.into_which_snarl(traversals[i].visit(j)), graph, true);
-                for (id_t node_id : contents.first) {
-                    sizes[i] += graph.get_length(graph.get_handle(node_id));
-                }
-            }
-        }
-    }
-    return sizes;
-    
+function<bool(const SnarlTraversal&)> SupportBasedSnarlCaller::get_skip_allele_fn() const {
+    // port over cutoff used in old support caller (there avg support used all the time, here
+    // we use the same toggles as when genotyping)
+    return [&](const SnarlTraversal& trav) -> bool {
+        return support_val(support_finder.get_traversal_support(trav)) < min_alt_path_support;
+    };
 }
 
-size_t SupportBasedSnarlCaller::get_average_traversal_support_switch_threshold() const {
-    return average_traversal_support_switch_threshold;
-}
 
 int SupportBasedSnarlCaller::get_min_total_support_for_call() const {
     return min_total_support_for_call;
 }
+
+const TraversalSupportFinder& SupportBasedSnarlCaller::get_support_finder() const {
+    return support_finder;
+}
+
 
 double SupportBasedSnarlCaller::get_bias(const vector<int>& traversal_sizes, int best_trav,
                                          int second_best_trav, int ref_trav_idx) const {
@@ -653,76 +429,7 @@ double SupportBasedSnarlCaller::get_bias(const vector<int>& traversal_sizes, int
     return bias_limit;
 }
 
-unordered_map<id_t, size_t> SupportBasedSnarlCaller::get_ref_offsets(const SnarlTraversal& ref_trav) const {
-    unordered_map<id_t, size_t> ref_offsets;
-    size_t offset = 0;
-    for (int i = 0; i < ref_trav.visit_size(); ++i) {
-        const Visit& visit = ref_trav.visit(i);
-        if (visit.node_id() != 0) {
-            if (visit.backward()) {
-                offset += graph.get_length(graph.get_handle(visit.node_id()));
-                ref_offsets[visit.node_id()] = offset;
-            } else {
-                ref_offsets[visit.node_id()] = offset;
-                offset += graph.get_length(graph.get_handle(visit.node_id()));
-            }
-        }
-    }
-    return ref_offsets;
-}
 
-PackedSupportSnarlCaller::PackedSupportSnarlCaller(const Packer& packer, SnarlManager& snarl_manager) :
-    SupportBasedSnarlCaller(*dynamic_cast<const PathHandleGraph*>(packer.get_graph()), snarl_manager),
-    packer(packer) {
-}
-
-PackedSupportSnarlCaller::~PackedSupportSnarlCaller() {
-}
-
-Support PackedSupportSnarlCaller::get_edge_support(const edge_t& edge) const {
-    return get_edge_support(graph.get_id(edge.first), graph.get_is_reverse(edge.first),
-                            graph.get_id(edge.second), graph.get_is_reverse(edge.second));
-}
-
-Support PackedSupportSnarlCaller::get_edge_support(id_t from, bool from_reverse,
-                                                   id_t to, bool to_reverse) const {
-    Edge proto_edge;
-    proto_edge.set_from(from);
-    proto_edge.set_from_start(from_reverse);
-    proto_edge.set_to(to);
-    proto_edge.set_to_end(to_reverse);
-    Support support;
-    support.set_forward(packer.edge_coverage(proto_edge));
-    return support;
-}
-
-Support PackedSupportSnarlCaller::get_min_node_support(id_t node) const {
-    Position pos;
-    pos.set_node_id(node);
-    size_t offset = packer.position_in_basis(pos);
-    size_t coverage = packer.coverage_at_position(offset);
-    size_t end_offset = offset + graph.get_length(graph.get_handle(node));
-    for (int i = offset + 1; i < end_offset; ++i) {
-        coverage = min(coverage, packer.coverage_at_position(i));
-    }
-    Support support;
-    support.set_forward(coverage);
-    return support;
-}
-
-Support PackedSupportSnarlCaller::get_avg_node_support(id_t node) const {
-    Position pos;
-    pos.set_node_id(node);
-    size_t offset = packer.position_in_basis(pos);
-    size_t coverage = 0;
-    size_t length = graph.get_length(graph.get_handle(node));
-    for (int i = 0; i < length; ++i) {
-        coverage += packer.coverage_at_position(offset + i);
-    }
-    Support support;
-    support.set_forward((double)coverage / (double)length);
-    return support;
-}
 
 
 }

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -1,7 +1,7 @@
 #include "snarl_caller.hpp"
 #include "genotypekit.hpp"
 
-//#define debug
+#define debug
 
 namespace vg {
 
@@ -18,23 +18,28 @@ SupportBasedSnarlCaller::SupportBasedSnarlCaller(const PathHandleGraph& graph, S
     graph(graph),
     snarl_manager(snarl_manager),
     support_finder(support_finder) {
+
 }
 
 SupportBasedSnarlCaller::~SupportBasedSnarlCaller() {
     
 }
 
-void SupportBasedSnarlCaller::set_het_bias(double het_bias, double ref_het_bias) {
-    // want to move away from ugly hacks that treat the reference traversal differently,
-    // so keep all these set the same
-    if (het_bias >= 0) {
-        max_het_bias = het_bias;
-        max_ref_het_bias = het_bias;
-        max_indel_het_bias = het_bias;
-    }
-    if (ref_het_bias >= 0) {
-        max_ref_het_bias = ref_het_bias;
-    }
+void SupportBasedSnarlCaller::update_vcf_info(const Snarl& snarl,
+                                              const vector<SnarlTraversal>& traversals,
+                                              const vector<int>& genotype,
+                                              const string& sample_name,
+                                              vcflib::Variant& variant) {
+    
+    
+}
+
+const TraversalSupportFinder& SupportBasedSnarlCaller::get_support_finder() const {
+    return support_finder;
+}
+
+int SupportBasedSnarlCaller::get_min_total_support_for_call() const {
+    return min_total_support_for_call;
 }
 
 void SupportBasedSnarlCaller::set_min_supports(double min_mad_for_call, double min_support_for_call, double min_site_support) {
@@ -49,10 +54,45 @@ void SupportBasedSnarlCaller::set_min_supports(double min_mad_for_call, double m
     }
 }
 
-vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
+int SupportBasedSnarlCaller::get_best_support(const vector<Support>& supports, const vector<int>& skips) {
+    int best_allele = -1;
+    for(size_t i = 0; i < supports.size(); i++) {
+        if(std::find(skips.begin(), skips.end(), i) == skips.end() && (
+               best_allele == -1 || support_val(supports[best_allele]) <= support_val(supports[i]))) {
+            best_allele = i;
+        }
+    }
+    return best_allele;
+}
+
+RatioSupportSnarlCaller::RatioSupportSnarlCaller(const PathHandleGraph& graph, SnarlManager& snarl_manager,
+                                                 TraversalSupportFinder& support_finder) :
+    SupportBasedSnarlCaller(graph, snarl_manager, support_finder)  {
+}
+
+RatioSupportSnarlCaller::~RatioSupportSnarlCaller() {
+    
+}
+
+void RatioSupportSnarlCaller::set_het_bias(double het_bias, double ref_het_bias) {
+    // want to move away from ugly hacks that treat the reference traversal differently,
+    // so keep all these set the same
+    if (het_bias >= 0) {
+        max_het_bias = het_bias;
+        max_ref_het_bias = het_bias;
+        max_indel_het_bias = het_bias;
+    }
+    if (ref_het_bias >= 0) {
+        max_ref_het_bias = ref_het_bias;
+    }
+}
+
+vector<int> RatioSupportSnarlCaller::genotype(const Snarl& snarl,
                                               const vector<SnarlTraversal>& traversals,
                                               int ref_trav_idx,
-                                              int ploidy) {
+                                              int ploidy,
+                                              const string& ref_path_name,
+                                              pair<size_t, size_t> ref_range) { 
 
 #ifdef debug
     cerr << "Support calling site " << pb2json(snarl) << endl;
@@ -62,7 +102,7 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
     vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);
 
     // get the supports of each traversal independently
-    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, false, false, ref_trav_idx);
+    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, false, false, false, ref_trav_idx);
     int best_allele = get_best_support(supports, {});
 
 #ifdef debug
@@ -77,7 +117,7 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
 
     // we prune out traversals whose exclusive support (structure that is not shared with best traversal)
     // doesn't meet a certain cutoff
-    vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, true, false, ref_trav_idx);    
+    vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, true, false, false, ref_trav_idx);    
     vector<int> skips = {best_allele};
     for (int i = 0; i < secondary_exclusive_supports.size(); ++i) {
         double bias = get_bias(traversal_sizes, i, best_allele, ref_trav_idx);
@@ -90,7 +130,7 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
         }
     }
     // get the supports of each traversal in light of best
-    vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, false, false, ref_trav_idx);
+    vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, false, false, false, ref_trav_idx);
     int second_best_allele = get_best_support(secondary_supports, {skips});
 
     // get the supports of each traversal in light of second best
@@ -99,7 +139,7 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
     int third_best_allele = -1;
     if (second_best_allele != -1) {
         // prune out traversals whose exclusive support relative to second best doesn't pass cut
-        vector<Support> tertiary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {second_best_allele}, true, false, ref_trav_idx);
+        vector<Support> tertiary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {second_best_allele}, true, false, false, ref_trav_idx);
         skips.push_back(best_allele);
         skips.push_back(second_best_allele);
         for (int i = 0; i < tertiary_exclusive_supports.size(); ++i) {
@@ -108,7 +148,7 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
                 skips.push_back(i);
             }
         }
-        tertiary_supports = support_finder.get_traversal_set_support(traversals, {second_best_allele}, false, false, ref_trav_idx);
+        tertiary_supports = support_finder.get_traversal_set_support(traversals, {second_best_allele}, false, false, false, ref_trav_idx);
         third_best_allele = get_best_support(tertiary_supports, skips);
     }
 
@@ -151,7 +191,7 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
 
     // Single ploidy case when doing recursive genotyping.  Just return the best allele
     if (ploidy == 1) {
-        return {best_allele};
+        return vector<int>(1, best_allele);
     }
     // Call 1/2 : REF-Alt1/Alt2 even if Alt2 has only third best support
     else if (ploidy >= 2 &&
@@ -238,12 +278,14 @@ vector<int> SupportBasedSnarlCaller::genotype(const Snarl& snarl,
             
     }
 
+    // Todo: specify call_info to use new interface, then fix up update_vcf_info to read it,
+    // and move common logic up to SupportBasedCaller if possible.
     return genotype;
 }
 
-void SupportBasedSnarlCaller::update_vcf_info(const Snarl& snarl,
+void RatioSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
                                               const vector<SnarlTraversal>& traversals,
-                                              const vector<int>& genotype,                                         
+                                              const vector<int>& genotype,
                                               const string& sample_name,
                                               vcflib::Variant& variant) {
 
@@ -255,11 +297,11 @@ void SupportBasedSnarlCaller::update_vcf_info(const Snarl& snarl,
         shared_travs.push_back(genotype[0]);
     }
     // compute the support of our called alleles
-    vector<Support> allele_supports = support_finder.get_traversal_set_support(traversals, shared_travs, false, false, 0);
+    // todo: I think this undercounts support.  shuold be fixed (as in Poisson version)
+    vector<Support> allele_supports = support_finder.get_traversal_set_support(traversals, shared_travs, false, false, false, 0);
 
     // get the support of our uncalled alleles, making sure to not include any called support
-    // TODO: handle shared support within this set
-    vector<Support> uncalled_supports = support_finder.get_traversal_set_support(traversals, genotype, false, true, 0);
+    vector<Support> uncalled_supports = support_finder.get_traversal_set_support(traversals, genotype, false, true, true, 0);
         
     // Set up the depth format field
     variant.format.push_back("DP");
@@ -353,7 +395,7 @@ void SupportBasedSnarlCaller::update_vcf_info(const Snarl& snarl,
     }
 }
 
-void SupportBasedSnarlCaller::update_vcf_header(string& header) const {
+void RatioSupportSnarlCaller::update_vcf_header(string& header) const {
     header += "##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">\n";
     header += "##FORMAT=<ID=AD,Number=.,Type=Integer,Description=\"Allelic depths for the ref and alt alleles in the order listed\">\n";
     header += "##FORMAT=<ID=XADL,Number=1,Type=Float,Description=\"Likelihood of allelic depths for called alleles\">\n";
@@ -368,18 +410,7 @@ void SupportBasedSnarlCaller::update_vcf_header(string& header) const {
         std::to_string(min_site_depth) + "\">\n";    
 }
 
-int SupportBasedSnarlCaller::get_best_support(const vector<Support>& supports, const vector<int>& skips) {
-    int best_allele = -1;
-    for(size_t i = 0; i < supports.size(); i++) {
-        if(std::find(skips.begin(), skips.end(), i) == skips.end() && (
-               best_allele == -1 || support_val(supports[best_allele]) <= support_val(supports[i]))) {
-            best_allele = i;
-        }
-    }
-    return best_allele;
-}
-
-function<bool(const SnarlTraversal&)> SupportBasedSnarlCaller::get_skip_allele_fn() const {
+function<bool(const SnarlTraversal&)> RatioSupportSnarlCaller::get_skip_allele_fn() const {
     // port over cutoff used in old support caller (there avg support used all the time, here
     // we use the same toggles as when genotyping)
     return [&](const SnarlTraversal& trav) -> bool {
@@ -387,17 +418,7 @@ function<bool(const SnarlTraversal&)> SupportBasedSnarlCaller::get_skip_allele_f
     };
 }
 
-
-int SupportBasedSnarlCaller::get_min_total_support_for_call() const {
-    return min_total_support_for_call;
-}
-
-const TraversalSupportFinder& SupportBasedSnarlCaller::get_support_finder() const {
-    return support_finder;
-}
-
-
-double SupportBasedSnarlCaller::get_bias(const vector<int>& traversal_sizes, int best_trav,
+double RatioSupportSnarlCaller::get_bias(const vector<int>& traversal_sizes, int best_trav,
                                          int second_best_trav, int ref_trav_idx) const {
     bool is_indel = ((best_trav >= 0 && traversal_sizes[best_trav] != traversal_sizes[ref_trav_idx]) ||
                      (second_best_trav >=0 && traversal_sizes[second_best_trav] != traversal_sizes[ref_trav_idx]));
@@ -430,6 +451,315 @@ double SupportBasedSnarlCaller::get_bias(const vector<int>& traversal_sizes, int
 }
 
 
+PoissonSupportSnarlCaller::PoissonSupportSnarlCaller(const PathHandleGraph& graph, SnarlManager& snarl_manager,
+                                                     TraversalSupportFinder& support_finder,
+                                                     const algorithms::BinnedDepthIndex& depth_index) :
+    SupportBasedSnarlCaller(graph, snarl_manager, support_finder),
+    depth_index(depth_index) {
+    
+}
+    
+PoissonSupportSnarlCaller::~PoissonSupportSnarlCaller() {
+    
+}
+
+vector<int> PoissonSupportSnarlCaller::genotype(const Snarl& snarl,
+                                                const vector<SnarlTraversal>& traversals,
+                                                int ref_trav_idx,
+                                                int ploidy,
+                                                const string& ref_path_name,
+                                                pair<size_t, size_t> ref_range) {
+    
+    
+#ifdef debug
+    cerr << "Poisson Support calling site " << pb2json(snarl)
+         << " on path " << ref_path_name << ":" << ref_range.first << "-" << ref_range.second << endl;
+#endif
+
+    assert(ploidy == 2 || ploidy == 1);
+    
+    // get the traversal sizes
+    vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);
+
+    // get the supports of each traversal independently
+    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, false, false, false, ref_trav_idx);
+
+    // sort the traversals by support
+    vector<int> ranked_traversals = rank_by_support(supports);
+    size_t max_trav = std::min(top_k, (size_t)ranked_traversals.size());
+
+    // the candidate genotypes and their supports.  the numbers here are alleles as indexed in traversals[]
+    map<vector<int>, vector<Support>> candidates;
+
+    // consider each of the top 25 traversals as our top_traversal
+    for (int i = 0; i < max_trav; ++i) {
+        
+        int best_allele = ranked_traversals[i];
+
+        if (ploidy == 1) {
+            candidates[{best_allele}] = {supports[best_allele]}; 
+        } else {
+            assert(ploidy == 2);
+        
+            // we prune out traversals whose exclusive support (structure that is not shared with best traversal)
+            // doesn't meet a certain cutoff
+            vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, true, false, false, ref_trav_idx);
+            set<int> skips = {best_allele};
+            for (int j = 0; j < secondary_exclusive_supports.size(); ++j) {
+                if (j != best_allele && support_val(secondary_exclusive_supports[j]) <= min_total_support_for_call) {
+                    skips.insert(j);
+                }
+            }
+
+            // get the supports of each traversal in light of best
+            vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, false, false, false, ref_trav_idx);
+            vector<int> ranked_secondary_traversals = rank_by_support(secondary_supports);
+
+            // add the homozygous genotype for our best allele
+            candidates[{best_allele, best_allele}] = {supports[best_allele], supports[best_allele]};
+
+            // now look at the top-k second-best traversals
+            size_t sec_count = 0;
+            for (int j = 0; j < ranked_secondary_traversals.size() && sec_count < top_k; ++j) {
+                int second_best_allele = ranked_secondary_traversals[j];
+                if (!skips.count(second_best_allele) && second_best_allele != best_allele) {
+                    // second best allele's support, sharing nodes with best
+                    Support& second_best_support = secondary_supports[second_best_allele];
+                    // best allele's support, sharing nodes with second best
+                    Support best_support_het = support_finder.get_traversal_set_support(
+                        {traversals[best_allele], traversals[second_best_allele]},
+                        {1}, false, false, false, ref_trav_idx)[0];
+                                
+                    // canonical ordering for our set
+                    if (best_allele < second_best_allele) {
+                        candidates[{best_allele, second_best_allele}] = {best_support_het, second_best_support};
+                    } else {
+                        candidates[{second_best_allele, best_allele}] = {second_best_support, best_support_het};
+                    }
+                    // also make sure we have our homozygous genotype for the second best allele
+                    candidates[{second_best_allele, second_best_allele}] = {supports[second_best_allele], supports[second_best_allele]};
+                    ++sec_count;
+                }
+            }
+        }
+    }
+
+    // expected depth from our coverage
+    const pair<double, double>& start_depth = algorithms::get_depth_from_index(depth_index, ref_path_name, ref_range.first);
+    const pair<double, double>& end_depth = algorithms::get_depth_from_index(depth_index, ref_path_name, ref_range.second);
+    double exp_depth = (start_depth.first + end_depth.first) / 2.;
+    double depth_err = (start_depth.second + end_depth.second) / 2.;
+    assert(!isnan(exp_depth) && !isnan(depth_err));
+
+    // genotype (log) likelihoods
+    double best_genotype_likelihood = -numeric_limits<double>::max();
+    vector<int> best_genotype;
+    for (const auto& candidate : candidates) {
+        double gl = genotype_likelihood(candidate.first, candidate.second, traversals, ref_trav_idx, exp_depth, depth_err);
+        if (gl > best_genotype_likelihood) {
+            best_genotype_likelihood = gl;
+            best_genotype = candidate.first;
+        }
+    }
+
+    return best_genotype;
+}
+
+double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotype,
+                                                      const vector<Support>& genotype_supports,
+                                                      const vector<SnarlTraversal>& traversals,
+                                                      int ref_trav_idx, double exp_depth, double depth_err) {
+    
+    assert(genotype_supports.size() == genotype.size());
+    assert(genotype.size() == 1 || genotype.size() == 2);
+
+
+    // we need the support of all traversals *not* in the genotype.
+    Support total_other_support;
+    // we are running in a mode that will ignore stuff in our genotype, and only count the remainders once.
+    vector<Support> other_supports = support_finder.get_traversal_set_support(traversals, genotype, false, true, true, ref_trav_idx);
+    for (auto& other_support : other_supports) {
+        total_other_support += other_support;
+    }
+
+    // split the homozygous support into two
+    // from now on we'll treat it like two separate observations, each with half coverage
+    vector<Support> fixed_genotype_supports = genotype_supports;
+    if (std::equal(genotype_supports.begin() + 1, genotype_supports.end(), genotype_supports.begin(),
+                   [&](const Support& s1, const Support& s2) { return support_val(s1) == support_val(s2); })) {
+        for (int i = 0; i < genotype_supports.size(); ++i) {
+            fixed_genotype_supports[i] = genotype_supports[i] / (double)genotype_supports.size();
+        }
+    }
+    
+    // total support of the site
+    Support total_site_support = total_other_support;
+    for (auto& support : fixed_genotype_supports) {
+        total_site_support += support;
+    }
+
+    // how many reads would we expect to not map to our genotype due to error
+    double error_rate = std::min(0.95, depth_err + baseline_mapping_error);
+    double other_poisson_lambda = error_rate * exp_depth; //support_val(total_site_support);
+
+    // and our likelihood for the unmapped reads we see:
+    double other_log_likelihood = poisson_prob_ln(std::round(support_val(total_other_support)), other_poisson_lambda);
+
+    // how many reads do we expect for an allele?  we use the expected coverage and just
+    // divide it out by the size of the genotype.  
+    double allele_poisson_lambda = (exp_depth / (double)genotype.size()) * (1. - error_rate);
+
+#ifdef debug
+    cerr << "Computing prob of genotype: {";
+    for (int i = 0; i < genotype.size(); ++i) {
+        cerr << genotype[i] << ",";
+    } 
+    cerr << "}: tot_other_sup = " << total_other_support << " tot site sup = " << total_site_support 
+         << " exp-depth = " << exp_depth << " depth-err = " << depth_err << " other-lambda = " << other_poisson_lambda
+         << " allele-lambda " << allele_poisson_lambda << endl;
+#endif
+    
+    // now we compute the likelihood of our genotype
+    double alleles_log_likelihood = 0;
+    for (int i = 0; i < fixed_genotype_supports.size(); ++i) {
+        double allele_ll = poisson_prob_ln(std::round(support_val(fixed_genotype_supports[i])), allele_poisson_lambda);        
+        alleles_log_likelihood += allele_ll;
+
+#ifdef debug
+        cerr << "  a[" << i <<"]=" << genotype[i] << " sup=" << genotype_supports[i] << " fix-sup=" << fixed_genotype_supports[i]
+             << " prob " << allele_ll << endl;
+#endif        
+    }
+
+#ifdef debug
+    cerr  << " allele-log-prob " << alleles_log_likelihood << " other-log-prob " << other_log_likelihood
+          << " total-prob " << (alleles_log_likelihood + other_log_likelihood) << endl;
+#endif
+
+    return alleles_log_likelihood + other_log_likelihood;
+}
+
+void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
+                                                const vector<SnarlTraversal>& traversals,
+                                                const vector<int>& genotype,
+                                                const string& sample_name,
+                                                vcflib::Variant& variant) {
+
+    assert(traversals.size() == variant.alleles.size());
+
+    // Get the depth of the site
+    
+    // get the unique supports (useful only for getting a total)
+    vector<Support> unique_supports = support_finder.get_traversal_set_support(traversals, {}, false, true, true, 0);
+    Support site_support;
+    for (const Support& sup : unique_supports) {
+        site_support += sup;
+    }
+    double total_site_depth = support_val(site_support);
+
+    // Set the variant's total depth            
+    string depth_string = std::to_string((int64_t)round(total_site_depth));
+    variant.format.push_back("DP");
+    variant.info["DP"].push_back(depth_string); // We only have one sample, so variant depth = sample depth
+            
+    // And for the sample
+    variant.samples[sample_name]["DP"].push_back(depth_string);            
+
+    // get the allele depths
+    variant.format.push_back("AD");
+    set<int> called_allele_set(genotype.begin(), genotype.end());
+
+    for (int i = 0; i < traversals.size(); ++i) {
+        vector<int> shared_travs;
+        bool in_genotype = called_allele_set.count(i);
+        if (in_genotype) {
+            // if we're in the genotype, then we share support with other alleles.
+            for (int a : called_allele_set) {
+                if (a != i) {
+                    shared_travs.push_back(a);
+                }
+            }
+        } else {
+            // if we're not in the genotype, then we ignore support of everything in the genotype
+            shared_travs = genotype;
+        }
+        // we recompute all supports for each allele to get it's support relative to the genotype
+        // there is certainly room for optimization via remembering some of this stuff here
+        vector<Support> allele_supports = support_finder.get_traversal_set_support(traversals, shared_travs, false, !in_genotype, false);
+        variant.samples[sample_name]["AD"].push_back(std::to_string((int64_t)round(support_val(allele_supports[i]))));
+    }
+
+    // get the genotype likelihoods
+    // as above, there's some overlap in these computations as those used in genotype() to begin with
+    // this is an issue with the class interface which probably tries too hard to avoid being VCF-dependent
+    // but if it causes a slowdown (hasn't seemed to be a factor so far), the code could be re-organized
+    // to either store some of this information, or comptue the genotype and vcf fields in a single shot
+    variant.format.push_back("GL");
+
+    // expected depth from our coverage
+    pair<size_t, size_t> ref_range = make_pair(variant.position, variant.position + variant.ref.length());
+    const pair<double, double>& start_depth = algorithms::get_depth_from_index(depth_index, variant.sequenceName, ref_range.first);
+    const pair<double, double>& end_depth = algorithms::get_depth_from_index(depth_index, variant.sequenceName, ref_range.second);
+    double exp_depth = (start_depth.first + end_depth.first) / 2.;
+    double depth_err = (start_depth.second + end_depth.second) / 2.;
+    assert(!isnan(exp_depth) && !isnan(depth_err));
+
+    // assume ploidy 2
+    for (int i = 0; i < traversals.size(); ++i) {
+        for (int j = i; j < traversals.size(); ++j) {
+            vector<Support> genotype_supports;
+            if (i == j) {
+                // put the full support of allele for each copy of homozygous (genotype method expects this)
+                vector<Support> gt_supports = support_finder.get_traversal_set_support(traversals, {}, false, false, false);
+                genotype_supports = {gt_supports[i], gt_supports[i]};
+            } else {
+                // compute each support relative to the other
+                // todo: we can speed this up by saving above, or filtering down traversal list to just our genotype alleles
+                vector<Support> gt_supports = support_finder.get_traversal_set_support(traversals, {j}, false, false, false);
+                genotype_supports.push_back(gt_supports[i]);
+                gt_supports = support_finder.get_traversal_set_support(traversals, {i}, false, false, false);
+                genotype_supports.push_back(gt_supports[j]);
+            }
+            double gl = genotype_likelihood({i, j}, genotype_supports, traversals, 0, exp_depth, depth_err);
+            // convert from natural log to log10 by dividing by ln(10)
+            gl /= 2.30258;
+            variant.samples[sample_name]["GL"].push_back(std::to_string(gl));
+        }
+    }
+
+    // todo
+    /*
+    // Now do the filters
+    variant.filter = "PASS";            
+    if (min_site_support < min_mad_for_filter) {
+        // Apply Min Allele Depth cutoff across all alleles (even ref)
+        variant.filter = "lowad";
+    } else if (min_ad_log_likelihood_for_filter != 0 &&
+               ad_log_likelihood < min_ad_log_likelihood_for_filter) {
+        // We have a het, but the assignment of reads between the two branches is just too weird
+        variant.filter = "lowxadl";
+    } else if ((int64_t)round(total(total_support)) < min_site_depth) {
+        // we don't have enough support to want to make a call
+        variant.filter = "lowdepth";
+    }
+    */
+}
+
+void PoissonSupportSnarlCaller::update_vcf_header(string& header) const {
+
+
+}
+
+vector<int> PoissonSupportSnarlCaller::rank_by_support(const vector<Support>& supports) {
+    vector<int> ranks(supports.size());
+    for (int i = 0; i < supports.size(); ++i) {
+        ranks[i] = i;
+    }
+    std::sort(ranks.begin(), ranks.end(), [&](int a, int b) {
+            return support_val(supports[a]) > support_val(supports[b]);
+        });
+    return ranks;
+}
 
 
 }

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -1,7 +1,7 @@
 #include "snarl_caller.hpp"
 #include "genotypekit.hpp"
 
-#define debug
+//#define debug
 
 namespace vg {
 

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -481,7 +481,7 @@ vector<int> PoissonSupportSnarlCaller::genotype(const Snarl& snarl,
     // sort the traversals by support
     vector<int> ranked_traversals = rank_by_support(supports);
     size_t max_trav = std::min(top_k, (size_t)ranked_traversals.size());
-    size_T max_sec_trav = std::min(top_m, (size_t)ranked_traversals.size());
+    size_t max_sec_trav = std::min(top_m, (size_t)ranked_traversals.size());
     // take the top-m traversals in order to check against the top traversal
     set<int> top_traversals(ranked_traversals.begin(), ranked_traversals.begin() + max_sec_trav);
 

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -496,6 +496,9 @@ vector<int> PoissonSupportSnarlCaller::genotype(const Snarl& snarl,
         if (skips.count(best_allele)) {
             continue;
         }
+        if (support_val(supports[best_allele]) < min_total_support_for_call) {
+            break;
+        }
 
         if (ploidy == 1) {
             candidates.insert({best_allele});
@@ -524,6 +527,9 @@ vector<int> PoissonSupportSnarlCaller::genotype(const Snarl& snarl,
             size_t sec_count = 0;
             for (int j = 0; j < ranked_secondary_traversals.size() && sec_count < top_k; ++j) {
                 int second_best_allele = ranked_secondary_traversals[j];
+                if (support_val(secondary_supports[second_best_allele]) < min_total_support_for_call) {
+                    break;
+                }
                 if (!skips.count(second_best_allele) && second_best_allele != best_allele) {
                     // canonical ordering for our set
                     candidates.insert({min(best_allele, second_best_allele), max(best_allele, second_best_allele)});

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -54,6 +54,19 @@ void SupportBasedSnarlCaller::set_min_supports(double min_mad_for_call, double m
     }
 }
 
+void SupportBasedSnarlCaller::set_het_bias(double het_bias, double ref_het_bias) {
+    // want to move away from ugly hacks that treat the reference traversal differently,
+    // so keep all these set the same
+    if (het_bias >= 0) {
+        max_het_bias = het_bias;
+        max_ref_het_bias = het_bias;
+        max_indel_het_bias = het_bias;
+    }
+    if (ref_het_bias >= 0) {
+        max_ref_het_bias = ref_het_bias;
+    }
+}
+
 int SupportBasedSnarlCaller::get_best_support(const vector<Support>& supports, const vector<int>& skips) {
     int best_allele = -1;
     for(size_t i = 0; i < supports.size(); i++) {
@@ -65,6 +78,38 @@ int SupportBasedSnarlCaller::get_best_support(const vector<Support>& supports, c
     return best_allele;
 }
 
+double SupportBasedSnarlCaller::get_bias(const vector<int>& traversal_sizes, int best_trav,
+                                         int second_best_trav, int ref_trav_idx) const {
+    bool is_indel = ((best_trav >= 0 && traversal_sizes[best_trav] != traversal_sizes[ref_trav_idx]) ||
+                     (second_best_trav >=0 && traversal_sizes[second_best_trav] != traversal_sizes[ref_trav_idx]));
+
+    double bias_limit = 1;
+
+    if (best_trav >= 0 && second_best_trav >=0) {
+        if (best_trav == ref_trav_idx) {
+            // Use ref bias limit
+            
+            // We decide closeness differently depending on whether best is ref
+            // or not. In practice, we use this to slightly penalize homozygous
+            // ref calls (by setting max_ref_het_bias higher than max_het_bias)
+            // and rather make a less supported alt call instead.  This boost
+            // max sensitivity, and because everything is homozygous ref by
+            // default in VCF, any downstream filters will effectively reset
+            // these calls back to homozygous ref. TODO: This shouldn't apply
+            // when off the primary path!
+            bias_limit = max_ref_het_bias;
+        } else if (is_indel) {
+            // This is an indel
+            // Use indel bias limit
+            bias_limit = max_indel_het_bias;
+        } else {
+            // Use normal het bias limit
+            bias_limit = max_het_bias;
+        }
+    }
+    return bias_limit;
+}
+
 RatioSupportSnarlCaller::RatioSupportSnarlCaller(const PathHandleGraph& graph, SnarlManager& snarl_manager,
                                                  TraversalSupportFinder& support_finder) :
     SupportBasedSnarlCaller(graph, snarl_manager, support_finder)  {
@@ -72,19 +117,6 @@ RatioSupportSnarlCaller::RatioSupportSnarlCaller(const PathHandleGraph& graph, S
 
 RatioSupportSnarlCaller::~RatioSupportSnarlCaller() {
     
-}
-
-void RatioSupportSnarlCaller::set_het_bias(double het_bias, double ref_het_bias) {
-    // want to move away from ugly hacks that treat the reference traversal differently,
-    // so keep all these set the same
-    if (het_bias >= 0) {
-        max_het_bias = het_bias;
-        max_ref_het_bias = het_bias;
-        max_indel_het_bias = het_bias;
-    }
-    if (ref_het_bias >= 0) {
-        max_ref_het_bias = ref_het_bias;
-    }
 }
 
 vector<int> RatioSupportSnarlCaller::genotype(const Snarl& snarl,
@@ -418,39 +450,6 @@ function<bool(const SnarlTraversal&)> RatioSupportSnarlCaller::get_skip_allele_f
     };
 }
 
-double RatioSupportSnarlCaller::get_bias(const vector<int>& traversal_sizes, int best_trav,
-                                         int second_best_trav, int ref_trav_idx) const {
-    bool is_indel = ((best_trav >= 0 && traversal_sizes[best_trav] != traversal_sizes[ref_trav_idx]) ||
-                     (second_best_trav >=0 && traversal_sizes[second_best_trav] != traversal_sizes[ref_trav_idx]));
-
-    double bias_limit = 1;
-
-    if (best_trav >= 0 && second_best_trav >=0) {
-        if (best_trav == ref_trav_idx) {
-            // Use ref bias limit
-            
-            // We decide closeness differently depending on whether best is ref
-            // or not. In practice, we use this to slightly penalize homozygous
-            // ref calls (by setting max_ref_het_bias higher than max_het_bias)
-            // and rather make a less supported alt call instead.  This boost
-            // max sensitivity, and because everything is homozygous ref by
-            // default in VCF, any downstream filters will effectively reset
-            // these calls back to homozygous ref. TODO: This shouldn't apply
-            // when off the primary path!
-            bias_limit = max_ref_het_bias;
-        } else if (is_indel) {
-            // This is an indel
-            // Use indel bias limit
-            bias_limit = max_indel_het_bias;
-        } else {
-            // Use normal het bias limit
-            bias_limit = max_het_bias;
-        }
-    }
-    return bias_limit;
-}
-
-
 PoissonSupportSnarlCaller::PoissonSupportSnarlCaller(const PathHandleGraph& graph, SnarlManager& snarl_manager,
                                                      TraversalSupportFinder& support_finder,
                                                      const algorithms::BinnedDepthIndex& depth_index) :
@@ -563,7 +562,7 @@ vector<int> PoissonSupportSnarlCaller::genotype(const Snarl& snarl,
     double best_genotype_likelihood = -numeric_limits<double>::max();
     vector<int> best_genotype;
     for (const auto& candidate : candidates) {
-        double gl = genotype_likelihood(candidate.first, candidate.second, traversals, ref_trav_idx, exp_depth, depth_err);
+        double gl = genotype_likelihood(candidate.first, candidate.second, traversals, traversal_sizes, ref_trav_idx, exp_depth, depth_err);
         if (gl > best_genotype_likelihood) {
             best_genotype_likelihood = gl;
             best_genotype = candidate.first;
@@ -579,6 +578,7 @@ vector<int> PoissonSupportSnarlCaller::genotype(const Snarl& snarl,
 double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotype,
                                                       const vector<Support>& genotype_supports,
                                                       const vector<SnarlTraversal>& traversals,
+                                                      const vector<int>& traversal_sizes,
                                                       int ref_trav_idx, double exp_depth, double depth_err) {
     
     assert(genotype_supports.size() == genotype.size());
@@ -602,6 +602,24 @@ double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotyp
             fixed_genotype_supports[i] = genotype_supports[i] / (double)genotype_supports.size();
         }
     }
+
+    // we preserve our het-bias from RatioSupportSnarlCaller as something prior-like here
+    // todo: use something better
+    double het_prior = 0.;
+    double ew_prior = 0.;
+    if (genotype.size() == 2) {
+        double het_bias = get_bias(traversal_sizes, genotype[0], genotype[1], ref_trav_idx);
+        if (genotype[0] != genotype[1]) {
+            // if the het_bias is greater than 1 (usually it's 6 by default), then
+            // we get a prior of 5/6 for a het
+            het_prior = log(1. - 1. / het_bias);
+            ew_prior = ewens_af_prob_ln({2, 0}, 0.001);
+        } else {
+            // and 1/6 for a hom
+            het_prior = log(1. / het_bias);
+            ew_prior = ewens_af_prob_ln({0, 1}, 0.001);
+        }
+    }    
     
     // total support of the site
     Support total_site_support = total_other_support;
@@ -643,11 +661,12 @@ double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotyp
     }
 
 #ifdef debug
-    cerr  << " allele-log-prob " << alleles_log_likelihood << " other-log-prob " << other_log_likelihood
-          << " total-prob " << (alleles_log_likelihood + other_log_likelihood) << endl;
+    cerr  << " allele-log-prob " << alleles_log_likelihood << " other-log-prob " << other_log_likelihood << " prior " << het_prior
+          << " ew prior " << ew_prior
+          << " total-prob " << (alleles_log_likelihood + other_log_likelihood + het_prior) << endl;
 #endif
 
-    return alleles_log_likelihood + other_log_likelihood;
+    return alleles_log_likelihood + other_log_likelihood + het_prior;
 }
 
 void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
@@ -668,6 +687,8 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
     }
     double total_site_depth = support_val(site_support);
 
+    vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);
+
     // Set the variant's total depth            
     string depth_string = std::to_string((int64_t)round(total_site_depth));
     variant.format.push_back("DP");
@@ -679,6 +700,7 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
     // get the allele depths
     variant.format.push_back("AD");
     set<int> called_allele_set(genotype.begin(), genotype.end());
+    double min_site_support = genotype.size() > 0 ? INFINITY : 0;
 
     for (int i = 0; i < traversals.size(); ++i) {
         vector<int> shared_travs;
@@ -698,6 +720,10 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
         // there is certainly room for optimization via remembering some of this stuff here
         vector<Support> allele_supports = support_finder.get_traversal_set_support(traversals, shared_travs, false, !in_genotype, false);
         variant.samples[sample_name]["AD"].push_back(std::to_string((int64_t)round(support_val(allele_supports[i]))));
+        if (in_genotype) {
+            // update the minimum support
+            min_site_support = min(min_site_support, total(allele_supports[i]));
+        }
     }
 
     // get the genotype likelihoods
@@ -731,7 +757,7 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
                 gt_supports = support_finder.get_traversal_set_support(traversals, {i}, false, false, false);
                 genotype_supports.push_back(gt_supports[j]);
             }
-            double gl = genotype_likelihood({i, j}, genotype_supports, traversals, 0, exp_depth, depth_err);
+            double gl = genotype_likelihood({i, j}, genotype_supports, traversals, traversal_sizes, 0, exp_depth, depth_err);
             // convert from natural log to log10 by dividing by ln(10)
             variant.samples[sample_name]["GL"].push_back(std::to_string(gl / 2.30258));
 
@@ -742,6 +768,9 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
             }
         }
     }
+
+    // use old quality for now
+    variant.quality = min_site_support;
 
     // todo
     /*

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -589,7 +589,7 @@ double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotyp
     }
     
     // how many reads would we expect to not map to our genotype due to error
-    double error_rate = std::min(0.25, depth_err + baseline_mapping_error);
+    double error_rate = std::min(0.05, depth_err + baseline_mapping_error);
     double other_poisson_lambda = error_rate * exp_depth; //support_val(total_site_support);
 
     // and our likelihood for the unmapped reads we see:

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -51,7 +51,7 @@ public:
     virtual void update_vcf_header(string& header) const = 0;
 
     /// Optional method used for pruning searches
-    virtual function<bool(const SnarlTraversal&)> get_skip_allele_fn() const;
+    virtual function<bool(const SnarlTraversal&, int iteration)> get_skip_allele_fn() const;
 };
 
 /**
@@ -82,6 +82,9 @@ public:
     /// Get the minimum total support for call
     virtual int get_min_total_support_for_call() const;
 
+    /// Use min_alt_path_support threshold as cutoff
+    virtual function<bool(const SnarlTraversal&, int iteration)> get_skip_allele_fn() const;
+
 protected:
 
     /// Get the best support out of a list of supports, ignoring skips
@@ -107,6 +110,9 @@ protected:
     /// what's the minimum total support (over all alleles) of the site to make
     /// a call
     size_t min_site_depth = 3;
+    /// used only for pruning alleles in the VCFTraversalFinder:  minimum support
+    /// of an allele's alt-path for it to be considered in the brute-force enumeration
+    double min_alt_path_support = 0.2;
 };
 
 
@@ -141,9 +147,6 @@ public:
     /// Define any header fields needed by the above
     virtual void update_vcf_header(string& header) const;
 
-    /// Use min_alt_path_support threshold as cutoff
-    virtual function<bool(const SnarlTraversal&)> get_skip_allele_fn() const;
-
 protected:
 
     /// Get the bias used to for comparing two traversals
@@ -171,11 +174,7 @@ protected:
     /// the reference, the call is made.  set to 0 to deactivate.
     double max_ma_bias = 0;
     /// what's the min log likelihood for allele depth assignments to PASS?
-    double min_ad_log_likelihood_for_filter = -9;
-    /// used only for pruning alleles in the VCFTraversalFinder:  minimum support
-    /// of an allele's alt-path for it to be considered in the brute-force enumeration
-    double min_alt_path_support = 0.2;
-    
+    double min_ad_log_likelihood_for_filter = -9;    
 };
 
 /**

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -224,7 +224,7 @@ protected:
     vector<int> rank_by_support(const vector<Support>& supports);
 
     /// Baseline mapping error rate (gets added to the standard error from coverage)
-    double baseline_mapping_error = 0.05;
+    double baseline_mapping_error = 0.005;
 
     /// Consider up to the top-k traversals (based on support) for genotyping
     size_t top_k = 25;

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -112,7 +112,7 @@ protected:
     size_t min_site_depth = 3;
     /// used only for pruning alleles in the VCFTraversalFinder:  minimum support
     /// of an allele's alt-path for it to be considered in the brute-force enumeration
-    double min_alt_path_support = 0.2;
+    double min_alt_path_support = 0.5;
 };
 
 

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -232,6 +232,9 @@ protected:
     /// Consider up to the tom-m secondary traversals (based on support) for each top traversal
     /// (so at most top_k * top_m considered)
     size_t top_m = 100;
+
+    /// padding to apply wrt to longest traversal to snarl ranges when looking up binned depth
+    double depth_padding_factor = 1.;
     
     /// Map path name to <mean, std_err> of depth coverage from the packer
     const algorithms::BinnedDepthIndex& depth_index;

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -216,7 +216,6 @@ protected:
     /// Homozygous alleles are split into two, with half support each
     /// The (natural) logoarithm is returned
     double genotype_likelihood(const vector<int>& genotype,
-                               const vector<Support>& genotype_supports,
                                const vector<SnarlTraversal>& traversals,
                                int ref_trav_idx, double exp_depth, double depth_err);
 

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -214,8 +214,11 @@ protected:
     /// P[allele1] * P[allle2] * P[uncalled alleles]
     /// Homozygous alleles are split into two, with half support each
     /// The (natural) logoarithm is returned
+    /// If trav_subset is not empty, traversals outside that set (and genotype)
+    /// will be ignored to save time
     double genotype_likelihood(const vector<int>& genotype,
                                const vector<SnarlTraversal>& traversals,
+                               const set<int>& trav_subset,
                                int ref_trav_idx, double exp_depth, double depth_err);
 
     /// Rank supports
@@ -225,7 +228,10 @@ protected:
     double baseline_mapping_error = 0.005;
 
     /// Consider up to the top-k traversals (based on support) for genotyping
-    size_t top_k = 25;
+    size_t top_k = 20;
+    /// Consider up to the tom-m secondary traversals (based on support) for each top traversal
+    /// (so at most top_k * top_m considered)
+    size_t top_m = 100;
     
     /// Map path name to <mean, std_err> of depth coverage from the packer
     const algorithms::BinnedDepthIndex& depth_index;

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -75,6 +75,8 @@ public:
 
     /// Set some of the parameters
     void set_min_supports(double min_mad_for_call, double min_support_for_call, double min_site_support);
+
+    void set_het_bias(double het_bias, double ref_het_bias = 0.);
     
     /// Get the traversal support finder
     const TraversalSupportFinder& get_support_finder() const;
@@ -89,6 +91,12 @@ protected:
 
     /// Relic from old code
     static double support_val(const Support& support) { return total(support); };
+
+    /// Get the bias used to for comparing two traversals
+    /// (It differrs heuristically depending whether they are alt/ref/het/hom/snp/indel
+    ///  see tuning parameters below)
+    double get_bias(const vector<int>& traversal_sizes, int best_trav,
+                    int second_best_trav, int ref_trav_idx) const;
 
     const PathHandleGraph& graph;
 
@@ -107,6 +115,15 @@ protected:
     /// what's the minimum total support (over all alleles) of the site to make
     /// a call
     size_t min_site_depth = 3;
+    /// What fraction of the reads supporting an alt are we willing to discount?
+    /// At 2, if twice the reads support one allele as the other, we'll call
+    /// homozygous instead of heterozygous. At infinity, every call will be
+    /// heterozygous if even one read supports each allele.
+    double max_het_bias = 6;
+    /// Like above, but applied to ref / alt ratio (instead of alt / ref)
+    double max_ref_het_bias = 6;
+    /// Like the max het bias, but applies to novel indels.
+    double max_indel_het_bias = 6;
 };
 
 
@@ -119,9 +136,6 @@ public:
     RatioSupportSnarlCaller(const PathHandleGraph& graph, SnarlManager& snarl_manager,
                             TraversalSupportFinder& support_finder);
     virtual ~RatioSupportSnarlCaller();
-
-    /// Set some of the parameters
-    void set_het_bias(double het_bias, double ref_het_bias = 0.);
 
     /// Get the genotype of a site
     virtual vector<int> genotype(const Snarl& snarl,
@@ -146,27 +160,12 @@ public:
 
 protected:
 
-    /// Get the bias used to for comparing two traversals
-    /// (It differrs heuristically depending whether they are alt/ref/het/hom/snp/indel
-    ///  see tuning parameters below)
-    double get_bias(const vector<int>& traversal_sizes, int best_trav,
-                    int second_best_trav, int ref_trav_idx) const;
-
     /// get a map of the beginning of a node (in forward orientation) on a traversal
     /// used for up-weighting large deletion edges in complex snarls with average support
     unordered_map<id_t, size_t> get_ref_offsets(const SnarlTraversal& ref_trav) const;
 
     /// Tuning
 
-    /// What fraction of the reads supporting an alt are we willing to discount?
-    /// At 2, if twice the reads support one allele as the other, we'll call
-    /// homozygous instead of heterozygous. At infinity, every call will be
-    /// heterozygous if even one read supports each allele.
-    double max_het_bias = 6;
-    /// Like above, but applied to ref / alt ratio (instead of alt / ref)
-    double max_ref_het_bias = 6;
-    /// Like the max het bias, but applies to novel indels.
-    double max_indel_het_bias = 6;
     /// Used for calling 1/2 calls.  If both alts (times this bias) are greater than
     /// the reference, the call is made.  set to 0 to deactivate.
     double max_ma_bias = 0;
@@ -218,13 +217,14 @@ protected:
     double genotype_likelihood(const vector<int>& genotype,
                                const vector<Support>& genotype_supports,
                                const vector<SnarlTraversal>& traversals,
+                               const vector<int>& traversal_sizes,                               
                                int ref_trav_idx, double exp_depth, double depth_err);
 
     /// Rank supports
     vector<int> rank_by_support(const vector<Support>& supports);
 
     /// Baseline mapping error rate (gets added to the standard error from coverage)
-    double baseline_mapping_error = 0.05;
+    double baseline_mapping_error = 0.005;
 
     /// Consider up to the top-k traversals (based on support) for genotyping
     size_t top_k = 25;

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -273,7 +273,7 @@ int main_call(int argc, char** argv) {
 
         if (ratio_caller == false) {
             // Make a depth index
-            depth_index = algorithms::binned_packed_depth_index(*packer, ref_paths, 500000, 0, true, true);
+            depth_index = algorithms::binned_packed_depth_index(*packer, ref_paths, 50, 0, true, true);
             // Make a new-stype probablistic caller
             auto poisson_caller = new PoissonSupportSnarlCaller(*graph, *snarl_manager, *packed_support_finder, depth_index);
             packed_caller = poisson_caller;

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -248,11 +248,16 @@ int main_call(int argc, char** argv) {
 
     // Make a Packed Support Caller
     unique_ptr<Packer> packer;
+    unique_ptr<TraversalSupportFinder> support_finder;
     if (!pack_filename.empty()) {        
         // Load our packed supports (they must have come from vg pack on graph)
         packer = unique_ptr<Packer>(new Packer(graph));
         packer->load_from_file(pack_filename);
-        PackedSupportSnarlCaller* packed_caller = new PackedSupportSnarlCaller(*packer, *snarl_manager);
+        // Make a packed traversal support finder
+        PackedTraversalSupportFinder* packed_support_finder = new PackedTraversalSupportFinder(*packer, *snarl_manager);
+        support_finder = unique_ptr<TraversalSupportFinder>(packed_support_finder);
+        // Make a support caller
+        SupportBasedSnarlCaller* packed_caller = new SupportBasedSnarlCaller(*graph, *snarl_manager, *packed_support_finder);
         if (het_bias >= 0) {
             packed_caller->set_het_bias(het_bias, ref_het_bias);
         }
@@ -263,7 +268,7 @@ int main_call(int argc, char** argv) {
     }
 
     if (!snarl_caller) {
-        cerr << "error [vg call]: pack file (-p) is required" << endl;
+        cerr << "error [vg call]: pack file (-k) is required" << endl;
         return 1;
     }
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -265,8 +265,8 @@ int main_call(int argc, char** argv) {
         // Load our packed supports (they must have come from vg pack on graph)
         packer = unique_ptr<Packer>(new Packer(graph));
         packer->load_from_file(pack_filename);
-        // Make a packed traversal support finder
-        PackedTraversalSupportFinder* packed_support_finder = new PackedTraversalSupportFinder(*packer, *snarl_manager);
+        // Make a packed traversal support finder (using cached veresion important for poisson caller)
+        PackedTraversalSupportFinder* packed_support_finder = new CachedPackedTraversalSupportFinder(*packer, *snarl_manager);
         support_finder = unique_ptr<TraversalSupportFinder>(packed_support_finder);
         
         SupportBasedSnarlCaller* packed_caller = nullptr;

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -28,8 +28,9 @@ void help_call(char** argv) {
        << endl
        << "support calling options:" << endl
        << "    -k, --pack FILE         Supports created from vg pack for given input graph" << endl
-       << "    -b, --het-bias M,N      Homozygous alt/ref allele must have >= M/N times more support than the next best allele [default = 6,6]" << endl
        << "    -m, --min-support M,N   Minimum allele support (M) and minimum site support (N) for call [default = 1,4]" << endl
+       << "    -B, --bias-mode         Use old ratio-based genotyping algorithm as opposed to porbablistic model" << endl
+       << "    -b, --het-bias M,N      Homozygous alt/ref allele must have >= M/N times more support than the next best allele [default = 6,6]" << endl
        << "general options:" << endl
        << "    -v, --vcf FILE          VCF file to genotype (must have been used to construct input graph with -a)" << endl
        << "    -f, --ref-fasta FILE    Reference fasta (required if VCF contains symbolic deletions or inversions)" << endl
@@ -55,6 +56,7 @@ int main_call(int argc, char** argv) {
     vector<size_t> ref_path_lengths;
     string min_support_string;
     string bias_string;
+    bool ratio_caller = false;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -62,6 +64,7 @@ int main_call(int argc, char** argv) {
 
         static const struct option long_options[] = {
             {"pack", required_argument, 0, 'k'},
+            {"bias-mode", no_argument, 0, 'B'},
             {"het-bias", required_argument, 0, 'b'},
             {"min-support", required_argument, 0, 'm'},
             {"vcf", required_argument, 0, 'v'},
@@ -79,7 +82,7 @@ int main_call(int argc, char** argv) {
 
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "k:b:m:v:f:i:s:r:p:o:l:t:h",
+        c = getopt_long (argc, argv, "k:Bb:m:v:f:i:s:r:p:o:l:t:h",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -90,6 +93,9 @@ int main_call(int argc, char** argv) {
         {
         case 'k':
             pack_filename = optarg;
+            break;
+        case 'B':
+            ratio_caller = true;
             break;
         case 'b':
             bias_string = optarg;
@@ -218,6 +224,11 @@ int main_call(int argc, char** argv) {
         cerr << "error [vg call]: when using -l, the same number paths must be given with -p" << endl;
         return 1;
     }
+    // Check bias option
+    if (!bias_string.empty() && !ratio_caller) {
+        cerr << "error [vg call]: -b can only be used with -B" << endl;
+        return 1;
+    }
 
     // No paths specified: use them all
     if (ref_paths.empty()) {
@@ -245,6 +256,7 @@ int main_call(int argc, char** argv) {
     
     unique_ptr<GraphCaller> graph_caller;
     unique_ptr<SnarlCaller> snarl_caller;
+    algorithms::BinnedDepthIndex depth_index;
 
     // Make a Packed Support Caller
     unique_ptr<Packer> packer;
@@ -256,14 +268,27 @@ int main_call(int argc, char** argv) {
         // Make a packed traversal support finder
         PackedTraversalSupportFinder* packed_support_finder = new PackedTraversalSupportFinder(*packer, *snarl_manager);
         support_finder = unique_ptr<TraversalSupportFinder>(packed_support_finder);
-        // Make a support caller
-        SupportBasedSnarlCaller* packed_caller = new SupportBasedSnarlCaller(*graph, *snarl_manager, *packed_support_finder);
-        if (het_bias >= 0) {
-            packed_caller->set_het_bias(het_bias, ref_het_bias);
+        
+        SupportBasedSnarlCaller* packed_caller = nullptr;
+
+        if (ratio_caller == false) {
+            // Make a depth index
+            depth_index = algorithms::binned_packed_depth_index(*packer, ref_paths, 1000000, 0, true, true);
+            // Make a new-stype probablistic caller
+            auto poisson_caller = new PoissonSupportSnarlCaller(*graph, *snarl_manager, *packed_support_finder, depth_index);
+            packed_caller = poisson_caller;
+        } else {
+            // Make an old-style ratio support caller
+            auto ratio_caller = new RatioSupportSnarlCaller(*graph, *snarl_manager, *packed_support_finder);
+            if (het_bias >= 0) {
+                ratio_caller->set_het_bias(het_bias, ref_het_bias);
+            }
+            packed_caller = ratio_caller;
         }
         if (min_allele_support >= 0) {
             packed_caller->set_min_supports(min_allele_support, min_allele_support, min_site_support);
         }
+        
         snarl_caller = unique_ptr<SnarlCaller>(packed_caller);
     }
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -224,11 +224,6 @@ int main_call(int argc, char** argv) {
         cerr << "error [vg call]: when using -l, the same number paths must be given with -p" << endl;
         return 1;
     }
-    // Check bias option
-    if (!bias_string.empty() && !ratio_caller) {
-        cerr << "error [vg call]: -b can only be used with -B" << endl;
-        return 1;
-    }
 
     // No paths specified: use them all
     if (ref_paths.empty()) {
@@ -273,20 +268,20 @@ int main_call(int argc, char** argv) {
 
         if (ratio_caller == false) {
             // Make a depth index
-            depth_index = algorithms::binned_packed_depth_index(*packer, ref_paths, 500000, 0, true, true);
+            depth_index = algorithms::binned_packed_depth_index(*packer, ref_paths, 50000, 0, true, true);
             // Make a new-stype probablistic caller
             auto poisson_caller = new PoissonSupportSnarlCaller(*graph, *snarl_manager, *packed_support_finder, depth_index);
             packed_caller = poisson_caller;
         } else {
             // Make an old-style ratio support caller
             auto ratio_caller = new RatioSupportSnarlCaller(*graph, *snarl_manager, *packed_support_finder);
-            if (het_bias >= 0) {
-                ratio_caller->set_het_bias(het_bias, ref_het_bias);
-            }
             packed_caller = ratio_caller;
         }
         if (min_allele_support >= 0) {
             packed_caller->set_min_supports(min_allele_support, min_allele_support, min_site_support);
+        }
+        if (het_bias >= 0) {
+            packed_caller->set_het_bias(het_bias, ref_het_bias);
         }
         
         snarl_caller = unique_ptr<SnarlCaller>(packed_caller);

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -273,7 +273,7 @@ int main_call(int argc, char** argv) {
 
         if (ratio_caller == false) {
             // Make a depth index
-            depth_index = algorithms::binned_packed_depth_index(*packer, ref_paths, 1000000, 0, true, true);
+            depth_index = algorithms::binned_packed_depth_index(*packer, ref_paths, 500000, 0, true, true);
             // Make a new-stype probablistic caller
             auto poisson_caller = new PoissonSupportSnarlCaller(*graph, *snarl_manager, *packed_support_finder, depth_index);
             packed_caller = poisson_caller;

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -2546,7 +2546,7 @@ VCFTraversalFinder::VCFTraversalFinder(const PathHandleGraph& graph, SnarlManage
                                        const vector<string>& ref_path_names,
                                        FastaReference* ref_fasta,
                                        FastaReference* ins_fasta,
-                                       function<bool(const SnarlTraversal&)> skip_alt,
+                                       function<bool(const SnarlTraversal&, int)> skip_alt,
                                        size_t max_traversal_cutoff) :
     graph(graph),
     snarl_manager(snarl_manager),
@@ -3248,7 +3248,7 @@ vector<vector<int>> VCFTraversalFinder::get_pruned_alt_alleles(
     }
 
     // only invoke pruning if we exceed our cutoff.  fairly rare on most graphs
-    if (!check_max_trav_cutoff(alt_alleles)) {
+    for (int prune_it = 0; prune_it < max_prune_iterations && !check_max_trav_cutoff(alt_alleles); ++prune_it) {
         for (auto& alleles : alt_alleles) {
             alleles.clear();
         }
@@ -3256,7 +3256,7 @@ vector<vector<int>> VCFTraversalFinder::get_pruned_alt_alleles(
         for (int var_i = 0; var_i < site_variants.size(); ++var_i) {
             for (int allele = 0; allele < site_variants[var_i]->alleles.size(); ++allele) {
                 if (skip_alt == nullptr ||
-                    skip_alt(get_alt_path(site_variants[var_i], allele, ref_path).first) == false) {
+                    skip_alt(get_alt_path(site_variants[var_i], allele, ref_path).first, prune_it) == false) {
                     alt_alleles[var_i].push_back(allele);
                 }
 #ifdef debug

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -416,13 +416,19 @@ protected:
 
     /// Use this method to prune the search space by selecting alt-alleles
     /// to skip by considering their paths (in SnarlTraversal) format
-    function<bool(const SnarlTraversal& alt_path)> skip_alt;
+    /// It will try again and again until enough traversals are pruned,
+    /// with iteration keeping track of how many tries (so it should become stricter
+    /// as iteration increases)
+    function<bool(const SnarlTraversal& alt_path, int iteration)> skip_alt;
 
     /// If a snarl has more than this many traversals, return nothing and print
     /// a warning.  Dense and large deletions will make this happen from time
     /// to time.  In practice, skip_alt (above) can be used to prune down
     /// the search space by selecting alleles to ignore.
     size_t max_traversal_cutoff;
+
+    /// Maximum number of pruning iterations
+    size_t max_prune_iterations = 1000;
     
     /// Include snarl endpoints in traversals
     bool include_endpoints = true;
@@ -446,7 +452,7 @@ public:
                        const vector<string>& ref_path_names = {},
                        FastaReference* fasta_ref = nullptr,
                        FastaReference* ins_ref = nullptr,
-                       function<bool(const SnarlTraversal&)> skip_alt = nullptr,
+                       function<bool(const SnarlTraversal&, int)> skip_alt = nullptr,
                        size_t max_traversal_cutoff = 500000);
         
     virtual ~VCFTraversalFinder();

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -428,7 +428,7 @@ protected:
     size_t max_traversal_cutoff;
 
     /// Maximum number of pruning iterations
-    size_t max_prune_iterations = 1000;
+    size_t max_prune_iterations = 2;
     
     /// Include snarl endpoints in traversals
     bool include_endpoints = true;
@@ -453,7 +453,7 @@ public:
                        FastaReference* fasta_ref = nullptr,
                        FastaReference* ins_ref = nullptr,
                        function<bool(const SnarlTraversal&, int)> skip_alt = nullptr,
-                       size_t max_traversal_cutoff = 500000);
+                       size_t max_traversal_cutoff = 50000);
         
     virtual ~VCFTraversalFinder();
     

--- a/src/traversal_support.cpp
+++ b/src/traversal_support.cpp
@@ -65,13 +65,14 @@ Support TraversalSupportFinder::get_traversal_support(const SnarlTraversal& trav
 
 vector<Support> TraversalSupportFinder::get_traversal_genotype_support(const vector<SnarlTraversal>& traversals,
                                                                        const vector<int>& genotype,
+                                                                       const set<int>& other_trav_subset,
                                                                        int ref_trav_idx) {
     set<int> tgt_trav_set(genotype.begin(), genotype.end());
     vector<int> tgt_travs(tgt_trav_set.begin(), tgt_trav_set.end());
     // get the support of just the alleles in the genotype, evenly splitting shared stuff
     vector<Support> allele_support = get_traversal_set_support(traversals, tgt_travs, tgt_trav_set, false, false, true, ref_trav_idx);
     // get the support of everythin else, treating stuff in the genotype alleles as 0
-    vector<Support> other_support = get_traversal_set_support(traversals, tgt_travs, {}, false, true, false, ref_trav_idx);
+    vector<Support> other_support = get_traversal_set_support(traversals, tgt_travs, other_trav_subset, false, true, false, ref_trav_idx);
     // combine the above two vectors
     for (int allele : tgt_travs) {
         other_support[allele] = allele_support[allele];

--- a/src/traversal_support.cpp
+++ b/src/traversal_support.cpp
@@ -63,26 +63,6 @@ Support TraversalSupportFinder::get_traversal_support(const SnarlTraversal& trav
     return get_traversal_set_support({traversal}, {}, {}, false, false, false).at(0);
 }
 
-Support TraversalSupportFinder::get_total_traversal_set_support(const vector<SnarlTraversal>& traversals,
-                                                                int ref_trav_idx) const {
-    // share everything
-    vector<int> shared_travs(traversals.size());
-    for (int i = 0; i < shared_travs.size(); ++i) {
-        shared_travs[i] = i;
-    }
-
-    // get the support of everything, where all shared nodes and edges are scaled by the number of times they're shared
-    vector<Support> supports = get_traversal_set_support(traversals, shared_travs, {}, false, false, true, ref_trav_idx);
-
-    // sum it up
-    Support total;
-    for (const Support& support : supports) {
-        total += support;
-    }
-
-    return total;
-}
-
 vector<Support> TraversalSupportFinder::get_traversal_genotype_support(const vector<SnarlTraversal>& traversals,
                                                                        const vector<int>& genotype,
                                                                        int ref_trav_idx) {

--- a/src/traversal_support.cpp
+++ b/src/traversal_support.cpp
@@ -1,0 +1,321 @@
+#include "traversal_support.hpp"
+#include "genotypekit.hpp"
+
+//#define debug
+
+namespace vg {
+
+TraversalSupportFinder::TraversalSupportFinder(const PathHandleGraph& graph, SnarlManager& snarl_manager) :
+    graph(graph),
+    snarl_manager(snarl_manager) {
+}
+
+TraversalSupportFinder::~TraversalSupportFinder() {
+    
+}
+
+int64_t TraversalSupportFinder::get_edge_length(const edge_t& edge, const unordered_map<id_t, size_t>& ref_offsets) const {
+    int len = -1;
+    // use our reference traversal to try to come up with a deletion length for our edge
+    // idea: if our edge corresponds to a huge deltion, it should be weighted accordingly
+    auto s_it = ref_offsets.find(graph.get_id(edge.first));
+    auto e_it = ref_offsets.find(graph.get_id(edge.second));
+    if (s_it != ref_offsets.end() && e_it != ref_offsets.end()) {
+        size_t start_offset = s_it->second;
+        if (!graph.get_is_reverse(edge.first)) {
+            start_offset += graph.get_length(edge.first);
+        }
+        size_t end_offset = e_it->second;
+        if (graph.get_is_reverse(edge.second)) {
+            end_offset += graph.get_length(edge.second);
+        }
+        if (start_offset > end_offset) {
+            std::swap(start_offset, end_offset);
+        }
+        len = end_offset - start_offset;
+    }
+    return std::max(len, 1);
+}
+
+tuple<Support, Support, int> TraversalSupportFinder::get_child_support(const Snarl& snarl) const {
+    // port over old functionality from support caller
+    // todo: do we need to flag nodes as covered like it does?
+    pair<unordered_set<id_t>, unordered_set<edge_t> > contents = snarl_manager.deep_contents(&snarl, graph, true);
+    Support child_max_support;
+    Support child_total_support;
+    size_t child_size = 0;
+    for (id_t node_id : contents.first) {
+        Support child_support = get_avg_node_support(node_id);
+        child_max_support = support_max(child_max_support, child_support);
+        child_size += graph.get_length(graph.get_handle(node_id));
+        child_total_support += child_support;
+    }
+    Support child_avg_support = child_total_support / child_size;
+    // we always use child_max like the old support_caller.
+    // this is the only way to get top-down recursion to work in many cases
+    // todo: fix to use bottom up, get get support from actual traversals
+    // every time!! 
+    return std::tie(child_max_support, child_max_support, child_size);
+}
+
+
+Support TraversalSupportFinder::get_traversal_support(const SnarlTraversal& traversal) const {
+    return get_traversal_set_support({traversal}, {}, false, false).at(0);
+}
+
+vector<Support> TraversalSupportFinder::get_traversal_set_support(const vector<SnarlTraversal>& traversals,
+                                                                   const vector<int>& shared_travs,
+                                                                   bool exclusive_only,
+                                                                   bool exclusive_count,
+                                                                   int ref_trav_idx) const {
+
+    // pass 1: how many times have we seen a node or edge
+    unordered_map<id_t, int> node_counts;
+    unordered_map<edge_t, int> edge_counts;
+    map<Snarl, int> child_counts;
+
+    for (auto trav_idx : shared_travs) {
+        const SnarlTraversal& trav = traversals[trav_idx];
+        for (int i = 0; i < trav.visit_size(); ++i) {
+            const Visit& visit = trav.visit(i);
+            if (visit.node_id() != 0) {
+                // Count the node once
+                if (node_counts.count(visit.node_id())) {
+                    node_counts[visit.node_id()] += 1;
+                } else {
+                    node_counts[visit.node_id()] = 1;
+                }
+            } else {
+                // Count the child once
+                if (child_counts.count(visit.snarl())) {
+                    child_counts[visit.snarl()] += 1;
+                } else {
+                    child_counts[visit.snarl()] = 1;
+                }
+            }
+            // note: there is no edge between adjacent snarls as they overlap
+            // on their endpoints. 
+            if (i > 0 && (trav.visit(i - 1).node_id() != 0 || trav.visit(i).node_id() != 0)) {
+                edge_t edge = to_edge(graph, trav.visit(i - 1), visit);
+                // Count the edge once
+                if (edge_counts.count(edge)) {
+                    edge_counts[edge] += 1;
+                } else {
+                    edge_counts[edge] = 1;
+                }
+            }
+        }
+    }
+
+    // pass 1.5: get index for looking up deletion edge lengths (so far we aren't dependent
+    // on having anything but a path handle graph, so we index on the fly)
+    unordered_map<id_t, size_t> ref_offsets;
+    if (ref_trav_idx >= 0) {
+        ref_offsets = get_ref_offsets(traversals[ref_trav_idx]);
+    }
+
+    // pass 2: get the supports
+    // we compute the various combinations of min/avg node/trav supports as we don't know which
+    // we will need until all the sizes are known
+    Support max_support;
+    max_support.set_forward(numeric_limits<int>::max());
+    vector<Support> min_supports_min(traversals.size(), max_support); // use min node support
+    vector<Support> min_supports_avg(traversals.size(), max_support); // use avg node support
+    vector<bool> has_support(traversals.size(), false);
+    vector<Support> tot_supports_min(traversals.size()); // weighted by lengths, using min node support
+    vector<Support> tot_supports_avg(traversals.size()); // weighted by lengths, using avg node support
+    vector<int> tot_sizes(traversals.size(), 0); // to compute average from to_supports;
+    vector<int> tot_sizes_all(traversals.size(), 0); // as above, but includes excluded lengths
+    int max_trav_size = 0; // size of longest traversal
+
+    bool count_end_nodes = false; // toggle to include snarl ends
+
+    auto update_support = [&] (int trav_idx, const Support& min_support,
+                               const Support& avg_support, int length, int share_count) {
+        // keep track of overall size of longest traversal
+        tot_sizes_all[trav_idx] += length;
+        max_trav_size = std::max(tot_sizes_all[trav_idx], max_trav_size);
+
+        // apply the scaling
+        double scale_factor = ((exclusive_only || exclusive_count) && share_count > 0) ? 0. : 1. / (1. + share_count);
+        
+        // when looking at exclusive support, we don't normalize by skipped lengths
+        if (scale_factor != 0 || !exclusive_only || exclusive_count) {
+            has_support[trav_idx] = true;
+            Support scaled_support_min = min_support * scale_factor;
+            Support scaled_support_avg = avg_support * scale_factor;
+
+            tot_supports_min[trav_idx] += scaled_support_min;
+            tot_supports_avg[trav_idx] += scaled_support_avg * length;
+            tot_sizes[trav_idx] += length;
+            min_supports_min[trav_idx] = support_min(min_supports_min[trav_idx], scaled_support_min);
+            min_supports_avg[trav_idx] = support_min(min_supports_avg[trav_idx], scaled_support_avg * length);
+        }
+    };
+
+    for (int trav_idx = 0; trav_idx < traversals.size(); ++trav_idx) {
+        const SnarlTraversal& trav = traversals[trav_idx];
+        for (int visit_idx = 0; visit_idx < trav.visit_size(); ++visit_idx) {
+            const Visit& visit = trav.visit(visit_idx);
+            Support min_support;
+            Support avg_support;
+            int64_t length;
+            int share_count = 0;
+
+            if (visit.node_id() != 0) {
+                // get the node support
+                min_support = get_min_node_support(visit.node_id());
+                avg_support = get_avg_node_support(visit.node_id());
+                length = graph.get_length(graph.get_handle(visit.node_id()));
+                if (node_counts.count(visit.node_id())) {
+                    share_count = node_counts[visit.node_id()];
+                }
+            } else {
+                // get the child support
+                tie(min_support, avg_support, length) = get_child_support(visit.snarl());
+                if (child_counts.count(visit.snarl())) {
+                    share_count = child_counts[visit.snarl()];
+                }
+            }
+            if (count_end_nodes || (visit_idx > 0 && visit_idx < trav.visit_size() - 1)) {
+                update_support(trav_idx, min_support, avg_support, length, share_count);
+            }
+            share_count = 0;
+            
+            if (visit_idx > 0 && (trav.visit(visit_idx - 1).node_id() != 0 || trav.visit(visit_idx).node_id() != 0)) {
+                // get the edge support
+                edge_t edge = to_edge(graph, trav.visit(visit_idx - 1), visit);
+                min_support = get_edge_support(edge);
+                length = get_edge_length(edge, ref_offsets);
+                if (edge_counts.count(edge)) {
+                    share_count = edge_counts[edge];
+                }
+                update_support(trav_idx, min_support, min_support, length, share_count);
+            }
+        }
+    }
+
+    // correct for case where no exclusive support found
+    for (int i = 0; i < min_supports_min.size(); ++i) {
+        if (!has_support[i]) {
+            min_supports_min[i] = Support();
+            min_supports_avg[i] = Support();
+        }
+    }
+
+    bool use_avg_trav_support = max_trav_size >= average_traversal_support_switch_threshold;
+    bool use_avg_node_support = max_trav_size >= average_node_support_switch_threshold;
+
+    if (use_avg_trav_support) {
+        vector<Support>& tot_supports = use_avg_node_support ? tot_supports_avg : tot_supports_min;
+        for (int i = 0; i < tot_supports.size(); ++i) {
+            if (tot_sizes[i] > 0) {
+                tot_supports[i] /= (double)tot_sizes[i];
+            } else {
+                tot_supports[i] = Support();
+            }
+        }
+        return tot_supports;
+    } else {
+        return use_avg_node_support ? min_supports_avg : min_supports_min;
+    }
+}   
+
+vector<int> TraversalSupportFinder::get_traversal_sizes(const vector<SnarlTraversal>& traversals) const {
+    vector<int> sizes(traversals.size(), 0);
+    for (int i = 0; i < traversals.size(); ++i) {
+        for (int j = 0; j < traversals[i].visit_size(); ++j) {
+            if (traversals[i].visit(j).node_id() != 0) {
+                sizes[i] += graph.get_length(graph.get_handle(traversals[i].visit(j).node_id()));
+            } else {
+                // just summing up the snarl contents, which isn't a great heuristic but will
+                // help in some cases
+                pair<unordered_set<id_t>, unordered_set<edge_t> > contents = snarl_manager.deep_contents(
+                    snarl_manager.into_which_snarl(traversals[i].visit(j)), graph, true);
+                for (id_t node_id : contents.first) {
+                    sizes[i] += graph.get_length(graph.get_handle(node_id));
+                }
+            }
+        }
+    }
+    return sizes;
+    
+}
+
+size_t TraversalSupportFinder::get_average_traversal_support_switch_threshold() const {
+    return average_traversal_support_switch_threshold;
+}
+
+unordered_map<id_t, size_t> TraversalSupportFinder::get_ref_offsets(const SnarlTraversal& ref_trav) const {
+    unordered_map<id_t, size_t> ref_offsets;
+    size_t offset = 0;
+    for (int i = 0; i < ref_trav.visit_size(); ++i) {
+        const Visit& visit = ref_trav.visit(i);
+        if (visit.node_id() != 0) {
+            if (visit.backward()) {
+                offset += graph.get_length(graph.get_handle(visit.node_id()));
+                ref_offsets[visit.node_id()] = offset;
+            } else {
+                ref_offsets[visit.node_id()] = offset;
+                offset += graph.get_length(graph.get_handle(visit.node_id()));
+            }
+        }
+    }
+    return ref_offsets;
+}
+
+PackedTraversalSupportFinder::PackedTraversalSupportFinder(const Packer& packer, SnarlManager& snarl_manager) :
+    TraversalSupportFinder(*dynamic_cast<const PathHandleGraph*>(packer.get_graph()), snarl_manager),
+    packer(packer) {
+}
+
+PackedTraversalSupportFinder::~PackedTraversalSupportFinder() {
+}
+
+Support PackedTraversalSupportFinder::get_edge_support(const edge_t& edge) const {
+    return get_edge_support(graph.get_id(edge.first), graph.get_is_reverse(edge.first),
+                            graph.get_id(edge.second), graph.get_is_reverse(edge.second));
+}
+
+Support PackedTraversalSupportFinder::get_edge_support(id_t from, bool from_reverse,
+                                                   id_t to, bool to_reverse) const {
+    Edge proto_edge;
+    proto_edge.set_from(from);
+    proto_edge.set_from_start(from_reverse);
+    proto_edge.set_to(to);
+    proto_edge.set_to_end(to_reverse);
+    Support support;
+    support.set_forward(packer.edge_coverage(proto_edge));
+    return support;
+}
+
+Support PackedTraversalSupportFinder::get_min_node_support(id_t node) const {
+    Position pos;
+    pos.set_node_id(node);
+    size_t offset = packer.position_in_basis(pos);
+    size_t coverage = packer.coverage_at_position(offset);
+    size_t end_offset = offset + graph.get_length(graph.get_handle(node));
+    for (int i = offset + 1; i < end_offset; ++i) {
+        coverage = min(coverage, packer.coverage_at_position(i));
+    }
+    Support support;
+    support.set_forward(coverage);
+    return support;
+}
+
+Support PackedTraversalSupportFinder::get_avg_node_support(id_t node) const {
+    Position pos;
+    pos.set_node_id(node);
+    size_t offset = packer.position_in_basis(pos);
+    size_t coverage = 0;
+    size_t length = graph.get_length(graph.get_handle(node));
+    for (int i = 0; i < length; ++i) {
+        coverage += packer.coverage_at_position(offset + i);
+    }
+    Support support;
+    support.set_forward((double)coverage / (double)length);
+    return support;
+}
+
+
+}

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -1,5 +1,5 @@
-#ifndef VG_SUPPORT_FINDER_HPP_INCLUDED
-#define VG_SUPPORT_FINDER_HPP_INCLUDED
+#ifndef VG_TRAVERSAL_SUPPORT_HPP_INCLUDED
+#define VG_TRAVERSAL_SUPPORT_HPP_INCLUDED
 
 #include <iostream>
 #include <algorithm>
@@ -52,10 +52,13 @@ public:
     /// exclusive_count is like exclusive only except shared traversals will be counted (as 0)
     /// when doing average and min support
     /// if the ref_trav_idx is given, it will be used for computing (deletion) edge lengths
+    /// if unique is true, then every node or edge will only be counted once
+    /// (useful for total support)
     virtual vector<Support> get_traversal_set_support(const vector<SnarlTraversal>& traversals,
                                                       const vector<int>& shared_travs,
                                                       bool exclusive_only,
                                                       bool exclusive_count,
+                                                      bool unique,
                                                       int ref_trav_idx = -1) const;
 
     /// Get the total length of all nodes in the traversal

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -50,9 +50,11 @@ public:
     /// some alleles in a genotype, where everything is split evently among them
     /// anything not in the genotype gets a support using "exclusive_count"
     /// where nodes taken by the genotype are counted as 0
+    /// stuff not in the genotype is limited to other_trav_subset (or all if empty)
     virtual vector<Support> get_traversal_genotype_support(const vector<SnarlTraversal>& traversals,
-                                                         const vector<int>& genotype,
-                                                         int ref_trav_idx = -1);
+                                                           const vector<int>& genotype,
+                                                           const set<int>& other_trav_subset,
+                                                           int ref_trav_idx = -1);
     
     /// traversals:      get support for each traversal in this set
     /// shared_travs:    if a node appears N times in shared_travs, then it will count as 1 / (N+1) support

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -1,0 +1,113 @@
+#ifndef VG_SUPPORT_FINDER_HPP_INCLUDED
+#define VG_SUPPORT_FINDER_HPP_INCLUDED
+
+#include <iostream>
+#include <algorithm>
+#include <functional>
+#include <cmath>
+#include <limits>
+#include <unordered_set>
+#include <tuple>
+#include "handle.hpp"
+#include "snarls.hpp"
+#include "genotypekit.hpp"
+#include "packer.hpp"
+
+namespace vg {
+
+using namespace std;
+
+
+/**
+ * Get the read support of snarl traversals or sets of snarl traversals
+ */ 
+class TraversalSupportFinder {
+public:
+    TraversalSupportFinder(const PathHandleGraph& graph, SnarlManager& snarl_manager);
+    virtual ~TraversalSupportFinder();
+
+    /// Support of an edge
+    virtual Support get_edge_support(const edge_t& edge) const = 0;
+    virtual Support get_edge_support(id_t from, bool from_reverse, id_t to, bool to_reverse) const = 0;
+
+    /// Effective length of an edge
+    virtual int64_t get_edge_length(const edge_t& edge, const unordered_map<id_t, size_t>& ref_offsets) const;
+
+    /// Minimum support of a node
+    virtual Support get_min_node_support(id_t node) const = 0;
+
+    /// Average support of a node
+    virtual Support get_avg_node_support(id_t node) const = 0;
+
+    /// Use node or edge support as proxy for child support (as was done in original calling code)
+    virtual tuple<Support, Support, int> get_child_support(const Snarl& snarl) const;
+
+    /// Get the support of a traversal
+    /// Child snarls are handled as in the old call code: their maximum support is used
+    virtual Support get_traversal_support(const SnarlTraversal& traversal) const;
+
+    /// Get the support of a set of traversals.  Any support overlapping traversals in shared_travs
+    /// will have their support split.  If exclusive_only is true, then any split support gets
+    /// rounded down to 0 (and ignored when computing mins or averages) .
+    /// exclusive_count is like exclusive only except shared traversals will be counted (as 0)
+    /// when doing average and min support
+    /// if the ref_trav_idx is given, it will be used for computing (deletion) edge lengths
+    virtual vector<Support> get_traversal_set_support(const vector<SnarlTraversal>& traversals,
+                                                      const vector<int>& shared_travs,
+                                                      bool exclusive_only,
+                                                      bool exclusive_count,
+                                                      int ref_trav_idx = -1) const;
+
+    /// Get the total length of all nodes in the traversal
+    virtual vector<int> get_traversal_sizes(const vector<SnarlTraversal>& traversals) const;
+
+    /// Get the average traversal support thresholdek
+    virtual size_t get_average_traversal_support_switch_threshold() const;
+
+    /// Relic from old code
+    static double support_val(const Support& support) { return total(support); };
+
+    /// get a map of the beginning of a node (in forward orientation) on a traversal
+    /// used for up-weighting large deletion edges in complex snarls with average support
+    unordered_map<id_t, size_t> get_ref_offsets(const SnarlTraversal& ref_trav) const;
+
+protected:
+
+    size_t average_traversal_support_switch_threshold = 50;
+    /// Use average instead of minimum support when determining a node's support
+    /// its position supports.
+    size_t average_node_support_switch_threshold = 50;
+
+    const PathHandleGraph& graph;
+
+    SnarlManager& snarl_manager;
+
+};
+
+/**
+ * Get the read support from a Packer object
+ */ 
+class PackedTraversalSupportFinder : public TraversalSupportFinder {
+public:
+    PackedTraversalSupportFinder(const Packer& packer, SnarlManager& snarl_manager);
+    virtual ~PackedTraversalSupportFinder();
+
+    /// Support of an edge
+    virtual Support get_edge_support(const edge_t& edge) const;
+    virtual Support get_edge_support(id_t from, bool from_reverse, id_t to, bool to_reverse) const;
+
+    /// Minimum support of a node
+    virtual Support get_min_node_support(id_t node) const;
+
+    /// Average support of a node
+    virtual Support get_avg_node_support(id_t node) const;
+    
+protected:
+
+    /// Derive supports from this pack index
+    const Packer& packer;
+};
+
+}
+
+#endif

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -119,6 +119,34 @@ protected:
     const Packer& packer;
 };
 
+/**
+ * Add a caching overlay to the PackedTravesalSupportFinder to avoid frequent
+ * base queries which can become expensive.  Even caching the edges seems
+ * to have an impact
+ */
+class CachedPackedTraversalSupportFinder : public PackedTraversalSupportFinder {
+public:
+    CachedPackedTraversalSupportFinder(const Packer& packer, SnarlManager& snarl_manager, size_t cache_size = 100000);
+    virtual ~CachedPackedTraversalSupportFinder();
+
+    /// Support of an edge
+    virtual Support get_edge_support(id_t from, bool from_reverse, id_t to, bool to_reverse) const;
+    
+    /// Minimum support of a node
+    virtual Support get_min_node_support(id_t node) const;
+
+    /// Average support of a node
+    virtual Support get_avg_node_support(id_t node) const;
+    
+protected:
+
+    /// One node cache per threade
+    mutable vector<LRUCache<edge_t, Support>*> edge_support_cache;
+    mutable vector<LRUCache<nid_t, Support>*> min_node_support_cache;
+    mutable vector<LRUCache<nid_t, Support>*> avg_node_support_cache;
+};
+
+
 }
 
 #endif

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -45,13 +45,7 @@ public:
     /// Get the support of a traversal
     /// Child snarls are handled as in the old call code: their maximum support is used
     virtual Support get_traversal_support(const SnarlTraversal& traversal) const;
-
-    /// wrapper for using get_traversal_set_support to get the total support
-    /// (sets shared_travs to the whole set, mutual_shared to true, then
-    /// sums over the results)
-    virtual Support get_total_traversal_set_support(const vector<SnarlTraversal>& traversals,
-                                                    int ref_trav_idx = -1) const;
-
+ 
     /// wrapper for using get_traversal_set_support to get the support for
     /// some alleles in a genotype, where everything is split evently among them
     /// anything not in the genotype gets a support using "exclusive_count"

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -46,19 +46,33 @@ public:
     /// Child snarls are handled as in the old call code: their maximum support is used
     virtual Support get_traversal_support(const SnarlTraversal& traversal) const;
 
-    /// Get the support of a set of traversals.  Any support overlapping traversals in shared_travs
-    /// will have their support split.  If exclusive_only is true, then any split support gets
-    /// rounded down to 0 (and ignored when computing mins or averages) .
-    /// exclusive_count is like exclusive only except shared traversals will be counted (as 0)
-    /// when doing average and min support
-    /// if the ref_trav_idx is given, it will be used for computing (deletion) edge lengths
-    /// if unique is true, then every node or edge will only be counted once
-    /// (useful for total support)
+    /// wrapper for using get_traversal_set_support to get the total support
+    /// (sets shared_travs to the whole set, mutual_shared to true, then
+    /// sums over the results)
+    virtual Support get_total_traversal_set_support(const vector<SnarlTraversal>& traversals,
+                                                    int ref_trav_idx = -1) const;
+
+    /// wrapper for using get_traversal_set_support to get the support for
+    /// some alleles in a genotype, where everything is split evently among them
+    /// anything not in the genotype gets a support using "exclusive_count"
+    /// where nodes taken by the genotype are counted as 0
+    virtual vector<Support> get_traversal_genotype_support(const vector<SnarlTraversal>& traversals,
+                                                         const vector<int>& genotype,
+                                                         int ref_trav_idx = -1);
+    
+    /// traversals:      get support for each traversal in this set
+    /// shared_travs:    if a node appears N times in shared_travs, then it will count as 1 / (N+1) support
+    /// tgt_travs:       if not empty, only compute support for these traversals (remaining slots in output vector left 0)
+    /// eclusive_only:   shared_travs are completely ignored
+    /// exclusive_count: anything in shared_travs treated as 0
+    /// mutual_shared:   shared_travs count as 1/N support (instead of 1/(N+1)).  usefuly for total support
+    /// ref_trav_idx:    index of reference traversal if known
     virtual vector<Support> get_traversal_set_support(const vector<SnarlTraversal>& traversals,
                                                       const vector<int>& shared_travs,
+                                                      const set<int>& tgt_travs,
                                                       bool exclusive_only,
                                                       bool exclusive_count,
-                                                      bool unique,
+                                                      bool mutual_shared,
                                                       int ref_trav_idx = -1) const;
 
     /// Get the total length of all nodes in the traversal


### PR DESCRIPTION
For the longest time `vg call` has used a thresholding approach to come up with genotypes.  This PR finally adds logic to use likelihood instead (keeping around the old way via option for now).

This resembles the Paragraph approach in that it uses a Poisson distribution to model the read coverage.   Some key differences are:
* `vg call` considers the support of the allele's entire path, rather than (independently) looking at breakpoitns
* `vg call` uses only the likelihood, with (for now) no option to specify prior
* `vg call` treats homozygous calls with support N as two alleles with support N/2 to be more comparable to het computation (and because it already needs  to partition support to handle overlapping traversals) 
* `vg call` includes the standard error of the read depth distribution when determining a coverage error rate (which is otherwise hardcoded).  Still work to be done tuning this.

Still a fair bit of testing to do before merging, but on smaller tests the accuracy is already better than the old way, with the difference more pronounced at lower coverages.  One exception being inversion genotypes which need to be looked into.  
 