### PR TITLE
Boost timeout for simulated chr21 CI mapping test

### DIFF
--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -1256,7 +1256,7 @@ class VGCITest(TestCase):
                            acc_threshold=0.0075, auc_threshold=0.075, mappers = ['map', 'mpmap'],
                            sim_opts='-l 150 -p 570 -v 150 -e 0.01 -i 0.002')
 
-    @timeout_decorator.timeout(2400)        
+    @timeout_decorator.timeout(4400)        
     def test_sim_chr21_snp1kg_trained(self):
         self._test_mapeval(100000, 'CHR21', 'snp1kg',
                            ['primary', 'snp1kg'],


### PR DESCRIPTION
`test_sim_chr21_snp1kg_trained` is often taking longer than the 2400 seconds given to it.  I'm giving it another 2000 seconds here in the hopes that comparing the generated report with an older one will help see if there have been any major running time regressions.  `mpmap` is my primary suspect. 