### PR TITLE
Fix missing metadata for multipath alignments

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1770,6 +1770,28 @@ namespace vg {
             *to.mutable_annotation() = from.annotation();
         }
     }
+
+    void transfer_proto_metadata(const Alignment& from, MultipathAlignment& to) {
+        // transfer over the fields that are included only in the protobuf object
+        to.set_name(from.name());
+        to.set_read_group(from.read_group());
+        to.set_sample_name(from.sample_name());
+        if (from.has_fragment_prev()) {
+            to.set_paired_read_name(from.fragment_prev().name());
+        }
+        else if (from.has_fragment_next()) {
+            to.set_paired_read_name(from.fragment_next().name());
+        }
+    }
+
+    void transfer_proto_metadata(const MultipathAlignment& from, Alignment& to) {
+        // transfer over the fields that are included only in the protobuf object
+        to.set_name(from.name());
+        to.set_read_group(from.read_group());
+        to.set_sample_name(from.sample_name());
+        
+        // not doing paired name because need extra logic to decide if it's prev or next
+    }
     
     void merge_non_branching_subpaths(multipath_alignment_t& multipath_aln) {
         vector<size_t> in_degree(multipath_aln.subpath_size(), 0);

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -278,10 +278,13 @@ namespace vg {
     ///
     void transfer_read_metadata(const Alignment& from, Alignment& to);
 
-
     void transfer_read_metadata(const MultipathAlignment& from, multipath_alignment_t& to);
 
     void transfer_read_metadata(const multipath_alignment_t& from, MultipathAlignment& to);
+
+    void transfer_proto_metadata(const Alignment& from, MultipathAlignment& to);
+
+    void transfer_proto_metadata(const MultipathAlignment& from, Alignment& to);
 
     /// Merges non-branching paths in a multipath alignment in place
     void merge_non_branching_subpaths(multipath_alignment_t& multipath_aln);

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -671,15 +671,19 @@ namespace vg {
     }
     
     bool MultipathMapper::likely_mismapping(const multipath_alignment_t& multipath_aln) {
-    
-        // empirically, we get better results by scaling the pseudo-length down, I have no good explanation for this probabilistically
-        auto p_val = random_match_p_value(pseudo_length(multipath_aln), multipath_aln.sequence().size());
-    
+        if (!suppress_mismapping_detection) {
+            // empirically, we get better results by scaling the pseudo-length down, I have no good explanation for this probabilistically
+            auto p_val = random_match_p_value(pseudo_length(multipath_aln), multipath_aln.sequence().size());
+            
 #ifdef debug_multipath_mapper
-        cerr << "effective match length of read " << multipath_aln.name() << " is " << pseudo_length(multipath_aln) << " in read length " << multipath_aln.sequence().size() << ", yielding p-value " << p_val << endl;
+            cerr << "effective match length of read " << multipath_aln.name() << " is " << pseudo_length(multipath_aln) << " in read length " << multipath_aln.sequence().size() << ", yielding p-value " << p_val << endl;
 #endif
-        
-        return p_val > max_mapping_p_value;
+            
+            return p_val > max_mapping_p_value;
+        }
+        else {
+            return false;
+        }
     }
     
     size_t MultipathMapper::pseudo_length(const multipath_alignment_t& multipath_aln) const {

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -178,6 +178,7 @@ namespace vg {
         bool suppress_p_value_memoization = false;
         size_t fragment_length_warning_factor = 0;
         size_t max_alignment_gap = 5000;
+        bool suppress_mismapping_detection = false;
         
         //static size_t PRUNE_COUNTER;
         //static size_t SUBGRAPH_TOTAL;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -230,6 +230,7 @@ int main_mpmap(int argc, char** argv) {
     double frag_length_mean = NAN;
     double frag_length_stddev = NAN;
     bool same_strand = false;
+    bool suppress_mismapping_detection = false;
     bool auto_calibrate_mismapping_detection = true;
     double max_mapping_p_value = 0.00001;
     size_t num_calibration_simulations = 100;
@@ -769,6 +770,8 @@ int main_mpmap(int argc, char** argv) {
         no_clustering = true;
         // we don't want to throw away short matches a priori in very short data
         min_clustering_mem_length = 1;
+        // we don't want to automatically distrust short mappings
+        suppress_mismapping_detection = true;
     }
     else if (read_length != "short") {
         // short is the default
@@ -1426,6 +1429,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.precollapse_order_length_hits = precollapse_order_length_hits;
     multipath_mapper.max_sub_mem_recursion_depth = max_sub_mem_recursion_depth;
     multipath_mapper.max_mapping_p_value = max_mapping_p_value;
+    multipath_mapper.suppress_mismapping_detection = suppress_mismapping_detection;
     if (min_clustering_mem_length) {
         multipath_mapper.min_clustering_mem_length = min_clustering_mem_length;
     }

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -117,6 +117,7 @@ int main_view(int argc, char** argv) {
     // and json-gam -> gam
     //     json-pileup -> pileup
 
+    bool which_read_in_pair = true;
     string output_type;
     string input_type;
     string rdf_base_uri;
@@ -569,6 +570,7 @@ int main_view(int argc, char** argv) {
                     to_multipath_alignment(aln, mp_aln);
                     buf.emplace_back();
                     to_proto_multipath_alignment(mp_aln, buf.back());
+                    transfer_proto_metadata(aln, buf.back());
                     vg::io::write_buffered(cout, buf, 1000);
                 };
                 get_input_file(file_name, [&](istream& in) {
@@ -594,6 +596,7 @@ int main_view(int argc, char** argv) {
                     to_multipath_alignment(aln, mp_aln);
                     buf.emplace_back();
                     to_proto_multipath_alignment(mp_aln, buf.back());
+                    transfer_proto_metadata(aln, buf.back());
                     vg::io::write_buffered(std::cout, buf, 1000);
                 }
                 vg::io::write_buffered(cout, buf, 0);
@@ -649,6 +652,17 @@ int main_view(int argc, char** argv) {
                     from_proto_multipath_alignment(proto_mp_aln, mp_aln);
                     buf.emplace_back();
                     optimal_alignment(mp_aln, buf.back());
+                    transfer_proto_metadata(proto_mp_aln, buf.back());
+                    if (!proto_mp_aln.paired_read_name().empty()) {
+                        // alternate using next/prev
+                        if (which_read_in_pair) {
+                            buf.back().mutable_fragment_next()->set_name(proto_mp_aln.paired_read_name());
+                        }
+                        else {
+                            buf.back().mutable_fragment_prev()->set_name(proto_mp_aln.paired_read_name());
+                        }
+                    }
+                    which_read_in_pair = !which_read_in_pair;
                     vg::io::write_buffered(std::cout, buf, 1000);
                 }
                 vg::io::write_buffered(cout, buf, 0);
@@ -696,6 +710,7 @@ int main_view(int argc, char** argv) {
                     from_proto_multipath_alignment(proto_mp_aln, mp_aln);
                     buf.emplace_back();
                     optimal_alignment(mp_aln, buf.back());
+                    transfer_proto_metadata(proto_mp_aln, buf.back());
                     vg::io::write_buffered(cout, buf, 1000);
                 };
                 get_input_file(file_name, [&](istream& in) {


### PR DESCRIPTION
Multipath alignments no longer lose their name when being converted to GAM, and the `very-short` read length preset turns off mpmap's mismapping detection, which is too aggressive for reads of this size.