### PR TITLE
Incorrect assert in sim and mpmap preset fix

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -1591,7 +1591,6 @@ pair<string, vector<bool>> NGSSimulator::sample_read_quality_internal(pair<uint8
 }
                                               
 void NGSSimulator::apply_N_mask(string& sequence, const vector<bool>& n_mask) {
-    assert(sequence.size() == n_mask.size() || sample_unsheared_paths);
     for (size_t i = 0; i < sequence.size(); i++) {
         if (n_mask[i]) {
             sequence[i] = 'N';

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -725,7 +725,7 @@ int main_mpmap(int argc, char** argv) {
     else if (read_length == "Very-Short" || read_length == "Very-short" || read_length == "VERY-SHORT") {
         read_length = "very-short";
     }
-    else if (read_length != "Short" || read_length != "SHORT") {
+    else if (read_length == "Short" || read_length == "SHORT") {
         read_length = "short";
     }
     


### PR DESCRIPTION
Fixes an outdated assert statement in vg sim and a preset bug in mpmap. This PR only contains these fixes and not the long-read developments as in #2838.