### PR TITLE
Add PR template that asks for a changelog message

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,6 @@
+## Changelog Entry
+To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:
+
+ * Whatsits now frobnicated
+
+## Description


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * PRs now come with changelog messages by default

## Description

I got tired of making up changelogs, so now I want PR writers to make them for me.