### PR TITLE
Better GBWT construction from GAM/GAF

### DIFF
--- a/src/haplotype_indexer.hpp
+++ b/src/haplotype_indexer.hpp
@@ -130,13 +130,17 @@ public:
         bool delete_graph) const;
     
     /**
-     * Build a GBWT from the embedded non-alt paths in the graph.
+     * Build a GBWT from the embedded non-alt paths in the graph. Use
+     * paths_as_samples to choose whether we treat the paths as contigs or
+     * samples.
      */
     std::unique_ptr<gbwt::DynamicGBWT> build_gbwt(const PathHandleGraph* graph) const;
 
     /**
-     * Build a GBWT with each alignment as a thread over a separate sample
-     * in the same contig.
+     * Build a GBWT from the alignments. Each distinct alignment name becomes
+     * a sample in the GBWT metadata. If there are multiple alignments with
+     * the same name, the corresponding GBWT path names will have the same
+     * sample identifier but different values in the count field.
      *
      * aln_format can be "GAM" or "GAF"
      */


### PR DESCRIPTION
## Changelog Entry

To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

* GBWT construction from GAM/GAF is faster and handles duplicate read names correctly.

## Description

GBWT construction did not like it when the number of distinct start nodes of paths/threads was too large. This PR updates GBWT to fix the issue. GBWT can now be built in a reasonable time from GAM/GAF files with tens (hundreds?) of millions of reads.

In many cases, a read and its pair have the same name. When building a GBWT from such reads, we used to create duplicate sample names in the GBWT metadata. This PR changes the behavior. All alignments with the same sample name now correspond to the same sample/haplotype in the GBWT metadata. We use the `count` field in GBWT path names to distinguish between them.