### PR TITLE
Trim extensions

### DIFF
--- a/src/gapless_extender.cpp
+++ b/src/gapless_extender.cpp
@@ -711,7 +711,7 @@ bool GaplessExtender::full_length_extensions(const std::vector<GaplessExtension>
     }
 
     for (auto& ext : result) {
-        if (ext.full()) {
+        if (!ext.full()) {
             // If any extension isn't full length, they aren't all full length.
             return false;
         }

--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -182,6 +182,17 @@ public:
     static bool full_length_extensions(const std::vector<GaplessExtension>& result, size_t max_mismatches = MAX_MISMATCHES);
 
     /**
+     * Trim mismatches from the extension to maximize the score. Returns true
+     * if the extension was trimmed.
+     */
+    static bool trim_mismatches(GaplessExtension& extension, const gbwtgraph::CachedGBWTGraph& graph, const Aligner& aligner);
+
+    /**
+     * Sort the extensions from left to right. Remove duplicates and empty extensions.
+     */
+    static void remove_duplicates(std::vector<GaplessExtension>& result);
+
+    /**
      * Find the distinct local haplotypes in the given subgraph and return the corresponding paths.
      * For each path haplotype_paths[i], the output graph will contain node 2i + 1 with sequence
      * corresponding to the path and node 2i + 2 with the reverse complement of the sequence.

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2827,7 +2827,7 @@ double MinimizerMapper::get_prob_of_disruption_in_column(const vector<Minimizer>
 #endif
     for (auto it = disrupt_begin; it != disrupt_end; ++it) {
         // For each minimizer to disrupt
-        auto m = minimizers[*it];
+        auto& m = minimizers[*it];
         
 #ifdef debug
         cerr << "\t\tRelative rank " << (it - disrupt_begin) << " is minimizer " << m.value.key.decode(m.length) << endl;

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2902,7 +2902,7 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
     // Find all seeds in the subgraph and try to get a full-length extension.
     GaplessExtender::cluster_type seeds = this->seeds_in_subgraph(minimizers, rescue_nodes);
     std::vector<GaplessExtension> extensions = this->extender.extend(seeds, rescued_alignment.sequence(), &cached_graph);
-    trim_extensions(extensions);
+    trim_extensions(extensions, &cached_graph);
 
     // If we have a full-length extension, use it as the rescued alignment.
     if (GaplessExtender::full_length_extensions(extensions)) {
@@ -3492,156 +3492,26 @@ int MinimizerMapper::score_extension_group(const Alignment& aln, const vector<Ga
 
 }
 
-void MinimizerMapper::trim_extension(GaplessExtension& extension) const {
-    // Grab an aligner we can get scores from.
-    const Aligner* aligner = this->get_regular_aligner();
+void MinimizerMapper::trim_extensions(vector<GaplessExtension>& extensions, gbwtgraph::CachedGBWTGraph* cache) const {
 
-    // We need to remember how many bases we trim off the left and right for rewriting the path and the GBWT search state (if needed)
-    size_t left_trimmed = 0;
-    size_t right_trimmed = 0;
-
-    // Trim suffix. A negative-score suffix must start at a mismatch, so we go
-    // back through the mismatches to find the first one that gives a
-    // negative-score suffix, computing score from the end left.
-    int64_t suffix_score = 0;
-    if (extension.right_full) {
-        suffix_score += aligner->full_length_bonus;
+    unique_ptr<gbwtgraph::CachedGBWTGraph> local_cache;
+    if (cache == nullptr) {
+        // Use a local cache
+        local_cache = std::make_unique<gbwtgraph::CachedGBWTGraph>(gbwt_graph);
+        cache = local_cache.get();
     }
-    // What base in the read have we computed up/back through? May be off the end of the read.
-    // Read interval end is exclusive
-    size_t done_through = extension.read_interval.second;
-
-    // What's the mismatch at and after which we want to cut off the suffix? If no such position, use rend().
-    auto cut_suffix = extension.mismatch_positions.rend();
-
-    for (auto it = extension.mismatch_positions.rbegin(); it != extension.mismatch_positions.rend(); ++it) {
-        if (*it+1 < done_through) {
-            // Account for any matches from *it+1 to just before done_through (i.e. from where we were before up to this mismatch)
-            suffix_score += aligner->match * (done_through - (*it+1));
-        }
-        // Penalize for this mismatch
-        suffix_score -= aligner->mismatch;
-
-        if (suffix_score < 0) {
-            // This is a new earlier nexative-score suffix to drop.
-            cut_suffix = it;
-        }
+    
+    bool trimmed = false;
+    for (GaplessExtension& extension : extensions) {
+        trimmed |= GaplessExtender::trim_mismatches(extension, *cache, *(get_regular_aligner()));
     }
-
-    if (cut_suffix != extension.mismatch_positions.rend()) {
-        // We found a negative-score suffix to cut off. Do it.
-
-        // Work out how many bases we are trimming
-        right_trimmed = extension.read_interval.second - *cut_suffix;
-        
-        // Note where we stop now
-        extension.read_interval.second = *cut_suffix;
-        // It definitely isn't the end
-        extension.right_full = false;
-        // Make the reverse iterator forward and erase from there to end
-        extension.mismatch_positions.erase(cut_suffix.base(), extension.mismatch_positions.end());
-    }
-
-    // Now do the negative score prefixes
-    size_t prefix_score = 0;
-    if (extension.left_full) {
-        prefix_score += aligner->full_length_bonus;
-    }
-
-    done_through = 0;
-
-    // What's the mismatch at and before which we want to cut off the prefix? If no such position, use end().
-    auto cut_prefix = extension.mismatch_positions.end();
-
-    for (auto it = extension.mismatch_positions.begin(); it != extension.mismatch_positions.end(); ++it) {
-        if (*it > done_through) {
-            // Account for any matches from done_through to just before *it (i.e. from where we were before up to this mismatch)
-            prefix_score += aligner->match * (*it - done_through);
-        }
-        // Penalize for this mismatch
-        prefix_score -= aligner->mismatch;
-
-        if (prefix_score < 0) {
-            // This is a new later nexative-score prefix to drop.
-            cut_prefix = it;
-        }
-    }
-
-    if (cut_prefix != extension.mismatch_positions.end()) {
-        // We found a negative-score prefix to cut off. Do it.
-
-        // Work out how many bases we are trimming
-        left_trimmed = *cut_prefix + 1 - extension.read_interval.first;
-        
-        // Note where we start now
-        extension.read_interval.first = *cut_prefix + 1;
-        // It definitely isn't the beginning
-        extension.left_full = false;
-        // Erase from start to there, inclusive
-        extension.mismatch_positions.erase(extension.mismatch_positions.begin(), cut_prefix + 1);
-    }
-
-    // Now we need to fix up the path
-    bool path_modified = false;
-    if (left_trimmed > 0) {
-        // We may need to drop from the start of ther path
-        size_t remaining_dropped_bases = left_trimmed;
-
-        auto drop_up_to = extension.path.begin();
-        while (remaining_dropped_bases != 0) {
-            assert(drop_up_to != extension.path.end());
-            // Work out how many bases we can drop by dropping the next item
-            size_t can_drop = gbwt_graph.get_length(*drop_up_to) - extension.offset;
-            if (can_drop > remaining_dropped_bases) {
-                // Just need to adjust the offset instead.
-                extension.offset += remaining_dropped_bases;
-                remaining_dropped_bases = 0;
-            } else {
-                // Need to drop the whole node.
-                extension.offset = 0;
-                remaining_dropped_bases -= can_drop;
-            }
-            ++drop_up_to;
-        }
-
-        // Note if we are actually modifying the path at all (and need to redo the GBWTState)
-        path_modified = (drop_up_to != extension.path.begin());
-        
-        // Erase what we must of the path, if anything.
-        extension.path.erase(extension.path.begin(), drop_up_to);
-    }
-
-    if (right_trimmed > 0) {
-        // We need to walk back the end of the path but we don't know how much of the last node wasn't in use before.
-
-        // Just find the iterator on the path that contains the last base of the trimmed-down interval
-        size_t length_seen = 0;
-        auto it = extension.path.begin();
-        while (length_seen < (extension.read_interval.second - extension.read_interval.first) + extension.offset) {
-            // Until we've seen all the bases we actually need in the path, collect nodes into the part we keep
-            assert(it != extension.path.end());
-            length_seen += gbwt_graph.get_length(*it);
-            ++it;
-        }
-
-        // Note if we're modifying the path
-        path_modified |= (it != extension.path.end());
-
-        // Erase what we didn't need
-        extension.path.erase(it, extension.path.end());
-    }
-
-    if (path_modified) {
-        // Now we need to fix up the GBWT state, if we changed the path.
-        // We don't have retract, so just search up the whole path again.
-        extension.state = gbwt_graph.bd_find(extension.path); 
-    }
-}
-
-void MinimizerMapper::trim_extensions(vector<GaplessExtension>& extensions) const {
-    for (auto& e : extensions) {
-        // Trim each extension in the list.
-        trim_extension(e);
+    if (trimmed) {
+        GaplessExtender::remove_duplicates(extensions);
+        // Re-sort by goodness
+        std::sort(extensions.begin(), extensions.end(), [&](const GaplessExtension& a, const GaplessExtension b) {
+            // Return true if a must come before b because it is better
+            return a.score > b.score; 
+        });
     }
 }
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -21,9 +21,9 @@
 #include <algorithm>
 #include <cmath>
 
-#define debug
+//#define debug
 //#define print_minimizers
-#define debug_dump_graph
+//#define debug_dump_graph
 
 namespace vg {
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -3507,11 +3507,8 @@ void MinimizerMapper::trim_extensions(vector<GaplessExtension>& extensions, gbwt
     }
     if (trimmed) {
         GaplessExtender::remove_duplicates(extensions);
-        // Re-sort by goodness
-        std::sort(extensions.begin(), extensions.end(), [&](const GaplessExtension& a, const GaplessExtension b) {
-            // Return true if a must come before b because it is better
-            return a.score > b.score; 
-        });
+        // Leave sorted by order along the read, because if any got trimmed
+        // they aren't all full length anymore.
     }
 }
 

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -464,11 +464,10 @@ protected:
     
     /**
      * Operating on the given input alignment, align the tails dangling off the
-     * given extended perfect-match seeds and produce an optimal alignment into
-     * the given output Alignment object, best, and the second best alignment
-     * into second_best.
+     * given extended perfect-match seeds and produce an optimal alignment and
+     * a second best alignment, plus more if more full-length extensions exist.
      */
-    void find_optimal_tail_alignments(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, Alignment& best, Alignment& second_best) const; 
+    void find_optimal_tail_alignments(const Alignment& aln, const vector<GaplessExtension>& extended_seeds, vector<Alignment>& out) const; 
     
     /**
      * Find for each pair of extended seeds all the haplotype-consistent graph

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -265,14 +265,10 @@ protected:
     void score_cluster(Cluster& cluster, size_t i, const std::vector<Minimizer>& minimizers, const std::vector<Seed>& seeds, size_t seq_length, Funnel& funnel) const;
 
     /**
-     * Trim off negative-score prefixes and suffixes of the given gapless extension.
-     */
-    void trim_extension(GaplessExtension& extension) const;
-
-    /**
      * Trim off negative-score prefixes and suffixes of all the given gapless extensions.
+     * Can use/share an optional GBWT graph cache.
      */
-    void trim_extensions(vector<GaplessExtension>& extensions) const;
+    void trim_extensions(vector<GaplessExtension>& extensions, gbwtgraph::CachedGBWTGraph* cache = nullptr) const;
     
     /**
      * Score the set of extensions for each cluster using score_extension_group().

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -265,6 +265,16 @@ protected:
     void score_cluster(Cluster& cluster, size_t i, const std::vector<Minimizer>& minimizers, const std::vector<Seed>& seeds, size_t seq_length, Funnel& funnel) const;
 
     /**
+     * Trim off negative-score prefixes and suffixes of the given gapless extension.
+     */
+    void trim_extension(GaplessExtension& extension) const;
+
+    /**
+     * Trim off negative-score prefixes and suffixes of all the given gapless extensions.
+     */
+    void trim_extensions(vector<GaplessExtension>& extensions) const;
+    
+    /**
      * Score the set of extensions for each cluster using score_extension_group().
      * Return the scores in the same order as the extensions.
      */

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -29,7 +29,7 @@
 
 #include <gbwtgraph/minimizer.h>
 
-//#define USE_CALLGRIND
+#define USE_CALLGRIND
 
 #ifdef USE_CALLGRIND
 #include <valgrind/callgrind.h>

--- a/src/unittest/gapless_extender.cpp
+++ b/src/unittest/gapless_extender.cpp
@@ -989,5 +989,65 @@ TEST_CASE("Alignment transformations", "[gapless_extender]") {
 
 //------------------------------------------------------------------------------
 
+TEST_CASE("GaplessExtender::full_length_extensions works", "[gapless_extender]") {
+    
+    // Define a collection of fake GaplessExtensions to inspect
+    vector<GaplessExtension> extensions;
+    
+    SECTION("No gapless extensions means not full length") {
+        REQUIRE(GaplessExtender::full_length_extensions(extensions) == false);
+    }
+    
+    SECTION("One-base extensions not marked as full length aren't") {
+    
+        extensions.emplace_back();
+        extensions.back().read_interval.first = 1;
+        extensions.back().read_interval.second = 2;
+        extensions.back().score = 1;
+        
+        SECTION("A 1-base gapless extension that doesn't abut either read end isn't a full-length set") {
+            REQUIRE(GaplessExtender::full_length_extensions(extensions) == false);
+        }
+        
+        extensions.emplace_back();
+        extensions.back().read_interval.first = 2;
+        extensions.back().read_interval.second = 3;
+        extensions.back().score = 1;
+        
+        SECTION("Two 1-base gapless extensions that doesn't abut either read end isn't a full-length set") {
+            REQUIRE(GaplessExtender::full_length_extensions(extensions) == false);
+        }
+        
+    }
+
+    SECTION("Longer extensions marked as full-length are") {
+    
+        extensions.clear();
+
+        extensions.emplace_back();
+        extensions.back().read_interval.first = 0;
+        extensions.back().read_interval.second = 10;
+        extensions.back().score = 10 + 10; // Matches plus full length bonus
+        extensions.back().left_full = true;
+        extensions.back().right_full = true;
+        
+        SECTION("A single full-length extension is full length") {
+            REQUIRE(GaplessExtender::full_length_extensions(extensions) == true);
+        }
+        
+        // Make another one that has a mismatch
+        extensions.emplace_back(extensions.back());
+        extensions.back().score -= 5;
+        extensions.back().mismatch_positions.push_back(5);
+        
+        SECTION("Two full-length extensions are full length") {
+            REQUIRE(GaplessExtender::full_length_extensions(extensions) == true);
+        }
+        
+    }
+}
+
+//------------------------------------------------------------------------------
+
 }
 }


### PR DESCRIPTION
PR to faster-cap, no independent changelog.

This trims the negative-score prefixes and suffixes of gapless extensions using the method @jltsiren recommended, and adjusts our logic to detect a collection of full-length extensions to cope with the sets being modified.

This fixes stuff like this:

```
000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011111111111111111111111111111111111111111111111111
000000000011111111112222222222333333333344444444445555555555666666666677777777778888888888999999999900000000001111111111222222222233333333334444444444
012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
TAAATAACTATGTATGCACAGCTTTTCCTTCTTTAAAATGATTTCCTTAAAATAAATTCCCAAAACTGGAAAGAATGGATGAAAAAAATGATGTTTTTTATAGCCCTTGATAAATATTGCATATATAAATACTCTCATAATTTGGAAAAT
TAAATAACTATGTATGCACAGCTTTTCC*TCTTTAAAATGATTTCCTTAAAATAAATTCCCAAAA*TGGAAA*AATGGATGAAAAA*ATGATGTTTTTTATAGCCCTTGATAAATATTGCATATATAAATACTCTCATAATTTGGAAAAT @ 200431901 200431902 200431904 200431906 200431907 200431908 200431910 200431912 200431913 200431914 200431916 200431918 200431919 200431920 200431921
TAAATAACTATGTATGCACAGCTTTTCCTTCTTTAAAATGATTTCCTTAAAATAAATTCCCAAAACTGGAAA*AATGGATGAAAAAAATGATGTTTTTTATAGCCCTTGATAAATATTGCATA*ATA****C*****T********A*AT @ 200431901 200431903 200431904 200431906 200431907 200431909 200431910 200431912 200431913 200431915 200431916 200431918 200431919 200431921 200431922 200431924
```

And this:
```
gapless extension group 0 is good enough (score=145)
        CORRECT!
000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011111111111111111111111111111111111111111111111111
000000000011111111112222222222333333333344444444445555555555666666666677777777778888888888999999999900000000001111111111222222222233333333334444444444
012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
ACAATACTGTCCTAAGTGGTCTCTGCCACTACCCCTGTACCCCTAGTCGGACCTCCATGTAGCAGCCAGAGTGATTCTTATAAAATGTAACTCAGAGTATATTACAGGAACTTCCCCATTCAGAACCCTTCAATGGAATCTCTTCTCATT
***ATACTGTCCTAAGTGGTCTCTGCCACTACCCCTGTACCCCTAGTCGGACCTCCATGTAGCAGCCAGAGTGATTCTTATAAAATGTAACTCAGAGTATATTACAGGAACTTCCCCATTCAGAACCCTTCAATGGAATCTCTTCTCATT @ 224615187 224615189 224615190 224615192 224615193 224615195 224615196 224615198 224615199 224615201 224615202 224615203 224615204 224615206 224615207
```
