### PR TITLE
Degree distribution option -D added to vg stats

### DIFF
--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 17
+plan tests 18
 
 vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 #is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
@@ -64,3 +64,10 @@ is "$(vg stats -F atgc.og)" "format: ODGI" "vg stats -F detects format of odgi g
 vg index graphs/atgc.vg -x atgc.xg
 is "$(vg stats -F atgc.xg)" "format: XG" "vg stats -F detects format of xg graph"
 rm -f  atgc.vg atgc.hg atgc.pg atgc.og atgc.xg
+
+vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa | vg stats -D - | head -4 | tail -1 > tiny.deg
+printf "2\t12\t3\t9\t8\n" > tiny.true.deg
+diff tiny.deg tiny.true.deg
+is "$?" 0 "vg stats -D found correct degree distribution of tiny graph"
+rm -f tiny.def tiny.true.deg
+


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * add `vg stats -D` option to print degree distribution

## Description

This is to help @jmonlong with evaluating graph construction techniques.  I couldn't decide which distribution to use, so four are printed (think I prefer `Sides` though):

```
Sides: number of sides with given degree
Nodes(min): number of nodes whose side with the minimum degree has given degree
Nodes(max): number of nodes whose side with the maximum degree has given degree
Nodes(total): number of nodes whose two side degrees total given degree
```
