### PR TITLE
GAF support for vg paths

### DIFF
--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -174,7 +174,7 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
                 // to work correctly, and must be passed in only via find_packed_breakpoints.
                 find_breakpoints(simplified_path, breakpoints, break_at_ends, "", 0, 1.);
             }
-        }, false, packed_mode && get_thread_count() > 1);
+        }, false, packed_mode);
 
     if (packed_mode) {
         // Filter the breakpoints by coverage

--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -174,7 +174,7 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
                 // to work correctly, and must be passed in only via find_packed_breakpoints.
                 find_breakpoints(simplified_path, breakpoints, break_at_ends, "", 0, 1.);
             }
-        }, false, packed_mode);
+        }, false, packed_mode && get_thread_count() > 1);
 
     if (packed_mode) {
         // Filter the breakpoints by coverage

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -50,7 +50,7 @@ void help_augment(char** argv, ConfigurableParser& parser) {
          << "    -B, --label-paths           don't augment with alignments, just use them for labeling the graph" << endl
          << "    -Z, --translation FILE      save translations from augmented back to base graph to FILE" << endl
          << "    -A, --alignment-out FILE    save augmented GAM reads to FILE" << endl
-         << "    -F, --gaf                   expect GAF instead of GAFM" << endl
+         << "    -F, --gaf                   expect GAF instead of GAM" << endl
          << "    -s, --subgraph              graph is a subgraph of the one used to create GAM. ignore alignments with missing nodes" << endl
          << "    -m, --min-coverage N        minimum coverage of a breakpoint required for it to be added to the graph" << endl
          << "    -c, --expected-cov N        expected coverage.  used only for memory tuning [default : 128]" << endl

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -50,6 +50,7 @@ void help_augment(char** argv, ConfigurableParser& parser) {
          << "    -B, --label-paths           don't augment with alignments, just use them for labeling the graph" << endl
          << "    -Z, --translation FILE      save translations from augmented back to base graph to FILE" << endl
          << "    -A, --alignment-out FILE    save augmented GAM reads to FILE" << endl
+         << "    -F, --gaf                   expect GAF instead of GAM" << endl
          << "    -s, --subgraph              graph is a subgraph of the one used to create GAM. ignore alignments with missing nodes" << endl
          << "    -m, --min-coverage N        minimum coverage of a breakpoint required for it to be added to the graph" << endl
          << "    -c, --expected-cov N        expected coverage.  used only for memory tuning [default : 128]" << endl

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -50,7 +50,6 @@ void help_augment(char** argv, ConfigurableParser& parser) {
          << "    -B, --label-paths           don't augment with alignments, just use them for labeling the graph" << endl
          << "    -Z, --translation FILE      save translations from augmented back to base graph to FILE" << endl
          << "    -A, --alignment-out FILE    save augmented GAM reads to FILE" << endl
-         << "    -F, --gaf                   expect GAF instead of GAM" << endl
          << "    -s, --subgraph              graph is a subgraph of the one used to create GAM. ignore alignments with missing nodes" << endl
          << "    -m, --min-coverage N        minimum coverage of a breakpoint required for it to be added to the graph" << endl
          << "    -c, --expected-cov N        expected coverage.  used only for memory tuning [default : 128]" << endl

--- a/test/t/11_vg_paths.t
+++ b/test/t/11_vg_paths.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order 
 
-plan tests 13
+plan tests 14
 
 vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
 vg construct -r small/x.fa -v small/x.vcf.gz > x2.vg
@@ -25,6 +25,9 @@ is $(vg paths --list -S 2 -g x.gbwt | wc -l) 0 "no threads are reported for inva
 
 # Extract threads as alignments
 is $(vg paths -x x.xg -g x.gbwt -X | vg view -a -  | wc -l) 2 "vg paths may be used to extract threads"
+
+# Extract threads as GAF alignments
+is $(vg paths -x x.xg -g x.gbwt -A | wc -l) 2 "vg paths may be used to extract threads as GAF"
 
 # Extract paths as fasta
 vg paths -x x.xg -Q x -F > x_from_xg.fa


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * new option `-A` in `vg paths` to output GAF

## Description

Also hacks `vg augment -t 1` to use single-thread GAM reader which will avoid message-to-long porotbuf errors.
