### PR TITLE
Mapq cap unit tests

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -1888,7 +1888,7 @@ double MinimizerMapper::window_breaking_quality(const vector<Minimizer>& minimiz
             auto& minimizer = minimizers[*next_agglomeration];
             
             // Determine its window size from its index.
-            size_t window_size = minimizer.length + minimizer.index_windows - 1;
+            size_t window_size = minimizer.length + minimizer.candidates_per_window - 1;
             
 #ifdef debug
             cerr << "\tBegin agglomeration of " << (minimizer.agglomeration_length - window_size + 1)
@@ -1898,7 +1898,7 @@ double MinimizerMapper::window_breaking_quality(const vector<Minimizer>& minimiz
 #endif
 
             // Make sure the minimizer instance isn't too far into the agglomeration to actually be conatined in the same k+w-1 window as the first base.
-            assert(minimizer.agglomeration_start + minimizer.index_windows >= minimizer.forward_offset());
+            assert(minimizer.agglomeration_start + minimizer.candidates_per_window >= minimizer.forward_offset());
 
             for (size_t start = minimizer.agglomeration_start;
                 start + window_size - 1 < minimizer.agglomeration_start + minimizer.agglomeration_length;

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -172,7 +172,7 @@ protected:
         size_t hits; // How many hits does the minimizer have?
         const gbwtgraph::hit_type* occs;
         int32_t length; // How long is the minimizer (index's k)
-        int32_t index_windows; // How many minimizers compete to be the best (index's w)  
+        int32_t candidates_per_window; // How many minimizers compete to be the best (index's w)  
         double score; // Scores as 1 + ln(hard_hit_cap) - ln(hits).
 
         // Sort the minimizers in descending order by score.

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -171,28 +171,28 @@ protected:
         size_t agglomeration_length; // What is the region of consecutive windows this minimizer instance is minimal in?
         size_t hits; // How many hits does the minimizer have?
         const gbwtgraph::hit_type* occs;
-        size_t origin; // This minimizer came from minimizer_indexes[origin].
+        int32_t length; // How long is the minimizer (index's k)
+        int32_t index_windows; // How many minimizers compete to be the best (index's w)  
         double score; // Scores as 1 + ln(hard_hit_cap) - ln(hits).
 
         // Sort the minimizers in descending order by score.
         inline bool operator< (const Minimizer& another) const {
             return (this->score > another.score);
         }
+        
+        /// Get the starting position of the given minimizer on the forward strand.
+        /// Use this instead of value.offset which can really be the last base for reverse strand minimizers.
+        inline size_t forward_offset() const {
+            if (this->value.is_reverse) {
+                // We have the position of the last base and we need the position of the first base.
+                return this->value.offset - (this->length - 1);
+            } else {
+                // We already have the position of the first base.
+                return this->value.offset;
+            }
+        }
     };
     
-    /// Get the starting position of the given minimizer on the forward strand.
-    /// Use this instead of minimizervalue.offset which can really be the last base for reverse strand minimizers.
-    /// Needs access to the minimizer indexes to get the length for strand conversion.
-    inline size_t forward_offset(const Minimizer& minimizer) const {
-        if (minimizer.value.is_reverse) {
-            // We have the position of the last base and we need the position of the first base.
-            return minimizer.value.offset - (minimizer_indexes[minimizer.origin]->k() - 1);
-        } else {
-            // We already have the position of the first base.
-            return minimizer.value.offset;
-        }
-    }
-
     /// The information we store for each seed.
     typedef SnarlSeedClusterer::Seed Seed;
 
@@ -213,19 +213,6 @@ protected:
     SnarlSeedClusterer clusterer;
 
     FragmentLengthDistribution fragment_length_distr;
-
-    /// Use this many bits for approximate probabilities.
-    constexpr static size_t PRECISION = 8;
-
-    /**
-     * Assume that we have n <= max_k independent events with probability p each.
-     * Let x be the PRECISION most significant bits of p. Then
-     *
-     *   phred_at_least_one[(n << PRECISION) + x]
-     *
-     * is an approximate phred score of at least one event occurring.
-     */
-    std::vector<double> phred_at_least_one;
 
 //-----------------------------------------------------------------------------
 
@@ -303,14 +290,6 @@ protected:
     int64_t distance_between(const Alignment& aln1, const Alignment& aln2);
 
     /**
-     * Assume that we have n <= max_k independent random events that occur with
-     * probability p each (p is interpreted as a real number between 0 and 1 and
-     * max_k is the largest k in the minimizer indexes). Return an approximate
-     * probability for at least one event occurring as a phred score.
-     */
-    double phred_for_at_least_one(size_t p, size_t n) const;
-
-    /**
      * Convert the GaplessExtension into an alignment. This assumes that the
      * extension is a full-length alignment and that the sequence field of the
      * alignment has been set.
@@ -356,8 +335,8 @@ protected:
      * easiest-to-disrupt possible layout of the windows, and the lowest
      * possible qualities for the disrupting bases.
      */
-    double window_breaking_quality(const vector<Minimizer>& minimizers, vector<size_t>& broken,
-        const string& sequence, const string& quality_bytes) const;
+    static double window_breaking_quality(const vector<Minimizer>& minimizers, vector<size_t>& broken,
+        const string& sequence, const string& quality_bytes);
     
     /**
      * Score the given group of gapless extensions. Determines the best score

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -486,6 +486,9 @@ double phred_for_at_least_one(size_t p, size_t n) {
         return to_return;
     }());
     
+    // Make sure we don't go out of bounds.
+    assert(n <= MAX_AT_LEAST_ONE_EVENTS);
+    
     p >>= 8 * sizeof(size_t) - AT_LEAST_ONE_PRECISION;
     return phred_at_least_one[(n << AT_LEAST_ONE_PRECISION) + p];
 }

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -455,6 +455,41 @@ double golden_section_search(const function<double(double)>& f, double x_min, do
     }
 }
 
+
+double phred_for_at_least_one(size_t p, size_t n) {
+
+    /**
+     * Assume that we have n <= MAX_AT_LEAST_ONE_EVENTS independent events with probability p each.
+     * Let x be the AT_LEAST_ONE_PRECISION most significant bits of p. Then
+     *
+     *   phred_at_least_one[(n << AT_LEAST_ONE_PRECISION) + x]
+     *
+     * is an approximate phred score of at least one event occurring.
+     *
+     * We exploit the magical thread-safety of static local initialization to
+     * fill this in exactly once when needed.
+     */
+    static std::vector<double> phred_at_least_one([](void) -> std::vector<double> {
+        // Initialize phred_at_least_one by copying from the result of this function.
+        std::vector<double> to_return;
+        size_t values = static_cast<size_t>(1) << AT_LEAST_ONE_PRECISION;
+        to_return.resize((MAX_AT_LEAST_ONE_EVENTS + 1) * values, 0.0);
+        for (size_t n = 1; n <= MAX_AT_LEAST_ONE_EVENTS; n++) {
+            for (size_t p = 0; p < values; p++) {
+                // Because each p represents a range of probabilities, we choose a value
+                // in the middle for the approximation.
+                double probability = (2 * p + 1) / (2.0 * values);
+                // Phred for at least one out of n.
+                to_return[(n << AT_LEAST_ONE_PRECISION) + p] = prob_to_phred(1.0 - std::pow(1.0 - probability, n));
+            }
+        }
+        return to_return;
+    }());
+    
+    p >>= 8 * sizeof(size_t) - AT_LEAST_ONE_PRECISION;
+    return phred_at_least_one[(n << AT_LEAST_ONE_PRECISION) + p];
+}
+
 vector<vector<double>> transpose(const vector<vector<double>>& A) {
     vector<vector<double>> AT(A.front().size());
     for (size_t i = 0; i < AT.size(); ++i) {

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -121,6 +121,22 @@ inline double phred_geometric_mean(double phred1, double phred2) {
     return prob_to_phred(sqrt(phred_to_prob(phred1 + phred2)));
 }
 
+/**
+ * Assume that we have n independent random events that occur with probability
+ * p each (p is interpreted as a real number between 0 at 0 and 1 at its
+ * maximum value). Return an approximate probability for at least one event
+ * occurring as a phred score.
+ *
+ * n must be <= MAX_AT_LEAST_ONE_EVENTS.
+ */
+double phred_for_at_least_one(size_t p, size_t n);
+
+/// How many events should we allow in phred_for_at_least_one?
+/// Should be >= our longest supported minimizer index.
+constexpr static size_t MAX_AT_LEAST_ONE_EVENTS = 32;
+/// Use this many bits for approximate probabilities.
+constexpr static size_t AT_LEAST_ONE_PRECISION = 8; 
+
 // normal pdf, from http://stackoverflow.com/a/10848293/238609
 template <typename T>
 T normal_pdf(T x, T m, T s)

--- a/src/unittest/minimizer_mapper.cpp
+++ b/src/unittest/minimizer_mapper.cpp
@@ -158,6 +158,19 @@ TEST_CASE("MinimizerMapper::score_extension_group works", "[giraffe][mapping]") 
     }
 }
 
+TEST_CASE("MinimizerMapper::window_breaking_quality works", "[giraffe][mapping]") {
+
+    Alignment aln;
+    aln.set_sequence("AAAAAAAAAA");
+    aln.set_quality(std::string(10, (char)30));
+    vector<TestMinimizerMapper::Minimizer> minimizers;
+    vector<size_t> to_break;
+    
+    SECTION("Cap of no minimizers is inf") {
+        double cap = TestMinimizerMapper::window_breaking_quality(minimizers, to_break, aln.sequence(), aln.quality());
+        REQUIRE(cap == numeric_limits<double>::infinity());
+    }
+}
 
 }
 

--- a/src/unittest/minimizer_mapper.cpp
+++ b/src/unittest/minimizer_mapper.cpp
@@ -14,11 +14,13 @@
 namespace vg {
 namespace unittest {
 
-// We define a child class to expose all the protected stuff for testing
+// We define a child class to expose protected stuff for testing
 class TestMinimizerMapper : public MinimizerMapper {
 public:
     using MinimizerMapper::MinimizerMapper;
     using MinimizerMapper::score_extension_group;
+    using MinimizerMapper::window_breaking_quality;
+    using MinimizerMapper::Minimizer;
 };
 
 TEST_CASE("MinimizerMapper::score_extension_group works", "[giraffe][mapping]") {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add unit tests for mapping quality capping logic in Giraffe

## Description

This refactors some of the Giraffe MAPQ capping to be testable (you don't need a whole graph or a mapper object) and adds (so far) some tiny, mostly-trivial tests.
