### PR TITLE
Multiple minimizer indexes, part 2

### DIFF
--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -291,7 +291,6 @@ void help_gaffe(char** argv) {
     << "  -g, --graph-name FILE         use this GBWTGraph (required if -x not specified)" << endl
     << "  -H, --gbwt-name FILE          use this GBWT index (required)" << endl
     << "  -m, --minimizer-name FILE     use this minimizer index (required; may repeat)" << endl
-    << "                                (subsequent indexes are used when the earlier ones find no seeds)" << endl
     << "  -d, --dist-name FILE          cluster using this distance index (required)" << endl
     << "  -p, --progress                show progress" << endl
     << "input options:" << endl


### PR DESCRIPTION
Get seeds from all minimizer indexes at the same time. With two indexes, the accuracy increases by 0.03% to 0.04% and the speed decreases by 30% from the single index with the highest accuracy.