### PR TITLE
Add a MEM finding heuristic to mpmap

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -270,12 +270,7 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
                                                      bool record_max_lcp,
                                                      int reseed_below) {
 #ifdef debug_mapper
-    cerr << "find_mems: sequence ";
-    for (auto iter = seq_begin; iter != seq_end; iter++) {
-        cerr << *iter;
-    }
-    cerr << ", max mem length " << max_mem_length << ", min mem length " <<
-    min_mem_length << ", reseed length " << reseed_length << endl;
+    cerr << "find_mems: sequence " << string(seq_begin, seq_end) << ", max mem length " << max_mem_length << ", min mem length " << min_mem_length << ", reseed length " << reseed_length << endl;
 #endif
 
     if (!gcsa) {
@@ -284,7 +279,7 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
     }
     
     if (min_mem_length > reseed_length && reseed_length) {
-        cerr << "error:[vg::Mapper] minimimum reseed length for MEMs cannot be less than minimum MEM length" << endl;
+        cerr << "error:[vg::Mapper] minimum reseed length for MEMs cannot be less than minimum MEM length" << endl;
         exit(1);
     }
     vector<MaximalExactMatch> mems;
@@ -355,7 +350,7 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
                 } else {
                     gcsa->locate(match.range, locations);
                 }
-                cerr << "adding MEM " << match.sequence() << " at positions ";
+                cerr << "adding MEM " << match.sequence() << " after hitting N at positions ";
                 for (auto nt : locations) {
                     cerr << make_pos_t(nt) << " ";
                 }
@@ -431,7 +426,7 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
                     } else {
                         gcsa->locate(match.range, locations);
                     }
-                    cerr << "adding MEM " << match.sequence() << " at positions ";
+                    cerr << "adding MEM " << match.sequence() << " after hitting an empty extension at positions ";
                     for (auto nt : locations) {
                         cerr << make_pos_t(nt) << " ";
                     }
@@ -507,6 +502,8 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
     if (mem_length >= min_mem_length) {
         if (record_max_lcp) max_lcp = (int)lcp->parent(match.range).lcp();
         mems.push_back(match);
+        mems.back().match_count = gcsa->count(mems.back().range);
+        mems.back().primary = true;
         lcp_maxima.push_back(max_lcp);
 #ifdef debug_mapper
         vector<gcsa::node_type> locations;
@@ -515,7 +512,7 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
         } else {
             gcsa->locate(match.range, locations);
         }
-        cerr << "adding MEM " << match.sequence() << " at positions ";
+        cerr << "adding MEM " << match.sequence() << " after hitting beginning of read at positions ";
         for (auto nt : locations) {
             cerr << make_pos_t(nt) << " ";
         }

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -414,7 +414,6 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
             else {
                 match.begin = cursor + 1;
                 match.range = last_range;
-                mem_length = match.end - match.begin;
                 
                 // record the last MEM, but check to make sure were not actually still searching
                 // for the end of the next MEM

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -270,15 +270,12 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
                                                      bool record_max_lcp,
                                                      int reseed_below) {
 #ifdef debug_mapper
-#pragma omp critical
-    {
-        cerr << "find_mems: sequence ";
-        for (auto iter = seq_begin; iter != seq_end; iter++) {
-            cerr << *iter;
-        }
-        cerr << ", max mem length " << max_mem_length << ", min mem length " <<
-        min_mem_length << ", reseed length " << reseed_length << endl;
+    cerr << "find_mems: sequence ";
+    for (auto iter = seq_begin; iter != seq_end; iter++) {
+        cerr << *iter;
     }
+    cerr << ", max mem length " << max_mem_length << ", min mem length " <<
+    min_mem_length << ", reseed length " << reseed_length << endl;
 #endif
 
     if (!gcsa) {
@@ -346,23 +343,23 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
             if (mem_length >= min_mem_length) {
 
                 mems.push_back(match);
+                mems.back().match_count = gcsa->count(mems.back().range);
+                mems.back().primary = true;
+                
                 lcp_maxima.push_back(max_lcp);
                 
 #ifdef debug_mapper
-#pragma omp critical
-                {
-                    vector<gcsa::node_type> locations;
-                    if (hit_max) {
-                        gcsa->locate(match.range, hit_max, locations);
-                    } else {
-                        gcsa->locate(match.range, locations);
-                    }
-                    cerr << "adding MEM " << match.sequence() << " at positions ";
-                    for (auto nt : locations) {
-                        cerr << make_pos_t(nt) << " ";
-                    }
-                    cerr << endl;
+                vector<gcsa::node_type> locations;
+                if (hit_max) {
+                    gcsa->locate(match.range, hit_max, locations);
+                } else {
+                    gcsa->locate(match.range, locations);
                 }
+                cerr << "adding MEM " << match.sequence() << " at positions ";
+                for (auto nt : locations) {
+                    cerr << make_pos_t(nt) << " ";
+                }
+                cerr << endl;
 #endif
             }
             
@@ -401,6 +398,8 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
                 
                 if (match.end - match.begin >= min_mem_length) {
                     mems.push_back(match);
+                    mems.back().match_count = gcsa->count(mems.back().range);
+                    mems.back().primary = true;
                     lcp_maxima.push_back(max_lcp);
                 }
                 
@@ -416,32 +415,72 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
                 match.begin = cursor + 1;
                 match.range = last_range;
                 mem_length = match.end - match.begin;
+                
                 // record the last MEM, but check to make sure were not actually still searching
                 // for the end of the next MEM
-                if (mem_length >= min_mem_length && !prev_iter_jumped_lcp) {
+                bool add_mem = (match.length() >= min_mem_length && !prev_iter_jumped_lcp);
+                if (add_mem) {
                     mems.push_back(match);
+                    mems.back().match_count = gcsa->count(mems.back().range);
+                    mems.back().primary = true;
                     lcp_maxima.push_back(max_lcp);
                     
 #ifdef debug_mapper
-#pragma omp critical
-                    {
-                        vector<gcsa::node_type> locations;
-                        if (hit_max) {
-                            gcsa->locate(match.range, hit_max, locations);
-                        } else {
-                            gcsa->locate(match.range, locations);
-                        }
-                        cerr << "adding MEM " << match.sequence() << " at positions ";
-                        for (auto nt : locations) {
-                            cerr << make_pos_t(nt) << " ";
-                        }
-                        cerr << endl;
+                    vector<gcsa::node_type> locations;
+                    if (hit_max) {
+                        gcsa->locate(match.range, hit_max, locations);
+                    } else {
+                        gcsa->locate(match.range, locations);
                     }
+                    cerr << "adding MEM " << match.sequence() << " at positions ";
+                    for (auto nt : locations) {
+                        cerr << make_pos_t(nt) << " ";
+                    }
+                    cerr << endl;
 #endif
                 }
                 
-                // get the parent suffix tree node corresponding to the parent of the last MEM's STNode
-                gcsa::STNode parent = lcp->parent(last_range);
+                // init this outside of the if condition so that we can avoid calling the
+                // expensive LCP::parent function twice in the code path that checks max LCP
+                gcsa::STNode parent;
+                
+                if (add_mem && use_greedy_mem_restarts
+                    && match.length() >= greedy_restart_min_length
+                    && mems.back().match_count <= greedy_restart_max_count) {
+                    // the current match was relatively long and unique, so we think
+                    // that we can get away with moving past it rather than looking
+                    // for MEMs that overlap it on its left side
+                    bool do_greedy_restart = true;
+                    if (greedy_restart_max_lcp) {
+                        // we also want to check whether this MEM has a long LCP (which
+                        // would indicate that there is another match overlapping it)
+                        parent = lcp->parent(last_range);
+                        do_greedy_restart = (parent.lcp() <= greedy_restart_max_lcp);
+#ifdef debug_mapper
+                        cerr << "greedy restart aborted because of LCP of length " << parent.lcp() << endl;
+#endif
+                    }
+                    if (do_greedy_restart) {
+#ifdef debug_mapper
+                        cerr << "doing greedy restart for next search iteration" << endl;
+#endif
+                        
+                        // set up the search past the left end of the current MEM
+                        match.end = match.begin;
+                        cursor = match.end - 1;
+                        match.begin = cursor;
+                        match.range = gcsa::range_type(0, gcsa->size() - 1);
+                        // we don't worry that we might still be jumping through prefixes
+                        // of the current MEM because we've moved completely past it
+                        prev_iter_jumped_lcp = false;
+                        continue;
+                    }
+                }
+                else {
+                    // get the parent suffix tree node corresponding to the parent of the last MEM's STNode
+                    parent = lcp->parent(last_range);
+                }
+                
                 // set the MEM to be the longest prefix that is shared with another MEM
                 match.end = match.begin + parent.lcp();
                 // and set up the next MEM using the parent node range
@@ -471,37 +510,23 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
         mems.push_back(match);
         lcp_maxima.push_back(max_lcp);
 #ifdef debug_mapper
-#pragma omp critical
-        {
-            vector<gcsa::node_type> locations;
-            if (hit_max) {
-                gcsa->locate(match.range, hit_max, locations);
-            } else {
-                gcsa->locate(match.range, locations);
-            }
-            cerr << "adding MEM " << match.sequence() << " at positions ";
-            for (auto nt : locations) {
-                cerr << make_pos_t(nt) << " ";
-            }
-            cerr << endl;
+        vector<gcsa::node_type> locations;
+        if (hit_max) {
+            gcsa->locate(match.range, hit_max, locations);
+        } else {
+            gcsa->locate(match.range, locations);
         }
+        cerr << "adding MEM " << match.sequence() << " at positions ";
+        for (auto nt : locations) {
+            cerr << make_pos_t(nt) << " ";
+        }
+        cerr << endl;
 #endif
     }
 
     if (record_max_lcp) longest_lcp = lcp_maxima.empty() ? 0 : *max_element(lcp_maxima.begin(), lcp_maxima.end());
 
     assert(!record_max_lcp || lcp_maxima.size() == mems.size());
-
-    // fill the MEMs' node lists and indicate they are primary MEMs
-    for (MaximalExactMatch& mem : mems) {
-        // invalid mem
-        if (mem.begin < seq_begin || mem.end > seq_end) continue;
-        mem.match_count = gcsa->count(mem.range);
-        mem.primary = true;
-        // keep track of the initial number of hits we query in case the nodes vector is
-        // modified later (e.g. by prefiltering)
-        mem.queried_count = mem.nodes.size();
-    }
     
     // the graph of containment relationships between MEMs by index, also keeps track of what the sub-MEM min
     // length the children should be
@@ -538,6 +563,7 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
                 int min_sub_mem_length = sub_mem_containment_graph[i].first;
                 
                 // should we look for sub-MEMs from this MEM?
+                // TODO: are the parentheses correct on the LCP heuristic
                 if (mem.length() >= min_mem_length &&
                     mem.length() > min_sub_mem_length &&
                     (use_lcp_reseed_heuristic && record_max_lcp
@@ -615,14 +641,11 @@ vector<MaximalExactMatch> BaseMapper::find_mems_deep(string::const_iterator seq_
             total_mems += mem.nodes.size();
         }
 #ifdef debug_mapper
-#pragma omp critical
-        {
-            cerr << "MEM " << mem.sequence() << " has " << mem.match_count << " hits: ";
-            for (auto nt : mem.nodes) {
-                cerr << make_pos_t(nt) << ", ";
-            }
-            cerr << endl;
+        cerr << "MEM " << mem.sequence() << " has " << mem.match_count << " hits: ";
+        for (auto nt : mem.nodes) {
+            cerr << make_pos_t(nt) << ", ";
         }
+        cerr << endl;
 #endif
     }
     
@@ -672,14 +695,11 @@ void BaseMapper::find_sub_mems(const vector<MaximalExactMatch>& mems,
     const MaximalExactMatch& mem = mems[mem_idx];
     
 #ifdef debug_mapper
-#pragma omp critical
-    {
-        cerr << "find_sub_mems: sequence ";
-        for (auto iter = mem.begin; iter != mem.end; iter++) {
-            cerr << *iter;
-        }
-        cerr << ", min mem length " << min_sub_mem_length << endl;
+    cerr << "find_sub_mems: sequence ";
+    for (auto iter = mem.begin; iter != mem.end; iter++) {
+        cerr << *iter;
     }
+    cerr << ", min mem length " << min_sub_mem_length << endl;
 #endif
     
     // how many times does the parent MEM occur in the index?
@@ -717,25 +737,21 @@ void BaseMapper::find_sub_mems(const vector<MaximalExactMatch>& mems,
                 sub_mems_out.emplace_back(MaximalExactMatch(sub_mem_begin, sub_mem_end, last_range),
                                           vector<size_t>(1, mem_idx));
 #ifdef debug_mapper
-#pragma omp critical
-                {
-                    vector<gcsa::node_type> locations;
-                    if (hit_max) {
-                        gcsa->locate(last_range, hit_max, locations);
-                    } else {
-                        gcsa->locate(last_range, locations);
-                    }
-                    cerr << "adding sub-MEM ";
-                    for (auto iter = sub_mem_begin; iter != sub_mem_end; iter++) {
-                        cerr << *iter;
-                    }
-                    cerr << " at positions ";
-                    for (auto nt : locations) {
-                        cerr << make_pos_t(nt) << " ";
-                    }
-                    cerr << endl;
-                    
+                vector<gcsa::node_type> locations;
+                if (hit_max) {
+                    gcsa->locate(last_range, hit_max, locations);
+                } else {
+                    gcsa->locate(last_range, locations);
                 }
+                cerr << "adding sub-MEM ";
+                for (auto iter = sub_mem_begin; iter != sub_mem_end; iter++) {
+                    cerr << *iter;
+                }
+                cerr << " at positions ";
+                for (auto nt : locations) {
+                    cerr << make_pos_t(nt) << " ";
+                }
+                cerr << endl;
 #endif
                 // identify all previous MEMs that also contain this sub-MEM
                 for (int64_t i = mem_idx - 1; i >= parent_layer_begin; --i) {
@@ -751,14 +767,11 @@ void BaseMapper::find_sub_mems(const vector<MaximalExactMatch>& mems,
             }
 #ifdef debug_mapper
             else {
-#pragma omp critical
-                {
-                    cerr << "minimally more frequent MEM is too short ";
-                    for (auto iter = sub_mem_begin; iter != sub_mem_end; iter++) {
-                        cerr << *iter;
-                    }
-                    cerr << endl;
+                cerr << "minimally more frequent MEM is too short ";
+                for (auto iter = sub_mem_begin; iter != sub_mem_end; iter++) {
+                    cerr << *iter;
                 }
+                cerr << endl;
             }
 #endif
             
@@ -782,28 +795,22 @@ void BaseMapper::find_sub_mems(const vector<MaximalExactMatch>& mems,
         sub_mems_out.emplace_back(MaximalExactMatch(mem.begin, sub_mem_end, range),
                                   vector<size_t>(1, mem_idx));
 #ifdef debug_mapper
-#pragma omp critical
-        {
-            cerr << "adding sub-MEM ";
-            for (auto iter = mem.begin; iter != sub_mem_end; iter++) {
-                cerr << *iter;
-            }
-            cerr << endl;
+        cerr << "adding sub-MEM ";
+        for (auto iter = mem.begin; iter != sub_mem_end; iter++) {
+            cerr << *iter;
         }
+        cerr << endl;
 #endif
         // note: this sub MEM is at the far left side of the parent MEM, so we don't need to
         // check whether earlier MEMs contain it as well
     }
 #ifdef debug_mapper
     else {
-#pragma omp critical
-        {
-            cerr << "minimally more frequent MEM is too short ";
-            for (auto iter = mem.begin; iter != sub_mem_end; iter++) {
-                cerr << *iter;
-            }
-            cerr << endl;
+        cerr << "minimally more frequent MEM is too short ";
+        for (auto iter = mem.begin; iter != sub_mem_end; iter++) {
+            cerr << *iter;
         }
+        cerr << endl;
     }
 #endif
     
@@ -835,7 +842,6 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                                     vector<pair<MaximalExactMatch, vector<size_t>>>& sub_mems_out) {
     
 #ifdef debug_mapper
-#pragma omp critical
     cerr << "find_sub_mems_fast: mem ";
     for (auto iter = mems[mem_idx].begin; iter != mems[mem_idx].end; iter++) {
         cerr << *iter;
@@ -862,7 +868,6 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
         string::const_iterator probe_string_begin = probe_string_end - min_sub_mem_length;
         
 #ifdef debug_mapper
-#pragma omp critical
         cerr << "probe string is mem[" << probe_string_begin - mems[mem_idx].begin << ":" << probe_string_end - mems[mem_idx].begin << "] ";
         for (auto iter = probe_string_begin; iter != probe_string_end; iter++) {
             cerr << *iter;
@@ -930,25 +935,28 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
             // it here, the binary search is guaranteed to LF along the full sub-MEM in some iteration)
             gcsa::range_type sub_mem_range = range;
             
+            // we'll keep track of the count of this sub-MEM during this loop and also remember it
+            // for later
+            size_t sub_mem_count = 0;
+            
             // iterate until inteveral contains only one index
             while (right_search_bound > left_search_bound) {
                 
                 string::const_iterator middle = left_search_bound + (right_search_bound - left_search_bound + 1) / 2;
                 
 #ifdef debug_mapper
-#pragma omp critical
-                {
-                    cerr << "checking extension mem[" << probe_string_begin - mems[mem_idx].begin << ":" << middle - mems[mem_idx].begin << "] ";
-                    for (auto iter = probe_string_begin; iter != middle; iter++) {
-                        cerr << *iter;
-                    }
-                    cerr << endl;
+                cerr << "checking extension mem[" << probe_string_begin - mems[mem_idx].begin << ":" << middle - mems[mem_idx].begin << "] ";
+                for (auto iter = probe_string_begin; iter != middle; iter++) {
+                    cerr << *iter;
                 }
+                cerr << endl;
 #endif
                 
                 // set up LF searching
                 cursor = middle - 1;
                 range = gcsa::range_type(0, gcsa->size() - 1);
+                
+                size_t extension_mem_count = 0;
                 
                 // check if there is an independent occurrence of this substring outside of the SMEM
                 bool contained_in_independent_match = true;
@@ -960,8 +968,11 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                     // burn in parameter
                     int64_t relative_idx = middle - cursor - 1;
                     if (cursor == probe_string_begin ||
-                        (relative_idx >= sub_mem_thinning_burn_in && (relative_idx - sub_mem_thinning_burn_in) % sub_mem_count_thinning == 0)) {
-                        if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
+                        (relative_idx >= sub_mem_thinning_burn_in
+                         && (relative_idx - sub_mem_thinning_burn_in) % sub_mem_count_thinning == 0)) {
+                        
+                        extension_mem_count = use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range);
+                        if (extension_mem_count <= parent_range_count) {
                             // this probe is too long and it no longer is contained in the indendent hit
                             // that we detected
                             contained_in_independent_match = false;
@@ -979,6 +990,9 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                     
                     // update the range of matches (this is the longest match we've verified so far)
                     sub_mem_range = range;
+                    
+                    // this current count is the count of the longest match we've verified so far
+                    sub_mem_count = extension_mem_count;
                 }
                 else {
                     // the end of the sub-MEM must be to the left
@@ -998,9 +1012,6 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                 cerr << "current: " << MaximalExactMatch(probe_string_begin, right_search_bound, sub_mem_range).sequence() << endl;
 #endif
                 
-                // the count of the current sub-MEM
-                size_t current_count = use_approx_sub_mem_count ? gcsa::Range::length(sub_mem_range) : gcsa->count(sub_mem_range);
-                
                 // get the GCSA range of the current sub-MEM extended one base past the end of the current parent MEM
                 cursor = right_search_bound;
                 range = gcsa::range_type(0, gcsa->size() - 1);
@@ -1012,7 +1023,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                     if (cursor == probe_string_begin ||
                         (relative_idx >= sub_mem_thinning_burn_in && (relative_idx - sub_mem_thinning_burn_in) % sub_mem_count_thinning == 0)) {
                         extended_count = use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range);
-                        if (extended_count < current_count) {
+                        if (extended_count < sub_mem_count) {
                             // the count of the full lengthened sub-MEM will be fewer than the one we just found
                             break;
                         }
@@ -1022,18 +1033,17 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                 }
                 
 #ifdef debug_mapper
-                cerr << "lengthened sub-MEM has count " << extended_count << ", compared to current count " << current_count << endl;
+                cerr << "lengthened sub-MEM has count " << extended_count << ", compared to current count " << sub_mem_count << endl;
 #endif
                 
                 // since the current sub-MEM is contained in the lengthened one, the lengthened sub-MEM can only have the same number
                 // of hits or fewer. if it has the same number then the current sub-MEM is artificially truncated
-                not_redundant = (extended_count < current_count);
+                not_redundant = (extended_count < sub_mem_count);
                 
             }
             
             if (not_redundant) {
 #ifdef debug_mapper
-#pragma omp critical
                 cerr << "final sub-MEM is mem[" << probe_string_begin - mems[mem_idx].begin << ":" << right_search_bound - mems[mem_idx].begin << "] ";
                 for (auto iter = probe_string_begin; iter != right_search_bound; iter++) {
                     cerr << *iter;
@@ -1044,6 +1054,11 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                 // record the sub-MEM
                 sub_mems_out.emplace_back(MaximalExactMatch(probe_string_begin, right_search_bound, sub_mem_range),
                                           vector<size_t>(1, mem_idx));
+                // annotate the sub-MEM
+                // note: the count will not be accurate if we were using the approximate algorithm,
+                // but we will handle that at the end of the function
+                sub_mems_out.back().first.match_count = sub_mem_count;
+                sub_mems_out.back().first.primary = false;
                 
                 // identify all previous MEMs that also contain this sub-MEM
                 for (int64_t i = mem_idx - 1; i >= parent_layer_begin; --i) {
@@ -1086,13 +1101,15 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
         }
     }
     
-    // annotate the MEMs
-    for (pair<MaximalExactMatch, vector<size_t>>& sub_mem_and_parents : sub_mems_out) {
-        // count in entire range, including parents
-        sub_mem_and_parents.first.match_count = gcsa->count(sub_mem_and_parents.first.range);
-        // mark this is a sub-MEM
-        sub_mem_and_parents.first.primary = false;
+    if (use_approx_sub_mem_count) {
+        // we didn't compute the exact count when looking for the sub-MEMs so now
+        // we have to
+        for (pair<MaximalExactMatch, vector<size_t>>& sub_mem_and_parents : sub_mems_out) {
+            // count in entire range, including parents
+            sub_mem_and_parents.first.match_count = gcsa->count(sub_mem_and_parents.first.range);
+        }
     }
+    
     
     // fast algorithm produces sub-MEMs left-to-right, switch the order so that they remain right-to-left
     // within the layer (as this algorithm expects in recursive calls)

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -221,8 +221,7 @@ public:
     // These are SMEMs by definition when shorter than the max_mem_length or GCSA2 order.
     // Designating reseed_length returns minimally-more-frequent sub-MEMs in addition to SMEMs when SMEM is >= reseed_length.
     // Minimally-more-frequent sub-MEMs are MEMs contained in an SMEM that have occurrences outside of the SMEM.
-    // SMEMs and sub-MEMs will be automatically filled with the nodes they contain, which the occurrences of the sub-MEMs
-    // that are inside SMEM hits filtered out. (filling sub-MEMs currently requires an PathPositionHandleGraph index)
+    // SMEMs and sub-MEMs will be automatically filled with the nodes they contain
     
     vector<MaximalExactMatch>
     find_mems_deep(string::const_iterator seq_begin,
@@ -282,6 +281,10 @@ public:
     bool use_approx_sub_mem_count = false;
     bool prefilter_redundant_hits = true;
     int max_sub_mem_recursion_depth = 2;
+    bool use_greedy_mem_restarts = false;
+    int greedy_restart_min_length = 40;
+    int greedy_restart_max_count = 2;
+    int greedy_restart_max_lcp = 0; // 0 for no max
     int unpaired_penalty = 17;
     bool precollapse_order_length_hits = true;
     double avg_node_length = 0;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -10,19 +10,10 @@
 //#define debug_report_startup_training
 //#define debug_pretty_print_alignments
 
-// note: only activated for single end mapping
-//#define debug_instrument_mem_statitics
-
 #include "multipath_mapper.hpp"
 
 // include this here to avoid a circular dependency
 #include "multipath_alignment_graph.hpp"
-
-
-#ifdef debug_instrument_mem_statitics
-fstream _mem_stats("_mem_statistics.tsv");
-bool _wrote_mem_stats_header = false;
-#endif
 
 namespace vg {
     
@@ -176,7 +167,7 @@ namespace vg {
         }
 #endif
         
-#ifdef debug_instrument_mem_statitics
+#ifdef mpmap_instrument_mem_statitics
         size_t num_mems = mems.size();
         size_t min_mem_length = numeric_limits<size_t>::max();
         size_t max_mem_length = 0;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -197,10 +197,10 @@ namespace vg {
 #pragma omp critical
         {
             if (!_wrote_mem_stats_header) {
-                _mem_stats << "name\tnum_mems\tmin_mem_length\tmax_mem_length\tavg_mem_length\tavg_mem_overlap\tnum_clusters\twinning_cluster_num_mems\twinning_cluster_min_mem_length\twinning_cluster_max_mem_length\twinning_cluster_total_bases" << endl;
+                _mem_stats << "name\tread_len\tnum_mems\tmin_mem_length\tmax_mem_length\tavg_mem_length\tavg_mem_overlap\tnum_clusters\twinning_cluster_num_mems\twinning_cluster_min_mem_length\twinning_cluster_max_mem_length\twinning_cluster_total_bases" << endl;
                 _wrote_mem_stats_header = true;
             }
-            _mem_stats << alignment.name() << "\t" << num_mems << "\t" << min_mem_length << "\t" << max_mem_length << "\t" << avg_mem_length << "\t" << avg_mem_overlap << "\t" << num_clusters << "\t" << winning_cluster_num_mems << "\t" << winning_cluster_min_mem_length << "\t" << winning_cluster_max_mem_length << "\t" << winning_cluster_total_bases << endl;
+            _mem_stats << alignment.name() << "\t" << alignment.sequence().size() << "\t" << num_mems << "\t" << min_mem_length << "\t" << max_mem_length << "\t" << avg_mem_length << "\t" << avg_mem_overlap << "\t" << num_clusters << "\t" << winning_cluster_num_mems << "\t" << winning_cluster_min_mem_length << "\t" << winning_cluster_max_mem_length << "\t" << winning_cluster_total_bases << endl;
         }
 #endif
     }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -199,7 +199,7 @@ namespace vg {
             order.push_back(i);
         }
         sort(order.begin(), order.end(), [&](size_t i, size_t j) {
-            return clusters[cluster_idxs.front()][i].first->begin < clusters[cluster_idxs.front()][i].first->begin;
+            return clusters[cluster_idxs.front()][i].first->begin < clusters[cluster_idxs.front()][j].first->begin;
         });
         
         size_t winning_cluster_tail_bases = ((clusters[cluster_idxs.front()][order.front()].first->begin - alignment.sequence().begin())
@@ -217,13 +217,27 @@ namespace vg {
             winning_cluster_avg_intermem_gap /= order.size() - 1;
         }
         
+        int64_t max_non_winning_mem_length = 0;
+        for (size_t i = 0; i < mems.size(); ++i) {
+            bool found = false;
+            for (const auto hit : clusters[cluster_idxs.front()]) {
+                if (hit.first == &mems[i]) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                max_non_winning_mem_length = max<int64_t>(max_non_winning_mem_length, mems[i].length());
+            }
+        }
+        
 #pragma omp critical
         {
             if (!_wrote_mem_stats_header) {
-                _mem_stats << "name\tread_len\tnum_mems\tmin_mem_length\tmax_mem_length\tavg_mem_length\tavg_mem_overlap\tnum_clusters\twinning_cluster_num_mems\twinning_cluster_min_mem_length\twinning_cluster_max_mem_length\twinning_cluster_total_bases\twinning_cluster_tail_bases\twinning_cluster_avg_intermem_gap" << endl;
+                _mem_stats << "name\tread_len\tnum_mems\tmin_mem_length\tmax_mem_length\tavg_mem_length\tavg_mem_overlap\tnum_clusters\twinning_cluster_num_mems\twinning_cluster_min_mem_length\twinning_cluster_max_mem_length\twinning_cluster_total_bases\twinning_cluster_tail_bases\twinning_cluster_avg_intermem_gap\tmax_non_winning_mem_length" << endl;
                 _wrote_mem_stats_header = true;
             }
-            _mem_stats << alignment.name() << "\t" << alignment.sequence().size() << "\t" << num_mems << "\t" << min_mem_length << "\t" << max_mem_length << "\t" << avg_mem_length << "\t" << avg_mem_overlap << "\t" << num_clusters << "\t" << winning_cluster_num_mems << "\t" << winning_cluster_min_mem_length << "\t" << winning_cluster_max_mem_length << "\t" << winning_cluster_total_bases << "\t" << winning_cluster_tail_bases << "\t" << winning_cluster_avg_intermem_gap << endl;
+            _mem_stats << alignment.name() << "\t" << alignment.sequence().size() << "\t" << num_mems << "\t" << min_mem_length << "\t" << max_mem_length << "\t" << avg_mem_length << "\t" << avg_mem_overlap << "\t" << num_clusters << "\t" << winning_cluster_num_mems << "\t" << winning_cluster_min_mem_length << "\t" << winning_cluster_max_mem_length << "\t" << winning_cluster_total_bases << "\t" << winning_cluster_tail_bases << "\t" << winning_cluster_avg_intermem_gap << "\t" << max_non_winning_mem_length << endl;
         }
 #endif
     }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -194,13 +194,36 @@ namespace vg {
             winning_cluster_max_mem_length = max<size_t>(winning_cluster_max_mem_length, hit.first->length());
             winning_cluster_total_bases += hit.first->length();
         }
+        vector<size_t> order;
+        for (size_t i = 0; i < clusters[cluster_idxs.front()].size(); ++i) {
+            order.push_back(i);
+        }
+        sort(order.begin(), order.end(), [&](size_t i, size_t j) {
+            return clusters[cluster_idxs.front()][i].first->begin < clusters[cluster_idxs.front()][i].first->begin;
+        });
+        
+        size_t winning_cluster_tail_bases = ((clusters[cluster_idxs.front()][order.front()].first->begin - alignment.sequence().begin())
+                                             + (alignment.sequence().end() - clusters[cluster_idxs.front()][order.back()].first->end));
+        
+        double winning_cluster_avg_intermem_gap = 0.0;
+        if (clusters[cluster_idxs.front()].size() == 0) {
+            winning_cluster_avg_intermem_gap = numeric_limits<double>::quiet_NaN();
+        }
+        else {
+            for (size_t i = 1; i < order.size(); ++i) {
+                winning_cluster_avg_intermem_gap += (clusters[cluster_idxs.front()][order[i]].first->begin
+                                                     - clusters[cluster_idxs.front()][order[i - 1]].first->end);
+            }
+            winning_cluster_avg_intermem_gap /= order.size() - 1;
+        }
+        
 #pragma omp critical
         {
             if (!_wrote_mem_stats_header) {
-                _mem_stats << "name\tread_len\tnum_mems\tmin_mem_length\tmax_mem_length\tavg_mem_length\tavg_mem_overlap\tnum_clusters\twinning_cluster_num_mems\twinning_cluster_min_mem_length\twinning_cluster_max_mem_length\twinning_cluster_total_bases" << endl;
+                _mem_stats << "name\tread_len\tnum_mems\tmin_mem_length\tmax_mem_length\tavg_mem_length\tavg_mem_overlap\tnum_clusters\twinning_cluster_num_mems\twinning_cluster_min_mem_length\twinning_cluster_max_mem_length\twinning_cluster_total_bases\twinning_cluster_tail_bases\twinning_cluster_avg_intermem_gap" << endl;
                 _wrote_mem_stats_header = true;
             }
-            _mem_stats << alignment.name() << "\t" << alignment.sequence().size() << "\t" << num_mems << "\t" << min_mem_length << "\t" << max_mem_length << "\t" << avg_mem_length << "\t" << avg_mem_overlap << "\t" << num_clusters << "\t" << winning_cluster_num_mems << "\t" << winning_cluster_min_mem_length << "\t" << winning_cluster_max_mem_length << "\t" << winning_cluster_total_bases << endl;
+            _mem_stats << alignment.name() << "\t" << alignment.sequence().size() << "\t" << num_mems << "\t" << min_mem_length << "\t" << max_mem_length << "\t" << avg_mem_length << "\t" << avg_mem_overlap << "\t" << num_clusters << "\t" << winning_cluster_num_mems << "\t" << winning_cluster_min_mem_length << "\t" << winning_cluster_max_mem_length << "\t" << winning_cluster_total_bases << "\t" << winning_cluster_tail_bases << "\t" << winning_cluster_avg_intermem_gap << endl;
         }
 #endif
     }

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -46,11 +46,13 @@
 #include "algorithms/extend.hpp"
 #include "algorithms/jump_along_path.hpp"
 
-
 #include "bdsg/hash_graph.hpp"
 
 #include <structures/union_find.hpp>
 #include <gbwt/gbwt.h>
+
+// note: only activated for single end mapping
+//#define mpmap_instrument_mem_statitics
 
 using namespace std;
 using namespace haplo;
@@ -436,6 +438,12 @@ namespace vg {
         
         // a memo for transcendental band padidng function (gets initialized at construction)
         vector<size_t> band_padding_memo;
+        
+#ifdef mpmap_instrument_mem_statitics
+    public:
+        ofstream _mem_stats;
+        bool _wrote_mem_stats_header = false;
+#endif
     };
         
 }

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -142,7 +142,7 @@ int main_mpmap(int argc, char** argv) {
     #define OPT_SECONDARY_RESCUE_ATTEMPTS 1017
     #define OPT_SECONDARY_MAX_DIFF 1018
     #define OPT_NO_CLUSTER 1019
-    #define OPT_GREEDY_MEM_RESTARTS 1020
+    #define OPT_NO_GREEDY_MEM_RESTARTS 1020
     #define OPT_GREEDY_MEM_RESTART_MAX_LCP 1021
     string matrix_file_name;
     string graph_name;
@@ -189,10 +189,10 @@ int main_mpmap(int argc, char** argv) {
     int stripped_match_alg_max_length = 0; // no maximum yet
     int default_strip_count = 10;
     int stripped_match_alg_target_count = default_strip_count;
-    bool use_greedy_mem_restarts = false;
+    bool use_greedy_mem_restarts = true;
     int greedy_restart_min_length = 40;
     int greedy_restart_max_count = 2;
-    int greedy_restart_max_lcp = 0;
+    int greedy_restart_max_lcp = 30;
     int reseed_length = 28;
     int reseed_length_arg = numeric_limits<int>::min();
     double reseed_diff = 0.45;
@@ -313,7 +313,7 @@ int main_mpmap(int argc, char** argv) {
             {"stripped-match", no_argument, 0, 'F'},
             {"strip-length", no_argument, 0, OPT_STRIP_LENGTH},
             {"strip-count", no_argument, 0, OPT_STRIP_COUNT},
-            {"greedy-restart", no_argument, 0, OPT_GREEDY_MEM_RESTARTS},
+            {"no-greedy-restart", no_argument, 0, OPT_NO_GREEDY_MEM_RESTARTS},
             {"greedy-max-lcp", required_argument, 0, OPT_GREEDY_MEM_RESTART_MAX_LCP},
             {"hit-max", required_argument, 0, 'c'},
             {"hard-hit-mult", required_argument, 0, OPT_HARD_HIT_MAX_MULTIPLIER},
@@ -572,8 +572,8 @@ int main_mpmap(int argc, char** argv) {
                 stripped_match_alg_target_count = parse<int>(optarg);
                 break;
                 
-            case OPT_GREEDY_MEM_RESTARTS:
-                use_greedy_mem_restarts = true;
+            case OPT_NO_GREEDY_MEM_RESTARTS:
+                use_greedy_mem_restarts = false;
                 break;
                 
             case OPT_GREEDY_MEM_RESTART_MAX_LCP:

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -88,7 +88,7 @@ void help_mpmap(char** argv) {
     //<< "  -W, --reseed-diff FLOAT       require internal MEMs to have length within this much of the SMEM's length [0.45]" << endl
     //<< "  -K, --clust-length INT        minimum MEM length used in clustering [automatic]" << endl
     //<< "  -F, --stripped-match          use stripped match algorithm instead of MEMs" << endl
-    << "  -c, --hit-max INT             use at most this many hits for any match seeds (0 for no limit) [1024 DNA / 256 RNA]" << endl
+    << "  -c, --hit-max INT             use at most this many hits for any match seeds (0 for no limit) [1024 DNA / 100 RNA]" << endl
     //<< "  --approx-exp FLOAT            let the approximate likelihood miscalculate likelihood ratios by this power [10.0 DNA / 5.0 RNA]" << endl
     //<< "  --recombination-penalty FLOAT use this log recombination penalty for GBWT haplotype scoring [20.7]" << endl
     //<< "  --always-check-population     always try to population-score reads, even if there is only a single mapping" << endl

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -138,6 +138,8 @@ int main_mpmap(int argc, char** argv) {
     #define OPT_SECONDARY_RESCUE_ATTEMPTS 1017
     #define OPT_SECONDARY_MAX_DIFF 1018
     #define OPT_NO_CLUSTER 1019
+    #define OPT_GREEDY_MEM_RESTARTS 1020
+    #define OPT_GREEDY_MEM_RESTART_MAX_LCP 1021
     string matrix_file_name;
     string graph_name;
     string gcsa_name;
@@ -183,6 +185,10 @@ int main_mpmap(int argc, char** argv) {
     int stripped_match_alg_max_length = 0; // no maximum yet
     int default_strip_count = 10;
     int stripped_match_alg_target_count = default_strip_count;
+    bool use_greedy_mem_restarts = false;
+    int greedy_restart_min_length = 40;
+    int greedy_restart_max_count = 2;
+    int greedy_restart_max_lcp = 0;
     int reseed_length = 28;
     int reseed_length_arg = numeric_limits<int>::min();
     double reseed_diff = 0.45;
@@ -303,6 +309,8 @@ int main_mpmap(int argc, char** argv) {
             {"stripped-match", no_argument, 0, 'F'},
             {"strip-length", no_argument, 0, OPT_STRIP_LENGTH},
             {"strip-count", no_argument, 0, OPT_STRIP_COUNT},
+            {"greedy-restart", no_argument, 0, OPT_GREEDY_MEM_RESTARTS},
+            {"greedy-max-lcp", required_argument, 0, OPT_GREEDY_MEM_RESTART_MAX_LCP},
             {"hit-max", required_argument, 0, 'c'},
             {"hard-hit-mult", required_argument, 0, OPT_HARD_HIT_MAX_MULTIPLIER},
             {"approx-exp", required_argument, 0, OPT_APPROX_EXP},
@@ -558,6 +566,14 @@ int main_mpmap(int argc, char** argv) {
                 
             case OPT_STRIP_COUNT:
                 stripped_match_alg_target_count = parse<int>(optarg);
+                break;
+                
+            case OPT_GREEDY_MEM_RESTARTS:
+                use_greedy_mem_restarts = true;
+                break;
+                
+            case OPT_GREEDY_MEM_RESTART_MAX_LCP:
+                greedy_restart_max_lcp = parse<int>(optarg);
                 break;
                 
             case 'c':
@@ -1370,6 +1386,10 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.stripped_match_alg_strip_length = stripped_match_alg_strip_length;
     multipath_mapper.stripped_match_alg_max_length = stripped_match_alg_max_length;
     multipath_mapper.stripped_match_alg_target_count = stripped_match_alg_target_count;
+    multipath_mapper.use_greedy_mem_restarts = use_greedy_mem_restarts;
+    multipath_mapper.greedy_restart_min_length = greedy_restart_min_length;
+    multipath_mapper.greedy_restart_max_count = greedy_restart_max_count;
+    multipath_mapper.greedy_restart_max_lcp = greedy_restart_max_lcp;
     multipath_mapper.use_stripped_match_alg = use_stripped_match_alg;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -27,6 +27,10 @@
 #include <iostream>
 #endif
 
+#ifdef mpmap_instrument_mem_statitics
+#define MEM_STATS_FILE "_mem_statistics.tsv"
+#endif
+
 using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
@@ -1140,6 +1144,14 @@ int main_mpmap(int argc, char** argv) {
         exit(1);
     }
     
+    
+#ifdef mpmap_instrument_mem_statitics
+    if (auto_calibrate_mismapping_detection) {
+        cerr << "error:[vg mpmap] set calibration off when profiling MEM statistics" << endl;
+        exit(1);
+    }
+#endif
+    
     // create in-memory objects
     
     ifstream graph_stream(graph_name);
@@ -1455,6 +1467,10 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.dynamic_max_alt_alns = dynamic_max_alt_alns;
     multipath_mapper.simplify_topologies = simplify_topologies;
     multipath_mapper.max_suboptimal_path_score_ratio = suboptimal_path_exponent;
+
+#ifdef mpmap_instrument_mem_statitics
+    multipath_mapper._mem_stats.open(MEM_STATS_FILE);
+#endif
     
     // if directed to, auto calibrate the mismapping detection to the graph
     if (auto_calibrate_mismapping_detection) {
@@ -1463,6 +1479,7 @@ int main_mpmap(int argc, char** argv) {
         }
         multipath_mapper.calibrate_mismapping_detection(num_calibration_simulations, calibration_read_lengths);
     }
+    
     
     // Count our threads 
     int thread_count = get_thread_count();


### PR DESCRIPTION
Adds a heuristic to the MEM-finding algorithm in mpmap that can reduce the total number of MEMs (and thus also expensive calls to `GCSA::locate`) around base errors.