### PR TITLE
[WIP] Gaf support in vg augment

### DIFF
--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -174,7 +174,7 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
                 // to work correctly, and must be passed in only via find_packed_breakpoints.
                 find_breakpoints(simplified_path, breakpoints, break_at_ends, "", 0, 1.);
             }
-        }, false, packed_mode);
+        }, false, packed_mode && get_thread_count() > 1);
 
     if (packed_mode) {
         // Filter the breakpoints by coverage

--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -1,10 +1,10 @@
 #include "vg.hpp"
 #include <vg/io/stream.hpp>
+#include <vg/io/alignment_emitter.hpp>
 
 #include "augment.hpp"
 #include "alignment.hpp"
 #include "packer.hpp"
-
 //#define debug
 
 using namespace vg::io;
@@ -15,9 +15,10 @@ using namespace std;
 
 // The correct way to edit the graph
 void augment(MutablePathMutableHandleGraph* graph,
-             istream& gam_stream,
+             const string& gam_path,
+             const string& aln_format,
              vector<Translation>* out_translations,
-             ostream* gam_out_stream,
+             const string& gam_out_path,
              bool embed_paths,
              bool break_at_ends,
              bool remove_softclips,
@@ -28,23 +29,58 @@ void augment(MutablePathMutableHandleGraph* graph,
              size_t min_bp_coverage,
              double max_frac_n) {
 
+    // memory-wasting hack: we need node lengths from the original graph in order to parse the GAF.  Unlesss we
+    // store them, they will be lost in the 2nd pass
+    unordered_map<nid_t, int64_t> id_to_length;
+    if (aln_format == "GAF") {
+        graph->for_each_handle([&](handle_t handle) {
+                id_to_length[graph->get_id(handle)] = graph->get_length(handle);
+            });
+    }
+
     function<void(function<void(Alignment&)>, bool, bool)> iterate_gam =
-        [&gam_stream] (function<void(Alignment&)> aln_callback, bool reset_stream, bool parallel) {
-        if (reset_stream) {
-            gam_stream.clear();
-            gam_stream.seekg(0, ios_base::beg);
-        }
-        if (parallel) {
-            vg::io::for_each_parallel(gam_stream, aln_callback, Packer::estimate_batch_size(get_thread_count()));
+        [&gam_path, &aln_format, &graph, &packer, &id_to_length] (function<void(Alignment&)> aln_callback, bool second_pass, bool parallel) {
+        if (aln_format == "GAM") {
+            get_input_file(gam_path, [&](istream& gam_stream) {
+                    if (parallel && false) {
+                        vg::io::for_each_parallel(gam_stream, aln_callback, Packer::estimate_batch_size(get_thread_count()));
+                    } else {
+                        vg::io::for_each(gam_stream, aln_callback);
+                    }
+                });
         } else {
-            vg::io::for_each(gam_stream, aln_callback);
+            assert(aln_format == "GAF");
+            function<size_t(nid_t)> node_to_length;
+            function<string(nid_t, bool)> node_to_sequence;
+            if (second_pass) {
+                // graph has changed, need to fall back on our table we saved from the original graph
+                node_to_length = [&id_to_length](nid_t node_id) {
+                    return id_to_length[node_id];
+                };
+                // try to do without sequences
+                node_to_sequence = nullptr;
+            } else {
+                // graph is valid on the first pass
+                node_to_length = [&graph](nid_t node_id) {
+                    return graph->get_length(graph->get_handle(node_id));
+                };
+                node_to_sequence = [&graph](nid_t node_id, bool is_reversed) {
+                    return graph->get_sequence(graph->get_handle(node_id, is_reversed));
+                };
+            }
+            if (parallel) {
+                vg::io::gaf_unpaired_for_each_parallel(node_to_length, node_to_sequence, gam_path, aln_callback);
+            } else {
+                vg::io::gaf_unpaired_for_each(node_to_length, node_to_sequence, gam_path, aln_callback);
+            }
         }
     };
 
-    augment_impl(graph,
+    augment_impl(graph,                 
                  iterate_gam,
+                 aln_format,
                  out_translations,
-                 gam_out_stream,
+                 gam_out_path,
                  embed_paths,
                  break_at_ends,
                  remove_softclips,
@@ -58,8 +94,9 @@ void augment(MutablePathMutableHandleGraph* graph,
 
 void augment(MutablePathMutableHandleGraph* graph,
              vector<Path>& path_vector,
+             const string& aln_format,
              vector<Translation>* out_translations,
-             ostream* gam_out_stream,
+             const string& gam_out_path,
              bool embed_paths,
              bool break_at_ends,
              bool remove_softclips,
@@ -71,7 +108,7 @@ void augment(MutablePathMutableHandleGraph* graph,
              double max_frac_n) {
     
     function<void(function<void(Alignment&)>, bool, bool)> iterate_gam =
-        [&path_vector] (function<void(Alignment&)> aln_callback, bool reset_stream, bool parallel) {
+        [&path_vector] (function<void(Alignment&)> aln_callback, bool second_pass, bool parallel) {
         if (parallel) {
 #pragma omp parallel for
             for (size_t i = 0; i < path_vector.size(); ++i) {
@@ -95,8 +132,9 @@ void augment(MutablePathMutableHandleGraph* graph,
 
     augment_impl(graph,
                  iterate_gam,
+                 aln_format,
                  out_translations,
-                 gam_out_stream,
+                 gam_out_path,
                  embed_paths,
                  break_at_ends,
                  remove_softclips,
@@ -129,9 +167,10 @@ static inline bool check_in_graph(const Path& path, const unordered_map<id_t, si
 }
 
 void augment_impl(MutablePathMutableHandleGraph* graph,
-                  function<void(function<void(Alignment&)>, bool, bool)> iterate_gam,
+                  function<void(function<void(Alignment&)>,bool, bool)> iterate_gam,
+                  const string& aln_format,                  
                   vector<Translation>* out_translations,
-                  ostream* gam_out_stream,
+                  const string& gam_out_path,
                   bool embed_paths,
                   bool break_at_ends,
                   bool remove_softclips,
@@ -174,7 +213,7 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
                 // to work correctly, and must be passed in only via find_packed_breakpoints.
                 find_breakpoints(simplified_path, breakpoints, break_at_ends, "", 0, 1.);
             }
-        }, false, packed_mode && get_thread_count() > 1);
+        }, false, packed_mode);
 
     if (packed_mode) {
         // Filter the breakpoints by coverage
@@ -206,8 +245,12 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
     unordered_map<pair<pos_t, string>, vector<id_t>> added_seqs;
     // we will record the nodes that we add, so we can correctly make the returned translation
     unordered_map<id_t, Path> added_nodes;
-    // output gam buffer
-    vector<Alignment> gam_buffer;
+    // output alignment emitter and buffer
+    unique_ptr<vg::io::AlignmentEmitter> aln_emitter;
+    if (!gam_out_path.empty()) {
+        aln_emitter = vg::io::get_non_hts_alignment_emitter(gam_out_path, aln_format, {}, get_thread_count(), graph);
+    }
+    vector<Alignment> aln_buffer;
 
     // Second pass: add the nodes and edges
     iterate_gam((function<void(Alignment&)>)[&](Alignment& aln) {
@@ -235,7 +278,7 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
 
             // Now go through each new path again, by reference so we can overwrite.
             // but only if we have a reason to
-            if (has_edits || gam_out_stream != nullptr || embed_paths) {
+            if (has_edits || !gam_out_path.empty() || embed_paths) {
 
                 // Create new nodes/wire things up. Get the added version of the path.
                 Path added = add_nodes_and_edges(graph, simplified_path, node_translation, added_seqs,
@@ -263,16 +306,19 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
                 }
 
                 // optionally write out the modified path to GAM
-                if (gam_out_stream != nullptr) {
+                if (!gam_out_path.empty()) {
                     *aln.mutable_path() = added;
-                    gam_buffer.push_back(aln);
-                    vg::io::write_buffered(*gam_out_stream, gam_buffer, 100);
+                    aln_buffer.push_back(aln);
+                    if (aln_buffer.size() >= 100) {
+                        aln_emitter->emit_singles(vector<Alignment>(aln_buffer));
+                        aln_buffer.clear();
+                    }
                 }
             }
         }, true, false);
-    if (gam_out_stream != nullptr) {
+    if (!aln_buffer.empty()) {
         // Flush the buffer
-        vg::io::write_buffered(*gam_out_stream, gam_buffer, 0);
+        aln_emitter->emit_singles(vector<Alignment>(aln_buffer));
     }
 
     // perform the same check as above, but on the paths that were already in the graph

--- a/src/augment.hpp
+++ b/src/augment.hpp
@@ -21,8 +21,11 @@ using namespace std;
 /// this method sorts the graph and rebuilds the path index, so it should
 /// not be called in a loop.
 ///
-/// If gam_out_stream is not null, the paths will be modified to reflect their
-/// embedding in the modified graph and written to the stream.
+/// if gam_path is "-", then stdin used
+/// if gam_out_path is "-", then stdout used
+/// If gam_out_path is not empty, the paths will be modified to reflect their
+/// embedding in the modified graph and written to the path.
+/// aln_format used to toggle between GAM and GAF
 /// If out_translation is not null, a list of translations, one per node existing
 /// after the edit, describing
 /// how each new or conserved node is embedded in the old graph. 
@@ -41,9 +44,10 @@ using namespace std;
 /// If a breakpoint has less than min_bp_coverage it is not included in the graph
 /// Edits with more than max_frac_n N content will be ignored
 void augment(MutablePathMutableHandleGraph* graph,
-             istream& gam_stream,
+             const string& gam_path,
+             const string& aln_format = "GAM",
              vector<Translation>* out_translation = nullptr,
-             ostream* gam_out_stream = nullptr,
+             const string& gam_out_path = "",
              bool embed_paths = false,
              bool break_at_ends = false,
              bool remove_soft_clips = false,
@@ -54,12 +58,13 @@ void augment(MutablePathMutableHandleGraph* graph,
              size_t min_bp_coverage = 0,
              double max_frac_n = 1.);
 
-/// Like above, but operates on a vector of Alignments, instead of a stream
-/// (Note: It is best to use stream interface for large numbers of alignments to save memory)
+/// Like above, but operates on a vector of Alignments, instead of a file
+/// (Note: It is best to use file interface to stream large numbers of alignments to save memory)
 void augment(MutablePathMutableHandleGraph* graph,
              vector<Path>& path_vector,
+             const string& aln_format = "GAM",
              vector<Translation>* out_translation = nullptr,
-             ostream* gam_out_stream = nullptr,
+             const string& gam_out_path = "",
              bool embed_paths = false,
              bool break_at_ends = false,
              bool remove_soft_clips = false,
@@ -70,11 +75,12 @@ void augment(MutablePathMutableHandleGraph* graph,
              size_t min_bp_coverage = 0,
              double max_frac_n = 1.);
 
-/// Generic version used to implement the above two methods.  
+/// Generic version used to implement the above three methods.  
 void augment_impl(MutablePathMutableHandleGraph* graph,
                   function<void(function<void(Alignment&)>, bool, bool)> iterate_gam,
+                  const string& aln_format,
                   vector<Translation>* out_translation,
-                  ostream* gam_out_stream,
+                  const string& gam_out_path,
                   bool embed_paths,
                   bool break_at_ends,
                   bool remove_soft_clips,

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -50,7 +50,6 @@ void help_augment(char** argv, ConfigurableParser& parser) {
          << "    -B, --label-paths           don't augment with alignments, just use them for labeling the graph" << endl
          << "    -Z, --translation FILE      save translations from augmented back to base graph to FILE" << endl
          << "    -A, --alignment-out FILE    save augmented GAM reads to FILE" << endl
-         << "    -F, --gaf                   expect GAF instead of GAFM" << endl
          << "    -s, --subgraph              graph is a subgraph of the one used to create GAM. ignore alignments with missing nodes" << endl
          << "    -m, --min-coverage N        minimum coverage of a breakpoint required for it to be added to the graph" << endl
          << "    -c, --expected-cov N        expected coverage.  used only for memory tuning [default : 128]" << endl

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -220,15 +220,17 @@ int main_pack(int argc, char** argv) {
     }
 
     std::function<void(Alignment&)> lambda = [&packer,&min_mapq,&min_baseq](Alignment& aln) {
-            packer.add(aln, min_mapq, min_baseq);
-        };
+        packer.add(aln, min_mapq, min_baseq);
+    };
 
     if (!gam_in.empty()) {
         get_input_file(gam_in, [&](istream& in) {
                 vg::io::for_each_parallel(in, lambda, batch_size);
             });
     } else if (!gaf_in.empty()) {
-        vg::io::gaf_unpaired_for_each_parallel(*graph, gaf_in, lambda, batch_size);
+        // computed batch size was tuned for GAM performance.  some small tests show that
+        // gaf benefits from a slightly larger one. 
+        vg::io::gaf_unpaired_for_each_parallel(*graph, gaf_in, lambda, batch_size * 4);
     }
 
     if (!packs_out.empty()) {

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -322,7 +322,7 @@ int main_paths(int argc, char** argv) {
     unique_ptr<vg::io::ProtobufEmitter<Graph>> graph_emitter;
     if (extract_as_gam || extract_as_gaf) {
         // Open up a GAM/GAF output stream
-        aln_emitter = vg::io::get_non_hts_alignment_emitter("-", extract_as_gaf ? "GAF" : "GAM", {}, 1,
+        aln_emitter = vg::io::get_non_hts_alignment_emitter("-", extract_as_gaf ? "GAF" : "GAM", {}, get_thread_count(),
                                                             graph.get());
     } else if (extract_as_vg || drop_paths || retain_paths) {
         // Open up a VG Graph chunk output stream

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -1250,7 +1250,7 @@ void Transcriptome::augment_splice_graph(list<EditedTranscriptPath> * edited_tra
     if (haplotype_index->empty()) {
 
         // Augment splice graph with edited paths. 
-        augment(static_cast<MutablePathMutableHandleGraph *>(_splice_graph.get()), edited_paths, nullptr, nullptr, false, break_at_transcript_ends);
+        augment(static_cast<MutablePathMutableHandleGraph *>(_splice_graph.get()), edited_paths, "GAM", nullptr, nullptr, false, break_at_transcript_ends);
       
     } else {
 
@@ -1262,7 +1262,7 @@ void Transcriptome::augment_splice_graph(list<EditedTranscriptPath> * edited_tra
 #endif
 
         // Augment splice graph with edited paths. 
-        augment(static_cast<MutablePathMutableHandleGraph *>(_splice_graph.get()), edited_paths, &translations, nullptr, false, break_at_transcript_ends);
+        augment(static_cast<MutablePathMutableHandleGraph *>(_splice_graph.get()), edited_paths, "GAM", &translations, nullptr, false, break_at_transcript_ends);
 
 #ifdef transcriptome_debug
     cerr << "\tDEBUG edit end: " << gcsa::readTimer() - time_edit_1 << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;

--- a/src/variant_recall.cpp
+++ b/src/variant_recall.cpp
@@ -71,7 +71,7 @@ void genotype_svs(VG* graph,
     vg::io::for_each_interleaved_pair_parallel(gamstream, readfunc);
     vector<Translation> transls;
     if (refpath != ""){
-        augment(graph, direct_ins, &transls);
+        augment(graph, direct_ins, "GAM", &transls);
 
         XG xg_index;
         xg_index.from_path_handle_graph(*graph); // Index the graph so deconstruct can get path positions

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -4351,9 +4351,9 @@ void VG::edit(vector<Path>& paths_to_add,
 
 // Streaming edit will use much less memory than the older version (above), at the cost of needing to
 // do multiple passes over the input paths. 
-void VG::edit(istream& paths_to_add,
+void VG::edit(const string& paths_to_add_path,
               vector<Translation>* out_translations,
-              bool save_paths, ostream* out_gam_stream,
+              bool save_paths, const string& out_gam_path,
               bool break_at_ends, bool remove_softclips) {
 
     // If we are going to actually add the paths to the graph, we need to break at path ends
@@ -4363,7 +4363,7 @@ void VG::edit(istream& paths_to_add,
     paths.compact_ranks();
     
     // Augment the graph with the paths, modifying paths in place if update true
-    augment(this, paths_to_add, out_translations, out_gam_stream, save_paths,
+    augment(this, paths_to_add_path, "GAM", out_translations, out_gam_path, save_paths,
             break_at_ends, remove_softclips);
 }
     

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -672,14 +672,15 @@ public:
               bool break_at_ends = false);
 
     /// Streaming version of above.  Instead of reading a list of paths into memory
-    /// all at once, a stream is used to go one-by-one.  Instead of an option to
-    /// updtate the in-memory list, an optional output stream is used
+    /// all at once, a file stream is opened from the given path and used to go one-by-one.
+     /// Instead of an option to
+    /// updtate the in-memory list, an optional output path for the paths is used
     ///
     /// todo: duplicate less code between the two versions. 
-    void edit(istream& paths_to_add,
+    void edit(const string& paths_to_add_path,
               vector<Translation>* out_translations = nullptr,
               bool save_paths = false,
-              ostream* out_path_stream = nullptr,
+              const string& out_gam_path = "",
               bool break_at_ends = false,
               bool remove_softclips = false);
     

--- a/test/t/11_vg_paths.t
+++ b/test/t/11_vg_paths.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order 
 
-plan tests 13
+plan tests 14
 
 vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
 vg construct -r small/x.fa -v small/x.vcf.gz > x2.vg
@@ -25,6 +25,9 @@ is $(vg paths --list -S 2 -g x.gbwt | wc -l) 0 "no threads are reported for inva
 
 # Extract threads as alignments
 is $(vg paths -x x.xg -g x.gbwt -X | vg view -a -  | wc -l) 2 "vg paths may be used to extract threads"
+
+# Extract threads as GAF alignments
+is $(vg paths -x x.xg -g x.gbwt -A | wc -l) 2 "vg paths may be used to extract threads as GAF"
 
 # Extract paths as fasta
 vg paths -x x.xg -Q x -F > x_from_xg.fa

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -1428,7 +1428,7 @@ class VGCITest(TestCase):
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'primary', True)
 
-    @timeout_decorator.timeout(1000)
+    @timeout_decorator.timeout(1200)
     def test_map_mhc_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for MHC snp1kg graph """
         log.info("Test start at {}".format(datetime.now()))

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -1428,7 +1428,7 @@ class VGCITest(TestCase):
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'primary', True)
 
-    @timeout_decorator.timeout(1200)
+    @timeout_decorator.timeout(2000)
     def test_map_mhc_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for MHC snp1kg graph """
         log.info("Test start at {}".format(datetime.now()))

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -1428,7 +1428,7 @@ class VGCITest(TestCase):
         log.info("Test start at {}".format(datetime.now()))
         self._test_bakeoff('MHC', 'primary', True)
 
-    @timeout_decorator.timeout(900)        
+    @timeout_decorator.timeout(1000)
     def test_map_mhc_snp1kg(self):
         """ Indexing, mapping and calling bakeoff F1 test for MHC snp1kg graph """
         log.info("Test start at {}".format(datetime.now()))


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GAF support added to `vg augment`

## Description

Realized why I hadn't done this earlier while testing: on its second pass through the alignment, augment starts editing the graph in place.  But the GAF reader can only read GAF records when it has the matching graph in hand.  So an edit from read `N` can break parsing for read `N+1` and crash everything.  

The way around is to
* keep a  copy of the unaugmented graph around (easy, but pretty terrible) or
* allow gaf parsing without a graph.  this should be doable, but will come at the cost of sanity checking and, if we want to read in the "sequence" field, storing it in the GAF.  Hopefully this will make gaf parsing faster as well.    