### PR TITLE
Cap the number of threads used in the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN bash -c "[[ -e deps/sdsl-lite/CMakeLists.txt ]] || git submodule update --in
 # UCSC has a Nehalem machine that we want to support.
 RUN sed -i s/march=native/march=nehalem/ deps/sdsl-lite/CMakeLists.txt
 # Do the build. Trim down the resulting binary but make sure to include enough debug info for profiling.
-RUN make get-deps && . ./source_me.sh && env && make include/vg_git_version.hpp && CXXFLAGS=" -march=nehalem " make -j ${THREADS} && make static && strip -d bin/vg
+RUN make get-deps && . ./source_me.sh && env && make include/vg_git_version.hpp && CXXFLAGS=" -march=nehalem " make -j $((THREADS < $(nproc) ? THREADS : $(nproc))) && make static && strip -d bin/vg
 
 ENV PATH /vg/bin:$PATH
 
@@ -72,10 +72,8 @@ RUN apt-get -qq -y update && \
 
 # Fail if any non-portable instructions were used
 RUN /bin/bash -e -c 'if objdump -d /vg/bin/vg | grep vperm2i128 ; then exit 1 ; else exit 0 ; fi'
-# Set the default number of threads to the number we are supposed to use.
-ENV OMP_NUM_THREADS ${THREADS}
 # Run tests in the middle so the final container that gets tagged is the run container.
-RUN make test
+RUN export OMP_NUM_THREADS=$((THREADS < $(nproc) ? THREADS : $(nproc))) make test
 
 
 ############################################################################################


### PR DESCRIPTION
We default to 8 threads to avoid trying to use all the cores on a Kubernetes host, but we should never use *more* threads than `nproc` reports, or we risk running out of memory on Quay like in #2721