### PR TITLE
Multiple minimizer indexes

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -479,8 +479,10 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
       temp.set_sequence(aln.sequence());
       temp.set_name(aln.name());
       temp.set_quality(aln.quality());
-      // Also store which minimizer index we ended up using.
-      set_annotation(temp, "minimizer_index_used", static_cast<double>(selected_index));
+      // Also store which minimizer index we ended up using if it was not the first.
+      if (selected_index > 0) {
+          set_annotation(temp, "minimizer_index_used", static_cast<double>(selected_index));
+      }
       aln = std::move(temp);
     }
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -480,7 +480,7 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
       temp.set_name(aln.name());
       temp.set_quality(aln.quality());
       // Also store which minimizer index we ended up using if it was not the first.
-      if (selected_index > 0) {
+      if (track_provenance && selected_index > 0) {
           set_annotation(temp, "minimizer_index_used", static_cast<double>(selected_index));
       }
       aln = std::move(temp);

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -458,16 +458,15 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
       temp.set_sequence(aln.sequence());
       temp.set_name(aln.name());
       temp.set_quality(aln.quality());
-
-      // Annotate the original read with metadata
-      if (!sample_name.empty()) {
-          aln.set_sample_name(sample_name);
-      }
-      if (!read_group.empty()) {
-          aln.set_read_group(read_group);
-      }
-
       aln = std::move(temp);
+    }
+
+    // Annotate the read with metadata
+    if (!sample_name.empty()) {
+        aln.set_sample_name(sample_name);
+    }
+    if (!read_group.empty()) {
+        aln.set_read_group(read_group);
     }
     
     // Go through the gapless extension groups in score order.

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -479,6 +479,8 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
       temp.set_sequence(aln.sequence());
       temp.set_name(aln.name());
       temp.set_quality(aln.quality());
+      // Also store which minimizer index we ended up using.
+      set_annotation(temp, "minimizer_index_used", static_cast<double>(selected_index));
       aln = std::move(temp);
     }
 

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -30,7 +30,8 @@ public:
      * as we only use it for correctness tracking.
      */
 
-    MinimizerMapper(const gbwtgraph::GBWTGraph& graph, const gbwtgraph::DefaultMinimizerIndex& minimizer_index,
+    MinimizerMapper(const gbwtgraph::GBWTGraph& graph,
+         const std::vector<std::unique_ptr<gbwtgraph::DefaultMinimizerIndex>>& minimizer_indexes,
          MinimumDistanceIndex& distance_index, const PathPositionHandleGraph* path_graph = nullptr);
 
     /**
@@ -95,7 +96,7 @@ public:
 protected:
     // These are our indexes
     const PathPositionHandleGraph* path_graph; // Can be nullptr; only needed for correctness tracking.
-    const gbwtgraph::DefaultMinimizerIndex& minimizer_index;
+    const std::vector<std::unique_ptr<gbwtgraph::DefaultMinimizerIndex>>& minimizer_indexes;
     MinimumDistanceIndex& distance_index;
 
     /// This is our primary graph.

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -291,6 +291,7 @@ void help_gaffe(char** argv) {
     << "  -g, --graph-name FILE         use this GBWTGraph (required if -x not specified)" << endl
     << "  -H, --gbwt-name FILE          use this GBWT index (required)" << endl
     << "  -m, --minimizer-name FILE     use this minimizer index (required)" << endl
+    << "                                (may repeat; subsequent indexes are used when the earlier ones find no seeds)"
     << "  -d, --dist-name FILE          cluster using this distance index (required)" << endl
     << "  -p, --progress                show progress" << endl
     << "input options:" << endl
@@ -339,7 +340,7 @@ int main_gaffe(int argc, char** argv) {
     string xg_name;
     string graph_name;
     string gbwt_name;
-    string minimizer_name;
+    vector<string> minimizer_names;
     string distance_name;
     string output_basename;
     string report_name;
@@ -468,8 +469,8 @@ int main_gaffe(int argc, char** argv) {
                 break;
                 
             case 'm':
-                minimizer_name = optarg;
-                if (minimizer_name.empty()) {
+                minimizer_names.emplace_back(optarg);
+                if (minimizer_names.back().empty()) {
                     cerr << "error:[vg gaffe] Must provide minimizer file with -m." << endl;
                     exit(1);
                 }
@@ -669,7 +670,7 @@ int main_gaffe(int argc, char** argv) {
         exit(1);
     }
     
-    if (minimizer_name.empty()) {
+    if (minimizer_names.empty()) {
         cerr << "error:[vg gaffe] Mapping requires a minimizer index (-m)" << endl;
         exit(1);
     }
@@ -696,10 +697,13 @@ int main_gaffe(int argc, char** argv) {
     }
     unique_ptr<gbwt::GBWT> gbwt_index = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_name);
 
-    if (progress) {
-        cerr << "Loading minimizer index " << minimizer_name << endl;
+    vector<unique_ptr<gbwtgraph::DefaultMinimizerIndex>> minimizer_indexes;
+    for (const string& minimizer_name : minimizer_names) {
+        if (progress) {
+            cerr << "Loading minimizer index " << minimizer_name << endl;
+        }
+        minimizer_indexes.emplace_back(vg::io::VPKG::load_one<gbwtgraph::DefaultMinimizerIndex>(minimizer_name));
     }
-    unique_ptr<gbwtgraph::DefaultMinimizerIndex> minimizer_index = vg::io::VPKG::load_one<gbwtgraph::DefaultMinimizerIndex>(minimizer_name);
 
     if (progress) {
         cerr << "Loading distance index " << distance_name << endl;
@@ -728,7 +732,7 @@ int main_gaffe(int argc, char** argv) {
     if (progress) {
         cerr << "Initializing MinimizerMapper" << endl;
     }
-    MinimizerMapper minimizer_mapper(*gbwt_graph, *minimizer_index, distance_index, xg_index);
+    MinimizerMapper minimizer_mapper(*gbwt_graph, minimizer_indexes, distance_index, xg_index);
     
     std::chrono::time_point<std::chrono::system_clock> init = std::chrono::system_clock::now();
     std::chrono::duration<double> init_seconds = init - launch;

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -290,8 +290,8 @@ void help_gaffe(char** argv) {
     << "  -x, --xg-name FILE            use this xg index or graph (required if -g not specified)" << endl
     << "  -g, --graph-name FILE         use this GBWTGraph (required if -x not specified)" << endl
     << "  -H, --gbwt-name FILE          use this GBWT index (required)" << endl
-    << "  -m, --minimizer-name FILE     use this minimizer index (required)" << endl
-    << "                                (may repeat; subsequent indexes are used when the earlier ones find no seeds)"
+    << "  -m, --minimizer-name FILE     use this minimizer index (required; may repeat)" << endl
+    << "                                (subsequent indexes are used when the earlier ones find no seeds)" << endl
     << "  -d, --dist-name FILE          cluster using this distance index (required)" << endl
     << "  -p, --progress                show progress" << endl
     << "input options:" << endl


### PR DESCRIPTION
An option to use multiple minimizer indexes in Giraffe. If we get no seeds from one index, we move to the next one. At the moment, the benefit from using a fallback index (with shorter kmers) is minimal, but we can use this as a starting point for using multiple minimizer lengths in a smart way.