### PR TITLE
Use STL-based objects for MultipathAlignments

### DIFF
--- a/src/annotation.hpp
+++ b/src/annotation.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include <type_traits>
+#include <functional>
 
 #include <google/protobuf/struct.pb.h>
 

--- a/src/mcmc_genotyper.cpp
+++ b/src/mcmc_genotyper.cpp
@@ -17,7 +17,7 @@ namespace vg {
     
     }
 
-    unique_ptr<PhasedGenome> MCMCGenotyper::run_genotype(const vector<MultipathAlignment>& reads, const double log_base) const{
+    unique_ptr<PhasedGenome> MCMCGenotyper::run_genotype(const vector<multipath_alignment_t>& reads, const double log_base) const{
 
         // set a flag for invalid contents so a message it observed 
         bool invalid_contents = false;
@@ -113,14 +113,13 @@ namespace vg {
         }
 
     }   
-    double MCMCGenotyper::log_target(PhasedGenome& phased_genome, const vector<MultipathAlignment>& reads)const{
+    double MCMCGenotyper::log_target(PhasedGenome& phased_genome, const vector<multipath_alignment_t>& reads)const{
         
         // sum of scores given the reads aligned on the haplotype 
         int32_t sum_scores = 0; 
         
         // get scores for mp alignments 
-        for(MultipathAlignment mp : reads){
-            identify_start_subpaths(mp);
+        for(const multipath_alignment_t& mp : reads){
             sum_scores += phased_genome.optimal_score_on_genome(mp, graph);
             
         } 

--- a/src/mcmc_genotyper.hpp
+++ b/src/mcmc_genotyper.hpp
@@ -10,6 +10,7 @@
 #include <vg/vg.pb.h>
 #include <vector>
 #include "phased_genome.hpp"
+#include "multipath_alignment.hpp"
 
 
 namespace vg {
@@ -36,13 +37,13 @@ public:
      * MCMC to find two optimal paths through the graph.
      * Output: phased genome 
      */    
-    unique_ptr<PhasedGenome> run_genotype(const vector<MultipathAlignment>& reads, const double log_base) const;
+    unique_ptr<PhasedGenome> run_genotype(const vector<multipath_alignment_t>& reads, const double log_base) const;
     
     /**
      * Represents the poseterior distribution function 
      * returns the posterir probability
      */ 
-     double log_target(PhasedGenome& phased_genome, const vector<MultipathAlignment>& reads) const;  
+     double log_target(PhasedGenome& phased_genome, const vector<multipath_alignment_t>& reads) const;  
 
     /**
      * Generates a proposal sample over the desired distrubution

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1668,10 +1668,9 @@ namespace vg {
     }
     
     void merge_non_branching_subpaths(multipath_alignment_t& multipath_aln) {
-        
         vector<size_t> in_degree(multipath_aln.subpath_size(), 0);
         for (const subpath_t& subpath : multipath_aln.subpath()) {
-            for (int64_t next : subpath.next()) {
+            for (auto next : subpath.next()) {
                 in_degree[next]++;
             }
         }
@@ -1689,7 +1688,6 @@ namespace vg {
         };
         
         for (size_t i = 0; i < multipath_aln.subpath_size(); i++) {
-            
             if (i > 0) {
                 removed_so_far[i] = removed_so_far[i - 1];
             }
@@ -1738,16 +1736,14 @@ namespace vg {
                 if (first_position.node_id() == final_position.node_id() &&
                     first_position.is_reverse() == final_position.is_reverse() &&
                     first_position.offset() == final_position.offset() + mapping_from_length(*final_mapping)) {
-                    
                     // do we need to merge the abutting edits?
                     int64_t edit_idx = 0;
                     if (final_mapping->edit_size() && first_mapping.edit_size()) {
-                        edit_t* final_edit = final_mapping->mutable_edit(0);
+                        edit_t* final_edit = final_mapping->mutable_edit(final_mapping->edit_size() - 1);
                         const edit_t& first_edit = first_mapping.edit(0);
                         if ((first_edit.from_length() > 0) == (final_edit->from_length() > 0) &&
                             (first_edit.to_length() > 0) == (final_edit->to_length() > 0) &&
                             first_edit.sequence().empty() == final_edit->sequence().empty()) {
-                            
                             final_edit->set_from_length(final_edit->from_length() + first_edit.from_length());
                             final_edit->set_to_length(final_edit->to_length() + first_edit.to_length());
                             final_edit->set_sequence(final_edit->sequence() + first_edit.sequence());
@@ -2350,7 +2346,54 @@ namespace vg {
         
         out << "}" << endl;
     }
-        
+    
+    string debug_string(const subpath_t& subpath) {
+        string to_return = "{path: " + debug_string(subpath.path());
+        if (!subpath.next().empty()) {
+            to_return += ", next: [";
+            for (size_t i = 0; i < subpath.next_size(); ++i) {
+                if (i > 0) {
+                    to_return += ", ";
+                }
+                to_return += to_string(subpath.next(i));
+            }
+            to_return += "]";
+        }
+        to_return += ", score: " + to_string(subpath.score());
+        to_return += "}";
+        return to_return;
+    }
+
+    string debug_string(const multipath_alignment_t& multipath_aln) {
+        string to_return = "{name: " + multipath_aln.name() + ", seq: " + multipath_aln.sequence();
+        if (!multipath_aln.quality().empty()) {
+            to_return += ", qual: " + string_quality_short_to_char(multipath_aln.quality());
+        }
+        if (!multipath_aln.subpath().empty()) {
+            to_return += ", subpath: [";
+            for (size_t i = 0; i < multipath_aln.subpath_size(); ++i) {
+                if (i > 0) {
+                    to_return += ", ";
+                }
+                to_return += debug_string(multipath_aln.subpath(i));
+            }
+            to_return += "]";
+        }
+        to_return += ", mapq: " + to_string(multipath_aln.mapping_quality());
+        if (!multipath_aln.start().empty()) {
+            to_return += ", start: [";
+            for (size_t i = 0; i < multipath_aln.start_size(); ++i) {
+                if (i > 0) {
+                    to_return += ", ";
+                }
+                to_return += to_string(multipath_aln.start(i));
+            }
+            to_return += "]";
+        }
+        to_return += "}";
+        return to_return;
+    }
+
 }
 
 

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -68,7 +68,7 @@ namespace vg {
 
     void multipath_alignment_t::set_annotation(const string& annotation_name, const string& value) {
         clear_annotation(annotation_name);
-        auto ptr = (string*) malloc(sizeof(string));
+        auto ptr = new string();
         *ptr = value;
         _annotation[annotation_name] = make_pair(String, (void*) ptr);
     }

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -16,6 +16,7 @@ using namespace std;
 using namespace structures;
 
 namespace vg {
+
     
     void topologically_order_subpaths(MultipathAlignment& multipath_aln) {
         // Kahn's algorithm

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -111,6 +111,9 @@ namespace vg {
         string _paired_read_name;
         map<string, string> _annotation;
     };
+
+    string debug_string(const subpath_t& subpath);
+    string debug_string(const multipath_alignment_t& multipath_aln);
     
     /// Put subpaths in topological order (assumed to be true for other algorithms)
     void topologically_order_subpaths(multipath_alignment_t& multipath_aln);

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -24,6 +24,149 @@ namespace haplo {
 }
 
 namespace vg {
+
+    /*
+     * STL implementations of the protobuf object for use in in-memory operations
+     */
+    class edit_t {
+    public:
+        edit_t() = default;
+        edit_t(const edit_t&) = default;
+        edit_t(edit_t&&) = default;
+        ~edit_t() = default;
+        edit_t& operator=(const edit_t&) = default;
+        edit_t& operator=(edit_t&&) = default;
+        inline int32_t from_length() const;
+        inline void set_from_length(int32_t l);
+        inline int32_t to_length() const;
+        inline void set_to_length(int32_t l);
+        inline const string& sequence() const;
+        inline void set_sequence(const string& s);
+        inline string* mutable_string();
+    private:
+        int32_t _from_length;
+        int32_t _to_length;
+        string _sequence;
+    };
+
+    // the mapping_t name is already taken
+    class path_mapping_t {
+    public:
+        path_mapping_t() = default;
+        path_mapping_t(const path_mapping_t&) = default;
+        path_mapping_t(path_mapping_t&&) = default;
+        ~path_mapping_t() = default;
+        path_mapping_t& operator=(const path_mapping_t&) = default;
+        path_mapping_t& operator=(path_mapping_t&&) = default;
+        inline const pos_t& position() const;
+        inline pos_t* mutable_position();
+        inline const vector<edit_t>& edit() const;
+        inline const edit_t& edit(size_t i) const;
+        inline vector<edit_t>* mutable_edit();
+        inline edit_t* mutable_edit(size_t i);
+        inline edit_t* add_edit();
+        inline size_t edit_size();
+    private:
+        pos_t _position;
+        vector<edit_t> _edit;
+    };
+
+    class path_t {
+    public:
+        path_t() = default;
+        path_t(const path_t&) = default;
+        path_t(path_t&&) = default;
+        ~path_t() = default;
+        path_t& operator=(const path_t&) = default;
+        path_t& operator=(path_t&&) = default;
+        inline const vector<path_mapping_t>& mapping() const;
+        inline const path_mapping_t& mapping(size_t i) const;
+        inline vector<path_mapping_t>* mutable_mapping();
+        inline path_mapping_t* mutable_mapping(size_t i);
+        inline path_mapping_t* add_mapping();
+        inline size_t mapping_size();
+    private:
+        vector<path_mapping_t> _mapping;
+    };
+
+    class subpath_t {
+    public:
+        subpath_t() = default;
+        subpath_t(const subpath_t&) = default;
+        subpath_t(subpath_t&&) = default;
+        ~subpath_t() = default;
+        subpath_t& operator=(const subpath_t&) = default;
+        subpath_t& operator=(subpath_t&&) = default;
+        inline const path_t& path() const;
+        inline path_t* mutable_path();
+        inline const vector<uint32_t>& next() const;
+        inline uint32_t next(size_t i) const;
+        inline vector<uint32_t>* mutable_next();
+        inline void set_next(size_t i, uint32_t n);
+        inline void add_next(uint32_t n);
+        inline size_t next_size() const;
+        inline int32_t score() const;
+        inline void set_score(int32_t s);
+    private:
+        path_t _path;
+        vector<uint32_t> _next;
+        int32_t _score;
+    };
+
+    class multipath_alignment_t {
+    public:
+        multipath_alignment_t() = default;
+        multipath_alignment_t(const multipath_alignment_t&) = default;
+        multipath_alignment_t(multipath_alignment_t&&) = default;
+        ~multipath_alignment_t() = default;
+        multipath_alignment_t& operator=(const multipath_alignment_t&) = default;
+        multipath_alignment_t& operator=(multipath_alignment_t&&) = default;
+        inline const string& sequence() const;
+        inline string* mutable_sequence();
+        inline void set_sequence(const string& s);
+        inline const string& quality() const;
+        inline string* mutable_quality();
+        inline void set_quality(const string& q);
+        inline const string& name() const;
+        inline string* mutable_name();
+        inline void set_name(const string& n);
+        inline const string& sample_name() const;
+        inline string* mutable_sample_name();
+        inline void set_sample_name(const string& n);
+        inline const string& read_group() const;
+        inline string* mutable_read_group();
+        inline void set_read_group(const string& g);
+        inline const vector<subpath_t>& subpath() const;
+        inline const subpath_t& subpath(size_t i) const;
+        inline vector<subpath_t>* mutable_subpath();
+        inline subpath_t* mutable_subpath(size_t i);
+        inline subpath_t* add_subpath();
+        inline size_t subpath_size() const;
+        inline int32_t mapping_quality() const;
+        inline void set_mapping_quality(int32_t q);
+        inline const vector<uint32_t>& start() const;
+        inline uint32_t start(size_t i) const;
+        inline vector<uint32_t>* mutable_start();
+        inline void set_start(size_t i, uint32_t s);
+        inline void add_start(uint32_t s);
+        inline size_t start_size() const;
+        inline const string& paired_read_name() const;
+        inline string* mutable_paired_read_name();
+        inline void set_paired_read_name(const string& n);
+        // TODO: how to handle annotations?
+        
+    private:
+        string _sequence;
+        string _quality;
+        string _name;
+        string _sample_name;
+        string _read_group;
+        vector<subpath_t> _subpath;
+        int32_t _mapping_quality;
+        vector<uint32_t> _start;
+        string _paired_read_name;
+        map<string, string> _annotation;
+    };
     
     /// Put subpaths in topological order (assumed to be true for other algorithms)
     void topologically_order_subpaths(MultipathAlignment& multipath_aln);
@@ -210,6 +353,222 @@ namespace vg {
     void view_multipath_alignment_as_dot(ostream& out, const MultipathAlignment& multipath_aln, bool show_graph = false);
     
     // TODO: function for adding a graph augmentation to an existing multipath alignment
+
+    /*
+     * Implementations of inline methods
+     */
+
+    /*
+     * edit_t
+     */
+    inline int32_t edit_t::from_length() const {
+        return _from_length;
+    }
+    inline void edit_t::set_from_length(int32_t l) {
+        _from_length = l;
+    }
+    inline int32_t edit_t::to_length() const {
+        return _to_length;
+    }
+    inline void edit_t::set_to_length(int32_t l) {
+        _to_length = l;
+    }
+    inline const string& edit_t::sequence() const {
+        return _sequence;
+    }
+    inline void edit_t::set_sequence(const string& s) {
+        _sequence = s;
+    }
+    inline string* edit_t::mutable_string() {
+        return &_sequence;
+    }
+
+    /*
+     * path_mapping_t
+     */
+    inline const pos_t& path_mapping_t::position() const {
+        return _position;
+    }
+    inline pos_t* path_mapping_t::mutable_position() {
+        return &_position;
+    }
+    inline const vector<edit_t>& path_mapping_t::edit() const {
+        return _edit;
+    }
+    inline const edit_t& path_mapping_t::edit(size_t i) const {
+        return _edit[i];
+    }
+    inline vector<edit_t>* path_mapping_t::mutable_edit() {
+        return &_edit;
+    }
+    inline edit_t* path_mapping_t::add_edit() {
+        _edit.emplace_back();
+        return &_edit.back();
+    }
+    inline edit_t* path_mapping_t::mutable_edit(size_t i) {
+        return &_edit[i];
+    }
+    inline size_t path_mapping_t::edit_size() {
+        return _edit.size();
+    }
+
+    /*
+     * path_t
+     */
+    inline const vector<path_mapping_t>& path_t::mapping() const {
+        return _mapping;
+    }
+    inline const path_mapping_t& path_t::mapping(size_t i) const {
+        return _mapping[i];
+    }
+    inline vector<path_mapping_t>* path_t::mutable_mapping() {
+        return &_mapping;
+    }
+    inline path_mapping_t* path_t::mutable_mapping(size_t i) {
+        return &_mapping[i];
+    }
+    inline path_mapping_t* path_t::add_mapping() {
+        _mapping.emplace_back();
+        return &_mapping.back();
+    }
+    inline size_t path_t::mapping_size() {
+        return _mapping.size();
+    }
+
+    /*
+     * subpath_t
+     */
+    inline const path_t& subpath_t::path() const {
+        return _path;
+    }
+    inline path_t* subpath_t::mutable_path() {
+        return &_path;
+    }
+    inline const vector<uint32_t>& subpath_t::next() const {
+        return _next;
+    }
+    inline uint32_t subpath_t::next(size_t i) const {
+        return _next[i];
+    }
+    inline vector<uint32_t>* subpath_t::mutable_next() {
+        return &_next;
+    }
+    inline void subpath_t::set_next(size_t i, uint32_t n) {
+        _next[i] = n;
+    }
+    inline void subpath_t::add_next(uint32_t n) {
+        _next.emplace_back(n);
+    }
+    inline size_t subpath_t::next_size() const {
+        return _next.size();
+    }
+    inline int32_t subpath_t::score() const {
+        return _score;
+    }
+    inline void subpath_t::set_score(int32_t s) {
+        _score = s;
+    }
+
+    /*
+     * multipath_alignment_t
+     */
+    inline const string& multipath_alignment_t::sequence() const {
+        return _sequence;
+    }
+    inline string* multipath_alignment_t::mutable_sequence() {
+        return &_sequence;
+    }
+    inline void multipath_alignment_t::set_sequence(const string& s) {
+        _sequence = s;
+    }
+    inline const string& multipath_alignment_t::quality() const {
+        return _quality;
+    }
+    inline string* multipath_alignment_t::mutable_quality() {
+        return &_quality;
+    }
+    inline void multipath_alignment_t::set_quality(const string& q) {
+        _quality = q;
+    }
+    inline const string& multipath_alignment_t::name() const {
+        return _name;
+    }
+    inline string* multipath_alignment_t::mutable_name() {
+        return &_name;
+    }
+    inline void multipath_alignment_t::set_name(const string& n) {
+        _name = n;
+    }
+    inline const string& multipath_alignment_t::sample_name() const {
+        return _sample_name;
+    }
+    inline string* multipath_alignment_t::mutable_sample_name() {
+        return &_sample_name;
+    }
+    inline void multipath_alignment_t::set_sample_name(const string& n) {
+        _sample_name = n;
+    }
+    inline const string& multipath_alignment_t::read_group() const {
+        return _read_group;
+    }
+    inline string* multipath_alignment_t::mutable_read_group() {
+        return &_read_group;
+    }
+    inline void multipath_alignment_t::set_read_group(const string& g) {
+        _read_group = g;
+    }
+    inline const vector<subpath_t>& multipath_alignment_t::subpath() const {
+        return _subpath;
+    }
+    inline const subpath_t& multipath_alignment_t::subpath(size_t i) const {
+        return _subpath[i];
+    }
+    inline vector<subpath_t>* multipath_alignment_t::mutable_subpath() {
+        return &_subpath;
+    }
+    inline subpath_t* multipath_alignment_t::mutable_subpath(size_t i) {
+        return &_subpath[i];
+    }
+    inline subpath_t* multipath_alignment_t::add_subpath() {
+        _subpath.emplace_back();
+        return &_subpath.back();
+    }
+    inline size_t multipath_alignment_t::subpath_size() const {
+        return _subpath.size();
+    }
+    inline int32_t multipath_alignment_t::mapping_quality() const {
+        return _mapping_quality;
+    }
+    inline void multipath_alignment_t::set_mapping_quality(int32_t q) {
+        _mapping_quality = q;
+    }
+    inline const vector<uint32_t>& multipath_alignment_t::start() const {
+        return _start;
+    }
+    inline uint32_t multipath_alignment_t::start(size_t i) const {
+        return _start[i];
+    }
+    inline vector<uint32_t>* multipath_alignment_t::mutable_start() {
+        return &_start;
+    }
+    inline void multipath_alignment_t::set_start(size_t i, uint32_t s) {
+        _start[i] = s;
+    }
+    inline void multipath_alignment_t::add_start(uint32_t s) {
+        _start.emplace_back(s);
+    }
+    inline size_t multipath_alignment_t::start_size() const {
+        return _start.size();
+    }
+    inline const string& multipath_alignment_t::paired_read_name() const {
+        return _paired_read_name;
+    }
+    inline string* multipath_alignment_t::mutable_paired_read_name() {
+        return &_paired_read_name;
+    }
+    inline void multipath_alignment_t::set_paired_read_name(const string& n) {
+        _paired_read_name = n;
+    }
 }
 
 

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -1,6 +1,6 @@
 /// \file multipath_alignment.hpp
 ///
-/// utility functions for the MultipathAlignment protobuf object
+/// utility functions for the multipath_alignment_t object
 ///
 
 #ifndef multipath_alignment_hpp
@@ -28,67 +28,6 @@ namespace vg {
     /*
      * STL implementations of the protobuf object for use in in-memory operations
      */
-    class edit_t {
-    public:
-        edit_t() = default;
-        edit_t(const edit_t&) = default;
-        edit_t(edit_t&&) = default;
-        ~edit_t() = default;
-        edit_t& operator=(const edit_t&) = default;
-        edit_t& operator=(edit_t&&) = default;
-        inline int32_t from_length() const;
-        inline void set_from_length(int32_t l);
-        inline int32_t to_length() const;
-        inline void set_to_length(int32_t l);
-        inline const string& sequence() const;
-        inline void set_sequence(const string& s);
-        inline string* mutable_string();
-    private:
-        int32_t _from_length;
-        int32_t _to_length;
-        string _sequence;
-    };
-
-    // the mapping_t name is already taken
-    class path_mapping_t {
-    public:
-        path_mapping_t() = default;
-        path_mapping_t(const path_mapping_t&) = default;
-        path_mapping_t(path_mapping_t&&) = default;
-        ~path_mapping_t() = default;
-        path_mapping_t& operator=(const path_mapping_t&) = default;
-        path_mapping_t& operator=(path_mapping_t&&) = default;
-        inline const pos_t& position() const;
-        inline pos_t* mutable_position();
-        inline const vector<edit_t>& edit() const;
-        inline const edit_t& edit(size_t i) const;
-        inline vector<edit_t>* mutable_edit();
-        inline edit_t* mutable_edit(size_t i);
-        inline edit_t* add_edit();
-        inline size_t edit_size();
-    private:
-        pos_t _position;
-        vector<edit_t> _edit;
-    };
-
-    class path_t {
-    public:
-        path_t() = default;
-        path_t(const path_t&) = default;
-        path_t(path_t&&) = default;
-        ~path_t() = default;
-        path_t& operator=(const path_t&) = default;
-        path_t& operator=(path_t&&) = default;
-        inline const vector<path_mapping_t>& mapping() const;
-        inline const path_mapping_t& mapping(size_t i) const;
-        inline vector<path_mapping_t>* mutable_mapping();
-        inline path_mapping_t* mutable_mapping(size_t i);
-        inline path_mapping_t* add_mapping();
-        inline size_t mapping_size();
-    private:
-        vector<path_mapping_t> _mapping;
-    };
-
     class subpath_t {
     public:
         subpath_t() = default;
@@ -99,11 +38,13 @@ namespace vg {
         subpath_t& operator=(subpath_t&&) = default;
         inline const path_t& path() const;
         inline path_t* mutable_path();
+        inline bool has_path() const;
         inline const vector<uint32_t>& next() const;
         inline uint32_t next(size_t i) const;
         inline vector<uint32_t>* mutable_next();
         inline void set_next(size_t i, uint32_t n);
         inline void add_next(uint32_t n);
+        inline void clear_next();
         inline size_t next_size() const;
         inline int32_t score() const;
         inline void set_score(int32_t s);
@@ -113,6 +54,7 @@ namespace vg {
         int32_t _score;
     };
 
+    // TODO: the metadata could be removed and only added to the protobuf at serialization time
     class multipath_alignment_t {
     public:
         multipath_alignment_t() = default;
@@ -141,6 +83,7 @@ namespace vg {
         inline vector<subpath_t>* mutable_subpath();
         inline subpath_t* mutable_subpath(size_t i);
         inline subpath_t* add_subpath();
+        inline void clear_subpath();
         inline size_t subpath_size() const;
         inline int32_t mapping_quality() const;
         inline void set_mapping_quality(int32_t q);
@@ -149,6 +92,7 @@ namespace vg {
         inline vector<uint32_t>* mutable_start();
         inline void set_start(size_t i, uint32_t s);
         inline void add_start(uint32_t s);
+        inline void clear_start();
         inline size_t start_size() const;
         inline const string& paired_read_name() const;
         inline string* mutable_paired_read_name();
@@ -169,13 +113,13 @@ namespace vg {
     };
     
     /// Put subpaths in topological order (assumed to be true for other algorithms)
-    void topologically_order_subpaths(MultipathAlignment& multipath_aln);
+    void topologically_order_subpaths(multipath_alignment_t& multipath_aln);
     
     /// Finds the start subpaths (i.e. the source nodes of the multipath DAG) and stores
-    /// them in the 'start' field of the MultipathAlignment
-    void identify_start_subpaths(MultipathAlignment& multipath_aln);
+    /// them in the 'start' field of the multipath_alignment_t
+    void identify_start_subpaths(multipath_alignment_t& multipath_aln);
     
-    /// Stores the highest scoring alignment contained in the MultipathAlignment in an Alignment
+    /// Stores the highest scoring alignment contained in the multipath_alignment_t in an Alignment
     ///
     /// Note: Assumes that each subpath's Path object uses one Mapping per node and that
     /// start subpaths have been identified
@@ -187,10 +131,10 @@ namespace vg {
     ///    subpath_global    if true, only allows alignments that source subpath to sink subpath
     ///                      in the multipath DAG, else allows any start and end subpath
     ///
-    void optimal_alignment(const MultipathAlignment& multipath_aln, Alignment& aln_out,
+    void optimal_alignment(const multipath_alignment_t& multipath_aln, Alignment& aln_out,
                            bool subpath_global = false);
     
-    /// Returns the score of the highest scoring alignment contained in the MultipathAlignment
+    /// Returns the score of the highest scoring alignment contained in the multipath_alignment_t
     ///
     /// Note: Assumes that each subpath's Path object uses one Mapping per node and that
     /// start subpaths have been identified
@@ -200,10 +144,10 @@ namespace vg {
     ///    subpath_global    if true, only allows alignments that source subpath to sink subpath
     ///                      in the multipath DAG, else allows any start and end subpath
     ///
-    int32_t optimal_alignment_score(const MultipathAlignment& multipath_aln,
+    int32_t optimal_alignment_score(const multipath_alignment_t& multipath_aln,
                                     bool subpath_global = false);
     
-    /// Returns the top k highest-scoring alignments contained in the MultipathAlignment.
+    /// Returns the top k highest-scoring alignments contained in the multipath_alignment_t.
     /// Note that some or all of these may be duplicate Alignments, which were spelled out
     /// by tracebacks through different sequences of subpaths that shared alignment material.
     ///
@@ -216,7 +160,7 @@ namespace vg {
     ///    multipath_aln     multipath alignment to find optimal paths through
     ///    count             maximum number of top alignments to return
     ///
-    vector<Alignment> optimal_alignments(const MultipathAlignment& multipath_aln, size_t count);
+    vector<Alignment> optimal_alignments(const multipath_alignment_t& multipath_aln, size_t count);
     
     /// Finds k or fewer top-scoring alignments using only distinct subpaths.
     /// Asymmetrical: the optimal alignment for each end subpath is found, greedily, subject to the constraint,
@@ -232,14 +176,14 @@ namespace vg {
     ///    multipath_aln     multipath alignment to find optimal paths through
     ///    count             maximum number of top alignments to return
     ///
-    vector<Alignment> optimal_alignments_with_disjoint_subpaths(const MultipathAlignment& multipath_aln, size_t count);
+    vector<Alignment> optimal_alignments_with_disjoint_subpaths(const multipath_alignment_t& multipath_aln, size_t count);
     
     /// Finds all alignments consistent with haplotypes available by incremental search with the given haplotype
     /// score provider. Pads to a certain count with haplotype-inconsistent alignments that are population-scorable
     /// (i.e. use only edges used by some haplotype in the index), and then with unscorable alignments if scorable
     /// ones are unavailable. This may result in an empty vector.
     ///
-    /// Output Alignments may not be unique. The input MultipathAlignment may have exponentially many ways to
+    /// Output Alignments may not be unique. The input multipath_alignment_t may have exponentially many ways to
     /// spell the same Alignment, and we will look at all of them. We also may have duplicates of the optimal
     /// alignment if we are asked to produce it unconsitionally.
     ///
@@ -254,10 +198,10 @@ namespace vg {
     ///    hard_count        maximum number of alignments, including haplotype-consistent (0 if no limit)
     ///    optimal_first     always compute and return first the optimal alignment, even if not haplotype-consistent
     ///
-    vector<Alignment> haplotype_consistent_alignments(const MultipathAlignment& multipath_aln, const haplo::ScoreProvider& score_provider,
+    vector<Alignment> haplotype_consistent_alignments(const multipath_alignment_t& multipath_aln, const haplo::ScoreProvider& score_provider,
         size_t soft_count, size_t hard_count, bool optimal_first = false);
     
-    /// Stores the reverse complement of a MultipathAlignment in another MultipathAlignment
+    /// Stores the reverse complement of a multipath_alignment_t in another multipath_alignment_t
     ///
     ///  Args:
     ///    multipath_aln     multipath alignment to reverse complement
@@ -265,57 +209,67 @@ namespace vg {
     ///    rev_comp_out      empty multipath alignment to store reverse complement in (some data may
     ///                      be overwritten if not empty)
     ///
-    void rev_comp_multipath_alignment(const MultipathAlignment& multipath_aln,
+    void rev_comp_multipath_alignment(const multipath_alignment_t& multipath_aln,
                                       const function<int64_t(int64_t)>& node_length,
-                                      MultipathAlignment& rev_comp_out);
+                                      multipath_alignment_t& rev_comp_out);
     
-    /// Stores the reverse complement of a MultipathAlignment in another MultipathAlignment
+    /// Stores the reverse complement of a multipath_alignment_t in another multipath_alignment_t
     ///
     ///  Args:
     ///    multipath_aln     multipath alignment to reverse complement in place
     ///    node_length       a function that returns the length of a node sequence from its node ID
     ///
-    void rev_comp_multipath_alignment_in_place(MultipathAlignment* multipath_aln,
+    void rev_comp_multipath_alignment_in_place(multipath_alignment_t* multipath_aln,
                                                const function<int64_t(int64_t)>& node_length);
 
     /// Replaces all U's in the sequence and the aligned Paths with T's
-    void convert_Us_to_Ts(MultipathAlignment& multipath_aln);
+    void convert_Us_to_Ts(multipath_alignment_t& multipath_aln);
 
     /// Replaces all T's in the sequence and the aligned Paths with U's
-    void convert_Ts_to_Us(MultipathAlignment& multipath_aln);
+    void convert_Ts_to_Us(multipath_alignment_t& multipath_aln);
     
-    /// Converts a Alignment into a Multipath alignment with one Subpath and stores it in an object
+    /// Convert an STL-based multipath_alignment_t to a protobuf MultipathAlignment
+    void to_proto_multipath_alignment(const multipath_alignment_t& multipath_aln,
+                                      MultipathAlignment& proto_multipath_aln_out);
+
+    /// Convert a protobuf MultipathAlignment to an STL-based multipath_alignment_t
+    void from_proto_multipath_alignment(const MultipathAlignment& proto_multipath_aln,
+                                        multipath_alignment_t& multipath_aln_out);
+
+    /// Converts a Alignment into a multipath_alignment_t  with one subpath and stores it in an object
     ///
     ///  Args:
     ///    aln               alignment to convert
     ///    multipath_aln     empty multipath alignment to store converted alignment in (data may be
     ///                      be overwritten if not empty)
     ///
-    void to_multipath_alignment(const Alignment& aln, MultipathAlignment& multipath_aln_out);
+    void to_multipath_alignment(const Alignment& aln, multipath_alignment_t& multipath_aln_out);
     
-    /// Copies metadata from an Alignment object and transfers it to a MultipathAlignment
+    // TODO: these metadata functions should also transfer annotations
+
+    /// Copies metadata from an Alignment object and transfers it to a multipath_alignment_t
     ///
     ///  Args:
     ///    from    copy metadata from this
     ///    to      into this
     ///
-    void transfer_read_metadata(const Alignment& from, MultipathAlignment& to);
+    void transfer_read_metadata(const Alignment& from, multipath_alignment_t& to);
     
-    /// Copies metadata from an MultipathAlignment object and transfers it to a Alignment
+    /// Copies metadata from an multipath_alignment_t object and transfers it to a Alignment
     ///
     ///  Args:
     ///    from    copy metadata from this
     ///    to      into this
     ///
-    void transfer_read_metadata(const MultipathAlignment& from, Alignment& to);
+    void transfer_read_metadata(const multipath_alignment_t& from, Alignment& to);
     
-    /// Copies metadata from an MultipathAlignment object and transfers it to another MultipathAlignment
+    /// Copies metadata from an multipath_alignment_t object and transfers it to another multipath_alignment_t
     ///
     ///  Args:
     ///    from    copy metadata from this
     ///    to      into this
     ///
-    void transfer_read_metadata(const MultipathAlignment& from, MultipathAlignment& to);
+    void transfer_read_metadata(const multipath_alignment_t& from, multipath_alignment_t& to);
     
     /// Copies metadata from an Alignment object and transfers it to another Alignment
     ///
@@ -325,115 +279,43 @@ namespace vg {
     ///
     void transfer_read_metadata(const Alignment& from, Alignment& to);
 
+
+    void transfer_read_metadata(const MultipathAlignment& from, multipath_alignment_t& to);
+
+    void transfer_read_metadata(const multipath_alignment_t& from, MultipathAlignment& to);
+
     /// Merges non-branching paths in a multipath alignment in place
-    void merge_non_branching_subpaths(MultipathAlignment& multipath_aln);
+    void merge_non_branching_subpaths(multipath_alignment_t& multipath_aln);
 
     /// Removes subpaths that have no aligned bases and adds in any implied edges crossing through them
-    void remove_empty_subpaths(MultipathAlignment& multipath_aln);
+    void remove_empty_subpaths(multipath_alignment_t& multipath_aln);
     
     /// Returns a vector whose elements are vectors with the indexes of the Subpaths in
-    /// each connected component. An unmapped MultipathAlignment with no subpaths produces an empty vector.
-    vector<vector<int64_t>> connected_components(const MultipathAlignment& multipath_aln);
+    /// each connected component. An unmapped multipath_alignment_t with no subpaths produces an empty vector.
+    vector<vector<int64_t>> connected_components(const multipath_alignment_t& multipath_aln);
     
-    /// Extract the MultipathAlignment consisting of the Subpaths with the given indexes
-    /// into a new MultipathAlignment object
-    void extract_sub_multipath_alignment(const MultipathAlignment& multipath_aln,
+    /// Extract the multipath_alignment_t consisting of the Subpaths with the given indexes
+    /// into a new multipath_alignment_t object
+    void extract_sub_multipath_alignment(const multipath_alignment_t& multipath_aln,
                                          const vector<int64_t>& subpath_indexes,
-                                         MultipathAlignment& sub_multipath_aln);
+                                         multipath_alignment_t& sub_multipath_aln);
     
     /// Debugging function to check that multipath alignment meets the formalism's basic
     /// invariants. Returns true if multipath alignment is valid, else false. Does not
     /// validate alignment score.
-    bool validate_multipath_alignment(const MultipathAlignment& multipath_aln, const HandleGraph& handle_graph);
+    bool validate_multipath_alignment(const multipath_alignment_t& multipath_aln, const HandleGraph& handle_graph);
     
-    /// Send a formatted string representation of the MultipathAlignment into the ostream
-    void view_multipath_alignment(ostream& out, const MultipathAlignment& multipath_aln, const HandleGraph& handle_graph);
+    /// Send a formatted string representation of the multipath_alignment_t into the ostream
+    void view_multipath_alignment(ostream& out, const multipath_alignment_t& multipath_aln, const HandleGraph& handle_graph);
     
-    /// Converts a MultipathAlignment to a GraphViz Dot representation, output to the given ostream.
-    void view_multipath_alignment_as_dot(ostream& out, const MultipathAlignment& multipath_aln, bool show_graph = false);
+    /// Converts a multipath_alignment_t to a GraphViz Dot representation, output to the given ostream.
+    void view_multipath_alignment_as_dot(ostream& out, const multipath_alignment_t& multipath_aln, bool show_graph = false);
     
     // TODO: function for adding a graph augmentation to an existing multipath alignment
 
     /*
      * Implementations of inline methods
      */
-
-    /*
-     * edit_t
-     */
-    inline int32_t edit_t::from_length() const {
-        return _from_length;
-    }
-    inline void edit_t::set_from_length(int32_t l) {
-        _from_length = l;
-    }
-    inline int32_t edit_t::to_length() const {
-        return _to_length;
-    }
-    inline void edit_t::set_to_length(int32_t l) {
-        _to_length = l;
-    }
-    inline const string& edit_t::sequence() const {
-        return _sequence;
-    }
-    inline void edit_t::set_sequence(const string& s) {
-        _sequence = s;
-    }
-    inline string* edit_t::mutable_string() {
-        return &_sequence;
-    }
-
-    /*
-     * path_mapping_t
-     */
-    inline const pos_t& path_mapping_t::position() const {
-        return _position;
-    }
-    inline pos_t* path_mapping_t::mutable_position() {
-        return &_position;
-    }
-    inline const vector<edit_t>& path_mapping_t::edit() const {
-        return _edit;
-    }
-    inline const edit_t& path_mapping_t::edit(size_t i) const {
-        return _edit[i];
-    }
-    inline vector<edit_t>* path_mapping_t::mutable_edit() {
-        return &_edit;
-    }
-    inline edit_t* path_mapping_t::add_edit() {
-        _edit.emplace_back();
-        return &_edit.back();
-    }
-    inline edit_t* path_mapping_t::mutable_edit(size_t i) {
-        return &_edit[i];
-    }
-    inline size_t path_mapping_t::edit_size() {
-        return _edit.size();
-    }
-
-    /*
-     * path_t
-     */
-    inline const vector<path_mapping_t>& path_t::mapping() const {
-        return _mapping;
-    }
-    inline const path_mapping_t& path_t::mapping(size_t i) const {
-        return _mapping[i];
-    }
-    inline vector<path_mapping_t>* path_t::mutable_mapping() {
-        return &_mapping;
-    }
-    inline path_mapping_t* path_t::mutable_mapping(size_t i) {
-        return &_mapping[i];
-    }
-    inline path_mapping_t* path_t::add_mapping() {
-        _mapping.emplace_back();
-        return &_mapping.back();
-    }
-    inline size_t path_t::mapping_size() {
-        return _mapping.size();
-    }
 
     /*
      * subpath_t
@@ -443,6 +325,9 @@ namespace vg {
     }
     inline path_t* subpath_t::mutable_path() {
         return &_path;
+    }
+    inline bool subpath_t::has_path() const {
+        return _path.mapping_size();
     }
     inline const vector<uint32_t>& subpath_t::next() const {
         return _next;
@@ -458,6 +343,9 @@ namespace vg {
     }
     inline void subpath_t::add_next(uint32_t n) {
         _next.emplace_back(n);
+    }
+    inline void subpath_t::clear_next() {
+        _next.clear();
     }
     inline size_t subpath_t::next_size() const {
         return _next.size();
@@ -533,6 +421,9 @@ namespace vg {
         _subpath.emplace_back();
         return &_subpath.back();
     }
+    inline void multipath_alignment_t::clear_subpath() {
+        _subpath.clear();
+    }
     inline size_t multipath_alignment_t::subpath_size() const {
         return _subpath.size();
     }
@@ -556,6 +447,9 @@ namespace vg {
     }
     inline void multipath_alignment_t::add_start(uint32_t s) {
         _start.emplace_back(s);
+    }
+    inline void multipath_alignment_t::clear_start() {
+        _start.clear();
     }
     inline size_t multipath_alignment_t::start_size() const {
         return _start.size();

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -17,6 +17,7 @@
 #include "alignment.hpp"
 #include "utility.hpp"
 #include "handle.hpp"
+#include "annotation.hpp"
 
 // Declare the haplo::ScoreProvider we use for haplotype-aware traceback generation.
 namespace haplo {
@@ -60,7 +61,7 @@ namespace vg {
         multipath_alignment_t() = default;
         multipath_alignment_t(const multipath_alignment_t&) = default;
         multipath_alignment_t(multipath_alignment_t&&) = default;
-        ~multipath_alignment_t() = default;
+        ~multipath_alignment_t();
         multipath_alignment_t& operator=(const multipath_alignment_t&) = default;
         multipath_alignment_t& operator=(multipath_alignment_t&&) = default;
         inline const string& sequence() const;
@@ -97,8 +98,17 @@ namespace vg {
         inline const string& paired_read_name() const;
         inline string* mutable_paired_read_name();
         inline void set_paired_read_name(const string& n);
-        // TODO: how to handle annotations?
         
+        // annotation interface
+        // TODO: add List and Struct from https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/struct.proto
+        enum anno_type_t {Null = 0, Double = 2, Bool = 3, String = 4};
+        void set_annotation(const string& annotation_name);
+        void set_annotation(const string& annotation_name, double value);
+        void set_annotation(const string& annotation_name, bool value);
+        void set_annotation(const string& annotation_name, const string& value);
+        void clear_annotation(const string& annotation_name);
+        pair<anno_type_t, const void*> get_annotation(const string& annotation_name) const;
+        void for_each_annotation(function<void(const string&, anno_type_t, const void*)> lambda) const;
     private:
         string _sequence;
         string _quality;
@@ -109,7 +119,7 @@ namespace vg {
         int32_t _mapping_quality;
         vector<uint32_t> _start;
         string _paired_read_name;
-        map<string, string> _annotation;
+        map<string, pair<anno_type_t, void*>> _annotation;
     };
 
     string debug_string(const subpath_t& subpath);

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -109,7 +109,7 @@ namespace vg {
         cerr << "nodes after adding, trimming, and collapsing:" << endl;
         for (size_t i = 0; i < path_nodes.size(); i++) {
             PathNode& path_node = path_nodes.at(i);
-            cerr << i << " " << pb2json(path_node.path) << " ";
+            cerr << i << " " << debug_string(path_node.path) << " ";
             for (auto iter = path_node.begin; iter != path_node.end; iter++) {
                 cerr << *iter;
             }
@@ -284,7 +284,7 @@ namespace vg {
                 }
                 
 #ifdef debug_multipath_alignment
-                cerr << "walked path: " << pb2json(path_node.path) << endl;
+                cerr << "walked path: " << debug_string(path_node.path) << endl;
 #endif
             }
         }
@@ -296,7 +296,7 @@ namespace vg {
                                                            int64_t* removed_end_from_length) {
         
 #ifdef debug_multipath_alignment
-        cerr << "trimming path node " << string(path_node.begin, path_node.end) << " " << pb2json(path_node.path) << endl;
+        cerr << "trimming path node " << string(path_node.begin, path_node.end) << " " << debug_string(path_node.path) << endl;
 #endif
         
         // Trim down the given PathNode of everything except softclips.
@@ -449,7 +449,7 @@ namespace vg {
                 mapping->add_edit();
                 
 #ifdef debug_multipath_alignment
-                cerr << "preserving start deletion path read[" << (path_node.begin - alignment.sequence().begin()) << "] " << pb2json(path_node.path) << endl;
+                cerr << "preserving start deletion path read[" << (path_node.begin - alignment.sequence().begin()) << "] " << debug_string(path_node.path) << endl;
 #endif
             }
             else if (ignore_deletion_end) {
@@ -468,7 +468,7 @@ namespace vg {
                 mapping->add_edit();
                 
 #ifdef debug_multipath_alignment
-                cerr << "preserving end deletion path read[" << (path_node.begin - alignment.sequence().begin()) << "] " << pb2json(path_node.path) << endl;
+                cerr << "preserving end deletion path read[" << (path_node.begin - alignment.sequence().begin()) << "] " << debug_string(path_node.path) << endl;
 #endif
             }
             else {
@@ -659,7 +659,7 @@ namespace vg {
                         // of the parent MEM by a distance equal to the relative offset
                         
 #ifdef debug_multipath_alignment
-                        cerr << "traversing putative parent MEM with path " << pb2json(path) << endl;
+                        cerr << "traversing putative parent MEM with path " << debug_string(path) << endl;
 #endif
                         
                         int64_t prefix_length = 0;
@@ -787,7 +787,7 @@ namespace vg {
                         }
                         
 #ifdef debug_multipath_alignment
-                        cerr << pb2json(path) << endl;
+                        cerr << debug_string(path) << endl;
 #endif
                     }
                     else if (node_idx == node_seq.size()) {
@@ -847,7 +847,7 @@ namespace vg {
                 cerr << *iter;
             }
             cerr << endl;
-            cerr << "\t" << pb2json(match_node.path) << endl;
+            cerr << "\t" << debug_string(match_node.path) << endl;
 #endif
             
             // try to find any run of MEMs that could be merged with this MEM
@@ -867,7 +867,7 @@ namespace vg {
                     cerr << *iter;
                 }
                 cerr << endl;
-                cerr << "\t" << pb2json(last_run_node.path) << endl;
+                cerr << "\t" << debug_string(last_run_node.path) << endl;
 #endif
                 
                 // do they overhang an amount on the read that indicates they overlap and could be merged?
@@ -1005,8 +1005,8 @@ namespace vg {
                     PathNode& merge_from_node = path_nodes.at(merge_group[i]);
                     
 #ifdef debug_multipath_alignment
-                    cerr << "merging into node " << merge_group[0] << " path " << pb2json(merge_into_node.path) << endl;
-                    cerr << "from node " << merge_group[i] << " path " << pb2json(merge_from_node.path) << endl;
+                    cerr << "merging into node " << merge_group[0] << " path " << debug_string(merge_into_node.path) << endl;
+                    cerr << "from node " << merge_group[i] << " path " << debug_string(merge_from_node.path) << endl;
 #endif
                     
                     // walk backwards until we find the first mapping to add
@@ -1039,7 +1039,7 @@ namespace vg {
                         final_edit->set_to_length(final_edit->to_length() + mapping_to_add_length);
                         
 #ifdef debug_multipath_alignment
-                        cerr << "merged mapping is " << pb2json(*final_merging_mapping) << endl;
+                        cerr << "merged mapping is " << debug_string(*final_merging_mapping) << endl;
 #endif
                     }
                     else {
@@ -1048,7 +1048,7 @@ namespace vg {
                         *new_mapping = first_mapping_to_add;
                         
 #ifdef debug_multipath_alignment
-                        cerr << "new adjacent mapping is " << pb2json(*new_mapping) << endl;
+                        cerr << "new adjacent mapping is " << debug_string(*new_mapping) << endl;
 #endif
                     }
                     
@@ -1058,7 +1058,7 @@ namespace vg {
                         *new_mapping = merge_from_node.path.mapping(j);
                         
 #ifdef debug_multipath_alignment
-                        cerr << "new transfer mapping is " << pb2json(*new_mapping) << endl;
+                        cerr << "new transfer mapping is " << debug_string(*new_mapping) << endl;
 #endif
                     }
                     
@@ -1066,7 +1066,7 @@ namespace vg {
                     merge_into_node.end = merge_from_node.end;
                     
 #ifdef debug_multipath_alignment
-                    cerr << "merged path is " << pb2json(merge_into_node.path) << endl;
+                    cerr << "merged path is " << debug_string(merge_into_node.path) << endl;
                     cerr << "merged substring is ";
                     for (auto iter = merge_into_node.begin; iter != merge_into_node.end; iter++) {
                         cerr << *iter;
@@ -1109,7 +1109,7 @@ namespace vg {
         for (PathNode& path_node : path_nodes) {
             
 #ifdef debug_multipath_alignment
-            cerr << "trimming to branch points within " << max_trim_length << " of ends in path " << pb2json(path_node.path) << endl;
+            cerr << "trimming to branch points within " << max_trim_length << " of ends in path " << debug_string(path_node.path) << endl;
 #endif
             
             // find the mapping where we are first pass the maximum trim length coming inward
@@ -1198,7 +1198,7 @@ namespace vg {
                 }
                 path_node.path = move(new_path);
 #ifdef debug_multipath_alignment
-                cerr << "trimmed path: " << pb2json(path_node.path) << endl;
+                cerr << "trimmed path: " << debug_string(path_node.path) << endl;
 #endif
                 // update the read interval
                 path_node.begin += trimmed_prefix_to_length;
@@ -1228,7 +1228,7 @@ namespace vg {
             path_t* path = &path_node->path;
             
 #ifdef debug_multipath_alignment
-            cerr << "cutting node at index " << i << " with path " << pb2json(*path) << endl;
+            cerr << "cutting node at index " << i << " with path " << debug_string(*path) << endl;
 #endif
             
             // this list holds the beginning of the current segment at each depth in the snarl hierarchy
@@ -1376,7 +1376,7 @@ namespace vg {
                 
                 
 #ifdef debug_multipath_alignment
-                cerr << "new cut path: " << pb2json(path_node->path) << endl;
+                cerr << "new cut path: " << debug_string(path_node->path) << endl;
 #endif
                 
                 // keep track of the index in the node vector of the previous segment
@@ -1419,7 +1419,7 @@ namespace vg {
                     cut_node.end = original_begin + prefix_to_length;
                     
 #ifdef debug_multipath_alignment
-                    cerr << "new cut path: " << pb2json(cut_path) << endl;
+                    cerr << "new cut path: " << debug_string(cut_path) << endl;
 #endif
                     
                     prev_segment_idx = path_nodes.size() - 1;
@@ -1482,7 +1482,7 @@ namespace vg {
                 
 #ifdef debug_multipath_alignment
                 cerr << "Handling " << (handling_right_tail ? "right" : "left") << " tail off of PathNode "
-                    << attached_path_node_index << " with path " << pb2json(path_nodes.at(attached_path_node_index).path) << endl;
+                    << attached_path_node_index << " with path " << debug_string(path_nodes.at(attached_path_node_index).path) << endl;
 #endif
                 
                 for (auto& aln : alns) {
@@ -1555,7 +1555,7 @@ namespace vg {
                         synth_path_node.begin = synth_path_node.end - curr_match_length;
                         
 #ifdef debug_multipath_alignment
-                        cerr << "\tyielded anchor with path " << pb2json(synth_path_node.path) << " and seq ";
+                        cerr << "\tyielded anchor with path " << debug_string(synth_path_node.path) << " and seq ";
                         for (auto it = synth_path_node.begin; it != synth_path_node.end; ++it) {
                             cerr << *it;
                         }
@@ -2824,7 +2824,7 @@ namespace vg {
             for (auto node_iter = onto_node->begin; node_iter != onto_node->end; node_iter++) {
                 cerr << *node_iter;
             }
-            cerr << endl << "\t" << pb2json(onto_node->path) << endl;
+            cerr << endl << "\t" << debug_string(onto_node->path) << endl;
 #endif
             
             // TODO: there should be a way to do this in a single pass over mappings and edits
@@ -2967,12 +2967,12 @@ namespace vg {
                 for (auto node_iter = onto_node->begin; node_iter != onto_node->end; node_iter++) {
                     cerr << *node_iter;
                 }
-                cerr << endl << "\t" << pb2json(onto_node->path) << endl;
+                cerr << endl << "\t" << debug_string(onto_node->path) << endl;
                 cerr << "suffix node:" << endl << "\t";
                 for (auto node_iter = suffix_node.begin; node_iter != suffix_node.end; node_iter++) {
                     cerr << *node_iter;
                 }
-                cerr << endl << "\t" << pb2json(suffix_node.path) << endl;
+                cerr << endl << "\t" << debug_string(suffix_node.path) << endl;
 #endif
                 
                 while (iter != iter_range_end) {
@@ -3003,7 +3003,7 @@ namespace vg {
         cerr << "final graph after adding reachability edges:" << endl;
         for (size_t i = 0; i < path_nodes.size(); i++) {
             PathNode& path_node = path_nodes.at(i);
-            cerr << i << " " << pb2json(path_node.path) << " ";
+            cerr << i << " " << debug_string(path_node.path) << " ";
             for (auto iter = path_node.begin; iter != path_node.end; iter++) {
                 cerr << *iter;
             }
@@ -3152,7 +3152,7 @@ namespace vg {
 #ifdef debug_multipath_alignment
         cerr << "removed transitive edges, topology is:" << endl;
         for (size_t i = 0; i < path_nodes.size(); i++) {
-            cerr << "node " << i << ", " << pb2json(path_nodes.at(i).path.mapping(0).position()) << " ";
+            cerr << "node " << i << ", " << debug_string(path_nodes.at(i).path.mapping(0).position()) << " ";
             for (auto iter = path_nodes.at(i).begin; iter != path_nodes.at(i).end; iter++) {
                 cerr << *iter;
             }
@@ -3294,7 +3294,7 @@ namespace vg {
 #ifdef debug_multipath_alignment
         cerr << "pruned to high scoring paths, topology is:" << endl;
         for (size_t i = 0; i < path_nodes.size(); i++) {
-            cerr << "node " << i << ", " << pb2json(path_nodes.at(i).path.mapping(0).position()) << " ";
+            cerr << "node " << i << ", " << debug_string(path_nodes.at(i).path.mapping(0).position()) << " ";
             for (auto iter = path_nodes.at(i).begin; iter != path_nodes.at(i).end; iter++) {
                 cerr << *iter;
             }
@@ -3409,7 +3409,7 @@ namespace vg {
         // perform alignment in the intervening sections
         for (int64_t j = 0; j < path_nodes.size(); j++) {
 #ifdef debug_multipath_alignment
-            cerr << "checking for intervening alignments from match node " << j << " with path " << pb2json(path_nodes.at(j).path) << " and sequence ";
+            cerr << "checking for intervening alignments from match node " << j << " with path " << debug_string(path_nodes.at(j).path) << " and sequence ";
             for (auto iter = path_nodes.at(j).begin; iter != path_nodes.at(j).end; iter++) {
                 cerr << *iter;
             }
@@ -3546,21 +3546,21 @@ namespace vg {
                     if (add_first_mapping) {
                         from_proto_mapping(first_mapping, *subpath_path->add_mapping());
 #ifdef debug_multipath_alignment
-                        cerr << "first mapping is not empty, formed mapping: " << pb2json(*mapping) << endl;
+                        cerr << "first mapping is not empty, formed mapping: " << pb2json(first_mapping) << endl;
 #endif
                     }
                     // add all mapping in between the ends
                     for (size_t j = 1; j < aligned_path.mapping_size() - 1; j++) {
                         from_proto_mapping(aligned_path.mapping(j), *subpath_path->add_mapping());
 #ifdef debug_multipath_alignment
-                        cerr << "added middle mapping: " << pb2json(*mapping) << endl;
+                        cerr << "added middle mapping: " << pb2json(aligned_path.mapping(j)) << endl;
 #endif
                     }
                     // check to make sure the last is not an empty anchoring mapping or the same as the first
                     if (add_last_mapping) {
                         from_proto_mapping(last_mapping, *subpath_path->add_mapping());
 #ifdef debug_multipath_alignment
-                        cerr << "final mapping is not empty, formed mapping: " << pb2json(*mapping) << endl;
+                        cerr << "final mapping is not empty, formed mapping: " << pb2json(last_mapping) << endl;
 #endif
                     }
                     
@@ -3579,7 +3579,7 @@ namespace vg {
                     
 #ifdef debug_multipath_alignment
                     cerr << "subpath from " << j << " to " << edge.first << ":" << endl;
-                    cerr << pb2json(*connecting_subpath) << endl;
+                    cerr << debug_string(*connecting_subpath) << endl;
 #endif
                 }
             }
@@ -3646,7 +3646,7 @@ namespace vg {
                 }
 #ifdef debug_multipath_alignment
                 cerr << "subpath from " << j << " to right tail:" << endl;
-                cerr << pb2json(*tail_subpath) << endl;
+                cerr << debug_string(*tail_subpath) << endl;
 #endif
             }
         }
@@ -3674,7 +3674,7 @@ namespace vg {
                     
 #ifdef debug_multipath_alignment
                     cerr << "subpath from " << j << " to left tail:" << endl;
-                    cerr << pb2json(*tail_subpath) << endl;
+                    cerr << debug_string(*tail_subpath) << endl;
 #endif
                     path_mapping_t* final_mapping = tail_subpath->mutable_path()->mutable_mapping(tail_subpath->path().mapping_size() - 1);
                     if (tail_subpath->path().mapping_size() == 1 && final_mapping->edit_size() == 1
@@ -3741,7 +3741,7 @@ namespace vg {
                 if (path_node.end != alignment.sequence().end()) {
     
 #ifdef debug_multipath_alignment
-                    cerr << "doing right end alignment from sink node " << j << " with path " << pb2json(path_node.path) << " and sequence ";
+                    cerr << "doing right end alignment from sink node " << j << " with path " << debug_string(path_node.path) << " and sequence ";
                     for (auto iter = path_node.begin; iter != path_node.end; iter++) {
                         cerr << *iter;
                     }

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3541,6 +3541,9 @@ namespace vg {
                     subpath_t* connecting_subpath = multipath_aln_out.add_subpath();
                     connecting_subpath->set_score(connecting_alignment.score());
                     path_t* subpath_path = connecting_subpath->mutable_path();
+                    
+                    // get a pointer to the subpath again in case the vector reallocated
+                    src_subpath = multipath_aln_out.mutable_subpath(j);
                                         
                     // check to make sure the first is not an empty anchoring mapping
                     if (add_first_mapping) {
@@ -3628,6 +3631,9 @@ namespace vg {
                 subpath_t* tail_subpath = multipath_aln_out.add_subpath();
                 from_proto_path(tail_alignment.path(), *tail_subpath->mutable_path());
                 tail_subpath->set_score(tail_alignment.score());
+                
+                // get the pointer again in case the vector reallocated
+                sink_subpath = multipath_aln_out.mutable_subpath(j);
                 
                 path_mapping_t* first_mapping = tail_subpath->mutable_path()->mutable_mapping(0);
 

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -27,7 +27,7 @@ namespace vg {
     public:
         string::const_iterator begin;
         string::const_iterator end;
-        Path path;
+        path_t path;
         
         // pairs of (target index, path length)
         vector<pair<size_t, size_t>> edges;
@@ -166,7 +166,7 @@ namespace vg {
                                     const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans);
                                     
         /// Do intervening and tail alignments between the anchoring paths and
-        /// store the result in a MultipathAlignment. Reachability edges must
+        /// store the result in a multipath_alignment_t. Reachability edges must
         /// be in the graph. The Alignment passed *must* be the same Alignment
         /// that owns the sequence into which iterators were passed when the
         /// MultipathAlignmentGraph was constructed! TODO: Shouldn't the class
@@ -177,10 +177,10 @@ namespace vg {
         /// with topologically_order_subpaths() before trying to run DP on it.
         void align(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t max_gap, double pessimistic_tail_gap_multiplier, size_t band_padding,
-                   MultipathAlignment& multipath_aln_out, bool allow_negative_scores = false);
+                   multipath_alignment_t& multipath_aln_out, bool allow_negative_scores = false);
         
         /// Do intervening and tail alignments between the anchoring paths and
-        /// store the result in a MultipathAlignment. Reachability edges must
+        /// store the result in a multipath_alignment_t. Reachability edges must
         /// be in the graph. Also, choose the band padding dynamically as a
         /// function of the inter-MEM sequence and graph. The Alignment passed
         /// *must* be the same Alignment that owns the sequence into which
@@ -194,7 +194,7 @@ namespace vg {
         void align(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t max_gap, double pessimistic_tail_gap_multiplier,
                    function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,
-                   MultipathAlignment& multipath_aln_out, bool allow_negative_scores = false);
+                   multipath_alignment_t& multipath_aln_out, bool allow_negative_scores = false);
         
         /// Converts a MultipathAlignmentGraph to a GraphViz Dot representation, output to the given ostream.
         /// If given the Alignment query we are working on, can produce information about subpath iterators.

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -421,7 +421,7 @@ namespace vg {
         for (multipath_alignment_t& multipath_aln : multipath_alns_out) {
 #ifdef debug_multipath_mapper
             cerr << "validating multipath alignment:" << endl;
-            cerr << pb2json(multipath_aln) << endl;
+            cerr << debug_string(multipath_aln) << endl;
 #endif
             if (!validate_multipath_alignment(multipath_aln, *xindex)) {
                 cerr << "### WARNING ###" << endl;
@@ -1202,8 +1202,8 @@ namespace vg {
         for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
 #ifdef debug_multipath_mapper
             cerr << "validating multipath alignments:" << endl;
-            cerr << pb2json(multipath_aln_pair.first) << endl;
-            cerr << pb2json(multipath_aln_pair.second) << endl;
+            cerr << debug_string(multipath_aln_pair.first) << endl;
+            cerr << debug_string(multipath_aln_pair.second) << endl;
 #endif
             if (!validate_multipath_alignment(multipath_aln_pair.first, *xindex)) {
                 cerr << "### WARNING ###" << endl;
@@ -1390,8 +1390,8 @@ namespace vg {
         for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : rescued_secondaries) {
 #ifdef debug_multipath_mapper
             cerr << "validating rescued secondary multipath alignments:" << endl;
-            cerr << pb2json(multipath_aln_pair.first) << endl;
-            cerr << pb2json(multipath_aln_pair.second) << endl;
+            cerr << debug_string(multipath_aln_pair.first) << endl;
+            cerr << debug_string(multipath_aln_pair.second) << endl;
 #endif
             if (!validate_multipath_alignment(multipath_aln_pair.first, *xindex)) {
                 cerr << "### WARNING ###" << endl;
@@ -2698,8 +2698,8 @@ namespace vg {
         for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
 #ifdef debug_multipath_mapper
             cerr << "validating multipath alignments:" << endl;
-            cerr << pb2json(multipath_aln_pair.first) << endl;
-            cerr << pb2json(multipath_aln_pair.second) << endl;
+            cerr << debug_string(multipath_aln_pair.first) << endl;
+            cerr << debug_string(multipath_aln_pair.second) << endl;
 #endif
             if (!validate_multipath_alignment(multipath_aln_pair.first, *xindex)) {
                 cerr << "### WARNING ###" << endl;
@@ -3235,14 +3235,14 @@ namespace vg {
         // connected components or whatever.
         
 #ifdef debug_multipath_mapper_alignment
-        cerr << "multipath alignment before translation: " << pb2json(multipath_aln_out) << endl;
+        cerr << "multipath alignment before translation: " << debug_string(multipath_aln_out) << endl;
 #endif
         for (size_t j = 0; j < multipath_aln_out.subpath_size(); j++) {
             translate_oriented_node_ids(*multipath_aln_out.mutable_subpath(j)->mutable_path(), translator);
         }
         
 #ifdef debug_multipath_mapper_alignment
-        cerr << "completed multipath alignment: " << pb2json(multipath_aln_out) << endl;
+        cerr << "completed multipath alignment: " << debug_string(multipath_aln_out) << endl;
 #endif
         
         // clean up (safe on nullptr if we didn't choose it)
@@ -3286,7 +3286,7 @@ namespace vg {
         topologically_order_subpaths(multipath_aln_out);
         
 #ifdef debug_multipath_mapper_alignment
-        cerr << "completed multipath alignment: " << pb2json(multipath_aln_out) << endl;
+        cerr << "completed multipath alignment: " << debug_string(multipath_aln_out) << endl;
 #endif
     }
     
@@ -3461,7 +3461,7 @@ namespace vg {
             cerr << "Got " << alignments.size() << " tracebacks for multipath " << i << endl;
 #endif
 #ifdef debug_multipath_mapper_alignment
-            cerr << pb2json(multipath_alns[i]) << endl;
+            cerr << debug_string(multipath_alns[i]) << endl;
 #endif
            
             // Now, we may have been fed a multipath_alignment_t where the best

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -466,7 +466,7 @@ namespace vg {
                                          bool rescue_forward, multipath_alignment_t& rescue_multipath_aln) {
         
 #ifdef debug_multipath_mapper
-        cerr << "attemping pair rescue in " << (rescue_forward ? "forward" : "backward") << " direction from " << pb2json(multipath_aln) << endl;
+        cerr << "attemping pair rescue in " << (rescue_forward ? "forward" : "backward") << " direction from " << debug_string(multipath_aln) << endl;
 #endif
         
         // get the position to jump from and the distance to jump
@@ -563,7 +563,7 @@ namespace vg {
         
 #ifdef debug_multipath_mapper
         cerr << "converted multipath alignment is" << endl;
-        cerr << pb2json(rescue_multipath_aln) << endl;
+        cerr << debug_string(rescue_multipath_aln) << endl;
         cerr << "rescued alignment has effective match length " << pseudo_length(rescue_multipath_aln) << ", which gives p-value " << random_match_p_value(pseudo_length(rescue_multipath_aln), rescue_multipath_aln.sequence().size()) << endl;
 #endif
 
@@ -1256,7 +1256,7 @@ namespace vg {
                 if (!likely_mismapping(cluster_multipath_alns.front())) {
                     bool rescued = attempt_rescue(cluster_multipath_alns.front(), rescue_aln, anchor_is_read_1, rescue_multipath_aln);
 #ifdef debug_multipath_mapper
-                    cerr << "rescued alignment is " << pb2json(rescue_multipath_aln) << endl;
+                    cerr << "rescued alignment is " << debug_string(rescue_multipath_aln) << endl;
 #endif
                     if (rescued) {
 #ifdef debug_multipath_mapper
@@ -1772,8 +1772,8 @@ namespace vg {
             multipath_aln_pair.second.set_paired_read_name(multipath_aln_pair.first.name());
             
             // Annotate with paired end distribution
-//            set_annotation(&multipath_aln_pair.first, "fragment_length_distribution", distribution);
-//            set_annotation(&multipath_aln_pair.second, "fragment_length_distribution", distribution);
+            multipath_aln_pair.first.set_annotation("fragment_length_distribution", distribution);
+            multipath_aln_pair.second.set_annotation("fragment_length_distribution", distribution);
         }
         
         // clean up the graph objects on the heap
@@ -1902,7 +1902,7 @@ namespace vg {
             
             if (comps.size() > 1) {
 #ifdef debug_multipath_mapper
-                cerr << "splitting multicomponent alignment " << pb2json(multipath_alns_out[i]) << endl;
+                cerr << "splitting multicomponent alignment " << debug_string(multipath_alns_out[i]) << endl;
 #endif
                 // split this multipath alignment into its connected components
                 for (size_t j = 1; j < comps.size(); j++) {
@@ -2464,8 +2464,8 @@ namespace vg {
                         
 #ifdef debug_multipath_mapper
                         cerr << "adding component pair at distance " << dist << ":" << endl;
-                        cerr  << pb2json(split_multipath_aln_pair.first) << endl;
-                        cerr  << pb2json(split_multipath_aln_pair.second) << endl;
+                        cerr  << debug_string(split_multipath_aln_pair.first) << endl;
+                        cerr  << debug_string(split_multipath_aln_pair.second) << endl;
 #endif
                         
                         if (!replaced_original) {
@@ -3495,7 +3495,7 @@ namespace vg {
                 
                 // Save the population score from the best total score Alignment.
                 // TODO: This is not the pop score of the linearization that the multipath_alignment_t wants to give us by default.
-//                set_annotation(multipath_alns[i], "haplotype_score", best_linearization_pop_score);
+                multipath_alns[i].set_annotation("haplotype_score", best_linearization_pop_score);
                 
                 // The multipath's base score is the base score of the
                 // best-base-score linear alignment. This is the "adjustment"
@@ -3523,7 +3523,7 @@ namespace vg {
             
             for (auto& mpaln : multipath_alns) {
                 // Remember that we did use population scoring on all these multipath_alignment_ts
-//                set_annotation(mpaln, "haplotype_score_used", true);
+                mpaln.set_annotation("haplotype_score_used", true);
             }
         } else {
             // Clean up pop score annotations and remove scores on all the reads.
@@ -3532,10 +3532,10 @@ namespace vg {
             cerr << "Haplotype consistency score is not being used." << endl;
 #endif
             
-//            for (auto& mpaln : multipath_alns) {
-//                clear_annotation(mpaln, "haplotype_score_used");
-//                clear_annotation(mpaln, "haplotype_score");
-//            }
+            for (auto& mpaln : multipath_alns) {
+                mpaln.clear_annotation("haplotype_score_used");
+                mpaln.clear_annotation("haplotype_score");
+            }
         }
         
         // Select whether to use base or adjusted scores depending on whether
@@ -3620,9 +3620,9 @@ namespace vg {
             // TODO: for some reason set_annotation will accept a double but not an int
             double group_mapq = min<double>(max_mapping_quality, mapq_scaling_factor * raw_mapq);
             
-//            for (size_t i = 0; i < num_reporting; ++i) {
-//                set_annotation(multipath_alns[i], "group_mapq", group_mapq);
-//            }
+            for (size_t i = 0; i < num_reporting; ++i) {
+                multipath_alns[i].set_annotation("group_mapq", group_mapq);
+            }
         }
     }
     
@@ -3840,10 +3840,10 @@ namespace vg {
                 // Compute the total pop adjusted score for this multipath_alignment_t
                 pop_adjusted_scores[i] = best_total_score[0] + best_total_score[1] + frag_score;
                 
-//                // Save the pop scores without the base scores to the multipath alignments.
-//                // TODO: Should we be annotating unmapped reads with 0 pop scores when the other read in the pair is mapped?
-//                set_annotation(multipath_aln_pair.first, "haplotype_score", best_pop_score[0]);
-//                set_annotation(multipath_aln_pair.second, "haplotype_score", best_pop_score[1]);
+                // Save the pop scores without the base scores to the multipath alignments.
+                // TODO: Should we be annotating unmapped reads with 0 pop scores when the other read in the pair is mapped?
+                multipath_aln_pair.first.set_annotation("haplotype_score", best_pop_score[0]);
+                multipath_aln_pair.second.set_annotation("haplotype_score", best_pop_score[1]);
                 
                 assert(!std::isnan(best_total_score[0]));
                 assert(!std::isnan(best_total_score[1]));
@@ -3872,24 +3872,24 @@ namespace vg {
 #ifdef debug_multipath_mapper
             cerr << "Haplotype consistency score is being used." << endl;
 #endif
-//            for (auto& multipath_aln_pair : multipath_aln_pairs) {
-//                // We have to do it on each read in each pair.
-//                // TODO: Come up with a simpler way to dump annotations in based on what happens during mapping.
-//                set_annotation(multipath_aln_pair.first, "haplotype_score_used", true);
-//                set_annotation(multipath_aln_pair.second, "haplotype_score_used", true);
-//            }
+            for (auto& multipath_aln_pair : multipath_aln_pairs) {
+                // We have to do it on each read in each pair.
+                // TODO: Come up with a simpler way to dump annotations in based on what happens during mapping.
+                multipath_aln_pair.first.set_annotation("haplotype_score_used", true);
+                multipath_aln_pair.second.set_annotation("haplotype_score_used", true);
+            }
         } else {
             // Clean up pop score annotations if present and remove scores from all the reads
 #ifdef debug_multipath_mapper
             cerr << "Haplotype consistency score is not being used." << endl;
 #endif
-//            for (auto& multipath_aln_pair : multipath_aln_pairs) {
-//                // We have to do it on each read in each pair.
-//                clear_annotation(multipath_aln_pair.first, "haplotype_score_used");
-//                clear_annotation(multipath_aln_pair.first, "haplotype_score");
-//                clear_annotation(multipath_aln_pair.second, "haplotype_score_used");
-//                clear_annotation(multipath_aln_pair.second, "haplotype_score");
-//            }
+            for (auto& multipath_aln_pair : multipath_aln_pairs) {
+                // We have to do it on each read in each pair.
+                multipath_aln_pair.first.clear_annotation("haplotype_score_used");
+                multipath_aln_pair.first.clear_annotation("haplotype_score");
+                multipath_aln_pair.second.clear_annotation("haplotype_score_used");
+                multipath_aln_pair.second.clear_annotation("haplotype_score");
+            }
         }
         
         // find the order of the scores
@@ -4072,12 +4072,12 @@ namespace vg {
                                        !multipath_aln_pairs.front().second.quality().empty());
             double raw_mapq = aligner->compute_group_mapping_quality(scores, reporting_idxs);
             
-//            // TODO: for some reason set_annotation will accept a double but not an int
-//            double group_mapq = min<double>(max_mapping_quality, mapq_scaling_factor * raw_mapq);
-//            for (size_t i = 0; i < num_reporting; ++i) {
-//                set_annotation(multipath_aln_pairs[i].first, "group_mapq", group_mapq);
-//                set_annotation(multipath_aln_pairs[i].second, "group_mapq", group_mapq);
-//            }
+            // TODO: for some reason set_annotation will accept a double but not an int
+            double group_mapq = min<double>(max_mapping_quality, mapq_scaling_factor * raw_mapq);
+            for (size_t i = 0; i < num_reporting; ++i) {
+                multipath_aln_pairs[i].first.set_annotation("group_mapq", group_mapq);
+                multipath_aln_pairs[i].second.set_annotation("group_mapq", group_mapq);
+            }
         }
     }
             

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -39,13 +39,13 @@ namespace vg {
     }
     
     void MultipathMapper::multipath_map(const Alignment& alignment,
-                                        vector<MultipathAlignment>& multipath_alns_out) {
+                                        vector<multipath_alignment_t>& multipath_alns_out) {
         multipath_map_internal(alignment, mapping_quality_method, multipath_alns_out);
     }
     
     void MultipathMapper::multipath_map_internal(const Alignment& alignment,
                                                  MappingQualityMethod mapq_method,
-                                                 vector<MultipathAlignment>& multipath_alns_out) {
+                                                 vector<multipath_alignment_t>& multipath_alns_out) {
         
 #ifdef debug_multipath_mapper
         cerr << "multipath mapping read " << pb2json(alignment) << endl;
@@ -109,7 +109,7 @@ namespace vg {
         // extract graphs around the clusters
         auto cluster_graphs = query_cluster_graphs(alignment, mems, clusters);
         
-        // actually perform the alignments and post-process to meet MultipathAlignment invariants
+        // actually perform the alignments and post-process to meet multipath_alignment_t invariants
         vector<size_t> cluster_idxs = range_vector(cluster_graphs.size());
         align_to_cluster_graphs(alignment, mapq_method, cluster_graphs, multipath_alns_out, num_mapping_attempts, &cluster_idxs);
         
@@ -145,13 +145,13 @@ namespace vg {
         }
         
         if (simplify_topologies) {
-            for (MultipathAlignment& multipath_aln : multipath_alns_out) {
+            for (multipath_alignment_t& multipath_aln : multipath_alns_out) {
                 merge_non_branching_subpaths(multipath_aln);
             }
         }
         
         if (strip_bonuses) {
-            for (MultipathAlignment& multipath_aln : multipath_alns_out) {
+            for (multipath_alignment_t& multipath_aln : multipath_alns_out) {
                 strip_full_length_bonuses(multipath_aln);
             }
         }
@@ -162,7 +162,7 @@ namespace vg {
         }
 #ifdef debug_pretty_print_alignments
         cerr << "final alignments being returned:" << endl;
-        for (const MultipathAlignment& multipath_aln : multipath_alns_out) {
+        for (const multipath_alignment_t& multipath_aln : multipath_alns_out) {
             view_multipath_alignment(cerr, multipath_aln, *xindex);
         }
 #endif
@@ -268,7 +268,7 @@ namespace vg {
     void MultipathMapper::align_to_cluster_graphs(const Alignment& alignment,
                                                   MappingQualityMethod mapq_method,
                                                   vector<clustergraph_t>& cluster_graphs,
-                                                  vector<MultipathAlignment>& multipath_alns_out,
+                                                  vector<multipath_alignment_t>& multipath_alns_out,
                                                   size_t num_mapping_attempts,
                                                   vector<size_t>* cluster_idxs) {
         
@@ -328,7 +328,7 @@ namespace vg {
 #ifdef debug_multipath_mapper
         cerr << "topologically ordering " << multipath_alns_out.size() << " multipath alignments" << endl;
 #endif
-        for (MultipathAlignment& multipath_aln : multipath_alns_out) {
+        for (multipath_alignment_t& multipath_aln : multipath_alns_out) {
             topologically_order_subpaths(multipath_aln);
         }
         
@@ -344,7 +344,7 @@ namespace vg {
         // for debugging: an expensive check for invariant validity that can be turned on
         // with a preprocessor flag
 #ifdef debug_validate_multipath_alignments
-        for (MultipathAlignment& multipath_aln : multipath_alns_out) {
+        for (multipath_alignment_t& multipath_aln : multipath_alns_out) {
 #ifdef debug_multipath_mapper
             cerr << "validating multipath alignment:" << endl;
             cerr << pb2json(multipath_aln) << endl;
@@ -359,12 +359,12 @@ namespace vg {
     }
     
     void MultipathMapper::attempt_unpaired_multipath_map_of_pair(const Alignment& alignment1, const Alignment& alignment2,
-                                                                 vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                                                 vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                                  vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer) {
         
         // compute single ended mappings, and make sure we also compute mapping qualities to assess
         // mapping ambiguity
-        vector<MultipathAlignment> multipath_alns_1, multipath_alns_2;
+        vector<multipath_alignment_t> multipath_alns_1, multipath_alns_2;
         multipath_map_internal(alignment1, mapping_quality_method == None ? Approx : mapping_quality_method,
                                multipath_alns_1);
         multipath_map_internal(alignment2, mapping_quality_method == None ? Approx : mapping_quality_method,
@@ -373,8 +373,8 @@ namespace vg {
         bool is_ambiguous = true;
         
         if (!multipath_alns_1.empty() && !multipath_alns_2.empty()) {
-            MultipathAlignment& multipath_aln_1 = multipath_alns_1.front();
-            MultipathAlignment& multipath_aln_2 = multipath_alns_2.front();
+            multipath_alignment_t& multipath_aln_1 = multipath_alns_1.front();
+            multipath_alignment_t& multipath_aln_2 = multipath_alns_2.front();
             
             auto aligner = get_aligner(!alignment1.quality().empty() && !alignment2.quality().empty());
             
@@ -462,8 +462,8 @@ namespace vg {
 #endif
     }
     
-    bool MultipathMapper::attempt_rescue(const MultipathAlignment& multipath_aln, const Alignment& other_aln,
-                                         bool rescue_forward, MultipathAlignment& rescue_multipath_aln) {
+    bool MultipathMapper::attempt_rescue(const multipath_alignment_t& multipath_aln, const Alignment& other_aln,
+                                         bool rescue_forward, multipath_alignment_t& rescue_multipath_aln) {
         
 #ifdef debug_multipath_mapper
         cerr << "attemping pair rescue in " << (rescue_forward ? "forward" : "backward") << " direction from " << pb2json(multipath_aln) << endl;
@@ -599,7 +599,7 @@ namespace vg {
         }
     }
     
-    bool MultipathMapper::likely_mismapping(const MultipathAlignment& multipath_aln) {
+    bool MultipathMapper::likely_mismapping(const multipath_alignment_t& multipath_aln) {
     
         // empirically, we get better results by scaling the pseudo-length down, I have no good explanation for this probabilistically
         auto p_val = random_match_p_value(pseudo_length(multipath_aln), multipath_aln.sequence().size());
@@ -611,7 +611,7 @@ namespace vg {
         return p_val > max_mapping_p_value;
     }
     
-    size_t MultipathMapper::pseudo_length(const MultipathAlignment& multipath_aln) const {
+    size_t MultipathMapper::pseudo_length(const multipath_alignment_t& multipath_aln) const {
         Alignment alignment;
         optimal_alignment(multipath_aln, alignment);
         const Path& path = alignment.path();
@@ -709,7 +709,7 @@ namespace vg {
                 
                 Alignment alignment;
                 alignment.set_sequence(pseudo_random_sequence(simulated_read_length, i * 716293332 + simulated_read_length));
-                vector<MultipathAlignment> multipath_alns;
+                vector<multipath_alignment_t> multipath_alns;
                 multipath_map(alignment, multipath_alns);
                 
                 if (!multipath_alns.empty()) {
@@ -783,8 +783,8 @@ namespace vg {
         suppress_p_value_memoization = false;
     }
     
-    int64_t MultipathMapper::distance_between(const MultipathAlignment& multipath_aln_1,
-                                              const MultipathAlignment& multipath_aln_2,
+    int64_t MultipathMapper::distance_between(const multipath_alignment_t& multipath_aln_1,
+                                              const multipath_alignment_t& multipath_aln_2,
                                               bool full_fragment, bool forward_strand) const {
                                               
         if (multipath_aln_1.subpath_size() == 0 || multipath_aln_2.subpath_size() == 0) {
@@ -837,14 +837,14 @@ namespace vg {
                 && distance > fragment_length_distr.mean() - 10.0 * fragment_length_distr.stdev());
     }
     
-    bool MultipathMapper::are_consistent(const MultipathAlignment& multipath_aln_1,
-                                         const MultipathAlignment& multipath_aln_2) const {
+    bool MultipathMapper::are_consistent(const multipath_alignment_t& multipath_aln_1,
+                                         const multipath_alignment_t& multipath_aln_2) const {
         
         return is_consistent(distance_between(multipath_aln_1, multipath_aln_2, true));
     }
     
-    bool MultipathMapper::share_terminal_positions(const MultipathAlignment& multipath_aln_1,
-                                                   const MultipathAlignment& multipath_aln_2) const {
+    bool MultipathMapper::share_terminal_positions(const multipath_alignment_t& multipath_aln_1,
+                                                   const multipath_alignment_t& multipath_aln_2) const {
         
         unordered_set<pos_t> terminal_positions;
         
@@ -864,14 +864,14 @@ namespace vg {
         
         // now look for matching ends
         for (size_t i = 0; i < multipath_aln_1.subpath_size(); i++) {
-            const Subpath& subpath = multipath_aln_1.subpath(i);
+            const subpath_t& subpath = multipath_aln_1.subpath(i);
             if (subpath.next_size() == 0) {
                 terminal_positions.insert(final_position(subpath.path()));
             }
         }
         
         for (size_t i = 0; i < multipath_aln_2.subpath_size(); i++) {
-            const Subpath& subpath = multipath_aln_2.subpath(i);
+            const subpath_t& subpath = multipath_aln_2.subpath(i);
             if (subpath.next_size() == 0) {
                 if (terminal_positions.count(final_position(subpath.path()))) {
                     return true;
@@ -886,12 +886,12 @@ namespace vg {
                                                               vector<clustergraph_t>& cluster_graphs1,
                                                               vector<clustergraph_t>& cluster_graphs2,
                                                               bool block_rescue_from_1, bool block_rescue_from_2,
-                                                              vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                                              vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                               vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances,
                                                               vector<double>& pair_multiplicities) {
         
         // align the two ends independently
-        vector<MultipathAlignment> multipath_alns_1, multipath_alns_2;
+        vector<multipath_alignment_t> multipath_alns_1, multipath_alns_2;
         vector<size_t> cluster_idxs_1, cluster_idxs_2;
         if (!block_rescue_from_1) {
             cluster_idxs_1 = range_vector(cluster_graphs1.size());
@@ -961,11 +961,11 @@ namespace vg {
         double estimated_multiplicity_from_2 = num_to_rescue_2 > 0 ? double(num_rescuable_alns_2) / num_to_rescue_2 : 1.0;
         
         // actually doe the rescues and record which ones succeeded
-        vector<MultipathAlignment> rescue_multipath_alns_1(num_to_rescue_2), rescue_multipath_alns_2(num_to_rescue_1);
+        vector<multipath_alignment_t> rescue_multipath_alns_1(num_to_rescue_2), rescue_multipath_alns_2(num_to_rescue_1);
         unordered_set<size_t> rescued_from_1, rescued_from_2;
         
         for (size_t i = 0; i < num_to_rescue_1; i++) {
-            MultipathAlignment rescue_multipath_aln;
+            multipath_alignment_t rescue_multipath_aln;
             if (attempt_rescue(multipath_alns_1[i], alignment2, true, rescue_multipath_aln)) {
                 rescued_from_1.insert(i);
                 rescue_multipath_alns_2[i] = move(rescue_multipath_aln);
@@ -973,7 +973,7 @@ namespace vg {
         }
         
         for (size_t i = 0; i < num_to_rescue_2; i++) {
-            MultipathAlignment rescue_multipath_aln;
+            multipath_alignment_t rescue_multipath_aln;
             if (attempt_rescue(multipath_alns_2[i], alignment1, false, rescue_multipath_aln)) {
                 rescued_from_2.insert(i);
                 rescue_multipath_alns_1[i] = move(rescue_multipath_aln);
@@ -1110,13 +1110,13 @@ namespace vg {
                     
                 }
                 else if (i < multipath_alns_1.size()) {
-                    multipath_aln_pairs_out.emplace_back(move(multipath_alns_1[i]), MultipathAlignment());
+                    multipath_aln_pairs_out.emplace_back(move(multipath_alns_1[i]), multipath_alignment_t());
                     to_multipath_alignment(alignment2, multipath_aln_pairs_out.back().second);
                     multipath_aln_pairs_out.back().second.clear_subpath();
                     multipath_aln_pairs_out.back().second.clear_start();
                 }
                 else {
-                    multipath_aln_pairs_out.emplace_back(MultipathAlignment(), move(multipath_alns_2[i]));
+                    multipath_aln_pairs_out.emplace_back(multipath_alignment_t(), move(multipath_alns_2[i]));
                     to_multipath_alignment(alignment1, multipath_aln_pairs_out.back().first);
                     multipath_aln_pairs_out.back().first.clear_subpath();
                     multipath_aln_pairs_out.back().first.clear_start();
@@ -1125,7 +1125,7 @@ namespace vg {
         }
         
 #ifdef debug_validate_multipath_alignments
-        for (pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair : multipath_aln_pairs_out) {
+        for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
 #ifdef debug_multipath_mapper
             cerr << "validating multipath alignments:" << endl;
             cerr << pb2json(multipath_aln_pair.first) << endl;
@@ -1143,9 +1143,9 @@ namespace vg {
 #endif
         
         if (mapping_quality_method == None) {
-            for (pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair : multipath_aln_pairs_out) {
-                multipath_aln_pair.first.clear_mapping_quality();
-                multipath_aln_pair.second.clear_mapping_quality();
+            for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
+                multipath_aln_pair.first.set_mapping_quality(0);
+                multipath_aln_pair.second.set_mapping_quality(0);
             }
         }
         
@@ -1156,7 +1156,7 @@ namespace vg {
                                                          vector<clustergraph_t>& cluster_graphs1,
                                                          vector<clustergraph_t>& cluster_graphs2,
                                                          vector<pair<size_t, size_t>>& duplicate_pairs,
-                                                         vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                                         vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                          vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs) {
         
 #ifdef debug_multipath_mapper
@@ -1183,7 +1183,7 @@ namespace vg {
         int32_t cluster_score_2 = aligner->match * get<2>(cluster_graphs2[cluster_pairs.front().first.second]);
         int32_t max_score_diff = secondary_rescue_score_diff * aligner->mapping_quality_score_diff(max_mapping_quality);
         
-        vector<pair<MultipathAlignment, MultipathAlignment>> rescued_secondaries;
+        vector<pair<multipath_alignment_t, multipath_alignment_t>> rescued_secondaries;
         vector<pair<pair<size_t, size_t>, int64_t>> rescued_distances;
         vector<double> rescued_multiplicities;
         
@@ -1234,7 +1234,7 @@ namespace vg {
                 // TODO: repetitive with align_to_cluster_graphs
                 
                 // make the alignment
-                vector<MultipathAlignment> cluster_multipath_alns;
+                vector<multipath_alignment_t> cluster_multipath_alns;
                 cluster_multipath_alns.emplace_back();
                 multipath_align(anchor_aln, get<0>(cluster_graphs[i]), get<1>(cluster_graphs[i]), cluster_multipath_alns.back());
                 
@@ -1242,7 +1242,7 @@ namespace vg {
                 split_multicomponent_alignments(cluster_multipath_alns);
                 
                 // order the subpaths
-                for (MultipathAlignment& multipath_aln : cluster_multipath_alns) {
+                for (multipath_alignment_t& multipath_aln : cluster_multipath_alns) {
                     topologically_order_subpaths(multipath_aln);
                 }
                 
@@ -1252,7 +1252,7 @@ namespace vg {
                 }
                 
                 // rescue from the alignment
-                MultipathAlignment rescue_multipath_aln;
+                multipath_alignment_t rescue_multipath_aln;
                 if (!likely_mismapping(cluster_multipath_alns.front())) {
                     bool rescued = attempt_rescue(cluster_multipath_alns.front(), rescue_aln, anchor_is_read_1, rescue_multipath_aln);
 #ifdef debug_multipath_mapper
@@ -1313,7 +1313,7 @@ namespace vg {
         align_and_rescue(alignment2, alignment1, cluster_graphs2, paired_clusters_2, cluster_score_2, false);
         
 #ifdef debug_validate_multipath_alignments
-        for (pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair : rescued_secondaries) {
+        for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : rescued_secondaries) {
 #ifdef debug_multipath_mapper
             cerr << "validating rescued secondary multipath alignments:" << endl;
             cerr << pb2json(multipath_aln_pair.first) << endl;
@@ -1385,7 +1385,7 @@ namespace vg {
     }
     
     void MultipathMapper::multipath_map_paired(const Alignment& alignment1, const Alignment& alignment2,
-                                               vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                               vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer) {
                 
 #ifdef debug_multipath_mapper
@@ -1628,7 +1628,7 @@ namespace vg {
                     // we're not happy with the pairs we got, try to get a good pair by rescuing from single ended alignments
                     // but block rescue from any sides that we already tried rescue from in the repeat rescue routine
                     
-                    vector<pair<MultipathAlignment, MultipathAlignment>> rescue_aln_pairs;
+                    vector<pair<multipath_alignment_t, multipath_alignment_t>> rescue_aln_pairs;
                     vector<pair<pair<size_t, size_t>, int64_t>> rescue_distances;
                     vector<double> rescue_multiplicities;
                     bool rescued = align_to_cluster_graphs_with_rescue(alignment1, alignment2, cluster_graphs1, cluster_graphs2,
@@ -1748,7 +1748,7 @@ namespace vg {
         }
         
         if (simplify_topologies) {
-            for (pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair : multipath_aln_pairs_out) {
+            for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
                 merge_non_branching_subpaths(multipath_aln_pair.first);
                 merge_non_branching_subpaths(multipath_aln_pair.second);
             }
@@ -1756,7 +1756,7 @@ namespace vg {
         
         // remove the full length bonus if we don't want it in the final score
         if (strip_bonuses) {
-            for (pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair : multipath_aln_pairs_out) {
+            for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
                 strip_full_length_bonuses(multipath_aln_pair.first);
                 strip_full_length_bonuses(multipath_aln_pair.second);
             }
@@ -1766,14 +1766,14 @@ namespace vg {
         // TODO: make this machine-readable instead of a copy-able string.
         string distribution = "-I " + to_string(fragment_length_distr.mean()) + " -D " + to_string(fragment_length_distr.stdev());
         
-        for (pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair : multipath_aln_pairs_out) {
+        for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
             // add pair names to connect the paired reads
             multipath_aln_pair.first.set_paired_read_name(multipath_aln_pair.second.name());
             multipath_aln_pair.second.set_paired_read_name(multipath_aln_pair.first.name());
             
             // Annotate with paired end distribution
-            set_annotation(&multipath_aln_pair.first, "fragment_length_distribution", distribution);
-            set_annotation(&multipath_aln_pair.second, "fragment_length_distribution", distribution);
+//            set_annotation(&multipath_aln_pair.first, "fragment_length_distribution", distribution);
+//            set_annotation(&multipath_aln_pair.second, "fragment_length_distribution", distribution);
         }
         
         // clean up the graph objects on the heap
@@ -1786,7 +1786,7 @@ namespace vg {
         
 #ifdef debug_pretty_print_alignments
         cerr << "final alignments being returned:" << endl;
-        for (const pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair : multipath_aln_pairs_out) {
+        for (const pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
             cerr << "read 1: " << endl;
             view_multipath_alignment(cerr, multipath_aln_pair.first, *xindex);
             cerr << "read 2: " << endl;
@@ -1795,7 +1795,7 @@ namespace vg {
 #endif
     }
     
-    void MultipathMapper::reduce_to_single_path(const MultipathAlignment& multipath_aln, vector<Alignment>& alns_out,
+    void MultipathMapper::reduce_to_single_path(const multipath_alignment_t& multipath_aln, vector<Alignment>& alns_out,
                                                 size_t max_number) const {
     
 #ifdef debug_multipath_mapper
@@ -1892,7 +1892,7 @@ namespace vg {
         }
     }
     
-    void MultipathMapper::split_multicomponent_alignments(vector<MultipathAlignment>& multipath_alns_out,
+    void MultipathMapper::split_multicomponent_alignments(vector<multipath_alignment_t>& multipath_alns_out,
                                                           vector<size_t>* cluster_idxs) const {
         
         size_t num_original_alns = multipath_alns_out.size();
@@ -1915,7 +1915,7 @@ namespace vg {
                     }
                 }
                 // put the first component into the original location
-                MultipathAlignment last_component;
+                multipath_alignment_t last_component;
                 extract_sub_multipath_alignment(multipath_alns_out[i], comps[0], last_component);
                 multipath_alns_out[i] = last_component;
             }
@@ -1927,7 +1927,7 @@ namespace vg {
                                                                    bool do_repeat_rescue_from_1, bool do_repeat_rescue_from_2,
                                                                    vector<memcluster_t>& clusters1, vector<memcluster_t>& clusters2,
                                                                    vector<clustergraph_t>& cluster_graphs1, vector<clustergraph_t>& cluster_graphs2,
-                                                                   vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                                                   vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                                    vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances,
                                                                    OrientedDistanceMeasurer& distance_measurer) {
         
@@ -1948,7 +1948,7 @@ namespace vg {
             cluster_graphs1 = query_cluster_graphs(alignment1, mems1, clusters1);
             
             // attempt rescue from these graphs
-            vector<pair<MultipathAlignment, MultipathAlignment>> rescued_pairs;
+            vector<pair<multipath_alignment_t, multipath_alignment_t>> rescued_pairs;
             vector<pair<pair<size_t, size_t>, int64_t>> rescued_distances;
             vector<double> rescued_multiplicities;
             rescue_succeeded_from_1 = align_to_cluster_graphs_with_rescue(alignment1, alignment2, cluster_graphs1, cluster_graphs2,
@@ -1987,7 +1987,7 @@ namespace vg {
             cluster_graphs2 = query_cluster_graphs(alignment2, mems2, clusters2);
             
             // attempt rescue from these graphs
-            vector<pair<MultipathAlignment, MultipathAlignment>> rescued_pairs;
+            vector<pair<multipath_alignment_t, multipath_alignment_t>> rescued_pairs;
             vector<pair<pair<size_t, size_t>, int64_t>> rescued_distances;
             vector<double> rescued_multiplicities;
             rescue_succeeded_from_2 = align_to_cluster_graphs_with_rescue(alignment1, alignment2, cluster_graphs1, cluster_graphs2,
@@ -2024,9 +2024,9 @@ namespace vg {
         }
     }
     
-    void MultipathMapper::merge_rescued_mappings(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+    void MultipathMapper::merge_rescued_mappings(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                  vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
-                                                 vector<pair<MultipathAlignment, MultipathAlignment>>& rescued_multipath_aln_pairs,
+                                                 vector<pair<multipath_alignment_t, multipath_alignment_t>>& rescued_multipath_aln_pairs,
                                                  vector<pair<pair<size_t, size_t>, int64_t>>& rescued_cluster_pairs,
                                                  vector<double>& rescued_multiplicities) const {
                 
@@ -2071,7 +2071,7 @@ namespace vg {
         sort_and_compute_mapping_quality(multipath_aln_pairs_out, cluster_pairs, nullptr, &merged_multiplicities);
     }
     
-    void MultipathMapper::cap_mapping_quality_by_rescue_probability(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+    void MultipathMapper::cap_mapping_quality_by_rescue_probability(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                                     vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                                                     vector<clustergraph_t>& cluster_graphs1,
                                                                     vector<clustergraph_t>& cluster_graphs2,
@@ -2173,7 +2173,7 @@ namespace vg {
         return prob_of_missing_all;
     }
     
-    void MultipathMapper::cap_mapping_quality_by_hit_sampling_probability(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+    void MultipathMapper::cap_mapping_quality_by_hit_sampling_probability(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                                           vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                                                           vector<clustergraph_t>& cluster_graphs1,
                                                                           vector<clustergraph_t>& cluster_graphs2,
@@ -2351,7 +2351,7 @@ namespace vg {
         }
     }
     
-    void MultipathMapper::cap_mapping_quality_by_hit_sampling_probability(vector<MultipathAlignment>& multipath_alns_out,
+    void MultipathMapper::cap_mapping_quality_by_hit_sampling_probability(vector<multipath_alignment_t>& multipath_alns_out,
                                                                           vector<size_t>& cluster_idxs,
                                                                           vector<clustergraph_t>& cluster_graphs) const {
         
@@ -2378,7 +2378,7 @@ namespace vg {
         }
     }
     
-    void MultipathMapper::split_multicomponent_alignments(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+    void MultipathMapper::split_multicomponent_alignments(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                           vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs) const {
         
         size_t original_num_pairs = multipath_aln_pairs_out.size();
@@ -2410,7 +2410,7 @@ namespace vg {
             }
 #endif
             // we will put pairs of split up components in here
-            vector<pair<MultipathAlignment, MultipathAlignment>> split_multipath_alns;
+            vector<pair<multipath_alignment_t, multipath_alignment_t>> split_multipath_alns;
             
             if (connected_components_1.size() > 1 && connected_components_2.size() > 1) {
 #ifdef debug_multipath_mapper
@@ -2433,7 +2433,7 @@ namespace vg {
 #endif
                 // only need to split first end
                 for (size_t j = 0; j < connected_components_1.size(); j++) {
-                    split_multipath_alns.emplace_back(MultipathAlignment(), multipath_aln_pairs_out[i].second);
+                    split_multipath_alns.emplace_back(multipath_alignment_t(), multipath_aln_pairs_out[i].second);
                     extract_sub_multipath_alignment(multipath_aln_pairs_out[i].first, connected_components_1[j],
                                                     split_multipath_alns.back().first);
                 }
@@ -2444,7 +2444,7 @@ namespace vg {
 #endif
                 // only need to split second end
                 for (size_t j = 0; j < connected_components_2.size(); j++) {
-                    split_multipath_alns.emplace_back(multipath_aln_pairs_out[i].first, MultipathAlignment());
+                    split_multipath_alns.emplace_back(multipath_aln_pairs_out[i].first, multipath_alignment_t());
                     extract_sub_multipath_alignment(multipath_aln_pairs_out[i].second, connected_components_2[j],
                                                     split_multipath_alns.back().second);
                 }
@@ -2454,7 +2454,7 @@ namespace vg {
             if (!split_multipath_alns.empty()) {
                 
                 bool replaced_original = false;
-                for (pair<MultipathAlignment, MultipathAlignment>& split_multipath_aln_pair : split_multipath_alns) {
+                for (pair<multipath_alignment_t, multipath_alignment_t>& split_multipath_aln_pair : split_multipath_alns) {
                     // we also need to measure the disance for scoring
                     int64_t dist = distance_between(split_multipath_aln_pair.first, split_multipath_aln_pair.second,
                                                     true);
@@ -2489,7 +2489,7 @@ namespace vg {
                                                        vector<clustergraph_t>& cluster_graphs1,
                                                        vector<clustergraph_t>& cluster_graphs2,
                                                        vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
-                                                       vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                                       vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                        vector<pair<size_t, size_t>>& duplicate_pairs_out) {
         
         assert(multipath_aln_pairs_out.empty());
@@ -2612,7 +2612,7 @@ namespace vg {
         
         // downstream algorithms assume multipath alignments are topologically sorted (including the scoring
         // algorithm in the next step)
-        for (pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair : multipath_aln_pairs_out) {
+        for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
             topologically_order_subpaths(multipath_aln_pair.first);
             topologically_order_subpaths(multipath_aln_pair.second);
         }
@@ -2621,7 +2621,7 @@ namespace vg {
         sort_and_compute_mapping_quality(multipath_aln_pairs_out, cluster_pairs, &duplicate_pairs_out);
         
 #ifdef debug_validate_multipath_alignments
-        for (pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair : multipath_aln_pairs_out) {
+        for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
 #ifdef debug_multipath_mapper
             cerr << "validating multipath alignments:" << endl;
             cerr << pb2json(multipath_aln_pair.first) << endl;
@@ -2990,7 +2990,7 @@ namespace vg {
     
     void MultipathMapper::multipath_align(const Alignment& alignment, const bdsg::HashGraph* graph,
                                           memcluster_t& graph_mems,
-                                          MultipathAlignment& multipath_aln_out) const {
+                                          multipath_alignment_t& multipath_aln_out) const {
 
 #ifdef debug_multipath_mapper_alignment
         cerr << "constructing alignment graph" << endl;
@@ -3152,11 +3152,11 @@ namespace vg {
                                                           : size_t(band_padding_multiplier * sqrt(read_length)) + 1;
         };
         
-        // do the connecting alignments and fill out the MultipathAlignment object
+        // do the connecting alignments and fill out the multipath_alignment_t object
         multi_aln_graph.align(alignment, *align_dag, aligner, true, num_alt_alns, dynamic_max_alt_alns, max_alignment_gap,
                               pessimistic_tail_gap_multiplier, choose_band_padding, multipath_aln_out);
         
-        // Note that we do NOT topologically order the MultipathAlignment. The
+        // Note that we do NOT topologically order the multipath_alignment_t. The
         // caller has to do that, after it is finished breaking it up into
         // connected components or whatever.
         
@@ -3177,7 +3177,7 @@ namespace vg {
             
     void MultipathMapper::make_nontrivial_multipath_alignment(const Alignment& alignment, const HandleGraph& subgraph,
                                                               const function<pair<id_t, bool>(id_t)>& translator,
-                                                              SnarlManager& snarl_manager, MultipathAlignment& multipath_aln_out) const {
+                                                              SnarlManager& snarl_manager, multipath_alignment_t& multipath_aln_out) const {
         
 #ifdef debug_multipath_mapper_alignment
         cerr << "attempting to make nontrivial alignment for " << alignment.name() << endl;
@@ -3201,7 +3201,7 @@ namespace vg {
                                                           : size_t(band_padding_multiplier * sqrt(read_length)) + 1;
         };
         
-        // do the connecting alignments and fill out the MultipathAlignment object
+        // do the connecting alignments and fill out the multipath_alignment_t object
         multi_aln_graph.align(alignment, subgraph, aligner, false, num_alt_alns, dynamic_max_alt_alns, max_alignment_gap,
                               pessimistic_tail_gap_multiplier, choose_band_padding, multipath_aln_out);
         
@@ -3244,7 +3244,7 @@ namespace vg {
         return total + (curr_end - curr_begin);
     }
     
-    void MultipathMapper::strip_full_length_bonuses(MultipathAlignment& multipath_aln) const {
+    void MultipathMapper::strip_full_length_bonuses(multipath_alignment_t& multipath_aln) const {
         
         // TODO: this could technically be wrong if only one read in a pair has qualities
         int32_t full_length_bonus = get_aligner(!multipath_aln.quality().empty())->full_length_bonus;
@@ -3252,8 +3252,9 @@ namespace vg {
         if (multipath_aln.start_size()) {
             // use the precomputed list of sources if we have it
             for (size_t i = 0; i < multipath_aln.start_size(); i++) {
-                Subpath* source_subpath = multipath_aln.mutable_subpath(multipath_aln.start(i));
-                if (edit_is_insertion(source_subpath->path().mapping(0).edit(0))) {
+                subpath_t* source_subpath = multipath_aln.mutable_subpath(multipath_aln.start(i));
+                const edit_t& edit = source_subpath->path().mapping(0).edit(0);
+                if (edit.to_length() > 0 && edit.from_length() == 0) {
                     source_subpath->set_score(source_subpath->score() - full_length_bonus);
                 }
             }
@@ -3262,7 +3263,7 @@ namespace vg {
             // find sources
             vector<bool> is_source(multipath_aln.subpath_size(), true);
             for (size_t i = 0; i < multipath_aln.subpath_size(); i++) {
-                const Subpath& subpath = multipath_aln.subpath(i);
+                const subpath_t& subpath = multipath_aln.subpath(i);
                 for (size_t j = 0; j < subpath.next_size(); j++) {
                     is_source[subpath.next(j)] = false;
                 }
@@ -3272,18 +3273,20 @@ namespace vg {
                 if (!is_source[i]) {
                     continue;
                 }
-                Subpath* source_subpath = multipath_aln.mutable_subpath(i);
-                if (edit_is_insertion(source_subpath->path().mapping(0).edit(0))) {
+                subpath_t* source_subpath = multipath_aln.mutable_subpath(i);
+                const edit_t& edit = source_subpath->path().mapping(0).edit(0);
+                if (edit.to_length() > 0 && edit.from_length() == 0) {
                     source_subpath->set_score(source_subpath->score() - full_length_bonus);
                 }
             }
         }
         // strip bonus from sink paths
         for (size_t i = 0; i < multipath_aln.subpath_size(); i++) {
-            Subpath* subpath = multipath_aln.mutable_subpath(i);
+            subpath_t* subpath = multipath_aln.mutable_subpath(i);
             if (subpath->next_size() == 0) {
-                const Mapping& final_mapping = subpath->path().mapping(subpath->path().mapping_size() - 1);
-                if (edit_is_insertion(final_mapping.edit(final_mapping.edit_size() - 1))) {
+                const path_mapping_t& final_mapping = subpath->path().mapping(subpath->path().mapping_size() - 1);
+                const edit_t& edit = final_mapping.edit(final_mapping.edit_size() - 1);
+                if (edit.to_length() > 0 && edit.from_length() == 0) {
                     subpath->set_score(subpath->score() - full_length_bonus);
                 }
             }
@@ -3318,7 +3321,7 @@ namespace vg {
 
     }
     
-    void MultipathMapper::sort_and_compute_mapping_quality(vector<MultipathAlignment>& multipath_alns,
+    void MultipathMapper::sort_and_compute_mapping_quality(vector<multipath_alignment_t>& multipath_alns,
                                                            MappingQualityMethod mapq_method,
                                                            vector<size_t>* cluster_idxs) const {
         if (multipath_alns.empty()) {
@@ -3337,9 +3340,9 @@ namespace vg {
         
         double log_base = get_aligner(!multipath_alns.front().quality().empty())->log_base;
         
-        // The score of the optimal Alignment for each MultipathAlignment, not adjusted for population
+        // The score of the optimal Alignment for each multipath_alignment_t, not adjusted for population
         vector<double> base_scores(multipath_alns.size(), 0.0);
-        // The scores of the best Alignment for each MultipathAlignment, adjusted for population.
+        // The scores of the best Alignment for each multipath_alignment_t, adjusted for population.
         // These can be negative but will be bumped up to all be positive later.
         vector<double> pop_adjusted_scores;
         if (include_population_component) {
@@ -3387,7 +3390,7 @@ namespace vg {
             cerr << pb2json(multipath_alns[i]) << endl;
 #endif
            
-            // Now, we may have been fed a MultipathAlignment where the best
+            // Now, we may have been fed a multipath_alignment_t where the best
             // single path alignment is to leave it unmapped alltogether. Maybe
             // we cut out a really terrible bit of the alignment graph somehow.
             // We used to fail an assert in that case, but we can handle it as
@@ -3491,8 +3494,8 @@ namespace vg {
 #endif
                 
                 // Save the population score from the best total score Alignment.
-                // TODO: This is not the pop score of the linearization that the MultipathAlignment wants to give us by default.
-                set_annotation(multipath_alns[i], "haplotype_score", best_linearization_pop_score); 
+                // TODO: This is not the pop score of the linearization that the multipath_alignment_t wants to give us by default.
+//                set_annotation(multipath_alns[i], "haplotype_score", best_linearization_pop_score);
                 
                 // The multipath's base score is the base score of the
                 // best-base-score linear alignment. This is the "adjustment"
@@ -3519,8 +3522,8 @@ namespace vg {
             }
             
             for (auto& mpaln : multipath_alns) {
-                // Remember that we did use population scoring on all these MultipathAlignments
-                set_annotation(mpaln, "haplotype_score_used", true);
+                // Remember that we did use population scoring on all these multipath_alignment_ts
+//                set_annotation(mpaln, "haplotype_score_used", true);
             }
         } else {
             // Clean up pop score annotations and remove scores on all the reads.
@@ -3529,10 +3532,10 @@ namespace vg {
             cerr << "Haplotype consistency score is not being used." << endl;
 #endif
             
-            for (auto& mpaln : multipath_alns) {
-                clear_annotation(mpaln, "haplotype_score_used");
-                clear_annotation(mpaln, "haplotype_score");
-            }
+//            for (auto& mpaln : multipath_alns) {
+//                clear_annotation(mpaln, "haplotype_score_used");
+//                clear_annotation(mpaln, "haplotype_score");
+//            }
         }
         
         // Select whether to use base or adjusted scores depending on whether
@@ -3617,14 +3620,14 @@ namespace vg {
             // TODO: for some reason set_annotation will accept a double but not an int
             double group_mapq = min<double>(max_mapping_quality, mapq_scaling_factor * raw_mapq);
             
-            for (size_t i = 0; i < num_reporting; ++i) {
-                set_annotation(multipath_alns[i], "group_mapq", group_mapq);
-            }
+//            for (size_t i = 0; i < num_reporting; ++i) {
+//                set_annotation(multipath_alns[i], "group_mapq", group_mapq);
+//            }
         }
     }
     
     // TODO: pretty duplicative with the unpaired version
-    void MultipathMapper::sort_and_compute_mapping_quality(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs,
+    void MultipathMapper::sort_and_compute_mapping_quality(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs,
                                                            vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                                            vector<pair<size_t, size_t>>* duplicate_pairs_out,
                                                            vector<double>* multiplicities) const {
@@ -3678,7 +3681,7 @@ namespace vg {
         
         for (size_t i = 0; i < multipath_aln_pairs.size(); i++) {
             // For each pair of read placements
-            pair<MultipathAlignment, MultipathAlignment>& multipath_aln_pair = multipath_aln_pairs[i];
+            pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair = multipath_aln_pairs[i];
             
             // We will query the population database for this alignment pair if it
             // is turned on and it succeeded for the others.
@@ -3834,13 +3837,13 @@ namespace vg {
                     continue;
                 }
                 
-                // Compute the total pop adjusted score for this MultipathAlignment
+                // Compute the total pop adjusted score for this multipath_alignment_t
                 pop_adjusted_scores[i] = best_total_score[0] + best_total_score[1] + frag_score;
                 
-                // Save the pop scores without the base scores to the multipath alignments.
-                // TODO: Should we be annotating unmapped reads with 0 pop scores when the other read in the pair is mapped?
-                set_annotation(multipath_aln_pair.first, "haplotype_score", best_pop_score[0]);
-                set_annotation(multipath_aln_pair.second, "haplotype_score", best_pop_score[1]);
+//                // Save the pop scores without the base scores to the multipath alignments.
+//                // TODO: Should we be annotating unmapped reads with 0 pop scores when the other read in the pair is mapped?
+//                set_annotation(multipath_aln_pair.first, "haplotype_score", best_pop_score[0]);
+//                set_annotation(multipath_aln_pair.second, "haplotype_score", best_pop_score[1]);
                 
                 assert(!std::isnan(best_total_score[0]));
                 assert(!std::isnan(best_total_score[1]));
@@ -3869,24 +3872,24 @@ namespace vg {
 #ifdef debug_multipath_mapper
             cerr << "Haplotype consistency score is being used." << endl;
 #endif
-            for (auto& multipath_aln_pair : multipath_aln_pairs) {
-                // We have to do it on each read in each pair.
-                // TODO: Come up with a simpler way to dump annotations in based on what happens during mapping.
-                set_annotation(multipath_aln_pair.first, "haplotype_score_used", true);
-                set_annotation(multipath_aln_pair.second, "haplotype_score_used", true);
-            }
+//            for (auto& multipath_aln_pair : multipath_aln_pairs) {
+//                // We have to do it on each read in each pair.
+//                // TODO: Come up with a simpler way to dump annotations in based on what happens during mapping.
+//                set_annotation(multipath_aln_pair.first, "haplotype_score_used", true);
+//                set_annotation(multipath_aln_pair.second, "haplotype_score_used", true);
+//            }
         } else {
             // Clean up pop score annotations if present and remove scores from all the reads
 #ifdef debug_multipath_mapper
             cerr << "Haplotype consistency score is not being used." << endl;
 #endif
-            for (auto& multipath_aln_pair : multipath_aln_pairs) {
-                // We have to do it on each read in each pair.
-                clear_annotation(multipath_aln_pair.first, "haplotype_score_used");
-                clear_annotation(multipath_aln_pair.first, "haplotype_score");
-                clear_annotation(multipath_aln_pair.second, "haplotype_score_used");
-                clear_annotation(multipath_aln_pair.second, "haplotype_score");
-            }
+//            for (auto& multipath_aln_pair : multipath_aln_pairs) {
+//                // We have to do it on each read in each pair.
+//                clear_annotation(multipath_aln_pair.first, "haplotype_score_used");
+//                clear_annotation(multipath_aln_pair.first, "haplotype_score");
+//                clear_annotation(multipath_aln_pair.second, "haplotype_score_used");
+//                clear_annotation(multipath_aln_pair.second, "haplotype_score");
+//            }
         }
         
         // find the order of the scores
@@ -4069,12 +4072,12 @@ namespace vg {
                                        !multipath_aln_pairs.front().second.quality().empty());
             double raw_mapq = aligner->compute_group_mapping_quality(scores, reporting_idxs);
             
-            // TODO: for some reason set_annotation will accept a double but not an int
-            double group_mapq = min<double>(max_mapping_quality, mapq_scaling_factor * raw_mapq);
-            for (size_t i = 0; i < num_reporting; ++i) {
-                set_annotation(multipath_aln_pairs[i].first, "group_mapq", group_mapq);
-                set_annotation(multipath_aln_pairs[i].second, "group_mapq", group_mapq);
-            }
+//            // TODO: for some reason set_annotation will accept a double but not an int
+//            double group_mapq = min<double>(max_mapping_quality, mapq_scaling_factor * raw_mapq);
+//            for (size_t i = 0; i < num_reporting; ++i) {
+//                set_annotation(multipath_aln_pairs[i].first, "group_mapq", group_mapq);
+//                set_annotation(multipath_aln_pairs[i].second, "group_mapq", group_mapq);
+//            }
         }
     }
             

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -72,22 +72,22 @@ namespace vg {
         
         /// Map read in alignment to graph and make multipath alignments.
         void multipath_map(const Alignment& alignment,
-                           vector<MultipathAlignment>& multipath_alns_out);
+                           vector<multipath_alignment_t>& multipath_alns_out);
                            
         /// Map a paired read to the graph and make paired multipath alignments. Assumes reads are on the
         /// same strand of the DNA/RNA molecule. If the fragment length distribution is still being estimated
         /// and the pair cannot be mapped unambiguously, adds the reads to a buffer for ambiguous pairs and
         /// does not output any multipath alignments.
         void multipath_map_paired(const Alignment& alignment1, const Alignment& alignment2,
-                                  vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                  vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                   vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer);
                                   
-        /// Given a mapped MultipathAlignment, reduce it to up to
+        /// Given a mapped multipath_alignment_t, reduce it to up to
         /// max_number + 1 nonoverlapping single path alignments, with
         /// mapping qualities accounting for positional uncertainty between
         /// them.
         /// Even if the read is unmapped, there will always be at least one (possibly score 0) output alignment.
-        void reduce_to_single_path(const MultipathAlignment& multipath_aln, vector<Alignment>& alns_out, size_t max_number) const;
+        void reduce_to_single_path(const multipath_alignment_t& multipath_aln, vector<Alignment>& alns_out, size_t max_number) const;
         
         /// Sets the minimum clustering MEM length to the approximate length that a MEM would have to be to
         /// have at most the given probability of occurring in random sequence of the same size as the graph
@@ -198,81 +198,81 @@ namespace vg {
         /// mapping quality method option.
         void multipath_map_internal(const Alignment& alignment,
                                     MappingQualityMethod mapq_method,
-                                    vector<MultipathAlignment>& multipath_alns_out);
+                                    vector<multipath_alignment_t>& multipath_alns_out);
         
         /// Before the fragment length distribution has been estimated, look for an unambiguous mapping of
         /// the reads using the single ended routine. If we find one record the fragment length and report
         /// the pair, if we don't find one, add the read pair to a buffer instead of the output vector.
         void attempt_unpaired_multipath_map_of_pair(const Alignment& alignment1, const Alignment& alignment2,
-                                                    vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                                    vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                     vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer);
         
-        /// Extracts a section of graph at a distance from the MultipathAlignment based on the fragment length
+        /// Extracts a section of graph at a distance from the multipath_alignment_t based on the fragment length
         /// distribution and attempts to align the other paired read to it. If rescuing forward, assumes the
-        /// provided MultipathAlignment is the first read and vice versa if rescuing backward. Rescue constructs
-        /// a conventional local alignment with gssw and converts the Alignment to a MultipathAlignment. The
-        /// MultipathAlignment will be stored in the object passed by reference as an argument.
-        bool attempt_rescue(const MultipathAlignment& multipath_aln, const Alignment& other_aln,
-                            bool rescue_forward, MultipathAlignment& rescue_multipath_aln);
+        /// provided multipath_alignment_t is the first read and vice versa if rescuing backward. Rescue constructs
+        /// a conventional local alignment with gssw and converts the Alignment to a multipath_alignment_t. The
+        /// multipath_alignment_t will be stored in the object passed by reference as an argument.
+        bool attempt_rescue(const multipath_alignment_t& multipath_aln, const Alignment& other_aln,
+                            bool rescue_forward, multipath_alignment_t& rescue_multipath_aln);
         
         
         /// After clustering MEMs, extracting graphs, and assigning hits to cluster graphs, perform
         /// multipath alignment.
-        /// Produces topologically sorted MultipathAlignments.
+        /// Produces topologically sorted multipath_alignment_ts.
         void align_to_cluster_graphs(const Alignment& alignment,
                                      MappingQualityMethod mapq_method,
                                      vector<clustergraph_t>& cluster_graphs,
-                                     vector<MultipathAlignment>& multipath_alns_out,
+                                     vector<multipath_alignment_t>& multipath_alns_out,
                                      size_t num_mapping_attempts,
                                      vector<size_t>* cluster_idxs = nullptr);
         
         /// After clustering MEMs, extracting graphs, assigning hits to cluster graphs, and determining
         /// which cluster graph pairs meet the fragment length distance constraints, perform multipath
         /// alignment
-        /// Produces topologically sorted MultipathAlignments.
+        /// Produces topologically sorted multipath_alignment_ts.
         void align_to_cluster_graph_pairs(const Alignment& alignment1, const Alignment& alignment2,
                                           vector<clustergraph_t>& cluster_graphs1,
                                           vector<clustergraph_t>& cluster_graphs2,
                                           vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
-                                          vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                          vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                           vector<pair<size_t, size_t>>& duplicate_pairs_out);
         
         /// Align the read ends independently, but also try to form rescue alignments for each from
         /// the other. Return true if output obeys pair consistency and false otherwise.
-        /// Produces topologically sorted MultipathAlignments.
+        /// Produces topologically sorted multipath_alignment_ts.
         bool align_to_cluster_graphs_with_rescue(const Alignment& alignment1, const Alignment& alignment2,
                                                  vector<clustergraph_t>& cluster_graphs1,
                                                  vector<clustergraph_t>& cluster_graphs2,
                                                  bool block_rescue_from_1, bool block_rescue_from_2,
-                                                 vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                                 vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                  vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances_out,
                                                  vector<double>& pair_multiplicities_out);
         
         /// Use the rescue routine on strong suboptimal clusters to see if we can find a good secondary.
-        /// Produces topologically sorted MultipathAlignments.
+        /// Produces topologically sorted multipath_alignment_ts.
         void attempt_rescue_for_secondaries(const Alignment& alignment1, const Alignment& alignment2,
                                             vector<clustergraph_t>& cluster_graphs1,
                                             vector<clustergraph_t>& cluster_graphs2,
                                             vector<pair<size_t, size_t>>& duplicate_pairs,
-                                            vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                            vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                             vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs);
         
         /// Cluster and extract subgraphs for (possibly) only one end, meant to be a non-repeat, and use them to rescue
         /// an alignment for the other end, meant to be a repeat.
-        /// Produces topologically sorted MultipathAlignments.
+        /// Produces topologically sorted multipath_alignment_ts.
         void attempt_rescue_of_repeat_from_non_repeat(const Alignment& alignment1, const Alignment& alignment2,
                                                       const vector<MaximalExactMatch>& mems1, const vector<MaximalExactMatch>& mems2,
                                                       bool do_repeat_rescue_from_1, bool do_repeat_rescue_from_2,
                                                       vector<memcluster_t>& clusters1, vector<memcluster_t>& clusters2,
                                                       vector<clustergraph_t>& cluster_graphs1, vector<clustergraph_t>& cluster_graphs2,
-                                                      vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+                                                      vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                       vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances,
                                                       OrientedDistanceMeasurer& distance_measurer);
         
         /// Merge the rescued mappings into the output vector and deduplicate pairs
-        void merge_rescued_mappings(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+        void merge_rescued_mappings(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                     vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
-                                    vector<pair<MultipathAlignment, MultipathAlignment>>& rescued_multipath_aln_pairs,
+                                    vector<pair<multipath_alignment_t, multipath_alignment_t>>& rescued_multipath_aln_pairs,
                                     vector<pair<pair<size_t, size_t>, int64_t>>& rescued_cluster_pairs,
                                     vector<double>& rescued_multiplicities) const;
         
@@ -300,65 +300,65 @@ namespace vg {
                                                     const vector<MaximalExactMatch>& mems,
                                                     const vector<memcluster_t>& clusters);
         
-        /// If there are any MultipathAlignments with multiple connected components, split them
+        /// If there are any multipath_alignment_ts with multiple connected components, split them
         /// up and add them to the return vector.
-        /// Properly handles MultipathAlignments that are unmapped.
-        /// Does not depend on or guarantee topological order in the MultipathAlignments.
-        void split_multicomponent_alignments(vector<MultipathAlignment>& multipath_alns_out,
+        /// Properly handles multipath_alignment_ts that are unmapped.
+        /// Does not depend on or guarantee topological order in the multipath_alignment_ts.
+        void split_multicomponent_alignments(vector<multipath_alignment_t>& multipath_alns_out,
                                              vector<size_t>* cluster_idxs = nullptr) const;
         
-        /// If there are any MultipathAlignments with multiple connected components, split them
+        /// If there are any multipath_alignment_ts with multiple connected components, split them
         /// up and add them to the return vector, also measure the distance between them and add
         /// a record to the cluster pairs vector.
-        /// Properly handles MultipathAlignments that are unmapped.
-        /// Does not depend on or guarantee topological order in the MultipathAlignments.
-        void split_multicomponent_alignments(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+        /// Properly handles multipath_alignment_ts that are unmapped.
+        /// Does not depend on or guarantee topological order in the multipath_alignment_ts.
+        void split_multicomponent_alignments(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                              vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs) const;
         
         
         /// Make a multipath alignment of the read against the indicated graph and add it to
         /// the list of multimappings.
-        /// Does NOT necessarily produce a MultipathAlignment in topological order.
+        /// Does NOT necessarily produce a multipath_alignment_t in topological order.
         void multipath_align(const Alignment& alignment, const bdsg::HashGraph* graph,
                              memcluster_t& graph_mems,
-                             MultipathAlignment& multipath_aln_out) const;
+                             multipath_alignment_t& multipath_aln_out) const;
         
         /// Removes the sections of an Alignment's path within snarls and re-aligns them with multiple traceback
         /// to create a multipath alignment with non-trivial topology.
-        /// Guarantees that the resulting MultipathAlignment is in topological order.
+        /// Guarantees that the resulting multipath_alignment_t is in topological order.
         void make_nontrivial_multipath_alignment(const Alignment& alignment, const HandleGraph& subgraph,
                                                  const function<pair<id_t, bool>(id_t)>& translator,
-                                                 SnarlManager& snarl_manager, MultipathAlignment& multipath_aln_out) const;
+                                                 SnarlManager& snarl_manager, multipath_alignment_t& multipath_aln_out) const;
         
         /// Remove the full length bonus from all source or sink subpaths that received it
-        void strip_full_length_bonuses(MultipathAlignment& multipath_aln) const;
+        void strip_full_length_bonuses(multipath_alignment_t& multipath_aln) const;
         
         /// Compute a mapping quality from a list of scores, using the selected method.
         /// Optionally considers non-present duplicates of the scores encoded as multiplicities
         int32_t compute_raw_mapping_quality_from_scores(const vector<double>& scores, MappingQualityMethod mapq_method,
                                                         bool have_qualities, const vector<double>* multiplicities = nullptr) const;
         
-        /// Sorts mappings by score and store mapping quality of the optimal alignment in the MultipathAlignment object
+        /// Sorts mappings by score and store mapping quality of the optimal alignment in the multipath_alignment_t object
         /// Optionally also sorts a vector of indexes to keep track of the cluster-of-origin
         /// Allows multipath alignments where the best single path alignment is leaving the read unmapped.
-        /// MultipathAlignments MUST be topologically sorted.
-        void sort_and_compute_mapping_quality(vector<MultipathAlignment>& multipath_alns, MappingQualityMethod mapq_method,
+        /// multipath_alignment_ts MUST be topologically sorted.
+        void sort_and_compute_mapping_quality(vector<multipath_alignment_t>& multipath_alns, MappingQualityMethod mapq_method,
                                               vector<size_t>* cluster_idxs = nullptr) const;
         
-        /// Sorts mappings by score and store mapping quality of the optimal alignment in the MultipathAlignment object
+        /// Sorts mappings by score and store mapping quality of the optimal alignment in the multipath_alignment_t object
         /// If there are ties between scores, breaks them by the expected distance between pairs as computed by the
         /// OrientedDistanceClusterer::cluster_pairs function (modified cluster_pairs vector)
         /// Allows multipath alignments where the best single path alignment is leaving the read unmapped.
-        /// MultipathAlignments MUST be topologically sorted.
+        /// multipath_alignment_ts MUST be topologically sorted.
         /// Optionally considers non-present duplicates of the scores encoded as multiplicities
-        void sort_and_compute_mapping_quality(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs,
+        void sort_and_compute_mapping_quality(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs,
                                               vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                               vector<pair<size_t, size_t>>* duplicate_pairs_out = nullptr,
                                               vector<double>* pair_multiplicities = nullptr) const;
 
         /// Estimates the probability that the correct cluster was not chosen as a cluster to rescue from and caps the
         /// mapping quality to the minimum of the current mapping quality and this probability (in Phred scale)
-        void cap_mapping_quality_by_rescue_probability(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+        void cap_mapping_quality_by_rescue_probability(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                        vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                                        vector<clustergraph_t>& cluster_graphs1,
                                                        vector<clustergraph_t>& cluster_graphs2,
@@ -366,13 +366,13 @@ namespace vg {
         
         /// Estimates the probability that the correct cluster was not identified because of sub-sampling MEM hits and
         /// caps the mapping quality to this probability (in Phred scale)
-        void cap_mapping_quality_by_hit_sampling_probability(vector<MultipathAlignment>& multipath_alns_out,
+        void cap_mapping_quality_by_hit_sampling_probability(vector<multipath_alignment_t>& multipath_alns_out,
                                                              vector<size_t>& cluster_idxs,
                                                              vector<clustergraph_t>& cluster_graphs) const;
         
         /// Estimates the probability that the correct cluster pair was not identified because of sub-sampling MEM hits and
         /// caps the mapping quality to this probability (in Phred scale)
-        void cap_mapping_quality_by_hit_sampling_probability(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs_out,
+        void cap_mapping_quality_by_hit_sampling_probability(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                              vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                                              vector<clustergraph_t>& cluster_graphs1,
                                                              vector<clustergraph_t>& cluster_graphs2,
@@ -389,21 +389,21 @@ namespace vg {
         static int64_t read_coverage(const memcluster_t& mem_hits);
         
         /// Would an alignment this good be expected against a graph this big by chance alone
-        bool likely_mismapping(const MultipathAlignment& multipath_aln);
+        bool likely_mismapping(const multipath_alignment_t& multipath_aln);
         
         /// A scaling of a score so that it approximately follows the distribution of the longest match in p-value test
-        size_t pseudo_length(const MultipathAlignment& multipath_aln) const;
+        size_t pseudo_length(const multipath_alignment_t& multipath_aln) const;
         
         /// The approximate p-value for a match length of the given size against the current graph
         double random_match_p_value(size_t match_length, size_t read_length);
         
         /// Compute the approximate distance between two multipath alignments
         /// If either is unmapped, or the distance cannot be obtained, returns numeric_limits<int64_t>::max()
-        int64_t distance_between(const MultipathAlignment& multipath_aln_1, const MultipathAlignment& multipath_aln_2,
+        int64_t distance_between(const multipath_alignment_t& multipath_aln_1, const multipath_alignment_t& multipath_aln_2,
                                  bool full_fragment = false, bool forward_strand = false) const;
         
         /// Are two multipath alignments consistently placed based on the learned fragment length distribution?
-        bool are_consistent(const MultipathAlignment& multipath_aln_1, const MultipathAlignment& multipath_aln_2) const;
+        bool are_consistent(const multipath_alignment_t& multipath_aln_1, const multipath_alignment_t& multipath_aln_2) const;
         
         /// Is this a consistent inter-pair distance based on the learned fragment length distribution?
         bool is_consistent(int64_t distance) const;
@@ -413,14 +413,14 @@ namespace vg {
         
         /// Return true if any of the initial positions of the source Subpaths are shared between the two
         /// multipath alignments
-        bool share_terminal_positions(const MultipathAlignment& multipath_aln_1, const MultipathAlignment& multipath_aln_2) const;
+        bool share_terminal_positions(const multipath_alignment_t& multipath_aln_1, const multipath_alignment_t& multipath_aln_2) const;
         
         /// Get a thread_local RRMemo with these parameters
         haploMath::RRMemo& get_rr_memo(double recombination_penalty, size_t population_size) const;;
         
         /// Detects if each pair can be assigned to a consistent strand of a path, and if not removes them. Also
         /// inverts the distances in the cluster pairs vector according to the strand
-        void establish_strand_consistency(vector<pair<MultipathAlignment, MultipathAlignment>>& multipath_aln_pairs,
+        void establish_strand_consistency(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs,
                                           vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs);
         
         SnarlManager* snarl_manager;

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -2664,4 +2664,46 @@ pos_t final_position(const path_t& path) {
     return pos;
 }
 
+string debug_string(const path_t& path) {
+    string to_return = "{";
+    if (!path.mapping().empty()) {
+        to_return += "mapping: [";
+        for (size_t i = 0; i < path.mapping_size(); ++i) {
+            if (i > 0) {
+                to_return += ", ";
+            }
+            to_return += debug_string(path.mapping(i));
+        }
+        to_return += "]";
+    }
+    to_return += "}";
+    return to_return;
+}
+
+string debug_string(const path_mapping_t& mapping) {
+    string to_return = "{pos: " + debug_string(mapping.position());
+    if (!mapping.edit().empty()) {
+        to_return += ", edit: [";
+        for (size_t i = 0; i < mapping.edit_size(); ++i) {
+            if (i > 0) {
+                to_return += ", ";
+            }
+            to_return += debug_string(mapping.edit(i));
+        }
+        to_return += "]";
+    }
+    to_return += "}";
+    return to_return;
+}
+
+string debug_string(const edit_t& edit) {
+    string to_return = "{fl: " + to_string(edit.from_length()) + ", tl: " + to_string(edit.to_length());
+    if (!edit.sequence().empty()) {
+        to_return += ", seq: " + edit.sequence();
+    }
+    to_return += "}";
+    return to_return;
+}
+
+
 }

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -2353,6 +2353,31 @@ void translate_oriented_node_ids(Path& path, const function<pair<id_t, bool>(id_
         position->set_is_reverse(translation.second != position->is_reverse());
     }
 }
+
+
+void translate_node_ids(path_t& path, const unordered_map<id_t, id_t>& translator) {
+    for (size_t i = 0; i < path.mapping_size(); i++) {
+        position_t* position = path.mutable_mapping(i)->mutable_position();
+        position->set_node_id(translator.at(position->node_id()));
+    }
+}
+void translate_oriented_node_ids(path_t& path, const unordered_map<id_t, pair<id_t, bool>>& translator) {
+    for (size_t i = 0; i < path.mapping_size(); i++) {
+        position_t* position = path.mutable_mapping(i)->mutable_position();
+        const pair<id_t, bool>& translation = translator.at(position->node_id());
+        position->set_node_id(translation.first);
+        position->set_is_reverse(translation.second != position->is_reverse());
+    }
+}
+
+void translate_oriented_node_ids(path_t& path, const function<pair<id_t, bool>(id_t)>& translator) {
+    for (size_t i = 0; i < path.mapping_size(); i++) {
+        position_t* position = path.mutable_mapping(i)->mutable_position();
+        const pair<id_t, bool>& translation = translator(position->node_id());
+        position->set_node_id(translation.first);
+        position->set_is_reverse(translation.second != position->is_reverse());
+    }
+}
     
 pos_t initial_position(const Path& path) {
     pos_t pos;
@@ -2450,5 +2475,193 @@ Alignment alignment_from_path(const HandleGraph& graph, const Path& path) {
     return aln;
 }
 
+void from_proto_edit(const Edit& proto_edit, edit_t& edit) {
+    edit.set_from_length(proto_edit.from_length());
+    edit.set_to_length(proto_edit.to_length());
+    edit.set_sequence(proto_edit.sequence());
+}
+
+void to_proto_edit(const edit_t& edit, Edit& proto_edit) {
+    proto_edit.set_from_length(edit.from_length());
+    proto_edit.set_to_length(edit.to_length());
+    proto_edit.set_sequence(edit.sequence());
+}
+
+void from_proto_mapping(const Mapping& proto_mapping, path_mapping_t& mapping) {
+    auto position = proto_mapping.position();
+    auto position_copy = mapping.mutable_position();
+    position_copy->set_node_id(position.node_id());
+    position_copy->set_offset(position.offset());
+    position_copy->set_is_reverse(position.is_reverse());
+    for (auto edit : proto_mapping.edit()) {
+        from_proto_edit(edit, *mapping.add_edit());
+    }
+}
+
+void to_proto_mapping(const path_mapping_t& mapping, Mapping& proto_mapping) {
+    auto position = mapping.position();
+    auto position_copy = proto_mapping.mutable_position();
+    position_copy->set_node_id(position.node_id());
+    position_copy->set_offset(position.offset());
+    position_copy->set_is_reverse(position.is_reverse());
+    for (auto edit : mapping.edit()) {
+        to_proto_edit(edit, *proto_mapping.add_edit());
+    }
+}
+
+void from_proto_path(const Path& proto_path, path_t& path) {
+    for (auto mapping : proto_path.mapping()) {
+        from_proto_mapping(mapping, *path.add_mapping());
+    }
+}
+void to_proto_path(const path_t& path, Path& proto_path) {
+    for (auto mapping : path.mapping()) {
+        auto mapping_copy = proto_path.add_mapping();
+        to_proto_mapping(mapping, *mapping_copy);
+        mapping_copy->set_rank(proto_path.mapping_size());
+    }
+}
+
+int mapping_from_length(const path_mapping_t& mapping) {
+    int length = 0;
+    for (auto edit : mapping.edit()) {
+        length += edit.from_length();
+    }
+    return length;
+}
+
+int path_from_length(const path_t& path) {
+    int length = 0;
+    for (auto mapping : path.mapping()) {
+        length += mapping_from_length(mapping);
+    }
+    return length;
+}
+
+int mapping_to_length(const path_mapping_t& mapping) {
+    int length = 0;
+    for (auto edit : mapping.edit()) {
+        length += edit.to_length();
+    }
+    return length;
+}
+
+int path_to_length(const path_t& path) {
+    int length = 0;
+    for (auto mapping : path.mapping()) {
+        length += mapping_to_length(mapping);
+    }
+    return length;
+}
+
+
+void reverse_complement_mapping_in_place(path_mapping_t* m,
+                                         const function<int64_t(id_t)>& node_length) {
+    
+    position_t* pos = m->mutable_position();
+    pos->set_is_reverse(!pos->is_reverse());
+    pos->set_offset(node_length(pos->node_id()) - pos->offset() - mapping_from_length(*m));
+    
+    size_t swap_size = m->edit_size() / 2;
+    for (size_t i = 0, j = m->edit_size() - 1; i < swap_size; i++, j--) {
+        edit_t* e1 = m->mutable_edit(i);
+        edit_t* e2 = m->mutable_edit(j);
+        
+        int64_t from_length_tmp = e1->from_length();
+        int64_t to_length_tmp = e1->to_length();
+        string sequence_tmp = e1->sequence();
+        
+        e1->set_from_length(e2->from_length());
+        e1->set_to_length(e2->to_length());
+        e1->set_sequence(reverse_complement(e2->sequence()));
+        
+        e2->set_from_length(from_length_tmp);
+        e2->set_to_length(to_length_tmp);
+        e2->set_sequence(reverse_complement(sequence_tmp));
+    }
+    
+    
+    if (m->edit_size() % 2) {
+        edit_t* e = m->mutable_edit(swap_size);
+        reverse_complement_in_place(*e->mutable_sequence());
+    }
+}
+
+path_mapping_t reverse_complement_mapping(const path_mapping_t& m,
+                                          const function<int64_t(id_t)>& node_length) {
+    
+    path_mapping_t reversed;
+    position_t* rev_pos = reversed.mutable_position();
+    rev_pos->set_node_id(m.position().node_id());
+    rev_pos->set_is_reverse(!m.position().is_reverse());
+    rev_pos->set_offset(node_length(m.position().node_id()) - m.position().offset() - mapping_from_length(m));
+    
+    for (int64_t i = m.edit_size() - 1; i >= 0; i--) {
+        const edit_t& e = m.edit(i);
+        edit_t* rev_edit = reversed.add_edit();
+        rev_edit->set_from_length(e.from_length());
+        rev_edit->set_to_length(e.to_length());
+        rev_edit->set_sequence(reverse_complement(e.sequence()));
+    }
+    
+    return reversed;
+}
+
+path_t reverse_complement_path(const path_t& path,
+                               const function<int64_t(id_t)>& node_length) {
+    
+    // Make a new reversed path
+    path_t reversed;
+    
+    for (int64_t i = path.mapping_size() - 1; i >= 0; i--) {
+        // For each mapping in reverse order, put it in reverse complemented and
+        // measured from the other end of the node.
+        *reversed.add_mapping() = reverse_complement_mapping(path.mapping(i), node_length);
+    }
+    
+    return reversed;
+}
+
+void reverse_complement_path_in_place(path_t* path,
+                                      const function<int64_t(id_t)>& node_length) {
+    
+    size_t swap_size = path->mapping_size() / 2;
+    for (size_t i = 0, j = path->mapping_size() - 1; i < swap_size; i++, j--) {
+        path_mapping_t* m1 = path->mutable_mapping(i);
+        path_mapping_t* m2 = path->mutable_mapping(j);
+        
+        reverse_complement_mapping_in_place(m1, node_length);
+        reverse_complement_mapping_in_place(m2, node_length);
+        
+        std::swap(*m1, *m2);
+    }
+    
+    if (path->mapping_size() % 2) {
+        reverse_complement_mapping_in_place(path->mutable_mapping(swap_size), node_length);
+    }
+}
+
+pos_t initial_position(const path_t& path) {
+    pos_t pos;
+    if (path.mapping_size()) {
+        const position_t& position = path.mapping(0).position();
+        get_id(pos) = position.node_id();
+        get_is_rev(pos) = position.is_reverse();
+        get_offset(pos) = position.offset();
+    }
+    return pos;
+}
+
+pos_t final_position(const path_t& path) {
+    pos_t pos;
+    if (path.mapping_size()) {
+        const path_mapping_t& mapping = path.mapping(path.mapping_size() - 1);
+        const position_t& position = mapping.position();
+        get_id(pos) = position.node_id();
+        get_is_rev(pos) = position.is_reverse();
+        get_offset(pos) = position.offset() + mapping_from_length(mapping);
+    }
+    return pos;
+}
 
 }

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -365,6 +365,188 @@ Path path_from_path_handle(const PathHandleGraph& graph, path_handle_t path_hand
 
 // Wrap a Path in an Alignment
 Alignment alignment_from_path(const HandleGraph& graph, const Path& path);
+
+
+/*
+ * STL implementations of the protobuf object for use in in-memory operations
+ */
+class edit_t {
+public:
+    edit_t() = default;
+    edit_t(const edit_t&) = default;
+    edit_t(edit_t&&) = default;
+    ~edit_t() = default;
+    edit_t& operator=(const edit_t&) = default;
+    edit_t& operator=(edit_t&&) = default;
+    inline int32_t from_length() const;
+    inline void set_from_length(int32_t l);
+    inline int32_t to_length() const;
+    inline void set_to_length(int32_t l);
+    inline const string& sequence() const;
+    inline void set_sequence(const string& s);
+    inline string* mutable_sequence();
+private:
+    int32_t _from_length;
+    int32_t _to_length;
+    string _sequence;
+};
+
+// the mapping_t name is already taken
+class path_mapping_t {
+public:
+    path_mapping_t() = default;
+    path_mapping_t(const path_mapping_t&) = default;
+    path_mapping_t(path_mapping_t&&) = default;
+    ~path_mapping_t() = default;
+    path_mapping_t& operator=(const path_mapping_t&) = default;
+    path_mapping_t& operator=(path_mapping_t&&) = default;
+    inline const position_t& position() const;
+    inline position_t* mutable_position();
+    inline const vector<edit_t>& edit() const;
+    inline const edit_t& edit(size_t i) const;
+    inline vector<edit_t>* mutable_edit();
+    inline edit_t* mutable_edit(size_t i);
+    inline edit_t* add_edit();
+    inline size_t edit_size() const;
+private:
+    position_t _position;
+    vector<edit_t> _edit;
+};
+
+class path_t {
+public:
+    path_t() = default;
+    path_t(const path_t&) = default;
+    path_t(path_t&&) = default;
+    ~path_t() = default;
+    path_t& operator=(const path_t&) = default;
+    path_t& operator=(path_t&&) = default;
+    inline const vector<path_mapping_t>& mapping() const;
+    inline const path_mapping_t& mapping(size_t i) const;
+    inline vector<path_mapping_t>* mutable_mapping();
+    inline path_mapping_t* mutable_mapping(size_t i);
+    inline path_mapping_t* add_mapping();
+    inline void clear_mapping();
+    inline size_t mapping_size() const;
+private:
+    vector<path_mapping_t> _mapping;
+};
+
+void from_proto_edit(const Edit& proto_edit, edit_t& edit);
+void to_proto_edit(const edit_t& edit, Edit& proto_edit);
+void from_proto_mapping(const Mapping& proto_mapping, path_mapping_t& mapping);
+void to_proto_mapping(const path_mapping_t& mapping, Mapping& proto_mapping);
+void from_proto_path(const Path& proto_path, path_t& path);
+void to_proto_path(const path_t& path, Path& proto_path);
+
+
+// repeated functions for the new path_t class
+void translate_node_ids(path_t& path, const unordered_map<id_t, id_t>& translator);
+void translate_oriented_node_ids(path_t& path, const unordered_map<id_t, pair<id_t, bool>>& translator);
+void translate_oriented_node_ids(path_t& path, const function<pair<id_t, bool>(id_t)>& translator);
+
+int mapping_from_length(const path_mapping_t& mapping);
+int path_from_length(const path_t& path);
+int mapping_to_length(const path_mapping_t& mapping);
+int path_to_length(const path_t& path);
+
+path_mapping_t reverse_complement_mapping(const path_mapping_t& m,
+                                          const function<int64_t(id_t)>& node_length);
+path_t reverse_complement_path(const path_t& path,
+                               const function<int64_t(id_t)>& node_length);
+void reverse_complement_mapping_in_place(path_mapping_t* m,
+                                         const function<int64_t(id_t)>& node_length);
+void reverse_complement_path_in_place(path_t* path,
+                                      const function<int64_t(id_t)>& node_length);
+
+// the first position on the path
+pos_t initial_position(const path_t& path);
+// the last position on the path
+pos_t final_position(const path_t& path);
+
+/*
+ * Implementations of inline methods
+ */
+
+/*
+ * edit_t
+ */
+inline int32_t edit_t::from_length() const {
+    return _from_length;
+}
+inline void edit_t::set_from_length(int32_t l) {
+    _from_length = l;
+}
+inline int32_t edit_t::to_length() const {
+    return _to_length;
+}
+inline void edit_t::set_to_length(int32_t l) {
+    _to_length = l;
+}
+inline const string& edit_t::sequence() const {
+    return _sequence;
+}
+inline void edit_t::set_sequence(const string& s) {
+    _sequence = s;
+}
+inline string* edit_t::mutable_sequence() {
+    return &_sequence;
+}
+
+/*
+ * path_mapping_t
+ */
+inline const position_t& path_mapping_t::position() const {
+    return _position;
+}
+inline position_t* path_mapping_t::mutable_position() {
+    return &_position;
+}
+inline const vector<edit_t>& path_mapping_t::edit() const {
+    return _edit;
+}
+inline const edit_t& path_mapping_t::edit(size_t i) const {
+    return _edit[i];
+}
+inline vector<edit_t>* path_mapping_t::mutable_edit() {
+    return &_edit;
+}
+inline edit_t* path_mapping_t::add_edit() {
+    _edit.emplace_back();
+    return &_edit.back();
+}
+inline edit_t* path_mapping_t::mutable_edit(size_t i) {
+    return &_edit[i];
+}
+inline size_t path_mapping_t::edit_size() const {
+    return _edit.size();
+}
+
+/*
+ * path_t
+ */
+inline const vector<path_mapping_t>& path_t::mapping() const {
+    return _mapping;
+}
+inline const path_mapping_t& path_t::mapping(size_t i) const {
+    return _mapping[i];
+}
+inline vector<path_mapping_t>* path_t::mutable_mapping() {
+    return &_mapping;
+}
+inline path_mapping_t* path_t::mutable_mapping(size_t i) {
+    return &_mapping[i];
+}
+inline path_mapping_t* path_t::add_mapping() {
+    _mapping.emplace_back();
+    return &_mapping.back();
+}
+inline void path_t::clear_mapping() {
+    _mapping.clear();
+}
+inline size_t path_t::mapping_size() const {
+    return _mapping.size();
+}
 }
 
 #endif

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -464,6 +464,10 @@ pos_t initial_position(const path_t& path);
 // the last position on the path
 pos_t final_position(const path_t& path);
 
+string debug_string(const path_t& path);
+string debug_string(const path_mapping_t& mapping);
+string debug_string(const edit_t& edit);
+
 /*
  * Implementations of inline methods
  */

--- a/src/phased_genome.cpp
+++ b/src/phased_genome.cpp
@@ -348,7 +348,7 @@ namespace vg {
         }
     }
     
-    int32_t PhasedGenome::optimal_score_on_genome(const MultipathAlignment& multipath_aln, VG& graph) {
+    int32_t PhasedGenome::optimal_score_on_genome(const multipath_alignment_t& multipath_aln, VG& graph) {
         
         
         // must have identified start subpaths before computing optimal score   
@@ -364,8 +364,8 @@ namespace vg {
         unordered_map< pair<HaplotypeNode*, bool>, vector<int>> candidate_start_positions;
         for (int i = 0; i < multipath_aln.start_size(); i++) {
             // a starting subpath in the multipath alignment
-            const Subpath& start_subpath = multipath_aln.subpath(multipath_aln.start(i));
-            const Position& start_pos = start_subpath.path().mapping(0).position();
+            const subpath_t& start_subpath = multipath_aln.subpath(multipath_aln.start(i));
+            const position_t& start_pos = start_subpath.path().mapping(0).position();
             
 #ifdef debug_phased_genome
             cerr << "[PhasedGenome::optimal_score_on_genome]: looking for candidate start positions for subpath " << multipath_aln.start(i) << " on node " << start_pos.node_id() << endl;
@@ -423,14 +423,14 @@ namespace vg {
                 cerr << "[PhasedGenome::optimal_score_on_genome]: checking subpath " << i << " for consistent paths" << endl;
 #endif
                 
-                const Subpath& subpath = multipath_aln.subpath(i);
+                const subpath_t& subpath = multipath_aln.subpath(i);
                 
                 // iterate through mappings in this subpath (assumes one mapping per node)
                 bool subpath_follows_path = true;
                 for (int j = 0; j < subpath.path().mapping_size(); j++) {
                     // check if mapping corresponds to the next node in the path in the correct orientation
-                    const Mapping& mapping = subpath.path().mapping(j);
-                    const Position& position = mapping.position();
+                    const path_mapping_t& mapping = subpath.path().mapping(j);
+                    const position_t& position = mapping.position();
                     if (position.node_id() != subpath_node->node_traversal.node->id()
                         || ((position.is_reverse() == subpath_node->node_traversal.backward) != oriented_forward)) {
                         subpath_follows_path = false;

--- a/src/phased_genome.hpp
+++ b/src/phased_genome.hpp
@@ -20,6 +20,7 @@
 #include "genotypekit.hpp"
 #include "hash_map.hpp"
 #include "snarls.hpp"
+#include "multipath_alignment.hpp"
 
 
 using namespace std;
@@ -118,8 +119,8 @@ namespace vg {
         /// Returns the score of the highest scoring alignment contained in the multipath alignment
         /// that is restricted to the phased genome's paths through the variation graph.
         ///
-        /// Note: assumes that MultipathAlignment has 'start' field filled in
-        int32_t optimal_score_on_genome(const MultipathAlignment& multipath_aln, VG& graph);
+        /// Note: assumes that multipath_alignment_t has 'start' field filled in
+        int32_t optimal_score_on_genome(const multipath_alignment_t& multipath_aln, VG& graph);
         
         // TODO: make a local subalignment optimal score function (main obstacle is scoring partial subpaths)
         

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -5,6 +5,10 @@ namespace vg {
 pos_t make_pos_t(const Position& pos) {
     return make_tuple(pos.node_id(), pos.is_reverse(), pos.offset());
 }
+
+pos_t make_pos_t(const position_t& pos) {
+    return make_tuple(pos.node_id(), pos.is_reverse(), pos.offset());
+}
     
 pos_t make_pos_t(gcsa::node_type node) {
     return make_tuple(gcsa::Node::id(node), gcsa::Node::rc(node), gcsa::Node::offset(node));

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -70,4 +70,9 @@ pair<int64_t, int64_t> min_oriented_distances(const unordered_map<path_handle_t,
     return make_pair(distance_same, distance_diff);
 }
 
+string debug_string(const position_t& pos) {
+    string to_return = "{id: " + to_string(pos.node_id()) + ", off: " + to_string(pos.offset()) + ", rev: " + (pos.is_reverse() ? "T" : "F") + "}";
+    return to_return;
+}
+
 }

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -58,7 +58,7 @@ Position make_position(gcsa::node_type node);
 pair<int64_t, int64_t> min_oriented_distances(const unordered_map<path_handle_t, vector<pair<size_t, bool> > >& path_offsets1,
                                               const unordered_map<path_handle_t, vector<pair<size_t, bool> > >& path_offsets2);
 
-
+string debug_string(const position_t& pos);
 
 
 /*

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -15,11 +15,37 @@
 namespace vg {
 
 using namespace std;
+
+
+
+// duplicative with pos_t, but this will make it so much easier
+// to refactor -- can always eliminate later
+class position_t {
+public:
+    position_t() = default;
+    position_t(const position_t&) = default;
+    position_t(position_t&&) = default;
+    ~position_t() = default;
+    position_t& operator=(const position_t&) = default;
+    position_t& operator=(position_t&&) = default;
+    inline int64_t node_id() const;
+    inline void set_node_id(int64_t i);
+    inline int64_t offset() const;
+    inline void set_offset(int64_t o);
+    inline bool is_reverse() const;
+    inline void set_is_reverse(bool r);
+private:
+    int64_t _node_id;
+    int64_t _offset;
+    bool _is_reverse;
+};
+
 /// Reverse a Position and get a Position at the same **point between bases**, going the other direction.
 /// To get a Position to the same *base*, subtract 1 from the resulting offset.
 Position reverse(const Position& pos, size_t node_length);
 /// Convert a Position to a (much smaller) pos_t.
 pos_t make_pos_t(const Position& pos);
+pos_t make_pos_t(const position_t& pos);
 /// Create a pos_t from a gcsa node
 pos_t make_pos_t(gcsa::node_type node);
 /// Convert a pos_t to a Position.
@@ -32,6 +58,30 @@ Position make_position(gcsa::node_type node);
 pair<int64_t, int64_t> min_oriented_distances(const unordered_map<path_handle_t, vector<pair<size_t, bool> > >& path_offsets1,
                                               const unordered_map<path_handle_t, vector<pair<size_t, bool> > >& path_offsets2);
 
+
+
+
+/*
+ * position_t
+ */
+inline int64_t position_t::node_id() const {
+    return _node_id;
+}
+inline void position_t::set_node_id(int64_t i) {
+    _node_id = i;
+}
+inline int64_t position_t::offset() const {
+    return _offset;
+}
+inline void position_t::set_offset(int64_t o) {
+    _offset = o;
+}
+inline bool position_t::is_reverse() const {
+    return _is_reverse;
+}
+inline void position_t::set_is_reverse(bool r) {
+    _is_reverse = r;
+}
 }
 
 #endif

--- a/src/subcommand/mcmc_main.cpp
+++ b/src/subcommand/mcmc_main.cpp
@@ -91,11 +91,12 @@ int main_mcmc(int argc, char** argv) {
     unique_ptr<VG> graph = (vg::io::VPKG::load_one<VG>(graph_file));
     unique_ptr<SnarlManager> snarls = (vg::io::VPKG::load_one<SnarlManager>(snarls_file));
 
-    vector<MultipathAlignment> reads;
+    vector<multipath_alignment_t> reads;
     get_input_file(multipath_file, [&] (istream& open_file){
         io::ProtobufIterator<MultipathAlignment> iter (open_file);
         while(iter.has_current()){
-            reads.push_back(*iter);
+            reads.emplace_back();
+            from_proto_multipath_alignment(*iter, reads.back());
             // vg::view_multipath_alignment_as_dot(cerr,*iter,true);
             ++iter;
         }

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1509,12 +1509,13 @@ int main_mpmap(int argc, char** argv) {
     vector<vector<MultipathAlignment> > multipath_output_buffer(thread_count);
     
     // write unpaired multipath alignments to stdout buffer
-    auto output_multipath_alignments = [&](vector<MultipathAlignment>& mp_alns) {
+    auto output_multipath_alignments = [&](vector<multipath_alignment_t>& mp_alns) {
         auto& output_buf = multipath_output_buffer[omp_get_thread_num()];
         
         // move all the alignments over to the output buffer
-        for (MultipathAlignment& mp_aln : mp_alns) {
-            output_buf.emplace_back(move(mp_aln));
+        for (multipath_alignment_t& mp_aln : mp_alns) {
+            output_buf.emplace_back();
+            to_proto_multipath_alignment(mp_aln, output_buf.back());
             
             // label with read group and sample name
             if (!read_group.empty()) {
@@ -1529,10 +1530,11 @@ int main_mpmap(int argc, char** argv) {
     };
     
     // convert to unpaired single path alignments and write stdout buffer
-    auto output_single_path_alignments = [&](vector<MultipathAlignment>& mp_alns) {
+    auto output_single_path_alignments = [&](vector<multipath_alignment_t>& mp_alns) {
         auto& output_buf = single_path_output_buffer[omp_get_thread_num()];
         // add optimal alignments to the output buffer
-        for (MultipathAlignment& mp_aln : mp_alns) {
+        for (multipath_alignment_t& mp_aln : mp_alns) {
+            // TODO: why are we computing 5 alignments if we just take the first one?
             // For each multipath alignment, get the greedy nonoverlapping
             // single-path alignments from the top k optimal single-path
             // alignments.
@@ -1545,10 +1547,10 @@ int main_mpmap(int argc, char** argv) {
             // compute the Alignment identity to make vg call happy
             output_buf.back().set_identity(identity(output_buf.back().path()));
             
-            if (mp_aln.has_annotation()) {
-                // Move over annotations
-                output_buf.back().set_allocated_annotation(mp_aln.release_annotation());
-            }
+//            if (mp_aln.has_annotation()) {
+//                // Move over annotations
+//                output_buf.back().set_allocated_annotation(mp_aln.release_annotation());
+//            }
             
             // label with read group and sample name
             if (!read_group.empty()) {
@@ -1563,12 +1565,14 @@ int main_mpmap(int argc, char** argv) {
     };
     
     // write paired multipath alignments to stdout buffer
-    auto output_multipath_paired_alignments = [&](vector<pair<MultipathAlignment, MultipathAlignment>>& mp_aln_pairs) {
+    auto output_multipath_paired_alignments = [&](vector<pair<multipath_alignment_t, multipath_alignment_t>>& mp_aln_pairs) {
         auto& output_buf = multipath_output_buffer[omp_get_thread_num()];
         
         // move all the alignments over to the output buffer
-        for (pair<MultipathAlignment, MultipathAlignment>& mp_aln_pair : mp_aln_pairs) {
-            output_buf.emplace_back(move(mp_aln_pair.first));
+        for (pair<multipath_alignment_t, multipath_alignment_t>& mp_aln_pair : mp_aln_pairs) {
+            
+            output_buf.emplace_back();
+            to_proto_multipath_alignment(mp_aln_pair.first, output_buf.back());
             
             // label with read group and sample name
             if (!read_group.empty()) {
@@ -1579,22 +1583,20 @@ int main_mpmap(int argc, char** argv) {
             }
             
             // switch second read back to the opposite strand if necessary
-            if (same_strand) {
-                output_buf.emplace_back(move(mp_aln_pair.second));
-            }
-            else {
-                output_buf.emplace_back();
-                rev_comp_multipath_alignment(mp_aln_pair.second,
-                                             [&](vg::id_t node_id) {
+            if (!same_strand) {
+                rev_comp_multipath_alignment_in_place(&mp_aln_pair.second, [&](vg::id_t node_id) {
                     return path_position_handle_graph->get_length(path_position_handle_graph->get_handle(node_id));
-                },
-                                             output_buf.back());
+                });
             }
+            
+            output_buf.emplace_back();
+            to_proto_multipath_alignment(mp_aln_pair.second, output_buf.back());
 
-            if (mp_aln_pair.second.has_annotation()) {
-                // Move over annotations
-                output_buf.back().set_allocated_annotation(mp_aln_pair.second.release_annotation());
-            }
+            //TODO: fix annotations with the new output format
+//            if (mp_aln_pair.second.has_annotation()) {
+//                // Move over annotations
+//                output_buf.back().set_allocated_annotation(mp_aln_pair.second.release_annotation());
+//            }
             
             // label with read group and sample name
             if (!read_group.empty()) {
@@ -1609,11 +1611,11 @@ int main_mpmap(int argc, char** argv) {
     };
     
     // convert to paired single path alignments and write stdout buffer
-    auto output_single_path_paired_alignments = [&](vector<pair<MultipathAlignment, MultipathAlignment>>& mp_aln_pairs) {
+    auto output_single_path_paired_alignments = [&](vector<pair<multipath_alignment_t, multipath_alignment_t>>& mp_aln_pairs) {
         auto& output_buf = single_path_output_buffer[omp_get_thread_num()];
         
         // add optimal alignments to the output buffer
-        for (pair<MultipathAlignment, MultipathAlignment>& mp_aln_pair : mp_aln_pairs) {
+        for (pair<multipath_alignment_t, multipath_alignment_t>& mp_aln_pair : mp_aln_pairs) {
             
             // Compute nonoverlapping single path alignments for each multipath alignment
             vector<Alignment> options;
@@ -1622,10 +1624,10 @@ int main_mpmap(int argc, char** argv) {
             // There will always be at least one result. Use the optimal alignment.
             output_buf.emplace_back(std::move(options.front()));
             
-            if (mp_aln_pair.first.has_annotation()) {
-                // Move over annotations
-                output_buf.back().set_allocated_annotation(mp_aln_pair.first.release_annotation());
-            }
+//            if (mp_aln_pair.first.has_annotation()) {
+//                // Move over annotations
+//                output_buf.back().set_allocated_annotation(mp_aln_pair.first.release_annotation());
+//            }
             
             // compute the Alignment identity to make vg call happy
             output_buf.back().set_identity(identity(output_buf.back().path()));
@@ -1645,10 +1647,10 @@ int main_mpmap(int argc, char** argv) {
             multipath_mapper.reduce_to_single_path(mp_aln_pair.second, options, localization_max_paths);
             output_buf.emplace_back(std::move(options.front()));
             
-            if (mp_aln_pair.second.has_annotation()) {
-                // Move over annotations
-                output_buf.back().set_allocated_annotation(mp_aln_pair.second.release_annotation());
-            }
+//            if (mp_aln_pair.second.has_annotation()) {
+//                // Move over annotations
+//                output_buf.back().set_allocated_annotation(mp_aln_pair.second.release_annotation());
+//            }
             
             // compute identity again
             output_buf.back().set_identity(identity(output_buf.back().path()));
@@ -1691,11 +1693,11 @@ int main_mpmap(int argc, char** argv) {
             convert_Us_to_Ts(alignment);
         }
 
-        vector<MultipathAlignment> mp_alns;
+        vector<multipath_alignment_t> mp_alns;
         multipath_mapper.multipath_map(alignment, mp_alns);
         
         if (is_rna) {
-            for (MultipathAlignment& mp_aln : mp_alns) {
+            for (multipath_alignment_t& mp_aln : mp_alns) {
                 convert_Ts_to_Us(mp_aln);
             }
         }
@@ -1749,11 +1751,11 @@ int main_mpmap(int argc, char** argv) {
         
         size_t num_buffered = ambiguous_pair_buffer.size();
         
-        vector<pair<MultipathAlignment, MultipathAlignment>> mp_aln_pairs;
+        vector<pair<multipath_alignment_t, multipath_alignment_t>> mp_aln_pairs;
         multipath_mapper.multipath_map_paired(alignment_1, alignment_2, mp_aln_pairs, ambiguous_pair_buffer);
         
         if (is_rna) {
-            for (pair<MultipathAlignment, MultipathAlignment>& mp_aln_pair : mp_aln_pairs) {
+            for (pair<multipath_alignment_t, multipath_alignment_t>& mp_aln_pair : mp_aln_pairs) {
                 convert_Ts_to_Us(mp_aln_pair.first);
                 convert_Ts_to_Us(mp_aln_pair.second);
             }
@@ -1813,21 +1815,21 @@ int main_mpmap(int argc, char** argv) {
         }
         
         // Align independently
-        vector<MultipathAlignment> mp_alns_1, mp_alns_2;
+        vector<multipath_alignment_t> mp_alns_1, mp_alns_2;
         multipath_mapper.multipath_map(alignment_1, mp_alns_1);
         multipath_mapper.multipath_map(alignment_2, mp_alns_2);
         
         
         if (is_rna) {
-            for (MultipathAlignment& mp_aln : mp_alns_1) {
+            for (multipath_alignment_t& mp_aln : mp_alns_1) {
                 convert_Ts_to_Us(mp_aln);
             }
-            for (MultipathAlignment& mp_aln : mp_alns_2) {
+            for (multipath_alignment_t& mp_aln : mp_alns_2) {
                 convert_Ts_to_Us(mp_aln);
             }
         }
                
-        vector<pair<MultipathAlignment, MultipathAlignment>> mp_aln_pairs;
+        vector<pair<multipath_alignment_t, multipath_alignment_t>> mp_aln_pairs;
         for (size_t i = 0; i < mp_alns_1.size() && i < mp_alns_2.size(); i++) {
             // Pair arbitrarily. Stop when one side runs out of alignments.
             mp_aln_pairs.emplace_back(mp_alns_1[i], mp_alns_2[i]);

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1409,6 +1409,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.greedy_restart_min_length = greedy_restart_min_length;
     multipath_mapper.greedy_restart_max_count = greedy_restart_max_count;
     multipath_mapper.greedy_restart_max_lcp = greedy_restart_max_lcp;
+    multipath_mapper.greedy_restart_assume_substitution = greedy_restart_assume_substitution;
     multipath_mapper.use_stripped_match_alg = use_stripped_match_alg;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -565,8 +565,10 @@ int main_view(int argc, char** argv) {
             else if (output_type == "multipath") {
                 vector<MultipathAlignment> buf;
                 function<void(Alignment&)> lambda = [&buf](Alignment& aln) {
+                    multipath_alignment_t mp_aln;
+                    to_multipath_alignment(aln, mp_aln);
                     buf.emplace_back();
-                    to_multipath_alignment(aln, buf.back());
+                    to_proto_multipath_alignment(mp_aln, buf.back());
                     vg::io::write_buffered(cout, buf, 1000);
                 };
                 get_input_file(file_name, [&](istream& in) {
@@ -588,8 +590,10 @@ int main_view(int argc, char** argv) {
                 vector<MultipathAlignment> buf;
                 Alignment aln;
                 while (json_helper.get_read_fn()(aln)) {
+                    multipath_alignment_t mp_aln;
+                    to_multipath_alignment(aln, mp_aln);
                     buf.emplace_back();
-                    to_multipath_alignment(aln, buf.back());
+                    to_proto_multipath_alignment(mp_aln, buf.back());
                     vg::io::write_buffered(std::cout, buf, 1000);
                 }
                 vg::io::write_buffered(cout, buf, 0);
@@ -639,8 +643,10 @@ int main_view(int argc, char** argv) {
             }
             else if (output_type == "gam") {
                 vector<Alignment> buf;
-                MultipathAlignment mp_aln;
-                while (json_helper.get_read_fn()(mp_aln)) {
+                MultipathAlignment proto_mp_aln;
+                while (json_helper.get_read_fn()(proto_mp_aln)) {
+                    multipath_alignment_t mp_aln;
+                    from_proto_multipath_alignment(proto_mp_aln, mp_aln);
                     buf.emplace_back();
                     optimal_alignment(mp_aln, buf.back());
                     vg::io::write_buffered(std::cout, buf, 1000);
@@ -685,7 +691,9 @@ int main_view(int argc, char** argv) {
             }
             else if (output_type == "gam") {
                 vector<Alignment> buf;
-                function<void(MultipathAlignment&)> lambda = [&buf](MultipathAlignment& mp_aln) {
+                function<void(MultipathAlignment&)> lambda = [&buf](MultipathAlignment& proto_mp_aln) {
+                    multipath_alignment_t mp_aln;
+                    from_proto_multipath_alignment(proto_mp_aln, mp_aln);
                     buf.emplace_back();
                     optimal_alignment(mp_aln, buf.back());
                     vg::io::write_buffered(cout, buf, 1000);

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -728,7 +728,7 @@ using namespace std;
         mp_aln_graph.remove_transitive_edges(topological_order);
         
         // align the intervening segments and store the result in a multipath alignment
-        MultipathAlignment mp_aln;
+        multipath_alignment_t mp_aln;
         mp_aln_graph.align(source, split_path_graph, get_aligner(), false, 1, false, numeric_limits<int64_t>::max(),
                            false, 1, mp_aln, allow_negative_scores);
         topologically_order_subpaths(mp_aln);

--- a/src/unittest/mcmc_genotyper.cpp
+++ b/src/unittest/mcmc_genotyper.cpp
@@ -127,10 +127,14 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths with same topology as graph
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -354,14 +358,22 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths with same topology as graph
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
-                subpath_t* subpath4 = multipath_aln.add_subpath();
-                subpath_t* subpath5 = multipath_aln.add_subpath();
-                subpath_t* subpath6 = multipath_aln.add_subpath();
-                subpath_t* subpath7 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
+                subpath_t* subpath4 = multipath_aln.mutable_subpath(4);
+                subpath_t* subpath5 = multipath_aln.mutable_subpath(5);
+                subpath_t* subpath6 = multipath_aln.mutable_subpath(6);
+                subpath_t* subpath7 = multipath_aln.mutable_subpath(7);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);

--- a/src/unittest/mcmc_genotyper.cpp
+++ b/src/unittest/mcmc_genotyper.cpp
@@ -46,16 +46,16 @@ namespace vg {
                 SnarlManager snarl_manager; 
             
                 string read = string("GCA");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                  // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
                  
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
-                Edit* edit0 = mapping0->add_edit();
+                edit_t* edit0 = mapping0->add_edit();
                 edit0->set_from_length(3); //a match 
                 edit0->set_to_length(3);
 
@@ -64,7 +64,7 @@ namespace vg {
                 multipath_aln.add_start(0);        
 
                 MCMCGenotyper mcmc_genotyper = MCMCGenotyper(snarl_manager, graph, n_iterations, seed);   
-                vector<MultipathAlignment> multipath_aln_vector = vector<MultipathAlignment>({multipath_aln}); 
+                vector<multipath_alignment_t> multipath_aln_vector = vector<multipath_alignment_t>({multipath_aln});
                 double log_base = gssw_dna_recover_log_base(1,4,.5,1e-12);
                 unique_ptr<PhasedGenome> genome = mcmc_genotyper.run_genotype(multipath_aln_vector, log_base);
 
@@ -123,14 +123,14 @@ namespace vg {
                 SnarlManager snarl_manager = bubble_finder.find_snarls();
                 
                 string read = string("GCATCTGA");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths with same topology as graph
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -145,28 +145,28 @@ namespace vg {
                 subpath3->set_score(1);
 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
-                Edit* edit0 = mapping0->add_edit();
+                edit_t* edit0 = mapping0->add_edit();
                 edit0->set_from_length(3); //a match 
                 edit0->set_to_length(3);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
-                Edit* edit1 = mapping1->add_edit();
+                edit_t* edit1 = mapping1->add_edit();
                 edit1->set_from_length(1); //a match 
                 edit1->set_to_length(1);
                 
-                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
-                Edit* edit2 = mapping2->add_edit();
+                edit_t* edit2 = mapping2->add_edit();
                 edit2->set_from_length(1); //a snip
                 edit2->set_to_length(1);
                 edit2->set_sequence("T"); 
 
-                Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath3->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(4);
-                Edit* edit3 = mapping3->add_edit();
+                edit_t* edit3 = mapping3->add_edit();
                 edit3->set_from_length(4); //a match 
                 edit3->set_to_length(4);
                 
@@ -174,7 +174,7 @@ namespace vg {
 
             
                 MCMCGenotyper mcmc_genotyper = MCMCGenotyper(snarl_manager, graph, n_iterations, seed);
-                vector<MultipathAlignment> multipath_aln_vector = vector<MultipathAlignment>({multipath_aln}); 
+                vector<multipath_alignment_t> multipath_aln_vector = vector<multipath_alignment_t>({multipath_aln});
                 double log_base = gssw_dna_recover_log_base(1,4,.5,1e-12);
                 unique_ptr<PhasedGenome> genome = mcmc_genotyper.run_genotype(multipath_aln_vector, log_base);
                 //cerr << "**************" <<endl;
@@ -269,9 +269,9 @@ namespace vg {
                 }
 
                MCMCGenotyper mcmc_genotyper = MCMCGenotyper(snarl_manager, graph, n_iterations, seed);
-               vector<MultipathAlignment> multipath_aln_vector = vector<MultipathAlignment>(); 
+               vector<multipath_alignment_t> multipath_aln_vector = vector<multipath_alignment_t>();
 
-               vector<vector<MultipathAlignment>> vect = {reads.size(),vector<MultipathAlignment>() };
+               vector<vector<multipath_alignment_t>> vect = {reads.size(),vector<multipath_alignment_t>() };
                     
                     
                 // map read in alignment to graph and make multipath alignments 
@@ -350,18 +350,18 @@ namespace vg {
                 SnarlManager snarl_manager = bubble_finder.find_snarls();
                 
                 string read = string("GGGCCCAGCTGG");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths with same topology as graph
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
-                Subpath* subpath4 = multipath_aln.add_subpath();
-                Subpath* subpath5 = multipath_aln.add_subpath();
-                Subpath* subpath6 = multipath_aln.add_subpath();
-                Subpath* subpath7 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath4 = multipath_aln.add_subpath();
+                subpath_t* subpath5 = multipath_aln.add_subpath();
+                subpath_t* subpath6 = multipath_aln.add_subpath();
+                subpath_t* subpath7 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -385,61 +385,61 @@ namespace vg {
                 subpath7->set_score(-10);
                 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
-                Edit* edit0 = mapping0->add_edit();
+                edit_t* edit0 = mapping0->add_edit();
                 edit0->set_from_length(3); //a match 
                 edit0->set_to_length(3);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
-                Edit* edit1 = mapping1->add_edit();
+                edit_t* edit1 = mapping1->add_edit();
                 edit1->set_from_length(3); //a match 
                 edit1->set_to_length(3);
                 
-                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
-                Edit* edit2 = mapping2->add_edit();
+                edit_t* edit2 = mapping2->add_edit();
                 edit2->set_from_length(1); //a match 
                 edit2->set_to_length(1);
                 
-                Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath3->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(4);
-                Edit* edit3 = mapping3->add_edit();
+                edit_t* edit3 = mapping3->add_edit();
                 edit3->set_from_length(1); //a mismatch, snp
                 edit3->set_to_length(1);
                 edit3->set_sequence("A");
 
-                Mapping* mapping4 = subpath4->mutable_path()->add_mapping();
+                path_mapping_t* mapping4 = subpath4->mutable_path()->add_mapping();
                 mapping4->mutable_position()->set_node_id(5);
-                Edit* edit4 = mapping4->add_edit();
+                edit_t* edit4 = mapping4->add_edit();
                 edit4->set_from_length(1); //a match 
                 edit4->set_to_length(1);
 
-                Mapping* mapping5 = subpath5->mutable_path()->add_mapping();
+                path_mapping_t* mapping5 = subpath5->mutable_path()->add_mapping();
                 mapping5->mutable_position()->set_node_id(6);
-                Edit* edit5 = mapping5->add_edit();
+                edit_t* edit5 = mapping5->add_edit();
                 edit5->set_from_length(3); //a match 
                 edit5->set_to_length(3);
 
-                Mapping* mapping6 = subpath6->mutable_path()->add_mapping();
+                path_mapping_t* mapping6 = subpath6->mutable_path()->add_mapping();
                 mapping6->mutable_position()->set_node_id(7);
-                Edit* edit6 = mapping6->add_edit();
+                edit_t* edit6 = mapping6->add_edit();
                 edit6->set_from_length(2); //a mismatch 
                 edit6->set_to_length(2); // will offset 2 positions in read and graph 
                 edit6->set_sequence("CC");
-                Edit* edit6b = mapping6->add_edit();
+                edit_t* edit6b = mapping6->add_edit();
                 edit6b->set_from_length(1); // a match
                 edit6b->set_to_length(1);
                 
 
-                Mapping* mapping7 = subpath7->mutable_path()->add_mapping();
+                path_mapping_t* mapping7 = subpath7->mutable_path()->add_mapping();
                 mapping7->mutable_position()->set_node_id(8);
-                Edit* edit7 = mapping7->add_edit();
+                edit_t* edit7 = mapping7->add_edit();
                 edit7->set_from_length(1); //a mismatch 
                 edit7->set_to_length(1);
                 edit7->set_sequence("A");
-                Edit* edit7b = mapping7->add_edit(); // a deletion , gap open 
+                edit_t* edit7b = mapping7->add_edit(); // a deletion , gap open
                 edit7b->set_from_length(1); // denotes the length of the gap observed in alt seq
                 edit7b->set_to_length(0); // length in alt sequence is zero because it is a gap
                 edit7b->set_sequence("G");
@@ -450,7 +450,7 @@ namespace vg {
                 double log_base = gssw_dna_recover_log_base(1,4,.5,1e-12);
 
                 MCMCGenotyper mcmc_genotyper = MCMCGenotyper(snarl_manager, graph, n_iterations, seed);
-                vector<MultipathAlignment> multipath_aln_vector = vector<MultipathAlignment>({multipath_aln}); 
+                vector<multipath_alignment_t> multipath_aln_vector = vector<multipath_alignment_t>({multipath_aln});
                 unique_ptr<PhasedGenome> genome = mcmc_genotyper.run_genotype(multipath_aln_vector, log_base);
 
                  // create a set of possible solutions
@@ -546,9 +546,9 @@ namespace vg {
                 
                 
                 MCMCGenotyper mcmc_genotyper = MCMCGenotyper(snarl_manager, graph, n_iterations, seed);
-                vector<MultipathAlignment> multipath_aln_vector = vector<MultipathAlignment>(); 
+                vector<multipath_alignment_t> multipath_aln_vector = vector<multipath_alignment_t>();
 
-                vector<vector<MultipathAlignment>> vect = {reads.size(),vector<MultipathAlignment>() };
+                vector<vector<multipath_alignment_t>> vect = {reads.size(),vector<multipath_alignment_t>() };
                     
                     
                 // map read in alignment to graph and make multipath alignments 
@@ -563,7 +563,7 @@ namespace vg {
 
                 double log_base = gssw_dna_recover_log_base(1,4,.5,1e-12);
                 
-                //pass vector with accumulated MultipathAlignment objects to run_genotype()
+                //pass vector with accumulated multipath_alignment_t objects to run_genotype()
                 unique_ptr<PhasedGenome> genome = mcmc_genotyper.run_genotype(multipath_aln_vector, log_base); 
                 
                 // // create a set of 2 possible solutions
@@ -682,9 +682,9 @@ namespace vg {
                     }
                     
                     MCMCGenotyper mcmc_genotyper = MCMCGenotyper(snarl_manager, graph, num_iterations, seed_i);
-                    vector<MultipathAlignment> multipath_aln_vector = vector<MultipathAlignment>(); 
+                    vector<multipath_alignment_t> multipath_aln_vector = vector<multipath_alignment_t>();
 
-                    vector<vector<MultipathAlignment>> vect = {reads.size(),vector<MultipathAlignment>() };
+                    vector<vector<multipath_alignment_t>> vect = {reads.size(),vector<multipath_alignment_t>() };
                     
                     
                     // map read in alignment to graph and make multipath alignments 
@@ -699,7 +699,7 @@ namespace vg {
                     
 
                     double log_base = gssw_dna_recover_log_base(1,4,.5,1e-12);
-                    //pass vector with accumulated MultipathAlignment objects to run_genotype()
+                    //pass vector with accumulated multipath_alignment_t objects to run_genotype()
                     unique_ptr<PhasedGenome> genome = mcmc_genotyper.run_genotype(multipath_aln_vector, log_base); 
                     
 
@@ -817,9 +817,9 @@ namespace vg {
                 }
 
                MCMCGenotyper mcmc_genotyper = MCMCGenotyper(snarl_manager, graph, n_iterations, seed);
-               vector<MultipathAlignment> multipath_aln_vector = vector<MultipathAlignment>(); 
+               vector<multipath_alignment_t> multipath_aln_vector = vector<multipath_alignment_t>();
 
-               vector<vector<MultipathAlignment>> vect = {reads.size(),vector<MultipathAlignment>() };
+               vector<vector<multipath_alignment_t>> vect = {reads.size(),vector<multipath_alignment_t>() };
                     
                     
                 // map read in alignment to graph and make multipath alignments 

--- a/src/unittest/multipath_alignment.cpp
+++ b/src/unittest/multipath_alignment.cpp
@@ -42,8 +42,11 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -57,7 +60,6 @@ namespace vg {
                 
                 path_mapping_t* mapping2 = subpath1->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(4);
-                
                 identify_start_subpaths(multipath_aln);
                 
                 REQUIRE(multipath_aln.start_size() == 1);
@@ -83,10 +85,14 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -154,8 +160,10 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
                 
                 // set edges between subpaths
                 
@@ -203,11 +211,16 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
-                subpath_t* subpath4 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
+                subpath_t* subpath4 = multipath_aln.mutable_subpath(4);
                 
                 // set edges between subpaths
                 subpath0->add_next(2);
@@ -274,12 +287,18 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
-                subpath_t* subpath4 = multipath_aln.add_subpath();
-                subpath_t* subpath5 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
+                subpath_t* subpath4 = multipath_aln.mutable_subpath(4);
+                subpath_t* subpath5 = multipath_aln.mutable_subpath(5);
                 
                 // set edges between subpaths
                 subpath0->add_next(2);
@@ -354,9 +373,12 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -429,8 +451,10 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
                 
                 // set edges between subpaths
                 
@@ -487,12 +511,18 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
-                subpath_t* subpath4 = multipath_aln.add_subpath();
-                subpath_t* subpath5 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
+                subpath_t* subpath4 = multipath_aln.mutable_subpath(4);
+                subpath_t* subpath5 = multipath_aln.mutable_subpath(5);
                 
                 // set edges between subpaths
                 subpath0->add_next(2);
@@ -656,10 +686,14 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -781,12 +815,18 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
-                subpath_t* subpath4 = multipath_aln.add_subpath();
-                subpath_t* subpath5 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
+                subpath_t* subpath4 = multipath_aln.mutable_subpath(4);
+                subpath_t* subpath5 = multipath_aln.mutable_subpath(5);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -838,11 +878,13 @@ namespace vg {
                 
                 path_mapping_t* mapping5 = subpath5->mutable_path()->add_mapping();
                 mapping5->mutable_position()->set_node_id(6);
-                edit_t* edit5a = mapping5->add_edit();
+                mapping5->add_edit();
+                mapping5->add_edit();
+                edit_t* edit5a = mapping5->mutable_edit(0);
+                edit_t* edit5b = mapping5->mutable_edit(1);
                 edit5a->set_from_length(1);
                 edit5a->set_to_length(1);
                 edit5a->set_sequence("A");
-                edit_t* edit5b = mapping5->add_edit();
                 edit5b->set_from_length(1);
                 edit5b->set_to_length(1);
                 
@@ -942,12 +984,18 @@ namespace vg {
             multipath_aln.set_sequence(read);
             
             // add subpaths
-            subpath_t* subpath0 = multipath_aln.add_subpath();
-            subpath_t* subpath1 = multipath_aln.add_subpath();
-            subpath_t* subpath2 = multipath_aln.add_subpath();
-            subpath_t* subpath3 = multipath_aln.add_subpath();
-            subpath_t* subpath4 = multipath_aln.add_subpath();
-            subpath_t* subpath5 = multipath_aln.add_subpath();
+            multipath_aln.add_subpath();
+            multipath_aln.add_subpath();
+            multipath_aln.add_subpath();
+            multipath_aln.add_subpath();
+            multipath_aln.add_subpath();
+            multipath_aln.add_subpath();
+            subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+            subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+            subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+            subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
+            subpath_t* subpath4 = multipath_aln.mutable_subpath(4);
+            subpath_t* subpath5 = multipath_aln.mutable_subpath(5);
             
             // set edges between subpaths
             subpath0->add_next(2);
@@ -982,10 +1030,12 @@ namespace vg {
             
             path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
             mapping2->mutable_position()->set_node_id(3);
-            edit_t* edit20 = mapping2->add_edit();
+            mapping2->add_edit();
+            mapping2->add_edit();
+            edit_t* edit20 = mapping2->mutable_edit(0);
+            edit_t* edit21 = mapping2->mutable_edit(1);
             edit20->set_from_length(1);
             edit20->set_to_length(0);
-            edit_t* edit21 = mapping2->add_edit();
             edit21->set_from_length(2);
             edit21->set_to_length(2);
             
@@ -1135,9 +1185,12 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1178,9 +1231,12 @@ namespace vg {
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1234,13 +1290,20 @@ namespace vg {
                 multipath_alignment_t multipath_aln;
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
-                subpath_t* subpath4 = multipath_aln.add_subpath();
-                subpath_t* subpath5 = multipath_aln.add_subpath();
-                subpath_t* subpath6 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
+                subpath_t* subpath4 = multipath_aln.mutable_subpath(4);
+                subpath_t* subpath5 = multipath_aln.mutable_subpath(5);
+                subpath_t* subpath6 = multipath_aln.mutable_subpath(6);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1320,13 +1383,20 @@ namespace vg {
                 multipath_alignment_t multipath_aln;
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
-                subpath_t* subpath4 = multipath_aln.add_subpath();
-                subpath_t* subpath5 = multipath_aln.add_subpath();
-                subpath_t* subpath6 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
+                subpath_t* subpath4 = multipath_aln.mutable_subpath(4);
+                subpath_t* subpath5 = multipath_aln.mutable_subpath(5);
+                subpath_t* subpath6 = multipath_aln.mutable_subpath(6);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1474,7 +1544,10 @@ namespace vg {
                 
                 multipath_alignment_t mpaln;
                 
-                subpath_t* sp1 = mpaln.add_subpath();
+                mpaln.add_subpath();
+                mpaln.add_subpath();
+                subpath_t* sp1 = mpaln.mutable_subpath(0);
+                subpath_t* sp2 = mpaln.mutable_subpath(1);
                 
                 path_mapping_t* m11 = sp1->mutable_path()->add_mapping();
                 position_t* p11 = m11->mutable_position();
@@ -1483,9 +1556,7 @@ namespace vg {
                 edit_t* e111 = m11->add_edit();
                 e111->set_from_length(1);
                 e111->set_to_length(1);
-                
-                subpath_t* sp2 = mpaln.add_subpath();
-                
+                                
                 path_mapping_t* m21 = sp2->mutable_path()->add_mapping();
                 position_t* p21 = m21->mutable_position();
                 p21->set_node_id(2);
@@ -1527,7 +1598,10 @@ namespace vg {
                 
                 multipath_alignment_t mpaln;
                 
-                subpath_t* sp1 = mpaln.add_subpath();
+                mpaln.add_subpath();
+                mpaln.add_subpath();
+                subpath_t* sp1 = mpaln.mutable_subpath(0);
+                subpath_t* sp2 = mpaln.mutable_subpath(1);
                 
                 path_mapping_t* m11 = sp1->mutable_path()->add_mapping();
                 position_t* p11 = m11->mutable_position();
@@ -1537,9 +1611,7 @@ namespace vg {
                 edit_t* e111 = m11->add_edit();
                 e111->set_from_length(1);
                 e111->set_to_length(1);
-                
-                subpath_t* sp2 = mpaln.add_subpath();
-                
+                                
                 path_mapping_t* m21 = sp2->mutable_path()->add_mapping();
                 position_t* p21 = m21->mutable_position();
                 p21->set_node_id(1);
@@ -1579,7 +1651,10 @@ namespace vg {
                 
                 multipath_alignment_t mpaln;
                 
-                subpath_t* sp1 = mpaln.add_subpath();
+                mpaln.add_subpath();
+                mpaln.add_subpath();
+                subpath_t* sp1 = mpaln.mutable_subpath(0);
+                subpath_t* sp2 = mpaln.mutable_subpath(1);
                 
                 path_mapping_t* m11 = sp1->mutable_path()->add_mapping();
                 position_t* p11 = m11->mutable_position();
@@ -1589,9 +1664,7 @@ namespace vg {
                 edit_t* e111 = m11->add_edit();
                 e111->set_from_length(1);
                 e111->set_to_length(1);
-                
-                subpath_t* sp2 = mpaln.add_subpath();
-                
+                                
                 path_mapping_t* m21 = sp2->mutable_path()->add_mapping();
                 position_t* p21 = m21->mutable_position();
                 p21->set_node_id(1);
@@ -1626,7 +1699,14 @@ namespace vg {
                 
                 multipath_alignment_t mpaln;
                 
-                subpath_t* sp1 = mpaln.add_subpath();
+                mpaln.add_subpath();
+                mpaln.add_subpath();
+                mpaln.add_subpath();
+                mpaln.add_subpath();
+                subpath_t* sp1 = mpaln.mutable_subpath(0);
+                subpath_t* sp2 = mpaln.mutable_subpath(1);
+                subpath_t* sp3 = mpaln.mutable_subpath(2);
+                subpath_t* sp4 = mpaln.mutable_subpath(3);
                 
                 path_mapping_t* m11 = sp1->mutable_path()->add_mapping();
                 position_t* p11 = m11->mutable_position();
@@ -1636,25 +1716,24 @@ namespace vg {
                 edit_t* e111 = m11->add_edit();
                 e111->set_from_length(1);
                 e111->set_to_length(1);
-                
-                subpath_t* sp2 = mpaln.add_subpath();
-                
+                                
                 path_mapping_t* m21 = sp2->mutable_path()->add_mapping();
                 position_t* p21 = m21->mutable_position();
                 p21->set_node_id(1);
                 p21->set_offset(1);
                 p21->set_is_reverse(true);
                 
-                edit_t* e211 = m21->add_edit();
+                m21->add_edit();
+                m21->add_edit();
+                edit_t* e211 = m21->mutable_edit(0);
+                edit_t* e212 = m21->mutable_edit(1);
+                
                 e211->set_from_length(2);
                 e211->set_to_length(2);
                 
-                edit_t* e212 = m21->add_edit();
                 e212->set_from_length(2);
                 e212->set_to_length(0);
-                
-                subpath_t* sp3 = mpaln.add_subpath();
-                
+                                
                 path_mapping_t* m31 = sp3->mutable_path()->add_mapping();
                 position_t* p31 = m31->mutable_position();
                 p31->set_node_id(2);
@@ -1663,9 +1742,7 @@ namespace vg {
                 edit_t* e311 = m31->add_edit();
                 e311->set_from_length(1);
                 e311->set_to_length(1);
-                
-                subpath_t* sp4 = mpaln.add_subpath();
-                
+                                
                 path_mapping_t* m41 = sp4->mutable_path()->add_mapping();
                 position_t* p41 = m41->mutable_position();
                 p41->set_node_id(3);

--- a/src/unittest/multipath_alignment.cpp
+++ b/src/unittest/multipath_alignment.cpp
@@ -38,24 +38,24 @@ namespace vg {
                 graph.create_edge(n3, n4);
                 
                 string read = string("GCATCTGA");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
                 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
                 
-                Mapping* mapping1 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath0->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
                 
-                Mapping* mapping2 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath1->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(4);
                 
                 identify_start_subpaths(multipath_aln);
@@ -79,14 +79,14 @@ namespace vg {
                 graph.create_edge(n3, n4);
                 
                 string read = string("GCATCTGA");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -94,16 +94,16 @@ namespace vg {
                 subpath2->add_next(3);
                 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
                 
-                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
                 
-                Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath3->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(4);
                 
                 
@@ -150,12 +150,12 @@ namespace vg {
                 graph.create_edge(n3, n4);
                 
                 string read = string("T");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 
@@ -164,10 +164,10 @@ namespace vg {
                 subpath1->set_score(0);
                 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(2);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(3);
                 
                 // get optimal alignment
@@ -199,15 +199,15 @@ namespace vg {
                 graph.create_edge(n3, n5);
                 
                 string read = string("GCAGCTGA");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
-                Subpath* subpath4 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath4 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(2);
@@ -223,19 +223,19 @@ namespace vg {
                 subpath4->set_score(4);
                 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
                 
-                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
                 
-                Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath3->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(4);
                 
-                Mapping* mapping4 = subpath4->mutable_path()->add_mapping();
+                path_mapping_t* mapping4 = subpath4->mutable_path()->add_mapping();
                 mapping4->mutable_position()->set_node_id(5);
                 
                 // get optimal alignment
@@ -270,16 +270,16 @@ namespace vg {
                 graph.create_edge(n3, n5);
                 
                 string read = string("GCAGTGACTGA");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
-                Subpath* subpath4 = multipath_aln.add_subpath();
-                Subpath* subpath5 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath4 = multipath_aln.add_subpath();
+                subpath_t* subpath5 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(2);
@@ -297,29 +297,29 @@ namespace vg {
                 subpath5->set_score(4);
                 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
                 
-                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
-                Edit* edit2 = mapping2->add_edit();
+                edit_t* edit2 = mapping2->add_edit();
                 edit2->set_from_length(2);
                 edit2->set_to_length(2);
                 
-                Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath3->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(3);
                 mapping3->mutable_position()->set_offset(2);
-                Edit* edit3 = mapping3->add_edit();
+                edit_t* edit3 = mapping3->add_edit();
                 edit3->set_from_length(3);
                 edit3->set_to_length(3);
                 
-                Mapping* mapping4 = subpath4->mutable_path()->add_mapping();
+                path_mapping_t* mapping4 = subpath4->mutable_path()->add_mapping();
                 mapping4->mutable_position()->set_node_id(4);
                 
-                Mapping* mapping5 = subpath5->mutable_path()->add_mapping();
+                path_mapping_t* mapping5 = subpath5->mutable_path()->add_mapping();
                 mapping5->mutable_position()->set_node_id(5);
                 
                 // get optimal alignment
@@ -350,13 +350,13 @@ namespace vg {
             SECTION( "The optimal alignment can be forced to take low-scoring intervening subpaths" ) {
                 
                 string read = "GCAGTG";
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -368,22 +368,22 @@ namespace vg {
                 subpath2->set_score(2);
                 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
-                Edit* edit0 = mapping0->add_edit();
+                edit_t* edit0 = mapping0->add_edit();
                 edit0->set_from_length(3);
                 edit0->set_to_length(3);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
-                Edit* edit1 = mapping0->add_edit();
+                edit_t* edit1 = mapping0->add_edit();
                 edit1->set_from_length(1);
                 edit1->set_to_length(1);
                 edit1->set_sequence("T");
                 
-                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
-                Edit* edit2 = mapping2->add_edit();
+                edit_t* edit2 = mapping2->add_edit();
                 edit2->set_from_length(2);
                 edit2->set_to_length(2);
                 
@@ -425,12 +425,12 @@ namespace vg {
                 graph.create_edge(n3, n4);
                 
                 string read = string("T");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 
@@ -439,10 +439,10 @@ namespace vg {
                 subpath1->set_score(0);
                 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(2);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(3);
                 
                 // get top 10 alignments
@@ -483,16 +483,16 @@ namespace vg {
                 graph.create_edge(n3, n5);
                 
                 string read = string("GCAGTGACTGA");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
-                Subpath* subpath4 = multipath_aln.add_subpath();
-                Subpath* subpath5 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath4 = multipath_aln.add_subpath();
+                subpath_t* subpath5 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(2);
@@ -511,29 +511,29 @@ namespace vg {
                 
                 // designate mappings
                 // TODO: Note that these edits aren't quite realistic
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
                 
-                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
-                Edit* edit2 = mapping2->add_edit();
+                edit_t* edit2 = mapping2->add_edit();
                 edit2->set_from_length(2);
                 edit2->set_to_length(2);
                 
-                Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath3->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(3);
                 mapping3->mutable_position()->set_offset(2);
-                Edit* edit3 = mapping3->add_edit();
+                edit_t* edit3 = mapping3->add_edit();
                 edit3->set_from_length(3);
                 edit3->set_to_length(3);
                 
-                Mapping* mapping4 = subpath4->mutable_path()->add_mapping();
+                path_mapping_t* mapping4 = subpath4->mutable_path()->add_mapping();
                 mapping4->mutable_position()->set_node_id(4);
                 
-                Mapping* mapping5 = subpath5->mutable_path()->add_mapping();
+                path_mapping_t* mapping5 = subpath5->mutable_path()->add_mapping();
                 mapping5->mutable_position()->set_node_id(5);
                 
                 // get top 10 alignments
@@ -652,14 +652,14 @@ namespace vg {
                 graph.create_edge(n3, n4);
                 
                 string read = string("GCATCTGA");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -674,28 +674,28 @@ namespace vg {
                 subpath3->set_score(4);
                 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
-                Edit* edit0 = mapping0->add_edit();
+                edit_t* edit0 = mapping0->add_edit();
                 edit0->set_from_length(3);
                 edit0->set_to_length(3);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
-                Edit* edit1 = mapping1->add_edit();
+                edit_t* edit1 = mapping1->add_edit();
                 edit1->set_from_length(1);
                 edit1->set_to_length(1);
                 
-                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
-                Edit* edit2 = mapping2->add_edit();
+                edit_t* edit2 = mapping2->add_edit();
                 edit2->set_from_length(1);
                 edit2->set_to_length(1);
                 edit2->set_sequence("T");
                 
-                Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath3->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(4);
-                Edit* edit3 = mapping3->add_edit();
+                edit_t* edit3 = mapping3->add_edit();
                 edit3->set_from_length(4);
                 edit3->set_to_length(4);
                 
@@ -777,16 +777,16 @@ namespace vg {
                 graph.create_edge(n4, n6);
                 
                 string read = string("GCATCTGAAC");
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
-                Subpath* subpath4 = multipath_aln.add_subpath();
-                Subpath* subpath5 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath4 = multipath_aln.add_subpath();
+                subpath_t* subpath5 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -805,44 +805,44 @@ namespace vg {
                 subpath5->set_score(0);
                 
                 // designate mappings
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
-                Edit* edit0 = mapping0->add_edit();
+                edit_t* edit0 = mapping0->add_edit();
                 edit0->set_from_length(3);
                 edit0->set_to_length(3);
                 
-                Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
-                Edit* edit1 = mapping1->add_edit();
+                edit_t* edit1 = mapping1->add_edit();
                 edit1->set_from_length(1);
                 edit1->set_to_length(1);
                 
-                Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
-                Edit* edit2 = mapping2->add_edit();
+                edit_t* edit2 = mapping2->add_edit();
                 edit2->set_from_length(1);
                 edit2->set_to_length(1);
                 edit2->set_sequence("T");
                 
-                Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath3->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(4);
-                Edit* edit3 = mapping3->add_edit();
+                edit_t* edit3 = mapping3->add_edit();
                 edit3->set_from_length(4);
                 edit3->set_to_length(4);
                 
-                Mapping* mapping4 = subpath4->mutable_path()->add_mapping();
+                path_mapping_t* mapping4 = subpath4->mutable_path()->add_mapping();
                 mapping4->mutable_position()->set_node_id(5);
-                Edit* edit4 = mapping4->add_edit();
+                edit_t* edit4 = mapping4->add_edit();
                 edit4->set_from_length(2);
                 edit4->set_to_length(2);
                 
-                Mapping* mapping5 = subpath5->mutable_path()->add_mapping();
+                path_mapping_t* mapping5 = subpath5->mutable_path()->add_mapping();
                 mapping5->mutable_position()->set_node_id(6);
-                Edit* edit5a = mapping5->add_edit();
+                edit_t* edit5a = mapping5->add_edit();
                 edit5a->set_from_length(1);
                 edit5a->set_to_length(1);
                 edit5a->set_sequence("A");
-                Edit* edit5b = mapping5->add_edit();
+                edit_t* edit5b = mapping5->add_edit();
                 edit5b->set_from_length(1);
                 edit5b->set_to_length(1);
                 
@@ -938,16 +938,16 @@ namespace vg {
             graph.create_edge(n3, n5);
             
             string read = string("CACCCTGA");
-            MultipathAlignment multipath_aln;
+            multipath_alignment_t multipath_aln;
             multipath_aln.set_sequence(read);
             
             // add subpaths
-            Subpath* subpath0 = multipath_aln.add_subpath();
-            Subpath* subpath1 = multipath_aln.add_subpath();
-            Subpath* subpath2 = multipath_aln.add_subpath();
-            Subpath* subpath3 = multipath_aln.add_subpath();
-            Subpath* subpath4 = multipath_aln.add_subpath();
-            Subpath* subpath5 = multipath_aln.add_subpath();
+            subpath_t* subpath0 = multipath_aln.add_subpath();
+            subpath_t* subpath1 = multipath_aln.add_subpath();
+            subpath_t* subpath2 = multipath_aln.add_subpath();
+            subpath_t* subpath3 = multipath_aln.add_subpath();
+            subpath_t* subpath4 = multipath_aln.add_subpath();
+            subpath_t* subpath5 = multipath_aln.add_subpath();
             
             // set edges between subpaths
             subpath0->add_next(2);
@@ -965,47 +965,47 @@ namespace vg {
             subpath5->set_score(0);
             
             // designate mappings
-            Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+            path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
             mapping0->mutable_position()->set_node_id(1);
             mapping0->mutable_position()->set_offset(1);
-            Edit* edit00 = mapping0->add_edit();
+            edit_t* edit00 = mapping0->add_edit();
             edit00->set_from_length(2);
             edit00->set_to_length(2);
             
-            Mapping* mapping1 = subpath1->mutable_path()->add_mapping();
+            path_mapping_t* mapping1 = subpath1->mutable_path()->add_mapping();
             mapping1->mutable_position()->set_node_id(2);
             mapping1->mutable_position()->set_offset(1);
-            Edit* edit10 = mapping1->add_edit();
+            edit_t* edit10 = mapping1->add_edit();
             edit10->set_from_length(0);
             edit10->set_to_length(2);
             edit10->set_sequence("CA");
             
-            Mapping* mapping2 = subpath2->mutable_path()->add_mapping();
+            path_mapping_t* mapping2 = subpath2->mutable_path()->add_mapping();
             mapping2->mutable_position()->set_node_id(3);
-            Edit* edit20 = mapping2->add_edit();
+            edit_t* edit20 = mapping2->add_edit();
             edit20->set_from_length(1);
             edit20->set_to_length(0);
-            Edit* edit21 = mapping2->add_edit();
+            edit_t* edit21 = mapping2->add_edit();
             edit21->set_from_length(2);
             edit21->set_to_length(2);
             
-            Mapping* mapping3 = subpath3->mutable_path()->add_mapping();
+            path_mapping_t* mapping3 = subpath3->mutable_path()->add_mapping();
             mapping3->mutable_position()->set_node_id(4);
-            Edit* edit30 = mapping3->add_edit();
+            edit_t* edit30 = mapping3->add_edit();
             edit30->set_from_length(0);
             edit30->set_to_length(4);
             edit30->set_sequence("CTGA");
             
-            Mapping* mapping4 = subpath4->mutable_path()->add_mapping();
+            path_mapping_t* mapping4 = subpath4->mutable_path()->add_mapping();
             mapping4->mutable_position()->set_node_id(5);
-            Edit* edit40 = mapping4->add_edit();
+            edit_t* edit40 = mapping4->add_edit();
             edit40->set_from_length(4);
             edit40->set_to_length(4);
             
-            Mapping* mapping5 = subpath5->mutable_path()->add_mapping();
+            path_mapping_t* mapping5 = subpath5->mutable_path()->add_mapping();
             mapping5->mutable_position()->set_node_id(3);
             mapping5->mutable_position()->set_offset(3);
-            Edit* edit50 = mapping5->add_edit();
+            edit_t* edit50 = mapping5->add_edit();
             edit50->set_from_length(0);
             edit50->set_to_length(6);
             edit50->set_sequence("CCCTGA");
@@ -1014,7 +1014,7 @@ namespace vg {
             multipath_aln.add_start(0);
             multipath_aln.add_start(1);
             
-            MultipathAlignment rc_multipath_aln;
+            multipath_alignment_t rc_multipath_aln;
             
             auto node_length = [&graph](int64_t node_id) { return graph.get_node(node_id)->sequence().length(); };
             rev_comp_multipath_alignment(multipath_aln, node_length, rc_multipath_aln);
@@ -1084,19 +1084,19 @@ namespace vg {
             REQUIRE(rc_multipath_aln.subpath_size() == multipath_aln.subpath_size());
             
             for (int64_t i = 0; i < multipath_aln.subpath_size(); i++) {
-                const Subpath& subpath_1 = multipath_aln.subpath(i);
-                const Subpath& subpath_2 = rc_multipath_aln.subpath(i);
+                const subpath_t& subpath_1 = multipath_aln.subpath(i);
+                const subpath_t& subpath_2 = rc_multipath_aln.subpath(i);
                 REQUIRE(subpath_1.score() == subpath_2.score());
-                const Path& path_1 = subpath_1.path();
-                const Path& path_2 = subpath_2.path();
+                const path_t& path_1 = subpath_1.path();
+                const path_t& path_2 = subpath_2.path();
                 REQUIRE(path_1.mapping_size() == path_2.mapping_size());
                 for (int64_t j = 0; j < path_1.mapping_size(); j++) {
-                    const Mapping& mapping_1 = path_1.mapping(j);
-                    const Mapping& mapping_2 = path_2.mapping(j);
+                    const path_mapping_t& mapping_1 = path_1.mapping(j);
+                    const path_mapping_t& mapping_2 = path_2.mapping(j);
                     REQUIRE(mapping_1.edit_size() == mapping_2.edit_size());
                     for (int64_t k = 0; k < mapping_1.edit_size(); k++) {
-                        const Edit& edit_1 = mapping_1.edit(k);
-                        const Edit& edit_2 = mapping_2.edit(k);
+                        const edit_t& edit_1 = mapping_1.edit(k);
+                        const edit_t& edit_2 = mapping_2.edit(k);
                         REQUIRE(edit_1.from_length() == edit_2.from_length());
                         REQUIRE(edit_1.to_length() == edit_2.to_length());
                         REQUIRE(edit_1.sequence() == edit_2.sequence());
@@ -1124,20 +1124,20 @@ namespace vg {
             }
         }
         
-        TEST_CASE( "Algorithm returns correct connected components for MultipathAlignments",
+        TEST_CASE( "Algorithm returns correct connected components for multipath_alignment_ts",
                   "[alignment][multipath]" ){
             
-            SECTION("Works for a single component MultipathAlignment") {
+            SECTION("Works for a single component multipath_alignment_t") {
                 
                 
                 string read = "CACCCTGA";
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1171,16 +1171,16 @@ namespace vg {
                 REQUIRE(found_1);
             }
             
-            SECTION("Works for a two component MultipathAlignment") {
+            SECTION("Works for a two component multipath_alignment_t") {
                 
                 string read = "CACCCTGA";
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence(read);
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1229,18 +1229,18 @@ namespace vg {
                 REQUIRE(found_2);
             }
             
-            SECTION("Works for a multi-component MultipathAlignment with complicated edge structure") {
+            SECTION("Works for a multi-component multipath_alignment_t with complicated edge structure") {
                 
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
-                Subpath* subpath4 = multipath_aln.add_subpath();
-                Subpath* subpath5 = multipath_aln.add_subpath();
-                Subpath* subpath6 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath4 = multipath_aln.add_subpath();
+                subpath_t* subpath5 = multipath_aln.add_subpath();
+                subpath_t* subpath6 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1312,21 +1312,21 @@ namespace vg {
             }
         }
         
-        TEST_CASE("We can extract subgraphs of a MultipathAlignment",
+        TEST_CASE("We can extract subgraphs of a multipath_alignment_t",
                   "[alignment][multipath]" ) {
             
             SECTION("Works correctly when splitting by connected components") {
                 
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
-                Subpath* subpath4 = multipath_aln.add_subpath();
-                Subpath* subpath5 = multipath_aln.add_subpath();
-                Subpath* subpath6 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath4 = multipath_aln.add_subpath();
+                subpath_t* subpath5 = multipath_aln.add_subpath();
+                subpath_t* subpath6 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1349,7 +1349,7 @@ namespace vg {
                 
                 for (size_t i = 0; i < comps.size(); i++) {
                     
-                    MultipathAlignment sub;
+                    multipath_alignment_t sub;
                     extract_sub_multipath_alignment(multipath_aln, comps[i], sub);
                                         
                     bool is_this_comp;
@@ -1472,25 +1472,25 @@ namespace vg {
         TEST_CASE( "Non-branching paths in a multipath alignment can be merged", "[alignment][multipath]") {
             SECTION("Non-branching paths can be merged across an edge") {
                 
-                MultipathAlignment mpaln;
+                multipath_alignment_t mpaln;
                 
-                Subpath* sp1 = mpaln.add_subpath();
+                subpath_t* sp1 = mpaln.add_subpath();
                 
-                Mapping* m11 = sp1->mutable_path()->add_mapping();
-                Position* p11 = m11->mutable_position();
+                path_mapping_t* m11 = sp1->mutable_path()->add_mapping();
+                position_t* p11 = m11->mutable_position();
                 p11->set_node_id(1);
                 
-                Edit* e111 = m11->add_edit();
+                edit_t* e111 = m11->add_edit();
                 e111->set_from_length(1);
                 e111->set_to_length(1);
                 
-                Subpath* sp2 = mpaln.add_subpath();
+                subpath_t* sp2 = mpaln.add_subpath();
                 
-                Mapping* m21 = sp2->mutable_path()->add_mapping();
-                Position* p21 = m21->mutable_position();
+                path_mapping_t* m21 = sp2->mutable_path()->add_mapping();
+                position_t* p21 = m21->mutable_position();
                 p21->set_node_id(2);
                 
-                Edit* e211 = m21->add_edit();
+                edit_t* e211 = m21->add_edit();
                 e211->set_from_length(2);
                 e211->set_to_length(2);
                 
@@ -1525,28 +1525,28 @@ namespace vg {
             
             SECTION("Non-branching paths can be merged within a node") {
                 
-                MultipathAlignment mpaln;
+                multipath_alignment_t mpaln;
                 
-                Subpath* sp1 = mpaln.add_subpath();
+                subpath_t* sp1 = mpaln.add_subpath();
                 
-                Mapping* m11 = sp1->mutable_path()->add_mapping();
-                Position* p11 = m11->mutable_position();
+                path_mapping_t* m11 = sp1->mutable_path()->add_mapping();
+                position_t* p11 = m11->mutable_position();
                 p11->set_node_id(1);
                 p11->set_is_reverse(true);
                 
-                Edit* e111 = m11->add_edit();
+                edit_t* e111 = m11->add_edit();
                 e111->set_from_length(1);
                 e111->set_to_length(1);
                 
-                Subpath* sp2 = mpaln.add_subpath();
+                subpath_t* sp2 = mpaln.add_subpath();
                 
-                Mapping* m21 = sp2->mutable_path()->add_mapping();
-                Position* p21 = m21->mutable_position();
+                path_mapping_t* m21 = sp2->mutable_path()->add_mapping();
+                position_t* p21 = m21->mutable_position();
                 p21->set_node_id(1);
                 p21->set_offset(1);
                 p21->set_is_reverse(true);
                 
-                Edit* e211 = m21->add_edit();
+                edit_t* e211 = m21->add_edit();
                 e211->set_from_length(0);
                 e211->set_to_length(2);
                 
@@ -1577,28 +1577,28 @@ namespace vg {
             
             SECTION("Non-branching paths can be merged within an edit") {
                 
-                MultipathAlignment mpaln;
+                multipath_alignment_t mpaln;
                 
-                Subpath* sp1 = mpaln.add_subpath();
+                subpath_t* sp1 = mpaln.add_subpath();
                 
-                Mapping* m11 = sp1->mutable_path()->add_mapping();
-                Position* p11 = m11->mutable_position();
+                path_mapping_t* m11 = sp1->mutable_path()->add_mapping();
+                position_t* p11 = m11->mutable_position();
                 p11->set_node_id(1);
                 p11->set_is_reverse(true);
                 
-                Edit* e111 = m11->add_edit();
+                edit_t* e111 = m11->add_edit();
                 e111->set_from_length(1);
                 e111->set_to_length(1);
                 
-                Subpath* sp2 = mpaln.add_subpath();
+                subpath_t* sp2 = mpaln.add_subpath();
                 
-                Mapping* m21 = sp2->mutable_path()->add_mapping();
-                Position* p21 = m21->mutable_position();
+                path_mapping_t* m21 = sp2->mutable_path()->add_mapping();
+                position_t* p21 = m21->mutable_position();
                 p21->set_node_id(1);
                 p21->set_offset(1);
                 p21->set_is_reverse(true);
                 
-                Edit* e211 = m21->add_edit();
+                edit_t* e211 = m21->add_edit();
                 e211->set_from_length(2);
                 e211->set_to_length(2);
                 
@@ -1624,54 +1624,54 @@ namespace vg {
             
             SECTION("Non-branching paths can be distinguished from branching paths") {
                 
-                MultipathAlignment mpaln;
+                multipath_alignment_t mpaln;
                 
-                Subpath* sp1 = mpaln.add_subpath();
+                subpath_t* sp1 = mpaln.add_subpath();
                 
-                Mapping* m11 = sp1->mutable_path()->add_mapping();
-                Position* p11 = m11->mutable_position();
+                path_mapping_t* m11 = sp1->mutable_path()->add_mapping();
+                position_t* p11 = m11->mutable_position();
                 p11->set_node_id(1);
                 p11->set_is_reverse(true);
                 
-                Edit* e111 = m11->add_edit();
+                edit_t* e111 = m11->add_edit();
                 e111->set_from_length(1);
                 e111->set_to_length(1);
                 
-                Subpath* sp2 = mpaln.add_subpath();
+                subpath_t* sp2 = mpaln.add_subpath();
                 
-                Mapping* m21 = sp2->mutable_path()->add_mapping();
-                Position* p21 = m21->mutable_position();
+                path_mapping_t* m21 = sp2->mutable_path()->add_mapping();
+                position_t* p21 = m21->mutable_position();
                 p21->set_node_id(1);
                 p21->set_offset(1);
                 p21->set_is_reverse(true);
                 
-                Edit* e211 = m21->add_edit();
+                edit_t* e211 = m21->add_edit();
                 e211->set_from_length(2);
                 e211->set_to_length(2);
                 
-                Edit* e212 = m21->add_edit();
+                edit_t* e212 = m21->add_edit();
                 e212->set_from_length(2);
                 e212->set_to_length(0);
                 
-                Subpath* sp3 = mpaln.add_subpath();
+                subpath_t* sp3 = mpaln.add_subpath();
                 
-                Mapping* m31 = sp3->mutable_path()->add_mapping();
-                Position* p31 = m31->mutable_position();
+                path_mapping_t* m31 = sp3->mutable_path()->add_mapping();
+                position_t* p31 = m31->mutable_position();
                 p31->set_node_id(2);
                 p31->set_offset(0);
                 
-                Edit* e311 = m31->add_edit();
+                edit_t* e311 = m31->add_edit();
                 e311->set_from_length(1);
                 e311->set_to_length(1);
                 
-                Subpath* sp4 = mpaln.add_subpath();
+                subpath_t* sp4 = mpaln.add_subpath();
                 
-                Mapping* m41 = sp4->mutable_path()->add_mapping();
-                Position* p41 = m41->mutable_position();
+                path_mapping_t* m41 = sp4->mutable_path()->add_mapping();
+                position_t* p41 = m41->mutable_position();
                 p41->set_node_id(3);
                 p41->set_offset(0);
                 
-                Edit* e411 = m41->add_edit();
+                edit_t* e411 = m41->add_edit();
                 e411->set_from_length(1);
                 e411->set_to_length(1);
                 
@@ -1742,9 +1742,10 @@ namespace vg {
             
             )"; // vim syntax highlighting gives up unless I put "
             
-            MultipathAlignment mpaln;
-            
-            json2pb(mpaln, multipath_json);
+            MultipathAlignment mpaln_pb;
+            json2pb(mpaln_pb, multipath_json.c_str(), multipath_json.size());
+            multipath_alignment_t mpaln;
+            from_proto_multipath_alignment(mpaln_pb, mpaln);
             
             auto alns = optimal_alignments_with_disjoint_subpaths(mpaln, 5);
             
@@ -1784,11 +1785,12 @@ namespace vg {
 ],"start":[0]}
             )";
             
-            MultipathAlignment mpaln;
+            MultipathAlignment mpaln_pb;
+            json2pb(mpaln_pb, multipath_json.c_str(), multipath_json.size());
+            multipath_alignment_t mpaln;
+            from_proto_multipath_alignment(mpaln_pb, mpaln);
             
-            json2pb(mpaln, multipath_json);
-            
-            // Topologically sort the MultipathAlignment so we can linearize it.
+            // Topologically sort the multipath_alignment_t so we can linearize it.
             topologically_order_subpaths(mpaln);
             
             // Generate the best linearization with optimal_alignments

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -184,6 +184,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         
         SECTION("Tries multiple traversals of snarls in tails") {
         
+            cerr << "### test start" << endl;
             // Generate 2 fake tail anchors
             mpg.synthesize_tail_anchors(query, vg, &aligner, 1, 2, false, 100, 0.0);
             
@@ -211,9 +212,12 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
                 auto& aln = opt[i];
                 
                 vector<id_t> ids;
+                cerr << "tail: ";
                 for (auto& mapping : aln.path().mapping()) {
+                    cerr << mapping.position().node_id() << " ";
                     ids.push_back(mapping.position().node_id());
                 }
+                cerr << endl;
                 
                 // Save each list of visited IDs for checking.
                 got.insert(ids);
@@ -225,6 +229,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
             REQUIRE(got.count({1, 3, 4, 6, 7}));
             REQUIRE(got.count({1, 3, 4, 5, 7}));
             
+            cerr << "### test end" << endl;
         }
         
         

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -184,7 +184,6 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         
         SECTION("Tries multiple traversals of snarls in tails") {
         
-            cerr << "### test start" << endl;
             // Generate 2 fake tail anchors
             mpg.synthesize_tail_anchors(query, vg, &aligner, 1, 2, false, 100, 0.0);
             
@@ -198,7 +197,6 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
             // Make sure to topologically sort the resulting alignment. TODO: Should
             // the MultipathAlignmentGraph guarantee this for us by construction?
             topologically_order_subpaths(out);
-            
             // Make sure it worked at all
             REQUIRE(out.sequence() == read);
             REQUIRE(out.subpath_size() > 0);
@@ -212,12 +210,9 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
                 auto& aln = opt[i];
                 
                 vector<id_t> ids;
-                cerr << "tail: ";
                 for (auto& mapping : aln.path().mapping()) {
-                    cerr << mapping.position().node_id() << " ";
                     ids.push_back(mapping.position().node_id());
                 }
-                cerr << endl;
                 
                 // Save each list of visited IDs for checking.
                 got.insert(ids);
@@ -228,8 +223,6 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
             REQUIRE(got.count({1, 2, 4, 5, 7}));
             REQUIRE(got.count({1, 3, 4, 6, 7}));
             REQUIRE(got.count({1, 3, 4, 5, 7}));
-            
-            cerr << "### test end" << endl;
         }
         
         

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -83,8 +83,8 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         // Make the MultipathAlignmentGraph to test
         MultipathAlignmentGraph mpg(vg, mem_hits, identity);
         
-        // Make the output MultipathAlignment
-        MultipathAlignment out;
+        // Make the output multipath_alignment_t
+        multipath_alignment_t out;
         
         SECTION("Tries multiple traversals of snarls in tails") {
         
@@ -178,8 +178,8 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         // Make the MultipathAlignmentGraph to test
         MultipathAlignmentGraph mpg(vg, mem_hits, identity);
         
-        // Make the output MultipathAlignment
-        MultipathAlignment out;
+        // Make the output multipath_alignment_t
+        multipath_alignment_t out;
         
         
         SECTION("Tries multiple traversals of snarls in tails") {
@@ -274,8 +274,8 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         // Make the MultipathAlignmentGraph to test
         MultipathAlignmentGraph mpg(vg, mem_hits, identity);
         
-        // Make the output MultipathAlignment
-        MultipathAlignment out;
+        // Make the output multipath_alignment_t
+        multipath_alignment_t out;
         
         SECTION("Tries multiple traversals of snarls in tails") {
         

--- a/src/unittest/multipath_mapper.cpp
+++ b/src/unittest/multipath_mapper.cpp
@@ -335,7 +335,7 @@ TEST_CASE( "MultipathMapper can map to a one-node graph", "[multipath][mapping][
         aln.set_sequence(read);
         
         // Have a list to fill with results
-        vector<MultipathAlignment> results;
+        vector<multipath_alignment_t> results;
         
         // Align for just one alignment
         mapper.multipath_map(aln, results);
@@ -384,7 +384,7 @@ TEST_CASE( "MultipathMapper can map to a one-node graph", "[multipath][mapping][
         read2.set_sequence("ACA");
         
         // Have a list to fill with results
-        vector<pair<MultipathAlignment, MultipathAlignment>> results;
+        vector<pair<multipath_alignment_t, multipath_alignment_t>> results;
         vector<pair<Alignment, Alignment>> buffer;
         
         // Align for just one pair of alignments
@@ -494,8 +494,10 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
         }
         )";
     
-        MultipathAlignment disordered;
-        json2pb(disordered, aln_json.c_str(), aln_json.size());
+        MultipathAlignment disordered_pb;
+        json2pb(disordered_pb, aln_json.c_str(), aln_json.size());
+        multipath_alignment_t disordered;
+        from_proto_multipath_alignment(disordered_pb, disordered);
         
         topologically_order_subpaths(disordered);
         
@@ -526,8 +528,10 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
         }
         )";
     
-        MultipathAlignment disordered;
-        json2pb(disordered, aln_json.c_str(), aln_json.size());
+        MultipathAlignment disordered_pb;
+        json2pb(disordered_pb, aln_json.c_str(), aln_json.size());
+        multipath_alignment_t disordered;
+        from_proto_multipath_alignment(disordered_pb, disordered);
         
         topologically_order_subpaths(disordered);
         
@@ -551,7 +555,7 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
         read2.set_sequence("TCCTT");
         
         // Have a list to fill with results
-        vector<pair<MultipathAlignment, MultipathAlignment>> results;
+        vector<pair<multipath_alignment_t, multipath_alignment_t>> results;
         vector<pair<Alignment, Alignment>> buffer;
         
         // Align for just one pair of alignments
@@ -573,7 +577,7 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
         read2.set_sequence("TCCTTGACTTCTTGAAACATTTGGCTATTGACCTCTTTCCTCCT");
         
         // Have a list to fill with results
-        vector<pair<MultipathAlignment, MultipathAlignment>> results;
+        vector<pair<multipath_alignment_t, multipath_alignment_t>> results;
         vector<pair<Alignment, Alignment>> buffer;
         
         // Align for just one pair of alignments
@@ -602,7 +606,7 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
         read2.set_sequence("TCCTT");
         
         // Have a list to fill with results
-        vector<pair<MultipathAlignment, MultipathAlignment>> results;
+        vector<pair<multipath_alignment_t, multipath_alignment_t>> results;
         vector<pair<Alignment, Alignment>> buffer;
         
         // Align for just one pair of alignments

--- a/src/unittest/phased_genome.cpp
+++ b/src/unittest/phased_genome.cpp
@@ -878,10 +878,14 @@ namespace vg {
                 multipath_aln.set_sequence("CACTGTATTGCGGATA");
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1011,10 +1015,14 @@ namespace vg {
                 multipath_aln.set_sequence("CACTGTATTGCGGATA");
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1123,10 +1131,14 @@ namespace vg {
                 multipath_aln.set_sequence("CCGCTGTATTGTGC");
                 
                 // add subpaths
-                subpath_t* subpath0 = multipath_aln.add_subpath();
-                subpath_t* subpath1 = multipath_aln.add_subpath();
-                subpath_t* subpath2 = multipath_aln.add_subpath();
-                subpath_t* subpath3 = multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.mutable_subpath(0);
+                subpath_t* subpath1 = multipath_aln.mutable_subpath(1);
+                subpath_t* subpath2 = multipath_aln.mutable_subpath(2);
+                subpath_t* subpath3 = multipath_aln.mutable_subpath(3);
                 
                 // set edges between subpaths
                 subpath0->add_next(1);

--- a/src/unittest/phased_genome.cpp
+++ b/src/unittest/phased_genome.cpp
@@ -874,14 +874,14 @@ namespace vg {
                 
                 // construct a multipath alignment
                 
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence("CACTGTATTGCGGATA");
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -890,47 +890,47 @@ namespace vg {
                 subpath2->add_next(3);
                 
                 // designate mappings and scores
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
                 mapping0->mutable_position()->set_offset(1);
-                Edit* edit00 = mapping0->add_edit();
+                edit_t* edit00 = mapping0->add_edit();
                 edit00->set_from_length(2);
                 edit00->set_to_length(2);
                 
-                Mapping* mapping1 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath0->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
-                Edit* edit10 = mapping1->add_edit();
+                edit_t* edit10 = mapping1->add_edit();
                 edit10->set_from_length(4);
                 edit10->set_to_length(4);
                 
                 subpath0->set_score(6);
                 
-                Mapping* mapping2 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath1->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
-                Edit* edit20 = mapping2->add_edit();
+                edit_t* edit20 = mapping2->add_edit();
                 edit20->set_from_length(1);
                 edit20->set_to_length(1);
                 edit20->set_sequence("A");
                 
                 subpath1->set_score(-4);
                 
-                Mapping* mapping3 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath2->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(4);
-                Edit* edit30 = mapping3->add_edit();
+                edit_t* edit30 = mapping3->add_edit();
                 edit30->set_from_length(1);
                 edit30->set_to_length(1);
                 
                 subpath2->set_score(1);
                 
-                Mapping* mapping4 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping4 = subpath3->mutable_path()->add_mapping();
                 mapping4->mutable_position()->set_node_id(5);
-                Edit* edit40 = mapping4->add_edit();
+                edit_t* edit40 = mapping4->add_edit();
                 edit40->set_from_length(3);
                 edit40->set_to_length(3);
                 
-                Mapping* mapping5 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping5 = subpath3->mutable_path()->add_mapping();
                 mapping5->mutable_position()->set_node_id(6);
-                Edit* edit50 = mapping5->add_edit();
+                edit_t* edit50 = mapping5->add_edit();
                 edit50->set_from_length(6);
                 edit50->set_to_length(6);
                 
@@ -1007,14 +1007,14 @@ namespace vg {
                 
                 // construct a multipath alignment
                 
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence("CACTGTATTGCGGATA");
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1023,47 +1023,47 @@ namespace vg {
                 subpath2->add_next(3);
                 
                 // designate mappings and scores
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(1);
                 mapping0->mutable_position()->set_offset(1);
-                Edit* edit00 = mapping0->add_edit();
+                edit_t* edit00 = mapping0->add_edit();
                 edit00->set_from_length(2);
                 edit00->set_to_length(2);
                 
-                Mapping* mapping1 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath0->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
-                Edit* edit10 = mapping1->add_edit();
+                edit_t* edit10 = mapping1->add_edit();
                 edit10->set_from_length(4);
                 edit10->set_to_length(4);
                 
                 subpath0->set_score(6);
                 
-                Mapping* mapping2 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath1->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
-                Edit* edit20 = mapping2->add_edit();
+                edit_t* edit20 = mapping2->add_edit();
                 edit20->set_from_length(1);
                 edit20->set_to_length(1);
                 edit20->set_sequence("A");
                 
                 subpath1->set_score(-4);
                 
-                Mapping* mapping3 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath2->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(4);
-                Edit* edit30 = mapping3->add_edit();
+                edit_t* edit30 = mapping3->add_edit();
                 edit30->set_from_length(1);
                 edit30->set_to_length(1);
                 
                 subpath2->set_score(1);
                 
-                Mapping* mapping4 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping4 = subpath3->mutable_path()->add_mapping();
                 mapping4->mutable_position()->set_node_id(5);
-                Edit* edit40 = mapping4->add_edit();
+                edit_t* edit40 = mapping4->add_edit();
                 edit40->set_from_length(3);
                 edit40->set_to_length(3);
                 
-                Mapping* mapping5 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping5 = subpath3->mutable_path()->add_mapping();
                 mapping5->mutable_position()->set_node_id(6);
-                Edit* edit50 = mapping5->add_edit();
+                edit_t* edit50 = mapping5->add_edit();
                 edit50->set_from_length(6);
                 edit50->set_to_length(6);
                 
@@ -1119,14 +1119,14 @@ namespace vg {
                 
                 // construct a multipath alignment
                 
-                MultipathAlignment multipath_aln;
+                multipath_alignment_t multipath_aln;
                 multipath_aln.set_sequence("CCGCTGTATTGTGC");
                 
                 // add subpaths
-                Subpath* subpath0 = multipath_aln.add_subpath();
-                Subpath* subpath1 = multipath_aln.add_subpath();
-                Subpath* subpath2 = multipath_aln.add_subpath();
-                Subpath* subpath3 = multipath_aln.add_subpath();
+                subpath_t* subpath0 = multipath_aln.add_subpath();
+                subpath_t* subpath1 = multipath_aln.add_subpath();
+                subpath_t* subpath2 = multipath_aln.add_subpath();
+                subpath_t* subpath3 = multipath_aln.add_subpath();
                 
                 // set edges between subpaths
                 subpath0->add_next(1);
@@ -1135,49 +1135,49 @@ namespace vg {
                 subpath2->add_next(3);
                 
                 // designate mappings and scores
-                Mapping* mapping0 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping0 = subpath0->mutable_path()->add_mapping();
                 mapping0->mutable_position()->set_node_id(6);
                 mapping0->mutable_position()->set_offset(3);
                 mapping0->mutable_position()->set_is_reverse(true);
-                Edit* edit00 = mapping0->add_edit();
+                edit_t* edit00 = mapping0->add_edit();
                 edit00->set_from_length(3);
                 edit00->set_to_length(3);
                 
-                Mapping* mapping1 = subpath0->mutable_path()->add_mapping();
+                path_mapping_t* mapping1 = subpath0->mutable_path()->add_mapping();
                 mapping1->mutable_position()->set_node_id(2);
-                Edit* edit10 = mapping1->add_edit();
+                edit_t* edit10 = mapping1->add_edit();
                 edit10->set_from_length(4);
                 edit10->set_to_length(4);
                 
                 subpath0->set_score(7);
                 
-                Mapping* mapping2 = subpath1->mutable_path()->add_mapping();
+                path_mapping_t* mapping2 = subpath1->mutable_path()->add_mapping();
                 mapping2->mutable_position()->set_node_id(3);
-                Edit* edit20 = mapping2->add_edit();
+                edit_t* edit20 = mapping2->add_edit();
                 edit20->set_from_length(1);
                 edit20->set_to_length(1);
                 edit20->set_sequence("A");
                 
                 subpath1->set_score(-4);
                 
-                Mapping* mapping3 = subpath2->mutable_path()->add_mapping();
+                path_mapping_t* mapping3 = subpath2->mutable_path()->add_mapping();
                 mapping3->mutable_position()->set_node_id(4);
-                Edit* edit30 = mapping3->add_edit();
+                edit_t* edit30 = mapping3->add_edit();
                 edit30->set_from_length(1);
                 edit30->set_to_length(1);
                 
                 subpath2->set_score(1);
                 
-                Mapping* mapping4 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping4 = subpath3->mutable_path()->add_mapping();
                 mapping4->mutable_position()->set_node_id(5);
-                Edit* edit40 = mapping4->add_edit();
+                edit_t* edit40 = mapping4->add_edit();
                 edit40->set_from_length(3);
                 edit40->set_to_length(3);
                 
-                Mapping* mapping5 = subpath3->mutable_path()->add_mapping();
+                path_mapping_t* mapping5 = subpath3->mutable_path()->add_mapping();
                 mapping5->mutable_position()->set_node_id(1);
                 mapping5->mutable_position()->set_is_reverse(true);
-                Edit* edit50 = mapping5->add_edit();
+                edit_t* edit50 = mapping5->add_edit();
                 edit50->set_from_length(3);
                 edit50->set_to_length(3);
                 


### PR DESCRIPTION
I replaced the `MultipathAlignment` data type with `multipath_alignment_t`, which has the same interface but is backed by STL objects. The old protobuf format is only constructed at serialization time now.

If someone wants to replace the `Alignment` object at some point, I think this PR could pave the way for it. I already implemented the `Path`, which expresses the actual alignment. One pitfall is that my implementation exposes raw pointers into a vector for repeated fields, rather than to heap memory. That means that the pointers can't be used as stable references to the objects anymore, because the vector might reallocate. 

Overall, it looks like the change improved speed modestly (maybe a few percent), but the old protobuf objects probably weren't a major performance bottleneck.