### PR TITLE
Parallelize snarl computation

### DIFF
--- a/src/cactus.hpp
+++ b/src/cactus.hpp
@@ -31,10 +31,13 @@ struct CactusSide {
 
 // Convert VG to Cactus Graph. Takes a list of path names to use to find
 // telomeres if present in a connected component.
+// If we know the graph is a single weakly connected component, single_component can
+// be set to ture to avoid recomputing components.
 // Notes:
 //  - returned cactus graph needs to be freed by stCactusGraph_destruct
 //  - returns a Cactus graph, and a list of stCactusEdgeEnd* telomeres, in pairs of adjacent items.
-pair<stCactusGraph*, stList*> handle_graph_to_cactus(const PathHandleGraph& graph, const unordered_set<string>& hint_paths);
+pair<stCactusGraph*, stList*> handle_graph_to_cactus(const PathHandleGraph& graph, const unordered_set<string>& hint_paths,
+                                                     bool single_component = false);
 
 // Convert back from Cactus to VG
 // (to, for example, display using vg view)

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -42,7 +42,9 @@ public:
     virtual SnarlManager find_snarls() = 0;
 
     /**
-     * Find all the snarls of weakly connected components in parallel
+     * Find all the snarls of weakly connected components in parallel.
+     * Even single-threaded, this may be worth using as it will use less
+     * memory by only considering one component at a time.
      */
     virtual SnarlManager find_snarls_parallel() = 0;
 };

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -251,7 +251,7 @@ int main_call(int argc, char** argv) {
         snarl_manager = vg::io::VPKG::load_one<SnarlManager>(snarl_file);
     } else {
         CactusSnarlFinder finder(*graph);
-        snarl_manager = unique_ptr<SnarlManager>(new SnarlManager(std::move(finder.find_snarls())));
+        snarl_manager = unique_ptr<SnarlManager>(new SnarlManager(std::move(finder.find_snarls_parallel())));
     }
     
     unique_ptr<GraphCaller> graph_caller;

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -32,11 +32,12 @@ void help_snarl(char** argv) {
          << "    -o, --top-level        restrict traversals to top level ultrabubbles" << endl
          << "    -a, --any-snarl-type   compute traversals for any snarl type (not limiting to ultrabubbles)" << endl
          << "    -m, --max-nodes N      only compute traversals for snarls with <= N nodes (with degree > 1) [10]" << endl
-         << "    -t, --include-trivial  report snarls that consist of a single edge" << endl
+         << "    -T, --include-trivial  report snarls that consist of a single edge" << endl
          << "    -s, --sort-snarls      return snarls in sorted order by node ID (for topologically ordered graphs)" << endl
          << "    -v, --vcf FILE         use vcf-based instead of exhaustive traversal finder with -r" << endl
          << "    -f  --fasta FILE       reference in FASTA format (required for SVs by -v)" << endl
-         << "    -i  --ins-fasta FILE   insertion sequences in FASTA format (required for SVs by -v)" << endl;
+         << "    -i  --ins-fasta FILE   insertion sequences in FASTA format (required for SVs by -v)" << endl
+         << "    -t, --threads N        number of threads to use [all available]" << endl;
 }
 
 int main_snarl(int argc, char** argv) {
@@ -71,17 +72,18 @@ int main_snarl(int argc, char** argv) {
                 {"top-level", no_argument, 0, 'o'},
                 {"any-snarl-type", no_argument, 0, 'a'},
                 {"max-nodes", required_argument, 0, 'm'},
-                {"include-trivial", no_argument, 0, 't'},
+                {"include-trivial", no_argument, 0, 'T'},
                 {"sort-snarls", no_argument, 0, 's'},
                 {"vcf", required_argument, 0, 'v'},
                 {"fasta", required_argument, 0, 'f'},
                 {"ins-fasta", required_argument, 0, 'i'},
+                {"threads", required_argument, 0, 't'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "sr:latopm:v:f:i:h?",
+        c = getopt_long (argc, argv, "sr:laTopm:v:f:i:h?t:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -111,7 +113,7 @@ int main_snarl(int argc, char** argv) {
             max_nodes = parse<int>(optarg);
             break;
             
-        case 't':
+        case 'T':
             filter_trivial_snarls = false;
             break;
             
@@ -130,7 +132,17 @@ int main_snarl(int argc, char** argv) {
         case 'i':
             ins_fasta_filename = optarg;
             break;
-            
+
+        case 't':
+        {
+            int num_threads = parse<int>(optarg);
+            if (num_threads <= 0) {
+                cerr << "error:[vg snarls] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                exit(1);
+            }
+            omp_set_num_threads(num_threads);
+            break;
+        }
         case 'h':
         case '?':
             /* getopt_long already printed an error message. */
@@ -194,7 +206,7 @@ int main_snarl(int argc, char** argv) {
     }
     
     // Load up all the snarls
-    SnarlManager snarl_manager = snarl_finder->find_snarls();
+    SnarlManager snarl_manager = snarl_finder->find_snarls_parallel();
     vector<const Snarl*> snarl_roots = snarl_manager.top_level_snarls();
     if (fill_path_names){
         if (vg_graph == nullptr) {

--- a/src/subgraph_overlay.cpp
+++ b/src/subgraph_overlay.cpp
@@ -1,0 +1,209 @@
+#include <atomic>
+#include "subgraph_overlay.hpp"
+
+#include <handlegraph/util.hpp>
+
+namespace vg {
+
+using namespace std;
+using namespace handlegraph;
+
+SubgraphOverlay::SubgraphOverlay(const HandleGraph* backing, const unordered_set<nid_t>* node_subset) :
+    backing_graph(backing),
+    node_subset(node_subset) {
+    if (!node_subset->empty()) {
+        auto minmax_nodes = std::minmax_element(node_subset->begin(), node_subset->end());
+        min_node = *minmax_nodes.first;
+        max_node = *minmax_nodes.second;
+    } 
+}
+
+SubgraphOverlay::~SubgraphOverlay() {
+    
+}
+
+bool SubgraphOverlay::has_node(nid_t node_id) const {
+    return node_subset->count(node_id);
+}
+   
+handle_t SubgraphOverlay::get_handle(const nid_t& node_id, bool is_reverse) const {
+    if (has_node(node_id)) {
+        return backing_graph->get_handle(node_id, is_reverse);
+    } else {
+        throw runtime_error("Node " + std::to_string(node_id) + " not in subgraph overlay");
+    }
+}
+    
+nid_t SubgraphOverlay::get_id(const handle_t& handle) const {
+    return backing_graph->get_id(handle);
+}
+    
+bool SubgraphOverlay::get_is_reverse(const handle_t& handle) const {
+    return backing_graph->get_is_reverse(handle);
+}
+
+handle_t SubgraphOverlay::flip(const handle_t& handle) const {
+    return backing_graph->flip(handle);
+}
+    
+size_t SubgraphOverlay::get_length(const handle_t& handle) const {
+    return backing_graph->get_length(handle);
+}
+
+std::string SubgraphOverlay::get_sequence(const handle_t& handle) const {
+    return backing_graph->get_sequence(handle);
+}
+    
+size_t SubgraphOverlay::get_node_count() const {
+    return node_subset->size();
+}
+
+nid_t SubgraphOverlay::min_node_id() const {
+    return min_node;
+}
+    
+nid_t SubgraphOverlay::max_node_id() const {
+    return max_node;
+}
+
+bool SubgraphOverlay::follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const {
+    std::function<bool(const handle_t&)> subgraph_iteratee = [&](const handle_t& handle) {
+        if (has_node(backing_graph->get_id(handle))) {
+            if (iteratee(handle) == false) {
+                return false;
+            }
+        }
+        return true;
+    };
+    if (has_node(backing_graph->get_id(handle))) {
+        return backing_graph->follow_edges(handle, go_left, subgraph_iteratee);
+    }
+    return true;
+}
+    
+bool SubgraphOverlay::for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel) const {
+
+    if (!parallel) {
+        bool keep_going = true;
+        for (auto node_it = node_subset->begin(); keep_going && node_it != node_subset->end(); ++node_it) {
+            keep_going = iteratee(get_handle(*node_it, false));
+        }
+        return keep_going;
+    } else {
+        // copy them into something easy to iterate with omp
+        vector<nid_t> node_vec(node_subset->begin(), node_subset->end());
+        std::atomic<bool> keep_going(true);
+#pragma omp parallel for
+        for (size_t i = 0; i < node_vec.size(); ++i) {
+            keep_going = keep_going && iteratee(backing_graph->get_handle(node_vec[i]));
+        }
+        return keep_going;
+    }
+}
+
+PathSubgraphOverlay::PathSubgraphOverlay(const PathHandleGraph* backing, const unordered_set<nid_t>* node_subset) :
+    SubgraphOverlay(backing, node_subset),
+    backing_path_graph(backing) {
+
+    backing->for_each_path_handle([&](const path_handle_t& path_handle) {
+            bool fully_contained = true;
+            backing->for_each_step_in_path(path_handle, [&](const step_handle_t& step_handle) -> bool {
+                    if (!has_node(backing->get_id(backing->get_handle_of_step(step_handle)))) {
+                        fully_contained = false;
+                        return false;
+                    }
+                    return true;
+                });
+            if (fully_contained) {
+                path_subset.insert(path_handle);
+            }
+        });
+}
+
+PathSubgraphOverlay::~PathSubgraphOverlay() {
+}
+
+size_t PathSubgraphOverlay::get_path_count() const {
+    return path_subset.size();
+}
+    
+bool PathSubgraphOverlay::has_path(const std::string& path_name) const {
+    return backing_path_graph->has_path(path_name) &&
+        path_subset.count(backing_path_graph->get_path_handle(path_name));
+}
+    
+path_handle_t PathSubgraphOverlay::get_path_handle(const std::string& path_name) const {
+    if (!has_path(path_name)) {
+        throw runtime_error("Path " + path_name + " not in subgraph overlay");
+    } else {
+        return backing_path_graph->get_path_handle(path_name);
+    }
+}
+
+std::string PathSubgraphOverlay::get_path_name(const path_handle_t& path_handle) const {
+    return backing_path_graph->get_path_name(path_handle);
+}
+    
+bool PathSubgraphOverlay::get_is_circular(const path_handle_t& path_handle) const {
+    return backing_path_graph->get_is_circular(path_handle);
+}
+    
+size_t PathSubgraphOverlay::get_step_count(const path_handle_t& path_handle) const {
+    return backing_path_graph->get_step_count(path_handle);
+}
+    
+handle_t PathSubgraphOverlay::get_handle_of_step(const step_handle_t& step_handle) const {
+    return backing_path_graph->get_handle_of_step(step_handle);
+}
+    
+path_handle_t PathSubgraphOverlay::get_path_handle_of_step(const step_handle_t& step_handle) const {
+    return backing_path_graph->get_path_handle_of_step(step_handle);
+}
+
+step_handle_t PathSubgraphOverlay::path_begin(const path_handle_t& path_handle) const {
+    return backing_path_graph->path_begin(path_handle);
+}
+    
+step_handle_t PathSubgraphOverlay::path_end(const path_handle_t& path_handle) const {
+    return backing_path_graph->path_end(path_handle);
+}
+    
+step_handle_t PathSubgraphOverlay::path_back(const path_handle_t& path_handle) const {
+    return backing_path_graph->path_back(path_handle);
+}
+    
+step_handle_t PathSubgraphOverlay::path_front_end(const path_handle_t& path_handle) const {
+    return backing_path_graph->path_front_end(path_handle);
+}
+
+bool PathSubgraphOverlay::has_next_step(const step_handle_t& step_handle) const {
+    return backing_path_graph->has_next_step(step_handle);
+}
+
+bool PathSubgraphOverlay::has_previous_step(const step_handle_t& step_handle) const {
+    return backing_path_graph->has_previous_step(step_handle);
+}
+    
+step_handle_t PathSubgraphOverlay::get_next_step(const step_handle_t& step_handle) const {
+    return backing_path_graph->get_next_step(step_handle);
+}
+    
+step_handle_t PathSubgraphOverlay::get_previous_step(const step_handle_t& step_handle) const {
+    return backing_path_graph->get_previous_step(step_handle);
+}
+
+bool PathSubgraphOverlay::for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const {
+    bool keep_going = true;
+    for (auto path_it = path_subset.begin(); keep_going && path_it != path_subset.end(); ++path_it) {
+        keep_going = iteratee(*path_it);
+    }
+
+    return keep_going;
+}
+
+bool PathSubgraphOverlay::for_each_step_on_handle_impl(const handle_t& handle,
+                                                       const std::function<bool(const step_handle_t&)>& iteratee) const {
+    return backing_path_graph->for_each_step_on_handle(handle, iteratee);
+}
+
+}

--- a/src/subgraph_overlay.hpp
+++ b/src/subgraph_overlay.hpp
@@ -1,0 +1,215 @@
+#ifndef VG_SUBGRAPH_OVERLAY_HPP_INCLUDED
+#define VG_SUBGRAPH_OVERLAY_HPP_INCLUDED
+
+/**
+ * \file subgraph_overlay.hpp
+ *
+ * Provides SourceSinkOverlay, a HandleGraph implementation that joins all the
+ * heads and tails of a backing graph to single source and sink nodes. 
+ *
+ */
+
+
+#include "handle.hpp"
+
+#include <handlegraph/util.hpp>
+
+
+namespace vg {
+
+using namespace handlegraph;
+
+/**
+ * Present a HandleGraph that is a backing HandleGraph but restricted
+ * to a subset of nodes.  It won't give handles to nodes not in the 
+ * subset, but it's not bulletproof: handles from outside the subset
+ * won't undergo any special checks.  
+ */
+class SubgraphOverlay : virtual public HandleGraph {
+
+public:
+    /**
+     * Make a new PathSubgraphOverlay. The backing graph must not be modified
+     * while the overlay exists.
+     *
+     */
+    SubgraphOverlay(const HandleGraph* backing, const unordered_set<nid_t>* node_subset);
+
+    virtual ~SubgraphOverlay();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Handle-based interface
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// Method to check if a node exists by ID
+    virtual bool has_node(nid_t node_id) const;
+   
+    /// Look up the handle for the node with the given ID in the given orientation
+    virtual handle_t get_handle(const nid_t& node_id, bool is_reverse = false) const;
+    
+    /// Get the ID from a handle
+    virtual nid_t get_id(const handle_t& handle) const;
+    
+    /// Get the orientation of a handle
+    virtual bool get_is_reverse(const handle_t& handle) const;
+    
+    /// Invert the orientation of a handle (potentially without getting its ID)
+    virtual handle_t flip(const handle_t& handle) const;
+    
+    /// Get the length of a node
+    virtual size_t get_length(const handle_t& handle) const;
+    
+    /// Get the sequence of a node, presented in the handle's local forward
+    /// orientation.
+    virtual std::string get_sequence(const handle_t& handle) const;
+    
+    /// Return the number of nodes in the graph
+    virtual size_t get_node_count() const;
+    
+    /// Return the smallest ID in the graph, or some smaller number if the
+    /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
+    virtual nid_t min_node_id() const;
+    
+    /// Return the largest ID in the graph, or some larger number if the
+    /// largest ID is unavailable. Return value is unspecified if the graph is empty.
+    virtual nid_t max_node_id() const;
+
+protected:
+    
+    /// Loop over all the handles to next/previous (right/left) nodes. Passes
+    /// them to a callback which returns false to stop iterating and true to
+    /// continue. Returns true if we finished and false if we stopped early.
+    virtual bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
+    
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee
+    /// returns false. Can be told to run in parallel, in which case stopping
+    /// after a false return value is on a best-effort basis and iteration
+    /// order is not defined. Returns true if we finished and false if we 
+    /// stopped early.
+    virtual bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+
+protected:
+
+    /// the backing graph
+    const HandleGraph* backing_graph;
+
+    /// the node subset. note, we don't own this so its up to client to keep in scope,
+    /// just like the backing graph
+    const unordered_set<nid_t>* node_subset;
+    
+    /// keep min_node_id() and max_node_id() constant
+    nid_t min_node = 0;
+    nid_t max_node = 0;
+};
+
+/**
+ * Present a PathHandleGraph that is a backing HandleGraph but restricted
+ * to a subset of nodes.
+ *
+ * Warning: we don't yet have a subgraph interface.  So we only consider paths
+ * from the backing graph that are fully contained in the subgraph.
+ */
+class PathSubgraphOverlay : virtual public SubgraphOverlay, virtual public PathHandleGraph  {
+
+public:
+    /**
+     * Make a new PathSubgraphOverlay. The backing graph must not be modified
+     * while the overlay exists.
+     *
+     */
+    PathSubgraphOverlay(const PathHandleGraph* backing, const unordered_set<nid_t>* node_subset);
+
+    virtual ~PathSubgraphOverlay();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Path handle interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Returns the number of paths stored in the graph
+    virtual size_t get_path_count() const;
+    
+    /// Determine if a path name exists and is legal to get a path handle for.
+    virtual bool has_path(const std::string& path_name) const;
+    
+    /// Look up the path handle for the given path name.
+    /// The path with that name must exist.
+    virtual path_handle_t get_path_handle(const std::string& path_name) const;
+    
+    /// Look up the name of a path from a handle to it
+    virtual std::string get_path_name(const path_handle_t& path_handle) const;
+    
+    /// Look up whether a path is circular
+    virtual bool get_is_circular(const path_handle_t& path_handle) const;
+    
+    /// Returns the number of node steps in the path
+    virtual size_t get_step_count(const path_handle_t& path_handle) const;
+    
+    /// Get a node handle (node ID and orientation) from a handle to an step on a path
+    virtual handle_t get_handle_of_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the path that an step is on
+    virtual path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
+    
+    /// Get a handle to the first step, which will be an arbitrary step in a circular path
+    /// that we consider "first" based on our construction of the path. If the path is empty,
+    /// then the implementation must return the same value as path_end().
+    virtual step_handle_t path_begin(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to a fictitious position past the end of a path. This position is
+    /// returned by get_next_step for the final step in a path in a non-circular path.
+    /// Note: get_next_step will *NEVER* return this value for a circular path.
+    virtual step_handle_t path_end(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to the last step, which will be an arbitrary step in a circular path that
+    /// we consider "last" based on our construction of the path. If the path is empty
+    /// then the implementation must return the same value as path_front_end().
+    virtual step_handle_t path_back(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to a fictitious position before the beginning of a path. This position is
+    /// return by get_previous_step for the first step in a path in a non-circular path.
+    /// Note: get_previous_step will *NEVER* return this value for a circular path.
+    virtual step_handle_t path_front_end(const path_handle_t& path_handle) const;
+
+    /// Returns true if the step is not the last step in a non-circular path.
+    virtual bool has_next_step(const step_handle_t& step_handle) const;
+
+    /// Returns true if the step is not the first step in a non-circular path.
+    virtual bool has_previous_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the next step on the path. If the given step is the final step
+    /// of a non-circular path, this method has undefined behavior. In a circular path,
+    /// the "last" step will loop around to the "first" step.
+    virtual step_handle_t get_next_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the previous step on the path. If the given step is the first
+    /// step of a non-circular path, this method has undefined behavior. In a circular path,
+    /// it will loop around from the "first" step (i.e. the one returned by path_begin) to
+    /// the "last" step.
+    virtual step_handle_t get_previous_step(const step_handle_t& step_handle) const;
+
+protected:    
+
+    /// Execute a function on each path in the graph. If it returns false, stop
+    /// iteration. Returns true if we finished and false if we stopped early.
+    virtual bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
+
+    /// Execute a function on each step of a handle in any path. If it
+    /// returns false, stop iteration. Returns true if we finished and false if
+    /// we stopped early.
+    virtual bool for_each_step_on_handle_impl(const handle_t& handle,
+                                              const std::function<bool(const step_handle_t&)>& iteratee) const;
+
+
+protected:
+
+    /// the backing path graph, just to not have to bother with dynamic cast
+    const PathHandleGraph* backing_path_graph;
+
+    /// the subset of paths from the backing graph that are entirely contained within our subgraph
+    unordered_set<path_handle_t> path_subset;
+};
+
+}
+
+#endif

--- a/test/t/32_vg_snarls.t
+++ b/test/t/32_vg_snarls.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 8
+plan tests 9
 
 vg view -J -v snarls/snarls.json > snarls.vg
 is $(vg snarls snarls.vg -r st.pb | vg view -R - | wc -l) 3 "vg snarls made right number of protobuf Snarls"
@@ -54,8 +54,13 @@ rm -f ins_and_del.vg ins_and_del.exhaustive.trav.sort ins_and_del.exhaustive.tra
 
 # parallelizing on components (which is deactivated with -t 1)
 vg construct -r small/xy.fa -v small/xy.vcf.gz > xy.vg
-is $(vg snarls xy.vg | vg view -R - | wc -l) $(vg snarls xy.vg -t 1 | vg view -R - | wc -l) "same number of snarls when parallelizing on components"
-rm -f xy.vg
+vg construct -r small/xy.fa -v small/xy.vcf.gz -R x > x.vg
+vg construct -r small/xy.fa -v small/xy.vcf.gz -R y > y.vg
+vg snarls x.vg > xy.snarls
+vg snarls y.vg >> xy.snarls
+is $(vg snarls xy.vg | vg view -R - | wc -l) 35 "correct number of snarls when parallelizing on compoents"
+is $(vg snarls xy.vg | vg view -R - | wc -l) $(vg view -R xy.snarls | wc -l) "same number of snarls when parallelizing on components"
+rm -f xy.vg xy.snarls
 
 
 

--- a/test/t/32_vg_snarls.t
+++ b/test/t/32_vg_snarls.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 7
+plan tests 8
 
 vg view -J -v snarls/snarls.json > snarls.vg
 is $(vg snarls snarls.vg -r st.pb | vg view -R - | wc -l) 3 "vg snarls made right number of protobuf Snarls"
@@ -51,4 +51,11 @@ diff ins_and_del.exhaustive.trav.sort ins_and_del.vcf.trav.sort
 is $? 0 "vcf traversals are the same as exhaustive traversals for ins_and_del graph"
 
 rm -f ins_and_del.vg ins_and_del.exhaustive.trav.sort ins_and_del.exhaustive.trav ins_and_del.vcf.trav.sort ins_and_del.vcf.trav
+
+# parallelizing on components (which is deactivated with -t 1)
+vg construct -r small/xy.fa -v small/xy.vcf.gz > xy.vg
+is $(vg snarls xy.vg | vg view -R - | wc -l) $(vg snarls xy.vg -t 1 | vg view -R - | wc -l) "same number of snarls when parallelizing on components"
+rm -f xy.vg
+
+
 


### PR DESCRIPTION
Compute snarls of connected components independently and in parallel when more than one thread available.  Should be much faster.  Memory usage (big issue with snarls) will be lower but only if there are fewer threads than components (ie not operating on the whole graph at once)

Only realized now as new test failed sporadically that cactus isn't thread safe.  Can't merge until fixed, but I think it's just a matter of getting rid of the global variables in https://github.com/benedictpaten/pinchesAndCacti/blob/87b93048b4deb0c77bdf0a36c95dff70b557f81e/externalTools/threeEdgeConnected/impl/3_Absorb3edge2x.c