### PR TITLE
Bigger bins for coverage stats in vg call

### DIFF
--- a/src/algorithms/coverage_depth.hpp
+++ b/src/algorithms/coverage_depth.hpp
@@ -39,16 +39,18 @@ vector<tuple<size_t, size_t, double, double>> binned_packed_depth(const Packer& 
 
 /// Use the above function to retrieve the binned depths of a list of paths, and store them indexed by start
 /// coordinate.  If std_err is true, store <mean, stderr> instead of <mean, variance>
-using BinnedDepthIndex = unordered_map<string, map<size_t, pair<float, float>>>;
+/// For each path, a series of indexes is computed, for bin sizes from min_bin_size, min_bin_size^(exp_growth_factor), etc.
+using BinnedDepthIndex = unordered_map<string, map<size_t, map<size_t, pair<float, float>>>>;
 BinnedDepthIndex binned_packed_depth_index(const Packer& packer,
                                            const vector<string>& path_names,
-                                           size_t bin_size,
+                                           size_t min_bin_size,
+                                           size_t max_bin_size,
+                                           double exp_growth_factor,
                                            size_t min_coverage,
                                            bool include_deletions,
                                            bool std_err);
 
 /// Query index created above
-const pair<float, float>& get_depth_from_index(const BinnedDepthIndex& depth_index, const string& path_name, size_t offset);
 pair<float, float> get_depth_from_index(const BinnedDepthIndex& depth_index, const string& path_name, size_t start_offset, size_t end_offset);
 
 /// Return the mean and variance of coverage of randomly sampled nodes from a GAM

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -67,7 +67,9 @@ int main_call(int argc, char** argv) {
     // constants
     const size_t avg_trav_threshold = 50;
     const size_t avg_node_threshold = 50;
-    const size_t depth_bin_width = 50;
+    const size_t min_depth_bin_width = 50;
+    const size_t max_depth_bin_width = 50000000;
+    const double depth_scale_fac = 1.5;
     const size_t max_yens_traversals = 50;
     
     int c;
@@ -323,7 +325,8 @@ int main_call(int argc, char** argv) {
 
         if (ratio_caller == false) {
             // Make a depth index
-            depth_index = algorithms::binned_packed_depth_index(*packer, ref_paths, depth_bin_width, 0, true, true);
+            depth_index = algorithms::binned_packed_depth_index(*packer, ref_paths, min_depth_bin_width, max_depth_bin_width,
+                                                                depth_scale_fac, 0, true, true);
             // Make a new-stype probablistic caller
             auto poisson_caller = new PoissonSupportSnarlCaller(*graph, *snarl_manager, *packed_support_finder, depth_index,
                                                                 packer->has_qualities());


### PR DESCRIPTION
The caller uses binned coverage along the reference as a baseline for poisson likelihoods.  The small default bin-size was not taking into account coverage from larger deletion edges, leading to misleadingly low coverages in some cases.  This patches that by using a more adaptive bin size. 

It's also reminded me that the heuristic used of using the reference path and deletion edges is going to break down on more compex graphs where, for example, deletions may be short paths instead of just edges. 