### PR TITLE
Distance option for gampcompare

### DIFF
--- a/src/subcommand/gampcompare_main.cpp
+++ b/src/subcommand/gampcompare_main.cpp
@@ -78,6 +78,10 @@ int main_gampcompare(int argc, char** argv) {
         case 'a':
             aligner_name = optarg;
             break;
+                
+        case 'd':
+            report_distance = true;
+            break;
 
         case 't':
             threads = parse<int>(optarg);


### PR DESCRIPTION
## Description

Adds a new option to `gampcompare` by request from @jonassibbesen . The new option `-d` makes the output contain the distance to the correct position rather than a binary correct/not correct call.