### PR TITLE
Giraffe rescue improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ test/*/*.lcp
 test/**/*.index/
 trash
 src/*.gch
+.vscode
 # Ignore a bunch of files people might dump in the root when testing
 /*.vg
 /*.gcsa

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1397,6 +1397,8 @@ void Aligner::align_xdrop(Alignment& alignment, const HandleGraph& g, const vect
     if (!alignment.has_path() && mems.empty()) {
         // dozeu couldn't find an alignment, probably because it's seeding heuristic failed
         // we'll just fall back on GSSW
+        // TODO: This is a bit inconsistent. GSSW gives a full-length bonus at both ends, while
+        // dozeu only gives it once.
         align(alignment, g, order);
     }
 }
@@ -1886,6 +1888,8 @@ void QualAdjAligner::align_xdrop(Alignment& alignment, const HandleGraph& g, con
     if (!alignment.has_path() && mems.empty()) {
         // dozeu couldn't find an alignment, probably because it's seeding heuristic failed
         // we'll just fall back on GSSW
+        // TODO: This is a bit inconsistent. GSSW gives a full-length bonus at both ends, while
+        // dozeu only gives it once.
         align(alignment, g, true);
     }
 }

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1397,8 +1397,6 @@ void Aligner::align_xdrop(Alignment& alignment, const HandleGraph& g, const vect
     if (!alignment.has_path() && mems.empty()) {
         // dozeu couldn't find an alignment, probably because it's seeding heuristic failed
         // we'll just fall back on GSSW
-        // TODO: This is a bit inconsistent. GSSW gives a full-length bonus at both ends, while
-        // dozeu only gives it once.
         align(alignment, g, order);
     }
 }
@@ -1888,8 +1886,6 @@ void QualAdjAligner::align_xdrop(Alignment& alignment, const HandleGraph& g, con
     if (!alignment.has_path() && mems.empty()) {
         // dozeu couldn't find an alignment, probably because it's seeding heuristic failed
         // we'll just fall back on GSSW
-        // TODO: This is a bit inconsistent. GSSW gives a full-length bonus at both ends, while
-        // dozeu only gives it once.
         align(alignment, g, true);
     }
 }

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2153,23 +2153,9 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         bdsg::HashGraph align_graph;
         this->extender.unfold_haplotypes(sub_graph, haplotype_paths, align_graph);
 
-        // TODO: The second read is flipped, so the high-quality bases are at the end.
-        // It would be better to align backward, but we don't have the functionality at
-        // the moment.
-        if (rescue_forward) {
-            reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
-        }
-
         // Align to the subgraph.
         this->get_regular_aligner()->align_xdrop(rescued_alignment, align_graph,
                                                  std::vector<MaximalExactMatch>(), false);
-
-        // TODO: And now we have to flip again.
-        if (rescue_forward) {
-            reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
-                return align_graph.get_length(align_graph.get_handle(node_id));
-            });
-        }
 
         // TODO: dozeu only gives the full-length bonus once, so we have to rescore
         // the alignment at the moment.
@@ -2182,20 +2168,8 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         std::vector<handle_t> topological_order = gbwtgraph::topological_order(cached_graph, rescue_nodes);
         if (!topological_order.empty()) {
             if (this->rescue_algorithm == rescue_dozeu) {
-                // TODO: The second read is flipped, so the high-quality bases are at the end.
-                // It would be better to align backward, but we don't have the functionality at
-                // the moment.
-                if (rescue_forward) {
-                    reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
-                }
                 get_regular_aligner()->align_xdrop(rescued_alignment, cached_graph, topological_order,
                                                    std::vector<MaximalExactMatch>(), false);
-                // TODO: And now we have to flip again.
-                if (rescue_forward) {
-                    reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
-                        return cached_graph.get_length(cached_graph.get_handle(node_id));
-                    });
-                }
                 // TODO: dozeu only gives the full-length bonus once, so we have to rescore
                 // the alignment at the moment.
                 rescued_alignment.set_score(this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment));
@@ -2219,20 +2193,8 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
 
             // Align to the subgraph.
             if (this->rescue_algorithm == rescue_dozeu) {
-                // TODO: The second read is flipped, so the high-quality bases are at the end.
-                // It would be better to align backward, but we don't have the functionality at
-                // the moment.
-                if (rescue_forward) {
-                    reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
-                }
                 get_regular_aligner()->align_xdrop(rescued_alignment, dagified,
                                                    std::vector<MaximalExactMatch>(), false);
-                // TODO: And now we have to flip again.
-                if (rescue_forward) {
-                    reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
-                        return dagified.get_length(dagified.get_handle(node_id));
-                    });
-                }
                 // TODO: dozeu only gives the full-length bonus once, so we have to rescore
                 // the alignment at the moment.
                 rescued_alignment.set_score(this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment));

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2153,9 +2153,27 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         bdsg::HashGraph align_graph;
         this->extender.unfold_haplotypes(sub_graph, haplotype_paths, align_graph);
 
+        // TODO: The second read is flipped, so the high-quality bases are at the end.
+        // It would be better to align backward, but we don't have the functionality at
+        // the moment.
+        if (rescue_forward) {
+            reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
+        }
+
         // Align to the subgraph.
         this->get_regular_aligner()->align_xdrop(rescued_alignment, align_graph,
                                                  std::vector<MaximalExactMatch>(), false);
+
+        // TODO: And now we have to flip again.
+        if (rescue_forward) {
+            reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
+                return align_graph.get_length(align_graph.get_handle(node_id));
+            });
+        }
+
+        // TODO: dozeu only gives the full-length bonus once, so we have to rescore
+        // the alignment for the moment.
+        this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
 
         // Get the corresponding alignment to the original graph.
         this->extender.transform_alignment(rescued_alignment, haplotype_paths);
@@ -2164,8 +2182,23 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         std::vector<handle_t> topological_order = gbwtgraph::topological_order(cached_graph, rescue_nodes);
         if (!topological_order.empty()) {
             if (this->rescue_algorithm == rescue_dozeu) {
+                // TODO: The second read is flipped, so the high-quality bases are at the end.
+                // It would be better to align backward, but we don't have the functionality at
+                // the moment.
+                if (rescue_forward) {
+                    reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
+                }
                 get_regular_aligner()->align_xdrop(rescued_alignment, cached_graph, topological_order,
                                                    std::vector<MaximalExactMatch>(), false);
+                // TODO: And now we have to flip again.
+                if (rescue_forward) {
+                    reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
+                        return cached_graph.get_length(cached_graph.get_handle(node_id));
+                    });
+                }
+                // TODO: dozeu only gives the full-length bonus once, so we have to rescore
+                // the alignment for the moment.
+                this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
             } else {
                 get_regular_aligner()->align(rescued_alignment, cached_graph, topological_order);
             }
@@ -2186,8 +2219,23 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
 
             // Align to the subgraph.
             if (this->rescue_algorithm == rescue_dozeu) {
+                // TODO: The second read is flipped, so the high-quality bases are at the end.
+                // It would be better to align backward, but we don't have the functionality at
+                // the moment.
+                if (rescue_forward) {
+                    reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
+                }
                 get_regular_aligner()->align_xdrop(rescued_alignment, dagified,
                                                    std::vector<MaximalExactMatch>(), false);
+                // TODO: And now we have to flip again.
+                if (rescue_forward) {
+                    reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
+                        return dagified.get_length(dagified.get_handle(node_id));
+                    });
+                }
+                // TODO: dozeu only gives the full-length bonus once, so we have to rescore
+                // the alignment for the moment.
+                this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
             } else {
                 get_regular_aligner()->align(rescued_alignment, dagified, true);
             }

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2153,27 +2153,9 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         bdsg::HashGraph align_graph;
         this->extender.unfold_haplotypes(sub_graph, haplotype_paths, align_graph);
 
-        // TODO: The second read is flipped, so the high-quality bases are at the end.
-        // It would be better to align backward, but we don't have the functionality at
-        // the moment.
-        if (rescue_forward) {
-            reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
-        }
-
         // Align to the subgraph.
         this->get_regular_aligner()->align_xdrop(rescued_alignment, align_graph,
                                                  std::vector<MaximalExactMatch>(), false);
-
-        // TODO: And now we have to flip again.
-        if (rescue_forward) {
-            reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
-                return align_graph.get_length(align_graph.get_handle(node_id));
-            });
-        }
-
-        // TODO: dozeu only gives the full-length bonus once, so we have to rescore
-        // the alignment at the moment.
-        this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
 
         // Get the corresponding alignment to the original graph.
         this->extender.transform_alignment(rescued_alignment, haplotype_paths);
@@ -2182,23 +2164,8 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         std::vector<handle_t> topological_order = gbwtgraph::topological_order(cached_graph, rescue_nodes);
         if (!topological_order.empty()) {
             if (this->rescue_algorithm == rescue_dozeu) {
-                // TODO: The second read is flipped, so the high-quality bases are at the end.
-                // It would be better to align backward, but we don't have the functionality at
-                // the moment.
-                if (rescue_forward) {
-                    reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
-                }
                 get_regular_aligner()->align_xdrop(rescued_alignment, cached_graph, topological_order,
                                                    std::vector<MaximalExactMatch>(), false);
-                // TODO: And now we have to flip again.
-                if (rescue_forward) {
-                    reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
-                        return cached_graph.get_length(cached_graph.get_handle(node_id));
-                    });
-                }
-                // TODO: dozeu only gives the full-length bonus once, so we have to rescore
-                // the alignment at the moment.
-                this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
             } else {
                 get_regular_aligner()->align(rescued_alignment, cached_graph, topological_order);
             }
@@ -2219,23 +2186,8 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
 
             // Align to the subgraph.
             if (this->rescue_algorithm == rescue_dozeu) {
-                // TODO: The second read is flipped, so the high-quality bases are at the end.
-                // It would be better to align backward, but we don't have the functionality at
-                // the moment.
-                if (rescue_forward) {
-                    reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
-                }
                 get_regular_aligner()->align_xdrop(rescued_alignment, dagified,
                                                    std::vector<MaximalExactMatch>(), false);
-                // TODO: And now we have to flip again.
-                if (rescue_forward) {
-                    reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
-                        return dagified.get_length(dagified.get_handle(node_id));
-                    });
-                }
-                // TODO: dozeu only gives the full-length bonus once, so we have to rescore
-                // the alignment at the moment.
-                this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
             } else {
                 get_regular_aligner()->align(rescued_alignment, dagified, true);
             }

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2172,7 +2172,7 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         }
 
         // TODO: dozeu only gives the full-length bonus once, so we have to rescore
-        // the alignment for the moment.
+        // the alignment at the moment.
         this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
 
         // Get the corresponding alignment to the original graph.
@@ -2197,7 +2197,7 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
                     });
                 }
                 // TODO: dozeu only gives the full-length bonus once, so we have to rescore
-                // the alignment for the moment.
+                // the alignment at the moment.
                 this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
             } else {
                 get_regular_aligner()->align(rescued_alignment, cached_graph, topological_order);
@@ -2234,7 +2234,7 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
                     });
                 }
                 // TODO: dozeu only gives the full-length bonus once, so we have to rescore
-                // the alignment for the moment.
+                // the alignment at the moment.
                 this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
             } else {
                 get_regular_aligner()->align(rescued_alignment, dagified, true);

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2153,9 +2153,27 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         bdsg::HashGraph align_graph;
         this->extender.unfold_haplotypes(sub_graph, haplotype_paths, align_graph);
 
+        // TODO: The second read is flipped, so the high-quality bases are at the end.
+        // It would be better to align backward, but we don't have the functionality at
+        // the moment.
+        if (rescue_forward) {
+            reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
+        }
+
         // Align to the subgraph.
         this->get_regular_aligner()->align_xdrop(rescued_alignment, align_graph,
                                                  std::vector<MaximalExactMatch>(), false);
+
+        // TODO: And now we have to flip again.
+        if (rescue_forward) {
+            reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
+                return align_graph.get_length(align_graph.get_handle(node_id));
+            });
+        }
+
+        // TODO: dozeu only gives the full-length bonus once, so we have to rescore
+        // the alignment at the moment.
+        this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
 
         // Get the corresponding alignment to the original graph.
         this->extender.transform_alignment(rescued_alignment, haplotype_paths);
@@ -2164,8 +2182,23 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         std::vector<handle_t> topological_order = gbwtgraph::topological_order(cached_graph, rescue_nodes);
         if (!topological_order.empty()) {
             if (this->rescue_algorithm == rescue_dozeu) {
+                // TODO: The second read is flipped, so the high-quality bases are at the end.
+                // It would be better to align backward, but we don't have the functionality at
+                // the moment.
+                if (rescue_forward) {
+                    reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
+                }
                 get_regular_aligner()->align_xdrop(rescued_alignment, cached_graph, topological_order,
                                                    std::vector<MaximalExactMatch>(), false);
+                // TODO: And now we have to flip again.
+                if (rescue_forward) {
+                    reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
+                        return cached_graph.get_length(cached_graph.get_handle(node_id));
+                    });
+                }
+                // TODO: dozeu only gives the full-length bonus once, so we have to rescore
+                // the alignment at the moment.
+                this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
             } else {
                 get_regular_aligner()->align(rescued_alignment, cached_graph, topological_order);
             }
@@ -2186,8 +2219,23 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
 
             // Align to the subgraph.
             if (this->rescue_algorithm == rescue_dozeu) {
+                // TODO: The second read is flipped, so the high-quality bases are at the end.
+                // It would be better to align backward, but we don't have the functionality at
+                // the moment.
+                if (rescue_forward) {
+                    reverse_complement_in_place(*(rescued_alignment.mutable_sequence()));
+                }
                 get_regular_aligner()->align_xdrop(rescued_alignment, dagified,
                                                    std::vector<MaximalExactMatch>(), false);
+                // TODO: And now we have to flip again.
+                if (rescue_forward) {
+                    reverse_complement_alignment_in_place(&rescued_alignment, [&](id_t node_id) -> int64_t {
+                        return dagified.get_length(dagified.get_handle(node_id));
+                    });
+                }
+                // TODO: dozeu only gives the full-length bonus once, so we have to rescore
+                // the alignment at the moment.
+                this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
             } else {
                 get_regular_aligner()->align(rescued_alignment, dagified, true);
             }

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2173,7 +2173,7 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
 
         // TODO: dozeu only gives the full-length bonus once, so we have to rescore
         // the alignment at the moment.
-        this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
+        rescued_alignment.set_score(this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment));
 
         // Get the corresponding alignment to the original graph.
         this->extender.transform_alignment(rescued_alignment, haplotype_paths);
@@ -2198,7 +2198,7 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
                 }
                 // TODO: dozeu only gives the full-length bonus once, so we have to rescore
                 // the alignment at the moment.
-                this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
+                rescued_alignment.set_score(this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment));
             } else {
                 get_regular_aligner()->align(rescued_alignment, cached_graph, topological_order);
             }
@@ -2235,7 +2235,7 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
                 }
                 // TODO: dozeu only gives the full-length bonus once, so we have to rescore
                 // the alignment at the moment.
-                this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment);
+                rescued_alignment.set_score(this->get_regular_aligner()->score_ungapped_alignment(rescued_alignment));
             } else {
                 get_regular_aligner()->align(rescued_alignment, dagified, true);
             }

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -161,6 +161,17 @@ public:
    void attempt_rescue(const Alignment& aligned_read, Alignment& rescued_alignment, bool rescue_forward);
 
     /**
+     * When we use dozeu for rescue, the reported alignment score is incorrect.
+     * 1) Dozeu only gives the full-length bonus once.
+     * 2) There is no penalty for a softclip at the edge of the subgraph.
+     * This function calculates the score correctly. If the score is incorrect,
+     * we realign the read using GSSW.
+     * TODO: This should be unnecessary.
+     */
+    void fix_dozeu_score(Alignment& rescued_alignment, const HandleGraph& rescue_graph,
+                         const std::vector<handle_t>& topological_order) const;
+
+    /**
      * Get the distance between a pair of read alignments
      */
     int64_t distance_between(const Alignment& aln1, const Alignment& aln2);


### PR DESCRIPTION
When we use dozeu for rescue in Giraffe, it does not score the alignment the way we would like:

* dozeu only applies the full-length bonus once.
* Softclips are not penalized at the start/end of the subgraph.

To fix this, we rescore the alignment after dozeu. If the resulting score is negative, we realign the read with GSSW. This increases the accuracy a bit with a negligible effect on speed.