### PR TITLE
Don't brew update to fix homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ls /etc/apt/sources.list.d; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir -p deps; touch "deps/gcc$(gcc -dumpversion)"; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"; fi
-  # Travis can't always avtually use Homebrew to install our dependencies
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew bundle --verbose; fi
+  # Travis can't always actually use Homebrew to install our dependencies
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew bundle --verbose; fi
   # Try installing gcc6 twice in case of errors like this:
   # Error: HOMEBREW_LOGS was not exported!
   # Please don't worry, you likely hit a bug auto-updating from an old version.


### PR DESCRIPTION
Travis is [having trouble upgrading Protobuf from 3.10 to 3.11](https://travis-ci.org/vgteam/vg/jobs/633390503) as a result of us running brew update. If we just keep whatever version was installed when Travis ran our Brewfile itself the first time, we shouldn't have this problem.