### PR TITLE
fully ignore single-node components when doing snarls

### DIFF
--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -24,7 +24,7 @@ CactusSnarlFinder::CactusSnarlFinder(const PathHandleGraph& graph, const string&
 
 SnarlManager CactusSnarlFinder::find_snarls_impl(bool known_single_component, bool finish_index) {
     
-    if (graph->get_node_count() == 0) {
+    if (graph->get_node_count() <= 1) {
         // No snarls here!
         return SnarlManager();
     }

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -215,8 +215,8 @@ TEST_CASE("CactusSnarlFinder safely rejects a single node graph", "[genotype]") 
   // Make a CactusSnarlFinder
   SnarlFinder* finder = new CactusSnarlFinder(graph);
     
-  SECTION("CactusSnarlFinder throws instead of crashing") {
-    REQUIRE_THROWS(finder->find_snarls());
+  SECTION("CactusSnarlFinder returns empty snarl manager instead of throwing or crashing") {
+    REQUIRE(finder->find_snarls().num_snarls() == 0);
   }
     
 }


### PR DESCRIPTION
Single-node components could trigger warnings if they were in the graph, or errors if they were the whole graph.  But when I parallelized `vg snarls`, components, including single-node components would end up treated as whole graphs where they weren't before.  And it looks like this may be the root issue of the first crash raised in #2629.  This is a patch to just ignore single-node components altogether.   