### PR TITLE
Better Giraffe rescue

### DIFF
--- a/src/dozeu_interface.cpp
+++ b/src/dozeu_interface.cpp
@@ -94,7 +94,7 @@ DozeuInterface::graph_pos_s DozeuInterface::calculate_seed_position(const Ordere
     graph_pos_s pos;
     
     // get node index
-	pos.node_index = graph.index_of.at(graph.graph.get_handle(gcsa::Node::id(seed_pos)));
+	pos.node_index = graph.index_of.at(graph.graph.get_handle(gcsa::Node::id(seed_pos), gcsa::Node::rc(seed_pos)));
     
 	// calc ref_offset
 	pos.ref_offset = direction ? (graph.graph.get_length(graph.order[pos.node_index]) - gcsa::Node::offset(seed_pos))
@@ -638,7 +638,7 @@ void DozeuInterface::align(Alignment& alignment, const HandleGraph& graph, const
         
         // we need seed to build edge table (for semi-global extension)
 		graph_pos_s seed_pos = calculate_seed_position(ordered_graph, mems, query_seq.size(), direction);
- 
+
         const char* pack_seq = direction ? query_seq.c_str() : query_seq.c_str() + seed_pos.query_offset;
         const uint8_t* pack_qual = nullptr;
         if (!alignment.quality().empty()) {

--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -16,7 +16,7 @@ constexpr size_t GaplessExtender::MAX_MISMATCHES;
 
 //------------------------------------------------------------------------------
 
-bool GaplessExtension::contains(const gbwtgraph::GBWTGraph& graph, seed_type seed) const {
+bool GaplessExtension::contains(const HandleGraph& graph, seed_type seed) const {
     handle_t expected_handle = GaplessExtender::get_handle(seed);
     size_t expected_node_offset = GaplessExtender::get_node_offset(seed);
     size_t expected_read_offset = GaplessExtender::get_read_offset(seed);
@@ -36,7 +36,7 @@ bool GaplessExtension::contains(const gbwtgraph::GBWTGraph& graph, seed_type see
     return false;
 }
 
-Position GaplessExtension::starting_position(const gbwtgraph::GBWTGraph& graph) const {
+Position GaplessExtension::starting_position(const HandleGraph& graph) const {
     Position position;
     if (this->empty()) {
         return position;
@@ -49,7 +49,7 @@ Position GaplessExtension::starting_position(const gbwtgraph::GBWTGraph& graph) 
     return position;
 }
 
-Position GaplessExtension::tail_position(const gbwtgraph::GBWTGraph& graph) const {
+Position GaplessExtension::tail_position(const HandleGraph& graph) const {
     Position position;
     if (this->empty()) {
         return position;
@@ -62,7 +62,7 @@ Position GaplessExtension::tail_position(const gbwtgraph::GBWTGraph& graph) cons
     return position;
 }
 
-size_t GaplessExtension::tail_offset(const gbwtgraph::GBWTGraph& graph) const {
+size_t GaplessExtension::tail_offset(const HandleGraph& graph) const {
     size_t result = this->offset + this->length();
     for (size_t i = 0; i + 1 < this->path.size(); i++) {
         result -= graph.get_length(this->path[i]);
@@ -70,7 +70,7 @@ size_t GaplessExtension::tail_offset(const gbwtgraph::GBWTGraph& graph) const {
     return result;
 }
 
-Path GaplessExtension::to_path(const gbwtgraph::GBWTGraph& graph, const std::string& sequence) const {
+Path GaplessExtension::to_path(const HandleGraph& graph, const std::string& sequence) const {
 
     Path result;
 
@@ -266,7 +266,7 @@ void remove_duplicates(std::vector<GaplessExtension>& result) {
 }
 
 // Realign the extensions to find the mismatching positions.
-void find_mismatches(const std::string& seq, const gbwtgraph::GBWTGraph& graph, std::vector<GaplessExtension>& result) {
+void find_mismatches(const std::string& seq, const gbwtgraph::CachedGBWTGraph& graph, std::vector<GaplessExtension>& result) {
     for (GaplessExtension& extension : result) {
         if (extension.internal_score == 0) {
             continue;
@@ -325,7 +325,7 @@ std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, con
     }
 
     // Allocate a GBWT record cache.
-    gbwt::CachedGBWT cache = this->graph->get_cache();
+    gbwtgraph::CachedGBWTGraph cache(*(this->graph));
 
     // Find either the best extension for each seed or the best two full-length alignments
     // for the entire cluster. The second-best full-length alignment has full_length_mismatches
@@ -338,7 +338,7 @@ std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, con
 
         // Check if the seed is contained in an exact full-length alignment.
         if (full_length_found && best_alignment.internal_score == 0) {
-            if (best_alignment.contains(*(this->graph), seed)) {
+            if (best_alignment.contains(cache, seed)) {
                 continue;
             }
         }
@@ -357,12 +357,12 @@ std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, con
             size_t read_offset = get_read_offset(seed);
             size_t node_offset = get_node_offset(seed);
             GaplessExtension match {
-                { seed.first }, node_offset, this->graph->get_bd_state(cache, seed.first),
+                { seed.first }, node_offset, cache.get_bd_state(seed.first),
                 { read_offset, read_offset }, { },
                 static_cast<int32_t>(0), false, false,
                 false, false, static_cast<uint32_t>(0), static_cast<uint32_t>(0)
             };
-            match_initial(match, sequence, this->graph->get_sequence_view(seed.first));
+            match_initial(match, sequence, cache.get_sequence_view(seed.first));
             if (match.internal_score >= full_length_mismatches) {
                 continue;
             }
@@ -395,7 +395,7 @@ std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, con
                     static_cast<uint32_t>(max_mismatches + 1),
                     static_cast<uint32_t>(max_mismatches / 2 + curr.old_score + 1));
                 mismatch_limit = std::min(mismatch_limit, full_length_mismatches);
-                this->graph->follow_paths(cache, curr.state, false, [&](const gbwt::BidirectionalState& next_state) -> bool {
+                cache.follow_paths(curr.state, false, [&](const gbwt::BidirectionalState& next_state) -> bool {
                     handle_t handle = gbwtgraph::GBWTGraph::node_to_handle(next_state.forward.node);
                     GaplessExtension next {
                         { }, curr.offset, next_state,
@@ -403,7 +403,7 @@ std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, con
                         curr.score, curr.left_full, curr.right_full,
                         curr.left_maximal, curr.right_maximal, curr.internal_score, curr.old_score
                     };
-                    size_t node_offset = match_forward(next, sequence, this->graph->get_sequence_view(handle), mismatch_limit);
+                    size_t node_offset = match_forward(next, sequence, cache.get_sequence_view(handle), mismatch_limit);
                     if (node_offset == 0) { // Did not match anything.
                         return true;
                     }
@@ -413,7 +413,7 @@ std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, con
                         next.right_full = true;
                         next.right_maximal = true;
                         next.old_score = next.internal_score;
-                    } else if (node_offset < this->graph->get_length(handle)) {
+                    } else if (node_offset < cache.get_length(handle)) {
                         next.right_maximal = true;
                         next.old_score = next.internal_score;
                     }
@@ -438,16 +438,16 @@ std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, con
                     static_cast<uint32_t>(max_mismatches + 1),
                     static_cast<uint32_t>(max_mismatches / 2 + curr.old_score + 1));
                 mismatch_limit = std::min(mismatch_limit, full_length_mismatches);
-                this->graph->follow_paths(cache, curr.state, true, [&](const gbwt::BidirectionalState& next_state) -> bool {
+                cache.follow_paths(curr.state, true, [&](const gbwt::BidirectionalState& next_state) -> bool {
                     handle_t handle = gbwtgraph::GBWTGraph::node_to_handle(gbwt::Node::reverse(next_state.backward.node));
-                    size_t node_length = this->graph->get_length(handle);
+                    size_t node_length = cache.get_length(handle);
                     GaplessExtension next {
                         { }, node_length, next_state,
                         curr.read_interval, { },
                         curr.score, curr.left_full, curr.right_full,
                         curr.left_maximal, curr.right_maximal, curr.internal_score, curr.old_score
                     };
-                    match_backward(next, sequence, this->graph->get_sequence_view(handle), mismatch_limit);
+                    match_backward(next, sequence, cache.get_sequence_view(handle), mismatch_limit);
                     if (next.offset >= node_length) { // Did not match anything.
                         return true;
                     }
@@ -516,7 +516,7 @@ std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, con
     // If we have a full-length alignment with sufficiently few mismatches, we do
     // not trim it.
     remove_duplicates(result);
-    find_mismatches(sequence, *(this->graph), result);
+    find_mismatches(sequence, cache, result);
     if (trim_extensions) {
         this->trim(result, max_mismatches, &cache);
     }
@@ -528,7 +528,7 @@ std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, con
 
 // Trim mismatches from the extension to maximize the score. Returns true if the
 // extension was trimmed.
-bool trim_mismatches(GaplessExtension& extension, const gbwtgraph::GBWTGraph& graph, const gbwt::CachedGBWT& cache, const Aligner& aligner) {
+bool trim_mismatches(GaplessExtension& extension, const gbwtgraph::CachedGBWTGraph& graph, const Aligner& aligner) {
 
     if (extension.exact()) {
         return false;
@@ -621,7 +621,7 @@ bool trim_mismatches(GaplessExtension& extension, const gbwtgraph::GBWTGraph& gr
     }
     if (head > 0 || tail < extension.path.size()) {
         in_place_subvector(extension.path, head, tail);
-        extension.state = graph.bd_find(cache, extension.path);
+        extension.state = graph.bd_find(extension.path);
     }
 
     // Trim the mismatches.
@@ -638,18 +638,18 @@ bool trim_mismatches(GaplessExtension& extension, const gbwtgraph::GBWTGraph& gr
     return true;
 }
 
-void GaplessExtender::trim(std::vector<GaplessExtension>& extensions, size_t max_mismatches, const gbwt::CachedGBWT* cache) const {
+void GaplessExtender::trim(std::vector<GaplessExtension>& extensions, size_t max_mismatches, const gbwtgraph::CachedGBWTGraph* cache) const {
 
     // Allocate a cache if we were not provided with one.
     bool free_cache = (cache == nullptr);
     if (free_cache) {
-        cache = new gbwt::CachedGBWT(this->graph->get_cache());
+        cache = new gbwtgraph::CachedGBWTGraph(*(this->graph));
     }
 
     bool trimmed = false;
     for (GaplessExtension& extension : extensions) {
         if (!extension.full() || extension.mismatches() > max_mismatches) {
-            trimmed |= trim_mismatches(extension, *(this->graph), *cache, *(this->aligner));
+            trimmed |= trim_mismatches(extension, *cache, *(this->aligner));
         }
     }
     if (trimmed) {
@@ -691,18 +691,18 @@ void GaplessExtender::unfold_haplotypes(const SubHandleGraph& subgraph, std::vec
     // Find the nodes where paths start/end or enter/exit the subgraph. Extend these states
     // to the other direction. Checking for starts/enters would be enough if we are sure
     // that there are no weird orientation flips.
-    gbwt::CachedGBWT cache = this->graph->get_cache();
+    gbwtgraph::CachedGBWTGraph cache(*(this->graph));
     std::stack<std::pair<gbwt::BidirectionalState, std::vector<handle_t>>> states;
     subgraph.for_each_handle([&](const handle_t& handle) {
-        gbwt::BidirectionalState state = this->graph->get_bd_state(cache, handle);
+        gbwt::BidirectionalState state = cache.get_bd_state(handle);
         size_t forward_covered = 0, backward_covered = 0;
-        this->graph->follow_paths(cache, state, false, [&](const gbwt::BidirectionalState& next) -> bool {
+        cache.follow_paths(state, false, [&](const gbwt::BidirectionalState& next) -> bool {
             if (subgraph.has_node(gbwt::Node::id(next.forward.node))) {
                 forward_covered += next.size();
             }
             return true;
         });
-        this->graph->follow_paths(cache, state, true, [&](const gbwt::BidirectionalState& prev) -> bool {
+        cache.follow_paths(state, true, [&](const gbwt::BidirectionalState& prev) -> bool {
             if (subgraph.has_node(gbwt::Node::id(prev.backward.node))) {
                 backward_covered += prev.size();
             }
@@ -713,7 +713,7 @@ void GaplessExtender::unfold_haplotypes(const SubHandleGraph& subgraph, std::vec
             states.push(std::make_pair(state, path)); // Left-maximal.
         }
         if (forward_covered < state.size()) {
-            std::vector<handle_t> path = { this->graph->flip(handle) };
+            std::vector<handle_t> path = { cache.flip(handle) };
             state.flip();
             states.push(std::make_pair(state, path)); // Right-maximal.
         }
@@ -729,7 +729,7 @@ void GaplessExtender::unfold_haplotypes(const SubHandleGraph& subgraph, std::vec
         states.pop();
         bool found_extension = false;
         size_t covered_size = 0;
-        this->graph->follow_paths(cache, state, false, [&](const gbwt::BidirectionalState& next) -> bool {
+        cache.follow_paths(state, false, [&](const gbwt::BidirectionalState& next) -> bool {
             if (!subgraph.has_node(gbwt::Node::id(next.forward.node))) {
                 return true;
             }
@@ -745,12 +745,12 @@ void GaplessExtender::unfold_haplotypes(const SubHandleGraph& subgraph, std::vec
                 haplotype_paths.push_back(path);
                 size_t result_size = 0;
                 for (handle_t handle : path) {
-                    result_size += this->graph->get_length(handle);
+                    result_size += cache.get_length(handle);
                 }
                 std::string sequence;
                 sequence.reserve(result_size);
                 for (handle_t handle : path) {
-                    gbwtgraph::GBWTGraph::view_type view = this->graph->get_sequence_view(handle);
+                    gbwtgraph::GBWTGraph::view_type view = cache.get_sequence_view(handle);
                     sequence.insert(sequence.size(), view.first, view.second);
                 }
                 unfolded.create_handle(sequence, 2 * haplotype_paths.size() - 1);
@@ -847,8 +847,6 @@ void GaplessExtender::transform_alignment(Alignment& aln, const std::vector<std:
             break;
         }
     }
-
-    // FIXME tests
 
     *(aln.mutable_path()) = std::move(result);
 }

--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -320,7 +320,7 @@ std::vector<handle_t> get_path(gbwt::node_type reverse_first, const std::vector<
 std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, const std::string& sequence, const gbwtgraph::CachedGBWTGraph* cache, size_t max_mismatches, bool trim_extensions) const {
 
     std::vector<GaplessExtension> result;
-    if (this->graph == nullptr || this->aligner == nullptr || sequence.empty()) {
+    if (this->graph == nullptr || this->aligner == nullptr || cluster.empty() || sequence.empty()) {
         return result;
     }
 

--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -580,7 +580,7 @@ bool trim_mismatches(GaplessExtension& extension, const gbwtgraph::CachedGBWTGra
         }
 
         // Update the best interval.
-        if (current_score > best_score || (current_score == best_score && interval_length(current_interval) > interval_length(best_interval))) {
+        if (current_score > best_score || (current_score > 0 && current_score == best_score && interval_length(current_interval) > interval_length(best_interval))) {
             best_interval = current_interval;
             best_score = current_score;
         }

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -6,10 +6,9 @@
  */
 
 #include <functional>
+#include <unordered_set>
 
 #include "aligner.hpp"
-#include "hash_map.hpp"
-#include "subgraph.hpp"
 
 #include <bdsg/hash_graph.hpp>
 #include <gbwtgraph/cached_gbwtgraph.h>
@@ -157,9 +156,10 @@ public:
      * max_mismatches / 2 mismatches on each flank. Flanks may have more mismatches
      * if it does not bring the total beyond max_mismatches. Then call trim() if
      * trim_extensions i set.
+     * Use the provided CachedGBWTGraph or allocate a new one.
      * The extensions are sorted by their coordinates in the sequence.
      */
-    std::vector<GaplessExtension> extend(cluster_type& cluster, const std::string& sequence, size_t max_mismatches = MAX_MISMATCHES, bool trim_extensions = true) const;
+    std::vector<GaplessExtension> extend(cluster_type& cluster, const std::string& sequence, const gbwtgraph::CachedGBWTGraph* cache = nullptr, size_t max_mismatches = MAX_MISMATCHES, bool trim_extensions = true) const;
 
     /**
      * Try to improve the score of each extension by trimming mismatches from the flanks.
@@ -169,12 +169,13 @@ public:
      */
     void trim(std::vector<GaplessExtension>& extensions, size_t max_mismatches = MAX_MISMATCHES, const gbwtgraph::CachedGBWTGraph* cache = nullptr) const;
 
-   /**
-    * Find the distinct local haplotypes in the given subgraph and return the corresponding paths.
-    * For each path haplotype_paths[i], the output graph will contain node 2i + 1 with sequence
-    * corresponding to the path and node 2i + 2 with the reverse complement of the sequence.
-    */
-    void unfold_haplotypes(const SubHandleGraph& subgraph, std::vector<std::vector<handle_t>>& haplotype_paths,  bdsg::HashGraph& unfolded) const;
+    /**
+     * Find the distinct local haplotypes in the given subgraph and return the corresponding paths.
+     * For each path haplotype_paths[i], the output graph will contain node 2i + 1 with sequence
+     * corresponding to the path and node 2i + 2 with the reverse complement of the sequence.
+     * Use the provided CachedGBWTGraph or allocate a new one.
+     */
+    void unfold_haplotypes(const std::unordered_set<nid_t>& subgraph, std::vector<std::vector<handle_t>>& haplotype_paths,  bdsg::HashGraph& unfolded, const gbwtgraph::CachedGBWTGraph* cache = nullptr) const;
 
     /**
      * Transform an alignment to a single node in the unfold_haplotypes() graph to an

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -12,7 +12,7 @@
 #include "subgraph.hpp"
 
 #include <bdsg/hash_graph.hpp>
-#include <gbwtgraph/gbwtgraph.h>
+#include <gbwtgraph/cached_gbwtgraph.h>
 
 namespace vg {
 
@@ -67,19 +67,19 @@ struct GaplessExtension
     size_t mismatches() const { return this->mismatch_positions.size(); }
 
     /// Does the extension contain the seed?
-    bool contains(const gbwtgraph::GBWTGraph& graph, seed_type seed) const;
+    bool contains(const HandleGraph& graph, seed_type seed) const;
 
     /// Return the starting position of the extension.
-    Position starting_position(const gbwtgraph::GBWTGraph& graph) const;
+    Position starting_position(const HandleGraph& graph) const;
 
     /// Return the position after the extension.
-    Position tail_position(const gbwtgraph::GBWTGraph& graph) const;
+    Position tail_position(const HandleGraph& graph) const;
 
     /// Return the node offset after the extension.
-    size_t tail_offset(const gbwtgraph::GBWTGraph& graph) const;
+    size_t tail_offset(const HandleGraph& graph) const;
 
     /// Convert the extension into a Path.
-    Path to_path(const gbwtgraph::GBWTGraph& graph, const std::string& sequence) const;
+    Path to_path(const HandleGraph& graph, const std::string& sequence) const;
 
     /// For priority queues.
     bool operator<(const GaplessExtension& another) const {
@@ -164,10 +164,10 @@ public:
     /**
      * Try to improve the score of each extension by trimming mismatches from the flanks.
      * Do not trim full-length alignments with <= max_mismatches mismatches.
-     * Use the provided CachedGBWT or allocate a new one.
+     * Use the provided CachedGBWTGraph or allocate a new one.
      * Note that extend() already calls this by default.
      */
-    void trim(std::vector<GaplessExtension>& extensions, size_t max_mismatches = MAX_MISMATCHES, const gbwt::CachedGBWT* cache = nullptr) const;
+    void trim(std::vector<GaplessExtension>& extensions, size_t max_mismatches = MAX_MISMATCHES, const gbwtgraph::CachedGBWTGraph* cache = nullptr) const;
 
    /**
     * Find the distinct local haplotypes in the given subgraph and return the corresponding paths.

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -155,7 +155,7 @@ public:
      * of the seeds, allowing any number of mismatches in the seed node and
      * max_mismatches / 2 mismatches on each flank. Flanks may have more mismatches
      * if it does not bring the total beyond max_mismatches. Then call trim() if
-     * trim_extensions i set.
+     * trim_extensions is set.
      * Use the provided CachedGBWTGraph or allocate a new one.
      * The extensions are sorted by their coordinates in the sequence.
      */

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2224,7 +2224,7 @@ void MinimizerMapper::fix_dozeu_score(Alignment& rescued_alignment, const Handle
 
     const Aligner* aligner = this->get_regular_aligner();
     int32_t score = aligner->score_ungapped_alignment(rescued_alignment);
-    if (score >= 0) {
+    if (score > 0) {
         rescued_alignment.set_score(score);
     } else {
         rescued_alignment.clear_path();

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2153,16 +2153,10 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
     rescued_alignment.clear_path();
 
     if (this->rescue_algorithm == rescue_haplotypes) {
-        // FIXME Implement this using the subset of nodes.
-        SubHandleGraph sub_graph(&cached_graph);
-        for (id_t id : rescue_nodes)  {
-            sub_graph.add_handle(gbwt_graph.get_handle(id));
-        }
-
         // Find and unfold the local haplotypes in the subgraph.
         std::vector<std::vector<handle_t>> haplotype_paths;
         bdsg::HashGraph align_graph;
-        this->extender.unfold_haplotypes(sub_graph, haplotype_paths, align_graph);
+        this->extender.unfold_haplotypes(rescue_nodes, haplotype_paths, align_graph);
 
         // Align to the subgraph.
         this->get_regular_aligner()->align_xdrop(rescued_alignment, align_graph,

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2219,6 +2219,10 @@ GaplessExtender::cluster_type MinimizerMapper::seeds_in_subgraph(const std::vect
     GaplessExtender::cluster_type result;
     for (const Minimizer& minimizer : minimizers) {
         gbwtgraph::hits_in_subgraph(minimizer.hits, minimizer.occs, sorted_ids, [&](pos_t pos, gbwtgraph::payload_type) {
+            if (minimizer.value.is_reverse) {
+                size_t node_length = this->gbwt_graph.get_length(this->gbwt_graph.get_handle(id(pos)));
+                pos = reverse_base_pos(pos, node_length);
+            }
             result.insert(GaplessExtender::to_seed(pos, minimizer.value.offset));
         });
     }

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -37,7 +37,6 @@ MinimizerMapper::MinimizerMapper(const gbwtgraph::GBWTGraph& graph,
     extender(gbwt_graph, *(get_regular_aligner())), clusterer(distance_index),
     fragment_length_distr(1000,1000,0.95),
     phred_at_least_one() {
-        //TODO: Picked fragment_length_distr params from mpmap
 
     // Initialize phred_at_least_one.
     size_t max_k = 0, values = static_cast<size_t>(1) << PRECISION;
@@ -720,7 +719,6 @@ pair<vector<Alignment>, vector< Alignment>> MinimizerMapper::map_paired(Alignmen
     // Cluster the seeds. Get sets of input seed indexes that go together.
     // If the fragment length distribution hasn't been fixed yet (if the expected fragment length = 0),
     // then everything will be in the same cluster and the best pair will be the two best independent mappings
-    // TODO: Choose a good distance for the fragment distance limit.
     if (track_provenance) {
         funnels[0].stage("cluster");
         funnels[1].stage("cluster");

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -164,7 +164,7 @@ public:
      * When we use dozeu for rescue, the reported alignment score is incorrect.
      * 1) Dozeu only gives the full-length bonus once.
      * 2) There is no penalty for a softclip at the edge of the subgraph.
-     * This function calculates the score correctly. If the score is incorrect,
+     * This function calculates the score correctly. If the score is <= 0,
      * we realign the read using GSSW.
      * TODO: This should be unnecessary.
      */

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -270,11 +270,6 @@ protected:
     GaplessExtender::cluster_type seeds_in_subgraph(const std::vector<Minimizer>& minimizers, const std::unordered_set<id_t>& subgraph) const;
 
     /**
-     * Rescue with GSSW or dozeu if the subgraph contains cycles.
-     */
-    void rescue_with_cycles(Alignment& rescued_alignment, const gbwtgraph::CachedGBWTGraph& graph, const std::unordered_set<id_t>& rescue_nodes) const;
-
-    /**
      * When we use dozeu for rescue, the reported alignment score is incorrect.
      * 1) Dozeu only gives the full-length bonus once.
      * 2) There is no penalty for a softclip at the edge of the subgraph.

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -160,10 +160,6 @@ public:
         } 
     }
 
-    /**
-     * Get the distance between a pair of read alignments
-     */
-    int64_t distance_between(const Alignment& aln1, const Alignment& aln2);
 protected:
 
     /**
@@ -291,13 +287,29 @@ protected:
 
 //-----------------------------------------------------------------------------
 
-   /**
-    * Assume that we have n <= max_k independent random events that occur with
-    * probability p each (p is interpreted as a real number between 0 and 1 and
-    * max_k is the largest k in the minimizer indexes). Return an approximate
-    * probability for at least one event occurring as a phred score.
-    */
-   double phred_for_at_least_one(size_t p, size_t n) const;
+    // Helper functions.
+
+    /**
+     * Get the distance between a pair of read alignments
+     */
+    int64_t distance_between(const Alignment& aln1, const Alignment& aln2);
+
+    /**
+     * Assume that we have n <= max_k independent random events that occur with
+     * probability p each (p is interpreted as a real number between 0 and 1 and
+     * max_k is the largest k in the minimizer indexes). Return an approximate
+     * probability for at least one event occurring as a phred score.
+     */
+    double phred_for_at_least_one(size_t p, size_t n) const;
+
+    /**
+     * Convert the GaplessExtension into an alignment. This assumes that the
+     * extension is a full-length alignment and that the sequence field of the
+     * alignment has been set.
+     */
+    void extension_to_alignment(const GaplessExtension& extension, Alignment& alignment) const;
+
+//-----------------------------------------------------------------------------
 
     /**
      * Compute MAPQ caps based on all minimizers present in extended clusters.

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -373,7 +373,7 @@ int main_giraffe(int argc, char** argv) {
     // How many mappings per read can we emit?
     Range<size_t> max_multimaps = 1;
     // How many clusters should we extend?
-    Range<size_t> max_extensions = 1000;
+    Range<size_t> max_extensions = 800;
     // How many extended clusters should we align, max?
     Range<size_t> max_alignments = 8;
     //Throw away cluster with scores that are this amount below the best


### PR DESCRIPTION
New approach for rescue in Giraffe:

1. Get all seeds in the rescue subgraph.
2. Extend the seeds using GaplessExtender.
3. If the best extension is a full-length alignment, use it regardless of the rescue algorithm.
4. Otherwise if the algorithm is dozeu, use the best extension as a seed for dp.