### PR TITLE
[WIP] Add option to agglomerate disconnected multipath alignments

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -490,7 +490,7 @@ double GSSWAligner::group_mapping_quality_exact(const vector<double>& scaled_sco
         
         total_log_sum_exp = add_log(total_log_sum_exp, multiple_score);
         
-        if (group_idx >= 0 ? i == group[group_idx] : false) {
+        if (group_idx >= 0 && i == group[group_idx]) {
             // this is the next index in the group
             group_idx--;
             if (multiplicities && multiplicities->at(i) > 1.0) {

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -2112,7 +2112,7 @@ void BaseMapper::rescue_high_count_order_length_mems(vector<MaximalExactMatch>& 
     for (size_t i = 0; i < mems.size(); i++) {
         if (mems[i].nodes.empty()) {
             unfilled_mem_ranges.emplace_back(i, 0);
-            while (i < mems.size() ? mems[i].nodes.empty() : false) {
+            while (i < mems.size() && mems[i].nodes.empty()) {
                 i++;
             }
             unfilled_mem_ranges.back().second = i;

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -2064,6 +2064,29 @@ namespace vg {
             identify_start_subpaths(sub_multipath_aln);
         }
     }
+
+    void append_multipath_alignment(multipath_alignment_t& multipath_aln,
+                                    const multipath_alignment_t& to_append) {
+        
+        size_t original_size = multipath_aln.subpath().size();
+        for (const subpath_t& appending_subpath : to_append.subpath()) {
+            subpath_t* new_subpath = multipath_aln.add_subpath();
+            new_subpath->set_score(appending_subpath.score());
+            *new_subpath->mutable_path() = appending_subpath.path();
+            new_subpath->mutable_next()->reserve(appending_subpath.next_size());
+            for (auto n : appending_subpath.next()) {
+                new_subpath->add_next(n + original_size);
+            }
+        }
+        if (multipath_aln.start_size() != 0 && to_append.start_size() != 0) {
+            for (auto s : to_append.start()) {
+                multipath_aln.add_start(s + original_size);
+            }
+        }
+        else if (multipath_aln.start_size() != 0) {
+            identify_start_subpaths(multipath_aln);
+        }
+    }
     
     bool validate_multipath_alignment(const multipath_alignment_t& multipath_aln, const HandleGraph& handle_graph) {
         

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -301,7 +301,11 @@ namespace vg {
     void extract_sub_multipath_alignment(const multipath_alignment_t& multipath_aln,
                                          const vector<int64_t>& subpath_indexes,
                                          multipath_alignment_t& sub_multipath_aln);
-    
+
+    /// Add the subpaths of one multipath alignment onto another
+    void append_multipath_alignment(multipath_alignment_t& multipath_aln,
+                                    const multipath_alignment_t& to_append);
+
     /// Debugging function to check that multipath alignment meets the formalism's basic
     /// invariants. Returns true if multipath alignment is valid, else false. Does not
     /// validate alignment score.

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -4,7 +4,7 @@
 //
 //
 
-#define debug_multipath_mapper
+//#define debug_multipath_mapper
 //#define debug_multipath_mapper_alignment
 //#define debug_validate_multipath_alignments
 //#define debug_report_startup_training

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -255,8 +255,9 @@ namespace vg {
         void align_to_cluster_graph_pairs(const Alignment& alignment1, const Alignment& alignment2,
                                           vector<clustergraph_t>& cluster_graphs1,
                                           vector<clustergraph_t>& cluster_graphs2,
-                                          vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                           vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
+                                          vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                          vector<double>& pair_multiplicities,
                                           vector<pair<size_t, size_t>>& duplicate_pairs_out,
                                           const match_fanouts_t* fanouts1, const match_fanouts_t* fanouts2);
         
@@ -266,7 +267,6 @@ namespace vg {
         bool align_to_cluster_graphs_with_rescue(const Alignment& alignment1, const Alignment& alignment2,
                                                  vector<clustergraph_t>& cluster_graphs1,
                                                  vector<clustergraph_t>& cluster_graphs2,
-                                                 bool block_rescue_from_1, bool block_rescue_from_2,
                                                  vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                  vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances_out,
                                                  vector<double>& pair_multiplicities_out,
@@ -280,11 +280,13 @@ namespace vg {
                                             vector<pair<size_t, size_t>>& duplicate_pairs,
                                             vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                             vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                            vector<double>& pair_multiplicities,
                                             const match_fanouts_t* fanouts1, const match_fanouts_t* fanouts2);
         
         /// Merge the rescued mappings into the output vector and deduplicate pairs
         void merge_rescued_mappings(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                     vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                    vector<double>& pair_multiplicities,
                                     vector<pair<multipath_alignment_t, multipath_alignment_t>>& rescued_multipath_aln_pairs,
                                     vector<pair<pair<size_t, size_t>, int64_t>>& rescued_cluster_pairs,
                                     vector<double>& rescued_multiplicities) const;
@@ -376,7 +378,7 @@ namespace vg {
         /// Allows multipath alignments where the best single path alignment is leaving the read unmapped.
         /// multipath_alignment_ts MUST be topologically sorted.
         void sort_and_compute_mapping_quality(vector<multipath_alignment_t>& multipath_alns, MappingQualityMethod mapq_method,
-                                              vector<size_t>* cluster_idxs = nullptr, vector<double>* multiplicities) const;
+                                              vector<size_t>* cluster_idxs = nullptr, vector<double>* multiplicities = nullptr) const;
         
         /// Sorts mappings by score and store mapping quality of the optimal alignment in the multipath_alignment_t object
         /// If there are ties between scores, breaks them by the expected distance between pairs as computed by the

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -351,6 +351,21 @@ namespace vg {
                                              vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                              vector<double>& multiplicities) const;
         
+        /// Combine all of the significant alignments into one. Requires alignments to be sorted by
+        /// significance already
+        void agglomerate_alignments(vector<multipath_alignment_t>& multipath_alns_out,
+                                    vector<double>* multiplicities = nullptr) const;
+        
+        /// Combine all of the significant alignments into one pair. Requires alignments to be sorted by
+        /// significance already
+        void agglomerate_alignment_pairs(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
+                                         vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                         vector<double>& multiplicities) const;
+        
+        /// The internal agglomeration procedure
+        void agglomerate(size_t idx, multipath_alignment_t& agglomerating, const multipath_alignment_t& multipath_aln,
+                         vector<size_t>& agglomerated_group, unordered_set<pos_t>& agg_start_positions,
+                         unordered_set<pos_t>& agg_end_positions) const;
         
         /// Make a multipath alignment of the read against the indicated graph and add it to
         /// the list of multimappings.
@@ -370,10 +385,18 @@ namespace vg {
         /// Remove the full length bonus from all source or sink subpaths that received it
         void strip_full_length_bonuses(multipath_alignment_t& multipath_aln) const;
         
+        /// Returns a vector of log-likelihoods for each mapping
+        vector<double> mapping_likelihoods(vector<multipath_alignment_t>& multipath_alns) const;
+        
+        /// Returns a vector of log-likelihoods for each pair mapping
+        vector<double> pair_mapping_likelihoods(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs,
+                                                const vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs) const;
+        
         /// Compute a mapping quality from a list of scores, using the selected method.
         /// Optionally considers non-present duplicates of the scores encoded as multiplicities
         int32_t compute_raw_mapping_quality_from_scores(const vector<double>& scores, MappingQualityMethod mapq_method,
                                                         bool have_qualities, const vector<double>* multiplicities = nullptr) const;
+        
         
         /// Sorts mappings by score and store mapping quality of the optimal alignment in the multipath_alignment_t object
         /// Optionally also sorts a vector of indexes to keep track of the cluster-of-origin
@@ -392,7 +415,7 @@ namespace vg {
                                               vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                               vector<pair<size_t, size_t>>* duplicate_pairs_out = nullptr,
                                               vector<double>* pair_multiplicities = nullptr) const;
-
+        
         /// Estimates the number of equivalent mappings (including this one), which we may not have seen due to
         /// unexplored rescues.
         double estimate_missed_rescue_multiplicity(size_t which_pair,

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -339,7 +339,8 @@ namespace vg {
         /// Properly handles multipath_alignment_ts that are unmapped.
         /// Does not depend on or guarantee topological order in the multipath_alignment_ts.
         void split_multicomponent_alignments(vector<multipath_alignment_t>& multipath_alns_out,
-                                             vector<size_t>* cluster_idxs = nullptr) const;
+                                             vector<size_t>* cluster_idxs = nullptr,
+                                             vector<double>* multiplicities = nullptr) const;
         
         /// If there are any multipath_alignment_ts with multiple connected components, split them
         /// up and add them to the return vector, also measure the distance between them and add
@@ -347,7 +348,8 @@ namespace vg {
         /// Properly handles multipath_alignment_ts that are unmapped.
         /// Does not depend on or guarantee topological order in the multipath_alignment_ts.
         void split_multicomponent_alignments(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
-                                             vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs) const;
+                                             vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                             vector<double>& multiplicities) const;
         
         
         /// Make a multipath alignment of the read against the indicated graph and add it to

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -105,6 +105,7 @@ namespace vg {
         // parameters
         
         size_t max_branch_trim_length = 1;
+        bool agglomerate_multipath_alns = false;
         int64_t max_snarl_cut_size = 5;
         bool suppress_tail_anchors = false;
         size_t min_tail_anchor_length = 3;
@@ -241,6 +242,7 @@ namespace vg {
                                      MappingQualityMethod mapq_method,
                                      vector<clustergraph_t>& cluster_graphs,
                                      vector<multipath_alignment_t>& multipath_alns_out,
+                                     vector<double>& multiplicities_out,
                                      size_t num_mapping_attempts,
                                      const match_fanouts_t* fanouts = nullptr,
                                      vector<size_t>* cluster_idxs = nullptr);
@@ -278,19 +280,6 @@ namespace vg {
                                             vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                             vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                             const match_fanouts_t* fanouts1, const match_fanouts_t* fanouts2);
-        
-        /// Cluster and extract subgraphs for (possibly) only one end, meant to be a non-repeat, and use them to rescue
-        /// an alignment for the other end, meant to be a repeat.
-        /// Produces topologically sorted multipath_alignment_ts.
-        void attempt_rescue_of_repeat_from_non_repeat(const Alignment& alignment1, const Alignment& alignment2,
-                                                      const vector<MaximalExactMatch>& mems1, const vector<MaximalExactMatch>& mems2,
-                                                      bool do_repeat_rescue_from_1, bool do_repeat_rescue_from_2,
-                                                      vector<memcluster_t>& clusters1, vector<memcluster_t>& clusters2,
-                                                      vector<clustergraph_t>& cluster_graphs1, vector<clustergraph_t>& cluster_graphs2,
-                                                      vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
-                                                      vector<pair<pair<size_t, size_t>, int64_t>>& pair_distances,
-                                                      OrientedDistanceMeasurer& distance_measurer,
-                                                      const match_fanouts_t* fanouts1, const match_fanouts_t* fanouts2);
         
         /// Merge the rescued mappings into the output vector and deduplicate pairs
         void merge_rescued_mappings(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
@@ -386,7 +375,7 @@ namespace vg {
         /// Allows multipath alignments where the best single path alignment is leaving the read unmapped.
         /// multipath_alignment_ts MUST be topologically sorted.
         void sort_and_compute_mapping_quality(vector<multipath_alignment_t>& multipath_alns, MappingQualityMethod mapq_method,
-                                              vector<size_t>* cluster_idxs = nullptr) const;
+                                              vector<size_t>* cluster_idxs = nullptr, vector<double>* multiplicities) const;
         
         /// Sorts mappings by score and store mapping quality of the optimal alignment in the multipath_alignment_t object
         /// If there are ties between scores, breaks them by the expected distance between pairs as computed by the
@@ -401,33 +390,40 @@ namespace vg {
 
         /// Estimates the probability that the correct cluster was not chosen as a cluster to rescue from and caps the
         /// mapping quality to the minimum of the current mapping quality and this probability (in Phred scale)
-        void cap_mapping_quality_by_rescue_probability(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
-                                                       vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
-                                                       vector<clustergraph_t>& cluster_graphs1,
-                                                       vector<clustergraph_t>& cluster_graphs2,
+        void cap_mapping_quality_by_rescue_probability(size_t which_pair,
+                                                       vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
+                                                       const vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                                       const vector<clustergraph_t>& cluster_graphs1,
+                                                       const vector<clustergraph_t>& cluster_graphs2,
                                                        bool from_secondary_rescue) const;
+        
+        double estimate_missed_rescue_multiplicity(size_t which_pair,
+                                                   const vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                                   const vector<clustergraph_t>& cluster_graphs1,
+                                                   const vector<clustergraph_t>& cluster_graphs2,
+                                                   bool from_secondary_rescue) const;
         
         /// Estimates the probability that the correct cluster was not identified because of sub-sampling MEM hits and
         /// caps the mapping quality to this probability (in Phred scale)
         void cap_mapping_quality_by_hit_sampling_probability(vector<multipath_alignment_t>& multipath_alns_out,
-                                                             vector<size_t>& cluster_idxs,
-                                                             vector<clustergraph_t>& cluster_graphs) const;
+                                                             const vector<size_t>& cluster_idxs,
+                                                             const vector<clustergraph_t>& cluster_graphs) const;
         
         /// Estimates the probability that the correct cluster pair was not identified because of sub-sampling MEM hits and
         /// caps the mapping quality to this probability (in Phred scale)
         void cap_mapping_quality_by_hit_sampling_probability(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
-                                                             vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
-                                                             vector<clustergraph_t>& cluster_graphs1,
-                                                             vector<clustergraph_t>& cluster_graphs2,
+                                                             const vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                                             const vector<clustergraph_t>& cluster_graphs1,
+                                                             const vector<clustergraph_t>& cluster_graphs2,
                                                              bool did_secondary_rescue) const;
-        
-        /// Reorganizes the fan-out breaks into the format that MultipathAlignmentGraph wants it in
-        match_fanouts_t record_fanouts(const vector<MaximalExactMatch>& mems,
-                                       vector<deque<pair<string::const_iterator, char>>>& fanouts) const;
         
         /// Estimates the probability that a cluster with the same hits would have been missed because of
         /// subsampling high-count SMEMs
         double prob_equivalent_clusters_hits_missed(const memcluster_t& cluster) const;
+        
+        double hit_sampling_multiplicity(const memcluster_t& cluster) const;
+        
+        double pair_hit_sampling_multiplicity(const memcluster_t& cluster_1, const memcluster_t& cluster_2) const;
         
         /// Computes the log-likelihood of a given fragment length in the trained distribution
         double fragment_length_log_likelihood(int64_t length) const;
@@ -443,6 +439,10 @@ namespace vg {
         
         /// The approximate p-value for a match length of the given size against the current graph
         double random_match_p_value(size_t match_length, size_t read_length);
+        
+        /// Reorganizes the fan-out breaks into the format that MultipathAlignmentGraph wants it in
+        match_fanouts_t record_fanouts(const vector<MaximalExactMatch>& mems,
+                                       vector<deque<pair<string::const_iterator, char>>>& fanouts) const;
         
         /// Compute the approximate distance between two multipath alignments
         /// If either is unmapped, or the distance cannot be obtained, returns numeric_limits<int64_t>::max()

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -393,41 +393,20 @@ namespace vg {
                                               vector<pair<size_t, size_t>>* duplicate_pairs_out = nullptr,
                                               vector<double>* pair_multiplicities = nullptr) const;
 
-        /// Estimates the probability that the correct cluster was not chosen as a cluster to rescue from and caps the
-        /// mapping quality to the minimum of the current mapping quality and this probability (in Phred scale)
-        void cap_mapping_quality_by_rescue_probability(size_t which_pair,
-                                                       vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
-                                                       const vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
-                                                       const vector<clustergraph_t>& cluster_graphs1,
-                                                       const vector<clustergraph_t>& cluster_graphs2,
-                                                       bool from_secondary_rescue) const;
-        
+        /// Estimates the number of equivalent mappings (including this one), which we may not have seen due to
+        /// unexplored rescues.
         double estimate_missed_rescue_multiplicity(size_t which_pair,
                                                    const vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                                    const vector<clustergraph_t>& cluster_graphs1,
                                                    const vector<clustergraph_t>& cluster_graphs2,
                                                    bool from_secondary_rescue) const;
         
-        /// Estimates the probability that the correct cluster was not identified because of sub-sampling MEM hits and
-        /// caps the mapping quality to this probability (in Phred scale)
-        void cap_mapping_quality_by_hit_sampling_probability(vector<multipath_alignment_t>& multipath_alns_out,
-                                                             const vector<size_t>& cluster_idxs,
-                                                             const vector<clustergraph_t>& cluster_graphs) const;
-        
-        /// Estimates the probability that the correct cluster pair was not identified because of sub-sampling MEM hits and
-        /// caps the mapping quality to this probability (in Phred scale)
-        void cap_mapping_quality_by_hit_sampling_probability(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
-                                                             const vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
-                                                             const vector<clustergraph_t>& cluster_graphs1,
-                                                             const vector<clustergraph_t>& cluster_graphs2,
-                                                             bool did_secondary_rescue) const;
-        
-        /// Estimates the probability that a cluster with the same hits would have been missed because of
-        /// subsampling high-count SMEMs
-        double prob_equivalent_clusters_hits_missed(const memcluster_t& cluster) const;
-        
+        /// Estimates the number of equivalent mappings (including this one), which we may not have seen due to
+        /// limits on the numbers of hits returns for a MEM
         double hit_sampling_multiplicity(const memcluster_t& cluster) const;
         
+        /// Estimates the number of equivalent pair mappings (including this one), which we may not have seen due to
+        /// limits on the numbers of hits returns for a MEM
         double pair_hit_sampling_multiplicity(const memcluster_t& cluster_1, const memcluster_t& cluster_2) const;
         
         /// Computes the log-likelihood of a given fragment length in the trained distribution

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -572,6 +572,10 @@ int main_mpmap(int argc, char** argv) {
                 max_mapq = parse<int>(optarg);
                 break;
                 
+            case 'a':
+                agglomerate_multipath_alns = true;
+                break;
+                
             case 'U':
                 report_group_mapq = true;
                 break;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -50,7 +50,7 @@ void help_mpmap(char** argv) {
     << "  -d, --dist-name FILE          use this snarl distance index for clustering" << endl
     //<< "      --linear-index FILE       use this sublinear Li and Stephens index file for population-based MAPQs" << endl
     //<< "      --linear-path PATH        use the given path name as the path that the linear index is against" << endl
-    << "  -s, --snarls FILE             align to alternate paths in these snarls" << endl
+    << "  -s, --snarls FILE             align to alternate paths in these snarls (unnecessary if providing -d)" << endl
     << "input:" << endl
     << "  -f, --fastq FILE              input FASTQ (possibly gzipped), can be given twice for paired ends (for stdin use -)" << endl
     << "  -i, --interleaved             input contains interleaved paired ends" << endl
@@ -59,6 +59,7 @@ void help_mpmap(char** argv) {
     << "  -l, --read-length TYPE        read length preset: 'very-short', 'short', or 'long' (approx. <50bp, 50-500bp, and >500bp) [short]" << endl
     << "  -e, --error-rate TYPE         error rate preset: 'low' or 'high' (approx. PHRED >20 and <20) [low]" << endl
     << "output:" << endl
+    << "  -a, --agglomerate-alns        combine separate multipath alignments into one (possibly disconnected) alignment" << endl
     << "  -S, --single-path-mode        output single-path alignments (GAM or GAF) instead of multipath alignments (GAMP)" << endl
     << "  -F, --single-path-fmt FMT     output in either 'gam' or 'gaf' format in single path mode [gam]" << endl
     << "  -N, --sample NAME             add this sample name to output" << endl
@@ -77,13 +78,13 @@ void help_mpmap(char** argv) {
     //<< "  -X, --snarl-max-cut INT       do not align to extra paths in a snarl if there is an exact match this long (0 for no limit) [5]" << endl
     //<< "  -a, --alt-paths INT           align to (up to) this many alternate paths in snarls [10]" << endl
     //<< "      --suppress-tail-anchors   don't produce extra anchors when aligning to alternate paths in snarls" << endl
-    << "  -T, --same-strand             read pairs are from the same strand of the DNA/RNA molecule" << endl
+    //<< "  -T, --same-strand             read pairs are from the same strand of the DNA/RNA molecule" << endl
     << "  -M, --max-multimaps INT       report (up to) this many mappings per read [1]" << endl
     << "  -Q, --mq-max INT              cap mapping quality estimates at this much [60]" << endl
     << "  -b, --frag-sample INT         look for this many unambiguous mappings to estimate the fragment length distribution [1000]" << endl
     << "  -I, --frag-mean FLOAT         mean for a pre-determined fragment length distribution (also requires -D)" << endl
     << "  -D, --frag-stddev FLOAT       standard deviation for a pre-determined fragment length distribution (also requires -I)" << endl
-    << "  -B, --no-calibrate            do not auto-calibrate mismapping dectection" << endl
+    //<< "  -B, --no-calibrate            do not auto-calibrate mismapping dectection" << endl
     << "  -G, --gam-input FILE          input GAM (for stdin, use -)" << endl
     //<< "  -P, --max-p-val FLOAT         background model p-value must be less than this to avoid mismapping detection [0.00001]" << endl
     << "  -U, --report-group-mapq       add an annotation for the collective mapping quality of all reported alignments" << endl
@@ -154,6 +155,7 @@ int main_mpmap(int argc, char** argv) {
     #define OPT_MAX_FANS_OUT 1026
     #define OPT_FAN_OUT_DIFF 1027
     #define OPT_PATH_RESCUE_GRAPH 1028
+    #define OPT_ALT_PATHS 1020
     string matrix_file_name;
     string graph_name;
     string gcsa_name;
@@ -234,6 +236,7 @@ int main_mpmap(int argc, char** argv) {
     int max_dist_error = 12;
     int default_num_alt_alns = 10;
     int num_alt_alns = default_num_alt_alns;
+    bool agglomerate_multipath_alns = false;
     double suboptimal_path_exponent = 1.25;
     double likelihood_approx_exp = 10.0;
     double likelihood_approx_exp_arg = numeric_limits<double>::lowest();
@@ -322,7 +325,7 @@ int main_mpmap(int argc, char** argv) {
             {"synth-tail-anchors", no_argument, 0, OPT_SUPPRESS_TAIL_ANCHORS},
             {"tvs-clusterer", no_argument, 0, 'v'},
             {"snarl-max-cut", required_argument, 0, 'X'},
-            {"alt-paths", required_argument, 0, 'a'},
+            {"alt-paths", required_argument, 0, OPT_ALT_PATHS},
             {"frag-sample", required_argument, 0, 'b'},
             {"frag-mean", required_argument, 0, 'I'},
             {"frag-stddev", required_argument, 0, 'D'},
@@ -333,6 +336,7 @@ int main_mpmap(int argc, char** argv) {
             {"no-calibrate", no_argument, 0, 'B'},
             {"max-p-val", required_argument, 0, 'P'},
             {"mq-max", required_argument, 0, 'Q'},
+            {"agglomerate-alns", no_argument, 0, 'a'},
             {"report-group-mapq", no_argument, 0, 'U'},
             {"padding-mult", required_argument, 0, OPT_BAND_PADDING_MULTIPLIER},
             {"map-attempts", required_argument, 0, 'u'},
@@ -382,7 +386,7 @@ int main_mpmap(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:iSs:vX:u:a:b:I:D:BP:Q:UpM:r:W:K:F:c:C:R:En:l:e:q:z:w:o:y:L:mAt:Z:",
+        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:iSs:vX:u:b:I:D:BP:Q:UpM:r:W:K:F:c:C:R:En:l:e:q:z:w:o:y:L:mAt:Z:a",
                          long_options, &option_index);
 
 
@@ -533,7 +537,7 @@ int main_mpmap(int argc, char** argv) {
                 snarl_cut_size = parse<int>(optarg);
                 break;
                 
-            case 'a':
+            case OPT_ALT_PATHS:
                 num_alt_alns = parse<int>(optarg);
                 break;
                 
@@ -1147,7 +1151,7 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (hard_hit_max < hit_max && hit_max && hard_hit_max) {
-        cerr << "warning:[vg mpmap] MEM hit query limit (-c) set to " << hit_max << ", which is higher than the threshold to ignore a MEM (" << hard_hit_max << ")" << endl;
+        cerr << "warning:[vg mpmap] MEM hit query limit (-c) set to " << hit_max << ", which is higher than the threshold to ignore a MEM (" << hard_hit_max << ")." << endl;
     }
     
     if (min_mem_length < 0) {
@@ -1156,7 +1160,11 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (single_path_format != default_single_path_format && !single_path_alignment_mode) {
-        cerr << "warning:[vg mpmap] Single path output format (-F) is ignored when not using single path alignment output (-S)" << endl;
+        cerr << "warning:[vg mpmap] Single path output format (-F) is ignored when not using single path alignment output (-S)." << endl;
+    }
+    
+    if (single_path_alignment_mode && agglomerate_multipath_alns) {
+        cerr << "warning:[vg mpmap] Disconnected alignments cannot be agglomerated (-a) in single path mode (-S)." << endl;
     }
     
     if (stripped_match_alg_strip_length <= 0) {
@@ -1659,6 +1667,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.dynamic_max_alt_alns = dynamic_max_alt_alns;
     multipath_mapper.simplify_topologies = simplify_topologies;
     multipath_mapper.max_suboptimal_path_score_ratio = suboptimal_path_exponent;
+    multipath_mapper.agglomerate_multipath_alns = agglomerate_multipath_alns;
 
 #ifdef mpmap_instrument_mem_statistics
     multipath_mapper._mem_stats.open(MEM_STATS_FILE);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Adds option to `mpmap` to return a single, possibly disconnected multipath alignment

## Description

Also includes a substantial revamping of the MAPQ capping logic to all be framed in terms of multiplicities.
@jonassibbesen This works on my small test cases, but I'll be interested to see if how it does on your inference problems.