### PR TITLE
Fix off-by-one error in vg annotate gff parser

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -2027,8 +2027,10 @@ void parse_gff_regions(istream& gffstream,
         getline(ss, source, '\t');
         getline(ss, type, '\t');
         getline(ss, buf, '\t');
-        sbuf = atoi(buf.c_str());
+        // Convert to 0-based 
+        sbuf = atoi(buf.c_str()) - 1;
         getline(ss, buf, '\t');
+        // 1-based inclusive == 0-based exclusive
         ebuf = atoi(buf.c_str());
 
         if (ss.fail() || !(sbuf < ebuf)) {

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -23,7 +23,7 @@ void help_annotate(char** argv) {
          << "graph annotation options:" << endl
          << "    -x, --xg-name FILE     xg index or graph to annotate (required)" << endl
          << "    -b, --bed-name FILE    a BED file to convert to GAM. May repeat." << endl
-         << "    -f, --gff-name FILE    a GFF3/GTF file to convert to GAM. May repeat." << endl
+         << "    -f, --gff-name FILE    a GFF3 file to convert to GAM. May repeat." << endl
          << "    -g, --ggff             output at GGFF subgraph annotation file instead of GAM (requires -s)" << endl
          << "    -s, --snarls FILE      file containing snarls to expand GFF intervals into" << endl
          << "alignment annotation options:" << endl


### PR DESCRIPTION
Resolves #2749. Also noticed that we have 3 different gff parser implementations. I will try to merge these in a future PR.