### PR TITLE
Optionally output a table of path usages from vg sim

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -856,7 +856,7 @@ NGSSimulator::NGSSimulator(PathPositionHandleGraph& graph,
 }
 
 void NGSSimulator::print_path_usage(ostream& out) const {
-    if (sample_paths.empty()) {
+    if (source_paths.empty()) {
         return;
     }
     if (source_path_frag_counts.size() == 1) {
@@ -864,8 +864,8 @@ void NGSSimulator::print_path_usage(ostream& out) const {
     }
     else {
         // combine the per-thread counts
-        vector<size_t> counts(sample_paths.size(), 0);
-        for (const thread_counts& source_path_frag_counts) {
+        vector<size_t> counts(source_paths.size(), 0);
+        for (const auto& thread_counts : source_path_frag_counts) {
             for (size_t i = 0; i < thread_counts.size(); ++i) {
                 counts[i] += thread_counts[i];
             }
@@ -887,7 +887,7 @@ void NGSSimulator::print_path_usage_internal(ostream& out, const vector<size_t>&
     double denom = total / 1000000.0;
     out << "path\tcount\tfrags_per_million" << endl;
     for (size_t i = 0; i < counts.size(); ++i) {
-        out << sample_paths[i] << '\t' << counts[i] << '\t' << (path_count / denom) << endl;
+        out << source_paths[i] << '\t' << counts[i] << '\t' << (counts[i] / denom) << endl;
     }
 }
 

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -2,6 +2,7 @@
 #define VG_SIMULATOR_HPP_INCLUDED
 
 #include <iostream>
+#include <iomanip>
 #include <map>
 #include <unordered_map>
 #include <vector>
@@ -185,6 +186,9 @@ public:
     /// Sample a pair of reads an alignments
     pair<Alignment, Alignment> sample_read_pair();
     
+    /// Print out a TSV of the fraction of fragments from different paths
+    void print_path_usage(ostream& out) const;
+    
 private:
     template<class From, class To>
     class MarkovDistribution {
@@ -208,6 +212,8 @@ private:
         unordered_map<From, vector<size_t>> cond_distrs;
         
     };
+    
+    void print_path_usage_internal(ostream& out, const vector<size_t>& counts) const;
     
     NGSSimulator(void) = delete;
     
@@ -331,6 +337,8 @@ private:
     
     /// Restrict reads to just these paths (path-only mode) if nonempty.
     vector<string> source_paths;
+    
+    vector<vector<size_t>> source_path_frag_counts;
 };
     
 /**


### PR DESCRIPTION
## Changelog Entry

* `vg sim` can now output a table of the number of reads simulated from each path

## Description

Adds a feature requested by @jonassibbesen to take some noise out of the transcript quantification evaluation.