### PR TITLE
this enables haplotype scoring in vg map based on graphs with embedded paths

### DIFF
--- a/src/haplotype_indexer.cpp
+++ b/src/haplotype_indexer.cpp
@@ -357,6 +357,8 @@ tuple<vector<string>, size_t, vector<string>> HaplotypeIndexer::generate_threads
         size_t path_rank = 0;
         graph->for_each_path_handle([&](path_handle_t path_handle) {
                 ++path_rank;
+                haplotype_count++;
+                sample_names.emplace_back(graph->get_path_name(path_handle));
                 if (graph->is_empty(path_handle) || Paths::is_alt(graph->get_path_name(path_handle))) {
                     return;
                 }
@@ -369,8 +371,8 @@ tuple<vector<string>, size_t, vector<string>> HaplotypeIndexer::generate_threads
             });
 
         // GBWT metadata: We assume that the XG index contains the reference paths.
-        sample_names.emplace_back("ref");
-        haplotype_count++;
+        //sample_names.emplace_back("ref");
+        //haplotype_count++;
         true_sample_offset++;
     }
 


### PR DESCRIPTION
Previously, these were not counted towards the total haplotype count in the index, and so we were unable to correctly calculate the score.

This updates the index construction code in vg to count the embedded paths in the metadata, which resolves this problem.

Review from someone with more experience with the GBWT and haplotype scoring would be helpful.