### PR TITLE
Fix position output in single stranded simulation

### DIFF
--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -748,7 +748,7 @@ using namespace std;
         identify_start_subpaths(mp_aln);
         
 #ifdef debug_anchored_surject
-        cerr << "made multipath alignment " << pb2json(mp_aln) << endl;
+        cerr << "made multipath alignment " << debug_string(mp_aln) << endl;
 #endif
         
 #ifdef debug_validate_anchored_multipath_alignment


### PR DESCRIPTION
## Changelog Entry

 * `vg sim -E` now produces correct positions in single-end simulations

## Description

I didn't add an earlier fix for the paired-end output to the single-end code path. PR also includes a tweak to the read length determination for miRNA simulation parameters.