### PR TITLE
Update XG encoding

### DIFF
--- a/src/algorithms/extract_containing_graph.cpp
+++ b/src/algorithms/extract_containing_graph.cpp
@@ -77,7 +77,7 @@ void extract_containing_graph(const HandleGraph* source,
     
     while (!queue.empty()) {
         // get the next shortest distance traversal from either the init
-        pair<handle_t, size_t> trav = queue.top();
+        pair<handle_t, int64_t> trav = queue.top();
         queue.pop();
         
         // make sure the node is in the graph


### PR DESCRIPTION
This PR switches to a new way to encode edges in the main XG vector, which seems to be slightly faster and also more memory efficient. I also wrote a conversion routine from the old encoding, so existing XGs should remain valid. Also, the conversion algorithm doesn't seem to be particularly burdensome.