### PR TITLE
Kubernetize

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,11 @@ before_script:
   - sudo apt-get -q -y install docker.io python-pip python-virtualenv libcurl4-gnutls-dev python-dev npm nodejs node-gyp nodejs-dev libssl1.0-dev uuid-runtime
   - which junit-merge || sudo npm install -g junit-merge
   - cat /etc/hosts
+  - startdocker || true
   - docker info
+
+after_script:
+  - stopdocker || true
   
 # We have two pipeline stages: build to make a Docker, and test to run tests.
 # TODO: make test stage parallel

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN echo build > /stage.txt
 # Copy vg build tree into place
 COPY . /vg
 
+# If we're trying to build from a non-recursively-cloned repo, go get the
+# submodules.
+RUN [[ -e deps/libhandlegraph ]] || git submodule update --init --recursive
+
 # Install the base packages needed to let vg install packages.
 # Make sure this runs after vg sources are imported so vg will always have an
 # up to date package index to get its dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . /vg
 
 # If we're trying to build from a non-recursively-cloned repo, go get the
 # submodules.
-RUN [[ -e deps/libhandlegraph ]] || git submodule update --init --recursive
+RUN bash -c "[[ -e deps/libhandlegraph ]] || git submodule update --init --recursive"
 
 # Install the base packages needed to let vg install packages.
 # Make sure this runs after vg sources are imported so vg will always have an

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,15 +46,13 @@ FROM build AS test
 
 RUN echo test > /stage.txt
 
-# The test need BWA
-COPY --from=quay.io/ucsc_cgl/bwa:0.7.15--a17c6544342330f6ea7a23a37d23273ab1c52d21 /usr/local/bin/bwa /usr/local/bin/bwa
-
-# The tests need some extra packages.
+# The tests also need some other extra packages.
 # TODO: Which of these can we remove?
 # No clean necessary since we aren't shipping this
 RUN apt-get -qq -y update && \
     apt-get -qq -y upgrade && \
     apt-get -qq -y install \
+    bwa \
     pigz \
     dstat \
     pv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,12 @@ RUN echo base > /stage.txt
 
 WORKDIR /vg
 
-RUN ls -lah /vg || echo "No vg directory exists yet"
-
 FROM base AS build
 
 RUN echo build > /stage.txt
 
-RUN ls -lah /vg || echo "No vg directory exists yet"
-
 # Copy vg build tree into place
 COPY . /vg
-
-RUN ls -lah /vg || echo "No vg directory exists yet"
 
 # Install the base packages needed to let vg install packages.
 # Make sure this runs after vg sources are imported so vg will always have an
@@ -75,15 +69,9 @@ FROM base AS run
 
 RUN echo run > /stage.txt
 
-RUN ls -lah /vg || echo "No vg directory exists yet"
-
 COPY --from=build /vg/bin/vg /vg/bin/
 
-RUN ls -lah /vg || echo "No vg directory exists yet"
-
 COPY --from=build /vg/scripts/* /vg/scripts/
-
-RUN ls -lah /vg || echo "No vg directory exists yet"
 
 # Install packages which toil-vg needs to be available inside the image, for pipes
 # TODO: which of these can be removed?


### PR DESCRIPTION
This PR sets up some of what we need to work on Kubernetes-based Gitlab runners, and also changes our Docker build a bit so we have a hope of building under [Kaniko](https://github.com/GoogleContainerTools/kaniko).

The Kaniko-based build can't work without the fix for https://github.com/GoogleContainerTools/kaniko/issues/1039, but after that it might start working.