### PR TITLE
Improved pinning in XdropAligner

### DIFF
--- a/src/xdrop_aligner.cpp
+++ b/src/xdrop_aligner.cpp
@@ -694,7 +694,7 @@ void XdropAligner::align(Alignment &alignment, const HandleGraph& graph, const v
 		graph_pos_s seed_pos = calculate_seed_position(ordered_graph, mems, qlen, direction);
 
 		// pack query (upward)
-		dz_query_s const *packed_query_seq_up = (direction
+		const dz_query_s* packed_query_seq_up = (direction
 			? dz_pack_query_reverse(dz, &query_seq.c_str()[0],                     seed_pos.query_offset)
 			: dz_pack_query_forward(dz, &query_seq.c_str()[seed_pos.query_offset], qlen - seed_pos.query_offset)
 		);
@@ -702,8 +702,7 @@ void XdropAligner::align(Alignment &alignment, const HandleGraph& graph, const v
 		// upward extension
 		head_pos = calculate_max_position(ordered_graph, seed_pos,
                                           extend(ordered_graph, packed_query_seq_up,
-                                                 {seed_pos},
-                                                 direction, dz, forefronts),
+                                                 {seed_pos}, direction, dz, forefronts),
                                           direction, dz, forefronts);
 	}
 	// fprintf(stderr, "head_node_index(%lu), rpos(%lu, %u), qpos(%u), direction(%d)\n", head_pos.node_index, head_pos.node_index, head_pos.ref_offset, head_pos.query_offset, direction);
@@ -808,6 +807,7 @@ void XdropAligner::align_pinned(Alignment& alignment, const HandleGraph& g, cons
     // Do the left-to-right alignment from the fixed head_pos seed, and then do the traceback.
     align_downward(alignment, ordered, head_positions, pin_left, dz, forefronts);
 
+    dz_destroy(dz);
 }
 
 /**

--- a/src/xdrop_aligner.hpp
+++ b/src/xdrop_aligner.hpp
@@ -214,7 +214,7 @@ namespace vg {
         /// Note that if no non-empty local alignment is found, it may not be
         /// safe to call dz_calc_max_qpos on the associated forefront!
 		size_t extend(const OrderedGraph& graph, const dz_query_s* packed_query,
-                      size_t seed_node_index, uint64_t seed_offset, bool right_to_left,
+                      const vector<graph_pos_s>& seed_positions, bool right_to_left,
                       dz_s* dz, vector<const dz_forefront_s*>& forefronts) const;
        
         /**
@@ -227,9 +227,10 @@ namespace vg {
          * left, and the internal traceback comes out in right to left order,
          * so we need to flip it.
          */
-        void calculate_and_save_alignment(Alignment &alignment, const OrderedGraph& graph,
-                                          const graph_pos_s& head_pos, size_t tail_node_index, bool left_to_right,
-                                          dz_s* dz, const vector<const dz_forefront_s*>& forefronts) const;
+        void calculate_and_save_alignment(Alignment& alignment, const OrderedGraph& graph,
+                                          const vector<graph_pos_s>& head_positions,
+                                          size_t tail_node_index, bool left_to_right, dz_s* dz,
+                                          const vector<const dz_forefront_s*>& forefronts) const;
 
 		// void debug_print(Alignment const &alignment, OrderedGraph const &graph, MaximalExactMatch const &seed, bool reverse_complemented);
 		// bench_t bench;
@@ -238,7 +239,8 @@ namespace vg {
         /// the downward alignment pass and traceback. If left_to_right is
         /// set, goes left to right and traces back the other way. If it is
         /// unset, goes right to left and traces back the other way.
-        void align_downward(Alignment &alignment, const OrderedGraph& graph, const graph_pos_s& head_pos,
+        void align_downward(Alignment &alignment, const OrderedGraph& graph,
+                            const vector<graph_pos_s>& head_positions,
                             bool left_to_right, dz_s* dz, vector<const dz_forefront_s*>& forefronts) const;
 
         


### PR DESCRIPTION
Pinned alignment in the XdropAligner now will automatically select the best head/tail node to pin to, rather than just arbitrarily choosing the first. Also fixes a memory leak I accidentally introduced in my last PR.