### PR TITLE
Integrated Snarl Finder Bugfixes

### DIFF
--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -519,7 +519,6 @@ vector<handle_t> IntegratedSnarlFinder::MergedAdjacencyGraph::find_cycle_path_in
     throw runtime_error("Cound not find cycle path!");
 }
 
-#define debug
 pair<vector<pair<size_t, vector<handle_t>>>, unordered_map<handle_t, handle_t>> IntegratedSnarlFinder::MergedAdjacencyGraph::longest_paths_in_forest(
     const vector<pair<size_t, handle_t>>& longest_simple_cycles) const {
     
@@ -1011,7 +1010,6 @@ pair<vector<pair<size_t, vector<handle_t>>>, unordered_map<handle_t, handle_t>> 
     
     return to_return;
 }
-#undef debug
 
 
 
@@ -1132,12 +1130,10 @@ void IntegratedSnarlFinder::traverse_decomposition(const function<void(handle_t)
         forest.merge(kv.first, kv.second);
     }
 
-#define debug
 #ifdef debug
     cerr << "Bridge forest:" << endl;
     forest.to_dot(cerr);
 #endif
-#undef debug
     
 #ifdef debug
     cerr << "Finding bridge edge paths..." << endl;

--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -519,7 +519,7 @@ vector<handle_t> IntegratedSnarlFinder::MergedAdjacencyGraph::find_cycle_path_in
     throw runtime_error("Cound not find cycle path!");
 }
 
-
+#define debug
 pair<vector<pair<size_t, vector<handle_t>>>, unordered_map<handle_t, handle_t>> IntegratedSnarlFinder::MergedAdjacencyGraph::longest_paths_in_forest(
     const vector<pair<size_t, handle_t>>& longest_simple_cycles) const {
     
@@ -821,7 +821,8 @@ pair<vector<pair<size_t, vector<handle_t>>>, unordered_map<handle_t, handle_t>> 
                             // Either we didn't root at a cycle, or we found a longer leaf-leaf path that should be the decomposition root instead.
                             
 #ifdef debug
-                            cerr << "\t\t\tTree has leaf-leaf path that is as long as or longer than any cycle at root." << endl;
+                            cerr << "\t\t\tTree has leaf-leaf path that is as long as or longer than any cycle at root ("
+                                << record.longest_subtree_path_length << "bp)." << endl;
 #endif
                             
                             // We need to record the longest tree path.
@@ -997,6 +998,7 @@ pair<vector<pair<size_t, vector<handle_t>>>, unordered_map<handle_t, handle_t>> 
     
     return to_return;
 }
+#undef debug
 
 
 
@@ -1116,11 +1118,13 @@ void IntegratedSnarlFinder::traverse_decomposition(const function<void(handle_t)
         // Merge along all cycles in the bridge forest
         forest.merge(kv.first, kv.second);
     }
-    
+
+#define debug
 #ifdef debug
     cerr << "Bridge forest:" << endl;
     forest.to_dot(cerr);
 #endif
+#undef debug
     
 #ifdef debug
     cerr << "Finding bridge edge paths..." << endl;

--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -831,25 +831,38 @@ pair<vector<pair<size_t, vector<handle_t>>>, unordered_map<handle_t, handle_t>> 
                             auto& path = longest_tree_paths.back().second;
                             
                             auto& path_root_frame = records[record.longest_subtree_path_root];
-                            assert(path_root_frame.has_second_deepest_child);
-                            // Collect the whole path down the second deepest child
-                            path.push_back(path_root_frame.second_deepest_child_edge);
-                            auto path_trace_it = deepest_child_edge.find(find(path.back()));
-                            while (path_trace_it != deepest_child_edge.end()) {
-                                // Follow the deepest child relationships until they run out.
-                                path.push_back(path_trace_it->second);
-                                path_trace_it = deepest_child_edge.find(find(path.back()));
+                            
+                            if (path_root_frame.has_second_deepest_child) {
+                                // This is an actual convergence point
+                            
+#ifdef debug
+                                cerr << "\t\t\t\tConverges at real convergence point" << endl;
+#endif
+                                
+                                // Collect the whole path down the second deepest child
+                                path.push_back(path_root_frame.second_deepest_child_edge);
+                                auto path_trace_it = deepest_child_edge.find(find(path.back()));
+                                while (path_trace_it != deepest_child_edge.end()) {
+                                    // Follow the deepest child relationships until they run out.
+                                    path.push_back(path_trace_it->second);
+                                    path_trace_it = deepest_child_edge.find(find(path.back()));
+                                }
+                                // Reverse what's there and flip all the edges
+                                vector<handle_t> flipped;
+                                flipped.reserve(path.size());
+                                for (auto path_it = path.rbegin(); path_it != path.rend(); ++path_it) {
+                                    flipped.push_back(graph->flip(*path_it));
+                                }
+                                path = std::move(flipped);
+                            } else {
+                                // There's no second-longest path; we statted at one of the most distant leaves.
+#ifdef debug
+                                cerr << "\t\t\t\tConverges at leaf" << endl;
+#endif
                             }
-                            // Reverse what's there and flip all the edges
-                            vector<handle_t> flipped;
-                            flipped.reserve(path.size());
-                            for (auto path_it = path.rbegin(); path_it != path.rend(); ++path_it) {
-                                flipped.push_back(graph->flip(*path_it));
-                            }
-                            path = std::move(flipped);
                             // Now trace the actual longest path from root to leaf and add it on
                             path.push_back(deepest_child_edge[record.longest_subtree_path_root]);
-                            path_trace_it = deepest_child_edge.find(find(path.back()));
+                            auto path_trace_it = deepest_child_edge.find(find(path.back()));
                             while (path_trace_it != deepest_child_edge.end()) {
                                 // Follow the deepest child relationships until they run out.
                                 path.push_back(path_trace_it->second);


### PR DESCRIPTION
This fixes bugs in the integrated snarl finder dealing with single node components, and other cases where there has to be connectivity in the root, unbounded snarl.

There should be no more of this complaint that @jeizenga had:

```
vg: src/integrated_snarl_finder.cpp:833: vg::IntegratedSnarlFinder::MergedAdjacencyGraph::longest_paths_in_forest(const std::vector<std::pair<long unsigned int, handlegraph::handle_t> >&) const::<lambda(vg::handle_t, size_t)>: Assertion `path_root_frame.has_second_deepest_child' failed.
```

On the `/public/home/hickey/dev/work/renzo-snarl-crash/combined.hg` graph recommended by @glennhickey as a test case, I now get equivalent snarls to Cactus, without crashing, although the new code is oddly slow on this case.

```
time vg snarls --algorithm integrated -t 1 /public/home/hickey/dev/work/renzo-snarl-crash/combined.hg > trash/combined.integrated.snarls

real	0m16.414s
user	0m5.227s
sys	0m8.515s

time vg snarls --algorithm cactus -t 1 /public/home/hickey/dev/work/renzo-snarl-crash/combined.hg > trash/combined.cactus.snarls

real	0m1.355s
user	0m1.248s
sys	0m0.096s
```

On the whole genome snp1kg graph I have lying around, before the bugfix (which shouldn't affect things), I saved ~25% CPU time and 25% memory, at the cost of 6% extra wall clock time, with the new algorithm. I'll see about doing some profiling, but we ought to merge this bugfix so things at least work.
