### PR TITLE
Fix an edge case in the spliced surject algorithm

### DIFF
--- a/src/alignment_emitter.cpp
+++ b/src/alignment_emitter.cpp
@@ -49,7 +49,7 @@ unique_ptr<AlignmentEmitter> get_alignment_emitter(const string& filename, const
         // Make an emitter that supports HTSlib formats
         if (splicing_graph) {
             // Use the graph to look for spliced alignments
-            backing = new SplicedHTSAlignmentEmitter(filename, format, *splicing_graph, max_threads);
+            backing = new SplicedHTSAlignmentEmitter(filename, format, path_length, *splicing_graph, max_threads);
         }
         else {
             // Assume alignments are contiguous
@@ -582,20 +582,12 @@ void HTSAlignmentEmitter::emit_mapped_pairs(vector<vector<Alignment>>&& alns1_ba
 }
 
 SplicedHTSAlignmentEmitter::SplicedHTSAlignmentEmitter(const string& filename, const string& format,
+                                                       const map<string, int64_t>& path_length,
                                                        const PathPositionHandleGraph& graph,
                                                        size_t max_threads) :
-    HTSAlignmentEmitter(filename, format, make_path_length_index(graph), max_threads), graph(graph) {
+    HTSAlignmentEmitter(filename, format, path_length, max_threads), graph(graph) {
     
     // nothing else to do
-}
-
-map<string, int64_t> SplicedHTSAlignmentEmitter::make_path_length_index(const PathPositionHandleGraph& graph) {
-    
-    map<string, int64_t> return_val;
-    graph.for_each_path_handle([&](const path_handle_t& path_handle) {
-        return_val[graph.get_path_name(path_handle)] = graph.get_path_length(path_handle);
-    });
-    return return_val;
 }
 
 void SplicedHTSAlignmentEmitter::convert_alignment(const Alignment& aln, vector<pair<int, char>>& cigar,

--- a/src/alignment_emitter.hpp
+++ b/src/alignment_emitter.hpp
@@ -275,6 +275,7 @@ class SplicedHTSAlignmentEmitter : public HTSAlignmentEmitter {
 public:
     
     SplicedHTSAlignmentEmitter(const string& filename, const string& format,
+                               const map<string, int64_t>& path_length,
                                const PathPositionHandleGraph& graph,
                                size_t max_threads);
     
@@ -284,9 +285,6 @@ public:
     size_t min_splice_length = 20;
     
 private:
-
-    /// Helper for constructor, makes path length map for parent class
-    static map<string, int64_t> make_path_length_index(const PathPositionHandleGraph& graph);
     
     /// Override for convert alignment that converts splices implicitly
     void convert_alignment(const Alignment& aln, vector<pair<int, char>>& cigar, bool& pos_rev, int64_t& pos, string& path_name) const;

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -82,16 +82,16 @@ namespace vg {
         /// path graph. Produces a graph with reachability edges.
         MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
                                 const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project,
-                                const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans);
+                                const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans, bool realign_Ns = true);
        
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
         MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
-                                const Alignment& alignment, const unordered_map<id_t, pair<id_t, bool>>& projection_trans);
+                                const Alignment& alignment, const unordered_map<id_t, pair<id_t, bool>>& projection_trans, bool realign_Ns = true);
         
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
         /// using a lambda for a projector
         MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
-                                const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project);
+                                const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project, bool realign_Ns = true);
         
         /// Make a multipath alignment graph using the path of a single-path alignment
         MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager& snarl_manager, size_t max_snarl_cut_size,
@@ -115,7 +115,7 @@ namespace vg {
         
         /// Removes non-softclip indels from path nodes. Does not update edges--should be called
         /// prior to adding computing edges.
-        void trim_hanging_indels(const Alignment& alignment);
+        void trim_hanging_indels(const Alignment& alignment, bool trim_Ns = true);
         
         /// Removes all transitive edges from graph (reduces to minimum equivalent graph).
         /// Note: reorders internal representation of adjacency lists.
@@ -217,7 +217,7 @@ namespace vg {
         /// Fills in removed_start_from_length and/or removed_end_from_length
         /// with the bases in the graph removed from the path on each end
         /// during trimming, if set.
-        static bool trim_and_check_for_empty(const Alignment& alignment, PathNode& path_node,
+        static bool trim_and_check_for_empty(const Alignment& alignment, bool trim_Ns, PathNode& path_node,
             int64_t* removed_start_from_length = nullptr, int64_t* removed_end_from_length = nullptr);
         
         /// Add the path chunks as nodes to the connectivity graph

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -96,7 +96,7 @@ using namespace std;
         for (pair<const path_handle_t, pair<vector<path_chunk_t>, vector<pair<step_handle_t, step_handle_t>>>>& surjection_record : path_overlapping_anchors) {
             if (!preserve_deletions) {
                 path_surjections[surjection_record.first] = realigning_surject(&memoizing_graph, source, surjection_record.first,
-                                                                               surjection_record.second.first, allow_negative_scores);
+                                                                               surjection_record.second.first, allow_negative_scores, false);
             }
             else {
                 path_surjections[surjection_record.first] = spliced_surject(&memoizing_graph, source, surjection_record.first,
@@ -446,7 +446,7 @@ using namespace std;
 #endif
             
             // perform a full length surjection within the section section
-            sections.push_back(realigning_surject(graph, section_source, path_handle, section_path_chunks, true));
+            sections.push_back(realigning_surject(graph, section_source, path_handle, section_path_chunks, true, true));
             read_ranges.push_back(read_range);
             ref_ranges.push_back(ref_range);
             
@@ -661,7 +661,7 @@ using namespace std;
 
     Alignment Surjector::realigning_surject(const PathPositionHandleGraph* path_position_graph, const Alignment& source,
                                             const path_handle_t& path_handle, const vector<path_chunk_t>& path_chunks,
-                                            bool allow_negative_scores) const {
+                                            bool allow_negative_scores, bool preserve_N_alignments) const {
         
 #ifdef debug_anchored_surject
         cerr << "using overlap chunks on path " << graph->get_path_name(path_handle) << ", performing realigning surjection" << endl;
@@ -701,7 +701,7 @@ using namespace std;
 #endif
         
         // compute the connectivity between the path chunks
-        MultipathAlignmentGraph mp_aln_graph(split_path_graph, path_chunks, source, node_trans);
+        MultipathAlignmentGraph mp_aln_graph(split_path_graph, path_chunks, source, node_trans, !preserve_N_alignments);
         
         // we don't overlap this reference path at all or we filtered out all of the path chunks, so just make a sentinel
         if (mp_aln_graph.empty()) {

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -77,7 +77,7 @@ using namespace std;
         Alignment
         realigning_surject(const PathPositionHandleGraph* graph, const Alignment& source,
                            const path_handle_t& path_handle, const vector<path_chunk_t>& path_chunks,
-                           bool allow_negative_scores) const;
+                           bool allow_negative_scores, bool preserve_N_alignments = false) const;
         
         Alignment
         spliced_surject(const PathPositionHandleGraph* path_position_graph, const Alignment& source,


### PR DESCRIPTION
Resolves a bug that @jonassibbesen found, which in rare cases created invalid CIGAR strings. Also fixes a separate issue I discovered, where the spliced algorithm would add SQ records in the header for every path in the graph, rather than just the ones being projected onto.