### PR TITLE
Cap or

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -1796,7 +1796,7 @@ double MinimizerMapper::compute_mapq_caps(const Alignment& aln,
             extended_cluster_minimizers.push_back(i);
         }
     }
-    double mapq_extended_cap = window_breaking_quality(minimizers, extended_cluster_minimizers, aln.sequence(), aln.quality(), true);
+    double mapq_extended_cap = window_breaking_quality(minimizers, extended_cluster_minimizers, aln.sequence(), aln.quality(), this->sum_mapq_cap);
     
     // And we also need to cap based on the probability of creating the windows
     // in the read that distinguish it from the most plausible (minimum created

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -331,14 +331,18 @@ protected:
      * Also takes the sequence of the read (to avoid Ns) and the quality string
      * (interpreted as a byte array).
      *
-     * Currently computes a lower-score-bound, upper-probability-bound,
+     * When sum is false, computes a lower-score-bound, upper-probability-bound,
      * suitable for use as a mapping quality cap, by assuming the
      * easiest-to-disrupt possible layout of the windows, and the lowest
      * possible qualities for the disrupting bases.
+     *
+     * When sum is true, computes a lower-score-bound, upper-probability-bound,
+     * suitable for use as a mapping quality cap, by summing over all possible
+     * sets of disrupting bases that disrupt the minimizers of all windows.
      */
     static double window_breaking_quality(const vector<Minimizer>& minimizers, vector<size_t>& broken,
-        const string& sequence, const string& quality_bytes);
-    
+        const string& sequence, const string& quality_bytes, bool sum = false);
+        
     /**
      * Score the given group of gapless extensions. Determines the best score
      * that can be obtained by chaining extensions together, using the given

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -135,6 +135,9 @@ public:
     /// and track if/when their descendants make it through stages of the
     /// algorithm. Only works if track_provenance is true.
     bool track_correctness = false;
+    
+    /// Cap MAPQ by sum of all possible disruptions, instead of most probable dusruption.
+    bool sum_mapq_cap = false;
 
     ////How many stdevs from fragment length distr mean do we cluster together?
     size_t paired_distance_stdevs = 2; 

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -71,55 +71,63 @@ inline double log10_to_ln(double l10) {
     return l10 * log(10);
 }
 
-// Convert a probability to a natural log probability.
+/// Convert a probability to a natural log probability.
 inline double prob_to_logprob(double prob) {
     return log(prob);
 }
-// Convert natural log probability to a probability
+/// Convert natural log probability to a probability
 inline double logprob_to_prob(double logprob) {
     return exp(logprob);
 }
-// Add two probabilities (expressed as logprobs) together and return the result
-// as a logprob.
+/// Add two probabilities (expressed as logprobs) together and return the result
+/// as a logprob.
 inline double logprob_add(double logprob1, double logprob2) {
     // Pull out the larger one to avoid underflows
     double pulled_out = max(logprob1, logprob2);
     return pulled_out + prob_to_logprob(logprob_to_prob(logprob1 - pulled_out) + logprob_to_prob(logprob2 - pulled_out));
 }
-// Invert a logprob, and get the probability of its opposite.
+/// Invert a logprob, and get the probability of its opposite.
 inline double logprob_invert(double logprob) {
     return prob_to_logprob(1.0 - logprob_to_prob(logprob));
 }
 
-// Convert integer Phred quality score to probability of wrongness.
+/// Convert integer Phred quality score to probability of wrongness.
 inline double phred_to_prob(int phred) {
     return pow(10, -((double)phred) / 10);
 }
 
-// Convert probability of wrongness to integer Phred quality score.
+/// Convert probability of wrongness to integer Phred quality score.
 inline double prob_to_phred(double prob) {
     return -10.0 * log10(prob);
 }
 
-// Convert a Phred quality score directly to a natural log probability of wrongness.
+/// Convert a Phred quality score directly to a natural log probability of wrongness.
 inline double phred_to_logprob(int phred) {
     return (-((double)phred) / 10) / log10(exp(1.0));
 }
 
-// Convert a natural log probability of wrongness directly to a Phred quality score.
+/// Convert a natural log probability of wrongness directly to a Phred quality score.
 inline double logprob_to_phred(double logprob ) {
     return -10.0 * logprob * log10(exp(1.0));
 }
 
-// Take the geometric mean of two logprobs
+/// Take the geometric mean of two logprobs
 inline double logprob_geometric_mean(double lnprob1, double lnprob2) {
     return log(sqrt(exp(lnprob1 + lnprob2)));
 }
 
-// Same thing in phred
+/// Take the geometric mean of two phred-encoded probabilities
 inline double phred_geometric_mean(double phred1, double phred2) {
     return prob_to_phred(sqrt(phred_to_prob(phred1 + phred2)));
 }
+
+/// Add two probabilities (expressed as phred scores) together and return the result
+/// as a phred score.
+inline double phred_add(double phred1, double phred2) {
+    return logprob_to_phred(logprob_add(phred_to_logprob(phred1), phred_to_logprob(phred2)));
+}
+
+
 
 /**
  * Assume that we have n independent random events that occur with probability

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -327,6 +327,7 @@ void help_giraffe(char** argv) {
     << "  -A, --rescue-algorithm NAME   use algorithm NAME for rescue (none / dozeu / gssw / haplotypes) [dozeu]" << endl
     << "  --track-provenance            track how internal intermediate alignment candidates were arrived at" << endl
     << "  --track-correctness           track if internal intermediate alignment candidates are correct (implies --track-provenance)" << endl
+    << "  --sum-mapq-cap                cap MAPQ based on sum of all possible minimizer disruptions, rather than most probable" << endl
     << "  -t, --threads INT             number of compute threads to use" << endl;
 }
 
@@ -343,6 +344,7 @@ int main_giraffe(int argc, char** argv) {
     #define OPT_REPORT_NAME 1002
     #define OPT_TRACK_PROVENANCE 1003
     #define OPT_TRACK_CORRECTNESS 1004
+    #define OPT_SUM_MAPQ_CAP 1005
     
 
     // initialize parameters with their default options
@@ -400,6 +402,8 @@ int main_giraffe(int argc, char** argv) {
     bool track_provenance = false;
     // Should we track candidate correctness?
     bool track_correctness = false;
+    // Should we allow multiple routes to disrupt minimizers?
+    bool sum_mapq_cap = false;
 
     // Chain all the ranges and get a function that loops over all combinations.
     auto for_each_combo = distance_limit
@@ -475,6 +479,7 @@ int main_giraffe(int argc, char** argv) {
             {"rescue-algorithm", required_argument, 0, 'A'},
             {"track-provenance", no_argument, 0, OPT_TRACK_PROVENANCE},
             {"track-correctness", no_argument, 0, OPT_TRACK_CORRECTNESS},
+            {"sum-mapq-cap", no_argument, 0, OPT_SUM_MAPQ_CAP},
             {"threads", required_argument, 0, 't'},
             {0, 0, 0, 0}
         };
@@ -781,6 +786,10 @@ int main_giraffe(int argc, char** argv) {
                 track_correctness = true;
                 break;
                 
+            case OPT_SUM_MAPQ_CAP:
+                sum_mapq_cap = true;
+                break;
+                
             case 't':
             {
                 int num_threads = parse<int>(optarg);
@@ -1078,6 +1087,11 @@ int main_giraffe(int argc, char** argv) {
             cerr << "--track-correctness " << endl;
         }
         minimizer_mapper.track_correctness = track_correctness;
+        
+        if (show_progress && sum_mapq_cap) {
+            cerr << "--sum-mapq-cap " << endl;
+        }
+        minimizer_mapper.sum_mapq_cap = sum_mapq_cap;
 
         if (show_progress && paired) {
             cerr << "--rescue-attempts " << rescue_attempts << endl;
@@ -1250,5 +1264,6 @@ int main_giraffe(int argc, char** argv) {
 
 // Register subcommand
 static Subcommand vg_giraffe("giraffe", "Graph Alignment Format Fast Emitter", DEVELOPMENT, main_giraffe);
+
 
 

--- a/src/unittest/statistics.cpp
+++ b/src/unittest/statistics.cpp
@@ -154,5 +154,17 @@ TEST_CASE("Max exponential fitting function learns parameters that are approxima
     REQUIRE(abs(params.second - 5.0) < 1.5);
 }
 
+TEST_CASE("Phred probability addition works", "[statistics]") {
+
+    vector<double> phred1 = {prob_to_phred(0.01), prob_to_phred(1E-8), prob_to_phred(0.1), 30 };
+    vector<double> phred2 = {prob_to_phred(0.1), prob_to_phred(0.3), prob_to_phred(0.2), 30 };
+    vector<double> result = {prob_to_phred(0.11), prob_to_phred(0.3+1E-8), prob_to_phred(0.3), 26.98970004336};
+    
+    for (size_t i = 0; i < phred1.size(); i++) {
+        REQUIRE((size_t) round(phred_add(phred1[i], phred2[i])) == (size_t) round(result[i]));
+    }
+    
+}
+
 }
 }

--- a/src/unittest/statistics.cpp
+++ b/src/unittest/statistics.cpp
@@ -166,5 +166,14 @@ TEST_CASE("Phred probability addition works", "[statistics]") {
     
 }
 
+TEST_CASE("Phred probability summation works", "[statistics]") {
+
+    vector<double> to_sum = {30, 30, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40};
+    double result = 25.2287874528;
+   
+    REQUIRE(phred_sum(to_sum) == Approx(result));
+    
+}
+
 }
 }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Allow summing different routes for minimizer disruption when capping MAPQ

## Description

This adds a `--sum-mapq-cap` option to Giraffe to use probability OR in the MAPQ cap DP, instead of just finding the highest-probability case.