### PR TITLE
Use flow-based traversal finder in vg call

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,14 +238,14 @@ vg augment x.vg aln.gam -i -S > aug_with_paths.vg
 
 The following examples show how to generate a VCF with vg using read support.  They depend on output from the Mapping and Augmentation examples above.  Small variants and SVs can be called using the same approach.  Currently, it is more accuracte for SVs.  
 
-Call only variants that are present in the graph:
+Call only variants that are present in the graph (use `-g`):
 
 ```sh
 # Compute the read support from the gam (ignoring mapping and base qualitiy < 5)
 vg pack -x x.xg -g aln.gam -Q 5 -o aln.pack
 
-# Generate a VCF from the support
-vg call x.xg -k aln.pack > graph_calls.vcf
+# Generate a VCF from the support.  
+vg call x.xg -k aln.pack -g > graph_calls.vcf
 ```
 
 In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -A`):
@@ -257,7 +257,7 @@ vg index aug.vg -x aug.xg
 # Compute the read support from the augmented gam (with ignoring qualitiy < 5)
 vg pack -x aug.xg -g aug.gam -Q 5 -o aln_aug.pack
 
-# Generate a VCF from the support
+# Generate a VCF from the support (do not use -g)
 vg call aug.xg -k aln_aug.pack > calls.vcf
 ```
 
@@ -273,7 +273,7 @@ vg index xa.vg -x xa.xg -L
 # Compute the support (we could also reuse aln.pack from above)
 vg pack -x xa.xg -g aln.gam -o aln.pack
 
-# Genotype the VCF
+# Genotype the VCF (use -v)
 vg call xa.xg -k aln.pack -v small/x.vcf.gz > genotypes.vcf
 ```
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Call only variants that are present in the graph (use `-g`):
 vg pack -x x.xg -g aln.gam -Q 5 -o aln.pack
 
 # Generate a VCF from the support.  
-vg call x.xg -k aln.pack -g > graph_calls.vcf
+vg call x.xg -k aln.pack > graph_calls.vcf
 ```
 
 In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -A`):
@@ -257,7 +257,7 @@ vg index aug.vg -x aug.xg
 # Compute the read support from the augmented gam (with ignoring qualitiy < 5)
 vg pack -x aug.xg -g aug.gam -Q 5 -o aln_aug.pack
 
-# Generate a VCF from the support (do not use -g)
+# Generate a VCF from the support
 vg call aug.xg -k aln_aug.pack > calls.vcf
 ```
 

--- a/src/algorithms/k_widest_paths.cpp
+++ b/src/algorithms/k_widest_paths.cpp
@@ -1,0 +1,241 @@
+/**
+ * \file k_widest_paths.cpp
+ *
+ * Implementation of Yen's Algorithm over the bidirected graph.
+ */
+
+#include "k_widest_paths.hpp"
+
+#include <structures/updateable_priority_queue.hpp>
+
+namespace vg {
+namespace algorithms {
+
+using namespace structures;
+
+//#define debug_vg_algorithms
+
+pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t source, handle_t sink,
+                                               function<double(const handle_t&)> node_weight_callback,
+                                               function<double(const edge_t&)> edge_weight_callback,
+                                               function<bool(const handle_t&)> is_node_ignored_callback,
+                                               function<bool(const edge_t&)> is_edge_ignored_callback) {
+
+    // We keep a priority queue so we can visit the handle with the shortest
+    // distance next. We put handles in here whenever we see them with shorter
+    // distances (since STL priority queue can't update), so we also need to
+    // make sure nodes coming out haven't been visited already.
+    // (score, previous, current)
+    using Record = tuple<double, handle_t, handle_t>;
+    
+    // We filter out handles that have already been visited.  And keep track of predecessors
+    unordered_map<handle_t, pair<handle_t, double>> visited;
+
+    // We need a custom ordering for the queue
+    struct IsFirstGreater {
+        inline bool operator()(const Record& a, const Record& b) {
+            return get<0>(a) < get<0>(b);
+        }
+    };
+    
+    // We use a filtered priority queue for auto-Dijkstra
+    UpdateablePriorityQueue<Record, handle_t, vector<Record>, IsFirstGreater> queue([](const Record& item) {
+            return get<2>(item);
+    });
+    
+    // We keep a current handle
+    handle_t current;
+    handle_t previous;
+    // we don't include the score of the source
+    // todo: should this be an option?
+    double score = numeric_limits<double>::max();
+    queue.push(make_tuple(score, source, source));
+    
+    while (!queue.empty()) {
+        // While there are things in the queue, get the first.
+        tie(score, previous, current) = queue.top();
+        queue.pop();
+
+#ifdef debug_vg_algorithms
+        cerr << "Visit " << g->get_id(current) << " " << g->get_is_reverse(current) << " at width " << score << endl;
+#endif    
+
+        // Remember that we made it here.
+        if (!visited.count(current) || score > visited[current].second) {
+            visited[current] = make_pair(previous, score);
+        }
+                
+        if (current != sink) {
+            g->follow_edges(current, false, [&](const handle_t& next) {
+                    // For each handle to the right of here
+                    if (!visited.count(next) && 
+                        !is_node_ignored_callback(next) &&
+                        !is_edge_ignored_callback(g->edge_handle(current, next))) {
+
+                        double next_score = score;
+
+                        if (next != source && next != sink) {
+                            // we don't include the source / sink
+                            // todo: should we? should it be an option?
+                            next_score = min(next_score, node_weight_callback(next));
+                        }
+                        next_score = min(next_score, edge_weight_callback(g->edge_handle(current, next)));
+
+                        // New shortest distance. Will never happen after the handle comes out of the queue because of Dijkstra.
+                        queue.push(make_tuple(next_score, current, next));
+                        
+#ifdef debug_vg_algorithms
+                        cerr << "\tNew best path to " << g->get_id(next) << ":" << g->get_is_reverse(next)
+                             << " at width " << next_score << endl;
+#endif
+                        
+                    } else {
+#ifdef debug_vg_algorithms
+                        cerr << "\tDisregard path to " << g->get_id(next) << ":" << g->get_is_reverse(next)
+                             << " at width " << score << endl;
+#endif
+                    }
+                });
+        }
+    }
+
+    // trace our results back out of the visited table
+    vector<handle_t> widest_path;
+    double width = 0;
+    if (visited.count(sink)) {
+        width = visited[sink].second;
+        for (handle_t tb = sink; widest_path.empty() || widest_path.back() != source; tb = visited[tb].first) {
+            widest_path.push_back(tb);
+        }
+        std::reverse(widest_path.begin(), widest_path.end());
+    }
+
+#ifdef debug_vg_algorithms
+    cerr << "Returning wideset path (w=" << width << "): ";
+    for (auto h : widest_path) {
+        cerr << g->get_id(h) << ":" << g->get_is_reverse(h) << ", ";
+    }
+    cerr << endl;
+#endif
+    
+    return make_pair(width, widest_path);
+}
+
+// https://en.wikipedia.org/wiki/Yen%27s_algorithm
+vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g, handle_t source, handle_t sink,
+                                                           size_t K,
+                                                           function<double(const handle_t&)> node_weight_callback,
+                                                           function<double(const edge_t&)> edge_weight_callback) {
+
+    vector<pair<double, vector<handle_t>>> best_paths;
+    best_paths.reserve(K);
+
+    // get the widest path from dijkstra
+    best_paths.push_back(widest_dijkstra(g, source, sink, node_weight_callback,
+                                         edge_weight_callback, [](handle_t) {return false;},
+                                         [](edge_t) {return false;}));
+    
+    // working path set, mapped to score
+    // todo: make more efficient
+    set<vector<handle_t>> B;
+    // used to pull out the biggest element in B
+    multimap<double, set<vector<handle_t>>::iterator> score_to_B;
+    
+    // start scanning for our k-1 next-widest paths
+    for (size_t k = 1; k < K; ++k) {
+
+        // we look for a "spur node" in the previous path.  the current path will be the previous path
+        // up to that spur node, then a new path to the sink. (i is the index of the spur node in
+        // the previous (k - 1) path
+        vector<handle_t>& prev_path = best_paths[k - 1].second;
+        for (size_t i = 0; i < prev_path.size() - 1; ++i) {
+            
+            handle_t spur_node = prev_path[i];
+            // root path = prev_path[0 : i]
+
+#ifdef debug_vg_algorithms
+            cerr << "k=" << k << ": spur node=" << g->get_id(spur_node) << ":" << g->get_is_reverse(spur_node) << endl;
+#endif
+            unordered_set<edge_t> forgotten_edges;
+            for (const auto& p_v : best_paths) {
+                const vector<handle_t>& p = p_v.second;
+
+                // check if the root path is a prefix of p
+                bool is_common_root = true;
+                for (size_t j = 0; j < i && is_common_root; ++j) {
+                    if (j >= prev_path.size() || p[j] != prev_path[j]) {
+                        is_common_root = false;
+                    }
+                }
+
+                // remove the links that are part of the previous shortest paths which share the same root path
+                if (is_common_root) {
+                    forgotten_edges.insert(g->edge_handle(p[i], p[i+1]));
+                }
+            }
+            
+            // forget the root path too (except spur node)
+            unordered_set<handle_t> forgotten_nodes;
+            for (int j = 0; j < (int)i - 1; ++j) {
+                forgotten_nodes.insert(prev_path[j]);
+            }
+
+            // find our path from the the spur_node to the sink
+            pair<double, vector<handle_t>> spur_path_v = widest_dijkstra(g, spur_node, sink, node_weight_callback, edge_weight_callback,
+                                                                         [&](handle_t h) {return forgotten_nodes.count(h);},
+                                                                         [&](edge_t e) {return forgotten_edges.count(e);});
+
+            if (!spur_path_v.second.empty()) {
+            
+                // make the path by combining the root path and the spur path
+                pair<double, vector<handle_t>> total_path;
+                double total_width = numeric_limits<double>::max();
+                for (size_t j = 0; j < i; ++j) {
+                    total_path.second.push_back(prev_path[j]);
+                    total_width = min(total_width, node_weight_callback(prev_path[j]));
+                    if (j > 0) {
+                        total_width = min(total_width, edge_weight_callback(g->edge_handle(prev_path[j-1], prev_path[j])));
+                    }
+                }
+                if (!total_path.second.empty()) {
+                    total_width = min(total_width, edge_weight_callback(g->edge_handle(total_path.second.back(), spur_path_v.second.front())));
+                }
+
+                // insert the path into our sorted set
+                total_path.second.insert(total_path.second.end(), spur_path_v.second.begin(), spur_path_v.second.end());
+                total_path.first = min(total_width, spur_path_v.first);
+                pair<set<vector<handle_t>>::iterator, bool> ins = B.insert(total_path.second);
+                if (ins.second == true) {
+                    score_to_B.insert(make_pair(total_path.first, ins.first));
+                } // todo: is there any reason we'd need to update the score of an existing entry in B?
+            }
+        }
+
+        if (B.empty()) {
+            break;
+        }
+
+        assert(score_to_B.size() == B.size());
+        multimap<double, set<vector<handle_t>>::iterator>::iterator best_B_it = std::prev(score_to_B.end());
+        
+        // the best path gets put into our output list
+        best_paths.push_back(make_pair(best_B_it->first, *best_B_it->second));
+        B.erase(best_B_it->second);
+        score_to_B.erase(best_B_it);
+
+#ifdef debug_vg_algorithms
+        cerr << "adding best path (w=" << best_paths.back().first << "): ";
+        for (auto h : best_paths.back().second) {
+            cerr << g->get_id(h) << ":" << g->get_is_reverse(h) << ", ";
+        }
+        cerr << endl;
+#endif
+
+    }
+
+    return best_paths;
+}
+
+
+}
+}

--- a/src/algorithms/k_widest_paths.cpp
+++ b/src/algorithms/k_widest_paths.cpp
@@ -92,7 +92,9 @@ pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t so
                     } else {
 #ifdef debug_vg_algorithms
                         cerr << "\tDisregard path to " << g->get_id(next) << ":" << g->get_is_reverse(next)
-                             << " at width " << score << endl;
+                             << " at width " << score << " due to " << visited.count(next) << " || "
+                             << is_node_ignored_callback(next) << " || " << is_edge_ignored_callback(g->edge_handle(current, next))
+                             <<endl;
 #endif
                     }
                 });
@@ -162,7 +164,7 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
 
                 // check if the root path is a prefix of p
                 bool is_common_root = true;
-                for (size_t j = 0; j < i && is_common_root; ++j) {
+                for (size_t j = 0; j <= i && is_common_root; ++j) {
                     if (j >= prev_path.size() || p[j] != prev_path[j]) {
                         is_common_root = false;
                     }
@@ -170,6 +172,10 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
 
                 // remove the links that are part of the previous shortest paths which share the same root path
                 if (is_common_root) {
+#ifdef debug_vg_algorithms
+                  cerr << "forgetting edge " << g->get_id(p[i]) << ":" << g->get_is_reverse(p[i]) << " -- "
+                       << g->get_id(p[i+1]) << ":" << g->get_is_reverse(p[i+1]) << endl;
+#endif
                     forgotten_edges.insert(g->edge_handle(p[i], p[i+1]));
                 }
             }
@@ -177,6 +183,9 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
             // forget the root path too (except spur node)
             unordered_set<handle_t> forgotten_nodes;
             for (int j = 0; j < (int)i - 1; ++j) {
+#ifdef debug_vg_algorithms
+              cerr << "forgetting node " << g->get_id(prev_path[j]) << ":" << g->get_is_reverse(prev_path[j]) << endl;
+#endif
                 forgotten_nodes.insert(prev_path[j]);
             }
 

--- a/src/algorithms/k_widest_paths.hpp
+++ b/src/algorithms/k_widest_paths.hpp
@@ -1,0 +1,41 @@
+#ifndef VG_ALGORITHMS_K_WIDEST_PATHS_HPP_INCLUDED
+#define VG_ALGORITHMS_K_WIDEST_PATHS_HPP_INCLUDED
+
+/**
+ * \file k_widest_paths.hpp
+ *
+ * Yen's algorithm to find the K widest 
+ */
+
+#include <vector>
+
+#include "../position.hpp"
+#include "../handle.hpp"
+
+namespace vg {
+namespace algorithms {
+
+/// This Dijkstra is the same underlying algorithm as the one in dijkstra.hpp
+/// but the interface is different enough that I opted to make it a seprate
+/// thing rather than add loads of optional arguments.   The key differences
+/// are these generalizations:
+///  -- looks for the "widest" path (maximum minimum weight) instead of shortest
+///  -- counts node and edge weights (via callbakcs)
+///  -- returns the path as well as the score
+///  -- option for ignoring certain nodes and edges in search (required by Yen's algorithm) 
+pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t source, handle_t sink,
+                                               function<double(const handle_t&)> node_weight_callback,
+                                               function<double(const edge_t&)> edge_weight_callback,
+                                               function<bool(const handle_t&)> is_node_ignored_callback,
+                                               function<bool(const edge_t&)> is_edge_ignored_callbback);
+
+/// Find the k widest paths
+vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g, handle_t source, handle_t sink,
+                                                           size_t K,
+                                                           function<double(const handle_t&)> node_weight_callback,
+                                                           function<double(const edge_t&)> edge_weight_callback);
+
+}
+}
+
+#endif

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -958,6 +958,8 @@ bool FlowCaller::call_snarl(const Snarl& snarl) {
         visit->set_backward(graph.get_is_reverse(cur_handle));
         if (cur == get<4>(ref_interval)) {
             break;
+        } else if (get<2>(ref_interval) == true) {
+            cur = graph.get_previous_step(cur);
         } else {
             cur = graph.get_next_step(cur);
         }

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -873,6 +873,7 @@ FlowCaller::FlowCaller(const PathPositionHandleGraph& graph,
     
     for (int i = 0; i < ref_paths.size(); ++i) {
         ref_offsets[ref_paths[i]] = i < ref_path_offsets.size() ? ref_path_offsets[i] : 0;
+        ref_path_set.insert(ref_paths[i]);
     }
 
     // todo: do we ever want to toggle in min-support?
@@ -911,7 +912,7 @@ bool FlowCaller::call_snarl(const Snarl& snarl) {
     set<string> start_path_names;
     graph.for_each_step_on_handle(start_handle, [&](step_handle_t step_handle) {
             string name = graph.get_path_name(graph.get_path_handle_of_step(step_handle));
-            if (!Paths::is_alt(name)) {
+            if (!Paths::is_alt(name) && (ref_path_set.empty() || ref_path_set.count(name))) {
                 start_path_names.insert(name);
             }
             return true;
@@ -921,7 +922,7 @@ bool FlowCaller::call_snarl(const Snarl& snarl) {
     if (!start_path_names.empty()) {
         graph.for_each_step_on_handle(end_handle, [&](step_handle_t step_handle) {
                 string name = graph.get_path_name(graph.get_path_handle_of_step(step_handle));
-                if (!Paths::is_alt(name)) {
+                if (!Paths::is_alt(name) && (ref_path_set.empty() || ref_path_set.count(name))) {                
                     end_path_names.insert(name);
                 }
                 return true;
@@ -957,9 +958,6 @@ bool FlowCaller::call_snarl(const Snarl& snarl) {
         visit->set_backward(graph.get_is_reverse(cur_handle));
         if (cur == get<4>(ref_interval)) {
             break;
-        }
-        else if (get<2>(ref_interval) == true) {
-            cur = graph.get_previous_step(cur);            
         } else {
             cur = graph.get_next_step(cur);
         }

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -260,6 +260,7 @@ protected:
 
     /// keep track of the reference paths
     vector<string> ref_paths;
+    unordered_set<string> ref_path_set;
 
     /// keep track of offsets in the reference paths
     map<string, size_t> ref_offsets;

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -69,10 +69,19 @@ public:
     
 protected:
 
+    /// print a vcf variant 
+    void emit_variant(const PathPositionHandleGraph& graph, SnarlCaller& snarl_caller,
+                      const Snarl& snarl, const vector<SnarlTraversal>& called_traversals,
+                      const vector<int>& genotype, int ref_trav_idx, const unique_ptr<SnarlCaller::CallInfo>& call_info,
+                      const string& ref_path_name, int ref_offset) const;
+
     /// get the interval of a snarl from our reference path using the PathPositionHandleGraph interface
     /// the bool is true if the snarl's backward on the path
     tuple<size_t, size_t, bool, step_handle_t, step_handle_t> get_ref_interval(const PathPositionHandleGraph& graph, const Snarl& snarl,
                                                                                const string& ref_path_name) const;
+
+    /// clean up the alleles to not share common prefixes / suffixes
+    void flatten_common_allele_ends(vcflib::Variant& variant, bool backward) const;
     
     /// output vcf
     mutable vcflib::VariantCallFile output_vcf;
@@ -171,18 +180,11 @@ protected:
                                                                                               const string& ref_path_name,
                                                                                               pair<size_t, size_t> ref_interval) const;
 
-    /// print a vcf variant 
-    void emit_variant(const Snarl& snarl, TraversalFinder& trav_finder, const vector<SnarlTraversal>& called_traversals,
-                      const vector<int>& genotype, const unique_ptr<SnarlCaller::CallInfo>& call_info, const string& ref_path_name) const;
-
     /// check if a site can be handled by the RepresentativeTraversalFinder
     bool is_traversable(const Snarl& snarl);
 
     /// look up a path index for a site and return its name too
     pair<string, PathIndex*> find_index(const Snarl& snarl, const vector<PathIndex*> path_indexes) const;
-
-    /// clean up the alleles to not share common prefixes / suffixes
-    void flatten_common_allele_ends(vcflib::Variant& variant, bool backward) const;
 
 protected:
 
@@ -247,18 +249,6 @@ public:
 
     virtual string vcf_header(const PathHandleGraph& graph, const vector<string>& contigs,
                               const vector<size_t>& contig_length_overrides = {}) const;
-
-protected:
-
-    // TODO:
-    // these methods can and should be merged with legacy caller, maybe by pushing up to VCFOutputCaller
-
-    /// print a vcf variant 
-    void emit_variant(const Snarl& snarl, int ref_trav_idx, const vector<SnarlTraversal>& called_traversals,
-                      const vector<int>& genotype, const unique_ptr<SnarlCaller::CallInfo>& call_info, const string& ref_path_name) const;
-
-    /// clean up the alleles to not share common prefixes / suffixes
-    void flatten_common_allele_ends(vcflib::Variant& variant, bool backward) const;
 
 protected:
 

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -220,6 +220,65 @@ protected:
 };
 
 
+/**
+ * FlowCaller : Uses the FlowTraversal finder to find best-supported
+ * traversals, and calls those.  should work on any graph but will not
+ * report cyclic traversals.  Does not (yet, anyway) support nested
+ * calling, so the entire site is processes in one shot. 
+ * Designed to replace LegacyCaller, as it should miss fewer obviously
+ * good traversals, and is not dependent on old protobuf-based structures. 
+ */
+class FlowCaller : public GraphCaller, public VCFOutputCaller {
+public:
+    FlowCaller(const PathPositionHandleGraph& graph,
+               SupportBasedSnarlCaller& snarl_caller,
+               SnarlManager& snarl_manager,
+               const string& sample_name,
+               size_t max_traverals = 100,
+               const vector<string>& ref_paths = {},
+               const vector<size_t>& ref_path_offsets = {},
+               ostream& out_stream = cout);
+   
+    virtual ~FlowCaller();
+
+    virtual bool call_snarl(const Snarl& snarl);
+
+    virtual string vcf_header(const PathHandleGraph& graph, const vector<string>& contigs,
+                              const vector<size_t>& contig_length_overrides = {}) const;
+
+protected:
+
+    // TODO:
+    // these methods can and should be merged with legacy caller, maybe by pushing up to VCFOutputCaller
+
+    /// print a vcf variant 
+    void emit_variant(const Snarl& snarl, int ref_trav_idx, const vector<SnarlTraversal>& called_traversals,
+                      const vector<int>& genotype, const unique_ptr<SnarlCaller::CallInfo>& call_info, const string& ref_path_name) const;
+
+    /// get the interval of a snarl from our reference path using the PathPositionHandleGraph interface
+    /// the bool is true if the snarl's backward on the path
+    tuple<size_t, size_t, bool, step_handle_t, step_handle_t> get_ref_interval(const Snarl& snarl, const string& ref_path_name) const;
+
+    /// clean up the alleles to not share common prefixes / suffixes
+    void flatten_common_allele_ends(vcflib::Variant& variant, bool backward) const;
+
+protected:
+
+    /// the graph
+    const PathPositionHandleGraph& graph;
+
+    /// the traversal finder
+    FlowTraversalFinder* traversal_finder;
+
+    /// keep track of the reference paths
+    vector<string> ref_paths;
+
+    /// keep track of offsets in the reference paths
+    map<string, size_t> ref_offsets;
+
+};
+
+
 
 }
 

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -68,6 +68,12 @@ public:
     void write_variants(ostream& out_stream) const;
     
 protected:
+
+    /// get the interval of a snarl from our reference path using the PathPositionHandleGraph interface
+    /// the bool is true if the snarl's backward on the path
+    tuple<size_t, size_t, bool, step_handle_t, step_handle_t> get_ref_interval(const PathPositionHandleGraph& graph, const Snarl& snarl,
+                                                                               const string& ref_path_name) const;
+    
     /// output vcf
     mutable vcflib::VariantCallFile output_vcf;
 
@@ -175,10 +181,6 @@ protected:
     /// look up a path index for a site and return its name too
     pair<string, PathIndex*> find_index(const Snarl& snarl, const vector<PathIndex*> path_indexes) const;
 
-    /// get the interval of a snarl from our reference path using the PathPositionHandleGraph interface
-    /// the bool is true if the snarl's backward on the path
-    tuple<size_t, size_t, bool> get_ref_interval(const Snarl& snarl, const string& ref_path_name) const;
-
     /// clean up the alleles to not share common prefixes / suffixes
     void flatten_common_allele_ends(vcflib::Variant& variant, bool backward) const;
 
@@ -254,10 +256,6 @@ protected:
     /// print a vcf variant 
     void emit_variant(const Snarl& snarl, int ref_trav_idx, const vector<SnarlTraversal>& called_traversals,
                       const vector<int>& genotype, const unique_ptr<SnarlCaller::CallInfo>& call_info, const string& ref_path_name) const;
-
-    /// get the interval of a snarl from our reference path using the PathPositionHandleGraph interface
-    /// the bool is true if the snarl's backward on the path
-    tuple<size_t, size_t, bool, step_handle_t, step_handle_t> get_ref_interval(const Snarl& snarl, const string& ref_path_name) const;
 
     /// clean up the alleles to not share common prefixes / suffixes
     void flatten_common_allele_ends(vcflib::Variant& variant, bool backward) const;

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -238,7 +238,7 @@ public:
                SupportBasedSnarlCaller& snarl_caller,
                SnarlManager& snarl_manager,
                const string& sample_name,
-               size_t max_traverals = 100,
+               size_t max_traverals,
                const vector<string>& ref_paths = {},
                const vector<size_t>& ref_path_offsets = {},
                ostream& out_stream = cout);

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -685,7 +685,7 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
                                                 const string& sample_name,
                                                 vcflib::Variant& variant) {
 
-  //assert(traversals.size() == variant.alleles.size());
+    assert(traversals.size() == variant.alleles.size());
 
     // get the traversal sizes
     vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -111,7 +111,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> RatioSupportSnarlCaller::ge
     vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);
 
     // get the supports of each traversal independently
-    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, {}, false, {}, false, ref_trav_idx);
+    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, {}, {}, false, {}, {}, ref_trav_idx);
     int best_allele = get_best_support(supports, {});
 
 #ifdef debug
@@ -126,7 +126,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> RatioSupportSnarlCaller::ge
 
     // we prune out traversals whose exclusive support (structure that is not shared with best traversal)
     // doesn't meet a certain cutoff
-    vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, true, {}, false, ref_trav_idx);    
+    vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, {}, true, {}, {}, ref_trav_idx);    
     vector<int> skips = {best_allele};
     for (int i = 0; i < secondary_exclusive_supports.size(); ++i) {
         double bias = get_bias(traversal_sizes, i, best_allele, ref_trav_idx);
@@ -139,7 +139,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> RatioSupportSnarlCaller::ge
         }
     }
     // get the supports of each traversal in light of best
-    vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, false, {}, false, ref_trav_idx);
+    vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, {}, false, {}, {}, ref_trav_idx);
     int second_best_allele = get_best_support(secondary_supports, {skips});
 
     // get the supports of each traversal in light of second best
@@ -148,7 +148,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> RatioSupportSnarlCaller::ge
     int third_best_allele = -1;
     if (second_best_allele != -1) {
         // prune out traversals whose exclusive support relative to second best doesn't pass cut
-        vector<Support> tertiary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {second_best_allele}, {}, true, {}, false, ref_trav_idx);
+        vector<Support> tertiary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {second_best_allele}, {}, {}, true, {}, {}, ref_trav_idx);
         skips.push_back(best_allele);
         skips.push_back(second_best_allele);
         for (int i = 0; i < tertiary_exclusive_supports.size(); ++i) {
@@ -157,7 +157,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> RatioSupportSnarlCaller::ge
                 skips.push_back(i);
             }
         }
-        tertiary_supports = support_finder.get_traversal_set_support(traversals, {second_best_allele}, {}, false, {}, false, ref_trav_idx);
+        tertiary_supports = support_finder.get_traversal_set_support(traversals, {second_best_allele}, {}, {}, false, {}, {}, ref_trav_idx);
         third_best_allele = get_best_support(tertiary_supports, skips);
     }
 
@@ -483,7 +483,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
     vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);
 
     // get the supports of each traversal independently
-    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, {}, false, {}, false, ref_trav_idx);
+    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, {}, {}, false, {}, {}, ref_trav_idx);
 
     // sort the traversals by support
     vector<int> ranked_traversals = rank_by_support(supports);
@@ -518,7 +518,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
         
             // we prune out traversals whose exclusive support (structure that is not shared with best traversal)
             // doesn't meet a certain cutoff
-            vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, top_traversals, true, {}, false, ref_trav_idx);
+            vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, top_traversals, true, {}, {}, ref_trav_idx);
             for (int j = 0; j < secondary_exclusive_supports.size(); ++j) {
                 if (j != best_allele &&
                     support_val(secondary_exclusive_supports[j]) < min_total_support_for_call &&
@@ -528,7 +528,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
             }
 
             // get the supports of each traversal in light of best
-            vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, top_traversals, false, {}, false, ref_trav_idx);
+            vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, top_traversals, false, {}, {}, ref_trav_idx);
             vector<int> ranked_secondary_traversals = rank_by_support(secondary_supports);
 
             // add the homozygous genotype for our best allele

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -739,7 +739,7 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
     double exp_depth = depth_info.first;
     assert(!isnan(exp_depth));
     // variance/std-err can be nan when binsize < 2.  We just clamp it to 0
-    double depth_err = depth_info.second ? !isnan(depth_info.second) : 0.;
+    double depth_err = !isnan(depth_info.second) ? depth_info.second  : 0.;
 
     double total_likelihood = 0.;
     double ref_likelihood = 1.;

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -685,7 +685,7 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
                                                 const string& sample_name,
                                                 vcflib::Variant& variant) {
 
-    assert(traversals.size() == variant.alleles.size());
+  //assert(traversals.size() == variant.alleles.size());
 
     // get the traversal sizes
     vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -33,6 +33,7 @@ void help_call(char** argv) {
        << "    -b, --het-bias M,N      Homozygous alt/ref allele must have >= M/N times more support than the next best allele [default = 6,6]" << endl
        << "general options:" << endl
        << "    -v, --vcf FILE          VCF file to genotype (must have been used to construct input graph with -a)" << endl
+       << "    -g, --genotype          Use genotyping logic without VCF (use when running on non-augmented graph without -v)" << endl
        << "    -f, --ref-fasta FILE    Reference fasta (required if VCF contains symbolic deletions or inversions)" << endl
        << "    -i, --ins-fasta FILE    Insertions fasta (required if VCF contains symbolic insertions)" << endl
        << "    -s, --sample NAME       Sample name [default=SAMPLE]" << endl
@@ -58,6 +59,7 @@ int main_call(int argc, char** argv) {
     string bias_string;
     bool ratio_caller = false;
     bool legacy = false;
+    bool genotype = false;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -69,6 +71,7 @@ int main_call(int argc, char** argv) {
             {"het-bias", required_argument, 0, 'b'},
             {"min-support", required_argument, 0, 'm'},
             {"vcf", required_argument, 0, 'v'},
+            {"genotype", no_argument, 0, 'g'},
             {"ref-fasta", required_argument, 0, 'f'},
             {"ins-fasta", required_argument, 0, 'i'},
             {"sample", required_argument, 0, 's'},            
@@ -84,7 +87,7 @@ int main_call(int argc, char** argv) {
 
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "k:Bb:m:v:f:i:s:r:p:o:l:Lt:h",
+        c = getopt_long (argc, argv, "k:Bb:m:v:gf:i:s:r:p:o:l:Lt:h",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -107,6 +110,10 @@ int main_call(int argc, char** argv) {
             break;
         case 'v':
             vcf_filename = optarg;
+            genotype = true;
+            break;
+        case 'g':
+            genotype = true;
             break;
         case 'f':
             ref_fasta_filename = optarg;
@@ -273,7 +280,15 @@ int main_call(int argc, char** argv) {
         // Make a packed traversal support finder (using cached veresion important for poisson caller)
         PackedTraversalSupportFinder* packed_support_finder = new CachedPackedTraversalSupportFinder(*packer, *snarl_manager);
         support_finder = unique_ptr<TraversalSupportFinder>(packed_support_finder);
-        
+        if (genotype) {
+            // need to use average support when genotyping as small differences in between sample and graph
+            // will lead to spots with 0-support, espeically in and around SVs. 
+            support_finder->set_support_switch_threshold(50, 50);
+        } else {
+            // if we're not genotyping, then the graph has been augmented with the reads and there's no
+            // excuse for calling something with 0-support
+            support_finder->set_support_switch_threshold(numeric_limits<size_t>::max(), 50);
+        }        
         SupportBasedSnarlCaller* packed_caller = nullptr;
 
         if (ratio_caller == false) {

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3307,7 +3307,7 @@ pair<step_handle_t, bool> VCFTraversalFinder::step_in_path(handle_t handle, path
 }
 
 
-FlowTraversalFinder::FlowTraversalFinder(const PathHandleGraph& graph, SnarlManager& snarl_manager,
+FlowTraversalFinder::FlowTraversalFinder(const HandleGraph& graph, SnarlManager& snarl_manager,
                                          size_t K,
                                          function<double(handle_t)> node_weight_callback,
                                          function<double(edge_t)> edge_weight_callback) :

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -2,6 +2,7 @@
 #include "genotypekit.hpp"
 #include "algorithms/topological_sort.hpp"
 #include "algorithms/is_acyclic.hpp"
+#include "algorithms/k_widest_paths.hpp"
 #include "cactus.hpp"
 
 //#define debug
@@ -3304,6 +3305,55 @@ pair<step_handle_t, bool> VCFTraversalFinder::step_in_path(handle_t handle, path
     }
     return make_pair(step_handle_t(), false);
 }
+
+
+FlowTraversalFinder::FlowTraversalFinder(const PathHandleGraph& graph, SnarlManager& snarl_manager,
+                                         size_t K,
+                                         function<double(handle_t)> node_weight_callback,
+                                         function<double(edge_t)> edge_weight_callback) :
+    graph(graph),
+    snarl_manager(snarl_manager),
+    K(K),
+    node_weight_callback(node_weight_callback),
+    edge_weight_callback(edge_weight_callback)  {
+    
+}
+
+void FlowTraversalFinder::setK(size_t k) {
+    K = k;
+}
+
+vector<SnarlTraversal> FlowTraversalFinder::find_traversals(const Snarl& site) {
+    return find_weighted_traversals(site).first;
+}
+
+pair<vector<SnarlTraversal>, vector<double>> FlowTraversalFinder::find_weighted_traversals(const Snarl& site) {
+
+    handle_t start_handle = graph.get_handle(site.start().node_id(), site.start().backward());
+    handle_t end_handle = graph.get_handle(site.end().node_id(), site.end().backward());
+
+    vector<pair<double, vector<handle_t>>> widest_paths = algorithms::yens_k_widest_paths(&graph, start_handle, end_handle, K,
+                                                                                          node_weight_callback,
+                                                                                          edge_weight_callback);
+
+    vector<SnarlTraversal> travs;
+    travs.reserve(widest_paths.size());
+    vector<double> weights;
+    weights.reserve(widest_paths.size());
+
+    for (const auto& wp : widest_paths) {
+        weights.push_back(wp.first);
+        travs.emplace_back();
+        for (const auto& h : wp.second) {
+            Visit* visit = travs.back().add_visit();
+            visit->set_node_id(graph.get_id(h));
+            visit->set_backward(graph.get_is_reverse(h));
+        }
+    }
+
+    return make_pair(travs, weights);
+}        
+
 
 
 }

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -573,7 +573,7 @@ protected:
 class FlowTraversalFinder : public TraversalFinder {
     
 protected:
-    const PathHandleGraph& graph;
+    const HandleGraph& graph;
     
     SnarlManager& snarl_manager;
 
@@ -587,7 +587,7 @@ protected:
 public:
     
     // if path_names not empty, only those paths will be considered
-    FlowTraversalFinder(const PathHandleGraph& graph, SnarlManager& snarl_manager,
+    FlowTraversalFinder(const HandleGraph& graph, SnarlManager& snarl_manager,
                         size_t K,
                         function<double(handle_t)> node_weight_callback,
                         function<double(edge_t)> edge_weight_callback);

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -558,6 +558,58 @@ protected:
                                 
 };
 
+/** Finds traversals with the most flow.  Node and edge weights are specified 
+ * using the callbacks and can be used, ex, to yield read supports.  
+ * If one traversal is requested, then the path with the highest flow (whose
+ * node or edge with the minimum weight is maximum) is returned.  If K
+ * traversals are specified, then the K highest flow traversals are returned.
+ * This is designed to be a replacement for RepresentativeTraversalFinder.
+ * It should do a better job of enumerating off-reference traversals, and will
+ * of course guarantee to return all the optimal traversals (in the context of max flow).
+ * Unlike RepresentativeTraversalFinder, it does not currently support nested
+ * snarls, so all traversals returned are explicit.  
+ * It is possible that it will blow up on massive snarls, espeically for large Ks. 
+ */ 
+class FlowTraversalFinder : public TraversalFinder {
+    
+protected:
+    const PathHandleGraph& graph;
+    
+    SnarlManager& snarl_manager;
+
+    /// The K-best traversals are returned
+    size_t K;
+
+    /// Callbacks to get supports
+    function<double(handle_t)> node_weight_callback;
+    function<double(edge_t)> edge_weight_callback;
+    
+public:
+    
+    // if path_names not empty, only those paths will be considered
+    FlowTraversalFinder(const PathHandleGraph& graph, SnarlManager& snarl_manager,
+                        size_t K,
+                        function<double(handle_t)> node_weight_callback,
+                        function<double(edge_t)> edge_weight_callback);
+
+    /**
+     * Return the K widest (most flow) traversals through the site
+     * The reference traversal will be returned first (regardless of its flow).
+     * After, the traversals are listed in decreasing order
+     */
+    virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
+
+    /**
+     * Return the K widest traversals, along with their flows
+     */
+    virtual pair<vector<SnarlTraversal>, vector<double>> find_weighted_traversals(const Snarl& site);
+
+    /// Set K
+    void setK(size_t k);
+
+};    
+
+
 }
 
 #endif

--- a/src/traversal_support.cpp
+++ b/src/traversal_support.cpp
@@ -60,7 +60,7 @@ tuple<Support, Support, int> TraversalSupportFinder::get_child_support(const Sna
 
 
 Support TraversalSupportFinder::get_traversal_support(const SnarlTraversal& traversal) const {
-    return get_traversal_set_support({traversal}, {}, {}, false, {}, false).at(0);
+    return get_traversal_set_support({traversal}, {}, {}, {}, false, {}, {}).at(0);
 }
 
 vector<Support> TraversalSupportFinder::get_traversal_genotype_support(const vector<SnarlTraversal>& traversals,
@@ -69,10 +69,20 @@ vector<Support> TraversalSupportFinder::get_traversal_genotype_support(const vec
                                                                        int ref_trav_idx) {
     set<int> tgt_trav_set(genotype.begin(), genotype.end());
     vector<int> tgt_travs(tgt_trav_set.begin(), tgt_trav_set.end());
-    // get the support of just the alleles in the genotype, evenly splitting shared stuff
-    vector<Support> allele_support = get_traversal_set_support(traversals, tgt_travs, tgt_trav_set, false, {}, true, ref_trav_idx);
+    vector<int> other_travs(other_trav_subset.begin(), other_trav_subset.end());
+    
+    // compute independent support of allele in the genotype
+    // todo:  pass this in instead of recomputing.  as there's no reason to compute this more than once
+    vector<Support> ind_allele_support = get_traversal_set_support(traversals, {}, {}, tgt_trav_set, false, {}, {}, ref_trav_idx);
+    
+    // get the support of just the alleles in the genotype, but splitting support of nodes/edges they share
+    // the split is weighted by the total support of the alleles compute above. for node N and genotype A,B:
+    // so support(node N in allele A) = support(node N) * support(allele A) / (support(allele A + allele B))
+    vector<Support> allele_support = get_traversal_set_support(traversals, genotype, ind_allele_support, tgt_trav_set, false, {}, {}, ref_trav_idx);
+    
     // get the support of everythin else, subtracting genotype supports, and splitting mutual supports
-    vector<Support> other_support = get_traversal_set_support(traversals, tgt_travs, other_trav_subset, false, allele_support, true, ref_trav_idx);
+    vector<Support> other_support = get_traversal_set_support(traversals, other_travs, {}, other_trav_subset, false, genotype, allele_support, ref_trav_idx);
+
     // combine the above two vectors
     for (int allele : tgt_travs) {
         other_support[allele] = allele_support[allele];
@@ -82,40 +92,65 @@ vector<Support> TraversalSupportFinder::get_traversal_genotype_support(const vec
 
 vector<Support> TraversalSupportFinder::get_traversal_set_support(const vector<SnarlTraversal>& traversals,
                                                                   const vector<int>& shared_travs,
+                                                                  const vector<Support>& shared_support,
                                                                   const set<int>& tgt_travs,
                                                                   bool exclusive_only,
+                                                                  const vector<int>& exclusive_count_travs,
                                                                   const vector<Support>& exclusive_count_support,
-                                                                  bool mutual_shared,
                                                                   int ref_trav_idx) const {
 
-    // mutual_shared only makes sense when everything is shared
-    assert(!mutual_shared || shared_travs.size() == traversals.size() || shared_travs.size() == tgt_travs.size());
     // exclusive_count_support corresponds to traversals
     assert(exclusive_count_support.empty() || exclusive_count_support.size() == traversals.size());
+    // shared support same as shared size
+    assert(shared_support.empty() || shared_support.size() == traversals.size());
     
     // pass 1: how many times have we seen a node or edge
-    unordered_map<id_t, double> node_counts;
-    unordered_map<edge_t, double> edge_counts;
-    map<Snarl, double> child_counts;
+    // share count (first): number of times a node is touched in {shared_travs} or.  if shared_supports is given
+    //                      then these supports are used for weighting instead of just a count
+    // exclusive count (second): how much exclusive support from {exclusive_count_travs} do we subtract
+    unordered_map<id_t, pair<double, double>> node_counts;
+    unordered_map<edge_t, pair<double, double>> edge_counts;
+    map<Snarl, pair<double, double>> child_counts;
 
-    for (auto trav_idx : shared_travs) {
+    // all the traversals we need for pass 1 {shared_travs U exclusive_count_travs}
+    set<int> share_set(shared_travs.begin(), shared_travs.end());
+    set<int> exclu_set(exclusive_count_travs.begin(), exclusive_count_travs.end());
+    set<int> pre_set;
+    std::set_union(share_set.begin(), share_set.end(), exclu_set.begin(), exclu_set.end(), std::inserter(pre_set, pre_set.begin()));
+    
+    for (auto trav_idx : pre_set) {
         const SnarlTraversal& trav = traversals[trav_idx];
         for (int i = 0; i < trav.visit_size(); ++i) {
             const Visit& visit = trav.visit(i);
-            double value = exclusive_count_support.empty() ? 1. : support_val(exclusive_count_support[trav_idx]);
+            // keep track of exclusive support count for the node so we can subtract it
+            double evalue = 0.;
+            if (!exclusive_count_support.empty() && exclu_set.count(trav_idx)) {
+                evalue = support_val(exclusive_count_support[trav_idx]);
+            }
+            // keep track of shared support count for scaling
+            // each visit gets a count of 1 unless shared_support is given, in that case the value is take from
+            // that.  the total value will be used to normalize while counting
+            double svalue = 0.;
+            if (share_set.count(trav_idx)) {
+                svalue = shared_support.empty() ? 1. : support_val(shared_support[trav_idx]);
+            }
             if (visit.node_id() != 0) {
                 // Count the node once
                 if (node_counts.count(visit.node_id())) {
-                    node_counts[visit.node_id()] += value;
+                    pair<double, double>& counts = node_counts[visit.node_id()];
+                    counts.first += svalue;
+                    counts.second += evalue;
                 } else {
-                    node_counts[visit.node_id()] = value;
+                    node_counts[visit.node_id()] = make_pair(svalue, evalue);
                 }
             } else {
                 // Count the child once
                 if (child_counts.count(visit.snarl())) {
-                    child_counts[visit.snarl()] += value;
+                    pair<double, double>& counts = child_counts[visit.snarl()];
+                    counts.first += svalue;
+                    counts.second += evalue;
                 } else {
-                    child_counts[visit.snarl()] = value;
+                    child_counts[visit.snarl()] = make_pair(svalue, evalue);
                 }
             }
             // note: there is no edge between adjacent snarls as they overlap
@@ -124,9 +159,11 @@ vector<Support> TraversalSupportFinder::get_traversal_set_support(const vector<S
                 edge_t edge = to_edge(graph, trav.visit(i - 1), visit);
                 // Count the edge once
                 if (edge_counts.count(edge)) {
-                    edge_counts[edge] += value;
+                    pair<double, double>& counts = edge_counts[edge];
+                    counts.first += svalue;
+                    counts.second += evalue;
                 } else {
-                    edge_counts[edge] = value;
+                    edge_counts[edge] = make_pair(svalue, evalue);
                 }
             }
         }
@@ -156,31 +193,43 @@ vector<Support> TraversalSupportFinder::get_traversal_set_support(const vector<S
     bool count_end_nodes = false; // toggle to include snarl ends
 
     auto update_support = [&] (int trav_idx, const Support& min_support,
-                               const Support& avg_support, int length, double share_count) {
+                               const Support& avg_support, int length, pair<double, double> share_count) {
         // keep track of overall size of longest traversal
         tot_sizes_all[trav_idx] += length;
         max_trav_size = std::max(tot_sizes_all[trav_idx], max_trav_size);
 
         // apply the scaling
-        double denom_add = mutual_shared ? 0 : 1;
-        double scale_factor = (exclusive_only && share_count > 0) ? 0. : 1. / (denom_add + share_count);
+        double scale_factor = 1.;
+        // scale zero when excluding
+        if (exclusive_only && share_count.first > 0) {
+            scale_factor = 0.;
+        } else if (share_count.first > 0.) {
+            if (shared_support.empty()) {
+                // our counts are just increments so we can divide by them;
+                scale_factor = 1. / share_count.first;
+            } else if (share_count.first > 0.) {
+                // our counts are supports, so we need to normalize by the support
+                // scale factor is the support of the traversal over the total support of the node
+                scale_factor = support_val(shared_support[trav_idx]) / share_count.first;
+            }
+        }
         
         // when looking at exclusive support, we don't normalize by skipped lengths
         if (scale_factor != 0 || !exclusive_only || !exclusive_count_support.empty()) {
             has_support[trav_idx] = true;
             Support scaled_support_min;
             Support scaled_support_avg;
-            if (!exclusive_count_support.empty()) {
-                scaled_support_min = min_support * scale_factor;
-                scaled_support_avg = avg_support * scale_factor;
-            } else {
-                if (support_val(min_support) > share_count) {
-                    scaled_support_min.set_forward(support_val(min_support) - share_count);
-                }
-                if (support_val(avg_support) > share_count) {
-                    scaled_support_avg.set_forward(support_val(avg_support) - share_count);
-                }                
+            // apply the subtraction of the exclusive count supports
+            if (support_val(min_support) >= share_count.second) {
+                scaled_support_min.set_forward(support_val(min_support) - share_count.second);
             }
+            if (support_val(avg_support) >= share_count.second) {
+                scaled_support_avg.set_forward(support_val(avg_support) - share_count.second);
+            }
+            // apply scaling from the shared counts
+            scaled_support_min *= scale_factor;
+            scaled_support_avg *= scale_factor;
+
             tot_supports_min[trav_idx] += scaled_support_min;
             tot_supports_avg[trav_idx] += scaled_support_avg * length;
             tot_sizes[trav_idx] += length;
@@ -200,7 +249,7 @@ vector<Support> TraversalSupportFinder::get_traversal_set_support(const vector<S
             Support min_support;
             Support avg_support;
             int64_t length;
-            int share_count = 0;
+            pair<double, double> share_count = make_pair(0., 0.);
 
             if (visit.node_id() != 0) {
                 // get the node support
@@ -220,7 +269,7 @@ vector<Support> TraversalSupportFinder::get_traversal_set_support(const vector<S
             if (count_end_nodes || (visit_idx > 0 && visit_idx < trav.visit_size() - 1)) {
                 update_support(trav_idx, min_support, avg_support, length, share_count);
             }
-            share_count = 0;
+            share_count = make_pair(0., 0.);
             
             if (visit_idx > 0 && (trav.visit(visit_idx - 1).node_id() != 0 || trav.visit(visit_idx).node_id() != 0)) {
                 // get the edge support

--- a/src/traversal_support.cpp
+++ b/src/traversal_support.cpp
@@ -71,8 +71,8 @@ vector<Support> TraversalSupportFinder::get_traversal_genotype_support(const vec
     vector<int> tgt_travs(tgt_trav_set.begin(), tgt_trav_set.end());
     // get the support of just the alleles in the genotype, evenly splitting shared stuff
     vector<Support> allele_support = get_traversal_set_support(traversals, tgt_travs, tgt_trav_set, false, {}, true, ref_trav_idx);
-    // get the support of everythin else, treating stuff in the genotype alleles as 0
-    vector<Support> other_support = get_traversal_set_support(traversals, tgt_travs, other_trav_subset, false, allele_support, false, ref_trav_idx);
+    // get the support of everythin else, subtracting genotype supports, and splitting mutual supports
+    vector<Support> other_support = get_traversal_set_support(traversals, tgt_travs, other_trav_subset, false, allele_support, true, ref_trav_idx);
     // combine the above two vectors
     for (int allele : tgt_travs) {
         other_support[allele] = allele_support[allele];
@@ -303,6 +303,11 @@ unordered_map<id_t, size_t> TraversalSupportFinder::get_ref_offsets(const SnarlT
         }
     }
     return ref_offsets;
+}
+
+void TraversalSupportFinder::set_support_switch_threshold(size_t trav_thresh, size_t node_thresh) {
+    average_traversal_support_switch_threshold = trav_thresh;
+    average_node_support_switch_threshold = node_thresh;
 }
 
 PackedTraversalSupportFinder::PackedTraversalSupportFinder(const Packer& packer, SnarlManager& snarl_manager) :

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -84,6 +84,9 @@ public:
     /// used for up-weighting large deletion edges in complex snarls with average support
     unordered_map<id_t, size_t> get_ref_offsets(const SnarlTraversal& ref_trav) const;
 
+    /// set the threshold
+    virtual void set_support_switch_threshold(size_t trav_thresh, size_t node_thresh);
+
 protected:
 
     size_t average_traversal_support_switch_threshold = 50;

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -64,6 +64,7 @@ public:
     /// exclusive_count_travs: these traversals get subtracted from supports in the target traversals
     /// exclusive_count_support: used with above, to determine amount of support to subtract
     /// ref_trav_idx:    index of reference traversal if known
+    /// max_trav_size:   optional input of max trav size.  useful when longest traversral is outside target set
     virtual vector<Support> get_traversal_set_support(const vector<SnarlTraversal>& traversals,
                                                       const vector<int>& shared_travs,
                                                       const vector<Support>& shared_support,
@@ -71,7 +72,8 @@ public:
                                                       bool exclusive_only,
                                                       const vector<int>& exclusive_count_travs,
                                                       const vector<Support>& exclusive_count_support,
-                                                      int ref_trav_idx = -1) const;
+                                                      int ref_trav_idx = -1,
+                                                      int* max_trav_size = nullptr) const;
     
     /// Get the total length of all nodes in the traversal
     virtual vector<int> get_traversal_sizes(const vector<SnarlTraversal>& traversals) const;

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -23,7 +23,7 @@ using namespace std;
  */ 
 class TraversalSupportFinder {
 public:
-    TraversalSupportFinder(const PathHandleGraph& graph, SnarlManager& snarl_manager);
+    TraversalSupportFinder(const HandleGraph& graph, SnarlManager& snarl_manager);
     virtual ~TraversalSupportFinder();
 
     /// Support of an edge
@@ -96,7 +96,7 @@ protected:
     /// its position supports.
     size_t average_node_support_switch_threshold = 50;
 
-    const PathHandleGraph& graph;
+    const HandleGraph& graph;
 
     SnarlManager& snarl_manager;
 

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -58,19 +58,21 @@ public:
     
     /// traversals:      get support for each traversal in this set
     /// shared_travs:    if a node appears N times in shared_travs, then it will count as 1 / (N+1) support
+    /// shared_support:  optional supports for shared_travs.  used to weight support split by traversal support.
     /// tgt_travs:       if not empty, only compute support for these traversals (remaining slots in output vector left 0)
     /// eclusive_only:   shared_travs are completely ignored
-    /// exclusive_count_support: anything in shared_travs has this much support subtracted from it
-    /// mutual_shared:   shared_travs count as 1/N support (instead of 1/(N+1)).  usefuly for total support
+    /// exclusive_count_travs: these traversals get subtracted from supports in the target traversals
+    /// exclusive_count_support: used with above, to determine amount of support to subtract
     /// ref_trav_idx:    index of reference traversal if known
     virtual vector<Support> get_traversal_set_support(const vector<SnarlTraversal>& traversals,
                                                       const vector<int>& shared_travs,
+                                                      const vector<Support>& shared_support,
                                                       const set<int>& tgt_travs,
                                                       bool exclusive_only,
+                                                      const vector<int>& exclusive_count_travs,
                                                       const vector<Support>& exclusive_count_support,
-                                                      bool mutual_shared,
                                                       int ref_trav_idx = -1) const;
-
+    
     /// Get the total length of all nodes in the traversal
     virtual vector<int> get_traversal_sizes(const vector<SnarlTraversal>& traversals) const;
 

--- a/src/unittest/k_widest_paths.cpp
+++ b/src/unittest/k_widest_paths.cpp
@@ -1,4 +1,4 @@
-/// \file yen.cpp
+/// \file k_widest_paths.cpp
 ///  
 /// Unit tests for the Yen's K Widest Paths algorithm
 ///
@@ -215,6 +215,40 @@ TEST_CASE("K Widest Paths works correctly on small Wikipedia example", "[k_wides
         REQUIRE(path_to_score.at(vector<handle_t>({C, E, F, G, H})) == 2.);
         
     }
+
+    SECTION("Does yens algorithm give the correct paths as verified by hand in reverse order") {
+
+        vector<pair<double, vector<handle_t>>> widest_paths;
+        widest_paths = algorithms::yens_k_widest_paths(&graph, graph.flip(H), graph.flip(C), 100, node_weight_callback, edge_weight_callback);
+
+        // correct number of paths
+        REQUIRE(widest_paths.size() == 8);
+        // paths listed in decreasing order based on score
+        for (int i = 1; i < widest_paths.size(); ++i) {
+            REQUIRE(widest_paths[i].first <= widest_paths[i-1].first);
+        }
+        // check each path as verified by hand
+        map<vector<handle_t>, double> path_to_score;
+        for (auto sp : widest_paths) {
+            vector<handle_t> flipped_path = sp.second;
+            // flip the paths around so we can use the comparison copy-pasted from above.
+            std::reverse(flipped_path.begin(), flipped_path.end());
+            for (int i = 0; i < flipped_path.size(); ++i) {
+                flipped_path[i] = graph.flip(flipped_path[i]);
+            }
+            path_to_score[flipped_path] = sp.first;
+        }
+        REQUIRE(path_to_score.at(vector<handle_t>({C, D, F, H})) == 1.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, D, F, G, H})) == 2.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, D, E, G, H})) == 1.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, D, E, F, H})) == 1.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, D, E, F, G, H})) == 1.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, E, G, H})) == 2.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, E, F, H})) == 1.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, E, F, G, H})) == 2.);
+        
+    }
+
 
 
 

--- a/src/unittest/k_widest_paths.cpp
+++ b/src/unittest/k_widest_paths.cpp
@@ -1,0 +1,226 @@
+/// \file yen.cpp
+///  
+/// Unit tests for the Yen's K Widest Paths algorithm
+///
+
+#include <iostream>
+#include <string>
+#include "../algorithms/k_widest_paths.hpp"
+#include "../handle.hpp"
+#include "../json2pb.h"
+#include "../proto_handle_graph.hpp"
+#include "catch.hpp"
+
+#include <vg/vg.pb.h>
+
+#include <bdsg/hash_graph.hpp>
+
+
+namespace vg {
+namespace unittest {
+using namespace std;
+
+using bdsg::HashGraph;
+
+TEST_CASE("K Widest Paths works correctly on tiny example", "[k_widest_paths][algorithms]") {
+    
+    HashGraph graph;
+    
+    handle_t start = graph.create_handle("GAT");
+    handle_t middle = graph.create_handle("TA");
+    handle_t snp1 = graph.create_handle("C");
+    handle_t snp2 = graph.create_handle("T");
+    handle_t end = graph.create_handle("A");
+    
+    graph.create_edge(start, middle);
+    graph.create_edge(middle, snp1);
+    graph.create_edge(middle, snp2);
+    graph.create_edge(snp1, end);
+    graph.create_edge(snp2, end);
+
+    unordered_map<handle_t, double> node_weights;
+    node_weights[start] = 1.;
+    node_weights[middle] = 0.75;
+    node_weights[snp1] = 1.;
+    node_weights[snp2] = 0.5;
+    node_weights[end] = 2.;
+
+    unordered_map<edge_t, double> edge_weights;
+    edge_weights[graph.edge_handle(start, middle)] = 1.;
+    edge_weights[graph.edge_handle(middle, snp1)] = 1.;
+    edge_weights[graph.edge_handle(middle, snp2)] = 1.;
+    edge_weights[graph.edge_handle(snp1, end)] = 1.;
+    edge_weights[graph.edge_handle(snp2, end)] = 1.;
+        
+    function<double(handle_t)> node_weight_callback = [&](handle_t h) {
+        if (!node_weights.count(h)) {
+            // canonicalize to forward strand so we can use callback in both directions
+            h = graph.flip(h);
+        }
+        return node_weights[h];
+    };
+
+    function<double(edge_t)> edge_weight_callback = [&](edge_t e) {
+        return edge_weights[e];
+    };
+    
+    // Track what we reach and at what distance
+    unordered_map<handle_t, size_t> seen;
+    
+    SECTION("Does widest_dijkstra find the widest path (through snp2)") {
+
+        double width;
+        vector<handle_t> path;
+        tie(width, path) = algorithms::widest_dijkstra(&graph, start, end, node_weight_callback, edge_weight_callback,
+                                                       [&](handle_t) { return false; },
+                                                       [&](edge_t) { return false; });
+
+
+        REQUIRE(width == 0.75);
+        REQUIRE(path == vector<handle_t>({start, middle, snp1, end}));        
+    }
+
+    SECTION("Does widest_dijkstra find the widest path (through snp2) in reverse direction") {
+
+        double width;
+        vector<handle_t> path;
+        tie(width, path) = algorithms::widest_dijkstra(&graph, graph.flip(end), graph.flip(start), node_weight_callback, edge_weight_callback,
+                                                       [&](handle_t) { return false; },
+                                                       [&](edge_t) { return false; });
+
+
+        REQUIRE(width == 0.75);
+        REQUIRE(path == vector<handle_t>({graph.flip(end), graph.flip(snp1), graph.flip(middle), graph.flip(start)}));
+    }
+
+
+    SECTION("Does yens algorithm give same path when K=1") {
+
+        vector<pair<double, vector<handle_t>>> widest_paths;
+        widest_paths = algorithms::yens_k_widest_paths(&graph, start, end, 1, node_weight_callback, edge_weight_callback);
+
+        REQUIRE(widest_paths.size() == 1);
+        REQUIRE(widest_paths[0].first == 0.75);
+        REQUIRE(widest_paths[0].second == vector<handle_t>({start, middle, snp1, end}));
+        
+    }
+
+    SECTION("Does yens algorithm find a second path when K=2") {
+
+        vector<pair<double, vector<handle_t>>> widest_paths;
+        widest_paths = algorithms::yens_k_widest_paths(&graph, start, end, 2, node_weight_callback, edge_weight_callback);
+
+        REQUIRE(widest_paths.size() == 2);
+        REQUIRE(widest_paths[0].first == 0.75);
+        REQUIRE(widest_paths[0].second == vector<handle_t>({start, middle, snp1, end}));
+        REQUIRE(widest_paths[1].first == 0.5);
+        REQUIRE(widest_paths[1].second == vector<handle_t>({start, middle, snp2, end}));
+        
+        
+    }
+
+    SECTION("Does yens algorithm find a second path when K>2") {
+
+        vector<pair<double, vector<handle_t>>> widest_paths;
+        widest_paths = algorithms::yens_k_widest_paths(&graph, start, end, 5, node_weight_callback, edge_weight_callback);
+
+        REQUIRE(widest_paths.size() == 2);
+        REQUIRE(widest_paths[0].first == 0.75);
+        REQUIRE(widest_paths[0].second == vector<handle_t>({start, middle, snp1, end}));
+        REQUIRE(widest_paths[1].first == 0.5);
+        REQUIRE(widest_paths[1].second == vector<handle_t>({start, middle, snp2, end}));
+        
+    }
+
+    SECTION("Does yesn algorithm find the equivalent paths when looking from sink to source?") {
+        vector<pair<double, vector<handle_t>>> widest_paths;
+        widest_paths = algorithms::yens_k_widest_paths(&graph, graph.flip(end), graph.flip(start), 5, node_weight_callback, edge_weight_callback);
+
+        REQUIRE(widest_paths.size() == 2);
+        REQUIRE(widest_paths[0].first == 0.75);
+        REQUIRE(widest_paths[0].second == vector<handle_t>({graph.flip(end), graph.flip(snp1), graph.flip(middle), graph.flip(start)}));
+        REQUIRE(widest_paths[1].first == 0.5);
+        REQUIRE(widest_paths[1].second == vector<handle_t>({graph.flip(end), graph.flip(snp2), graph.flip(middle), graph.flip(start)}));
+        
+    }
+
+}
+
+TEST_CASE("K Widest Paths works correctly on small Wikipedia example", "[k_widest_paths][algorithms]") {
+    
+    HashGraph graph;
+
+    handle_t C = graph.create_handle("C");
+    handle_t D = graph.create_handle("A");
+    handle_t E = graph.create_handle("C");
+    handle_t F = graph.create_handle("A");
+    handle_t G = graph.create_handle("C");
+    handle_t H = graph.create_handle("A");
+    
+    graph.create_edge(C, D);
+    graph.create_edge(C, E);
+    graph.create_edge(D, E);
+    graph.create_edge(D, F);
+    graph.create_edge(E, F);
+    graph.create_edge(E, G);
+    graph.create_edge(F, G);
+    graph.create_edge(F, H);
+    graph.create_edge(G, H);
+
+    unordered_map<edge_t, double> edge_weights;
+    edge_weights[graph.edge_handle(C, D)] = 3.;
+    edge_weights[graph.edge_handle(C, E)] = 2.;
+    edge_weights[graph.edge_handle(D, E)] = 1.;
+    edge_weights[graph.edge_handle(D, F)] = 4.;
+    edge_weights[graph.edge_handle(E, F)] = 2.;
+    edge_weights[graph.edge_handle(E, G)] = 3.;
+    edge_weights[graph.edge_handle(F, G)] = 2.;
+    edge_weights[graph.edge_handle(F, H)] = 1.;
+    edge_weights[graph.edge_handle(G, H)] = 2.;
+
+    function<double(handle_t)> node_weight_callback = [&](handle_t h) {
+        return 10;
+    };
+
+    function<double(edge_t)> edge_weight_callback = [&](edge_t e) {
+        return edge_weights[e];
+    };
+    
+    // Track what we reach and at what distance
+    unordered_map<handle_t, size_t> seen;
+    
+    SECTION("Does yens algorithm give the correct paths as verified by hand") {
+
+        vector<pair<double, vector<handle_t>>> widest_paths;
+        widest_paths = algorithms::yens_k_widest_paths(&graph, C, H, 100, node_weight_callback, edge_weight_callback);
+
+        // correct number of paths
+        REQUIRE(widest_paths.size() == 8);
+        // paths listed in decreasing order based on score
+        for (int i = 1; i < widest_paths.size(); ++i) {
+            REQUIRE(widest_paths[i].first <= widest_paths[i-1].first);
+        }
+        // check each path as verified by hand
+        map<vector<handle_t>, double> path_to_score;
+        for (auto sp : widest_paths) {
+            path_to_score[sp.second] = sp.first;
+        }
+        REQUIRE(path_to_score.at(vector<handle_t>({C, D, F, H})) == 1.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, D, F, G, H})) == 2.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, D, E, G, H})) == 1.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, D, E, F, H})) == 1.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, D, E, F, G, H})) == 1.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, E, G, H})) == 2.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, E, F, H})) == 1.);
+        REQUIRE(path_to_score.at(vector<handle_t>({C, E, F, G, H})) == 2.);
+        
+    }
+
+
+
+}
+
+
+}
+}
+        

--- a/src/unittest/traversal_support.cpp
+++ b/src/unittest/traversal_support.cpp
@@ -1,0 +1,165 @@
+//
+//  snarls.cpp
+//
+//  Unit tests for TraversalSupportFinder
+//
+
+#include <stdio.h>
+#include <iostream>
+#include <sstream>
+#include <set>
+#include "json2pb.h"
+#include <vg/vg.pb.h>
+#include "catch.hpp"
+#include "traversal_support.hpp"
+#include "traversal_finder.hpp"
+#include "../handle.hpp"
+#include "../json2pb.h"
+#include "../proto_handle_graph.hpp"
+#include <vg/io/protobuf_emitter.hpp>
+#include <vg/io/vpkg.hpp>
+
+//#define debug
+
+namespace vg {
+namespace unittest {
+
+
+/**
+ * Get the read support from some maps
+ */ 
+class TestTraversalSupportFinder : public TraversalSupportFinder {
+public:
+    TestTraversalSupportFinder(const HandleGraph& graph, SnarlManager& snarl_manager,
+                               const unordered_map<nid_t, double>& node_supports,
+                               const unordered_map<edge_t, double>& edge_supports) :
+        TraversalSupportFinder(graph, snarl_manager),
+        node_supports(node_supports),
+        edge_supports(edge_supports) {
+    }    
+    ~TestTraversalSupportFinder() = default;
+
+    Support get_edge_support(const edge_t& edge) const {
+        Support s;
+        s.set_forward(edge_supports.at(edge));
+        return s;
+    }
+    Support get_edge_support(id_t from, bool from_reverse, id_t to, bool to_reverse) const {
+        return get_edge_support(graph.edge_handle(graph.get_handle(from, from_reverse),
+                                                  graph.get_handle(to, to_reverse)));
+    }
+    virtual Support get_min_node_support(id_t node) const {
+        Support s;
+        s.set_forward(node_supports.at(node));
+        return s;
+    }
+    virtual Support get_avg_node_support(id_t node) const {
+        return get_min_node_support(node);
+    }
+    
+protected:    
+    const unordered_map<nid_t, double> node_supports;
+    const unordered_map<edge_t, double> edge_supports;
+};
+
+TEST_CASE( "Deletion allele supports found correctly",
+           "[traversal_support]" ) {
+
+        string graph_json = R"(
+{"edge": [{"from": "31041", "to": "31042"}, {"from": "31040", "to": "31041"}, {"from": "31040", "to": "31043"}, {"from": "134035", "to": "148994"}, {"from": "31042", "to": "134035"}, {"from": "31043", "from_start": true, "to": "134035", "to_end": true}, {"from": "31043", "from_start": true, "to": "148994", "to_end": true}], "node": [{"id": "31041", "sequence": "TATTTCCTAATGGGGTAGTGTCAGAGAGAGTA"}, {"id": "31040", "sequence": "GGCCCTGGAATATC"}, {"id": "134035", "sequence": "ATC"}, {"id": "31042", "sequence": "ATAACGCAGTATTTGTGA"}, {"id": "148994", "sequence": "A"}, {"id": "31043", "sequence": "GATCCCCTCTCCTTTACGAACTGGTAGAAGTG"}]}
+    )";
+    
+    Graph g;
+    json2pb(g, graph_json);
+    
+    // Wrap the graph in a HandleGraph
+    ProtoHandleGraph graph(&g);
+
+    unordered_map<nid_t, double> node_supports = {
+        {31040, 17.5},
+        {31041, 17.3438},
+        {31042, 21.2778},
+        {31043, 24.3125},
+        {134035, 23.6667},
+        {148994, 2}
+    };
+
+    unordered_map<edge_t, double> edge_supports = {
+        {graph.edge_handle(graph.get_handle(31040, false), graph.get_handle(31041, false)), 17},
+        {graph.edge_handle(graph.get_handle(31040, false), graph.get_handle(31043, false)), 1},
+        {graph.edge_handle(graph.get_handle(31041, false), graph.get_handle(31042, false)), 18},
+        {graph.edge_handle(graph.get_handle(31042, false), graph.get_handle(134035, false)), 24},
+        {graph.edge_handle(graph.get_handle(134035, false), graph.get_handle(148994, false)), 2},
+        {graph.edge_handle(graph.get_handle(134035, false), graph.get_handle(31043, false)), 23},
+        {graph.edge_handle(graph.get_handle(148994, false), graph.get_handle(31043, false)), 2},
+    };
+
+    Snarl snarl;
+    snarl.mutable_start()->set_node_id(31040);
+    snarl.mutable_start()->set_backward(false);
+    snarl.mutable_end()->set_node_id(31043);
+    snarl.mutable_end()->set_backward(false);
+
+    SnarlManager snarl_manager;
+    TestTraversalSupportFinder support_finder(graph, snarl_manager, node_supports, edge_supports);
+    // work with minimum supports (like call_main does when *not* genotyping)
+    support_finder.set_support_switch_threshold(numeric_limits<size_t>::max(), 50);
+
+    // test out our traversal finder while we're at it
+    SnarlTraversal trav_0;
+    json2pb(trav_0, R"({"visit": [{"node_id": "31040"}, {"node_id": "31041"}, {"node_id": "31042"}, {"node_id": "134035"}, {"node_id": "31043"}]})");
+    SnarlTraversal trav_1;
+    json2pb(trav_1, R"({"visit": [{"node_id": "31040"}, {"node_id": "31041"}, {"node_id": "31042"}, {"node_id": "134035"}, {"node_id": "148994"}, {"node_id": "31043"}]})");
+    SnarlTraversal trav_2;
+    json2pb(trav_2, R"({"visit": [{"node_id": "31040"}, {"node_id": "31043"}]})");
+    
+    function<double(handle_t)> node_weight = [&](handle_t h) {
+        return node_supports.at(graph.get_id(h));
+    };
+    function<double(edge_t)> edge_weight = [&](edge_t e) {
+        return edge_supports.at(e);
+    };
+    FlowTraversalFinder trav_finder(graph, snarl_manager, 100, node_weight, edge_weight);
+    pair<vector<SnarlTraversal>, vector<double>> weighted_travs = trav_finder.find_weighted_traversals(snarl);
+    REQUIRE(weighted_travs.first.size() == 3);
+    REQUIRE(weighted_travs.first[0] == trav_0);
+    REQUIRE(weighted_travs.first[1] == trav_1);
+    REQUIRE(weighted_travs.first[2] == trav_2);
+
+    REQUIRE(weighted_travs.second[0] == 17);
+    REQUIRE(weighted_travs.second[1] == 2);
+    REQUIRE(weighted_travs.second[2] == 1);
+
+    const vector<SnarlTraversal>& travs = weighted_travs.first;
+
+    // get the indidivual supports
+    vector<Support> ind_supports = support_finder.get_traversal_set_support(travs, {}, {}, {}, false, {}, {}, 0);
+
+    REQUIRE(TraversalSupportFinder::support_val(ind_supports[0]) == weighted_travs.second[0]);
+    REQUIRE(TraversalSupportFinder::support_val(ind_supports[1]) == weighted_travs.second[1]);
+    REQUIRE(TraversalSupportFinder::support_val(ind_supports[2]) == weighted_travs.second[2]);
+
+    // get the exclusive support of trav 1.
+    vector<Support> exc_supports1 = support_finder.get_traversal_set_support(travs, {0}, {}, {1}, true, {}, {}, 0);
+
+    REQUIRE(TraversalSupportFinder::support_val(ind_supports[1]) == 2);
+
+    // get the shared support of trav 0 and 1
+    vector<Support> shared_supports = support_finder.get_traversal_set_support(travs, {0,1}, {}, {}, false, {}, {}, 0);
+
+    REQUIRE(TraversalSupportFinder::support_val(shared_supports[0]) == 0.5 * weighted_travs.second[0]);
+    REQUIRE(TraversalSupportFinder::support_val(shared_supports[1]) == weighted_travs.second[1]);
+    REQUIRE(TraversalSupportFinder::support_val(shared_supports[2]) == weighted_travs.second[2]);
+
+    // get the shared support of trav 0 and 1 but weighting by their relative scores
+    vector<Support> rel_shared_supports = support_finder.get_traversal_set_support(travs, {0,1}, ind_supports, {}, false, {}, {}, 0);
+
+    REQUIRE(TraversalSupportFinder::support_val(rel_shared_supports[0]) == (17./19.) * weighted_travs.second[0]);
+    REQUIRE(TraversalSupportFinder::support_val(rel_shared_supports[1]) == (2./19.) * weighted_travs.second[0]);
+    REQUIRE(TraversalSupportFinder::support_val(rel_shared_supports[2]) == weighted_travs.second[2]);
+
+    
+}
+
+}
+}

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -90,6 +90,6 @@ vg augment c.vg m.gam -A m.aug.gam >c.aug.vg
 vg index -x c.aug.xg c.aug.vg
 vg pack -x c.aug.xg -g m.aug.gam -o m.aug.pack
 vg call c.aug.xg -k m.aug.pack >m.vcf
-is $(cat m.vcf | grep -v "^#" | wc -l) 3 "vg call finds true homozygous variants in a cyclic graph"
+is $(cat m.vcf | grep -v "^#" | grep -v "0/0" | wc -l) 3 "vg call finds true homozygous variants in a cyclic graph"
 rm -f c.vg c.xg c.gcsa c.gcsa.lcp m.fa m.vg m.xg m.sim m.gam m.aug.gam c.aug.vg c.aug.xg m.aug.pack m.vcf
 


### PR DESCRIPTION
This updates `vg call` to enumerate traversals through a snarl using Yen's K-Shortest Paths algorithm.   It replaces some quite old (predating the snarl decomposition) code, currently in `RepresentativeTraversalFinder` that heuristically finds traversals using a reference path as a backbone.  This code favours paths that bubble into and out of reference paths, and often misses traversals that, say, connect multiple alts in a row.  It is also inextricably tied to the VG class which we're trying to deprecate.  

The new algorithm is much simpler and just llists the best paths in terms flow (maximum minimum edge/node support).  It shuold find the best alleles in most cases. It still needs a bit of a cleanup and results from whole genome tests before merging.  Also, an informed default for "K" is important as speed could be an issue for bigger snarls.  Yen's algorithm works by running Dijkstra over and over and over again.  

