### PR TITLE
WIP: Better SV breakpoint detection in augmented graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ vg pack -x x.xg -g aln.gam -Q 5 -o aln.pack
 vg call x.xg -k aln.pack > graph_calls.vcf
 ```
 
-In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -A`), and specify the `-a` option to `vg call` to let it know that the graph has been augmented with the reads:
+In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -A`):
 
 ```sh
 # Index our augmented graph
@@ -257,8 +257,8 @@ vg index aug.vg -x aug.xg
 # Compute the read support from the augmented gam (with ignoring qualitiy < 5)
 vg pack -x aug.xg -g aug.gam -Q 5 -o aln_aug.pack
 
-# Generate a VCF from the support using the augmented graph.
-vg call aug.xg -k aln_aug.pack -a > calls.vcf
+# Generate a VCF from the support
+vg call aug.xg -k aln_aug.pack > calls.vcf
 ```
 
 A similar process can by used to *genotype* known variants from a VCF. To do this, the graph must be constructed from the VCF with `vg construct -a`:

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ vg pack -x x.xg -g aln.gam -Q 5 -o aln.pack
 vg call x.xg -k aln.pack > graph_calls.vcf
 ```
 
-In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -A`):
+In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -A`), and specify the `-a` option to `vg call` to let it know that the graph has been augmented with the reads:
 
 ```sh
 # Index our augmented graph
@@ -257,8 +257,8 @@ vg index aug.vg -x aug.xg
 # Compute the read support from the augmented gam (with ignoring qualitiy < 5)
 vg pack -x aug.xg -g aug.gam -Q 5 -o aln_aug.pack
 
-# Generate a VCF from the support
-vg call aug.xg -k aln_aug.pack > calls.vcf
+# Generate a VCF from the support using the augmented graph.
+vg call aug.xg -k aln_aug.pack -a > calls.vcf
 ```
 
 A similar process can by used to *genotype* known variants from a VCF. To do this, the graph must be constructed from the VCF with `vg construct -a`:

--- a/src/algorithms/k_widest_paths.cpp
+++ b/src/algorithms/k_widest_paths.cpp
@@ -180,10 +180,11 @@ static bool edge_support_filter(const HandleGraph* g, const edge_t& edge,
     if (start_meets_threshold) {
         // if the edge fails the support check, see if there are any other edges from the
         // end node that pass it
-        g->follow_edges(edge.second, true, [&] (handle_t next) {
-                if (next != edge.first) {
-                    min_end_weight = std::min(node_weight_callback(edge.second), node_weight_callback(next));
-                    end_meets_threshold = edge_weight_callback(g->edge_handle(next, edge.second)) >=
+        handle_t fs = g->flip(edge.second); // going left too confusing
+        g->follow_edges(fs, false, [&] (handle_t next) {
+                if (next != g->flip(edge.first)) {
+                    min_end_weight = std::min(node_weight_callback(fs), node_weight_callback(next));
+                    end_meets_threshold = edge_weight_callback(g->edge_handle(fs, next)) >=
                         min_edge_weight_ratio * min_end_weight;
                 }
                 return !end_meets_threshold;

--- a/src/algorithms/k_widest_paths.cpp
+++ b/src/algorithms/k_widest_paths.cpp
@@ -310,7 +310,7 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
                     }
                     total_path.first = total_length > 0 ? total_support / total_length : 0;
                 }                    
-                pair<map<vector<handle_t>, size_t>::iterator, bool> ins = B.insert(make_pair(total_path.second, i + 1));
+                pair<map<vector<handle_t>, size_t>::iterator, bool> ins = B.insert(make_pair(total_path.second, i));
                 if (ins.second == true) {
                     score_to_B.insert(make_pair(total_path.first, ins.first));
                 } // todo: is there any reason we'd need to update the score of an existing entry in B?

--- a/src/algorithms/k_widest_paths.hpp
+++ b/src/algorithms/k_widest_paths.hpp
@@ -37,7 +37,10 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
                                                            size_t K,
                                                            function<double(const handle_t&)> node_weight_callback,
                                                            function<double(const edge_t&)> edge_weight_callback,
-                                                           bool greedy_avg = false);
+                                                           bool greedy_avg = false,
+                                                           // use to ignore edges with
+                                                           // weight < min_edge_weight_ratio * (min weight of endpoint nodes)
+                                                           double min_edge_weight_ratio = 0.);
 
 }
 }

--- a/src/snarl_caller.cpp
+++ b/src/snarl_caller.cpp
@@ -724,7 +724,6 @@ double PoissonSupportSnarlCaller::genotype_likelihood(const vector<int>& genotyp
     }
 
     if (insertion) {
-        cerr << "insertion bias makes other oerror go from " << other_error_rate << " to " << (other_error_rate * insertion_bias) << endl;
         other_error_rate *= insertion_bias;
     }
 

--- a/src/snarl_caller.hpp
+++ b/src/snarl_caller.hpp
@@ -197,6 +197,10 @@ public:
     PoissonSupportSnarlCaller(const PathHandleGraph& graph, SnarlManager& snarl_manager,
                               TraversalSupportFinder& support_finder,
                               const algorithms::BinnedDepthIndex& depth_index,
+                              double baseline_error_small,
+                              double baseline_error_large,
+                              double insertion_bias,
+                              double insertion_size_factor,
                               bool use_mapq);
     virtual ~PoissonSupportSnarlCaller();
 
@@ -207,6 +211,7 @@ public:
         double expected_depth;
         double depth_err;
         int max_trav_size;
+        int endpoints_length;
     };
 
     /// Set some parameters
@@ -245,7 +250,7 @@ protected:
                                const vector<int>& traversal_sizes,
                                const vector<double>& traversal_mapqs,
                                int ref_trav_idx, double exp_depth, double depth_err,
-                               int max_trav_size);
+                               int max_trav_size, int endpoints_length);
 
     /// Rank supports
     vector<int> rank_by_support(const vector<Support>& supports);
@@ -256,18 +261,23 @@ protected:
     /// get added to these baselines when computing the scores. 
     
     /// Baseline error rate for larger variants
-    double  baseline_error_large = 0.001;
+    double baseline_error_large;
     /// Baseline error rate for smaller variants
-    double  baseline_error_small = 0.005;
+    double baseline_error_small;
+
+    /// Insertions have more chance of non-allele reads, as they need to cover a smaller area
+    /// We compensate in the model with this
+    double insertion_bias;
+
+    /// In order to test if an allele is an insertion, we check if it's this much bigger than
+    /// the reference path
+    double insertion_size_factor;
 
     /// Consider up to the top-k traversals (based on support) for genotyping
     size_t top_k = 20;
     /// Consider up to the tom-m secondary traversals (based on support) for each top traversal
     /// (so at most top_k * top_m considered)
     size_t top_m = 100;
-
-    /// padding to apply wrt to longest traversal to snarl ranges when looking up binned depth
-    double depth_padding_factor = 1.;
     
     /// Map path name to <mean, std_err> of depth coverage from the packer
     const algorithms::BinnedDepthIndex& depth_index;

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3310,12 +3310,14 @@ pair<step_handle_t, bool> VCFTraversalFinder::step_in_path(handle_t handle, path
 FlowTraversalFinder::FlowTraversalFinder(const HandleGraph& graph, SnarlManager& snarl_manager,
                                          size_t K,
                                          function<double(handle_t)> node_weight_callback,
-                                         function<double(edge_t)> edge_weight_callback) :
+                                         function<double(edge_t)> edge_weight_callback,
+                                         double min_edge_weight_ratio) :
     graph(graph),
     snarl_manager(snarl_manager),
     K(K),
     node_weight_callback(node_weight_callback),
-    edge_weight_callback(edge_weight_callback)  {
+    edge_weight_callback(edge_weight_callback),
+    min_edge_weight_ratio(min_edge_weight_ratio) {
     
 }
 
@@ -3335,7 +3337,8 @@ pair<vector<SnarlTraversal>, vector<double>> FlowTraversalFinder::find_weighted_
     vector<pair<double, vector<handle_t>>> widest_paths = algorithms::yens_k_widest_paths(&graph, start_handle, end_handle, K,
                                                                                           node_weight_callback,
                                                                                           edge_weight_callback,
-                                                                                          greedy_avg);
+                                                                                          greedy_avg,
+                                                                                          min_edge_weight_ratio);
 
     vector<SnarlTraversal> travs;
     travs.reserve(widest_paths.size());

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -584,6 +584,9 @@ protected:
     /// Callbacks to get supports
     function<double(handle_t)> node_weight_callback;
     function<double(edge_t)> edge_weight_callback;
+
+    /// Heuristic for ignoring poorly supported edges connecting well-supported nodes
+    double min_edge_weight_ratio;
     
 public:
     
@@ -591,7 +594,8 @@ public:
     FlowTraversalFinder(const HandleGraph& graph, SnarlManager& snarl_manager,
                         size_t K,
                         function<double(handle_t)> node_weight_callback,
-                        function<double(edge_t)> edge_weight_callback);
+                        function<double(edge_t)> edge_weight_callback,
+                        double min_edge_weight_ratio = 0.);
 
     /**
      * Return the K widest (most flow) traversals through the site


### PR DESCRIPTION
There's usually a bit of wobble between the SV breakpoints in the graph and the SV breakpoints in the reads.  `vg call` accounts for this somewhat by averaging out support across longer traversals (instead of taking the minimum).

But if the graph has been augmented by the reads before calling, there's no excuse for this -- the exact breakpoints should be in the graph.  This adds the `-a` option for `vg call` to dissuade it from taking low-support edges in augmented graphs.   It helps considerably on some small simulated examples I've looked at so far, but needs further testing. 