### PR TITLE
Tweak calling error rate

### DIFF
--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -644,6 +644,8 @@ double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotyp
     //double error_rate = std::min(0.05, depth_err + baseline_mapping_error);
     double error_rate = baseline_mapping_error;
     double other_poisson_lambda = error_rate * exp_depth; //support_val(total_site_support);
+    // extremely low error rates can dominate the probability calculations later on so clamp
+    other_poisson_lambda = max(0.5, other_poisson_lambda);
 
     // and our likelihood for the unmapped reads we see:
     double other_log_likelihood = poisson_prob_ln(std::round(support_val(total_other_support)), other_poisson_lambda);

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -245,7 +245,7 @@ protected:
     vector<int> rank_by_support(const vector<Support>& supports);
 
     /// Baseline mapping error rate (gets added to the standard error from coverage)
-    double baseline_mapping_error = 0.005;
+    double baseline_mapping_error = 0.01;
 
     /// Consider up to the top-k traversals (based on support) for genotyping
     size_t top_k = 20;


### PR DESCRIPTION
It was set to really promote het calls (brought up in #2683), so tune it down a bit.  Also be more careful of poisson terms with tiny rates as they were dominatiing the final probabilities.  Still would be useful to get quality statistics via vg pack. 