### PR TITLE
New subcommand for evaluating multipath alignment correctness

### DIFF
--- a/src/algorithms/alignment_path_offsets.cpp
+++ b/src/algorithms/alignment_path_offsets.cpp
@@ -66,6 +66,103 @@ alignment_path_offsets(const PathPositionHandleGraph& graph,
     return offsets;
 }
 
+unordered_map<path_handle_t, vector<pair<size_t, bool> > >
+multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
+                                 const multipath_alignment_t& mp_aln) {
+    
+    using path_positions_t = unordered_map<path_handle_t, vector<pair<size_t, bool>>;
+    
+    // collect the search results for each mapping on each subpath
+    vector<vector<path_positions_t>> search_results(mp_aln.subpath_size());
+    for (size_t i = 0; i < mp_aln.subpath_size(); ++i) {
+        const subpath_t& subpath = mp_aln.subpath(i);
+        auto& subpath_search_results = search_results[i];
+        subpath_search_results.resize(subpath.path().mapping_size());
+        for (size_t j = 0; j < subpath.path().mapping_size()) {
+            // get the positions on paths that this mapping touches
+            pos_t mapping_pos = make_pos_t(subpath.mapping(j).position());
+            subpath_search_results[j] = nearest_offsets_in_paths(graph, mapping_pos, 0, false);
+            // make sure that offsets are stored in increasing order
+            for (pair<const path_handle_t, vector<pair<size_t, bool>>>& search_record : subpath_search_results[j]) {
+                sort(search_record.second.begin(), search_record.second.end());
+            }
+        }
+    }
+    
+    path_positions_t return_val;
+    
+    // to keep track of whether we've already chosen a position on each path
+    // earlier in the multipath alignment in either the forward or reverse pass
+    vector<set<path_handle_t>> covered_fwd(mp_aln.subpath_size());
+    vector<set<path_handle_t>> covered_rev(mp_aln.subpath_size());
+    
+    // forward pass looking for positions on the forward strand of paths
+    for (size_t i = 0; i < mp_aln.subpath_size(); ++i) {
+        const auto& subpath_search_results = search_results[i];
+        for (size_t j = 0; j < subpath_search_results.size(); ++j) {
+            for (const auto& path_pos : subpath_search_results[j]) {
+                if (!covered_fwd[i].count(path_pos.first)) {
+                    // we haven't already covered this path at an earlier position on the alignment
+                    for (const auto& path_offset : path_pos.second) {
+                        if (!path_offset.second) {
+                            // there's a position on the forward strand of this path
+                            return_val[path_pos.first].emplace_back(path_offset);
+                            
+                            // we're now covering this path for future search results
+                            covered_fwd[i].insert(path_pos.first);
+                            
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        
+        // the following subpaths will be covered for any path that this
+        // one is covered for
+        for (auto n : mp_aln.subpath(i).next()) {
+            auto& next_coverings = covered_fwd[n];
+            for (auto path_handle : covered_fwd[i]) {
+                next_coverings.insert(path_handle);
+            }
+        }
+    }
+    
+    // now do a backward pass for the reverse strand of paths
+    for (int64_t i = mp_aln.subpath_size() - 1; i >= 0; --i) {
+        // find which paths are already covered in the reverse
+        for (auto n : mp_aln.subpath(i).next()) {
+            for (auto path_handle : covered_rev[n]) {
+                covered_rev[i].insert(path_handle);
+            }
+        }
+        
+        const auto& subpath_search_results = search_results[i];
+        for (int64_t j = subpath_search_results.size() - 1; j >= 0; --j) {
+            for (const auto& path_pos : subpath_search_results[j]) {
+                if (!covered_rev[i].count(path_pos.first)) {
+                    // we haven't already covered this path at an earlier position on the alignment
+                    for (const auto& path_offset : path_pos.second) {
+                        if (path_offset.second) {
+                            // there's a position on the reverse strand of this path
+                            return_val[path_pos.first].emplace_back(path_offset.first - mapping_from_length(mp_aln.subpath(i).mapping(j)),
+                                                                    path_offset.second);
+                            
+                            
+                            // we're now covering this path for future search results
+                            covered_rev[i].insert(path_pos.first);
+                            
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    return return_val;
+}
+
 void annotate_with_initial_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, size_t search_limit) {
     if (!aln.refpos_size()) {
         unordered_map<path_handle_t, vector<pair<size_t, bool> > > positions = alignment_path_offsets(graph, aln, true, false, search_limit);

--- a/src/algorithms/alignment_path_offsets.cpp
+++ b/src/algorithms/alignment_path_offsets.cpp
@@ -1,5 +1,6 @@
 #include "alignment_path_offsets.hpp"
 
+//#define debug_mpaln_offsets
 
 namespace vg {
 namespace algorithms {
@@ -81,11 +82,20 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
         for (size_t j = 0; j < subpath.path().mapping_size(); ++j) {
             // get the positions on paths that this mapping touches
             pos_t mapping_pos = make_pos_t(subpath.path().mapping(j).position());
-            subpath_search_results[j] = nearest_offsets_in_paths(&graph, mapping_pos, 0, false);
+            subpath_search_results[j] = nearest_offsets_in_paths(&graph, mapping_pos, 0);
             // make sure that offsets are stored in increasing order
             for (pair<const path_handle_t, vector<pair<size_t, bool>>>& search_record : subpath_search_results[j]) {
                 sort(search_record.second.begin(), search_record.second.end());
             }
+#ifdef debug_mpaln_offsets
+            cerr << "subpath " << i << ", mapping " << j << " path locations" << endl;
+            for (const auto& pps : subpath_search_results[j]) {
+                cerr << graph.get_path_name(pps.first) << endl;
+                for (const auto& pp : pps.second) {
+                    cerr << "\t" << pp.first << " " << pp.second << endl;
+                }
+            }
+#endif
         }
     }
     
@@ -110,6 +120,10 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
                             
                             // we're now covering this path for future search results
                             covered_fwd[i].insert(path_pos.first);
+                            
+#ifdef debug_mpaln_offsets
+                            cerr << "found fwd pass pos, subpath " << i << ", mapping " << j << ", path " << graph.get_path_name(path_pos.first) << ", pos " << path_offset.first << " " << path_offset.second << endl;
+#endif
                             
                             break;
                         }
@@ -149,7 +163,9 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
                             return_val[path_pos.first].emplace_back(path_offset.first - mapping_len,
                                                                     path_offset.second);
                             
-                            
+#ifdef debug_mpaln_offsets
+                            cerr << "found rev pass pos, subpath " << i << ", mapping " << j << ", path " << graph.get_path_name(path_pos.first) << ", pos " << path_offset.first - mapping_len << " " << path_offset.second << endl;
+#endif
                             // we're now covering this path for future search results
                             covered_rev[i].insert(path_pos.first);
                             

--- a/src/algorithms/alignment_path_offsets.cpp
+++ b/src/algorithms/alignment_path_offsets.cpp
@@ -70,7 +70,7 @@ unordered_map<path_handle_t, vector<pair<size_t, bool> > >
 multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
                                  const multipath_alignment_t& mp_aln) {
     
-    using path_positions_t = unordered_map<path_handle_t, vector<pair<size_t, bool>>;
+    using path_positions_t = unordered_map<path_handle_t, vector<pair<size_t, bool>>>;
     
     // collect the search results for each mapping on each subpath
     vector<vector<path_positions_t>> search_results(mp_aln.subpath_size());
@@ -78,10 +78,10 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
         const subpath_t& subpath = mp_aln.subpath(i);
         auto& subpath_search_results = search_results[i];
         subpath_search_results.resize(subpath.path().mapping_size());
-        for (size_t j = 0; j < subpath.path().mapping_size()) {
+        for (size_t j = 0; j < subpath.path().mapping_size(); ++j) {
             // get the positions on paths that this mapping touches
-            pos_t mapping_pos = make_pos_t(subpath.mapping(j).position());
-            subpath_search_results[j] = nearest_offsets_in_paths(graph, mapping_pos, 0, false);
+            pos_t mapping_pos = make_pos_t(subpath.path().mapping(j).position());
+            subpath_search_results[j] = nearest_offsets_in_paths(&graph, mapping_pos, 0, false);
             // make sure that offsets are stored in increasing order
             for (pair<const path_handle_t, vector<pair<size_t, bool>>>& search_record : subpath_search_results[j]) {
                 sort(search_record.second.begin(), search_record.second.end());
@@ -145,7 +145,8 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
                     for (const auto& path_offset : path_pos.second) {
                         if (path_offset.second) {
                             // there's a position on the reverse strand of this path
-                            return_val[path_pos.first].emplace_back(path_offset.first - mapping_from_length(mp_aln.subpath(i).mapping(j)),
+                            auto mapping_len = mapping_from_length(mp_aln.subpath(i).path().mapping(j));
+                            return_val[path_pos.first].emplace_back(path_offset.first - mapping_len,
                                                                     path_offset.second);
                             
                             

--- a/src/algorithms/alignment_path_offsets.hpp
+++ b/src/algorithms/alignment_path_offsets.hpp
@@ -3,6 +3,7 @@
 #include "../handle.hpp"
 #include "../position.hpp"
 #include "../path.hpp"
+#include "../multipath_alignment.hpp"
 #include <vg/vg.pb.h>
 #include <functional>
 #include "nearest_offsets_in_paths.hpp"

--- a/src/algorithms/alignment_path_offsets.hpp
+++ b/src/algorithms/alignment_path_offsets.hpp
@@ -20,6 +20,14 @@ alignment_path_offsets(const PathPositionHandleGraph& graph,
                        bool nearby,
                        size_t search_limit = 0);
 
+/// Find the position of a multipath alignment on paths. Returns the lowest offset
+/// position on a path for each contiguous stretch of the multipath alignment, but
+/// multiple positions on the same path may be returned if the multipath alignment
+/// is disconnected or fans out toward the sources or sinks.
+unordered_map<path_handle_t, vector<pair<size_t, bool> > >
+multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
+                                 const multipath_alignment_t& mp_aln);
+
 /// Use the graph to annotate an Alignment with the first
 /// position it touches on each reference path. Thread safe.
 ///

--- a/src/algorithms/nearest_offsets_in_paths.cpp
+++ b/src/algorithms/nearest_offsets_in_paths.cpp
@@ -15,8 +15,7 @@ using namespace std;
 
 unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
                                                                                   const pos_t& pos,
-                                                                                  int64_t max_search,
-                                                                                  bool adjust_by_search_dist) {
+                                                                                  int64_t max_search) {
     
     // init the return value
     unordered_map<path_handle_t, vector<pair<size_t, bool>>> return_val;
@@ -61,12 +60,9 @@ unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_path
             int64_t path_offset = graph->get_position_of_step(step);
             
             if (rev_on_path != search_left) {
-                path_offset += graph->get_length(oriented);
-                if (adjust_by_search_dist) {
-                    path_offset += dist;
-                }
+                path_offset += graph->get_length(oriented) + dist;
             }
-            else if (adjust_by_search_dist) {
+            else {
                 path_offset -= dist;
             }
             

--- a/src/algorithms/nearest_offsets_in_paths.cpp
+++ b/src/algorithms/nearest_offsets_in_paths.cpp
@@ -15,7 +15,8 @@ using namespace std;
 
 unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
                                                                                   const pos_t& pos,
-                                                                                  int64_t max_search) {
+                                                                                  int64_t max_search,
+                                                                                  bool adjust_by_search_dist) {
     
     // init the return value
     unordered_map<path_handle_t, vector<pair<size_t, bool>>> return_val;
@@ -59,11 +60,14 @@ unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_path
             // the offset of this step on the forward strand
             int64_t path_offset = graph->get_position_of_step(step);
             
-            if (rev_on_path == search_left) {
-                path_offset -= dist;
+            if (rev_on_path != search_left) {
+                path_offset += graph->get_length(oriented)
+                if (adjust_by_search_dist) {
+                    path_offset += dist;
+                }
             }
-            else {
-                path_offset += graph->get_length(oriented) + dist;
+            else if (adjust_by_search_dist) {
+                path_offset -= dist;
             }
             
 #ifdef debug

--- a/src/algorithms/nearest_offsets_in_paths.cpp
+++ b/src/algorithms/nearest_offsets_in_paths.cpp
@@ -61,7 +61,7 @@ unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_path
             int64_t path_offset = graph->get_position_of_step(step);
             
             if (rev_on_path != search_left) {
-                path_offset += graph->get_length(oriented)
+                path_offset += graph->get_length(oriented);
                 if (adjust_by_search_dist) {
                     path_offset += dist;
                 }

--- a/src/algorithms/nearest_offsets_in_paths.hpp
+++ b/src/algorithms/nearest_offsets_in_paths.hpp
@@ -27,7 +27,8 @@ using namespace std;
 /// subject to the given max search distance, a mapping from path name to
 /// all positions on each path where that pos_t occurs.
 unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
-                                                                                  const pos_t& pos, int64_t max_search);
+                                                                                  const pos_t& pos, int64_t max_search,
+                                                                                  bool adjust_by_search_dist = true);
     
 /// Wrapper for the above to support some earlier code. Only looks for paths
 /// that directly touch the position, and returns the paths by name.

--- a/src/algorithms/nearest_offsets_in_paths.hpp
+++ b/src/algorithms/nearest_offsets_in_paths.hpp
@@ -27,8 +27,7 @@ using namespace std;
 /// subject to the given max search distance, a mapping from path name to
 /// all positions on each path where that pos_t occurs.
 unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
-                                                                                  const pos_t& pos, int64_t max_search,
-                                                                                  bool adjust_by_search_dist = true);
+                                                                                  const pos_t& pos, int64_t max_search);
     
 /// Wrapper for the above to support some earlier code. Only looks for paths
 /// that directly touch the position, and returns the paths by name.

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -18,6 +18,10 @@ using namespace vg::io;
 
 namespace vg {
 
+    multipath_alignment_t::multipath_alignment_t() : _mapping_quality(0) {
+        // i don't understand why this is necessary, but somehow mapq is getting defaulted to 160?
+    }
+
     multipath_alignment_t::~multipath_alignment_t() {
         while (!_annotation.empty()) {
             clear_annotation(_annotation.begin()->first);

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -59,7 +59,7 @@ namespace vg {
     // TODO: the metadata could be removed and only added to the protobuf at serialization time
     class multipath_alignment_t {
     public:
-        multipath_alignment_t() = default;
+        multipath_alignment_t();
         multipath_alignment_t(const multipath_alignment_t&) = default;
         multipath_alignment_t(multipath_alignment_t&&) = default;
         ~multipath_alignment_t();

--- a/src/subcommand/gampcompare_main.cpp
+++ b/src/subcommand/gampcompare_main.cpp
@@ -198,7 +198,7 @@ int main_gampcompare(int argc, char** argv) {
                     for (size_t i = 0; i < path_true_positions.size() && !correct; ++i) {
                         for (size_t j = 0; j < path_mapped_positions.size() && !correct; ++j) {
                             if (path_true_positions[i].second == path_mapped_positions[j].second
-                                && abs<int64_t>(path_true_positions[i].first - path_mapped_positions[j].first) <= range) {
+                                && abs<int>(path_true_positions[i].first - path_mapped_positions[j].first) <= range) {
                                 // there is a pair of positions on the same strand of the same path
                                 // within the distance limit
                                 correct = true;

--- a/src/subcommand/gampcompare_main.cpp
+++ b/src/subcommand/gampcompare_main.cpp
@@ -101,7 +101,7 @@ int main_gampcompare(int argc, char** argv) {
     string test_file_name = get_input_file_name(optind, argc, argv);
     string truth_file_name = get_input_file_name(optind, argc, argv);
 
-    if ((truth_file_name == "-") + (test_file_name == "-") + (graph_file_name == "-") <= 1) {
+    if ((truth_file_name == "-") + (test_file_name == "-") + (graph_file_name == "-") > 1) {
         cerr << "error[vg gampcompare]: Standard input can only be used for one input file" << endl;
         exit(1);
     }

--- a/src/subcommand/gampcompare_main.cpp
+++ b/src/subcommand/gampcompare_main.cpp
@@ -1,0 +1,277 @@
+// gampcompare_main.cpp: defines a GAMP to GAM annotation function
+
+#include <omp.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <string>
+#include <vector>
+#include <set>
+
+#include <subcommand.hpp>
+
+#include "../algorithms/alignment_path_offsets.hpp"
+#include "../multipath_alignment.hpp"
+#include "../alignment.hpp"
+#include "../vg.hpp"
+#include <vg/io/stream.hpp>
+
+using namespace std;
+using namespace vg;
+using namespace vg::subcommand;
+
+void help_gampcompare(char** argv) {
+    cerr << "usage: " << argv[0] << " gampcompare [options] alngraph.xg aln.gamp truth.gam > output.tsv" << endl
+         << endl
+         << "options:" << endl
+         << "    -G, --gam                alignments are in GAM format rather than GAMP" << endl
+         << "    -r, --range N            distance within which to consider reads correct [100]" << endl
+         << "    -a, --aligner STR        aligner name for TSV output [\"vg\"]" << endl
+         << "    -t, --threads N          number of threads to use [1]" << endl;
+}
+
+int main_gampcompare(int argc, char** argv) {
+
+    if (argc == 2) {
+        help_gampcompare(argv);
+        exit(1);
+    }
+
+    int threads = 1;
+    int64_t range = 100;
+    string aligner_name = "vg";
+    int buffer_size = 10000;
+    bool gam_input = false;
+
+    int c;
+    optind = 2;
+    while (true) {
+        static struct option long_options[] =
+        {
+            {"help", no_argument, 0, 'h'},
+            {"range", required_argument, 0, 'r'},
+            {"gam", no_argument, 0, 'G'},
+            {"aligner", required_argument, 0, 'a'},
+            {"threads", required_argument, 0, 't'},
+            {0, 0, 0, 0}
+        };
+
+        int option_index = 0;
+        c = getopt_long (argc, argv, "hr:a:t:G",
+                         long_options, &option_index);
+
+        // Detect the end of the options.
+        if (c == -1) break;
+
+        switch (c)
+        {
+
+        case 'r':
+            range = parse<int>(optarg);
+            break;
+            
+        case 'a':
+            aligner_name = optarg;
+            break;
+
+        case 't':
+            threads = parse<int>(optarg);
+            omp_set_num_threads(threads);
+            break;
+                
+        case 'G':
+            gam_input = true;
+            break;
+
+        case 'h':
+        case '?':
+            help_gampcompare(argv);
+            exit(1);
+            break;
+
+        default:
+            abort ();
+        }
+    }
+
+    // We need to read the second argument first, so we can't use get_input_file with its free error checking.
+    string graph_file_name = get_input_file_name(optind, argc, argv);
+    string test_file_name = get_input_file_name(optind, argc, argv);
+    string truth_file_name = get_input_file_name(optind, argc, argv);
+
+    if ((truth_file_name == "-") + (test_file_name == "-") + (graph_file_name == "-") <= 1) {
+        cerr << "error[vg gampcompare]: Standard input can only be used for one input file" << endl;
+        exit(1);
+    }
+    
+    // Load the graph we mapped to
+    unique_ptr<PathHandleGraph> path_handle_graph;
+    if (graph_file_name == "-") {
+        path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(std::cin);
+    }
+    else {
+        ifstream graph_stream(graph_file_name);
+        if (!graph_stream) {
+            cerr << "error:[vg mpmap] Cannot open graph file " << graph_file_name << endl;
+            exit(1);
+        }
+        path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(graph_stream);
+    }
+    
+    bdsg::PathPositionOverlayHelper overlay_helper;
+    PathPositionHandleGraph* path_position_handle_graph = overlay_helper.apply(path_handle_graph.get());
+    
+    // We will collect all the truth positions
+    string_hash_map<string, map<string ,vector<pair<size_t, bool> > > > true_positions;
+    function<void(Alignment&)> record_truth = [&true_positions](Alignment& aln) {
+        auto val = alignment_refpos_to_path_offsets(aln);
+#pragma omp critical (truth_table)
+        true_positions[move(*aln.mutable_name())] = move(val);
+    };
+    
+    if (truth_file_name == "-") {
+        // Read truth fropm standard input, if it looks good.
+        if (!std::cin) {
+            cerr << "error[vg gampcompare]: Unable to read standard input when looking for true reads" << endl;
+            exit(1);
+        }
+        vg::io::for_each_parallel(std::cin, record_truth);
+    }
+    else {
+        // Read truth from this file, if it looks good.
+        ifstream truth_file_in(truth_file_name);
+        if (!truth_file_in) {
+            cerr << "error[vg gampcompare]: Unable to read " << truth_file_name << " when looking for true reads" << endl;
+            exit(1);
+        }
+        vg::io::for_each_parallel(truth_file_in, record_truth);
+    }
+    
+    // A buffer we use for the TSV output
+    vector<vector<tuple<bool, int64_t, string>>> buffers(get_thread_count());
+    
+    // We have an output function to dump all the reads in the text buffer in TSV
+    auto flush_buffer = [&](vector<tuple<bool, int64_t, string>>& buffer) {
+        // We print exactly one header line.
+        static bool header_printed = false;
+        // Output TSV to standard out in the format plot-qq.R needs.
+        if (!header_printed) {
+            // It needs a header
+            cout << "correct\tmq\taligner\tread" << endl;
+            header_printed = true;
+        }
+        
+        for (auto& result : buffer) {
+            // Dump each alignment
+            cout << get<0>(result) << '\t' << get<1>(result) << '\t' << aligner_name << '\t' << get<2>(result) << endl;
+        }
+        buffer.clear();
+    };
+   
+    // We want to count correct reads
+    vector<size_t> correct_counts(get_thread_count(), 0);
+   
+    // This function annotates every read with distance and correctness, and batch-outputs them.
+    function<void(MultipathAlignment&)> evaluate_correctness = [&](MultipathAlignment& proto_mp_aln) {
+        
+        // check the multipath mapping for correctness
+        bool correct = false;
+        auto f = true_positions.find(proto_mp_aln.name());
+        if (f != true_positions.end()) {
+            
+            multipath_alignment_t mp_aln;
+            from_proto_multipath_alignment(proto_mp_aln, mp_aln);
+            
+            auto& true_positions = f->second;
+            auto mapped_positions = algorithms::multipath_alignment_path_offsets(*path_position_handle_graph,
+                                                                                 mp_aln);
+            
+            for (auto it = true_positions.begin(); it != true_positions.end() && !correct; ++it) {
+                if (mapped_positions.count(it->first)) {
+                    // the true and mapped positions share this path
+                    auto& path_true_positions = it->second;
+                    auto& path_mapped_positions = mapped_positions[it->first];
+                    // check all pairs of positions
+                    for (size_t i = 0; i < path_true_positions.size() && !correct; ++i) {
+                        for (size_t j = 0; j < path_mapped_positions.size() && !correct; ++j) {
+                            if (path_true_positions[i].second == path_mapped_positions[j].second
+                                && abs(path_true_positions[i].first - path_mapped_positions[j].first) <= range) {
+                                // there is a pair of positions on the same strand of the same path
+                                // within the distance limit
+                                correct = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        if (correct) {
+            correct_counts[omp_get_thread_num()]++;
+        }
+        
+        // put the result on the IO buffer
+        auto& buffer = buffers[omp_get_thread_num()];
+        buffer.emplace_back(correct, proto_mp_aln.mapping_quality(), move(*proto_mp_aln.mutable_name()));
+        if (buffer.size() > buffer_size) {
+#pragma omp critical
+            flush_text_buffer(buffer);
+#endif
+        }
+    };
+    
+    function<void(Alignment&)> evaluate_gam_correctness = [&](Alignment& aln) {
+        // TODO: kinda ugly, but whatever
+        mulipath_alignment_t mp_aln;
+        to_multipath_alignment(aln, mp_aln);
+        MultipathAlignment proto_mp_aln;
+        to_proto_multipath_alignment(mp_aln, proto_mp_aln);
+        // we need the name to survive transit in multipath_alignment_t
+        proto_mp_aln.set_name(aln.name());
+        // now use the same evaluation function
+        evaluate_correctness(proto_mp_aln);
+    };
+
+    if (test_file_name == "-") {
+        if (!std::cin) {
+            cerr << "error[vg gampcompare]: Unable to read standard input when looking for mapped reads" << endl;
+            exit(1);
+        }
+        if (gam_input) {
+            vg::io::for_each_parallel(std::cin, evaluate_gam_correctness);
+        }
+        else {
+            vg::io::for_each_parallel(std::cin, evaluate_correctness);
+        }
+    } else {
+        ifstream test_file_in(test_file_name);
+        if (!test_file_in) {
+            cerr << "error[vg gampcompare]: Unable to read " << test_file_name << " when looking for mapped reads" << endl;
+            exit(1);
+        }
+        if (gam_input) {
+            vg::io::for_each_parallel(test_file_in, evaluate_gam_correctness);
+        }
+        else {
+            vg::io::for_each_parallel(test_file_in, evaluate_correctness);
+        }
+    }
+
+    // Empty out whatever's in the buffers at the end.
+    for (auto& buffer : buffers) {
+        flush_buffer(buffer);
+    }
+    
+    // We are flagging reads correct/incorrect. So report the total correct.
+    size_t total_correct = 0;
+    for (auto& count : correct_counts) {
+        total_correct += count;
+    }
+    
+    cerr << total_correct << " reads correct" << endl;
+    
+    return 0;
+}
+
+// Register subcommand
+static Subcommand vg_gampcompare("gampcompare", "compare multipath alignment positions", main_gampcompare);

--- a/src/unittest/multipath_alignment.cpp
+++ b/src/unittest/multipath_alignment.cpp
@@ -7,13 +7,16 @@
 #include <iostream>
 
 #include <gbwt/dynamic_gbwt.h>
+#include "xg.hpp"
 
+#include "bdsg/hash_graph.hpp"
 #include "../haplotypes.hpp"
 #include "vg/io/json2pb.h"
 #include <vg/vg.pb.h>
 #include "../vg.hpp"
 #include "../multipath_alignment.hpp"
 #include "../utility.hpp"
+#include "../algorithms/alignment_path_offsets.hpp"
 
 #include "catch.hpp"
 
@@ -1896,6 +1899,144 @@ namespace vg {
             REQUIRE(mapping_is_match(alns[0].path().mapping(4)));
             
             
+        }
+    }
+
+    TEST_CASE("multipath_alignment_path_offsets can identify multiple positions on a path when appropriate",
+              "[multipath][newmultipath]") {
+        
+        bdsg::HashGraph build_graph;
+        
+        handle_t h1 = build_graph.create_handle("AA");
+        handle_t h2 = build_graph.create_handle("AA");
+        handle_t h3 = build_graph.create_handle("AA");
+        
+        build_graph.create_edge(h1, h2);
+        build_graph.create_edge(h1, h3);
+        build_graph.create_edge(h2, h3);
+        
+        path_handle_t p = build_graph.create_path_handle("p");
+        
+        build_graph.append_step(p, h1);
+        build_graph.append_step(p, h2);
+        build_graph.append_step(p, h3);
+        
+        xg::XG graph;
+        graph.from_path_handle_graph(build_graph);
+        h1 = graph.get_handle(build_graph.get_id(h1));
+        h2 = graph.get_handle(build_graph.get_id(h2));
+        h3 = graph.get_handle(build_graph.get_id(h3));
+        p = graph.get_path_handle("p");
+        
+        SECTION("Multiple paths can be found on the forward strand") {
+            
+            multipath_alignment_t mp_aln;
+            mp_aln.set_sequence("AAAA");
+                        
+            mp_aln.add_subpath();
+            mp_aln.add_subpath();
+            mp_aln.add_subpath();
+            
+            subpath_t* s0 = mp_aln.mutable_subpath(0);
+            subpath_t* s1 = mp_aln.mutable_subpath(1);
+            subpath_t* s2 = mp_aln.mutable_subpath(2);
+            
+            path_mapping_t* m0 = s0->mutable_path()->add_mapping();
+            m0->mutable_position()->set_node_id(graph.get_id(h1));
+            edit_t* e0 = m0->add_edit();
+            e0->set_from_length(2);
+            e0->set_to_length(2);
+            s0->add_next(2);
+            
+            path_mapping_t* m1 = s1->mutable_path()->add_mapping();
+            m1->mutable_position()->set_node_id(graph.get_id(h2));
+            edit_t* e1 = m1->add_edit();
+            e1->set_from_length(2);
+            e1->set_to_length(2);
+            s2->add_next(2);
+            
+            path_mapping_t* m2 = s2->mutable_path()->add_mapping();
+            m2->mutable_position()->set_node_id(graph.get_id(h3));
+            edit_t* e2 = m2->add_edit();
+            e2->set_from_length(2);
+            e2->set_to_length(2);
+                        
+            auto path_positions = algorithms::multipath_alignment_path_offsets(graph, mp_aln);
+            
+            REQUIRE(path_positions.size() == 1);
+            REQUIRE(path_positions.count(p));
+            
+            auto& positions = path_positions[p];
+            
+            REQUIRE(positions.size() == 2);
+            bool found1 = false, found2 = false;
+            for (auto pos : positions) {
+                if (pos.first == 0 && !pos.second) {
+                    found1 = true;
+                }
+                if (pos.first == 2 && !pos.second) {
+                    found2 = true;
+                }
+            }
+            REQUIRE(found1);
+            REQUIRE(found2);
+        }
+        
+        SECTION("Multiple paths can be found on the reverse strand") {
+                        
+            multipath_alignment_t mp_aln;
+            mp_aln.set_sequence("AAAA");
+            
+            mp_aln.add_subpath();
+            mp_aln.add_subpath();
+            mp_aln.add_subpath();
+            
+            subpath_t* s0 = mp_aln.mutable_subpath(0);
+            subpath_t* s1 = mp_aln.mutable_subpath(1);
+            subpath_t* s2 = mp_aln.mutable_subpath(2);
+            
+            path_mapping_t* m0 = s0->mutable_path()->add_mapping();
+            m0->mutable_position()->set_node_id(graph.get_id(h3));
+            m0->mutable_position()->set_is_reverse(true);
+            edit_t* e0 = m0->add_edit();
+            e0->set_from_length(2);
+            e0->set_to_length(2);
+            s0->add_next(1);
+            s0->add_next(2);
+            
+            path_mapping_t* m1 = s1->mutable_path()->add_mapping();
+            m1->mutable_position()->set_node_id(graph.get_id(h2));
+            m1->mutable_position()->set_is_reverse(true);
+            edit_t* e1 = m1->add_edit();
+            e1->set_from_length(2);
+            e1->set_to_length(2);
+            
+            path_mapping_t* m2 = s2->mutable_path()->add_mapping();
+            m2->mutable_position()->set_node_id(graph.get_id(h1));
+            m2->mutable_position()->set_is_reverse(true);
+            edit_t* e2 = m2->add_edit();
+            e2->set_from_length(2);
+            e2->set_to_length(2);
+            
+            auto path_positions = algorithms::multipath_alignment_path_offsets(graph, mp_aln);
+            
+            REQUIRE(path_positions.size() == 1);
+            REQUIRE(path_positions.count(p));
+            
+            auto& positions = path_positions[p];
+            
+            REQUIRE(positions.size() == 2);
+            bool found1 = false, found2 = false;
+            for (auto pos : positions) {
+                if (pos.first == 0 && pos.second) {
+                    found1 = true;
+                }
+                if (pos.first == 2 && pos.second) {
+                    found2 = true;
+                }
+            }
+            REQUIRE(found1);
+            REQUIRE(found2);
         }
     }
 }


### PR DESCRIPTION
## Changelog Entry

* Added a subcommand `gampcompare` to evaluate mapping correctness of multipath alignments

## Description

The new subcommand has some features that are more suited to multipath alignments than `gamcompare`. In particular, it allows multipath alignments to be in multiple positions along an embedded path rather than just at a single position.