### PR TITLE
Overlap threshold in GaplessExtender

### DIFF
--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -288,7 +288,9 @@ void handle_full_length(const HandleGraph& graph, std::vector<GaplessExtension>&
                 continue; // Duplicate.
             }
             if (result[i].overlap(graph, result.front()) <= overlap_threshold * result.front().length()) {
-                result[tail] = std::move(result[i]);
+                if (i > tail) {
+                    result[tail] = std::move(result[i]);
+                }
                 tail++;
                 break; // Found a non-overlapping extension.
             }

--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -13,6 +13,7 @@ namespace vg {
 // Numerical class constants.
 
 constexpr size_t GaplessExtender::MAX_MISMATCHES;
+constexpr double GaplessExtender::OVERLAP_THRESHOLD;
 
 //------------------------------------------------------------------------------
 
@@ -66,6 +67,36 @@ size_t GaplessExtension::tail_offset(const HandleGraph& graph) const {
     size_t result = this->offset + this->length();
     for (size_t i = 0; i + 1 < this->path.size(); i++) {
         result -= graph.get_length(this->path[i]);
+    }
+    return result;
+}
+
+size_t GaplessExtension::overlap(const HandleGraph& graph, const GaplessExtension& another) const {
+    size_t result = 0;
+    size_t this_pos = this->read_interval.first, another_pos = another.read_interval.first;
+    auto this_iter = this->path.begin(), another_iter = another.path.begin();
+    size_t this_offset = this->offset, another_offset = another.offset;
+    while (this_pos < this->read_interval.second && another_pos < another.read_interval.second) {
+        if (this_pos == another_pos && *this_iter == *another_iter && this_offset == another_offset) {
+            size_t len = std::min({ graph.get_length(*this_iter) - this_offset,
+                                    this->read_interval.second - this_pos,
+                                    another.read_interval.second - another_pos });
+            result += len;
+            this_pos += len;
+            another_pos += len;
+            ++this_iter;
+            ++another_iter;
+            this_offset = 0;
+            another_offset = 0;
+        } else if (this_pos <= another_pos) {
+            this_pos += graph.get_length(*this_iter) - this_offset;
+            ++this_iter;
+            this_offset = 0;
+        } else {
+            another_pos += graph.get_length(*another_iter) - another_offset;
+            ++another_iter;
+            another_offset = 0;
+        }
     }
     return result;
 }
@@ -235,6 +266,37 @@ void match_backward(GaplessExtension& match, const std::string& seq, gbwtgraph::
     }
 }
 
+// Sort full-length extensions by internal_score, remove ones that are not
+// full-length alignments, remove duplicates, and return the best two
+// extensions that have sufficiently low overlap.
+void handle_full_length(const HandleGraph& graph, std::vector<GaplessExtension>& result, double overlap_threshold) {
+    std::sort(result.begin(), result.end(), [](const GaplessExtension& a, const GaplessExtension& b) -> bool {
+        if (a.full() && b.full()) {
+            return (a.internal_score < b.internal_score);
+        }
+        return a.full();
+    });
+    size_t tail = 0;
+    for (size_t i = 0; i < result.size(); i++) {
+        if (!(result[i].full())) {
+            break; // No remaining full-length extensions.
+        }
+        if (tail == 0) {
+            tail = 1; // Best extension.
+        } else {
+            if (result[i] == result.front()) {
+                continue; // Duplicate.
+            }
+            if (result[i].overlap(graph, result.front()) <= overlap_threshold * result.front().length()) {
+                result[tail] = std::move(result[i]);
+                tail++;
+                break; // Found a non-overlapping extension.
+            }
+        }
+    }
+    result.resize(tail);
+}
+
 // Sort the extensions from left to right. Remove duplicates and empty extensions.
 void remove_duplicates(std::vector<GaplessExtension>& result) {
     auto sort_order = [](const GaplessExtension& a, const GaplessExtension& b) -> bool {
@@ -313,224 +375,6 @@ std::vector<handle_t> get_path(const std::vector<handle_t>& first, gbwt::node_ty
 
 std::vector<handle_t> get_path(gbwt::node_type reverse_first, const std::vector<handle_t>& second) {
     return get_path(gbwtgraph::GBWTGraph::node_to_handle(gbwt::Node::reverse(reverse_first)), second);
-}
-
-//------------------------------------------------------------------------------
-
-std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, const std::string& sequence, const gbwtgraph::CachedGBWTGraph* cache, size_t max_mismatches, bool trim_extensions) const {
-
-    std::vector<GaplessExtension> result;
-    if (this->graph == nullptr || this->aligner == nullptr || cluster.empty() || sequence.empty()) {
-        return result;
-    }
-
-    // Allocate a cache if we were not provided with one.
-    bool free_cache = (cache == nullptr);
-    if (free_cache) {
-        cache = new gbwtgraph::CachedGBWTGraph(*(this->graph));
-    }
-
-    // Find either the best extension for each seed or the best two full-length alignments
-    // for the entire cluster. The second-best full-length alignment has full_length_mismatches
-    // mismatches; we are not interested in extensions with this many mismatches anymore.
-    bool full_length_found = false;
-    GaplessExtension best_alignment;
-    GaplessExtension second_best_alignment;
-    uint32_t full_length_mismatches = std::numeric_limits<uint32_t>::max();
-    for (seed_type seed : cluster) {
-
-        // Check if the seed is contained in an exact full-length alignment.
-        if (full_length_found && best_alignment.internal_score == 0) {
-            if (best_alignment.contains(*cache, seed)) {
-                continue;
-            }
-        }
-
-        GaplessExtension best_match {
-            { }, static_cast<size_t>(0), gbwt::BidirectionalState(),
-            { static_cast<size_t>(0), static_cast<size_t>(0) }, { },
-            std::numeric_limits<int32_t>::min(), false, false,
-            false, false, std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max()
-        };
-
-        // Match the initial node and add it to the queue, unless we already have
-        // two at least as good full-length alignments.
-        std::priority_queue<GaplessExtension> extensions;
-        {
-            size_t read_offset = get_read_offset(seed);
-            size_t node_offset = get_node_offset(seed);
-            GaplessExtension match {
-                { seed.first }, node_offset, cache->get_bd_state(seed.first),
-                { read_offset, read_offset }, { },
-                static_cast<int32_t>(0), false, false,
-                false, false, static_cast<uint32_t>(0), static_cast<uint32_t>(0)
-            };
-            match_initial(match, sequence, cache->get_sequence_view(seed.first));
-            if (match.internal_score >= full_length_mismatches) {
-                continue;
-            }
-            if (match.read_interval.first == 0) {
-                match.left_full = true;
-                match.left_maximal = true;
-            }
-            if (match.read_interval.second >= sequence.length()) {
-                match.right_full = true;
-                match.right_maximal = true;
-            }
-            set_score(match, this->aligner);
-            extensions.push(std::move(match));
-        }
-
-        // Extend the most promising extensions first, using alignment scores for priority.
-        // First make the extension right-maximal and then left-maximal.
-        while (!extensions.empty()) {
-            GaplessExtension curr = std::move(extensions.top());
-            extensions.pop();
-            if (curr.internal_score >= full_length_mismatches) {
-                continue;
-            }
-
-            // Case 1: Extend to the right.
-            if (!curr.right_maximal) {
-                bool found_extension = false;
-                // Always allow at least max_mismatches / 2 mismatches in the current flank.
-                uint32_t mismatch_limit = std::max(
-                    static_cast<uint32_t>(max_mismatches + 1),
-                    static_cast<uint32_t>(max_mismatches / 2 + curr.old_score + 1));
-                mismatch_limit = std::min(mismatch_limit, full_length_mismatches);
-                cache->follow_paths(curr.state, false, [&](const gbwt::BidirectionalState& next_state) -> bool {
-                    handle_t handle = gbwtgraph::GBWTGraph::node_to_handle(next_state.forward.node);
-                    GaplessExtension next {
-                        { }, curr.offset, next_state,
-                        curr.read_interval, { },
-                        curr.score, curr.left_full, curr.right_full,
-                        curr.left_maximal, curr.right_maximal, curr.internal_score, curr.old_score
-                    };
-                    size_t node_offset = match_forward(next, sequence, cache->get_sequence_view(handle), mismatch_limit);
-                    if (node_offset == 0) { // Did not match anything.
-                        return true;
-                    }
-                    next.path = get_path(curr.path, handle);
-                    // Did the extension become right-maximal?
-                    if (next.read_interval.second >= sequence.length()) {
-                        next.right_full = true;
-                        next.right_maximal = true;
-                        next.old_score = next.internal_score;
-                    } else if (node_offset < cache->get_length(handle)) {
-                        next.right_maximal = true;
-                        next.old_score = next.internal_score;
-                    }
-                    set_score(next, this->aligner);
-                    extensions.push(std::move(next));
-                    found_extension = true;
-                    return true;
-                });
-                if (!found_extension) {
-                    curr.right_maximal = true;
-                    curr.old_score = curr.internal_score;
-                } else {
-                    continue;
-                }
-            }
-
-            // Case 2: Extend to the left.
-            if (!curr.left_maximal) {
-                bool found_extension = false;
-                // Always allow at least max_mismatches / 2 mismatches in the current flank.
-                uint32_t mismatch_limit = std::max(
-                    static_cast<uint32_t>(max_mismatches + 1),
-                    static_cast<uint32_t>(max_mismatches / 2 + curr.old_score + 1));
-                mismatch_limit = std::min(mismatch_limit, full_length_mismatches);
-                cache->follow_paths(curr.state, true, [&](const gbwt::BidirectionalState& next_state) -> bool {
-                    handle_t handle = gbwtgraph::GBWTGraph::node_to_handle(gbwt::Node::reverse(next_state.backward.node));
-                    size_t node_length = cache->get_length(handle);
-                    GaplessExtension next {
-                        { }, node_length, next_state,
-                        curr.read_interval, { },
-                        curr.score, curr.left_full, curr.right_full,
-                        curr.left_maximal, curr.right_maximal, curr.internal_score, curr.old_score
-                    };
-                    match_backward(next, sequence, cache->get_sequence_view(handle), mismatch_limit);
-                    if (next.offset >= node_length) { // Did not match anything.
-                        return true;
-                    }
-                    next.path = get_path(handle, curr.path);
-                    // Did the extension become left-maximal?
-                    if (next.read_interval.first == 0) {
-                        next.left_full = true;
-                        next.left_maximal = true;
-                        // No need to set old_score.
-                    } else if (next.offset > 0) {
-                        next.left_maximal = true;
-                        // No need to set old_score.
-                    }
-                    set_score(next, this->aligner);
-                    extensions.push(std::move(next));
-                    found_extension = true;
-                    return true;
-                });
-                if (!found_extension) {
-                    curr.left_maximal = true;
-                    // No need to set old_score.
-                } else {
-                    continue;
-                }
-            }
-
-            // Case 3: Maximal extension with a better score than the best extension so far.
-            if (best_match < curr) {
-                best_match = std::move(curr);
-            }
-        }
-
-        // Handle the best match. If we have a full-length alignment, check if it is among
-        // the best two we have found so far. Otherwise add the partial extension to the
-        // result, if we do not have full-length alignments.
-        if (best_match.full() && best_match.internal_score <= max_mismatches) {
-            full_length_found = true;
-            if (best_alignment.empty() || best_match.internal_score < best_alignment.internal_score) {
-                second_best_alignment = std::move(best_alignment);
-                best_alignment = std::move(best_match);
-            }
-            // If the best alignment contains mismatches, we may reach it from multiple seeds.
-            // Make sure that we do not report it as the best and the second best alignment.
-            else if ((second_best_alignment.empty() || best_match.internal_score < second_best_alignment.internal_score) && best_match != best_alignment) {
-                second_best_alignment = std::move(best_match);
-                full_length_mismatches = second_best_alignment.internal_score;
-            }
-            // We can stop the search, because we have two exact full-length alignments.
-            if (full_length_mismatches == 0) {
-                break;
-            }
-        } else if (!full_length_found && !best_match.empty()) {
-            result.emplace_back(std::move(best_match));
-        }
-    }
-
-    if (full_length_found) {
-        result.clear();
-        result.emplace_back(std::move(best_alignment));
-        if (!second_best_alignment.empty()) {
-            result.emplace_back(std::move(second_best_alignment));
-        }
-    }
-
-    // Remove duplicates, find mismatches, and trim mismatches to maximize score.
-    // If we have a full-length alignment with sufficiently few mismatches, we do
-    // not trim it.
-    remove_duplicates(result);
-    find_mismatches(sequence, *cache, result);
-    if (trim_extensions) {
-        this->trim(result, max_mismatches, cache);
-    }
-
-    // Free the cache if we allocated it.
-    if (free_cache) {
-        delete cache;
-        cache = nullptr;
-    }
-
-    return result;
 }
 
 //------------------------------------------------------------------------------
@@ -647,7 +491,15 @@ bool trim_mismatches(GaplessExtension& extension, const gbwtgraph::CachedGBWTGra
     return true;
 }
 
-void GaplessExtender::trim(std::vector<GaplessExtension>& extensions, size_t max_mismatches, const gbwtgraph::CachedGBWTGraph* cache) const {
+//------------------------------------------------------------------------------
+
+std::vector<GaplessExtension> GaplessExtender::extend(cluster_type& cluster, const std::string& sequence, const gbwtgraph::CachedGBWTGraph* cache, size_t max_mismatches, double overlap_threshold) const {
+
+    std::vector<GaplessExtension> result;
+    if (this->graph == nullptr || this->aligner == nullptr || cluster.empty() || sequence.empty()) {
+        return result;
+    }
+    result.reserve(cluster.size());
 
     // Allocate a cache if we were not provided with one.
     bool free_cache = (cache == nullptr);
@@ -655,14 +507,173 @@ void GaplessExtender::trim(std::vector<GaplessExtension>& extensions, size_t max
         cache = new gbwtgraph::CachedGBWTGraph(*(this->graph));
     }
 
-    bool trimmed = false;
-    for (GaplessExtension& extension : extensions) {
-        if (!extension.full() || extension.mismatches() > max_mismatches) {
-            trimmed |= trim_mismatches(extension, *cache, *(this->aligner));
+    // Find the best extension starting from each seed.
+    GaplessExtension* best_alignment = nullptr;
+    for (seed_type seed : cluster) {
+
+        // Check if the seed is contained in an exact full-length alignment.
+        if (best_alignment != nullptr && best_alignment->internal_score == 0) {
+            if (best_alignment->contains(*cache, seed)) {
+                continue;
+            }
+        }
+
+        GaplessExtension best_match {
+            { }, static_cast<size_t>(0), gbwt::BidirectionalState(),
+            { static_cast<size_t>(0), static_cast<size_t>(0) }, { },
+            std::numeric_limits<int32_t>::min(), false, false,
+            false, false, std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max()
+        };
+
+        // Match the initial node and add it to the queue.
+        std::priority_queue<GaplessExtension> extensions;
+        {
+            size_t read_offset = get_read_offset(seed);
+            size_t node_offset = get_node_offset(seed);
+            GaplessExtension match {
+                { seed.first }, node_offset, cache->get_bd_state(seed.first),
+                { read_offset, read_offset }, { },
+                static_cast<int32_t>(0), false, false,
+                false, false, static_cast<uint32_t>(0), static_cast<uint32_t>(0)
+            };
+            match_initial(match, sequence, cache->get_sequence_view(seed.first));
+            if (match.read_interval.first == 0) {
+                match.left_full = true;
+                match.left_maximal = true;
+            }
+            if (match.read_interval.second >= sequence.length()) {
+                match.right_full = true;
+                match.right_maximal = true;
+            }
+            set_score(match, this->aligner);
+            extensions.push(std::move(match));
+        }
+
+        // Extend the most promising extensions first, using alignment scores for priority.
+        // First make the extension right-maximal and then left-maximal.
+        while (!extensions.empty()) {
+            GaplessExtension curr = std::move(extensions.top());
+            extensions.pop();
+
+            // Case 1: Extend to the right.
+            if (!curr.right_maximal) {
+                bool found_extension = false;
+                // Always allow at least max_mismatches / 2 mismatches in the current flank.
+                uint32_t mismatch_limit = std::max(
+                    static_cast<uint32_t>(max_mismatches + 1),
+                    static_cast<uint32_t>(max_mismatches / 2 + curr.old_score + 1));
+                cache->follow_paths(curr.state, false, [&](const gbwt::BidirectionalState& next_state) -> bool {
+                    handle_t handle = gbwtgraph::GBWTGraph::node_to_handle(next_state.forward.node);
+                    GaplessExtension next {
+                        { }, curr.offset, next_state,
+                        curr.read_interval, { },
+                        curr.score, curr.left_full, curr.right_full,
+                        curr.left_maximal, curr.right_maximal, curr.internal_score, curr.old_score
+                    };
+                    size_t node_offset = match_forward(next, sequence, cache->get_sequence_view(handle), mismatch_limit);
+                    if (node_offset == 0) { // Did not match anything.
+                        return true;
+                    }
+                    next.path = get_path(curr.path, handle);
+                    // Did the extension become right-maximal?
+                    if (next.read_interval.second >= sequence.length()) {
+                        next.right_full = true;
+                        next.right_maximal = true;
+                        next.old_score = next.internal_score;
+                    } else if (node_offset < cache->get_length(handle)) {
+                        next.right_maximal = true;
+                        next.old_score = next.internal_score;
+                    }
+                    set_score(next, this->aligner);
+                    extensions.push(std::move(next));
+                    found_extension = true;
+                    return true;
+                });
+                if (!found_extension) {
+                    curr.right_maximal = true;
+                    curr.old_score = curr.internal_score;
+                } else {
+                    continue;
+                }
+            }
+
+            // Case 2: Extend to the left.
+            if (!curr.left_maximal) {
+                bool found_extension = false;
+                // Always allow at least max_mismatches / 2 mismatches in the current flank.
+                uint32_t mismatch_limit = std::max(
+                    static_cast<uint32_t>(max_mismatches + 1),
+                    static_cast<uint32_t>(max_mismatches / 2 + curr.old_score + 1));
+                cache->follow_paths(curr.state, true, [&](const gbwt::BidirectionalState& next_state) -> bool {
+                    handle_t handle = gbwtgraph::GBWTGraph::node_to_handle(gbwt::Node::reverse(next_state.backward.node));
+                    size_t node_length = cache->get_length(handle);
+                    GaplessExtension next {
+                        { }, node_length, next_state,
+                        curr.read_interval, { },
+                        curr.score, curr.left_full, curr.right_full,
+                        curr.left_maximal, curr.right_maximal, curr.internal_score, curr.old_score
+                    };
+                    match_backward(next, sequence, cache->get_sequence_view(handle), mismatch_limit);
+                    if (next.offset >= node_length) { // Did not match anything.
+                        return true;
+                    }
+                    next.path = get_path(handle, curr.path);
+                    // Did the extension become left-maximal?
+                    if (next.read_interval.first == 0) {
+                        next.left_full = true;
+                        next.left_maximal = true;
+                        // No need to set old_score.
+                    } else if (next.offset > 0) {
+                        next.left_maximal = true;
+                        // No need to set old_score.
+                    }
+                    set_score(next, this->aligner);
+                    extensions.push(std::move(next));
+                    found_extension = true;
+                    return true;
+                });
+                if (!found_extension) {
+                    curr.left_maximal = true;
+                    // No need to set old_score.
+                } else {
+                    continue;
+                }
+            }
+
+            // Case 3: Maximal extension with a better score than the best extension so far.
+            if (best_match < curr) {
+                best_match = std::move(curr);
+            }
+        }
+
+        // Add the best match to the result and update the best_alignment pointer.
+        if (!best_match.empty()) {
+            result.emplace_back(std::move(best_match));
+            if (result.back().full() && (best_alignment == nullptr || result.back().internal_score < best_alignment->internal_score)) {
+                best_alignment = &(result.back());
+            }
         }
     }
-    if (trimmed) {
-        remove_duplicates(extensions);
+
+    // If we have a good enough full-length alignment, return the best two sufficiently
+    // distinct full-length alingments.
+    if (best_alignment != nullptr && best_alignment->internal_score <= max_mismatches) {
+        handle_full_length(*cache, result, overlap_threshold);
+        find_mismatches(sequence, *cache, result);
+    }
+
+    // Otherwise remove duplicates, find mismatches, and trim the extensions to maximize
+    // score.
+    else {
+        remove_duplicates(result);
+        find_mismatches(sequence, *cache, result);
+        bool trimmed = false;
+        for (GaplessExtension& extension : result) {
+            trimmed |= trim_mismatches(extension, *cache, *(this->aligner));
+        }
+        if (trimmed) {
+            remove_duplicates(result);
+        }
     }
 
     // Free the cache if we allocated it.
@@ -670,6 +681,8 @@ void GaplessExtender::trim(std::vector<GaplessExtension>& extensions, size_t max
         delete cache;
         cache = nullptr;
     }
+
+    return result;
 }
 
 //------------------------------------------------------------------------------

--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -287,7 +287,7 @@ void handle_full_length(const HandleGraph& graph, std::vector<GaplessExtension>&
             if (result[i] == result.front()) {
                 continue; // Duplicate.
             }
-            if (result[i].overlap(graph, result.front()) <= overlap_threshold * result.front().length()) {
+            if (result[i].overlap(graph, result.front()) < overlap_threshold * result.front().length()) {
                 if (i > tail) {
                     result[tail] = std::move(result[i]);
                 }

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -120,7 +120,7 @@ public:
 
     /// Two full-length alignments are distinct, if the fraction of overlapping
     /// position pairs is at most this.
-    constexpr static double OVERLAP_THRESHOLD = 0.9;
+    constexpr static double OVERLAP_THRESHOLD = 0.8;
 
     /// Create an empty GaplessExtender.
     GaplessExtender();
@@ -159,8 +159,8 @@ public:
      * Find the highest-scoring extension for each seed in the cluster.
      * If there is a full-length extension with at most max_mismatches
      * mismatches, return the (up to two) best full-length extensions with
-     * up to overlap_threshold fraction of overlap, sorted by score in
-     * descending order.
+     * less than overlap_threshold overlap, sorted by score in descending
+     * order.
      * If that is not possible, trim the extensions to maximize score,
      * sort them by read interval, and remove duplicates.
      * Allow any number of mismatches in the initial node, at least

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -333,8 +333,14 @@ vector<Alignment> MinimizerMapper::map(Alignment& aln) {
             // Get an Alignments best_ and second_best_alignment of it somehow, and throw it in.
             Alignment best_alignment = aln;
             Alignment second_best_alignment = aln;
-            
-            if (extensions[0].full()) {
+
+            // Determine if we got full-length alignments or local alignments.
+            bool full_length_extensions = (extensions.size() <= 2);
+            for (auto& extension : extensions) {
+                full_length_extensions &= extension.full();
+            }
+
+            if (full_length_extensions) {
                 // We got full-length extensions, so directly convert to an Alignment.
                 
                 if (track_provenance) {
@@ -1029,7 +1035,14 @@ pair<vector<Alignment>, vector< Alignment>> MinimizerMapper::map_paired(Alignmen
                 Alignment best_alignment = aln;
                 Alignment second_best_alignment = aln;
                 
-                if (extensions[0].full()) {
+
+                // Determine if we got full-length alignments or local alignments.
+                bool full_length_extensions = (extensions.size() <= 2);
+                for (auto& extension : extensions) {
+                    full_length_extensions &= extension.full();
+                }
+
+                if (full_length_extensions) {
                     // We got full-length extensions, so directly convert to an Alignment.
                     
                     if (track_provenance) {

--- a/src/unittest/gapless_extender.cpp
+++ b/src/unittest/gapless_extender.cpp
@@ -216,12 +216,12 @@ void full_length_match(const std::vector<std::pair<pos_t, size_t>>& seeds, const
     }
 }
 
-void full_length_matches(const std::vector<std::pair<pos_t, size_t>>& seeds, const std::string& read, const std::vector<std::vector<std::pair<pos_t, std::string>>>& correct_alignments, const GaplessExtender& extender, size_t error_bound) {
+void full_length_matches(const std::vector<std::pair<pos_t, size_t>>& seeds, const std::string& read, const std::vector<std::vector<std::pair<pos_t, std::string>>>& correct_alignments, const GaplessExtender& extender, size_t error_bound, double overlap_threshold) {
     GaplessExtender::cluster_type cluster;
     for (auto seed : seeds) {
         cluster.insert(GaplessExtender::to_seed(seed.first, seed.second));
     }
-    auto result = extender.extend(cluster, read, nullptr, error_bound);
+    auto result = extender.extend(cluster, read, nullptr, error_bound, overlap_threshold);
 
     REQUIRE(result.size() == correct_alignments.size());
     for (size_t i = 0; i < result.size(); i++) {
@@ -238,7 +238,7 @@ void partial_matches(const std::vector<std::pair<pos_t, size_t>>& seeds, const s
     for (auto seed : seeds) {
         cluster.insert(GaplessExtender::to_seed(seed.first, seed.second));
     }
-    auto result = extender.extend(cluster, read, nullptr, error_bound, false);
+    auto result = extender.extend(cluster, read, nullptr, error_bound);
 
     REQUIRE(result.size() == correct_extensions.size());
     for (size_t i = 0; i < result.size(); i++) {
@@ -249,27 +249,6 @@ void partial_matches(const std::vector<std::pair<pos_t, size_t>>& seeds, const s
         REQUIRE(result[i].read_interval.first == correct_offsets[i]);
         correct_score(result.front(), *(extender.aligner));
         paths_match(result[i].to_path(*(extender.graph), read), get_path(correct_extensions[i]));
-    }
-}
-
-void trimmed_extensions(std::vector<GaplessExtension>& extensions, std::vector<GaplessExtension>& correct, const GaplessExtender& extender, size_t error_bound) {
-    for (GaplessExtension& extension : extensions) {
-        extension.state = extender.graph->bd_find(extension.path);
-    }
-    extender.trim(extensions, error_bound);
-
-    REQUIRE(extensions.size() == correct.size());
-    for (size_t i = 0; i < extensions.size(); i++) {
-        correct_score(extensions[i], *(extender.aligner));
-        REQUIRE(extensions[i].path == correct[i].path);
-        REQUIRE(extensions[i].offset == correct[i].offset);
-        correct[i].state = extender.graph->bd_find(correct[i].path);
-        REQUIRE(extensions[i].state == correct[i].state);
-        REQUIRE(extensions[i].read_interval == correct[i].read_interval);
-        REQUIRE(extensions[i].mismatch_positions == correct[i].mismatch_positions);
-        REQUIRE(extensions[i].score == correct[i].score);
-        REQUIRE(extensions[i].left_full == correct[i].left_full);
-        REQUIRE(extensions[i].right_full == correct[i].right_full);
     }
 }
 
@@ -389,6 +368,174 @@ TEST_CASE("Gapless extensions report correct positions", "[gapless_extender]") {
         Position correct_tail = make_position(4, false, 2);
         same_position(extension.starting_position(gbwt_graph), correct_start);
         same_position(extension.tail_position(gbwt_graph), correct_tail);
+    }
+}
+
+TEST_CASE("Overlap detection for gapless extensions", "[gapless_extender]") {
+
+    // Build a GBWT with three threads including a duplicate.
+    gbwt::GBWT gbwt_index = build_gbwt_index();
+
+    // Build a GBWT-backed graph.
+    gbwtgraph::GBWTGraph gbwt_graph = build_gbwt_graph(gbwt_index);
+ 
+    SECTION("unrelated extensions") {
+        GaplessExtension a {
+            {
+                gbwt_graph.get_handle(1, false),
+                gbwt_graph.get_handle(4, false)
+            },
+            0, gbwt::BidirectionalState(),
+            { 0, 4 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        GaplessExtension b {
+            {
+                gbwt_graph.get_handle(5, false),
+                gbwt_graph.get_handle(6, false),
+                gbwt_graph.get_handle(8, false),
+                gbwt_graph.get_handle(9, false)
+            },
+            0, gbwt::BidirectionalState(),
+            { 0, 4 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        size_t expected_overlap = 0;
+        REQUIRE(a.overlap(gbwt_graph, b) == expected_overlap);
+    }
+
+    SECTION("identical extensions") {
+        GaplessExtension a {
+            {
+                gbwt_graph.get_handle(1, false),
+                gbwt_graph.get_handle(4, false)
+            },
+            0, gbwt::BidirectionalState(),
+            { 0, 4 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        GaplessExtension b = a;
+        size_t expected_overlap = a.length();
+        REQUIRE(a.overlap(gbwt_graph, b) == expected_overlap);
+    }
+
+    SECTION("one difference") {
+        GaplessExtension a {
+            {
+                gbwt_graph.get_handle(5, false),
+                gbwt_graph.get_handle(6, false),
+                gbwt_graph.get_handle(7, false),
+                gbwt_graph.get_handle(9, false)
+            },
+            0, gbwt::BidirectionalState(),
+            { 0, 4 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        GaplessExtension b {
+            {
+                gbwt_graph.get_handle(5, false),
+                gbwt_graph.get_handle(6, false),
+                gbwt_graph.get_handle(8, false),
+                gbwt_graph.get_handle(9, false)
+            },
+            0, gbwt::BidirectionalState(),
+            { 0, 4 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        REQUIRE(a.overlap(gbwt_graph, b) == a.length() - 1);
+        size_t expected_overlap = a.length() - 1;
+    }
+
+    SECTION("partial overlap") {
+        GaplessExtension a {
+            {
+                gbwt_graph.get_handle(4, false),
+                gbwt_graph.get_handle(5, false),
+                gbwt_graph.get_handle(6, false),
+                gbwt_graph.get_handle(8, false)
+            },
+            2, gbwt::BidirectionalState(),
+            { 0, 4 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        GaplessExtension b {
+            {
+                gbwt_graph.get_handle(5, false),
+                gbwt_graph.get_handle(6, false),
+                gbwt_graph.get_handle(8, false),
+                gbwt_graph.get_handle(9, false)
+            },
+            0, gbwt::BidirectionalState(),
+            { 1, 5 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        size_t expected_overlap = a.length() - 1;
+        REQUIRE(a.overlap(gbwt_graph, b) == expected_overlap);
+    }
+
+    SECTION("shifted by one") {
+        GaplessExtension a {
+            {
+                gbwt_graph.get_handle(4, false),
+                gbwt_graph.get_handle(5, false),
+                gbwt_graph.get_handle(6, false),
+                gbwt_graph.get_handle(8, false),
+                gbwt_graph.get_handle(9, false)
+            },
+            2, gbwt::BidirectionalState(),
+            { 0, 5 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        GaplessExtension b {
+            {
+                gbwt_graph.get_handle(5, false),
+                gbwt_graph.get_handle(6, false),
+                gbwt_graph.get_handle(8, false),
+                gbwt_graph.get_handle(9, false)
+            },
+            0, gbwt::BidirectionalState(),
+            { 0, 4 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        size_t expected_overlap = 0;
+        REQUIRE(a.overlap(gbwt_graph, b) == expected_overlap);
+    }
+
+    SECTION("paths of different lengths") {
+        GaplessExtension a {
+            {
+                gbwt_graph.get_handle(1, false),
+                gbwt_graph.get_handle(2, false),
+                gbwt_graph.get_handle(4, false),
+                gbwt_graph.get_handle(5, false)
+            },
+            0, gbwt::BidirectionalState(),
+            { 0, 6 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        GaplessExtension b {
+            {
+                gbwt_graph.get_handle(1, false),
+                gbwt_graph.get_handle(4, false),
+                gbwt_graph.get_handle(5, false)
+            },
+            0, gbwt::BidirectionalState(),
+            { 1, 6 }, { },
+            0, false, false,
+            false, false, 0, 0
+        };
+        size_t expected_overlap = b.length() - 1;
+        REQUIRE(a.overlap(gbwt_graph, b) == expected_overlap);
     }
 }
 
@@ -530,30 +677,6 @@ TEST_CASE("Full-length alignments", "[gapless_extender]") {
         full_length_match(seeds, read, { }, extender, error_bound, false);
     }
 
-    SECTION("there is a secondary alignment") {
-        std::vector<std::pair<pos_t, size_t>> seeds {
-            { make_pos_t(4, false, 2), 0 },
-            { make_pos_t(6, true, 0), 1 }
-        };
-        std::string read = "GTAC";
-        size_t error_bound = 1;
-        std::vector<std::vector<std::pair<pos_t, std::string>>> correct_alignments {
-            {
-                { make_pos_t(4, false, 2), "1" },
-                { make_pos_t(5, false, 0), "1" },
-                { make_pos_t(6, false, 0), "1" },
-                { make_pos_t(7, false, 0), "1" }
-            },
-            {
-                { make_pos_t(7, true, 0), "1" },
-                { make_pos_t(6, true, 0), "1" },
-                { make_pos_t(5, true, 0), "1" },
-                { make_pos_t(4, true, 0), "1" }
-            }
-        };
-        full_length_matches(seeds, read, correct_alignments, extender, error_bound);
-    }
-
     // We also test that we avoid finding the same best alignment from multiple seeds.
     SECTION("secondary alignment has more mismatches") {
         std::vector<std::pair<pos_t, size_t>> seeds {
@@ -563,6 +686,7 @@ TEST_CASE("Full-length alignments", "[gapless_extender]") {
         };
         std::string read = "GAGGA";
         size_t error_bound = 2;
+        double overlap_threshold = 0.9;
         std::vector<std::vector<std::pair<pos_t, std::string>>> correct_alignments {
             {
                 { make_pos_t(1, false, 0), "1" },
@@ -575,13 +699,32 @@ TEST_CASE("Full-length alignments", "[gapless_extender]") {
                 { make_pos_t(5, false, 0), "A" }
             }
         };
-        full_length_matches(seeds, read, correct_alignments, extender, error_bound);
+        full_length_matches(seeds, read, correct_alignments, extender, error_bound, overlap_threshold);
+    }
+
+    SECTION("no secondary alignment found if the overlap is too high") {
+        std::vector<std::pair<pos_t, size_t>> seeds {
+            { make_pos_t(2, false, 0), 1 }, // First seed for the best alignment (1 mismatch).
+            { make_pos_t(4, false, 0), 2 }, // Second seed for the best alignment (1 mismatch).
+            { make_pos_t(4, false, 0), 1 }  // Seed for the secondary alignment (2 mismatches).
+        };
+        std::string read = "GAGGA";
+        size_t error_bound = 2;
+        double overlap_threshold = 0.1;
+        std::vector<std::vector<std::pair<pos_t, std::string>>> correct_alignments {
+            {
+                { make_pos_t(1, false, 0), "1" },
+                { make_pos_t(2, false, 0), "1" },
+                { make_pos_t(4, false, 0), "2A" }
+            }
+        };
+        full_length_matches(seeds, read, correct_alignments, extender, error_bound, overlap_threshold);
     }
 }
 
 //------------------------------------------------------------------------------
 
-TEST_CASE("Partial alignments without trimming", "[gapless_extender]") {
+TEST_CASE("Local alignments", "[gapless_extender]") {
 
     // Build a GBWT with three threads including a duplicate.
     gbwt::GBWT gbwt_index = build_gbwt_index();
@@ -639,27 +782,26 @@ TEST_CASE("Partial alignments without trimming", "[gapless_extender]") {
         partial_matches(seeds, read, correct_extensions, correct_offsets, extender, error_bound);
     }
 
-    SECTION("exact matching with mismatches in the initial node") {
+    SECTION("trim left flank") {
         std::vector<std::pair<pos_t, size_t>> seeds {
             { make_pos_t(4, false, 2), 4 }
         };
         std::string read = "xAGxGTAx";
         std::vector<std::vector<std::pair<pos_t, std::string>>> correct_extensions {
             {
-                { make_pos_t(2, false, 0), "1" },
-                { make_pos_t(4, false, 0), "1x1" },
+                { make_pos_t(4, false, 2), "1" },
                 { make_pos_t(5, false, 0), "1" },
                 { make_pos_t(6, false, 0), "1" }
             }
         };
         std::vector<size_t> correct_offsets {
-            static_cast<size_t>(1)
+            static_cast<size_t>(4)
         };
         size_t error_bound = 0;
         partial_matches(seeds, read, correct_extensions, correct_offsets, extender, error_bound);
     }
 
-    SECTION("approximate matching") {
+    SECTION("trim right flank") {
         std::vector<std::pair<pos_t, size_t>> seeds {
             { make_pos_t(4, false, 2), 4 }
         };
@@ -668,9 +810,7 @@ TEST_CASE("Partial alignments without trimming", "[gapless_extender]") {
             {
                 { make_pos_t(2, false, 0), "1" },
                 { make_pos_t(4, false, 0), "3" },
-                { make_pos_t(5, false, 0), "1" },
-                { make_pos_t(6, false, 0), "x" },
-                { make_pos_t(8, false, 0), "1" }
+                { make_pos_t(5, false, 0), "1" }
             }
         };
         std::vector<size_t> correct_offsets {
@@ -680,7 +820,7 @@ TEST_CASE("Partial alignments without trimming", "[gapless_extender]") {
         partial_matches(seeds, read, correct_extensions, correct_offsets, extender, error_bound);
     }
 
-    SECTION("removing duplicates") {
+    SECTION("remove duplicates") {
         std::vector<std::pair<pos_t, size_t>> seeds {
             { make_pos_t(2, false, 0), 1 },
             { make_pos_t(4, false, 2), 4 }
@@ -690,9 +830,7 @@ TEST_CASE("Partial alignments without trimming", "[gapless_extender]") {
             {
                 { make_pos_t(2, false, 0), "1" },
                 { make_pos_t(4, false, 0), "3" },
-                { make_pos_t(5, false, 0), "1" },
-                { make_pos_t(6, false, 0), "x" },
-                { make_pos_t(8, false, 0), "1" }
+                { make_pos_t(5, false, 0), "1" }
             }
         };
         std::vector<size_t> correct_offsets {
@@ -700,220 +838,6 @@ TEST_CASE("Partial alignments without trimming", "[gapless_extender]") {
         };
         size_t error_bound = 1;
         partial_matches(seeds, read, correct_extensions, correct_offsets, extender, error_bound);
-    }
-}
-
-//------------------------------------------------------------------------------
-
-TEST_CASE("Trimming mismatches", "[gapless_extender]") {
-
-    // Build a GBWT with three threads including a duplicate.
-    gbwt::GBWT gbwt_index = build_gbwt_index();
-
-    // Build a GBWT-backed graph.
-    gbwtgraph::GBWTGraph gbwt_graph = build_gbwt_graph(gbwt_index);
-
-    // And finally wrap it in a GaplessExtender with an Aligner.
-    Aligner aligner;
-    GaplessExtender extender(gbwt_graph, aligner);
-
-    SECTION("basic trimming") {
-        std::vector<GaplessExtension> extensions {
-            { // Trim right end.
-                {
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false)
-                },
-                static_cast<size_t>(1), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(5, 9), { static_cast<size_t>(7) },
-                static_cast<int32_t>(-1), false, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            },
-            { // Trim left end.
-                {
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false),
-                    gbwt_graph.get_handle(8, false),
-                    gbwt_graph.get_handle(9, false)
-                },
-                static_cast<size_t>(0), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(2, 9), { static_cast<size_t>(3) },
-                static_cast<int32_t>(2), false, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            },
-            { // Trim both ends.
-                {
-                    gbwt_graph.get_handle(2, false),
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false),
-                    gbwt_graph.get_handle(8, false),
-                    gbwt_graph.get_handle(9, false)
-                },
-                static_cast<size_t>(0), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(1, 9), { static_cast<size_t>(2), static_cast<size_t>(7) },
-                static_cast<int32_t>(-2), false, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            }
-        };
-        std::vector<GaplessExtension> correct {
-            { // Trim both ends.
-                {
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false)
-                },
-                static_cast<size_t>(1), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(3, 7), { },
-                static_cast<int32_t>(4), false, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            },
-            { // Trim left end.
-                {
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false),
-                    gbwt_graph.get_handle(8, false),
-                    gbwt_graph.get_handle(9, false)
-                },
-                static_cast<size_t>(2), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(4, 9), { },
-                static_cast<int32_t>(5), false, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            },
-            { // Trim right end.
-                {
-                    gbwt_graph.get_handle(4, false),
-                },
-                static_cast<size_t>(1), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(5, 7), { },
-                static_cast<int32_t>(2), false, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            }
-        };
-        size_t error_bound = 0;
-        trimmed_extensions(extensions, correct, extender, error_bound);
-    }
-
-    SECTION("trimming full-length alignments") {
-        std::vector<GaplessExtension> extensions {
-            { // Number of mismatches is below the bound.
-                {
-                    gbwt_graph.get_handle(2, false),
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false),
-                    gbwt_graph.get_handle(8, false),
-                    gbwt_graph.get_handle(9, false)
-                },
-                static_cast<size_t>(0), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(0, 8), { static_cast<size_t>(6), static_cast<size_t>(7) },
-                static_cast<int32_t>(8), true, true,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            },
-            { // Full-length bonus means more than a single mismatch.
-                {
-                    gbwt_graph.get_handle(2, false),
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false),
-                    gbwt_graph.get_handle(8, false),
-                    gbwt_graph.get_handle(9, false)
-                },
-                static_cast<size_t>(0), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(0, 8), { static_cast<size_t>(0), static_cast<size_t>(6), static_cast<size_t>(7) },
-                static_cast<int32_t>(3), true, true,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            }
-        };
-        std::vector<GaplessExtension> correct {
-            { // Full-length bonus means more than a single mismatch.
-                {
-                    gbwt_graph.get_handle(2, false),
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false)
-                },
-                static_cast<size_t>(0), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(0, 6), { static_cast<size_t>(0) },
-                static_cast<int32_t>(6), true, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            },
-            { // Number of mismatches is below the bound.
-                {
-                    gbwt_graph.get_handle(2, false),
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false),
-                    gbwt_graph.get_handle(8, false),
-                    gbwt_graph.get_handle(9, false)
-                },
-                static_cast<size_t>(0), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(0, 8), { static_cast<size_t>(6), static_cast<size_t>(7) },
-                static_cast<int32_t>(8), true, true,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            }
-        };
-        size_t error_bound = 2;
-        trimmed_extensions(extensions, correct, extender, error_bound);
-    }
-
-    SECTION("removing duplicates and empty extensions") {
-        std::vector<GaplessExtension> extensions {
-            { // First duplicate.
-                {
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false),
-                    gbwt_graph.get_handle(8, false),
-                    gbwt_graph.get_handle(9, false)
-                },
-                static_cast<size_t>(0), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(4, 11), { static_cast<size_t>(5) },
-                static_cast<int32_t>(2), false, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            },
-            { // Second duplicate.
-                {
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false),
-                    gbwt_graph.get_handle(8, false),
-                    gbwt_graph.get_handle(9, false)
-                },
-                static_cast<size_t>(1), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(5, 11), { static_cast<size_t>(5) },
-                static_cast<int32_t>(1), false, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            },
-            { // Empty extension.
-                {
-                },
-                static_cast<size_t>(0), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(0, 0), { },
-                static_cast<int32_t>(0), false, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            }
-        };
-        std::vector<GaplessExtension> correct {
-            { // Duplicates.
-                {
-                    gbwt_graph.get_handle(4, false),
-                    gbwt_graph.get_handle(5, false),
-                    gbwt_graph.get_handle(6, false),
-                    gbwt_graph.get_handle(8, false),
-                    gbwt_graph.get_handle(9, false)
-                },
-                static_cast<size_t>(2), gbwt::BidirectionalState(),
-                std::pair<size_t, size_t>(6, 11), { },
-                static_cast<int32_t>(5), false, false,
-                false, false, static_cast<int32_t>(0), static_cast<int32_t>(0)
-            }
-        };
-        size_t error_bound = 0;
-        trimmed_extensions(extensions, correct, extender, error_bound);
     }
 }
 


### PR DESCRIPTION
GaplessExtender used to return the best two full-length alignments, as long as they were distinct. This confused mapq estimation, as the alignments were often almost exactly the same.

This PR adds an overlap threshold (default 0.8). The fraction of overlapping base mappings between the primary and the secondary alignment must be below the threshold.