### PR TITLE
Reduce information copying on multipath alignments

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1743,25 +1743,12 @@ namespace vg {
     void transfer_read_metadata(const Alignment& from, multipath_alignment_t& to) {
         to.set_sequence(from.sequence());
         to.set_quality(from.quality());
-        to.set_read_group(from.read_group());
-        to.set_name(from.name());
-        to.set_sample_name(from.sample_name());
-        
-        // no difference in these fields for multipath_alignment_ts
-        if (from.has_fragment_prev()) {
-            to.set_paired_read_name(from.fragment_prev().name());
-        }
-        else if (from.has_fragment_next()) {
-            to.set_paired_read_name(from.fragment_next().name());
-        }
-        
         transfer_from_proto_annotation(from, to);
     }
     
     void transfer_read_metadata(const multipath_alignment_t& from, Alignment& to) {
         to.set_sequence(from.sequence());
         to.set_quality(from.quality());
-        
         transfer_to_proto_annotation(from, to);
     }
 

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1442,10 +1442,6 @@ namespace vg {
         rev_comp_out.set_quality(string(multipath_aln.quality().rbegin(), multipath_aln.quality().rend()));
         
         // transfer the rest of the metadata directly
-        rev_comp_out.set_read_group(multipath_aln.read_group());
-        rev_comp_out.set_name(multipath_aln.name());
-        rev_comp_out.set_sample_name(multipath_aln.sample_name());
-        rev_comp_out.set_paired_read_name(multipath_aln.paired_read_name());
         rev_comp_out.set_mapping_quality(multipath_aln.mapping_quality());
         
         vector< vector<size_t> > reverse_edge_lists(multipath_aln.subpath_size());
@@ -1711,30 +1707,18 @@ namespace vg {
     void transfer_read_metadata(const MultipathAlignment& from, multipath_alignment_t& to) {
         to.set_sequence(from.sequence());
         to.set_quality(from.quality());
-        to.set_read_group(from.read_group());
-        to.set_name(from.name());
-        to.set_sample_name(from.sample_name());
-        to.set_paired_read_name(from.paired_read_name());
         transfer_from_proto_annotation(from, to);
     }
 
     void transfer_read_metadata(const multipath_alignment_t& from, MultipathAlignment& to) {
         to.set_sequence(from.sequence());
         to.set_quality(from.quality());
-        to.set_read_group(from.read_group());
-        to.set_name(from.name());
-        to.set_sample_name(from.sample_name());
-        to.set_paired_read_name(from.paired_read_name());
         transfer_to_proto_annotation(from, to);
     }
     
     void transfer_read_metadata(const multipath_alignment_t& from, multipath_alignment_t& to) {
         to.set_sequence(from.sequence());
         to.set_quality(from.quality());
-        to.set_read_group(from.read_group());
-        to.set_name(from.name());
-        to.set_sample_name(from.sample_name());
-        to.set_paired_read_name(from.paired_read_name());
         from.for_each_annotation([&](const string& anno_name, multipath_alignment_t::anno_type_t type, const void* value) {
             switch (type) {
                 case multipath_alignment_t::Null:
@@ -1777,12 +1761,6 @@ namespace vg {
     void transfer_read_metadata(const multipath_alignment_t& from, Alignment& to) {
         to.set_sequence(from.sequence());
         to.set_quality(from.quality());
-        to.set_read_group(from.read_group());
-        to.set_name(from.name());
-        to.set_sample_name(from.sample_name());
-        
-        // note: not transferring paired_read_name because it is unclear whether
-        // it should go into fragment_prev or fragment_next
         
         transfer_to_proto_annotation(from, to);
     }
@@ -1790,6 +1768,8 @@ namespace vg {
     void transfer_read_metadata(const Alignment& from, Alignment& to) {
         to.set_sequence(from.sequence());
         to.set_quality(from.quality());
+        // TODO: do I still care about these fields now that they're taken out
+        // of multipath_alignment_t?
         to.set_read_group(from.read_group());
         to.set_name(from.name());
         to.set_sample_name(from.sample_name());
@@ -2239,7 +2219,7 @@ namespace vg {
                     for (size_t j = 0; j < edit.from_length(); j++, node_idx++, seq_idx++) {
                         if ((mapping.position().is_reverse() ? rev_node_seq[node_idx] : node_seq[node_idx]) != subseq[seq_idx]) {
 #ifdef debug_verbose_validation
-                            cerr << "validation failure on match that does not match for read " << multipath_aln.name() << endl;
+                            cerr << "validation failure on match that does not match" << endl;
                             cerr << "Node sequence: " << node_seq << " orientation: "
                                 << mapping.position().is_reverse() << " offset: " << node_idx << endl;
                             cerr << "Read subsequence: " << subseq << " offset: " << seq_idx << endl;
@@ -2502,7 +2482,7 @@ namespace vg {
     }
 
     string debug_string(const multipath_alignment_t& multipath_aln) {
-        string to_return = "{name: " + multipath_aln.name() + ", seq: " + multipath_aln.sequence();
+        string to_return = "{seq: " + multipath_aln.sequence();
         if (!multipath_aln.quality().empty()) {
             to_return += ", qual: " + string_quality_short_to_char(multipath_aln.quality());
         }

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -71,15 +71,6 @@ namespace vg {
         inline const string& quality() const;
         inline string* mutable_quality();
         inline void set_quality(const string& q);
-        inline const string& name() const;
-        inline string* mutable_name();
-        inline void set_name(const string& n);
-        inline const string& sample_name() const;
-        inline string* mutable_sample_name();
-        inline void set_sample_name(const string& n);
-        inline const string& read_group() const;
-        inline string* mutable_read_group();
-        inline void set_read_group(const string& g);
         inline const vector<subpath_t>& subpath() const;
         inline const subpath_t& subpath(size_t i) const;
         inline vector<subpath_t>* mutable_subpath();
@@ -97,9 +88,6 @@ namespace vg {
         inline void clear_start();
         inline size_t start_size() const;
         inline bool has_start() const;
-        inline const string& paired_read_name() const;
-        inline string* mutable_paired_read_name();
-        inline void set_paired_read_name(const string& n);
         
         // annotation interface
         // TODO: add List and Struct from https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/struct.proto
@@ -114,13 +102,9 @@ namespace vg {
     private:
         string _sequence;
         string _quality;
-        string _name;
-        string _sample_name;
-        string _read_group;
         vector<subpath_t> _subpath;
         int32_t _mapping_quality;
         vector<uint32_t> _start;
-        string _paired_read_name;
         map<string, pair<anno_type_t, void*>> _annotation;
     };
 
@@ -396,33 +380,6 @@ namespace vg {
     inline void multipath_alignment_t::set_quality(const string& q) {
         _quality = q;
     }
-    inline const string& multipath_alignment_t::name() const {
-        return _name;
-    }
-    inline string* multipath_alignment_t::mutable_name() {
-        return &_name;
-    }
-    inline void multipath_alignment_t::set_name(const string& n) {
-        _name = n;
-    }
-    inline const string& multipath_alignment_t::sample_name() const {
-        return _sample_name;
-    }
-    inline string* multipath_alignment_t::mutable_sample_name() {
-        return &_sample_name;
-    }
-    inline void multipath_alignment_t::set_sample_name(const string& n) {
-        _sample_name = n;
-    }
-    inline const string& multipath_alignment_t::read_group() const {
-        return _read_group;
-    }
-    inline string* multipath_alignment_t::mutable_read_group() {
-        return &_read_group;
-    }
-    inline void multipath_alignment_t::set_read_group(const string& g) {
-        _read_group = g;
-    }
     inline const vector<subpath_t>& multipath_alignment_t::subpath() const {
         return _subpath;
     }
@@ -474,15 +431,6 @@ namespace vg {
     }
     inline bool multipath_alignment_t::has_start() const {
         return !_start.empty();
-    }
-    inline const string& multipath_alignment_t::paired_read_name() const {
-        return _paired_read_name;
-    }
-    inline string* multipath_alignment_t::mutable_paired_read_name() {
-        return &_paired_read_name;
-    }
-    inline void multipath_alignment_t::set_paired_read_name(const string& n) {
-        _paired_read_name = n;
     }
 }
 

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -185,5 +185,7 @@ void MultipathAlignmentEmitter::convert_multipath_alignment(const multipath_alig
     if (next_name) {
         aln.mutable_fragment_next()->set_name(*next_name);
     }
+    // at one point vg call needed these, maybe it doesn't anymore though
+    aln.set_identity(identity(aln.path()));
 }
 }

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -45,15 +45,39 @@ MultipathAlignmentEmitter::~MultipathAlignmentEmitter() {
     }
 }
 
-void MultipathAlignmentEmitter::emit_pairs(vector<pair<multipath_alignment_t, multipath_alignment_t>>&& mp_aln_pairs) {
+void MultipathAlignmentEmitter::set_read_group(const string& read_group) {
+    this->read_group = read_group;
+}
+
+void MultipathAlignmentEmitter::set_sample_name(const string& sample_name) {
+    this->sample_name = sample_name;
+}
+
+void MultipathAlignmentEmitter::emit_pairs(const string& name_1, const string& name_2,
+                                           vector<pair<multipath_alignment_t, multipath_alignment_t>>&& mp_aln_pairs) {
     
     int thread_number = omp_get_thread_num();
     
     if (!mp_aln_emitters.empty()) {
         vector<MultipathAlignment> mp_alns_out(2 * mp_aln_pairs.size());
         for (size_t i = 0; i < mp_aln_pairs.size(); ++i) {
-            to_proto_multipath_alignment(mp_aln_pairs[i].first, mp_alns_out[2 * i]);
-            to_proto_multipath_alignment(mp_aln_pairs[i].second, mp_alns_out[2 * i + 1]);
+            MultipathAlignment& mp_aln_out_1 = mp_alns_out[2 * i];
+            MultipathAlignment& mp_aln_out_2 = mp_alns_out[2 * i + 1];
+            to_proto_multipath_alignment(mp_aln_pairs[i].first, mp_aln_out_1);
+            to_proto_multipath_alignment(mp_aln_pairs[i].second, mp_aln_out_2);
+            mp_aln_out_1.set_name(name_1);
+            mp_aln_out_2.set_name(name_2);
+            mp_aln_out_1.set_paired_read_name(name_2);
+            mp_aln_out_2.set_paired_read_name(name_1);
+            if (!sample_name.empty()) {
+                mp_aln_out_1.set_sample_name(sample_name);
+                mp_aln_out_2.set_sample_name(sample_name);
+            }
+            if (!read_group.empty()) {
+                mp_aln_out_1.set_read_group(read_group);
+                mp_aln_out_2.set_read_group(read_group);
+            }
+            
         }
         
         mp_aln_emitters[thread_number]->write_many(std::move(mp_alns_out));
@@ -68,12 +92,24 @@ void MultipathAlignmentEmitter::emit_pairs(vector<pair<multipath_alignment_t, mu
     else {
         vector<Alignment> alns_out(2 * mp_aln_pairs.size());
         for (size_t i = 0; i < mp_aln_pairs.size(); ++i) {
-            convert_multipath_alignment(mp_aln_pairs[i].first, alns_out[2 * i],
+            Alignment& aln_out_1 = alns_out[2 * i];
+            Alignment& aln_out_2 = alns_out[2 * i + 1];
+            convert_multipath_alignment(mp_aln_pairs[i].first, aln_out_1,
                                         nullptr,
-                                        &mp_aln_pairs[i].second);
-            convert_multipath_alignment(mp_aln_pairs[i].second, alns_out[2 * i + 1],
-                                        &mp_aln_pairs[i].first,
+                                        &name_2);
+            convert_multipath_alignment(mp_aln_pairs[i].second, aln_out_2,
+                                        &name_1,
                                         nullptr);
+            aln_out_1.set_name(name_1);
+            aln_out_2.set_name(name_2);
+            if (!sample_name.empty()) {
+                aln_out_1.set_sample_name(sample_name);
+                aln_out_2.set_sample_name(sample_name);
+            }
+            if (!read_group.empty()) {
+                aln_out_1.set_read_group(read_group);
+                aln_out_2.set_read_group(read_group);
+            }
         }
         
         aln_emitters[thread_number]->write_many(std::move(alns_out));
@@ -87,14 +123,22 @@ void MultipathAlignmentEmitter::emit_pairs(vector<pair<multipath_alignment_t, mu
     }
 }
 
-void MultipathAlignmentEmitter::emit_singles(vector<multipath_alignment_t>&& mp_alns) {
+void MultipathAlignmentEmitter::emit_singles(const string& name, vector<multipath_alignment_t>&& mp_alns) {
     
     int thread_number = omp_get_thread_num();
     
     if (!mp_aln_emitters.empty()) {
         vector<MultipathAlignment> mp_alns_out(mp_alns.size());
         for (size_t i = 0; i < mp_alns.size(); ++i) {
-            to_proto_multipath_alignment(mp_alns[i], mp_alns_out[i]);
+            MultipathAlignment& mp_aln_out = mp_alns_out[i];
+            to_proto_multipath_alignment(mp_alns[i], mp_aln_out);
+            mp_aln_out.set_name(name);
+            if (!sample_name.empty()) {
+                mp_aln_out.set_sample_name(sample_name);
+            }
+            if (!read_group.empty()) {
+                mp_aln_out.set_read_group(read_group);
+            }
         }
         
         mp_aln_emitters[thread_number]->write_many(std::move(mp_alns_out));
@@ -109,7 +153,15 @@ void MultipathAlignmentEmitter::emit_singles(vector<multipath_alignment_t>&& mp_
     else {
         vector<Alignment> alns_out(mp_alns.size());
         for (size_t i = 0; i < mp_alns.size(); ++i) {
-            convert_multipath_alignment(mp_alns[i], alns_out[i]);
+            Alignment& aln_out = alns_out[i];
+            convert_multipath_alignment(mp_alns[i], aln_out);
+            aln_out.set_name(name);
+            if (!sample_name.empty()) {
+                aln_out.set_sample_name(sample_name);
+            }
+            if (!read_group.empty()) {
+                aln_out.set_read_group(read_group);
+            }
         }
         
         aln_emitters[thread_number]->write_many(std::move(alns_out));
@@ -124,16 +176,14 @@ void MultipathAlignmentEmitter::emit_singles(vector<multipath_alignment_t>&& mp_
 }
 
 void MultipathAlignmentEmitter::convert_multipath_alignment(const multipath_alignment_t& mp_aln, Alignment& aln,
-                                                            const multipath_alignment_t* prev_frag,
-                                                            const multipath_alignment_t* next_frag) const {
+                                                            const string* prev_name,
+                                                            const string* next_name) const {
     optimal_alignment(mp_aln, aln);
-    if (prev_frag) {
-        aln.mutable_fragment_prev()->set_name(prev_frag->name());
+    if (prev_name) {
+        aln.mutable_fragment_prev()->set_name(*prev_name);
     }
-    if (next_frag) {
-        aln.mutable_fragment_next()->set_name(next_frag->name());
+    if (next_name) {
+        aln.mutable_fragment_next()->set_name(*next_name);
     }
-    // at one point vg call needed these, maybe it doesn't anymore though
-    aln.set_identity(identity(aln.path()));
 }
 }

--- a/src/multipath_alignment_emitter.hpp
+++ b/src/multipath_alignment_emitter.hpp
@@ -31,17 +31,24 @@ public:
     MultipathAlignmentEmitter(ostream& out, int num_threads, bool emit_single_path = false);
     ~MultipathAlignmentEmitter();
     
+    /// Choose a read group to apply to all emitted alignments
+    void set_read_group(const string& read_group);
+    
+    /// Choose a sample name to apply to all emitted alignments
+    void set_sample_name(const string& sample_name);
+    
     /// Emit paired read mappings as interleaved protobuf messages
-    void emit_pairs(vector<pair<multipath_alignment_t, multipath_alignment_t>>&& mp_aln_pairs);
+    void emit_pairs(const string& name_1, const string& name_2,
+                    vector<pair<multipath_alignment_t, multipath_alignment_t>>&& mp_aln_pairs);
     
     /// Emit read mappings as protobuf messages
-    void emit_singles(vector<multipath_alignment_t>&& mp_alns);
+    void emit_singles(const string& name, vector<multipath_alignment_t>&& mp_alns);
     
 private:
     
     void convert_multipath_alignment(const multipath_alignment_t& mp_aln, Alignment& aln,
-                                     const multipath_alignment_t* prev_frag = nullptr,
-                                     const multipath_alignment_t* next_frag = nullptr) const;
+                                     const string* prev_name = nullptr,
+                                     const string* next_name = nullptr) const;
     
     /// the stream that everything is emitted into
     ostream& out;
@@ -54,6 +61,12 @@ private:
     
     /// a MultipathAlignment emitter for each thread
     vector<unique_ptr<vg::io::ProtobufEmitter<MultipathAlignment>>> mp_aln_emitters;
+    
+    /// read group applied to alignments
+    string read_group;
+    
+    /// sample name applied to alignments
+    string sample_name;
     
 };
 

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -485,9 +485,6 @@ namespace vg {
 #endif
                     
                     multipath_aln_pairs_out.emplace_back(move(multipath_aln_1), move(multipath_aln_2));
-                    multipath_aln_pairs_out.front().first.set_paired_read_name(multipath_aln_pairs_out.front().second.name());
-                    multipath_aln_pairs_out.front().second.set_paired_read_name(multipath_aln_pairs_out.front().first.name());
-                    
                     fragment_length_distr.register_fragment_length(fragment_length);
                     
                     is_ambiguous = false;
@@ -1841,10 +1838,6 @@ namespace vg {
         string distribution = "-I " + to_string(fragment_length_distr.mean()) + " -D " + to_string(fragment_length_distr.stdev());
         
         for (pair<multipath_alignment_t, multipath_alignment_t>& multipath_aln_pair : multipath_aln_pairs_out) {
-            // add pair names to connect the paired reads
-            multipath_aln_pair.first.set_paired_read_name(multipath_aln_pair.second.name());
-            multipath_aln_pair.second.set_paired_read_name(multipath_aln_pair.first.name());
-            
             // Annotate with paired end distribution
             multipath_aln_pair.first.set_annotation("fragment_length_distribution", distribution);
             multipath_aln_pair.second.set_annotation("fragment_length_distribution", distribution);

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1714,16 +1714,17 @@ int main_mpmap(int argc, char** argv) {
         mp_alns_1.resize(min(mp_alns_1.size(), mp_alns_2.size()));
         mp_alns_2.resize(min(mp_alns_1.size(), mp_alns_2.size()));
         
-        // combine into a single vector
-        vector<multipath_alignment_t> mp_alns_combined;
-        mp_alns_combined.reserve(mp_alns_1.size() + mp_alns_2.size());
-        for (size_t i = 0; i < mp_alns_1.size(); ++i) {
-            mp_alns_combined.emplace_back(std::move(mp_alns_1[i]));
-            mp_alns_combined.emplace_back(std::move(mp_alns_2[i]));
-        }
-        
         if (!no_output) {
-            emitter->emit_singles(move(mp_alns_combined));
+            // interface expects vectors, but we'll be doing one at a time
+            vector<multipath_alignment_t> buffer;
+            for (size_t i = 0; i < mp_alns_1.size(); ++i) {
+                buffer.emplace_back(move(mp_alns_1[i]));
+                emitter->emit_singles(alignment_1.name(), move(buffer));
+                buffer.clear();
+                buffer.emplace_back(move(mp_alns_2[i]));
+                emitter->emit_singles(alignment_2.name(), move(buffer));
+                buffer.clear();
+            }
         }
         
         if (watchdog) {

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1554,6 +1554,8 @@ int main_mpmap(int argc, char** argv) {
     
     // init a writer for the output
     MultipathAlignmentEmitter* emitter = new MultipathAlignmentEmitter(cout, thread_count, single_path_alignment_mode);
+    emitter->set_read_group(read_group);
+    emitter->set_sample_name(sample_name);
     
     // a buffer to hold read pairs that can't be unambiguously mapped before the fragment length distribution
     // is estimated
@@ -1588,7 +1590,7 @@ int main_mpmap(int argc, char** argv) {
         }
         
         if (!no_output) {
-            emitter->emit_singles(move(mp_alns));
+            emitter->emit_singles(alignment.name(), move(mp_alns));
         }
         
         if (watchdog) {
@@ -1654,7 +1656,7 @@ int main_mpmap(int argc, char** argv) {
         }
         
         if (!no_output) {
-            emitter->emit_pairs(move(mp_aln_pairs));
+            emitter->emit_pairs(alignment_1.name(), alignment_2.name(), move(mp_aln_pairs));
         }
         
         if (watchdog) {

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -762,13 +762,19 @@ using namespace std;
         Alignment surjected;
         optimal_alignment(mp_aln, surjected, allow_negative_scores);
         
-        // transfer applicable metadata
+        // transfer applicable metadata (including data that doesn't transit through multipath_alignment_t)
+        surjected.set_name(source.name());
+        surjected.set_read_group(source.read_group());
+        surjected.set_sample_name(source.sample_name());
         surjected.set_mapping_quality(source.mapping_quality());
         if (source.has_fragment_next()) {
             *surjected.mutable_fragment_next() = source.fragment_next();
         }
         if (source.has_fragment_prev()) {
             *surjected.mutable_fragment_prev() = source.fragment_prev();
+        }
+        if (source.has_annotation()) {
+            *surjected.mutable_annotation() = source.annotation();
         }
         
 #ifdef debug_anchored_surject


### PR DESCRIPTION
This strips down some of the information copying so that it only occurs at serialization time.