### PR TITLE
Greedy average option for min-flow traversal finder

### DIFF
--- a/src/algorithms/k_widest_paths.cpp
+++ b/src/algorithms/k_widest_paths.cpp
@@ -65,7 +65,7 @@ pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t so
             visited[current] = make_pair(previous, score);
         }
                 
-        if (current != sink) {
+        if (current != sink && current != g->flip(source)) {
             g->follow_edges(current, false, [&](const handle_t& next) {
                     // For each handle to the right of here
                     if (!visited.count(next) && 
@@ -192,6 +192,8 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
               cerr << "forgetting node " << g->get_id(prev_path[j]) << ":" << g->get_is_reverse(prev_path[j]) << endl;
 #endif
                 forgotten_nodes.insert(prev_path[j]);
+                // don't allow loop-backs in paths
+                forgotten_nodes.insert(g->flip(prev_path[j]));
             }
 
             // find our path from the the spur_node to the sink

--- a/src/algorithms/k_widest_paths.cpp
+++ b/src/algorithms/k_widest_paths.cpp
@@ -19,14 +19,15 @@ pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t so
                                                function<double(const handle_t&)> node_weight_callback,
                                                function<double(const edge_t&)> edge_weight_callback,
                                                function<bool(const handle_t&)> is_node_ignored_callback,
-                                               function<bool(const edge_t&)> is_edge_ignored_callback) {
+                                               function<bool(const edge_t&)> is_edge_ignored_callback,
+                                               double cutoff) {
 
     // We keep a priority queue so we can visit the handle with the shortest
     // distance next. We put handles in here whenever we see them with shorter
     // distances (since STL priority queue can't update), so we also need to
     // make sure nodes coming out haven't been visited already.
     // (score, previous, current)
-    using Record = tuple<double, handle_t, handle_t>;
+    using Record = tuple<double, handle_t, handle_t, double>;
     
     // We filter out handles that have already been visited.  And keep track of predecessors
     unordered_map<handle_t, pair<handle_t, double>> visited;
@@ -34,7 +35,7 @@ pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t so
     // We need a custom ordering for the queue
     struct IsFirstGreater {
         inline bool operator()(const Record& a, const Record& b) {
-            return get<0>(a) < get<0>(b);
+            return get<0>(a) < get<0>(b) || (get<0>(a) == get<0>(b) && get<3>(a) < get<3>(b));
         }
     };
     
@@ -49,11 +50,11 @@ pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t so
     // we don't include the score of the source
     // todo: should this be an option?
     double score = numeric_limits<double>::max();
-    queue.push(make_tuple(score, source, source));
-    
+    queue.push(make_tuple(score, source, source, 0));
+
     while (!queue.empty()) {
         // While there are things in the queue, get the first.
-        tie(score, previous, current) = queue.top();
+        tie(score, previous, current, std::ignore) = queue.top();
         queue.pop();
 
 #ifdef debug_vg_algorithms
@@ -73,16 +74,24 @@ pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t so
                         !is_edge_ignored_callback(g->edge_handle(current, next))) {
 
                         double next_score = score;
+                        double greedy_hint = 0;
 
                         if (next != source && next != sink) {
                             // we don't include the source / sink
                             // todo: should we? should it be an option?
-                            next_score = min(next_score, node_weight_callback(next));
+                            double node_weight = node_weight_callback(next);
+                            next_score = min(next_score, node_weight);
+                            greedy_hint = node_weight;
                         }
-                        next_score = min(next_score, edge_weight_callback(g->edge_handle(current, next)));
+                        double edge_weight = edge_weight_callback(g->edge_handle(current, next));
+                        next_score = min(next_score, edge_weight);
+                        // if all the scores are 0, try to prioritize stuff that looks better locally
+                        greedy_hint = min(next_score, edge_weight);
 
-                        // New shortest distance. Will never happen after the handle comes out of the queue because of Dijkstra.
-                        queue.push(make_tuple(next_score, current, next));
+                        if (next_score >= cutoff) {
+                            // New shortest distance. Will never happen after the handle comes out of the queue because of Dijkstra.
+                            queue.push(make_tuple(next_score, current, next, greedy_hint));
+                        }
                         
 #ifdef debug_vg_algorithms
                         cerr << "\tNew best path to " << g->get_id(next) << ":" << g->get_is_reverse(next)
@@ -119,7 +128,7 @@ pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t so
     }
     cerr << endl;
 #endif
-    
+
     return make_pair(width, widest_path);
 }
 
@@ -151,6 +160,8 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
     // start scanning for our k-1 next-widest paths
     for (size_t k = 1; k < K; ++k) {
 
+        // use to prune search
+        double best_this_iteration = numeric_limits<double>::lowest();
         // we look for a "spur node" in the previous path.  the current path will be the previous path
         // up to that spur node, then a new path to the sink. (i is the index of the spur node in
         // the previous (k - 1) path
@@ -197,8 +208,8 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
             // find our path from the the spur_node to the sink
             pair<double, vector<handle_t>> spur_path_v = widest_dijkstra(g, spur_node, sink, node_weight_callback, edge_weight_callback,
                                                                          [&](handle_t h) {return forgotten_nodes.count(h);},
-                                                                         [&](edge_t e) {return forgotten_edges.count(e);});
-
+                                                                         [&](edge_t e) {return forgotten_edges.count(e);},
+                                                                         best_this_iteration);
             if (!spur_path_v.second.empty()) {
             
                 // make the path by combining the root path and the spur path
@@ -222,6 +233,14 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
                 if (ins.second == true) {
                     score_to_B.insert(make_pair(total_path.first, ins.first));
                 } // todo: is there any reason we'd need to update the score of an existing entry in B?
+
+                best_this_iteration = max(total_path.first, best_this_iteration);
+                // optimization: if we've found a tie for the previous best path, we're never going to do better,
+                // so stop iterating spur nodes.  this saves us O(n) a lot when the current best path has score
+                // 0 and we're just exhaustively enumerating
+                if (total_path.first == best_paths.back().first) {
+                    break;
+                }
             }
         }
 

--- a/src/algorithms/k_widest_paths.hpp
+++ b/src/algorithms/k_widest_paths.hpp
@@ -22,18 +22,22 @@ namespace algorithms {
 ///  -- looks for the "widest" path (maximum minimum weight) instead of shortest
 ///  -- counts node and edge weights (via callbakcs)
 ///  -- returns the path as well as the score
-///  -- option for ignoring certain nodes and edges in search (required by Yen's algorithm) 
+///  -- option for ignoring certain nodes and edges in search (required by Yen's algorithm)
+///  -- greedy_avg option switches the algorithm to a heuristic (no optimal guarantee) search
+///     using the running averages support instead of min-flow support as objective function.
 pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t source, handle_t sink,
                                                function<double(const handle_t&)> node_weight_callback,
                                                function<double(const edge_t&)> edge_weight_callback,
                                                function<bool(const handle_t&)> is_node_ignored_callback,
-                                               function<bool(const edge_t&)> is_edge_ignored_callbback);
+                                               function<bool(const edge_t&)> is_edge_ignored_callbback,
+                                               bool greedy_avg = false);
 
 /// Find the k widest paths
 vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g, handle_t source, handle_t sink,
                                                            size_t K,
                                                            function<double(const handle_t&)> node_weight_callback,
-                                                           function<double(const edge_t&)> edge_weight_callback);
+                                                           function<double(const edge_t&)> edge_weight_callback,
+                                                           bool greedy_avg = false);
 
 }
 }

--- a/src/algorithms/k_widest_paths.hpp
+++ b/src/algorithms/k_widest_paths.hpp
@@ -22,12 +22,14 @@ namespace algorithms {
 ///  -- looks for the "widest" path (maximum minimum weight) instead of shortest
 ///  -- counts node and edge weights (via callbakcs)
 ///  -- returns the path as well as the score
-///  -- option for ignoring certain nodes and edges in search (required by Yen's algorithm) 
+///  -- option for ignoring certain nodes and edges in search (required by Yen's algorithm)
+///  -- stop if score dips below cutoff
 pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t source, handle_t sink,
                                                function<double(const handle_t&)> node_weight_callback,
                                                function<double(const edge_t&)> edge_weight_callback,
                                                function<bool(const handle_t&)> is_node_ignored_callback,
-                                               function<bool(const edge_t&)> is_edge_ignored_callbback);
+                                               function<bool(const edge_t&)> is_edge_ignored_callbback,
+                                               double cutoff = 0.0);
 
 /// Find the k widest paths
 vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g, handle_t source, handle_t sink,

--- a/src/algorithms/k_widest_paths.hpp
+++ b/src/algorithms/k_widest_paths.hpp
@@ -22,14 +22,12 @@ namespace algorithms {
 ///  -- looks for the "widest" path (maximum minimum weight) instead of shortest
 ///  -- counts node and edge weights (via callbakcs)
 ///  -- returns the path as well as the score
-///  -- option for ignoring certain nodes and edges in search (required by Yen's algorithm)
-///  -- stop if score dips below cutoff
+///  -- option for ignoring certain nodes and edges in search (required by Yen's algorithm) 
 pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t source, handle_t sink,
                                                function<double(const handle_t&)> node_weight_callback,
                                                function<double(const edge_t&)> edge_weight_callback,
                                                function<bool(const handle_t&)> is_node_ignored_callback,
-                                               function<bool(const edge_t&)> is_edge_ignored_callbback,
-                                               double cutoff = 0.0);
+                                               function<bool(const edge_t&)> is_edge_ignored_callbback);
 
 /// Find the k widest paths
 vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g, handle_t source, handle_t sink,

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -1017,7 +1017,7 @@ bool FlowCaller::call_snarl(const Snarl& snarl, int ploidy) {
     emit_variant(graph, snarl_caller, snarl, weighted_travs.first, trav_genotype, ref_trav_idx, trav_call_info, ref_path_name,
                  ref_offsets[ref_path_name]);
 
-    return trav_genotype.size() == 2;    
+    return trav_genotype.size() == ploidy;
 }
 
 string FlowCaller::vcf_header(const PathHandleGraph& graph, const vector<string>& contigs,

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -32,10 +32,10 @@ public:
     /// Run call_snarl() on every top-level snarl in the manager.
     /// For any that return false, try the children, etc. (when recurse_on_fail true)
     /// Snarls are processed in parallel
-    virtual void call_top_level_snarls(bool recurse_on_fail = true);
+    virtual void call_top_level_snarls(int ploidy, bool recurse_on_fail = true);
 
     /// Call a given snarl, and print the output to out_stream
-    virtual bool call_snarl(const Snarl& snarl) = 0;
+    virtual bool call_snarl(const Snarl& snarl, int ploidy) = 0;
    
 protected:
 
@@ -110,7 +110,7 @@ public:
 
     virtual ~VCFGenotyper();
 
-    virtual bool call_snarl(const Snarl& snarl);
+    virtual bool call_snarl(const Snarl& snarl, int ploidy);
 
     virtual string vcf_header(const PathHandleGraph& graph, const vector<string>& contigs,
                               const vector<size_t>& contig_length_overrides = {}) const;
@@ -154,7 +154,7 @@ public:
 
     virtual ~LegacyCaller();
 
-    virtual bool call_snarl(const Snarl& snarl);
+    virtual bool call_snarl(const Snarl& snarl, int ploidy);
 
     virtual string vcf_header(const PathHandleGraph& graph, const vector<string>& contigs,
                               const vector<size_t>& contig_length_overrides = {}) const;
@@ -245,7 +245,7 @@ public:
    
     virtual ~FlowCaller();
 
-    virtual bool call_snarl(const Snarl& snarl);
+    virtual bool call_snarl(const Snarl& snarl, int ploidy);
 
     virtual string vcf_header(const PathHandleGraph& graph, const vector<string>& contigs,
                               const vector<size_t>& contig_length_overrides = {}) const;
@@ -264,6 +264,9 @@ protected:
 
     /// keep track of offsets in the reference paths
     map<string, size_t> ref_offsets;
+
+    /// until we support nested snarls, cap snarl size we attempt to process
+    size_t max_snarl_edges = 500000;
 
 };
 

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -483,7 +483,8 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
     vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);
 
     // get the supports of each traversal independently
-    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, {}, {}, false, {}, {}, ref_trav_idx);
+    int max_trav_size = -1;
+    vector<Support> supports = support_finder.get_traversal_set_support(traversals, {}, {}, {}, false, {}, {}, ref_trav_idx, &max_trav_size);
 
     // sort the traversals by support
     vector<int> ranked_traversals = rank_by_support(supports);
@@ -518,7 +519,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
         
             // we prune out traversals whose exclusive support (structure that is not shared with best traversal)
             // doesn't meet a certain cutoff
-            vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, top_traversals, true, {}, {}, ref_trav_idx);
+            vector<Support> secondary_exclusive_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, top_traversals, true, {}, {}, ref_trav_idx, &max_trav_size);
             for (int j = 0; j < secondary_exclusive_supports.size(); ++j) {
                 if (j != best_allele &&
                     support_val(secondary_exclusive_supports[j]) < min_total_support_for_call &&
@@ -528,7 +529,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
             }
 
             // get the supports of each traversal in light of best
-            vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, top_traversals, false, {}, {}, ref_trav_idx);
+            vector<Support> secondary_supports = support_finder.get_traversal_set_support(traversals, {best_allele}, {}, top_traversals, false, {}, {}, ref_trav_idx, &max_trav_size);
             vector<int> ranked_secondary_traversals = rank_by_support(secondary_supports);
 
             // add the homozygous genotype for our best allele
@@ -565,7 +566,7 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
     double total_likelihood = 0;
     vector<int> best_genotype;
     for (const auto& candidate : candidates) {
-        double gl = genotype_likelihood(candidate, traversals, top_traversals, ref_trav_idx, exp_depth, depth_err);
+        double gl = genotype_likelihood(candidate, traversals, top_traversals, ref_trav_idx, exp_depth, depth_err, max_trav_size);
         if (gl > best_genotype_likelihood) {
             second_best_genotype_likelihood = best_genotype_likelihood;
             best_genotype_likelihood = gl;
@@ -593,6 +594,8 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
     }
 
     call_info->expected_depth = exp_depth;
+    call_info->depth_err = depth_err;
+    call_info->max_trav_size = max_trav_size;
 
 #ifdef debug
     cerr << " best genotype: "; for (auto a : best_genotype) {cerr << a <<",";} cerr << " gl=" << best_genotype_likelihood << endl;
@@ -603,12 +606,14 @@ pair<vector<int>, unique_ptr<SnarlCaller::CallInfo>> PoissonSupportSnarlCaller::
 double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotype,
                                                       const vector<SnarlTraversal>& traversals,
                                                       const set<int>& trav_subset, 
-                                                      int ref_trav_idx, double exp_depth, double depth_err) {
+                                                      int ref_trav_idx, double exp_depth, double depth_err,
+                                                      int max_trav_size) {
     
     assert(genotype.size() == 1 || genotype.size() == 2);
 
     // get the genotype support
-    vector<Support> genotype_supports = support_finder.get_traversal_genotype_support(traversals, genotype, trav_subset, ref_trav_idx);
+    vector<Support> genotype_supports = support_finder.get_traversal_genotype_support(traversals, genotype, trav_subset, ref_trav_idx,
+                                                                                      &max_trav_size);
 
     // get the total support over the site
     Support total_site_support = std::accumulate(genotype_supports.begin(), genotype_supports.end(), Support());    
@@ -651,10 +656,10 @@ double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotyp
     cerr << "Computing prob of genotype: {";
     for (int i = 0; i < genotype.size(); ++i) {
         cerr << genotype[i] << ",";
-    } 
+    }
     cerr << "}: tot_other_sup = " << total_other_support << " tot site sup = " << total_site_support 
          << " exp-depth = " << exp_depth << " depth-err = " << depth_err << " other-lambda = " << other_poisson_lambda
-         << " allele-lambda " << allele_poisson_lambda << endl;
+         << " allele-lambda " << allele_poisson_lambda << " ref-idx " << ref_trav_idx << endl;
 #endif
     
     // now we compute the likelihood of our genotype
@@ -684,16 +689,19 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
                                                 const unique_ptr<CallInfo>& call_info,
                                                 const string& sample_name,
                                                 vcflib::Variant& variant) {
-
+    
     assert(traversals.size() == variant.alleles.size());
 
     // get the traversal sizes
     vector<int> traversal_sizes = support_finder.get_traversal_sizes(traversals);
 
-    // get the genotype support
-    vector<Support> genotype_supports = support_finder.get_traversal_genotype_support(traversals, genotype, {}, 0);
+    // get the maximum size from the info
+    const SnarlCaller::CallInfo* s_call_info = call_info.get();
+    const PoissonCallInfo* p_call_info = dynamic_cast<const PoissonCallInfo*>(call_info.get());
+    int max_trav_size = p_call_info->max_trav_size;
 
-    // get the genotype_
+    // get the genotype support
+    vector<Support> genotype_supports = support_finder.get_traversal_genotype_support(traversals, genotype, {}, 0, &max_trav_size);
 
     // Get the depth of the site
     Support total_site_support = std::accumulate(genotype_supports.begin(), genotype_supports.end(), Support());    
@@ -728,32 +736,43 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
     double gen_likelihood;    
     variant.format.push_back("GL");
 
-    // expected depth from our coverage.  we look at the reference-range from the snarl plus a bit of padding,
-    // averaging over every depth bin this touches.  todo: adaptively compute nearby coverage without bins
-    // (requires VCFGenotyper to be refactored to require a PathPositionIndex)
-    size_t longest_traversal = *max_element(traversal_sizes.begin(), traversal_sizes.end());
-    size_t padding = (depth_padding_factor * longest_traversal) / 2;
-    pair<size_t, size_t> ref_range = make_pair(max((long)0, (long)(variant.position - padding)),
-					       variant.position + variant.ref.length() + padding);
-    auto depth_info = algorithms::get_depth_from_index(depth_index, variant.sequenceName, ref_range.first, ref_range.second);
-    double exp_depth = depth_info.first;
-    assert(!isnan(exp_depth));
+    assert(!isnan(p_call_info->expected_depth));
     // variance/std-err can be nan when binsize < 2.  We just clamp it to 0
-    double depth_err = !isnan(depth_info.second) ? depth_info.second  : 0.;
+    double depth_err = !isnan(p_call_info->depth_err) ? p_call_info->depth_err  : 0.;
 
     double total_likelihood = 0.;
     double ref_likelihood = 1.;
     double alt_likelihood = 0.;
-    
-    // assume ploidy 2
-    for (int i = 0; i < traversals.size(); ++i) {
-        for (int j = i; j < traversals.size(); ++j) {
-            double gl = genotype_likelihood({i, j}, traversals, {}, 0, exp_depth, depth_err);
+
+    if (genotype.size() == 2) {
+        // assume ploidy 2
+        for (int i = 0; i < traversals.size(); ++i) {
+            for (int j = i; j < traversals.size(); ++j) {
+                double gl = genotype_likelihood({i, j}, traversals, {}, 0, p_call_info->expected_depth, depth_err, max_trav_size);
+                gen_likelihoods.push_back(gl);
+                if (vector<int>({i, j}) == genotype || vector<int>({j,i}) == genotype) {
+                    gen_likelihood = gl;
+                }
+                if (i == 0 && j == 0) {
+                    ref_likelihood = gl;
+                } else {
+                    alt_likelihood = alt_likelihood == 0. ? gl : add_log(alt_likelihood, gl);
+                }
+                total_likelihood = total_likelihood == 0 ? gl : add_log(total_likelihood, gl);
+                // convert from natural log to log10 by dividing by ln(10)
+                variant.samples[sample_name]["GL"].push_back(std::to_string(gl / 2.30258));
+            }
+        }
+    } else if (genotype.size() == 1) {
+        // assume ploidy 1
+        // todo: generalize this iteration (as is, it is copy pased from above)
+        for (int i = 0; i < traversals.size(); ++i) {
+            double gl = genotype_likelihood({i}, traversals, {}, 0, p_call_info->expected_depth, depth_err, max_trav_size);
             gen_likelihoods.push_back(gl);
-            if (vector<int>({i, j}) == genotype || vector<int>({j,i}) == genotype) {
+            if (vector<int>({i}) == genotype) {
                 gen_likelihood = gl;
             }
-            if (i == 0 && j == 0) {
+            if (i == 0) {
                 ref_likelihood = gl;
             } else {
                 alt_likelihood = alt_likelihood == 0. ? gl : add_log(alt_likelihood, gl);
@@ -763,9 +782,7 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
             variant.samples[sample_name]["GL"].push_back(std::to_string(gl / 2.30258));
         }
     }
-
-    const SnarlCaller::CallInfo* s_call_info = call_info.get();
-    const PoissonCallInfo* p_call_info = dynamic_cast<const PoissonCallInfo*>(call_info.get());
+    
     variant.format.push_back("GQ");
     variant.samples[sample_name]["GQ"].push_back(std::to_string(min((int)256, max((int)0, (int)p_call_info->gq))));
 
@@ -779,10 +796,10 @@ void PoissonSupportSnarlCaller::update_vcf_info(const Snarl& snarl,
     // We derive this from the posterior probability of the reference genotype.
     // But if it's a reference call, we take the total of all the alts
     variant.quality = 0;
-    if (genotype.size() == 2) {
+    if (genotype.size() > 0) {
         // our flat prior and p[traversal coverage]
         double posterior = -log(gen_likelihoods.size()) - total_likelihood;
-        if (genotype[0] != 0 || genotype[1] != 0) {
+        if (!all_of(genotype.begin(), genotype.end(), [&](int a) {return a == 0;})) {
             posterior += ref_likelihood;
         } else {
             posterior += alt_likelihood;

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -204,6 +204,8 @@ public:
         double gq;
         double posterior;
         double expected_depth;
+        double depth_err;
+        int max_trav_size;
     };
 
     /// Get the genotype of a site
@@ -236,7 +238,8 @@ protected:
     double genotype_likelihood(const vector<int>& genotype,
                                const vector<SnarlTraversal>& traversals,
                                const set<int>& trav_subset,
-                               int ref_trav_idx, double exp_depth, double depth_err);
+                               int ref_trav_idx, double exp_depth, double depth_err,
+                               int max_trav_size);
 
     /// Rank supports
     vector<int> rank_by_support(const vector<Support>& supports);

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3327,14 +3327,15 @@ vector<SnarlTraversal> FlowTraversalFinder::find_traversals(const Snarl& site) {
     return find_weighted_traversals(site).first;
 }
 
-pair<vector<SnarlTraversal>, vector<double>> FlowTraversalFinder::find_weighted_traversals(const Snarl& site) {
+pair<vector<SnarlTraversal>, vector<double>> FlowTraversalFinder::find_weighted_traversals(const Snarl& site, bool greedy_avg) {
 
     handle_t start_handle = graph.get_handle(site.start().node_id(), site.start().backward());
     handle_t end_handle = graph.get_handle(site.end().node_id(), site.end().backward());
 
     vector<pair<double, vector<handle_t>>> widest_paths = algorithms::yens_k_widest_paths(&graph, start_handle, end_handle, K,
                                                                                           node_weight_callback,
-                                                                                          edge_weight_callback);
+                                                                                          edge_weight_callback,
+                                                                                          greedy_avg);
 
     vector<SnarlTraversal> travs;
     travs.reserve(widest_paths.size());

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -602,7 +602,8 @@ public:
     /**
      * Return the K widest traversals, along with their flows
      */
-    virtual pair<vector<SnarlTraversal>, vector<double>> find_weighted_traversals(const Snarl& site);
+    virtual pair<vector<SnarlTraversal>, vector<double>> find_weighted_traversals(const Snarl& site,
+                                                                                  bool greedy_avg = false);
 
     /// Set K
     void setK(size_t k);

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -136,7 +136,8 @@ protected:
  */
 class CachedPackedTraversalSupportFinder : public PackedTraversalSupportFinder {
 public:
-    CachedPackedTraversalSupportFinder(const Packer& packer, SnarlManager& snarl_manager, size_t cache_size = 100000);
+    // good if cache_size lines up with FlowCaller::max_snarl_edges in graph_caller.hpp
+    CachedPackedTraversalSupportFinder(const Packer& packer, SnarlManager& snarl_manager, size_t cache_size = 500000);
     virtual ~CachedPackedTraversalSupportFinder();
 
     /// Support of an edge

--- a/src/traversal_support.hpp
+++ b/src/traversal_support.hpp
@@ -54,7 +54,8 @@ public:
     virtual vector<Support> get_traversal_genotype_support(const vector<SnarlTraversal>& traversals,
                                                            const vector<int>& genotype,
                                                            const set<int>& other_trav_subset,
-                                                           int ref_trav_idx = -1);
+                                                           int ref_trav_idx = -1,
+                                                           int* max_trav_size = nullptr);
     
     /// traversals:      get support for each traversal in this set
     /// shared_travs:    if a node appears N times in shared_travs, then it will count as 1 / (N+1) support


### PR DESCRIPTION
The caller relies on average support instead of minimum support on larger snarls to handle patchy coverage.  The widest-paths traversal finder only works with minimum support, though.  This PR adds an option to turn it into a greedy heuristic search for average paths (while losing all optimality guarantees), that seems to help a bit in practice (both in accuracy and running time).  Stacked on #2708