### PR TITLE
synchronize semantics for OVERLAP_THRESHOLD

### DIFF
--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -287,7 +287,7 @@ void handle_full_length(const HandleGraph& graph, std::vector<GaplessExtension>&
             if (result[i] == result.front()) {
                 continue; // Duplicate.
             }
-            if (result[i].overlap(graph, result.front()) < overlap_threshold * result.front().length()) {
+            if (result[i].overlap(graph, result.front()) <= overlap_threshold * result.front().length()) {
                 if (i > tail) {
                     result[tail] = std::move(result[i]);
                 }

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -159,7 +159,7 @@ public:
      * Find the highest-scoring extension for each seed in the cluster.
      * If there is a full-length extension with at most max_mismatches
      * mismatches, return the (up to two) best full-length extensions with
-     * less than overlap_threshold overlap, sorted by score in descending
+     * at most overlap_threshold overlap, sorted by score in descending
      * order.
      * If that is not possible, trim the extensions to maximize score,
      * sort them by read interval, and remove duplicates.


### PR DESCRIPTION
I also tried lowering the overlap threshold, but it did not meaningfully change
the number of MAPQ 60 reads in my tiny test set (1000 reads from
/public/groups/cgl/graph-genomes/xhchang/whole_genome_graph/filtered_graph/mapped_reads/compared_novaseq6000_cover_master.json
against the 1kg v1 graph). So I am leaving it as is.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Synchronized semantics for OVERLAP_THRESHOLD
