### PR TITLE
Further debugging for mpmap presets and alignment

### DIFF
--- a/src/dozeu_interface.cpp
+++ b/src/dozeu_interface.cpp
@@ -203,13 +203,13 @@ size_t DozeuInterface::do_poa(const OrderedGraph& graph, const dz_query_s* packe
     
     // initialze an alignment
     dz_alignment_init_s aln_init = dz_align_init(dz, max_gap_length);
-    
+
     // seed an alignment at each of the seed positions
     for (const graph_pos_s& seed_pos : seed_positions) {
         
         // get root node
         auto root_seq = graph.graph.get_sequence(graph.order[seed_pos.node_index]);
-        
+         
         // load position and length
         int64_t rlen = (right_to_left ? 0 : root_seq.size()) - seed_pos.ref_offset;
         

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -153,7 +153,9 @@ namespace vg {
         create_path_chunk_nodes(graph, path_holder, alignment, project, injection_trans);
         
         // cut the snarls out of the aligned path so we can realign through them
-        resect_snarls_from_paths(&snarl_manager, project, max_snarl_cut_size);
+        if (max_snarl_cut_size) {
+            resect_snarls_from_paths(&snarl_manager, project, max_snarl_cut_size);
+        }
         
         // the snarls algorithm adds edges where necessary
         has_reachability_edges = true;
@@ -778,7 +780,7 @@ namespace vg {
             PathNode& match_node = path_nodes.at(i);
             
 #ifdef debug_multipath_alignment
-            cerr << "## checking if MEM " << i << " can be an extension: " << endl;
+            cerr << "checking if MEM " << i << " can be an extension: " << endl;
             cerr << "\t";
             for (auto iter = match_node.begin; iter != match_node.end; iter++) {
                 cerr << *iter;
@@ -1195,7 +1197,7 @@ namespace vg {
                         // as we enter this node, we are leaving the snarl we were in
                         
                         // since we're going up a level, we need to check whether we need to cut out the segment we've traversed
-                        if (prefix_length - curr_level->first <= max_snarl_cut_size || !max_snarl_cut_size) {
+                        if (prefix_length - curr_level->first <= max_snarl_cut_size) {
                             cut_segments.emplace_back(curr_level->second, j);
                         }
                         
@@ -1235,7 +1237,7 @@ namespace vg {
             // check the final segment for a cut unless we're at the highest level in the match
             auto last = level_segment_begin.end();
             last--;
-            if ((prefix_length - curr_level->first <= max_snarl_cut_size || !max_snarl_cut_size) && curr_level != last) {
+            if ((prefix_length - curr_level->first <= max_snarl_cut_size) && curr_level != last) {
                 cut_segments.emplace_back(curr_level->second, path->mapping_size());
             }
             
@@ -3656,8 +3658,8 @@ namespace vg {
         }
         else {
             vector<int64_t>& memo = pessimistic_tail_gap_memo[multiplier];
-            while (memo.size() >= tail_length) {
-                memo.emplace_back(multiplier * sqrt(tail_length));
+            while (memo.size() <= tail_length) {
+                memo.emplace_back(multiplier * sqrt(memo.size()));
             }
             gap_length = memo[tail_length];
         }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3127,7 +3127,9 @@ namespace vg {
 #endif
         
             // Do the snarl cutting, which modifies the nodes in the multipath alignment graph
-            multi_aln_graph.resect_snarls_from_paths(snarl_manager, translator, max_snarl_cut_size);
+            if (max_snarl_cut_size) {
+                multi_aln_graph.resect_snarls_from_paths(snarl_manager, translator, max_snarl_cut_size);
+            }
         }
 
 


### PR DESCRIPTION
I found a couple of bugs in dozeu and one in gssw with the new configurations that the mpmap presets choose. Turns out we've been protected by our scoring parameters, which disfavor indels so much that some indel bugs have gone unfixed for a long time.