### PR TITLE
Disqualify ultrabubbles with tips

### DIFF
--- a/src/algorithms/append_graph.cpp
+++ b/src/algorithms/append_graph.cpp
@@ -1,6 +1,6 @@
 #include "append_graph.hpp"
 
-#include "topological_sort.hpp"
+#include "find_tips.hpp"
 #include "copy_graph.hpp"
 
 using namespace std;

--- a/src/algorithms/distance_to_head.hpp
+++ b/src/algorithms/distance_to_head.hpp
@@ -14,8 +14,6 @@ namespace algorithms {
 
 using namespace std;
 
-/// Find all of the nodes with no edges on their left sides.
-vector<handle_t> head_nodes(const HandleGraph* g);
 int32_t distance_to_head(handle_t h, int32_t limit, const HandleGraph* graph);
 /// Get the distance in bases from start of node to start of closest head node of graph, or -1 if that distance exceeds the limit.
 /// dist increases by the number of bases of each previous node until you reach the head node

--- a/src/algorithms/distance_to_tail.hpp
+++ b/src/algorithms/distance_to_tail.hpp
@@ -14,8 +14,6 @@ namespace algorithms {
 
 using namespace std;
 
-/// Find all of the nodes with no edges on their left sides.
-vector<handle_t> tail_nodes(const HandleGraph* g);
 int32_t distance_to_tail(handle_t h, int32_t limit, const HandleGraph* graph);
 /// Get the distance in bases from end of node to end of closest tail node of graph, or -1 if that distance exceeds the limit.
 /// dist increases by the number of bases of each previous node until you reach the head node

--- a/src/algorithms/find_tips.cpp
+++ b/src/algorithms/find_tips.cpp
@@ -1,0 +1,65 @@
+#include "find_tips.hpp"
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+vector<handle_t> head_nodes(const HandleGraph* g) {
+    vector<handle_t> to_return;
+    g->for_each_handle([&](const handle_t& found) {
+        // For each (locally forward) node
+        
+        bool no_left_edges = true;
+        g->follow_edges(found, true, [&](const handle_t& ignored) {
+            // We found a left edge!
+            no_left_edges = false;
+            // We only need one
+            return false;
+        });
+        
+        if (no_left_edges) {
+            to_return.push_back(found);
+        }
+    });
+    
+    return to_return;
+    
+}
+
+vector<handle_t> tail_nodes(const HandleGraph* g) {
+    vector<handle_t> to_return;
+    g->for_each_handle([&](const handle_t& found) {
+        // For each (locally forward) node
+        
+        bool no_right_edges = true;
+        g->follow_edges(found, false, [&](const handle_t& ignored) {
+            // We found a right edge!
+            no_right_edges = false;
+            // We only need one
+            return false;
+        });
+        
+        if (no_right_edges) {
+            to_return.push_back(found);
+        }
+    });
+    
+    return to_return;
+    
+}
+
+vector<handle_t> find_tips(const HandleGraph* g) {
+    // Start with the heads
+    vector<handle_t> tips = head_nodes(g);
+    vector<handle_t> tails = tail_nodes(g);
+    tips.reserve(tips.size() + tails.size());
+    for (auto tip : tails) {
+        // And add all the tails backward
+        tips.push_back(g->flip(tip));
+    }
+    return tips;
+}
+
+}
+}

--- a/src/algorithms/find_tips.hpp
+++ b/src/algorithms/find_tips.hpp
@@ -1,0 +1,32 @@
+#ifndef VG_ALGORITHMS_FIND_TIPS_HPP_INCLUDED
+#define VG_ALGORITHMS_FIND_TIPS_HPP_INCLUDED
+
+/**
+ * \file find_tips.hpp
+ *
+ * Defines algorithms for finding heads, tails, and general tips.
+ */
+
+#include "../handle.hpp"
+
+#include <vector>
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+/// Find all of the nodes with no edges on their left sides.
+vector<handle_t> head_nodes(const HandleGraph* g);
+
+/// Find all of the nodes with no edges on their right sides.
+vector<handle_t> tail_nodes(const HandleGraph* g);
+
+/// Find all of the tips in the graph, facing inward.
+/// Nodes with no edges will appear once in each orientation.
+vector<handle_t> find_tips(const HandleGraph* g);
+
+}
+}
+
+#endif

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -1,53 +1,11 @@
 #include "topological_sort.hpp"
 
+#include "find_tips.hpp"
+
 namespace vg {
 namespace algorithms {
 
 using namespace std;
-
-vector<handle_t> head_nodes(const HandleGraph* g) {
-    vector<handle_t> to_return;
-    g->for_each_handle([&](const handle_t& found) {
-        // For each (locally forward) node
-        
-        bool no_left_edges = true;
-        g->follow_edges(found, true, [&](const handle_t& ignored) {
-            // We found a left edge!
-            no_left_edges = false;
-            // We only need one
-            return false;
-        });
-        
-        if (no_left_edges) {
-            to_return.push_back(found);
-        }
-    });
-    
-    return to_return;
-    
-}
-
-vector<handle_t> tail_nodes(const HandleGraph* g) {
-    vector<handle_t> to_return;
-    g->for_each_handle([&](const handle_t& found) {
-        // For each (locally forward) node
-        
-        bool no_right_edges = true;
-        g->follow_edges(found, false, [&](const handle_t& ignored) {
-            // We found a right edge!
-            no_right_edges = false;
-            // We only need one
-            return false;
-        });
-        
-        if (no_right_edges) {
-            to_return.push_back(found);
-        }
-    });
-    
-    return to_return;
-    
-}
 
 vector<handle_t> topological_order(const HandleGraph* g) {
     

--- a/src/algorithms/topological_sort.hpp
+++ b/src/algorithms/topological_sort.hpp
@@ -22,12 +22,6 @@ namespace algorithms {
 
 using namespace std;
 
-/// Find all of the nodes with no edges on their left sides.
-vector<handle_t> head_nodes(const HandleGraph* g);
-
-/// Find all of the nodes with no edges on their right sides.
-vector<handle_t> tail_nodes(const HandleGraph* g);
-
 /**
  * Order and orient the nodes in the graph using a topological sort. The sort is
  * guaranteed to be machine-independent given the initial graph's node and edge

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1,6 +1,7 @@
 #include "aligner.hpp"
 
 #include "hash_map.hpp"
+#include "algorithms/find_tips.hpp"
 
 //#define debug_print_score_matrices
 

--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -7,6 +7,7 @@
 
 #include "banded_global_aligner.hpp"
 #include "json2pb.h"
+#include "algorithms/find_tips.hpp"
 
 //#define debug_banded_aligner_objects
 //#define debug_banded_aligner_graph_processing

--- a/src/cactus.cpp
+++ b/src/cactus.cpp
@@ -1,7 +1,7 @@
 #include <unordered_set>
 #include "cactus.hpp"
 #include "vg.hpp"
-#include "algorithms/topological_sort.hpp"
+#include "algorithms/find_tips.hpp"
 #include "algorithms/weakly_connected_components.hpp"
 #include "algorithms/strongly_connected_components.hpp"
 #include "algorithms/find_shortest_paths.hpp"
@@ -321,26 +321,19 @@ pair<stCactusGraph*, stList*> handle_graph_to_cactus(const PathHandleGraph& grap
         }
     }
        
-    // Then we find the heads and tails
-    auto all_heads = algorithms::head_nodes(&graph);
-    auto all_tails = algorithms::tail_nodes(&graph);
+    // Then we find all the tips, inward-facing
+    auto all_tips = algorithms::find_tips(&graph);
     
 #ifdef debug
-    cerr << "Found " << all_heads.size() << " heads and " << all_tails.size() << " tails in graph" << endl;
+    cerr << "Found " << all_tips.size() << " tips in graph" << endl;
 #endif
     
-    // Alot them to components. We store tips in an inward-facing direction
+    // Allot them to components. We store tips in an inward-facing direction
     vector<unordered_set<handle_t>> component_tips(weak_components.size());
-    for (auto& head : all_heads) {
-        component_tips[node_to_component[graph.get_id(head)]].insert(head);
+    for (auto& tip : all_tips) {
+        component_tips[node_to_component[graph.get_id(tip)]].insert(tip);
 #ifdef debug
-        cerr << "Found head " << graph.get_id(head) << " in component " << node_to_component[graph.get_id(head)] << endl;
-#endif
-    }
-    for (auto& tail : all_tails) {
-        component_tips[node_to_component[graph.get_id(tail)]].insert(graph.flip(tail));
-#ifdef debug
-        cerr << "Found tail " << graph.get_id(tail) << " in component " << node_to_component[graph.get_id(tail)] << endl;
+        cerr << "Found tip " << graph.get_id(tip) << (graph.get_is_reverse(tip) ? '-' : '+') << " in component " << node_to_component[graph.get_id(tip)] << endl;
 #endif
     }
     

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -9,10 +9,8 @@
 
 #include "snarls.hpp"
 #include "json2pb.h"
-#include "algorithms/topological_sort.hpp"
+#include "algorithms/find_tips.hpp"
 #include "algorithms/is_acyclic.hpp"
-// TODO: This is where the head and tail finding algorithms live
-#include "algorithms/topological_sort.hpp"
 #include "algorithms/weakly_connected_components.hpp"
 #include "subgraph_overlay.hpp"
 
@@ -203,14 +201,32 @@ SnarlManager HandleGraphSnarlFinder::find_snarls_unindexed() {
 #ifdef debug
         cerr << "Connectivity: " << connected_start_start << " " << connected_end_end << " " << connected_start_end << endl;
 #endif
+
+        /////
+        // Determine tip presence
+        /////
+        
+        // Make a net graph that just pretends child snarls/chains are ordinary nodes
+        NetGraph flat_net_graph(snarl.start(), snarl.end(), managed_child_chains, graph);
+        
+        // Having internal tips in the net graph disqualifies a snarl from being an ultrabubble
+        auto tips = algorithms::find_tips(&flat_net_graph);
+
+#ifdef debug
+        cerr << "Tips: " << endl;
+        for (auto& tip : tips) {
+            cerr << "\t" << flat_net_graph.get_id(tip) << (flat_net_graph.get_is_reverse(tip) ? '-' : '+') << endl;
+        }
+#endif
+
+        // We should have at least the bounding nodes.
+        assert(tips.size() >= 2);
+        bool has_internal_tips = (tips.size() > 2); 
         
         /////
         // Determine cyclicity/acyclicity
         /////
     
-        // Make a net graph that just pretends child snarls/chains are ordinary nodes
-        NetGraph flat_net_graph(snarl.start(), snarl.end(), managed_child_chains, graph);
-        
         // This definitely should be calculated based on the internal-connectivity-ignoring net graph.
         snarl.set_directed_acyclic_net_graph(algorithms::is_directed_acyclic(&flat_net_graph));
 
@@ -254,13 +270,18 @@ SnarlManager HandleGraphSnarlFinder::find_snarls_unindexed() {
                 }
             }
             
-            // Note that ultrabubbles *can* loop back on their start or end.
-            
             if (!all_ultrabubble_children) {
                 // If we have non-ultrabubble children, we can't be an ultrabubble.
                 snarl.set_type(UNCLASSIFIED);
 #ifdef debug
                 cerr << "Snarl is UNCLASSIFIED because it has non-ultrabubble children" << endl;
+#endif
+            } else if (has_internal_tips) {
+                // If we have internal tips, we can't be an ultrabubble
+                snarl.set_type(UNCLASSIFIED);
+                
+#ifdef debug
+                cerr << "Snarl is UNCLASSIFIED because it contains internal tips" << endl;
 #endif
             } else if (!snarl.directed_acyclic_net_graph()) {
                 // If all our children are ultrabubbles but we ourselves are cyclic, we can't be an ultrabubble

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -11,6 +11,8 @@
 #include "json2pb.h"
 #include "algorithms/topological_sort.hpp"
 #include "algorithms/is_acyclic.hpp"
+// TODO: This is where the head and tail finding algorithms live
+#include "algorithms/topological_sort.hpp"
 #include "algorithms/weakly_connected_components.hpp"
 #include "subgraph_overlay.hpp"
 

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -17,6 +17,7 @@
 #include "subcommand.hpp"
 #include "../algorithms/distance_to_head.hpp"
 #include "../algorithms/distance_to_tail.hpp"
+#include "../algorithms/find_tips.hpp"
 #include "../algorithms/is_acyclic.hpp"
 #include "../algorithms/strongly_connected_components.hpp"
 #include "../algorithms/weakly_connected_components.hpp"

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -950,6 +950,13 @@ TEST_CASE("IntegratedSnarlFinder sees tips as disqualifying ultrabubbles", "[gen
     
     // The snarl shouldn't be an ultrabubble because it has tips.
     REQUIRE(snarl->type() == UNCLASSIFIED);
+    
+    // Grab some other trivial snarl
+    const Snarl snarl2 = manager.into_which_snarl(1, false);
+    
+    // Make sure it is still an ultrabubble
+    REQUIRE(snarl2 != nullptr);
+    REQUIRE(snarl2->type() == ULTRABUBBLE);
 }
 
 TEST_CASE("CactusSnarlFinder throws an error instead of crashing when the graph has no edges", "[genotype][cactus-snarl-finder]") {

--- a/src/unittest/genotypekit.cpp
+++ b/src/unittest/genotypekit.cpp
@@ -952,7 +952,7 @@ TEST_CASE("IntegratedSnarlFinder sees tips as disqualifying ultrabubbles", "[gen
     REQUIRE(snarl->type() == UNCLASSIFIED);
     
     // Grab some other trivial snarl
-    const Snarl snarl2 = manager.into_which_snarl(1, false);
+    const Snarl* snarl2 = manager.into_which_snarl(1, false);
     
     // Make sure it is still an ultrabubble
     REQUIRE(snarl2 != nullptr);


### PR DESCRIPTION
This fixes #2792 by counting the tips in each net graph. If a net graph has more than the two bounding tips (i.e. it has internal tips), its snarl is disqualified from being an ultrabubble.

Only the IntegratedSnarlFinder can set up net graphs that have tips in them but are otherwise ultrabubble-like; the CactusSnarlFinder tries to make unary snarls to encapsulate the tips, which themselves disqualify the parent from being an ultrabubble.

As part of this, I've moved the tip-finding code around.