### PR TITLE
Use auto-indexing in Giraffe

### DIFF
--- a/doc/asciidoc/man/vg-gaffe.adoc
+++ b/doc/asciidoc/man/vg-gaffe.adoc
@@ -12,29 +12,40 @@ vg-gaffe - map unpaired short reads using minimizers and gapless extension
 
 == Synopsis
 
-*vg gaffe* [_OPTION_] > output.gam
+*vg gaffe* [_OPTION_]... [_FASTA_ [_VCF_]] > output.gam
+
+== Arguments
+
+_FASTA_::
+    Specify a FASTA file to build the graph from. Must have an extension *.fa*, *.fna*, or *.fasta*, with optional *.gz*. The name without extension is used as the _basename_ under which to look for index files with their own extensions, if *-x*/*--xg-name* is not specified. If omitted, *-x*/*--xg-name* is required.
+    
+_VCF_::
+    Variant Call Format file containing phased haplotypes, used to build the graph and haplotype database (GBWT) if those are not themselves provided. Must have a *.vcf.gz* extension, and an associated *.vcf.gz.tbi* index file. If omitted, a graph and GBWT must already exist and must be provided, either explicitly with *-x*/*--xg-name* and *-H*/*--gbwt-name*, or via the _FASTA_ or *-x*/*--xg-name* derived _basename_.
+    
+_TAG_::
+    Specify a collection of tests to run, via []-enclosed tag. Tag may need to be quoted to avoid being interpreted as a shell wildcard character class.
 
 == Options
 
 *-x*::
 *--xg-name*=_FILE_::
-  Use this xg index or graph (required if -g not specified)
+  Use this xg index or graph. The file name without extension is also used as the _basename_ for finding indexes, overriding any FASTA-derived _basename_. If omitted, _FASTA_ is required. If not specified, will load _basename.vg_ and create that file if not present.
  
 *-g*::
 *--graph-name*=_FILE_:: 
-  Use this GBWTGraph (required if -x not specified)
+  Load this GBWTGraph. If not specified, will load _basename.gg_ and create that file if not present.
 
 *-H*::
 *--gbwt-name*=_FILE_:: 
-  Use this GBWT index (required)
+  Use this GBWT index. If not specified, will load _basename.gbwt_ and create that file if not present.
 
 *-m*::
 *--minimizer-name*=_FILE_:: 
-  Use this minimizer index (required)
+  Use this minimizer index. If not specified, will load _basename.min_ and create that file if not present.
 
 *-d*::
 *--dist-name*=_FILE_:: 
-  Cluster using this distance index (required)
+  Cluster using this distance index. If not specified, will load _basename.dist_ and create that file if not present.
 
 *-p*::
 *--progress*:: 
@@ -136,23 +147,57 @@ It is specialized for low-error-rate short reads.
 Giraffe uses minimizers of the graph's haplotypes and gapless extension to map the reads.
 Because the graph is expected to contain a relatively complete inventory of a certain type of variation, gapless alignment is sufficient to align most reads and a more expensive gapped alignment step is required for only a minority of cases.
 
-*vg gaffe* requires four graph indexes: An xg index or gbwt graph, gbwt index, minimizer index, and distance index. 
-These are built with *vg index* and *vg minimizer*
+*vg gaffe* requires four input files to define the reference: A graph or GBWTGraph, a GBWT index, a minimizer index, and a distance index. 
+Each can also be automatically produced by *vg gaffe*, given the requisite input files.
+The graph and indexes can be produced automatically if _FASTA_ and _VCF_ are specified.
+The _basename_ is a file path derived from the graph file (specified by *-x*/*--xg-name*), or from the _FASTA_ argument if no graph file is specified. It is combined with an extension for each index type to produce the filename from which that index will be loaded, or to which it will be saved if it is constructed.
 
+Because indexing is resource-intensive, the graph and indexes can be manually constructed in advance.
+The graph can be built wiht *vg construct*.
+Indexes can be manually built with *vg index* and *vg minimizer*, as well as *vg snarls* to provide the snarls file needed for the distance index.
+If desired, the GBWTgraph can also be pre-generated with *vg gbwt*.
+
+When building the graph with *vg construct* for use with *vg gaffe*, it is important to provide the *-a* option in order to embed the variant information necessary to later build the GBWT.
+
+When building snarls with *vg snarls*, it is important to provide the *-T*/*--include-trivial* option to include trivial snarls, which are required when building the distance index.
 
 == Examples
 
 To map reads to an indexed graph and write the alignment to a gam file:
 
 ----
-$ vg gaffe -x graph.xg -H graph.gbwt -m graph.min -d graph.dist -G reads.gam > mapped.gam
+$ vg gaffe -x reference.xg -H reference.gbwt -m reference.min -d reference.dist -G reads.gam > mapped.gam
+----
+
+Same as above, but implicitly finding other indexes using the graph's filename:
+
+----
+$ vg gaffe -x reference.xg -G reads.gam > mapped.gam
+----
+
+To map reads building all indexes dynamically, if not found, from a FASTA and indexed VCF:
+
+----
+$ vg gaffe reference.fa phased_haplotypes.vcf.gz -G reads.gam > mapped.gam
+----
+
+Same as above, but manually pre-building the graph and all indexes, and providing the graph to define _basename_:
+
+----
+$ vg construct -a -r reference.fa -v phased_haplotypes.vcf.gz >reference.vg
+$ vg index -G reference.gbwt -v phased_haplotypes.vcf.gz reference.vg
+$ vg snarls --include-trivial reference.vg > reference.snarls
+$ vg index -s reference.snarls -j reference.dist reference.vg
+$ vg minimizer -k 29 -w 11 -g reference.gbwt -i reference.min reference.vg
+$ vg gbwt -g reference.gg -x reference.vg reference.gbwt
+$ vg gaffe -x reference.vg -G reads.gam > mapped.gam
 ----
 
 == See Also
-*vg*(1), *git*(1)
+*vg*(1)
 
 == Copyright
 
-Copyright (C) 2019 {author}.
+Copyright (C) 2020 {author}.
 
 Free use of this documentation is granted under the terms of the MIT License.

--- a/doc/asciidoc/man/vg-test.adoc
+++ b/doc/asciidoc/man/vg-test.adoc
@@ -14,6 +14,17 @@ vg-test - run internal vg unit tests
 
 *vg test* [_TESTNAME_ | _PATTERN_ | _TAG_]... [_OPTION_]... 
 
+== Arguments
+
+_TESTNAME_::
+    Specify a test to run, by full name.
+    
+_PATTERN_::
+    Specify a collection of tests to run, via regular expression match.
+    
+_TAG_::
+    Specify a collection of tests to run, via []-enclosed tag. Tag may need to be quoted to avoid being interpreted as a shell wildcard character class.
+
 == Options
 
 *-?*::
@@ -138,6 +149,6 @@ vg test [a-star]
 
 == Copyright
 
-Copyright (C) 2019 {author}.
+Copyright (C) 2020 {author}.
 
 Free use of this documentation is granted under the terms of the MIT License.

--- a/src/index_manager.cpp
+++ b/src/index_manager.cpp
@@ -136,7 +136,7 @@ void IndexManager::ensure_distance() {
 void IndexManager::ensure_gbwt() {
     ensure(gbwt, "gbwt", [&](istream& in) {
         // Load GBWT from the file
-        auto loaded = vg::io::VPKG::load_one<gbwt::DynamicGBWT>(in);
+        auto loaded = vg::io::VPKG::load_one<gbwt::GBWT>(in);
         gbwt.reset(loaded.release());
     }, [&](ostream& out) {
         // Make and save
@@ -147,11 +147,12 @@ void IndexManager::ensure_gbwt() {
         HaplotypeIndexer indexer;
         indexer.show_progress = show_progress;
 
-        // Make it
+        // Make it, making sure to convert to non-dynamic GBWT
         map<string, Path> alt_paths;
         vector<string> insertion_filenames;
         auto built = indexer.build_gbwt(graph.get(), alt_paths, false, vcf_filename, insertion_filenames);
-        gbwt.reset(built.release());
+        gbwt = make_shared<gbwt::GBWT>(*built);
+        built.reset();
 
         // Save it
         vg::io::VPKG::save(*gbwt, out);

--- a/src/index_manager.cpp
+++ b/src/index_manager.cpp
@@ -29,7 +29,7 @@ IndexManager::IndexManager(const string& fasta_filename, const string& vcf_filen
 
 void IndexManager::set_fasta_filename(const string& filename) {
     fasta_filename = filename;
-    if (!fasta_filename.empty()) {
+    if (!fasta_filename.empty() && basename.empty()) {
         // Work out the basename from the FASTA name, which may be .fa or .fa.gz
         pair<string, string> parts = split_ext(fasta_filename);
         if (parts.second == "gz") {

--- a/src/index_manager.cpp
+++ b/src/index_manager.cpp
@@ -113,13 +113,15 @@ void IndexManager::ensure(IndexHolderType& member, const string& filename_overri
 
     // Work out where to load from/save to
     string filename = get_filename(extension);
-    
+
     // Load from the normal filename, or the override if set
-    ifstream in(filename_override.empty() ? filename : filename_override);
+    string input_filename = filename_override.empty() ? filename : filename_override;
+    
+    ifstream in(input_filename);
     if (in) {
         // Load the item
         if (show_progress) {
-            cerr << "Loading " << extension << "..." << endl;
+            cerr << "Loading " << extension << " from " << input_filename << endl;
         }
         load(in);
     } else {
@@ -132,7 +134,7 @@ void IndexManager::ensure(IndexHolderType& member, const string& filename_overri
         }
         
         if (show_progress) {
-            cerr << "Building " << extension << "..." << endl;
+            cerr << "Building " << extension << " to " << filename << endl;
         }
         make_and_save(out);
     }

--- a/src/index_manager.hpp
+++ b/src/index_manager.hpp
@@ -44,6 +44,28 @@ public:
      * The fasta must be .fa or .fa.gz
      */
     IndexManager(const string& fasta_filename, const string& vcf_filename = "");
+
+    // Functions to set a source filename override, and get an index, for each index type.
+
+    /// Override the file to load the minimizer index from
+    void set_minimizer_override(const string& filename);
+    /// Get the minimizer index
+    shared_ptr<gbwtgraph::DefaultMinimizerIndex> get_minimizer();
+
+    /// Override the file to load the gbwtgraph index from
+    void set_gbwtgraph_override(const string& filename);
+    /// Get the gbwtgraph index
+    shared_ptr<gbwtgraph::GBWTGraph> get_gbwtgraph();
+
+    /// Override the file to load the gbwt index from
+    void set_gbwt_override(const string& filename);
+    /// Get the gbwt index
+    shared_ptr<gbwt::GBWT> get_gbwt();
+
+    /// Override the file to load the distance index from
+    void set_distance_override(const string& filename);
+    /// Get the gbwt index
+    shared_ptr<vg::MinimumDistanceIndex> get_distance();
     
     /**
      * Get the indexes that are used for mapping. If not available, they will be generated.
@@ -63,6 +85,14 @@ protected:
     string vcf_filename;
     // And the basename of the FASTA, which is where we expect to find our indexes.
     string basename;
+
+    // Override filenames for loading all the indexes from
+    string minimizer_override;
+    string gbwtgraph_override;
+    string gbwt_override;
+    string distance_override;
+    string snarls_override;
+    string graph_override;
 
     // Store the final mapping indexes
     shared_ptr<gbwtgraph::DefaultMinimizerIndex> minimizer;
@@ -98,7 +128,8 @@ protected:
     /// We have a template to help us stamp out these ensure functions.
     /// We define it in the CPP since only we ever use it.
     template<typename IndexHolderType>
-    void ensure(IndexHolderType& member, const string& extension, const function<void(istream&)>& load, const function<void(ostream&)>& make_and_save);
+    void ensure(IndexHolderType& member, const string& filename_override, const string& extension,
+        const function<void(istream&)>& load, const function<void(ostream&)>& make_and_save);
 
 
     

--- a/src/index_manager.hpp
+++ b/src/index_manager.hpp
@@ -45,7 +45,8 @@ using namespace std;
  * 4. A public method "set_foo_override()" to set the override filename.
  * 5. A public method "get_foo()" to fill it in (via "ensure_foo()") and return it.
  * 6. A public method "can_get_foo()" which returns true if it thinks get_foo()
- *    will be successful, and false if e.g. necessary files are missing.
+ *    will be successful, and false (and prints a warning) if e.g. necessary
+ *    files are missing.
  */
 class IndexManager : public Progressive {
 public:

--- a/src/index_manager.hpp
+++ b/src/index_manager.hpp
@@ -47,6 +47,10 @@ using namespace std;
  * 6. A public method "can_get_foo()" which returns true if it thinks get_foo()
  *    will be successful, and false (and prints a warning) if e.g. necessary
  *    files are missing.
+ *
+ * Note that the IndexManager may exit the process, instead of throwing an
+ * exception, if something goes wrong during a "get_foo()" method, so you
+ * should check "can_get_foo()" first.
  */
 class IndexManager : public Progressive {
 public:
@@ -170,7 +174,7 @@ protected:
     /// basename and a file to write to.
     template<typename IndexHolderType>
     void ensure(IndexHolderType& member, const string& filename_override, const string& extension,
-        const function<void(istream&)>& load, const function<void(ostream&)>& make_and_save);
+        const function<void(ifstream&)>& load, const function<void(ofstream&)>& make_and_save);
         
     
     /// We have a template for helping write the can_get functions. Defined in

--- a/src/index_manager.hpp
+++ b/src/index_manager.hpp
@@ -67,8 +67,8 @@ protected:
     // Store the final mapping indexes
     shared_ptr<gbwtgraph::DefaultMinimizerIndex> minimizer;
     // GBWTGraph needs to keep a reference to the used GBWT alive, so it is stored in a different type.
-    pair<shared_ptr<gbwtgraph::GBWTGraph>, shared_ptr<gbwt::DynamicGBWT>> gbwtgraph;
-    shared_ptr<gbwt::DynamicGBWT> gbwt;
+    pair<shared_ptr<gbwtgraph::GBWTGraph>, shared_ptr<gbwt::GBWT>> gbwtgraph;
+    shared_ptr<gbwt::GBWT> gbwt;
     shared_ptr<vg::MinimumDistanceIndex> distance;
     
     // And then the intermediate types: snarls and base non-GBWT graph

--- a/src/index_manager.hpp
+++ b/src/index_manager.hpp
@@ -18,6 +18,7 @@
 #include "handle.hpp"
 #include "min_distance.hpp"
 #include "snarls.hpp"
+#include "progressive.hpp"
 
 namespace vg {
 
@@ -34,7 +35,7 @@ using namespace std;
  * that the corresponding index is populated, either from disk if available, or
  * from the indexes it depends on, first calling the ensure method for each.
  */
-class IndexManager {
+class IndexManager : public Progressive {
 public:
     /*
      * Make a new IndexManager with the given FASTA providing the basename, and
@@ -49,6 +50,11 @@ public:
      */
     tuple<gbwtgraph::GBWTGraph*, gbwt::GBWT*, gbwtgraph::DefaultMinimizerIndex*, vg::MinimumDistanceIndex*> get_mapping_indexes();
 
+    /// Minimizer kmer length to use when minimizer indexing
+    size_t minimizer_k = 29;
+    /// Minimizer window size to use when minimizer indexing
+    size_t minimizer_w = 11;
+
 protected:
 
     // Save the input FASTA filename
@@ -61,8 +67,8 @@ protected:
     // Store the final mapping indexes
     shared_ptr<gbwtgraph::DefaultMinimizerIndex> minimizer;
     // GBWTGraph needs to keep a reference to the used GBWT alive, so it is stored in a different type.
-    pair<shared_ptr<gbwtgraph::GBWTGraph>, shared_ptr<gbwt::GBWT>> gbwtgraph;
-    shared_ptr<gbwt::GBWT> gbwt;
+    pair<shared_ptr<gbwtgraph::GBWTGraph>, shared_ptr<gbwt::DynamicGBWT>> gbwtgraph;
+    shared_ptr<gbwt::DynamicGBWT> gbwt;
     shared_ptr<vg::MinimumDistanceIndex> distance;
     
     // And then the intermediate types: snarls and base non-GBWT graph

--- a/src/index_manager.hpp
+++ b/src/index_manager.hpp
@@ -79,16 +79,12 @@ public:
     /// Get the snarls
     shared_ptr<vg::SnarlManager> get_snarls();
 
-    /// Override the file to load the graph from
+    /// Override the file to load the graph from.
+    /// Also sets index basename to be based on this graph file.
     void set_graph_override(const string& filename);
     /// Get the graph
     shared_ptr<PathHandleGraph> get_graph();
     
-    /**
-     * Get the indexes that are used for mapping. If not available, they will be generated.
-     */
-    tuple<gbwtgraph::GBWTGraph*, gbwt::GBWT*, gbwtgraph::DefaultMinimizerIndex*, vg::MinimumDistanceIndex*> get_mapping_indexes();
-
     /// Minimizer kmer length to use when minimizer indexing
     size_t minimizer_k = 29;
     /// Minimizer window size to use when minimizer indexing
@@ -144,6 +140,8 @@ protected:
 
     /// We have a template to help us stamp out these ensure functions.
     /// We define it in the CPP since only we ever use it.
+    /// Note that the ostream to make_and_save is only open if there is a
+    /// basename and a file to write to.
     template<typename IndexHolderType>
     void ensure(IndexHolderType& member, const string& filename_override, const string& extension,
         const function<void(istream&)>& load, const function<void(ostream&)>& make_and_save);
@@ -153,6 +151,7 @@ protected:
     /// Get the filename for the index file having the given extension.
     /// Extension should not include the dot.
     /// May or may not exist yet.
+    /// Returns "" if there is no basename.
     string get_filename(const string& extension) const;
 
     

--- a/src/index_manager.hpp
+++ b/src/index_manager.hpp
@@ -45,7 +45,7 @@ public:
      */
     IndexManager(const string& fasta_filename = "", const string& vcf_filename = "");
 
-    /// Set the FASTA filename (and thus the basename for looking for other indexes.
+    /// Set the FASTA filename (and thus the basename for looking for other indexes, if not already set).
     void set_fasta_filename(const string& filename);
 
     /// Set the VCF filename

--- a/src/index_manager.hpp
+++ b/src/index_manager.hpp
@@ -43,7 +43,14 @@ public:
      *
      * The fasta must be .fa or .fa.gz
      */
-    IndexManager(const string& fasta_filename, const string& vcf_filename = "");
+    IndexManager(const string& fasta_filename = "", const string& vcf_filename = "");
+
+    /// Set the FASTA filename (and thus the basename for looking for other indexes.
+    void set_fasta_filename(const string& filename);
+
+    /// Set the VCF filename
+    void set_vcf_filename(const string& filename);
+
 
     // Functions to set a source filename override, and get an index, for each index type.
 
@@ -66,6 +73,16 @@ public:
     void set_distance_override(const string& filename);
     /// Get the gbwt index
     shared_ptr<vg::MinimumDistanceIndex> get_distance();
+
+    /// Override the file to load the snarls from
+    void set_snarls_override(const string& filename);
+    /// Get the snarls
+    shared_ptr<vg::SnarlManager> get_snarls();
+
+    /// Override the file to load the graph from
+    void set_graph_override(const string& filename);
+    /// Get the graph
+    shared_ptr<PathHandleGraph> get_graph();
     
     /**
      * Get the indexes that are used for mapping. If not available, they will be generated.

--- a/src/index_manager.hpp
+++ b/src/index_manager.hpp
@@ -88,11 +88,20 @@ protected:
     
     /// Load the minimizer index, or make it from the GBWTGraph and the GBWT and save it to disk.
     void ensure_minimizer();
+
+    /// We have a template to help us stamp out these ensure functions.
+    /// We define it in the CPP since only we ever use it.
+    template<typename IndexHolderType>
+    void ensure(IndexHolderType& member, const string& extension, const function<void(istream&)>& load, const function<void(ostream&)>& make_and_save);
+
+
     
     /// Get the filename for the index file having the given extension.
     /// Extension should not include the dot.
     /// May or may not exist yet.
     string get_filename(const string& extension) const;
+
+    
     
 };
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -23,7 +23,7 @@ using namespace std;
 constexpr size_t MinimizerMapper::PRECISION;
 
 MinimizerMapper::MinimizerMapper(const gbwtgraph::GBWTGraph& graph,
-    const std::vector<std::unique_ptr<gbwtgraph::DefaultMinimizerIndex>>& minimizer_indexes,
+    const std::vector<gbwtgraph::DefaultMinimizerIndex*>& minimizer_indexes,
     MinimumDistanceIndex& distance_index, const PathPositionHandleGraph* path_graph) :
     path_graph(path_graph), minimizer_indexes(minimizer_indexes),
     distance_index(distance_index), gbwt_graph(graph),

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <cmath>
 
-#define debug
+//#define debug
 
 namespace vg {
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <cmath>
 
-//#define debug
+#define debug
 
 namespace vg {
 
@@ -972,8 +972,8 @@ pair<vector<Alignment>, vector< Alignment>> MinimizerMapper::map_paired(Alignmen
                         // Insert the (graph position, read offset) pair.
                         seed_matchings.insert(GaplessExtender::to_seed(seeds[seed_index], minimizers[seed_to_source[seed_index]].value.offset));
 #ifdef debug
-                        cerr << "Seed read:" << minimizers[seed_to_source[seed_index]].offset << " = " << seeds[seed_index]
-                            << " from minimizer " << seed_to_source[seed_index] << "(" << minimizer.hits << ")" << endl;
+                        cerr << "Seed read:" << minimizers[seed_to_source[seed_index]].value.offset << " = " << seeds[seed_index]
+                            << " from minimizer " << seed_to_source[seed_index] << endl;
 #endif
                     }
                     
@@ -2002,7 +2002,7 @@ double MinimizerMapper::window_breaking_quality(const vector<Minimizer>& minimiz
 #ifdef debug
                 cerr << "\t\tBase flanks minimizer " << active_index << " (" << active.value.offset
                     << "-" << (active.value.offset + index.k()) << ") and has " << possible_minimizers
-                    << " chances to have beaten it at P=" << (1.0 - each_not_beat) << " each; cost to have beaten with any is Phred " << any_beat_phred << endl;
+                    << " chances to have beaten it; cost to have beaten with any is Phred " << any_beat_phred << endl;
 #endif
 
                 // Then we AND (sum) the Phred of that in, as an additional cost to mutating this base and kitting all the windows it covers.

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -33,7 +33,7 @@ public:
      */
 
     MinimizerMapper(const gbwtgraph::GBWTGraph& graph,
-         const std::vector<std::unique_ptr<gbwtgraph::DefaultMinimizerIndex>>& minimizer_indexes,
+         const std::vector<gbwtgraph::DefaultMinimizerIndex*>& minimizer_indexes,
          MinimumDistanceIndex& distance_index, const PathPositionHandleGraph* path_graph = nullptr);
 
     /**
@@ -178,7 +178,7 @@ protected:
 
     // These are our indexes
     const PathPositionHandleGraph* path_graph; // Can be nullptr; only needed for correctness tracking.
-    const std::vector<std::unique_ptr<gbwtgraph::DefaultMinimizerIndex>>& minimizer_indexes;
+    const std::vector<gbwtgraph::DefaultMinimizerIndex*>& minimizer_indexes;
     MinimumDistanceIndex& distance_index;
 
     /// This is our primary graph.

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -5,6 +5,8 @@
 
 //#define debug
 
+#include <vg/io/protobuf_emitter.hpp>
+
 #include "snarls.hpp"
 #include "json2pb.h"
 #include "algorithms/topological_sort.hpp"
@@ -612,6 +614,30 @@ SnarlManager::SnarlManager(const function<void(const function<void(Snarl&)>&)>& 
     });
     // Record the tree structure and build the other indexes
     finish();
+}
+
+void SnarlManager::serialize(ostream& out) const {
+    
+    vg::io::ProtobufEmitter<Snarl> emitter(out);
+    list<const Snarl*> stack;
+
+    for (const Snarl* root : top_level_snarls()) {
+        stack.push_back(root);
+        
+        while (!stack.empty()) {
+            // Grab a snarl from the stack
+            const Snarl* snarl = stack.back();
+            stack.pop_back();
+            
+            // Write out the snarl
+            emitter.write_copy(*root);
+
+            for (const Snarl* child_snarl : children_of(snarl)) {
+                // Stack up its children
+                stack.push_back(child_snarl);
+            }
+        }
+    }
 }
     
 const vector<const Snarl*>& SnarlManager::children_of(const Snarl* snarl) const {

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -426,6 +426,9 @@ public:
     /// Can be moved
     SnarlManager(SnarlManager&& other) = default;
     SnarlManager& operator=(SnarlManager&& other) = default;
+
+    // Can be serialized
+    void serialize(ostream& out) const;
     
     ///////////////////////////////////////////////////////////////////////////
     // Write API

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -719,6 +719,22 @@ int main_gaffe(int argc, char** argv) {
     }
 
     // TODO: check for indexes we won't be able to build but we will need.
+    
+    if (have_input_file(optind, argc, argv)) {
+        // Must be the FASTA
+        indexes.set_fasta_filename(get_input_file_name(optind, argc, argv));
+        
+        if (have_input_file(optind, argc, argv)) {
+            // Next one must be VCF
+            indexes.set_vcf_filename(get_input_file_name(optind, argc, argv));
+        }
+    }
+    
+    if (have_input_file(optind, argc, argv)) {
+        // TODO: work out how to interpret additional files as reads.
+        cerr << "error:[vg gaffe] Extraneous input file: " << get_input_file_name(optind, argc, argv) << endl;
+        exit(1);
+    }
    
     if (interleaved && !fastq_filename_2.empty()) {
         cerr << "error:[vg gaffe] Cannot designate both interleaved paired ends (-i) and separate paired end file (-f)." << endl;

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -718,9 +718,49 @@ int main_gaffe(int argc, char** argv) {
         }
     }
 
-    // TODO: check for indexes we won't be able to build but we will need.
+   
+    // Propagate progress
+    indexes.show_progress = show_progress;
     
-    if (!indexes.can_get_graph() && !indexes.can_get_gbwtgraph()) {
+    // Get positional arguments before validating user intent
+    if (have_input_file(optind, argc, argv)) {
+        // Must be the FASTA, but check.
+        
+        string fasta_filename = get_input_file_name(optind, argc, argv);
+        
+        auto fasta_parts = split_ext(fasta_filename);
+        if (fasta_parts.second == "gz") {
+            fasta_parts = split_ext(fasta_parts.first);
+        }
+        if (fasta_parts.second != "fa" && fasta_parts.second != "fasta" && fasta_parts.second != "fna") {
+            cerr << "error:[vg gaffe] FASTA file " << fasta_filename << " is not named like a FASTA" << endl;
+            exit(1);
+        }
+        
+        indexes.set_fasta_filename(fasta_filename);
+        
+        if (have_input_file(optind, argc, argv)) {
+            // Next one must be VCF, but check.
+            // TODO: Unify with FASTA check?
+            // TODO: Move over to the index manager?
+            
+            string vcf_filename = get_input_file_name(optind, argc, argv);
+            
+            auto vcf_parts = split_ext(vcf_filename);
+            if (vcf_parts.second == "gz") {
+                vcf_parts = split_ext(vcf_parts.first);
+            }
+            if (vcf_parts.second != "vcf") {
+                cerr << "error:[vg gaffe] VCF file " << vcf_filename << " is not named like a VCF" << endl;
+                exit(1);
+            }
+            
+            indexes.set_vcf_filename(vcf_filename);
+        }
+    }
+   
+    // Now all the arguments are parsed, so see if they make sense
+    if (!indexes.can_get_gbwtgraph() && !indexes.can_get_graph()) {
         cerr << "error:[vg gaffe] Mapping requires a normal graph (-x) or a GBWTGraph (-g)" << endl;
         exit(1);
     }
@@ -756,24 +796,11 @@ int main_gaffe(int argc, char** argv) {
     }
     
     if (have_input_file(optind, argc, argv)) {
-        // Must be the FASTA
-        indexes.set_fasta_filename(get_input_file_name(optind, argc, argv));
-        
-        if (have_input_file(optind, argc, argv)) {
-            // Next one must be VCF
-            indexes.set_vcf_filename(get_input_file_name(optind, argc, argv));
-        }
-    }
-    
-    if (have_input_file(optind, argc, argv)) {
         // TODO: work out how to interpret additional files as reads.
         cerr << "error:[vg gaffe] Extraneous input file: " << get_input_file_name(optind, argc, argv) << endl;
         exit(1);
     }
 
-    // Propagate progress
-    indexes.show_progress = show_progress;
-    
     // create in-memory objects
     
 

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -288,11 +288,11 @@ void help_gaffe(char** argv) {
     << "Map unpaired reads using minimizers and gapless extension." << endl
     << endl
     << "basic options:" << endl
-    << "  -x, --xg-name FILE            use this xg index or graph (required if -g not specified)" << endl
-    << "  -g, --graph-name FILE         use this GBWTGraph (required if -x not specified)" << endl
-    << "  -H, --gbwt-name FILE          use this GBWT index (required)" << endl
-    << "  -m, --minimizer-name FILE     use this minimizer index (required; may repeat)" << endl
-    << "  -d, --dist-name FILE          cluster using this distance index (required)" << endl
+    << "  -x, --xg-name FILE            use this xg index or graph" << endl
+    << "  -g, --graph-name FILE         use this GBWTGraph" << endl
+    << "  -H, --gbwt-name FILE          use this GBWT index" << endl
+    << "  -m, --minimizer-name FILE     use this minimizer index (may repeat)" << endl
+    << "  -d, --dist-name FILE          cluster using this distance index" << endl
     << "  -p, --progress                show progress" << endl
     << "input options:" << endl
     << "  -G, --gam-in FILE             read and realign GAM-format reads from FILE" << endl

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -720,6 +720,41 @@ int main_gaffe(int argc, char** argv) {
 
     // TODO: check for indexes we won't be able to build but we will need.
     
+    if (!indexes.can_get_graph() && !indexes.can_get_gbwtgraph()) {
+        cerr << "error:[vg gaffe] Mapping requires a normal graph (-x) or a GBWTGraph (-g)" << endl;
+        exit(1);
+    }
+    
+    if (track_correctness && !indexes.can_get_graph()) {
+        cerr << "error:[vg gaffe] Tracking correctness requires a normal graph (-x)" << endl;
+        exit(1);
+    }
+    
+    if (!indexes.can_get_gbwt()) {
+        cerr << "error:[vg gaffe] Mapping requires a GBWT index (-H)" << endl;
+        exit(1);
+    }
+    
+    if (!indexes.can_get_minimizer()) {
+        cerr << "error:[vg gaffe] Mapping requires a minimizer index (-m)" << endl;
+        exit(1);
+    }
+    
+    if (!indexes.can_get_distance()) {
+        cerr << "error:[vg gaffe] Mapping requires a distance index (-d)" << endl;
+        exit(1);
+    }
+    
+    if (interleaved && !fastq_filename_2.empty()) {
+        cerr << "error:[vg gaffe] Cannot designate both interleaved paired ends (-i) and separate paired end file (-f)." << endl;
+        exit(1);
+    }
+
+    if (!fastq_filename_1.empty() && !gam_filename.empty()) {
+        cerr << "error:[vg gaffe] Cannot designate both FASTQ input (-f) and GAM input (-G) in same run." << endl;
+        exit(1);
+    }
+    
     if (have_input_file(optind, argc, argv)) {
         // Must be the FASTA
         indexes.set_fasta_filename(get_input_file_name(optind, argc, argv));
@@ -733,16 +768,6 @@ int main_gaffe(int argc, char** argv) {
     if (have_input_file(optind, argc, argv)) {
         // TODO: work out how to interpret additional files as reads.
         cerr << "error:[vg gaffe] Extraneous input file: " << get_input_file_name(optind, argc, argv) << endl;
-        exit(1);
-    }
-   
-    if (interleaved && !fastq_filename_2.empty()) {
-        cerr << "error:[vg gaffe] Cannot designate both interleaved paired ends (-i) and separate paired end file (-f)." << endl;
-        exit(1);
-    }
-
-    if (!fastq_filename_1.empty() && !gam_filename.empty()) {
-        cerr << "error:[vg gaffe] Cannot designate both FASTQ input (-f) and GAM input (-G) in same run." << endl;
         exit(1);
     }
 

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -803,13 +803,19 @@ int main_gaffe(int argc, char** argv) {
 
     // create in-memory objects
     
-
-    // Load the base graph
-    auto graph = indexes.get_graph();
-    // And make sure it has path position support.
-    // Overlay is owned by the overlay_helper, if one is needed.
+    // If we are tracking correctness, we will fill this in with a graph for
+    // getting offsets along ref paths.
+    PathPositionHandleGraph* positional_graph = nullptr;
+    // One of these will actually own it
     bdsg::PathPositionOverlayHelper overlay_helper;
-    PathPositionHandleGraph* positional_graph = overlay_helper.apply(graph.get());
+    shared_ptr<PathHandleGraph> graph;
+    if (track_correctness) {
+        // Load the base graph
+        graph = indexes.get_graph();
+        // And make sure it has path position support.
+        // Overlay is owned by the overlay_helper, if one is needed.
+        positional_graph = overlay_helper.apply(graph.get());
+    }
 
     vector<unique_ptr<gbwtgraph::DefaultMinimizerIndex>> minimizer_index_owner;
     shared_ptr<gbwtgraph::DefaultMinimizerIndex> minimizer_index_ref;

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -269,6 +269,9 @@ int main_snarl(int argc, char** argv) {
     }
   
 
+    // Now we have to output stuff.
+    // TODO: remove extra features and just use SnarlManager::serialize()
+
     // Protobuf output buffers
     vector<Snarl> snarl_buffer;
     vector<SnarlTraversal> traversal_buffer;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -497,6 +497,13 @@ pair<string, string> split_ext(const string& filename) {
     return parts;
 }
 
+bool file_exists(const string& filename) {
+    // TODO: use C++17 features to actually poll existence.
+    // For now we see if we can open it.
+    ifstream in(filename);
+    return in.is_open();
+}
+
     
 void create_ref_allele(vcflib::Variant& variant, const std::string& allele) {
     // Set the ref allele

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -432,6 +432,10 @@ void get_input_file(const string& file_name, function<void(istream&)> callback);
 /// Split off the extension from a filename and return both parts. 
 pair<string, string> split_ext(const string& filename);
 
+/// Determine if a file exists.
+/// Only works for files readable by the current user.
+bool file_exists(const string& filename);
+
 /// Parse a command-line argument string. Exits with an error if the string
 /// does not contain exactly an item fo the appropriate type.
 template<typename Result>

--- a/test/reads/small.middle.ref.fq
+++ b/test/reads/small.middle.ref.fq
@@ -1,0 +1,4 @@
+@read
+TTATTTACTATGAATCCTCACCTTCCTTGACTTCTTGAAACATTTGGCTATTGACCTCTTTCC
++
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/test/t/50_vg_gaffe.t
+++ b/test/t/50_vg_gaffe.t
@@ -32,7 +32,6 @@ vg view -aj mapped2.gam >mapped2.json
 
 # Make sure at least one file converted successfully
 SIZE="$(wc -c mapped2.json | cut -f1 -d' ')"
-echo "Size: ${SIZE}"
 EMPTY=0
 if [ "${SIZE}" == "0" ] ; then
     EMPTY=1

--- a/test/t/50_vg_gaffe.t
+++ b/test/t/50_vg_gaffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 3
+plan tests 4
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -G x.gbwt -v small/x.vcf.gz x.vg
@@ -20,12 +20,28 @@ rm -f x.vg x.xg x.gbwt x.snarls x.min x.dist x.gg
 
 cp small/x.fa .
 cp small/x.vcf.gz .
-cp small/x.vcf.gx.tbi .
+cp small/x.vcf.gz.tbi .
 
 vg gaffe x.fa x.vcf.gz -f reads/small.middle.ref.fq > mapped2.gam
 is "${?}" "0" "a read can be mapped with just FASTA and VCF without crashing"
 
-diff mapped1.gam mapped2.gam
+# These files can differ as serialized and still represent the same data, dur to protobuf field order not being specified.
+# Tripping through JSON will sort all the keys.
+vg view -aj mapped1.gam >mapped1.json
+vg view -aj mapped2.gam >mapped2.json
+
+# Make sure at least one file converted successfully
+SIZE="$(wc -c mapped2.json | cut -f1 -d' ')"
+echo "Size: ${SIZE}"
+EMPTY=0
+if [ "${SIZE}" == "0" ] ; then
+    EMPTY=1
+fi
+is "${EMPTY}" "0" "mapping with just a FASTA and a VCF produced JSON-able alignments"
+
+diff mapped1.json mapped2.json
 is "${?}" "0" "mapping to manually-generated indexes and automatically-generated indexes is the same"
+
+rm -f x.vg x.gbwt x.gg x.snarls x.min x.dist x.gg x.fa x.fa.fai x.vcf.gz x.vcf.gz.tbi mapped1.gam mapped1.json mapped2.gam mapped2.json
 
 

--- a/test/t/50_vg_gaffe.t
+++ b/test/t/50_vg_gaffe.t
@@ -16,4 +16,4 @@ vg minimizer -k 29 -w 11 -g x.gbwt -i x.min x.xg
 vg gaffe -x x.xg -H x.gbwt -m x.min -d x.dist -f reads/small.middle.ref.fq > mapped.gam
 is "${?}" "0" "a read can be mapped with all indexes specified without crashing"
 
-rm -f x.vg x.xg x.gbwt x.snarls x.min x.dist mapped.gam
+rm -f x.vg x.xg x.gbwt x.snarls x.min x.dist x.gg mapped.gam

--- a/test/t/50_vg_gaffe.t
+++ b/test/t/50_vg_gaffe.t
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 1
+
+vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
+vg index -x x.xg -G x.gbwt -v small/x.vcf.gz x.vg
+vg snarls --include-trivial x.vg > x.snarls
+vg index -s x.snarls -j x.dist x.vg
+vg minimizer -k 29 -w 11 -g x.gbwt -i x.min x.xg
+
+vg gaffe -x x.xg -H x.gbwt -m x.min -d x.dist -f reads/small.middle.ref.fq > mapped.gam
+is "${?}" "0" "a read can be mapped with all indexes specified without crashing"
+
+rm -f x.vg x.xg x.gbwt x.snarls x.min x.dist mapped.gam

--- a/test/t/50_vg_gaffe.t
+++ b/test/t/50_vg_gaffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 1
+plan tests 3
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -G x.gbwt -v small/x.vcf.gz x.vg
@@ -13,7 +13,19 @@ vg snarls --include-trivial x.vg > x.snarls
 vg index -s x.snarls -j x.dist x.vg
 vg minimizer -k 29 -w 11 -g x.gbwt -i x.min x.xg
 
-vg gaffe -x x.xg -H x.gbwt -m x.min -d x.dist -f reads/small.middle.ref.fq > mapped.gam
+vg gaffe -x x.xg -H x.gbwt -m x.min -d x.dist -f reads/small.middle.ref.fq > mapped1.gam
 is "${?}" "0" "a read can be mapped with all indexes specified without crashing"
 
-rm -f x.vg x.xg x.gbwt x.snarls x.min x.dist x.gg mapped.gam
+rm -f x.vg x.xg x.gbwt x.snarls x.min x.dist x.gg
+
+cp small/x.fa .
+cp small/x.vcf.gz .
+cp small/x.vcf.gx.tbi .
+
+vg gaffe x.fa x.vcf.gz -f reads/small.middle.ref.fq > mapped2.gam
+is "${?}" "0" "a read can be mapped with just FASTA and VCF without crashing"
+
+diff mapped1.gam mapped2.gam
+is "${?}" "0" "mapping to manually-generated indexes and automatically-generated indexes is the same"
+
+


### PR DESCRIPTION
This lets Giraffe work with just a FASTA and VCF, building the other indexes dynamically and saving them in sensible locations.

If it can't load an index, it will print a nice error instead of crashing and telling the user to file a vg bug.

All the old switches should still work, so most scripts shouldn't break. But if you have stray `.gg` files laying around that you didn't intend to use, they may now get used, instead of the GBWTGraph being built in memory. And if the GBWTGraph isn't on disk, it may now be saved next to the XG.