### PR TITLE
Handlify vg concat and add path linking option

### DIFF
--- a/src/algorithms/append_graph.cpp
+++ b/src/algorithms/append_graph.cpp
@@ -1,0 +1,81 @@
+#include "append_graph.hpp"
+
+#include "topological_sort.hpp"
+#include "copy_graph.hpp"
+
+using namespace std;
+
+namespace vg {
+namespace algorithms {
+
+void append_handle_graph(const HandleGraph* from, MutableHandleGraph* into) {
+
+    // get the heads and tails before copying
+    vector<handle_t> heads = algorithms::head_nodes(from);
+    vector<handle_t> tails = algorithms::tail_nodes(into);
+
+    // copy over the nodes and edges
+    // beware: no checking duplicates
+    copy_handle_graph(from, into);
+
+    // connect all the tips
+    for (handle_t head : heads) {
+        handle_t into_head = into->get_handle(from->get_id(head), from->get_is_reverse(head));
+        for (handle_t tail : tails) {
+            into->create_edge(tail, into_head);
+        }
+    }
+}
+    
+void append_path_handle_graph(const PathHandleGraph* from, MutablePathMutableHandleGraph* into,
+                              bool only_connect_path_tips) {
+
+    // get the heads and tails before copying
+    vector<handle_t> heads;
+    vector<handle_t> tails;
+    if (!only_connect_path_tips) {
+        heads = algorithms::head_nodes(from);
+        tails = algorithms::tail_nodes(into);
+    }
+
+    // copy over the nodes and edges
+    // beware: no checking duplicates
+    copy_handle_graph(from, into);
+    
+    // connect all the tips
+    for (handle_t head : heads) {
+        handle_t into_head = into->get_handle(from->get_id(head), from->get_is_reverse(head));
+        for (handle_t tail : tails) {
+            into->create_edge(tail, into_head);
+        }
+    }
+
+    // append the paths, adding linking edges
+    from->for_each_path_handle([&](const path_handle_t& path_handle) {
+            string path_name = from->get_path_name(path_handle);
+            if (!into->has_path(path_name)) {
+                // just copy it over if it's not there
+                copy_path(from, path_handle, into);
+            } else {
+                // else we append it
+                path_handle_t into_path_handle = into->get_path_handle(path_name);
+                
+                // add the missing edge
+                handle_t tail = into->get_handle_of_step(into->path_back(into_path_handle));
+                handle_t head = from->get_handle_of_step(from->path_begin(path_handle));
+                if (!into->has_edge(tail, head)) {
+                    into->create_edge(tail, head);
+                }
+                
+                // append the steps
+                from->for_each_step_in_path(path_handle, [&](const step_handle_t& step_handle) {
+                        handle_t handle = from->get_handle_of_step(step_handle);
+                        handle_t into_handle = into->get_handle(from->get_id(handle), from->get_is_reverse(handle));
+                        into->append_step(into_path_handle, into_handle);
+                    });
+            }                    
+        });
+    
+}
+}
+}

--- a/src/algorithms/append_graph.hpp
+++ b/src/algorithms/append_graph.hpp
@@ -1,0 +1,30 @@
+#ifndef VG_ALGORITHMS_APPEND_GRAPH_HPP_INCLUDED
+#define VG_ALGORITHMS_APPEND_GRAPH_HPP_INCLUDED
+
+/**
+ * \file append_graph.hpp
+ *
+ * Defines algorithms for appending handle graphs (as was once done in VG::merge())
+ */
+
+#include <iostream>
+
+#include "../handle.hpp"
+
+namespace vg {
+namespace algorithms {
+
+/// Append the heads of from to the tails of into
+void append_handle_graph(const HandleGraph* from, MutableHandleGraph* into);
+    
+/// Append the heads of from to the tails of into
+/// Append all (shared) paths of from to into, copy the rest.
+/// If only_connect_path_tips is true, then only edges linking appended paths will be added
+/// (as opposed to every head and tail)
+void append_path_handle_graph(const PathHandleGraph* from, MutablePathMutableHandleGraph* into,
+                              bool only_connect_path_tips = false);
+
+}
+}
+
+#endif

--- a/src/subcommand/concat_main.cpp
+++ b/src/subcommand/concat_main.cpp
@@ -11,8 +11,14 @@
 #include <iostream>
 
 #include "subcommand.hpp"
-
+#include "../option.hpp"
+#include "../xg.hpp"
 #include "../vg.hpp"
+#include "algorithms/append_graph.hpp"
+#include <vg/io/stream.hpp>
+#include <vg/io/vpkg.hpp>
+#include "../io/save_handle_graph.hpp"
+#include <handlegraph/mutable_path_mutable_handle_graph.hpp>
 
 using namespace std;
 using namespace vg;
@@ -20,9 +26,13 @@ using namespace vg::subcommand;
 
 void help_concat(char** argv) {
     cerr << "usage: " << argv[0] << " concat [options] <graph1.vg> [graph2.vg ...] >merged.vg" << endl
-        << "Concatenates graphs in order by adding edges from the tail nodes of the" << endl
-        << "predecessor to the head nodes of the following graph. Node IDs are" << endl
-        << "compacted, so care should be taken if consistent IDs are required." << endl;
+         << "Concatenates graphs in order by adding edges from the tail nodes of the" << endl
+         << "predecessor to the head nodes of the following graph.  If node ID spaces overlap "
+         << "between graphs, they will be resolved (as in vg ids -j)" << endl
+         << endl
+         << "Options:" << endl
+         << "    -p, --only-join-paths         Only add edges necessary to join up appended paths (as opposed between all heads/tails)" << endl
+         << endl;
 }
 
 int main_concat(int argc, char** argv) {
@@ -32,17 +42,20 @@ int main_concat(int argc, char** argv) {
         return 1;
     }
 
+    bool only_join_paths = false;
+    
     int c;
     optind = 2; // force optind past command positional argument
     while (true) {
         static struct option long_options[] =
         {
             {"help", no_argument, 0, 'h'},
+            {"only-join-paths", no_argument, 0, 'p'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "h",
+        c = getopt_long (argc, argv, "hp",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -51,34 +64,46 @@ int main_concat(int argc, char** argv) {
 
         switch (c)
         {
-            case 'h':
-            case '?':
-                help_concat(argv);
-                exit(1);
-                break;
-
-            default:
-                abort ();
+        case 'p':
+            only_join_paths = true;
+            break;
+        case 'h':
+        case '?':
+            help_concat(argv);
+            exit(1);
+            break;
+        default:
+            abort ();
         }
     }
 
-    list<VG*> graphs;
+    unique_ptr<MutablePathMutableHandleGraph> first_graph;
+    get_input_file(optind, argc, argv, [&](istream& in) {
+            first_graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(in);
+        });
+    int64_t max_node_id = first_graph->max_node_id();
 
     while (optind < argc) {
-        VG* graph;
+
+        unique_ptr<MutablePathMutableHandleGraph> graph;
         get_input_file(optind, argc, argv, [&](istream& in) {
-            graph = new VG(in);
-        });
-        graphs.push_back(graph);
+                graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(in);
+            });
+
+        // join the id spaces if necessary
+        int64_t delta = max_node_id - graph->min_node_id();
+        if (delta >= 0) {
+            graph->increment_node_ids(delta + 1);
+            // necessary for HashGraph not to crash during append_path_handle_graph():
+            graph->reassign_node_ids([](nid_t node_id) { return node_id; });
+        }
+        max_node_id = graph->max_node_id();
+
+        algorithms::append_path_handle_graph(graph.get(), first_graph.get(), only_join_paths);
     }
 
-    VG merged;
-    for (list<VG*>::iterator g = graphs.begin(); g != graphs.end(); ++g) {
-        merged.append(**g);
-    }
-
-    // output
-    merged.serialize_to_ostream(std::cout);
+    // Serialize the graph using VPKG.
+    vg::io::save_handle_graph(first_graph.get(), cout);
 
     return 0;
 }

--- a/src/vg_set.cpp
+++ b/src/vg_set.cpp
@@ -58,8 +58,6 @@ id_t VGset::max_node_id(void) {
 
 int64_t VGset::merge_id_space(void) {
     int64_t max_node_id = 0;
-    // TODO: for now, only vg::VG actually implements increment_node_ids,
-    // despite it being in the interface.
     auto lambda = [&max_node_id](MutableHandleGraph* g) {
         int64_t delta = max_node_id - g->min_node_id();
         if (delta >= 0) {

--- a/test/t/09_vg_concat.t
+++ b/test/t/09_vg_concat.t
@@ -5,14 +5,28 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 1
+plan tests 4
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 
 num_nodes=$(vg view -g x.vg | grep ^S | wc -l)
+num_edges=$(vg view -g x.vg | grep ^L | wc -l)
 
 #echo $num_nodes
 
 is $(vg concat x.vg x.vg | vg view -g - | grep ^S | wc -l) $(echo "$num_nodes * 2" | bc) "concat doubles the number of nodes"
+is $(vg concat x.vg x.vg | vg view -g - | grep ^L | wc -l) $(echo "$num_edges * 2 + 1" | bc) "concat doubles the number of edges + 1"
 
 rm -f x.vg
+
+vg view -Jv ./reversing/reversing_path.json  > reversing.vg
+
+num_nodes=$(vg view -g reversing.vg | grep ^S | wc -l)
+num_edges=$(vg view -g reversing.vg | grep ^L | wc -l)
+
+is $(vg concat reversing.vg reversing.vg -p | vg view -g - | grep ^S | wc -l) $(echo "$num_nodes * 2" | bc) "concat -p doubles the number of nodes on reversing graph"
+# without -p, the heads/tails are backwards so you get something uglier
+is $(vg concat reversing.vg reversing.vg -p | vg view -g - | grep ^L | wc -l) $(echo "$num_edges * 2 + 1" | bc) "concat -p doubles the number of edges + 1 on reversing graph"
+
+rm -f reversing.vg
+


### PR DESCRIPTION
To address #2688:

`vg concat` ported to handle graph interface.

By default, `vg concat` will link every tail in graph `i` to every head in `i+1`.  This doesn't make sense a lot of time so the `-p` option is added to only add edges necessary to link up paths (of the same name between graphs, which get appended).  