### PR TITLE
use parallel snarl finder in deconstruct

### DIFF
--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -145,7 +145,7 @@ int main_deconstruct(int argc, char** argv){
         if (show_progress) {
             cerr << "Finding snarls" << endl;
         }
-        snarl_manager = unique_ptr<SnarlManager>(new SnarlManager(std::move(finder.find_snarls())));
+        snarl_manager = unique_ptr<SnarlManager>(new SnarlManager(std::move(finder.find_snarls_parallel())));
     }
 
     // We use this to map, for example, from chromosome to genome (eg S288C.chrXVI --> S288C)


### PR DESCRIPTION
Resolves #2790.  Why `find_snarls()` crashes but not `find_snarls_parallel()` is another question, but perhaps moot as we replace everything with the integreated snarl finder (#2785)