### PR TITLE
Add into_which_snarl for distance index

### DIFF
--- a/src/min_distance.hpp
+++ b/src/min_distance.hpp
@@ -60,6 +60,12 @@ class MinimumDistanceIndex {
     int64_t max_distance(pos_t pos1, pos_t pos2) const;
 
 
+    ///Get the start node (id and orientation pointing  into the snarl) of the
+    //snarl that this point into
+    //Returns <0, false> if this doesn't point into a snarl
+    pair<id_t, bool> into_which_snarl(id_t node_id, bool reverse) const;
+
+
     //Given an alignment to a graph and a range, find the set of nodes in the
     //graph for which the minimum distance from the position to any position
     //in the node is within the given distance range
@@ -103,7 +109,7 @@ class MinimumDistanceIndex {
     void write_snarls_to_json();
 
     ///print the distance index for debugging
-    void print_self();
+    void print_self() const;
     // Prints the number of nodes in each snarl netgraph and number of snarls in each chain
     void print_snarl_stats();
 
@@ -171,7 +177,7 @@ class MinimumDistanceIndex {
             void insert_distance(size_t start, size_t end, int64_t dist);
 
 
-            void print_self();
+            void print_self() const;
             json_t* snarl_to_json();
 
         protected:
@@ -270,7 +276,7 @@ class MinimumDistanceIndex {
                 return prefix_sum[prefix_sum.size() - 1] - 1;
             }
 
-            void print_self();
+            void print_self() const;
             json_t* chain_to_json();
 
         protected:

--- a/src/unittest/min_distance.cpp
+++ b/src/unittest/min_distance.cpp
@@ -1242,6 +1242,15 @@ int64_t min_distance(VG* graph, pos_t pos1, pos_t pos2){
                 //Check distances for random pairs of positions 
                 const Snarl* snarl1 = allSnarls[randSnarlIndex(generator)];
                 const Snarl* snarl2 = allSnarls[randSnarlIndex(generator)];
+
+                id_t start1_id = snarl1->start().node_id();
+                bool start1_rev = snarl1->start().backward();
+                id_t end1_id = snarl1->end().node_id();
+                bool end1_rev = !snarl1->end().backward();
+
+                REQUIRE((di.into_which_snarl(start1_id, start1_rev) == make_pair(start1_id, start1_rev) ||
+                         di.into_which_snarl(start1_id, start1_rev) == make_pair(end1_id, end1_rev)));
+
                  
                 pair<unordered_set<Node*>, unordered_set<Edge*>> contents1 = 
                     pb_contents(graph, snarl_manager.shallow_contents(snarl1, graph, true));
@@ -1268,6 +1277,17 @@ int64_t min_distance(VG* graph, pos_t pos1, pos_t pos2){
                 auto chain_info = di.get_minimizer_distances(pos1);
                 auto encoded_chain_info = MIPayload::decode(MIPayload::encode(di.get_minimizer_distances(pos1)));
                 assert (chain_info == encoded_chain_info);
+
+                const Snarl* pos1_snarl = snarl_manager.into_which_snarl(nodeID1, false);
+
+                if (pos1_snarl == nullptr) {
+                    auto n = di.into_which_snarl(nodeID1, false);
+                    REQUIRE(di.into_which_snarl(nodeID1, false) == make_pair((id_t)0, false));
+                } else {
+                    pair<id_t, bool> n = di.into_which_snarl(nodeID1, false);
+                    REQUIRE((di.into_which_snarl(nodeID1, false) == make_pair((id_t)pos1_snarl->start().node_id(), pos1_snarl->start().backward()) ||
+                             di.into_which_snarl(nodeID1, false) == make_pair((id_t)pos1_snarl->end().node_id(), !pos1_snarl->end().backward())));
+                }
 
  
                 if (!(nodeID1 != snarl1->start().node_id() && 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * add into_which_snarl() to distance index

## Description
into_which_snarl() returns the snarl (as node id and orientation of start node) that a given node and orientation points into