### PR TITLE
Add a collective MAPQ option to mpmap

### DIFF
--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -79,7 +79,10 @@ public:
         
         // Default copy constructor and assignment operator.
         iterator(const iterator& other) = default;
-        iterator& operator=(const iterator& other) = default;
+        
+        // TODO: This gets implicitly deleted and generates warning because of the const reference
+        // member variable
+        //iterator& operator=(const iterator& other) = default;
         
     private:
         // What is the ordinal value of this element in the permutation?
@@ -560,7 +563,7 @@ public:
  */
 class SnarlMinDistance : public DistanceHeuristic {
 public:
-    SnarlMinDistance() = default;
+    SnarlMinDistance() = delete;
     SnarlMinDistance(MinimumDistanceIndex& distance_index);
     ~SnarlMinDistance() = default;
     
@@ -576,7 +579,7 @@ private:
  */
 class TipAnchoredMaxDistance : public DistanceHeuristic {
 public:
-    TipAnchoredMaxDistance() = default;
+    TipAnchoredMaxDistance() = delete;
     TipAnchoredMaxDistance(MinimumDistanceIndex& distance_index);
     ~TipAnchoredMaxDistance() = default;
     
@@ -591,7 +594,7 @@ private:
  */
 class TargetValueSearch {
 public:
-    TargetValueSearch() = default;
+    TargetValueSearch() = delete;
     TargetValueSearch(const HandleGraph& handle_graph,
                       DistanceHeuristic* upper_bound_heuristic,
                       DistanceHeuristic* lower_bound_heuristic);

--- a/src/indexed_vg.hpp
+++ b/src/indexed_vg.hpp
@@ -54,16 +54,24 @@ public:
     /// not, an index will be generated and saved.
     IndexedVG(string graph_filename);
     
+    // TODO: This gets implicitly deleted and generates warning because of the
+    // StreamIndex member variable
     // We are moveable
-    IndexedVG(IndexedVG&& other) = default;
-    IndexedVG& operator=(IndexedVG&& other) = default;
+    //IndexedVG(IndexedVG&& other) = default;
+    
+    // TODO: This gets implicitly deleted and generates warning because StreamIndex
+    // member variable is not movable
+    //IndexedVG& operator=(IndexedVG&& other) = default;
     
     void print_report() const;
 
 private:
     // We are not copyable because we keep a pool of open files
     IndexedVG(const IndexedVG& other) = delete;
-    IndexedVG& operator=(const IndexedVG& other) = delete;
+    
+    // TODO: This gets implicitly deleted and generates warning because of the
+    // StreamIndex member variable
+    //IndexedVG& operator=(const IndexedVG& other) = delete;
     
 public:
 

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -39,15 +39,13 @@ namespace vg {
     }
     
     void MultipathMapper::multipath_map(const Alignment& alignment,
-                                        vector<MultipathAlignment>& multipath_alns_out,
-                                        size_t max_alt_mappings) {
-        multipath_map_internal(alignment, mapping_quality_method, multipath_alns_out, max_alt_mappings);
+                                        vector<MultipathAlignment>& multipath_alns_out) {
+        multipath_map_internal(alignment, mapping_quality_method, multipath_alns_out);
     }
     
     void MultipathMapper::multipath_map_internal(const Alignment& alignment,
                                                  MappingQualityMethod mapq_method,
-                                                 vector<MultipathAlignment>& multipath_alns_out,
-                                                 size_t max_alt_mappings) {
+                                                 vector<MultipathAlignment>& multipath_alns_out) {
         
 #ifdef debug_multipath_mapper
         cerr << "multipath mapping read " << pb2json(alignment) << endl;
@@ -352,9 +350,9 @@ namespace vg {
         // mapping ambiguity
         vector<MultipathAlignment> multipath_alns_1, multipath_alns_2;
         multipath_map_internal(alignment1, mapping_quality_method == None ? Approx : mapping_quality_method,
-                               multipath_alns_1, 1);
+                               multipath_alns_1);
         multipath_map_internal(alignment2, mapping_quality_method == None ? Approx : mapping_quality_method,
-                               multipath_alns_2, 1);
+                               multipath_alns_2);
         
         bool is_ambiguous = true;
         
@@ -644,7 +642,7 @@ namespace vg {
             Alignment alignment;
             alignment.set_sequence(random_sequence(simulated_read_length));
             vector<MultipathAlignment> multipath_alns;
-            multipath_map(alignment, multipath_alns, 1);
+            multipath_map(alignment, multipath_alns);
             
             if (!multipath_alns.empty()) {
                 lengths[i] = pseudo_length(multipath_alns.front());
@@ -827,8 +825,7 @@ namespace vg {
                                                               vector<clustergraph_t>& cluster_graphs2,
                                                               bool block_rescue_from_1, bool block_rescue_from_2,
                                                               vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
-                                                              vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances,
-                                                              size_t max_alt_mappings) {
+                                                              vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances) {
         
         vector<MultipathAlignment> multipath_alns_1, multipath_alns_2;
         vector<size_t> cluster_idxs_1, cluster_idxs_2;
@@ -1279,8 +1276,7 @@ namespace vg {
     
     void MultipathMapper::multipath_map_paired(const Alignment& alignment1, const Alignment& alignment2,
                                                vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
-                                               vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer,
-                                               size_t max_alt_mappings) {
+                                               vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer) {
                 
 #ifdef debug_multipath_mapper
         cerr << "multipath mapping paired reads " << pb2json(alignment1) << " and " << pb2json(alignment2) << endl;
@@ -1386,7 +1382,7 @@ namespace vg {
             
             attempt_rescue_of_repeat_from_non_repeat(alignment1, alignment2, mems1, mems2, do_repeat_rescue_from_1, do_repeat_rescue_from_2,
                                                      clusters1, clusters2, cluster_graphs1, cluster_graphs2, multipath_aln_pairs_out,
-                                                     cluster_pairs, max_alt_mappings, *distance_measurer);
+                                                     cluster_pairs, *distance_measurer);
             
             if (multipath_aln_pairs_out.empty() && do_repeat_rescue_from_1 && !do_repeat_rescue_from_2) {
                 // we've clustered and extracted read 1, but rescue failed, so do the same for read 2 to prepare for the
@@ -1515,7 +1511,7 @@ namespace vg {
                     vector<pair<pair<size_t, size_t>, int64_t>> rescue_distances;
                     bool rescued = align_to_cluster_graphs_with_rescue(alignment1, alignment2, cluster_graphs1, cluster_graphs2,
                                                                        do_repeat_rescue_from_1, do_repeat_rescue_from_2,
-                                                                       rescue_aln_pairs, rescue_distances, max_alt_mappings);
+                                                                       rescue_aln_pairs, rescue_distances);
                     
                     // if we find consistent pairs by rescue, merge the two lists
                     if (rescued) {
@@ -1611,7 +1607,7 @@ namespace vg {
 #endif
                 
                 bool rescued = align_to_cluster_graphs_with_rescue(alignment1, alignment2, cluster_graphs1, cluster_graphs2, do_repeat_rescue_from_1,
-                                                                   do_repeat_rescue_from_2, multipath_aln_pairs_out, cluster_pairs, max_alt_mappings);
+                                                                   do_repeat_rescue_from_2, multipath_aln_pairs_out, cluster_pairs);
                 
                 if (rescued) {
                     // We found valid pairs from rescue
@@ -1706,7 +1702,7 @@ namespace vg {
     }
     
     void MultipathMapper::reduce_to_single_path(const MultipathAlignment& multipath_aln, vector<Alignment>& alns_out,
-                                                size_t max_alt_mappings) const {
+                                                size_t max_number) const {
     
 #ifdef debug_multipath_mapper
         cerr << "linearizing multipath alignment to assess positional diversity" << endl;
@@ -1714,7 +1710,7 @@ namespace vg {
         // Compute a few optimal alignments using disjoint sets of subpaths.
         // This hopefully gives us a feel for the positional diversity of the MultipathMapping.
         // But we still may have duplicates or overlaps in vg node space.
-        auto alns = optimal_alignments_with_disjoint_subpaths(multipath_aln, max_alt_mappings + 1);
+        auto alns = optimal_alignments_with_disjoint_subpaths(multipath_aln, max_number + 1);
         
         if (alns.empty()) {
             // This happens only if the read is totally unmapped
@@ -1782,7 +1778,7 @@ namespace vg {
         
 #ifdef debug_multipath_mapper
         cerr << "overall found optimal mapping with score " << alns_out[0].score() << " plus " << (alns_out.size() - 1)
-            << " of " << max_alt_mappings << " alternate linearizations";
+            << " of " << max_number << " alternate linearizations";
         if (alns_out.size() >= 2) {
             cerr << " with best score " << alns_out[1].score();
         }
@@ -1837,7 +1833,7 @@ namespace vg {
                                                                    vector<memcluster_t>& clusters1, vector<memcluster_t>& clusters2,
                                                                    vector<clustergraph_t>& cluster_graphs1, vector<clustergraph_t>& cluster_graphs2,
                                                                    vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
-                                                                   vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances, size_t max_alt_mappings,
+                                                                   vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances,
                                                                    OrientedDistanceMeasurer& distance_measurer) {
         
         bool rescue_succeeded_from_1 = false, rescue_succeeded_from_2 = false;
@@ -1858,7 +1854,7 @@ namespace vg {
             vector<pair<MultipathAlignment, MultipathAlignment>> rescued_pairs;
             vector<pair<pair<size_t, size_t>, int64_t>> rescued_distances;
             rescue_succeeded_from_1 = align_to_cluster_graphs_with_rescue(alignment1, alignment2, cluster_graphs1, cluster_graphs2,
-                                                                          false, true, rescued_pairs, pair_distances, max_alt_mappings);
+                                                                          false, true, rescued_pairs, pair_distances);
             
             // move the rescued pairs to the output vectors
             if (rescue_succeeded_from_1) {
@@ -1893,7 +1889,7 @@ namespace vg {
             vector<pair<MultipathAlignment, MultipathAlignment>> rescued_pairs;
             vector<pair<pair<size_t, size_t>, int64_t>> rescued_distances;
             rescue_succeeded_from_2 = align_to_cluster_graphs_with_rescue(alignment1, alignment2, cluster_graphs1, cluster_graphs2,
-                                                                          true, false, rescued_pairs, pair_distances, max_alt_mappings);
+                                                                          true, false, rescued_pairs, pair_distances);
             
             // move the rescued pairs to the output vectors
             if (rescue_succeeded_from_2) {
@@ -3451,6 +3447,21 @@ namespace vg {
             int32_t raw_mapq = compute_raw_mapping_quality_from_scores(scores, mapq_method);
             multipath_alns.front().set_mapping_quality(min<int32_t>(raw_mapq, max_mapping_quality));
         }
+        
+        if (report_group_mapq) {
+            size_t num_reporting = min(multipath_alns.size(), max_alt_mappings);
+            vector<size_t> reporting_idxs(num_reporting, 0);
+            for (size_t i = 1; i < num_reporting; ++i) {
+                reporting_idxs[i] = i;
+            }
+            double raw_mapq = get_aligner()->compute_group_mapping_quality(scores, reporting_idxs);
+            // TODO: for some reason set_annotation will accept a double but not an int
+            double group_mapq = min<double>(max_mapping_quality, mapq_scaling_factor * raw_mapq);
+            
+            for (size_t i = 0; i < num_reporting; ++i) {
+                set_annotation(multipath_alns[i], "group_mapq", group_mapq);
+            }
+        }
     }
     
     // TODO: pretty duplicative with the unpaired version
@@ -3869,6 +3880,22 @@ namespace vg {
                     multipath_aln_pairs.front().first.set_mapping_quality(mapq_1);
                     multipath_aln_pairs.front().second.set_mapping_quality(mapq_2);
                 }
+            }
+        }
+        
+        if (report_group_mapq) {
+            size_t num_reporting = min(multipath_aln_pairs.size(), max_alt_mappings);
+            vector<size_t> reporting_idxs(num_reporting, 0);
+            for (size_t i = 1; i < num_reporting; ++i) {
+                reporting_idxs[i] = i;
+            }
+            double raw_mapq = get_aligner()->compute_group_mapping_quality(scores, reporting_idxs);
+            // TODO: for some reason set_annotation will accept a double but not an int
+            double group_mapq = min<double>(max_mapping_quality, mapq_scaling_factor * raw_mapq);
+            
+            for (size_t i = 0; i < num_reporting; ++i) {
+                set_annotation(multipath_aln_pairs[i].first, "group_mapq", group_mapq);
+                set_annotation(multipath_aln_pairs[i].second, "group_mapq", group_mapq);
             }
         }
     }

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -70,8 +70,7 @@ namespace vg {
         
         /// Map read in alignment to graph and make multipath alignments.
         void multipath_map(const Alignment& alignment,
-                           vector<MultipathAlignment>& multipath_alns_out,
-                           size_t max_alt_mappings);
+                           vector<MultipathAlignment>& multipath_alns_out);
                            
         /// Map a paired read to the graph and make paired multipath alignments. Assumes reads are on the
         /// same strand of the DNA/RNA molecule. If the fragment length distribution is still being estimated
@@ -79,15 +78,14 @@ namespace vg {
         /// does not output any multipath alignments.
         void multipath_map_paired(const Alignment& alignment1, const Alignment& alignment2,
                                   vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
-                                  vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer,
-                                  size_t max_alt_mappings);
+                                  vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer);
                                   
         /// Given a mapped MultipathAlignment, reduce it to up to
-        /// max_alt_mappings + 1 nonoverlapping single path alignments, with
+        /// max_number + 1 nonoverlapping single path alignments, with
         /// mapping qualities accounting for positional uncertainty between
         /// them.
         /// Even if the read is unmapped, there will always be at least one (possibly score 0) output alignment.
-        void reduce_to_single_path(const MultipathAlignment& multipath_aln, vector<Alignment>& alns_out, size_t max_alt_mappings) const;
+        void reduce_to_single_path(const MultipathAlignment& multipath_aln, vector<Alignment>& alns_out, size_t max_number) const;
         
         /// Sets the minimum clustering MEM length to the approximate length that a MEM would have to be to
         /// have at most the given probability of occurring in random sequence of the same size as the graph
@@ -118,12 +116,14 @@ namespace vg {
         size_t band_padding_memo_size = 500;
         double pseudo_length_multiplier = 1.65;
         double max_mapping_p_value = 0.00001;
+        size_t max_alt_mappings = 1;
         size_t max_single_end_mappings_for_rescue = 64;
         size_t max_rescue_attempts = 32;
         size_t plausible_rescue_cluster_coverage_diff = 5;
         size_t secondary_rescue_attempts = 4;
         double secondary_rescue_score_diff = 1.0;
         double mapq_scaling_factor = 1.0 / 4.0;
+        bool report_group_mapq = false;
         // There must be a ScoreProvider provided, and a positive population_max_paths, if this is true
         bool use_population_mapqs = false;
         // If this is nonzero, it takes precedence over any haplotype count
@@ -176,8 +176,7 @@ namespace vg {
         /// mapping quality method option.
         void multipath_map_internal(const Alignment& alignment,
                                     MappingQualityMethod mapq_method,
-                                    vector<MultipathAlignment>& multipath_alns_out,
-                                    size_t max_alt_mappings);
+                                    vector<MultipathAlignment>& multipath_alns_out);
         
         /// Before the fragment length distribution has been estimated, look for an unambiguous mapping of
         /// the reads using the single ended routine. If we find one record the fragment length and report
@@ -224,8 +223,7 @@ namespace vg {
                                                  vector<clustergraph_t>& cluster_graphs2,
                                                  bool block_rescue_from_1, bool block_rescue_from_2,
                                                  vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
-                                                 vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances,
-                                                 size_t max_alt_mappings);
+                                                 vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances);
         
         /// Use the rescue routine on strong suboptimal clusters to see if we can find a good secondary.
         /// Produces topologically sorted MultipathAlignments.
@@ -246,7 +244,6 @@ namespace vg {
                                                       vector<clustergraph_t>& cluster_graphs1, vector<clustergraph_t>& cluster_graphs2,
                                                       vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
                                                       vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances,
-                                                      size_t max_alt_mappings,
                                                       OrientedDistanceMeasurer& distance_measurer);
         
         /// Merge the rescued mappings into the output vector and deduplicate pairs

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -238,7 +238,7 @@ int main_mpmap(int argc, char** argv) {
             {"no-calibrate", no_argument, 0, 'B'},
             {"max-p-val", required_argument, 0, 'P'},
             {"mq-max", required_argument, 0, 'Q'},
-            {"report-group-mapq", required_argument, 0, OPT_REPORT_GROUP_MAPQ},
+            {"report-group-mapq", no_argument, 0, OPT_REPORT_GROUP_MAPQ},
             {"padding-mult", required_argument, 0, 'p'},
             {"map-attempts", required_argument, 0, 'u'},
             {"max-paths", required_argument, 0, 'O'},

--- a/src/unittest/dijkstra.cpp
+++ b/src/unittest/dijkstra.cpp
@@ -112,7 +112,6 @@ TEST_CASE("Dijkstra search works on a particular problem graph", "[dijkstra][alg
     
     algorithms::dijkstra(&graph, start, [&](const handle_t& reached, size_t distance) {
         seen[reached] = distance;
-        cerr << "Saw " << graph.get_id(reached) << " " << graph.get_is_reverse(reached) << " at distance " << distance << endl;
         return true;
     });
     

--- a/src/unittest/mcmc_genotyper.cpp
+++ b/src/unittest/mcmc_genotyper.cpp
@@ -275,7 +275,7 @@ namespace vg {
                     
                 // map read in alignment to graph and make multipath alignments 
                 for(int i = 0; i< reads.size(); i++){
-                    multipath_mapper.multipath_map(alns[i], vect[i], 1);
+                    multipath_mapper.multipath_map(alns[i], vect[i]);
                 }
 
                 // accumulate the mapped reads in one vector
@@ -552,7 +552,7 @@ namespace vg {
                     
                 // map read in alignment to graph and make multipath alignments 
                 for(int i = 0; i< reads.size(); i++){
-                    multipath_mapper.multipath_map(alns[i], vect[i], 1);
+                    multipath_mapper.multipath_map(alns[i], vect[i]);
                 }
                     
                 // accumulate the mapped reads in one vector
@@ -688,7 +688,7 @@ namespace vg {
                     
                     // map read in alignment to graph and make multipath alignments 
                     for(int i = 0; i< reads.size(); i++){
-                        multipath_mapper.multipath_map(alns[i], vect[i], 1);
+                        multipath_mapper.multipath_map(alns[i], vect[i]);
                     }
                     
                     // accumulate the mapped reads in one vector
@@ -823,7 +823,7 @@ namespace vg {
                     
                 // map read in alignment to graph and make multipath alignments 
                 for(int i = 0; i< reads.size(); i++){
-                    multipath_mapper.multipath_map(alns[i], vect[i], 1);
+                    multipath_mapper.multipath_map(alns[i], vect[i]);
                 }
 
 

--- a/src/unittest/multipath_mapper.cpp
+++ b/src/unittest/multipath_mapper.cpp
@@ -338,7 +338,7 @@ TEST_CASE( "MultipathMapper can map to a one-node graph", "[multipath][mapping][
         vector<MultipathAlignment> results;
         
         // Align for just one alignment
-        mapper.multipath_map(aln, results, 1);
+        mapper.multipath_map(aln, results);
         
         SECTION("there should be one alignment") {
             REQUIRE(results.size() == 1);
@@ -388,7 +388,7 @@ TEST_CASE( "MultipathMapper can map to a one-node graph", "[multipath][mapping][
         vector<pair<Alignment, Alignment>> buffer;
         
         // Align for just one pair of alignments
-        mapper.multipath_map_paired(read1, read2, results, buffer, 1);
+        mapper.multipath_map_paired(read1, read2, results, buffer);
         
         SECTION("there should be one pair of alignments") {
             REQUIRE(results.size() == 1);
@@ -555,7 +555,7 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
         vector<pair<Alignment, Alignment>> buffer;
         
         // Align for just one pair of alignments
-        mapper.multipath_map_paired(read1, read2, results, buffer, 1);
+        mapper.multipath_map_paired(read1, read2, results, buffer);
         
         // The second read was ambiguous so we should have buffered this read.
         REQUIRE(results.empty());
@@ -577,7 +577,7 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
         vector<pair<Alignment, Alignment>> buffer;
         
         // Align for just one pair of alignments
-        mapper.multipath_map_paired(read1, read2, results, buffer, 1);
+        mapper.multipath_map_paired(read1, read2, results, buffer);
         
         // The pair was not ambiguous so we should have produced a result.
         REQUIRE(results.size() == 1);
@@ -606,7 +606,7 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
         vector<pair<Alignment, Alignment>> buffer;
         
         // Align for just one pair of alignments
-        mapper.multipath_map_paired(read1, read2, results, buffer, 1);
+        mapper.multipath_map_paired(read1, read2, results, buffer);
         
         // The distribution has been estimated so we should have produced a result.
         REQUIRE(results.size() == 1);


### PR DESCRIPTION
Implements a feature requested by @jonassibbesen where reads can be annotated with the likelihood that at least one of the reported mappings is the correct one. It's activated by `--report-group-mapq` and then the result gets stored as an annotation on the read.

I also removed some code that the compiler was implicitly deleting anyway because the most recent Mac clang release complains about it a lot.