### PR TITLE
path traversals option for vg snarls

### DIFF
--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -31,6 +31,7 @@ void help_snarl(char** argv) {
          << "    -A, --algorithm NAME   compute snarls using 'cactus' or 'integrated' algorithms (default: integrated)" << endl
          << "    -p, --pathnames        output variant paths as SnarlTraversals to STDOUT" << endl
          << "    -r, --traversals FILE  output SnarlTraversals for ultrabubbles." << endl
+         << "    -e, --path-traversals  only consider traversals that correspond to paths in the graph. (-m ignored)" << endl
          << "    -l, --leaf-only        restrict traversals to leaf ultrabubbles." << endl
          << "    -o, --top-level        restrict traversals to top level ultrabubbles" << endl
          << "    -a, --any-snarl-type   compute traversals for any snarl type (not limiting to ultrabubbles)" << endl
@@ -64,7 +65,8 @@ int main_snarl(int argc, char** argv) {
     string vcf_filename;
     string ref_fasta_filename;
     string ins_fasta_filename;
-
+    bool path_traversals = false;
+        
     int c;
     optind = 2; // force optind past command positional argument
     while (true) {
@@ -82,13 +84,14 @@ int main_snarl(int argc, char** argv) {
                 {"vcf", required_argument, 0, 'v'},
                 {"fasta", required_argument, 0, 'f'},
                 {"ins-fasta", required_argument, 0, 'i'},
+                {"path-traversals", no_argument, 0, 'e'},                
                 {"threads", required_argument, 0, 't'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "A:sr:laTopm:v:f:i:h?t:",
+        c = getopt_long (argc, argv, "A:sr:laTopm:v:f:i:eh?t:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -141,6 +144,9 @@ int main_snarl(int argc, char** argv) {
         case 'i':
             ins_fasta_filename = optarg;
             break;
+        case 'e':
+            path_traversals = true;
+            break;
 
         case 't':
         {
@@ -190,7 +196,19 @@ int main_snarl(int argc, char** argv) {
     } else if (algorithm == "integrated") {
         snarl_finder.reset(new IntegratedSnarlFinder(*graph));
     } else {
-        cerr << "error:[vg snarl]: Algorithm must be 'cactus' or 'integrated', not '" << algorithm << "'" << endl;
+        cerr << "error:[vg snarls]: Algorithm must be 'cactus' or 'integrated', not '" << algorithm << "'" << endl;
+        return 1;
+    }
+    if (!vcf_filename.empty() && path_traversals) {
+        cerr << "error:[vg snarls]: -v cannot be used with -e" << endl;
+        return 1;
+    }
+    if (path_traversals && traversal_file.empty()) {
+        cerr << "error:[vg snarls]: -e requires -r" << endl;
+        return 1;
+    }
+    if (!vcf_filename.empty() && traversal_file.empty()) {
+        cerr << "error:[vg snarls]: -v requires -r" << endl;
         return 1;
     }
 
@@ -198,7 +216,6 @@ int main_snarl(int argc, char** argv) {
     vcflib::VariantCallFile variant_file;
     unique_ptr<FastaReference> ref_fasta;
     unique_ptr<FastaReference> ins_fasta;
-
     
     if (!vcf_filename.empty()) {
         variant_file.parseSamples = false;
@@ -240,7 +257,10 @@ int main_snarl(int argc, char** argv) {
         exit(0);
     }
 
-    if (vcf_filename.empty()) {
+    if (path_traversals) {
+        // Limit traversals to embedded paths
+        trav_finder.reset(new PathTraversalFinder(*graph, snarl_manager));
+    } else if (vcf_filename.empty()) {
         // This finder works with any backing graph
         trav_finder.reset(new ExhaustiveTraversalFinder(*graph, snarl_manager));
     } else {
@@ -334,7 +354,7 @@ int main_snarl(int argc, char** argv) {
                 (!ultrabubble_only || snarl->type() == ULTRABUBBLE) &&
                 (!leaf_only || snarl_manager.is_leaf(snarl)) &&
                 (!top_level_only || snarl_manager.is_root(snarl)) &&
-                (check_max_nodes(snarl_manager.deep_contents(snarl, *graph, true).first))) { 
+                (path_traversals || check_max_nodes(snarl_manager.deep_contents(snarl, *graph, true).first))) { 
                 
 #ifdef debug
                 cerr << "Look for traversals of " << pb2json(*snarl) << endl;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg snarls -e` will output a traversal for every embedded path through each snarl, regardless of snarl complexity

## Description

This should help with #2878 