### PR TITLE
Make vg add work with various graph formats as input

### DIFF
--- a/src/subcommand/add_main.cpp
+++ b/src/subcommand/add_main.cpp
@@ -15,6 +15,10 @@
 
 #include "../vg.hpp"
 #include "../variant_adder.hpp"
+#include "../algorithms/copy_graph.hpp"
+
+#include <vg/io/vpkg.hpp>
+
 
 
 
@@ -161,22 +165,44 @@ int main_add(int argc, char** argv) {
     }
     
     // Load the graph
-    VG* graph;
+    
+    unique_ptr<handlegraph::MutablePathDeletableHandleGraph> graph;
     get_input_file(optind, argc, argv, [&](istream& in) {
-        graph = new VG(in, show_progress);
+        graph = vg::io::VPKG::load_one<handlegraph::MutablePathDeletableHandleGraph>(in);
     });
     
-    if (graph == nullptr) {
+    VG* vg_graph = dynamic_cast<vg::VG*>(graph.get());
+    
+    // Call this to populate the vg_graph if it isn't populated.
+    auto ensure_vg = [&]() -> vg::VG* {
+        if (vg_graph == nullptr) {
+            // Copy instead.
+            vg_graph = new vg::VG();
+            algorithms::copy_path_handle_graph(graph.get(), vg_graph);
+            // Give the unique_ptr ownership and delete the graph we loaded.
+            graph.reset(vg_graph);
+            // Make sure the paths are all synced up
+            vg_graph->paths.to_graph(vg_graph->graph);
+        }
+        return vg_graph;
+    };
+    
+    // TODO: We need to move VariantAdder away from vg::VG eventually.
+    // Right now we always need the vg format graph.
+    // TODO: deduplicate ensure_vg with other subcommands?
+    ensure_vg();
+    
+    if (vg_graph == nullptr) {
         cerr << "error:[vg add]: Could not load graph" << endl;
         exit(1);
     }
     
     {
         // Clear existing path ranks (since we invalidate them)
-        graph->paths.clear_mapping_ranks();
+        vg_graph->paths.clear_mapping_ranks();
     
         // Make a VariantAdder for the graph
-        VariantAdder adder(*graph);
+        VariantAdder adder(*vg_graph);
         // Report updates when running interactively
         adder.print_updates = true;
         
@@ -207,14 +233,12 @@ int main_add(int argc, char** argv) {
         // TODO: should we sort the graph?
         
         // Rebuild all the path ranks and stuff
-        graph->paths.rebuild_mapping_aux();
+        vg_graph->paths.rebuild_mapping_aux();
     }
         
     // Output the modified graph
-    graph->serialize_to_ostream(std::cout);
+    vg_graph->serialize_to_ostream(std::cout);
     
-    delete graph;
-
     // NB: If you worry about "still reachable but possibly lost" warnings in valgrind,
     // this would free all the memory used by protobuf:
     //ShutdownProtobufLibrary();

--- a/test/t/31_vg_add.t
+++ b/test/t/31_vg_add.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 9
+plan tests 11
 
 vg construct -r add/ref.fa > ref.vg
 vg add -v add/benedict.vcf ref.vg > benedict.vg
@@ -16,6 +16,13 @@ is "$?" "0" "vg add can create a graph with contig renames"
 
 diff benedict.vg benedict2.vg
 is "$?" "0" "vg add produces the same graph from VCFs with different contig names"
+
+vg convert -p ref.vg >ref.pg
+vg add -v add/benedict.vcf ref.pg > benedict3.vg
+is "$?" "0" "vg add can create a graph from a PackedGraph"
+
+diff benedict.vg benedict3.vg
+is "$?" "0" "vg add produces the same graph from the same input in different formats"
 
 vg add -v add/separated.vcf ref.vg > no-n.vg
 vg construct -r add/refN.fa > refN.vg
@@ -39,5 +46,5 @@ is "$(vg view -Jv add/backward.json | vg add -v add/benedict.vcf - | vg mod --un
 
 is "$(vg view -Jv add/backward_and_forward.json | vg add -v add/benedict.vcf - | vg mod --unchop - | vg stats -N -)" "5" "graphs with backward and forward nodes can be added to"
 
-rm -rf ref.vg benedict.vg benedict2.vg x-ref.vg x.vg refN.vg no-n.vg with-n.vg ngap.vg ngap-add.vg
+rm -rf ref.vg ref.pg benedict.vg benedict2.vg benedict3.vg x-ref.vg x.vg refN.vg no-n.vg with-n.vg ngap.vg ngap-add.vg
 


### PR DESCRIPTION
This should fix #2729. Although, now for vg format inputs it will be slower, because it will convert them to HashGraph and then back again.