### PR TITLE
Better write parallelism in mpmap

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1616,14 +1616,14 @@ namespace vg {
         proto_multipath_aln_out.clear_start();
         transfer_read_metadata(multipath_aln, proto_multipath_aln_out);
         proto_multipath_aln_out.set_mapping_quality(multipath_aln.mapping_quality());
-        for (auto subpath : multipath_aln.subpath()) {
+        for (const auto& subpath : multipath_aln.subpath()) {
             auto subpath_copy = proto_multipath_aln_out.add_subpath();
             subpath_copy->set_score(subpath.score());
             for (auto next : subpath.next()) {
                 subpath_copy->add_next(next);
             }
             if (subpath.has_path()) {
-                auto path = subpath.path();
+                const auto& path = subpath.path();
                 auto path_copy = subpath_copy->mutable_path();
                 to_proto_path(path, *path_copy);
             }

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -1,0 +1,139 @@
+/**
+ * \file multipath_alignment_emitter.cpp
+ *
+ * Implements a system for emitting multipath alignments and groups of multipath alignments in multiple formats.
+ */
+
+#include "multipath_alignment_emitter.hpp"
+#include "json2pb.h"
+
+namespace vg {
+using namespace std;
+
+MultipathAlignmentEmitter::MultipathAlignmentEmitter(ostream& out, int num_threads,
+                                                     bool emit_single_path) :
+    out(out),
+    multiplexer(out, num_threads)
+{
+    // init the emitters for the correct output type
+    if (emit_single_path) {
+        aln_emitters.reserve(num_threads);
+        for (int i = 0; i < num_threads; ++i) {
+            aln_emitters.emplace_back(new vg::io::ProtobufEmitter<Alignment>(multiplexer.get_thread_stream(i)));
+        }
+    }
+    else {
+        mp_aln_emitters.reserve(num_threads);
+        for (int i = 0; i < num_threads; ++i) {
+            mp_aln_emitters.emplace_back(new vg::io::ProtobufEmitter<MultipathAlignment>(multiplexer.get_thread_stream(i)));
+        }
+    }
+}
+
+MultipathAlignmentEmitter::~MultipathAlignmentEmitter() {
+    for (auto& emitter : aln_emitters) {
+        // Flush each ProtobufEmitter
+        emitter->flush();
+        // Make it go away before the stream
+        emitter.reset();
+    }
+    for (auto& emitter : mp_aln_emitters) {
+        // Flush each ProtobufEmitter
+        emitter->flush();
+        // Make it go away before the stream
+        emitter.reset();
+    }
+}
+
+void MultipathAlignmentEmitter::emit_pairs(vector<pair<multipath_alignment_t, multipath_alignment_t>>&& mp_aln_pairs) {
+    
+    int thread_number = omp_get_thread_num();
+    
+    if (!mp_aln_emitters.empty()) {
+        vector<MultipathAlignment> mp_alns_out(2 * mp_aln_pairs.size());
+        for (size_t i = 0; i < mp_aln_pairs.size(); ++i) {
+            to_proto_multipath_alignment(mp_aln_pairs[i].first, mp_alns_out[2 * i]);
+            to_proto_multipath_alignment(mp_aln_pairs[i].second, mp_alns_out[2 * i + 1]);
+        }
+        
+        mp_aln_emitters[thread_number]->write_many(std::move(mp_alns_out));
+        
+        if (multiplexer.want_breakpoint(thread_number)) {
+            // The multiplexer wants our data.
+            // Flush and create a breakpoint.
+            mp_aln_emitters[thread_number]->flush();
+            multiplexer.register_breakpoint(thread_number);
+        }
+    }
+    else {
+        vector<Alignment> alns_out(2 * mp_aln_pairs.size());
+        for (size_t i = 0; i < mp_aln_pairs.size(); ++i) {
+            convert_multipath_alignment(mp_aln_pairs[i].first, alns_out[2 * i],
+                                        nullptr,
+                                        &mp_aln_pairs[i].second);
+            convert_multipath_alignment(mp_aln_pairs[i].second, alns_out[2 * i + 1],
+                                        &mp_aln_pairs[i].first,
+                                        nullptr);
+        }
+        
+        aln_emitters[thread_number]->write_many(std::move(alns_out));
+        
+        if (multiplexer.want_breakpoint(thread_number)) {
+            // The multiplexer wants our data.
+            // Flush and create a breakpoint.
+            aln_emitters[thread_number]->flush();
+            multiplexer.register_breakpoint(thread_number);
+        }
+    }
+}
+
+void MultipathAlignmentEmitter::emit_singles(vector<multipath_alignment_t>&& mp_alns) {
+    
+    int thread_number = omp_get_thread_num();
+    
+    if (!mp_aln_emitters.empty()) {
+        vector<MultipathAlignment> mp_alns_out(mp_alns.size());
+        for (size_t i = 0; i < mp_alns.size(); ++i) {
+            to_proto_multipath_alignment(mp_alns[i], mp_alns_out[i]);
+        }
+        
+        mp_aln_emitters[thread_number]->write_many(std::move(mp_alns_out));
+        
+        if (multiplexer.want_breakpoint(thread_number)) {
+            // The multiplexer wants our data.
+            // Flush and create a breakpoint.
+            mp_aln_emitters[thread_number]->flush();
+            multiplexer.register_breakpoint(thread_number);
+        }
+    }
+    else {
+        vector<Alignment> alns_out(mp_alns.size());
+        for (size_t i = 0; i < mp_alns.size(); ++i) {
+            convert_multipath_alignment(mp_alns[i], alns_out[i]);
+        }
+        
+        aln_emitters[thread_number]->write_many(std::move(alns_out));
+        
+        if (multiplexer.want_breakpoint(thread_number)) {
+            // The multiplexer wants our data.
+            // Flush and create a breakpoint.
+            aln_emitters[thread_number]->flush();
+            multiplexer.register_breakpoint(thread_number);
+        }
+    }
+}
+
+void MultipathAlignmentEmitter::convert_multipath_alignment(const multipath_alignment_t& mp_aln,
+                                                            Alignment& aln,
+                                                            const multipath_alignment_t* prev_pair,
+                                                            const multipath_alignment_t* next_pair) const {
+    optimal_alignment(mp_aln, aln);
+    if (prev_pair) {
+        aln.mutable_fragment_prev()->set_name(prev_pair->name());
+    }
+    if (next_pair) {
+        aln.mutable_fragment_next()->set_name(next_pair->name());
+    }
+    aln.set_identity(identity(aln.path()));
+}
+}

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -123,17 +123,17 @@ void MultipathAlignmentEmitter::emit_singles(vector<multipath_alignment_t>&& mp_
     }
 }
 
-void MultipathAlignmentEmitter::convert_multipath_alignment(const multipath_alignment_t& mp_aln,
-                                                            Alignment& aln,
-                                                            const multipath_alignment_t* prev_pair,
-                                                            const multipath_alignment_t* next_pair) const {
+void MultipathAlignmentEmitter::convert_multipath_alignment(const multipath_alignment_t& mp_aln, Alignment& aln,
+                                                            const multipath_alignment_t* prev_frag,
+                                                            const multipath_alignment_t* next_frag) const {
     optimal_alignment(mp_aln, aln);
-    if (prev_pair) {
+    if (prev_frag) {
         aln.mutable_fragment_prev()->set_name(prev_pair->name());
     }
-    if (next_pair) {
+    if (next_frag) {
         aln.mutable_fragment_next()->set_name(next_pair->name());
     }
+    // at one point vg call needed these, maybe it doesn't anymore though
     aln.set_identity(identity(aln.path()));
 }
 }

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -128,10 +128,10 @@ void MultipathAlignmentEmitter::convert_multipath_alignment(const multipath_alig
                                                             const multipath_alignment_t* next_frag) const {
     optimal_alignment(mp_aln, aln);
     if (prev_frag) {
-        aln.mutable_fragment_prev()->set_name(prev_pair->name());
+        aln.mutable_fragment_prev()->set_name(prev_frag->name());
     }
     if (next_frag) {
-        aln.mutable_fragment_next()->set_name(next_pair->name());
+        aln.mutable_fragment_next()->set_name(next_frag->name());
     }
     // at one point vg call needed these, maybe it doesn't anymore though
     aln.set_identity(identity(aln.path()));

--- a/src/multipath_alignment_emitter.hpp
+++ b/src/multipath_alignment_emitter.hpp
@@ -1,0 +1,56 @@
+#ifndef VG_MULTIPATH_ALIGNMENT_EMITTER_HPP_INCLUDED
+#define VG_MULTIPATH_ALIGNMENT_EMITTER_HPP_INCLUDED
+
+/**
+ * \file multipath_alignment_emitter.hpp
+ *
+ * Defines a system for emitting multipath alignments and groups of multipath alignments in multiple formats.
+ */
+
+#include <mutex>
+#include <iostream>
+#include <sstream>
+
+#include <vg/vg.pb.h>
+#include <vg/io/protobuf_emitter.hpp>
+#include <vg/io/stream_multiplexer.hpp>
+#include "multipath_alignment.hpp"
+
+namespace vg {
+using namespace std;
+
+class MultipathAlignmentEmitter {
+public:
+    
+    MultipathAlignmentEmitter(ostream& out, int num_threads, bool emit_single_path = false);
+    ~MultipathAlignmentEmitter();
+    
+    void emit_pairs(vector<pair<multipath_alignment_t, multipath_alignment_t>>&& mp_aln_pairs);
+    
+    void emit_singles(vector<multipath_alignment_t>&& mp_alns);
+    
+private:
+    
+    void convert_multipath_alignment(const multipath_alignment_t& mp_aln,
+                                     Alignment& aln,
+                                     const multipath_alignment_t* prev_pair = nullptr,
+                                     const multipath_alignment_t* next_pair = nullptr) const;
+    
+    /// the stream that everything is emitted into
+    ostream& out;
+    
+    /// shared multiplexer across streams
+    vg::io::StreamMultiplexer multiplexer;
+    
+    /// an Alignment emitter for each thread
+    vector<unique_ptr<vg::io::ProtobufEmitter<Alignment>>> aln_emitters;
+    
+    /// a MultipathAlignment emitter for each thread
+    vector<unique_ptr<vg::io::ProtobufEmitter<MultipathAlignment>>> mp_aln_emitters;
+    
+};
+
+}
+
+
+#endif

--- a/src/multipath_alignment_emitter.hpp
+++ b/src/multipath_alignment_emitter.hpp
@@ -31,10 +31,9 @@ public:
     
 private:
     
-    void convert_multipath_alignment(const multipath_alignment_t& mp_aln,
-                                     Alignment& aln,
-                                     const multipath_alignment_t* prev_pair = nullptr,
-                                     const multipath_alignment_t* next_pair = nullptr) const;
+    void convert_multipath_alignment(const multipath_alignment_t& mp_aln, Alignment& aln,
+                                     const multipath_alignment_t* prev_frag = nullptr,
+                                     const multipath_alignment_t* next_frag = nullptr) const;
     
     /// the stream that everything is emitted into
     ostream& out;

--- a/src/multipath_alignment_emitter.hpp
+++ b/src/multipath_alignment_emitter.hpp
@@ -19,14 +19,22 @@
 namespace vg {
 using namespace std;
 
+/*
+ * Class that handles multithreaded output for multipath alignments
+ */
 class MultipathAlignmentEmitter {
 public:
     
+    /// Initialize with the intended output stream and the maximum number of threads that
+    /// will be outputting. Optionally convert to single path alignments instead of multipath
+    /// alignments.
     MultipathAlignmentEmitter(ostream& out, int num_threads, bool emit_single_path = false);
     ~MultipathAlignmentEmitter();
     
+    /// Emit paired read mappings as interleaved protobuf messages
     void emit_pairs(vector<pair<multipath_alignment_t, multipath_alignment_t>>&& mp_aln_pairs);
     
+    /// Emit read mappings as protobuf messages
     void emit_singles(vector<multipath_alignment_t>&& mp_alns);
     
 private:

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -2488,34 +2488,34 @@ void to_proto_edit(const edit_t& edit, Edit& proto_edit) {
 }
 
 void from_proto_mapping(const Mapping& proto_mapping, path_mapping_t& mapping) {
-    auto position = proto_mapping.position();
+    const auto& position = proto_mapping.position();
     auto position_copy = mapping.mutable_position();
     position_copy->set_node_id(position.node_id());
     position_copy->set_offset(position.offset());
     position_copy->set_is_reverse(position.is_reverse());
-    for (auto edit : proto_mapping.edit()) {
+    for (const auto& edit : proto_mapping.edit()) {
         from_proto_edit(edit, *mapping.add_edit());
     }
 }
 
 void to_proto_mapping(const path_mapping_t& mapping, Mapping& proto_mapping) {
-    auto position = mapping.position();
+    const auto& position = mapping.position();
     auto position_copy = proto_mapping.mutable_position();
     position_copy->set_node_id(position.node_id());
     position_copy->set_offset(position.offset());
     position_copy->set_is_reverse(position.is_reverse());
-    for (auto edit : mapping.edit()) {
+    for (const auto& edit : mapping.edit()) {
         to_proto_edit(edit, *proto_mapping.add_edit());
     }
 }
 
 void from_proto_path(const Path& proto_path, path_t& path) {
-    for (auto mapping : proto_path.mapping()) {
+    for (const auto& mapping : proto_path.mapping()) {
         from_proto_mapping(mapping, *path.add_mapping());
     }
 }
 void to_proto_path(const path_t& path, Path& proto_path) {
-    for (auto mapping : path.mapping()) {
+    for (const auto& mapping : path.mapping()) {
         auto mapping_copy = proto_path.add_mapping();
         to_proto_mapping(mapping, *mapping_copy);
         mapping_copy->set_rank(proto_path.mapping_size());
@@ -2524,7 +2524,7 @@ void to_proto_path(const path_t& path, Path& proto_path) {
 
 int mapping_from_length(const path_mapping_t& mapping) {
     int length = 0;
-    for (auto edit : mapping.edit()) {
+    for (const auto& edit : mapping.edit()) {
         length += edit.from_length();
     }
     return length;
@@ -2532,7 +2532,7 @@ int mapping_from_length(const path_mapping_t& mapping) {
 
 int path_from_length(const path_t& path) {
     int length = 0;
-    for (auto mapping : path.mapping()) {
+    for (const auto& mapping : path.mapping()) {
         length += mapping_from_length(mapping);
     }
     return length;
@@ -2540,7 +2540,7 @@ int path_from_length(const path_t& path) {
 
 int mapping_to_length(const path_mapping_t& mapping) {
     int length = 0;
-    for (auto edit : mapping.edit()) {
+    for (const auto& edit : mapping.edit()) {
         length += edit.to_length();
     }
     return length;
@@ -2548,7 +2548,7 @@ int mapping_to_length(const path_mapping_t& mapping) {
 
 int path_to_length(const path_t& path) {
     int length = 0;
-    for (auto mapping : path.mapping()) {
+    for (const auto& mapping : path.mapping()) {
         length += mapping_to_length(mapping);
     }
     return length;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -10,6 +10,7 @@
 
 #include <vg/io/vpkg.hpp>
 #include "../multipath_mapper.hpp"
+#include "../multipath_alignment_emitter.hpp"
 #include "../path.hpp"
 #include "../watchdog.hpp"
 #include "../watchdog.hpp"
@@ -1551,178 +1552,14 @@ int main_mpmap(int argc, char** argv) {
         }
     };
     
+    // init a writer for the output
+    MultipathAlignmentEmitter* emitter = new MultipathAlignmentEmitter(cout, thread_count, single_path_alignment_mode);
+    
     // a buffer to hold read pairs that can't be unambiguously mapped before the fragment length distribution
     // is estimated
     // note: sufficient to have only one buffer because multithreading code enforces single threaded mode
     // during distribution estimation
     vector<pair<Alignment, Alignment>> ambiguous_pair_buffer;
-    
-    vector<vector<Alignment> > single_path_output_buffer(thread_count);
-    vector<vector<MultipathAlignment> > multipath_output_buffer(thread_count);
-    
-    // write unpaired multipath alignments to stdout buffer
-    auto output_multipath_alignments = [&](vector<multipath_alignment_t>& mp_alns) {
-        auto& output_buf = multipath_output_buffer[omp_get_thread_num()];
-        
-        // move all the alignments over to the output buffer
-        for (multipath_alignment_t& mp_aln : mp_alns) {
-            output_buf.emplace_back();
-            to_proto_multipath_alignment(mp_aln, output_buf.back());
-            
-            // label with read group and sample name
-            if (!read_group.empty()) {
-                output_buf.back().set_read_group(read_group);
-            }
-            if (!sample_name.empty()) {
-                output_buf.back().set_sample_name(sample_name);
-            }
-            if (no_output) {
-                output_buf.pop_back();
-            }
-        }
-        
-        vg::io::write_buffered(cout, output_buf, buffer_size);
-    };
-    
-    // convert to unpaired single path alignments and write stdout buffer
-    auto output_single_path_alignments = [&](vector<multipath_alignment_t>& mp_alns) {
-        auto& output_buf = single_path_output_buffer[omp_get_thread_num()];
-        // add optimal alignments to the output buffer
-        for (multipath_alignment_t& mp_aln : mp_alns) {
-            // TODO: why are we computing 5 alignments if we just take the first one?
-            // For each multipath alignment, get the greedy nonoverlapping
-            // single-path alignments from the top k optimal single-path
-            // alignments.
-            vector<Alignment> options;
-            multipath_mapper.reduce_to_single_path(mp_aln, options, localization_max_paths);
-            
-            // There will always be at least one result. Use the optimal alignment.
-            output_buf.emplace_back(std::move(options.front()));
-            
-            // compute the Alignment identity to make vg call happy
-            output_buf.back().set_identity(identity(output_buf.back().path()));
-            
-            // label with read group and sample name
-            if (!read_group.empty()) {
-                output_buf.back().set_read_group(read_group);
-            }
-            if (!sample_name.empty()) {
-                output_buf.back().set_sample_name(sample_name);
-            }
-            
-            if (no_output) {
-                output_buf.pop_back();
-            }
-        }
-        
-        vg::io::write_buffered(cout, output_buf, buffer_size);
-    };
-    
-    // write paired multipath alignments to stdout buffer
-    auto output_multipath_paired_alignments = [&](vector<pair<multipath_alignment_t, multipath_alignment_t>>& mp_aln_pairs) {
-        auto& output_buf = multipath_output_buffer[omp_get_thread_num()];
-        
-        // move all the alignments over to the output buffer
-        for (pair<multipath_alignment_t, multipath_alignment_t>& mp_aln_pair : mp_aln_pairs) {
-            
-            output_buf.emplace_back();
-            to_proto_multipath_alignment(mp_aln_pair.first, output_buf.back());
-            
-            // label with read group and sample name
-            if (!read_group.empty()) {
-                output_buf.back().set_read_group(read_group);
-            }
-            if (!sample_name.empty()) {
-                output_buf.back().set_sample_name(sample_name);
-            }
-            
-            // switch second read back to the opposite strand if necessary
-            if (!same_strand) {
-                rev_comp_multipath_alignment_in_place(&mp_aln_pair.second, [&](vg::id_t node_id) {
-                    return path_position_handle_graph->get_length(path_position_handle_graph->get_handle(node_id));
-                });
-            }
-            
-            output_buf.emplace_back();
-            to_proto_multipath_alignment(mp_aln_pair.second, output_buf.back());
-            
-            // label with read group and sample name
-            if (!read_group.empty()) {
-                output_buf.back().set_read_group(read_group);
-            }
-            if (!sample_name.empty()) {
-                output_buf.back().set_sample_name(sample_name);
-            }
-            
-            if (no_output) {
-                output_buf.pop_back();
-                output_buf.pop_back();
-            }
-        }
-        
-        vg::io::write_buffered(cout, output_buf, buffer_size);
-    };
-    
-    // convert to paired single path alignments and write stdout buffer
-    auto output_single_path_paired_alignments = [&](vector<pair<multipath_alignment_t, multipath_alignment_t>>& mp_aln_pairs) {
-        auto& output_buf = single_path_output_buffer[omp_get_thread_num()];
-        
-        // add optimal alignments to the output buffer
-        for (pair<multipath_alignment_t, multipath_alignment_t>& mp_aln_pair : mp_aln_pairs) {
-            
-            // Compute nonoverlapping single path alignments for each multipath alignment
-            vector<Alignment> options;
-            multipath_mapper.reduce_to_single_path(mp_aln_pair.first, options, localization_max_paths);
-            
-            // There will always be at least one result. Use the optimal alignment.
-            output_buf.emplace_back(std::move(options.front()));
-            
-            // compute the Alignment identity to make vg call happy
-            output_buf.back().set_identity(identity(output_buf.back().path()));
-            
-            // label with read group and sample name
-            if (!read_group.empty()) {
-                output_buf.back().set_read_group(read_group);
-            }
-            if (!sample_name.empty()) {
-                output_buf.back().set_sample_name(sample_name);
-            }
-            // arbitrarily decide that this is the "previous" fragment
-            output_buf.back().mutable_fragment_next()->set_name(mp_aln_pair.second.name());
-            
-            // Now do the second read
-            options.clear();
-            multipath_mapper.reduce_to_single_path(mp_aln_pair.second, options, localization_max_paths);
-            output_buf.emplace_back(std::move(options.front()));
-            
-            // compute identity again
-            output_buf.back().set_identity(identity(output_buf.back().path()));
-            
-            // switch second read back to the opposite strand if necessary
-            if (!same_strand) {
-                reverse_complement_alignment_in_place(&output_buf.back(),
-                                                      [&](vg::id_t node_id) {
-                    return path_position_handle_graph->get_length(path_position_handle_graph->get_handle(node_id));
-                });
-            }
-            
-            // label with read group and sample name
-            if (!read_group.empty()) {
-                output_buf.back().set_read_group(read_group);
-            }
-            if (!sample_name.empty()) {
-                output_buf.back().set_sample_name(sample_name);
-            }
-            // arbitrarily decide that this is the "next" fragment
-            output_buf.back().mutable_fragment_prev()->set_name(mp_aln_pair.first.name());
-            
-            if (no_output) {
-                output_buf.pop_back();
-                output_buf.pop_back();
-            }
-        }
-        vg::io::write_buffered(cout, output_buf, buffer_size);
-    };
     
     // do unpaired multipath alignment and write to buffer
     function<void(Alignment&)> do_unpaired_alignments = [&](Alignment& alignment) {
@@ -1750,11 +1587,8 @@ int main_mpmap(int argc, char** argv) {
             }
         }
         
-        if (single_path_alignment_mode) {
-            output_single_path_alignments(mp_alns);
-        }
-        else {
-            output_multipath_alignments(mp_alns);
+        if (!no_output) {
+            emitter->emit_singles(move(mp_alns));
         }
         
         if (watchdog) {
@@ -1794,13 +1628,23 @@ int main_mpmap(int argc, char** argv) {
         if (!same_strand) {
             // remove the path so we won't try to RC it (the path may not refer to this graph)
             alignment_2.clear_path();
-            reverse_complement_alignment_in_place(&alignment_2, [&](vg::id_t node_id) { return path_position_handle_graph->get_length(path_position_handle_graph->get_handle(node_id)); });
+            reverse_complement_alignment_in_place(&alignment_2, [&](vg::id_t node_id) {
+                return path_position_handle_graph->get_length(path_position_handle_graph->get_handle(node_id));
+            });
         }
         
         size_t num_buffered = ambiguous_pair_buffer.size();
         
         vector<pair<multipath_alignment_t, multipath_alignment_t>> mp_aln_pairs;
         multipath_mapper.multipath_map_paired(alignment_1, alignment_2, mp_aln_pairs, ambiguous_pair_buffer);
+        
+        
+        if (!same_strand) {
+            for (auto& mp_aln_pair : mp_aln_pairs) {
+                rev_comp_multipath_alignment_in_place(&mp_aln_pair.second, [&](vg::id_t node_id) { return path_position_handle_graph->get_length(path_position_handle_graph->get_handle(node_id));
+                });
+            }
+        }
         
         if (is_rna) {
             for (pair<multipath_alignment_t, multipath_alignment_t>& mp_aln_pair : mp_aln_pairs) {
@@ -1809,11 +1653,8 @@ int main_mpmap(int argc, char** argv) {
             }
         }
         
-        if (single_path_alignment_mode) {
-            output_single_path_paired_alignments(mp_aln_pairs);
-        }
-        else {
-            output_multipath_paired_alignments(mp_aln_pairs);
+        if (!no_output) {
+            emitter->emit_pairs(move(mp_aln_pairs));
         }
         
         if (watchdog) {
@@ -1852,21 +1693,11 @@ int main_mpmap(int argc, char** argv) {
             convert_Us_to_Ts(alignment_1);
             convert_Us_to_Ts(alignment_2);
         }
-
-        if (!same_strand) {
-            // the algorithm expects the read pairs to be on the same strand, so we need to flip read 2
-            // (the output functions will undo the transformation)
-        
-            // remove the path so we won't try to RC it (the path may not refer to this graph)
-            alignment_2.clear_path();
-            reverse_complement_alignment_in_place(&alignment_2, [&](vg::id_t node_id) { return path_position_handle_graph->get_length(path_position_handle_graph->get_handle(node_id)); });
-        }
         
         // Align independently
         vector<multipath_alignment_t> mp_alns_1, mp_alns_2;
         multipath_mapper.multipath_map(alignment_1, mp_alns_1);
         multipath_mapper.multipath_map(alignment_2, mp_alns_2);
-        
         
         if (is_rna) {
             for (multipath_alignment_t& mp_aln : mp_alns_1) {
@@ -1876,20 +1707,21 @@ int main_mpmap(int argc, char** argv) {
                 convert_Ts_to_Us(mp_aln);
             }
         }
-               
-        vector<pair<multipath_alignment_t, multipath_alignment_t>> mp_aln_pairs;
-        for (size_t i = 0; i < mp_alns_1.size() && i < mp_alns_2.size(); i++) {
-            // Pair arbitrarily. Stop when one side runs out of alignments.
-            mp_aln_pairs.emplace_back(mp_alns_1[i], mp_alns_2[i]);
+            
+        // keep an equal number to protect interleaving
+        mp_alns_1.resize(min(mp_alns_1.size(), mp_alns_2.size()));
+        mp_alns_2.resize(min(mp_alns_1.size(), mp_alns_2.size()));
+        
+        // combine into a single vector
+        vector<multipath_alignment_t> mp_alns_combined;
+        mp_alns_combined.reserve(mp_alns_1.size() + mp_alns_2.size());
+        for (size_t i = 0; i < mp_alns_1.size(); ++i) {
+            mp_alns_combined.emplace_back(std::move(mp_alns_1[i]));
+            mp_alns_combined.emplace_back(std::move(mp_alns_2[i]));
         }
         
-        // TODO: Set a flag or annotation or something to say we don't really believe the pairing
-       
-        if (single_path_alignment_mode) {
-            output_single_path_paired_alignments(mp_aln_pairs);
-        }
-        else {
-            output_multipath_paired_alignments(mp_aln_pairs);
+        if (!no_output) {
+            emitter->emit_singles(move(mp_alns_combined));
         }
         
         if (watchdog) {
@@ -1939,9 +1771,6 @@ int main_mpmap(int argc, char** argv) {
             if (!gam_in) {
                 cerr << "error:[vg mpmap] Cannot open GAM file " << gam_file_name << endl;
                 exit(1);
-            }
-            if (!suppress_progress) {
-                cerr << "[vg mpmap] Mapping reads from " << (gam_file_name == "-" ? "STDIN" : gam_file_name) << endl;
             }
             
             if (interleaved_input) {
@@ -1994,15 +1823,8 @@ int main_mpmap(int argc, char** argv) {
         }
     }
     
-    // flush output buffers
-    for (int i = 0; i < thread_count; i++) {
-        if (single_path_alignment_mode) {
-            vg::io::write_buffered(cout, single_path_output_buffer[i], 0);
-        }
-        else {
-            vg::io::write_buffered(cout, multipath_output_buffer[i], 0);
-        }
-    }
+    // flush output
+    delete emitter;
     cout.flush();
     
     if (!suppress_progress) {

--- a/test/t/33_vg_mpmap.t
+++ b/test/t/33_vg_mpmap.t
@@ -63,7 +63,7 @@ rm -f temp_paired_alignment.json temp_distant_alignment.json temp_independent_al
 
 vg sim -x graphs/refonly-lrc_kir.vg.xg -n 1000 -p 500 -l 100 -a > input.gam
 
-vg mpmap -B -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -G input.gam -i --single-path-mode --no-qual-adjust > output.gam
+vg mpmap -B -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -G input.gam -I 500 -D 100 -i --single-path-mode --no-qual-adjust > output.gam
 is "$(vg view -aj output.gam | jq -c 'select(.fragment_next == null and .fragment_prev == null)' | wc -l)" "0" "small batches are still all paired in the output"
 
 rm -f graphs/refonly-lrc_kir.vg.xg graphs/refonly-lrc_kir.vg.gcsa graphs/refonly-lrc_kir.vg.gcsa.lcp input.gam output.gam


### PR DESCRIPTION
Before this PR, mpmap was choking on writing output at ~40 threads. This PR rips off @adamnovak 's solution for GAMs to make a new GAMP writer, which I've tested successfully at 64 threads. I'm not entirely sure what the upper limit is, but it's certainly better than previously.

@jonassibbesen 