### PR TITLE
Speed up the miRNA-targeted seeding algorithm

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -3656,8 +3656,18 @@ MEMClusterer::HitGraph ComponentMinDistanceClusterer::make_hit_graph(const Align
                     // the distance between the seeds on the read
                     int64_t read_dist = hit_node_2.mem->begin - hit_node_1.mem->end;
                     
-                    // is it possible that an alignment containing both could be detected with local alignment?
-                    if (abs(read_dist - graph_dist) < longest_gap) {
+                    if (min_dist == hit_node_2.mem->begin - hit_node_1.mem->begin &&
+                        ((hit_node_2.mem->begin >= hit_node_1.mem->begin && hit_node_2.mem->end <= hit_node_1.mem->end)
+                         || hit_node_1.mem->end <= hit_node_2.mem->end)) {
+                        // this has the appearance of being a redundant hit of a sub-MEM, which we don't want to form
+                        // a separate cluster
+                        
+                        // we add a dummy edge, but only to connect the nodes' components and join the clusters,
+                        // not to actually use in dynamic programming (given arbitrary low weight that should not
+                        // cause overflow)
+                        hit_graph.add_edge(i, j, numeric_limits<int32_t>::lowest() / 2, graph_dist);
+                    }
+                    else if (abs(read_dist - graph_dist) < longest_gap) {
                         // there's a path within in the limit
                         
 #ifdef debug_mem_clusterer

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -3658,14 +3658,18 @@ MEMClusterer::HitGraph ComponentMinDistanceClusterer::make_hit_graph(const Align
                     
                     if (min_dist == hit_node_2.mem->begin - hit_node_1.mem->begin &&
                         ((hit_node_2.mem->begin >= hit_node_1.mem->begin && hit_node_2.mem->end <= hit_node_1.mem->end)
-                         || hit_node_1.mem->end <= hit_node_2.mem->end)) {
+                         || (hit_node_1.mem->begin >= hit_node_2.mem->begin && hit_node_1.mem->end <= hit_node_2.mem->end))) {
                         // this has the appearance of being a redundant hit of a sub-MEM, which we don't want to form
                         // a separate cluster
+                        
+#ifdef debug_mem_clusterer
+                        cerr << "adding dummy hit edge edge " << component[i] << " -> " << component[j] << " to join componenents" << endl;
+#endif
                         
                         // we add a dummy edge, but only to connect the nodes' components and join the clusters,
                         // not to actually use in dynamic programming (given arbitrary low weight that should not
                         // cause overflow)
-                        hit_graph.add_edge(i, j, numeric_limits<int32_t>::lowest() / 2, graph_dist);
+                        hit_graph.add_edge(component[i], component[j], numeric_limits<int32_t>::lowest() / 2, graph_dist);
                     }
                     else if (abs(read_dist - graph_dist) < longest_gap) {
                         // there's a path within in the limit

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -749,7 +749,7 @@ protected:
     
     
     /// Minimum distance between two seeds on the read
-    const int64_t min_read_separation = -10;
+    const int64_t min_read_separation = 0;
     
     /// The number of connections from one hit in a component to another that we will consider (0 for no maximum)
     const int64_t early_stop_number = 2;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -330,28 +330,6 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
         }
     };
     
-    // a struct to hold the information needed to reconstruct the results of a fan-out search
-    struct SearchResult {
-        gcsa::range_type range;
-        string::const_iterator begin;
-        string::const_iterator end;
-        deque<pair<string::const_iterator, char>> fanout_breaks;
-        
-        SearchResult(string::const_iterator begin,
-                     string::const_iterator end,
-                     gcsa::range_type range,
-                     const deque<pair<string::const_iterator, char>>& fanout_breaks)
-            : range(range), begin(begin), end(end), fanout_breaks(fanout_breaks) {
-                
-        }
-        SearchResult(const SearchResult& other) = default;
-        SearchResult(SearchResult&& other) = default;
-        SearchResult& operator=(const SearchResult& other) = default;
-        SearchResult& operator=(SearchResult&& other) = default;
-        SearchResult() = default;
-        ~SearchResult() = default;
-    };
-    
     gcsa::range_type full_range = gcsa::range_type(0, gcsa->size() - 1);
     
     // initialize the stack of search problems
@@ -376,12 +354,7 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
             }
         }
     }
-    /*
-     gcsa::range_type range;
-     string::const_iterator begin;
-     string::const_iterator end;
-     deque<pair<string::const_iterator, char>> fanout_breaks;
-     */
+    
     vector<tuple<gcsa::range_type, string::const_iterator, string::const_iterator, deque<pair<string::const_iterator, char>>>> search_results;
     
     while (!stack.empty()) {

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -7,7 +7,7 @@
 #include "algorithms/is_acyclic.hpp"
 #include "algorithms/split_strands.hpp"
 
-//#define debug_mapper
+#define debug_mapper
 //#define debug_strip_match
 
 namespace vg {
@@ -498,6 +498,10 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
         
         const auto& search_result = *it;
         
+        if (search_result.end - search_result.begin < min_mem_length) {
+            continue;
+        }
+        
         // there are no mismatches in the search, so the whole thing can become 1 MEM
         mems.emplace_back(search_result.begin, search_result.end, search_result.range,
                           gcsa->count(search_result.range));
@@ -505,7 +509,8 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
             if (hit_max) {
                 gcsa->locate(mems.back().range, hit_max, mems.back().nodes);
                 
-            } else {
+            }
+            else {
                 gcsa->locate(mems.back().range, mems.back().nodes);
             }
         }
@@ -521,7 +526,7 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
         // modified later (e.g. by prefiltering)
         mems.back().queried_count =  mems.back().nodes.size();
         
-        if (!mem_fanout_breaks) {
+        if (mem_fanout_breaks) {
             // we're communicating fan-out breaks to the calling environment rather than
             // breaking them into exact matches right now
             mem_fanout_breaks->emplace_back(move(search_result.fanout_breaks));

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -691,6 +691,9 @@ vector<MaximalExactMatch> BaseMapper::find_fanout_mems(string::const_iterator se
             containment_graph.reserve(mems.size() + sub_mems.size());
             for (auto& sub_mem_and_parents : sub_mems) {
                 mems.emplace_back(move(sub_mem_and_parents.first));
+                if (mem_fanout_breaks) {
+                    mem_fanout_breaks->emplace_back();
+                }
                 containment_graph.emplace_back(0, move(sub_mem_and_parents.second));
             }
             

--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -252,16 +252,22 @@ public:
                           size_t max_match_length,
                           size_t target_count);
     
+    // finds MEMs where a pre-specified number of low-quality bases are
+    // allowed to be any base. if the optional vector is provided, then it
+    // will be filled to include all of the places that each returned MEM
+    // mismatches the graph sequence. otherwise, the MEMs are walked out
+    // and split into exact matches (can be expensive)
     vector<MaximalExactMatch>
     find_fanout_mems(string::const_iterator seq_begin,
                      string::const_iterator seq_end,
                      string::const_iterator qual_begin,
                      int max_fans_out,
-                     char max_fanout_base_quality);
+                     char max_fanout_base_quality,
+                     vector<deque<pair<string::const_iterator, char>>>* mem_fanout_breaks = nullptr);
     
     vector<pos_t> walk_fanout_path(string::const_iterator begin,
                                    string::const_iterator end,
-                                   const list<pair<string::const_iterator, char>>& fanout_breaks,
+                                   const deque<pair<string::const_iterator, char>>& fanout_breaks,
                                    gcsa::node_type pos);
     
     /// identifies tracts of order-length MEMs that were unfilled because their hit count was above the max

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -852,7 +852,9 @@ namespace vg {
                                     ++j;
                                 }
                                 // manipulate the offset on the stack so that we start on the correct position
-                                get<1>(stack[j]) += length_to_advance;
+                                if (j < stack.size()) {
+                                    get<1>(stack[j]) += length_to_advance;
+                                }
                                 
                                 
                                 // move the marker for the next fan-out ahead

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -847,8 +847,8 @@ namespace vg {
                                 // walk the path until finding the corresponding position
                                 length_remaining -= length_to_advance;
                                 while (j < stack.size() &&
-                                       length_to_advance >= get<1>(stack[j]) + graph.get_length(get<3>(stack[j])[get<2>(stack[j]) - 1])) {
-                                    length_to_advance -= graph.get_length(get<3>(stack[j])[get<2>(stack[j]) - 1]);
+                                       get<1>(stack[j]) + length_to_advance >= graph.get_length(get<3>(stack[j])[get<2>(stack[j]) - 1])) {
+                                    length_to_advance -= graph.get_length(get<3>(stack[j])[get<2>(stack[j]) - 1]) - get<1>(stack[j]);
                                     ++j;
                                 }
                                 // manipulate the offset on the stack so that we start on the correct position

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -4,7 +4,7 @@
 
 #include "multipath_alignment_graph.hpp"
 
-//#define debug_multipath_alignment
+#define debug_multipath_alignment
 
 using namespace std;
 namespace vg {

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -4,7 +4,7 @@
 
 #include "multipath_alignment_graph.hpp"
 
-#define debug_multipath_alignment
+//#define debug_multipath_alignment
 
 using namespace std;
 namespace vg {
@@ -751,6 +751,9 @@ namespace vg {
                             // we're at the next place where we substituted the read character
                             // for a different one
                             read_char = fanout_breaks->at(hit.first)[get<4>(back)].second;
+#ifdef debug_multipath_alignment
+                            cerr << "\tapplying fanout break to " << read_char << " instead of " << *read_iter << " at index " << (read_iter - begin) << " of MEM" << endl;
+#endif
                             ++get<4>(back);
                         }
                         else {
@@ -768,7 +771,7 @@ namespace vg {
                     if (read_iter == end) {
                         // finished walking match
 #ifdef debug_multipath_alignment
-                        cerr << "reached end of read sequence, converting into path(s) start at idx " << path_nodes.size() << endl;
+                        cerr << "reached end of read sequence, converting into path node(s) starting at idx " << path_nodes.size() << endl;
 #endif
                         assert(get<4>(back) == fanout_size);
                         
@@ -809,9 +812,17 @@ namespace vg {
                                 if (curr_node_begin < node_end) {
                                     // the node is non-empty
                                     
+#ifdef debug_multipath_alignment
+                                    cerr << "adding path node for walked match of sequence " << string(curr_node_begin, node_end) << endl;
+                                    cerr << debug_string(path) << endl;
+#endif
+                                    
                                     for (const auto& m : path.mapping()) {
                                         // record that each node occurs in this match so we can filter out sub-MEMs
                                         node_matches[m.position().node_id()].push_back(path_nodes.size());
+#ifdef debug_multipath_alignment
+                                        cerr << "associating node " << m.position().node_id() << " with a match at idx " << path_nodes.size() << endl;
+#endif
                                     }
                                     
                                     // create a path node
@@ -820,6 +831,11 @@ namespace vg {
                                     match_node.begin = curr_node_begin;
                                     match_node.end = node_end;
                                 }
+#ifdef debug_multipath_alignment
+                                else {
+                                    cerr << "skipping a walked path that has no sequence" << endl;
+                                }
+#endif
                                 
                                 // set up the next path walk
                                 path = path_t();
@@ -854,15 +870,9 @@ namespace vg {
                                 // tick down the length trackers
                                 length_remaining -= length_on_node;
                                 length_until_fanout -=  length_on_node;
-#ifdef debug_multipath_alignment
-                                cerr << "associating node " << graph.get_id(handle) << " with a match at idx " << path_nodes.size() - 1 << endl;
-#endif
+
                             }
                         }
-                        
-#ifdef debug_multipath_alignment
-                        cerr << debug_string(path) << endl;
-#endif
                     }
                     else if (node_idx == node_seq.size()) {
                         // matched entire node, move to next node(s)

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -806,7 +806,6 @@ namespace vg {
                                 edit->set_from_length(length_until_fanout);
                                 edit->set_to_length(length_until_fanout);
                                 
-                                path_nodes.emplace_back();
                                 auto node_end = end - length_remaining + length_until_fanout;
                                 
                                 if (curr_node_begin < node_end) {
@@ -826,6 +825,7 @@ namespace vg {
                                     }
                                     
                                     // create a path node
+                                    path_nodes.emplace_back();
                                     PathNode& match_node = path_nodes.back();
                                     match_node.path = move(path);
                                     match_node.begin = curr_node_begin;

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -65,18 +65,21 @@ namespace vg {
         MultipathAlignmentGraph(const HandleGraph& graph, const MultipathMapper::memcluster_t& hits,
                                 const function<pair<id_t, bool>(id_t)>& project,
                                 const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans,
-                                size_t max_branch_trim_length = 0, gcsa::GCSA* gcsa = nullptr);
+                                size_t max_branch_trim_length = 0, gcsa::GCSA* gcsa = nullptr,
+                                const MultipathMapper::match_fanouts_t* fanout_breaks = nullptr);
                                 
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily.
         MultipathAlignmentGraph(const HandleGraph& graph, const MultipathMapper::memcluster_t& hits,
                                 const unordered_map<id_t, pair<id_t, bool>>& projection_trans,
-                                size_t max_branch_trim_length = 0, gcsa::GCSA* gcsa = nullptr);
+                                size_t max_branch_trim_length = 0, gcsa::GCSA* gcsa = nullptr,
+                                const MultipathMapper::match_fanouts_t* fanout_breaks = nullptr);
         
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
         /// using a lambda for a projector
         MultipathAlignmentGraph(const HandleGraph& graph, const MultipathMapper::memcluster_t& hits,
                                 const function<pair<id_t, bool>(id_t)>& project,
-                                size_t max_branch_trim_length = 0, gcsa::GCSA* gcsa = nullptr);
+                                size_t max_branch_trim_length = 0, gcsa::GCSA* gcsa = nullptr,
+                                const MultipathMapper::match_fanouts_t* fanout_breaks = nullptr);
         
         /// Construct a graph of the reachability between aligned chunks in a linearized
         /// path graph. Produces a graph with reachability edges.
@@ -238,7 +241,8 @@ namespace vg {
         /// Walk out MEMs into match nodes and filter out redundant sub-MEMs
         void create_match_nodes(const HandleGraph& graph, const MultipathMapper::memcluster_t& hits,
                                 const function<pair<id_t, bool>(id_t)>& project,
-                                const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans);
+                                const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans,
+                                const MultipathMapper::match_fanouts_t* fanout_breaks);
         
         /// Identifies runs of exact matches that are sub-maximal because they hit the order of the GCSA
         /// index and merges them into a single node, assumes that match nodes are sorted by length and

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -46,7 +46,6 @@ namespace vg {
     void MultipathMapper::multipath_map_internal(const Alignment& alignment,
                                                  MappingQualityMethod mapq_method,
                                                  vector<multipath_alignment_t>& multipath_alns_out) {
-        
 #ifdef debug_multipath_mapper
         cerr << "multipath mapping read " << pb2json(alignment) << endl;
         cerr << "querying MEMs..." << endl;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2436,6 +2436,21 @@ namespace vg {
                                                                hit_sampling_mapq));
         }
     }
+
+    MultipathMapper::match_fanouts_t MultipathMapper::record_fanouts(const vector<MaximalExactMatch>& mems,
+                                                                     vector<deque<pair<string::const_iterator, char>>>& fanouts) const {
+        
+        match_fanouts_t match_fanouts;
+        if (!fanouts.empty()) {
+            assert(fanouts.size() == mems.size());
+            for (size_t i = 0; i < mems.size(); ++i) {
+                if (!fanouts[i].empty()) {
+                    match_fanouts[&mems[i]] = move(fanouts[i]);
+                }
+            }
+        }
+        return match_fanouts;
+    }
     
     void MultipathMapper::split_multicomponent_alignments(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                           vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs) const {
@@ -2717,7 +2732,7 @@ namespace vg {
         unordered_map<size_t, bdsg::HashGraph*> cluster_graphs;
         
         // to keep track of which clusters have been merged
-        UnionFind union_find(clusters.size());
+        UnionFind union_find(clusters.size(), false);
         
         // (for the suppressed merge code path)
         // maps the hits that make up a cluster to the index of the cluster

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -4,8 +4,8 @@
 //
 //
 
-#define debug_multipath_mapper
-#define debug_multipath_mapper_alignment
+//#define debug_multipath_mapper
+//#define debug_multipath_mapper_alignment
 //#define debug_validate_multipath_alignments
 //#define debug_report_startup_training
 //#define debug_pretty_print_alignments

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -234,6 +234,7 @@ namespace vg {
                                      vector<clustergraph_t>& cluster_graphs,
                                      vector<multipath_alignment_t>& multipath_alns_out,
                                      size_t num_mapping_attempts,
+                                     const match_fanouts_t* fanouts = nullptr,
                                      vector<size_t>* cluster_idxs = nullptr);
         
         /// After clustering MEMs, extracting graphs, assigning hits to cluster graphs, and determining
@@ -245,7 +246,8 @@ namespace vg {
                                           vector<clustergraph_t>& cluster_graphs2,
                                           vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                           vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
-                                          vector<pair<size_t, size_t>>& duplicate_pairs_out);
+                                          vector<pair<size_t, size_t>>& duplicate_pairs_out,
+                                          const match_fanouts_t* fanouts1, const match_fanouts_t* fanouts2);
         
         /// Align the read ends independently, but also try to form rescue alignments for each from
         /// the other. Return true if output obeys pair consistency and false otherwise.
@@ -256,7 +258,8 @@ namespace vg {
                                                  bool block_rescue_from_1, bool block_rescue_from_2,
                                                  vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                  vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances_out,
-                                                 vector<double>& pair_multiplicities_out);
+                                                 vector<double>& pair_multiplicities_out,
+                                                 const match_fanouts_t* fanouts1, const match_fanouts_t* fanouts2);
         
         /// Use the rescue routine on strong suboptimal clusters to see if we can find a good secondary.
         /// Produces topologically sorted multipath_alignment_ts.
@@ -265,7 +268,8 @@ namespace vg {
                                             vector<clustergraph_t>& cluster_graphs2,
                                             vector<pair<size_t, size_t>>& duplicate_pairs,
                                             vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
-                                            vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs);
+                                            vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                            const match_fanouts_t* fanouts1, const match_fanouts_t* fanouts2);
         
         /// Cluster and extract subgraphs for (possibly) only one end, meant to be a non-repeat, and use them to rescue
         /// an alignment for the other end, meant to be a repeat.
@@ -277,7 +281,8 @@ namespace vg {
                                                       vector<clustergraph_t>& cluster_graphs1, vector<clustergraph_t>& cluster_graphs2,
                                                       vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                       vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances,
-                                                      OrientedDistanceMeasurer& distance_measurer);
+                                                      OrientedDistanceMeasurer& distance_measurer,
+                                                      const match_fanouts_t* fanouts1, const match_fanouts_t* fanouts2);
         
         /// Merge the rescued mappings into the output vector and deduplicate pairs
         void merge_rescued_mappings(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
@@ -331,7 +336,8 @@ namespace vg {
         /// Does NOT necessarily produce a multipath_alignment_t in topological order.
         void multipath_align(const Alignment& alignment, const bdsg::HashGraph* graph,
                              memcluster_t& graph_mems,
-                             multipath_alignment_t& multipath_aln_out) const;
+                             multipath_alignment_t& multipath_aln_out,
+                             const match_fanouts_t* fanouts) const;
         
         /// Removes the sections of an Alignment's path within snarls and re-aligns them with multiple traceback
         /// to create a multipath alignment with non-trivial topology.
@@ -438,7 +444,10 @@ namespace vg {
                                           vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs);
         
         /// Return exact matches according to the object's parameters
-        vector<MaximalExactMatch> find_mems(const Alignment& alignment);
+        /// If using the fan-out algorithm, we can optionally leave fan-out MEMs in tact and
+        /// return a vector of their breaks.
+        vector<MaximalExactMatch> find_mems(const Alignment& alignment,
+                                            vector<deque<pair<string::const_iterator, char>>>* mem_fanout_breaks = nullptr);
         
         SnarlManager* snarl_manager;
         MinimumDistanceIndex* distance_index;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -198,6 +198,10 @@ namespace vg {
         /// as a priority).
         using clustergraph_t = tuple<bdsg::HashGraph*, memcluster_t, size_t>;
         
+        /// Represents the mismatches that were allowed in "MEMs" from the fanout
+        /// match algorithm
+        using match_fanouts_t = unordered_map<const MaximalExactMatch*, deque<pair<string::const_iterator, char>>>;
+        
     protected:
         
         /// Wrapped internal function that allows some code paths to circumvent the current
@@ -383,6 +387,10 @@ namespace vg {
                                                              vector<clustergraph_t>& cluster_graphs1,
                                                              vector<clustergraph_t>& cluster_graphs2,
                                                              bool did_secondary_rescue) const;
+        
+        /// Reorganizes the fan-out breaks into the format that MultipathAlignmentGraph wants it in
+        match_fanouts_t record_fanouts(const vector<MaximalExactMatch>& mems,
+                                       vector<deque<pair<string::const_iterator, char>>>& fanouts) const;
         
         /// Estimates the probability that a cluster with the same hits would have been missed because of
         /// subsampling high-count SMEMs

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -4,7 +4,7 @@
 
 #include <omp.h>
 #include <unistd.h>
-#include <time.h>
+#include <ctime>
 #include <getopt.h>
 
 #include "subcommand.hpp"
@@ -1266,19 +1266,20 @@ int main_mpmap(int argc, char** argv) {
     // a convenience function to preface a stderr log with an indicator of the command
     // and the time elapse
     bool clock_init = false;
-    clock_t time_start = 0;
+    time_t time_start;
     auto progress_boilerplate = [&]() {
         stringstream strm;
         strm.precision(1);
         strm << fixed;
         if (!clock_init) {
-            time_start = clock();
-            strm << "0.0 s";
+            time(&time_start);
+            strm << 0.0 << " s";
             clock_init = true;
         }
         else {
-            clock_t time_now = clock();
-            double secs = ((double) (time_now - time_start)) / CLOCKS_PER_SEC;
+            time_t time_now;
+            time(&time_now);
+            double secs = (double) difftime(time_now, time_start);
             if (secs <= 60.0) {
                 strm << secs << " s";
             }

--- a/src/unittest/mapper.cpp
+++ b/src/unittest/mapper.cpp
@@ -585,7 +585,7 @@ TEST_CASE( "Mapper can walk paths from fan-out MEM algorithm", "[mapping][mapper
         //            ...X....
         string seq = "TGGGCACC";
         
-        list<pair<string::const_iterator, char>> fanout_breaks;
+        deque<pair<string::const_iterator, char>> fanout_breaks;
         fanout_breaks.emplace_back(seq.begin() + 3, 'A');
         
         gcsa::node_type pos = gcsa::Node::encode(graph.get_id(h1), 3, false);
@@ -606,7 +606,7 @@ TEST_CASE( "Mapper can walk paths from fan-out MEM algorithm", "[mapping][mapper
         //              ..X.X....
         string seq =   "AGTTTGCCA";
         
-        list<pair<string::const_iterator, char>> fanout_breaks;
+        deque<pair<string::const_iterator, char>> fanout_breaks;
         fanout_breaks.emplace_back(seq.begin() + 2, 'C');
         fanout_breaks.emplace_back(seq.begin() + 4, 'G');
         
@@ -631,7 +631,7 @@ TEST_CASE( "Mapper can walk paths from fan-out MEM algorithm", "[mapping][mapper
         //            ..X.X..X.
         string seq = "CCGCGGTTA";
         
-        list<pair<string::const_iterator, char>> fanout_breaks;
+        deque<pair<string::const_iterator, char>> fanout_breaks;
         fanout_breaks.emplace_back(seq.begin() + 2, 'A');
         fanout_breaks.emplace_back(seq.begin() + 4, 'A');
         fanout_breaks.emplace_back(seq.begin() + 7, 'C');


### PR DESCRIPTION
A pretty substantial refactor of the seeding algorithm from https://github.com/vgteam/vg/pull/2856. Basically, the seeds are now passed through the clustering, etc. with mismatches included. They are only broken into matches in the extracted alignment subgraph, which has much faster accesses. Moreover, this step of the algorithm already had to walk out seeds, so it's not a lot of extra work.

In addition, I added a mechanism to abort mismatching seed searches if they don't look promising. I think this should prevent the number of seeds from exploding to the same extent.