### PR TITLE
Seed random tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -743,7 +743,8 @@ $(UNITTEST_OBJ_DIR)/%.d: ;
 	@if [ ! -d $(UNITTEST_OBJ_DIR) ]; then mkdir -p $(UNITTEST_OBJ_DIR); fi
 	@if [ ! -d $(INC_DIR) ]; then mkdir -p $(INC_DIR); fi
 	@if [ -e $(INC_DIR)/vg/vg.pb.h ] ; then \
-		HEADER_COMBINED=$$(cat $(INC_DIR)/vg/vg.pb.h | grep GOOGLE_PROTOBUF_MIN_PROTOC_VERSION | cut -d' ' -f2); \
+		cat $(INC_DIR)/vg/vg.pb.h | head -n100 ; \
+		HEADER_COMBINED=$$(cat $(INC_DIR)/vg/vg.pb.h | grep VERSION | sed 's/[^0-9]*\([0-9]*\)[^0-9]*/\1/' | head -n1); \
 		PROTOC_MAJOR=$$(protoc --version | cut -d' ' -f2 | cut -d'.' -f1); \
 		PROTOC_MINOR=$$(protoc --version | cut -d' ' -f2 | cut -d'.' -f2); \
 		PROTOC_PATCH=$$(protoc --version | cut -d' ' -f2 | cut -d'.' -f2); \

--- a/Makefile
+++ b/Makefile
@@ -743,11 +743,10 @@ $(UNITTEST_OBJ_DIR)/%.d: ;
 	@if [ ! -d $(UNITTEST_OBJ_DIR) ]; then mkdir -p $(UNITTEST_OBJ_DIR); fi
 	@if [ ! -d $(INC_DIR) ]; then mkdir -p $(INC_DIR); fi
 	@if [ -e $(INC_DIR)/vg/vg.pb.h ] ; then \
-		cat $(INC_DIR)/vg/vg.pb.h | head -n100 ; \
 		HEADER_COMBINED=$$(cat $(INC_DIR)/vg/vg.pb.h | grep VERSION | sed 's/[^0-9]*\([0-9]*\)[^0-9]*/\1/' | head -n1); \
 		PROTOC_MAJOR=$$(protoc --version | cut -d' ' -f2 | cut -d'.' -f1); \
 		PROTOC_MINOR=$$(protoc --version | cut -d' ' -f2 | cut -d'.' -f2); \
-		PROTOC_PATCH=$$(protoc --version | cut -d' ' -f2 | cut -d'.' -f2); \
+		PROTOC_PATCH=$$(protoc --version | cut -d' ' -f2 | cut -d'.' -f3); \
 		PROTOC_COMBINED=$$(expr '(' $${PROTOC_MAJOR} '*' 1000 '+' $${PROTOC_MINOR} ')' '*' 1000 '+' $${PROTOC_PATCH}); \
 		if [ "$${HEADER_COMBINED}" != "$${PROTOC_COMBINED}" ] ; then \
 			echo "Protobuf version has changed!"; \

--- a/Makefile
+++ b/Makefile
@@ -742,7 +742,24 @@ $(UNITTEST_OBJ_DIR)/%.d: ;
 	@if [ ! -d $(SUBCOMMAND_OBJ_DIR) ]; then mkdir -p $(SUBCOMMAND_OBJ_DIR); fi
 	@if [ ! -d $(UNITTEST_OBJ_DIR) ]; then mkdir -p $(UNITTEST_OBJ_DIR); fi
 	@if [ ! -d $(INC_DIR) ]; then mkdir -p $(INC_DIR); fi
-
+	@if [ -e $(INC_DIR)/vg/vg.pb.h ] ; then \
+		HEADER_COMBINED=$$(cat $(INC_DIR)/vg/vg.pb.h | grep GOOGLE_PROTOBUF_MIN_PROTOC_VERSION | cut -d' ' -f2); \
+		PROTOC_MAJOR=$$(protoc --version | cut -d' ' -f2 | cut -d'.' -f1); \
+		PROTOC_MINOR=$$(protoc --version | cut -d' ' -f2 | cut -d'.' -f2); \
+		PROTOC_PATCH=$$(protoc --version | cut -d' ' -f2 | cut -d'.' -f2); \
+		PROTOC_COMBINED=$$(expr '(' $${PROTOC_MAJOR} '*' 1000 '+' $${PROTOC_MINOR} ')' '*' 1000 '+' $${PROTOC_PATCH}); \
+		if [ "$${HEADER_COMBINED}" != "$${PROTOC_COMBINED}" ] ; then \
+			echo "Protobuf version has changed!"; \
+			echo "Headers are from $${HEADER_COMBINED} but we have $${PROTOC_COMBINED}"; \
+			echo "Need to rebuild libvgio"; \
+			rm -f $(LIB_DIR)/libvgio.a; \
+			rm -f $(INC_DIR)/vg/vg.pb.h; \
+		fi; \
+	fi;
+	
+	
+	
+	
 # run .pre-build before we make anything at all.
 -include .pre-build
 

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -604,9 +604,11 @@ private:
     /// followed by indexing metadata, one after the other in memory. We can
     /// just cast a Snarl* to a pointer to one of these to get access to all
     /// the metadata.
-    struct SnarlRecord : public Snarl {
-        // Instead of relying on the first member being at offset 0, we inherit
-        // from the Protobuf type.
+    struct alignas(alignof(Snarl)) SnarlRecord {
+        /// With recent Protobuf, we can't inherit from Protobuf generated
+        /// classes, so we rely on the first member here being at offset 0.
+        /// This is achieved by making sure SnarlRecord is aligned like Snarl. 
+        Snarl snarl;
         
         /// This is a vector of pointers into the master snarl container at
         /// children. We know the pointers are to valid SnarlRecords. A

--- a/src/unittest/hash_graph.cpp
+++ b/src/unittest/hash_graph.cpp
@@ -9,6 +9,7 @@
 
 #include "../json2pb.h"
 #include "random_graph.hpp"
+#include "randomness.hpp"
 
 #include "algorithms/are_equivalent.hpp"
 
@@ -28,8 +29,7 @@ using namespace std;
         int num_variants = 30;
         int long_var_length = 10;
         
-        random_device rd;
-        default_random_engine gen(rd());
+        default_random_engine gen(test_seed_source());
         uniform_int_distribution<int> circ_distr(0, 1);
         
         for (int i = 0; i < num_graphs; i++) {

--- a/src/unittest/min_distance.cpp
+++ b/src/unittest/min_distance.cpp
@@ -12,6 +12,7 @@
 #include "../min_distance.hpp"
 #include "../genotypekit.hpp"
 #include "random_graph.hpp"
+#include "randomness.hpp"
 #include <fstream>
 #include <random>
 #include <time.h> 
@@ -1380,8 +1381,7 @@ int64_t min_distance(VG* graph, pos_t pos1, pos_t pos2){
        DistanceIndex di(&vg, snarl_manager, dist_stream);
        dist_stream.close();
 
-       random_device seed_source;
-       default_random_engine generator(seed_source());
+       default_random_engine generator(test_seed_source());
        for (size_t i = 0; i < 1000 ; i++) {
     
            size_t maxPos = xg.seq_length;

--- a/src/unittest/packed_graph.cpp
+++ b/src/unittest/packed_graph.cpp
@@ -9,6 +9,7 @@
 
 #include "../json2pb.h"
 #include "random_graph.hpp"
+#include "randomness.hpp"
 
 #include "algorithms/are_equivalent.hpp"
 
@@ -419,8 +420,7 @@ using namespace std;
         int num_variants = 30;
         int long_var_length = 10;
         
-        random_device rd;
-        default_random_engine gen(rd());
+        default_random_engine gen(test_seed_source());
         uniform_int_distribution<int> circ_distr(0, 1);
         
         for (int i = 0; i < num_graphs; i++) {

--- a/src/unittest/packed_structs.cpp
+++ b/src/unittest/packed_structs.cpp
@@ -10,6 +10,7 @@
 
 #include "../json2pb.h"
 #include "catch.hpp"
+#include "randomness.hpp"
 
 #include <bdsg/internal/packed_structs.hpp>
 
@@ -21,8 +22,7 @@ using namespace std;
         
         enum vec_op_t {SET = 0, GET = 1, APPEND = 2, POP = 3, SERIALIZE = 4};
         
-        random_device rd;
-        default_random_engine prng(rd());
+        default_random_engine prng(test_seed_source());
         uniform_int_distribution<int> op_distr(0, 4);
         
         int num_runs = 1000;
@@ -113,8 +113,7 @@ using namespace std;
     TEST_CASE("PagedVector acts the same as STL vector", "[packed]") {
         
         enum vec_op_t {SET = 0, GET = 1, APPEND = 2, POP = 3, SERIALIZE = 4};
-        std::random_device rd;
-        std::default_random_engine prng(rd());
+        std::default_random_engine prng(test_seed_source());
         std::uniform_int_distribution<int> op_distr(0, 4);
         std::uniform_int_distribution<int> page_distr(1, 5);
         std::uniform_int_distribution<int> val_distr(0, 100);
@@ -207,8 +206,7 @@ using namespace std;
     TEST_CASE("PackedDeque acts the same as STL deque", "[packed]") {
         
         enum deque_op_t {SET = 0, GET = 1, APPEND_LEFT = 2, POP_LEFT = 3, APPEND_RIGHT = 4, POP_RIGHT = 5, SERIALIZE = 6};
-        std::random_device rd;
-        std::default_random_engine prng(rd());
+        std::default_random_engine prng(test_seed_source());
         std::uniform_int_distribution<int> op_distr(0, 6);
         
         int num_runs = 1000;

--- a/src/unittest/random_graph.cpp
+++ b/src/unittest/random_graph.cpp
@@ -3,6 +3,8 @@
 #include <random>
 #include <time.h>
 
+#include "randomness.hpp"
+
 
 namespace vg {
 namespace unittest {
@@ -19,8 +21,7 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                   //Index of original sequence to node that starts at that index
     
     //Get random number generator for lengths and variation types
-    random_device seed_source;
-    default_random_engine generator(seed_source());
+    default_random_engine generator(test_seed_source());
     
     uniform_int_distribution<int> base_distribution(0, 3);
     poisson_distribution<size_t> length_distribution(variant_len);
@@ -225,8 +226,7 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
 vector<vector<size_t>> random_adjacency_list(size_t node_count, size_t edge_count) {
 
     // Work out how to randomly pick a node
-    random_device seed_source;
-    default_random_engine generator(seed_source());
+    default_random_engine generator(test_seed_source());
     uniform_int_distribution<size_t> node_distribution(0, node_count - 1);
     
     vector<vector<size_t>> to_return(node_count);

--- a/src/unittest/random_graph.hpp
+++ b/src/unittest/random_graph.hpp
@@ -1,6 +1,9 @@
 #include "handle.hpp"
 #include <vector>
 
+#ifndef VG_UNITTEST_RANDOM_GRAPH_HPP_INCLUDED
+#define VG_UNITTEST_RANDOM_GRAPH_HPP_INCLUDED
+
 namespace vg{
 namespace unittest{
 
@@ -17,3 +20,5 @@ std::vector<std::vector<size_t>> random_adjacency_list(size_t node_count, size_t
 
 }
 }
+
+#endif

--- a/src/unittest/randomness.hpp
+++ b/src/unittest/randomness.hpp
@@ -1,0 +1,31 @@
+#ifndef VG_UNITTEST_RANDOMNESS_HPP_INCLUDED
+#define VG_UNITTEST_RANDOMNESS_HPP_INCLUDED
+
+/**
+ * \file randomness.hpp
+ * Provide C++11 <random>-compatible randomness that is seedable via Catch.hpp RNG seeding.
+ *
+ * NO TEST SHOULD USE RANDOMNESS FROM ANY OTHER SOURCE!
+ */
+
+#include <random>
+#include <cstdlib>
+
+namespace vg {
+namespace unittest {
+
+/**
+ * Return a random seed for testing purposes.
+ * Respects catch.hpp --rng-seed option to `vg test`.
+ *
+ * USE INSTEAD OF A NEW std::random_device FOR ALL TESTING PURPOSES!
+ */
+inline unsigned int test_seed_source() {
+    // TODO: make thread safe
+    return (unsigned int) rand();
+}
+
+}
+}
+
+#endif

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -12,6 +12,7 @@
 #include <vg/vg.pb.h>
 #include "catch.hpp"
 #include "random_graph.hpp"
+#include "randomness.hpp"
 #include "../snarls.hpp"
 #include "../cactus_snarl_finder.hpp"
 #include "../integrated_snarl_finder.hpp"
@@ -3722,8 +3723,7 @@ namespace vg {
         
             // Each actual graph takes a fairly long time to do so we randomize sizes...
             
-            random_device seed_source;
-            default_random_engine generator(seed_source());
+            default_random_engine generator(test_seed_source());
             
             for (size_t repeat = 0; repeat < 100; repeat++) {
             

--- a/src/unittest/vg_algorithms.cpp
+++ b/src/unittest/vg_algorithms.cpp
@@ -10,33 +10,34 @@
 #include <set>
 #include <random>
 #include "catch.hpp"
-#include "algorithms/extract_connecting_graph.hpp"
-#include "algorithms/extract_containing_graph.hpp"
-#include "algorithms/extract_extending_graph.hpp"
-#include "algorithms/topological_sort.hpp"
-#include "algorithms/weakly_connected_components.hpp"
-#include "algorithms/is_acyclic.hpp"
-#include "algorithms/split_strands.hpp"
-#include "algorithms/is_single_stranded.hpp"
-#include "algorithms/distance_to_head.hpp"
-#include "algorithms/distance_to_tail.hpp"
-#include "algorithms/apply_bulk_modifications.hpp"
-#include "algorithms/count_walks.hpp"
-#include "algorithms/strongly_connected_components.hpp"
-#include "algorithms/a_star.hpp"
-#include "algorithms/eades_algorithm.hpp"
-#include "algorithms/shortest_cycle.hpp"
-#include "algorithms/reverse_complement.hpp"
-#include "algorithms/jump_along_path.hpp"
-#include "algorithms/expand_context.hpp"
-#include "algorithms/are_equivalent.hpp"
-#include "algorithms/simplify_siblings.hpp"
-#include "algorithms/unchop.hpp"
-#include "unittest/random_graph.hpp"
-#include "vg.hpp"
-#include "xg.hpp"
-#include "bdsg/hash_graph.hpp"
-#include "json2pb.h"
+#include "../algorithms/extract_connecting_graph.hpp"
+#include "../algorithms/extract_containing_graph.hpp"
+#include "../algorithms/extract_extending_graph.hpp"
+#include "../algorithms/topological_sort.hpp"
+#include "../algorithms/weakly_connected_components.hpp"
+#include "../algorithms/is_acyclic.hpp"
+#include "../algorithms/split_strands.hpp"
+#include "../algorithms/is_single_stranded.hpp"
+#include "../algorithms/distance_to_head.hpp"
+#include "../algorithms/distance_to_tail.hpp"
+#include "../algorithms/apply_bulk_modifications.hpp"
+#include "../algorithms/count_walks.hpp"
+#include "../algorithms/strongly_connected_components.hpp"
+#include "../algorithms/a_star.hpp"
+#include "../algorithms/eades_algorithm.hpp"
+#include "../algorithms/shortest_cycle.hpp"
+#include "../algorithms/reverse_complement.hpp"
+#include "../algorithms/jump_along_path.hpp"
+#include "../algorithms/expand_context.hpp"
+#include "../algorithms/are_equivalent.hpp"
+#include "../algorithms/simplify_siblings.hpp"
+#include "../algorithms/unchop.hpp"
+#include "random_graph.hpp"
+#include "randomness.hpp"
+#include "../vg.hpp"
+#include "../xg.hpp"
+#include <bdsg/hash_graph.hpp>
+#include "../json2pb.h"
 
 
 using namespace google::protobuf;
@@ -4255,8 +4256,7 @@ TEST_CASE("apply_orientations works as expected", "[algorithms]") {
     Node* n4 = vg.create_node("A");
     Node* n5 = vg.create_node("A");
             
-    random_device rd;
-    default_random_engine prng(rd());
+    default_random_engine prng(test_seed_source());
             
     SECTION("apply_orientations works with random orientations") {
                 
@@ -5039,8 +5039,7 @@ TEST_CASE("A* search works on random graphs","[a-star][algorithms]") {
                     all_handles.push_back(handle);
                     total_seq_len += graph.get_length(handle) * 2;
                 });
-            random_device rd;
-            default_random_engine gen(rd());
+            default_random_engine gen(test_seed_source());
                     
             function<pos_t(void)> random_pos = [&](void) {
                 handle_t h = all_handles[uniform_int_distribution<int>(0, all_handles.size() - 1)(gen)];
@@ -5130,8 +5129,7 @@ TEST_CASE("A* search works on random graphs","[a-star][algorithms]") {
                     all_handles.push_back(handle);
                     total_seq_len += graph.get_length(handle) * 2;
                 });
-            random_device rd;
-            default_random_engine gen(rd());
+            default_random_engine gen(test_seed_source());
                     
             function<pos_t(void)> random_pos = [&](void) {
                 handle_t h = all_handles[uniform_int_distribution<int>(0, all_handles.size() - 1)(gen)];

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -3903,7 +3903,7 @@ void VG::divide_node(Node* node, vector<int>& positions, vector<Node*>& parts) {
                 
                 cerr << " -- position (" << pos << ") is less than 0 or greater than sequence length ("
                      << node->sequence().size() << ")" << endl;
-                exit(1);
+                throw runtime_error("Unacceptable node division");
             }
         }
     }


### PR DESCRIPTION
This is half of #2806 
With this in, I can reliably crash `random_graph()` with:

```
vg test --rng-seed 21 "NetGraph can traverse all the snarls in random graphs"
```