### PR TITLE
Add a no clustering option to mpmap

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -1215,6 +1215,24 @@ vector<MEMClusterer::cluster_t> MEMClusterer::clusters(const Alignment& alignmen
                               min_median_mem_coverage_for_split, suboptimal_edge_pruning_factor);
     
 }
+
+MEMClusterer::HitGraph NullClusterer::make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems,
+                                                     const GSSWAligner* aligner, size_t min_mem_length) {
+    // intialize the hit nodes, but do not add any edges, and ignore the min mem length
+    return HitGraph(mems, alignment, aligner, 1);
+}
+
+vector<pair<pair<size_t, size_t>, int64_t>>  NullClusterer::pair_clusters(const Alignment& alignment_1,
+                                                                          const Alignment& alignment_2,
+                                                                          const vector<cluster_t*>& left_clusters,
+                                                                          const vector<cluster_t*>& right_clusters,
+                                                                          const vector<pair<size_t, size_t>>& left_alt_cluster_anchors,
+                                                                          const vector<pair<size_t, size_t>>& right_alt_cluster_anchors,
+                                                                          int64_t optimal_separation,
+                                                                          int64_t max_deviation) {
+    // do not cluster pairs.
+    return vector<pair<pair<size_t, size_t>, int64_t>>();
+}
     
 PathOrientedDistanceMeasurer::PathOrientedDistanceMeasurer(const PathPositionHandleGraph* graph,
                                                            const PathComponentIndex* path_component_index) :
@@ -2848,7 +2866,12 @@ vector<handle_t> TargetValueSearch::tv_path(const pos_t& pos_1, const pos_t& pos
     return tv_phase2(pos_1, pos_2, target_value, tolerance, node_to_target_shorter, node_to_target_longer, best_long, next_best, node_to_path);
 }
  
-vector<handle_t> TargetValueSearch::tv_phase2(const pos_t& pos_1, const pos_t& pos_2, int64_t target_value, int64_t tolerance,  hash_map<pair<id_t, bool>, int64_t> node_to_target_shorter, hash_map<pair<id_t, bool>, int64_t>node_to_target_longer,  pair<int64_t, pair<pair<id_t, bool>, int64_t>> best_long,  pair<int64_t, pair<pair<id_t, bool>, int64_t>> next_best, hash_map<pair<pair<id_t, bool>, int64_t>, pair<pair<id_t, bool>, int64_t>> node_to_path) {
+vector<handle_t> TargetValueSearch::tv_phase2(const pos_t& pos_1, const pos_t& pos_2, int64_t target_value, int64_t tolerance,
+                                              hash_map<pair<id_t, bool>, int64_t>& node_to_target_shorter,
+                                              hash_map<pair<id_t, bool>, int64_t>& node_to_target_longer,
+                                              pair<int64_t, pair<pair<id_t, bool>, int64_t>>& best_long,
+                                              pair<int64_t, pair<pair<id_t, bool>, int64_t>>& next_best,
+                                              hash_map<pair<pair<id_t, bool>, int64_t>, pair<pair<id_t, bool>, int64_t>>& node_to_path) {
 //TODO: Any path that has been found is probably still pretty good, could return it here 
 
     DistanceHeuristic& min_distance = *lower_bound_heuristic;

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -329,6 +329,32 @@ public:
         return nodes[i].dp_score < nodes[j].dp_score;
     }
 };
+        
+/*
+ * A clustering implementation that actually doesn't do any clustering
+ */
+class NullClusterer : public MEMClusterer {
+public:
+    NullClusterer() = default;
+    virtual ~NullClusterer() = default;
+
+    /// Concrete implementation of virtual method from MEMClusterer
+    vector<pair<pair<size_t, size_t>, int64_t>> pair_clusters(const Alignment& alignment_1,
+                                                              const Alignment& alignment_2,
+                                                              const vector<cluster_t*>& left_clusters,
+                                                              const vector<cluster_t*>& right_clusters,
+                                                              const vector<pair<size_t, size_t>>& left_alt_cluster_anchors,
+                                                              const vector<pair<size_t, size_t>>& right_alt_cluster_anchors,
+                                                              int64_t optimal_separation,
+                                                              int64_t max_deviation);
+
+protected:
+
+    /// Concrete implementation of virtual method from MEMClusterer
+    /// Note: ignores the min_mem_length parameter
+    HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, const GSSWAligner* aligner,
+                            size_t min_mem_length);
+};
     
     
 /*
@@ -602,7 +628,15 @@ public:
     
 protected:
     
-    vector<handle_t> tv_phase2(const pos_t& pos_1, const pos_t& pos_2, int64_t target_value, int64_t tolerance, hash_map<pair<id_t, bool>,int64_t> node_to_target_shorter, hash_map<pair<id_t, bool>, int64_t> node_to_target_longer, pair<int64_t, pair<pair<id_t, bool>,int64_t>> best_lng, pair<int64_t, pair<pair<id_t, bool>, int64_t>> next_best, hash_map<pair<pair<id_t, bool>, int64_t>, pair<pair<id_t, bool>, int64_t>> node_to_path);
+    vector<handle_t> tv_phase2(const pos_t& pos_1,
+                               const pos_t& pos_2,
+                               int64_t target_value,
+                               int64_t tolerance,
+                               hash_map<pair<id_t, bool>,int64_t>& node_to_target_shorter,
+                               hash_map<pair<id_t, bool>, int64_t>& node_to_target_longer,
+                               pair<int64_t, pair<pair<id_t, bool>,int64_t>>& best_lng,
+                               pair<int64_t, pair<pair<id_t, bool>, int64_t>>& next_best,
+                               hash_map<pair<pair<id_t, bool>, int64_t>, pair<pair<id_t, bool>, int64_t>>& node_to_path);
     
     const HandleGraph& handle_graph;
     unique_ptr<DistanceHeuristic> upper_bound_heuristic;
@@ -658,7 +692,7 @@ protected:
     
     /// Concrete implementation of virtual method from MEMClusterer
     virtual HitGraph make_hit_graph(const Alignment& alignment, const vector<MaximalExactMatch>& mems, const GSSWAligner* aligner,
-                            size_t min_mem_length);
+                                    size_t min_mem_length);
     
     const HandleGraph* handle_graph;
     MinimumDistanceIndex* distance_index;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -169,6 +169,7 @@ namespace vg {
         bool use_min_dist_clusterer = false;
         bool greedy_min_dist = false;
         bool component_min_dist = false;
+        bool no_clustering = false;
         // length of reversing walks during graph extraction
         size_t reversing_walk_length = 0;
         bool suppress_p_value_memoization = false;


### PR DESCRIPTION
Intended for very short reads (e.g. miRNA), in which clustering will incur a computational cost but is not likely to significantly improve mapping accuracy.

@jonassibbesen I'll add it to a preset with my grand interface redesign PR later, but if you want to mess around with it now it's on the mpmap secret menu as `--no-cluster`.