### PR TITLE
Add error messages for deprecated mod flags

### DIFF
--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -269,7 +269,7 @@ int main_chunk(int argc, char** argv) {
     if ((n_chunks == 0 ? 0 : 1) + (region_strings.empty() ? 0 : 1) + (path_list_file.empty() ? 0 : 1) + (in_bed_file.empty() ? 0 : 1) +
         (node_ranges_file.empty() ? 0 : 1) + (node_range_string.empty() ? 0 : 1) + (gam_split_size == 0 ? 0 : 1)  +
         (path_components ? 1 : 0) > 1) {
-        cerr << "error:[vg chunk] at most one of {-n, -p, -P, -e, -r, -R, -m, -P} required to specify input regions" << endl;
+        cerr << "error:[vg chunk] at most one of {-n, -p, -P, -e, -r, -R, -m} required to specify input regions" << endl;
         return 1;
     }
     // need -a if using -f

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -166,11 +166,14 @@ int main_mod(int argc, char** argv) {
             {"sample-vcf", required_argument, 0, 'v'},
             {"sample-graph", required_argument, 0, 'G'},
             {"max-degree", required_argument, 0, 'M'},
+            {"drop-paths", no_argument, 0, 'D'},
+            {"retain-path", required_argument, 0, 'r'},
+            {"retain-complement", no_argument, 0, 'I'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hk:oi:q:Q:cpl:e:mt:SX:KPsunzNAf:Cg:x:RTU:Bbd:Ow:L:y:Z:Eav:G:M:",
+        c = getopt_long (argc, argv, "hk:oi:q:Q:cpl:e:mt:SX:KPsunzNAf:Cg:x:RTU:Bbd:Ow:L:y:Z:Eav:G:M:Dr:I",
                 long_options, &option_index);
 
 
@@ -182,20 +185,35 @@ int main_mod(int argc, char** argv) {
         {
 
         case 'i':
-            cerr << "[vg mod] warning: vg mod -i is deprecated.  please switch to vg augment" << endl;
+            cerr << "[vg mod] error: vg mod -i is deprecated.  please switch to vg augment" << endl;
             exit(1);
 
         case 'q':
-            cerr << "[vg mod] warning: vg mod -q is deprecated.  please switch to vg augment -l" << endl;
+            cerr << "[vg mod] error: vg mod -q is deprecated.  please switch to vg augment -l" << endl;
             exit(1);
 
         case 'Q':
-            cerr << "[vg mod] warning: vg mod -Q is deprecated.  please switch to vg augment -L" << endl;
+            cerr << "[vg mod] error: vg mod -Q is deprecated.  please switch to vg augment -L" << endl;
             exit(1);
             break;
 
         case 'Z':
-            cerr << "[vg mod] warning: vg mod -Z is deprecated.  please switch to vg augment -Z" << endl;
+            cerr << "[vg mod] error: vg mod -Z is deprecated.  please switch to vg augment -Z" << endl;
+            exit(1);
+            break;
+
+        case 'D':
+            cerr << "[vg mod] error: vg mod -D is deprecated.  please switch to vg paths -d" << endl;
+            exit(1);
+            break;
+
+        case 'r':
+            cerr << "[vg mod] error: vg mod -r is deprecated.  please switch to vg paths -r" << endl;
+            exit(1);
+            break;
+
+        case 'I':
+            cerr << "[vg mod] error: vg mod -I is deprecated.  please switch to vg paths -d" << endl;
             exit(1);
             break;
 


### PR DESCRIPTION
Print more informative errors when trying `mod` options that were moved to `paths` by #2500.