### PR TITLE
Handlify vg chunk more and fold explode into it

### DIFF
--- a/src/algorithms/subgraph.cpp
+++ b/src/algorithms/subgraph.cpp
@@ -8,7 +8,7 @@ void expand_subgraph_by_steps(const HandleGraph& source, MutableHandleGraph& sub
     subgraph.for_each_handle([&](const handle_t& h) {
             curr_handles.push_back(h);
         });
-    for (uint64_t i = 0; i < steps; ++i) {
+    for (uint64_t i = 0; i < steps && !curr_handles.empty(); ++i) {
         std::vector<handle_t> next_handles;
         for (auto& h : curr_handles) {
             handle_t old_h = source.get_handle(subgraph.get_id(h));

--- a/src/chunker.cpp
+++ b/src/chunker.cpp
@@ -3,6 +3,7 @@
 #include <vg/io/stream.hpp>
 #include "chunker.hpp"
 #include "algorithms/subgraph.hpp"
+#include "convert_handle.hpp"
 
 //#define debug
 
@@ -19,7 +20,16 @@ PathChunker::~PathChunker() {
 }
 
 void PathChunker::extract_subgraph(const Region& region, int context, int length, bool forward_only,
-                                   VG& subgraph, Region& out_region) {
+                                   MutablePathMutableHandleGraph& subgraph, Region& out_region) {
+    // This method still depends on VG
+    // (not a super high priority to port, as calling can now be done at genome scale and we no longer
+    // have to chunk up paths)
+    VG* vg_subgraph = dynamic_cast<VG*>(&subgraph);
+    if (vg_subgraph == nullptr) {
+        vg_subgraph = new VG();
+        assert(subgraph.get_node_count() == 0);
+    }
+    
     // extract our path range into the graph
     path_handle_t path_handle = graph->get_path_handle(region.seq);
     step_handle_t start_step = graph->get_step_at_position(path_handle, region.start);
@@ -42,28 +52,28 @@ void PathChunker::extract_subgraph(const Region& region, int context, int length
         if (graph->get_is_reverse(step_handle)) {
             step_handle = graph->flip(step_handle);
         }
-        if (!subgraph.has_node(graph->get_id(step_handle))) {
-            subgraph.create_handle(graph->get_sequence(step_handle), graph->get_id(step_handle));
+        if (!vg_subgraph->has_node(graph->get_id(step_handle))) {
+            vg_subgraph->create_handle(graph->get_sequence(step_handle), graph->get_id(step_handle));
         }
     };
     // expand the context and get path information
     // if forward_only true, then we only go forward.
     if (context > 0) {
-        algorithms::expand_subgraph_by_steps(*graph, subgraph, context, forward_only);
+        algorithms::expand_subgraph_by_steps(*graph, *vg_subgraph, context, forward_only);
     }
     if (length > 0) {
-        algorithms::expand_subgraph_by_length(*graph, subgraph, context, forward_only);
+        algorithms::expand_subgraph_by_length(*graph, *vg_subgraph, context, forward_only);
     }
     else if (context == 0 && length == 0) {
-        algorithms::add_connecting_edges_to_subgraph(*graph, subgraph);
+        algorithms::add_connecting_edges_to_subgraph(*graph, *vg_subgraph);
     }
-    algorithms::add_subpaths_to_subgraph(*graph, subgraph);
+    algorithms::add_subpaths_to_subgraph(*graph, *vg_subgraph);
         
     // build the vg of the subgraph
-    subgraph.remove_orphan_edges();
+    vg_subgraph->remove_orphan_edges();
 
     // get our range endpoints before context expansion
-    list<mapping_t>& mappings = subgraph.paths.get_path(region.seq);
+    list<mapping_t>& mappings = vg_subgraph->paths.get_path(region.seq);
     assert(!mappings.empty());
     size_t mappings_size = mappings.size();
     int64_t input_start_node = graph->get_id(start_handle);
@@ -126,13 +136,13 @@ void PathChunker::extract_subgraph(const Region& region, int context, int length
             for (; prev_it != mappings.begin(); --prev_it) {
                 cur_it = prev_it;
                 --cur_it;
-                handle_t  prev_handle = subgraph.get_handle(prev_it->node_id(),
+                handle_t  prev_handle = vg_subgraph->get_handle(prev_it->node_id(),
                                                             prev_it->is_reverse());
-                handle_t cur_handle = subgraph.get_handle(cur_it->node_id(),
+                handle_t cur_handle = vg_subgraph->get_handle(cur_it->node_id(),
                                                           cur_it->is_reverse());
-                edge_t edge = subgraph.edge_handle(cur_handle, prev_handle);
-                if (!path_edge_set.count(make_pair(make_pair(subgraph.get_id(edge.first), subgraph.get_is_reverse(edge.first)),
-                                                   make_pair(subgraph.get_id(edge.second), subgraph.get_is_reverse(edge.second))))) {
+                edge_t edge = vg_subgraph->edge_handle(cur_handle, prev_handle);
+                if (!path_edge_set.count(make_pair(make_pair(vg_subgraph->get_id(edge.first), vg_subgraph->get_is_reverse(edge.first)),
+                                                   make_pair(vg_subgraph->get_id(edge.second), vg_subgraph->get_is_reverse(edge.second))))) {
 #ifdef debug
 #pragma omp critical(cerr)
                     {
@@ -150,13 +160,13 @@ void PathChunker::extract_subgraph(const Region& region, int context, int length
         cur_it = end_it;
         prev_it = cur_it;
         for (++cur_it; cur_it != mappings.end(); ++prev_it, ++cur_it) {
-            handle_t  prev_handle = subgraph.get_handle(prev_it->node_id(),
+            handle_t  prev_handle = vg_subgraph->get_handle(prev_it->node_id(),
                                                         prev_it->is_reverse());
-            handle_t cur_handle = subgraph.get_handle(cur_it->node_id(),
+            handle_t cur_handle = vg_subgraph->get_handle(cur_it->node_id(),
                                                       cur_it->is_reverse());
-            edge_t edge = subgraph.edge_handle(prev_handle, cur_handle);
-            if (!path_edge_set.count(make_pair(make_pair(subgraph.get_id(edge.first), subgraph.get_is_reverse(edge.first)),
-                                               make_pair(subgraph.get_id(edge.second), subgraph.get_is_reverse(edge.second))))) {
+            edge_t edge = vg_subgraph->edge_handle(prev_handle, cur_handle);
+            if (!path_edge_set.count(make_pair(make_pair(vg_subgraph->get_id(edge.first), vg_subgraph->get_is_reverse(edge.first)),
+                                               make_pair(vg_subgraph->get_id(edge.second), vg_subgraph->get_is_reverse(edge.second))))) {
 #ifdef debug
 #pragma omp critical(cerr)
                     {
@@ -192,64 +202,70 @@ void PathChunker::extract_subgraph(const Region& region, int context, int length
 
     // Cut our graph so that our reference path end points are graph tips.  This will let the
     // snarl finder use the path to find telomeres.
-    path_handle_t sg_path_handle = subgraph.get_path_handle(region.seq);
-    Node* start_node = subgraph.get_node(mappings.begin()->node_id());
-    auto sg_start_steps = path_steps_of_handle(subgraph, subgraph.get_handle(start_node->id()), sg_path_handle); 
+    path_handle_t sg_path_handle = vg_subgraph->get_path_handle(region.seq);
+    Node* start_node = vg_subgraph->get_node(mappings.begin()->node_id());
+    auto sg_start_steps = path_steps_of_handle(*vg_subgraph, vg_subgraph->get_handle(start_node->id()), sg_path_handle); 
     if (rewrite_paths && sg_start_steps.size() == 1) {
-        if (!mappings.begin()->is_reverse() && subgraph.start_degree(start_node) != 0) {
-            for (auto edge : subgraph.edges_to(start_node)) {
+        if (!mappings.begin()->is_reverse() && vg_subgraph->start_degree(start_node) != 0) {
+            for (auto edge : vg_subgraph->edges_to(start_node)) {
 #ifdef debug
 #pragma omp crticial(cerr)
                 {
                     cerr << "clipping out edge " << pb2json(*edge) << " in order to make path start a tip" << endl;
                 }
 #endif
-                subgraph.destroy_edge(edge);
+                vg_subgraph->destroy_edge(edge);
             }
-        } else if (mappings.begin()->is_reverse() && subgraph.end_degree(start_node) != 0) {
-            for (auto edge : subgraph.edges_from(start_node)) {
+        } else if (mappings.begin()->is_reverse() && vg_subgraph->end_degree(start_node) != 0) {
+            for (auto edge : vg_subgraph->edges_from(start_node)) {
 #ifdef debug
 #pragma omp crticial(cerr)
                 {
                     cerr << "clipping out edge " << pb2json(*edge) << " in order to make path start a tip" << endl;
                 }
 #endif
-                subgraph.destroy_edge(edge);
+                vg_subgraph->destroy_edge(edge);
             }
         }
     }
-    Node* end_node = subgraph.get_node(mappings.rbegin()->node_id());
-    auto sg_end_steps = path_steps_of_handle(subgraph, subgraph.get_handle(end_node->id()), sg_path_handle); 
+    Node* end_node = vg_subgraph->get_node(mappings.rbegin()->node_id());
+    auto sg_end_steps = path_steps_of_handle(*vg_subgraph, vg_subgraph->get_handle(end_node->id()), sg_path_handle); 
     if (rewrite_paths && sg_end_steps.size() == 1) {
-        if (!mappings.rbegin()->is_reverse() && subgraph.end_degree(end_node) != 0) {
-            for (auto edge : subgraph.edges_from(end_node)) {
+        if (!mappings.rbegin()->is_reverse() && vg_subgraph->end_degree(end_node) != 0) {
+            for (auto edge : vg_subgraph->edges_from(end_node)) {
 #ifdef debug
 #pragma omp crticial(cerr)
                 {
                     cerr << "clipping out edge " << pb2json(*edge) << " in order to make path end a tip" << endl;
                 }
 #endif
-                subgraph.destroy_edge(edge);
+                vg_subgraph->destroy_edge(edge);
             }
-        } else if (mappings.rbegin()->is_reverse() && subgraph.start_degree(end_node) != 0) {
-            for (auto edge : subgraph.edges_to(end_node)) {
+        } else if (mappings.rbegin()->is_reverse() && vg_subgraph->start_degree(end_node) != 0) {
+            for (auto edge : vg_subgraph->edges_to(end_node)) {
 #ifdef debug
 #pragma omp crticial(cerr)
                 {
                     cerr << "clipping out edge " << pb2json(*edge) << " in order to make path end a tip" << endl;
                 }
 #endif
-                subgraph.destroy_edge(edge);
+                vg_subgraph->destroy_edge(edge);
             }
         }
     }
 
     // Sync our updated paths lists back into the Graph protobuf
     if (rewrite_paths) {
-        subgraph.paths.rebuild_node_mapping();
-        subgraph.paths.rebuild_mapping_aux();
-        subgraph.graph.clear_path();
-        subgraph.paths.to_graph(subgraph.graph);
+        vg_subgraph->paths.rebuild_node_mapping();
+        vg_subgraph->paths.rebuild_mapping_aux();
+        vg_subgraph->graph.clear_path();
+        vg_subgraph->paths.to_graph(vg_subgraph->graph);
+    }
+
+    // copy back out of vg if necessary
+    if (dynamic_cast<VG*>(&subgraph) == nullptr) {
+        convert_path_handle_graph(vg_subgraph, &subgraph);
+        delete vg_subgraph;
     }
 
     // start could fall inside a node.  we find out where in the path the
@@ -262,32 +278,22 @@ void PathChunker::extract_subgraph(const Region& region, int context, int length
 }
 
 void PathChunker::extract_id_range(vg::id_t start, vg::id_t end, int context, int length,
-                                   bool forward_only, VG& subgraph,
+                                   bool forward_only, MutablePathMutableHandleGraph& subgraph,
                                    Region& out_region) {
 
-    Graph g;
-
     for (vg::id_t i = start; i <= end; ++i) {
-        Node node;
-        node.set_id(i);
-        node.set_sequence(graph->get_sequence(graph->get_handle(i)));
-        *g.add_node() = node;
+        subgraph.create_handle(graph->get_sequence(graph->get_handle(i)), i);
     }
 
-    VG vg_g(g);
-    
     // expand the context and get path information
     // if forward_only true, then we only go forward.
-    algorithms::expand_subgraph_by_steps(*graph, vg_g, context, forward_only);
+    algorithms::expand_subgraph_by_steps(*graph, subgraph, context, forward_only);
     if (length) {
-        algorithms::expand_subgraph_by_length(*graph, vg_g, context, forward_only);
+        algorithms::expand_subgraph_by_length(*graph, subgraph, context, forward_only);
     }
-    algorithms::add_subpaths_to_subgraph(*graph, vg_g);
+    algorithms::add_subpaths_to_subgraph(*graph, subgraph);
 
     // build the vg
-    subgraph.extend(vg_g);
-    subgraph.remove_orphan_edges();
-
     out_region.start = subgraph.min_node_id();
     out_region.end = subgraph.max_node_id();
 }

--- a/src/chunker.hpp
+++ b/src/chunker.hpp
@@ -39,20 +39,30 @@ public:
      * NOTE: we follow convention of Region coordinates being 0-based 
      * inclusive. 
      * */
-    void extract_subgraph(const Region& region, int context, int length, bool forward_only,
+    void extract_subgraph(const Region& region, int64_t context, int64_t length, bool forward_only,
                           MutablePathMutableHandleGraph& subgraph, Region& out_region);
+
+    /**
+     * Extract a connected component containing a given path
+     */
+    void extract_path_component(const string& path_name, MutablePathMutableHandleGraph& subgraph, Region& out_region);
+   
+    /**
+     * Extract a connected component starting from an id set
+     */
+    void extract_component(const unordered_set<nid_t>& node_ids, MutablePathMutableHandleGraph& subgraph);   
 
     /**
      * Like above, but use (inclusive) id range instead of region on path.
      */
-    void extract_id_range(vg::id_t start, vg::id_t end, int context, int length, bool forward_only,
-                         MutablePathMutableHandleGraph& subgraph, Region& out_region);
+    void extract_id_range(vg::id_t start, vg::id_t end, int64_t context, int64_t length, bool forward_only,
+                          MutablePathMutableHandleGraph& subgraph, Region& out_region);
 
     /**
      * Get a set of all edges in the graph along a path region (to check for discontinuities later on)
      */ 
     set<pair<pair<id_t, bool>, pair<id_t, bool>>> get_path_edge_index(step_handle_t start_step,
-                                                                      step_handle_t end_step, int context) const;
+                                                                      step_handle_t end_step, int64_t context) const;
 
 };
 

--- a/src/chunker.hpp
+++ b/src/chunker.hpp
@@ -40,13 +40,13 @@ public:
      * inclusive. 
      * */
     void extract_subgraph(const Region& region, int context, int length, bool forward_only,
-                          VG& subgraph, Region& out_region);
+                          MutablePathMutableHandleGraph& subgraph, Region& out_region);
 
     /**
      * Like above, but use (inclusive) id range instead of region on path.
      */
     void extract_id_range(vg::id_t start, vg::id_t end, int context, int length, bool forward_only,
-                         VG& subgraph, Region& out_region);
+                         MutablePathMutableHandleGraph& subgraph, Region& out_region);
 
     /**
      * Get a set of all edges in the graph along a path region (to check for discontinuities later on)

--- a/src/io/save_handle_graph.hpp
+++ b/src/io/save_handle_graph.hpp
@@ -56,7 +56,26 @@ inline void save_handle_graph(HandleGraph* graph, const string& dest_path) {
         throw runtime_error("Internal error: unable to serialize graph");
     }    
 }
-    
+
+// Check that output format specifier is a valid graph type
+inline bool valid_output_format(const string& fmt_string) {
+    return fmt_string == "vg" || fmt_string == "pg" || fmt_string == "hg";
+}
+
+// Create a new graph (of handle graph type T) where the implementation is chosen using the format string
+template<class T>
+T* new_output_graph(const string& fmt_string) {
+    if (fmt_string == "vg") {
+        return new VG();
+    } else if (fmt_string == "pg") {
+        return new bdsg::PackedGraph();
+    } else if (fmt_string == "hg") {
+        return new bdsg::HashGraph();
+    } else {
+        return nullptr;
+    }
+}
+
 }
 
 }

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -446,7 +446,9 @@ int main_chunk(int argc, char** argv) {
         graph->for_each_path_handle([&](path_handle_t path_handle) {
                 Region region;
                 region.seq = graph->get_path_name(path_handle);
-                regions.push_back(region);
+                if (!Paths::is_alt(region.seq)) {
+                    regions.push_back(region);
+                }
             });
     }
 

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -21,6 +21,7 @@
 #include "../region.hpp"
 #include "../haplotype_extracter.hpp"
 #include "../algorithms/sorted_id_ranges.hpp"
+#include "../algorithms/weakly_connected_components.hpp"
 #include <bdsg/overlay_helper.hpp>
 #include "../io/save_handle_graph.hpp"
 #include "convert_handle.hpp"
@@ -29,7 +30,7 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
-static string chunk_name(const string& out_chunk_prefix, int i, const Region& region, string ext, int gi = 0);
+static string chunk_name(const string& out_chunk_prefix, int i, const Region& region, string ext, int gi = 0, bool components = false);
 static int split_gam(istream& gam_stream, size_t chunk_size, const string& out_prefix,
                      size_t gam_buffer_size = 100);
 
@@ -43,12 +44,12 @@ void help_chunk(char** argv) {
          << "For a single-range chunk (-p or -r), the graph data is sent to standard output instead of a file." << endl
          << endl
          << "options:" << endl
-         << "    -x, --xg-name FILE       use this xg index to chunk subgraphs" << endl
+         << "    -x, --xg-name FILE       use this graph or xg index to chunk subgraphs" << endl
          << "    -G, --gbwt-name FILE     use this GBWT haplotype index for haplotype extraction" << endl
          << "    -a, --gam-name FILE      chunk this gam file (not stdin, sorted, with FILE.gai index) instead of the graph (multiple allowed)" << endl
          << "    -g, --gam-and-graph      when used in combination with -a, both gam and graph will be chunked" << endl 
          << "path chunking:" << endl
-         << "    -p, --path TARGET        write the chunk in the specified (0-based inclusive)\n"
+         << "    -p, --path TARGET        write the chunk in the specified (0-based inclusive, multiple allowed)\n"
          << "                             path range TARGET=path[:pos1[-pos2]] to standard output" << endl
          << "    -P, --path-list FILE     write chunks for all path regions in (line - separated file). format" << endl
          << "                             for each as in -p (all paths chunked unless otherwise specified)" << endl
@@ -59,6 +60,9 @@ void help_chunk(char** argv) {
          << "    -n, --n-chunks N         generate this many id-range chunks, which are determined using the xg index" << endl
          << "simple gam chunking:" << endl
          << "    -m, --gam-split-size N   split gam (specified with -a, sort/index not required) up into chunks with at most N reads each" << endl
+         << "component chunking:" << endl
+         << "    -C, --components         create a chunk for each connected component.  if a targets given with (-p, -P, -r, -R), limit to components containing them" << endl
+         << "    -M, --path-components    create a chunk for each path in the graph's connected component" << endl
          << "general:" << endl
          << "    -s, --chunk-size N       create chunks spanning N bases (or nodes with -r/-R) for all input regions." << endl
          << "    -o, --overlap N          overlap between chunks when using -s [0]" << endl        
@@ -86,7 +90,7 @@ int main_chunk(int argc, char** argv) {
     string gbwt_file;
     vector<string> gam_files;
     bool gam_and_graph = false;
-    string region_string;
+    vector<string> region_strings;
     string path_list_file;
     int chunk_size = 0;
     int overlap = 0;
@@ -104,6 +108,8 @@ int main_chunk(int argc, char** argv) {
     int n_chunks = 0;
     size_t gam_split_size = 0;
     string output_format = "vg";
+    bool components = false;
+    bool path_components = false;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -131,12 +137,14 @@ int main_chunk(int argc, char** argv) {
             {"n-chunks", required_argument, 0, 'n'},
             {"context-length", required_argument, 0, 'l'},
             {"gam-split-size", required_argument, 0, 'm'},
+            {"components", no_argument, 0, 'C'},
+            {"path-components", no_argument, 0, 'M'},
             {"output-fmt", required_argument, 0, 'O'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:G:a:gp:P:s:o:e:E:b:c:r:R:Tft:n:l:m:O:",
+        c = getopt_long (argc, argv, "hx:G:a:gp:P:s:o:e:E:b:c:r:R:Tft:n:l:m:CMO:",
                 long_options, &option_index);
 
 
@@ -164,7 +172,7 @@ int main_chunk(int argc, char** argv) {
             break;            
 
         case 'p':
-            region_string = optarg;
+            region_strings.push_back(optarg);
             break;
 
         case 'P':
@@ -219,6 +227,15 @@ int main_chunk(int argc, char** argv) {
             gam_split_size = parse<int>(optarg);
             break;
 
+        case 'C':
+            components = true;
+            break;
+
+        case 'M':
+            components = true;
+            path_components = true;
+            break;
+
         case 'T':
             trace = true;
             break;
@@ -249,14 +266,19 @@ int main_chunk(int argc, char** argv) {
     omp_set_num_threads(threads);            
 
     // need at most one of -n, -p, -P, -e, -r, -R, -m  as an input
-    if ((n_chunks == 0 ? 0 : 1) + (region_string.empty() ? 0 : 1) + (path_list_file.empty() ? 0 : 1) + (in_bed_file.empty() ? 0 : 1) +
-        (node_ranges_file.empty() ? 0 : 1) + (node_range_string.empty() ? 0 : 1) + (gam_split_size == 0 ? 0 : 1) > 1) {
-        cerr << "error:[vg chunk] at most one of {-n, -p, -P, -e, -r, -R, m} required to specify input regions" << endl;
+    if ((n_chunks == 0 ? 0 : 1) + (region_strings.empty() ? 0 : 1) + (path_list_file.empty() ? 0 : 1) + (in_bed_file.empty() ? 0 : 1) +
+        (node_ranges_file.empty() ? 0 : 1) + (node_range_string.empty() ? 0 : 1) + (gam_split_size == 0 ? 0 : 1)  +
+        (path_components ? 1 : 0) > 1) {
+        cerr << "error:[vg chunk] at most one of {-n, -p, -P, -e, -r, -R, -m, -P} required to specify input regions" << endl;
         return 1;
     }
     // need -a if using -f
     if ((gam_split_size != 0 || fully_contained) && gam_files.empty()) {
         cerr << "error:[vg chunk] gam file must be specified with -a when using -f or -m" << endl;
+        return 1;
+    }
+    if (components == true && context_steps >= 0) {
+        cerr << "error:[vg chunk] context cannot be specified (-c) when splitting into components (-C)" << endl;
         return 1;
     }
     // context steps default to 1 if using id_ranges.  otherwise, force user to specify to avoid
@@ -266,7 +288,7 @@ int main_chunk(int argc, char** argv) {
             if (!context_length) {
                 context_steps = 1;
             }
-        } else {
+        } else if (!components){
             cerr << "error:[vg chunk] context expansion steps must be specified with -c/--context when chunking on paths" << endl;
             return 1;
         }
@@ -291,15 +313,15 @@ int main_chunk(int argc, char** argv) {
     unique_ptr<PathHandleGraph> path_handle_graph;
     bdsg::PathPositionOverlayHelper overlay_helper;
 
-    if (chunk_graph || trace || context_steps > 0 || context_length > 0 || (!id_range && gam_split_size == 0)) {
+    if (chunk_graph || trace || context_steps > 0 || context_length > 0 || (!id_range && gam_split_size == 0) || components) {
         if (xg_file.empty()) {
-            cerr << "error:[vg chunk] xg index (-x) required" << endl;
+            cerr << "error:[vg chunk] graph or xg index (-x) required" << endl;
             return 1;
         }
 
         ifstream in(xg_file.c_str());
         if (!in) {
-            cerr << "error:[vg chunk] unable to load xg index file " << xg_file << endl;
+            cerr << "error:[vg chunk] unable to load graph / xg index file " << xg_file << endl;
             return 1;
         }
         
@@ -337,10 +359,12 @@ int main_chunk(int argc, char** argv) {
     
     // parse the regions into a list
     vector<Region> regions;
-    if (!region_string.empty()) {
-        Region region;
-        parse_region(region_string, region);
-        regions.push_back(region);
+    if (!region_strings.empty()) {
+        for (auto& region_string : region_strings) {
+            Region region;
+            parse_region(region_string, region);
+            regions.push_back(region);
+        }
     }
     else if (!path_list_file.empty()) {
         ifstream pr_stream(path_list_file.c_str());
@@ -417,7 +441,7 @@ int main_chunk(int argc, char** argv) {
             delete range_stream;
         }
     }
-    else if (graph != nullptr) {
+    else if (graph != nullptr && (!components || path_components)) {
         // every path
         graph->for_each_path_handle([&](path_handle_t path_handle) {
                 Region region;
@@ -443,7 +467,7 @@ int main_chunk(int argc, char** argv) {
             region.start = max((int64_t)0, region.start);
             if (region.end == -1) {
                 region.end = get_path_length(region.seq) - 1;
-            } else if (!id_range) {
+            } else if (!id_range && !components) {
                 if (region.start < 0 || region.end >= get_path_length(region.seq)) {
                     cerr << "error[vg chunk]: input region " << region.seq << ":" << region.start << "-" << region.end
                          << " is out of bounds of path " << region.seq << " which has length "<< get_path_length(region.seq)
@@ -470,6 +494,20 @@ int main_chunk(int argc, char** argv) {
             }
         }
         swap(regions, chunked_regions);
+    }
+
+    // when using -C for components, regions will be derived from the connected components
+    vector<unordered_set<nid_t>> component_ids; 
+    if (components == true && regions.empty()) {
+        // no regions given, we find our components from scratch and make some dummy regions
+        component_ids = algorithms::weakly_connected_components(graph);
+        for (int i = 0; i < component_ids.size(); ++i) {
+            Region region;
+            region.seq = "";
+            region.start = 0;
+            region.end = 0;
+            regions.push_back(region);
+        }
     }
 
     // now ready to get our chunk on
@@ -536,17 +574,26 @@ int main_chunk(int argc, char** argv) {
         PathChunker& chunker = chunkers[tid];
         MutablePathMutableHandleGraph* subgraph = NULL;
         map<string, int> trace_thread_frequencies;
-        if (id_range == false) {
+        if (!component_ids.empty()) {
             subgraph = vg::io::new_output_graph<MutablePathMutableHandleGraph>(output_format);
-            chunker.extract_subgraph(region, context_steps, context_length,
-                                     trace, *subgraph, output_regions[i]);
-            
+            chunker.extract_component(component_ids[i], *subgraph);
+            output_regions[i] = region;
+        }
+        else if (id_range == false) {
+            subgraph = vg::io::new_output_graph<MutablePathMutableHandleGraph>(output_format);
+            if (components == true) {
+                chunker.extract_path_component(region.seq, *subgraph, output_regions[i]);
+            } else {
+                chunker.extract_subgraph(region, context_steps, context_length,
+                                         trace, *subgraph, output_regions[i]);
+            }
         } else {
             if (chunk_graph || context_steps > 0) {
                 subgraph = vg::io::new_output_graph<MutablePathMutableHandleGraph>(output_format);
                 output_regions[i].seq = region.seq;
                 chunker.extract_id_range(region.start, region.end,
-                                         context_steps, context_length, trace,
+                                         components ? numeric_limits<int64_t>::max() : context_steps,
+                                         context_length, trace && !components,
                                          *subgraph, output_regions[i]);
             } else {
                 // in this case, there's no need to actually build the subgraph, so we don't
@@ -595,7 +642,7 @@ int main_chunk(int argc, char** argv) {
         ofstream out_file;
         ostream* out_stream = NULL;
         if (chunk_graph) {
-            if ((!region_string.empty() || !node_range_string.empty()) &&
+            if ((!region_strings.empty() || !node_range_string.empty()) &&
                 (regions.size()  == 1) && chunk_size == 0) {
                 // If we are going to output only one chunk, it should go to
                 // stdout instead of to a file on disk
@@ -603,7 +650,7 @@ int main_chunk(int argc, char** argv) {
             } else {
                 // Otherwise, we write files under the specified prefix, using
                 // a prefix-i-seq-start-end convention.
-                string name = chunk_name(out_chunk_prefix, i, output_regions[i], ".vg");
+                string name = chunk_name(out_chunk_prefix, i, output_regions[i], "." + output_format, 0, components);
                 out_file.open(name);
                 if (!out_file) {
                     cerr << "error[vg chunk]: can't open output chunk file " << name << endl;
@@ -622,7 +669,7 @@ int main_chunk(int argc, char** argv) {
                 assert(gam_index.get() != nullptr);
                 GAMIndex::cursor_t& cursor = cursors_vec[gi][tid];
             
-                string gam_name = chunk_name(out_chunk_prefix, i, output_regions[i], ".gam", gi);
+                string gam_name = chunk_name(out_chunk_prefix, i, output_regions[i], ".gam", gi, components);
                 ofstream out_gam_file(gam_name);
                 if (!out_gam_file) {
                     cerr << "error[vg chunk]: can't open output gam file " << gam_name << endl;
@@ -647,7 +694,7 @@ int main_chunk(int argc, char** argv) {
         if (trace) {
             // Even if we have only one chunk, the trace annotation data always
             // ends up in a file.
-            string annot_name = chunk_name(out_chunk_prefix, i, output_regions[i], ".annotate.txt");
+            string annot_name = chunk_name(out_chunk_prefix, i, output_regions[i], ".annotate.txt", 0, components);
             ofstream out_annot_file(annot_name);
             if (!out_annot_file) {
                 cerr << "error[vg chunk]: can't open output trace annotation file " << annot_name << endl;
@@ -671,9 +718,9 @@ int main_chunk(int argc, char** argv) {
             const Region& oregion = output_regions[i];
             string seq = id_range ? "ids" : oregion.seq;
             obed << seq << "\t" << oregion.start << "\t" << (oregion.end + 1)
-                 << "\t" << chunk_name(out_chunk_prefix, i, oregion, chunk_gam ? ".gam" : ".vg");
+                 << "\t" << chunk_name(out_chunk_prefix, i, oregion, chunk_gam ? ".gam" : "." + output_format, 0, components);
             if (trace) {
-                obed << "\t" << chunk_name(out_chunk_prefix, i, oregion, ".annotate.txt");
+                obed << "\t" << chunk_name(out_chunk_prefix, i, oregion, ".annotate.txt", 0, components);
             }
             obed << "\n";
         }
@@ -686,15 +733,21 @@ int main_chunk(int argc, char** argv) {
 static Subcommand vg_chunk("chunk", "split graph or alignment into chunks", main_chunk);
 
 // Output name of a chunk
-string chunk_name(const string& out_chunk_prefix, int i, const Region& region, string ext, int gi) {
+string chunk_name(const string& out_chunk_prefix, int i, const Region& region, string ext, int gi, bool components) {
     stringstream chunk_name;
     string seq = region.seq.empty() ? "ids" : region.seq;
     chunk_name << out_chunk_prefix;
     if (gi > 0) {
         chunk_name << "-" << gi;
     }
-    chunk_name << "_" << i << "_" << seq << "_"
-               << region.start << "_" << region.end << ext;
+    if (!components) {
+        chunk_name << "_" << i << "_" << seq << "_" << region.start << "_" << region.end;
+    } else if (region.seq.empty()) {
+        chunk_name << "_" << i;
+    } else {
+        chunk_name << "_" << region.seq;
+    }
+    chunk_name << ext;
     return chunk_name.str();
 }
 

--- a/src/subcommand/explode_main.cpp
+++ b/src/subcommand/explode_main.cpp
@@ -71,6 +71,10 @@ int main_explode(int argc, char** argv) {
         }
     }
 
+    cerr << "vg explode is deprecated.  Please use \"vg chunk -C source.vg -b part_dir/component\" for same* functionality as \"vg explode source.vg part_dir\"" << endl
+         << " * (unlike explode, the output directory must already exist when running chunk, though)" << endl;
+    return 1;
+
     VG* graph;
     get_input_file(optind, argc, argv, [&](istream& in) {
         graph = new VG(in);

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 16
+plan tests 17
 
 # Construct a graph with alt paths so we can make a gPBWT and later a GBWT
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz -a >x.vg
@@ -18,6 +18,9 @@ is $(vg chunk -x x.xg -p x -c 10| vg stats - -E) 291 "vg chunk with no options p
 
 # check a small chunk
 is $(vg chunk -x x.xg -p x:20-30 -c 0 | vg view - -j | jq -c '.path[0].mapping[].position' | jq 'select ((.node_id == "9"))' | grep node | sed s/,// | sort | uniq | wc -l) 1 "chunk has path going through node 9"
+
+# check a small chunk, but using vg input and packed graph output
+is $(vg chunk -x x.vg -p x:20-30 -c 0 -O pg | vg convert -v - | vg view - -j | jq -c '.path[0].mapping[].position' | jq 'select ((.node_id == "9"))' | grep node | sed s/,// | sort | uniq | wc -l) 1 "chunk has path going through node 9"
 
 # check no crash when using chunk_size, and filenames deterministic
 rm -f _chunk_test*


### PR DESCRIPTION
This adds a samtools-like `-O` option for output format to `vg chunk` (currently supported vg,pg,hg but can be and handle graph).  Would like to add this eventually to other graph-creating tools like `vg construct`.  

The goal for now is to quickly produce a set of chromosome packed graphs from an xg, then augment them in parallel, without dealing with the overhead of working with large vgs.  

Some of the chunk internals still rely on the VG class internally, but I'm not sure how necessary they are any more.  May be better to re-write or phase out than handligraphify.  