### PR TITLE
Update the statistic used to identify mismapping in mpmap

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -956,6 +956,11 @@ namespace vg {
         bool reset_quality_adjustments = adjust_alignments_for_base_quality;
         adjust_alignments_for_base_quality = false;
         
+        // these p-values will eventually be used internally where the scores still have the bonus applied, so we
+        // want to make sure we don't strip them off here
+        bool reset_strip_bonuses = strip_bonuses;
+        strip_bonuses = false;
+        
         // and we expect small MEMs, so don't filter them out
         int reset_min_mem_length = min_mem_length;
         size_t reset_min_clustering_mem_length = min_clustering_mem_length;
@@ -1009,7 +1014,7 @@ namespace vg {
             }
             vector<pair<size_t, size_t>> sorted_length_counts(length_counts.begin(), length_counts.end());
             sort(sorted_length_counts.begin(), sorted_length_counts.end());
-            cerr << "date for length " << simulated_read_length << endl;
+            cerr << "data for length " << simulated_read_length << endl;
             for (auto length_count : sorted_length_counts) {
                 cerr << "\t" << length_count.first << ": " << length_count.second << endl;
             }
@@ -1062,6 +1067,7 @@ namespace vg {
         
         // reset mapping parameters to their original values
         adjust_alignments_for_base_quality = reset_quality_adjustments;
+        strip_bonuses = reset_strip_bonuses;
         min_clustering_mem_length = reset_min_clustering_mem_length;
         min_mem_length = reset_min_mem_length;
         max_alt_mappings = reset_max_alt_mappings;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -723,9 +723,9 @@ namespace vg {
         
         auto p_val = random_match_p_value(pseudo_length(rescue_multipath_aln), rescue_multipath_aln.sequence().size());
         
-        if (p_val >= max_mapping_p_value * 10.0) {
+        if (p_val >= max_rescue_p_value) {
 #ifdef debug_multipath_mapper
-            cerr << "rescue fails because p value " << p_val << " >= " <<  (max_mapping_p_value * 10.0) << endl;
+            cerr << "rescue fails because p value " << p_val << " >= " <<  max_rescue_p_value << endl;
 #endif
             return false;
         }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1003,6 +1003,16 @@ namespace vg {
             log_mle_max_exponential_shapes.push_back(log(max_exp_params.second));
                         
 #ifdef debug_report_startup_training
+            unordered_map<size_t, size_t> length_counts;
+            for (auto length : pseudo_lengths) {
+                length_counts[round(length)]++;
+            }
+            vector<pair<size_t, size_t>> sorted_length_counts(length_counts.begin(), length_counts.end());
+            sort(sorted_length_counts.begin(), sorted_length_counts.end());
+            cerr << "date for length " << simulated_read_length << endl;
+            for (auto length_count : sorted_length_counts) {
+                cerr << "\t" << length_count.first << ": " << length_count.second << endl;
+            }
             cerr << "trained parameters for length " << simulated_read_length << ": " << endl;
             cerr << "\tweibull scale: " << get<0>(weibull_params) << endl;
             cerr << "\tweibull shape: " << get<1>(weibull_params) << endl;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -721,9 +721,9 @@ namespace vg {
         
         auto p_val = random_match_p_value(pseudo_length(rescue_multipath_aln), rescue_multipath_aln.sequence().size());
         
-        if (p_val >= max_mapping_p_value * 0.1) {
+        if (p_val >= max_mapping_p_value * 10.0) {
 #ifdef debug_multipath_mapper
-            cerr << "rescue fails because p value " << p_val << " >= " <<  (max_mapping_p_value * 0.1) << endl;
+            cerr << "rescue fails because p value " << p_val << " >= " <<  (max_mapping_p_value * 10.0) << endl;
 #endif
             return false;
         }
@@ -887,33 +887,7 @@ namespace vg {
     }
     
     size_t MultipathMapper::pseudo_length(const multipath_alignment_t& multipath_aln) const {
-        Alignment alignment;
-        optimal_alignment(multipath_aln, alignment);
-        const Path& path = alignment.path();
-        
-        int64_t net_matches = 0;
-        for (size_t i = 0; i < path.mapping_size(); i++) {
-            const Mapping& mapping = path.mapping(i);
-            for (size_t j = 0; j < mapping.edit_size(); j++) {
-                const Edit& edit = mapping.edit(j);
-                
-                // skip soft clips
-                if (((i == 0 && j == 0) || (i == path.mapping_size() - 1 && j == mapping.edit_size() - 1))
-                    && edit.from_length() == 0 && edit.to_length() > 0) {
-                    continue;
-                }
-                
-                // add matches and subtract mismatches/indels
-                if (edit.from_length() == edit.to_length() && edit.sequence().empty()) {
-                    net_matches += edit.from_length();
-                }
-                else {
-                    net_matches -= max(edit.from_length(), edit.to_length());
-                }
-            }
-        }
-        
-        return max<int64_t>(0, net_matches);
+        return optimal_alignment_score(multipath_aln);
     }
     
     // make the memo live in this .o file

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -139,7 +139,8 @@ namespace vg {
         double weibull_shape_slope = 0.199;
         double weibull_offset_intercept = 2.342;
         double weibull_offset_slope = 0.07168;
-        double max_mapping_p_value = 0.001;
+        double max_mapping_p_value = 0.0001;
+        double max_rescue_p_value = 0.1;
         size_t max_alt_mappings = 1;
         size_t max_single_end_mappings_for_rescue = 64;
         size_t max_rescue_attempts = 32;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -129,10 +129,10 @@ namespace vg {
         size_t max_p_value_memo_size = 500;
         size_t band_padding_memo_size = 2000;
         bool use_weibull_calibration = false;
-        double max_exponential_rate_intercept = 0.7612;
-        double max_exponential_rate_slope = 0.0001496;
-        double max_exponential_shape_intercept = 12.37;
-        double max_exponential_shape_slope = 0.007191;
+        double max_exponential_rate_intercept = 0.612045;
+        double max_exponential_rate_slope = 0.000555181;
+        double max_exponential_shape_intercept = 12.136;
+        double max_exponential_shape_slope = 0.0113637;
         double weibull_scale_intercept = 1.05;
         double weibull_scale_slope = 0.0601;
         double weibull_shape_intercept = -0.176;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -139,7 +139,7 @@ namespace vg {
         double weibull_shape_slope = 0.199;
         double weibull_offset_intercept = 2.342;
         double weibull_offset_slope = 0.07168;
-        double max_mapping_p_value = 0.00001;
+        double max_mapping_p_value = 0.001;
         size_t max_alt_mappings = 1;
         size_t max_single_end_mappings_for_rescue = 64;
         size_t max_rescue_attempts = 32;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -439,6 +439,9 @@ namespace vg {
         /// Would an alignment this good be expected against a graph this big by chance alone
         bool likely_mismapping(const multipath_alignment_t& multipath_aln);
         
+        /// Would an alignment this good be expected against a graph this big by chance alone
+        bool likely_misrescue(const multipath_alignment_t& multipath_aln);
+        
         /// A scaling of a score so that it approximately follows the distribution of the longest match in p-value test
         size_t pseudo_length(const multipath_alignment_t& multipath_aln) const;
         

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -154,6 +154,7 @@ int main_mpmap(int argc, char** argv) {
     #define OPT_MAX_FANS_OUT 1026
     #define OPT_FAN_OUT_DIFF 1027
     #define OPT_PATH_RESCUE_GRAPH 1028
+    #define OPT_MAX_RESCUE_P_VALUE 1029
     string matrix_file_name;
     string graph_name;
     string gcsa_name;
@@ -250,7 +251,8 @@ int main_mpmap(int argc, char** argv) {
     bool same_strand = false;
     bool suppress_mismapping_detection = false;
     bool auto_calibrate_mismapping_detection = true;
-    double max_mapping_p_value = 0.00001;
+    double max_mapping_p_value = 0.0001;
+    double max_rescue_p_value = 0.1;
     size_t num_calibration_simulations = 100;
     vector<size_t> calibration_read_lengths{50, 100, 150, 250, 450};
     bool use_weibull_calibration = false;
@@ -332,6 +334,7 @@ int main_mpmap(int argc, char** argv) {
             {"path-rescue-graph", no_argument, 0, OPT_PATH_RESCUE_GRAPH},
             {"no-calibrate", no_argument, 0, 'B'},
             {"max-p-val", required_argument, 0, 'P'},
+            {"max-rescue-p-val", required_argument, 0, OPT_MAX_RESCUE_P_VALUE},
             {"mq-max", required_argument, 0, 'Q'},
             {"report-group-mapq", no_argument, 0, 'U'},
             {"padding-mult", required_argument, 0, OPT_BAND_PADDING_MULTIPLIER},
@@ -555,6 +558,10 @@ int main_mpmap(int argc, char** argv) {
                 
             case 'P':
                 max_mapping_p_value = parse<double>(optarg);
+                break;
+                
+            case OPT_MAX_RESCUE_P_VALUE:
+                max_rescue_p_value = parse<double>(optarg);
                 break;
                 
             case 'Q':
@@ -1039,6 +1046,11 @@ int main_mpmap(int argc, char** argv) {
     
     if (max_mapping_p_value <= 0.0) {
         cerr << "error:[vg mpmap] Max mapping p-value (-P) set to " << max_mapping_p_value << ", must set to a positive number." << endl;
+        exit(1);
+    }
+    
+    if (max_rescue_p_value <= 0.0) {
+        cerr << "error:[vg mpmap] Max mapping p-value (--max-rescue-p-val) set to " << max_rescue_p_value << ", must set to a positive number." << endl;
         exit(1);
     }
     
@@ -1595,6 +1607,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.precollapse_order_length_hits = precollapse_order_length_hits;
     multipath_mapper.max_sub_mem_recursion_depth = max_sub_mem_recursion_depth;
     multipath_mapper.max_mapping_p_value = max_mapping_p_value;
+    multipath_mapper.max_rescue_p_value = max_rescue_p_value;
     multipath_mapper.suppress_mismapping_detection = suppress_mismapping_detection;
     if (min_clustering_mem_length) {
         multipath_mapper.min_clustering_mem_length = min_clustering_mem_length;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -85,7 +85,7 @@ void help_mpmap(char** argv) {
     << "  -D, --frag-stddev FLOAT       standard deviation for a pre-determined fragment length distribution (also requires -I)" << endl
     << "  -B, --no-calibrate            do not auto-calibrate mismapping dectection" << endl
     << "  -G, --gam-input FILE          input GAM (for stdin, use -)" << endl
-    //<< "  -P, --max-p-val FLOAT         background model p-value must be less than this to avoid mismapping detection [0.00001]" << endl
+    //<< "  -P, --max-p-val FLOAT         background model p-value must be less than this to avoid mismapping detection [0.0001]" << endl
     << "  -U, --report-group-mapq       add an annotation for the collective mapping quality of all reported alignments" << endl
     //<< "      --padding-mult FLOAT      pad dynamic programming bands in inter-MEM alignment FLOAT * sqrt(read length) [1.0]" << endl
     << "  -u, --map-attempts INT        perform (up to) this many mappings per read (0 for no limit) [24 paired / 64 unpaired]" << endl
@@ -252,7 +252,7 @@ int main_mpmap(int argc, char** argv) {
     bool suppress_mismapping_detection = false;
     bool auto_calibrate_mismapping_detection = true;
     double max_mapping_p_value = 0.0001;
-    double max_rescue_p_value = 0.1;
+    double max_rescue_p_value = 0.03;
     size_t num_calibration_simulations = 100;
     vector<size_t> calibration_read_lengths{50, 100, 150, 250, 450};
     bool use_weibull_calibration = false;


### PR DESCRIPTION
## Changelog Entry

* The statistic used to detect mismapping in `mpmap` has been changed back to alignment score, but with some bugs fixed.

## Description

The distribution that would be learned for the mismapping detection was incorrect when stripping full length bonuses from the final output.