### PR TITLE
Resize mapq vector if needed

### DIFF
--- a/src/subcommand/gamcompare_main.cpp
+++ b/src/subcommand/gamcompare_main.cpp
@@ -197,6 +197,11 @@ int main_gamcompare(int argc, char** argv) {
                 }
                 auto mapq = aln.mapping_quality();
                 if (mapq) {
+                    if (mapq >= mapq_count_by_thread.at(omp_get_thread_num()).size()) {
+                        mapq_count_by_thread.at(omp_get_thread_num()).resize(mapq+1);
+                        correct_count_by_mapq_by_thread.at(omp_get_thread_num()).resize(mapq+1);
+                    }
+
                     read_count_by_thread.at(omp_get_thread_num()) += 1;
                     mapq_count_by_thread.at(omp_get_thread_num()).at(mapq) += 1;
                     if (correctly_mapped) {
@@ -257,7 +262,12 @@ int main_gamcompare(int argc, char** argv) {
         vector<size_t> correct_count_by_mapq (61, 0);
         for (size_t i = 0 ; i < get_thread_count() ; i++) {
             total_reads += read_count_by_thread.at(i);
-            for (size_t mq = 0 ; mq < 61 ; mq++) {
+            for (size_t mq = 0 ; mq < mapq_count_by_thread.at(i).size() ; mq++) {
+                if (mq >= mapq_count.size()) {
+                    mapq_count.resize(mq+1);
+                    correct_count_by_mapq.resize(mq+1);
+                }
+
                 mapq_count.at(mq) += mapq_count_by_thread.at(i).at(mq);
                 correct_count_by_mapq.at(mq) += correct_count_by_mapq_by_thread.at(i).at(mq);
             }
@@ -265,7 +275,7 @@ int main_gamcompare(int argc, char** argv) {
         size_t accumulated_count = 0;
         size_t accumulated_correct_count = 0;
         float mapping_goodness_score = 0.0;
-        for (int i = 60 ; i >= 0 ; i--) {
+        for (int i = mapq_count.size() ; i >= 0 ; i--) {
             accumulated_count += mapq_count[i];
             accumulated_correct_count += correct_count_by_mapq[i];
             double fraction_incorrect = accumulated_count == 0 ? 0.0 :


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fix bug in gamcompare that caused segfault

## Description
Gamcompare used to assumed that mapqs only go up to 60, now it can accept higher mapqs