### PR TITLE
better error msg when xg index not found

### DIFF
--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -653,12 +653,16 @@ int main_map(int argc, char** argv) {
     
     // One of them may be used to provide haplotype scores
     haplo::ScoreProvider* haplo_score_provider = nullptr;
-
-    // We try opening the file, and then see if it worked
-    ifstream xg_stream(xg_name);
     
-    if(xg_stream) {
+    if(!xg_name.empty()) {
         // We have an xg index!
+
+        // We try opening the file, and then see if it worked
+        ifstream xg_stream(xg_name);
+        if (!xg_stream) {
+            cerr << "Error[vg map]: Unable to open xg file \"" << xg_name << "\"" << endl;
+            exit(1);
+        }
         
         // TODO: tell when the user asked for an XG vs. when we guessed one,
         // and error when the user asked for one and we can't find it.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Better `vg map` error message when xg input not found

## Description

See https://github.com/vgteam/vg/issues/2889#issuecomment-660649554