### PR TITLE
Giraffe output formats

### DIFF
--- a/src/index_manager.cpp
+++ b/src/index_manager.cpp
@@ -24,6 +24,10 @@ using namespace std;
 
 namespace vg {
 
+// Numerical class constants.
+constexpr size_t IndexManager::minimizer_k;
+constexpr size_t IndexManager::minimizer_w;
+
 IndexManager::IndexManager(const string& fasta_filename, const string& vcf_filename) {
     set_fasta_filename(fasta_filename);
     set_vcf_filename(vcf_filename);

--- a/src/index_manager.hpp
+++ b/src/index_manager.hpp
@@ -116,9 +116,9 @@ public:
     
     
     /// Minimizer kmer length to use when minimizer indexing
-    size_t minimizer_k = 29;
+    constexpr static size_t minimizer_k = 29;
     /// Minimizer window size to use when minimizer indexing
-    size_t minimizer_w = 11;
+    constexpr static size_t minimizer_w = 11;
 
 protected:
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2138,6 +2138,17 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
     int64_t max_distance = fragment_length_distr.mean() + 4 * fragment_length_distr.stdev();
     distance_index.subgraph_in_range(aligned_read.path(), &cached_graph, min_distance, max_distance, rescue_nodes, rescue_forward);
 
+    // Remove node ids that do not exist in the GBWTGraph from the subgraph.
+    // We may be using the distance index of the original graph, and nodes
+    // not visited by any thread are missing from the GBWTGraph.
+    for (auto iter = rescue_nodes.begin(); iter != rescue_nodes.end(); ) {
+        if (!cached_graph.has_node(*iter)) {
+            iter = rescue_nodes.erase(iter);
+        } else {
+            ++iter;
+        }
+    }
+
     // Get rid of the old path.
     rescued_alignment.clear_path();
 

--- a/src/subcommand/gaffe_main.cpp
+++ b/src/subcommand/gaffe_main.cpp
@@ -7,6 +7,7 @@
 #include <getopt.h>
 #include <iostream>
 #include <cassert>
+#include <cstring>
 #include <map>
 #include <vector>
 #include <unordered_set>
@@ -303,7 +304,7 @@ void help_gaffe(char** argv) {
     << "  -M, --max-multimaps INT       produce up to INT alignments for each read [1]" << endl
     << "  -N, --sample NAME             add this sample name" << endl
     << "  -R, --read-group NAME         add this read group" << endl
-    << "  -o, --output-format NAME      output the alignments in format NAME (GAM / GAF / JSON / TSV) [GAM]" << endl
+    << "  -o, --output-format NAME      output the alignments in NAME format (gam / gaf / json / tsv) [gam]" << endl
     << "  -n, --discard                 discard all output alignments (for profiling)" << endl
     << "  --output-basename NAME        write output to a GAM file beginning with the given prefix for each setting combination" << endl
     << "  --report-name NAME            write a TSV of output file and mapping speed to the given file" << endl
@@ -579,8 +580,11 @@ int main_gaffe(int argc, char** argv) {
             case 'o':
                 {
                     output_format = optarg;
+                    for (char& c : output_format) {
+                        c = std::toupper(c);
+                    }
                     if (output_formats.find(output_format) == output_formats.end()) {
-                        std::cerr << "error: [vg gaffe] Invalid output format: " << output_format << std::endl;
+                        std::cerr << "error: [vg gaffe] Invalid output format: " << optarg << std::endl;
                         std::exit(1);
                     }
                 }
@@ -730,7 +734,11 @@ int main_gaffe(int argc, char** argv) {
 
             case 'A':
                 {
-                    auto iter = rescue_algorithms.find(optarg);
+                    std::string algo_name = optarg;
+                    for (char& c : algo_name) {
+                        c = std::tolower(c);
+                    }
+                    auto iter = rescue_algorithms.find(algo_name);
                     if (iter == rescue_algorithms.end()) {
                         std::cerr << "error: [vg gaffe] Invalid rescue algorithm: " << optarg << std::endl;
                         std::exit(1);

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -31,6 +31,8 @@
 #include <getopt.h>
 #include <omp.h>
 
+#include "../index_manager.hpp"
+
 #include <gbwtgraph/index.h>
 
 #include "../min_distance.hpp"
@@ -47,6 +49,14 @@ int get_default_threads() {
     return std::min(omp_get_max_threads(), DEFAULT_MAX_THREADS);
 }
 
+size_t get_default_k() {
+    return IndexManager::minimizer_k;
+}
+
+size_t get_default_w() {
+    return IndexManager::minimizer_w;
+}
+
 void help_minimizer(char** argv) {
     std::cerr << "usage: " << argv[0] << " minimizer -g gbwt_name -i index_name [options] graph" << std::endl;
     std::cerr << std::endl;
@@ -59,8 +69,8 @@ void help_minimizer(char** argv) {
     std::cerr << "    -i, --index-name X      store the index to file X" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Minimizer options:" << std::endl;
-    std::cerr << "    -k, --kmer-length N     length of the kmers in the index (default " << gbwtgraph::DefaultMinimizerIndex::key_type::KMER_LENGTH << ", max " << gbwtgraph::DefaultMinimizerIndex::key_type::KMER_MAX_LENGTH << ")" << std::endl;
-    std::cerr << "    -w, --window-length N   choose the minimizer from a window of N kmers (default " << gbwtgraph::DefaultMinimizerIndex::key_type::WINDOW_LENGTH << ")" << std::endl;
+    std::cerr << "    -k, --kmer-length N     length of the kmers in the index (default " << get_default_k() << ", max " << gbwtgraph::DefaultMinimizerIndex::key_type::KMER_MAX_LENGTH << ")" << std::endl;
+    std::cerr << "    -w, --window-length N   choose the minimizer from a window of N kmers (default " << get_default_w() << ")" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
     std::cerr << "    -d, --distance-index X  annotate the hits with positions in this distance index" << std::endl;
@@ -81,8 +91,8 @@ int main_minimizer(int argc, char** argv) {
     }
 
     // Command-line options.
-    size_t kmer_length = gbwtgraph::DefaultMinimizerIndex::key_type::KMER_LENGTH;
-    size_t window_length = gbwtgraph::DefaultMinimizerIndex::key_type::WINDOW_LENGTH;
+    size_t kmer_length = get_default_k();
+    size_t window_length = get_default_w();
     std::string index_name, distance_name, load_index, gbwt_name, graph_name;
     bool is_gbwt_graph = false;
     bool progress = false;

--- a/test/t/46_vg_minimizer.t
+++ b/test/t/46_vg_minimizer.t
@@ -22,7 +22,7 @@ is $? 0 "default parameters"
 vg minimizer -t 1 -i x.mi -g x.gbwt x.xg
 is $? 0 "single-threaded construction"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 1a9e7e953b2c921b78bb847d8019774d "construction is deterministic"
+is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 4e409c662cb41fc6dcd4c8a245ee2a1d "construction is deterministic"
 
 # Minimizer parameters
 vg minimizer -t 1 -k 7 -w 3 -i x.mi -g x.gbwt x.xg
@@ -35,13 +35,13 @@ vg gbwt -x x.xg -g x.gg x.gbwt
 vg minimizer -t 1 -g x.gbwt -G -i x.mi x.gg
 is $? 0 "construction from GBWTGraph"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 1a9e7e953b2c921b78bb847d8019774d "construction is deterministic"
+is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 4e409c662cb41fc6dcd4c8a245ee2a1d "construction is deterministic"
 
 # Store payload in the index
 vg minimizer -t 1 -i x.mi -g x.gbwt -d x.dist -G x.gg
 is $? 0 "construction with payload"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 41449d6fc61acefbd27fc714a7e50996 "construction is deterministic"
+is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 37b3778ab99e3a751765cb84d5440f25 "construction is deterministic"
 
 rm -f x.vg x.xg x.gbwt x.snarls x.dist x.mi x.extracted.mi x.gg
 
@@ -59,7 +59,7 @@ is $? 0 "multiple graphs: first"
 vg minimizer -t 1 -l x.mi -i xy.mi -g y.gbwt y.xg
 is $? 0 "multiple graphs: second"
 vg view --extract-tag MinimizerIndex xy.mi > xy.extracted.mi
-is $(md5sum xy.extracted.mi | cut -f 1 -d\ ) 633b3965745c53aef25d8b7e42d55eb3 "construction is deterministic"
+is $(md5sum xy.extracted.mi | cut -f 1 -d\ ) 04a93695acc3b169721f4a6510cc8705 "construction is deterministic"
 
 rm -f x.vg y.vg
 rm -f x.xg y.xg


### PR DESCRIPTION
Use option `--output-format` / `-o` to select the output format in `vg gaffe`. GAM is the default, GAF is somewhat faster, and JSON could be useful in some evaluation scripts.

`vg minimizer` now takes the default minimizer parameters from `IndexManager`.