### PR TITLE
Update pangenome ontology: add linkZoomLayer

### DIFF
--- a/ontology/README.md
+++ b/ontology/README.md
@@ -58,36 +58,36 @@ At this moment VG RDF wants a fully embedded variation graph. e.g. all positions
 On top of VG RDF, we can describe the same path information on Pantograph format as well.
 
 ```ttl
-<pg/zoom10> a vg:ZoomLevel ;
-   vg:components <pg/zoom10/component1>, <pg/zoom10/component2> ;
+<vg/zoom10> a vg:ZoomLevel ;
+   vg:components <vg/zoom10/component1>, <vg/zoom10/component2> ;
    vg:zoomFactor 10 .
-<pg/zoom1000> a vg:ZoomLevel ;
-   vg:components <pg/zoom1000/component1>, <pg/zoom1000/component2> ;
+<vg/zoom1000> a vg:ZoomLevel ;
+   vg:components <vg/zoom1000/component1>, <vg/zoom1000/component2> ;
    vg:zoomFactor 1000 . // zoomFactor is binWidth here.
-<pg/zoom1000/component1> a vg:Component ;
+<vg/zoom1000/component1> a vg:Component ;
    vg:componentRank 1 ;   # The order of component is inferred by rank.
-   vg:forwardComponentEdge <pg/zoom1000/component2> ;
-   vg:bins <pg/zoom1000/component1/bin1>, <pg/zoom1000/component1/bin2> .
-<pg/zoom1000/component1/bin1> a vg:Bin ;
-   vg:forwardBinEdge <pg/zoom1000/component2/bin2> ;
+   vg:forwardComponentEdge <vg/zoom1000/component2> ;
+   vg:bins <vg/zoom1000/component1/bin1>, <vg/zoom1000/component1/bin2> .
+<vg/zoom1000/component1/bin1> a vg:Bin ;
+   vg:forwardBinEdge <vg/zoom1000/component2/bin2> ;
    vg:binRank 1 ;
-   vg:cells <pg/zoom1000/component1/bin1/cell1>, <pg/zoom1000/component1/bin1/cell2> .
-<pg/zoom1000/component2/bin2> a vg:Bin ;
-   vg:reverseBinEdge <pg/zoom1000/component2/bin3> ;
-   vg:forwardBinEdge <pg/zoom1000/component2/bin3> ;
+   vg:cells <vg/zoom1000/component1/bin1/cell1>, <vg/zoom1000/component1/bin1/cell2> .
+<vg/zoom1000/component2/bin2> a vg:Bin ;
+   vg:reverseBinEdge <vg/zoom1000/component2/bin3> ;
+   vg:forwardBinEdge <vg/zoom1000/component2/bin3> ;
    vg:binRank 2 ;
-   vg:cells <pg/zoom1000/component1/bin2/cell1>, <pg/zoom1000/component1/bin2/cell2> .
-<pg/zoom1000/component1/bin1/cell1> a vg:Cell ;
+   vg:cells <vg/zoom1000/component1/bin2/cell1>, <vg/zoom1000/component1/bin2/cell2> .
+<vg/zoom1000/component1/bin1/cell1> a vg:Cell ;
    vg:positionPercent 0.04 ;
    vg:inversionPercent 0.98 ;
    vg:cellRegion <path1/region/6-100> .  # To infer firstNucleotide and last Nucleotide. faldo:begin of stepRegion is the first position. faldo:end of cellRegion is the last position.
-<pg/zoom1000/link1> a vg:Link ; # This is a non-linear connection between Bins.
-   vg:arrival <pg/zoom1000/component1/bin1> ;
-   vg:departure <pg/zoom1000/component2/bin2> ;
-   vg:forwardLinkEdge <pg/zoom1000/link2> ;
+<vg/zoom1000/link1> a vg:Link ; # This is a non-linear connection between Bins.
+   vg:arrival <vg/zoom1000/component1/bin1> ;
+   vg:departure <vg/zoom1000/component2/bin2> ;
+   vg:forwardLinkEdge <vg/zoom1000/link2> ;
    vg:linkRank 1 ;
    vg:linkPaths <path1> <path2> ; # Participants of the link
-   vg:linkZoomLevel <pg/zoom10> .
+   vg:linkZoomLevel <vg/zoom10> .
 <path1/region/6-100> a faldo:Region ;
    faldo:begin <path1/position/6>  ;
    faldo:end <path1/position/100>  .

--- a/ontology/README.md
+++ b/ontology/README.md
@@ -3,7 +3,7 @@
 ## Conceptual model
 
 `Node`s, `Path`s and `Step`s, are the three core parts of any VG graph in RDF.
-A `Node` in the VG RDF corersponds directly to the Node concept in the VG protobuf serialization.
+A `Node` in the VG RDF corresponds directly to the Node concept in the VG protobuf serialization.
 `Paths` are a number of `Step`s that represent a sequence of Node visits that generate a linear biological sequence.
 Each `Step` connects a `Node` into a `Path`
 
@@ -86,7 +86,8 @@ On top of VG RDF, we can describe the same path information on Pantograph format
    vg:departure <pg/zoom1000/component2/bin2> ;
    vg:forwardLinkEdge <pg/zoom1000/link2> ;
    vg:linkRank 1 ;
-   vg:linkPaths <path1> <path2> . # Participants of the link
+   vg:linkPaths <path1> <path2> ; # Participants of the link
+   vg:linkZoomLevel <pg/zoom10> .
 <path1/region/6-100> a faldo:Region ;
    faldo:begin <path1/position/6>  ;
    faldo:end <path1/position/100>  .

--- a/ontology/owl2xhtml.xsl
+++ b/ontology/owl2xhtml.xsl
@@ -611,7 +611,7 @@ by Masahide Kanzaki, and from the OWL2HTML stylesheet (2), by Li Ding. We are ve
                  
 		<xsl:for-each select="@rdf:datatype">
                    <sup>
-                       <a href=".">
+                       <a href="{concat(namespace-uri(),.)}">
                         <xsl:call-template name="prettyUrl">
                           <xsl:with-param name="name" select="."/>
                         </xsl:call-template>

--- a/ontology/vg.html
+++ b/ontology/vg.html
@@ -280,7 +280,7 @@
 					owl:versionInfo</a></td>
 <td>
 						"Created at the DBCLS RDF Summit 2, Sendai Japan and COVID-19 Virtual Biohackathon"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -306,7 +306,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A bin in the output of odgi bin, representing a sequence section."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -315,7 +315,7 @@
 					rdfs:label</a></td>
 <td>
 						"Bin"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -342,7 +342,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A cell along a path of a specific group (component) of a specific zoom. A cell to a :Component and a :Path with supplemental informations."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -351,7 +351,7 @@
 					rdfs:label</a></td>
 <td>
 						"Cell"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -378,7 +378,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A region between Links structuring all bins and their present individuals into one component."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -387,7 +387,7 @@
 					rdfs:label</a></td>
 <td>
 						"Component"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -527,7 +527,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A link marks a graph traversal along a nonlinear connection."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -536,7 +536,7 @@
 					rdfs:label</a></td>
 <td>
 						"Link"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -563,7 +563,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A node in the variant graph, representing a sequence section."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -572,7 +572,7 @@
 					rdfs:label</a></td>
 <td>
 						"Node"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -599,7 +599,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A Path is a collection of steps from path to path that represent an asserdfs:labelmbled sequence integrated into the variant graph."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -608,7 +608,7 @@
 					rdfs:label</a></td>
 <td>
 						"Path"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -689,7 +689,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A step along a path in the variant graph. A series of steps along a path represent an assembled sequence that was originally inserted into the the variant graph. A step points to a :Node or the reverse complement of a node and has a rank (step number)."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -698,7 +698,7 @@
 					rdfs:label</a></td>
 <td>
 						"Step"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -795,7 +795,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A zoom level of Pangenome."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -804,7 +804,7 @@
 					rdfs:label</a></td>
 <td>
 						"ZoomLevel"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -839,7 +839,7 @@
 					rdfs:comment</a></td>
 <td>
 						"An end bin of nonlinear link. Incoming edge of the bin."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -854,7 +854,7 @@
 					rdfs:label</a></td>
 <td>
 						"arrival"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -887,7 +887,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A Component has one or more Bins."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -902,7 +902,7 @@
 					rdfs:label</a></td>
 <td>
 						"bins"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -929,7 +929,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A cell is composed of the specific subsequence of paths."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -944,7 +944,7 @@
 					rdfs:label</a></td>
 <td>
 						"cellRegions"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -970,7 +970,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A Bin has one or more paths of a specific group (component) of a specific zoom. That is represented as cells on the matrix."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -985,7 +985,7 @@
 					rdfs:label</a></td>
 <td>
 						"cells"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1012,7 +1012,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A zoom level has one or more components."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1027,7 +1027,7 @@
 					rdfs:label</a></td>
 <td>
 						"components"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1054,7 +1054,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A start bin of nonlinear link. Outgoing edge of the bin."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1069,7 +1069,7 @@
 					rdfs:label</a></td>
 <td>
 						"departure"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1102,7 +1102,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The super property that says two bins are linked in forward orientation on the pangenome sequence."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1117,7 +1117,7 @@
 					rdfs:label</a></td>
 <td>
 						"forwardBinEdge"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1144,7 +1144,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The super property that says two components are linked in forward orientation on the pangenome sequence."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1159,7 +1159,7 @@
 					rdfs:label</a></td>
 <td>
 						"forwardComponentEdge"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1186,7 +1186,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The super property that says two links are linked in forward orientation on the link column."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1201,7 +1201,7 @@
 					rdfs:label</a></td>
 <td>
 						"forwardLinkEdge"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1228,7 +1228,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A list of paths that follow the same non-linear link between two bins."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1243,7 +1243,7 @@
 					rdfs:label</a></td>
 <td>
 						"linkPaths"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1270,7 +1270,7 @@
 					rdfs:comment</a></td>
 <td>
 						"A link is related to each zoom level."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1285,7 +1285,7 @@
 					rdfs:label</a></td>
 <td>
 						"linkZoomLevel"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1312,7 +1312,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The super property that says two nodes are linked and does not allow one to infer which side to side it goes"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1327,7 +1327,7 @@
 					rdfs:label</a></td>
 <td>
 						"links"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1354,7 +1354,7 @@
 					rdfs:comment</a></td>
 <td>
 						"This links a node from the forward (5' to 3') strand on the subject node to the forward (5' to 3') strand on the predicate node."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1369,7 +1369,7 @@
 					rdfs:label</a></td>
 <td>
 						"++"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1378,7 +1378,7 @@
 					rdfs:label</a></td>
 <td>
 						"linksForwardToForward"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1411,7 +1411,7 @@
 					rdfs:comment</a></td>
 <td>
 						"This links a node from the forward (5' to 3') strand on the subject node to the reverse (3' to 5') strand on the predicate node."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1426,7 +1426,7 @@
 					rdfs:label</a></td>
 <td>
 						"+-"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1435,7 +1435,7 @@
 					rdfs:label</a></td>
 <td>
 						"linksForwardToReverse"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1468,7 +1468,7 @@
 					rdfs:comment</a></td>
 <td>
 						"This links a node from the reverse (3' to 5') strand on the subject node to the forward (5' to 3') strand on the predicate node."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1483,7 +1483,7 @@
 					rdfs:label</a></td>
 <td>
 						"-+"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1492,7 +1492,7 @@
 					rdfs:label</a></td>
 <td>
 						"linksReverseToForward"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1525,7 +1525,7 @@
 					rdfs:comment</a></td>
 <td>
 						"This links a node from the reverse (3' to 5') strand on the subject node to the reverse (3' to 5') strand on the predicate node."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1540,7 +1540,7 @@
 					rdfs:label</a></td>
 <td>
 						"--"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1549,7 +1549,7 @@
 					rdfs:label</a></td>
 <td>
 						"linksReverseToReverse"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1582,7 +1582,7 @@
 					rdfs:comment</a></td>
 <td>
 						"This means that this step occurs on the forward strand of the sequence attaced to the node (i.e. it is on the explicit encoded forward (5' to 3') strand) of the predicate node."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1597,7 +1597,7 @@
 					rdfs:label</a></td>
 <td>
 						"node"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1624,7 +1624,7 @@
 					rdfs:comment</a></td>
 <td>
 						"This means that this step occurs on the path that is the object of this statment"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1639,7 +1639,7 @@
 					rdfs:label</a></td>
 <td>
 						"path"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1666,7 +1666,7 @@
 					rdfs:comment</a></td>
 <td>
 						"This is the position on the reference path at which this step starts."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1681,7 +1681,7 @@
 					rdfs:label</a></td>
 <td>
 						"position"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1708,7 +1708,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The super property that says two bins are linked in reverse orientation on the pangenome sequence."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1723,7 +1723,7 @@
 					rdfs:label</a></td>
 <td>
 						"reverseBinEdge"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1750,7 +1750,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The super property that says two components are linked in reverse orientation on the pangenome sequence."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1765,7 +1765,7 @@
 					rdfs:label</a></td>
 <td>
 						"reverseComponentEdge"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1792,7 +1792,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The super property that says two links are linked in reverse orientation on the link column."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1807,7 +1807,7 @@
 					rdfs:label</a></td>
 <td>
 						"reverseLinkEdge"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1834,7 +1834,7 @@
 					rdfs:comment</a></td>
 <td>
 						"This means this step occurs on the revese complement of the sequence attaced to the node (i.e. it is on the implicit reverse (3' to 5') strand) of the predicate node."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1849,7 +1849,7 @@
 					rdfs:label</a></td>
 <td>
 						"reverseOfNode"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1877,7 +1877,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The rank records that step place along its pangenome sequence."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1892,7 +1892,7 @@
 					rdfs:label</a></td>
 <td>
 						"binRank"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1919,7 +1919,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The rank records that step place along its pangenome sequence."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1934,7 +1934,7 @@
 					rdfs:label</a></td>
 <td>
 						"componentRank"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1961,7 +1961,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The inversion percent of the path in the component."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -1976,7 +1976,7 @@
 					rdfs:label</a></td>
 <td>
 						"inversionPercent"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -2003,7 +2003,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The rank records that step place along a link column."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -2018,7 +2018,7 @@
 					rdfs:label</a></td>
 <td>
 						"linkRank"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -2045,7 +2045,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The position coverage percent of the path in the component."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -2060,7 +2060,7 @@
 					rdfs:label</a></td>
 <td>
 						"positionPercent"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -2087,7 +2087,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The rank records the step place along its path."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -2102,7 +2102,7 @@
 					rdfs:label</a></td>
 <td>
 						"rank"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -2129,7 +2129,7 @@
 					rdfs:comment</a></td>
 <td>
 						"The zoom factor of pangenome, which is defined as bin width, generally."
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>
@@ -2144,7 +2144,7 @@
 					rdfs:label</a></td>
 <td>
 						"zoomFactor"
-						<sup><a href=".">
+						<sup><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#http://www.w3.org/2001/XMLSchema#string">
 				xsd:string</a></sup>
 </td>
 </tr>

--- a/ontology/vg.html
+++ b/ontology/vg.html
@@ -154,13 +154,13 @@
 </tr>
 <tr><td><a href="#Properties">
                                     Properties (
-                                    29
+                                    30
                                     )
                             </a></td></tr>
 <tr>
 <td><a style="objectPropertySearch" href="#ObjectProperties">
                                     Object properties (
-                                    22
+                                    23
                                     )
                             </a></td>
 <td><select onChange="window.location.hash = document.getElementById('navi3').value" id="navi3"><option value="arrival">
@@ -183,6 +183,8 @@
 				vg:forwardLinkEdge</option>
 <option value="linkPaths">
 				vg:linkPaths</option>
+<option value="linkZoomLevel">
+				vg:linkZoomLevel</option>
 <option value="links">
 				vg:links</option>
 <option value="linksForwardToForward">
@@ -1250,6 +1252,48 @@
 					rdfs:range</a></td>
 <td><a href="http://biohackathon.org/resource/vg#Path">
 				vg:Path</a></td>
+</tr>
+</tbody>
+</table>
+<table class="subsection">
+<a name="http://biohackathon.org/resource/vg#linkZoomLevel"></a><tbody>
+<tr><th id="linkZoomLevel">
+				vg:linkZoomLevel<span class="cp-type">
+								(rdf:type
+								<a href="http://www.w3.org/2002/07/owl#ObjectProperty">
+					owl:ObjectProperty</a>
+								)
+							</span>
+</th></tr>
+<tr>
+<td><a href="http://www.w3.org/2000/01/rdf-schema#comment">
+					rdfs:comment</a></td>
+<td>
+						"A link is related to each zoom level."
+						<sup><a href=".">
+				xsd:string</a></sup>
+</td>
+</tr>
+<tr>
+<td><a href="http://www.w3.org/2000/01/rdf-schema#domain">
+					rdfs:domain</a></td>
+<td><a href="http://biohackathon.org/resource/vg#Link">
+				vg:Link</a></td>
+</tr>
+<tr>
+<td><a href="http://www.w3.org/2000/01/rdf-schema#label">
+					rdfs:label</a></td>
+<td>
+						"linkZoomLevel"
+						<sup><a href=".">
+				xsd:string</a></sup>
+</td>
+</tr>
+<tr>
+<td><a href="http://www.w3.org/2000/01/rdf-schema#range">
+					rdfs:range</a></td>
+<td><a href="http://biohackathon.org/resource/vg#ZoomLevel">
+				vg:ZoomLevel</a></td>
 </tr>
 </tbody>
 </table>

--- a/ontology/vg.ttl
+++ b/ontology/vg.ttl
@@ -249,6 +249,13 @@
   rdfs:label "linkRank"^^xsd:string ;
   rdfs:range xsd:positiveInteger ;
 .
+:linkZoomLevel
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "A link is related to each zoom level."^^xsd:string ;
+  rdfs:domain :Link ;
+  rdfs:label "linkZoomLevel"^^xsd:string ;
+  rdfs:range :ZoomLevel ;
+.
 :cells
   rdf:type owl:ObjectProperty ;
   rdfs:comment "A Bin has one or more paths of a specific group (component) of a specific zoom. That is represented as cells on the matrix."^^xsd:string ;


### PR DESCRIPTION
In the previous ontology, there is no way to know the zoomLayer from links. This is a pitfall when we start to write actual queries. In this PR, we add linkZoomLayer to point out the zoom Layer from links. Also we fixed some typos.