### PR TITLE
Extract kmers from specific BED regions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -122,6 +122,6 @@
 [submodule "deps/mmmultimap"]
 	path = deps/mmmultimap
 	url = https://github.com/ekg/mmmultimap.git
-[submodule "deps/BBHash"]
+[submodule "vgteam_bbhash"]
 	path = deps/BBHash
-	url = https://github.com/rizkg/BBHash.git
+	url = https://github.com/vgteam/BBHash.git

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -9,6 +9,7 @@
 #include "../stream_index.hpp"
 #include "../algorithms/sorted_id_ranges.hpp"
 #include "../algorithms/approx_path_distance.hpp"
+#include "../kmer.hpp"
 #include <bdsg/overlay_helper.hpp>
 
 #include <unistd.h>
@@ -39,6 +40,7 @@ void help_find(char** argv) {
          << "    -E, --path-dag         with -p or -R, gets any node in the partial order from pos1 to pos2, assumes id sorted DAG" << endl
          << "    -W, --save-to PREFIX   instead of writing target subgraphs to stdout," << endl
          << "                           write one per given target to a separate file named PREFIX[path]:[start]-[end].vg" << endl
+         << "    -K, --subgraph-k K     instead of graphs, write kmers from the subgraphs" << endl
          << "alignments:" << endl
          << "    -d, --db-name DIR      use this RocksDB database to retrieve alignments" << endl
          << "    -l, --sorted-gam FILE  use this sorted, indexed GAM file" << endl
@@ -111,6 +113,7 @@ int main_find(int argc, char** argv) {
     bool path_dag = false;
     string bed_targets_file;
     string save_to_prefix;
+    int subgraph_k = 0;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -153,11 +156,12 @@ int main_find(int argc, char** argv) {
                 {"min-mem", required_argument, 0, 'Z'},
                 {"paths-named", required_argument, 0, 'Q'},
                 {"list-paths", no_argument, 0, 'I'},
+                {"subgraph-k", required_argument, 0, 'K'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "d:x:n:e:s:o:k:hc:LS:z:j:CTp:P:r:l:amg:M:B:fDG:N:A:Y:Z:IQ:ER:W:",
+        c = getopt_long (argc, argv, "d:x:n:e:s:o:k:hc:LS:z:j:CTp:P:r:l:amg:M:B:fDG:N:A:Y:Z:IQ:ER:W:K:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -307,6 +311,10 @@ int main_find(int argc, char** argv) {
 
         case 'A':
             to_graph_file = optarg;
+            break;
+
+        case 'K':
+            subgraph_k = atoi(optarg);
             break;
 
         case 'h':
@@ -643,8 +651,37 @@ int main_find(int argc, char** argv) {
                     VG empty;
                     graph = empty;
                 }
+                if (subgraph_k) {
+                    // enumerate the kmers, calculating including their start positions relative to the reference
+                    // and write to stdout?
+                    for_each_kmer(graph, subgraph_k,
+                                  [&](const kmer_t& kmer) {
+                                      // get the reference-relative position
+                                      string start_str, end_str;
+                                      for (auto& p : algorithms::nearest_offsets_in_paths(xindex, kmer.begin, subgraph_k*2)) {
+                                          const uint64_t& start_p = p.second.front().first;
+                                          const bool& start_rev = p.second.front().second;
+                                          if (p.first == path_handle && (!start_rev && start_p >= target.start || start_rev && start_p <= target.end)) {
+                                              start_str = target.seq + ":" + std::to_string(start_p) + (p.second.front().second ? "-" : "+");
+                                          }
+                                      }
+                                      for (auto& p : algorithms::nearest_offsets_in_paths(xindex, kmer.end, subgraph_k*2)) {
+                                          const uint64_t& end_p = p.second.front().first;
+                                          const bool& end_rev = p.second.front().second;
+                                          if (p.first == path_handle && (!end_rev && end_p <= target.end || end_rev && end_p >= target.start)) {
+                                              end_str = target.seq + ":" + std::to_string(end_p) + (p.second.front().second ? "-" : "+");
+                                          }
+                                      }
+                                      if (!start_str.empty() && !end_str.empty()) {
+                                          // write our record
+#pragma omp critical (cout)
+                                          cout << target.seq << ":" << target.start << "-" << target.end << "\t"
+                                               << kmer.seq << "\t" << start_str << "\t" << end_str << std::endl;
+                                      }
+                                  });
+                }
             }
-            if (save_to_prefix.empty()) {
+            if (save_to_prefix.empty() && !subgraph_k) {
                 prep_graph();
                 graph.serialize_to_ostream(cout);
             }

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 27
+plan tests 28
 
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 is $? 0 "construction"
@@ -107,6 +107,8 @@ is $((vg view t.x:30:35.vg; vg view t.x:10:20.vg) | wc -l) 20 "we can extract a 
 echo x 30 36 | tr ' ' '\t' >t.bed
 echo x 10 21 | tr ' ' '\t' >>t.bed
 vg find -x t.xg -E -R t.bed -W q.
-is $((vg view q.x:10:20.vg; vg view q.x:30:35.vg) | md5sum | cut -f 1 -d\ ) $((vg view t.x:10:20.vg ; vg view t.x:30:35.vg)| md5sum | cut -f 1 -d\ ) "the same extraction can be made using BEd input"
+is $((vg view q.x:10:20.vg; vg view q.x:30:35.vg) | md5sum | cut -f 1 -d\ ) $((vg view t.x:10:20.vg ; vg view t.x:30:35.vg)| md5sum | cut -f 1 -d\ ) "the same extraction can be made using BED input"
+
+is $(vg find -x t.xg -E -p x:30-35 -p x:10-20 -K 5 | wc -l) 22 "we see the expected number of kmers in the given targets"
 
 rm -f t.xg t.vg t.x:30:35.vg t.x:10:20.vg q.x:30:35.vg q.x:10:20.vg t.bed


### PR DESCRIPTION
This adds a feature to `vg find` that lets us extract the kmers in particular graph regions, annotating the kmers with their reference-relative positions. It assumes that we only see one reference position for each kmer, so it's only going to be safe to use on VCF-based graphs. This could be changed but would make the output format tricky to parse. 

Usage (in test directory):

```
vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg
vg index -x t.xg t.vg
vg find -x t.xg -E -p x:10-15 -p x:25-32 -K 5 
```

Note that we can specify a BED file with `-R` rather than specifying the individual regions with `-p`.

This writes the kmers in the following format:

<region spec> <kmer> <kmer start> <kmer end>

```
x:10-15 TTGGA   x:10+   x:15+
x:10-15 TCCAA   x:15-   x:10-
x:25-32 GTTCT   x:26+   x:31+
x:25-32 GTTCT   x:26+   x:31+
x:25-32 TTCTA   x:27+   x:32+
x:25-32 TTCTA   x:27+   x:32+
x:25-32 AGTTC   x:25+   x:30+
x:25-32 AGAAC   x:31-   x:26-
x:25-32 AGTTC   x:25+   x:30+
x:25-32 TAGAA   x:32-   x:27-
x:25-32 AGAAC   x:31-   x:26-
x:25-32 GAACT   x:30-   x:25-
x:25-32 TAGAA   x:32-   x:27-
x:25-32 GAACT   x:30-   x:25-
```

For kmers on the reverse strand, the start and end are flipped relative to the forward. kmers with their head or tail outside of the target bounds are removed.

For comment from @ManuelTgn and @lucapinello.