### PR TITLE
Add option to prespecify topological order for dozeu

### DIFF
--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -147,8 +147,15 @@ namespace vg {
         virtual void align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments,
                                                const HandleGraph& g, int32_t max_alt_alns, int32_t band_padding = 0,
                                                bool permissive_banding = true) const = 0;
-        // xdrop aligner
-        virtual void align_xdrop(Alignment& alignment, const HandleGraph& g, const vector<MaximalExactMatch>& mems, bool reverse_complemented, uint16_t max_gap_length = default_xdrop_max_gap_length) const = 0;
+        /// xdrop aligner
+        virtual void align_xdrop(Alignment& alignment, const HandleGraph& g, const vector<MaximalExactMatch>& mems,
+                                 bool reverse_complemented, uint16_t max_gap_length = default_xdrop_max_gap_length) const = 0;
+        
+        /// xdrop aligner, but with a precomputed topological order on the graph, which need not include
+        /// all of the graph's handles and which may contain both orientations of a handle
+        virtual void align_xdrop(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& order,
+                                 const vector<MaximalExactMatch>& mems, bool reverse_complemented,
+                                 uint16_t max_gap_length = default_xdrop_max_gap_length) const = 0;
 
         /// Compute the score of an exact match in the given alignment, from the
         /// given offset, of the given length.
@@ -320,9 +327,15 @@ namespace vg {
         void align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
                                        int32_t max_alt_alns, int32_t band_padding = 0, bool permissive_banding = true) const;
 
-        // xdrop aligner
+        /// xdrop aligner
         void align_xdrop(Alignment& alignment, const HandleGraph& g, const vector<MaximalExactMatch>& mems,
                          bool reverse_complemented, uint16_t max_gap_length = default_xdrop_max_gap_length) const;
+        
+        /// xdrop aligner, but with a precomputed topological order on the graph, which need not include
+        /// all of the graph's handles and which may contain both orientations of a handle
+        void align_xdrop(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& order,
+                         const vector<MaximalExactMatch>& mems, bool reverse_complemented,
+                         uint16_t max_gap_length = default_xdrop_max_gap_length) const;
 
         int32_t score_exact_match(const Alignment& aln, size_t read_offset, size_t length) const;
         int32_t score_exact_match(const string& sequence, const string& base_quality) const;
@@ -376,6 +389,9 @@ namespace vg {
                                 
         void align_xdrop(Alignment& alignment, const HandleGraph& g, const vector<MaximalExactMatch>& mems,
                          bool reverse_complemented, uint16_t max_gap_length = default_xdrop_max_gap_length) const;
+        void align_xdrop(Alignment& alignment, const HandleGraph& g, const vector<handle_t>& order,
+                         const vector<MaximalExactMatch>& mems, bool reverse_complemented,
+                         uint16_t max_gap_length = default_xdrop_max_gap_length) const;
         
         int32_t score_exact_match(const Alignment& aln, size_t read_offset, size_t length) const;
         int32_t score_exact_match(const string& sequence, const string& base_quality) const;

--- a/src/dozeu_interface.hpp
+++ b/src/dozeu_interface.hpp
@@ -93,6 +93,15 @@ public:
                bool reverse_complemented, uint16_t max_gap_length = default_xdrop_max_gap_length);
     
     /**
+     * Same as above except using a precomputed topological order, which
+     * need not include all handles in the graph, and which may contain both
+     * orientations of a handle.
+     */
+    void align(Alignment& alignment, const HandleGraph& graph, const vector<handle_t>& order,
+               const vector<MaximalExactMatch>& mems,  bool reverse_complemented,
+               uint16_t max_gap_length = default_xdrop_max_gap_length);
+    
+    /**
      * Compute a pinned alignment, where the start (pin_left=true) or end
      * (pin_left=false) end of the Alignment sequence is pinned to the
      * start of the first (pin_left=true) or end of the last
@@ -123,6 +132,9 @@ protected:
      */
     struct OrderedGraph {
         OrderedGraph(const HandleGraph& graph, const vector<handle_t>& order);
+        void for_each_neighbor(const size_t i, bool go_left, const function<void(size_t)>& lambda) const;
+        size_t size() const;
+        
         const HandleGraph& graph;
         const vector<handle_t>& order;
         unordered_map<handle_t, size_t> index_of;


### PR DESCRIPTION
Adds an alternate code path into `align_xdrop` that @jltsiren thought might be useful