### PR TITLE
Add libbdsg, xg, algorithms, and io to Doxygen

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -758,7 +758,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src src/subcommand src/unittest/driver.cpp src/unittest/driver.hpp deps/libhandlegraph/src deps/libhandlegraph/src/include/handlegraph deps/libvgio/src deps/libvgio/include/vg/io deps/libvgio/deps
+INPUT                  = src src/algorithms src/io src/subcommand src/unittest/driver.cpp src/unittest/driver.hpp deps/xg/src/xg.cpp deps/xg/src/xg.hpp deps/libbdsg/src deps/libbdsg/include/bdsg deps/libhandlegraph/src deps/libhandlegraph/src/include/handlegraph deps/libvgio/src deps/libvgio/include/vg/io deps/libvgio/deps
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This will fix #2679.

In addition to not having libbdsg and the new xg::XG, we were also forgetting to make docs for thw algorithms and io folders in vg itself. For some reason it's not recursive; we need to list each folder with source files individually.