### PR TITLE
Multi-annotate

### DIFF
--- a/src/algorithms/alignment_path_offsets.cpp
+++ b/src/algorithms/alignment_path_offsets.cpp
@@ -181,8 +181,17 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
 }
 
 void annotate_with_initial_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, size_t search_limit) {
+    annotate_with_path_positions(graph, aln, true, search_limit);
+}
+
+void annotate_with_node_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, size_t search_limit) {
+    annotate_with_path_positions(graph, aln, false, search_limit);
+}
+
+void annotate_with_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, bool just_min, size_t search_limit) {
     if (!aln.refpos_size()) {
-        unordered_map<path_handle_t, vector<pair<size_t, bool> > > positions = alignment_path_offsets(graph, aln, true, false, search_limit);
+        // Get requested path positions
+        unordered_map<path_handle_t, vector<pair<size_t, bool> > > positions = alignment_path_offsets(graph, aln, just_min, false, search_limit);
         // emit them in order of the path handle
         vector<path_handle_t> ordered;
         for (auto& path : positions) { ordered.push_back(path.first); }

--- a/src/algorithms/alignment_path_offsets.cpp
+++ b/src/algorithms/alignment_path_offsets.cpp
@@ -197,11 +197,13 @@ void annotate_with_path_positions(const PathPositionHandleGraph& graph, Alignmen
         for (auto& path : positions) { ordered.push_back(path.first); }
         std::sort(ordered.begin(), ordered.end(), [](const path_handle_t& a, const path_handle_t& b) { return as_integer(a) < as_integer(b); });
         for (auto& path : ordered) {
-            auto& p = positions[path];
-            Position* refpos = aln.add_refpos();
-            refpos->set_name(graph.get_path_name(path));
-            refpos->set_offset(p.front().first);
-            refpos->set_is_reverse(p.front().second);
+            for (auto& p : positions[path]) {
+                // Add each determined refpos
+                Position* refpos = aln.add_refpos();
+                refpos->set_name(graph.get_path_name(path));
+                refpos->set_offset(p.first);
+                refpos->set_is_reverse(p.second);
+            }
         }
     }
 }

--- a/src/algorithms/alignment_path_offsets.hpp
+++ b/src/algorithms/alignment_path_offsets.hpp
@@ -13,7 +13,12 @@ namespace algorithms {
 
 using namespace std;
 
-/// gives just the path positions of the alignment
+/// Gives the path positions of the alignment. If just_min is set, gives the
+/// minimum position on each path. Else, gives all Mapping start positions on
+/// each path. If nearby is set, will search for a nearby path. Will recurse
+/// with nearby set if it is not set on initial call and no positions are
+/// found. Respects search_limit in bp in that case. If search_limit is 0, read
+/// length is used.
 unordered_map<path_handle_t, vector<pair<size_t, bool> > >
 alignment_path_offsets(const PathPositionHandleGraph& graph,
                        const Alignment& aln,
@@ -36,6 +41,25 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
 /// alignment does not actually touch any paths. If 0, the alignment's
 /// sequence length is used.
 void annotate_with_initial_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, size_t search_limit = 0);
+
+/// Use the graph to annotate an Alignment with the first
+/// position it touches on each node it visits in each reference path. Thread
+/// safe. If no nodes on any path are visited, searches for a nearby path
+/// position to use.
+///
+/// search_limit gives the maximum distance to search for a path if the
+/// alignment does not actually touch any paths. If 0, the alignment's
+/// sequence length is used.
+void annotate_with_node_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, size_t search_limit = 0);
+
+/// Use the graph to annotate an Alignment with positions on each reference
+/// path. Thread safe.
+///
+/// If just_min is set, gives the minimum position on each path. Else, gives
+/// all Mapping start positions on each path. If nearby is set, will search for
+/// a nearby path of no path is actually touched. Respects search_limit in bp
+/// in that case. If search_limit is 0, read length is used.
+void annotate_with_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, bool just_min, size_t search_limit = 0);
 
 /// Use the graph annotate Alignments with the first position
 /// they touch on each reference path. Thread safe.

--- a/src/algorithms/alignment_path_offsets.hpp
+++ b/src/algorithms/alignment_path_offsets.hpp
@@ -56,9 +56,9 @@ void annotate_with_node_path_positions(const PathPositionHandleGraph& graph, Ali
 /// path. Thread safe.
 ///
 /// If just_min is set, gives the minimum position on each path. Else, gives
-/// all Mapping start positions on each path. If nearby is set, will search for
-/// a nearby path of no path is actually touched. Respects search_limit in bp
-/// in that case. If search_limit is 0, read length is used.
+/// all Mapping start positions on each path. If no positions on the path are
+/// found, looks for nearby path positions in graph space. Respects
+/// search_limit in bp in that case. If search_limit is 0, read length is used.
 void annotate_with_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, bool just_min, size_t search_limit = 0);
 
 /// Use the graph annotate Alignments with the first position

--- a/test/t/36_vg_annotate.t
+++ b/test/t/36_vg_annotate.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 7
+plan tests 9
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg
 
@@ -23,6 +23,16 @@ is "$(vg view -aj annotated.gam | jq -c '.annotation.features' | grep feat2 | gr
 is "$(vg view -aj annotated.gam | jq -c '.annotation.features' | grep featAll | wc -l)" 30 "vg annotate shows all reads overlapping a whole-reference-covering feature"
 
 rm -f t.vg t.ref.vg t.xg t.ref.xg annotated.gam
+
+vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
+vg index -x x.xg x.vg
+
+vg annotate -p -x x.xg -a small/x-s1337-n1.gam > annot.gam
+
+is "$(vg annotate -p -x x.xg -a small/x-s1337-n1.gam | vg view -aj - | jq -c '.refpos[]' | wc -l)" "1" "annotating with earliest path position produces one position"
+is "$(vg annotate -m -x x.xg -a small/x-s1337-n1.gam | vg view -aj - | jq -c '.refpos[]' | wc -l)" "13" "annotating with multiple path positions produces multiple positions"
+
+rm -f x.xg x.vg annot.gam
 
 vg view -Jv cyclic/circular_path.json > circular_path.vg
 vg index -x circular_path.xg circular_path.vg

--- a/test/t/40_vg_gamcompare.t
+++ b/test/t/40_vg_gamcompare.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 2
+plan tests 5
 
 vg construct -r small/x.fa -v small/x.vcf.gz >s.vg
 vg index -x s.xg -g s.gcsa s.vg
@@ -15,5 +15,19 @@ vg sim -n 1000 -l 100 -e 0.01 -i 0.005 -x s.xg -a >s.sim
 is $(vg map -x s.xg -g s.gcsa -G s.sim --surject-to sam | vg inject -x s.xg - | vg gamcompare - s.sim | vg view -a - | wc -l) 1000 "gamcompare completes"
 
 is $(vg gamcompare --range 10 s.sim s.sim | vg view -aj - | jq -c 'select(.correctly_mapped)' | wc -l) 1000 "gamcompare says the truth is correctly mapped"
+
+# Map a couple adjacent reads with multi-positioning
+vg map -x s.xg  -g s.gcsa -s "AATCTCTCTGAACTTCAGTTTAATTATC" > read1.gam
+vg annotate -a read1.gam -p -x s.xg > read1.single.gam
+vg annotate -a read1.gam -m -x s.xg > read1.multi.gam
+vg map -x s.xg  -g s.gcsa -s "TCTAATATGGAGATGATACTACTGACAG" > read2.gam
+vg annotate -a read2.gam -p -x s.xg > read2.single.gam
+vg annotate -a read2.gam -m -x s.xg > read2.multi.gam
+
+is "$(vg gamcompare -r 30 read1.single.gam read2.single.gam | vg view -aj - | jq -c 'select(.correctly_mapped)' | wc -l)" "1" "Reads annotated with leftmost position only are close enough at a long distance"
+is "$(vg gamcompare -r 10 read1.single.gam read2.single.gam | vg view -aj - | jq -c 'select(.correctly_mapped)' | wc -l)" "0" "Reads annotated with leftmost position only are too far apart at a short distance"
+is "$(vg gamcompare -r 10 read1.multi.gam read2.multi.gam | vg view -aj - | jq -c 'select(.correctly_mapped)' | wc -l)" "1" "Reads annotated with multiple positions only are close enough at a short distance"
+
+rm -f read1.gam read1.single.gam read1.multi.gam read2.gam read2.single.gam read2.multi.gam 
 
 rm -f s.vg s.xg s.gcsa s.gcsa.lcp s.sim


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg annotate -m` can annotate reads with a path position for each Mapping to a node
* `vg annotate` now actually respects passed search limit (`-l`)

## Description

This adds a `-m` option to `vg annotate` that lets you annotate reads with a `refpos` per Mapping. Then `vg gamcompare` will look for the shortest distance between refpos values when doing comparison.

This should let us work around the problem we're having in our HGSVC graph mapping evaluations where it's ambiguous whether the left end of the read should take a big deletion arc or not, and that gives us a very different `refpos` from the truth.

Also, it turns out `vg annotate`'s search limit wasn't being used propelry before.