### PR TITLE
RNA simulation tune up

### DIFF
--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -167,6 +167,7 @@ public:
                  double insert_length_stdev = 50.0,
                  double error_multiplier = 1.0,
                  bool retry_on_Ns = true,
+                 bool sample_unsheared_paths = false,
                  size_t seed = 0);
     
     /// Sample an individual read and alignment
@@ -291,9 +292,6 @@ private:
     
     PathPositionHandleGraph& graph;
     
-    LRUCache<id_t, Node> node_cache;
-    LRUCache<id_t, vector<Edge> > edge_cache;
-    
     default_random_engine prng;
     vg::discrete_distribution<> path_sampler;
     vector<vg::uniform_int_distribution<size_t>> start_pos_samplers;
@@ -313,6 +311,7 @@ private:
     size_t seed;
     
     const bool retry_on_Ns;
+    const bool sample_unsheared_paths;
     
     /// Restrict reads to just these paths (path-only mode) if nonempty.
     vector<string> source_paths;

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -231,13 +231,16 @@ private:
     void sample_read_internal(Alignment& aln, size_t& offset, bool& is_reverse, pos_t& curr_pos,
                               const string& source_path);
     
+    /// Return the index of a path if using source_paths or else numeric_limits<size_t>::max()
+    size_t sample_path();
+    
     /// Sample an appropriate starting position according to the mode. Updates the arguments.
-    void sample_start_pos(size_t& offset, bool& is_reverse, pos_t& pos, string& source_path);
+    void sample_start_pos(const size_t& source_path_idx, size_t& offset, bool& is_reverse, pos_t& pos);
     
     /// Get a random position in the graph
     pos_t sample_start_graph_pos();
     /// Get a random position along the source path
-    tuple<size_t, bool, pos_t, string> sample_start_path_pos();
+    tuple<size_t, bool, pos_t> sample_start_path_pos(const size_t& source_path_idx);
     
     /// Get an unclashing read name
     string get_read_name();

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -104,6 +104,7 @@ void help_sim(char** argv) {
          << "    -p, --frag-len N            make paired end reads with given fragment length N" << endl
          << "    -v, --frag-std-dev FLOAT    use this standard deviation for fragment length estimation" << endl
          << "    -N, --allow-Ns              allow reads to be sampled from the graph with Ns in them" << endl
+         << "    -u, --unsheared             sample from unsheared fragments" << endl
          << "simulate from paths:" << endl
          << "    -P, --path PATH             simulate from this path (may repeat; cannot also give -T)" << endl
          << "    -A, --any-path              simulate from any path (overrides -P)" << endl
@@ -136,6 +137,7 @@ int main_sim(int argc, char** argv) {
     bool reads_may_contain_Ns = false;
     bool strip_bonuses = false;
     bool interleaved = false;
+    bool unsheared_fragments = false;
     double indel_prop = 0.0;
     double error_scale_factor = 1.0;
     string fastq_name;
@@ -179,6 +181,7 @@ int main_sim(int argc, char** argv) {
             {"align-out", no_argument, 0, 'a'},
             {"json-out", no_argument, 0, 'J'},
             {"allow-Ns", no_argument, 0, 'N'},
+            {"unsheared", no_argument, 0, 'u'},
             {"sub-rate", required_argument, 0, 'e'},
             {"indel-rate", required_argument, 0, 'i'},
             {"indel-err-prop", required_argument, 0, 'd'},
@@ -189,7 +192,7 @@ int main_sim(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hrl:n:s:e:i:fax:Jp:v:Nd:F:P:Am:g:T:H:S:I",
+        c = getopt_long (argc, argv, "hrl:n:s:e:i:fax:Jp:v:Nud:F:P:Am:g:T:H:S:I",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -296,6 +299,10 @@ int main_sim(int argc, char** argv) {
 
         case 'N':
             reads_may_contain_Ns = true;
+            break;
+                
+        case 'u':
+            unsheared_fragments = true;
             break;
 
         case 'p':
@@ -624,6 +631,7 @@ int main_sim(int argc, char** argv) {
                              fragment_std_dev ? fragment_std_dev : 0.000001, // eliminates errors from having 0 as stddev without substantial difference
                              error_scale_factor,
                              !reads_may_contain_Ns,
+                             unsheared_fragments,
                              seed_val);
         
         if (fragment_length) {


### PR DESCRIPTION
Adds an option `-u` to vg sim, which you can use to indicate that you want to simulate from full-length unsheared paths (up to the read length). This option is intended to get around some edge cases for very short fragments from miRNA that the original simulation algorithm didn't handle well. I also found a bug in how I was using TPM, which is also fixed in this PR.

@jonassibbesen If you feel like it's important, I can also revamp the simulation algorithm to handle the issue we discussed about the bias introduced by restarting at the end of a transcript. That will be a more substantial PR though.