### PR TITLE
Check for and skip bed lines with out of range positions

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1759,7 +1759,7 @@ void parse_bed_regions(istream& bedstream,
 
         if (ss.fail()) {
             // Skip lines that can't be parsed
-            cerr << "Error parsing bed line " << line << ": " << row << endl;
+            cerr << "warning: Error parsing bed line " << line << ", skipping: " << row << endl;
             continue;
         } 
         
@@ -1768,6 +1768,18 @@ void parse_bed_regions(istream& bedstream,
             // That's not the case, so complain and skip the region.
             cerr << "warning: path \"" << seq << "\" is not circular, skipping end-spanning region on line "
                 << line << ": " << row << endl;
+            continue;
+        }
+        
+        if (ebuf > graph->get_path_length(path_handle)) {
+            // Skip ends that are too late
+            cerr << "warning: out of range path end " << ebuf << " in bed line " << line << ", skipping: " << row << endl;
+            continue;
+        }
+        
+        if (sbuf >= graph->get_path_length(path_handle)) {
+            // Skip starts that are too late
+            cerr << "warning: out of range path start " << sbuf << " in bed line " << line << ", skipping: " << row << endl;
             continue;
         }
         

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1773,13 +1773,15 @@ void parse_bed_regions(istream& bedstream,
         
         if (ebuf > graph->get_path_length(path_handle)) {
             // Skip ends that are too late
-            cerr << "warning: out of range path end " << ebuf << " in bed line " << line << ", skipping: " << row << endl;
+            cerr << "warning: out of range path end " << ebuf << " > " << graph->get_path_length(path_handle)
+                << " in bed line " << line << ", skipping: " << row << endl;
             continue;
         }
         
         if (sbuf >= graph->get_path_length(path_handle)) {
             // Skip starts that are too late
-            cerr << "warning: out of range path start " << sbuf << " in bed line " << line << ", skipping: " << row << endl;
+            cerr << "warning: out of range path start " << sbuf << " >= " << graph->get_path_length(path_handle)
+                << " in bed line " << line << ", skipping: " << row << endl;
             continue;
         }
         


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Skip out-of-range BED coordinates

## Description

@cmarkello Can you see if this fixes #2929, or can you link me the graph you are using there in addition to the BED? This just skips BED lines that go out of bounds.
