### PR TITLE
Fix underflow error in banded global aligner

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1277,7 +1277,7 @@ void Aligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
     g.for_each_handle([&](const handle_t& handle) {
         total_bases += g.get_length(handle);
     });
-    int64_t worst_score = max(alignment.sequence().size(), total_bases) * -max(max(mismatch, gap_open), gap_extension);
+    int64_t worst_score = (alignment.sequence().size() + total_bases) * -max(max(mismatch, gap_open), gap_extension);
     
     // TODO: put this all into another template somehow?
     
@@ -1318,7 +1318,6 @@ void Aligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     }
-
 }
 
 void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
@@ -1331,7 +1330,7 @@ void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>&
     g.for_each_handle([&](const handle_t& handle) {
         total_bases += g.get_length(handle);
     });
-    int64_t worst_score = max(alignment.sequence().size(), total_bases) * -max(max(mismatch, gap_open), gap_extension);
+    int64_t worst_score = (alignment.sequence().size() + total_bases) * -max(max(mismatch, gap_open), gap_extension);
     
     if (best_score <= numeric_limits<int8_t>::max() && worst_score >= numeric_limits<int8_t>::min()) {
         // We'll fit in int8
@@ -1845,27 +1844,111 @@ void QualAdjAligner::align_pinned_multi(Alignment& alignment, vector<Alignment>&
 void QualAdjAligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
                                          int32_t band_padding, bool permissive_banding) const {
     
-    BandedGlobalAligner<int16_t> band_graph = BandedGlobalAligner<int16_t>(alignment,
-                                                                           g,
-                                                                           band_padding,
-                                                                           permissive_banding,
-                                                                           true);
+    int64_t best_score = alignment.sequence().size() * match;
+    size_t total_bases = 0;
+    g.for_each_handle([&](const handle_t& handle) {
+        total_bases += g.get_length(handle);
+    });
+    int64_t worst_score = (alignment.sequence().size() + total_bases) * -max(max(mismatch, gap_open), gap_extension);
     
-    band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
+    // TODO: put this all into another template somehow?
+    
+    if (best_score <= numeric_limits<int8_t>::max() && worst_score >= numeric_limits<int8_t>::min()) {
+        // We'll fit in int8
+        BandedGlobalAligner<int8_t> band_graph(alignment,
+                                               g,
+                                               band_padding,
+                                               permissive_banding,
+                                               true);
+        
+        band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
+    } else if (best_score <= numeric_limits<int16_t>::max() && worst_score >= numeric_limits<int16_t>::min()) {
+        // We'll fit in int16
+        BandedGlobalAligner<int16_t> band_graph(alignment,
+                                                g,
+                                                band_padding,
+                                                permissive_banding,
+                                                true);
+        
+        band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
+    } else if (best_score <= numeric_limits<int32_t>::max() && worst_score >= numeric_limits<int32_t>::min()) {
+        // We'll fit in int32
+        BandedGlobalAligner<int32_t> band_graph(alignment,
+                                                g,
+                                                band_padding,
+                                                permissive_banding,
+                                                true);
+        
+        band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
+    } else {
+        // Fall back to int64
+        BandedGlobalAligner<int64_t> band_graph(alignment,
+                                                g,
+                                                band_padding,
+                                                permissive_banding,
+                                                true);
+        
+        band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
+    }
 }
 
 void QualAdjAligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
                                                int32_t max_alt_alns, int32_t band_padding, bool permissive_banding) const {
     
-    BandedGlobalAligner<int16_t> band_graph = BandedGlobalAligner<int16_t>(alignment,
-                                                                           g,
-                                                                           alt_alignments,
-                                                                           max_alt_alns,
-                                                                           band_padding,
-                                                                           permissive_banding,
-                                                                           true);
+    // We need to figure out what size ints we need to use.
+    // Get upper and lower bounds on the scores. TODO: if these overflow int64 we're out of luck
+    int64_t best_score = alignment.sequence().size() * match;
+    size_t total_bases = 0;
+    g.for_each_handle([&](const handle_t& handle) {
+        total_bases += g.get_length(handle);
+    });
+    int64_t worst_score = (alignment.sequence().size() + total_bases) * -max(max(mismatch, gap_open), gap_extension);
     
-    band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
+    if (best_score <= numeric_limits<int8_t>::max() && worst_score >= numeric_limits<int8_t>::min()) {
+        // We'll fit in int8
+        BandedGlobalAligner<int8_t> band_graph(alignment,
+                                               g,
+                                               alt_alignments,
+                                               max_alt_alns,
+                                               band_padding,
+                                               permissive_banding,
+                                               true);
+        
+        band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
+    } else if (best_score <= numeric_limits<int16_t>::max() && worst_score >= numeric_limits<int16_t>::min()) {
+        // We'll fit in int16
+        BandedGlobalAligner<int16_t> band_graph(alignment,
+                                                g,
+                                                alt_alignments,
+                                                max_alt_alns,
+                                                band_padding,
+                                                permissive_banding,
+                                                true);
+        
+        band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
+    } else if (best_score <= numeric_limits<int32_t>::max() && worst_score >= numeric_limits<int32_t>::min()) {
+        // We'll fit in int32
+        BandedGlobalAligner<int32_t> band_graph(alignment,
+                                                g,
+                                                alt_alignments,
+                                                max_alt_alns,
+                                                band_padding,
+                                                permissive_banding,
+                                                true);
+        
+        band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
+    } else {
+        // Fall back to int64
+        BandedGlobalAligner<int64_t> band_graph(alignment,
+                                                g,
+                                                alt_alignments,
+                                                max_alt_alns,
+                                                band_padding,
+                                                permissive_banding,
+                                                true);
+        
+        band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
+    }
 }
 
 void QualAdjAligner::align_xdrop(Alignment& alignment, const HandleGraph& g, const vector<MaximalExactMatch>& mems,

--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -8,11 +8,11 @@
 #include "banded_global_aligner.hpp"
 #include "json2pb.h"
 
-//#define debug_banded_aligner_objects
-//#define debug_banded_aligner_graph_processing
-//#define debug_banded_aligner_fill_matrix
-//#define debug_banded_aligner_traceback
-//#define debug_banded_aligner_print_matrices
+#define debug_banded_aligner_objects
+#define debug_banded_aligner_graph_processing
+#define debug_banded_aligner_fill_matrix
+#define debug_banded_aligner_traceback
+#define debug_banded_aligner_print_matrices
 
 namespace vg {
 
@@ -224,12 +224,7 @@ BandedGlobalAligner<IntType>::BAMatrix::BAMatrix(Alignment& alignment, handle_t 
 template <class IntType>
 BandedGlobalAligner<IntType>::BAMatrix::~BAMatrix() {
 #ifdef debug_banded_aligner_objects
-    if (node != nullptr) {
-        cerr << "[BAMatrix::~BAMatrix] destructing matrix for node " << as_integer(node) << endl;
-    }
-    else {
-        cerr << "[BAMatrix::~BAMatrix] destructing null matrix" << endl;
-    }
+    cerr << "[BAMatrix::~BAMatrix] destructing matrix for handle " << handlegraph::as_integer(node) << endl;
 #endif
     free(match);
     free(insert_row);

--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -8,11 +8,11 @@
 #include "banded_global_aligner.hpp"
 #include "json2pb.h"
 
-#define debug_banded_aligner_objects
-#define debug_banded_aligner_graph_processing
-#define debug_banded_aligner_fill_matrix
-#define debug_banded_aligner_traceback
-#define debug_banded_aligner_print_matrices
+//#define debug_banded_aligner_objects
+//#define debug_banded_aligner_graph_processing
+//#define debug_banded_aligner_fill_matrix
+//#define debug_banded_aligner_traceback
+//#define debug_banded_aligner_print_matrices
 
 namespace vg {
 
@@ -483,7 +483,7 @@ void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(const HandleGraph& grap
     if (treat_as_source && ncols > 0) {
         if (cumulative_seq_len != 0) {
             cerr << "error:[BandedGlobalAligner] banded alignment has no node predecessor for node in middle of path" << endl;
-            assert(0);
+            exit(0);
         }
         
 #ifdef debug_banded_aligner_fill_matrix
@@ -2289,7 +2289,6 @@ BandedGlobalAligner<IntType>::AltTracebackStack::AltTracebackStack(const HandleG
                 // get the coordinates of the bottom right corner
                 const handle_t& node = band_matrix->node;
                 int64_t node_id = graph.get_id(node);
-                
                 int64_t read_length = band_matrix->alignment.sequence().length();
                 int64_t ncols = graph.get_length(node);
                 

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1560,6 +1560,9 @@ namespace vg {
         to.set_name(from.name());
         to.set_sample_name(from.sample_name());
         to.set_paired_read_name(from.paired_read_name());
+        if (from.has_annotation()) {
+            *to.mutable_annotation() = from.annotation();
+        }
     }
     
     void transfer_read_metadata(const Alignment& from, MultipathAlignment& to) {
@@ -1576,6 +1579,10 @@ namespace vg {
         else if (from.has_fragment_next()) {
             to.set_paired_read_name(from.fragment_next().name());
         }
+        
+        if (from.has_annotation()) {
+            *to.mutable_annotation() = from.annotation();
+        }
     }
     
     void transfer_read_metadata(const MultipathAlignment& from, Alignment& to) {
@@ -1587,6 +1594,10 @@ namespace vg {
         
         // note: not transferring paired_read_name because it is unclear whether
         // it should go into fragment_prev or fragment_next
+        
+        if (from.has_annotation()) {
+            *to.mutable_annotation() = from.annotation();
+        }
     }
 
     void transfer_read_metadata(const Alignment& from, Alignment& to) {
@@ -1600,6 +1611,9 @@ namespace vg {
         }
         if (from.has_fragment_next()) {
             *to.mutable_fragment_next() = from.fragment_next();
+        }
+        if (from.has_annotation()) {
+            *to.mutable_annotation() = from.annotation();
         }
     }
     

--- a/src/unittest/banded_global_aligner.cpp
+++ b/src/unittest/banded_global_aligner.cpp
@@ -3505,7 +3505,7 @@ namespace vg {
             }
         }
     
-        TEST_CASE( "Banded global aligner doesn't crash on a hard example",
+        TEST_CASE( "Banded global aligner doesn't crash when the worst possible score is just on the edge of needing a larger int size",
                   "[alignment][banded][mapping]" ) {
             
             bdsg::HashGraph graph;
@@ -3533,6 +3533,7 @@ namespace vg {
             aln.set_sequence(sequence);
             
             TestAligner aligner_source;
+            aligner_source.set_alignment_scores(1, 1, 1, 1, 0);
             const Aligner& aligner = *aligner_source.get_regular_aligner();
             
             aligner.align_global_banded(aln, graph, 2, true);


### PR DESCRIPTION
The previous code that we used to select the size integers to use in the BandedGlobalAligner didn't use correct bounds on the score, which could rarely lead to underflow errors.