### PR TITLE
Add vg view arg -u for more compact dot

### DIFF
--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -63,6 +63,7 @@ void help_view(char** argv) {
 
          << "    -d, --dot                  output dot format" << endl
          << "    -S, --simple-dot           simplify the dot output; remove node labels, simplify alignments" << endl
+         << "    -u, --noseq-dot            shows size information instead of sequence in the dot output" << endl
          << "    -e, --ascii-labels         use labels for paths or superbubbles with char/colors rather than emoji" << endl
          << "    -Y, --ultra-label          label nodes with emoji/colors that correspond to ultrabubbles" << endl
          << "    -m, --skip-missing         skip mappings to nodes not in the graph when drawing alignments" << endl
@@ -134,6 +135,7 @@ int main_view(int argc, char** argv) {
     bool invert_edge_ports_in_dot = false;
     bool show_mappings_in_dot = false;
     bool simple_dot = false;
+    bool noseq_dot = false;
     int seed_val = time(NULL);
     bool color_variants = false;
     bool ultrabubble_labeling = false;
@@ -177,6 +179,7 @@ int main_view(int argc, char** argv) {
                 {"invert-ports", no_argument, 0, 'I'},
                 {"show-mappings", no_argument, 0, 'M'},
                 {"simple-dot", no_argument, 0, 'S'},
+                {"noseq-dot", no_argument, 0, 'u'},
                 {"color", no_argument, 0, 'C'},
                 {"translation-in", no_argument, 0, 'Z'},
                 {"ultra-label", no_argument, 0, 'Y'},
@@ -197,7 +200,7 @@ int main_view(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "dgFjJhvVpaGbifA:s:wnlLIMcTtr:SCZYmqQ:zXBREDx:kKe7:",
+        c = getopt_long (argc, argv, "dgFjJhvVpaGbifA:s:wnlLIMcTtr:SuCZYmqQ:zXBREDx:kKe7:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -216,6 +219,10 @@ int main_view(int argc, char** argv) {
 
         case 'S':
             simple_dot = true;
+            break;
+
+        case 'u':
+            noseq_dot = true;
             break;
 
         case 'Y':
@@ -942,6 +949,7 @@ int main_view(int argc, char** argv) {
                         annotate_paths_in_dot,
                         show_mappings_in_dot,
                         simple_dot,
+                        noseq_dot,
                         invert_edge_ports_in_dot,
                         color_variants,
                         ultrabubble_labeling,

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -4816,6 +4816,7 @@ void VG::to_dot(ostream& out,
                 bool annotate_paths,
                 bool show_mappings,
                 bool simple_mode,
+                bool noseq_mode,
                 bool invert_edge_ports,
                 bool color_variants,
                 bool ultrabubble_labeling,
@@ -4878,7 +4879,11 @@ void VG::to_dot(ostream& out,
         stringstream inner_label;
         if (ultrabubble_labeling) {
             inner_label << "<TD ROWSPAN=\"3\" BORDER=\"2\" CELLPADDING=\"5\">";
-            inner_label << "<FONT COLOR=\"black\">" << n->id() << ":" << n->sequence() << "</FONT> ";
+            if (noseq_mode){
+              inner_label << "<FONT COLOR=\"black\">" << n->id() << ":" << n->sequence().size() << " bp</FONT> ";
+            } else {
+              inner_label << "<FONT COLOR=\"black\">" << n->id() << ":" << n->sequence() << "</FONT> ";
+            }
             for(auto& string_and_color : symbols_for_node[n->id()]) {
                 // Put every symbol in its font tag.
                 inner_label << "<FONT COLOR=\"" << string_and_color.first << "\">" << string_and_color.second << "</FONT>";
@@ -4890,7 +4895,11 @@ void VG::to_dot(ostream& out,
             //inner_label << "</TD>";
         } else {
             inner_label << "<TD ROWSPAN=\"3\" BORDER=\"2\" CELLPADDING=\"5\">";
-            inner_label << n->id() << ":" << n->sequence();
+            if (noseq_mode){
+              inner_label << n->id() << ":" << n->sequence().size() << " bp";
+            } else {
+              inner_label << n->id() << ":" << n->sequence();
+            }
             inner_label << "</TD>";
         }
 

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -1008,6 +1008,7 @@ public:
                 bool annotate_paths = false,
                 bool show_mappings = false,
                 bool simple_mode = false,
+                bool noseq_mode = false,
                 bool invert_edge_ports = false,
                 bool color_variants = false,
                 bool ultrabubble_labeling = false,


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * "no sequence" mode using `vg view -du` where the node sequence is replaced by its size, e.g. to visualize large graphs with dot

## Description

It is sometimes difficult to visualize large regions using `vg view -d`. The image quickly becomes very wide. For example:

![ex view](https://user-images.githubusercontent.com/5704457/90340383-98413280-dfac-11ea-8f2b-72f16f8db6a9.png)

To address that I had been using the simplified view (`vg view -Sd`) after unchopping nodes with `vg mod`. It's more compact but we lose the bi-directed representation which complicates the interpretation when the reverse complements of nodes are involved. For example, for the same region, it looks like there is a cycle around node 2439865:

![ex view S](https://user-images.githubusercontent.com/5704457/90340416-e9512680-dfac-11ea-8da8-7cdb24502a13.png)

The new argument to `vg view`, called `-u`, uses the bi-directed representation but shows the size of a node instead of the full sequence.  I had started tweaking the existing `-S` option but felt bad for destroying a simplified view that some people might like. For example, this view helps us understand that the "cycle" around node 2439865 is actually just a path through the reverse complement:

![ex view u](https://user-images.githubusercontent.com/5704457/90340471-49e06380-dfad-11ea-905a-0bdceb138eeb.png)


