### PR TITLE
Have vg augment cut softclips by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,11 +224,12 @@ Variation from alignments can be embedded back into the graph.  This process is 
 
 ```sh
 # augment the graph with all variation from the GAM except that implied by soft clips, saving to aug.vg.  aug.gam contains the same reads as aln.gam but mapped to aug.vg
-vg augment x.vg aln.gam -C -A aug.gam > aug.vg
+vg augment x.vg aln.gam -A aug.gam > aug.vg
 
 # augment the graph with all variation from the GAM, saving each mapping as a path in the graph.
+# softclips of alignment paths are preserved (`-S`).
 # Note, this can be much less efficient than the above example if there are many alignments in the GAM
-vg augment x.vg aln.gam -i > aug_with_paths.vg
+vg augment x.vg aln.gam -i -S > aug_with_paths.vg
 ```
 
 ### Variant Calling
@@ -247,7 +248,7 @@ vg pack -x x.xg -g aln.gam -Q 5 -o aln.pack
 vg call x.xg -k aln.pack > graph_calls.vcf
 ```
 
-In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -C -A`):
+In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -A`):
 
 ```sh
 # Index our augmented graph

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -121,6 +121,7 @@ int main_augment(int argc, char** argv) {
         {"translation", required_argument, 0, 'Z'},
         {"alignment-out", required_argument, 0, 'A'},
         {"include-paths", no_argument, 0, 'i'},
+        {"cut-softclips", no_argument, 0, 'C'},
         {"keep-softclips", no_argument, 0, 'S'},
         {"label-paths", no_argument, 0, 'B'},
         {"subgraph", no_argument, 0, 's'},

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -44,7 +44,7 @@ void help_augment(char** argv, ConfigurableParser& parser) {
          << endl
          << "general options:" << endl
          << "    -i, --include-paths         merge the paths implied by alignments into the graph" << endl
-         << "    -C, --cut-softclips         drop softclips from the paths (recommended)" << endl
+         << "    -S, --keep-softclips        include softclips from input alignments (they are cut by default)" << endl
          << "    -B, --label-paths           don't augment with alignments, just use them for labeling the graph" << endl
          << "    -Z, --translation FILE      save translations from augmented back to base graph to FILE" << endl
          << "    -A, --alignment-out FILE    save augmented GAM reads to FILE" << endl
@@ -74,7 +74,7 @@ int main_augment(int argc, char** argv) {
     bool include_paths = false;
 
     // Include the softclips for each path
-    bool include_softclips = true;
+    bool include_softclips = false;
 
     // Just label the paths with the GAM
     bool label_paths = false;
@@ -121,7 +121,7 @@ int main_augment(int argc, char** argv) {
         {"translation", required_argument, 0, 'Z'},
         {"alignment-out", required_argument, 0, 'A'},
         {"include-paths", no_argument, 0, 'i'},
-        {"cut-softclips", no_argument, 0, 'C'},
+        {"keep-softclips", no_argument, 0, 'S'},
         {"label-paths", no_argument, 0, 'B'},
         {"subgraph", no_argument, 0, 's'},
         {"min-coverage", required_argument, 0, 'm'},
@@ -137,7 +137,7 @@ int main_augment(int argc, char** argv) {
         {"include-gt", required_argument, 0, 'L'},
         {0, 0, 0, 0}
     };
-    static const char* short_options = "a:Z:A:iCBhpvt:l:L:sm:c:q:Q:";
+    static const char* short_options = "a:Z:A:iCSBhpvt:l:L:sm:c:q:Q:";
     optind = 2; // force optind past command positional arguments
 
     // This is our command-line parser
@@ -160,7 +160,10 @@ int main_augment(int argc, char** argv) {
             include_paths = true;
             break;
         case 'C':
-            include_softclips = false;
+            cerr << "[vg augment] warning: -C / --cut-softclips option is deprecated (now enabled by default)" << endl;
+            break;
+        case 'S':
+            include_softclips = true;
             break;
         case 'B':
             label_paths = true;

--- a/test/t/04_vg_align.t
+++ b/test/t/04_vg_align.t
@@ -37,8 +37,8 @@ is $(vg align -js GGCTATGTCTGAACTAGGAGGGTAGAAAGAATATTCATTTTGGTTGCCACAAACCATCGAAA
 
 vg construct -m 1000 -r tiny/tiny.fa >t.vg
 seq=CAAATAAGGCTTGGAAATGTTCTGGAGTTCTATTATATTCCAACTCTCTT
-vg align -s $seq t.vg | vg augment t.vg - -i  >t2.vg
-is $(vg align -s $seq -Q query t2.vg | vg augment t2.vg - -i -B | vg view - | grep "query" | cut -f 3 | grep -o "[0-9]\+" | wc -l) 4 "align can use query names and outputs GAM"
+vg align -s $seq t.vg | vg augment t.vg - -i -S >t2.vg
+is $(vg align -s $seq -Q query t2.vg | vg augment t2.vg - -i -B -S | vg view - | grep "query" | cut -f 3 | grep -o "[0-9]\+" | wc -l) 4 "align can use query names and outputs GAM"
 rm t.vg t2.vg
 
 

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -104,6 +104,6 @@ vg augment c.vg m.gam -A m.aug.gam >c.aug.vg
 vg index -x c.aug.xg c.aug.vg
 vg pack -x c.aug.xg -g m.aug.gam -o m.aug.pack
 vg call c.aug.xg -k m.aug.pack >m.vcf
-is $(cat m.vcf | grep -v "^#" | wc -l) 3 "vg call finds true homozygous variants in a cyclic graph"
+is $(cat m.vcf | grep -v "^#" | wc -l) 4 "vg call finds true homozygous variants in a cyclic graph"
 rm -f c.vg c.xg c.gcsa c.gcsa.lcp m.fa m.vg m.xg m.sim m.gam m.aug.gam c.aug.vg c.aug.xg m.aug.pack m.vcf
 


### PR DESCRIPTION
Embedding softclips from the alignments in the graph generally causes trouble.  For one, it bloats the augmented graph and for two, the dangling ends throw off `vg snarls` which in turn can affect calling.  So I think in most cases, users probably don't want softclips.  Now, instead of running `vg augment -C` to **cut** softclips, you'd run `vg augment -S` to **keep** softclips.  