### PR TITLE
Fix propagation of convergence point in IntegratedSnarlFinder

### DIFF
--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -17,7 +17,7 @@
 
 namespace vg {
 
-#define debug
+//#define debug
 
 using namespace std;
 

--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -865,6 +865,9 @@ pair<vector<pair<size_t, vector<handle_t>>>, unordered_map<handle_t, handle_t>> 
 #ifdef debug
                                 cerr << "\t\t\t\tConverges at leaf" << endl;
 #endif
+
+                                // We need to start out with our leaf's bit of the path.
+                                path.push_back(record.longest_subtree_path_root);
                             }
                             
                             if (deepest_child_edge.count(record.longest_subtree_path_root)) {

--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -17,7 +17,7 @@
 
 namespace vg {
 
-//#define debug
+#define debug
 
 using namespace std;
 

--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -807,11 +807,13 @@ pair<vector<pair<size_t, vector<handle_t>>>, unordered_map<handle_t, handle_t>> 
                             parent_record.longest_subtree_path_length < record.longest_subtree_path_length) {
                             
 #ifdef debug
-                            cerr << "\t\tLongest path in our subtree is the new longest path in our parent's subtree." << endl;
+                            cerr << "\t\tLongest path in our subtree converging at "
+                                << graph->get_id(record.longest_subtree_path_root) << (graph->get_is_reverse(record.longest_subtree_path_root) ? "-" : "+")
+                                << " is the new longest path in our parent's subtree." << endl;
 #endif
                             
                             // No child has contributed their leaf-leaf path so far, or ours is better.
-                            parent_record.longest_subtree_path_root = frame_head;
+                            parent_record.longest_subtree_path_root = record.longest_subtree_path_root;
                             parent_record.longest_subtree_path_length = record.longest_subtree_path_length;
                         }
                     }
@@ -865,9 +867,6 @@ pair<vector<pair<size_t, vector<handle_t>>>, unordered_map<handle_t, handle_t>> 
 #ifdef debug
                                 cerr << "\t\t\t\tConverges at leaf" << endl;
 #endif
-
-                                // We need to start out with our leaf's bit of the path.
-                                path.push_back(record.longest_subtree_path_root);
                             }
                             
                             if (deepest_child_edge.count(record.longest_subtree_path_root)) {
@@ -876,7 +875,9 @@ pair<vector<pair<size_t, vector<handle_t>>>, unordered_map<handle_t, handle_t>> 
                                 cerr << "\t\t\t\tNonempty path to distinct other leaf" << endl;
 #endif
                             
-                                // There's a nonempty path to another leaf (and we aren't just a point).
+                                // There's a nonempty path to another leaf,
+                                // other than the furthest one (and we aren't
+                                // just a point).
                                 // Trace the actual longest path from root to leaf and add it on
                                 path.push_back(deepest_child_edge[record.longest_subtree_path_root]);
                                 auto path_trace_it = deepest_child_edge.find(find(path.back()));

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -374,6 +374,79 @@ TEST_CASE("IntegratedSnarlFinder works when cactus graph contains back-to-back c
     REQUIRE(sites.size() == 1);
 }
 
+TEST_CASE("IntegratedSnarlFinder works on an all bridge edge Y graph with specific numbering", "[genotype][integrated-snarl-finder]") {
+    
+    // Build a toy graph
+    const string graph_json = R"(
+    {
+      "node": [
+        {
+          "id": "2",
+          "sequence": "G"
+        },
+        {
+          "id": "3",
+          "sequence": "G"
+        },
+        {
+          "id": "4",
+          "sequence": "G"
+        },
+        {
+          "id": "5",
+          "sequence": "G"
+        },
+        {
+          "id": "6",
+          "sequence": "G"
+        },
+        {
+          "id": "11",
+          "sequence": "G"
+        }
+      ],
+      "edge": [
+        {
+          "from": "2",
+          "to": "3"
+        },
+        {
+          "from": "3",
+          "to": "6"
+        },
+        {
+          "from": "4",
+          "to": "5"
+        },
+        {
+          "from": "5",
+          "to": "6"
+        },
+        {
+          "from": "6",
+          "to": "11"
+        }
+      ]
+    }
+    )";
+
+    // Make an actual graph
+    VG graph;
+    Graph chunk;
+    json2pb(chunk, graph_json.c_str(), graph_json.size());
+    graph.merge(chunk);
+
+    // Make an IntegratedSnarlFinder
+    unique_ptr<SnarlFinder> finder(new IntegratedSnarlFinder(graph));
+
+    SnarlManager manager = finder->find_snarls();
+        
+    auto sites = manager.top_level_snarls();
+        
+    // There should just be 1 top snarl, with an internal adjacency component
+    REQUIRE(sites.size() == 1);
+}
+
 TEST_CASE("IntegratedSnarlFinder works when cactus graph contains longer back-to-back cycles along root path", "[genotype][integrated-snarl-finder]") {
     
     // Build a toy graph

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -378,56 +378,8 @@ TEST_CASE("IntegratedSnarlFinder works on an all bridge edge Y graph with specif
     
     // Build a toy graph
     const string graph_json = R"(
-    {
-      "node": [
-        {
-          "id": "2",
-          "sequence": "G"
-        },
-        {
-          "id": "3",
-          "sequence": "G"
-        },
-        {
-          "id": "4",
-          "sequence": "G"
-        },
-        {
-          "id": "5",
-          "sequence": "G"
-        },
-        {
-          "id": "6",
-          "sequence": "G"
-        },
-        {
-          "id": "11",
-          "sequence": "G"
-        }
-      ],
-      "edge": [
-        {
-          "from": "2",
-          "to": "3"
-        },
-        {
-          "from": "3",
-          "to": "6"
-        },
-        {
-          "from": "4",
-          "to": "5"
-        },
-        {
-          "from": "5",
-          "to": "6"
-        },
-        {
-          "from": "6",
-          "to": "11"
-        }
-      ]
-    }
+    {"node":[{"id":"2","sequence":"G"},{"id":"3","sequence":"G"},{"id":"4","sequence":"G"},{"id":"5","sequence":"G"},{"id":"6","sequence":"G"},{"id":"11","sequence":"G"}],
+    "edge":[{"from":"2","to":"3"},{"from":"3","to":"6"},{"from":"4","to":"5"},{"from":"5","to":"6"},{"from":"6","to":"11"}]}    
     )";
 
     // Make an actual graph
@@ -443,8 +395,30 @@ TEST_CASE("IntegratedSnarlFinder works on an all bridge edge Y graph with specif
         
     auto sites = manager.top_level_snarls();
         
-    // There should just be 1 top snarl, with an internal adjacency component
-    REQUIRE(sites.size() == 1);
+    // There should be 3 snarls in a chain, and 1 nested snarl
+    REQUIRE(sites.size() == 3);
+    REQUIRE(manager.num_snarls() == 4);
+    
+    // Top snarls should have the right bounds
+    REQUIRE(sites[0]->start().node_id() == 6);
+    REQUIRE(sites[0]->start().backward() == false);
+    REQUIRE(sites[0]->end().node_id() == 11);
+    REQUIRE(sites[0]->end().backward() == false);
+    // These are coming out backward vs chain order
+    REQUIRE(manager.chain_rank_of(sites[0]) == 2);
+    
+    REQUIRE(sites[1]->start().node_id() == 5);
+    REQUIRE(sites[1]->start().backward() == false);
+    REQUIRE(sites[1]->end().node_id() == 6);
+    REQUIRE(sites[1]->end().backward() == false);
+    REQUIRE(manager.chain_rank_of(sites[1]) == 1);
+    
+    REQUIRE(sites[2]->start().node_id() == 4);
+    REQUIRE(sites[2]->start().backward() == false);
+    REQUIRE(sites[2]->end().node_id() == 5);
+    REQUIRE(sites[2]->end().backward() == false);
+    REQUIRE(manager.chain_rank_of(sites[2]) == 0);
+    
 }
 
 TEST_CASE("IntegratedSnarlFinder works when cactus graph contains longer back-to-back cycles along root path", "[genotype][integrated-snarl-finder]") {


### PR DESCRIPTION
The `IntegratedSnarlFinder` was having some trouble getting the rooting path right in a lot of tree-shaped graphs. I fixed it to properly propagate its winning path information, and it now successfully finds snarls in `s3://vg-k8s/users/jsibbesen/vgrna/benchmark/whole_genome/data/graphs/gencode100_gene/1/gencode100_gene_1.pg` and `s3://vg-k8s/users/jsibbesen/vgrna/benchmark/whole_genome/data/graphs/gencode100_gene/gencode100_gene.xg`.