### PR TITLE
Register magic numbers for libbdsg graph types

### DIFF
--- a/src/io/register_loader_saver_hash_graph.cpp
+++ b/src/io/register_loader_saver_hash_graph.cpp
@@ -19,7 +19,15 @@ using namespace std;
 using namespace vg::io;
 
 void register_loader_saver_hash_graph() {
-    Registry::register_bare_loader_saver<bdsg::HashGraph, MutablePathDeletableHandleGraph, MutablePathMutableHandleGraph, MutableHandleGraph, PathHandleGraph, HandleGraph>("HashGraph", [](istream& input) -> void* {
+
+    // Convert the HashGraph SerializableHandleGraph magic number to a string
+    bdsg::HashGraph empty;
+    // Make sure it is in network byte order
+    uint32_t new_magic_number = htonl(empty.get_magic_number());
+    // Load all 4 characters of it into a string
+    string new_magic((char*)&new_magic_number, 4);
+
+    Registry::register_bare_loader_saver_with_magic<bdsg::HashGraph, MutablePathDeletableHandleGraph, MutablePathMutableHandleGraph, MutableHandleGraph, PathHandleGraph, HandleGraph>("HashGraph", new_magic, [](istream& input) -> void* {
         // Allocate a HashGraph
         bdsg::HashGraph* hash_graph = new bdsg::HashGraph();
         

--- a/src/io/register_loader_saver_odgi.cpp
+++ b/src/io/register_loader_saver_odgi.cpp
@@ -17,7 +17,15 @@ using namespace std;
 using namespace vg::io;
 
 void register_loader_saver_odgi() {
-    Registry::register_bare_loader_saver<bdsg::ODGI, MutablePathDeletableHandleGraph, MutablePathMutableHandleGraph, MutableHandleGraph, PathHandleGraph, HandleGraph>("ODGI", [](istream& input) -> void* {
+
+    // Convert the ODGI SerializableHandleGraph magic number to a string
+    bdsg::ODGI empty;
+    // Make sure it is in network byte order
+    uint32_t new_magic_number = htonl(empty.get_magic_number());
+    // Load all 4 characters of it into a string
+    string new_magic((char*)&new_magic_number, 4);
+
+    Registry::register_bare_loader_saver_with_magic<bdsg::ODGI, MutablePathDeletableHandleGraph, MutablePathMutableHandleGraph, MutableHandleGraph, PathHandleGraph, HandleGraph>("ODGI", new_magic, [](istream& input) -> void* {
         // Allocate an ODGI graph
         bdsg::ODGI* odgi = new bdsg::ODGI();
         

--- a/src/io/register_loader_saver_packed_graph.cpp
+++ b/src/io/register_loader_saver_packed_graph.cpp
@@ -17,7 +17,15 @@ using namespace std;
 using namespace vg::io;
 
 void register_loader_saver_packed_graph() {
-  Registry::register_bare_loader_saver<bdsg::PackedGraph, MutablePathDeletableHandleGraph, MutablePathMutableHandleGraph, MutableHandleGraph, PathHandleGraph, HandleGraph>("PackedGraph", [](istream& input) -> void* {
+
+    // Convert the PackedGraph SerializableHandleGraph magic number to a string
+    bdsg::PackedGraph empty;
+    // Make sure it is in network byte order
+    uint32_t new_magic_number = htonl(empty.get_magic_number());
+    // Load all 4 characters of it into a string
+    string new_magic((char*)&new_magic_number, 4);
+    
+    Registry::register_bare_loader_saver_with_magic<bdsg::PackedGraph, MutablePathDeletableHandleGraph, MutablePathMutableHandleGraph, MutableHandleGraph, PathHandleGraph, HandleGraph>("PackedGraph", new_magic, [](istream& input) -> void* {
         // Allocate a PackedGraph
          bdsg::PackedGraph* packed_graph = new bdsg::PackedGraph();
         


### PR DESCRIPTION
This lets graphs written by `SerializableHandleGraph::serialize()` get loaded by vg. 