### PR TITLE
set id before name to avoid race condition

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -348,8 +348,8 @@ int64_t Paths::get_path_id(const string& name) const {
                 // Assign an ID.
                 // These members are mutable.
                 ++max_path_id;
-                name_to_id[name] = max_path_id;
                 id_to_name[max_path_id] = name;
+                name_to_id[name] = max_path_id;
             }
         }
     }


### PR DESCRIPTION
Travis has been failing randomly on Mac since #2555 (which computes snarls in parallel). See #2563 for example.  I'd been thinking it was the cache, at a second glance, it does seem that I left a race condition in `Paths::get_path_id` where one thread could set `name_to_id` in the critical section, letting another thread access `id_to_name` before it gets set.  This should fix that, and if doesn't work, I'll try something more drastic. 