### PR TITLE
Avoid out-of-bounds CNV and inversion breakpoints

### DIFF
--- a/src/unittest/random_graph.cpp
+++ b/src/unittest/random_graph.cpp
@@ -17,7 +17,7 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
     
             
 #ifdef debug
-    cerr << "Make random graph of " << seq_size << " bp with " << variant_count << " ~" << variant_len << "-bp variants" << endl;
+    cerr << "Make random graph of " << seq_size << " bp with " << variant_count << " ~" << variant_len << "-bp large variants" << endl;
 #endif
     
     //Create a random graph for a sequence of length seq_size

--- a/src/unittest/random_graph.cpp
+++ b/src/unittest/random_graph.cpp
@@ -2,6 +2,7 @@
 
 #include <random>
 #include <time.h>
+#include <iostream>
 
 #include "randomness.hpp"
 
@@ -13,6 +14,12 @@ using namespace std;
 
 void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                   MutablePathMutableHandleGraph* graph) {
+    
+            
+#ifdef debug
+    cerr << "Make random graph of " << seq_size << " bp with " << variant_count << " ~" << variant_len << "-bp variants" << endl;
+#endif
+    
     //Create a random graph for a sequence of length seq_size
     //variant_len is the mean length of a larger variation and variationCount
     //is the number of variations in the graph
@@ -46,9 +53,20 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
     auto do_split = [&] (size_t index) -> pair<handle_t, handle_t> {
         //Split graph at index and update the path index
         
+#ifdef debug
+        cerr << "Split original sequence at base " << index << "/" << seq_size << endl;
+#endif
+        
+        // Make sure we aren't trying to split out of bounds
+        assert(index < seq_size);
+        
         auto n = --index_to_id.upper_bound(index); //orig node containing pos
         size_t first_index = n->first;               //Index of first node
         handle_t first_handle = graph->get_handle(n->second);    //handle of first node
+        
+#ifdef debug
+        cerr << "\tFalls in node " << graph->get_id(first_handle) << " length " << graph->get_length(first_handle) << " at " << first_index << endl;
+#endif
         
         pair<handle_t, handle_t> return_val;
         
@@ -57,7 +75,16 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
             
             size_t split_length = index - first_index;
             
+#ifdef debug
+            cerr << "\t\tSplit at " << split_length << " along node" << endl;
+#endif
+            
             return_val = graph->divide_handle(first_handle, split_length);
+            
+#ifdef debug
+            cerr << "\t\t\tCreate " << graph->get_id(return_val.first) << " at " << first_index << endl;
+            cerr << "\t\t\tCreate " << graph->get_id(return_val.second) << " at " << index << endl;
+#endif
             
             index_to_id[first_index] = graph->get_id(return_val.first);
             index_to_id[index] = graph->get_id(return_val.second);
@@ -149,8 +176,9 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                 //Copy number variation
                 size_t length = length_distribution(generator);
                 
-                if (length > 0 ) {
-                    if (start_index == 0) {
+                if (length > 0) {
+                    if (start_index == 0 && length + start_index < seq_size - 1) {
+                        // Very first base is involved, but very last base isn't (we don't handle that case)
                         pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
                         
                         auto node_pair = index_to_id.begin();//first node
@@ -159,8 +187,8 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                         graph->create_edge(end_nodes.first, first_handle);
                         
                     }
-                    else if ( length + start_index < seq_size - 1) {
-                        
+                    else if (length + start_index < seq_size - 1) {
+                        // Only interior bases are involved
                         pair<handle_t, handle_t> start_nodes = do_split(start_index);
                         pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
                         // hack: this won't redo the split since it's already there, but it
@@ -171,7 +199,8 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                         graph->create_edge(end_nodes.first, start_nodes.second);
                         
                     }
-                    else if ( length + start_index == seq_size - 1) {
+                    else if (length + start_index == seq_size - 1) {
+                        // Very last base is involved (but not very first)
                         pair<handle_t, handle_t> start_nodes = do_split(start_index);
                         
                         //last node
@@ -189,14 +218,15 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                 //Inversion
                 size_t length = length_distribution(generator);
                 if (length > 0) {
-                    if (start_index == 0) {
-                        
+                    if (start_index == 0 && length + start_index < seq_size - 1) {
+                        // Very first base is involved, but very last base isn't (we don't handle that case)
                         pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
                         
                         graph->create_edge(graph->flip(end_nodes.first), end_nodes.second);
                         
                         
-                    } else if ( length + start_index < seq_size-1) {
+                    } else if (length + start_index < seq_size-1) {
+                        // Only interior bases are involved
                         pair<handle_t, handle_t> start_nodes = do_split(start_index);
                         pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
                         // hack: this won't redo the split since it's already there, but it
@@ -208,7 +238,7 @@ void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                         graph->create_edge(graph->flip(start_nodes.second), end_nodes.second);
                         
                     } else if (length + start_index == seq_size - 1) {
-                        
+                        // Very last base is involved (but not very first)
                         pair<handle_t, handle_t> start_nodes = do_split(start_index);
                         
                         graph->create_edge(start_nodes.first, graph->flip(start_nodes.second));

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -3729,13 +3729,13 @@ namespace vg {
             
                 uniform_int_distribution<size_t> bases_dist(100, 10000);
                 size_t bases = bases_dist(generator);
-                uniform_int_distribution<size_t> variant_bases_dist(1, bases);
+                uniform_int_distribution<size_t> variant_bases_dist(1, bases/2);
                 size_t variant_bases = variant_bases_dist(generator);
-                uniform_int_distribution<size_t> variant_count_dist(1, variant_bases);
+                uniform_int_distribution<size_t> variant_count_dist(1, bases/2);
                 size_t variant_count = variant_count_dist(generator);
                         
 #ifdef debug
-                cerr << repeat << ": Do graph of " << bases << " bp with " << variant_bases << " bp variable in " << variant_count << " events" << endl;
+                cerr << repeat << ": Do graph of " << bases << " bp with ~" << variant_bases << " bp large variant length and " << variant_count << " events" << endl;
 #endif
             
                 VG graph;


### PR DESCRIPTION
This fixes an intermittent test failure in random graph generation.

Also, I misunderstood one of the random_graph parameters so now I'm not asking it for such weird graphs.