### PR TITLE
Path cover of components without haplotypes

### DIFF
--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -49,7 +49,7 @@ void help_gbwt(char** argv) {
     std::cerr << "    -g, --graph-name FILE   build GBWTGraph and serialize it to FILE (required)" << std::endl;
     std::cerr << "    -x, --xg-name FILE      use the node sequences from the graph in FILE (required)" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Path cover (for GBWTGraph construction; requires -o and one of { -l, -P }):" << std::endl;
+    std::cerr << "Path cover (for GBWTGraph construction; requires -o and one of { -a, -l, -P }):" << std::endl;
     std::cerr << "    -a, --augment-gbwt      add a path cover of missing components (one input GBWT)" << std::endl;
     std::cerr << "    -l, --local-haplotypes  sample local haplotypes (one input GBWT)" << std::endl;
     std::cerr << "    -P, --path-cover        build a greedy path cover (no input GBWTs)" << std::endl;

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -43,11 +43,11 @@ void help_gbwt(char** argv) {
     std::cerr << "    -c, --count-threads     print the number of threads" << std::endl;
     std::cerr << "    -e, --extract FILE      extract threads in SDSL format to FILE" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "GBWTGraph construction (based on path cover GBWT or one input GBWT):" << std::endl;
+    std::cerr << "GBWTGraph construction (based on one input GBWT or path cover GBWT):" << std::endl;
     std::cerr << "    -g, --graph-name FILE   build GBWTGraph and serialize it to FILE (required)" << std::endl;
     std::cerr << "    -x, --xg-name FILE      use the node sequences from the graph in FILE (required)" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Path cover options (requires -o and one of { -l, -P }):" << std::endl;
+    std::cerr << "Path cover (for GBWTGraph construction; requires -o and one of { -l, -P }):" << std::endl;
     std::cerr << "    -l, --local-haplotypes  sample local haplotypes (one input GBWT)" << std::endl;
     std::cerr << "    -P, --path-cover        build a greedy path cover (no input GBWTs)" << std::endl;
     std::cerr << "    -n, --num-paths N       find N paths per component (default " << gbwtgraph::PATH_COVER_DEFAULT_N << ")" << std::endl;
@@ -62,7 +62,9 @@ void help_gbwt(char** argv) {
     std::cerr << "    -S, --samples           print the number of samples" << std::endl;
     std::cerr << "    -L, --list-names        list contig/sample names (use with -C or -S)" << std::endl;
     std::cerr << "    -T, --thread-names      list thread names" << std::endl;
-    std::cerr << "    -R, --remove-sample X   remove sample X from the index (overwrites input if -o is not used)" << std::endl;
+    std::cerr << std::endl;
+    std::cerr << "Remove sample (one input GBWT; requires -o):" << std::endl;
+    std::cerr << "    -R, --remove-sample X   remove sample X from the index" << std::endl;
     std::cerr << std::endl;
 }
 
@@ -125,6 +127,8 @@ int main_gbwt(int argc, char** argv)
                 { "samples", no_argument, 0, 'S' },
                 { "list_names", no_argument, 0, 'L' },
                 { "thread_names", no_argument, 0, 'T' },
+
+                // Remove sample
                 { "remove-sample", required_argument, 0, 'R' },
 
                 { "help", no_argument, 0, 'h' },
@@ -220,6 +224,8 @@ int main_gbwt(int argc, char** argv)
             thread_names = true;
             other_options = true;
             break;
+
+        // Remove sample
         case 'R':
             to_remove = optarg;
             remove_sample = true;
@@ -445,7 +451,7 @@ int main_gbwt(int argc, char** argv)
             }
             loaded_gbwt = vg::io::VPKG::load_one<gbwt::GBWT>(argv[optind]);
             if (loaded_gbwt.get() == nullptr) {
-                std::cerr << "error: [vg gbwt]: could not load GBWT " << argv[optind] << std::endl;
+                std::cerr << "error: [vg gbwt] could not load GBWT " << argv[optind] << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             if (local_haplotypes) {
@@ -483,9 +489,13 @@ int main_gbwt(int argc, char** argv)
             std::cerr << "error: [vg gbwt] one input GBWT is required for removing a sample" << std::endl;
             std::exit(EXIT_FAILURE);
         }
+        if (gbwt_output.empty()) {
+            std::cerr << "error: [vg gbwt] output file not specified for removing a sample" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
         std::unique_ptr<gbwt::DynamicGBWT> index = vg::io::VPKG::load_one<gbwt::DynamicGBWT>(argv[optind]);
         if (index.get() == nullptr) {
-            std::cerr << "error: [vg gbwt]: could not load dynamic GBWT " << argv[optind] << std::endl;
+            std::cerr << "error: [vg gbwt] could not load dynamic GBWT " << argv[optind] << std::endl;
             std::exit(EXIT_FAILURE);
         }
         if (!(index->hasMetadata() && index->metadata.hasPathNames() && index->metadata.hasSampleNames())) {
@@ -513,7 +523,7 @@ int main_gbwt(int argc, char** argv)
         }
         std::unique_ptr<gbwt::GBWT> index = vg::io::VPKG::load_one<gbwt::GBWT>(argv[optind]);
         if (index.get() == nullptr) {
-            std::cerr << "error: [vg gbwt]: could not load GBWT " << argv[optind] << std::endl;
+            std::cerr << "error: [vg gbwt] could not load GBWT " << argv[optind] << std::endl;
             std::exit(EXIT_FAILURE);
         }
 

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -32,28 +32,30 @@ void help_gbwt(char** argv) {
     std::cerr << "Manipulate GBWTs." << std::endl;
     std::cerr << std::endl;
     std::cerr << "General options:" << std::endl;
-    std::cerr << "    -o, --output X          write output GBWT to X (required with -m, -f, and -P)" << std::endl;
+    std::cerr << "    -o, --output FILE       write output GBWT to FILE" << std::endl;
     std::cerr << "    -p, --progress          show progress and statistics" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Merging (requires -o; use deps/gbwt/merge_gbwt for more options):" << std::endl;
     std::cerr << "    -m, --merge             merge the GBWT files from the input args and write to output" << std::endl;
     std::cerr << "    -f, --fast              fast merging algorithm (node ids must not overlap; implies -m)" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Threads (one GBWT file as an input arg):" << std::endl;
+    std::cerr << "Threads (one input GBWT):" << std::endl;
     std::cerr << "    -c, --count-threads     print the number of threads" << std::endl;
     std::cerr << "    -e, --extract FILE      extract threads in SDSL format to FILE" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "GBWTGraph construction (0 or 1 GBWT files as input args):" << std::endl;
-    std::cerr << "    -g, --graph-name FILE   build GBWTGraph and serialize it to FILE (requires -x)" << std::endl;
-    std::cerr << "    -x, --xg-name FILE      use the node sequences from the graph in FILE" << std::endl;
-    std::cerr << "    -l, --local-haplotypes  sample local haplotypes from the input (requires -o)" << std::endl;
-    std::cerr << "    -P, --path-cover        build GBWT from a greedy path cover (requires -o)" << std::endl;
-    std::cerr << "    -n, --num-paths N       find N paths per component in -l or -P (default " << gbwtgraph::PATH_COVER_DEFAULT_N << ")" << std::endl;
-    std::cerr << "    -k, --context-length N  use N-node contexts in -l or -P (default " << gbwtgraph::PATH_COVER_DEFAULT_K << ")" << std::endl;
+    std::cerr << "GBWTGraph construction (based on path cover GBWT or one input GBWT):" << std::endl;
+    std::cerr << "    -g, --graph-name FILE   build GBWTGraph and serialize it to FILE (required)" << std::endl;
+    std::cerr << "    -x, --xg-name FILE      use the node sequences from the graph in FILE (required)" << std::endl;
+    std::cerr << std::endl;
+    std::cerr << "Path cover options (requires -o and one of { -l, -P }):" << std::endl;
+    std::cerr << "    -l, --local-haplotypes  sample local haplotypes (one input GBWT)" << std::endl;
+    std::cerr << "    -P, --path-cover        build a greedy path cover (no input GBWTs)" << std::endl;
+    std::cerr << "    -n, --num-paths N       find N paths per component (default " << gbwtgraph::PATH_COVER_DEFAULT_N << ")" << std::endl;
+    std::cerr << "    -k, --context-length N  use N-node contexts (default " << gbwtgraph::PATH_COVER_DEFAULT_K << ")" << std::endl;
     std::cerr << "    -b, --buffer-size N     GBWT construction buffer size in millions of nodes (default " << (gbwt::DynamicGBWT::INSERT_BATCH_SIZE / gbwt::MILLION) << ")" << std::endl;
     std::cerr << "    -i, --id-interval N     store path ids at one out of N positions (default " << gbwt::DynamicGBWT::SAMPLE_INTERVAL << ")" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Metadata (one GBWT file as an input arg; use deps/gbwt/metadata_tool to modify):" << std::endl;
+    std::cerr << "Metadata (one input GBWT; use deps/gbwt/metadata_tool to modify):" << std::endl;
     std::cerr << "    -M, --metadata          print basic metadata" << std::endl;
     std::cerr << "    -C, --contigs           print the number of contigs" << std::endl;
     std::cerr << "    -H, --haplotypes        print the number of haplotypes" << std::endl;
@@ -107,6 +109,8 @@ int main_gbwt(int argc, char** argv)
                 // GBWTGraph
                 { "graph-name", required_argument, 0, 'g' },
                 { "xg-name", required_argument, 0, 'x' },
+
+                // Path cover
                 { "local-haplotypes", no_argument, 0, 'l' },
                 { "path-cover", no_argument, 0, 'P' },
                 { "num-paths", required_argument, 0, 'n' },
@@ -171,6 +175,8 @@ int main_gbwt(int argc, char** argv)
         case 'x':
             xg_name = optarg;
             break;
+
+        // Path cover
         case 'l':
             local_haplotypes = true;
             break;

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -25,6 +25,8 @@ using namespace vg::subcommand;
 
 #include <unistd.h>
 
+enum operation_mode { operation_none, operation_merge, operation_graph, operation_remove, operation_other };
+enum path_cover_mode { path_cover_none, path_cover_augment, path_cover_local, path_cover_greedy };
 
 void help_gbwt(char** argv) {
     std::cerr << "usage: " << argv[0] << " [options] [args]" << std::endl;
@@ -48,6 +50,7 @@ void help_gbwt(char** argv) {
     std::cerr << "    -x, --xg-name FILE      use the node sequences from the graph in FILE (required)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Path cover (for GBWTGraph construction; requires -o and one of { -l, -P }):" << std::endl;
+    std::cerr << "    -a, --augment-gbwt      add a path cover of missing components (one input GBWT)" << std::endl;
     std::cerr << "    -l, --local-haplotypes  sample local haplotypes (one input GBWT)" << std::endl;
     std::cerr << "    -P, --path-cover        build a greedy path cover (no input GBWTs)" << std::endl;
     std::cerr << "    -n, --num-paths N       find N paths per component (default " << gbwtgraph::PATH_COVER_DEFAULT_N << ")" << std::endl;
@@ -76,14 +79,14 @@ int main_gbwt(int argc, char** argv)
         std::exit(EXIT_FAILURE);
     }
 
-    // Operation modes. Only one of these can be active.
-    bool merge = false, build_graph = false, remove_sample = false, other_options = false;
+    // Operation modes.
+    operation_mode mode = operation_none;
+    path_cover_mode path_cover = path_cover_none;
 
     bool fast_merging = false;
     bool show_progress = false;
     bool count_threads = false;
     bool metadata = false, contigs = false, haplotypes = false, samples = false, list_names = false, thread_names = false;
-    bool local_haplotypes = false, path_cover = false;
     size_t num_paths = gbwtgraph::PATH_COVER_DEFAULT_N, context_length = gbwtgraph::PATH_COVER_DEFAULT_K;
     size_t buffer_size = gbwt::DynamicGBWT::INSERT_BATCH_SIZE;
     size_t id_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL;
@@ -113,6 +116,7 @@ int main_gbwt(int argc, char** argv)
                 { "xg-name", required_argument, 0, 'x' },
 
                 // Path cover
+                { "augment-gbwt", no_argument, 0, 'a' },
                 { "local-haplotypes", no_argument, 0, 'l' },
                 { "path-cover", no_argument, 0, 'P' },
                 { "num-paths", required_argument, 0, 'n' },
@@ -136,7 +140,7 @@ int main_gbwt(int argc, char** argv)
             };
 
         int option_index = 0;
-        c = getopt_long(argc, argv, "o:pmfce:g:x:lPn:k:b:i:MCHSLTR:h?", long_options, &option_index);
+        c = getopt_long(argc, argv, "o:pmfce:g:x:alPn:k:b:i:MCHSLTR:h?", long_options, &option_index);
 
         /* Detect the end of the options. */
         if (c == -1)
@@ -154,38 +158,41 @@ int main_gbwt(int argc, char** argv)
 
         // Merging
         case 'm':
-            merge = true;
+            mode = operation_merge;
             break;
         case 'f':
+            mode = operation_merge;
             fast_merging = true;
-            merge = true;
             break;
 
         // Threads
         case 'c':
+            mode = operation_other;
             count_threads = true;
-            other_options = true;
             break;
         case 'e':
+            mode = operation_other;
             thread_output = optarg;
-            other_options = true;
             break;
 
         // GBWTGraph
         case 'g':
+            mode = operation_graph;
             graph_output = optarg;
-            build_graph = true;
             break;
         case 'x':
             xg_name = optarg;
             break;
 
         // Path cover
+        case 'a':
+            path_cover = path_cover_augment;
+            break;
         case 'l':
-            local_haplotypes = true;
+            path_cover = path_cover_local;
             break;
         case 'P':
-            path_cover = true;
+            path_cover = path_cover_greedy;
             break;
         case 'n':
             num_paths = parse<size_t>(optarg);
@@ -202,33 +209,33 @@ int main_gbwt(int argc, char** argv)
 
         // Metadata
         case 'M':
+            mode = operation_other;
             metadata = true;
-            other_options = true;
             break;
         case 'C':
+            mode = operation_other;
             contigs = true;
-            other_options = true;
             break;
         case 'H':
+            mode = operation_other;
             haplotypes = true;
-            other_options = true;
             break;
         case 'S':
+            mode = operation_other;
             samples = true;
-            other_options = true;
             break;
         case 'L':
             list_names = true;
             break;
         case 'T':
+            mode = operation_other;
             thread_names = true;
-            other_options = true;
             break;
 
         // Remove sample
         case 'R':
+            mode = operation_remove;
             to_remove = optarg;
-            remove_sample = true;
             break;
 
         case 'h':
@@ -244,24 +251,7 @@ int main_gbwt(int argc, char** argv)
     }
 
     // Sanity checks.
-    size_t active_modes = 0;
-    if (merge) {
-        active_modes++;
-    }
-    if (build_graph) {
-        active_modes++;
-    }
-    if (remove_sample) {
-        active_modes++;
-    }
-    if (other_options) {
-        active_modes++;
-    }
-    if (active_modes > 1) {
-        std::cerr << "error: [vg gbwt] merging, graph construction, removing samples, and other options are mutually exclusive" << std::endl;
-        std::exit(EXIT_FAILURE);
-    }
-    if (active_modes == 0) {
+    if (mode == operation_none) {
         help_gbwt(argv);
         std::exit(EXIT_FAILURE);
     }
@@ -271,7 +261,7 @@ int main_gbwt(int argc, char** argv)
 
 
     // Merging options.
-    if (merge) {
+    if (mode == operation_merge) {
 
         // Ugly hack here. GBWT prints to stdout, and we want to direct it to stderr.
         std::streambuf* cout_buf = std::cout.rdbuf();
@@ -379,22 +369,22 @@ int main_gbwt(int argc, char** argv)
 
 
     // GBWTGraph construction.
-    if (build_graph) {
-        if (local_haplotypes || path_cover) {
-            if (local_haplotypes && path_cover) {
-                std::cerr << "error: [vg gbwt] cannot build both local haplotypes and path cover" << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-            if (local_haplotypes && optind + 1 != argc) {
+    if (mode == operation_graph) {
+        if (path_cover != path_cover_none) {
+            if (path_cover == path_cover_local && optind + 1 != argc) {
                 std::cerr << "error: [vg gbwt] no input GBWT given for finding local haplotypes" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
-            if (path_cover && optind != argc) {
-                std::cerr << "error: [vg gbwt] input GBWTs are not used with path cover" << std::endl;
+            if (path_cover == path_cover_augment && optind + 1 != argc) {
+                std::cerr << "error: [vg gbwt] no input GBWT to augment" << std::endl;
+                std::exit(EXIT_FAILURE);
+            }
+            if (path_cover == path_cover_greedy && optind != argc) {
+                std::cerr << "error: [vg gbwt] input GBWTs are not used with greedy path cover" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             if (num_paths == 0) {
-                std::cerr << "error: [vg gbwt] number of paths must be non-zero for -l and -P" << std::endl;
+                std::cerr << "error: [vg gbwt] number of paths must be non-zero for path cover" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             if (context_length < gbwtgraph::PATH_COVER_MIN_K) {
@@ -433,7 +423,7 @@ int main_gbwt(int argc, char** argv)
         // Load or build GBWT.
         std::unique_ptr<gbwt::GBWT> loaded_gbwt(nullptr);
         gbwt::GBWT generated_gbwt;
-        if (path_cover) {
+        if (path_cover == path_cover_greedy) {
             if (show_progress) {
                 std::cerr << "Finding " << num_paths << "-path cover with context length " << context_length << std::endl;
             }
@@ -445,6 +435,27 @@ int main_gbwt(int argc, char** argv)
                 std::cerr << "Serializing path cover GBWT to " << gbwt_output << std::endl;
             }
             vg::io::VPKG::save(generated_gbwt, gbwt_output);
+        } else if (path_cover == path_cover_augment) {
+            if (show_progress) {
+                std::cerr << "Loading GBWT " << argv[optind] << std::endl;
+            }
+            std::unique_ptr<gbwt::DynamicGBWT> input_gbwt = vg::io::VPKG::load_one<gbwt::DynamicGBWT>(argv[optind]);
+            if (input_gbwt.get() == nullptr) {
+                std::cerr << "error: [vg gbwt] could not load GBWT " << argv[optind] << std::endl;
+                std::exit(EXIT_FAILURE);
+            }
+            if (show_progress) {
+                std::cerr << "Finding " << num_paths << "-path cover with context length " << context_length << " for missing components" << std::endl;
+            }
+            double start = gbwt::readTimer();
+            gbwtgraph::augment_gbwt(*handle_graph, *input_gbwt, num_paths, context_length, buffer_size, id_interval, show_progress);
+            if (show_progress) {
+                double seconds = gbwt::readTimer() - start;
+                std::cerr << "GBWT augmented in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+                std::cerr << "Serializing augmented GBWT to " << gbwt_output << std::endl;
+            }
+            generated_gbwt = gbwt::GBWT(*input_gbwt);
+            vg::io::VPKG::save(generated_gbwt, gbwt_output);
         } else {
             if (show_progress) {
                 std::cerr << "Loading GBWT " << argv[optind] << std::endl;
@@ -454,7 +465,7 @@ int main_gbwt(int argc, char** argv)
                 std::cerr << "error: [vg gbwt] could not load GBWT " << argv[optind] << std::endl;
                 std::exit(EXIT_FAILURE);
             }
-            if (local_haplotypes) {
+            if (path_cover == path_cover_local) {
                 if (show_progress) {
                     std::cerr << "Finding " << num_paths << "-path cover with context length " << context_length << std::endl;
                 }
@@ -469,7 +480,7 @@ int main_gbwt(int argc, char** argv)
                 loaded_gbwt.reset();
             }
         }
-        const gbwt::GBWT& selected_gbwt = ((path_cover || local_haplotypes) ? generated_gbwt : *loaded_gbwt);
+        const gbwt::GBWT& selected_gbwt = (path_cover == path_cover_none ? *loaded_gbwt : generated_gbwt);
 
         if (show_progress) {
             std::cerr << "Building GBWTGraph" << std::endl;
@@ -484,7 +495,7 @@ int main_gbwt(int argc, char** argv)
 
 
     // Remove a sample from the GBWT.
-    if (remove_sample) {
+    if (mode == operation_remove) {
         if (optind + 1 != argc) {
             std::cerr << "error: [vg gbwt] one input GBWT is required for removing a sample" << std::endl;
             std::exit(EXIT_FAILURE);
@@ -516,7 +527,7 @@ int main_gbwt(int argc, char** argv)
 
 
     // Other options.
-    if (other_options) {
+    if (mode == operation_other) {
         if (optind + 1 != argc) {
             std::cerr << "error: [vg gbwt] selected options require one input GBWT" << std::endl;
             std::exit(EXIT_FAILURE);

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -65,11 +65,11 @@ vg index -G x_both.gbwt -T -v small/xy2.vcf.gz x.vg
 is $(vg gbwt -c x_both.gbwt) 3 "there are 3 threads in the index"
 
 # Remove a sample (actually the reference) from a GBWT
-vg gbwt -R ref x_both.gbwt
+vg gbwt -R ref x_both.gbwt -o removed.gbwt
 is $? 0 "samples can be removed from a GBWT index"
-is $(vg gbwt -c x_both.gbwt) 2 "the sample was removed"
+is $(vg gbwt -c removed.gbwt) 2 "the sample was removed"
 
-rm x_ref.gbwt x_both.gbwt
+rm x_ref.gbwt x_both.gbwt removed.gbwt
 
 
 # Store haplotypes in both GBWT and a binary file

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -5,13 +5,16 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 42
+plan tests 48
 
 
 # Build vg graphs for two chromosomes
 vg construct -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a > x.vg 2> /dev/null
 vg construct -r small/xy.fa -v small/xy2.vcf.gz -R y -C -a > y.vg 2> /dev/null
 vg ids -j x.vg y.vg
+
+vg index -x x.xg x.vg
+vg index -x xy.xg x.vg y.vg
 
 
 # Chromosome X
@@ -86,17 +89,16 @@ rm -f x.gbwt x.bin x.extract
 
 
 # Build and serialize GBWTGraph
-vg index -x x.xg -G x.gbwt -v small/xy2.vcf.gz x.vg
+vg index -G x.gbwt -v small/xy2.vcf.gz x.vg
 vg gbwt -g x.gg -x x.xg x.gbwt
 is $? 0 "GBWTGraph construction was successful"
 vg view --extract-tag GBWTGraph x.gg > x.extracted.gg
 is $(md5sum x.extracted.gg | cut -f 1 -d\ ) 62d451917c5076d7e84a6837dfb836cb "GBWTGraph was correctly serialized"
 
-rm -f x.xg x.gbwt x.gg x.extracted.gg
+rm -f x.gbwt x.gg x.extracted.gg
 
 
 # Build both GBWT and GBWTGraph from a 16-path cover
-vg index -x xy.xg x.vg y.vg
 vg gbwt -P -n 16 -x xy.xg -g xy.gg -o xy.gbwt
 is $? 0 "GBWT/GBWTGraph construction from path cover was successful"
 vg view --extract-tag GBWTGraph xy.gg > xy.extracted.gg
@@ -106,11 +108,11 @@ is $(vg gbwt -C xy.gbwt) 2 "path cover: 2 contigs"
 is $(vg gbwt -H xy.gbwt) 16 "path cover: 16 haplotypes"
 is $(vg gbwt -S xy.gbwt) 16 "path cover: 16 samples"
 
-rm -f xy.xg xy.gg xy.gbwt xy.extracted.gg
+rm -f xy.gg xy.gbwt xy.extracted.gg
 
 
 # Build both GBWT and GBWTGraph from 16 paths of local haplotypes
-vg index -x xy.xg -G xy.gbwt -v small/xy2.vcf.gz x.vg y.vg
+vg index -G xy.gbwt -v small/xy2.vcf.gz x.vg y.vg
 vg gbwt -l -n 16 -x xy.xg -g xy.gg -o xy.local.gbwt xy.gbwt
 is $? 0 "GBWT/GBWTGraph construction from local haplotypes was successful"
 vg view --extract-tag GBWTGraph xy.gg > xy.extracted.gg
@@ -120,7 +122,21 @@ is $(vg gbwt -C xy.local.gbwt) 2 "local haplotypes: 2 contigs"
 is $(vg gbwt -H xy.local.gbwt) 16 "local haplotypes: 16 haplotypes"
 is $(vg gbwt -S xy.local.gbwt) 16 "local haplotypes: 16 samples"
 
-rm -f xy.xg xy.gg xy.gbwt xy.local.gbwt xy.extracted.gg
+rm -f xy.gg xy.gbwt xy.local.gbwt xy.extracted.gg
 
 
-rm -f x.vg y.vg
+# Build GBWTGraph from an augmented GBWT
+vg index -G x.gbwt -v small/xy2.vcf.gz x.vg
+vg gbwt -a -n 16 -x xy.xg -g augmented.gg -o augmented.gbwt x.gbwt
+is $? 0 "GBWT/GBWTGraph construction by augmenting GBWT was successful"
+vg view --extract-tag GBWTGraph augmented.gg > augmented.extracted.gg
+is $(md5sum augmented.extracted.gg | cut -f 1 -d\ ) b7b40fb5296ded80cc659cd2300015af "GBWTGraph was correctly serialized"
+is $(vg gbwt -c augmented.gbwt) 18 "augmented: 18 threads"
+is $(vg gbwt -C augmented.gbwt) 2 "augmented: 2 contigs"
+is $(vg gbwt -H augmented.gbwt) 2 "augmented: 2 haplotypes"
+is $(vg gbwt -S augmented.gbwt) 17 "augmented: 17 samples"
+
+rm -f x.gbwt augmented.gg augmented.gbwt augmented.extracted.gg
+
+
+rm -f x.vg y.vg x.xg xy.xg


### PR DESCRIPTION
`vg gbwt -a` adds a path cover of components without haplotypes to an existing GBWT. This resolves the Giraffe issue with a large number of incorrect mapq 60 reads in some graphs with the full GBWT.