### PR TITLE
Tweak behavior to perform better on miRNA

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3367,10 +3367,11 @@ namespace vg {
         // compute the weight of edges and node matches
         for (size_t i = 0; i < path_nodes.size(); i++) {
             PathNode& from_node = path_nodes.at(i);
-            node_weights[i] = aligner->match * (from_node.end - from_node.begin)
-            + aligner->full_length_bonus * ((from_node.begin == alignment.sequence().begin())
-                                            + (from_node.end == alignment.sequence().end()));
-            
+            node_weights[i] = (aligner->score_exact_match(from_node.begin, from_node.end,
+                                                          alignment.quality().begin() + (from_node.begin - alignment.sequence().begin()))
+                               + aligner->full_length_bonus * ((from_node.begin == alignment.sequence().begin())
+                                                               + (from_node.end == alignment.sequence().end())));
+                        
             for (const pair<size_t, size_t>& edge : from_node.edges) {
                 PathNode& to_node = path_nodes.at(edge.first);
                 

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -481,8 +481,10 @@ namespace vg {
         cerr << "splitting multicomponent alignments..." << endl;
 #endif
         
-        // split up any alignments that ended up being disconnected
-        split_multicomponent_alignments(multipath_alns_out, cluster_idxs);
+        if (!suppress_multicomponent_splitting) {
+            // split up any alignments that ended up being disconnected
+            split_multicomponent_alignments(multipath_alns_out, cluster_idxs);
+        }
         
 #ifdef debug_multipath_mapper
         cerr << "topologically ordering " << multipath_alns_out.size() << " multipath alignments" << endl;
@@ -1377,8 +1379,10 @@ namespace vg {
                 multipath_align(anchor_aln, get<0>(cluster_graphs[i]), get<1>(cluster_graphs[i]),
                                 cluster_multipath_alns.back(), anchor_fanouts);
                 
-                // split it up if it turns out to be multiple components
-                split_multicomponent_alignments(cluster_multipath_alns);
+                if (!suppress_multicomponent_splitting) {
+                    // split it up if it turns out to be multiple components
+                    split_multicomponent_alignments(cluster_multipath_alns);
+                }
                 
                 // order the subpaths
                 for (multipath_alignment_t& multipath_aln : cluster_multipath_alns) {
@@ -2756,8 +2760,10 @@ namespace vg {
             num_mappings++;
         }
         
-        // split up any multi-component multipath alignments
-        split_multicomponent_alignments(multipath_aln_pairs_out, cluster_pairs);
+        if (!suppress_multicomponent_splitting) {
+            // split up any multi-component multipath alignments
+            split_multicomponent_alignments(multipath_aln_pairs_out, cluster_pairs);
+        }
         
         // downstream algorithms assume multipath alignments are topologically sorted (including the scoring
         // algorithm in the next step)

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -170,6 +170,7 @@ namespace vg {
         int32_t secondary_rescue_subopt_diff = 10;
         size_t min_median_mem_coverage_for_split = 0;
         bool suppress_cluster_merging = false;
+        bool suppress_multicomponent_splitting = false;
         size_t alt_anchor_max_length_diff = 5;
         bool dynamic_max_alt_alns = false;
         bool simplify_topologies = false;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -268,6 +268,7 @@ int main_mpmap(int argc, char** argv) {
     int secondary_rescue_subopt_diff = 35;
     int min_median_mem_coverage_for_split = 0;
     bool suppress_cluster_merging = false;
+    bool suppress_multicomponent_splitting = false;
     bool dynamic_max_alt_alns = true;
     bool simplify_topologies = true;
     int max_alignment_gap = 5000;
@@ -851,6 +852,11 @@ int main_mpmap(int argc, char** argv) {
         }
         likelihood_approx_exp = 3.5;
         mapq_scaling_factor = 0.5;
+        if (read_length == "very-short") {
+            // we'll allow multicomponent alignments so that the two sides of a shRNA
+            // can be one alignment
+            suppress_multicomponent_splitting = true;
+        }
     }
     else if (nt_type != "dna") {
         // DNA is the default
@@ -1606,6 +1612,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.num_mapping_attempts = max_map_attempts;
     multipath_mapper.min_median_mem_coverage_for_split = min_median_mem_coverage_for_split;
     multipath_mapper.suppress_cluster_merging = suppress_cluster_merging;
+    multipath_mapper.suppress_multicomponent_splitting = suppress_multicomponent_splitting;
     multipath_mapper.use_tvs_clusterer = use_tvs_clusterer;
     multipath_mapper.reversing_walk_length = reversing_walk_length;
     multipath_mapper.max_alt_mappings = max_num_mappings;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -824,6 +824,12 @@ int main_mpmap(int argc, char** argv) {
         reseed_diff = 0.8;
         // but actually only use this other MEM algorithm if we have base qualities
         use_fanout_match_alg = true;
+        
+        // removing too many bases of matches distorts the multipath alignment
+        // graph's pruning algorithms for very short reads
+        max_branch_trim_length = 1;
+        snarl_cut_size = 2;
+        suboptimal_path_exponent = 1.5;
     }
     else if (read_length != "short") {
         // short is the default


### PR DESCRIPTION
## Changelog Entry

 * Made match pruning in mpmap less aggressive for very short reads

## Description

There were some pruning parameters that we're well suited for very short reads and would sometimes result in removing a large percentage of a match. This behavior is now adjusted in the `very-short` parameter preset.

@jonassibbesen I think we should be able to get better performance with high full-length bonuses now.