### PR TITLE
Ploidy option for deconstruct

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -197,7 +197,7 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const vector<int>& trav
     
     // find the <ploidy> most frequent traversals
     vector<int> most_frequent_travs;
-    for (int i = sorted_travs.size() - 1; i >= 0; --i) {
+    for (int i = sorted_travs.size() - 1; i >= 0 && most_frequent_travs.size() < ploidy; --i) {
         most_frequent_travs.push_back(sorted_travs[i]);
     }
 

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -139,13 +139,17 @@ void Deconstructor::get_genotypes(vcflib::Variant& v, const vector<string>& name
         if (sample_to_traversals.count(sample_name)) {
             const vector<int>& travs = sample_to_traversals[sample_name];
             assert(!travs.empty());
-            int chosen_trav;
+            vector<int> chosen_travs;
             bool conflict;
-            std::tie(chosen_trav, conflict) = choose_traversal(travs, trav_to_allele, names);
+            std::tie(chosen_travs, conflict) = choose_traversals(travs, trav_to_allele, names);
             if (conflict) {
                 conflicts.insert(sample_name);
             }
-            v.samples[sample_name]["GT"] = {std::to_string(trav_to_allele[chosen_trav])};
+            string genotype = std::to_string(trav_to_allele[chosen_travs[0]]);
+            for (int i = 1; i < chosen_travs.size(); ++i) {
+                genotype += "/" + std::to_string(trav_to_allele[chosen_travs[i]]);
+            }
+            v.samples[sample_name]["GT"] = {genotype};
             if (path_to_sample) {
                 for (auto trav : travs) {
                     v.samples[sample_name]["PI"].push_back(names[trav] + "=" + std::to_string(trav_to_allele[trav]));
@@ -163,32 +167,45 @@ void Deconstructor::get_genotypes(vcflib::Variant& v, const vector<string>& name
     }
 }
 
-pair<int, bool> Deconstructor::choose_traversal(const vector<int>& travs, const vector<int>& trav_to_allele,
-                                                const vector<string>& trav_to_name) {
+pair<vector<int>, bool> Deconstructor::choose_traversals(const vector<int>& travs, const vector<int>& trav_to_allele,
+                                                         const vector<string>& trav_to_name) {
     assert(!travs.empty());
-    vector<int> frequencies(trav_to_allele.size(), 0);
+    // count the number of times each allele comes up in a traversal
+    vector<int> allele_frequencies(trav_to_allele.size(), 0);
     for (auto trav : travs) {
-        ++frequencies[trav];
+        ++allele_frequencies[trav_to_allele[trav]];
     }
-
-    int most_frequent = -1;
-    bool conflict = false;
-
-    for (auto trav: travs) {
-        if (most_frequent == -1 ||
+    // sort on frquency
+    function<bool(int, int)> comp = [&] (int trav1, int trav2) {
+        if (allele_frequencies[trav_to_allele[trav1]] < allele_frequencies[trav_to_allele[trav2]]) {
+            return true;
+        } else if (allele_frequencies[trav_to_allele[trav1]] == allele_frequencies[trav_to_allele[trav2]]) {
             // prefer non-ref when possible
-            (trav_to_allele[most_frequent] == 0 && trav_to_allele[trav] != 0) ||
-            // otherwise use frequency
-            (((trav_to_allele[most_frequent] == 0) == (trav_to_allele[trav] == 0)) &&
-             (frequencies[trav] > frequencies[most_frequent] ||
-              // break frequency tie using lex order on path name
-              (frequencies[trav] == frequencies[most_frequent] && trav_to_name[trav] < trav_to_name[most_frequent])))) {
-            most_frequent = trav;
+            if (trav_to_allele[trav1] == 0 && trav_to_allele[trav2] != 0) {
+                return true;
+            }
+            // or break tie using lex order on path name
+            else {
+                return trav_to_name[trav1] < trav_to_name[trav2];
+            }
+        } else {
+            return false;
         }
-        conflict = conflict || trav_to_allele[trav] != trav_to_allele[travs[0]];
+    };
+    vector<int> sorted_travs = travs;
+    std::sort(sorted_travs.begin(), sorted_travs.end());
+    
+    // find the <ploidy> most frequent traversals
+    vector<int> most_frequent_travs;
+    for (int i = sorted_travs.size() - 1; i >= 0; --i) {
+        most_frequent_travs.push_back(sorted_travs[i]);
     }
 
-    return make_pair(most_frequent, conflict);
+    // check if there's a conflict
+    size_t zero_count = std::count(allele_frequencies.begin(), allele_frequencies.end(), 0);
+    bool conflict = allele_frequencies.size() - zero_count > ploidy;
+
+    return make_pair(most_frequent_travs, conflict);
 }
     
 bool Deconstructor::deconstruct_site(const Snarl* snarl) {
@@ -329,6 +346,8 @@ bool Deconstructor::deconstruct_site(const Snarl* snarl) {
         first_path_pos += 1;
 
         v.position = first_path_pos;
+
+        v.id = std::to_string(snarl->start().node_id()) + "_" + std::to_string(snarl->end().node_id());
         
         // Convert the snarl traversals to strings and add them to the variant
         vector<int> trav_to_allele = get_alleles(v, path_travs.first, ref_trav_idx, prev_char, use_start);
@@ -353,12 +372,13 @@ bool Deconstructor::deconstruct_site(const Snarl* snarl) {
  * Convenience wrapper function for deconstruction of multiple paths.
  */
 void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHandleGraph* graph, SnarlManager* snarl_manager,
-                                bool path_restricted_traversals,
+                                bool path_restricted_traversals, int ploidy,
                                 const unordered_map<string, string>* path_to_sample) {
 
     this->graph = graph;
     this->snarl_manager = snarl_manager;
     this->path_restricted = path_restricted_traversals;
+    this->ploidy =ploidy;
     this->path_to_sample = path_to_sample;
     this->ref_paths = set<string>(ref_paths.begin(), ref_paths.end());
     assert(path_to_sample == nullptr || path_restricted);
@@ -369,8 +389,11 @@ void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHand
             string path_name = graph->get_path_name(path_handle);
             if (!this->ref_paths.count(path_name)) {
                 // rely on the given map.  if a path isn't in it, it'll be ignored
-                if (path_to_sample && path_to_sample->count(path_name)) {
-                    sample_names.insert(path_to_sample->find(path_name)->second);
+                if (path_to_sample) {
+                    if (path_to_sample->count(path_name)) {
+                        sample_names.insert(path_to_sample->find(path_name)->second);
+                    }
+                    // if we have the map, we only consider paths there-in
                 }
                 else {
                     // no name mapping, just use every path as is

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -32,7 +32,7 @@ public:
 
     // deconstruct the entire graph to cout
     void deconstruct(vector<string> refpaths, const PathPositionHandleGraph* grpah, SnarlManager* snarl_manager,
-                     bool path_restricted_traversals,
+                     bool path_restricted_traversals, int ploidy,
                      const unordered_map<string, string>* path_to_sample = nullptr); 
     
 private:
@@ -48,11 +48,11 @@ private:
     // write traversal path names as genotypes
     void get_genotypes(vcflib::Variant& v, const vector<string>& names, const vector<int>& trav_to_allele);
 
-    // given a set of traversals associated with a particular sample, select one for the VCF
+    // given a set of traversals associated with a particular sample, select a set of size <ploidy> for the VCF
     // the highest-frequency ALT traversal is chosen
-    // the bool returned is true if multiple traversals map to different alleles.
-    pair<int, bool> choose_traversal(const vector<int>& travs, const vector<int>& trav_to_allele,
-                                     const vector<string>& trav_to_name);
+    // the bool returned is true if multiple traversals map to different alleles, more than ploidy.
+    pair<vector<int>, bool> choose_traversals(const vector<int>& travs, const vector<int>& trav_to_allele,
+                                              const vector<string>& trav_to_name);
 
 
     // check to see if a snarl is too big to exhaustively traverse
@@ -67,6 +67,9 @@ private:
     
     // toggle between exhaustive and path restricted traversal finder
     bool path_restricted = false;
+
+    // the max ploidy we expect.
+    int ploidy;
 
     // the graph
     const PathPositionHandleGraph* graph;

--- a/src/gafkluge.hpp
+++ b/src/gafkluge.hpp
@@ -30,6 +30,12 @@ inline std::string int_to_string(int64_t i) {
 inline int64_t string_to_int(const std::string& s) {
     return s == missing_string ? missing_int : std::stol(s);
 }
+inline bool is_missing(const std::string& s) {
+    return s == missing_string;
+}
+inline bool is_missing(int64_t i) {
+    return i == missing_int;
+}
 
 /**
  * One step of a GAF path

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -112,7 +112,7 @@ protected:
 class GAFOutputCaller {
 public:
     /// The emitter object is created and owned by external forces
-    GAFOutputCaller(AlignmentEmitter* emitter);
+    GAFOutputCaller(AlignmentEmitter* emitter, const string& sample_name);
     virtual ~GAFOutputCaller();
 
     /// print the GAF traversals
@@ -126,6 +126,9 @@ public:
 protected:
     
     AlignmentEmitter* emitter;
+
+    /// Sample name
+    string gaf_sample_name;
 };
 
 /**

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -50,6 +50,7 @@ void help_augment(char** argv, ConfigurableParser& parser) {
          << "    -B, --label-paths           don't augment with alignments, just use them for labeling the graph" << endl
          << "    -Z, --translation FILE      save translations from augmented back to base graph to FILE" << endl
          << "    -A, --alignment-out FILE    save augmented GAM reads to FILE" << endl
+         << "    -F, --gaf                   expect GAF instead of GAFM" << endl
          << "    -s, --subgraph              graph is a subgraph of the one used to create GAM. ignore alignments with missing nodes" << endl
          << "    -m, --min-coverage N        minimum coverage of a breakpoint required for it to be added to the graph" << endl
          << "    -c, --expected-cov N        expected coverage.  used only for memory tuning [default : 128]" << endl
@@ -114,6 +115,9 @@ int main_augment(int argc, char** argv) {
     // Maximum fraction of Ns
     double max_frac_n = 0.25;
 
+    // GAF format toggle
+    string aln_format = "GAM";
+
     // Print some progress messages to screen
     bool show_progress = false;
 
@@ -136,6 +140,7 @@ int main_augment(int argc, char** argv) {
         {"min-baseq", required_argument, 0, 'q'},
         {"min-mapq", required_argument, 0, 'Q'},
         {"max-n", required_argument, 0, 'N'},
+        {"gaf", no_argument, 0, 'F'},
         {"help", no_argument, 0, 'h'},
         {"progress", required_argument, 0, 'p'},
         {"verbose", no_argument, 0, 'v'},
@@ -145,7 +150,7 @@ int main_augment(int argc, char** argv) {
         {"include-gt", required_argument, 0, 'L'},
         {0, 0, 0, 0}
     };
-    static const char* short_options = "a:Z:A:iCSBhpvt:l:L:sm:c:q:Q:N:";
+    static const char* short_options = "a:Z:A:iCSBhpvt:l:L:sm:c:q:Q:N:F";
     optind = 2; // force optind past command positional arguments
 
     // This is our command-line parser
@@ -193,6 +198,9 @@ int main_augment(int argc, char** argv) {
             break;
         case 'N':
             max_frac_n = parse<double>(optarg);
+            break;
+        case 'F':
+            aln_format = "GAF";
             break;
         case 'h':
         case '?':

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -27,13 +27,14 @@ void help_deconstruct(char** argv){
     cerr << "usage: " << argv[0] << " deconstruct [options] [-p|-P] <PATH> <GRAPH>" << endl
          << "Outputs VCF records for Snarls present in a graph (relative to a chosen reference path)." << endl
          << "options: " << endl
-         << "    -p, --path NAME        A reference path to deconstruct against (comma-separated list accepted)." << endl
-         << "    -P, --path-prefix NAME All paths beginning with NAME used as reference (comma-separated list accepted)." << endl
-         << "    -A, --alt-prefix NAME  Non-reference paths beginning with NAME get lumped together to same sample in VCF (comma-separated list accepted)." << endl
-         << "    -r, --snarls FILE      Snarls file (from vg snarls) to avoid recomputing." << endl
-         << "    -e, --path-traversals  Only consider traversals that correspond to paths in the grpah." << endl
-         << "    -t, --threads N        Use N threads" << endl
-         << "    -v, --verbose          Print some status messages" << endl
+         << "    -p, --path NAME          A reference path to deconstruct against (multiple allowed)." << endl
+         << "    -P, --path-prefix NAME   All paths beginning with NAME used as reference (multiple allowed)." << endl
+         << "    -A, --alt-prefix NAME    Non-reference paths beginning with NAME get lumped together to same sample in VCF (multiple allowed).  Other non-ref paths not considered as samples." << endl
+         << "    -r, --snarls FILE        Snarls file (from vg snarls) to avoid recomputing." << endl
+         << "    -e, --path-traversals    Only consider traversals that correspond to paths in the grpah." << endl
+         << "    -d, --ploidy N           Expected ploidy.  If more traversals found, they will be flagged as conflicts (default: 2)" << endl
+         << "    -t, --threads N          Use N threads" << endl
+         << "    -v, --verbose            Print some status messages" << endl
          << endl;
 }
 
@@ -50,6 +51,7 @@ int main_deconstruct(int argc, char** argv){
     string snarl_file_name;
     bool path_restricted_traversals = false;
     bool show_progress = false;
+    int ploidy = 2;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -62,6 +64,7 @@ int main_deconstruct(int argc, char** argv){
                 {"alt-prefix", required_argument, 0, 'A'},
                 {"snarls", required_argument, 0, 'r'},
                 {"path-traversals", no_argument, 0, 'e'},
+                {"ploidy", required_argument, 0, 'd'},                
                 {"threads", required_argument, 0, 't'},
                 {"verbose", no_argument, 0, 'v'},
                 {0, 0, 0, 0}
@@ -69,7 +72,7 @@ int main_deconstruct(int argc, char** argv){
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hp:P:A:r:et:v",
+        c = getopt_long (argc, argv, "hp:P:A:r:ed:t:v",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -79,20 +82,23 @@ int main_deconstruct(int argc, char** argv){
         switch (c)
         {
         case 'p':
-            refpaths = split(optarg, ",");
+            refpaths.push_back(optarg);
             break;
         case 'P':
-            refpath_prefixes = split(optarg, ",");
+            refpath_prefixes.push_back(optarg);
             break;
         case 'A':
-            altpath_prefixes = split(optarg, ",");
-            break;            
+            altpath_prefixes.push_back(optarg);
+            break;
         case 'r':
             snarl_file_name = optarg;
             break;
         case 'e':
             path_restricted_traversals = true;
             break;
+        case 'd':
+            ploidy = parse<int>(optarg);
+            break;            
         case 't':
             omp_set_num_threads(parse<int>(optarg));
             break;
@@ -118,7 +124,7 @@ int main_deconstruct(int argc, char** argv){
     if (!altpath_prefixes.empty() && !path_restricted_traversals) {
         cerr << "Error [vg decontruct]: -A can only be used with -e" << endl;
     }
-    
+
     // Read the graph
     unique_ptr<PathHandleGraph> path_handle_graph;
     get_input_file(optind, argc, argv, [&](istream& in) {
@@ -152,7 +158,7 @@ int main_deconstruct(int argc, char** argv){
     unordered_map<string, string> alt_path_to_prefix;
     
     // process the prefixes
-    if (!refpath_prefixes.empty()) {
+    if (!refpath_prefixes.empty() || !altpath_prefixes.empty()) {
         graph->for_each_path_handle([&](const path_handle_t& path_handle) {
                 string path_name = graph->get_path_name(path_handle);
                 bool is_ref = false;
@@ -189,7 +195,7 @@ int main_deconstruct(int argc, char** argv){
     if (show_progress) {
         cerr << "Decsontructing top-level snarls" << endl;
     }
-    dd.deconstruct(refpaths, graph, snarl_manager.get(), path_restricted_traversals,
+    dd.deconstruct(refpaths, graph, snarl_manager.get(), path_restricted_traversals, ploidy,
                    !alt_path_to_prefix.empty() ? &alt_path_to_prefix : nullptr);
     return 0;
 }

--- a/src/variant_recall.cpp
+++ b/src/variant_recall.cpp
@@ -78,7 +78,7 @@ void genotype_svs(VG* graph,
         Deconstructor decon;
         CactusSnarlFinder finder(xg_index);
         SnarlManager snarl_manager = finder.find_snarls();
-        decon.deconstruct({refpath}, &xg_index, &snarl_manager, false);
+        decon.deconstruct({refpath}, &xg_index, &snarl_manager, false, 1);
     }
     direct_ins.clear();
 

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -108,11 +108,11 @@ printf "P\talt2.3\t1+,2+,4+,6+,8+,9+,11+,12+,14+,15+\t8M,1M,1M,3M,1M,19M,1M,4M,1
 printf "P\talt2.3\t1+,2+,4+,6+,8+,9+,11+,12+,14+,15+\t8M,1M,1M,3M,1M,19M,1M,4M,1M,11M\n" >> tiny_names.gfa
 vg view -Fv tiny_names.gfa > tiny_names.vg
 vg index tiny_names.vg -x tiny_names.xg
-vg deconstruct tiny_names.xg -P ref -A alt1,alt2 -e | sort > tiny_names_decon.vcf
+vg deconstruct tiny_names.xg -P ref -A alt1 -A alt2 -e -d 1 | sort > tiny_names_decon.vcf
 is $(grep -v "#" tiny_names_decon.vcf | wc -l) 2 "-P -A options return correct number of variants"
 is $(grep -v "#" tiny_names_decon.vcf | grep ref.1 | wc -l) 2 "-P -A options use correct reference name"
 is $(grep -v "#" tiny_names_decon.vcf | grep ref.1 | grep 14 | grep "CONFLICT=alt1" | wc -l) 1 "-P -A identifies conflict in alt1 in second variant"
-vg deconstruct tiny_names.vg -P ref -A alt1,alt2 -e | sort > tiny_names_decon_vg.vcf
+vg deconstruct tiny_names.vg -P ref -A alt1 -A alt2 -e -d 1 | sort > tiny_names_decon_vg.vcf
 diff tiny_names_decon.vcf tiny_names_decon_vg.vcf
 is "$?" 0 "deconstructing vg graph gives same output as xg graph"
 


### PR DESCRIPTION
`vg deconstruct` was expecting one path per sample when doing genotypes with `-e`.  This generalizes it to any ploidy, and defaults it to 2.  In particular, it should enable this extremely convoluted genotyping pipeline:

Following up a [previous example](https://github.com/vgteam/vg/pull/2840#issuecomment-641991771)

```
aws s3 cp s3://vg-k8s/users/jmonlong/hsvlr_srdedup17_aug/gaffe_benchmark/hg38-hsvlr_srdedup17_aug.xg .
aws s3 cp s3://vg-k8s/users/jmonlong/hsvlr_srdedup17_aug/gaffe_benchmark/HG00514_49e05f2/HG00514-hg38-hsvlr_srdedup17_aug.gaffe39k15w16N.q5.pack .
vg snarls hg38-hsvlr_srdedup17_aug.xg > hg38-hsvlr_srdedup17_aug.snarls

# extract and index all candidate traversals
vg call hg38-hsvlr_srdedup17_aug.xg -k HG00514-hg38-hsvlr_srdedup17_aug.gaffe39k15w16N.q5.pack -r hg38-hsvlr_srdedup17_aug.snarls -p chr16 -s HG00514 -T | bgzip > travs.gaf.gz
vg index hg38-hsvlr_srdedup17_aug.xg -F travs.gaf.gz -G travs.gbwt

# genotype the traversals, outputting 2 per snarl
vg call hg38-hsvlr_srdedup17_aug.xg -k HG00514-hg38-hsvlr_srdedup17_aug.gaffe39k15w16N.q5.pack -r hg38-hsvlr_srdedup17_aug.snarls -p chr16 -s HG00514 -g travs.gbwt -G | bgzip > call.gaf.gz

# augment the graph with the traversals
vg convert hg38-hsvlr_srdedup17_aug.xg -p > hg38-hsvlr_srdedup17_aug.pg
# todo: gaf support in augment
vg convert hg38-hsvlr_srdedup17_aug.xg -F call.gaf.gz | vg augment hg38-hsvlr_srdedup17_aug.pg - -i > hg38-hsvlr_srdedup17_aug_aug.pg

# deconstruct the augmented paths into a VCF
vg deconstruct -p chr16 hg38-hsvlr_srdedup17_aug_aug.pg -A HG00514 -e  -r hg38-hsvlr_srdedup17_aug.snarls > decon.vcf
```