### PR TITLE
Don't pick bad minimizers

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2417,6 +2417,8 @@ std::vector<MinimizerMapper::Seed> MinimizerMapper::find_seeds(const std::vector
                 funnel.pass("hard-hit-cap", i);
                 funnel.fail("hit-cap||score-fraction", i, (selected_score + minimizer.score) / base_target_score);
             }
+            //Stop looking for more minimizers once we fail the score fraction
+            target_score = selected_score; 
         } else {
             // Failed hard hit cap
             took_last = false;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fixed a bug where giraffe sometimes continues accepting minimizers after the score fraction was exceeded

## Description
