### PR TITLE
provide kmer paths and reference status in `vg find`

### DIFF
--- a/src/algorithms/kmer.cpp
+++ b/src/algorithms/kmer.cpp
@@ -1,0 +1,114 @@
+#include "kmer.hpp"
+
+namespace vg {
+
+namespace algorithms {
+
+void for_each_kmer(const HandleGraph& graph, size_t k, size_t edge_max,
+                   const std::function<void(const kmer_t&)>& lambda) {
+    graph.for_each_handle([&](const handle_t& h) {
+            // for the forward and reverse of this handle
+            // walk k bases from the end, so that any kmer starting on the node will be represented in the tree we build
+            for (auto handle_is_rev : { false, true }) {
+                handle_t handle = handle_is_rev ? graph.flip(h) : h;
+                std::list<kmer_t> kmers;
+                // for each position in the node, set up a kmer with that start position and the node end or kmer length as the end position
+                // determine next positions
+                nid_t handle_id = graph.get_id(handle);
+                size_t handle_length = graph.get_length(handle);
+                std::string handle_seq = graph.get_sequence(handle);
+                for (size_t i = 0; i < handle_length;  ++i) {
+                    pos_t begin = make_pos_t(handle_id, handle_is_rev, i);
+                    pos_t end = make_pos_t(handle_id, handle_is_rev, std::min(handle_length, i+k));
+                    kmer_t kmer = kmer_t(handle_seq.substr(offset(begin), offset(end)-offset(begin)), begin, end, handle);
+                    if (kmer.seq.size() < k) {
+                        size_t next_count = 0;
+                        if (edge_max) graph.follow_edges(kmer.curr, false, [&](const handle_t& next) { ++next_count; return next_count <= 1; });
+                        //kmer.seq.reserve(k); // may reduce allocation costs
+                        // follow edges if we haven't completed the kmer here
+                        if (next_count > 1 && (edge_max && edge_max == kmer.forks)) {
+                        } else {
+                            graph.follow_edges(kmer.curr, false, [&](const handle_t& next) {
+                                    kmers.push_back(kmer);
+                                    auto& todo = kmers.back();
+                                    todo.curr = next;
+                                    if (next_count > 1) {
+                                        ++todo.forks;
+                                    }
+                            });
+                        }
+                    } else {
+                        kmers.push_back(kmer);
+                    }
+                }
+
+                // now expand the kmers until they reach k
+                while (!kmers.empty()) {
+                    // first we check which ones have reached length k in the current handle; for each of these we run lambda and remove them from our list
+                    auto kmers_end = kmers.end();
+                    for (std::list<kmer_t>::iterator q = kmers.begin(); q != kmers_end; ++q) {
+                        auto& kmer = *q;
+                        // did we reach our target length?
+                        if (kmer.seq.size() == k) {
+                            // TODO here check if we are at the beginning of the reverse head or the beginning of the forward tail and would need special handling
+                            // establish the context
+                            handle_t end_handle = graph.get_handle(id(kmer.end), is_rev(kmer.end));
+                            size_t end_length = graph.get_length(end_handle);
+                            // now pass the kmer to our callback
+                            lambda(kmer);
+                            q = kmers.erase(q);
+                        } else {
+                            // do we finish in the current node?
+                            nid_t curr_id = graph.get_id(kmer.curr);
+                            size_t curr_length = graph.get_length(kmer.curr);
+                            bool curr_is_rev = graph.get_is_reverse(kmer.curr);
+                            std::string curr_seq = graph.get_sequence(kmer.curr);
+                            size_t take = std::min(curr_length, k-kmer.seq.size());
+                            kmer.end = make_pos_t(curr_id, curr_is_rev, take);
+                            kmer.seq.append(curr_seq.substr(0,take));
+                            if (kmer.seq.size() < k) {
+                                size_t next_count = 0;
+                                if (edge_max) graph.follow_edges(kmer.curr, false, [&](const handle_t& next) { ++next_count; return next_count <= 1; });
+                                //kmer.seq.reserve(k); // may reduce allocation costs
+                                // follow edges if we haven't completed the kmer here
+                                if (next_count > 1 && (edge_max && edge_max == kmer.forks)) {
+                                } else {
+                                    graph.follow_edges(kmer.curr, false, [&](const handle_t& next) {
+                                            kmers.push_back(kmer);
+                                            auto& todo = kmers.back();
+                                            todo.curr = next;
+                                            if (next_count > 1) {
+                                                ++todo.forks;
+                                            }
+                                        });
+                                }
+                                // if not, we need to expand through the node then follow on
+                                /*
+                                graph.follow_edges(kmer.curr, false, [&](const handle_t& next) {
+                                        kmers.push_back(kmer);
+                                        auto& todo = kmers.back();
+                                        todo.curr = next;
+                                    });
+                                */
+                                q = kmers.erase(q);
+                            } else {
+                                if (kmer.seq.size() > k) {
+                                    assert(kmer.seq.size() <= k);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }, true);
+}
+
+std::ostream& operator<<(std::ostream& out, const kmer_t& kmer) {
+    out << kmer.seq << "\t"
+        << id(kmer.begin) << ":" << (is_rev(kmer.begin) ? "-":"") << offset(kmer.begin) << "\t";
+    return out;
+}
+
+}
+
+}

--- a/src/algorithms/kmer.hpp
+++ b/src/algorithms/kmer.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <list>
+#include <handlegraph/util.hpp>
+#include <handlegraph/handle_graph.hpp>
+#include "position.hpp"
+
+/** \file 
+ * Functions for working with `kmers_t`'s in HandleGraphs.
+ */
+
+namespace vg {
+
+namespace algorithms {
+
+using namespace handlegraph;
+
+/// Stores a kmer in the context of a graph.
+struct kmer_t {
+    kmer_t(const std::string& s,
+           const pos_t& b,
+           const pos_t& e,
+           const handle_t& c)
+        : seq(s), begin(b), end(e), curr(c) { };
+    /// the kmer
+    std::string seq;
+    /// our start position
+    pos_t begin;
+    /// Used in construction
+    pos_t end; /// one past the (current) end of the kmer
+    handle_t curr; /// the next handle we extend into
+    uint16_t forks; /// how many branching edge crossings we took to get here
+};
+
+/// Iterate over all the kmers in the graph, running lambda on each
+void for_each_kmer(const HandleGraph& graph, size_t k, size_t edge_max,
+                   const std::function<void(const kmer_t&)>& lambda);
+    
+/// Print a kmer_t to a stream.
+std::ostream& operator<<(std::ostream& out, const kmer_t& kmer);
+
+}
+
+}

--- a/src/algorithms/walk.cpp
+++ b/src/algorithms/walk.cpp
@@ -1,0 +1,115 @@
+#include "walk.hpp"
+
+namespace vg {
+
+namespace algorithms {
+
+void for_each_walk(const HandleGraph& graph, size_t k, size_t edge_max,
+                   const std::function<void(const walk_t&)>& lambda) {
+    graph.for_each_handle([&](const handle_t& h) {
+            // for the forward and reverse of this handle
+            // walk k bases from the end, so that any walk starting on the node will be represented in the tree we build
+            for (auto handle_is_rev : { false, true }) {
+                handle_t handle = handle_is_rev ? graph.flip(h) : h;
+                std::list<walk_t> walks;
+                // for each position in the node, set up a walk with that start position and the node end or walk length as the end position
+                // determine next positions
+                nid_t handle_id = graph.get_id(handle);
+                size_t handle_length = graph.get_length(handle);
+                std::string handle_seq = graph.get_sequence(handle);
+                for (size_t i = 0; i < handle_length;  ++i) {
+                    pos_t begin = make_pos_t(handle_id, handle_is_rev, i);
+                    pos_t end = make_pos_t(handle_id, handle_is_rev, std::min(handle_length, i+k));
+                    walk_t walk = walk_t(handle_seq.substr(offset(begin), offset(end)-offset(begin)), begin, end, handle);
+                    if (walk.seq.size() < k) {
+                        size_t next_count = 0;
+                        if (edge_max) graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; return next_count <= 1; });
+                        //walk.seq.reserve(k); // may reduce allocation costs
+                        // follow edges if we haven't completed the walk here
+                        if (next_count > 1 && (edge_max && edge_max == walk.forks)) {
+                        } else {
+                            graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
+                                    walks.push_back(walk);
+                                    auto& todo = walks.back();
+                                    todo.curr = next;
+                                    if (next_count > 1) {
+                                        ++todo.forks;
+                                    }
+                            });
+                        }
+                    } else {
+                        walks.push_back(walk);
+                    }
+                }
+
+                // now expand the walks until they reach k
+                while (!walks.empty()) {
+                    // first we check which ones have reached length k in the current handle; for each of these we run lambda and remove them from our list
+                    auto walks_end = walks.end();
+                    for (std::list<walk_t>::iterator q = walks.begin(); q != walks_end; ++q) {
+                        auto& walk = *q;
+                        // did we reach our target length?
+                        if (walk.seq.size() == k) {
+                            // TODO here check if we are at the beginning of the reverse head or the beginning of the forward tail and would need special handling
+                            // establish the context
+                            handle_t end_handle = graph.get_handle(id(walk.end), is_rev(walk.end));
+                            size_t end_length = graph.get_length(end_handle);
+                            // now pass the walk to our callback
+                            lambda(walk);
+                            q = walks.erase(q);
+                        } else {
+                            // do we finish in the current node?
+                            nid_t curr_id = graph.get_id(walk.curr);
+                            size_t curr_length = graph.get_length(walk.curr);
+                            bool curr_is_rev = graph.get_is_reverse(walk.curr);
+                            std::string curr_seq = graph.get_sequence(walk.curr);
+                            size_t take = std::min(curr_length, k-walk.seq.size());
+                            walk.end = make_pos_t(curr_id, curr_is_rev, take);
+                            walk.seq.append(curr_seq.substr(0,take));
+			    walk.path.push_back(walk.curr);
+                            if (walk.seq.size() < k) {
+                                size_t next_count = 0;
+                                if (edge_max) graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; return next_count <= 1; });
+                                //walk.seq.reserve(k); // may reduce allocation costs
+                                // follow edges if we haven't completed the walk here
+                                if (next_count > 1 && (edge_max && edge_max == walk.forks)) {
+                                } else {
+                                    graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
+                                            walks.push_back(walk);
+                                            auto& todo = walks.back();
+                                            todo.curr = next;
+                                            if (next_count > 1) {
+                                                ++todo.forks;
+                                            }
+                                        });
+                                }
+                                // if not, we need to expand through the node then follow on
+                                /*
+                                graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
+                                        walks.push_back(walk);
+                                        auto& todo = walks.back();
+                                        todo.curr = next;
+                                    });
+                                */
+                                q = walks.erase(q);
+                            } else {
+                                if (walk.seq.size() > k) {
+                                    assert(walk.seq.size() <= k);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }, true);
+}
+
+std::ostream& operator<<(std::ostream& out, const walk_t& walk) {
+    out << walk.seq << "\t"
+        << id(walk.begin) << ":" << (is_rev(walk.begin) ? "-":"") << offset(walk.begin) << "\t";
+    return out;
+}
+
+}
+
+}

--- a/src/algorithms/walk.hpp
+++ b/src/algorithms/walk.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <list>
+#include <handlegraph/util.hpp>
+#include <handlegraph/handle_graph.hpp>
+#include "position.hpp"
+
+/** \file 
+ * Functions for working with `kmers_t`'s in HandleGraphs.
+ */
+
+namespace vg {
+
+namespace algorithms {
+
+using namespace handlegraph;
+
+/// Stores a walk in the context of a graph.
+struct walk_t {
+    walk_t(const std::string& s,
+           const pos_t& b,
+           const pos_t& e,
+           const handle_t& c)
+        : seq(s), begin(b), end(e), curr(c), path({c}) { };
+    /// the walk
+    std::vector<handle_t> path;
+    /// the sequence
+    std::string seq;
+    /// our start position
+    pos_t begin;
+    /// Used in construction
+    pos_t end; /// one past the (current) end of the walk
+    handle_t curr; /// the next handle we extend into
+    uint16_t forks; /// how many branching edge crossings we took to get here
+};
+
+/// Iterate over all the walks in the graph, running lambda on each
+void for_each_walk(const HandleGraph& graph, size_t k, size_t edge_max,
+                   const std::function<void(const walk_t&)>& lambda);
+    
+/// Print a walk_t to a stream.
+std::ostream& operator<<(std::ostream& out, const walk_t& walk);
+
+}
+
+}

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -9,7 +9,7 @@
 #include "../stream_index.hpp"
 #include "../algorithms/sorted_id_ranges.hpp"
 #include "../algorithms/approx_path_distance.hpp"
-#include "../kmer.hpp"
+#include "../algorithms/kmer.hpp"
 #include <bdsg/overlay_helper.hpp>
 
 #include <unistd.h>
@@ -655,31 +655,32 @@ int main_find(int argc, char** argv) {
 		    prep_graph(); // don't forget to prep the graph, or the kmer set will be wrong[
                     // enumerate the kmers, calculating including their start positions relative to the reference
                     // and write to stdout?
-                    for_each_kmer(graph, subgraph_k,
-                                  [&](const kmer_t& kmer) {
-                                      // get the reference-relative position
-                                      string start_str, end_str;
-                                      for (auto& p : algorithms::nearest_offsets_in_paths(xindex, kmer.begin, subgraph_k*2)) {
-                                          const uint64_t& start_p = p.second.front().first;
-                                          const bool& start_rev = p.second.front().second;
-                                          if (p.first == path_handle && (!start_rev && start_p >= target.start || start_rev && start_p <= target.end)) {
-                                              start_str = target.seq + ":" + std::to_string(start_p) + (p.second.front().second ? "-" : "+");
-                                          }
-                                      }
-                                      for (auto& p : algorithms::nearest_offsets_in_paths(xindex, kmer.end, subgraph_k*2)) {
-                                          const uint64_t& end_p = p.second.front().first;
-                                          const bool& end_rev = p.second.front().second;
-                                          if (p.first == path_handle && (!end_rev && end_p <= target.end || end_rev && end_p >= target.start)) {
-                                              end_str = target.seq + ":" + std::to_string(end_p) + (p.second.front().second ? "-" : "+");
-                                          }
-                                      }
-                                      if (!start_str.empty() && !end_str.empty()) {
-                                          // write our record
+		    algorithms::for_each_kmer(
+			graph, subgraph_k, 0,
+			[&](const algorithms::kmer_t& kmer) {
+			    // get the reference-relative position
+			    string start_str, end_str;
+			    for (auto& p : algorithms::nearest_offsets_in_paths(xindex, kmer.begin, subgraph_k*2)) {
+				const uint64_t& start_p = p.second.front().first;
+				const bool& start_rev = p.second.front().second;
+				if (p.first == path_handle && (!start_rev && start_p >= target.start || start_rev && start_p <= target.end)) {
+				    start_str = target.seq + ":" + std::to_string(start_p) + (p.second.front().second ? "-" : "+");
+				}
+			    }
+			    for (auto& p : algorithms::nearest_offsets_in_paths(xindex, kmer.end, subgraph_k*2)) {
+				const uint64_t& end_p = p.second.front().first;
+				const bool& end_rev = p.second.front().second;
+				if (p.first == path_handle && (!end_rev && end_p <= target.end || end_rev && end_p >= target.start)) {
+				    end_str = target.seq + ":" + std::to_string(end_p) + (p.second.front().second ? "-" : "+");
+				}
+			    }
+			    if (!start_str.empty() && !end_str.empty()) {
+				// write our record
 #pragma omp critical (cout)
-                                          cout << target.seq << ":" << target.start << "-" << target.end << "\t"
-                                               << kmer.seq << "\t" << start_str << "\t" << end_str << std::endl;
-                                      }
-                                  });
+				cout << target.seq << ":" << target.start << "-" << target.end << "\t"
+				     << kmer.seq << "\t" << start_str << "\t" << end_str << std::endl;
+			    }
+			});
                 }
             }
             if (save_to_prefix.empty() && !subgraph_k) {

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -675,16 +675,29 @@ int main_find(int argc, char** argv) {
 				}
 			    }
 			    if (!start_str.empty() && !end_str.empty()) {
+				stringstream ss;
+				ss << target.seq << ":" << target.start << "-" << target.end << "\t"
+				   << walk.seq << "\t" << start_str << "\t" << end_str << "\t";
+				uint64_t on_path = 0;
+				for (auto& h : walk.path) {
+				    xindex->for_each_step_on_handle(xindex->get_handle(graph.get_id(h), graph.get_is_reverse(h)),
+				        [&](const step_handle_t& step) {
+					    if (xindex->get_path_handle_of_step(step) == path_handle) {
+						++on_path;
+					    }
+					});
+				}
+				if (on_path == walk.path.size()) {
+				    ss << "ref" << "\t";
+				} else {
+				    ss << "non.ref" << "\t";
+				}
+				for (auto& h : walk.path) {
+				    ss << graph.get_id(h) << (graph.get_is_reverse(h)?"-":"+") << ",";
+				}
 				// write our record
 #pragma omp critical (cout)
-				{
-				    cout << target.seq << ":" << target.start << "-" << target.end << "\t"
-					 << walk.seq << "\t" << start_str << "\t" << end_str << "\t";
-				    for (auto& h : walk.path) {
-					cout << graph.get_id(h) << (graph.get_is_reverse(h)?"-":"+") << ",";
-				    }
-				    cout << std::endl;
-				}
+				cout << ss.str() << std::endl;
 			    }
 			});
                 }


### PR DESCRIPTION
This further improves the BED based kmer extraction routine, so that it reports if the kmer is in the reference or not, and also the path through the graph that the kmer takes (which we can use later to remove kmers that aren't in haplotype sets in GBWT).