### PR TITLE
New algorithms in mpmap for long read alignment

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1832,6 +1832,56 @@ void normalize_alignment(Alignment& alignment) {
     }
 }
 
+bool uses_Us(const Alignment& alignment) {
+    
+    for (char nt : alignment.sequence()) {
+        switch (nt) {
+            case 'U':
+                return true;
+                break;
+                
+            case 'T':
+                return false;
+                break;
+                
+            default:
+                break;
+        }
+    }
+    return false;
+}
+
+void convert_alignment_char(Alignment& alignment, char from, char to) {
+    auto& seq = *alignment.mutable_sequence();
+    for (size_t i = 0; i < seq.size(); ++i) {
+        if (seq[i] == from) {
+            seq[i] = to;
+        }
+    }
+    if (alignment.has_path()) {
+        for (Mapping& mapping : *alignment.mutable_path()->mutable_mapping()) {
+            for (Edit& edit : *mapping.mutable_edit()) {
+                if (!edit.sequence().empty()) {
+                    auto& eseq = *edit.mutable_sequence();
+                    for (size_t i = 0; i < eseq.size(); ++i) {
+                        if (eseq[i] == from) {
+                            eseq[i] = to;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void convert_Us_to_Ts(Alignment& alignment) {
+    convert_alignment_char(alignment, 'U', 'T');
+}
+
+void convert_Ts_to_Us(Alignment& alignment) {
+    convert_alignment_char(alignment, 'T', 'U');
+}
+
 map<id_t, int> alignment_quality_per_node(const Alignment& aln) {
     map<id_t, int> quals;
     int to_pos = 0; // offset in quals

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -125,7 +125,7 @@ bool get_next_alignment_from_fastq(gzFile fp, char* buffer, size_t len, Alignmen
         } else {
             throw runtime_error("Found unexpected delimiter " + name.substr(0,1) + " in fastq/fasta input");
         }
-        name = name.substr(1, name.find(' ')); // trim off leading @ and things after the first whitespace
+        name = name.substr(1, name.find(' ') - 1); // trim off leading @ and things after the first whitespace
         // keep trailing /1 /2
         alignment.set_name(name);
     } else { return false; }

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -218,6 +218,17 @@ void translate_nodes(Alignment& a, const unordered_map<id_t, pair<id_t, bool> >&
 // listed. It needs a callback to ask the length of any given node.
 void flip_nodes(Alignment& a, const set<int64_t>& ids, const std::function<size_t(int64_t)>& node_length);
 
+/// Returns true if the alignment sequence contains any U's and false if the alignment sequence contains
+/// and T's. In the case that both T's and U's are included, responds according to whichever comes first.
+/// If the sequence contains neither U's nor T's, returns false.
+bool uses_Us(const Alignment& alignment);
+
+/// Replaces any U's in the sequence or the Path with T's
+void convert_Us_to_Ts(Alignment& alignment);
+
+/// Replaces any T's in the sequence or the Path with U's
+void convert_Ts_to_Us(Alignment& alignment);
+
 /// Simplifies the Path in the Alignment. Note that this removes deletions at
 /// the start and end of Mappings, so code that handles simplified Alignments
 /// needs to handle offsets on internal Mappings.

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -3524,6 +3524,8 @@ MEMClusterer::HitGraph GreedyMinDistanceClusterer::make_hit_graph(const Alignmen
                                    estimate_edge_score(hit_node_1.mem, hit_node_2.mem, graph_dist, aligner),
                                    graph_dist);
                 
+                // TODO: should i have a stricter criterion to fully block a connection?
+                
                 // we won't look for any more connections involving this end of these two
                 blocked[comparison.first].second = true;
                 blocked[comparison.second].first = true;

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -3444,6 +3444,18 @@ vector<pair<pair<size_t, size_t>, int64_t>> MinDistanceClusterer::pair_clusters(
     
     return hit_graph;
 }
+
+GreedyMinDistanceClusterer::GreedyMinDistanceClusterer(MinimumDistanceIndex* distance_index) : MinDistanceClusterer(distance_index) {
+    // nothing else to do
+}
+
+MEMClusterer::HitGraph GreedyMinDistanceClusterer::make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems,
+                                                                  const GSSWAligner* aligner, size_t min_mem_length) {
+    HitGraph hit_graph(mems, alignment, aligner, min_mem_length);
+    throw runtime_error("not yet implemented");
+    return hit_graph;
+}
+
     
 // collect node starts to build out graph
 vector<pair<gcsa::node_type, size_t> > mem_node_start_positions(const HandleGraph& graph, const vg::MaximalExactMatch& mem) {

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -5,7 +5,7 @@
 
 #include "cluster.hpp"
 
-//#define debug_mem_clusterer
+#define debug_mem_clusterer
 
 using namespace std;
 using namespace structures;
@@ -3478,6 +3478,12 @@ MEMClusterer::HitGraph GreedyMinDistanceClusterer::make_hit_graph(const Alignmen
         auto comparison = next_comparisons.back();
         next_comparisons.pop_back();
         
+#ifdef debug_mem_clusterer
+        cerr << "greedy cluster comparing:" << endl;
+        cerr << "\t" << comparison.first << ": " << hit_graph.nodes[comparison.first].start_pos << " " << hit_graph.nodes[comparison.first].mem->sequence() << endl;
+        cerr << "\t" << comparison.first << ": " << hit_graph.nodes[comparison.second].start_pos << " " << hit_graph.nodes[comparison.second].mem->sequence() << endl;
+#endif
+        
         if (blocked[comparison.first].second) {
             // we've already greedily accumulated out of this match, so we don't
             // need to look for more connections from it
@@ -3505,6 +3511,10 @@ MEMClusterer::HitGraph GreedyMinDistanceClusterer::make_hit_graph(const Alignmen
                     min_dist = -rev_min_dist;
                 }
             }
+            
+#ifdef debug_mem_clusterer
+            cerr << "read dist: " << read_dist << ", found graph dist? " << finite_distance << ", graph dist: " << min_dist << endl;
+#endif
             
             // TODO: i'm ignoring sub-matches here because it's intended to be used with the stripped
             // algorithm. that might come back to haunt me later

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -3427,11 +3427,12 @@ MEMClusterer::HitGraph GreedyMinDistanceClusterer::make_hit_graph(const Alignmen
     next_comparisons.reserve(2 * hit_graph.nodes.size());
     
     // assumes that MEMs are given in lexicographic order by read interval
-    size_t i = 0, j = 1;
-    while (i < hit_graph.nodes.size()) {
-        // the best seed is immediately abutting the end of this one
-        auto target = hit_graph.nodes[j].mem->end;
+    for (size_t i = 0, j = 1; i < hit_graph.nodes.size(); ++i) {
         
+        // the best seed is immediately abutting the end of this one
+        auto target = hit_graph.nodes[i].mem->end;
+        
+        // start either at the previous target or one past i
         j = max(j, i + 1);
         
         // move forward until we are past the target
@@ -3535,14 +3536,14 @@ MEMClusterer::HitGraph GreedyMinDistanceClusterer::make_hit_graph(const Alignmen
         if (!blocked[comparison.first].second) {
             // we didn't just block off connections out of this match,
             // so we can queue up the next one
-            if (read_dist >= 0 && j + 1 < hit_graph.nodes.size()) {
+            if (read_dist >= 0 && comparison.second + 1 < hit_graph.nodes.size()) {
                 // the next in the forward direction
-                next_comparisons.emplace_back(i, j + 1);
+                next_comparisons.emplace_back(comparison.first, comparison.second + 1);
                 push_heap(next_comparisons.begin(), next_comparisons.end(), priority_cmp);
             }
-            else if (read_dist < 0 && hit_graph.nodes[j - 1].mem->begin > hit_node_1.mem->begin) {
+            else if (read_dist < 0 && hit_graph.nodes[comparison.second - 1].mem->begin > hit_node_1.mem->begin) {
                 // the next in the backward direction, requiring read colinearity
-                next_comparisons.emplace_back(i, j - 1);
+                next_comparisons.emplace_back(comparison.first, comparison.second - 1);
                 push_heap(next_comparisons.begin(), next_comparisons.end(), priority_cmp);
             }
         }

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -158,8 +158,8 @@ public:
 };
 
 /*
- * A base class to hold some shared methods and data types between the TVS and
- * oriented distance clusterers.
+ * A base class to hold some shared methods and data types between the TVS,
+ * oriented distance, and minimum distance clusterers.
  */
 class MEMClusterer {
 public:
@@ -204,6 +204,7 @@ public:
                                                                       int64_t max_deviation) = 0;
     
 protected:
+    
     class HitNode;
     class HitEdge;
     class HitGraph;
@@ -462,7 +463,7 @@ public:
     //static size_t SUCCESSFUL_SPLIT_ATTEMPT_COUNTER;
     //static size_t POST_SPLIT_CLUSTER_COUNTER;
     
-private:
+protected:
 
     /**
      * Given a certain number of items, and a callback to get each item's
@@ -611,7 +612,7 @@ public:
     /// path within the tolerance of the target value, returns an empty vector.
     vector<handle_t> tv_path(const pos_t& pos_1, const pos_t& pos_2, int64_t target_value, int64_t tolerance);
     
-private:
+protected:
     
     vector<handle_t> tv_phase2(const pos_t& pos_1, const pos_t& pos_2, int64_t target_value, int64_t tolerance, hash_map<pair<id_t, bool>,int64_t> node_to_target_shorter, hash_map<pair<id_t, bool>, int64_t> node_to_target_longer, pair<int64_t, pair<pair<id_t, bool>,int64_t>> best_lng, pair<int64_t, pair<pair<id_t, bool>, int64_t>> next_best, hash_map<pair<pair<id_t, bool>, int64_t>, pair<pair<id_t, bool>, int64_t>> node_to_path);
     
@@ -638,7 +639,7 @@ public:
                                                               int64_t optimal_separation,
                                                               int64_t max_deviation);
     
-private:
+protected:
     
     /// Concrete implementation of virtual method from MEMClusterer
     HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, const GSSWAligner* aligner,
@@ -646,11 +647,14 @@ private:
     
     TargetValueSearch tvs;
 };
-    
+
+/*
+ * A MEM clusterer based on finding the minimum distance between all pairs of seeds or clusters
+ */
 class MinDistanceClusterer : public MEMClusterer {
 public:
     MinDistanceClusterer(MinimumDistanceIndex* distance_index);
-    ~MinDistanceClusterer() = default;
+    virtual ~MinDistanceClusterer() = default;
     
     /// Concrete implementation of virtual method from MEMClusterer
     vector<pair<pair<size_t, size_t>, int64_t>> pair_clusters(const Alignment& alignment_1,
@@ -662,16 +666,35 @@ public:
                                                               int64_t optimal_separation,
                                                               int64_t max_deviation);
     
-private:
+protected:
     
     /// Concrete implementation of virtual method from MEMClusterer
-    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, const GSSWAligner* aligner,
+    virtual HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, const GSSWAligner* aligner,
                             size_t min_mem_length);
     
     const HandleGraph* handle_graph;
     MinimumDistanceIndex* distance_index;
 };
+
+/*
+ * A version of the MinDistanceClusterer that greedily agglomerates seeds into connected components
+ * based on minimum distance, iterating over pairs in a sensible order
+ */
+class GreedyMinDistanceClusterer : public MinDistanceClusterer {
+public:
+    GreedyMinDistanceClusterer(MinimumDistanceIndex* distance_index);
+    ~GreedyMinDistanceClusterer() = default;
     
+protected:
+    
+    /// Concrete implementation of virtual method from MEMClusterer, overides the inherited one from MinDistanceClusterer
+    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, const GSSWAligner* aligner,
+                            size_t min_mem_length);
+    
+    /// How more bases would we search forward to find the next seed before we think
+    /// it's worth searching 1 base backward?
+    const int64_t forward_multiplier = 5;
+};
 
 /// get the handles that a mem covers
 vector<pair<gcsa::node_type, size_t> > mem_node_start_positions(const HandleGraph& graph, const vg::MaximalExactMatch& mem);

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -10,6 +10,7 @@
 #include "mem.hpp"
 #include "handle.hpp"
 #include "min_distance.hpp"
+#include "seed_clusterer.hpp"
 #include "path_component_index.hpp"
 #include "bdsg/hash_graph.hpp"
 #include "algorithms/subgraph.hpp"
@@ -692,6 +693,32 @@ protected:
     /// Maximum distance between two seeds on the read
     const int64_t max_separation = 250;
     
+};
+
+/*
+ * A version of the MinDistanceClusterer that uses the SeedClusterer to partition reads
+ * into nearby clusters and only measures distances within clusters
+ */
+class ComponentMinDistanceClusterer : public MinDistanceClusterer {
+public:
+    ComponentMinDistanceClusterer(MinimumDistanceIndex* distance_index);
+    ~ComponentMinDistanceClusterer() = default;
+    
+protected:
+    
+    /// Concrete implementation of virtual method from MEMClusterer, overides the inherited one from MinDistanceClusterer
+    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, const GSSWAligner* aligner,
+                            size_t min_mem_length);
+    
+    
+    /// Minimum distance between two seeds on the read
+    const int64_t min_read_separation = -10;
+    
+    /// Maximum distance between two seeds on the read
+    const int64_t max_read_separation = 750;
+    
+    /// The maximum distance we will look during component finding
+    const int64_t max_graph_separation = 5000;
 };
 
 /// get the handles that a mem covers

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -245,19 +245,6 @@ public:
     
     vector<HitNode> nodes;
     
-    /// Execute a lambda on each pair of indexes of nodes (i, j), where i < j. Pairs
-    /// are produced in lexicographic order.
-    void for_each_hit_pair(const function<void(pair<size_t, size_t>)>& lambda);
-    
-    /// Execute a lambda on each pair of indexes of nodes (i, j), where 1) i < j, and
-    /// 2) i and j are not in the same connected component. The edges (and hence the
-    /// the connected components) are allowed to change as a side effect of lambda.
-    /// Pairs are produced in increasing order of the absolute distance on the read
-    /// of the end of node i's MEM and the beginning of node j's MEM. Hit graph must
-    /// have been constructed to track components to filter out pairs that are in the
-    /// same component.
-    void for_each_hit_pair_greedy(const function<void(pair<size_t, size_t>)>& lambda);
-    
 private:
     
     /// Identify weakly connected components in the graph

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -680,7 +680,7 @@ protected:
     
     /// How more bases would we search forward to find the next seed before we think
     /// it's worth searching 1 base backward?
-    const int64_t forward_multiplier = 5;
+    const int64_t forward_multiplier = 10;
     
 };
 

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -694,6 +694,7 @@ protected:
     /// How more bases would we search forward to find the next seed before we think
     /// it's worth searching 1 base backward?
     const int64_t forward_multiplier = 5;
+    
 };
 
 /// get the handles that a mem covers

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -678,9 +678,19 @@ protected:
     HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, const GSSWAligner* aligner,
                             size_t min_mem_length);
     
+    
+    /// How far apart do we expect the seeds to be on the read?
+    const int64_t expected_separation = 20;
+    
     /// How more bases would we search forward to find the next seed before we think
     /// it's worth searching 1 base backward?
-    const int64_t forward_multiplier = 10;
+    const int64_t forward_multiplier = 3;
+    
+    /// Minimum distance between two seeds on the read
+    const int64_t min_separation = -10;
+    
+    /// Maximum distance between two seeds on the read
+    const int64_t max_separation = 250;
     
 };
 

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1163,6 +1163,8 @@ vector<MaximalExactMatch> BaseMapper::find_stripped_matches(string::const_iterat
                     // this match is entirely contained within the larger match
                     // of the previous strip, so it's not likely to give us any
                     // new information
+                    // also, filtering this helps us maintain reverse lexicographic
+                    // order
                     continue;
                 }
             }
@@ -1172,6 +1174,8 @@ vector<MaximalExactMatch> BaseMapper::find_stripped_matches(string::const_iterat
         }
     }
     
+    // matches are queried in reverse lexicographic order, flip them around
+    reverse(matches.begin(), matches.end());
     
     for (MaximalExactMatch& match : matches) {
         // figure out how many occurrences there are
@@ -1184,11 +1188,13 @@ vector<MaximalExactMatch> BaseMapper::find_stripped_matches(string::const_iterat
                 gcsa->locate(match.range, hit_max, match.nodes);
                 
             } else {
-                // we won't
+                // we won't subsample down to a prespecified maximum
                 gcsa->locate(match.range, match.nodes);
             }
         }
+        match.queried_count = match.nodes.size();
     }
+    
     
     return matches;
 }

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -4,6 +4,7 @@
 #include "annotation.hpp"
 
 //#define debug_mapper
+//#define debug_strip_match
 
 namespace vg {
 
@@ -1108,6 +1109,15 @@ vector<MaximalExactMatch> BaseMapper::find_stripped_matches(string::const_iterat
         throw runtime_error("error:[vg::Mapper] target match count must be positive, set to " + to_string(target_count));
     }
     
+#ifdef debug_strip_match
+    cerr << "starting stripped match algorithm" << endl;
+    cerr << "\tstrip length:" << strip_length << endl;
+    cerr << "\tmax match length:" << max_match_length << endl;
+    cerr << "\ttarget count:" << target_count << endl;
+    cerr << "\tsequence:" << string(seq_begin, seq_end) << endl;
+    
+#endif
+    
     // init the return value
     vector<MaximalExactMatch> matches;
     
@@ -1116,6 +1126,10 @@ vector<MaximalExactMatch> BaseMapper::find_stripped_matches(string::const_iterat
         int64_t seq_len = seq_end - seq_begin;
         int64_t num_strips = (seq_len - 1) / strip_length + 1;
         for (int64_t strip_num = 0; strip_num < num_strips; ++strip_num) {
+            
+#ifdef debug_strip_match
+            cerr << "strip number " << strip_num << " of " << num_strips << endl;
+#endif
             
             // the end of other strip match we will find
             auto strip_end = seq_end - strip_num * strip_length;
@@ -1169,8 +1183,17 @@ vector<MaximalExactMatch> BaseMapper::find_stripped_matches(string::const_iterat
                 }
             }
             
+#ifdef debug_strip_match
+            cerr << "adding match of sequence " << string(cursor + 1, strip_end) << " and " << gcsa->count(range) << " hits" << endl;
+#endif
+            
             matches.emplace_back(cursor + 1, strip_end, range, gcsa->count(range));
             matches.back().primary = true;
+            
+            if (cursor < seq_begin) {
+                // all further hits will be contained in ones we've already seen
+                break;
+            }
         }
     }
     

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1149,6 +1149,10 @@ vector<MaximalExactMatch> BaseMapper::find_stripped_matches(string::const_iterat
                 // match one more char
                 auto next_range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
                 
+#ifdef debug_strip_match
+                cerr << "\tgot next range which is length " << gcsa::Range::length(next_range) << " and " << ((gcsa::Range::empty(next_range) ? "" : "not ") << "empty" << endl;
+#endif
+                
                 if (gcsa::Range::empty(next_range)) {
                     // we've gone too far, there are no more hits
                     break;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1139,7 +1139,7 @@ vector<MaximalExactMatch> BaseMapper::find_stripped_matches(string::const_iterat
             auto cursor = strip_end - 1;
             
             while (cursor >= seq_begin &&
-                   (max_match_length && strip_end - cursor <= max_match_length)) {
+                   (!max_match_length || strip_end - cursor <= max_match_length)) {
                 
                 if (*cursor == 'N') {
                     // N matches are uninformative, so we don't want to match them
@@ -1150,7 +1150,7 @@ vector<MaximalExactMatch> BaseMapper::find_stripped_matches(string::const_iterat
                 auto next_range = gcsa->LF(range, gcsa->alpha.char2comp[*cursor]);
                 
 #ifdef debug_strip_match
-                cerr << "\tgot next range which is length " << gcsa::Range::length(next_range) << " and " << ((gcsa::Range::empty(next_range) ? "" : "not ") << "empty" << endl;
+                cerr << "\tgot next range which is length " << gcsa::Range::length(next_range) << " and " << (gcsa::Range::empty(next_range) ? "" : "not ") << "empty" << endl;
 #endif
                 
                 if (gcsa::Range::empty(next_range)) {

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -248,7 +248,7 @@ public:
                           string::const_iterator seq_end,
                           size_t strip_length,
                           size_t max_match_length,
-                          size_t target_count)
+                          size_t target_count);
     
     /// identifies tracts of order-length MEMs that were unfilled because their hit count was above the max
     /// and fills one MEM in the tract (the one with the smallest hit count), assumes MEMs are lexicographically

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -243,6 +243,13 @@ public:
                      int min_mem_length = 1,
                      int reseed_length = 0);
     
+    vector<MaximalExactMatch>
+    find_stripped_matches(string::const_iterator seq_begin,
+                          string::const_iterator seq_end,
+                          size_t strip_length,
+                          size_t max_match_length,
+                          size_t target_count)
+    
     /// identifies tracts of order-length MEMs that were unfilled because their hit count was above the max
     /// and fills one MEM in the tract (the one with the smallest hit count), assumes MEMs are lexicographically
     /// ordered by read index

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1397,6 +1397,37 @@ namespace vg {
             }
         }
     }
+
+    void convert_multipath_alignment_char(MultipathAlignment& multipath_aln, char from, char to) {
+        auto& seq = *multipath_aln.mutable_sequence();
+        for (size_t i = 0; i < seq.size(); ++i) {
+            if (seq[i] == from) {
+                seq[i] = to;
+            }
+        }
+        for (Subpath& subpath : *multipath_aln.mutable_subpath()) {
+            for (Mapping& mapping : *subpath.mutable_path()->mutable_mapping()) {
+                for (Edit& edit : *mapping.mutable_edit()) {
+                    if (!edit.sequence().empty()) {
+                        auto& eseq = *edit.mutable_sequence();
+                        for (size_t i = 0; i < eseq.size(); ++i) {
+                            if (eseq[i] == from) {
+                                eseq[i] = to;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    void convert_Us_to_Ts(MultipathAlignment& multipath_aln) {
+        convert_multipath_alignment_char(multipath_aln, 'U', 'T');
+    }
+
+    void convert_Ts_to_Us(MultipathAlignment& multipath_aln) {
+        convert_multipath_alignment_char(multipath_aln, 'T', 'U');
+    }
     
     void to_multipath_alignment(const Alignment& aln, MultipathAlignment& multipath_aln_out) {
         

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -134,6 +134,12 @@ namespace vg {
     ///
     void rev_comp_multipath_alignment_in_place(MultipathAlignment* multipath_aln,
                                                const function<int64_t(int64_t)>& node_length);
+
+    /// Replaces all U's in the sequence and the aligned Paths with T's
+    void convert_Us_to_Ts(MultipathAlignment& multipath_aln);
+
+    /// Replaces all T's in the sequence and the aligned Paths with U's
+    void convert_Ts_to_Us(MultipathAlignment& multipath_aln);
     
     /// Converts a Alignment into a Multipath alignment with one Subpath and stores it in an object
     ///

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -51,11 +51,20 @@ namespace vg {
         cerr << "multipath mapping read " << pb2json(alignment) << endl;
         cerr << "querying MEMs..." << endl;
 #endif
-    
-        // query MEMs using GCSA2
-        double dummy1; double dummy2;
-        vector<MaximalExactMatch> mems = find_mems_deep(alignment.sequence().begin(), alignment.sequence().end(), dummy1, dummy2,
-                                                        0, min_mem_length, mem_reseed_length, false, true, true, false);
+        
+        vector<MaximalExactMatch> mems;
+        if (use_stripped_match_alg) {
+            mems = find_stripped_matches(alignment.sequence().begin(), alignment.sequence().end(),
+                                         stripped_match_alg_strip_length, stripped_match_alg_max_length,
+                                         stripped_match_alg_target_count);
+        }
+        else {
+            // query MEMs using GCSA2
+            double dummy1; double dummy2;
+            mems = find_mems_deep(alignment.sequence().begin(), alignment.sequence().end(), dummy1, dummy2,
+                                  0, min_mem_length, mem_reseed_length, false, true, true, false);
+        }
+        
         
 #ifdef debug_multipath_mapper
         cerr << "obtained MEMs:" << endl;
@@ -1389,13 +1398,26 @@ namespace vg {
         }
         
         // the fragment length distribution has been estimated, so we can do full-fledged paired mode
-    
-        // query MEMs using GCSA2
-        double dummy1, dummy2;
-        vector<MaximalExactMatch> mems1 = find_mems_deep(alignment1.sequence().begin(), alignment1.sequence().end(), dummy1, dummy2,
-                                                         0, min_mem_length, mem_reseed_length, false, true, true, false);
-        vector<MaximalExactMatch> mems2 = find_mems_deep(alignment2.sequence().begin(), alignment2.sequence().end(), dummy1, dummy2,
-                                                         0, min_mem_length, mem_reseed_length, false, true, true, false);
+        vector<MaximalExactMatch> mems1, mems2;
+        if (use_stripped_match_alg) {
+            // query matches along strips of the read
+            mems1 = find_stripped_matches(alignment1.sequence().begin(), alignment1.sequence().end(),
+                                          stripped_match_alg_strip_length, stripped_match_alg_max_length,
+                                          stripped_match_alg_target_count);
+            mems2 = find_stripped_matches(alignment2.sequence().begin(), alignment2.sequence().end(),
+                                          stripped_match_alg_strip_length, stripped_match_alg_max_length,
+                                          stripped_match_alg_target_count);
+        }
+        else {
+            // query MEMs
+            double dummy1, dummy2;
+            mems1 = find_mems_deep(alignment1.sequence().begin(), alignment1.sequence().end(), dummy1, dummy2,
+                                   0, min_mem_length, mem_reseed_length, false, true, true, false);
+            mems2 = find_mems_deep(alignment2.sequence().begin(), alignment2.sequence().end(), dummy1, dummy2,
+                                   0, min_mem_length, mem_reseed_length, false, true, true, false);
+        }
+        
+        
         
 #ifdef debug_multipath_mapper
         cerr << "obtained read1 MEMs:" << endl;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -179,11 +179,14 @@ namespace vg {
         if (use_tvs_clusterer) {
             clusterer = unique_ptr<MEMClusterer>(new TVSClusterer(xindex, distance_index));
         }
-        else if (use_min_dist_clusterer && !greedy_min_dist) {
-            clusterer = unique_ptr<MEMClusterer>(new MinDistanceClusterer(distance_index));
+        else if (use_min_dist_clusterer && greedy_min_dist) {
+            clusterer = unique_ptr<MEMClusterer>(new GreedyMinDistanceClusterer(distance_index));
+        }
+        else if (use_min_dist_clusterer && component_min_dist) {
+            clusterer = unique_ptr<MEMClusterer>(new ComponentMinDistanceClusterer(distance_index));
         }
         else if (use_min_dist_clusterer) {
-            clusterer = unique_ptr<MEMClusterer>(new GreedyMinDistanceClusterer(distance_index));
+            clusterer = unique_ptr<MEMClusterer>(new MinDistanceClusterer(distance_index));
         }
         else {
             clusterer = unique_ptr<MEMClusterer>(new OrientedDistanceClusterer(*distance_measurer,

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -114,6 +114,10 @@ namespace vg {
         size_t num_mapping_attempts = 48;
         double log_likelihood_approx_factor = 1.0;
         size_t min_clustering_mem_length = 0;
+        bool use_stripped_match_alg = false;
+        size_t stripped_match_alg_strip_length = 16;
+        size_t stripped_match_alg_max_length = 0;
+        size_t stripped_match_alg_target_count = 5;
         size_t max_p_value_memo_size = 500;
         size_t band_padding_memo_size = 500;
         bool use_weibull_calibration = false;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -168,6 +168,7 @@ namespace vg {
         bool use_tvs_clusterer = false;
         bool use_min_dist_clusterer = false;
         bool greedy_min_dist = false;
+        bool component_min_dist = false;
         // length of reversing walks during graph extraction
         size_t reversing_walk_length = 0;
         bool suppress_p_value_memoization = false;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -167,6 +167,7 @@ namespace vg {
         bool simplify_topologies = false;
         bool use_tvs_clusterer = false;
         bool use_min_dist_clusterer = false;
+        bool greedy_min_dist = false;
         // length of reversing walks during graph extraction
         size_t reversing_walk_length = 0;
         bool suppress_p_value_memoization = false;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1283,7 +1283,7 @@ int main_mpmap(int argc, char** argv) {
 #ifdef record_read_run_times
         clock_t finish = clock();
 #pragma omp critical
-        read_time_file << alignment.name() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
+        read_time_file << alignment.name() << "\t" << alignment.sequence().size() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
 #endif
     };
     
@@ -1338,7 +1338,7 @@ int main_mpmap(int argc, char** argv) {
 #ifdef record_read_run_times
         clock_t finish = clock();
 #pragma omp critical
-        read_time_file << alignment_1.name() << "\t" << alignment_2.name() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
+        read_time_file << alignment_1.name() << "\t" << alignment_2.name() << "\t" << alignment_1.sequence().size() << "\t" << alignment_2.sequence().size() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
 #endif
     };
     
@@ -1409,7 +1409,7 @@ int main_mpmap(int argc, char** argv) {
 #ifdef record_read_run_times
         clock_t finish = clock();
 #pragma omp critical
-        read_time_file << alignment_1.name() << "\t" << alignment_2.name() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
+        read_time_file << alignment_1.name() << "\t" << alignment_2.name() << "\t" << alignment_1.sequence().size() << "\t" << alignment_2.sequence().size() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
 #endif
     };
     

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1254,9 +1254,21 @@ int main_mpmap(int argc, char** argv) {
         if (watchdog) {
             watchdog->check_in(thread_num, alignment.name());
         }
+        
+        bool is_rna = uses_Us(alignment);
+        if (is_rna) {
+            convert_Us_to_Ts(alignment);
+        }
 
         vector<MultipathAlignment> mp_alns;
         multipath_mapper.multipath_map(alignment, mp_alns);
+        
+        if (is_rna) {
+            for (MultipathAlignment& mp_aln : mp_alns) {
+                convert_Ts_to_Us(mp_aln);
+            }
+        }
+        
         if (single_path_alignment_mode) {
             output_single_path_alignments(mp_alns);
         }
@@ -1290,6 +1302,12 @@ int main_mpmap(int argc, char** argv) {
             watchdog->check_in(thread_num, alignment_1.name());
         }
         
+        bool is_rna = (uses_Us(alignment_1) || uses_Us(alignment_2));
+        if (is_rna) {
+            convert_Us_to_Ts(alignment_1);
+            convert_Us_to_Ts(alignment_2);
+        }
+        
         if (!same_strand) {
             // remove the path so we won't try to RC it (the path may not refer to this graph)
             alignment_2.clear_path();
@@ -1298,6 +1316,14 @@ int main_mpmap(int argc, char** argv) {
                 
         vector<pair<MultipathAlignment, MultipathAlignment>> mp_aln_pairs;
         multipath_mapper.multipath_map_paired(alignment_1, alignment_2, mp_aln_pairs, ambiguous_pair_buffer);
+        
+        if (is_rna) {
+            for (pair<MultipathAlignment, MultipathAlignment>& mp_aln_pair : mp_aln_pairs) {
+                convert_Ts_to_Us(mp_aln_pair.first);
+                convert_Ts_to_Us(mp_aln_pair.second);
+            }
+        }
+        
         if (single_path_alignment_mode) {
             output_single_path_paired_alignments(mp_aln_pairs);
         }
@@ -1330,9 +1356,16 @@ int main_mpmap(int argc, char** argv) {
         if (watchdog) {
             watchdog->check_in(thread_num, alignment_1.name());
         }
+        
+        bool is_rna = (uses_Us(alignment_1) || uses_Us(alignment_2));
+        if (is_rna) {
+            convert_Us_to_Ts(alignment_1);
+            convert_Us_to_Ts(alignment_2);
+        }
 
         if (!same_strand) {
-            // TODO: the output functions undo this transformation, so we have to do it here.
+            // the algorithm expects the read pairs to be on the same strand, so we need to flip read 2
+            // (the output functions will undo the transformation)
         
             // remove the path so we won't try to RC it (the path may not refer to this graph)
             alignment_2.clear_path();
@@ -1343,6 +1376,16 @@ int main_mpmap(int argc, char** argv) {
         vector<MultipathAlignment> mp_alns_1, mp_alns_2;
         multipath_mapper.multipath_map(alignment_1, mp_alns_1);
         multipath_mapper.multipath_map(alignment_2, mp_alns_2);
+        
+        
+        if (is_rna) {
+            for (MultipathAlignment& mp_aln : mp_alns_1) {
+                convert_Ts_to_Us(mp_aln);
+            }
+            for (MultipathAlignment& mp_aln : mp_alns_2) {
+                convert_Ts_to_Us(mp_aln);
+            }
+        }
                
         vector<pair<MultipathAlignment, MultipathAlignment>> mp_aln_pairs;
         for (size_t i = 0; i < mp_alns_1.size() && i < mp_alns_2.size(); i++) {

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -120,6 +120,7 @@ int main_mpmap(int argc, char** argv) {
     #define OPT_APPROX_EXP 1008
     #define OPT_MAX_PATHS 1009
     #define OPT_GREEDY_MIN_DIST 1010
+    #define OPT_COMPONENT_MIN_DIST 1011
     string matrix_file_name;
     string xg_name;
     string gcsa_name;
@@ -168,6 +169,7 @@ int main_mpmap(int argc, char** argv) {
     bool use_tvs_clusterer = false;
     bool use_min_dist_clusterer = false;
     bool greedy_min_dist = false;
+    bool component_min_dist = false;
     bool qual_adjusted = true;
     bool strip_full_length_bonus = false;
     MappingQualityMethod mapq_method = Exact;
@@ -267,6 +269,7 @@ int main_mpmap(int argc, char** argv) {
             {"force-haplotype-count", required_argument, 0, OPT_FORCE_HAPLOTYPE_COUNT},
             {"min-dist-cluster", no_argument, 0, OPT_MIN_DIST_CLUSTER},
             {"greedy-min-dist", no_argument, 0, OPT_GREEDY_MIN_DIST},
+            {"component-min-dist", no_argument, 0, OPT_COMPONENT_MIN_DIST},
             {"drop-subgraph", required_argument, 0, 'C'},
             {"prune-exp", required_argument, 0, OPT_PRUNE_EXP},
             {"long-read-scoring", no_argument, 0, 'E'},
@@ -514,6 +517,10 @@ int main_mpmap(int argc, char** argv) {
                 
             case OPT_GREEDY_MIN_DIST:
                 greedy_min_dist = true;
+                break;
+                
+            case OPT_COMPONENT_MIN_DIST:
+                component_min_dist = true;
                 break;
                 
             case 'C':
@@ -780,7 +787,11 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (greedy_min_dist && !use_min_dist_clusterer) {
-        cerr << "warning:[vg mpmap] greedy minimum distance clustering (--greedy-min-dist) is ignored if not using minimum distance clustering (--min-dist-cluster)" << endl;
+        cerr << "warning:[vg mpmap] greedy minimum distance clustering (--greedy-min-dist) is ignored if not using minimum distance clustering (-d)" << endl;
+    }
+    
+    if (component_min_dist && !use_min_dist_clusterer) {
+        cerr << "warning:[vg mpmap] minimum distance component clustering (--component-min-dist) is ignored if not using minimum distance clustering (-d)" << endl;
     }
     
     if (suboptimal_path_exponent < 1.0) {
@@ -1054,6 +1065,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.use_tvs_clusterer = use_tvs_clusterer;
     multipath_mapper.use_min_dist_clusterer = use_min_dist_clusterer;
     multipath_mapper.greedy_min_dist = greedy_min_dist;
+    multipath_mapper.component_min_dist = component_min_dist;
     multipath_mapper.max_expected_dist_approx_error = max_dist_error;
     multipath_mapper.mem_coverage_min_ratio = cluster_ratio;
     multipath_mapper.log_likelihood_approx_factor = likelihood_approx_exp;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -154,6 +154,10 @@ int main_mpmap(int argc, char** argv) {
     int hit_max = 1024;
     int min_mem_length = 1;
     int min_clustering_mem_length = 0;
+    bool use_stripped_match_alg = false;
+    int stripped_match_alg_strip_length = 16;
+    int stripped_match_alg_max_length = 0; // no maximum yet
+    int stripped_match_alg_target_count = 5;
     int reseed_length = 28;
     double reseed_diff = 0.45;
     double reseed_exp = 0.065;
@@ -715,6 +719,25 @@ int main_mpmap(int argc, char** argv) {
     
     if (hard_hit_max < hit_max) {
         cerr << "warning:[vg mpmap] MEM hit query limit (-c) set to " << hit_max << ", which is higher than the threshold to ignore a MEM (" << hard_hit_max << ")" << endl;
+    }
+    
+    if (min_mem_length < 0) {
+        cerr << "error:[vg mpmap] minimum MEM length set to " << min_mem_length << ", must set to a positive integer or 0 for no maximum." << endl;
+        exit(1);
+    }
+    
+    if (stripped_match_alg_strip_length <= 0) {
+        cerr << "error:[vg mpmap] match strip length set to " << stripped_match_alg_strip_length << ", must set to a positive integer or 0 for no maximum." << endl;
+        exit(1);
+    }
+    
+    if (stripped_match_alg_max_length < 0) {
+        cerr << "error:[vg mpmap] maximum seed match length set to " << stripped_match_alg_max_length << ", must set to a positive integer or 0 for no maximum." << endl;
+        exit(1);
+    }
+    
+    if (stripped_match_alg_target_count < 0) {
+        cerr << "error:[vg mpmap] target seed count set to " << stripped_match_alg_target_count << ", must set to a positive integer or 0 for no maximum." << endl;
         exit(1);
     }
     
@@ -978,6 +1001,10 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.sub_mem_thinning_burn_in = sub_mem_thinning_burn_in;
     multipath_mapper.order_length_repeat_hit_max = order_length_repeat_hit_max;
     multipath_mapper.min_mem_length = min_mem_length;
+    multipath_mapper.stripped_match_alg_strip_length = stripped_match_alg_strip_length;
+    multipath_mapper.stripped_match_alg_max_length = stripped_match_alg_max_length;
+    multipath_mapper.stripped_match_alg_target_count = stripped_match_alg_target_count;
+    multipath_mapper.use_stripped_match_alg = use_stripped_match_alg;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;
     multipath_mapper.use_approx_sub_mem_count = false;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -77,7 +77,8 @@ void help_mpmap(char** argv) {
     //<< "  -r, --reseed-length INT       reseed SMEMs for internal MEMs if they are at least this long (0 for no reseeding) [28]" << endl
     //<< "  -W, --reseed-diff FLOAT       require internal MEMs to have length within this much of the SMEM's length [0.45]" << endl
     //<< "  -K, --clust-length INT        minimum MEM length used in clustering [automatic]" << endl
-    << "  -c, --hit-max INT             use at most this many hits for any MEM (0 for no limit) [1024]" << endl
+    << "  -F, --stripped-match          use stripped match algorithm instead of MEMs" << endl
+    << "  -c, --hit-max INT             use at most this many hits for any match seeds (0 for no limit) [1024]" << endl
     //<< "  --approx-exp FLOAT            let the approximate likelihood miscalculate likelihood ratios by this power [10.0]" << endl
     //<< "  --recombination-penalty FLOAT use this log recombination penalty for GBWT haplotype scoring [20.7]" << endl
     //<< "  --always-check-population     always try to population-score reads, even if there is only a single mapping" << endl
@@ -256,6 +257,7 @@ int main_mpmap(int argc, char** argv) {
             {"reseed-length", required_argument, 0, 'r'},
             {"reseed-diff", required_argument, 0, 'W'},
             {"clustlength", required_argument, 0, 'K'},
+            {"stripped-match", no_argument, 0, 'F'},
             {"hit-max", required_argument, 0, 'c'},
             {"approx-exp", required_argument, 0, OPT_APPROX_EXP},
             {"recombination-penalty", required_argument, 0, OPT_RECOMBINATION_PENALTY},
@@ -279,7 +281,7 @@ int main_mpmap(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:ieSs:vX:u:a:b:I:D:BP:Q:Up:M:r:W:K:c:C:R:Eq:z:w:o:y:L:mAt:Z:",
+        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:ieSs:vX:u:a:b:I:D:BP:Q:Up:M:r:W:K:Fc:C:R:Eq:z:w:o:y:L:mAt:Z:",
                          long_options, &option_index);
 
 
@@ -476,6 +478,10 @@ int main_mpmap(int argc, char** argv) {
                 
             case 'K':
                 min_clustering_mem_length = parse<int>(optarg);
+                break;
+                
+            case 'F':
+                use_stripped_match_alg = true;
                 break;
                 
             case 'c':
@@ -1497,7 +1503,7 @@ int main_mpmap(int argc, char** argv) {
             }
         }
         else {
-            cerr << "warning:[vg mpmap] Could not find " << frag_length_sample_size << " unambiguous read pair mappings to estimate fragment length ditribution. Mapping read pairs as independent single-ended reads. Consider decreasing sample size (-b)." << endl;
+            cerr << "warning:[vg mpmap] Could not find " << frag_length_sample_size << " (-b) unambiguous read pair mappings to estimate fragment length ditribution. This can happen due to data issues (e.g. sorted reads, unpaired reads being mapped as pairs) or because the sample size is too large for the read set. Mapping read pairs as independent single-ended reads." << endl;
             
 #pragma omp parallel for
             for (size_t i = 0; i < ambiguous_pair_buffer.size(); i++) {

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -514,6 +514,7 @@ int main_mpmap(int argc, char** argv) {
                 
             case OPT_GREEDY_MIN_DIST:
                 greedy_min_dist = true;
+                break;
                 
             case 'C':
                 cluster_ratio = parse<double>(optarg);


### PR DESCRIPTION
Several new things in this PR, including two pretty big ones. The first is a new seeding algorithm that does not use any LCP queries and tries to find uncommon matches rather than maximal matches. I believe this is a better method for high-error reads. There are also two new clustering algorithms based on the DistanceIndex. The first is a greedy algorithm, which is okay but honestly not as good as I had hoped. The second is a thin extra layer on top of the SeedClusterer algorithm, which seems to do quite well on long reads.

Next I want to integrate dozeu into mpmap for aligning tails, which I think is the last big thing I need in order to be pretty functional on long reads.