### PR TITLE
GBWT traversal finder

### DIFF
--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3355,6 +3355,140 @@ pair<vector<SnarlTraversal>, vector<double>> FlowTraversalFinder::find_weighted_
     return make_pair(travs, weights);
 }        
 
-
+GBWTTraversalFinder::GBWTTraversalFinder(const HandleGraph& graph, const gbwt::GBWT& gbwt) : 
+    graph(graph),
+    gbwt(gbwt) {
 
 }
+    
+GBWTTraversalFinder::~GBWTTraversalFinder() {
+
+}
+
+vector<SnarlTraversal> GBWTTraversalFinder::find_traversals(const Snarl& site) {
+
+    // follow all gbwt threads from start to end
+    vector<vector<gbwt::node_type>> forward_traversals = get_spanning_haplotypes(
+        graph.get_handle(site.start().node_id(), site.start().backward()),
+        graph.get_handle(site.end().node_id(), site.end().backward()));
+
+    // follow all gbwt threads from end to start
+    vector<vector<gbwt::node_type>> backward_traversals = get_spanning_haplotypes(
+        graph.get_handle(site.end().node_id(), !site.end().backward()),
+        graph.get_handle(site.start().node_id(), !site.start().backward()));
+
+    // store them all as snarltraversals
+    vector<SnarlTraversal> traversals;
+    traversals.reserve(forward_traversals.size() + backward_traversals.size());
+
+    // copy the forward traversals from gbwt vectors to snarl traversals
+    for (int i = 0; i < forward_traversals.size(); ++i) {
+        traversals.emplace_back();
+        for (auto j = forward_traversals[i].begin(); j != forward_traversals[i].end(); ++j) {
+            Visit* visit = traversals.back().add_visit();
+            *visit = to_visit(gbwt::Node::id(*j), gbwt::Node::is_reverse(*j));
+        }
+    }
+
+    if (!backward_traversals.empty()) {
+
+        // want to check we don't have the same element twice
+        std::sort(forward_traversals.begin(), forward_traversals.end());
+        
+        // copy and reverse the backward traversals into the snarl traversals
+        for (int i = 0; i < backward_traversals.size(); ++i) {
+
+            // orient along the snarl
+            std::reverse(backward_traversals[i].begin(), backward_traversals[i].end());
+            for (auto& gnode : backward_traversals[i]) {
+                gnode = gbwt::Node::encode(gbwt::Node::id(gnode), !gbwt::Node::is_reverse(gnode));
+            }
+            // insert if not duplicate of existing forward traversal
+            if (!std::binary_search(forward_traversals.begin(), forward_traversals.end(), backward_traversals[i])) {
+                traversals.emplace_back();
+                for (auto j = backward_traversals[i].begin(); j != backward_traversals[i].end(); ++j) {
+                    Visit* visit = traversals.back().add_visit();
+                    *visit = to_visit(gbwt::Node::id(*j), gbwt::Node::is_reverse(*j));
+                }
+            }
+        }
+    }
+    return traversals;
+}
+
+
+vector<vector<gbwt::node_type>> GBWTTraversalFinder::get_spanning_haplotypes(handle_t start, handle_t end) {
+
+    // Note: this code is derived from list_haplotypes() in haplotype_extractor.cpp
+    
+    // Keep track of all the different paths we're extending
+    vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > search_intermediates;
+    vector<vector<gbwt::node_type>> search_results;
+
+    // Look up the start node in GBWT and start a thread
+    gbwt::node_type start_node = handle_to_gbwt(graph, start);    
+    vector<gbwt::node_type> first_thread = {start_node};
+    gbwt::SearchState first_state = gbwt.find(start_node);
+    
+#ifdef debug
+    cerr << "Start with state " << first_state << " for node " << gbwt::Node::id(start_node)  << ":"
+         << gbwt::Node::is_reverse(start_node) << endl;
+#endif
+
+    if (!first_state.empty()) {
+        search_intermediates.push_back(make_pair(first_thread, first_state));
+    }
+
+    while(!search_intermediates.empty()) {
+
+        // pick up a thread to continue from the queue
+        auto last = std::move(search_intermediates.back());
+        search_intermediates.pop_back();
+
+        graph.follow_edges(gbwt_to_handle(graph, last.first.back()), false, [&](const handle_t& next) {
+
+                // cut off loop-backs
+                if (graph.get_id(next) == graph.get_id(start)) {
+                    assert(graph.get_is_reverse(next) != graph.get_is_reverse(start));
+                    return;
+                }
+                
+                // extend the last node of the thread using gbwt
+                auto extend_node = handle_to_gbwt(graph, next);
+                auto new_state = gbwt.extend(last.second, extend_node);
+#ifdef debug
+                cerr << "Extend state " << last.second << " to " << new_state << " with " << gbwt::Node::id(extend_node) << endl;
+#endif
+                if(!new_state.empty()) {
+
+                    // todo: possible to save a copy here by carefully moving (would change extending a big
+                    // reference haplotype from O(n^2) to O(n)
+                    vector<gbwt::node_type> new_thread = last.first;
+                    new_thread.push_back(extend_node);
+
+                    if (next == end) {
+#ifdef debug
+                        cerr << "\tGot " << new_state.size() << " results at limit; emitting" << endl;
+#endif
+                        search_results.push_back(std::move(new_thread));
+                    }
+                    else {
+#ifdef debug
+                        cerr << "\tGot " << new_state.size() << " results; extending more" << endl;
+#endif
+                        search_intermediates.push_back(make_pair(std::move(new_thread), new_state));
+                    }
+                }
+            });
+    }
+    
+    return search_results;
+}
+
+
+    
+
+}
+
+
+

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -27,6 +27,7 @@
 #include "snarls.hpp"
 #include "path_index.hpp"
 #include "genotypekit.hpp"
+#include "gbwt_helper.hpp"
 
 namespace vg {
 
@@ -610,6 +611,32 @@ public:
 
 };    
 
+/** Rerturn all traversals of a snarl that correspond to haplotypes stored in a GBWT
+ */
+class GBWTTraversalFinder : public TraversalFinder {
+
+protected:
+    
+    const HandleGraph& graph;
+    const gbwt::GBWT& gbwt;
+    
+public:
+    
+    GBWTTraversalFinder(const HandleGraph& graph, const gbwt::GBWT& gbwt);
+    
+    virtual ~GBWTTraversalFinder();
+
+    virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
+
+protected:
+
+    /**
+     * Breadth first search from the start to the end, only branching if there's a haplotype 
+     * in the GBWT, and returning all unique haplotypes found. 
+     */
+    vector<vector<gbwt::node_type>> get_spanning_haplotypes(handle_t start, handle_t end);
+    
+};
 
 }
 


### PR DESCRIPTION
Enumerate all traversals in a snarl that are contained in at least one GBWT haplotype.  I haven't implemented it yet, but this will allow an option in `vg call` to work with GBWT haplotypes, either exclusively or in conjunction with haplotypes it finds with existing searches.  Perhaps it could also be a step towards integrating with ideas from https://github.com/jonassibbesen/rpvg which has a cool read-scoring procedure that seems better than pack. 