### PR TITLE
Add more multiplicity components in mpmap

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -1048,7 +1048,8 @@ vector<MEMClusterer::cluster_t> MEMClusterer::HitGraph::clusters(const Alignment
                                                                  int32_t max_qual_score,
                                                                  int32_t log_likelihood_approx_factor,
                                                                  size_t min_median_mem_coverage_for_split,
-                                                                 double suboptimal_edge_pruning_factor) {
+                                                                 double suboptimal_edge_pruning_factor,
+                                                                 double cluster_multiplicity_diff) {
     
     vector<cluster_t> to_return;
     if (nodes.size() == 0) {
@@ -1150,15 +1151,11 @@ vector<MEMClusterer::cluster_t> MEMClusterer::HitGraph::clusters(const Alignment
     // TODO: this approximation could break down sometimes, need to look into it
     int32_t top_score = component_traceback_ends.front().first;
     int32_t suboptimal_score_cutoff = top_score - log_likelihood_approx_factor * aligner->mapping_quality_score_diff(max_qual_score);
-    
+    // keep track of the scores of the clusters we take off the heap
+    vector<int32_t> returned_cluster_scores;
     while (!component_traceback_ends.empty()) {
         // get the next highest scoring traceback end(s)
         auto traceback_end = component_traceback_ends.front();
-        std::pop_heap(component_traceback_ends.begin(), component_traceback_ends.end());
-        component_traceback_ends.pop_back();
-        
-        // get the index of the node
-        vector<size_t>& trace_stack = traceback_end.second;
         
 #ifdef debug_mem_clusterer
         cerr << "checking traceback of component starting at " << traceback_end.second.front() << endl;
@@ -1174,6 +1171,13 @@ vector<MEMClusterer::cluster_t> MEMClusterer::HitGraph::clusters(const Alignment
             //            PRUNE_COUNTER += component_traceback_ends.size() + 1;
             break;
         }
+        
+        // we're going to add this cluster to the return vector, take it off the heap
+        std::pop_heap(component_traceback_ends.begin(), component_traceback_ends.end());
+        component_traceback_ends.pop_back();
+        
+        // get the index of the node
+        vector<size_t>& trace_stack = traceback_end.second;
         
         // traceback all optimal paths in this connected component
         
@@ -1207,14 +1211,48 @@ vector<MEMClusterer::cluster_t> MEMClusterer::HitGraph::clusters(const Alignment
         auto& cluster = to_return.back();
         for (size_t traced_idx : stacked) {
             HitNode& node = nodes[traced_idx];
-            cluster.emplace_back(node.mem, node.start_pos);
+            cluster.first.emplace_back(node.mem, node.start_pos);
         }
+        // it starts with multiplicity 1 be default
+        cluster.second = 1.0;
+        // keep track of its score for further multiplicity calculations
+        returned_cluster_scores.push_back(traceback_end.first);
         
         // put the cluster in order by read position
-        sort(cluster.begin(), cluster.end(), [](const hit_t& hit_1, const hit_t& hit_2) {
+        sort(cluster.first.begin(), cluster.first.end(), [](const hit_t& hit_1, const hit_t& hit_2) {
             return hit_1.first->begin < hit_2.first->begin ||
             (hit_1.first->begin == hit_2.first->begin && hit_1.first->end < hit_2.first->end);
         });
+    }
+    
+    assert(returned_cluster_scores.size() == to_return.size());
+    
+    // find out how many of the remaining clusters had similar score to the final
+    // ones we're returning
+    int32_t tail_equiv_diff = round(aligner->mapping_quality_score_diff(cluster_multiplicity_diff));
+    int32_t min_tail_score = returned_cluster_scores.back() - tail_equiv_diff;
+    int64_t num_tail_cutoff = 0;
+    while (!component_traceback_ends.empty() &&
+           component_traceback_ends.front().first >= min_tail_score) {
+        // count it and remove it
+        ++num_tail_cutoff;
+        std::pop_heap(component_traceback_ends.begin(), component_traceback_ends.end());
+        component_traceback_ends.pop_back();
+    }
+    if (num_tail_cutoff > 0) {
+        // find out how many of the clusters we're returning also have similar score
+        int32_t max_tail_score = returned_cluster_scores.back() + tail_equiv_diff;
+        int64_t max_tail_idx = to_return.size() - 1;
+        while (max_tail_idx > 0 && returned_cluster_scores[max_tail_idx - 1] <= max_tail_score) {
+            --max_tail_idx;
+        }
+        
+        // assign the corresponding multiplicity to all of clusters we're returning with similar scores
+        double cluster_multiplicity = (double(to_return.size() - max_tail_idx + num_tail_cutoff)
+                                       / double(to_return.size() - max_tail_idx));
+        for (int64_t i = max_tail_idx; i < to_return.size(); ++i) {
+            to_return[i].second = cluster_multiplicity;
+        }
     }
     
     return std::move(to_return);
@@ -1228,11 +1266,13 @@ vector<MEMClusterer::cluster_t> MEMClusterer::clusters(const Alignment& alignmen
                                                        int32_t log_likelihood_approx_factor,
                                                        size_t min_median_mem_coverage_for_split,
                                                        double suboptimal_edge_pruning_factor,
+                                                       double cluster_multiplicity_diff,
                                                        const match_fanouts_t* fanouts) {
     
     HitGraph hit_graph = make_hit_graph(alignment, mems, aligner, min_mem_length, fanouts);
     return hit_graph.clusters(alignment, aligner, max_qual_score, log_likelihood_approx_factor,
-                              min_median_mem_coverage_for_split, suboptimal_edge_pruning_factor);
+                              min_median_mem_coverage_for_split, suboptimal_edge_pruning_factor,
+                              cluster_multiplicity_diff);
     
 }
 
@@ -2442,39 +2482,39 @@ vector<pair<pair<size_t, size_t>, int64_t>> OrientedDistanceClusterer::pair_clus
              // Assumes the clusters are nonempty.
              if (cluster_num < left_clusters.size()) {
                  // Grab the pos_t for the first hit in the cluster, which is sorted to be the largest one.
-                 return left_clusters[cluster_num]->front().second;
+                 return left_clusters[cluster_num]->first.front().second;
              }
              else if (cluster_num < total_clusters) {
                  // Grab the pos_t for the largest hit from the other cluster
-                 return right_clusters[cluster_num - left_clusters.size()]->front().second;
+                 return right_clusters[cluster_num - left_clusters.size()]->first.front().second;
              }
              else if (cluster_num < total_clusters + left_alt_cluster_anchors.size()) {
                  // Grab a lower pos_t in the list of hits according to the alt anchor
                  const pair<size_t, size_t>& alt_anchor = left_alt_cluster_anchors[cluster_num - total_clusters];
-                 return left_clusters[alt_anchor.first]->at(alt_anchor.second).second;
+                 return left_clusters[alt_anchor.first]->first.at(alt_anchor.second).second;
              }
              else {
                  // Grab an alternate pos_t for a right cluster
                  const pair<size_t, size_t>& alt_anchor = right_alt_cluster_anchors[cluster_num - total_clusters - left_alt_cluster_anchors.size()];
-                 return right_clusters[alt_anchor.first]->at(alt_anchor.second).second;
+                 return right_clusters[alt_anchor.first]->first.at(alt_anchor.second).second;
              }
              
          },
          [&](size_t cluster_num) {
              // Give the offset of the position we chose to either the start or end of the read
              if (cluster_num < left_clusters.size()) {
-                 return alignment_1.sequence().begin() - left_clusters[cluster_num]->front().first->begin;
+                 return alignment_1.sequence().begin() - left_clusters[cluster_num]->first.front().first->begin;
              }
              else if (cluster_num < total_clusters) {
-                 return alignment_2.sequence().end() - right_clusters[cluster_num - left_clusters.size()]->front().first->begin;
+                 return alignment_2.sequence().end() - right_clusters[cluster_num - left_clusters.size()]->first.front().first->begin;
              }
              else if (cluster_num < total_clusters + left_alt_cluster_anchors.size()) {
                  const pair<size_t, size_t>& alt_anchor = left_alt_cluster_anchors[cluster_num - total_clusters];
-                 return alignment_1.sequence().begin() - left_clusters[alt_anchor.first]->at(alt_anchor.second).first->begin;
+                 return alignment_1.sequence().begin() - left_clusters[alt_anchor.first]->first.at(alt_anchor.second).first->begin;
              }
              else {
                  const pair<size_t, size_t>& alt_anchor = right_alt_cluster_anchors[cluster_num - total_clusters - left_alt_cluster_anchors.size()];
-                 return alignment_2.sequence().end() - right_clusters[alt_anchor.first]->at(alt_anchor.second).first->begin;
+                 return alignment_2.sequence().end() - right_clusters[alt_anchor.first]->first.at(alt_anchor.second).first->begin;
              }
          });
     
@@ -2486,18 +2526,18 @@ vector<pair<pair<size_t, size_t>, int64_t>> OrientedDistanceClusterer::pair_clus
         cerr << "strand reconstruction: "  << endl;
         for (const auto& record : strand) {
             if (record.first < left_clusters.size()) {
-                cerr << "\t" << record.first << " left: " << record.second << "\t" << left_clusters[record.first]->front().second << endl;
+                cerr << "\t" << record.first << " left: " << record.second << "\t" << left_clusters[record.first]->first.front().second << endl;
             }
             else if (record.first < total_clusters) {
-                cerr << "\t" << record.first - left_clusters.size() << " right: " << record.second << "\t" << right_clusters[record.first - left_clusters.size()]->front().second << endl;
+                cerr << "\t" << record.first - left_clusters.size() << " right: " << record.second << "\t" << right_clusters[record.first - left_clusters.size()]->first.front().second << endl;
             }
             else if (record.first < total_clusters + left_alt_cluster_anchors.size()) {
                 const pair<size_t, size_t>& alt_anchor = left_alt_cluster_anchors[record.first - total_clusters];
-                cerr << "\t" << alt_anchor.first << "(alt " << alt_anchor.second << ") left: " << record.second << "\t" << left_clusters[alt_anchor.first]->front().second << endl;
+                cerr << "\t" << alt_anchor.first << "(alt " << alt_anchor.second << ") left: " << record.second << "\t" << left_clusters[alt_anchor.first]->first.front().second << endl;
             }
             else {
                 const pair<size_t, size_t>& alt_anchor = right_alt_cluster_anchors[record.first - total_clusters - left_alt_cluster_anchors.size()];
-                cerr << "\t" << alt_anchor.first << "(alt " << alt_anchor.second << ") right: " << record.second << "\t" << right_clusters[alt_anchor.first]->front().second << endl;
+                cerr << "\t" << alt_anchor.first << "(alt " << alt_anchor.second << ") right: " << record.second << "\t" << right_clusters[alt_anchor.first]->first.front().second << endl;
             }
 
         }
@@ -2549,11 +2589,11 @@ vector<pair<pair<size_t, size_t>, int64_t>> OrientedDistanceClusterer::pair_clus
             
 #ifdef debug_mem_clusterer
             if (sorted_pos[i].second < total_clusters) {
-                cerr << "looking for clusters consistent with cluster that starts with " << left_clusters[sorted_pos[i].second]->front().second << " at relative position " << sorted_pos[i].first << " in coordinate window " << coord_interval_start << ":" << coord_interval_end << endl;
+                cerr << "looking for clusters consistent with cluster that starts with " << left_clusters[sorted_pos[i].second]->first.front().second << " at relative position " << sorted_pos[i].first << " in coordinate window " << coord_interval_start << ":" << coord_interval_end << endl;
             }
             else {
                 const pair<size_t, size_t>& alt_anchor = left_alt_cluster_anchors[sorted_pos[i].second - total_clusters];
-                cerr << "looking for clusters consistent with (alt) cluster that starts with " << left_clusters[alt_anchor.first]->front().second << " at relative position " << sorted_pos[i].first << " in coordinate window " << coord_interval_start << ":" << coord_interval_end << endl;
+                cerr << "looking for clusters consistent with (alt) cluster that starts with " << left_clusters[alt_anchor.first]->first.front().second << " at relative position " << sorted_pos[i].first << " in coordinate window " << coord_interval_start << ":" << coord_interval_end << endl;
             }
 #endif
             
@@ -2596,7 +2636,7 @@ vector<pair<pair<size_t, size_t>, int64_t>> OrientedDistanceClusterer::pair_clus
                 }
                 
 #ifdef debug_mem_clusterer
-                cerr << "adding pair (" << left_idx << ", " << right_idx << ") with cluster relative position " << sorted_pos[j].first << " starting with " << right_clusters[right_idx]->front().second << endl;
+                cerr << "adding pair (" << left_idx << ", " << right_idx << ") with cluster relative position " << sorted_pos[j].first << " starting with " << right_clusters[right_idx]->first.front().second << endl;
 #endif
                 
                 to_return.emplace_back(make_pair(left_idx, right_idx),
@@ -3223,12 +3263,12 @@ vector<pair<pair<size_t, size_t>, int64_t>> TVSClusterer::pair_clusters(const Al
         hit_t left_clust_hit;
         if (i < left_clusters.size()) {
             left_clust_idx = i;
-            left_clust_hit = left_clusters[i]->front();
+            left_clust_hit = left_clusters[i]->first.front();
         }
         else {
             auto& alt_anchor = left_alt_cluster_anchors[i - left_clusters.size()];
             left_clust_idx = alt_anchor.first;
-            left_clust_hit = left_clusters[left_clust_idx]->at(alt_anchor.second);
+            left_clust_hit = left_clusters[left_clust_idx]->first.at(alt_anchor.second);
         }
         
         for (size_t j = 0, j_end  = right_clusters.size() + right_alt_cluster_anchors.size(); j < j_end; j++) {
@@ -3238,12 +3278,12 @@ vector<pair<pair<size_t, size_t>, int64_t>> TVSClusterer::pair_clusters(const Al
             hit_t right_clust_hit;
             if (j < right_clusters.size()) {
                 right_clust_idx = j;
-                right_clust_hit = right_clusters[j]->front();
+                right_clust_hit = right_clusters[j]->first.front();
             }
             else {
                 auto& alt_anchor = right_alt_cluster_anchors[j - right_clusters.size()];
                 right_clust_idx = alt_anchor.first;
-                right_clust_hit = right_clusters[right_clust_idx]->at(alt_anchor.second);
+                right_clust_hit = right_clusters[right_clust_idx]->first.at(alt_anchor.second);
             }
             
             // adjust the target value by how far away we are from the ends of the fragment
@@ -3305,12 +3345,12 @@ vector<pair<pair<size_t, size_t>, int64_t>> MinDistanceClusterer::pair_clusters(
         hit_t left_clust_hit;
         if (i < left_clusters.size()) {
             left_clust_idx = i;
-            left_clust_hit = left_clusters[i]->front();
+            left_clust_hit = left_clusters[i]->first.front();
         }
         else {
             auto& alt_anchor = left_alt_cluster_anchors[i - left_clusters.size()];
             left_clust_idx = alt_anchor.first;
-            left_clust_hit = left_clusters[left_clust_idx]->at(alt_anchor.second);
+            left_clust_hit = left_clusters[left_clust_idx]->first.at(alt_anchor.second);
         }
         
         for (size_t j = 0, j_end  = right_clusters.size() + right_alt_cluster_anchors.size(); j < j_end; j++) {
@@ -3320,12 +3360,12 @@ vector<pair<pair<size_t, size_t>, int64_t>> MinDistanceClusterer::pair_clusters(
             hit_t right_clust_hit;
             if (j < right_clusters.size()) {
                 right_clust_idx = j;
-                right_clust_hit = right_clusters[j]->front();
+                right_clust_hit = right_clusters[j]->first.front();
             }
             else {
                 auto& alt_anchor = right_alt_cluster_anchors[j - right_clusters.size()];
                 right_clust_idx = alt_anchor.first;
-                right_clust_hit = right_clusters[right_clust_idx]->at(alt_anchor.second);
+                right_clust_hit = right_clusters[right_clust_idx]->first.at(alt_anchor.second);
             }
             
 #ifdef debug_mem_clusterer

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -171,8 +171,8 @@ public:
     /// particular hit in the graph.
     using hit_t = pair<const MaximalExactMatch*, pos_t>;
     
-    /// Each cluster is a vector of hits.
-    using cluster_t = vector<hit_t>;
+    /// Each cluster is a vector of hits and a paired multiplicity
+    using cluster_t = pair<vector<hit_t>, double>;
     
     /// Represents the mismatches that were allowed in "MEMs" from the fanout
     /// match algorithm
@@ -188,6 +188,7 @@ public:
                                int32_t log_likelihood_approx_factor = 0,
                                size_t min_median_mem_coverage_for_split = 0,
                                double suboptimal_edge_pruning_factor = .75,
+                               double cluster_multiplicity_diff = 10.0,
                                const match_fanouts_t* fanouts = nullptr);
     
     /**
@@ -251,7 +252,8 @@ public:
                                int32_t max_qual_score,
                                int32_t log_likelihood_approx_factor,
                                size_t min_median_mem_coverage_for_split,
-                               double suboptimal_edge_pruning_factor);
+                               double suboptimal_edge_pruning_factor,
+                               double cluster_multiplicity_diff);
     
     vector<HitNode> nodes;
     

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -710,8 +710,8 @@ MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const
             }
             else {
                 bool found_any_breaks = false;
-                for (size_t i = 0; i < hits.size() && !found_any_breaks; ++i) {
-                    found_any_breaks = fanout_breaks->count(hits[i].first);
+                for (size_t i = 0; i < hits.first.size() && !found_any_breaks; ++i) {
+                    found_any_breaks = fanout_breaks->count(hits.first[i].first);
                 }
                 filter_sub_mems_on_fly = !found_any_breaks;
             }
@@ -721,9 +721,9 @@ MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph, const
         }
         
         // walk the matches and filter out redundant sub-MEMs
-        for (int64_t i = 0; i < hits.size(); i++) {
+        for (int64_t i = 0; i < hits.first.size(); i++) {
             
-            const pair<const MaximalExactMatch*, pos_t>& hit = hits[i];
+            const pair<const MaximalExactMatch*, pos_t>& hit = hits.first[i];
             
             // the part of the read we're going to match
             string::const_iterator begin = hit.first->begin;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -4,7 +4,7 @@
 //
 //
 
-#define debug_multipath_mapper
+//#define debug_multipath_mapper
 //#define debug_multipath_mapper_alignment
 //#define debug_validate_multipath_alignments
 //#define debug_report_startup_training
@@ -113,16 +113,14 @@ namespace vg {
         
         // actually perform the alignments and post-process to meet multipath_alignment_t invariants
         // TODO: do i still need cluster_idx? i think it might have only been used for capping
-        vector<size_t> cluster_idxs;
         vector<double> multiplicities;
         align_to_cluster_graphs(alignment, mapq_method, cluster_graphs, multipath_alns_out, multiplicities,
-                                num_mapping_attempts, fanouts.get(), &cluster_idxs);
+                                num_mapping_attempts, fanouts.get());
         
         if (multipath_alns_out.empty()) {
             // add a null alignment so we know it wasn't mapped
             multipath_alns_out.emplace_back();
             cluster_graphs.emplace_back();
-            cluster_idxs.push_back(0);
             multiplicities.push_back(1.0);
             to_multipath_alignment(alignment, multipath_alns_out.back());
             
@@ -1253,11 +1251,11 @@ namespace vg {
 #ifdef debug_multipath_mapper
                     cerr << "checking duplication between mapped read1 " << i << " and rescued read1 " << j << endl;
 #endif
-                    if (abs(distance_between(multipath_alns_1[i], rescue_multipath_alns_1[j])) < 20) {
+                    if (share_terminal_positions(multipath_alns_1[i], rescue_multipath_alns_1[j])) {
 #ifdef debug_multipath_mapper
                         cerr << "found duplicate, now checking rescued read2 " << i << " and mapped read2 " << j << endl;
 #endif
-                        if (abs(distance_between(rescue_multipath_alns_2[i], multipath_alns_2[j])) < 20) {
+                        if (share_terminal_positions(rescue_multipath_alns_2[i], multipath_alns_2[j])) {
 #ifdef debug_multipath_mapper
                             cerr << "found duplicate, marking entire pair as duplicate" << endl;
 #endif
@@ -1609,8 +1607,8 @@ namespace vg {
             vector<bool> duplicate(rescued_secondaries.size(), false);
             for (size_t i = 1; i < rescued_secondaries.size(); i++) {
                 for (size_t j = 0; j < i; j++) {
-                    if (abs(distance_between(rescued_secondaries[i].first, rescued_secondaries[j].first)) < 20) {
-                        if (abs(distance_between(rescued_secondaries[i].second, rescued_secondaries[j].second)) < 20) {
+                    if (share_terminal_positions(rescued_secondaries[i].first, rescued_secondaries[j].first)) {
+                        if (share_terminal_positions(rescued_secondaries[i].second, rescued_secondaries[j].second)) {
                             duplicate[i] = true;
                             duplicate[j] = true;
                         }
@@ -2185,8 +2183,8 @@ namespace vg {
 #ifdef debug_multipath_mapper
                 cerr << "checking if rescue pair " << j << " is duplicate of original pair " << i << endl;
 #endif
-                if (abs(distance_between(multipath_aln_pairs_out[i].first, rescued_multipath_aln_pairs[j].first)) < 20) {
-                    if (abs(distance_between(multipath_aln_pairs_out[i].second, rescued_multipath_aln_pairs[j].second)) < 20) {
+                if (share_terminal_positions(multipath_aln_pairs_out[i].first, rescued_multipath_aln_pairs[j].first)) {
+                    if (share_terminal_positions(multipath_aln_pairs_out[i].second, rescued_multipath_aln_pairs[j].second)) {
 #ifdef debug_multipath_mapper
                         cerr << "found a duplicate" << endl;
 #endif

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -33,7 +33,7 @@ namespace vg {
     {
         // nothing to do
     }
-    
+
     MultipathMapper::~MultipathMapper() {
         
     }
@@ -338,7 +338,8 @@ namespace vg {
         // generate clusters
         return clusterer->clusters(alignment, mems, get_aligner(!alignment.quality().empty()),
                                    min_clustering_mem_length, max_mapping_quality, log_likelihood_approx_factor,
-                                   min_median_mem_coverage_for_split, 0.75, fanouts);;
+                                   min_median_mem_coverage_for_split, 0.75, unused_cluster_multiplicity_mq_limit,
+                                   fanouts);;
     }
     
     vector<MaximalExactMatch> MultipathMapper::find_mems(const Alignment& alignment,
@@ -378,7 +379,7 @@ namespace vg {
         // Find the clusters that have a tie for the longest MEM, and create alternate anchor points for those clusters
         vector<pair<size_t, size_t>> alt_anchors_1, alt_anchors_2;
         for (size_t i = 0; i < cluster_mems_1.size(); i++) {
-            auto& mem_cluster = *cluster_mems_1[i];
+            auto& mem_cluster = cluster_mems_1[i]->first;
             for (size_t j = 1; j < mem_cluster.size(); j++) {
                 if (mem_cluster[j].first->length() + alt_anchor_max_length_diff >= mem_cluster.front().first->length()) {
                     alt_anchors_1.emplace_back(i, j);
@@ -389,7 +390,7 @@ namespace vg {
             }
         }
         for (size_t i = 0; i < cluster_mems_2.size(); i++) {
-            auto& mem_cluster = *cluster_mems_2[i];
+            auto& mem_cluster = cluster_mems_2[i]->first;
             for (size_t j = 1; j < mem_cluster.size(); j++) {
                 if (mem_cluster[j].first->length() + alt_anchor_max_length_diff >= mem_cluster.front().first->length()) {
                     alt_anchors_2.emplace_back(i, j);
@@ -468,7 +469,7 @@ namespace vg {
             multipath_alns_out.emplace_back();
             multipath_align(alignment, get<0>(cluster_graph), get<1>(cluster_graph), multipath_alns_out.back(),
                             fanouts);
-            multiplicities_out.emplace_back(hit_sampling_multiplicity(get<1>(cluster_graph)));
+            multiplicities_out.emplace_back(cluster_multiplicity(get<1>(cluster_graph)));
             num_mappings++;
         }
         
@@ -927,7 +928,6 @@ namespace vg {
             return p_value;
         }
     }
-    
     
     void MultipathMapper::calibrate_mismapping_detection(size_t num_simulations, const vector<size_t>& simulated_read_lengths) {
         
@@ -1542,11 +1542,11 @@ namespace vg {
                 double hit_multiplicity;
                 if (rescued_cluster_pair.first.first == cluster_graphs1.size()) {
                     // the read 1 mapping is from a rescue, get the hit sampling multiplicity for read 2
-                    hit_multiplicity = hit_sampling_multiplicity(get<1>(cluster_graphs2[rescued_cluster_pair.first.second]));
+                    hit_multiplicity = cluster_multiplicity(get<1>(cluster_graphs2[rescued_cluster_pair.first.second]));
                 }
                 else {
                     // the read 2 mapping is from a rescue, get the hit sampling multiplicity for read 1
-                    hit_multiplicity = hit_sampling_multiplicity(get<1>(cluster_graphs1[rescued_cluster_pair.first.first]));
+                    hit_multiplicity = cluster_multiplicity(get<1>(cluster_graphs1[rescued_cluster_pair.first.first]));
                 }
                 rescued_multiplicities.push_back(rescue_multiplicity * hit_multiplicity);
             }
@@ -2285,17 +2285,17 @@ namespace vg {
         return multiplicity;
     }
 
-    double MultipathMapper::hit_sampling_multiplicity(const memcluster_t& cluster) const {
+    double MultipathMapper::cluster_multiplicity(const memcluster_t& cluster) const {
         double max_fraction_sampled = 0.0;
-        for (const pair<const MaximalExactMatch*, pos_t>& hit : cluster) {
+        for (const pair<const MaximalExactMatch*, pos_t>& hit : cluster.first) {
             const MaximalExactMatch& mem = *hit.first;
             max_fraction_sampled = max(max_fraction_sampled, double(mem.queried_count) / double(mem.match_count));
         }
-        return 1.0 / max_fraction_sampled;
+        return cluster.second / max_fraction_sampled;
     }
 
-    double MultipathMapper::pair_hit_sampling_multiplicity(const memcluster_t& cluster_1, const memcluster_t& cluster_2) const {
-        return min(hit_sampling_multiplicity(cluster_1), hit_sampling_multiplicity(cluster_2));
+    double MultipathMapper::pair_cluster_multiplicity(const memcluster_t& cluster_1, const memcluster_t& cluster_2) const {
+        return min(cluster_multiplicity(cluster_1), cluster_multiplicity(cluster_2));
     }
 
     MultipathMapper::match_fanouts_t MultipathMapper::record_fanouts(const vector<MaximalExactMatch>& mems,
@@ -2494,8 +2494,8 @@ namespace vg {
 #endif
             // create multipath alignments to fill
             multipath_aln_pairs_out.emplace_back();
-            pair_multiplicities.push_back(pair_hit_sampling_multiplicity(get<1>(cluster_graphs1[cluster_pair.first.first]),
-                                                                         get<1>(cluster_graphs2[cluster_pair.first.second])));
+            pair_multiplicities.push_back(pair_cluster_multiplicity(get<1>(cluster_graphs1[cluster_pair.first.first]),
+                                                                    get<1>(cluster_graphs2[cluster_pair.first.second])));
                         
             auto prev_1 = previous_multipath_alns_1.find(cluster_pair.first.first);
             if (prev_1 == previous_multipath_alns_1.end()) {
@@ -2616,10 +2616,12 @@ namespace vg {
         
     }
 
-    pair<bdsg::HashGraph*, bool> MultipathMapper::extract_maximal_graph(const Alignment& alignment, const memcluster_t& cluster) {
+    pair<bdsg::HashGraph*, bool> MultipathMapper::extract_maximal_graph(const Alignment& alignment, const memcluster_t& mem_cluster) {
         
         // Figure out the aligner to use
         auto aligner = get_aligner(!alignment.quality().empty());
+        // get the seed hits
+        const auto& cluster = mem_cluster.first;
         
         vector<pos_t> positions;
         vector<size_t> forward_max_dist;
@@ -2669,10 +2671,12 @@ namespace vg {
         return gap_length;
     }
 
-    pair<bdsg::HashGraph*, bool> MultipathMapper::extract_restrained_graph(const Alignment& alignment, const memcluster_t& cluster) {
+    pair<bdsg::HashGraph*, bool> MultipathMapper::extract_restrained_graph(const Alignment& alignment, const memcluster_t& mem_cluster) {
         
         // Figure out the aligner to use
         auto aligner = get_aligner(!alignment.quality().empty());
+        // get the seed hits
+        const auto& cluster = mem_cluster.first;
         
         // the MEMs are size sorted, we want to know the read order so we can
         // use the inter-MEM distance to figure out how much to extract
@@ -2779,12 +2783,12 @@ namespace vg {
         return make_pair(cluster_graph, connected);
     }
 
-    pair<bdsg::HashGraph*, bool> MultipathMapper::extract_cluster_graph(const Alignment& alignment, const memcluster_t& cluster) {
+    pair<bdsg::HashGraph*, bool> MultipathMapper::extract_cluster_graph(const Alignment& alignment, const memcluster_t& mem_cluster) {
         if (restrained_graph_extraction) {
-            return extract_restrained_graph(alignment, cluster);
+            return extract_restrained_graph(alignment, mem_cluster);
         }
         else {
-            return extract_maximal_graph(alignment, cluster);
+            return extract_maximal_graph(alignment, mem_cluster);
         }
     }
     
@@ -2806,7 +2810,8 @@ namespace vg {
         
         // to hold the clusters as they are (possibly) merged, bools indicate
         // whether we've verified that the graph is connected
-        unordered_map<size_t, pair<bdsg::HashGraph*, bool>> cluster_graphs;
+        // doubles are the cluster graph's multiplicity
+        unordered_map<size_t, tuple<bdsg::HashGraph*, bool, double>> cluster_graphs;
         
         // to keep track of which clusters have been merged
         UnionFind union_find(clusters.size(), false);
@@ -2823,15 +2828,16 @@ namespace vg {
             
             // gather the parameters for subgraph extraction from the MEM hits
             auto& cluster = clusters[i];
-            auto cluster_graph = extract_cluster_graph(alignment, cluster);
+            auto extracted = extract_cluster_graph(alignment, cluster);
+            tuple<bdsg::HashGraph*, bool, double> cluster_graph(extracted.first, extracted.second, cluster.second);
             
             // check if this subgraph overlaps with any previous subgraph (indicates a probable clustering failure where
             // one cluster was split into multiple clusters)
             unordered_set<size_t> overlapping_graphs;
             
             if (!do_merge_suppression) {
-                cluster_graph.first->for_each_handle([&](const handle_t& handle) {
-                    id_t node_id = cluster_graph.first->get_id(handle);
+                get<0>(cluster_graph)->for_each_handle([&](const handle_t& handle) {
+                    id_t node_id = get<0>(cluster_graph)->get_id(handle);
                     if (node_id_to_cluster.count(node_id)) {
                         overlapping_graphs.insert(node_id_to_cluster[node_id]);
                     }
@@ -2843,7 +2849,7 @@ namespace vg {
             }
             else {
                 // assign the hits to clusters
-                for (auto& mem_hit : cluster) {
+                for (auto& mem_hit : cluster.first) {
                     hit_to_cluster[mem_hit] = i;
                 }
             }
@@ -2878,31 +2884,38 @@ namespace vg {
                 
                 bdsg::HashGraph* merging_graph;
                 bool all_connected;
+                double multiplicity;
                 if (remaining_idx == i) {
                     // the new graph was chosen to remain, so add it to the record
                     cluster_graphs[i] = cluster_graph;
-                    merging_graph = cluster_graph.first;
-                    all_connected = cluster_graph.second;
+                    merging_graph = get<0>(cluster_graph);
+                    all_connected = get<1>(cluster_graph);
+                    multiplicity = get<2>(cluster_graph);
                 }
                 else {
                     // the new graph will be merged into an existing graph
-                    merging_graph = cluster_graphs[remaining_idx].first;
-                    all_connected = cluster_graphs[remaining_idx].second && cluster_graph.second;
-                    algorithms::extend(cluster_graph.first, merging_graph);
-                    delete cluster_graph.first;
+                    merging_graph = get<0>(cluster_graphs[remaining_idx]);
+                    
+                    // add in the new graph
+                    algorithms::extend(get<0>(cluster_graph), merging_graph);
+                    all_connected = get<1>(cluster_graphs[remaining_idx]) && get<1>(cluster_graph);
+                    multiplicity = min(get<2>(cluster_graphs[remaining_idx]), get<2>(cluster_graph));
+                    delete get<0>(cluster_graph);
                 }
                 
                 // merge any other chained graphs into the remaining graph
                 for (size_t j : overlapping_graphs) {
                     if (j != remaining_idx) {
                         auto removing_graph = cluster_graphs[j];
-                        algorithms::extend(removing_graph.first, merging_graph);
-                        all_connected = all_connected && removing_graph.second;
-                        delete removing_graph.first;
+                        algorithms::extend(get<0>(removing_graph), merging_graph);
+                        all_connected = all_connected && get<1>(removing_graph);
+                        multiplicity = min(multiplicity, get<2>(removing_graph));
+                        delete get<0>(removing_graph);
                         cluster_graphs.erase(j);
                     }
                 }
-                cluster_graphs[remaining_idx].second = all_connected;
+                get<1>(cluster_graphs[remaining_idx]) = all_connected;
+                get<2>(cluster_graphs[remaining_idx]) = multiplicity;
                 
                 // update the node-to-cluster mapping
                 merging_graph->for_each_handle([&](const handle_t& handle) {
@@ -2921,8 +2934,8 @@ namespace vg {
         
         size_t max_graph_idx = 0;
         for (const auto& cluster_graph : cluster_graphs) {
-            if (!cluster_graph.second.second) {
-                vector<unordered_set<id_t>> connected_components = algorithms::weakly_connected_components(cluster_graph.second.first);
+            if (!get<1>(cluster_graph.second)) {
+                vector<unordered_set<id_t>> connected_components = algorithms::weakly_connected_components(get<0>(cluster_graph.second));
                 if (connected_components.size() > 1) {
                     multicomponent_graphs.emplace_back(cluster_graph.first, std::move(connected_components));
                 }
@@ -2946,16 +2959,17 @@ namespace vg {
 #endif
             
             for (size_t i = 0; i < multicomponent_graph.second.size(); i++) {
-                cluster_graphs[max_graph_idx + i] = make_pair(new bdsg::HashGraph(), true);
+                cluster_graphs[max_graph_idx + i] = make_tuple(new bdsg::HashGraph(), true,
+                                                               get<2>(cluster_graphs[multicomponent_graph.first]));
             }
             
             // divvy up the nodes
-            auto joined_graph = cluster_graphs[multicomponent_graph.first].first;
+            auto joined_graph = get<0>(cluster_graphs[multicomponent_graph.first]);
             joined_graph->for_each_handle([&](const handle_t& handle) {
                 for (size_t j = 0; j < multicomponent_graph.second.size(); j++) {
                     if (multicomponent_graph.second[j].count(joined_graph->get_id(handle))) {
-                        cluster_graphs[max_graph_idx + j].first->create_handle(joined_graph->get_sequence(handle),
-                                                                               joined_graph->get_id(handle));
+                        get<0>(cluster_graphs[max_graph_idx + j])->create_handle(joined_graph->get_sequence(handle),
+                                                                                 joined_graph->get_id(handle));
                         // if we're suppressing cluster merging, we don't maintain this index
                         if (!do_merge_suppression) {
                             node_id_to_cluster[joined_graph->get_id(handle)] = max_graph_idx + j;
@@ -2970,7 +2984,7 @@ namespace vg {
             joined_graph->for_each_edge([&](const edge_t& edge) {
                 for (size_t j = 0; j < multicomponent_graph.second.size(); j++) {
                     if (multicomponent_graph.second[j].count(joined_graph->get_id(edge.first))) {
-                        auto comp_graph = cluster_graphs[max_graph_idx + j].first;
+                        auto comp_graph = get<0>(cluster_graphs[max_graph_idx + j]);
                         comp_graph->create_edge(comp_graph->get_handle(joined_graph->get_id(edge.first),
                                                                        joined_graph->get_is_reverse(edge.first)),
                                                 comp_graph->get_handle(joined_graph->get_id(edge.second),
@@ -2982,12 +2996,12 @@ namespace vg {
             });
             
             // remove the old graph
-            delete cluster_graphs[multicomponent_graph.first].first;
+            delete get<0>(cluster_graphs[multicomponent_graph.first]);
             cluster_graphs.erase(multicomponent_graph.first);
             
             if (do_merge_suppression) {
                 // we need to re-assign the hits to the new cluster graphs
-                for (auto& mem_hit : clusters[multicomponent_graph.first]) {
+                for (auto& mem_hit : clusters[multicomponent_graph.first].first) {
                     for (size_t i = 0; i < multicomponent_graph.second.size(); i++) {
                         if (multicomponent_graph.second[i].count(id(mem_hit.second))) {
                             hit_to_cluster[mem_hit] = max_graph_idx + i;
@@ -3009,7 +3023,8 @@ namespace vg {
             cerr << "adding cluster graph " << cluster_graph.first << " to return vector at index " << cluster_graphs_out.size() << endl;
 #endif
             cluster_to_idx[cluster_graph.first] = cluster_graphs_out.size();
-            cluster_graphs_out.emplace_back(cluster_graph.second.first, memcluster_t(), 0);
+            cluster_graphs_out.emplace_back(get<0>(cluster_graph.second), memcluster_t(), 0);
+            get<1>(cluster_graphs_out.back()).second = get<2>(cluster_graph.second);
         }
 
         
@@ -3023,7 +3038,7 @@ namespace vg {
                     id_t node_id = gcsa::Node::id(hit);
                     if (node_id_to_cluster.count(node_id)) {
                         size_t cluster_idx = cluster_to_idx[node_id_to_cluster[node_id]];
-                        get<1>(cluster_graphs_out[cluster_idx]).push_back(make_pair(&mem, make_pos_t(hit)));
+                        get<1>(cluster_graphs_out[cluster_idx]).first.push_back(make_pair(&mem, make_pos_t(hit)));
 #ifdef debug_multipath_mapper
                         cerr << "\tMEM " << mem.sequence() << " at " << make_pos_t(hit) << " found in cluster " << node_id_to_cluster[node_id] << " at index " << cluster_idx << endl;
 #endif
@@ -3057,7 +3072,7 @@ namespace vg {
                     // force the hits that generated a cluster to be assigned to it
                     auto iter = hit_to_cluster.find(mem_hit);
                     if (iter != hit_to_cluster.end()) {
-                        get<1>(cluster_graphs_out[cluster_to_idx[iter->second]]).push_back(mem_hit);
+                        get<1>(cluster_graphs_out[cluster_to_idx[iter->second]]).first.push_back(mem_hit);
 #ifdef debug_multipath_mapper
                         cerr << "\tMEM " << mem.sequence() << " at " << mem_hit.second << " assigned as seed to cluster at index " << cluster_to_idx[iter->second] << endl;
 #endif
@@ -3067,7 +3082,7 @@ namespace vg {
                         auto id_iter = node_id_to_cluster_idxs.find(id(mem_hit.second));
                         if (id_iter != node_id_to_cluster_idxs.end()) {
                             for (size_t cluster_idx : id_iter->second) {
-                                get<1>(cluster_graphs_out[cluster_idx]).push_back(mem_hit);
+                                get<1>(cluster_graphs_out[cluster_idx]).first.push_back(mem_hit);
 #ifdef debug_multipath_mapper
                                 cerr << "\tMEM " << mem.sequence() << " at " << mem_hit.second << " found in cluster at index " << cluster_idx << endl;
 #endif
@@ -3086,7 +3101,7 @@ namespace vg {
 #ifdef debug_multipath_mapper
             cerr << "compute read coverage of cluster at index " << i << " to be " << get<2>(cluster_graph) << endl;
 #endif
-            sort(get<1>(cluster_graph).begin(), get<1>(cluster_graph).end(),
+            sort(get<1>(cluster_graph).first.begin(), get<1>(cluster_graph).first.end(),
                  [](const pair<const MaximalExactMatch*, pos_t>& hit_1,
                     const pair<const MaximalExactMatch*, pos_t>& hit_2) {
                 return hit_1.first->length() > hit_2.first->length() ||
@@ -3114,7 +3129,7 @@ namespace vg {
                                  wang_hash<pair<id_t, id_t>>()(node_range[get<0>(cluster_graph_1)]) < wang_hash<pair<id_t, id_t>>()(node_range[get<0>(cluster_graph_2)])));
                     });
         
-        return move(cluster_graphs_out);
+        return cluster_graphs_out;
         
         
     }
@@ -3136,9 +3151,9 @@ namespace vg {
         bool use_single_stranded = algorithms::is_single_stranded(graph);
         bool mem_strand = false;
         if (use_single_stranded) {
-            mem_strand = is_rev(graph_mems[0].second);
-            for (size_t i = 1; i < graph_mems.size(); i++) {
-                if (is_rev(graph_mems[i].second) != mem_strand) {
+            mem_strand = is_rev(graph_mems.first[0].second);
+            for (size_t i = 1; i < graph_mems.first.size(); i++) {
+                if (is_rev(graph_mems.first[i].second) != mem_strand) {
                     use_single_stranded = false;
                     break;
                 }
@@ -3353,13 +3368,13 @@ namespace vg {
     }
     
     int64_t MultipathMapper::read_coverage(const memcluster_t& mem_hits) {
-        if (mem_hits.empty()) {
+        if (mem_hits.first.empty()) {
             return 0;
         }
         
         vector<pair<string::const_iterator, string::const_iterator>> mem_read_segments;
-        mem_read_segments.reserve(mem_hits.size());
-        for (auto& mem_hit : mem_hits) {
+        mem_read_segments.reserve(mem_hits.first.size());
+        for (auto& mem_hit : mem_hits.first) {
             mem_read_segments.emplace_back(mem_hit.first->begin, mem_hit.first->end);
         }
         std::sort(mem_read_segments.begin(), mem_read_segments.end());

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -130,17 +130,10 @@ namespace vg {
         int max_fans_out = 5;
         size_t max_p_value_memo_size = 500;
         size_t band_padding_memo_size = 2000;
-        bool use_weibull_calibration = false;
         double max_exponential_rate_intercept = 0.612045;
         double max_exponential_rate_slope = 0.000555181;
         double max_exponential_shape_intercept = 12.136;
         double max_exponential_shape_slope = 0.0113637;
-        double weibull_scale_intercept = 1.05;
-        double weibull_scale_slope = 0.0601;
-        double weibull_shape_intercept = -0.176;
-        double weibull_shape_slope = 0.199;
-        double weibull_offset_intercept = 2.342;
-        double weibull_offset_slope = 0.07168;
         double max_mapping_p_value = 0.0001;
         double max_rescue_p_value = 0.1;
         size_t max_alt_mappings = 1;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -190,8 +190,8 @@ namespace vg {
         //static size_t SECONDARY_RESCUE_ATTEMPT;
         //static size_t SECONDARY_RESCUE_TOTAL;
         
-        /// We often pass around clusters of MEMs and their graph positions.
-        using memcluster_t = vector<pair<const MaximalExactMatch*, pos_t>>;
+        /// We often pass around clusters of MEMs and their graph positions, paired with a multiplicity
+        using memcluster_t = pair<vector<pair<const MaximalExactMatch*, pos_t>>, double>;
         
         /// This represents a graph for a cluster, and holds a pointer to the
         /// actual extracted graph, a list of assigned MEMs, and the number of
@@ -313,20 +313,20 @@ namespace vg {
         /// Return a graph (on the heap) that contains a cluster. The paired bool
         /// indicates whether the graph is known to be connected (but it is possible
         /// for the graph to be connected and have it return false)
-        pair<bdsg::HashGraph*, bool> extract_cluster_graph(const Alignment& alignment, const memcluster_t& cluster);
+        pair<bdsg::HashGraph*, bool> extract_cluster_graph(const Alignment& alignment, const memcluster_t& mem_cluster);
         
         /// Extract a graph that is guaranteed to contain all local alignments that include
         /// the MEMs of the cluster.  The paired bool indicates whether the graph is
         /// known to be connected (but it is possible for the graph to be connected and have
         /// it return false)
-        pair<bdsg::HashGraph*, bool> extract_maximal_graph(const Alignment& alignment, const memcluster_t& cluster);
+        pair<bdsg::HashGraph*, bool> extract_maximal_graph(const Alignment& alignment, const memcluster_t& mem_cluster);
         
         /// Extract a graph with an algorithm that tries to extract not much more than what
         /// is required to contain the cluster in a single connected component (can be slower
         /// than the maximal algorithm for alignments that require large indels),  The paired bool
         /// indicates whether the graph is known to be connected (but it is possible
         /// for the graph to be connected and have it return false)
-        pair<bdsg::HashGraph*, bool> extract_restrained_graph(const Alignment& alignment, const memcluster_t& cluster);
+        pair<bdsg::HashGraph*, bool> extract_restrained_graph(const Alignment& alignment, const memcluster_t& mem_cluster);
         
         /// If there are any multipath_alignment_ts with multiple connected components, split them
         /// up and add them to the return vector.
@@ -420,11 +420,11 @@ namespace vg {
         
         /// Estimates the number of equivalent mappings (including this one), which we may not have seen due to
         /// limits on the numbers of hits returns for a MEM
-        double hit_sampling_multiplicity(const memcluster_t& cluster) const;
+        double cluster_multiplicity(const memcluster_t& cluster) const;
         
         /// Estimates the number of equivalent pair mappings (including this one), which we may not have seen due to
         /// limits on the numbers of hits returns for a MEM
-        double pair_hit_sampling_multiplicity(const memcluster_t& cluster_1, const memcluster_t& cluster_2) const;
+        double pair_cluster_multiplicity(const memcluster_t& cluster_1, const memcluster_t& cluster_2) const;
         
         /// Computes the log-likelihood of a given fragment length in the trained distribution
         double fragment_length_log_likelihood(int64_t length) const;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -116,7 +116,7 @@ namespace vg {
         size_t max_expected_dist_approx_error = 8;
         int32_t num_alt_alns = 4;
         double mem_coverage_min_ratio = 0.5;
-        double unused_cluster_multiplicity_mq_limit = 5.0;
+        double unused_cluster_multiplicity_mq_limit = 7.0;
         double max_suboptimal_path_score_ratio = 2.0;
         size_t num_mapping_attempts = 48;
         double log_likelihood_approx_factor = 1.0;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -116,6 +116,7 @@ namespace vg {
         size_t max_expected_dist_approx_error = 8;
         int32_t num_alt_alns = 4;
         double mem_coverage_min_ratio = 0.5;
+        double unused_cluster_multiplicity_mq_limit = 5.0;
         double max_suboptimal_path_score_ratio = 2.0;
         size_t num_mapping_attempts = 48;
         double log_likelihood_approx_factor = 1.0;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -258,7 +258,6 @@ int main_mpmap(int argc, char** argv) {
     double max_rescue_p_value = 0.03;
     size_t num_calibration_simulations = 100;
     vector<size_t> calibration_read_lengths{50, 100, 150, 250, 450};
-    bool use_weibull_calibration = false;
     size_t order_length_repeat_hit_max = 3000;
     size_t sub_mem_count_thinning = 4;
     size_t sub_mem_thinning_burn_in = 16;
@@ -1633,7 +1632,6 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.max_mapping_quality = max_mapq;
     multipath_mapper.mapq_scaling_factor = mapq_scaling_factor;
     multipath_mapper.report_group_mapq = report_group_mapq;
-    multipath_mapper.use_weibull_calibration = use_weibull_calibration;
     // Use population MAPQs when we have the right option combination to make that sensible.
     multipath_mapper.use_population_mapqs = (haplo_score_provider != nullptr && population_max_paths > 0);
     multipath_mapper.population_max_paths = population_max_paths;

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -72,7 +72,9 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
     
     // This will hold our MEMs and their start positions in the imaginary graph.
     // Note that this is also a memcluster_t
-    vector<pair<const MaximalExactMatch*, pos_t>> mem_hits;
+    pair<vector<pair<const MaximalExactMatch*, pos_t>>, double> mem_hits;
+    mem_hits.second = 1.0;
+    
     
     /*
     SECTION ("Works with right tail only") {
@@ -80,7 +82,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         // Make a MEM hit over all of node 1's sequence
         mems.emplace_back(query.sequence().begin(), query.sequence().begin() + 4, make_pair(5, 5), 1);
         // Drop it on node 1 where it should sit
-        mem_hits.emplace_back(&mems.back(), make_pos_t(1, false, 0));
+        mem_hits.first.emplace_back(&mems.back(), make_pos_t(1, false, 0));
         
         // Make the MultipathAlignmentGraph to test
         MultipathAlignmentGraph mpg(vg, mem_hits, identity);
@@ -175,7 +177,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         // Make a MEM hit over all of node 4's sequence
         mems.emplace_back(query.sequence().begin() + 5, query.sequence().begin() + 6, make_pair(5, 5), 1);
         // Drop it on node 4 where it should sit
-        mem_hits.emplace_back(&mems.back(), make_pos_t(4, false, 0));
+        mem_hits.first.emplace_back(&mems.back(), make_pos_t(4, false, 0));
         
         // Make the MultipathAlignmentGraph to test
         MultipathAlignmentGraph mpg(vg, mem_hits, identity);
@@ -269,7 +271,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         // Make a MEM hit over all of node 7's sequence
         mems.emplace_back(query.sequence().begin() + 7, query.sequence().begin() + 8, make_pair(5, 5), 1);
         // Drop it on node 7 where it should sit
-        mem_hits.emplace_back(&mems.back(), make_pos_t(7, false, 0));
+        mem_hits.first.emplace_back(&mems.back(), make_pos_t(7, false, 0));
         
         // Make the MultipathAlignmentGraph to test
         MultipathAlignmentGraph mpg(vg, mem_hits, identity);

--- a/src/unittest/multipath_mapper.cpp
+++ b/src/unittest/multipath_mapper.cpp
@@ -39,7 +39,8 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
     vector<MaximalExactMatch> mems;
     
     // This will hold our MEMs and their start positions in the imaginary graph.
-    vector<pair<const MaximalExactMatch*, pos_t>> mem_hits;
+    pair<vector<pair<const MaximalExactMatch*, pos_t>>, double> mem_hits;
+    mem_hits.second = 1.0;
     
     // We need a fake read
     string read("GATTACA");
@@ -53,7 +54,7 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
         // Make a MEM hit
         mems.emplace_back(read.begin(), read.begin(), make_pair(5, 5), 1);
         // Drop it on some arbitrary node
-        mem_hits.emplace_back(&mems.back(), make_pos_t(999, false, 3));
+        mem_hits.first.emplace_back(&mems.back(), make_pos_t(999, false, 3));
         
         auto covered = TestMultipathMapper::read_coverage(mem_hits);
         REQUIRE(covered == 0);
@@ -63,7 +64,7 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
         // Make a MEM hit
         mems.emplace_back(read.begin(), read.begin() + 1, make_pair(5, 5), 1);
         // Drop it on some arbitrary node
-        mem_hits.emplace_back(&mems.back(), make_pos_t(999, false, 3));
+        mem_hits.first.emplace_back(&mems.back(), make_pos_t(999, false, 3));
         
         auto covered = TestMultipathMapper::read_coverage(mem_hits);
         REQUIRE(covered == 1);
@@ -73,7 +74,7 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
         // Make a MEM hit
         mems.emplace_back(read.begin(), read.end(), make_pair(5, 5), 1);
         // Drop it on some arbitrary node
-        mem_hits.emplace_back(&mems.back(), make_pos_t(999, false, 3));
+        mem_hits.first.emplace_back(&mems.back(), make_pos_t(999, false, 3));
         
         auto covered = TestMultipathMapper::read_coverage(mem_hits);
         REQUIRE(covered == read.size());
@@ -87,8 +88,8 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
         mems.emplace_back(read.begin() + 2, read.end(), make_pair(6, 6), 1);
         
         // Point into vector *after* it's done.
-        mem_hits.emplace_back(&mems[0], make_pos_t(999, false, 3));
-        mem_hits.emplace_back(&mems[1], make_pos_t(888, false, 3));
+        mem_hits.first.emplace_back(&mems[0], make_pos_t(999, false, 3));
+        mem_hits.first.emplace_back(&mems[1], make_pos_t(888, false, 3));
         
         auto covered = TestMultipathMapper::read_coverage(mem_hits);
         REQUIRE(covered == read.size());
@@ -101,8 +102,8 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
         mems.emplace_back(read.begin() + 3, read.end(), make_pair(6, 6), 1);
 
         // Point into vector *after* it's done.
-        mem_hits.emplace_back(&mems[0], make_pos_t(999, false, 3));
-        mem_hits.emplace_back(&mems[1], make_pos_t(888, false, 3));
+        mem_hits.first.emplace_back(&mems[0], make_pos_t(999, false, 3));
+        mem_hits.first.emplace_back(&mems[1], make_pos_t(888, false, 3));
         
         auto covered = TestMultipathMapper::read_coverage(mem_hits);
         REQUIRE(covered == read.size());
@@ -184,7 +185,7 @@ TEST_CASE( "MultipathMapper::query_cluster_graphs works", "[multipath][mapping][
         
         // Make a cluster
         clusters.resize(1);
-        clusters.back().emplace_back(&mems.at(0), make_pos_t(1, false, 0));
+        clusters.back().first.emplace_back(&mems.at(0), make_pos_t(1, false, 0));
         
         REQUIRE(mems.size() == 1);
         
@@ -196,10 +197,10 @@ TEST_CASE( "MultipathMapper::query_cluster_graphs works", "[multipath][mapping][
         // It has one node
         REQUIRE(get<0>(results[0])->get_node_count() == 1);
         // It contains the one MEM we fed in
-        REQUIRE(get<1>(results[0]).size() == 1);
+        REQUIRE(get<1>(results[0]).first.size() == 1);
         MultipathMapper::memcluster_t& assigned_mems = get<1>(results[0]);
-        const MaximalExactMatch* mem = assigned_mems[0].first;
-        pos_t where = assigned_mems[0].second;
+        const MaximalExactMatch* mem = assigned_mems.first[0].first;
+        pos_t where = assigned_mems.first[0].second;
         REQUIRE(mem == &mems.back());
         REQUIRE(where == make_pos_t(1, false, 0));
         // It covers 3 bases from that MEM
@@ -220,8 +221,8 @@ TEST_CASE( "MultipathMapper::query_cluster_graphs works", "[multipath][mapping][
         mems.emplace_back(read.begin() + 3, read.end(), make_pair(6, 6), 1);
         mems.back().nodes.push_back(gcsa::Node::encode(1, 3));
         clusters.resize(1);
-        clusters.back().emplace_back(&mems[0], make_pos_t(1, false, 0));
-        clusters.back().emplace_back(&mems[1], make_pos_t(1, false, 3));
+        clusters.back().first.emplace_back(&mems[0], make_pos_t(1, false, 0));
+        clusters.back().first.emplace_back(&mems[1], make_pos_t(1, false, 3));
         
         REQUIRE(mems.size() == 2);
 
@@ -233,10 +234,10 @@ TEST_CASE( "MultipathMapper::query_cluster_graphs works", "[multipath][mapping][
         // It has one node
         REQUIRE(get<0>(results[0])->get_node_count() == 1);
         // It came from two MEM hits
-        REQUIRE(get<1>(results[0]).size() == 2);
+        REQUIRE(get<1>(results[0]).first.size() == 2);
         // They are hits of the two MEMs we fed in at the right places
-        set<pair<const MaximalExactMatch*, pos_t>> found{get<1>(results[0]).begin(), get<1>(results[0]).end()};
-        set<pair<const MaximalExactMatch*, pos_t>> wanted{clusters.back().begin(), clusters.back().end()};
+        set<pair<const MaximalExactMatch*, pos_t>> found{get<1>(results[0]).first.begin(), get<1>(results[0]).first.end()};
+        set<pair<const MaximalExactMatch*, pos_t>> wanted{clusters.back().first.begin(), clusters.back().first.end()};
         REQUIRE(found == wanted);
         // It covers all 7 bases, like the MEMs do together
         REQUIRE(get<2>(results[0]) == 7);
@@ -257,8 +258,8 @@ TEST_CASE( "MultipathMapper::query_cluster_graphs works", "[multipath][mapping][
         mems.emplace_back(read.begin() + 3, read.end(), make_pair(6, 6), 1);
         mems.back().nodes.push_back(gcsa::Node::encode(1, 3));
         clusters.resize(2);
-        clusters.front().emplace_back(&mems[0], make_pos_t(1, false, 0));
-        clusters.back().emplace_back(&mems[1], make_pos_t(1, false, 3));
+        clusters.front().first.emplace_back(&mems[0], make_pos_t(1, false, 0));
+        clusters.back().first.emplace_back(&mems[1], make_pos_t(1, false, 3));
         
         REQUIRE(mems.size() == 2);
         
@@ -270,10 +271,10 @@ TEST_CASE( "MultipathMapper::query_cluster_graphs works", "[multipath][mapping][
         // It has one node
         REQUIRE(get<0>(results[0])->get_node_count() == 1);
         // It came from two MEM hits
-        REQUIRE(get<1>(results[0]).size() == 2);
+        REQUIRE(get<1>(results[0]).first.size() == 2);
         // They are hits of the two MEMs we fed in at the right places
-        set<pair<const MaximalExactMatch*, pos_t>> found{get<1>(results[0]).begin(), get<1>(results[0]).end()};
-        set<pair<const MaximalExactMatch*, pos_t>> wanted{clusters.front()[0], clusters.back()[0]};
+        set<pair<const MaximalExactMatch*, pos_t>> found{get<1>(results[0]).first.begin(), get<1>(results[0]).first.end()};
+        set<pair<const MaximalExactMatch*, pos_t>> wanted{clusters.front().first[0], clusters.back().first[0]};
         REQUIRE(found == wanted);
         // It covers all 7 bases, like the MEMs do together
         REQUIRE(get<2>(results[0]) == 7);


### PR DESCRIPTION
## Changelog Entry

* `mpmap`'s MAPQ now incorporates multiplicities from cluster and alignment hard caps

## Description

Adds multiplicity components that correspond to the cluster and alignment hard caps, and makes the rescue correctness criteria be more consistently applied across `mpmap`. 