### PR TITLE
update to latest vgteam/gssw

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/vgteam/fastahack.git
 [submodule "gssw"]
 	path = deps/gssw
-	url = https://github.com/ekg/gssw.git
+	url = https://github.com/vgteam/gssw.git
 [submodule "bash-tap"]
 	path = deps/bash-tap
 	url = https://github.com/illusori/bash-tap.git


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * gssw no longer requires x86

## Description

update to latest vgteam/gssw