### PR TITLE
Add some randomized tests for the new snarls

### DIFF
--- a/src/min_distance.cpp
+++ b/src/min_distance.cpp
@@ -13,6 +13,8 @@
 using namespace std;
 namespace vg {
 
+//#define debugIndex
+
 /*TODO: Remove old distance index from vg index 
  * Also change how nodes are stored in chain - in case of loops/unary snarls -might not actually need this
  * Make snarls/chains represented by the node id in netgraph
@@ -129,11 +131,11 @@ MinimumDistanceIndex::MinimumDistanceIndex(const HandleGraph* graph,
         }
 
         handle_t handle = graph->get_handle(id, false);
-        if ( node_length(id-min_node_id)!=  graph->get_length(handle)){
+        if ( node_length(id)!=  graph->get_length(handle)){
             cerr << id << ": predicted " <<
-                   node_length(id-min_node_id)  << " actual " << graph->get_length(handle);
+                   node_length(id)  << " actual " << graph->get_length(handle);
         }
-        assert( node_length(id-min_node_id  ==  graph->get_length(handle));
+        assert( node_length(id)  ==  graph->get_length(handle) );
         return true;
                
     };

--- a/src/min_distance.hpp
+++ b/src/min_distance.hpp
@@ -457,6 +457,10 @@ class MinimumDistanceIndex {
     /// Get the index into chain_indexes/rank in chain of node i.
     /// Detects and throws an error if node i never got assigned to a snarl.
     size_t get_primary_assignment(id_t i) const {
+        if (i - min_node_id > primary_snarl_assignments.size()) {
+            throw runtime_error("Node " + std::to_string(i) + " not in any snarl. Distance index does " +
+                                "not match graph or was not generated from a snarl set including trivial snarls.");
+        }
         auto stored = primary_snarl_assignments[i - min_node_id];
         if (stored == 0) {
             // Somebody asked for a node. It should be assigned to a snarl, but it isn't.

--- a/src/unittest/random_graph.cpp
+++ b/src/unittest/random_graph.cpp
@@ -243,7 +243,10 @@ vector<vector<size_t>> random_adjacency_list(size_t node_count, size_t edge_coun
     
         // Record the edge in both directions
         to_return[a].push_back(b);
-        to_return[b].push_back(a);
+        if (a != b) {
+            // Unless it's a self loop
+            to_return[b].push_back(a);
+        }
     }
     
     return to_return;

--- a/src/unittest/random_graph.cpp
+++ b/src/unittest/random_graph.cpp
@@ -1,7 +1,13 @@
 #include "random_graph.hpp"
 
+#include <random>
+#include <time.h>
+
+
 namespace vg {
 namespace unittest {
+
+using namespace std;
 
 void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                   MutablePathMutableHandleGraph* graph) {
@@ -215,6 +221,35 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
         }
     }
 };
+
+vector<vector<size_t>> random_adjacency_list(size_t node_count, size_t edge_count) {
+
+    // Work out how to randomly pick a node
+    random_device seed_source;
+    default_random_engine generator(seed_source());
+    uniform_int_distribution<size_t> node_distribution(0, node_count - 1);
+    
+    vector<vector<size_t>> to_return(node_count);
+    
+    if (node_count == 0) {
+        // Can't have edges without nodes
+        return to_return;
+    }
+    
+    for (size_t i = 0; i < edge_count; i++) {
+        // Pick two nodes
+        size_t a = node_distribution(generator);
+        size_t b = node_distribution(generator);
+    
+        // Record the edge in both directions
+        to_return[a].push_back(b);
+        to_return[b].push_back(a);
+    }
+    
+    return to_return;
+    
+}
+    
 
 }
 }

--- a/src/unittest/random_graph.hpp
+++ b/src/unittest/random_graph.hpp
@@ -1,6 +1,5 @@
 #include "handle.hpp"
-#include <random>
-#include <time.h>
+#include <vector>
 
 namespace vg{
 namespace unittest{
@@ -10,6 +9,11 @@ namespace unittest{
 /// is the number of variations added to the graph
 void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                   MutablePathMutableHandleGraph* graph);
+                  
+              
+/// Create a random undirected graph over numbered nodes.
+/// Returns a list of adjacency lists for each node.
+std::vector<std::vector<size_t>> random_adjacency_list(size_t node_count, size_t edge_count);
 
 }
 }

--- a/src/unittest/three_edge_connected_components.cpp
+++ b/src/unittest/three_edge_connected_components.cpp
@@ -505,7 +505,6 @@ TEST_CASE("Tsin 2014 handles a graph with self loops and extra-edge triangles", 
     REQUIRE(components.all_groups().size() == 6);
 }
 
-#define debug
 TEST_CASE("Tsin 2014 works correctly on random graphs", "[3ecc][algorithms]") {
     
     for (size_t node_count = 2; node_count <= 20; node_count++) {


### PR DESCRIPTION
This uses the random graph system to find snarls and traverse net graphs on some random graphs. It does a bit of validation of the net graphs it sees.

I've also added random adjacency-list undirected graphs, and I'm using those to test the 3 edge connected component logic independently.