### PR TITLE
Option to pad traversals in call -T

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -793,7 +793,9 @@ void gaf_to_alignment(const HandleGraph& graph, const gafkluge::GafRecord& gaf, 
 
     aln.Clear();
 
-    aln.set_name(gaf.query_name);
+    if (!gafkluge::is_missing(gaf.query_name)) {
+        aln.set_name(gaf.query_name);
+    }
 
     for (size_t i = 0; i < gaf.path.size(); ++i) {
         const auto& gaf_step = gaf.path[i];

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -434,11 +434,11 @@ void VCFOutputCaller::flatten_common_allele_ends(vcflib::Variant& variant, bool 
 }
 
 GAFOutputCaller::GAFOutputCaller(AlignmentEmitter* emitter, const string& sample_name, const vector<string>& ref_paths,
-                                 size_t min_trav_len) :
+                                 size_t trav_padding) :
     emitter(emitter),
     gaf_sample_name(sample_name),
     ref_paths(ref_paths.begin(), ref_paths.end()),
-    min_trav_len(min_trav_len) {
+    trav_padding(trav_padding) {
     
 }
 
@@ -457,14 +457,9 @@ void GAFOutputCaller::emit_gaf_traversals(const PathHandleGraph& graph, const ve
     }
     
     for (int i = 0; i < travs.size(); ++i) {
-        size_t trav_len = 0;
-        // we compute the traversal length only if we think we need to pad it
-        for (int j = 0; j < travs[i].visit_size() && trav_len < min_trav_len; ++j) {
-            trav_len += graph.get_length(graph.get_handle(travs[i].visit(j).node_id()));
-        }
         Alignment trav_aln;
-        if (trav_len < min_trav_len) {
-            trav_aln = to_alignment(pad_traversal(graph, travs[i], trav_len), graph);
+        if (trav_padding > 0) {
+            trav_aln = to_alignment(pad_traversal(graph, travs[i]), graph);
         } else {
             trav_aln = to_alignment(travs[i], graph);
         }
@@ -493,11 +488,11 @@ void GAFOutputCaller::emit_gaf_variant(const HandleGraph& graph,
     emitter->emit_singles(std::move(aln_gt));
 }
 
-SnarlTraversal GAFOutputCaller::pad_traversal(const PathHandleGraph& graph, const SnarlTraversal& trav, size_t trav_len) const {
+SnarlTraversal GAFOutputCaller::pad_traversal(const PathHandleGraph& graph, const SnarlTraversal& trav) const {
 
     assert(trav.visit_size() >= 2);
 
-    SnarlTraversal out_trav = trav;
+    SnarlTraversal out_trav;
 
     // traversal endpoints
     handle_t start_handle = graph.get_handle(trav.visit(0).node_id(), trav.visit(0).backward());
@@ -508,6 +503,7 @@ SnarlTraversal GAFOutputCaller::pad_traversal(const PathHandleGraph& graph, cons
     path_handle_t reference_path;
     step_handle_t reference_step;
     bool found = false;
+    size_t padding = 0;
     graph.for_each_step_on_handle(start_handle, [&](step_handle_t step_handle) {
             reference_path = graph.get_path_handle_of_step(step_handle);
             string name = graph.get_path_name(reference_path);
@@ -520,24 +516,28 @@ SnarlTraversal GAFOutputCaller::pad_traversal(const PathHandleGraph& graph, cons
 
     // add left padding
     if (found) {
+        deque<Visit> left_padding;
+
         if (graph.get_is_reverse(start_handle) == graph.get_is_reverse(graph.get_handle_of_step(reference_step))) {
             // path and handle oriented the same, we can just backtrack along the path to get previous stuff
             for (step_handle_t step = graph.get_previous_step(reference_step);
-                 step != graph.path_front_end(reference_path) && trav_len < min_trav_len;
+                 step != graph.path_front_end(reference_path) && padding < trav_padding;
                  step = graph.get_previous_step(step)) {
-                Visit* visit = out_trav.add_visit();
-                *visit = to_visit(graph, graph.get_handle_of_step(step));
-                trav_len += graph.get_length(graph.get_handle_of_step(step));
+                left_padding.push_front(to_visit(graph, graph.get_handle_of_step(step)));
+                padding += graph.get_length(graph.get_handle_of_step(step));
             }
         } else {
             // path and handle oriented differently, we go forward in the path, flipping each step
             for (step_handle_t step = graph.get_next_step(reference_step);
-                 step != graph.path_end(reference_path) && trav_len < min_trav_len;
+                 step != graph.path_end(reference_path) && padding < trav_padding;
                  step = graph.get_next_step(step)) {
-                Visit* visit = out_trav.add_visit();
-                *visit = to_visit(graph, graph.flip(graph.get_handle_of_step(step)));
-                trav_len += graph.get_length(graph.get_handle_of_step(step));
+                left_padding.push_front(to_visit(graph, graph.get_handle_of_step(step)));
+                padding += graph.get_length(graph.get_handle_of_step(step));
             }
+        }
+
+        for (const Visit& visit : left_padding) {
+            *out_trav.add_visit() = visit;
         }
     }
 
@@ -546,39 +546,38 @@ SnarlTraversal GAFOutputCaller::pad_traversal(const PathHandleGraph& graph, cons
         *out_trav.add_visit() = trav.visit(i);
     }
 
-    if (trav_len < min_trav_len) {
-        // go through the whole thing again with the end
-        found = false;
-        graph.for_each_step_on_handle(end_handle, [&](step_handle_t step_handle) {
-                reference_path = graph.get_path_handle_of_step(step_handle);
-                string name = graph.get_path_name(reference_path);
-                if (!Paths::is_alt(name) && (ref_paths.empty() || ref_paths.count(name))) {
-                    reference_step = step_handle;
-                    found = true;
-                }
-                return !found;
-            });
+    // go through the whole thing again with the end
+    found = false;
+    padding = 0;
+    graph.for_each_step_on_handle(end_handle, [&](step_handle_t step_handle) {
+            reference_path = graph.get_path_handle_of_step(step_handle);
+            string name = graph.get_path_name(reference_path);
+            if (!Paths::is_alt(name) && (ref_paths.empty() || ref_paths.count(name))) {
+                reference_step = step_handle;
+                found = true;
+            }
+            return !found;
+        });
 
-        // add right padding
-        if (found) {
-            if (graph.get_is_reverse(end_handle) == graph.get_is_reverse(graph.get_handle_of_step(reference_step))) {
-                // path and handle oriented the same, we can just continue along the path to get next stuff
-                for (step_handle_t step = graph.get_next_step(reference_step);
-                     step != graph.path_end(reference_path) && trav_len < min_trav_len;
-                     step = graph.get_next_step(step)) {
-                    Visit* visit = out_trav.add_visit();
-                    *visit = to_visit(graph, graph.get_handle_of_step(step));
-                    trav_len += graph.get_length(graph.get_handle_of_step(step));
-                }
-            } else {
-                // path and handle oriented differently, we go backward in the path, flipping each step
-                for (step_handle_t step = graph.get_previous_step(reference_step);
-                     step != graph.path_front_end(reference_path) && trav_len < min_trav_len;
-                     step = graph.get_previous_step(step)) {
-                    Visit* visit = out_trav.add_visit();
-                    *visit = to_visit(graph, graph.flip(graph.get_handle_of_step(step)));
-                    trav_len += graph.get_length(graph.get_handle_of_step(step));
-                }
+    // add right padding
+    if (found) {
+        if (graph.get_is_reverse(end_handle) == graph.get_is_reverse(graph.get_handle_of_step(reference_step))) {
+            // path and handle oriented the same, we can just continue along the path to get next stuff
+            for (step_handle_t step = graph.get_next_step(reference_step);
+                 step != graph.path_end(reference_path) && padding < trav_padding;
+                 step = graph.get_next_step(step)) {
+                Visit* visit = out_trav.add_visit();
+                *visit = to_visit(graph, graph.get_handle_of_step(step));
+                padding += graph.get_length(graph.get_handle_of_step(step));
+            }
+        } else {
+            // path and handle oriented differently, we go backward in the path, flipping each step
+            for (step_handle_t step = graph.get_previous_step(reference_step);
+                 step != graph.path_front_end(reference_path) && padding < trav_padding;
+                 step = graph.get_previous_step(step)) {
+                Visit* visit = out_trav.add_visit();
+                *visit = to_visit(graph, graph.flip(graph.get_handle_of_step(step)));
+                padding += graph.get_length(graph.get_handle_of_step(step));
             }
         }
     }
@@ -598,10 +597,10 @@ VCFGenotyper::VCFGenotyper(const PathHandleGraph& graph,
                            AlignmentEmitter* aln_emitter,
                            bool traversals_only,
                            bool gaf_output,
-                           size_t min_trav_len) :
+                           size_t trav_padding) :
     GraphCaller(snarl_caller, snarl_manager),
     VCFOutputCaller(sample_name),
-    GAFOutputCaller(aln_emitter, sample_name, ref_paths, min_trav_len),
+    GAFOutputCaller(aln_emitter, sample_name, ref_paths, trav_padding),
     graph(graph),
     input_vcf(variant_file),
     traversal_finder(graph, snarl_manager, variant_file, ref_paths, ref_fasta, ins_fasta, snarl_caller.get_skip_allele_fn()),
@@ -1164,10 +1163,10 @@ FlowCaller::FlowCaller(const PathPositionHandleGraph& graph,
                        AlignmentEmitter* aln_emitter,
                        bool traversals_only,
                        bool gaf_output,
-                       size_t min_trav_len) :
+                       size_t trav_padding) :
     GraphCaller(snarl_caller, snarl_manager),
     VCFOutputCaller(sample_name),
-    GAFOutputCaller(aln_emitter, sample_name, ref_paths, min_trav_len),
+    GAFOutputCaller(aln_emitter, sample_name, ref_paths, trav_padding),
     graph(graph),
     traversal_finder(traversal_finder),
     ref_paths(ref_paths),

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -433,16 +433,19 @@ void VCFOutputCaller::flatten_common_allele_ends(vcflib::Variant& variant, bool 
     }
 }
 
-GAFOutputCaller::GAFOutputCaller(AlignmentEmitter* emitter, const string& sample_name) :
+GAFOutputCaller::GAFOutputCaller(AlignmentEmitter* emitter, const string& sample_name, const vector<string>& ref_paths,
+                                 size_t min_trav_len) :
     emitter(emitter),
-    gaf_sample_name(sample_name) {
+    gaf_sample_name(sample_name),
+    ref_paths(ref_paths.begin(), ref_paths.end()),
+    min_trav_len(min_trav_len) {
     
 }
 
 GAFOutputCaller::~GAFOutputCaller() {
 }
 
-void GAFOutputCaller::emit_gaf_traversals(const HandleGraph& graph, const vector<SnarlTraversal>& travs) {
+void GAFOutputCaller::emit_gaf_traversals(const PathHandleGraph& graph, const vector<SnarlTraversal>& travs) {
     assert(emitter != nullptr);
     vector<Alignment> aln_batch;
     aln_batch.reserve(travs.size());
@@ -454,8 +457,19 @@ void GAFOutputCaller::emit_gaf_traversals(const HandleGraph& graph, const vector
     }
     
     for (int i = 0; i < travs.size(); ++i) {
-        aln_batch.push_back(to_alignment(travs[i], graph));
-        aln_batch.back().set_name(variant_id + std::to_string(i));
+        size_t trav_len = 0;
+        // we compute the traversal length only if we think we need to pad it
+        for (int j = 0; j < travs[i].visit_size() && trav_len < min_trav_len; ++j) {
+            trav_len += graph.get_length(graph.get_handle(travs[i].visit(j).node_id()));
+        }
+        Alignment trav_aln;
+        if (trav_len < min_trav_len) {
+            trav_aln = to_alignment(pad_traversal(graph, travs[i], trav_len), graph);
+        } else {
+            trav_aln = to_alignment(travs[i], graph);
+        }
+        trav_aln.set_name(variant_id + "_" + std::to_string(i));
+        aln_batch.push_back(trav_aln);
     }
     emitter->emit_singles(std::move(aln_batch)); 
 }
@@ -479,6 +493,100 @@ void GAFOutputCaller::emit_gaf_variant(const HandleGraph& graph,
     emitter->emit_singles(std::move(aln_gt));
 }
 
+SnarlTraversal GAFOutputCaller::pad_traversal(const PathHandleGraph& graph, const SnarlTraversal& trav, size_t trav_len) const {
+
+    assert(trav.visit_size() >= 2);
+
+    SnarlTraversal out_trav = trav;
+
+    // traversal endpoints
+    handle_t start_handle = graph.get_handle(trav.visit(0).node_id(), trav.visit(0).backward());
+    handle_t end_handle = graph.get_handle(trav.visit(trav.visit_size() - 1).node_id(), trav.visit(trav.visit_size() - 1).backward());
+
+    // find a reference path that touches the start node
+    // todo: we could be more clever by finding the longest one or something
+    path_handle_t reference_path;
+    step_handle_t reference_step;
+    bool found = false;
+    graph.for_each_step_on_handle(start_handle, [&](step_handle_t step_handle) {
+            reference_path = graph.get_path_handle_of_step(step_handle);
+            string name = graph.get_path_name(reference_path);
+            if (!Paths::is_alt(name) && (ref_paths.empty() || ref_paths.count(name))) {
+                reference_step = step_handle;
+                found = true;
+            }
+            return !found;
+        });
+
+    // add left padding
+    if (found) {
+        if (graph.get_is_reverse(start_handle) == graph.get_is_reverse(graph.get_handle_of_step(reference_step))) {
+            // path and handle oriented the same, we can just backtrack along the path to get previous stuff
+            for (step_handle_t step = graph.get_previous_step(reference_step);
+                 step != graph.path_front_end(reference_path) && trav_len < min_trav_len;
+                 step = graph.get_previous_step(step)) {
+                Visit* visit = out_trav.add_visit();
+                *visit = to_visit(graph, graph.get_handle_of_step(step));
+                trav_len += graph.get_length(graph.get_handle_of_step(step));
+            }
+        } else {
+            // path and handle oriented differently, we go forward in the path, flipping each step
+            for (step_handle_t step = graph.get_next_step(reference_step);
+                 step != graph.path_end(reference_path) && trav_len < min_trav_len;
+                 step = graph.get_next_step(step)) {
+                Visit* visit = out_trav.add_visit();
+                *visit = to_visit(graph, graph.flip(graph.get_handle_of_step(step)));
+                trav_len += graph.get_length(graph.get_handle_of_step(step));
+            }
+        }
+    }
+
+    // copy over center
+    for (int i = 0; i < trav.visit_size(); ++i) {
+        *out_trav.add_visit() = trav.visit(i);
+    }
+
+    if (trav_len < min_trav_len) {
+        // go through the whole thing again with the end
+        found = false;
+        graph.for_each_step_on_handle(end_handle, [&](step_handle_t step_handle) {
+                reference_path = graph.get_path_handle_of_step(step_handle);
+                string name = graph.get_path_name(reference_path);
+                if (!Paths::is_alt(name) && (ref_paths.empty() || ref_paths.count(name))) {
+                    reference_step = step_handle;
+                    found = true;
+                }
+                return !found;
+            });
+
+        // add right padding
+        if (found) {
+            if (graph.get_is_reverse(end_handle) == graph.get_is_reverse(graph.get_handle_of_step(reference_step))) {
+                // path and handle oriented the same, we can just continue along the path to get next stuff
+                for (step_handle_t step = graph.get_next_step(reference_step);
+                     step != graph.path_end(reference_path) && trav_len < min_trav_len;
+                     step = graph.get_next_step(step)) {
+                    Visit* visit = out_trav.add_visit();
+                    *visit = to_visit(graph, graph.get_handle_of_step(step));
+                    trav_len += graph.get_length(graph.get_handle_of_step(step));
+                }
+            } else {
+                // path and handle oriented differently, we go backward in the path, flipping each step
+                for (step_handle_t step = graph.get_previous_step(reference_step);
+                     step != graph.path_front_end(reference_path) && trav_len < min_trav_len;
+                     step = graph.get_previous_step(step)) {
+                    Visit* visit = out_trav.add_visit();
+                    *visit = to_visit(graph, graph.flip(graph.get_handle_of_step(step)));
+                    trav_len += graph.get_length(graph.get_handle_of_step(step));
+                }
+            }
+        }
+    }
+        
+    return out_trav;
+}
+
+
 VCFGenotyper::VCFGenotyper(const PathHandleGraph& graph,
                            SnarlCaller& snarl_caller,
                            SnarlManager& snarl_manager,
@@ -489,10 +597,11 @@ VCFGenotyper::VCFGenotyper(const PathHandleGraph& graph,
                            FastaReference* ins_fasta,
                            AlignmentEmitter* aln_emitter,
                            bool traversals_only,
-                           bool gaf_output) :
+                           bool gaf_output,
+                           size_t min_trav_len) :
     GraphCaller(snarl_caller, snarl_manager),
     VCFOutputCaller(sample_name),
-    GAFOutputCaller(aln_emitter, sample_name),
+    GAFOutputCaller(aln_emitter, sample_name, ref_paths, min_trav_len),
     graph(graph),
     input_vcf(variant_file),
     traversal_finder(graph, snarl_manager, variant_file, ref_paths, ref_fasta, ins_fasta, snarl_caller.get_skip_allele_fn()),
@@ -1054,10 +1163,11 @@ FlowCaller::FlowCaller(const PathPositionHandleGraph& graph,
                        const vector<size_t>& ref_path_offsets,
                        AlignmentEmitter* aln_emitter,
                        bool traversals_only,
-                       bool gaf_output) :
+                       bool gaf_output,
+                       size_t min_trav_len) :
     GraphCaller(snarl_caller, snarl_manager),
     VCFOutputCaller(sample_name),
-    GAFOutputCaller(aln_emitter, sample_name),
+    GAFOutputCaller(aln_emitter, sample_name, ref_paths, min_trav_len),
     graph(graph),
     traversal_finder(traversal_finder),
     ref_paths(ref_paths),

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -112,23 +112,36 @@ protected:
 class GAFOutputCaller {
 public:
     /// The emitter object is created and owned by external forces
-    GAFOutputCaller(AlignmentEmitter* emitter, const string& sample_name);
+    GAFOutputCaller(AlignmentEmitter* emitter, const string& sample_name, const vector<string>& ref_paths,
+                    size_t min_trav_len);
     virtual ~GAFOutputCaller();
 
     /// print the GAF traversals
-    void emit_gaf_traversals(const HandleGraph& graph, const vector<SnarlTraversal>& travs);
+    void emit_gaf_traversals(const PathHandleGraph& graph, const vector<SnarlTraversal>& travs);
 
     /// print the GAF genotype
     void emit_gaf_variant(const HandleGraph& graph,
                           const Snarl& snarl,
                           const vector<SnarlTraversal>& traversals,
                           const vector<int>& genotype);
+
+    /// pad a traversal with (first found) reference path to make it at least min_trav_len long
+    SnarlTraversal pad_traversal(const PathHandleGraph& graph, const SnarlTraversal& trav, size_t trav_len) const;
+    
 protected:
     
     AlignmentEmitter* emitter;
 
     /// Sample name
     string gaf_sample_name;
+
+    /// Add padding from reference paths to traversals to make them at least this long
+    /// (only in emit_gaf_traversals(), not emit_gaf_variant)
+    size_t min_trav_len = 0;
+
+    /// Reference paths are used to pad out traversals.  If there are none, then first path found is used
+    unordered_set<string> ref_paths;
+
 };
 
 /**
@@ -146,7 +159,8 @@ public:
                  FastaReference* ins_fasta,
                  AlignmentEmitter* aln_emitter,
                  bool traversals_only,
-                 bool gaf_output);
+                 bool gaf_output,
+                 size_t min_trav_len);
 
     virtual ~VCFGenotyper();
 
@@ -289,7 +303,8 @@ public:
                const vector<size_t>& ref_path_offsets,
                AlignmentEmitter* aln_emitter,
                bool traversals_only,
-               bool gaf_output);
+               bool gaf_output,
+               size_t min_trav_len);
    
     virtual ~FlowCaller();
 

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -113,7 +113,7 @@ class GAFOutputCaller {
 public:
     /// The emitter object is created and owned by external forces
     GAFOutputCaller(AlignmentEmitter* emitter, const string& sample_name, const vector<string>& ref_paths,
-                    size_t min_trav_len);
+                    size_t trav_padding);
     virtual ~GAFOutputCaller();
 
     /// print the GAF traversals
@@ -125,8 +125,8 @@ public:
                           const vector<SnarlTraversal>& traversals,
                           const vector<int>& genotype);
 
-    /// pad a traversal with (first found) reference path to make it at least min_trav_len long
-    SnarlTraversal pad_traversal(const PathHandleGraph& graph, const SnarlTraversal& trav, size_t trav_len) const;
+    /// pad a traversal with (first found) reference path, adding up to trav_padding to each side
+    SnarlTraversal pad_traversal(const PathHandleGraph& graph, const SnarlTraversal& trav) const;
     
 protected:
     
@@ -137,7 +137,7 @@ protected:
 
     /// Add padding from reference paths to traversals to make them at least this long
     /// (only in emit_gaf_traversals(), not emit_gaf_variant)
-    size_t min_trav_len = 0;
+    size_t trav_padding = 0;
 
     /// Reference paths are used to pad out traversals.  If there are none, then first path found is used
     unordered_set<string> ref_paths;
@@ -160,7 +160,7 @@ public:
                  AlignmentEmitter* aln_emitter,
                  bool traversals_only,
                  bool gaf_output,
-                 size_t min_trav_len);
+                 size_t trav_padding);
 
     virtual ~VCFGenotyper();
 
@@ -304,7 +304,7 @@ public:
                AlignmentEmitter* aln_emitter,
                bool traversals_only,
                bool gaf_output,
-               size_t min_trav_len);
+               size_t trav_padding);
    
     virtual ~FlowCaller();
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -36,7 +36,7 @@ void help_call(char** argv) {
        << "GAF options:" << endl
        << "    -G, --gaf               Output GAF genotypes instead of VCF" << endl
        << "    -T, --traversals        Output all candidate traversals in GAF without doing any genotyping" << endl
-       << "    -M, --min-trav-len N    Pad output traversals (when using -T) using reference paths so they are at least N bases if possible" << endl
+       << "    -M, --trav-padding N    Extend each flank of traversals (from -T) with reference path by N bases if possible" << endl
        << "general options:" << endl
        << "    -v, --vcf FILE          VCF file to genotype (must have been used to construct input graph with -a)" << endl
        << "    -f, --ref-fasta FILE    Reference fasta (required if VCF contains symbolic deletions or inversions)" << endl
@@ -71,7 +71,7 @@ int main_call(int argc, char** argv) {
     int ploidy = 2;
     bool traversals_only = false;
     bool gaf_output = false;
-    size_t min_trav_len = 0;
+    size_t trav_padding = 0;
 
     // constants
     const size_t avg_trav_threshold = 50;
@@ -177,7 +177,7 @@ int main_call(int argc, char** argv) {
             gaf_output = true;
             break;
         case 'M':
-            min_trav_len = parse<size_t>(optarg);
+            trav_padding = parse<size_t>(optarg);
             break;
         case 'L':
             legacy = true;
@@ -251,7 +251,7 @@ int main_call(int argc, char** argv) {
         return 1;
     }
 
-    if (min_trav_len > 0 && traversals_only == false) {
+    if (trav_padding > 0 && traversals_only == false) {
         cerr << "error [vg call]: -M option can only be used in conjunction with -T" << endl;
         return 1;
     }
@@ -445,7 +445,7 @@ int main_call(int argc, char** argv) {
                                                        alignment_emitter.get(),
                                                        traversals_only,
                                                        gaf_output,
-                                                       min_trav_len);
+                                                       trav_padding);
         graph_caller = unique_ptr<GraphCaller>(vcf_genotyper);
     } else if (legacy) {
         // de-novo caller (port of the old vg call code, which requires a support based caller)
@@ -491,7 +491,7 @@ int main_call(int argc, char** argv) {
                                                  alignment_emitter.get(),
                                                  traversals_only,
                                                  gaf_output,
-                                                 min_trav_len);
+                                                 trav_padding);
         graph_caller = unique_ptr<GraphCaller>(flow_caller);
     }
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -33,6 +33,10 @@ void help_call(char** argv) {
        << "    -e, --baseline-error X,Y Baseline error rates for Poisson model for small (X) and large (Y) variants [default= 0.005,0.001]" << endl
        << "    -B, --bias-mode          Use old ratio-based genotyping algorithm as opposed to porbablistic model" << endl
        << "    -b, --het-bias M,N       Homozygous alt/ref allele must have >= M/N times more support than the next best allele [default = 6,6]" << endl
+       << "GAF options:" << endl
+       << "    -G, --gaf               Output GAF genotypes instead of VCF" << endl
+       << "    -T, --traversals        Output all candidate traversals in GAF without doing any genotyping" << endl
+       << "    -M, --min-trav-len N    Pad output traversals (when using -T) using reference paths so they are at least N bases if possible" << endl
        << "general options:" << endl
        << "    -v, --vcf FILE          VCF file to genotype (must have been used to construct input graph with -a)" << endl
        << "    -f, --ref-fasta FILE    Reference fasta (required if VCF contains symbolic deletions or inversions)" << endl
@@ -44,8 +48,6 @@ void help_call(char** argv) {
        << "    -o, --ref-offset N      Offset in reference path (multiple allowed, 1 per path)" << endl
        << "    -l, --ref-length N      Override length of reference in the contig field of output VCF" << endl
        << "    -d, --ploidy N          Ploidy of sample.  Only 1 and 2 supported. (default: 2)" << endl
-       << "    -G, --gaf               Output GAF genotypes instead of VCF" << endl
-       << "    -T, --traversals        Output all candidate traversals in GAF without doing any genotyping" << endl
        << "    -t, --threads N         number of threads to use" << endl;
 }    
 
@@ -69,6 +71,7 @@ int main_call(int argc, char** argv) {
     int ploidy = 2;
     bool traversals_only = false;
     bool gaf_output = false;
+    size_t min_trav_len = 0;
 
     // constants
     const size_t avg_trav_threshold = 50;
@@ -103,6 +106,7 @@ int main_call(int argc, char** argv) {
             {"ploidy", required_argument, 0, 'd'},
             {"gaf", no_argument, 0, 'G'},
             {"traversals", no_argument, 0, 'T'},
+            {"min-trav-len", required_argument, 0, 'M'},
             {"legacy", no_argument, 0, 'L'},
             {"threads", required_argument, 0, 't'},
             {"help", no_argument, 0, 'h'},
@@ -111,7 +115,7 @@ int main_call(int argc, char** argv) {
 
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "k:Be:b:m:v:f:i:s:r:g:p:o:l:d:GTLt:h",
+        c = getopt_long (argc, argv, "k:Be:b:m:v:f:i:s:r:g:p:o:l:d:GTLM:t:h",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -171,7 +175,10 @@ int main_call(int argc, char** argv) {
         case 'T':
             traversals_only = true;
             gaf_output = true;
-            break;            
+            break;
+        case 'M':
+            min_trav_len = parse<size_t>(optarg);
+            break;
         case 'L':
             legacy = true;
             break;
@@ -241,6 +248,11 @@ int main_call(int argc, char** argv) {
         }
     } else if (error_toks.size() != 0) {
         cerr << "error [vg call]: -e option expects exactly two comma-separated numbers X,Y" << endl;
+        return 1;
+    }
+
+    if (min_trav_len > 0 && traversals_only == false) {
+        cerr << "error [vg call]: -M option can only be used in conjunction with -T" << endl;
         return 1;
     }
     
@@ -432,7 +444,8 @@ int main_call(int argc, char** argv) {
                                                        ins_fasta.get(),
                                                        alignment_emitter.get(),
                                                        traversals_only,
-                                                       gaf_output);
+                                                       gaf_output,
+                                                       min_trav_len);
         graph_caller = unique_ptr<GraphCaller>(vcf_genotyper);
     } else if (legacy) {
         // de-novo caller (port of the old vg call code, which requires a support based caller)
@@ -477,7 +490,8 @@ int main_call(int argc, char** argv) {
                                                  sample_name, *traversal_finder, ref_paths, ref_path_offsets,
                                                  alignment_emitter.get(),
                                                  traversals_only,
-                                                 gaf_output);
+                                                 gaf_output,
+                                                 min_trav_len);
         graph_caller = unique_ptr<GraphCaller>(flow_caller);
     }
 


### PR DESCRIPTION
This is kind of quick and dirty, but will hopefully be useful to extend the traversals @jonassibbesen.  

If you specify a length with `call -M`, it will greedily scan along the first reference path it finds, first left, then right, until the given size is exceeded.   