### PR TITLE
Add is_trivial_snarl to distance index

### DIFF
--- a/src/min_distance.cpp
+++ b/src/min_distance.cpp
@@ -1133,7 +1133,7 @@ int64_t MinimumDistanceIndex::max_distance(pos_t pos1, pos_t pos2) const {
     }
 }
 
-pair<id_t, bool> MinimumDistanceIndex::into_which_snarl(id_t node_id, bool reverse) const {
+tuple<id_t, bool, bool> MinimumDistanceIndex::into_which_snarl(id_t node_id, bool reverse) const {
     size_t primary_assignment = get_primary_assignment(node_id);
     const SnarlIndex& primary_snarl_index = snarl_indexes[primary_assignment];
 
@@ -1157,7 +1157,7 @@ pair<id_t, bool> MinimumDistanceIndex::into_which_snarl(id_t node_id, bool rever
     if ((node_id == primary_start.first && reverse == primary_start.second) || 
         (node_id == primary_end.first && reverse == primary_end.second )) {
         //If this is then end node and it points in
-        return primary_start;
+        return make_tuple(primary_start.first, primary_start.second, primary_snarl_index.is_trivial_snarl());
     }
 
     if (has_secondary_snarl_bv[node_id-min_node_id]){ 
@@ -1178,11 +1178,11 @@ pair<id_t, bool> MinimumDistanceIndex::into_which_snarl(id_t node_id, bool rever
         if ( (node_id == secondary_start.first && reverse == secondary_start.second) ||
              (node_id == secondary_end.first && reverse == secondary_end.second)) {
             //If this is the inward facing start or end node of the secondary snarl
-            return secondary_start;
+            return make_tuple(secondary_start.first, secondary_start.second, secondary_snarl_index.is_trivial_snarl());
         }
     }
     //This does not point into a snarl
-    return make_pair(0, false);
+    return make_tuple(0, false, false);
 }
 
 int64_t MinimumDistanceIndex::node_length(id_t id) const {
@@ -1875,6 +1875,9 @@ pair<int64_t, int64_t> MinimumDistanceIndex::SnarlIndex::dist_to_ends(size_t ran
     return make_pair(dist_start, dist_end);
 }
 
+bool MinimumDistanceIndex::SnarlIndex::is_trivial_snarl() const {
+    return num_nodes == 2 && !is_unary_snarl && snarl_distance(0,1) == -1 && snarl_distance(4,3) == -1; 
+}
 
 json_t*  MinimumDistanceIndex::SnarlIndex::snarl_to_json() {
     json_t* out_json = json_object();

--- a/src/min_distance.hpp
+++ b/src/min_distance.hpp
@@ -61,9 +61,9 @@ class MinimumDistanceIndex {
 
 
     ///Get the start node (id and orientation pointing  into the snarl) of the
-    //snarl that this point into
-    //Returns <0, false> if this doesn't point into a snarl
-    pair<id_t, bool> into_which_snarl(id_t node_id, bool reverse) const;
+    //snarl that this point into and a bool is_trivial_snarl
+    //Returns <0, false, false> if this doesn't point into a snarl
+    tuple<id_t, bool, bool> into_which_snarl(id_t node_id, bool reverse) const;
 
 
     //Given an alignment to a graph and a range, find the set of nodes in the
@@ -176,6 +176,8 @@ class MinimumDistanceIndex {
             ///add the distance from start to end to the index
             void insert_distance(size_t start, size_t end, int64_t dist);
 
+
+            bool is_trivial_snarl() const;
 
             void print_self() const;
             json_t* snarl_to_json();

--- a/src/unittest/min_distance.cpp
+++ b/src/unittest/min_distance.cpp
@@ -1248,8 +1248,8 @@ int64_t min_distance(VG* graph, pos_t pos1, pos_t pos2){
                 id_t end1_id = snarl1->end().node_id();
                 bool end1_rev = !snarl1->end().backward();
 
-                REQUIRE((di.into_which_snarl(start1_id, start1_rev) == make_pair(start1_id, start1_rev) ||
-                         di.into_which_snarl(start1_id, start1_rev) == make_pair(end1_id, end1_rev)));
+                REQUIRE((di.into_which_snarl(start1_id, start1_rev) == make_tuple(start1_id, start1_rev, snarl_manager.is_trivial(snarl1, graph)) ||
+                         di.into_which_snarl(start1_id, start1_rev) == make_tuple(end1_id, end1_rev,     snarl_manager.is_trivial(snarl1, graph))));
 
                  
                 pair<unordered_set<Node*>, unordered_set<Edge*>> contents1 = 
@@ -1281,12 +1281,15 @@ int64_t min_distance(VG* graph, pos_t pos1, pos_t pos2){
                 const Snarl* pos1_snarl = snarl_manager.into_which_snarl(nodeID1, false);
 
                 if (pos1_snarl == nullptr) {
-                    auto n = di.into_which_snarl(nodeID1, false);
-                    REQUIRE(di.into_which_snarl(nodeID1, false) == make_pair((id_t)0, false));
+                    REQUIRE(di.into_which_snarl(nodeID1, false) == make_tuple((id_t)0, false, false));
                 } else {
-                    pair<id_t, bool> n = di.into_which_snarl(nodeID1, false);
-                    REQUIRE((di.into_which_snarl(nodeID1, false) == make_pair((id_t)pos1_snarl->start().node_id(), pos1_snarl->start().backward()) ||
-                             di.into_which_snarl(nodeID1, false) == make_pair((id_t)pos1_snarl->end().node_id(), !pos1_snarl->end().backward())));
+                    auto result = di.into_which_snarl(nodeID1, false);
+                    //cerr << "node: " << nodeID1 << ": guess: " << std::get<0>(result) << " " << std::get<1>(result) << " " << std::get<2>(result) 
+                    //     << " actual snarl start: "<< pos1_snarl->start().node_id() << " " <<  pos1_snarl->start().backward() 
+                    //     << ", actual snarl end: " << pos1_snarl->end().node_id() << " " <<  pos1_snarl->end().backward() 
+                    //     << " trivial? " <<  snarl_manager.is_trivial(pos1_snarl, graph) << endl; 
+                    REQUIRE((di.into_which_snarl(nodeID1, false) == make_tuple((id_t)pos1_snarl->start().node_id(), pos1_snarl->start().backward(), snarl_manager.is_trivial(pos1_snarl, graph)) ||
+                             di.into_which_snarl(nodeID1, false) == make_tuple((id_t)pos1_snarl->end().node_id(), !pos1_snarl->end().backward(), snarl_manager.is_trivial(pos1_snarl, graph))));
                 }
 
  


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

## Description

Made distance index's into_which_snarl() also return a bool for whether the snarl is trivial