### PR TITLE
Update to latest toil-vg

### DIFF
--- a/vgci/vgci.sh
+++ b/vgci/vgci.sh
@@ -30,11 +30,11 @@ KEEP_INTERMEDIATE_FILES=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@d097d913352d07418b5ec7743a2527f57c3e30b6"
+TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@1206fd5215defbef46ef3ede5ba51895aa5abfd1"
 # What toil should we install?
 # Could be something like "toil[aws,mesos]==3.20.0"
 # or "git+https://github.com/adamnovak/toil.git@2b696bec34fa1381afdcf187456571d2b41f3842#egg=toil[aws,mesos]"
-TOIL_PACKAGE="toil[aws,mesos]==3.20.0"
+TOIL_PACKAGE="toil[aws,mesos]==3.24.0"
 # What tests should we run?
 # Should be something like "vgci/vgci.py::VGCITest::test_sim_brca2_snp1kg_mpmap"
 # Must have the Python file in it or Pytest can't find the tests.


### PR DESCRIPTION
I'm hoping this will fix the error logging in #2845, where a python 3 conversion bug is preventing the currently used toil-vg from capturing stderr. 