### PR TITLE
Compact tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ test-job:
   # Run in parallel, setting CI_NODE_INDEX and CI_NODE_TOTAL
   # We will find our share of tests from vgci/test-list.txt and run them
   # We ought to run one job per test, but we can wrap around.
-  parallel: 16 
+  parallel: 6 
   script:
     - docker pull "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"
     - docker tag "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" vgci-docker-vg-local

--- a/vgci/test-list.txt
+++ b/vgci/test-list.txt
@@ -1,16 +1,6 @@
-vgci/vgci.py::VGCITest::test_call_chr21_snp1kg
-vgci/vgci.py::VGCITest::test_full_brca2_cactus
-vgci/vgci.py::VGCITest::test_full_brca2_primary
-vgci/vgci.py::VGCITest::test_full_brca2_snp1kg
-vgci/vgci.py::VGCITest::test_map_brca1_cactus
-vgci/vgci.py::VGCITest::test_map_brca1_primary
-vgci/vgci.py::VGCITest::test_map_brca1_snp1kg
-vgci/vgci.py::VGCITest::test_map_brca1_snp1kg_mpmap
-vgci/vgci.py::VGCITest::test_map_mhc_primary
-vgci/vgci.py::VGCITest::test_map_mhc_snp1kg
 vgci/vgci.py::VGCITest::test_sim_chr21_snp1kg
+vgci/vgci.py::VGCITest::test_full_brca2_cactus vgci/vgci.py::VGCITest::test_full_brca2_primary vgci/vgci.py::VGCITest::test_full_brca2_snp1kg vgci/vgci.py::VGCITest::test_map_brca1_cactus vgci/vgci.py::VGCITest::test_map_brca1_primary vgci/vgci.py::VGCITest::test_map_brca1_snp1kg vgci/vgci.py::VGCITest::test_map_brca1_snp1kg_mpmap vgci/vgci.py::VGCITest::test_map_mhc_primary vgci/vgci.py::VGCITest::test_map_mhc_snp1kg vgci/vgci.py::VGCITest::test_sim_mhc_cactus
+vgci/vgci.py::VGCITest::test_sim_mhc_snp1kg vgci/vgci.py::VGCITest::test_sim_mhc_snp1kg_mpmap
+vgci/vgci.py::VGCITest::test_call_chr21_snp1kg
 vgci/vgci.py::VGCITest::test_sim_chr21_snp1kg_trained
-vgci/vgci.py::VGCITest::test_sim_mhc_cactus
-vgci/vgci.py::VGCITest::test_sim_mhc_snp1kg
-vgci/vgci.py::VGCITest::test_sim_mhc_snp1kg_mpmap
 vgci/vgci.py::VGCITest::test_sim_yeast_cactus

--- a/vgci/vgci.sh
+++ b/vgci/vgci.sh
@@ -38,6 +38,7 @@ TOIL_PACKAGE="toil[aws,mesos]==3.20.0"
 # What tests should we run?
 # Should be something like "vgci/vgci.py::VGCITest::test_sim_brca2_snp1kg_mpmap"
 # Must have the Python file in it or Pytest can't find the tests.
+# May contain multiple space-separated test specifiers.
 PYTEST_TEST_SPEC="vgci/vgci.py"
 # What scratch directory should we use to run the tests?
 # If unset we use vgci_work and don't persist it.
@@ -71,7 +72,7 @@ usage() {
     printf "\t-i\t\tKeep intermediate on-disk output from tests. \n"
     printf "\t-s\t\tShow test output and error streams (pass -s to pytest). \n"
     printf "\t-p PACKAGE\tUse the given Python package specifier to install toil-vg.\n"
-    printf "\t-t TESTSPEC\tUse the given PyTest test specifier to select tests to run, or 'None' for no tests.\n"
+    printf "\t-t TESTSPEC\tUse the given PyTest test specifier(s), space-separated, to select tests to run, or 'None' for no tests.\n"
     printf "\t-w WORKDIR\tOutput test result data to the given absolute or ./ path (also used for scratch)\n"
     printf "\t-W WORKDIR\tLoad test result data from the given path instead of building or running tests\n"
     printf "\t-j FILE\tSave the JUnit test report XML to the given file (default: test-report.xml)\n"
@@ -409,7 +410,7 @@ then
     
     # run the tests, output the junit report 
     rm -f test-report.xml
-    pytest -vv "${PYTEST_TEST_SPEC}" --junitxml=test-report.xml ${SHOW_OPT}
+    pytest -vv ${PYTEST_TEST_SPEC} --junitxml=test-report.xml ${SHOW_OPT}
     TEST_FAIL="$?"
     
     if [ ! -z "${SAVE_JUNIT}" ]


### PR DESCRIPTION
This PR reworks the way we parallelize our Gitlab tests. Instead of running 16 Gitlab jobs, each with ~5 minutes of installing packages and pulling Docker containers while taking up 16 Kubernetes cores, I've set it up to run some of the shorter tests in serial in the same Gitlab job. We should still be bound by the longest test in terms of total runtime, but rather than racing to run all the shorter tests as soon as possible and wasting a bunch of setup time, we can run them one at a time in the time we have while we wait for the longest test to finish.

This should have us running only 6 parallel Gitlab jobs.