### PR TITLE
vg call option to genotype all snarls

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ vg pack -x x.xg -g aln.gam -Q 5 -o aln.pack
 vg call x.xg -k aln.pack > graph_calls.vcf
 ```
 
-By default, `vg call` omits `0/0` variants and tries to normalize alleles to make the VCF more compact.  Both these steps can make it difficult to compare the outputs from different samples as the VCFs will have different coordinates even though they were created using the same graph.  The `-a` option addresses this by calling every snarl using the same coordinates and including reference calls.
+By default, `vg call` omits `0/0` variants and tries to normalize alleles to make the VCF more compact.  Both these steps can make it difficult to compare the outputs from different samples as the VCFs will have different coordinates even though they were created using the same graph.  The `-a` option addresses this by calling every snarl using the same coordinates and including reference calls.  Outputs for different samples can be combined with `bcftools merge -m all`.   
 ```
 vg call x.xg -k aln.pack -a > snarl_genotypes.vcf
 ```

--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ vg pack -x x.xg -g aln.gam -Q 5 -o aln.pack
 vg call x.xg -k aln.pack > graph_calls.vcf
 ```
 
+By default, `vg call` omits `0/0` variants and tries to normalize alleles to make the VCF more compact.  Both these steps can make it difficult to compare the outputs from different samples as the VCFs will have different coordinates even though they were created using the same graph.  The `-a` option addresses this by calling every snarl using the same coordinates and including reference calls.
+```
+vg call x.xg -k aln.pack -a > snarl_genotypes.vcf
+```
+
 In order to also consider *novel* variants from the reads, use the augmented graph and gam (as created in the previous example using `vg augment -A`):
 
 ```sh

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -353,7 +353,7 @@ void VCFOutputCaller::emit_variant(const PathPositionHandleGraph& graph, SnarlCa
     // add some support info
     snarl_caller.update_vcf_info(snarl, site_traversals, site_genotype, call_info, sample_name, out_variant);
 
-    if (!genotype_snarls || !out_variant.alt.empty()) {
+    if (genotype_snarls || !out_variant.alt.empty()) {
         add_variant(out_variant);
     }
 }

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -88,7 +88,7 @@ protected:
     void emit_variant(const PathPositionHandleGraph& graph, SnarlCaller& snarl_caller,
                       const Snarl& snarl, const vector<SnarlTraversal>& called_traversals,
                       const vector<int>& genotype, int ref_trav_idx, const unique_ptr<SnarlCaller::CallInfo>& call_info,
-                      const string& ref_path_name, int ref_offset) const;
+                      const string& ref_path_name, int ref_offset, bool genotype_snarls) const;
 
     /// get the interval of a snarl from our reference path using the PathPositionHandleGraph interface
     /// the bool is true if the snarl's backward on the path
@@ -96,7 +96,8 @@ protected:
                                                                                const string& ref_path_name) const;
 
     /// clean up the alleles to not share common prefixes / suffixes
-    void flatten_common_allele_ends(vcflib::Variant& variant, bool backward) const;
+    /// if len_override given, just do that many bases without thinking
+    void flatten_common_allele_ends(vcflib::Variant& variant, bool backward, size_t len_override) const;
     
     /// output vcf
     mutable vcflib::VariantCallFile output_vcf;
@@ -106,6 +107,9 @@ protected:
 
     /// output buffers (1/thread) (for sorting)
     mutable vector<vector<vcflib::Variant>> output_variants;
+
+    /// print up to this many uncalled alleles when doing ref-genotpes in -a mode
+    size_t max_uncalled_alleles = 5;
 };
 
 /**
@@ -306,7 +310,8 @@ public:
                AlignmentEmitter* aln_emitter,
                bool traversals_only,
                bool gaf_output,
-               size_t trav_padding);
+               size_t trav_padding,
+               bool genotype_snarls);
    
     virtual ~FlowCaller();
 
@@ -342,6 +347,11 @@ protected:
 
     /// toggle whether to output vcf or gaf
     bool gaf_output;
+
+    /// toggle whether to genotype every snarl
+    /// (by default, uncalled snarls are skipped, and coordinates are flattened
+    ///  out to minimize variant size -- this turns all that off)
+    bool genotype_snarls;
 };
 
 

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 11
+plan tests 12
 
 # Toy example of hand-made pileup (and hand inspected truth) to make sure some
 # obvious (and only obvious) SNPs are detected by vg call
@@ -80,6 +80,13 @@ DIFF_COUNT=$(diff -y --suppress-common-lines baseline_gts1.txt gts1.txt | grep '
 LESS_EIGHT=$(if (( $DIFF_COUNT <= 8 )); then echo 1; else echo 0; fi)
 is "${LESS_EIGHT}" "1" "Fewer than 8 differences between called haploid and truncated true SV genotypes"
 
+# call all the snarls with -a
+vg call HGSVC_alts.xg -k HGSVC_alts.pack -s HG00514 -a > HGSVC2.vcf
+REF_COUNT_V=$(grep "0/0" HGSVC.vcf | wc -l)
+REF_COUNT_A=$(grep "0/0" HGSVC2.vcf | wc -l)
+# this probably doesn't need to be exact (coincidence?), but it works now
+is "${REF_COUNT_V}" "${REF_COUNT_A}" "Same number of reference calls with -a as with -v"
+
 # Output snarl traversals into a GBWT then genotype that
 vg call HGSVC_alts.xg -k HGSVC_alts.pack -s HG00514 -T | gzip > HGSVC_travs.gaf.gz
 vg index HGSVC_alts.xg -F HGSVC_travs.gaf.gz -G HGSVC_travs.gbwt
@@ -99,7 +106,7 @@ LESS_THREE=$(if (( $DIFF_COUNT < 3 )); then echo 1; else echo 0; fi)
 # there is some wobble here
 is "${LESS_THREE}" "1" "Fewer than 3 differences between allales called via traversals or directly"
 
-rm -f HGSVC_alts.vg HGSVC_alts.xg HGSVC_alts.pack HGSVC.vcf baseline_gts.txt gts.txt HGSVC1.vcf HGSVC_travs.gaf.gz HGSVC_travs.gbwt HGSVC_travs.vcf HGSVC_direct.vcf baseline_gts1.txt gts1.txt gts-travs.txt gts-direct.txt calls-travs.txt calls-direct.txt
+rm -f HGSVC_alts.vg HGSVC_alts.xg HGSVC_alts.pack HGSVC.vcf baseline_gts.txt gts.txt HGSVC1.vcf HGSVC2.vcf HGSVC_travs.gaf.gz HGSVC_travs.gbwt HGSVC_travs.vcf HGSVC_direct.vcf baseline_gts1.txt gts1.txt gts-travs.txt gts-direct.txt calls-travs.txt calls-direct.txt
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz > x.vg
 vg index -x x.xg x.vg -L


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * New option `-a` for `vg call` calls every snarl including `0/0` calls.  It can be used to compare and merge VCFs from multiple samples called against the same graph.  

## Description

When the same graph is called with different samples, a given snarl could be present in one and absent in another.  Making it more confusing, it could be present in both with different start positions due to normalizing.  So `vg call -a` makes every effort to ensure that all snarls are called with the same positions no matter what's in the reads.  This way if two VCFs are created with `vg call -a` on the same graph, they should be trivial to merge with `bcftools merge`.  