### PR TITLE
Cap number of walked paths per MEM to limit memory explosion on especially spliceful graphs

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -769,6 +769,10 @@ MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const
                 cerr << "performing DFS to walk out match" << endl;
 #endif
                 
+                // TODO: magic constant
+                size_t matches_found = 0;
+                size_t max_matches_walked = 32;
+                
                 // stack for DFS, each record contains tuples of
                 // (read begin, node offset, next node index, next node handles, fan-out index)
                 vector<tuple<string::const_iterator, size_t, size_t, vector<handle_t>, size_t>> stack;
@@ -778,7 +782,7 @@ MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const
                 if (fanout_breaks && fanout_breaks->count(hit.first)) {
                     fanout_size = fanout_breaks->at(hit.first).size();
                 }
-                while (!stack.empty()) {
+                while (!stack.empty() && matches_found < max_matches_walked) {
                     auto& back = stack.back();
                     if (get<2>(back) == get<3>(back).size()) {
 #ifdef debug_multipath_alignment
@@ -838,6 +842,7 @@ MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const
                         cerr << "reached end of read sequence, converting into path node(s) starting at idx " << path_nodes.size() << endl;
 #endif
                         assert(fanout_idx == fanout_size);
+                        ++matches_found;
                         
                         path_t path;
                         int64_t path_length = end - begin;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3372,17 +3372,6 @@ namespace vg {
         }
         
 #ifdef debug_multipath_mapper_alignment
-        cerr << "making multipath alignment MEM graph" << endl;
-#endif
-        
-        // construct a graph that summarizes reachability between MEMs
-        
-        function<pair<id_t, bool>(id_t)> translator = [&](const id_t& node_id) {
-            handle_t original = align_digraph->get_underlying_handle(align_dag->get_underlying_handle(align_dag->get_handle(node_id)));
-            return make_pair(graph->get_id(original), graph->get_is_reverse(original));
-        };
-        
-#ifdef debug_multipath_mapper_alignment
         cerr << "final alignment graph:" << endl;
         align_dag->for_each_handle([&](const handle_t& h) {
             auto tr = translator(align_dag->get_id(h));
@@ -3394,6 +3383,17 @@ namespace vg {
                 cerr << "\t " << align_dag->get_id(n) << " " << (align_dag->get_is_reverse(n) ? "-" : "+") << " <-" << endl;
             });
         });
+#endif
+        
+        // construct a graph that summarizes reachability between MEMs
+        
+        function<pair<id_t, bool>(id_t)> translator = [&](const id_t& node_id) {
+            handle_t original = align_digraph->get_underlying_handle(align_dag->get_underlying_handle(align_dag->get_handle(node_id)));
+            return make_pair(graph->get_id(original), graph->get_is_reverse(original));
+        };
+        
+#ifdef debug_multipath_mapper_alignment
+        cerr << "making multipath alignment MEM graph" << endl;
 #endif
         
         MultipathAlignmentGraph multi_aln_graph(*align_dag, graph_mems, translator, max_branch_trim_length, gcsa, fanouts);


### PR DESCRIPTION
## Changelog Entry

 * Memory should no longer blow up in mpmap on splice-abundant graphs

## Description

Nothing especially inspired here, just a hard cap to avoid possible exponential behavior.