### PR TITLE
Filter N's in vg augment and fix bug with coverage filter. 

### DIFF
--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -23,7 +23,8 @@ void augment(MutablePathMutableHandleGraph* graph,
              double min_baseq,
              double min_mapq,
              Packer* packer,
-             size_t min_bp_coverage) {
+             size_t min_bp_coverage,
+             double max_frac_n) {
 
     function<void(function<void(Alignment&)>, bool, bool)> iterate_gam =
         [&gam_stream] (function<void(Alignment&)> aln_callback, bool reset_stream, bool parallel) {
@@ -49,7 +50,8 @@ void augment(MutablePathMutableHandleGraph* graph,
                  min_baseq,
                  min_mapq,                 
                  packer,
-                 min_bp_coverage);
+                 min_bp_coverage,
+                 max_frac_n);
 }
 
 void augment(MutablePathMutableHandleGraph* graph,
@@ -63,7 +65,8 @@ void augment(MutablePathMutableHandleGraph* graph,
              double min_baseq,
              double min_mapq,
              Packer* packer,
-             size_t min_bp_coverage) {
+             size_t min_bp_coverage,
+             double max_frac_n) {
     
     function<void(function<void(Alignment&)>, bool, bool)> iterate_gam =
         [&path_vector] (function<void(Alignment&)> aln_callback, bool reset_stream, bool parallel) {
@@ -99,7 +102,8 @@ void augment(MutablePathMutableHandleGraph* graph,
                  min_baseq,
                  min_mapq,
                  packer,
-                 min_bp_coverage);
+                 min_bp_coverage,
+                 max_frac_n);
 }
 
 void augment_impl(MutablePathMutableHandleGraph* graph,
@@ -113,10 +117,11 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
                   double min_baseq,
                   double min_mapq,
                   Packer* packer,
-                  size_t min_bp_coverage) {
+                  size_t min_bp_coverage,
+                  double max_frac_n) {
 
     // toggle between using Packer to store breakpoints or the STL map
-    bool packed_mode = min_bp_coverage > 0 || min_baseq > 0;
+    bool packed_mode = min_bp_coverage > 0 || min_baseq > 0 || max_frac_n < 1.;
     assert(!packed_mode || packer != nullptr);
     
     unordered_map<id_t, set<pos_t>> breakpoints;
@@ -150,11 +155,11 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
 
             // Add in breakpoints from each path
             if (packed_mode) {
-                find_packed_breakpoints(simplified_path, *packer, break_at_ends, aln.quality(), min_baseq);
+                find_packed_breakpoints(simplified_path, *packer, break_at_ends, aln.quality(), min_baseq, max_frac_n);
             } else {
                 // note: we cannot pass non-zero min_baseq here.  it relies on filter_breakpoints_by_coverage
                 // to work correctly, and must be passed in only via find_packed_breakpoints.
-                find_breakpoints(simplified_path, breakpoints, break_at_ends, "", 0);
+                find_breakpoints(simplified_path, breakpoints, break_at_ends, "", 0, 1.);
             }
         }, false, packed_mode);
 
@@ -211,7 +216,8 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
             // criteria
             bool has_edits = true;
             if (min_bp_coverage > 0) {
-                has_edits = simplify_filtered_edits(graph, simplified_path, node_translation, orig_node_sizes);
+                has_edits = simplify_filtered_edits(graph, simplified_path, node_translation, orig_node_sizes,
+                                                    aln.quality(), min_baseq, max_frac_n);
             }
 
             // Now go through each new path again, by reference so we can overwrite.
@@ -315,7 +321,7 @@ double get_avg_baseq(const Edit& edit, const string& base_quals, size_t position
 
 // returns breakpoints on the forward strand of the nodes
 void find_breakpoints(const Path& path, unordered_map<id_t, set<pos_t>>& breakpoints, bool break_ends,
-                      const string& base_quals, double min_baseq) {
+                      const string& base_quals, double min_baseq, double max_frac_n) {
     // We need to work out what offsets we will need to break each node at, if
     // we want to add in all the new material and edges in this path.
 
@@ -367,7 +373,9 @@ void find_breakpoints(const Path& path, unordered_map<id_t, set<pos_t>>& breakpo
 #endif
 
             // Do the base quality check if applicable.  If it fails we just ignore the edit
-            if (min_baseq == 0 || get_avg_baseq(e, base_quals, position_in_read) >= min_baseq) {
+            if ((min_baseq == 0 || get_avg_baseq(e, base_quals, position_in_read) >= min_baseq) &&
+                (max_frac_n == 1. || get_fraction_of_ns(e.sequence()) <= max_frac_n)) {
+
                 
                 if (!edit_is_match(e) || (j == 0 && (i != 0 || break_ends))) {
                     // If this edit is not a perfect match, or if this is the first
@@ -452,11 +460,11 @@ unordered_map<id_t, set<pos_t>> forwardize_breakpoints(const HandleGraph* graph,
 
 // returns breakpoints on the forward strand of the nodes
 void find_packed_breakpoints(const Path& path, Packer& packed_breakpoints, bool break_ends,
-                             const string& base_quals, double min_baseq) {
+                             const string& base_quals, double min_baseq, double max_frac_n) {
     // use existing methods to find the breakpoints, then copy them into a packer
     // todo: streamline?
     unordered_map<id_t, set<pos_t>> breakpoints;
-    find_breakpoints(path, breakpoints, break_ends, base_quals, min_baseq);
+    find_breakpoints(path, breakpoints, break_ends, base_quals, min_baseq, max_frac_n);
     breakpoints = forwardize_breakpoints(packed_breakpoints.get_graph(), breakpoints);
     const HandleGraph* graph = packed_breakpoints.get_graph();
     for (auto& id_set : breakpoints) {
@@ -465,7 +473,7 @@ void find_packed_breakpoints(const Path& path, Packer& packed_breakpoints, bool 
         position.set_node_id(id_set.first);
         for (auto pos : id_set.second) {
             size_t offset = get_offset(pos);
-            if (offset < node_len - 1) {
+            if (offset <= node_len - 1) {
                 position.set_offset(offset);
                 packed_breakpoints.increment_coverage(packed_breakpoints.position_in_basis(position));
             }
@@ -627,27 +635,18 @@ static nid_t find_new_node(HandleGraph* graph, pos_t old_pos, const map<pos_t, i
 
 bool simplify_filtered_edits(HandleGraph* graph, Path& path, const map<pos_t, id_t>& node_translation,
                              const unordered_map<id_t, size_t>& orig_node_sizes,
-                             const string& base_quals, double min_baseq) {
+                             const string& base_quals, double min_baseq, double max_frac_n) {
 
     // check if an edit position is chopped at its next or prev position
-    auto is_chopped = [&](pos_t edit_position, bool look_next) {
-        // are we adding to the offset?
-        bool forward = look_next != is_rev(edit_position);
-        bool chopped = true;
-        if (forward) {
-            // check if its chopped in the original graph
-            chopped = offset(edit_position) == orig_node_sizes.find(id(edit_position))->second - 1;
-            // check if its chopped in the translation
-            if (!chopped) {
+    auto is_chopped = [&](pos_t edit_position, bool forward) {
+        // todo: better coverage support at node ends (problem is pack structure doesn't have that extra bin)
+        bool chopped = offset(edit_position) >= orig_node_sizes.find(id(edit_position))->second - 1 || offset(edit_position) <= 0;
+        if (!chopped) {
+            if (forward) {
                 auto edit_next_position = edit_position;
                 ++get_offset(edit_next_position);
                 chopped = find_new_node(graph, edit_position, node_translation) != find_new_node(graph, edit_next_position, node_translation);
-            }
-        } else {
-            // check if its chopped in the original graph
-            chopped = offset(edit_position) == 0;
-            // check if its chopped in the translation
-            if (!chopped) {
+            } else {
                 auto edit_prev_position = edit_position;
                 --get_offset(edit_prev_position);
                 chopped = find_new_node(graph, edit_position, node_translation) != find_new_node(graph, edit_prev_position, node_translation);
@@ -686,11 +685,20 @@ bool simplify_filtered_edits(HandleGraph* graph, Path& path, const map<pos_t, id
             // skip edits whose breakpoitns weren't added due to the coverage filter
             // or edits whose avg base quality fails the min_baseq filter
             if (!edit_is_match(e)) {
-                if (!is_chopped(edit_first_position, true) || !is_chopped(edit_last_position, false)
-                    || (min_baseq > 0 && get_avg_baseq(e, base_quals, position_in_read) < min_baseq)) {
+                bool chopped;
+                if (e.from_length() == 0) {
+                    // Just need one-side (prev) test when insertion
+                    chopped = is_chopped(edit_first_position, false);
+                } else {
+                    chopped = is_chopped(edit_first_position, false) && is_chopped(edit_last_position, true);
+                }
+                if (!chopped || 
+                    (min_baseq > 0 && get_avg_baseq(e, base_quals, position_in_read) < min_baseq) ||
+                    (max_frac_n < 1. && get_fraction_of_ns(e.sequence()) > max_frac_n)) {
                     e.set_to_length(e.from_length());
                     e.set_sequence("");
                     filtered_an_edit = true;
+                    
                 } else {
                     kept_an_edit = true;
                 }

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -55,6 +55,7 @@ void help_augment(char** argv, ConfigurableParser& parser) {
          << "    -c, --expected-cov N        expected coverage.  used only for memory tuning [default : 128]" << endl
          << "    -q, --min-baseq N           ignore edits whose sequence have average base quality < N" << endl
          << "    -Q, --min-mapq N            ignore alignments with mapping quality < N" << endl
+         << "    -N, --max-n F               maximum fraction of N bases in an edit for it to be included [default : 0.25]" << endl
          << "    -h, --help                  print this help message" << endl
          << "    -p, --progress              show progress" << endl
          << "    -v, --verbose               print information and warnings about vcf generation" << endl
@@ -110,6 +111,9 @@ int main_augment(int argc, char** argv) {
     // Minimum mapping quality of an alignment for it to be used
     double min_mapq = 0;
 
+    // Maximum fraction of Ns
+    double max_frac_n = 0.25;
+
     // Print some progress messages to screen
     bool show_progress = false;
 
@@ -131,6 +135,7 @@ int main_augment(int argc, char** argv) {
         {"expected-cov", required_argument, 0, 'c'},
         {"min-baseq", required_argument, 0, 'q'},
         {"min-mapq", required_argument, 0, 'Q'},
+        {"max-n", required_argument, 0, 'N'},
         {"help", no_argument, 0, 'h'},
         {"progress", required_argument, 0, 'p'},
         {"verbose", no_argument, 0, 'v'},
@@ -140,7 +145,7 @@ int main_augment(int argc, char** argv) {
         {"include-gt", required_argument, 0, 'L'},
         {0, 0, 0, 0}
     };
-    static const char* short_options = "a:Z:A:iCSBhpvt:l:L:sm:c:q:Q:";
+    static const char* short_options = "a:Z:A:iCSBhpvt:l:L:sm:c:q:Q:N:";
     optind = 2; // force optind past command positional arguments
 
     // This is our command-line parser
@@ -185,6 +190,9 @@ int main_augment(int argc, char** argv) {
             break;
         case 'Q':
             min_mapq = parse<double>(optarg);
+            break;
+        case 'N':
+            max_frac_n = parse<double>(optarg);
             break;
         case 'h':
         case '?':
@@ -269,12 +277,14 @@ int main_augment(int argc, char** argv) {
     unique_ptr<Packer> packer;
     bdsg::VectorizableOverlayHelper overlay_helper;
     // the packer's required for any kind of filtering logic -- so we use it when
-    // baseq is present as well.
-    if (min_coverage > 0 || min_baseq ) {
+    // baseq is present as well, or n-fraction
+    if (min_coverage > 0 || min_baseq || max_frac_n < 1.) {
         vectorizable_graph = dynamic_cast<HandleGraph*>(overlay_helper.apply(graph.get()));
         size_t data_width = Packer::estimate_data_width(expected_coverage);
         size_t bin_count = Packer::estimate_bin_count(get_thread_count());
         packer = make_unique<Packer>(vectorizable_graph, 0, bin_count, data_width, true, false, false);
+        // makes sure filters are activated. 
+        min_coverage = max(size_t(min_coverage), size_t(1));
     }
     
     if (label_paths) {
@@ -355,7 +365,8 @@ int main_augment(int argc, char** argv) {
                     min_baseq,
                     min_mapq,
                     packer.get(),
-                    min_coverage);
+                    min_coverage,
+                    max_frac_n);
         } else {
             // much better to stream from a file so we can do two passes without storing in memory
             get_input_file(gam_in_file_name, [&](istream& alignment_stream) {
@@ -370,7 +381,8 @@ int main_augment(int argc, char** argv) {
                             min_baseq,
                             min_mapq,
                             packer.get(),
-                            min_coverage);
+                            min_coverage,
+                            max_frac_n);
                 });
         }
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -75,6 +75,20 @@ bool is_all_n(const string& seq) {
     return true;
 }
 
+double get_fraction_of_ns(const string& seq) {
+    double n_frac = 0.;
+    if (!seq.empty()) {
+        size_t n_count = 0;
+        for (char c : seq) {
+            if (c == 'n' || c == 'N') {
+                ++n_count;
+            }
+        }
+        n_frac = (double)n_count/(double) seq.length();
+    }
+    return n_frac;
+}
+
 int get_thread_count(void) {
     int thread_count = 1;
 #pragma omp parallel

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -31,6 +31,9 @@ void reverse_complement_in_place(string& seq);
 /// Return True if the given string is entirely Ns of either case, and false
 /// otherwise.
 bool is_all_n(const string& seq);
+/// Return the number of Ns as a fraction of the total sequence length
+/// (or 0 if the sequence is empty)
+double get_fraction_of_ns(const string& seq);
 /// Return the number of threads that OMP will produce for a parallel section.
 /// TODO: Assumes that this is the same for every parallel section.
 int get_thread_count(void);

--- a/test/t/17_vg_augment.t
+++ b/test/t/17_vg_augment.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 23
+plan tests 35
 
 vg view -J -v pileup/tiny.json > tiny.vg
 
@@ -124,3 +124,66 @@ is "$?" 0 "augmenting a hash graph produces same results as a vg graph"
 
 rm -f flat.vg flat.gcsa flat.xg flat.pg flat.hg 2snp.vg 2snp.xg 2snp.sim 2snp.gam vg_augment.nodes packed_graph_augment.nodes hash_graph_augment.nodes
 rm -f 2err.sim 2err.gam 4edits.gam 2snp_default.nodes 2snp_m1.nodes 4edits_m11.nodes 2qual.gam qual.fq
+
+vg construct -m 10 -r tiny/tiny.fa >t.vg
+vg index -k 11 -g t.idx.gcsa -x t.idx.xg t.vg
+vg view t.vg | grep ^S | awk '{print $3}' | sort > t.nodes
+( vg view t.vg | grep ^S | awk '{print $3}' ; echo "GGNGG" ) | sort > t.aug.nodes
+
+vg map -s CAAATAAGGCTTGGAAATTTGGNGGTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.aug1.vg
+vg view t.aug1.vg | grep ^S | awk '{print $3}' | sort > t.aug1.nodes
+diff t.aug1.nodes t.aug.nodes
+is "$?" 0 "augmenting between nodes without filters works as expected"
+
+vg map -s CAAATAAGGCTTGGAAATTTGGNGGTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.aug1f.vg
+vg view t.aug1f.vg | grep ^S | awk '{print $3}' | sort > t.aug1f.nodes
+diff t.aug1f.nodes t.aug.nodes
+is "$?" 0 "augmenting between nodes with inactive filters works as expected"
+
+vg map -s CAAATAAGGCTTGGAAATTTGGNGGTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.1 > t.aug1nf.vg
+vg view t.aug1nf.vg | grep ^S | awk '{print $3}' | sort > t.aug1nf.nodes
+diff t.aug1nf.nodes t.nodes
+is "$?" 0 "augmenting between nodes N filter works as expected"
+
+rm -f t.aug1.vg t.aug1.nodes t.aug1f.vg t.aug1f.nodes t.aug1nf.vg t.aug1nf.nodes
+
+vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGACCNCCAAATTTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.augr1.vg
+vg view t.augr1.vg | grep ^S | awk '{print $3}' | sort > t.augr1.nodes
+diff t.augr1.nodes t.aug.nodes
+is "$?" 0 "augmenting between nodes without filters works as expected on reverse strand"
+
+vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGACCNCCAAATTTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.augr1f.vg
+vg view t.augr1f.vg | grep ^S | awk '{print $3}' | sort > t.augr1f.nodes
+diff t.augr1f.nodes t.aug.nodes
+is "$?" 0 "augmenting between nodes with inactive filters works as expected on reverse strand"
+
+vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGACCNCCAAATTTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.1 > t.augr1nf.vg
+vg view t.augr1nf.vg | grep ^S | awk '{print $3}' | sort > t.augr1nf.nodes
+diff t.augr1nf.nodes t.nodes
+is "$?" 0 "augmenting between nodes N filter works as expected on reverse strand"
+
+rm -f t.augr1.vg t.augr1.nodes t.augr1f.vg t.augr1f.nodes t.augr1nf.vg t.augr1nf.nodes
+
+vg map -s CAAATAAGGCTTGGAGGNGGAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.aug1.vg
+is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 1 "augmenting within node without filters works as expected"
+
+vg map -s CAAATAAGGCTTGGAGGNGGAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.aug1.vg
+is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 1 "augmenting within node with inactive filters works as expected"
+
+vg map -s CAAATAAGGCTTGGAGGNGGAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.1  > t.aug1.vg
+is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 0 "augmenting within node with N filter  works as expected"
+
+rm -f t.aug.nodes t.aug1.vg t.aug1.nodes t.aug1f.vg t.aug1f.nodes t.aug1nf.vg t.aug1nf.nodes
+
+vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGAAAATTCCNCCTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.aug1.vg
+is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 1 "augmenting within node without filters works as expected on reverse strand"
+
+vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGAAAATTCCNCCTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.aug1.vg
+is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 1 "augmenting within node with inactive filters works as expected on reverse strand"
+
+vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGAAAATTCCNCCTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.1  > t.aug1.vg
+is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 0 "augmenting within node with N filter  works as expected on reverse strand"
+
+rm -f t.augr1.vg t.augr1.nodes t.augr1f.vg t.augr1f.nodes t.augr1nf.vg t.augr1nf.nodes
+
+rm -f t.vg t.idx.gcsa t.idx.xg t.nodes t.aug.nodes


### PR DESCRIPTION
In #2594 it came up that `N`'s from reads were getting augmented into the graph.  `vg augment` is now changed to ignore edits that are more that 25% `N`'s (a different threshold can be specified with the `-N` option, where `-N 1` will mimic old logic of adding all Ns)

This PR also fixes a serious bug in `vg augment` where filter options  `-m` and/or `-q` could cause softclips, isertions and multibase SNPs to sometimes not be included when they should. 