### PR TITLE
Support cutoff fow flow traversal enumeration

### DIFF
--- a/src/algorithms/k_widest_paths.cpp
+++ b/src/algorithms/k_widest_paths.cpp
@@ -58,8 +58,9 @@ pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t so
     } else {
         // heuristic average flow
         acc_node = [&](double next_score, handle_t next, double& total_score, double& total_length) {
-            total_length += g->get_length(next);
-            total_score += node_weight_callback(next);
+            size_t length = g->get_length(next);
+            total_length += length;
+            total_score += node_weight_callback(next) * length;
             return total_score / total_length;
         };
         acc_edge = [&](double next_score, edge_t edge, double& total_score, double& total_length) {
@@ -74,7 +75,7 @@ pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t so
     handle_t previous;
     // we don't include the score of the source
     // todo: should this be an option?
-    double score = 0;
+    double score = avg_flow ? 0 : numeric_limits<double>::max();
     double total_score = 0;
     double total_length = 0;
     queue.push(make_tuple(score, source, source, total_score, total_length));
@@ -177,7 +178,7 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
     map<vector<handle_t>, size_t> B;
     // used to pull out the biggest element in B
     multimap<double, map<vector<handle_t>, size_t>::iterator> score_to_B;
-    
+
     // start scanning for our k-1 next-widest paths
     for (size_t k = 1; k < K && best_paths.back().first > cutoff; ++k) {
 

--- a/src/algorithms/k_widest_paths.hpp
+++ b/src/algorithms/k_widest_paths.hpp
@@ -22,18 +22,28 @@ namespace algorithms {
 ///  -- looks for the "widest" path (maximum minimum weight) instead of shortest
 ///  -- counts node and edge weights (via callbakcs)
 ///  -- returns the path as well as the score
-///  -- option for ignoring certain nodes and edges in search (required by Yen's algorithm) 
+///  -- option for ignoring certain nodes and edges in search (required by Yen's algorithm)
+///  -- when avg_flow is set to true, use the average instead of minimum flow.
+///     the guarantee of getting the true maximum is lost, due to the lack of optimal substructure.
+///     (a short crappy path can be a better prefix than a long better-supported path)
 pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t source, handle_t sink,
                                                function<double(const handle_t&)> node_weight_callback,
                                                function<double(const edge_t&)> edge_weight_callback,
                                                function<bool(const handle_t&)> is_node_ignored_callback,
-                                               function<bool(const edge_t&)> is_edge_ignored_callbback);
+                                               function<bool(const edge_t&)> is_edge_ignored_callbback,
+                                               bool avg_flow = false);
+
 
 /// Find the k widest paths
+/// Cutoff: stop searching once best path has score < cutoff
+/// Avg_flow: search using maximum average flow instead of width (min flow).  Unlike min flow, the solution
+///           is not guarateed to be optimal.
 vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g, handle_t source, handle_t sink,
                                                            size_t K,
                                                            function<double(const handle_t&)> node_weight_callback,
-                                                           function<double(const edge_t&)> edge_weight_callback);
+                                                           function<double(const edge_t&)> edge_weight_callback,
+                                                           double cutoff = numeric_limits<double>::lowest(),
+                                                           bool avg_flow = false);
 
 }
 }

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -14,7 +14,7 @@ GraphCaller::GraphCaller(SnarlCaller& snarl_caller,
 GraphCaller::~GraphCaller() {
 }
 
-void GraphCaller::call_top_level_snarls(bool recurse_on_fail) {
+void GraphCaller::call_top_level_snarls(int ploidy, bool recurse_on_fail) {
 
     // Used to recurse on children of parents that can't be called
     size_t thread_count = get_thread_count();
@@ -26,7 +26,7 @@ void GraphCaller::call_top_level_snarls(bool recurse_on_fail) {
 #ifdef debug
         cerr << "GraphCaller running call_snarl on " << pb2json(*snarl) << endl;
 #endif
-        bool was_called = call_snarl(*snarl);
+        bool was_called = call_snarl(*snarl, ploidy);
         if (!was_called && recurse_on_fail) {
             const vector<const Snarl*>& children = snarl_manager.children_of(snarl);
             vector<const Snarl*>& thread_queue = snarl_queue[omp_get_thread_num()];
@@ -335,7 +335,7 @@ VCFGenotyper::~VCFGenotyper() {
 
 }
 
-bool VCFGenotyper::call_snarl(const Snarl& snarl) {
+bool VCFGenotyper::call_snarl(const Snarl& snarl, int ploidy) {
 
     // could be that our graph is a subgraph of the graph the snarls were computed from
     // so bypass snarls we can't process
@@ -372,10 +372,10 @@ bool VCFGenotyper::call_snarl(const Snarl& snarl) {
         // use our support caller to choose our genotype (int traversal coordinates)
         vector<int> trav_genotype;
         unique_ptr<SnarlCaller::CallInfo> trav_call_info;
-        std::tie(trav_genotype, trav_call_info) = snarl_caller.genotype(snarl, travs, ref_trav_idx, 2, get<0>(ref_positions),
+        std::tie(trav_genotype, trav_call_info) = snarl_caller.genotype(snarl, travs, ref_trav_idx, ploidy, get<0>(ref_positions),
                                                                         make_pair(get<1>(ref_positions), get<2>(ref_positions)));
 
-        assert(trav_genotype.empty() || trav_genotype.size() == 2);
+        assert(trav_genotype.size() <= 2);
 
         // map our genotype back to the vcf
         for (int i = 0; i < variants.size(); ++i) {
@@ -570,7 +570,7 @@ LegacyCaller::~LegacyCaller() {
     }
 }
 
-bool LegacyCaller::call_snarl(const Snarl& snarl) {
+bool LegacyCaller::call_snarl(const Snarl& snarl, int ploidy) {
 
     // if we can't handle the snarl, then the GraphCaller framework will recurse on its children
     if (!is_traversable(snarl)) {
@@ -656,14 +656,14 @@ bool LegacyCaller::call_snarl(const Snarl& snarl) {
         // these integers map the called traversals to their positions in the list of all traversals
         // of the top level snarl.  
         vector<int> genotype;
-        std::tie(called_traversals, genotype) = top_down_genotype(snarl, *rep_trav_finder, 2,
+        std::tie(called_traversals, genotype) = top_down_genotype(snarl, *rep_trav_finder, ploidy,
                                                                   path_name, make_pair(get<0>(ref_interval), get<1>(ref_interval)));
     
         if (!called_traversals.empty()) {
             // regenotype our top-level traversals now that we know they aren't nested, and we have a
             // good idea of all the sizes
             unique_ptr<SnarlCaller::CallInfo> call_info;
-            std::tie(called_traversals, genotype, call_info) = re_genotype(snarl, *rep_trav_finder, called_traversals, genotype, 2,
+            std::tie(called_traversals, genotype, call_info) = re_genotype(snarl, *rep_trav_finder, called_traversals, genotype, ploidy,
                                                                            path_name, make_pair(get<0>(ref_interval), get<1>(ref_interval)));
 
             // emit our vcf variant
@@ -900,7 +900,7 @@ FlowCaller::~FlowCaller() {
     delete traversal_finder;
 }
 
-bool FlowCaller::call_snarl(const Snarl& snarl) {
+bool FlowCaller::call_snarl(const Snarl& snarl, int ploidy) {
 
     if (snarl.start().node_id() == snarl.end().node_id() ||
         !graph.has_node(snarl.start().node_id()) || !graph.has_node(snarl.end().node_id())) {
@@ -1020,10 +1020,10 @@ bool FlowCaller::call_snarl(const Snarl& snarl) {
     // use our support caller to choose our genotype
     vector<int> trav_genotype;
     unique_ptr<SnarlCaller::CallInfo> trav_call_info;
-    std::tie(trav_genotype, trav_call_info) = snarl_caller.genotype(snarl, weighted_travs.first, ref_trav_idx, 2, ref_path_name,
+    std::tie(trav_genotype, trav_call_info) = snarl_caller.genotype(snarl, weighted_travs.first, ref_trav_idx, ploidy, ref_path_name,
                                                                     make_pair(get<0>(ref_interval), get<1>(ref_interval)));
 
-    assert(trav_genotype.empty() || trav_genotype.size() == 2);
+    assert(trav_genotype.empty() || trav_genotype.size() == ploidy);
 
     emit_variant(graph, snarl_caller, snarl, weighted_travs.first, trav_genotype, ref_trav_idx, trav_call_info, ref_path_name,
                  ref_offsets[ref_path_name]);

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -265,6 +265,9 @@ protected:
     /// keep track of offsets in the reference paths
     map<string, size_t> ref_offsets;
 
+    /// until we support nested snarls, cap snarl size we attempt to process
+    size_t max_snarl_edges = 500000;
+
 };
 
 

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -32,10 +32,10 @@ public:
     /// Run call_snarl() on every top-level snarl in the manager.
     /// For any that return false, try the children, etc. (when recurse_on_fail true)
     /// Snarls are processed in parallel
-    virtual void call_top_level_snarls(bool recurse_on_fail = true);
+    virtual void call_top_level_snarls(int ploidy, bool recurse_on_fail = true);
 
     /// Call a given snarl, and print the output to out_stream
-    virtual bool call_snarl(const Snarl& snarl) = 0;
+    virtual bool call_snarl(const Snarl& snarl, int ploidy) = 0;
    
 protected:
 
@@ -110,7 +110,7 @@ public:
 
     virtual ~VCFGenotyper();
 
-    virtual bool call_snarl(const Snarl& snarl);
+    virtual bool call_snarl(const Snarl& snarl, int ploidy);
 
     virtual string vcf_header(const PathHandleGraph& graph, const vector<string>& contigs,
                               const vector<size_t>& contig_length_overrides = {}) const;
@@ -154,7 +154,7 @@ public:
 
     virtual ~LegacyCaller();
 
-    virtual bool call_snarl(const Snarl& snarl);
+    virtual bool call_snarl(const Snarl& snarl, int ploidy);
 
     virtual string vcf_header(const PathHandleGraph& graph, const vector<string>& contigs,
                               const vector<size_t>& contig_length_overrides = {}) const;
@@ -245,7 +245,7 @@ public:
    
     virtual ~FlowCaller();
 
-    virtual bool call_snarl(const Snarl& snarl);
+    virtual bool call_snarl(const Snarl& snarl, int ploidy);
 
     virtual string vcf_header(const PathHandleGraph& graph, const vector<string>& contigs,
                               const vector<size_t>& contig_length_overrides = {}) const;

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -483,7 +483,8 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
     vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);
 
     // get the supports of each traversal independently
-    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, {}, {}, false, {}, {}, ref_trav_idx);
+    int max_trav_size = -1;
+    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, {}, {}, false, {}, {}, ref_trav_idx, &max_trav_size);
 
     // sort the traversals by support
     vector<int> ranked_traversals = rank_by_support(supports);
@@ -518,7 +519,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
         
             // we prune out traversals whose exclusive support (structure that is not shared with best traversal)
             // doesn't meet a certain cutoff
-            vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, top_traversals, true, {}, {}, ref_trav_idx);
+            vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, top_traversals, true, {}, {}, ref_trav_idx, &max_trav_size);
             for (int j = 0; j < secondary_exclusive_supports.size(); ++j) {
                 if (j != best_allele &&
                     support_val(secondary_exclusive_supports[j]) < min_total_support_for_call &&
@@ -528,7 +529,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
             }
 
             // get the supports of each traversal in light of best
-            vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, top_traversals, false, {}, {}, ref_trav_idx);
+            vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, top_traversals, false, {}, {}, ref_trav_idx, &max_trav_size);
             vector<int> ranked_secondary_traversals = rank_by_support(secondary_supports);
 
             // add the homozygous genotype for our best allele
@@ -565,7 +566,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
     double total_likelihood = 0;
     vector<int> best_genotype;
     for (const auto& candidate : candidates) {
-        double gl = genotype_likelihood(candidate, traversals, top_traversals, ref_trav_idx, exp_depth, depth_err);
+        double gl = genotype_likelihood(candidate, traversals, top_traversals, ref_trav_idx, exp_depth, depth_err, max_trav_size);
         if (gl > best_genotype_likelihood) {
             second_best_genotype_likelihood = best_genotype_likelihood;
             best_genotype_likelihood = gl;
@@ -593,6 +594,8 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
     }
 
     call_info->expected_depth = exp_depth;
+    call_info->depth_err = depth_err;
+    call_info->max_trav_size = max_trav_size;
 
 #ifdef debug
     cerr << " best genotype: "; for (auto a : best_genotype) {cerr << a <<",";} cerr << " gl=" << best_genotype_likelihood << endl;
@@ -603,12 +606,14 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
 double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotype,
                                                       const vector<SnarlTraversal>& traversals,
                                                       const set<int>& trav_subset, 
-                                                      int ref_trav_idx, double exp_depth, double depth_err) {
+                                                      int ref_trav_idx, double exp_depth, double depth_err,
+                                                      int max_trav_size) {
     
     assert(genotype.size() == 1 || genotype.size() == 2);
 
     // get the genotype support
-    vector<Support> genotype_supports = support_finder.get_traversal_genotype_support(traversals, genotype, trav_subset, ref_trav_idx);
+    vector<Support> genotype_supports = support_finder.get_traversal_genotype_support(traversals, genotype, trav_subset, ref_trav_idx,
+                                                                                      &max_trav_size);
 
     // get the total support over the site
     Support total_site_support = std::accumulate(genotype_supports.begin(), genotype_supports.end(), Support());    
@@ -651,10 +656,10 @@ double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotyp
     cerr << "Computing prob of genotype: {";
     for (int i = 0; i < genotype.size(); ++i) {
         cerr << genotype[i] << ",";
-    } 
+    }
     cerr << "}: tot_other_sup = " << total_other_support << " tot site sup = " << total_site_support 
          << " exp-depth = " << exp_depth << " depth-err = " << depth_err << " other-lambda = " << other_poisson_lambda
-         << " allele-lambda " << allele_poisson_lambda << endl;
+         << " allele-lambda " << allele_poisson_lambda << " ref-idx " << ref_trav_idx << endl;
 #endif
     
     // now we compute the likelihood of our genotype
@@ -684,16 +689,19 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
                                                 const unique_ptr<CallInfo>& call_info,
                                                 const string& sample_name,
                                                 vcflib::Variant& variant) {
-
+    
     assert(traversals.size() == variant.alleles.size());
 
     // get the traversal sizes
     vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);
 
-    // get the genotype support
-    vector<Support> genotype_supports = support_finder.get_traversal_genotype_support(traversals, genotype, {}, 0);
+    // get the maximum size from the info
+    const SnarlCaller::CallInfo* s_call_info = call_info.get();
+    const PoissonCallInfo* p_call_info = dynamic_cast<const PoissonCallInfo*>(call_info.get());
+    int max_trav_size = p_call_info->max_trav_size;
 
-    // get the genotype_
+    // get the genotype support
+    vector<Support> genotype_supports = support_finder.get_traversal_genotype_support(traversals, genotype, {}, 0, &max_trav_size);
 
     // Get the depth of the site
     Support total_site_support = std::accumulate(genotype_supports.begin(), genotype_supports.end(), Support());    
@@ -728,32 +736,43 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
     double gen_likelihood;    
     variant.format.push_back("GL");
 
-    // expected depth from our coverage.  we look at the reference-range from the snarl plus a bit of padding,
-    // averaging over every depth bin this touches.  todo: adaptively compute nearby coverage without bins
-    // (requires VCFGenotyper to be refactored to require a PathPositionIndex)
-    size_t longest_traversal = *max_element(traversal_sizes.begin(), traversal_sizes.end());
-    size_t padding = (depth_padding_factor * longest_traversal) / 2;
-    pair<size_t, size_t> ref_range = make_pair(max((long)0, (long)(variant.position - padding)),
-					       variant.position + variant.ref.length() + padding);
-    auto depth_info = algorithms::get_depth_from_index(depth_index, variant.sequenceName, ref_range.first, ref_range.second);
-    double exp_depth = depth_info.first;
-    assert(!isnan(exp_depth));
+    assert(!isnan(p_call_info->expected_depth));
     // variance/std-err can be nan when binsize < 2.  We just clamp it to 0
-    double depth_err = !isnan(depth_info.second) ? depth_info.second  : 0.;
+    double depth_err = !isnan(p_call_info->depth_err) ? p_call_info->depth_err  : 0.;
 
     double total_likelihood = 0.;
     double ref_likelihood = 1.;
     double alt_likelihood = 0.;
-    
-    // assume ploidy 2
-    for (int i = 0; i < traversals.size(); ++i) {
-        for (int j = i; j < traversals.size(); ++j) {
-            double gl = genotype_likelihood({i, j}, traversals, {}, 0, exp_depth, depth_err);
+
+    if (genotype.size() == 2) {
+        // assume ploidy 2
+        for (int i = 0; i < traversals.size(); ++i) {
+            for (int j = i; j < traversals.size(); ++j) {
+                double gl = genotype_likelihood({i, j}, traversals, {}, 0, p_call_info->expected_depth, depth_err, max_trav_size);
+                gen_likelihoods.push_back(gl);
+                if (vector<int>({i, j}) == genotype || vector<int>({j,i}) == genotype) {
+                    gen_likelihood = gl;
+                }
+                if (i == 0 && j == 0) {
+                    ref_likelihood = gl;
+                } else {
+                    alt_likelihood = alt_likelihood == 0. ? gl : add_log(alt_likelihood, gl);
+                }
+                total_likelihood = total_likelihood == 0 ? gl : add_log(total_likelihood, gl);
+                // convert from natural log to log10 by dividing by ln(10)
+                variant.samples[sample_name]["GL"].push_back(std::to_string(gl / 2.30258));
+            }
+        }
+    } else if (genotype.size() == 1) {
+        // assume ploidy 1
+        // todo: generalize this iteration (as is, it is copy pased from above)
+        for (int i = 0; i < traversals.size(); ++i) {
+            double gl = genotype_likelihood({i}, traversals, {}, 0, p_call_info->expected_depth, depth_err, max_trav_size);
             gen_likelihoods.push_back(gl);
-            if (vector<int>({i, j}) == genotype || vector<int>({j,i}) == genotype) {
+            if (vector<int>({i}) == genotype) {
                 gen_likelihood = gl;
             }
-            if (i == 0 && j == 0) {
+            if (i == 0) {
                 ref_likelihood = gl;
             } else {
                 alt_likelihood = alt_likelihood == 0. ? gl : add_log(alt_likelihood, gl);
@@ -763,9 +782,7 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
             variant.samples[sample_name]["GL"].push_back(std::to_string(gl / 2.30258));
         }
     }
-
-    const SnarlCaller::CallInfo* s_call_info = call_info.get();
-    const PoissonCallInfo* p_call_info = dynamic_cast<const PoissonCallInfo*>(call_info.get());
+    
     variant.format.push_back("GQ");
     variant.samples[sample_name]["GQ"].push_back(std::to_string(min((int)256, max((int)0, (int)p_call_info->gq))));
 
@@ -779,10 +796,10 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
     // We derive this from the posterior probability of the reference genotype.
     // But if it's a reference call, we take the total of all the alts
     variant.quality = 0;
-    if (genotype.size() == 2) {
+    if (genotype.size() > 0) {
         // our flat prior and p[traversal coverage]
         double posterior = -log(gen_likelihoods.size()) - total_likelihood;
-        if (genotype[0] != 0 || genotype[1] != 0) {
+        if (!all_of(genotype.begin(), genotype.end(), [&](int a) {return a == 0;})) {
             posterior += ref_likelihood;
         } else {
             posterior += alt_likelihood;

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -204,6 +204,8 @@ public:
         double gq;
         double posterior;
         double expected_depth;
+        double depth_err;
+        int max_trav_size;
     };
 
     /// Get the genotype of a site
@@ -236,7 +238,8 @@ protected:
     double genotype_likelihood(const vector<int>& genotype,
                                const vector<SnarlTraversal>& traversals,
                                const set<int>& trav_subset,
-                               int ref_trav_idx, double exp_depth, double depth_err);
+                               int ref_trav_idx, double exp_depth, double depth_err,
+                               int max_trav_size);
 
     /// Rank supports
     vector<int> rank_by_support(const vector<Support>& supports);

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3327,14 +3327,16 @@ vector<SnarlTraversal> FlowTraversalFinder::find_traversals(const Snarl& site) {
     return find_weighted_traversals(site).first;
 }
 
-pair<vector<SnarlTraversal>, vector<double>> FlowTraversalFinder::find_weighted_traversals(const Snarl& site) {
+pair<vector<SnarlTraversal>, vector<double>> FlowTraversalFinder::find_weighted_traversals(const Snarl& site, bool avg_flow) {
 
     handle_t start_handle = graph.get_handle(site.start().node_id(), site.start().backward());
     handle_t end_handle = graph.get_handle(site.end().node_id(), site.end().backward());
 
     vector<pair<double, vector<handle_t>>> widest_paths = algorithms::yens_k_widest_paths(&graph, start_handle, end_handle, K,
                                                                                           node_weight_callback,
-                                                                                          edge_weight_callback);
+                                                                                          edge_weight_callback,
+                                                                                          0.0,
+                                                                                          avg_flow);
 
     vector<SnarlTraversal> travs;
     travs.reserve(widest_paths.size());

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -602,7 +602,8 @@ public:
     /**
      * Return the K widest traversals, along with their flows
      */
-    virtual pair<vector<SnarlTraversal>, vector<double>> find_weighted_traversals(const Snarl& site);
+    virtual pair<vector<SnarlTraversal>, vector<double>> find_weighted_traversals(const Snarl& site,
+                                                                                  bool avg_flow = false);
 
     /// Set K
     void setK(size_t k);

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -54,7 +54,8 @@ public:
     virtual vector<Support> get_traversal_genotype_support(const vector<SnarlTraversal>& traversals,
                                                            const vector<int>& genotype,
                                                            const set<int>& other_trav_subset,
-                                                           int ref_trav_idx = -1);
+                                                           int ref_trav_idx = -1,
+                                                           int* max_trav_size = nullptr);
     
     /// traversals:      get support for each traversal in this set
     /// shared_travs:    if a node appears N times in shared_travs, then it will count as 1 / (N+1) support


### PR DESCRIPTION
Data from #2683 was crippling the latest version of the caller.  The problem seems to be big snarls with no support anywhere crippling the traversal enumeration.  Without any good paths for guidance, the running time in practice tends towards the worst case which is bad.  So when enumerating the K best traversals, it now stops when it hits a traversal with 0 support.  Also, uses an average support heuristic for larger snarls to make it more consistent with computations elsewhere. 