### PR TITLE
Fix absolute distance calculation in gampcompare

### DIFF
--- a/src/subcommand/gampcompare_main.cpp
+++ b/src/subcommand/gampcompare_main.cpp
@@ -217,7 +217,8 @@ int main_gampcompare(int argc, char** argv) {
                         for (size_t j = 0; j < path_mapped_positions.size(); ++j) {
                             if (path_true_positions[i].second == path_mapped_positions[j].second) {
                                 // there is a pair of positions on the same strand of the same path
-                                abs_dist = min<int64_t>(abs_dist, path_true_positions[i].first - path_mapped_positions[j].first);
+                                abs_dist = min<int64_t>(abs_dist,
+                                                        abs<int64_t>(path_true_positions[i].first - path_mapped_positions[j].first));
                             }
                         }
                     }


### PR DESCRIPTION
## Changelog Entry

 * `gampcompare` now returns the correct distances with the `-d` option

## Description

I forgot to take the absolute value of a difference to derive a distance.