### PR TITLE
Fix construct to catch deletion end breakpoints that were previously missed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,9 +424,9 @@ $(INC_DIR)/gbwtgraph/gbwtgraph.h: $(LIB_DIR)/libgbwtgraph.a
 
 $(LIB_DIR)/libgbwtgraph.a: $(LIB_DIR)/libgbwt.a $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libdivsufsort.a $(LIB_DIR)/libdivsufsort64.a $(LIB_DIR)/libhandlegraph.a $(wildcard $(GBWTGRAPH_DIR)/*.cpp) $(wildcard $(GBWTGRAPH_DIR)/include/gbwtgraph/*.h)
 ifeq ($(shell uname -s),Darwin)
-	+. ./source_me.sh && cp -r $(GBWTGRAPH_DIR)/include/gbwtgraph $(CWD)/$(INC_DIR)/ && cd $(GBWTGRAPH_DIR) && AS_INTEGRATED_ASSEMBLER=1 $(MAKE) $(FILTER) && mv libgbwtgraph.a $(CWD)/$(LIB_DIR)
+	+. ./source_me.sh && cp -r $(GBWTGRAPH_DIR)/include/gbwtgraph $(CWD)/$(INC_DIR)/ && cd $(GBWTGRAPH_DIR) && $(MAKE) clean && AS_INTEGRATED_ASSEMBLER=1 $(MAKE) $(FILTER) && mv libgbwtgraph.a $(CWD)/$(LIB_DIR)
 else
-	+. ./source_me.sh && cp -r $(GBWTGRAPH_DIR)/include/gbwtgraph $(CWD)/$(INC_DIR)/ && cd $(GBWTGRAPH_DIR) && $(MAKE) $(FILTER) && mv libgbwtgraph.a $(CWD)/$(LIB_DIR)
+	+. ./source_me.sh && cp -r $(GBWTGRAPH_DIR)/include/gbwtgraph $(CWD)/$(INC_DIR)/ && cd $(GBWTGRAPH_DIR) && $(MAKE) clean && $(MAKE) $(FILTER) && mv libgbwtgraph.a $(CWD)/$(LIB_DIR)
 endif
 
 $(INC_DIR)/BooPHF.h: $(BBHASH_DIR)/BooPHF.h

--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -13,7 +13,7 @@
 #include <algorithm>
 #include <memory>
 
-#define debug
+//#define debug
 
 namespace vg {
 
@@ -283,8 +283,6 @@ namespace vg {
         // And we need to rember the highest past-the-end base of anything in the
         // clump, to catch all the overlaps.
         size_t clump_end = 0;
-        // And also where the clump started, for debugging
-        size_t clump_start = 0;
 
         // We use this to remember path ranks. It will initialize to 0 for new
         // paths.
@@ -448,11 +446,6 @@ namespace vg {
                 // TODO: make sure long SVs don't fall outside chunk
                 clump_end = max(clump_end, next_variant->zeroBasedPosition() + next_variant->ref.size() - chunk_offset);
 
-                if (clump.size() == 1) {
-                    // We started the clump
-                    clump_start = next_variant->zeroBasedPosition() - chunk_offset;
-                }
-
                 // Try the variant after that
                 next_variant++;
             } else {
@@ -460,8 +453,7 @@ namespace vg {
                 // Handle the clump.
                 
                 #ifdef debug
-                cerr << "Handling clump of " << clump.size() << " variants "
-                    << (clump_start + chunk_offset) << " - " << (clump_end + chunk_offset) << endl;
+                cerr << "Handling clump of " << clump.size() << " variants up to " << (clump_end + chunk_offset) << endl;
                 #endif
 
                 // Parse all the variants into VariantAllele edits


### PR DESCRIPTION
I thought I had a good reason to use the exclusive bound query on the deletion endpoints, but changing it to the inclusive one seems to fix @glennhickey's missing deletion, which was caused by the reference never getting broken where the deletion was supposed to end in order to make the deletion arc.

I've changed the bound query and it seems to solve the problem. It might also result in extra/unnecessary reference breaks; we don't have a good test set to screen for those, but they should be mostly harmless.