### PR TITLE
Partial bug fix for surjection soft clips in splice-variation graphs

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2018,6 +2018,7 @@ namespace vg {
                         cerr << "found a duplicate" << endl;
 #endif
                         duplicate = true;
+                        // TODO: should i take the max of the multiplicities, or let it stay at 1?
                         break;
                     }
                 }

--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -537,18 +537,17 @@ ReadFilter::Counts ReadFilter::filter_alignment(Alignment& aln) {
                     found = true;
                     break;
                 }
-                    
-                if (center_match < name_prefixes[center].size() && center_match < aln.name().size()) {
-                    // There's a character that differs
-                    if (name_prefixes[center][center_match] < aln.name()[center_match]) {
-                        // The match, if it exists, must be after us.
-                        left_bound = center;
-                        left_match = center_match;
-                    } else {
-                        // The match, if it exists, must be before us
-                        right_bound = center;
-                        right_match = center_match;
-                    }
+                
+                if (center_match == aln.name().size() ||
+                    name_prefixes[center][center_match] > aln.name()[center_match]) {
+                    // The match, if it exists, must be before us
+                    right_bound = center;
+                    right_match = center_match;
+                }
+                else {
+                    // The match, if it exists, must be after us.
+                    left_bound = center;
+                    left_match = center_match;
                 }
             }
         }

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -534,7 +534,7 @@ using namespace std;
         for (size_t i = 0; i < sections.size(); ++i) {
             score_dp[i] = sections[i].score();
         }
-        if (!allow_negative_scores) {
+        if (allow_negative_scores) {
             // remove the initialization if it's not a source so we don't allow subpath local alignments
             for (size_t i = 0; i < constriction_targets.size(); ++i) {
                 score_dp[constriction_comps[constriction_targets[i]]] = numeric_limits<int32_t>::min();
@@ -549,9 +549,11 @@ using namespace std;
             is_sink[from] = false;
             
             int32_t extended_score = score_dp[from] + section_edge_scores[i] + sections[to].score();
+            
 #ifdef debug_spliced_surject
-            cerr << "extending from component " << from << " (DP score" << score_dp[from] << ") with score of " << extended_score << " to " << to << " (DP score " << score_dp[to] << ")" << endl;
+            cerr << "extending from component " << from << " (DP score " << score_dp[from] << ") with score of " << extended_score << " to " << to << " (DP score " << score_dp[to] << ")" << endl;
 #endif
+            
             if (extended_score > score_dp[to]) {
                 score_dp[to] = extended_score;
                 backpointer[to] = from;

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -519,6 +519,10 @@ using namespace std;
                                (deletion_length > 1 ? (deletion_length - 1) * get_aligner()->gap_extension : 0));
             }
             section_edge_scores[i] = edge_score;
+            
+#ifdef debug_spliced_surject
+            cerr << "edge has score " << edge_score << endl;
+#endif
         }
         
         // now we find use dynamic programming to find the best alignment across chunks
@@ -545,6 +549,9 @@ using namespace std;
             is_sink[from] = false;
             
             int32_t extended_score = score_dp[from] + section_edge_scores[i] + sections[to].score();
+#ifdef debug_spliced_surject
+            cerr << "extending from component " << from << " (DP score" << score_dp[from] << ") with score of " << extended_score << " to " << to << " (DP score " << score_dp[to] << ")" << endl;
+#endif
             if (extended_score > score_dp[to]) {
                 score_dp[to] = extended_score;
                 backpointer[to] = from;
@@ -569,6 +576,9 @@ using namespace std;
         
 #ifdef debug_spliced_surject
         cerr << "combining " << traceback.size() << " sections into surjected alignment" << endl;
+        for (int64_t i = traceback.size() - 1; i >= 0; --i) {
+            cerr << "\t" << traceback[i] << endl;
+        }
 #endif
         
         // make an alignment to build out the path in


### PR DESCRIPTION
The surject algorithm doesn't properly detect splice junctions in splice-variation graphs. It also had a bug that was interacting with this problem, leading to big soft-clips on transcript alignments. This PR fixes the bug, which will (approximately) fix the problem of soft-clipping. However, the algorithm can still have some micro-alignment issues around splice junctions, and the alignment scores will not be accurate.

@jonassibbesen I think this should work as a stop-gap for your pipeline, since the transcript surjections will be mostly accurate (although some splices will be identified as deletions instead of unaligned sequences, i.e. D rather than N in the CIGAR).