### PR TITLE
Return all non-overlapping full-length extensions

### DIFF
--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -311,7 +311,13 @@ void remove_duplicates(std::vector<GaplessExtension>& result) {
         if (a.state.forward.node != b.state.forward.node) {
             return (a.state.forward.node < b.state.forward.node);
         }
-        return (a.state.backward.range < b.state.backward.range);
+        if (a.state.backward.range != b.state.backward.range) {
+           return (a.state.backward.range < b.state.backward.range);
+        }
+        if (a.state.forward.range != b.state.forward.range) {
+           return (a.state.forward.range < b.state.forward.range);
+        }
+        return (a.offset < b.offset);
     };
     std::sort(result.begin(), result.end(), sort_order);
     size_t tail = 0;

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -106,8 +106,7 @@ struct GaplessExtension
  * is a pair of matching read/graph positions and each extension is a gapless alignment
  * of an interval of the read to a haplotype.
  * A cluster is an unordered set of distinct seeds. Seeds in the same node with the same
- * (read_offset - node_offset) difference are considered equivalent. All seeds in a cluster
- * should correspond to the same alignment or positions near it.
+ * (read_offset - node_offset) difference are considered equivalent.
  * GaplessExtender also needs an Aligner object for scoring the extension candidates.
  */
 class GaplessExtender {
@@ -158,17 +157,28 @@ public:
     /**
      * Find the highest-scoring extension for each seed in the cluster.
      * If there is a full-length extension with at most max_mismatches
-     * mismatches, return the (up to two) best full-length extensions with
-     * at most overlap_threshold overlap, sorted by score in descending
-     * order.
-     * If that is not possible, trim the extensions to maximize score,
-     * sort them by read interval, and remove duplicates.
+     * mismatches, sort them in descending order by score and return the
+     * best non-overlapping full-length extensions. Two extensions overlap
+     * if the fraction of identical base mappings is greater than
+     * overlap_threshold.
+     * If there are no good enough full-length extensions, trim the
+     * extensions to maximize the score and remove duplicates. In this
+     * case, the extensions are sorted by read interval.
+     * Use full_length_extensions() to determine the type of the returned
+     * extension set.
      * Allow any number of mismatches in the initial node, at least
      * max_mismatches mismatches in the entire extension, and at least
      * max_mismatches / 2 mismatches on each flank.
      * Use the provided CachedGBWTGraph or allocate a new one.
      */
     std::vector<GaplessExtension> extend(cluster_type& cluster, const std::string& sequence, const gbwtgraph::CachedGBWTGraph* cache = nullptr, size_t max_mismatches = MAX_MISMATCHES, double overlap_threshold = OVERLAP_THRESHOLD) const;
+
+    /**
+     * Determine whether the extension set contains non-overlapping
+     * full-length extensions sorted in descending order by score. Use
+     * the same value of max_mismatches as in extend().
+     */
+    static bool full_length_extensions(const std::vector<GaplessExtension>& result, size_t max_mismatches = MAX_MISMATCHES);
 
     /**
      * Find the distinct local haplotypes in the given subgraph and return the corresponding paths.

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -88,12 +88,13 @@ struct GaplessExtension
         return (this->score < another.score);
     }
 
-    /// Two extensions are equal if the same read interval matches the same search state.
+    /// Two extensions are equal if the same read interval matches the same search state
+    /// with the same node offset.
     bool operator==(const GaplessExtension& another) const {
-        return (this->read_interval == another.read_interval && this->state == another.state);
+        return (this->read_interval == another.read_interval && this->state == another.state && this->offset == another.offset);
     }
 
-    /// Two extensions are not equal if the state or the read is different.
+    /// Two extensions are not equal if the state, the read interval, or the node offset is different.
     bool operator!=(const GaplessExtension& another) const {
         return !(this->operator==(another));
     }

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -320,13 +320,7 @@ vector<Alignment> MinimizerMapper::map(Alignment& aln) {
             Alignment best_alignment = aln;
             Alignment second_best_alignment = aln;
 
-            // Determine if we got full-length alignments or local alignments.
-            bool full_length_extensions = (extensions.size() <= 2);
-            for (auto& extension : extensions) {
-                full_length_extensions &= extension.full();
-            }
-
-            if (full_length_extensions) {
+            if (GaplessExtender::full_length_extensions(extensions)) {
                 // We got full-length extensions, so directly convert to an Alignment.
                 
                 if (track_provenance) {
@@ -342,7 +336,7 @@ vector<Alignment> MinimizerMapper::map(Alignment& aln) {
 
                 if (extensions.size() > 1) {
                     //Do the same thing for the second extension, if one exists
-                    this->extension_to_alignment(extensions.back(), second_best_alignment);
+                    this->extension_to_alignment(extensions[1], second_best_alignment);
                     
 #ifdef debug
                     cerr << "Produced additional alignment directly from full length gapless extension " << extension_num << endl;
@@ -1036,13 +1030,7 @@ pair<vector<Alignment>, vector< Alignment>> MinimizerMapper::map_paired(Alignmen
                 Alignment second_best_alignment = aln;
                 
 
-                // Determine if we got full-length alignments or local alignments.
-                bool full_length_extensions = (extensions.size() <= 2);
-                for (auto& extension : extensions) {
-                    full_length_extensions &= extension.full();
-                }
-
-                if (full_length_extensions) {
+                if (GaplessExtender::full_length_extensions(extensions)) {
                     // We got full-length extensions, so directly convert to an Alignment.
                     
                     if (track_provenance) {
@@ -1058,7 +1046,7 @@ pair<vector<Alignment>, vector< Alignment>> MinimizerMapper::map_paired(Alignmen
 
                     if (extensions.size() > 1) {
                         //Do the same thing for the second extension, if one exists
-                        this->extension_to_alignment(extensions.back(), second_best_alignment);
+                        this->extension_to_alignment(extensions[1], second_best_alignment);
                         
 #ifdef debug
                         cerr << "Produced additional alignment directly from full length gapless extension " << extension_num << endl;
@@ -2149,16 +2137,10 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
     // Find all seeds in the subgraph and try to get a full-length extension.
     GaplessExtender::cluster_type seeds = this->seeds_in_subgraph(minimizers, rescue_nodes);
     std::vector<GaplessExtension> extensions = this->extender.extend(seeds, rescued_alignment.sequence(), &cached_graph);
-    size_t best = extensions.size();
-    for (size_t i = 0; i < extensions.size(); i++) {
-        if (best >= extensions.size() || extensions[i].score > extensions[best].score) {
-            best = i;
-        }
-    }
 
     // If we have a full-length extension, use it as the rescued alignment.
-    if (best < extensions.size() && extensions[best].full()) {
-        this->extension_to_alignment(extensions[best], rescued_alignment);
+    if (GaplessExtender::full_length_extensions(extensions)) {
+        this->extension_to_alignment(extensions.front(), rescued_alignment);
         return;
     }
 
@@ -2178,6 +2160,14 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         // Get the corresponding alignment to the original graph.
         this->extender.transform_alignment(rescued_alignment, haplotype_paths);
         return;
+    }
+
+    // Determine the best extension.
+    size_t best = extensions.size();
+    for (size_t i = 0; i < extensions.size(); i++) {
+        if (best >= extensions.size() || extensions[i].score > extensions[best].score) {
+            best = i;
+        }
     }
 
     // Use the best extension as a seed for dozeu.
@@ -2554,13 +2544,9 @@ int MinimizerMapper::score_extension_group(const Alignment& aln, const vector<Ga
     if (extended_seeds.empty()) {
         // TODO: We should never see an empty group of extensions
         return 0;
-    } else if (extended_seeds.front().full()) {
-        // These are length matches. We already have the score.
-        int best_score = 0;
-        for (auto& extension : extended_seeds) {
-            best_score = max(best_score, extension.score);
-        }
-        return best_score;
+    } else if (GaplessExtender::full_length_extensions(extended_seeds)) {
+        // These are full-length matches. We already have the score.
+        return extended_seeds.front().score;
     } else {
         // This is a collection of one or more non-full-length extended seeds.
         


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GaplessExtender returns all non-overlapping full-length extensions.

## Description

When GaplessExtender finds a full-length alignment with sufficiently few mismatches, it now sorts the full-length extensions in descending order by score and greedily selects all non-overlapping ones. Before it only returned the top two.