### PR TITLE
Handle failures to seed from dozeu without crashing

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1393,6 +1393,11 @@ void Aligner::align_xdrop(Alignment& alignment, const HandleGraph& g, const vect
     // thread-safety by having one per thread, which makes this method const-ish.
     XdropAligner& xdrop = const_cast<XdropAligner&>(xdrops[omp_get_thread_num()]);
     xdrop.align(alignment, g, order, mems, reverse_complemented, max_gap_length);
+    if (!alignment.has_path() && mems.empty()) {
+        // dozeu couldn't find an alignment, probably because it's seeding heuristic failed
+        // we'll just fall back on GSSW
+        align(alignment, g, true);
+    }
 }
 
 
@@ -1877,6 +1882,11 @@ void QualAdjAligner::align_xdrop(Alignment& alignment, const HandleGraph& g, con
     // thread-safety by having one per thread, which makes this method const-ish.
     QualAdjXdropAligner& xdrop = const_cast<QualAdjXdropAligner&>(xdrops[omp_get_thread_num()]);
     xdrop.align(alignment, g, order, mems, reverse_complemented, max_gap_length);
+    if (!alignment.has_path() && mems.empty()) {
+        // dozeu couldn't find an alignment, probably because it's seeding heuristic failed
+        // we'll just fall back on GSSW
+        align(alignment, g, true);
+    }
 }
 
 int32_t QualAdjAligner::score_exact_match(const Alignment& aln, size_t read_offset, size_t length) const {

--- a/src/dozeu_interface.cpp
+++ b/src/dozeu_interface.cpp
@@ -630,6 +630,7 @@ void DozeuInterface::align(Alignment& alignment, const HandleGraph& graph, const
             // we failed to find a seed, so we will not attempt an alignment
             // clear the path just in case we're realigning a GAM
             alignment.clear_path();
+            return;
         }
 	}
     else {

--- a/src/dozeu_interface.hpp
+++ b/src/dozeu_interface.hpp
@@ -173,8 +173,12 @@ protected:
     /// If direction is false, finds a seed hit on the first node of the graph. If it is true, finds a hit on the last node.
     ///
     /// This replaces calculate_seed_position for the case where we have no MEMs.
-    graph_pos_s scan_seed_position(const OrderedGraph& graph, const Alignment& alignment, bool direction,
-                                   vector<const dz_forefront_s*>& forefronts, uint16_t max_gap_length);
+    ///
+    /// The bool return with the position indicates whether the scan succeeded or failed.
+    /// If the scan failed, then the alignment should not be attempted.
+    pair<graph_pos_s, bool> scan_seed_position(const OrderedGraph& graph, const Alignment& alignment,
+                                               bool direction, vector<const dz_forefront_s*>& forefronts,
+                                               uint16_t max_gap_length);
     
     /// Append an edit at the end of the current mapping array.
     /// Returns the length passed in.

--- a/src/unittest/xdrop_aligner.cpp
+++ b/src/unittest/xdrop_aligner.cpp
@@ -636,6 +636,26 @@ TEST_CASE("QualAdjXdropAligner will not penalize a low quality mismatch", "[xdro
     REQUIRE(aln.path().mapping(0).edit(2).to_length() == 2);
     REQUIRE(aln.path().mapping(0).edit(2).sequence() == "");
 }
+
+TEST_CASE("XdropAligner doesn't crash on a case where it is hard to find a seed", "[xdrop][alignment][mapping]") {
+    
+    string graph_json = R"({"edge": [{"from": "92345167", "to": "92345168"}, {"from": "92345182", "to": "92345183"}, {"from": "92345165", "to": "92345166"}, {"from": "92345177", "to": "92345178"}, {"from": "92345171", "to": "92345172"}, {"from": "92345161", "to": "92345162"}, {"from": "92345183", "to": "92345184"}, {"from": "92345181", "to": "92345182"}, {"from": "92345178", "to": "92345179"}, {"from": "92345166", "to": "92345167"}, {"from": "92345179", "to": "92345180"}, {"from": "92345173", "to": "92345174"}, {"from": "92345184", "to": "92345185"}, {"from": "92345169", "to": "92345170"}, {"from": "92345185", "to": "92345186"}, {"from": "92345160", "to": "92345161"}, {"from": "92345174", "to": "92345175"}, {"from": "92345162", "to": "92345163"}, {"from": "92345175", "to": "92345176"}, {"from": "92345168", "to": "92345169"}, {"from": "92345163", "to": "92345164"}, {"from": "92345172", "to": "92345173"}, {"from": "92345180", "to": "92345181"}, {"from": "92345176", "to": "92345177"}, {"from": "92345170", "to": "92345171"}, {"from": "92345164", "to": "92345165"}], "node": [{"id": "92345167", "sequence": "TTTATATATATATATTTATATATATATATTTA"}, {"id": "92345182", "sequence": "TATATATATTTATATATATATTTATATATATA"}, {"id": "92345165", "sequence": "ATATATATATATTTATATATATTTATATATTA"}, {"id": "92345177", "sequence": "TTTATATATATATTTATATATATATATTATAT"}, {"id": "92345171", "sequence": "TTATATATATATTTATATATATATTTATATAT"}, {"id": "92345161", "sequence": "ATATATTTATATATTTTTATATATTATATATT"}, {"id": "92345183", "sequence": "TTTATATATATTTATATATATATTTATATATA"}, {"id": "92345181", "sequence": "ATATATTATATATATATTTATATATATATTTA"}, {"id": "92345178", "sequence": "ATATATTTATATATATATTTATATATATATTT"}, {"id": "92345166", "sequence": "TTTATATATATTTATATATATATTTATATATA"}, {"id": "92345179", "sequence": "ATATATATATTTATATATATATTTATATATAT"}, {"id": "92345173", "sequence": "ATATTTATATATATATATTTATATATATATTT"}, {"id": "92345184", "sequence": "TATTTATATATATATTTATATATATTTATATA"}, {"id": "92345169", "sequence": "TTTATATATATATTTATATATATATTTATATA"}, {"id": "92345185", "sequence": "TATATTTATATATATATATATATATTTATATA"}, {"id": "92345160", "sequence": "ATTTATATATATATTTATATATATATTTATAT"}, {"id": "92345174", "sequence": "ATATATATATTTATATATATATTATTTATATA"}, {"id": "92345162", "sequence": "TATATATATATTTATATATTATATATATATTT"}, {"id": "92345175", "sequence": "TATATTTATATATATATTATATATATATTTAT"}, {"id": "92345168", "sequence": "TATATATATTTATATATATATTTATATATATA"}, {"id": "92345163", "sequence": "ATATATTTATATATATATTTATATATATTTAT"}, {"id": "92345172", "sequence": "ATATATATATATTTATATATATATTTATATAT"}, {"id": "92345180", "sequence": "ATTTATATATATATTTATATATATATTTATAT"}, {"id": "92345176", "sequence": "ATATATATATTATATATATATTTATATATATA"}, {"id": "92345170", "sequence": "TATATTTATATATATATATTATATATATATAT"}, {"id": "92345164", "sequence": "ATATATATTTATATATATTTATATATATATTT"}, {"id": "92345186", "sequence": "TATATTTATATATATTTATATATATATTTATA"}]})";
+    
+    Graph source;
+    json2pb(source, graph_json.c_str(), graph_json.size());
+    
+    VG graph;
+    graph.extend(source);
+    
+    Alignment aln;
+    aln.set_sequence("CAGCACTTTGGGAGGCCAAGGTGGGTGGATCATCTGAGGTCAGGAGTTTGAGACCAGCCTGACCAACATGGTGAAATCCTGTCTCTACTGAAAATACTAAAATTAGCCAGGCGTGGCGGCCAGTGCCTGTAATCCCGGCTACTGGGGAGG");
+    
+    TestAligner aligner_source;
+    aligner_source.set_alignment_scores(1, 4, 6, 1, 10);
+    const Aligner& aligner = *aligner_source.get_regular_aligner();
+    
+    aligner.align_xdrop(aln, graph, vector<MaximalExactMatch>(), false);
+}
    
 }
 }

--- a/src/xdrop_aligner.cpp
+++ b/src/xdrop_aligner.cpp
@@ -20,6 +20,10 @@ enum { MISMATCH = 1, MATCH = 2, INS = 3, DEL = 4 };
 #define DZ_CIGAR_OP 0x04030201
 #endif
 
+// To turn on debugging:
+//#define DEBUG
+//#define DZ_PRINT_VECTOR
+
 #include <dozeu/dozeu.h>
 
 using namespace vg;


### PR DESCRIPTION
The seeding heuristic in dozeu is really quite rudimentary. It looks for an alignment of the first 15 bases of the read starting anywhere in the graph, or of any subsequence of the first 15 bases at the start of a source node. In some cases this fails to find any positive scoring alignment, which previously would cause a crash. I've modified the alignment algorithm so that it can detect when the seeding fails and fall back on GSSW.

@jltsiren I haven't implemented this code path in a particularly optimized way, but I think it's understandable enough if you want to work on it.