### PR TITLE
New seeding algorithm targeted at miRNA

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -258,7 +258,6 @@ BaseMapper::find_mems_simple(string::const_iterator seq_begin,
 vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator seq_begin,
                                                        string::const_iterator seq_end,
                                                        string::const_iterator qual_begin,
-                                                       int reseed_length,
                                                        char max_fanout_base_quality) {
 
 

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -545,6 +545,7 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
                     while (remain_len < left_to_walk) {
                         left_to_walk -= remain_len;
                         ++path_pos.first;
+                        path_pos.second = 0;
                         remain_len = xindex->get_length(xindex->get_handle(id(paths[i][path_pos.first])));
                     }
                     

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -692,12 +692,16 @@ vector<pos_t> BaseMapper::walk_fanout_path(string::const_iterator begin,
             
             continue;
         }
-        
+    
         
         // get the next position we're searching from
         handle_t handle;
         size_t off;
         tie(handle, off) = get<2>(stack_record)[get<3>(stack_record)++];
+        
+#ifdef debug_mapper
+        cerr << "offset " << off << " on node " << xindex->get_id(handle) << ": " << xindex->get_sequence(handle) << endl;
+#endif
         
         auto read_it = get<0>(stack_record);
         auto next_break = get<1>(stack_record);

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -343,6 +343,7 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
         // walk backwards from end until finding a non-N base or a base where we want to fan out
         auto start_cursor = seq_end - 1;
         while (start_cursor >= seq_begin && *start_cursor == 'N' && !do_fanout[start_cursor - seq_begin]) {
+            seq_end = start_cursor;
             --start_cursor;
         }
         if (start_cursor >= seq_begin) {
@@ -391,14 +392,12 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
 #ifdef debug_mapper
             cerr << "LF iter at cursor " << (cursor - seq_begin) << " char " << ch << ", fanout? " << use_fanout_char << endl;
 #endif
-            
-            // TODO: choose X lowest quality bases rather than fanning out greedily
-            
+                        
             if (!use_fanout_char && do_fanout[cursor - seq_begin]) {
 #ifdef debug_mapper
                 cerr << "aborting to search to queue up fan-out searches" << endl;
 #endif
-                // fan out at into all possiblities
+                // fan out into all possiblities
                 for (char nt : {'A', 'C', 'G', 'T'}) {
                     stack.emplace_back(range, seq_begin, match_end, cursor, nt, fanout_breaks);
                 }

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -366,6 +366,8 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
             cerr << "LF iter at cursor " << (cursor - seq_begin) << " char " << ch << ", fanout? " << use_fanout_char << endl;
 #endif
             
+            // TODO: choose X lowest quality bases rather than fanning out greedily
+            
             if (!use_fanout_char && (ch == 'N' || *(qual_begin + (cursor - seq_begin)) <= max_fanout_base_quality)
                 && fanout_breaks.size() < max_fans_out) {
 #ifdef debug_mapper
@@ -546,7 +548,7 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
                         remain_len = xindex->get_length(xindex->get_handle(id(paths[i][path_pos.first])));
                     }
                     
-                    path_pos.second = left_to_walk;
+                    path_pos.second += left_to_walk;
                     path_step = paths[i][path_pos.first];
                     
 #ifdef debug_mapper

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -256,7 +256,6 @@ public:
     find_fanout_mems(string::const_iterator seq_begin,
                      string::const_iterator seq_end,
                      string::const_iterator qual_begin,
-                     int reseed_length,
                      char max_fanout_base_quality);
     
     vector<pos_t> walk_fanout_path(string::const_iterator begin,

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -252,6 +252,18 @@ public:
                           size_t max_match_length,
                           size_t target_count);
     
+    vector<MaximalExactMatch>
+    find_fanout_mems(string::const_iterator seq_begin,
+                     string::const_iterator seq_end,
+                     string::const_iterator qual_begin,
+                     int reseed_length,
+                     char max_fanout_base_quality);
+    
+    vector<pos_t> walk_fanout_path(string::const_iterator begin,
+                                   string::const_iterator end,
+                                   const list<pair<string::const_iterator, char>>& fanout_breaks,
+                                   gcsa::node_type pos);
+    
     /// identifies tracts of order-length MEMs that were unfilled because their hit count was above the max
     /// and fills one MEM in the tract (the one with the smallest hit count), assumes MEMs are lexicographically
     /// ordered by read index

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -256,6 +256,7 @@ public:
     find_fanout_mems(string::const_iterator seq_begin,
                      string::const_iterator seq_end,
                      string::const_iterator qual_begin,
+                     int max_fans_out,
                      char max_fanout_base_quality);
     
     vector<pos_t> walk_fanout_path(string::const_iterator begin,

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -274,7 +274,7 @@ namespace vg {
         }
         else if (use_fanout_match_alg) {
             return find_fanout_mems(alignment.sequence().begin(), alignment.sequence().end(),
-                                    alignment.quality().begin(), max_fanout_base_quality);
+                                    alignment.quality().begin(), max_fans_out, max_fanout_base_quality);
         }
         else {
             return find_stripped_matches(alignment.sequence().begin(), alignment.sequence().end(),

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -52,19 +52,7 @@ namespace vg {
         cerr << "querying MEMs..." << endl;
 #endif
         
-        vector<MaximalExactMatch> mems;
-        if (use_stripped_match_alg) {
-            mems = find_stripped_matches(alignment.sequence().begin(), alignment.sequence().end(),
-                                         stripped_match_alg_strip_length, stripped_match_alg_max_length,
-                                         stripped_match_alg_target_count);
-        }
-        else {
-            // query MEMs using GCSA2
-            double dummy1; double dummy2;
-            mems = find_mems_deep(alignment.sequence().begin(), alignment.sequence().end(), dummy1, dummy2,
-                                  0, min_mem_length, mem_reseed_length, false, true, true, false);
-        }
-        
+        auto mems = find_mems(alignment);
         
 #ifdef debug_multipath_mapper
         cerr << "obtained MEMs:" << endl;
@@ -277,6 +265,24 @@ namespace vg {
                                    min_median_mem_coverage_for_split);;
     }
     
+    vector<MaximalExactMatch> MultipathMapper::find_mems(const Alignment& alignment) {
+        if (!use_stripped_match_alg &&
+            (!use_fanout_match_alg || (use_fanout_match_alg && alignment.quality().empty()))) {
+            double dummy1, dummy2;
+            return find_mems_deep(alignment.sequence().begin(), alignment.sequence().end(), dummy1, dummy2,
+                                  0, min_mem_length, mem_reseed_length, false, true, true, false);
+        }
+        else if (use_fanout_match_alg) {
+            return find_fanout_mems(alignment.sequence().begin(), alignment.sequence().end(),
+                                    alignment.quality().begin(), max_fanout_base_quality);
+        }
+        else {
+            return find_stripped_matches(alignment.sequence().begin(), alignment.sequence().end(),
+                                         stripped_match_alg_strip_length, stripped_match_alg_max_length,
+                                         stripped_match_alg_target_count);
+        }
+    }
+
     vector<pair<pair<size_t, size_t>, int64_t>> MultipathMapper::get_cluster_pairs(const Alignment& alignment1,
                                                                                    const Alignment& alignment2,
                                                                                    vector<clustergraph_t>& cluster_graphs1,
@@ -1484,27 +1490,9 @@ namespace vg {
         }
         
         // the fragment length distribution has been estimated, so we can do full-fledged paired mode
-        vector<MaximalExactMatch> mems1, mems2;
-        if (use_stripped_match_alg) {
-            // query matches along strips of the read
-            mems1 = find_stripped_matches(alignment1.sequence().begin(), alignment1.sequence().end(),
-                                          stripped_match_alg_strip_length, stripped_match_alg_max_length,
-                                          stripped_match_alg_target_count);
-            mems2 = find_stripped_matches(alignment2.sequence().begin(), alignment2.sequence().end(),
-                                          stripped_match_alg_strip_length, stripped_match_alg_max_length,
-                                          stripped_match_alg_target_count);
-        }
-        else {
-            // query MEMs
-            double dummy1, dummy2;
-            mems1 = find_mems_deep(alignment1.sequence().begin(), alignment1.sequence().end(), dummy1, dummy2,
-                                   0, min_mem_length, mem_reseed_length, false, true, true, false);
-            mems2 = find_mems_deep(alignment2.sequence().begin(), alignment2.sequence().end(), dummy1, dummy2,
-                                   0, min_mem_length, mem_reseed_length, false, true, true, false);
-        }
-        
-        
-        
+        auto mems1 = find_mems(alignment1);
+        auto mems2 = find_mems(alignment2);
+                
 #ifdef debug_multipath_mapper
         cerr << "obtained read1 MEMs:" << endl;
         for (MaximalExactMatch mem : mems1) {

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -431,7 +431,7 @@ namespace vg {
 #endif
             if (!validate_multipath_alignment(multipath_aln, *xindex)) {
                 cerr << "### WARNING ###" << endl;
-                cerr << "multipath alignment of read " << multipath_aln.name() << " failed to validate" << endl;
+                cerr << "multipath alignment of read " << multipath_aln.sequence() << " failed to validate" << endl;
             }
         }
 #endif
@@ -682,7 +682,7 @@ namespace vg {
             auto p_val = random_match_p_value(pseudo_length(multipath_aln), multipath_aln.sequence().size());
             
 #ifdef debug_multipath_mapper
-            cerr << "effective match length of read " << multipath_aln.name() << " is " << pseudo_length(multipath_aln) << " in read length " << multipath_aln.sequence().size() << ", yielding p-value " << p_val << endl;
+            cerr << "effective match length of read " << multipath_aln.sequence() << " is " << pseudo_length(multipath_aln) << " in read length " << multipath_aln.sequence().size() << ", yielding p-value " << p_val << endl;
 #endif
             
             return p_val > max_mapping_p_value;
@@ -1214,11 +1214,11 @@ namespace vg {
 #endif
             if (!validate_multipath_alignment(multipath_aln_pair.first, *xindex)) {
                 cerr << "### WARNING ###" << endl;
-                cerr << "multipath alignment of read " << multipath_aln_pair.first.name() << " failed to validate" << endl;
+                cerr << "multipath alignment of read " << multipath_aln_pair.first.sequence() << " failed to validate" << endl;
             }
             if (!validate_multipath_alignment(multipath_aln_pair.second, *xindex)) {
                 cerr << "### WARNING ###" << endl;
-                cerr << "multipath alignment of read " << multipath_aln_pair.second.name() << " failed to validate" << endl;
+                cerr << "multipath alignment of read " << multipath_aln_pair.second.sequence() << " failed to validate" << endl;
             }
         }
 #endif
@@ -1402,11 +1402,11 @@ namespace vg {
 #endif
             if (!validate_multipath_alignment(multipath_aln_pair.first, *xindex)) {
                 cerr << "### WARNING ###" << endl;
-                cerr << "multipath alignment of read " << multipath_aln_pair.first.name() << " failed to validate" << endl;
+                cerr << "multipath alignment of read " << multipath_aln_pair.first.sequence() << " failed to validate" << endl;
             }
             if (!validate_multipath_alignment(multipath_aln_pair.second, *xindex)) {
                 cerr << "### WARNING ###" << endl;
-                cerr << "multipath alignment of read " << multipath_aln_pair.second.name() << " failed to validate" << endl;
+                cerr << "multipath alignment of read " << multipath_aln_pair.second.sequence() << " failed to validate" << endl;
             }
         }
 #endif
@@ -2688,11 +2688,11 @@ namespace vg {
 #endif
             if (!validate_multipath_alignment(multipath_aln_pair.first, *xindex)) {
                 cerr << "### WARNING ###" << endl;
-                cerr << "multipath alignment of read " << multipath_aln_pair.first.name() << " failed to validate" << endl;
+                cerr << "multipath alignment of read " << multipath_aln_pair.first.sequence() << " failed to validate" << endl;
             }
             if (!validate_multipath_alignment(multipath_aln_pair.second, *xindex)) {
                 cerr << "### WARNING ###" << endl;
-                cerr << "multipath alignment of read " << multipath_aln_pair.second.name() << " failed to validate" << endl;
+                cerr << "multipath alignment of read " << multipath_aln_pair.second.sequence() << " failed to validate" << endl;
             }
         }
 #endif

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -121,6 +121,8 @@ namespace vg {
         size_t stripped_match_alg_strip_length = 16;
         size_t stripped_match_alg_max_length = 0;
         size_t stripped_match_alg_target_count = 5;
+        bool use_fanout_match_alg = false;
+        int max_fanout_base_quality = 20;
         size_t max_p_value_memo_size = 500;
         size_t band_padding_memo_size = 2000;
         bool use_weibull_calibration = false;
@@ -425,6 +427,9 @@ namespace vg {
         /// inverts the distances in the cluster pairs vector according to the strand
         void establish_strand_consistency(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs,
                                           vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs);
+        
+        /// Return exact matches according to the object's parameters
+        vector<MaximalExactMatch> find_mems(const Alignment& alignment);
         
         SnarlManager* snarl_manager;
         MinimumDistanceIndex* distance_index;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -123,6 +123,7 @@ namespace vg {
         size_t stripped_match_alg_target_count = 5;
         bool use_fanout_match_alg = false;
         int max_fanout_base_quality = 20;
+        int max_fans_out = 5;
         size_t max_p_value_memo_size = 500;
         size_t band_padding_memo_size = 2000;
         bool use_weibull_calibration = false;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -768,7 +768,7 @@ int main_mpmap(int argc, char** argv) {
     }
     else if (read_length == "very-short") {
         // clustering is unlikely to improve accuracy in very short data
-        no_clustering = false; // might actually be important?
+        no_clustering = false;//true; might actually be important?
         // we don't want to throw away short matches a priori in very short data
         min_clustering_mem_length = 1;
         // we don't want to automatically distrust short mappings

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -766,12 +766,13 @@ int main_mpmap(int argc, char** argv) {
     }
     else if (read_length == "very-short") {
         // clustering is unlikely to improve accuracy in very short data
-        // TODO: should i add a way to override this option?
-        no_clustering = true;
+        no_clustering = false; // might actually be important?
         // we don't want to throw away short matches a priori in very short data
         min_clustering_mem_length = 1;
         // we don't want to automatically distrust short mappings
         suppress_mismapping_detection = true;
+        // we want to look for short MEMs even on small reads
+        reseed_length = 20;
     }
     else if (read_length != "short") {
         // short is the default
@@ -788,7 +789,6 @@ int main_mpmap(int argc, char** argv) {
         secondary_rescue_attempts = 1;
         max_single_end_mappings_for_rescue = 32;
         hit_max = 100;
-        reseed_length = 28; // TODO: returned to the DNA value
         reseed_diff = 0.6;
         likelihood_approx_exp = 3.5;
     }

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -193,8 +193,8 @@ int main_mpmap(int argc, char** argv) {
     int default_strip_count = 10;
     int stripped_match_alg_target_count = default_strip_count;
     bool use_fanout_match_alg = false;
-    int max_fanout_base_quality = 20;
-    int max_fans_out = 5;
+    int max_fanout_base_quality = 15;
+    int max_fans_out = 2;
     bool use_greedy_mem_restarts = true;
     // TODO: it would be best if these parameters responded to the size of the graph...
     int greedy_restart_min_length = 30;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -191,6 +191,8 @@ int main_mpmap(int argc, char** argv) {
     int stripped_match_alg_max_length = 0; // no maximum yet
     int default_strip_count = 10;
     int stripped_match_alg_target_count = default_strip_count;
+    bool use_fanout_match_alg = false;
+    int max_fanout_base_quality = 20;
     bool use_greedy_mem_restarts = true;
     // TODO: it would be best if these parameters responded to the size of the graph...
     int greedy_restart_min_length = 30;
@@ -773,6 +775,8 @@ int main_mpmap(int argc, char** argv) {
         suppress_mismapping_detection = true;
         // we want to look for short MEMs even on small reads
         reseed_length = 20;
+        // but actually only use this other MEM algorithm if we have base qualities
+        use_fanout_match_alg = true;
     }
     else if (read_length != "short") {
         // short is the default
@@ -1082,6 +1086,12 @@ int main_mpmap(int argc, char** argv) {
     if (stripped_match_alg_strip_length != default_strip_length && !use_stripped_match_alg) {
         cerr << "warning:[vg mpmap] Strip length (--strip-length) set to " << stripped_match_alg_strip_length << ", but stripped algorithm (--stripped-match) was not selected. Ignoring strip length." << endl;
     }
+    
+    // people shouldn't really be setting these anyway, but there may be combinations of presets that do this
+//    if (use_fanout_match_alg && use_stripped_match_alg) {
+//        cerr << "error:[vg mpmap] Cannot perform both stripped and fan-out match algorithms." << endl;
+//        exit(1);
+//    }
     
     if (likelihood_approx_exp < 1.0) {
         cerr << "error:[vg mpmap] Likelihood approximation exponent (--approx-exp) set to " << likelihood_approx_exp << ", must set to at least 1.0." << endl;
@@ -1422,6 +1432,8 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.greedy_restart_max_lcp = greedy_restart_max_lcp;
     multipath_mapper.greedy_restart_assume_substitution = greedy_restart_assume_substitution;
     multipath_mapper.use_stripped_match_alg = use_stripped_match_alg;
+    multipath_mapper.use_fanout_match_alg = use_fanout_match_alg;
+    multipath_mapper.max_fanout_base_quality = max_fanout_base_quality;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;
     multipath_mapper.use_approx_sub_mem_count = false;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -193,6 +193,7 @@ int main_mpmap(int argc, char** argv) {
     int stripped_match_alg_target_count = default_strip_count;
     bool use_fanout_match_alg = false;
     int max_fanout_base_quality = 20;
+    int max_fans_out = 5;
     bool use_greedy_mem_restarts = true;
     // TODO: it would be best if these parameters responded to the size of the graph...
     int greedy_restart_min_length = 30;
@@ -1434,6 +1435,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.use_stripped_match_alg = use_stripped_match_alg;
     multipath_mapper.use_fanout_match_alg = use_fanout_match_alg;
     multipath_mapper.max_fanout_base_quality = max_fanout_base_quality;
+    multipath_mapper.max_fans_out = max_fans_out;
     multipath_mapper.adaptive_reseed_diff = use_adaptive_reseed;
     multipath_mapper.adaptive_diff_exponent = reseed_exp;
     multipath_mapper.use_approx_sub_mem_count = false;

--- a/src/unittest/mapper.cpp
+++ b/src/unittest/mapper.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include "json2pb.h"
 #include <vg/vg.pb.h>
+#include <bdsg/hash_graph.hpp>
 #include "../mapper.hpp"
 #include "xg.hpp"
 #include "../build_index.hpp"
@@ -532,6 +533,126 @@ TEST_CASE( "Mapper can annotate positions correctly on both strands", "[mapper][
     
 }
 
+TEST_CASE( "Mapper can walk paths from fan-out MEM algorithm", "[mapping][mapper][mem]" ) {
+    
+    
+    bdsg::HashGraph graph;
+    auto h1 = graph.create_handle("GATTGGACACCCATAGC");
+    auto h2 = graph.create_handle("TGGCCAC");
+    auto h3 = graph.create_handle("AGT");
+    auto h4 = graph.create_handle("AGT");
+    auto h5 = graph.create_handle("AGT");
+    auto h6 = graph.create_handle("AGT");
+    auto h7 = graph.create_handle("AGT");
+    auto h8 = graph.create_handle("AGTCA");
+    auto h9 = graph.create_handle("C");
+    auto h10 = graph.create_handle("C");
+    auto h11 = graph.create_handle("C");
+    
+    graph.create_edge(h1, h2);
+    graph.create_edge(h2, h3);
+    graph.create_edge(h2, h4);
+    graph.create_edge(h2, h5);
+    graph.create_edge(h2, h6);
+    graph.create_edge(h2, h7);
+    graph.create_edge(h2, h8);
+    graph.create_edge(h3, h9);
+    graph.create_edge(h4, h10);
+    graph.create_edge(h5, h11);
+    
+    // Configure GCSA temp directory to the system temp directory
+    gcsa::TempFile::setDirectory(temp_file::get_dir());
+    // And make it quiet
+    gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
+    
+    // Make pointers to fill in
+    gcsa::GCSA* gcsaidx = nullptr;
+    gcsa::LCPArray* lcpidx = nullptr;
+    
+    // Build the GCSA index
+    build_gcsa_lcp(graph, gcsaidx, lcpidx, 16, 3);
+    
+    // Build the xg index
+    xg::XG xg_index;
+    xg_index.from_path_handle_graph(graph);
+    
+    // Make a multipath mapper to map against the graph.
+    Mapper mapper(&xg_index, gcsaidx, lcpidx);
+    
+    SECTION("Path within a node") {
+        
+        //         GATTGGACACCCATAGC
+        //            ...X....
+        string seq = "TGGGCACC";
+        
+        list<pair<string::const_iterator, char>> fanout_breaks;
+        fanout_breaks.emplace_back(seq.begin() + 3, 'A');
+        
+        gcsa::node_type pos = gcsa::Node::encode(graph.get_id(h1), 3, false);
+        
+        auto path = mapper.walk_fanout_path(seq.begin(), seq.end(),
+                                            fanout_breaks, pos);
+        
+        REQUIRE(path.size() == 1);
+        REQUIRE(id(path[0]) == graph.get_id(h1));
+        REQUIRE(offset(path[0]) == 3);
+        REQUIRE(is_rev(path[0]) == false);
+    }
+    
+    SECTION("Path across two nodes") {
+        
+        //                 |
+        //GATTGGACACCCATAGCTGGCCAC
+        //              ..X.X....
+        string seq =   "AGTTTGCCA";
+        
+        list<pair<string::const_iterator, char>> fanout_breaks;
+        fanout_breaks.emplace_back(seq.begin() + 2, 'C');
+        fanout_breaks.emplace_back(seq.begin() + 4, 'G');
+        
+        gcsa::node_type pos = gcsa::Node::encode(graph.get_id(h1), 14, false);
+        
+        auto path = mapper.walk_fanout_path(seq.begin(), seq.end(),
+                                            fanout_breaks, pos);
+        
+        REQUIRE(path.size() == 2);
+        REQUIRE(id(path[0]) == graph.get_id(h1));
+        REQUIRE(offset(path[0]) == 14);
+        REQUIRE(is_rev(path[0]) == false);
+        REQUIRE(id(path[1]) == graph.get_id(h2));
+        REQUIRE(offset(path[1]) == 0);
+        REQUIRE(is_rev(path[1]) == false);
+    }
+    
+    SECTION("Path across two nodes that requires backtracking") {
+        
+        //                |
+        //         TGGCCACAGTCA
+        //            ..X.X..X.
+        string seq = "CCGCGGTTA";
+        
+        list<pair<string::const_iterator, char>> fanout_breaks;
+        fanout_breaks.emplace_back(seq.begin() + 2, 'A');
+        fanout_breaks.emplace_back(seq.begin() + 4, 'A');
+        fanout_breaks.emplace_back(seq.begin() + 7, 'C');
+        
+        gcsa::node_type pos = gcsa::Node::encode(graph.get_id(h2), 3, false);
+        
+        auto path = mapper.walk_fanout_path(seq.begin(), seq.end(),
+                                            fanout_breaks, pos);
+        
+        REQUIRE(path.size() == 2);
+        REQUIRE(id(path[0]) == graph.get_id(h2));
+        REQUIRE(offset(path[0]) == 3);
+        REQUIRE(is_rev(path[0]) == false);
+        REQUIRE(id(path[1]) == graph.get_id(h8));
+        REQUIRE(offset(path[1]) == 0);
+        REQUIRE(is_rev(path[1]) == false);
+    }
+    
+    delete gcsaidx;
+    delete lcpidx;
 }
 
+}
 }


### PR DESCRIPTION
This PR adds an algorithm that finds seeds that contain a small number of mismatches as specified sites (chosen based on base quality). It's very expensive on typical NGS reads, but I think it might be practical when applied to very short reads such as miRNA. mpmap now uses this algorithm to find seeds when the `very-short` preset is selected. 

@jonassibbesen I'm expecting this to be slower, but it would nice to know if it's slow to the point of being impractical. I could still turn some knobs to tweak the tradeoff.