### PR TITLE
Giraffe bug fixes

### DIFF
--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -213,7 +213,7 @@ void remove_duplicates(std::vector<GaplessExtension>& result) {
         if (result[i].empty()) {
             continue;
         }
-        if (tail == 0 || result[i].read_interval != result[tail - 1].read_interval || result[i].state != result[tail - 1].state) {
+        if (tail == 0 || result[i] != result[tail - 1]) {
             if (i > tail) {
                 result[tail] = std::move(result[i]);
             }
@@ -423,7 +423,10 @@ std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, con
             if (best_alignment.empty() || best_match.internal_score < best_alignment.internal_score) {
                 second_best_alignment = std::move(best_alignment);
                 best_alignment = std::move(best_match);
-            } else if (second_best_alignment.empty() || best_match.internal_score < second_best_alignment.internal_score) {
+            }
+            // If the best alignment contains mismatches, we may reach it from multiple seeds.
+            // Make sure that we do not report it as the best and the second best alignment.
+            else if ((second_best_alignment.empty() || best_match.internal_score < second_best_alignment.internal_score) && best_match != best_alignment) {
                 second_best_alignment = std::move(best_match);
                 full_length_mismatches = second_best_alignment.internal_score;
             }

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -83,6 +83,16 @@ struct GaplessExtension
     bool operator<(const GaplessExtension& another) const {
         return (this->score < another.score);
     }
+
+    /// Two extensions are equal if the same read interval matches the same search state.
+    bool operator==(const GaplessExtension& another) const {
+        return (this->read_interval == another.read_interval && this->state == another.state);
+    }
+
+    /// Two extensions are not equal if the state or the read is different.
+    bool operator!=(const GaplessExtension& another) const {
+        return !(this->operator==(another));
+    }
 };
 
 //------------------------------------------------------------------------------

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -49,6 +49,8 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
     // Minimizers from each index and scores as 1 + ln(hard_hit_cap) - ln(hits).
     struct Minimizer {
         typename gbwtgraph::DefaultMinimizerIndex::minimizer_type value;
+        size_t hits;
+        const typename gbwtgraph::DefaultMinimizerIndex::code_type* occs;
         size_t origin; // From minimizer_indexes[origin].
         double score;
 
@@ -66,15 +68,15 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         auto current_minimizers = minimizer_indexes[i]->minimizers(aln.sequence());
         for (auto& minimizer : current_minimizers) {
             double score = 0.0;
-            size_t hits = minimizer_indexes[i]->count(minimizer);
-            if (hits > 0) {
-                if (hits <= hard_hit_cap) {
-                    score = base_score - std::log(hits);
+            auto hits = minimizer_indexes[i]->count_and_find(minimizer);
+            if (hits.first > 0) {
+                if (hits.first <= hard_hit_cap) {
+                    score = base_score - std::log(hits.first);
                 } else {
                     score = 1.0;
                 }
             }
-            minimizers.push_back({ minimizer, i, score });
+            minimizers.push_back({ minimizer, hits.first, hits.second, i, score });
             base_target_score += score;
         }
     }
@@ -105,21 +107,21 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
         // Select the minimizer if it is informative enough or if the total score
         // of the selected minimizers is not high enough.
         const Minimizer& minimizer = minimizers[i];
-        size_t hits = minimizer_indexes[minimizer.origin]->count(minimizer.value);
         
 #ifdef debug
         cerr << "Minimizer " << i << " = " << minimizer.value.key.decode(minimizer_indexes[minimizer.origin]->k())
-             << " has " << hits << " hits" << endl;
+             << " has " << minimizer.hits << " hits" << endl;
 #endif
         
-        if (hits == 0) {
+        if (minimizer.hits == 0) {
             // A minimizer with no hits can't go on.
             if (track_provenance) {
                 funnel.fail("any-hits", i);
             }
-        } else if (seeds.size() == 1 || hits <= hit_cap || (hits <= hard_hit_cap && selected_score + minimizer.score <= target_score)) {
+        } else if (seeds.size() == 1 || minimizer.hits <= hit_cap || (minimizer.hits <= hard_hit_cap && selected_score + minimizer.score <= target_score)) {
             // Locate the hits.
-            for (auto& hit : minimizer_indexes[minimizer.origin]->find(minimizer.value)) {
+            for (size_t j = 0; j < minimizer.hits; j++) {
+                pos_t hit = gbwtgraph::DefaultMinimizerIndex::decode(minimizer.occs[j]);
                 // Reverse the hits for a reverse minimizer
                 if (minimizer.value.is_reverse) {
                     size_t node_length = gbwt_graph.get_length(gbwt_graph.get_handle(id(hit)));
@@ -136,9 +138,9 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
                 funnel.pass("any-hits", i);
                 funnel.pass("hard-hit-cap", i);
                 funnel.pass("hit-cap||score-fraction", i, selected_score  / base_target_score);
-                funnel.expand(i, hits);
+                funnel.expand(i, minimizer.hits);
             }
-        } else if (hits <= hard_hit_cap) {
+        } else if (minimizer.hits <= hard_hit_cap) {
             // Passed hard hit cap but failed score fraction/normal hit cap
             rejected_count++;
             if (track_provenance) {
@@ -359,7 +361,7 @@ void MinimizerMapper::map(Alignment& aln, AlignmentEmitter& alignment_emitter) {
 #ifdef debug
                 const Minimizer& minimizer = minimizers[seed_to_source[seed_index]];
                 cerr << "Seed read:" << minimizer.value.offset << " = " << seeds[seed_index]
-                    << " from minimizer " << seed_to_source[seed_index] << "(" << minimizer_indexes[minimizer.origin]->count(minimizer.value) << ")" << endl;
+                    << " from minimizer " << seed_to_source[seed_index] << "(" << minimizer.hits << ")" << endl;
 #endif
             }
             

--- a/src/unittest/gapless_extender.cpp
+++ b/src/unittest/gapless_extender.cpp
@@ -472,6 +472,30 @@ TEST_CASE("Full-length alignments", "[gapless_extender]") {
         };
         full_length_matches(seeds, read, correct_alignments, extender, error_bound);
     }
+
+    // We also test that we avoid finding the same best alignment from multiple seeds.
+    SECTION("secondary alignment has more mismatches") {
+        std::vector<std::pair<pos_t, size_t>> seeds {
+            { make_pos_t(2, false, 0), 1 }, // First seed for the best alignment (1 mismatch).
+            { make_pos_t(4, false, 0), 2 }, // Second seed for the best alignment (1 mismatch).
+            { make_pos_t(4, false, 0), 1 }  // Seed for the secondary alignment (2 mismatches).
+        };
+        std::string read = "GAGGA";
+        size_t error_bound = 2;
+        std::vector<std::vector<std::pair<pos_t, std::string>>> correct_alignments {
+            {
+                { make_pos_t(1, false, 0), "1" },
+                { make_pos_t(2, false, 0), "1" },
+                { make_pos_t(4, false, 0), "2A" }
+            },
+            {
+                { make_pos_t(1, false, 0), "1" },
+                { make_pos_t(4, false, 0), "A2" },
+                { make_pos_t(5, false, 0), "A" }
+            }
+        };
+        full_length_matches(seeds, read, correct_alignments, extender, error_bound);
+    }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Some bug fixes for Giraffe. These seem to reduce the number of incorrect mapq 60 alignments. The two main fixes are:

* If GaplessExtender finds a full-length alignment with a mismatches as the best extension, it now tries to find a different full-length alignment in the same cluster. Earlier it could choose the same alignment as the secondary alignment, if it found it again starting from another node. Because the extensions were identical, GaplessExtender reported only one alignment.
* Find all minimizers in repetitive regions. If there were multiple occurrences of the minimizer in the window and there were further occurrences in subsequent windows, new occurrences were not reported if the window contained at least one reported occurrence. Minimizer indexes should be rebuilt to take full advantage of this fix.

Giraffe now uses `MinimizerIndex::count_and_find()` instead of calling `count()` and `find()` separately. After the call, hit count and a pointer to the hits are stored in minimizer metadata. This may make things a bit faster.