### PR TITLE
Giraffe improvements and refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ include $(wildcard $(UNITTEST_OBJ_DIR)/*.d)
 CXXFLAGS := -O3 -Werror=return-type -std=c++14 -ggdb -g -MMD -MP $(CXXFLAGS)
 
 # Set include flags. All -I options need to go in here, so the first directory listed is genuinely searched first.
-INCLUDE_FLAGS:=-I$(CWD)/$(INC_DIR) -I. -I$(CWD)/$(SRC_DIR) -I$(CWD)/$(UNITTEST_SRC_DIR) -I$(CWD)/$(SUBCOMMAND_SRC_DIR) -I$(CWD)/$(INC_DIR)/dynamic -I$(CWD)/$(INC_DIR)/sonLib $(shell pkg-config --cflags cairo jansson)
+INCLUDE_FLAGS:=-I$(CWD)/$(INC_DIR) -I. -I$(CWD)/$(SRC_DIR) -I$(CWD)/$(UNITTEST_SRC_DIR) -I$(CWD)/$(SUBCOMMAND_SRC_DIR) -I$(CWD)/$(INC_DIR)/dynamic $(shell pkg-config --cflags cairo jansson)
 
 # Define libraries to link against. Make sure to always link statically against
 # htslib and libdeflate and Protobuf so that we can use position-dependent code

--- a/src/cactus.cpp
+++ b/src/cactus.cpp
@@ -6,11 +6,6 @@
 #include "algorithms/strongly_connected_components.hpp"
 #include "algorithms/find_shortest_paths.hpp"
 
-extern "C" {
-#include "sonLib.h"
-#include "stCactusGraphs.h"
-}
-
 //#define debug
 
 namespace vg {

--- a/src/cactus.hpp
+++ b/src/cactus.hpp
@@ -15,8 +15,8 @@
 #include "vg.hpp"
 
 extern "C" {
-#include "sonLib.h"
-#include "stCactusGraphs.h"
+#include <sonLib/sonLib.h>
+#include <sonLib/stCactusGraphs.h>
 }
 
 using namespace std;

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -3571,14 +3571,16 @@ MEMClusterer::HitGraph ComponentMinDistanceClusterer::make_hit_graph(const Align
     for (size_t i = 0; i < hit_graph.nodes.size(); ++i)  {
         positions[i] = hit_graph.nodes[i].start_pos;
     }
-    
+ 
+    typedef SnarlSeedClusterer::Cluster Cluster;
     SnarlSeedClusterer seed_clusterer(*distance_index);
-    vector<vector<size_t>> distance_components = seed_clusterer.cluster_seeds(positions, max_graph_separation);
+    std::vector<Cluster> distance_components = seed_clusterer.cluster_seeds(positions, max_graph_separation);
     
     // these components are returned by the structures::UnionFind::all_groups() method, which
     // always returns them in sorted order, so we can assume that they are still lexicographically
     // ordered internally
-    for (vector<size_t>& component : distance_components) {
+    for (Cluster& cluster : distance_components) {
+        std::vector<size_t>& component = cluster.seeds;
 #ifdef debug_mem_clusterer
         cerr << "looking edges in distance component containing:" << endl;
         for (size_t i : component) {

--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -2,7 +2,7 @@
 #include <gfakluge.hpp>
 
 // Use sonLib pinch graphs
-#include <stPinchGraphs.h>
+#include <sonLib/stPinchGraphs.h>
 
 #include <structures/union_find.hpp>
 

--- a/src/index_manager.cpp
+++ b/src/index_manager.cpp
@@ -470,10 +470,13 @@ void IndexManager::ensure_minimizer() {
         // Make and save
 
         ensure_gbwtgraph();
+        ensure_distance();
 
         // Make it
         minimizer.reset(new gbwtgraph::DefaultMinimizerIndex(minimizer_k, minimizer_w));
-        gbwtgraph::index_haplotypes(*gbwtgraph.first, *minimizer);
+        gbwtgraph::index_haplotypes(*gbwtgraph.first, *minimizer, [&](const pos_t& pos) -> gbwtgraph::payload_type {
+            return MIPayload::encode(distance->offset_in_root_chain(pos));
+        });
 
         if (out.is_open()) {
             // Save it

--- a/src/min_distance.cpp
+++ b/src/min_distance.cpp
@@ -2532,7 +2532,7 @@ pair<size_t, size_t> MinimumDistanceIndex::offset_in_root_chain (pos_t pos) {
                             snarl_rank == snarl_index.num_nodes*2-1 || snarl_rank == snarl_index.num_nodes*2-2;
     size_t component = node_to_component[id - min_node_id]; 
     if (component == 0 || !is_boundary_node || !snarl_index.depth == 0) {
-        return make_pair(std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max());
+        return make_pair(MIPayload::NO_VALUE, MIPayload::NO_VALUE);
     }
     int64_t node_offset = get_offset(pos);
     bool node_is_rev_in_snarl = snarl_rank% 2;
@@ -2556,5 +2556,10 @@ pair<size_t, size_t> MinimumDistanceIndex::offset_in_root_chain (pos_t pos) {
 bool MinimumDistanceIndex::in_same_connected_component(id_t node_id1, id_t node_id2) {
     return node_to_component[node_id1-min_node_id] == node_to_component[node_id1 - min_node_id];
 }
+
+constexpr MIPayload::code_type MIPayload::NO_CODE;
+constexpr size_t MIPayload::NO_VALUE;
+constexpr size_t MIPayload::ID_OFFSET;
+constexpr MIPayload::code_type MIPayload::OFFSET_MASK;
 
 }

--- a/src/min_distance.hpp
+++ b/src/min_distance.hpp
@@ -71,7 +71,7 @@ class MinimumDistanceIndex {
     //the offset of the node in the root chain - the minimum distance from the beginning of the chain to 
     //the position
     //If the position is not on a root node (that is, a boundary node of a snarl in a root chain), returns
-    //<std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()> 
+    //<MIPayload::NO_VALUE, MIPayload::NO_VALUE> 
     pair<size_t, size_t> offset_in_root_chain (pos_t pos);
 
     bool in_same_connected_component(id_t node_id1, id_t node_id2);
@@ -476,7 +476,29 @@ class MinimumDistanceIndex {
 
 
 };
- 
+
+/**
+ * The encoding of (chain id, chain offset) pairs for positions in top-level chains.
+ * We store this information in the minimizer index.
+ */
+struct MIPayload {
+    typedef std::uint64_t code_type; // We assume that this fits into gbwtgraph::payload_type.
+
+    constexpr static code_type NO_CODE = std::numeric_limits<code_type>::max();
+    constexpr static size_t NO_VALUE = std::numeric_limits<size_t>::max(); // From offset_in_root_chain().
+
+    constexpr static size_t ID_OFFSET = 32;
+    constexpr static code_type OFFSET_MASK = (static_cast<code_type>(1) << ID_OFFSET) - 1;
+
+    static code_type encode(std::pair<size_t, size_t> chain_pos) {
+        return (chain_pos.first << ID_OFFSET) | (chain_pos.second & OFFSET_MASK);
+    }
+
+    static std::pair<size_t, size_t> decode(code_type code) {
+        return std::pair<size_t, size_t>(code >> ID_OFFSET, code & OFFSET_MASK);
+    }
+};
+
 }
 
 #endif

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2322,10 +2322,10 @@ std::tuple<std::vector<pos_t>, std::vector<size_t>, std::vector<bool>> Minimizer
             // sufficiently rare, or we want it to make target_score, or it is
             // the same sequence as the previous minimizer which we also took.
 
-            // Locate the hits.
+            // Locate the hits. We ignore the payload for now.
             minimizer_located[i] = true;
             for (size_t j = 0; j < minimizer.hits; j++) {
-                pos_t hit = gbwtgraph::DefaultMinimizerIndex::decode(minimizer.occs[j]);
+                pos_t hit = gbwtgraph::Position::decode(minimizer.occs[j].pos);
                 // Reverse the hits for a reverse minimizer
                 if (minimizer.value.is_reverse) {
                     size_t node_length = this->gbwt_graph.get_length(this->gbwt_graph.get_handle(id(hit)));

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -741,7 +741,7 @@ pair<vector<Alignment>, vector< Alignment>> MinimizerMapper::map_paired(Alignmen
     std::vector<std::vector<pos_t>> temp_seeds_by_read(seeds_by_read.size());
     for (size_t read = 0; read < seeds_by_read.size(); read++) {
         std::vector<Seed>& seeds = seeds_by_read[read];
-        std::vector<pos_t> temp_seeds = temp_seeds_by_read[read];
+        std::vector<pos_t>& temp_seeds = temp_seeds_by_read[read];
         temp_seeds.reserve(seeds.size());
         for (size_t i = 0; i < seeds.size(); i++) {
             temp_seeds.push_back(seeds[i].pos);

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -172,14 +172,14 @@ public:
 protected:
 
     /**
-     * We define our own type for minimizers, to use during mapping and to apss around between our internal functions.
+     * We define our own type for minimizers, to use during mapping and to pass around between our internal functions.
      */
     struct Minimizer {
         typename gbwtgraph::DefaultMinimizerIndex::minimizer_type value;
         size_t agglomeration_start; // What is the start base of the first window this minimizer instance is minimal in?
         size_t agglomeration_length; // What is the regioin of consecutive windows this minimizer instance is minimal in?
         size_t hits; // How many hits does the minimizer have?
-        const typename gbwtgraph::DefaultMinimizerIndex::code_type* occs;
+        const gbwtgraph::hit_type* occs;
         size_t origin; // This minimizer came from minimizer_indexes[origin].
         double score; // Scores as 1 + ln(hard_hit_cap) - ln(hits).
 
@@ -232,6 +232,7 @@ protected:
      * Find seeds for all minimizers passing the filters. Return the seeds, the
      * corresponding source minimizers, and a bit vector over all minimizers
      * flagging the ones that were located.
+     * TODO JS: We should define a seed struct to store all the necessary fields.
      */
     std::tuple<std::vector<pos_t>, std::vector<size_t>, std::vector<bool>> find_seeds(const std::vector<Minimizer>& minimizers, const Alignment& aln, Funnel& funnel) const;
 

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -189,6 +189,9 @@ protected:
         }
     };
 
+    /// The information we store for each seed.
+    typedef SnarlSeedClusterer::Seed Seed;
+
     // These are our indexes
     const PathPositionHandleGraph* path_graph; // Can be nullptr; only needed for correctness tracking.
     const std::vector<gbwtgraph::DefaultMinimizerIndex*>& minimizer_indexes;
@@ -229,21 +232,17 @@ protected:
     std::vector<Minimizer> find_minimizers(const std::string& sequence, Funnel& funnel) const;
 
     /**
-     * Find seeds for all minimizers passing the filters. Return the seeds, the
-     * corresponding source minimizers, and a bit vector over all minimizers
-     * flagging the ones that were located.
-     * TODO JS: We should define a seed struct to store all the necessary fields.
+     * Find seeds for all minimizers passing the filters.
      */
-    std::tuple<std::vector<pos_t>, std::vector<size_t>, std::vector<bool>> find_seeds(const std::vector<Minimizer>& minimizers, const Alignment& aln, Funnel& funnel) const;
+    std::vector<Seed> find_seeds(const std::vector<Minimizer>& minimizers, const Alignment& aln, Funnel& funnel) const;
 
     /**
      * Return cluster score and read coverage, and a vector of flags for the
      * minimizers present in the cluster. Score is the sum of the scores of
      * distinct minimizers in the cluster, while read coverage is the fraction
      * of the read covered by seeds in the cluster.
-     * TODO JS: Score all clusters at once; calculate fragment scores afterwards.
      */
-    std::tuple<double, double, sdsl::bit_vector> score_cluster(const std::vector<size_t>& cluster, size_t i, const std::vector<Minimizer>& minimizers, const std::vector<size_t>& seed_to_source, size_t seq_length, Funnel& funnel) const;
+    std::tuple<double, double, sdsl::bit_vector> score_cluster(const std::vector<size_t>& cluster, size_t i, const std::vector<Minimizer>& minimizers, const std::vector<Seed>& seeds, size_t seq_length, Funnel& funnel) const;
 
    /**
     * Score the set of extensions for each cluster using score_extension_group().

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -192,6 +192,9 @@ protected:
     /// The information we store for each seed.
     typedef SnarlSeedClusterer::Seed Seed;
 
+    /// The information we store for each cluster.
+    typedef SnarlSeedClusterer::Cluster Cluster;
+
     // These are our indexes
     const PathPositionHandleGraph* path_graph; // Can be nullptr; only needed for correctness tracking.
     const std::vector<gbwtgraph::DefaultMinimizerIndex*>& minimizer_indexes;
@@ -237,12 +240,12 @@ protected:
     std::vector<Seed> find_seeds(const std::vector<Minimizer>& minimizers, const Alignment& aln, Funnel& funnel) const;
 
     /**
-     * Return cluster score and read coverage, and a vector of flags for the
+     * Determine cluster score, read coverage, and a vector of flags for the
      * minimizers present in the cluster. Score is the sum of the scores of
      * distinct minimizers in the cluster, while read coverage is the fraction
      * of the read covered by seeds in the cluster.
      */
-    std::tuple<double, double, sdsl::bit_vector> score_cluster(const std::vector<size_t>& cluster, size_t i, const std::vector<Minimizer>& minimizers, const std::vector<Seed>& seeds, size_t seq_length, Funnel& funnel) const;
+    void score_cluster(Cluster& cluster, size_t i, const std::vector<Minimizer>& minimizers, const std::vector<Seed>& seeds, size_t seq_length, Funnel& funnel) const;
 
    /**
     * Score the set of extensions for each cluster using score_extension_group().
@@ -447,28 +450,28 @@ protected:
      * items that would fail the score threshold.
      */
     template<typename Item, typename Score = double>
-    void process_until_threshold(const vector<Item>& items, const function<Score(size_t)>& get_score,
+    void process_until_threshold_a(const vector<Item>& items, const function<Score(size_t)>& get_score,
         double threshold, size_t min_count, size_t max_count,
         const function<bool(size_t)>& process_item,
         const function<void(size_t)>& discard_item_by_count,
         const function<void(size_t)>& discard_item_by_score) const;
      
     /**
-     * Same as the other process_until_threshold overload, except using a vector to supply scores.
+     * Same as the other process_until_threshold functions, except using a vector to supply scores.
      */
     template<typename Item, typename Score = double>
-    void process_until_threshold(const vector<Item>& items, const vector<Score>& scores,
+    void process_until_threshold_b(const vector<Item>& items, const vector<Score>& scores,
         double threshold, size_t min_count, size_t max_count,
         const function<bool(size_t)>& process_item,
         const function<void(size_t)>& discard_item_by_count,
         const function<void(size_t)>& discard_item_by_score) const;
      
     /**
-     * Same as the other process_until_threshold overload, except user supplies 
+     * Same as the other process_until_threshold functions, except user supplies 
      * comparator to sort the items (must still be sorted by score).
      */
     template<typename Item, typename Score = double>
-    void process_until_threshold(const vector<Item>& items, const vector<Score>& scores,
+    void process_until_threshold_c(const vector<Item>& items, const function<Score(size_t)>& get_score,
         const function<bool(size_t, size_t)>& comparator,
         double threshold, size_t min_count, size_t max_count,
         const function<bool(size_t)>& process_item,
@@ -477,70 +480,19 @@ protected:
 };
 
 template<typename Item, typename Score>
-void MinimizerMapper::process_until_threshold(const vector<Item>& items, const function<Score(size_t)>& get_score,
+void MinimizerMapper::process_until_threshold_a(const vector<Item>& items, const function<Score(size_t)>& get_score,
     double threshold, size_t min_count, size_t max_count,
     const function<bool(size_t)>& process_item,
     const function<void(size_t)>& discard_item_by_count,
     const function<void(size_t)>& discard_item_by_score) const {
 
-    // Sort item indexes by item score
-    vector<size_t> indexes_in_order;
-    indexes_in_order.reserve(items.size());
-    for (size_t i = 0; i < items.size(); i++) {
-        indexes_in_order.push_back(i);
-    }
-    
-    // Put the highest scores first
-    std::sort(indexes_in_order.begin(), indexes_in_order.end(), [&](const size_t& a, const size_t& b) -> bool {
-        // Return true if a must come before b, and false otherwise
-        return get_score(a) > get_score(b);
-    });
-
-    // Retain items only if their score is at least as good as this
-    double cutoff = items.size() == 0 ? 0 : get_score(indexes_in_order[0]) - threshold;
-    
-    // Count up non-skipped items for min_count and max_count
-    size_t unskipped = 0;
-    
-    // Go through the items in descending score order.
-    for (size_t i = 0; i < indexes_in_order.size(); i++) {
-        // Find the item we are talking about
-        size_t& item_num = indexes_in_order[i];
-        
-        if (threshold != 0 && get_score(item_num) <= cutoff) {
-            // Item would fail the score threshold
-            
-            if (unskipped < min_count) {
-                // But we need it to make up the minimum number.
-                
-                // Go do it.
-                // If it is not skipped by the user, add it to the total number
-                // of unskipped items, for min/max number accounting.
-                unskipped += (size_t) process_item(item_num);
-            } else {
-                // We will reject it for score
-                discard_item_by_score(item_num);
-            }
-        } else {
-            // The item has a good enough score
-            
-            if (unskipped < max_count) {
-                // We have room for it, so accept it.
-                
-                // Go do it.
-                // If it is not skipped by the user, add it to the total number
-                // of unskipped items, for min/max number accounting.
-                unskipped += (size_t) process_item(item_num);
-            } else {
-                // We are out of room! Reject for count.
-                discard_item_by_count(item_num);
-            }
-        }
-    }
+    process_until_threshold_c<Item, Score>(items, get_score, [&](size_t a, size_t b) -> bool {
+        return (get_score(a) > get_score(b));
+    },threshold, min_count, max_count, process_item, discard_item_by_count, discard_item_by_score);
 }
 
 template<typename Item, typename Score>
-void MinimizerMapper::process_until_threshold(const vector<Item>& items, const vector<Score>& scores,
+void MinimizerMapper::process_until_threshold_b(const vector<Item>& items, const vector<Score>& scores,
     double threshold, size_t min_count, size_t max_count,
     const function<bool(size_t)>& process_item,
     const function<void(size_t)>& discard_item_by_count,
@@ -548,13 +500,15 @@ void MinimizerMapper::process_until_threshold(const vector<Item>& items, const v
     
     assert(scores.size() == items.size());
     
-    process_until_threshold<Item, Score>(items, [&](size_t i) -> Score {
-        return scores.at(i);
-    }, threshold, min_count, max_count, process_item, discard_item_by_count, discard_item_by_score);
-    
+    process_until_threshold_c<Item, Score>(items, [&](size_t i) -> Score {
+        return scores[i];
+    }, [&](size_t a, size_t b) -> bool {
+        return (scores[a] > scores[b]);
+    },threshold, min_count, max_count, process_item, discard_item_by_count, discard_item_by_score);
 }
+
 template<typename Item, typename Score>
-void MinimizerMapper::process_until_threshold(const vector<Item>& items, const vector<Score>& scores,
+void MinimizerMapper::process_until_threshold_c(const vector<Item>& items, const function<Score(size_t)>& get_score,
         const function<bool(size_t, size_t)>& comparator,
         double threshold, size_t min_count, size_t max_count,
         const function<bool(size_t)>& process_item,
@@ -572,7 +526,7 @@ void MinimizerMapper::process_until_threshold(const vector<Item>& items, const v
     std::sort(indexes_in_order.begin(), indexes_in_order.end(), comparator);
 
     // Retain items only if their score is at least as good as this
-    double cutoff = items.size() == 0 ? 0 : scores[indexes_in_order[0]] - threshold;
+    double cutoff = items.size() == 0 ? 0 : get_score(indexes_in_order[0]) - threshold;
     
     // Count up non-skipped items for min_count and max_count
     size_t unskipped = 0;
@@ -582,7 +536,7 @@ void MinimizerMapper::process_until_threshold(const vector<Item>& items, const v
         // Find the item we are talking about
         size_t& item_num = indexes_in_order[i];
         
-        if (threshold != 0 && scores[item_num] <= cutoff) {
+        if (threshold != 0 && get_score(item_num) <= cutoff) {
             // Item would fail the score threshold
             
             if (unskipped < min_count) {

--- a/src/seed_clusterer.hpp
+++ b/src/seed_clusterer.hpp
@@ -5,6 +5,7 @@
 #include "min_distance.hpp"
 #include "hash_map.hpp"
 #include <structures/union_find.hpp>
+#include <sdsl/int_vector.hpp>
 
 namespace vg{
 
@@ -20,13 +21,22 @@ class SnarlSeedClusterer {
             size_t offset; // Offset in the root chain.
         };
 
+        /// Cluster information used in Giraffe.
+        struct Cluster {
+            std::vector<size_t> seeds; // Seed ids.
+            size_t fragment; // Fragment id.
+            double score; // Sum of scores of distinct source minimizers of the seeds.
+            double coverage; // Fraction of read covered by the seeds.
+            sdsl::bit_vector present; // Minimizers that are present in the cluster.
+        };
+
         SnarlSeedClusterer(MinimumDistanceIndex& dist_index);
 
         ///Given a vector of seeds (pos_t) and a distance limit, 
         //cluster the seeds such that two seeds whose minimum distance
         //between them (including both of the positions) is less than
         // the distance limit are in the same cluster
-        vector<vector<size_t>> cluster_seeds ( const vector<pos_t>& seeds, int64_t read_distance_limit) const;
+        vector<Cluster> cluster_seeds ( const vector<pos_t>& seeds, int64_t read_distance_limit) const;
         
         ///The same thing, but for paired end reads.
         //Given seeds from multiple reads of a fragment, cluster each read
@@ -37,9 +47,8 @@ class SnarlSeedClusterer {
         //The fragment clusters give seeds the index they would get if the vectors of
         // seeds were appended to each other in the order given
         // TODO: Fix documentation
-        // Returns: For each read, a vector of clusters. One cluster is a pair of the index of the fragment cluster and
-        // a vector of the indices of the seeds it contains
-        vector<vector<pair<vector<size_t>, size_t>>> cluster_seeds ( 
+        // Returns: For each read, a vector of clusters.
+        vector<vector<Cluster>> cluster_seeds ( 
                 const vector<vector<pos_t>>& all_seeds, int64_t read_distance_limit, int64_t fragment_distance_limit=0) const;
 
     private:

--- a/src/seed_clusterer.hpp
+++ b/src/seed_clusterer.hpp
@@ -12,6 +12,14 @@ class SnarlSeedClusterer {
 
     public:
 
+        /// Seed information used in Giraffe.
+        struct Seed {
+            pos_t  pos;
+            size_t source; // Source minimizer.
+            size_t component; // Component id in the distance index.
+            size_t offset; // Offset in the root chain.
+        };
+
         SnarlSeedClusterer(MinimumDistanceIndex& dist_index);
 
         ///Given a vector of seeds (pos_t) and a distance limit, 

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -246,7 +246,7 @@ int main_cluster(int argc, char** argv) {
                         // reverse minimizers, as the clusterer only cares about node ids.
                         for (auto& hit : minimizer_index->find(minimizers[i])) {
                             // For each position, remember it and what minimizer it came from
-                            seeds.push_back(hit);
+                            seeds.push_back(hit.first);
                             seed_to_source.push_back(i);
                         }
                     }

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -257,7 +257,7 @@ int main_cluster(int argc, char** argv) {
             // Cluster the seeds. Get sets of input seed indexes that go together.
             // Make sure to time it.
             std::chrono::time_point<std::chrono::system_clock> start = std::chrono::system_clock::now();
-            vector<vector<size_t>> clusters = clusterer.cluster_seeds(seeds, distance_limit);
+            vector<SnarlSeedClusterer::Cluster> clusters = clusterer.cluster_seeds(seeds, distance_limit);
             std::chrono::time_point<std::chrono::system_clock> end = std::chrono::system_clock::now();
             std::chrono::duration<double> elapsed_seconds = end-start;
             
@@ -269,7 +269,7 @@ int main_cluster(int argc, char** argv) {
                 // We use this to convert iterators to indexes
                 auto start = aln.sequence().begin();
                 
-                for (auto& hit_index : cluster) {
+                for (auto hit_index : cluster.seeds) {
                     // For each hit in the cluster, work out what anchor sequence it is from.
                     size_t source_index = seed_to_source.at(hit_index);
                     
@@ -325,7 +325,7 @@ int main_cluster(int argc, char** argv) {
                     read_coverage_by_cluster.at(cluster_indexes_in_order[i]) >= best_coverage; i++) {
                     
                     // For each cluster covering that much or more of the read
-                    for (auto& seed_index : clusters.at(cluster_indexes_in_order[i])) {
+                    for (auto seed_index : clusters.at(cluster_indexes_in_order[i]).seeds) {
                         // For each seed in those clusters
                         
                         // Mark that seed as being part of the best cluster(s)
@@ -363,7 +363,7 @@ int main_cluster(int argc, char** argv) {
             vector<double> cluster_sizes;
             cluster_sizes.reserve(clusters.size());
             for (auto& cluster : clusters) {
-                cluster_sizes.push_back((double)cluster.size());
+                cluster_sizes.push_back((double)cluster.seeds.size());
             }
             
             // Tag the alignment with cluster accuracy

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -354,12 +354,15 @@ int main_mpmap(int argc, char** argv) {
                 
             case OPT_MAX_RESCUE_ATTEMPTS:
                 max_rescue_attempts = parse<int>(optarg);
+                break;
                 
             case OPT_SECONDARY_RESCUE_ATTEMPTS:
                 secondary_rescue_attempts = parse<int>(optarg);
+                break;
                 
             case OPT_SECONDARY_MAX_DIFF:
                 secondary_rescue_score_diff = parse<double>(optarg);
+                break;
                 
             case 1: // --linear-index
                 sublinearLS_name = optarg;

--- a/src/unittest/seed_clusterer.cpp
+++ b/src/unittest/seed_clusterer.cpp
@@ -75,7 +75,7 @@ namespace unittest {
                 seeds.push_back(make_pos_t(n, false, 0));
             }
 
-            vector<vector<size_t>> clusters = clusterer.cluster_seeds(seeds, 10); 
+            vector<SnarlSeedClusterer::Cluster> clusters = clusterer.cluster_seeds(seeds, 10); 
             REQUIRE(clusters.size() == 1); 
 
         }
@@ -90,11 +90,11 @@ namespace unittest {
             }
 
 
-            vector<vector<size_t>> clusters = clusterer.cluster_seeds(seeds, 7); 
+            vector<SnarlSeedClusterer::Cluster> clusters = clusterer.cluster_seeds(seeds, 7); 
             vector<hash_set<size_t>> cluster_sets;
-            for (vector<size_t> v : clusters) {
+            for (auto& c : clusters) {
                 hash_set<size_t> h;
-                for (size_t s : v) {
+                for (size_t s : c.seeds) {
                     h.insert(s);
                 }
                 cluster_sets.push_back(h);
@@ -137,14 +137,14 @@ namespace unittest {
             all_seeds.push_back(seeds1);
 
 
-            vector<vector<pair<vector<size_t>, size_t>>> paired_clusters = clusterer.cluster_seeds(all_seeds, 7, 15); 
+            vector<vector<SnarlSeedClusterer::Cluster>> paired_clusters = clusterer.cluster_seeds(all_seeds, 7, 15); 
             //Should be [[<[0,1,2], 0>],[<[3,4,5,6], 0>]] 
             REQUIRE( paired_clusters.size() == 2);
             REQUIRE( paired_clusters[0].size() == 1);
             REQUIRE( paired_clusters[1].size() == 1);
-            REQUIRE( paired_clusters[0][0].first.size() == 3);
-            REQUIRE( paired_clusters[1][0].first.size() == 4);
-            REQUIRE( paired_clusters[0][0].second == paired_clusters[1][0].second);
+            REQUIRE( paired_clusters[0][0].seeds.size() == 3);
+            REQUIRE( paired_clusters[1][0].seeds.size() == 4);
+            REQUIRE( paired_clusters[0][0].fragment == paired_clusters[1][0].fragment);
         }
         SECTION( "Two fragment clusters" ) {
  
@@ -165,15 +165,15 @@ namespace unittest {
             all_seeds.push_back(seeds1);
 
 
-            vector<vector<pair<vector<size_t>, size_t>>> paired_clusters = clusterer.cluster_seeds(all_seeds, 2, 7); 
+            vector<vector<SnarlSeedClusterer::Cluster>> paired_clusters = clusterer.cluster_seeds(all_seeds, 2, 7); 
             // read_clusters = [ [[0,1,2]],[[3,4],[5,6]] ]
             // fragment_clusters = [ [0,1,2], [3,4,5,6] ]
             REQUIRE( paired_clusters.size() == 2) ;
             REQUIRE( paired_clusters[0].size() == 1);
             REQUIRE( paired_clusters[1].size() == 2);
-            REQUIRE( paired_clusters[0][0].second != paired_clusters[1][0].second);
-            REQUIRE( paired_clusters[0][0].second != paired_clusters[1][1].second);
-            REQUIRE( paired_clusters[1][0].second == paired_clusters[1][1].second);
+            REQUIRE( paired_clusters[0][0].fragment != paired_clusters[1][0].fragment);
+            REQUIRE( paired_clusters[0][0].fragment != paired_clusters[1][1].fragment);
+            REQUIRE( paired_clusters[1][0].fragment == paired_clusters[1][1].fragment);
 
         }
     }//End test case
@@ -221,7 +221,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(4, false, 0));
 
 
-            vector<vector<size_t>> clusters = clusterer.cluster_seeds(seeds, 13); 
+            vector<SnarlSeedClusterer::Cluster> clusters = clusterer.cluster_seeds(seeds, 13); 
 
             REQUIRE( clusters.size() == 1);
         }
@@ -230,7 +230,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(3, false, 0));
             seeds.push_back(make_pos_t(11, false, 9));
 
-            vector<vector<size_t>> clusters = clusterer.cluster_seeds(seeds, 8); 
+            vector<SnarlSeedClusterer::Cluster> clusters = clusterer.cluster_seeds(seeds, 8); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -279,7 +279,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(7, false, 0));
             seeds.push_back(make_pos_t(6, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 20); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 20); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -289,7 +289,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(2, false, 0));
             seeds.push_back(make_pos_t(6, true, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 20); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 20); 
 
 
         }
@@ -298,7 +298,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(8, false, 0));
             seeds.push_back(make_pos_t(6, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 20); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 20); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -371,13 +371,13 @@ namespace unittest {
             seeds.push_back(make_pos_t(6, false, 0));
             seeds.push_back(make_pos_t(8, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 3); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 3); 
 
             REQUIRE( clusters.size() == 2);
             vector<hash_set<size_t>> cluster_sets;
-            for (vector<size_t> v : clusters) {
+            for (auto& c : clusters) {
                 hash_set<size_t> h;
-                for (size_t s : v) {
+                for (size_t s : c.seeds) {
                     h.insert(s);
                 }
                 cluster_sets.push_back(h);
@@ -413,22 +413,22 @@ namespace unittest {
             seeds.push_back(make_pos_t(14, false, 0));
             seeds.push_back(make_pos_t(15, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 3); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 3); 
 
             REQUIRE( clusters.size() == 4);
 
             vector<vector<pos_t>> all_seeds;
             all_seeds.push_back(seeds);
-            vector<vector<pair<vector<size_t>, size_t>>> paired_clusters = clusterer.cluster_seeds(all_seeds, 3, 3); 
+            vector<vector<SnarlSeedClusterer::Cluster>> paired_clusters = clusterer.cluster_seeds(all_seeds, 3, 3); 
 
             REQUIRE( paired_clusters.size() == 1);
             REQUIRE( paired_clusters[0].size() == 4);
-            REQUIRE( paired_clusters[0][0].second != paired_clusters[0][1].second);
-            REQUIRE( paired_clusters[0][0].second != paired_clusters[0][2].second);
-            REQUIRE( paired_clusters[0][0].second != paired_clusters[0][3].second);
-            REQUIRE( paired_clusters[0][1].second != paired_clusters[0][2].second);
-            REQUIRE( paired_clusters[0][1].second != paired_clusters[0][3].second);
-            REQUIRE( paired_clusters[0][2].second != paired_clusters[0][3].second);
+            REQUIRE( paired_clusters[0][0].fragment != paired_clusters[0][1].fragment);
+            REQUIRE( paired_clusters[0][0].fragment != paired_clusters[0][2].fragment);
+            REQUIRE( paired_clusters[0][0].fragment != paired_clusters[0][3].fragment);
+            REQUIRE( paired_clusters[0][1].fragment != paired_clusters[0][2].fragment);
+            REQUIRE( paired_clusters[0][1].fragment != paired_clusters[0][3].fragment);
+            REQUIRE( paired_clusters[0][2].fragment != paired_clusters[0][3].fragment);
 
             //New fragment clusters
         } SECTION ("Four fragment clusters") {
@@ -450,16 +450,16 @@ namespace unittest {
             seeds.push_back(make_pos_t(15, false, 0));
             all_seeds.push_back(seeds);
 
-            vector<vector<pair<vector<size_t>, size_t>>> paired_clusters = clusterer.cluster_seeds(all_seeds, 3, 3);
+            vector<vector<SnarlSeedClusterer::Cluster>> paired_clusters = clusterer.cluster_seeds(all_seeds, 3, 3);
 
             REQUIRE( paired_clusters.size() == 2);
             REQUIRE( paired_clusters[0].size() == 2);
             REQUIRE( paired_clusters[1].size() == 2);
-            REQUIRE( paired_clusters[0][0].second != paired_clusters[0][1].second);
-            REQUIRE( paired_clusters[0][0].second != paired_clusters[1][0].second);
-            REQUIRE( paired_clusters[0][0].second != paired_clusters[1][1].second);
-            REQUIRE( paired_clusters[0][1].second != paired_clusters[1][0].second);
-            REQUIRE( paired_clusters[0][1].second != paired_clusters[1][1].second);
+            REQUIRE( paired_clusters[0][0].fragment != paired_clusters[0][1].fragment);
+            REQUIRE( paired_clusters[0][0].fragment != paired_clusters[1][0].fragment);
+            REQUIRE( paired_clusters[0][0].fragment != paired_clusters[1][1].fragment);
+            REQUIRE( paired_clusters[0][1].fragment != paired_clusters[1][0].fragment);
+            REQUIRE( paired_clusters[0][1].fragment != paired_clusters[1][1].fragment);
 
             //New fragment clusters
 
@@ -468,12 +468,12 @@ namespace unittest {
             REQUIRE( paired_clusters.size() == 2);
             REQUIRE( paired_clusters[0].size() == 2);
             REQUIRE( paired_clusters[1].size() == 2);
-            REQUIRE( paired_clusters[0][0].second == paired_clusters[0][1].second);
-            REQUIRE( paired_clusters[0][0].second == paired_clusters[1][0].second);
-            REQUIRE( paired_clusters[0][0].second != paired_clusters[1][1].second);
-            REQUIRE( paired_clusters[0][1].second == paired_clusters[1][0].second);
-            REQUIRE( paired_clusters[0][1].second != paired_clusters[1][1].second);
-            REQUIRE( paired_clusters[1][0].second != paired_clusters[1][1].second);
+            REQUIRE( paired_clusters[0][0].fragment == paired_clusters[0][1].fragment);
+            REQUIRE( paired_clusters[0][0].fragment == paired_clusters[1][0].fragment);
+            REQUIRE( paired_clusters[0][0].fragment != paired_clusters[1][1].fragment);
+            REQUIRE( paired_clusters[0][1].fragment == paired_clusters[1][0].fragment);
+            REQUIRE( paired_clusters[0][1].fragment != paired_clusters[1][1].fragment);
+            REQUIRE( paired_clusters[1][0].fragment != paired_clusters[1][1].fragment);
         }
         SECTION( "Same node, same cluster" ) {
             vector<pos_t> seeds;
@@ -481,7 +481,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(5, false, 11));
             seeds.push_back(make_pos_t(5, false, 5));
 
-            vector<vector<size_t>> clusters = clusterer.cluster_seeds(seeds, 7); 
+            vector<SnarlSeedClusterer::Cluster> clusters = clusterer.cluster_seeds(seeds, 7); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -527,7 +527,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(2, false, 0));
             seeds.push_back(make_pos_t(7, false, 0));
 
-            vector<vector<size_t>> clusters= clusterer.cluster_seeds(seeds, 10); 
+            vector<SnarlSeedClusterer::Cluster> clusters= clusterer.cluster_seeds(seeds, 10); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -539,7 +539,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(7, false, 0));
             seeds.push_back(make_pos_t(4, false, 0));
 
-            vector<vector<size_t>> clusters = clusterer.cluster_seeds(seeds, 10); 
+            vector<SnarlSeedClusterer::Cluster> clusters = clusterer.cluster_seeds(seeds, 10); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -549,7 +549,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(2, false, 0));
             seeds.push_back(make_pos_t(4, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 10); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 10); 
 
 
 
@@ -561,7 +561,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(4, false, 1));
             seeds.push_back(make_pos_t(6, false, 0));
 
-            vector<vector<size_t>> clusters = clusterer.cluster_seeds(seeds, 5); 
+            vector<SnarlSeedClusterer::Cluster> clusters = clusterer.cluster_seeds(seeds, 5); 
 
 
             REQUIRE( clusters.size() == 2);
@@ -569,7 +569,7 @@ namespace unittest {
         SECTION("No clusters") {
             vector<pos_t> seeds;
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 5); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 5); 
 
 
             REQUIRE( clusters.size() == 0);
@@ -623,7 +623,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(3, false, 0));
             seeds.push_back(make_pos_t(9, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 5); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 5); 
 
 
             REQUIRE( clusters.size() == 2);
@@ -673,7 +673,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(3, false, 0));
             seeds.push_back(make_pos_t(8, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 3); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 3); 
 
 
             REQUIRE( clusters.size() == 2);
@@ -685,7 +685,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(2, false, 0));
             seeds.push_back(make_pos_t(7, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 6); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 6); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -697,7 +697,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(8, false, 0));
             seeds.push_back(make_pos_t(10, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 3); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 3); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -744,7 +744,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(3, false, 0));
             seeds.push_back(make_pos_t(4, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 10); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 10); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -754,7 +754,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(5, false, 0));
             seeds.push_back(make_pos_t(3, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 10); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 10); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -765,7 +765,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(3, false, 0));
             seeds.push_back(make_pos_t(8, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 3); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 3); 
 
 
 
@@ -776,7 +776,7 @@ namespace unittest {
             seeds.push_back(make_pos_t(2, false, 0));
             seeds.push_back(make_pos_t(3, false, 0));
 
-            vector<vector<size_t>> clusters =  clusterer.cluster_seeds(seeds, 15); 
+            vector<SnarlSeedClusterer::Cluster> clusters =  clusterer.cluster_seeds(seeds, 15); 
 
 
             REQUIRE( clusters.size() == 1);
@@ -815,10 +815,10 @@ namespace unittest {
         all_seeds[0].push_back(make_pos_t(245, false, 0));
         all_seeds[0].push_back(make_pos_t(248, true, 0));
 
-        tuple<vector<vector<vector<size_t>>>, vector<vector<size_t>>> paired_clusters = 
+        tuple<vector<vector<SnarlSeedClusterer::Cluster>>, vector<SnarlSeedClusterer::Cluster>> paired_clusters = 
             clusterer.cluster_seeds(all_seeds, read_lim, fragment_lim); 
-        vector<vector<vector<size_t>>> read_clusters = std::get<0>(paired_clusters);
-        vector<vector<size_t>> fragment_clusters = std::get<1>(paired_clusters);
+        vector<vector<SnarlSeedClusterer::Cluster>> read_clusters = std::get<0>(paired_clusters);
+        vector<SnarlSeedClusterer::Cluster> fragment_clusters = std::get<1>(paired_clusters);
         cerr << "read cluster: " << read_clusters[0].size() << endl << "fragment clusters: " << fragment_clusters.size() << endl;
 
         REQUIRE(fragment_clusters.size() == 2);
@@ -879,7 +879,7 @@ namespace unittest {
 
                     }
                 }
-                vector<vector<pair<vector<size_t>, size_t>>> paired_clusters = clusterer.cluster_seeds(all_seeds, read_lim, fragment_lim); 
+                vector<vector<SnarlSeedClusterer::Cluster>> paired_clusters = clusterer.cluster_seeds(all_seeds, read_lim, fragment_lim); 
 
 
                 
@@ -891,8 +891,8 @@ namespace unittest {
                         for (size_t a = 0; a < one_read_clusters.size(); a++) {
                             // For each cluster -cluster this cluster to ensure that 
                             // there is only one
-                            vector<size_t> clust = one_read_clusters[a].first;
-                            size_t fragment_cluster = one_read_clusters[a].second;
+                            vector<size_t> clust = one_read_clusters[a].seeds;
+                            size_t fragment_cluster = one_read_clusters[a].fragment;
                             if (fragment_cluster >= fragment_clusters.size()) {
                                 fragment_clusters.resize(fragment_cluster+1);
                             }
@@ -908,7 +908,7 @@ namespace unittest {
                                 for (size_t b = 0 ; b < one_read_clusters.size() ; b++) {
                                     if (b != a) {
                                         //For each other cluster
-                                        vector<size_t> clust2 = one_read_clusters[b].first;
+                                        vector<size_t> clust2 = one_read_clusters[b].seeds;
                                         for (size_t i2 = 0 ; i2 < clust2.size() ; i2++) {
                                             //And each position in each other cluster,
                                             //make sure that this position is far away from i1

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -10,7 +10,7 @@
 #include "augment.hpp"
 #include "prune.hpp"
 #include <raptor2/raptor2.h>
-#include <stPinchGraphs.h>
+#include <sonLib/stPinchGraphs.h>
 
 #include <handlegraph/util.hpp>
 

--- a/test/t/46_vg_minimizer.t
+++ b/test/t/46_vg_minimizer.t
@@ -5,12 +5,14 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 10
+plan tests 12
 
 
 # Indexing a single graph
 vg construct -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a > x.vg 2> /dev/null
 vg index -x x.xg -G x.gbwt -v small/xy2.vcf.gz x.vg
+vg snarls -T x.vg > x.snarls
+vg index -s x.snarls -j x.dist -x x.xg
 
 # Default construction
 vg minimizer -i x.mi -g x.gbwt x.xg
@@ -20,23 +22,28 @@ is $? 0 "default parameters"
 vg minimizer -t 1 -i x.mi -g x.gbwt x.xg
 is $? 0 "single-threaded construction"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 6c85e2438939fcadb332cb46899c8e79 "construction is deterministic"
+is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 1a9e7e953b2c921b78bb847d8019774d "construction is deterministic"
 
 # Minimizer parameters
 vg minimizer -t 1 -k 7 -w 3 -i x.mi -g x.gbwt x.xg
 is $? 0 "minimizer parameters"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) fef89fc3b7783932f9568960bb512c56 "setting -k -w works correctly"
-# FIXME
+is $(md5sum x.extracted.mi | cut -f 1 -d\ ) e3e3fe7ef79452b28f84bd7b5401ac61 "setting -k -w works correctly"
 
 # Construction from GBWTGraph
 vg gbwt -x x.xg -g x.gg x.gbwt
 vg minimizer -t 1 -g x.gbwt -G -i x.mi x.gg
 is $? 0 "construction from GBWTGraph"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 6c85e2438939fcadb332cb46899c8e79 "construction is deterministic"
+is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 1a9e7e953b2c921b78bb847d8019774d "construction is deterministic"
 
-rm -f x.vg x.xg x.gbwt x.mi x.extracted.mi x.gg
+# Store payload in the index
+vg minimizer -t 1 -i x.mi -g x.gbwt -d x.dist -G x.gg
+is $? 0 "construction with payload"
+vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
+is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 93b0dc32c9a0d717f7af32627474cd1e "construction is deterministic"
+
+rm -f x.vg x.xg x.gbwt x.snarls x.dist x.mi x.extracted.mi x.gg
 
 
 # Indexing two graphs
@@ -52,7 +59,7 @@ is $? 0 "multiple graphs: first"
 vg minimizer -t 1 -l x.mi -i xy.mi -g y.gbwt y.xg
 is $? 0 "multiple graphs: second"
 vg view --extract-tag MinimizerIndex xy.mi > xy.extracted.mi
-is $(md5sum xy.extracted.mi | cut -f 1 -d\ ) fa4dc8d8e8f7c2f754916e46a227ad7e "construction is deterministic"
+is $(md5sum xy.extracted.mi | cut -f 1 -d\ ) 633b3965745c53aef25d8b7e42d55eb3 "construction is deterministic"
 
 rm -f x.vg y.vg
 rm -f x.xg y.xg


### PR DESCRIPTION
A number of improvements to Giraffe. **Distance indexes and minimizer indexes must be rebuilt.**

* Store (component id, chain offset) for seeds in top-level chains in the minimizer index. This information can be used to speed up seed clustering.
* Combine the information about seeds and clusters in structs instead of having a separate vector for each field. It's now easier to pass the information around and add/remove fields.