### PR TITLE
Handlify vg concat and add path-linking option

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ before_script:
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
   # We also need Node >4 for junit merging (so we need to be on Ubuntu 18.04+)
   # And the CI report upload needs uuidgen from uuid-runtime
-  - sudo apt-get -q -y install docker.io python-pip python-virtualenv libcurl4-gnutls-dev python-dev npm nodejs node-gyp nodejs-dev libssl1.0-dev uuid-runtime
+  - sudo apt-get -q -y install docker.io python-pip python-virtualenv libcurl4-gnutls-dev python-dev npm nodejs node-gyp nodejs-dev libssl1.0-dev uuid-runtime libgnutls28-dev
   - which junit-merge || sudo npm install -g junit-merge
   - cat /etc/hosts
   - startdocker || true

--- a/README.md
+++ b/README.md
@@ -349,3 +349,4 @@ A variety of commands are available:
 ## License
 
 MIT
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_logging = all

--- a/src/algorithms/append_graph.cpp
+++ b/src/algorithms/append_graph.cpp
@@ -1,0 +1,81 @@
+#include "append_graph.hpp"
+
+#include "topological_sort.hpp"
+#include "copy_graph.hpp"
+
+using namespace std;
+
+namespace vg {
+namespace algorithms {
+
+void append_handle_graph(const HandleGraph* from, MutableHandleGraph* into) {
+
+    // get the heads and tails before copying
+    vector<handle_t> heads = algorithms::head_nodes(from);
+    vector<handle_t> tails = algorithms::tail_nodes(into);
+
+    // copy over the nodes and edges
+    // beware: no checking duplicates
+    copy_handle_graph(from, into);
+
+    // connect all the tips
+    for (handle_t head : heads) {
+        handle_t into_head = into->get_handle(from->get_id(head), from->get_is_reverse(head));
+        for (handle_t tail : tails) {
+            into->create_edge(tail, into_head);
+        }
+    }
+}
+    
+void append_path_handle_graph(const PathHandleGraph* from, MutablePathMutableHandleGraph* into,
+                              bool only_connect_path_tips) {
+
+    // get the heads and tails before copying
+    vector<handle_t> heads;
+    vector<handle_t> tails;
+    if (!only_connect_path_tips) {
+        heads = algorithms::head_nodes(from);
+        tails = algorithms::tail_nodes(into);
+    }
+
+    // copy over the nodes and edges
+    // beware: no checking duplicates
+    copy_handle_graph(from, into);
+    
+    // connect all the tips
+    for (handle_t head : heads) {
+        handle_t into_head = into->get_handle(from->get_id(head), from->get_is_reverse(head));
+        for (handle_t tail : tails) {
+            into->create_edge(tail, into_head);
+        }
+    }
+
+    // append the paths, adding linking edges
+    from->for_each_path_handle([&](const path_handle_t& path_handle) {
+            string path_name = from->get_path_name(path_handle);
+            if (!into->has_path(path_name)) {
+                // just copy it over if it's not there
+                copy_path(from, path_handle, into);
+            } else {
+                // else we append it
+                path_handle_t into_path_handle = into->get_path_handle(path_name);
+                
+                // add the missing edge
+                handle_t tail = into->get_handle_of_step(into->path_back(into_path_handle));
+                handle_t head = from->get_handle_of_step(from->path_begin(path_handle));
+                if (!into->has_edge(tail, head)) {
+                    into->create_edge(tail, head);
+                }
+                
+                // append the steps
+                from->for_each_step_in_path(path_handle, [&](const step_handle_t& step_handle) {
+                        handle_t handle = from->get_handle_of_step(step_handle);
+                        handle_t into_handle = into->get_handle(from->get_id(handle), from->get_is_reverse(handle));
+                        into->append_step(into_path_handle, into_handle);
+                    });
+            }                    
+        });
+    
+}
+}
+}

--- a/src/algorithms/append_graph.hpp
+++ b/src/algorithms/append_graph.hpp
@@ -1,0 +1,30 @@
+#ifndef VG_ALGORITHMS_APPEND_GRAPH_HPP_INCLUDED
+#define VG_ALGORITHMS_APPEND_GRAPH_HPP_INCLUDED
+
+/**
+ * \file append_graph.hpp
+ *
+ * Defines algorithms for appending handle graphs (as was once done in VG::merge())
+ */
+
+#include <iostream>
+
+#include "../handle.hpp"
+
+namespace vg {
+namespace algorithms {
+
+/// Append the heads of from to the tails of into
+void append_handle_graph(const HandleGraph* from, MutableHandleGraph* into);
+    
+/// Append the heads of from to the tails of into
+/// Append all (shared) paths of from to into, copy the rest.
+/// If only_connect_path_tips is true, then only edges linking appended paths will be added
+/// (as opposed to every head and tail)
+void append_path_handle_graph(const PathHandleGraph* from, MutablePathMutableHandleGraph* into,
+                              bool only_connect_path_tips = false);
+
+}
+}
+
+#endif

--- a/src/vg_set.cpp
+++ b/src/vg_set.cpp
@@ -58,8 +58,6 @@ id_t VGset::max_node_id(void) {
 
 int64_t VGset::merge_id_space(void) {
     int64_t max_node_id = 0;
-    // TODO: for now, only vg::VG actually implements increment_node_ids,
-    // despite it being in the interface.
     auto lambda = [&max_node_id](MutableHandleGraph* g) {
         int64_t delta = max_node_id - g->min_node_id();
         if (delta >= 0) {

--- a/test/t/09_vg_concat.t
+++ b/test/t/09_vg_concat.t
@@ -5,14 +5,28 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 1
+plan tests 4
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 
 num_nodes=$(vg view -g x.vg | grep ^S | wc -l)
+num_edges=$(vg view -g x.vg | grep ^L | wc -l)
 
 #echo $num_nodes
 
 is $(vg concat x.vg x.vg | vg view -g - | grep ^S | wc -l) $(echo "$num_nodes * 2" | bc) "concat doubles the number of nodes"
+is $(vg concat x.vg x.vg | vg view -g - | grep ^L | wc -l) $(echo "$num_edges * 2 + 1" | bc) "concat doubles the number of edges + 1"
 
 rm -f x.vg
+
+vg view -Jv ./reversing/reversing_path.json  > reversing.vg
+
+num_nodes=$(vg view -g reversing.vg | grep ^S | wc -l)
+num_edges=$(vg view -g reversing.vg | grep ^L | wc -l)
+
+is $(vg concat reversing.vg reversing.vg -p | vg view -g - | grep ^S | wc -l) $(echo "$num_nodes * 2" | bc) "concat -p doubles the number of nodes on reversing graph"
+# without -p, the heads/tails are backwards so you get something uglier
+is $(vg concat reversing.vg reversing.vg -p | vg view -g - | grep ^L | wc -l) $(echo "$num_edges * 2 + 1" | bc) "concat -p doubles the number of edges + 1 on reversing graph"
+
+rm -f reversing.vg
+

--- a/vgci/mine-logs.py
+++ b/vgci/mine-logs.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 Mine the CI test log XML and the test output files and generate a report
 of how good VG is at various tasks.
 """
-from __future__ import unicode_literals
+
 import logging
 import subprocess
 import tempfile
@@ -188,30 +188,30 @@ def parse_testcase_xml(testcase):
     # depending on if the parser thinks we have UTF-8 or ASCII data in a field.
     
     tc = dict()
-    tc['name'] = unicode(testcase.get('name'))
+    tc['name'] = str(testcase.get('name'))
     tc['time'] = int(float(testcase.get('time', 0)))
 
     if testcase.find('system-out') is not None:
-        tc['stdout'] = unicode(testcase.find('system-out').text)
+        tc['stdout'] = str(testcase.find('system-out').text)
     else:
         tc['stdout'] = None
 
     if testcase.find('system-err') is not None:
-        tc['stderr'] = unicode(testcase.find('system-err').text)
+        tc['stderr'] = str(testcase.find('system-err').text)
     else:
         tc['stderr'] = None
 
     if testcase.find('skipped') is not None:
         tc['skipped'] = True
-        tc['skip-msg'] = unicode(testcase.find('skipped').text)
+        tc['skip-msg'] = str(testcase.find('skipped').text)
     else:
         tc['skipped'] = False
         tc['skip-msg'] = None
 
     failure = testcase.find('failure')
     if failure is not None:
-        tc['fail-txt'] = unicode(failure.text)
-        tc['fail-msg'] = unicode(failure.get('message'))
+        tc['fail-txt'] = str(failure.text)
+        tc['fail-msg'] = str(failure.get('message'))
         tc['failed'] = True
     else:
         tc['fail-txt'] = None

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import logging
@@ -289,7 +289,7 @@ class VGCITest(TestCase):
             int(max(1, self.cores / 2)), self.cores)
         
         cmd = 'toil-vg run {} {} {} {}'.format(job_store, sample_name, out_store, opts)
-        print(("Run toil-vg with {}".format(cmd)))
+        print("Run toil-vg with {}".format(cmd))
         
         subprocess.check_call(cmd, shell=True)
 
@@ -897,7 +897,7 @@ class VGCITest(TestCase):
         self._end_message()
 
         # test the mapeval results, only looking at baseline keys
-        for key, val in baseline_dict.items():
+        for key, val in list(baseline_dict.items()):
             if key in stats_dict:
                 # For each graph we have a baseline and stats for, compare the
                 # columns we actually have in both.
@@ -946,7 +946,7 @@ class VGCITest(TestCase):
                 # Parse out the real stat values
                 score_stats_dict = self._tsv_to_dict(io.open(score_stats_path, 'r', encoding='utf8').read())
                     
-                for key in score_stats_dict.keys():
+                for key in list(score_stats_dict.keys()):
                     # For every kind of graph
                     
                     if compare_against == 'input' and (key != read_source_graph and

--- a/vgci/vgci.sh
+++ b/vgci/vgci.sh
@@ -496,7 +496,7 @@ then
     # Generate a report in two files: HTML full output, and a Markdown summary.
     # Takes as input the test result XML and the work directory with the
     # test output files.
-    vgci/mine-logs.py test-report.xml "${LOAD_WORK_DIR}/" report-html/ summary.md
+    python3 vgci/mine-logs.py test-report.xml "${LOAD_WORK_DIR}/" report-html/ summary.md
     if [ "$?" -ne 0 ]
     then
         echo "Log mining fail"


### PR DESCRIPTION
To address #2688:

`vg concat` ported to handle graph interface.

By default, `vg concat` will link every tail in graph `i` to every head in `i+1`.  This doesn't make sense a lot of time so the `-p` option is added to only add edges necessary to link up paths (of the same name between graphs, which get appended).  