### PR TITLE
Dist snarl cut

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -144,7 +144,8 @@ namespace vg {
         
     }
     
-    MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager& snarl_manager, size_t max_snarl_cut_size,
+    MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager* snarl_manager,
+                                                     MinimumDistanceIndex* dist_index, size_t max_snarl_cut_size,
                                                      const function<pair<id_t, bool>(id_t)>& project,
                                                      const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans) {
         
@@ -160,7 +161,7 @@ namespace vg {
         
         // cut the snarls out of the aligned path so we can realign through them
         if (max_snarl_cut_size) {
-            resect_snarls_from_paths(&snarl_manager, project, max_snarl_cut_size);
+            resect_snarls_from_paths(snarl_manager, dist_index, dist_index, project, max_snarl_cut_size);
         }
         
         // the snarls algorithm adds edges where necessary
@@ -170,17 +171,20 @@ namespace vg {
         trim_hanging_indels(alignment, true);
     }
 
-    MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager& snarl_manager, size_t max_snarl_cut_size,
+MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager* snarl_manager,
+                                                 MinimumDistanceIndex* dist_index, size_t max_snarl_cut_size,
                                                      const unordered_map<id_t, pair<id_t, bool>>& projection_trans) :
-                                                     MultipathAlignmentGraph(graph, alignment, snarl_manager, max_snarl_cut_size, create_projector(projection_trans),
+                                                     MultipathAlignmentGraph(graph, alignment, snarl_manager, dist_index, max_snarl_cut_size,
+                                                                             create_projector(projection_trans),
                                                                              create_injection_trans(projection_trans)) {
         // Nothing to do
     }
 
-    MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager& snarl_manager, size_t max_snarl_cut_size,
+MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager* snarl_manager,
+                                                 MinimumDistanceIndex* dist_index, size_t max_snarl_cut_size,
                                                      const function<pair<id_t, bool>(id_t)>& project) :
-                                                     MultipathAlignmentGraph(graph, alignment, snarl_manager, max_snarl_cut_size, project,
-                                                                             create_injection_trans(graph, project)) {
+                                                     MultipathAlignmentGraph(graph, alignment, snarl_manager, dist_index, max_snarl_cut_size,
+                                                                             project, create_injection_trans(graph, project)) {
         // Nothing to do
     }
     
@@ -1389,6 +1393,7 @@ namespace vg {
     }
     
     void MultipathAlignmentGraph::resect_snarls_from_paths(SnarlManager* cutting_snarls,
+                                                           MinimumDistanceIndex* dist_index,
                                                            const function<pair<id_t, bool>(id_t)>& project,
                                                            int64_t max_snarl_cut_size) {
 #ifdef debug_multipath_alignment
@@ -1430,7 +1435,7 @@ namespace vg {
                 
                 if (j > 0) {
                     // we have entered this node on this iteration
-                    if (cutting_snarls->into_which_snarl(projected_id, !projected_rev)) {
+                    if (into_cutting_snarl(projected_id, !projected_rev, snarl_manager, dist_index)) {
                         // as we enter this node, we are leaving the snarl we were in
                         
                         // since we're going up a level, we need to check whether we need to cut out the segment we've traversed
@@ -1453,7 +1458,7 @@ namespace vg {
                 
                 if (j < last) {
                     // we are going to leave this node next iteration
-                    if (cutting_snarls->into_which_snarl(projected_id, projected_rev)) {
+                    if (into_cutting_snarl(projected_id, projected_rev, snarl_manager, dist_index)) {
                         // as we leave this node, we are entering a new deeper snarl
                         
                         // the segment in the new level will begin at the end of the current node
@@ -4214,6 +4219,24 @@ namespace vg {
             }
         }
         out << "}" << endl;
+    }
+
+    bool MultipathAlignmentGraph::into_cutting_snarl(id_t node_id, bool is_rev,
+                                                     SnarlManager* snarl_manager, MinimumDistancIndex* dist_index) {
+        
+        if (dist_index) {
+            auto result = dist_index->into_cutting_snarl(node_id, is_rev);
+            // points into a snarl and snarl is nontrivial
+            return get<1>(result) && get<2>(result);
+        }
+        else if (snarl_manager) {
+            // no mechanism to check for triviality without traversing graph
+            return snarl_manager->into_which_snarl(node_id, is_rev);
+        }
+        else {
+            // no snarls provided
+            return false;
+        }
     }
     
     vector<vector<id_t>> MultipathAlignmentGraph::get_connected_components() const {

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -4227,7 +4227,7 @@ MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const
         if (dist_index) {
             auto result = dist_index->into_which_snarl(node_id, is_rev);
             // points into a snarl and snarl is nontrivial
-            return get<1>(result) && get<2>(result);
+            return get<0>(result) != 0 && !get<2>(result);
         }
         else if (snarl_manager) {
             // no mechanism to check for triviality without traversing graph

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -4222,10 +4222,10 @@ MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const
     }
 
     bool MultipathAlignmentGraph::into_cutting_snarl(id_t node_id, bool is_rev,
-                                                     SnarlManager* snarl_manager, MinimumDistancIndex* dist_index) {
+                                                     SnarlManager* snarl_manager, MinimumDistanceIndex* dist_index) {
         
         if (dist_index) {
-            auto result = dist_index->into_cutting_snarl(node_id, is_rev);
+            auto result = dist_index->into_which_snarl(node_id, is_rev);
             // points into a snarl and snarl is nontrivial
             return get<1>(result) && get<2>(result);
         }

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -161,7 +161,7 @@ namespace vg {
         
         // cut the snarls out of the aligned path so we can realign through them
         if (max_snarl_cut_size) {
-            resect_snarls_from_paths(snarl_manager, dist_index, dist_index, project, max_snarl_cut_size);
+            resect_snarls_from_paths(snarl_manager, dist_index, project, max_snarl_cut_size);
         }
         
         // the snarls algorithm adds edges where necessary
@@ -1435,7 +1435,7 @@ MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const
                 
                 if (j > 0) {
                     // we have entered this node on this iteration
-                    if (into_cutting_snarl(projected_id, !projected_rev, snarl_manager, dist_index)) {
+                    if (into_cutting_snarl(projected_id, !projected_rev, cutting_snarls, dist_index)) {
                         // as we enter this node, we are leaving the snarl we were in
                         
                         // since we're going up a level, we need to check whether we need to cut out the segment we've traversed
@@ -1458,7 +1458,7 @@ MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const
                 
                 if (j < last) {
                     // we are going to leave this node next iteration
-                    if (into_cutting_snarl(projected_id, projected_rev, snarl_manager, dist_index)) {
+                    if (into_cutting_snarl(projected_id, projected_rev, cutting_snarls, dist_index)) {
                         // as we leave this node, we are entering a new deeper snarl
                         
                         // the segment in the new level will begin at the end of the current node

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -150,7 +150,7 @@ namespace vg {
         /// Cut the interior of snarls out of anchoring paths (and split
         /// alignment nodes accordingly) unless they are longer than the max
         /// cut size. Snarls can be stored either in a SnarlManager or a
-        /// MinimumDistancIndex (only one need be supplied).
+        /// MinimumDistanceIndex (only one need be supplied).
         void resect_snarls_from_paths(SnarlManager* cutting_snarls, MinimumDistanceIndex* dist_index,
                                       const function<pair<id_t, bool>(id_t)>& project, int64_t max_snarl_cut_size = 5);
         
@@ -266,7 +266,7 @@ namespace vg {
         
         /// Returns true if we're pointing into a snarl that we want to cut out of paths
         bool into_cutting_snarl(id_t node_id, bool is_rev,
-                                SnarlManager* snarl_manager, MinimumDistancIndex* dist_index);
+                                SnarlManager* snarl_manager, MinimumDistanceIndex* dist_index);
         
         /// Generate alignments of the tails of the query sequence, beyond the
         /// sources and sinks. The Alignment passed *must* be the one that owns

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -99,18 +99,22 @@ namespace vg {
                                 const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project, bool realign_Ns = true,
                                 bool preserve_tail_anchors = false);
         
-        /// Make a multipath alignment graph using the path of a single-path alignment
-        MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager& snarl_manager, size_t max_snarl_cut_size,
+        /// Make a multipath alignment graph using the path of a single-path alignment. Only
+        /// one of snarl_manager and dist_index need be supplied.
+        MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager* snarl_manager,
+                                MinimumDistanceIndex* dist_index, size_t max_snarl_cut_size,
                                 const function<pair<id_t, bool>(id_t)>& project,
                                 const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans);
         
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
-        MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager& snarl_manager, size_t max_snarl_cut_size,
+        MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager* snarl_manager,
+                                MinimumDistanceIndex* dist_index, size_t max_snarl_cut_size,
                                 const unordered_map<id_t, pair<id_t, bool>>& projection_trans);
         
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
         /// using a function instead of a map
-        MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager& snarl_manager, size_t max_snarl_cut_size,
+        MultipathAlignmentGraph(const HandleGraph& graph, const Alignment& alignment, SnarlManager* snarl_manager,
+                                MinimumDistanceIndex* dist_index, size_t max_snarl_cut_size,
                                 const function<pair<id_t, bool>(id_t)>& project);
         
         ~MultipathAlignmentGraph();
@@ -145,9 +149,10 @@ namespace vg {
         
         /// Cut the interior of snarls out of anchoring paths (and split
         /// alignment nodes accordingly) unless they are longer than the max
-        /// cut size. Reachability edges must be cleared.
-        void resect_snarls_from_paths(SnarlManager* cutting_snarls, const function<pair<id_t, bool>(id_t)>& project,
-                                      int64_t max_snarl_cut_size = 5);
+        /// cut size. Snarls can be stored either in a SnarlManager or a
+        /// MinimumDistancIndex (only one need be supplied).
+        void resect_snarls_from_paths(SnarlManager* cutting_snarls, MinimumDistanceIndex* dist_index,
+                                      const function<pair<id_t, bool>(id_t)>& project, int64_t max_snarl_cut_size = 5);
         
         /// Do some exploratory alignments of the tails of the graph, outside
         /// the outermost existing anchors, and define new anchoring paths from
@@ -258,6 +263,10 @@ namespace vg {
         /// Return the pessimistic gap length corresponding to a certain tail length and multiplier (proportional to
         /// the square root of the tail length)
         int64_t pessimistic_tail_gap(int64_t tail_length, double multiplier);
+        
+        /// Returns true if we're pointing into a snarl that we want to cut out of paths
+        bool into_cutting_snarl(id_t node_id, bool is_rev,
+                                SnarlManager* snarl_manager, MinimumDistancIndex* dist_index);
         
         /// Generate alignments of the tails of the query sequence, beyond the
         /// sources and sinks. The Alignment passed *must* be the one that owns

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3484,7 +3484,7 @@ namespace vg {
             
     void MultipathMapper::make_nontrivial_multipath_alignment(const Alignment& alignment, const HandleGraph& subgraph,
                                                               const function<pair<id_t, bool>(id_t)>& translator,
-                                                              SnarlManager& snarl_manager, multipath_alignment_t& multipath_aln_out) const {
+                                                              multipath_alignment_t& multipath_aln_out) const {
         
 #ifdef debug_multipath_mapper_alignment
         cerr << "attempting to make nontrivial alignment for " << alignment.name() << endl;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3493,7 +3493,7 @@ namespace vg {
         auto aligner = get_aligner(!alignment.quality().empty());
         
         // create an alignment graph with the internals of snarls removed
-        MultipathAlignmentGraph multi_aln_graph(subgraph, alignment, snarl_manager, max_snarl_cut_size, translator);
+        MultipathAlignmentGraph multi_aln_graph(subgraph, alignment, snarl_manager, distance_index, max_snarl_cut_size, translator);
         
         // remove any transitive edges that may have found their way in there
         // TODO: is this necessary? all edges should be across snarls, how could they be transitive? from trimmed indels maybe?

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -702,7 +702,7 @@ namespace vg {
         
         if (num_alt_alns > 1 && snarl_manager != nullptr) {
             // make an interesting multipath alignment by realigning the single path alignment inside snarls
-            make_nontrivial_multipath_alignment(aln, *align_dag, translator, *snarl_manager, rescue_multipath_aln);
+            make_nontrivial_multipath_alignment(aln, *align_dag, translator, rescue_multipath_aln);
             
         }
         else {

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3434,7 +3434,7 @@ namespace vg {
         
             // Do the snarl cutting, which modifies the nodes in the multipath alignment graph
             if (max_snarl_cut_size) {
-                multi_aln_graph.resect_snarls_from_paths(snarl_manager, translator, max_snarl_cut_size);
+                multi_aln_graph.resect_snarls_from_paths(snarl_manager, distance_index, translator, max_snarl_cut_size);
             }
         }
 

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -365,7 +365,7 @@ namespace vg {
         /// Guarantees that the resulting multipath_alignment_t is in topological order.
         void make_nontrivial_multipath_alignment(const Alignment& alignment, const HandleGraph& subgraph,
                                                  const function<pair<id_t, bool>(id_t)>& translator,
-                                                 SnarlManager& snarl_manager, multipath_alignment_t& multipath_aln_out) const;
+                                                 multipath_alignment_t& multipath_aln_out) const;
         
         /// Remove the full length bonus from all source or sink subpaths that received it
         void strip_full_length_bonuses(multipath_alignment_t& multipath_aln) const;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1300,10 +1300,15 @@ int main_mpmap(int argc, char** argv) {
     
     ifstream snarl_stream;
     if (!snarls_name.empty()) {
-        snarl_stream.open(snarls_name);
-        if (!snarl_stream) {
-            cerr << "error:[vg mpmap] Cannot open Snarls file " << snarls_name << endl;
-            exit(1);
+        if (distance_index_name.empty()) {
+            snarl_stream.open(snarls_name);
+            if (!snarl_stream) {
+                cerr << "error:[vg mpmap] Cannot open Snarls file " << snarls_name << endl;
+                exit(1);
+            }
+        }
+        else {
+            cerr << "warning:[vg mpmap] Snarls file (-s) is unnecessary and will be ignored when the distance index (-d) is provided" << endl;
         }
     }
     
@@ -1500,7 +1505,7 @@ int main_mpmap(int argc, char** argv) {
     }
     
     unique_ptr<SnarlManager> snarl_manager;
-    if (!snarls_name.empty()) {
+    if (!snarls_name.empty() && distance_index_name.empty()) {
         if (!suppress_progress) {
             cerr << progress_boilerplate() << "Loading snarls from " << snarls_name << endl;
         }

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1202,8 +1202,8 @@ int main_mpmap(int argc, char** argv) {
         exit(1);
     }
     
-    if (no_clustering && !distance_index_name.empty()) {
-        cerr << "warning:[vg mpmap] No clustering option (--no-cluster) causes distance index (-d) to be ignored. This option is activated by default for 'very-short' read lengths (-l)." << endl;
+    if (no_clustering && !distance_index_name.empty() && !snarls_name.empty()) {
+        cerr << "warning:[vg mpmap] No clustering option (--no-cluster) causes distance index (-d) to be ignored when snarls (-s) are provided. This option is activated by default for 'very-short' read lengths (-l)." << endl;
     }
     
     if (suboptimal_path_exponent < 1.0) {
@@ -1290,7 +1290,7 @@ int main_mpmap(int argc, char** argv) {
     }
     
     ifstream distance_index_stream;
-    if (!distance_index_name.empty() && !no_clustering) {
+    if (!distance_index_name.empty() && !(no_clustering && !snarls_name.empty())) {
         distance_index_stream.open(distance_index_name);
         if (!distance_index_stream) {
             cerr << "error:[vg mpmap] Cannot open distance index file " << distance_index_name << endl;
@@ -1300,7 +1300,7 @@ int main_mpmap(int argc, char** argv) {
     
     ifstream snarl_stream;
     if (!snarls_name.empty()) {
-        if (distance_index_name.empty()) {
+        if (distance_index_name.empty() || no_clustering) {
             snarl_stream.open(snarls_name);
             if (!snarl_stream) {
                 cerr << "error:[vg mpmap] Cannot open Snarls file " << snarls_name << endl;
@@ -1308,7 +1308,7 @@ int main_mpmap(int argc, char** argv) {
             }
         }
         else {
-            cerr << "warning:[vg mpmap] Snarls file (-s) is unnecessary and will be ignored when the distance index (-d) is provided" << endl;
+            cerr << "warning:[vg mpmap] Snarls file (-s) is unnecessary and will be ignored when the distance index (-d) is provided." << endl;
         }
     }
     
@@ -1505,7 +1505,7 @@ int main_mpmap(int argc, char** argv) {
     }
     
     unique_ptr<SnarlManager> snarl_manager;
-    if (!snarls_name.empty() && distance_index_name.empty()) {
+    if (!snarls_name.empty() && (distance_index_name.empty() || no_clustering)) {
         if (!suppress_progress) {
             cerr << progress_boilerplate() << "Loading snarls from " << snarls_name << endl;
         }
@@ -1513,7 +1513,7 @@ int main_mpmap(int argc, char** argv) {
     }
     
     unique_ptr<MinimumDistanceIndex> distance_index;
-    if (!distance_index_name.empty() && !no_clustering) {
+    if (!distance_index_name.empty() && !(no_clustering && !snarls_name.empty())) {
         if (!suppress_progress) {
             cerr << progress_boilerplate() << "Loading distance index from " << distance_index_name << endl;
         }

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -188,7 +188,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
             mpg.synthesize_tail_anchors(query, vg, &aligner, 1, 2, false, 100, 0.0);
             
             // Cut new anchors on snarls
-            mpg.resect_snarls_from_paths(&snarl_manager,
+            mpg.resect_snarls_from_paths(&snarl_manager, nullptr,
                                          MultipathAlignmentGraph::create_projector(identity), 5);
             
             // Make it align, with alignments per gap/tail
@@ -280,7 +280,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
             mpg.synthesize_tail_anchors(query, vg, &aligner, 1, 2, false, 100, 0.0);
             
             // Cut new anchors on snarls
-            mpg.resect_snarls_from_paths(&snarl_manager,
+            mpg.resect_snarls_from_paths(&snarl_manager, nullptr,
                                          MultipathAlignmentGraph::create_projector(identity), 5);
             
             // Make it align, with alignments per gap/tail

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -7,6 +7,7 @@
 #include <vg/vg.pb.h>
 #include "../cactus_snarl_finder.hpp"
 #include "../multipath_alignment_graph.hpp"
+#include "../min_distance.hpp"
 #include "catch.hpp"
 
 namespace vg {
@@ -46,7 +47,8 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
     
     // Make snarls on it
     CactusSnarlFinder bubble_finder(vg);
-    SnarlManager snarl_manager = bubble_finder.find_snarls(); 
+    SnarlManager snarl_manager = bubble_finder.find_snarls();
+    MinimumDistanceIndex dist_index(&vg, &snarl_manager);
     
     // We need a fake read
     string read("GATTACAA");
@@ -280,7 +282,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
             mpg.synthesize_tail_anchors(query, vg, &aligner, 1, 2, false, 100, 0.0);
             
             // Cut new anchors on snarls
-            mpg.resect_snarls_from_paths(&snarl_manager, nullptr,
+            mpg.resect_snarls_from_paths(nullptr, &dist_index,
                                          MultipathAlignmentGraph::create_projector(identity), 5);
             
             // Make it align, with alignments per gap/tail


### PR DESCRIPTION
## Changelog Entry

 * mpmap now can use the distance index in place of a snarl manager to guide the structure of multipath alignments

## Description

The distance index encodes the snarl tree, so there was really no reason to import a snarl manager into mpmap when the distance index was already being loaded. This PR adds the option to use the distance index functions added in https://github.com/vgteam/vg/pull/2913 and https://github.com/vgteam/vg/pull/2910 in place of the snarl manager. This will help bring down mpmap's memory footprint.