### PR TITLE
Improve usability for mpmap

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -643,7 +643,7 @@ namespace vg {
                 double shape = exp(max_exponential_shape_intercept + max_exponential_shape_slope * read_length);
                 p_value = 1.0 - max_exponential_cdf(match_length, rate, shape);
             }
-            if (p_value_memo.size() < max_p_value_memo_size) {
+            if (p_value_memo.size() < max_p_value_memo_size && !suppress_p_value_memoization) {
                 p_value_memo[make_pair(match_length, read_length)] = p_value;
             }
             return p_value;
@@ -652,6 +652,10 @@ namespace vg {
     
     
     void MultipathMapper::calibrate_mismapping_detection(size_t num_simulations, const vector<size_t>& simulated_read_lengths) {
+        
+        // we are calibrating the parameters, so we don't want to memoize any p-values using the default values
+        suppress_p_value_memoization = true;
+        
         // we don't want to do base quality adjusted alignments for this stage since we are just simulating random sequences
         // with no base qualities
         bool reset_quality_adjustments = adjust_alignments_for_base_quality;
@@ -756,6 +760,7 @@ namespace vg {
         min_clustering_mem_length = reset_min_clustering_mem_length;
         min_mem_length = reset_min_mem_length;
         max_alt_mappings = reset_max_alt_mappings;
+        suppress_p_value_memoization = false;
     }
     
     int64_t MultipathMapper::distance_between(const MultipathAlignment& multipath_aln_1,

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -684,7 +684,7 @@ namespace vg {
             for (size_t i = 0; i < num_simulations; i++) {
                 
                 Alignment alignment;
-                alignment.set_sequence(pseudo_random_sequence(simulated_read_length, i));
+                alignment.set_sequence(pseudo_random_sequence(simulated_read_length, i * 716293332 + simulated_read_length));
                 vector<MultipathAlignment> multipath_alns;
                 multipath_map(alignment, multipath_alns);
                 

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -168,19 +168,20 @@ namespace vg {
                                                                         OrientedDistanceMeasurer* distance_measurer) const {
         
         vector<MultipathMapper::memcluster_t> return_val;
+        auto aligner = get_aligner(!alignment.quality().empty());
         if (use_tvs_clusterer) {
             TVSClusterer clusterer(xindex, distance_index);
-            return_val = clusterer.clusters(alignment, mems, get_aligner(), min_clustering_mem_length, max_mapping_quality,
+            return_val = clusterer.clusters(alignment, mems, aligner, min_clustering_mem_length, max_mapping_quality,
                                             log_likelihood_approx_factor, min_median_mem_coverage_for_split);
         }
         else if (use_min_dist_clusterer) {
             MinDistanceClusterer clusterer(distance_index);
-            return_val = clusterer.clusters(alignment, mems, get_aligner(), min_clustering_mem_length, max_mapping_quality,
+            return_val = clusterer.clusters(alignment, mems, aligner, min_clustering_mem_length, max_mapping_quality,
                                             log_likelihood_approx_factor, min_median_mem_coverage_for_split);
         }
         else {
             OrientedDistanceClusterer clusterer(*distance_measurer, max_expected_dist_approx_error);
-            return_val = clusterer.clusters(alignment, mems, get_aligner(), min_clustering_mem_length, max_mapping_quality,
+            return_val = clusterer.clusters(alignment, mems, aligner, min_clustering_mem_length, max_mapping_quality,
                                             log_likelihood_approx_factor, min_median_mem_coverage_for_split);
         }
         return return_val;
@@ -360,7 +361,7 @@ namespace vg {
             MultipathAlignment& multipath_aln_1 = multipath_alns_1.front();
             MultipathAlignment& multipath_aln_2 = multipath_alns_2.front();
             
-            auto aligner = get_aligner();
+            auto aligner = get_aligner(!alignment1.quality().empty() && !alignment2.quality().empty());
             
             // score possible of a perfect match (at full base quality)
             int32_t max_score_1 = multipath_aln_1.sequence().size() * aligner->match + 2 * aligner->full_length_bonus * !strip_bonuses;
@@ -482,7 +483,8 @@ namespace vg {
         // TODO: repetitive code with multipath_align
         
         // the longest path we could possibly align to (full gap and a full sequence)
-        size_t target_length = other_aln.sequence().size() + get_aligner()->longest_detectable_gap(other_aln);
+        auto aligner = get_aligner(!multipath_aln.quality().empty() && !other_aln.quality().empty());
+        size_t target_length = other_aln.sequence().size() + aligner->longest_detectable_gap(other_aln);
         
         // convert from bidirected to directed
         StrandSplitGraph align_digraph(&rescue_graph);
@@ -508,7 +510,7 @@ namespace vg {
         // in case we're realigning a GAM, get rid of the path
         aln.clear_path();
         
-        get_aligner()->align(aln, *align_dag, true, false);
+        aligner->align(aln, *align_dag, true, false);
         
         // get the IDs back into the space of the reference graph
         function<pair<id_t, bool>(id_t)> translator = [&](const id_t& node_id) {
@@ -535,7 +537,7 @@ namespace vg {
         identify_start_subpaths(rescue_multipath_aln);
         
         vector<double> score(1, aln.score());
-        int32_t raw_mapq = get_aligner()->compute_mapping_quality(score, mapping_quality_method == None || mapping_quality_method == Approx);
+        int32_t raw_mapq = aligner->compute_mapping_quality(score, mapping_quality_method == None || mapping_quality_method == Approx);
         int32_t adjusted_mapq = min(raw_mapq, min(max_mapping_quality, multipath_aln.mapping_quality()));
         rescue_multipath_aln.set_mapping_quality(adjusted_mapq);
         
@@ -890,7 +892,8 @@ namespace vg {
             return true;
         }
         
-        int32_t max_score_diff = get_aligner()->mapping_quality_score_diff(max_mapping_quality);
+        int32_t max_score_diff = get_aligner(!alignment1.quality().empty() &&
+                                             !alignment2.quality().empty())->mapping_quality_score_diff(max_mapping_quality);
         
         int32_t top_score_1 = multipath_alns_1.empty() ? 0 : optimal_alignment_score(multipath_alns_1.front());
         int32_t top_score_2 = multipath_alns_2.empty() ? 0 : optimal_alignment_score(multipath_alns_2.front());
@@ -1126,9 +1129,10 @@ namespace vg {
             paired_clusters_2.insert(duplicate_pairs[i].second);
         }
         
-        int32_t cluster_score_1 = get_aligner()->match * get<2>(cluster_graphs1[cluster_pairs.front().first.first]);
-        int32_t cluster_score_2 = get_aligner()->match * get<2>(cluster_graphs2[cluster_pairs.front().first.second]);
-        int32_t max_score_diff = secondary_rescue_score_diff * get_aligner()->mapping_quality_score_diff(max_mapping_quality);
+        auto aligner = get_aligner(!alignment1.quality().empty() && !alignment2.quality().empty());
+        int32_t cluster_score_1 = aligner->match * get<2>(cluster_graphs1[cluster_pairs.front().first.first]);
+        int32_t cluster_score_2 = aligner->match * get<2>(cluster_graphs2[cluster_pairs.front().first.second]);
+        int32_t max_score_diff = secondary_rescue_score_diff * aligner->mapping_quality_score_diff(max_mapping_quality);
         
         vector<pair<MultipathAlignment, MultipathAlignment>> rescued_secondaries;
         vector<pair<pair<size_t, size_t>, int64_t>> rescued_distances;
@@ -1154,10 +1158,10 @@ namespace vg {
                 }
                 
 #ifdef debug_multipath_mapper
-                cerr << "cluster " << i << "'s approximate score is " << get<2>(cluster_graphs[i]) * get_aligner()->match << ", looking for " << max_score - max_score_diff << endl;
+                cerr << "cluster " << i << "'s approximate score is " << get<2>(cluster_graphs[i]) * aligner->match << ", looking for " << max_score - max_score_diff << endl;
 #endif
                 
-                if (get<2>(cluster_graphs[i]) * get_aligner()->match < max_score - max_score_diff) {
+                if (get<2>(cluster_graphs[i]) * aligner->match < max_score - max_score_diff) {
 #ifdef debug_multipath_mapper
                     cerr << "the approximate score of the remaining is too low to consider" << endl;
 #endif
@@ -1822,7 +1826,8 @@ namespace vg {
        
         if (mapping_quality_method != None) {
             // Now compute the MAPQ for the best alignment
-            auto placement_mapq = compute_raw_mapping_quality_from_scores(scores, mapping_quality_method);
+            auto placement_mapq = compute_raw_mapping_quality_from_scores(scores, mapping_quality_method,
+                                                                          !multipath_aln.quality().empty());
             // And min it in with what;s there already.
             alns_out[0].set_mapping_quality(min(alns_out[0].mapping_quality(), placement_mapq));
             for (size_t i = 1; i < alns_out.size(); i++) {
@@ -2193,9 +2198,11 @@ namespace vg {
             }
             
             // the score parameters from the secondary rescue code that we use to decide which clusters to rescue from
-            int32_t cluster_score_1 = get_aligner()->match * get<2>(cluster_graphs1[cluster_pairs.front().first.first]);
-            int32_t cluster_score_2 = get_aligner()->match * get<2>(cluster_graphs2[cluster_pairs.front().first.second]);
-            int32_t max_score_diff = secondary_rescue_score_diff * get_aligner()->mapping_quality_score_diff(max_mapping_quality);
+            auto aligner = get_aligner(multipath_aln_pairs_out.empty() ? false :
+                                       !multipath_aln_pairs_out.front().first.quality().empty() && !multipath_aln_pairs_out.front().second.quality().empty());
+            int32_t cluster_score_1 = aligner->match * get<2>(cluster_graphs1[cluster_pairs.front().first.first]);
+            int32_t cluster_score_2 = aligner->match * get<2>(cluster_graphs2[cluster_pairs.front().first.second]);
+            int32_t max_score_diff = secondary_rescue_score_diff * aligner->mapping_quality_score_diff(max_mapping_quality);
             
             // we'll count up how many of the equivalent clusters we would have done secondary rescue from
             size_t num_equivalent_1 = 0;
@@ -2209,7 +2216,7 @@ namespace vg {
                 bool equiv = cluster_contained_in(get<1>(cluster_graphs1[cluster_pairs.front().first.first]), get<1>(cluster_graphs1[i]));
                 // and would we have done used it for a secondary rescue?
                 bool did_rescue = (!paired_clusters_1.count(i) && num_rescues_1 < secondary_rescue_attempts
-                                   && get<2>(cluster_graphs1[i]) * get_aligner()->match >= cluster_score_1 - max_score_diff);
+                                   && get<2>(cluster_graphs1[i]) * aligner->match >= cluster_score_1 - max_score_diff);
                 // keep track of the counts
                 num_rescues_1 += did_rescue;
                 num_equivalent_1 += equiv;
@@ -2222,7 +2229,7 @@ namespace vg {
                 bool equiv = cluster_contained_in(get<1>(cluster_graphs2[cluster_pairs.front().first.second]), get<1>(cluster_graphs2[i]));
                 // and would we have done used it for a secondary rescue?
                 bool did_rescue = (!paired_clusters_2.count(i) && num_rescues_2 < secondary_rescue_attempts
-                                   && get<2>(cluster_graphs2[i]) * get_aligner()->match >= cluster_score_2 - max_score_diff);
+                                   && get<2>(cluster_graphs2[i]) * aligner->match >= cluster_score_2 - max_score_diff);
                 // keep track of the counts
                 num_rescues_2 += did_rescue;
                 num_equivalent_2 += equiv;
@@ -2410,9 +2417,10 @@ namespace vg {
         
         assert(multipath_aln_pairs_out.empty());
         
+        auto aligner = get_aligner(!alignment1.quality().empty() && !alignment2.quality().empty());
         auto get_pair_approx_likelihood = [&](const pair<pair<size_t, size_t>, int64_t>& cluster_pair) {
             return ((get<2>(cluster_graphs1[cluster_pair.first.first])
-                     + get<2>(cluster_graphs2[cluster_pair.first.second])) * get_aligner()->match * get_aligner()->log_base
+                     + get<2>(cluster_graphs2[cluster_pair.first.second])) * aligner->match * aligner->log_base
                     + fragment_length_log_likelihood(cluster_pair.second));
         };
         
@@ -2560,7 +2568,7 @@ namespace vg {
                                                const vector<memcluster_t>& clusters) -> vector<clustergraph_t> {
         
         // Figure out the aligner to use
-        const GSSWAligner* aligner = get_aligner();
+        auto aligner = get_aligner(!alignment.quality().empty());
         
         // We populate this with all the cluster graphs.
         vector<clustergraph_t> cluster_graphs_out;
@@ -2912,7 +2920,8 @@ namespace vg {
 #endif
         
         // the longest path we could possibly align to (full gap and a full sequence)
-        size_t target_length = alignment.sequence().size() + get_aligner()->longest_detectable_gap(alignment);
+        auto aligner = get_aligner(!alignment.quality().empty());
+        size_t target_length = alignment.sequence().size() + aligner->longest_detectable_gap(alignment);
         
         // check if we can get away with using only one strand of the graph
         bool use_single_stranded = algorithms::is_single_stranded(graph);
@@ -3016,7 +3025,7 @@ namespace vg {
             multi_aln_graph.remove_transitive_edges(topological_order);
             
             // prune this graph down the paths that have reasonably high likelihood
-            multi_aln_graph.prune_to_high_scoring_paths(alignment, get_aligner(),
+            multi_aln_graph.prune_to_high_scoring_paths(alignment, aligner,
                                                         max_suboptimal_path_score_ratio, topological_order);
         }
         if (snarl_manager) {
@@ -3029,7 +3038,7 @@ namespace vg {
 #endif
 
                 // Make fake anchor paths to cut the snarls out of in the tails
-                multi_aln_graph.synthesize_tail_anchors(alignment, *align_dag, get_aligner(), min_tail_anchor_length, num_alt_alns, false);
+                multi_aln_graph.synthesize_tail_anchors(alignment, *align_dag, aligner, min_tail_anchor_length, num_alt_alns, false);
                 
             }
        
@@ -3063,7 +3072,7 @@ namespace vg {
         };
         
         // do the connecting alignments and fill out the MultipathAlignment object
-        multi_aln_graph.align(alignment, *align_dag, get_aligner(), true, num_alt_alns, dynamic_max_alt_alns, choose_band_padding, multipath_aln_out);
+        multi_aln_graph.align(alignment, *align_dag, aligner, true, num_alt_alns, dynamic_max_alt_alns, choose_band_padding, multipath_aln_out);
         
         // Note that we do NOT topologically order the MultipathAlignment. The
         // caller has to do that, after it is finished breaking it up into
@@ -3092,6 +3101,8 @@ namespace vg {
         cerr << "attempting to make nontrivial alignment for " << alignment.name() << endl;
 #endif
         
+        auto aligner = get_aligner(!alignment.quality().empty());
+        
         // create an alignment graph with the internals of snarls removed
         MultipathAlignmentGraph multi_aln_graph(subgraph, alignment, snarl_manager, max_snarl_cut_size, translator);
         
@@ -3109,7 +3120,7 @@ namespace vg {
         };
         
         // do the connecting alignments and fill out the MultipathAlignment object
-        multi_aln_graph.align(alignment, subgraph, get_aligner(), false, num_alt_alns, dynamic_max_alt_alns, choose_band_padding, multipath_aln_out);
+        multi_aln_graph.align(alignment, subgraph, aligner, false, num_alt_alns, dynamic_max_alt_alns, choose_band_padding, multipath_aln_out);
         
         for (size_t j = 0; j < multipath_aln_out.subpath_size(); j++) {
             translate_oriented_node_ids(*multipath_aln_out.mutable_subpath(j)->mutable_path(), translator);
@@ -3152,7 +3163,8 @@ namespace vg {
     
     void MultipathMapper::strip_full_length_bonuses(MultipathAlignment& multipath_aln) const {
         
-        int32_t full_length_bonus = get_aligner()->full_length_bonus;
+        // TODO: this could technically be wrong if only one read in a pair has qualities
+        int32_t full_length_bonus = get_aligner(!multipath_aln.quality().empty())->full_length_bonus;
         // strip bonus from source paths
         if (multipath_aln.start_size()) {
             // use the precomputed list of sources if we have it
@@ -3195,7 +3207,8 @@ namespace vg {
         }
     }
     
-    int32_t MultipathMapper::compute_raw_mapping_quality_from_scores(const vector<double>& scores, MappingQualityMethod mapq_method) const {
+    int32_t MultipathMapper::compute_raw_mapping_quality_from_scores(const vector<double>& scores, MappingQualityMethod mapq_method,
+                                                                     bool have_qualities) const {
    
         // We should never actually compute a MAPQ with the None method. If we try, it means something has gonbe wrong.
         assert(mapq_method != None);
@@ -3205,14 +3218,15 @@ namespace vg {
         // This can be removed when GSSWAligner is fixed to take const score lists.
         vector<double> mutable_scores(scores.begin(), scores.end());
    
+        auto aligner = get_aligner(have_qualities);
         int32_t raw_mapq;
         if (mapping_quality_method == Adaptive) {
-            raw_mapq = get_aligner()->compute_mapping_quality(mutable_scores, mutable_scores.size() < 2 ? true :
-                                                              (mutable_scores[1] < mutable_scores[0] - 
-                                                              get_aligner()->mapping_quality_score_diff(max_mapping_quality)));
+            raw_mapq = aligner->compute_mapping_quality(mutable_scores, mutable_scores.size() < 2 ? true :
+                                                        (mutable_scores[1] < mutable_scores[0] -
+                                                         aligner->mapping_quality_score_diff(max_mapping_quality)));
         }
         else {
-            raw_mapq = get_aligner()->compute_mapping_quality(mutable_scores, mapping_quality_method == Approx);
+            raw_mapq = aligner->compute_mapping_quality(mutable_scores, mapping_quality_method == Approx);
         }
         
         // arbitrary scaling, seems to help performance
@@ -3243,7 +3257,7 @@ namespace vg {
         // consistent.
         bool all_multipaths_pop_consistent = true;
         
-        double log_base = get_aligner()->log_base;
+        double log_base = get_aligner(!multipath_alns.front().quality().empty())->log_base;
         
         // The score of the optimal Alignment for each MultipathAlignment, not adjusted for population
         vector<double> base_scores(multipath_alns.size(), 0.0);
@@ -3511,7 +3525,7 @@ namespace vg {
         if (mapq_method != None) {
             // Sometimes we are passed None, which means to not update the MAPQs at all. But otherwise, we do MAPQs.
             // Compute and set the mapping quality
-            int32_t raw_mapq = compute_raw_mapping_quality_from_scores(scores, mapq_method);
+            int32_t raw_mapq = compute_raw_mapping_quality_from_scores(scores, mapq_method, !multipath_alns.front().quality().empty());
             multipath_alns.front().set_mapping_quality(min<int32_t>(raw_mapq, max_mapping_quality));
         }
         
@@ -3521,7 +3535,7 @@ namespace vg {
             for (size_t i = 1; i < num_reporting; ++i) {
                 reporting_idxs[i] = i;
             }
-            double raw_mapq = get_aligner()->compute_group_mapping_quality(scores, reporting_idxs);
+            double raw_mapq = get_aligner(!multipath_alns.front().quality().empty())->compute_group_mapping_quality(scores, reporting_idxs);
             // TODO: for some reason set_annotation will accept a double but not an int
             double group_mapq = min<double>(max_mapping_quality, mapq_scaling_factor * raw_mapq);
             
@@ -3560,7 +3574,8 @@ namespace vg {
         // they cross are pop consistent.
         bool all_multipaths_pop_consistent = true;
         
-        double log_base = get_aligner()->log_base;
+        double log_base = get_aligner(!multipath_aln_pairs.front().first.quality().empty() &&
+                                      !multipath_aln_pairs.front().second.quality().empty())->log_base;
         
         // the scores of the optimal alignments and fragments, ignoring population
         vector<double> base_scores(multipath_aln_pairs.size(), 0.0);
@@ -3854,7 +3869,9 @@ namespace vg {
         
         if (mapping_quality_method != None) {
             // Compute the raw mapping quality
-            int32_t raw_mapq = compute_raw_mapping_quality_from_scores(scores, mapping_quality_method);
+            int32_t raw_mapq = compute_raw_mapping_quality_from_scores(scores, mapping_quality_method,
+                                                                       !multipath_aln_pairs.front().first.quality().empty() &&
+                                                                       !multipath_aln_pairs.front().second.quality().empty());
             // Limit it to the max.
             int32_t mapq = min<int32_t>(raw_mapq, max_mapping_quality);
             multipath_aln_pairs.front().first.set_mapping_quality(mapq);
@@ -3930,8 +3947,10 @@ namespace vg {
                 // did we find any duplicates with the optimal pair?
                 if (duplicates_1.size() > 1 || duplicates_2.size() > 1 || !to_remove.empty()) {
                     // compute the mapping quality of the whole group of duplicates for each end
-                    int32_t raw_mapq_1 = get_aligner()->compute_group_mapping_quality(scores, duplicates_1);
-                    int32_t raw_mapq_2 = get_aligner()->compute_group_mapping_quality(scores, duplicates_2);
+                    auto aligner = get_aligner(!multipath_aln_pairs.front().first.quality().empty() &&
+                                               !multipath_aln_pairs.front().second.quality().empty());
+                    int32_t raw_mapq_1 = aligner->compute_group_mapping_quality(scores, duplicates_1);
+                    int32_t raw_mapq_2 = aligner->compute_group_mapping_quality(scores, duplicates_2);
                     
                     // arbitrary scaling, seems to help performance
                     raw_mapq_1 *= mapq_scaling_factor;
@@ -3956,10 +3975,12 @@ namespace vg {
             for (size_t i = 1; i < num_reporting; ++i) {
                 reporting_idxs[i] = i;
             }
-            double raw_mapq = get_aligner()->compute_group_mapping_quality(scores, reporting_idxs);
+            auto aligner = get_aligner(!multipath_aln_pairs.front().first.quality().empty() &&
+                                       !multipath_aln_pairs.front().second.quality().empty());
+            double raw_mapq = aligner->compute_group_mapping_quality(scores, reporting_idxs);
+            
             // TODO: for some reason set_annotation will accept a double but not an int
             double group_mapq = min<double>(max_mapping_quality, mapq_scaling_factor * raw_mapq);
-            
             for (size_t i = 0; i < num_reporting; ++i) {
                 set_annotation(multipath_aln_pairs[i].first, "group_mapq", group_mapq);
                 set_annotation(multipath_aln_pairs[i].second, "group_mapq", group_mapq);

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -166,6 +166,7 @@ namespace vg {
         bool use_min_dist_clusterer = false;
         // length of reversing walks during graph extraction
         size_t reversing_walk_length = 0;
+        bool suppress_p_value_memoization = false;
         
         //static size_t PRUNE_COUNTER;
         //static size_t SUBGRAPH_TOTAL;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -322,7 +322,8 @@ namespace vg {
         void strip_full_length_bonuses(MultipathAlignment& multipath_aln) const;
         
         /// Compute a mapping quality from a list of scores, using the selected method.
-        int32_t compute_raw_mapping_quality_from_scores(const vector<double>& scores, MappingQualityMethod mapq_method) const;
+        int32_t compute_raw_mapping_quality_from_scores(const vector<double>& scores, MappingQualityMethod mapq_method,
+                                                        bool have_qualities) const;
         
         /// Sorts mappings by score and store mapping quality of the optimal alignment in the MultipathAlignment object
         /// Optionally also sorts a vector of indexes to keep track of the cluster-of-origin

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -328,7 +328,8 @@ double max_exponential_log_likelihood(const vector<double>& x, double rate, doub
     double accumulator_2 = 0.0;
     for (const double& val : x) {
         if (val <= location) {
-            return numeric_limits<double>::lowest();
+            // this should be -inf, but doing this avoids some numerical problems
+            continue;
         }
         accumulator_1 += log(1.0 - exp(-rate * (val - location)));
         accumulator_2 += (val - location);

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -36,65 +36,66 @@ void help_mpmap(char** argv) {
     << "graph/index:" << endl
     << "  -x, --xg-name FILE            use this xg index (required)" << endl
     << "  -g, --gcsa-name FILE          use this GCSA2/LCP index pair (required; both FILE and FILE.lcp)" << endl
-    << "  -H, --gbwt-name FILE          use this GBWT haplotype index for population-based MAPQs" << endl
-    << "  -d, --dist-name FILE          use this snarl distance index for clustering (if given, requires matched snarls from -s)" << endl
-    << "      --linear-index FILE       use this sublinear Li and Stephens index file for population-based MAPQs" << endl
-    << "      --linear-path PATH        use the given path name as the path that the linear index is against" << endl
+    //<< "  -H, --gbwt-name FILE          use this GBWT haplotype index for population-based MAPQs" << endl
+    << "  -d, --dist-name FILE          use this snarl distance index for clustering" << endl
+    //<< "      --linear-index FILE       use this sublinear Li and Stephens index file for population-based MAPQs" << endl
+    //<< "      --linear-path PATH        use the given path name as the path that the linear index is against" << endl
     << "input:" << endl
     << "  -f, --fastq FILE              input FASTQ (possibly compressed), can be given twice for paired ends (for stdin use -)" << endl
     << "  -G, --gam-input FILE          input GAM (for stdin, use -)" << endl
     << "  -i, --interleaved             FASTQ or GAM contains interleaved paired ends" << endl
-    << "  -N, --sample NAME             add this sample name to output GAMP" << endl
-    << "  -R, --read-group NAME         add this read group to output GAMP" << endl
+    << "  -N, --sample NAME             add this sample name to output" << endl
+    << "  -R, --read-group NAME         add this read group to output" << endl
     << "  -e, --same-strand             read pairs are from the same strand of the DNA molecule" << endl
     << "algorithm:" << endl
-    << "  -S, --single-path-mode        produce single-path alignments (GAM) instead of multipath alignments (GAMP) (ignores -sua)" << endl
+    << "  -S, --single-path-mode        produce single-path alignments (GAM) instead of multipath alignments (GAMP) (ignores -sXa)" << endl
+    << "  -O, --min-dist-cluster        use the minimum distance based clusterer (requires a distance index from -d)" << endl
     << "  -s, --snarls FILE             align to alternate paths in these snarls" << endl
     << "scoring:" << endl
-    << "  -A, --no-qual-adjust          do not perform base quality adjusted alignments (required if input does not have base qualities)" << endl
     << "  -E, --long-read-scoring       set alignment scores to long-read defaults: -q1 -z1 -o1 -y1 -L0 (can be overridden)" << endl
+    << "computational parameters:" << endl
+    << "  -t, --threads INT             number of compute threads to use [all available]" << endl
     << endl
     << "advanced options:" << endl
     << "algorithm:" << endl
-    << "  -v, --tvs-clusterer           use the target value search based clusterer (requies a distance index from -d)" << endl
-    << "      --min-dist-cluster        use the minimum distance based clusterer (requies a distance index from -d)" << endl
+    << "  -v, --tvs-clusterer           use the target value search-based clusterer (requires a distance index from -d)" << endl
     << "  -X, --snarl-max-cut INT       do not align to alternate paths in a snarl if an exact match is at least this long (0 for no limit) [5]" << endl
     << "  -a, --alt-paths INT           align to (up to) this many alternate paths in between MEMs or in snarls [10]" << endl
-    << "      --suppress-tail-anchors   don't produce extra anchors when aligning to alternate paths in snarls" << endl
+    //<< "      --suppress-tail-anchors   don't produce extra anchors when aligning to alternate paths in snarls" << endl
     << "  -b, --frag-sample INT         look for this many unambiguous mappings to estimate the fragment length distribution [1000]" << endl
     << "  -I, --frag-mean               mean for fixed fragment length distribution" << endl
     << "  -D, --frag-stddev             standard deviation for fixed fragment length distribution" << endl
     << "  -B, --no-calibrate            do not auto-calibrate mismapping dectection" << endl
     << "  -P, --max-p-val FLOAT         background model p value must be less than this to avoid mismapping detection [0.00001]" << endl
     << "  -Q, --mq-max INT              cap mapping quality estimates at this much [60]" << endl
-    << "  --report-group-mapq           add an annotation for the collective mapping quality of all reported alignments" << endl
-    << "  -p, --padding-mult FLOAT      pad dynamic programming bands in inter-MEM alignment FLOAT * sqrt(read length) [1.0]" << endl
+    << "  -U, --report-group-mapq       add an annotation for the collective mapping quality of all reported alignments" << endl
+    //<< "  -p, --padding-mult FLOAT      pad dynamic programming bands in inter-MEM alignment FLOAT * sqrt(read length) [1.0]" << endl
     << "  -u, --map-attempts INT        perform (up to) this many mappings per read (0 for no limit) [24 paired / 64 unpaired]" << endl
-    << "  -O, --max-paths INT           consider (up to) this many paths per alignment for population consistency scoring, 0 to disable [10]" << endl
-    << "      --top-tracebacks          consider paths for each alignment based only on alignment score and not based on haplotypes" << endl
+    //<< "      --max-paths INT           consider (up to) this many paths per alignment for population consistency scoring, 0 to disable [10]" << endl
+    //<< "      --top-tracebacks          consider paths for each alignment based only on alignment score and not based on haplotypes" << endl
     << "  -M, --max-multimaps INT       report (up to) this many mappings per read [1]" << endl
     << "  -r, --reseed-length INT       reseed SMEMs for internal MEMs if they are at least this long (0 for no reseeding) [28]" << endl
     << "  -W, --reseed-diff FLOAT       require internal MEMs to have length within this much of the SMEM's length [0.45]" << endl
-    << "  -K, --clust-length INT        minimum MEM length used in clustering [automatic]" << endl
+    //<< "  -K, --clust-length INT        minimum MEM length used in clustering [automatic]" << endl
     << "  -c, --hit-max INT             use at most this many hits for any MEM (0 for no limit) [1024]" << endl
-    << "  -w, --approx-exp FLOAT        let the approximate likelihood miscalculate likelihood ratios by this power [10.0]" << endl
-    << "  --recombination-penalty FLOAT use this log recombination penalty for GBWT haplotype scoring [20.7]" << endl
-    << "  --always-check-population     always try to population-score reads, even if there is only a single mapping" << endl
-    << "  --delay-population            do not apply population scoring at intermediate stages of the mapping algorithm" << endl
-    << "  --force-haplotype-count INT   assume that INT haplotypes ought to run through each fixed part of the graph, if nonzero [0]" << endl
+    //<< "  --approx-exp FLOAT            let the approximate likelihood miscalculate likelihood ratios by this power [10.0]" << endl
+    //<< "  --recombination-penalty FLOAT use this log recombination penalty for GBWT haplotype scoring [20.7]" << endl
+    //<< "  --always-check-population     always try to population-score reads, even if there is only a single mapping" << endl
+    //<< "  --delay-population            do not apply population scoring at intermediate stages of the mapping algorithm" << endl
+    //<< "  --force-haplotype-count INT   assume that INT haplotypes ought to run through each fixed part of the graph, if nonzero [0]" << endl
     << "  -C, --drop-subgraph FLOAT     drop alignment subgraphs whose MEMs cover this fraction less of the read than the best subgraph [0.2]" << endl
-    << "  -U, --prune-exp FLOAT         prune MEM anchors if their approximate likelihood is this root less than the optimal anchors [1.25]" << endl
+    //<< "  --prune-exp FLOAT         prune MEM anchors if their approximate likelihood is this root less than the optimal anchors [1.25]" << endl
     << "scoring:" << endl
+    << "  -A, --no-qual-adjust          do not perform base quality adjusted alignments even when base qualities are available" << endl
     << "  -q, --match INT               use this match score [1]" << endl
     << "  -z, --mismatch INT            use this mismatch penalty [4]" << endl
-    << "  --score-matrix FILE           read a 5x5 integer substitution scoring matrix from a file" << endl
+    << "  -w, --score-matrix FILE           read a 5x5 integer substitution scoring matrix from a file (in the order ACGTN)" << endl
     << "  -o, --gap-open INT            use this gap open penalty [6]" << endl
     << "  -y, --gap-extend INT          use this gap extension penalty [1]" << endl
     << "  -L, --full-l-bonus INT        add this score to alignments that use the full length of the read [5]" << endl
     << "  -m, --remove-bonuses          remove full length alignment bonuses in reported scores" << endl
     << "computational parameters:" << endl
-    << "  -t, --threads INT             number of compute threads to use" << endl
-    << "  -Z, --buffer-size INT         buffer this many alignments together (per compute thread) before outputting to stdout [100]" << endl;
+    << "  -Z, --buffer-size INT         buffer this many alignments together (per compute thread) before outputting to stdout [200]" << endl;
     
 }
 
@@ -106,15 +107,15 @@ int main_mpmap(int argc, char** argv) {
     }
 
     // initialize parameters with their default options
-    #define OPT_SCORE_MATRIX 1000
+    #define OPT_PRUNE_EXP 1000
     #define OPT_RECOMBINATION_PENALTY 1001
     #define OPT_ALWAYS_CHECK_POPULATION 1002
     #define OPT_DELAY_POPULATION_SCORING 1003
     #define OPT_FORCE_HAPLOTYPE_COUNT 1004
     #define OPT_SUPPRESS_TAIL_ANCHORS 1005
     #define OPT_TOP_TRACEBACKS 1006
-    #define OPT_MIN_DIST_CLUSTER 1007
-    #define OPT_REPORT_GROUP_MAPQ 1008
+    #define OPT_APPROX_EXP 1008
+    #define OPT_MAX_PATHS 1009
     string matrix_file_name;
     string xg_name;
     string gcsa_name;
@@ -146,7 +147,7 @@ int main_mpmap(int argc, char** argv) {
     // TODO: create an option.
     int localization_max_paths = 5;
     int max_num_mappings = 1;
-    int buffer_size = 100;
+    int buffer_size = 200;
     int hit_max = 1024;
     int min_mem_length = 1;
     int min_clustering_mem_length = 0;
@@ -239,28 +240,28 @@ int main_mpmap(int argc, char** argv) {
             {"no-calibrate", no_argument, 0, 'B'},
             {"max-p-val", required_argument, 0, 'P'},
             {"mq-max", required_argument, 0, 'Q'},
-            {"report-group-mapq", no_argument, 0, OPT_REPORT_GROUP_MAPQ},
+            {"report-group-mapq", no_argument, 0, 'U'},
             {"padding-mult", required_argument, 0, 'p'},
             {"map-attempts", required_argument, 0, 'u'},
-            {"max-paths", required_argument, 0, 'O'},
+            {"max-paths", required_argument, 0, OPT_MAX_PATHS},
             {"top-tracebacks", no_argument, 0, OPT_TOP_TRACEBACKS},
             {"max-multimaps", required_argument, 0, 'M'},
             {"reseed-length", required_argument, 0, 'r'},
             {"reseed-diff", required_argument, 0, 'W'},
             {"clustlength", required_argument, 0, 'K'},
             {"hit-max", required_argument, 0, 'c'},
-            {"approx-exp", required_argument, 0, 'w'},
+            {"approx-exp", required_argument, 0, OPT_APPROX_EXP},
             {"recombination-penalty", required_argument, 0, OPT_RECOMBINATION_PENALTY},
             {"always-check-population", no_argument, 0, OPT_ALWAYS_CHECK_POPULATION},
             {"delay-population", no_argument, 0, OPT_DELAY_POPULATION_SCORING},
             {"force-haplotype-count", required_argument, 0, OPT_FORCE_HAPLOTYPE_COUNT},
-            {"min-dist-cluster", no_argument, 0, OPT_MIN_DIST_CLUSTER},
+            {"min-dist-cluster", no_argument, 0, 'O'},
             {"drop-subgraph", required_argument, 0, 'C'},
-            {"prune-exp", required_argument, 0, 'U'},
+            {"prune-exp", required_argument, 0, OPT_PRUNE_EXP},
             {"long-read-scoring", no_argument, 0, 'E'},
             {"match", required_argument, 0, 'q'},
             {"mismatch", required_argument, 0, 'z'},
-            {"score-matrix", required_argument, 0, OPT_SCORE_MATRIX},
+            {"score-matrix", required_argument, 0, 'w'},
             {"gap-open", required_argument, 0, 'o'},
             {"gap-extend", required_argument, 0, 'y'},
             {"full-l-bonus", required_argument, 0, 'L'},
@@ -272,7 +273,7 @@ int main_mpmap(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:ieSs:vX:u:O:a:b:I:D:BP:Q:p:M:r:W:K:c:w:C:R:Eq:z:o:y:L:mAt:Z:",
+        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:ieSO:s:vX:u:a:b:I:D:BP:Q:Up:M:r:W:K:c:C:R:Eq:z:w:o:y:L:mAt:Z:",
                          long_options, &option_index);
 
 
@@ -427,7 +428,7 @@ int main_mpmap(int argc, char** argv) {
                 max_mapq = parse<int>(optarg);
                 break;
                 
-            case OPT_REPORT_GROUP_MAPQ:
+            case 'U':
                 report_group_mapq = true;
                 break;
                 
@@ -443,7 +444,7 @@ int main_mpmap(int argc, char** argv) {
                 }
                 break;
                 
-            case 'O':
+            case OPT_MAX_PATHS:
                 population_max_paths = parse<int>(optarg);
                 break;
                 
@@ -471,7 +472,7 @@ int main_mpmap(int argc, char** argv) {
                 hit_max = parse<int>(optarg);
                 break;
                 
-            case 'w':
+            case OPT_APPROX_EXP:
                 likelihood_approx_exp = parse<double>(optarg);
                 break;
                 
@@ -491,7 +492,7 @@ int main_mpmap(int argc, char** argv) {
                 force_haplotype_count = parse<size_t>(optarg);
                 break;
                 
-            case OPT_MIN_DIST_CLUSTER:
+            case 'O':
                 use_min_dist_clusterer = true;
                 break;
                 
@@ -499,7 +500,7 @@ int main_mpmap(int argc, char** argv) {
                 cluster_ratio = parse<double>(optarg);
                 break;
                 
-            case 'U':
+            case OPT_PRUNE_EXP:
                 suboptimal_path_exponent = parse<double>(optarg);
                 break;
                 
@@ -515,7 +516,7 @@ int main_mpmap(int argc, char** argv) {
                 mismatch_score_arg = parse<int>(optarg);
                 break;
                 
-            case OPT_SCORE_MATRIX:
+            case 'w':
                 matrix_file_name = optarg;
                 if (matrix_file_name.empty()) {
                     cerr << "error:[vg mpmap] Must provide matrix file with --matrix-file." << endl;
@@ -615,7 +616,7 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (snarl_cut_size < 0) {
-        cerr << "error:[vg mpmap] Max snarl cut size (-U) set to " << snarl_cut_size << ", must set to a positive integer or 0 for no maximum." << endl;
+        cerr << "error:[vg mpmap] Max snarl cut size (-X) set to " << snarl_cut_size << ", must set to a positive integer or 0 for no maximum." << endl;
         exit(1);
     }
     
@@ -640,14 +641,14 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (population_max_paths < 0) {
-        cerr << "error:[vg mpmap] Maximum number of paths per alignment for population scoring (-O) set to " << population_max_paths << ", must set to a nonnegative integer." << endl;
+        cerr << "error:[vg mpmap] Maximum number of paths per alignment for population scoring (--max-paths) set to " << population_max_paths << ", must set to a nonnegative integer." << endl;
         exit(1);
     }
     
     if (population_max_paths != 10 && population_max_paths != 0 && gbwt_name.empty() && sublinearLS_name.empty()) {
         // Don't allow anything but the default or the "disabled" setting without an index.
         // TODO: This restriction makes neat auto-generation of command line options for different conditions hard.
-        cerr << "error:[vg mpmap] Maximum number of paths per alignment for population scoring (-O) is specified but population database (-H or --linear-index) was not provided." << endl;
+        cerr << "error:[vg mpmap] Maximum number of paths per alignment for population scoring (--max-paths) is specified but population database (-H or --linear-index) was not provided." << endl;
         exit(1);
     }
     
@@ -712,7 +713,7 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (likelihood_approx_exp < 1.0) {
-        cerr << "error:[vg mpmap] Likelihood approximation exponent (-w) set to " << likelihood_approx_exp << ", must set to at least 1.0." << endl;
+        cerr << "error:[vg mpmap] Likelihood approximation exponent (--approx-exp) set to " << likelihood_approx_exp << ", must set to at least 1.0." << endl;
         exit(1);
     }
     
@@ -727,17 +728,17 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (use_min_dist_clusterer && distance_index_name.empty()) {
-        cerr << "error:[vg mpmap] The minimum distance clusterer (--min-dist-cluster) requires a distance index (-d)." << endl;
+        cerr << "error:[vg mpmap] The minimum distance clusterer (-O) requires a distance index (-d)." << endl;
         exit(1);
     }
     
     if (use_min_dist_clusterer && use_tvs_clusterer) {
-        cerr << "error:[vg mpmap] Cannot perform both minimum distance clustering (--min-dist-cluster) and target value clustering (-v)." << endl;
+        cerr << "error:[vg mpmap] Cannot perform both minimum distance clustering (-O) and target value clustering (-v)." << endl;
         exit(1);
     }
     
     if (suboptimal_path_exponent < 1.0) {
-        cerr << "error:[vg mpmap] Suboptimal path likelihood root (-R) set to " << suboptimal_path_exponent << ", must set to at least 1.0." << endl;
+        cerr << "error:[vg mpmap] Suboptimal path likelihood root (--prune-exp) set to " << suboptimal_path_exponent << ", must set to at least 1.0." << endl;
         exit(1);
     }
     
@@ -790,16 +791,16 @@ int main_mpmap(int argc, char** argv) {
     if (single_path_alignment_mode && population_max_paths == 0) {
         // TODO: I don't like having these constants floating around in two different places, but it's not very risky, just a warning
         if (!snarls_name.empty()) {
-            cerr << "warning:[vg mpmap] Snarl file (-s) is ignored in single path mode (-S) without multipath population scoring (-O)." << endl;
+            cerr << "warning:[vg mpmap] Snarl file (-s) is ignored in single path mode (-S) without multipath population scoring (--max-paths)." << endl;
             // TODO: Not true!
         }
         
         if (snarl_cut_size != 5) {
-            cerr << "warning:[vg mpmap] Snarl cut limit (-u) is ignored in single path mode (-S) without multipath population scoring (-O)." << endl;
+            cerr << "warning:[vg mpmap] Snarl cut limit (-X) is ignored in single path mode (-S) without multipath population scoring (--max-paths)." << endl;
         }
         
         if (num_alt_alns != 4) {
-            cerr << "warning:[vg mpmap] Number of alternate alignments (-a) is ignored in single path mode (-S) without multipath population scoring (-O)." << endl;
+            cerr << "warning:[vg mpmap] Number of alternate alignments (-a) is ignored in single path mode (-S) without multipath population scoring (--max-paths)." << endl;
         }
         
         num_alt_alns = 1;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -185,7 +185,7 @@ int main_mpmap(int argc, char** argv) {
     bool same_strand = false;
     bool auto_calibrate_mismapping_detection = true;
     double max_mapping_p_value = 0.00001;
-    size_t num_calibration_simulations = 500;
+    size_t num_calibration_simulations = 100;
     vector<size_t> calibration_read_lengths{50, 75, 100, 150, 250, 450, 750};
     bool use_weibull_calibration = false;
     size_t order_length_repeat_hit_max = 3000;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -275,7 +275,7 @@ int main_mpmap(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:ieS:s:vX:u:a:b:I:D:BP:Q:Up:M:r:W:K:c:C:R:Eq:z:w:o:y:L:mAt:Z:",
+        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:ieSs:vX:u:a:b:I:D:BP:Q:Up:M:r:W:K:c:C:R:Eq:z:w:o:y:L:mAt:Z:",
                          long_options, &option_index);
 
 

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -34,22 +34,22 @@ void help_mpmap(char** argv) {
     << endl
     << "basic options:" << endl
     << "graph/index:" << endl
-    << "  -x, --xg-name FILE            use this xg index (required)" << endl
-    << "  -g, --gcsa-name FILE          use this GCSA2/LCP index pair (required; both FILE and FILE.lcp)" << endl
+    << "  -x, --xg-name FILE            use this XG index of the graph (required)" << endl
+    << "  -g, --gcsa-name FILE          use this GCSA2/LCP index pair for MEMs (required; both FILE and FILE.lcp)" << endl
     //<< "  -H, --gbwt-name FILE          use this GBWT haplotype index for population-based MAPQs" << endl
     << "  -d, --dist-name FILE          use this snarl distance index for clustering" << endl
     //<< "      --linear-index FILE       use this sublinear Li and Stephens index file for population-based MAPQs" << endl
     //<< "      --linear-path PATH        use the given path name as the path that the linear index is against" << endl
     << "input:" << endl
-    << "  -f, --fastq FILE              input FASTQ (possibly compressed), can be given twice for paired ends (for stdin use -)" << endl
+    << "  -f, --fastq FILE              input FASTQ (possibly gzipped), can be given twice for paired ends (for stdin use -)" << endl
     << "  -G, --gam-input FILE          input GAM (for stdin, use -)" << endl
     << "  -i, --interleaved             FASTQ or GAM contains interleaved paired ends" << endl
     << "  -N, --sample NAME             add this sample name to output" << endl
     << "  -R, --read-group NAME         add this read group to output" << endl
     << "  -e, --same-strand             read pairs are from the same strand of the DNA molecule" << endl
     << "algorithm:" << endl
-    << "  -S, --single-path-mode        produce single-path alignments (GAM) instead of multipath alignments (GAMP) (ignores -sXa)" << endl
-    << "  -O, --min-dist-cluster        use the minimum distance based clusterer (requires a distance index from -d)" << endl
+    << "  -S, --single-path-mode        output single-path alignments (GAM) instead of multipath alignments (GAMP) (ignores -saX)" << endl
+    //<< "       --min-dist-cluster        use the minimum distance based clusterer (requires a distance index from -d)" << endl
     << "  -s, --snarls FILE             align to alternate paths in these snarls" << endl
     << "scoring:" << endl
     << "  -E, --long-read-scoring       set alignment scores to long-read defaults: -q1 -z1 -o1 -y1 -L0 (can be overridden)" << endl
@@ -58,15 +58,15 @@ void help_mpmap(char** argv) {
     << endl
     << "advanced options:" << endl
     << "algorithm:" << endl
-    << "  -v, --tvs-clusterer           use the target value search-based clusterer (requires a distance index from -d)" << endl
-    << "  -X, --snarl-max-cut INT       do not align to alternate paths in a snarl if an exact match is at least this long (0 for no limit) [5]" << endl
-    << "  -a, --alt-paths INT           align to (up to) this many alternate paths in between MEMs or in snarls [10]" << endl
+    //<< "  -v, --tvs-clusterer           use the target value search-based clusterer (requires a distance index from -d)" << endl
+    << "  -X, --snarl-max-cut INT       do not align to extra paths in a snarl if there is an exact match this long (0 for no limit) [5]" << endl
+    << "  -a, --alt-paths INT           align to (up to) this many alternate paths in snarls [10]" << endl
     //<< "      --suppress-tail-anchors   don't produce extra anchors when aligning to alternate paths in snarls" << endl
     << "  -b, --frag-sample INT         look for this many unambiguous mappings to estimate the fragment length distribution [1000]" << endl
-    << "  -I, --frag-mean               mean for fixed fragment length distribution" << endl
-    << "  -D, --frag-stddev             standard deviation for fixed fragment length distribution" << endl
+    << "  -I, --frag-mean FLOAT         mean for a pre-determined fragment length distribution (also requires -D)" << endl
+    << "  -D, --frag-stddev FLOAT       standard deviation for a pre-determined fragment length distribution (also requires -I)" << endl
     << "  -B, --no-calibrate            do not auto-calibrate mismapping dectection" << endl
-    << "  -P, --max-p-val FLOAT         background model p value must be less than this to avoid mismapping detection [0.00001]" << endl
+    //<< "  -P, --max-p-val FLOAT         background model p-value must be less than this to avoid mismapping detection [0.00001]" << endl
     << "  -Q, --mq-max INT              cap mapping quality estimates at this much [60]" << endl
     << "  -U, --report-group-mapq       add an annotation for the collective mapping quality of all reported alignments" << endl
     //<< "  -p, --padding-mult FLOAT      pad dynamic programming bands in inter-MEM alignment FLOAT * sqrt(read length) [1.0]" << endl
@@ -74,8 +74,8 @@ void help_mpmap(char** argv) {
     //<< "      --max-paths INT           consider (up to) this many paths per alignment for population consistency scoring, 0 to disable [10]" << endl
     //<< "      --top-tracebacks          consider paths for each alignment based only on alignment score and not based on haplotypes" << endl
     << "  -M, --max-multimaps INT       report (up to) this many mappings per read [1]" << endl
-    << "  -r, --reseed-length INT       reseed SMEMs for internal MEMs if they are at least this long (0 for no reseeding) [28]" << endl
-    << "  -W, --reseed-diff FLOAT       require internal MEMs to have length within this much of the SMEM's length [0.45]" << endl
+    //<< "  -r, --reseed-length INT       reseed SMEMs for internal MEMs if they are at least this long (0 for no reseeding) [28]" << endl
+    //<< "  -W, --reseed-diff FLOAT       require internal MEMs to have length within this much of the SMEM's length [0.45]" << endl
     //<< "  -K, --clust-length INT        minimum MEM length used in clustering [automatic]" << endl
     << "  -c, --hit-max INT             use at most this many hits for any MEM (0 for no limit) [1024]" << endl
     //<< "  --approx-exp FLOAT            let the approximate likelihood miscalculate likelihood ratios by this power [10.0]" << endl
@@ -83,21 +83,23 @@ void help_mpmap(char** argv) {
     //<< "  --always-check-population     always try to population-score reads, even if there is only a single mapping" << endl
     //<< "  --delay-population            do not apply population scoring at intermediate stages of the mapping algorithm" << endl
     //<< "  --force-haplotype-count INT   assume that INT haplotypes ought to run through each fixed part of the graph, if nonzero [0]" << endl
-    << "  -C, --drop-subgraph FLOAT     drop alignment subgraphs whose MEMs cover this fraction less of the read than the best subgraph [0.2]" << endl
+    //<< "  -C, --drop-subgraph FLOAT     drop alignment subgraphs whose MEMs cover this fraction less of the read than the best subgraph [0.2]" << endl
     //<< "  --prune-exp FLOAT         prune MEM anchors if their approximate likelihood is this root less than the optimal anchors [1.25]" << endl
     << "scoring:" << endl
     << "  -A, --no-qual-adjust          do not perform base quality adjusted alignments even when base qualities are available" << endl
     << "  -q, --match INT               use this match score [1]" << endl
     << "  -z, --mismatch INT            use this mismatch penalty [4]" << endl
-    << "  -w, --score-matrix FILE           read a 5x5 integer substitution scoring matrix from a file (in the order ACGTN)" << endl
     << "  -o, --gap-open INT            use this gap open penalty [6]" << endl
     << "  -y, --gap-extend INT          use this gap extension penalty [1]" << endl
-    << "  -L, --full-l-bonus INT        add this score to alignments that use the full length of the read [5]" << endl
+    << "  -L, --full-l-bonus INT        add this score to alignments that align each end of the read [5]" << endl
+    << "  -w, --score-matrix FILE       read a 5x5 integer substitution scoring matrix from a file (in the order ACGTN)" << endl
     << "  -m, --remove-bonuses          remove full length alignment bonuses in reported scores" << endl
     << "computational parameters:" << endl
     << "  -Z, --buffer-size INT         buffer this many alignments together (per compute thread) before outputting to stdout [200]" << endl;
     
 }
+
+
 
 int main_mpmap(int argc, char** argv) {
 
@@ -114,6 +116,7 @@ int main_mpmap(int argc, char** argv) {
     #define OPT_FORCE_HAPLOTYPE_COUNT 1004
     #define OPT_SUPPRESS_TAIL_ANCHORS 1005
     #define OPT_TOP_TRACEBACKS 1006
+    #define OPT_MIN_DIST_CLUSTER 1007
     #define OPT_APPROX_EXP 1008
     #define OPT_MAX_PATHS 1009
     string matrix_file_name;
@@ -133,7 +136,8 @@ int main_mpmap(int argc, char** argv) {
     int gap_extension_score = default_gap_extension;
     int full_length_bonus = default_full_length_bonus;
     bool interleaved_input = false;
-    int snarl_cut_size = 5;
+    int default_snarl_cut_size = 5;
+    int snarl_cut_size = default_snarl_cut_size;
     int max_branch_trim_length = 5;
     bool suppress_tail_anchors = false;
     int max_paired_end_map_attempts = 24;
@@ -164,7 +168,8 @@ int main_mpmap(int argc, char** argv) {
     bool report_group_mapq = false;
     double band_padding_multiplier = 1.0;
     int max_dist_error = 12;
-    int num_alt_alns = 10;
+    int default_num_alt_alns = 10;
+    int num_alt_alns = default_num_alt_alns;
     double suboptimal_path_exponent = 1.25;
     double likelihood_approx_exp = 10.0;
     double recombination_penalty = 20.7;
@@ -255,7 +260,7 @@ int main_mpmap(int argc, char** argv) {
             {"always-check-population", no_argument, 0, OPT_ALWAYS_CHECK_POPULATION},
             {"delay-population", no_argument, 0, OPT_DELAY_POPULATION_SCORING},
             {"force-haplotype-count", required_argument, 0, OPT_FORCE_HAPLOTYPE_COUNT},
-            {"min-dist-cluster", no_argument, 0, 'O'},
+            {"min-dist-cluster", no_argument, 0, OPT_MIN_DIST_CLUSTER},
             {"drop-subgraph", required_argument, 0, 'C'},
             {"prune-exp", required_argument, 0, OPT_PRUNE_EXP},
             {"long-read-scoring", no_argument, 0, 'E'},
@@ -273,7 +278,7 @@ int main_mpmap(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:ieSO:s:vX:u:a:b:I:D:BP:Q:Up:M:r:W:K:c:C:R:Eq:z:w:o:y:L:mAt:Z:",
+        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:ieS:s:vX:u:a:b:I:D:BP:Q:Up:M:r:W:K:c:C:R:Eq:z:w:o:y:L:mAt:Z:",
                          long_options, &option_index);
 
 
@@ -312,6 +317,9 @@ int main_mpmap(int argc, char** argv) {
                 if (distance_index_name.empty()) {
                     cerr << "error:[vg mpmap] Must provide distance index file with -d" << endl;
                     exit(1);
+                }
+                if (!use_tvs_clusterer) {
+                    use_min_dist_clusterer = true;
                 }
                 break;
                 
@@ -394,6 +402,7 @@ int main_mpmap(int argc, char** argv) {
                 
             case 'v':
                 use_tvs_clusterer = true;
+                use_min_dist_clusterer = false;
                 break;
                 
             case 'X':
@@ -492,8 +501,9 @@ int main_mpmap(int argc, char** argv) {
                 force_haplotype_count = parse<size_t>(optarg);
                 break;
                 
-            case 'O':
-                use_min_dist_clusterer = true;
+            case OPT_MIN_DIST_CLUSTER:
+                // This the default behavior
+                //use_min_dist_clusterer = true;
                 break;
                 
             case 'C':
@@ -728,12 +738,12 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (use_min_dist_clusterer && distance_index_name.empty()) {
-        cerr << "error:[vg mpmap] The minimum distance clusterer (-O) requires a distance index (-d)." << endl;
+        cerr << "error:[vg mpmap] The minimum distance clusterer (--min-dist-cluster) requires a distance index (-d)." << endl;
         exit(1);
     }
     
     if (use_min_dist_clusterer && use_tvs_clusterer) {
-        cerr << "error:[vg mpmap] Cannot perform both minimum distance clustering (-O) and target value clustering (-v)." << endl;
+        cerr << "error:[vg mpmap] Cannot perform both minimum distance clustering (--min-dist-cluster) and target value clustering (-v)." << endl;
         exit(1);
     }
     
@@ -789,17 +799,16 @@ int main_mpmap(int argc, char** argv) {
     // adjust parameters that produce irrelevant extra work or bad behavior single path mode
     
     if (single_path_alignment_mode && population_max_paths == 0) {
-        // TODO: I don't like having these constants floating around in two different places, but it's not very risky, just a warning
         if (!snarls_name.empty()) {
             cerr << "warning:[vg mpmap] Snarl file (-s) is ignored in single path mode (-S) without multipath population scoring (--max-paths)." << endl;
             // TODO: Not true!
         }
         
-        if (snarl_cut_size != 5) {
+        if (snarl_cut_size != default_snarl_cut_size) {
             cerr << "warning:[vg mpmap] Snarl cut limit (-X) is ignored in single path mode (-S) without multipath population scoring (--max-paths)." << endl;
         }
         
-        if (num_alt_alns != 4) {
+        if (num_alt_alns != default_num_alt_alns) {
             cerr << "warning:[vg mpmap] Number of alternate alignments (-a) is ignored in single path mode (-S) without multipath population scoring (--max-paths)." << endl;
         }
         


### PR DESCRIPTION
This PR removes some options from the mpmap help that nobody would know how to tune but me or that we've moved away from. The long versions are maintained but hidden, but some of the short names are reallocated, which could in theory break some existing pipelines (I doubt anyone is using the parameters though). Also, mpmap will no longer complain and crash when directed to use quality-adjusted scoring but given input without base qualities. 

Also fixes some stability problems in the calibration routine for mismapping detection and improves the speed of the fitting. 