### PR TITLE
Update dozeu to a version that properly handles the full length bonus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -589,7 +589,10 @@ $(INC_DIR)/sha1.hpp: $(SHA1_DIR)/sha1.hpp
 $(INC_DIR)/backward.hpp: $(BACKWARD_CPP_DIR)/backward.hpp
 	+cp $(BACKWARD_CPP_DIR)/backward.hpp $(CWD)/$(INC_DIR)/
 
-$(INC_DIR)/dozeu/dozeu.h: $(DOZEU_DIR)/*.h
+$(INC_DIR)/simde/x86/sse4.1.h: $(DOZEU_DIR)/simde/*.h $(DOZEU_DIR)/simde/x86/*.h
+	+cp -r $(DOZEU_DIR)/simde $(INC_DIR)
+
+$(INC_DIR)/dozeu/dozeu.h: $(DOZEU_DIR)/*.h $(INC_DIR)/simde/x86/sse4.1.h
 	+mkdir -p $(CWD)/$(INC_DIR)/dozeu && cp $(DOZEU_DIR)/*.h $(CWD)/$(INC_DIR)/dozeu/
 
 $(LIB_DIR)/libebl.a: $(LIB_DIR)/libelf.a

--- a/src/dozeu_interface.cpp
+++ b/src/dozeu_interface.cpp
@@ -6,7 +6,7 @@
 #include <cstdio>
 #include <assert.h>
 #include <utility>
-
+ 
 #include "dozeu_interface.hpp"
 
 #include "algorithms/topological_sort.hpp"
@@ -128,7 +128,7 @@ DozeuInterface::graph_pos_s DozeuInterface::calculate_max_position(const Ordered
     assert(forefronts.at(max_node_index)->mcap != nullptr);
 
 	// calc max position on the node
-	uint64_t max_pos = (uint64_t) dz_calc_max_pos(dz, forefronts[max_node_index]);
+	uint64_t max_pos = (uint64_t) dz_calc_max_pos(forefronts[max_node_index]);
 
 	// ref-side offset fixup
 	int32_t rpos = (int32_t)(max_pos>>32);
@@ -293,14 +293,16 @@ size_t DozeuInterface::do_poa(const OrderedGraph& graph, const dz_query_s* packe
     // Get max query pos
     assert(max_idx <= forefronts.size());
     assert(forefronts[max_idx] != nullptr);
-    
+
+#ifdef DEBUG    
     if (forefronts[max_idx]->mcap != nullptr) {
         
-        uint64_t query_max_pos = dz_calc_max_qpos(dz, forefronts[max_idx]);
-        uint64_t ref_node_max_pos = dz_calc_max_rpos(dz, forefronts[max_idx]);
+        uint64_t query_max_pos = dz_calc_max_qpos(forefronts[max_idx]);
+        uint64_t ref_node_max_pos = dz_calc_max_rpos(forefronts[max_idx]);
         
         debug("max(%p), score(%d), qpos(%ld), rpos(%ld)", forefronts[max_idx], forefronts[max_idx]->max, query_max_pos, ref_node_max_pos);
     }
+#endif
     return max_idx;
 }
 

--- a/src/unittest/xdrop_aligner.cpp
+++ b/src/unittest/xdrop_aligner.cpp
@@ -658,7 +658,7 @@ TEST_CASE("XdropAligner doesn't crash on a case where it is hard to find a seed"
     aligner.align_xdrop(aln, graph, vector<MaximalExactMatch>(), false);
 }
 
-TEST_CASE("XdropAligner pinned alignment doesn't crash on an example that revealed a bug",
+TEST_CASE("XdropAligner pinned alignment doesn't crash when aligning to a long stretch of mismatches",
           "[xdrop][alignment][mapping][pinned]") {
     
     bdsg::HashGraph graph;
@@ -694,6 +694,26 @@ TEST_CASE("XdropAligner pinned alignment doesn't crash on an example that reveal
     const Aligner& aligner = *aligner_source.get_regular_aligner();
     
     aligner.align_pinned(aln, graph, false, true, 10);
+}
+
+TEST_CASE("XdropAligner pinned alignment doesn't crash when the optimal alignment column would be x-dropped if not for the full length bonus",
+          "[xdrop][alignment][mapping][pinned]") {
+    
+    bdsg::HashGraph graph;
+    
+    handle_t h0 = graph.create_handle("AAGGG");
+    
+    
+    Alignment aln;
+    aln.set_sequence("AACGT");
+    
+    TestAligner aligner_source;
+    aligner_source.set_alignment_scores(1, 4, 6, 1, 9);
+    const Aligner& aligner = *aligner_source.get_regular_aligner();
+    
+    aligner.align_pinned(aln, graph, true, true, 0);
+    
+    REQUIRE(aln.score() == 1 + 1 + 1 - 4 - 4 + 9);
 }
    
 }


### PR DESCRIPTION
## Changelog Entry

 * Alignment with dozeu can now handle large full length bonuses without crashing
 * dozeu is now non-x86 compatible. 

## Description

The implementation of the full length alignment bonus in dozeu was a little half-baked. This PR updates to the most recent commit, which includes a fix to the bug and also @mr-c 's update that made dozeu compatible on non-x86 architectures.

@jonassibbesen This should fix the crash you ran into while trying out different settings for miRNA reads.

Supercedes https://github.com/vgteam/vg/pull/2871.