### PR TITLE
Don't crash consutructing "uncanonicalizable" symbolic allele 

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1844,7 +1844,7 @@ namespace vg {
                         
                         // Canonicalize the variant and see if that disqualifies it.
                         // This also takes care of setting the variant's alt sequences.
-                        variant_acceptable = vvar->canonicalize(reference, insertions, true);
+                        variant_acceptable = vvar->canonicalizable() && vvar->canonicalize(reference, insertions, true);
          
                         if (variant_acceptable) {
                             // Worth checking for multiple alts.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg construct -S` slightly less crashy

## Description

Will fix the crash in #2857 (provided `-f` is also passed to `construct`).  There are still tons of cryptic warnings though.  