### PR TITLE
Handle inability to learn paired end distribution in reasonable time

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -733,11 +733,31 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
     }
 }
 
-pair<vector<Alignment>, vector< Alignment>> MinimizerMapper::map_paired(Alignment& aln1, Alignment& aln2) {
+pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment& aln1, Alignment& aln2) {
     
 #ifdef debug
     cerr << "Read pair " << aln1.name() << ": " << aln1.sequence() << " and " << aln2.name() << ": " << aln2.sequence() << endl;
 #endif
+
+    // Make sure we actually have a working fragment length distribution that the clusterer will accept.
+    int64_t fragment_distance_limit = fragment_length_distr.mean() + paired_distance_stdevs * fragment_length_distr.std_dev();
+    if (fragment_distance_limit < get_distance_limit(aln1.sequence().size())) {
+        // We can't use this distribution
+        
+        if (!warned_about_bad_distribution.test_and_set()) {
+            // We get to print the warning
+            cerr << "warning[vg::giraffe]: Cannot cluster reads with a fragment distance smaller than read distance" << endl;
+            cerr << "                      Fragment length distribution: mean=" << fragment_length_distr.mean() 
+                 << ", stdev=" << fragment_length_distr.std_dev() << endl;
+            cerr << "                      Fragment distance limit: " << fragment_distance_limit 
+                 << ", read distance limit: " << get_distance_limit(aln1.sequence().size()) << endl;
+            cerr << "warning[vg::giraffe]: Falling back on single-end mapping" << endl;
+        }
+        
+        // Map single-ended and bail
+        return make_pair(map(aln1), map(aln2)); 
+    }
+
 
     // Assume reads are in inward orientations on input, and
     // convert to rightward orientations before mapping
@@ -780,15 +800,6 @@ pair<vector<Alignment>, vector< Alignment>> MinimizerMapper::map_paired(Alignmen
     if (track_provenance) {
         funnels[0].stage("cluster");
         funnels[1].stage("cluster");
-    }
-    int64_t fragment_distance_limit = fragment_length_distr.mean() + paired_distance_stdevs * fragment_length_distr.std_dev();
-    if (fragment_distance_limit < get_distance_limit(aln1.sequence().size())) {
-        cerr << "error[vg::giraffe]: Cannot cluster reads with a fragment distance smaller than read distance" << endl;
-        cerr << "                    Fragment length distribution: mean=" << fragment_length_distr.mean() 
-             << ", stdev=" << fragment_length_distr.std_dev() << endl;
-        cerr << "                    Fragment distance limit: " << fragment_distance_limit 
-             << ", read distance limit: " << get_distance_limit(aln1.sequence().size()) << endl;
-        exit(1);
     }
     std::vector<std::vector<Cluster>> all_clusters = clusterer.cluster_seeds(seeds_by_read, get_distance_limit(aln1.sequence().size()), fragment_distance_limit);
 

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -20,6 +20,8 @@
 #include <gbwtgraph/minimizer.h>
 #include <structures/immutable_list.hpp>
 
+#include <atomic>
+
 namespace vg {
 
 using namespace std;
@@ -240,6 +242,7 @@ protected:
     SnarlSeedClusterer clusterer;
 
     FragmentLengthDistribution fragment_length_distr;
+    atomic_flag warned_about_bad_distribution = ATOMIC_FLAG_INIT;
 
 //-----------------------------------------------------------------------------
 

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -408,6 +408,8 @@ int main_giraffe(int argc, char** argv) {
     double cluster_stdev = 2.0;
     //How many stdevs do we look out when rescuing? 
     double rescue_stdev = 4.0;
+    // How many pairs should we be willing to buffer before giving up on fragment length estimation?
+    size_t MAX_BUFFERED_PAIRS = 100000;
     // What sample name if any should we apply?
     string sample_name;
     // What read group if any should we apply?
@@ -1199,6 +1201,18 @@ int main_giraffe(int argc, char** argv) {
                     return is_ready;
                 };
                 
+                // Define a way to force the distribution ready
+                auto require_distribution_finalized = [&]() {
+                    if (!minimizer_mapper.fragment_distr_is_finalized()){
+                        cerr << "warning[vg::giraffe]: Finalizing fragment length distribution before reaching maximum sample size" << endl;
+                        cerr << "                      mapped " << minimizer_mapper.get_fragment_length_sample_size() 
+                             << " reads single ended with " << ambiguous_pair_buffer.size() << " pairs of reads left unmapped" << endl;
+                        cerr << "                      mean: " << minimizer_mapper.get_fragment_length_mean() << ", stdev: " 
+                             << minimizer_mapper.get_fragment_length_stdev() << endl;
+                        minimizer_mapper.finalize_fragment_length_distr();
+                    }
+                };
+                
                 // Define how to align and output a read pair, in a thread.
                 auto map_read_pair = [&](Alignment& aln1, Alignment& aln2) {
                     
@@ -1209,6 +1223,14 @@ int main_giraffe(int argc, char** argv) {
                         alignment_emitter->emit_mapped_pair(std::move(mapped_pairs.first), std::move(mapped_pairs.second));
                         // Record that we mapped a read.
                         reads_mapped_by_thread.at(omp_get_thread_num()) += 2;
+                    }
+                    
+                    if (!minimizer_mapper.fragment_distr_is_finalized() && ambiguous_pair_buffer.size() >= MAX_BUFFERED_PAIRS) {
+                        // We risk running out of memory if we keep this up.
+                        cerr << "warning[vg::giraffe]: Encountered " << ambiguous_pair_buffer.size() << " ambiguously-paired reads before finding enough" << endl
+                             << "                      unambiguously-paired reads to learn fragment length distribution. Are you sure" << endl
+                             << "                      your reads are paired and your graph is not a hairball?" << endl;
+                        require_distribution_finalized();
                     }
                 };
 
@@ -1228,16 +1250,9 @@ int main_giraffe(int argc, char** argv) {
                     fastq_paired_interleaved_for_each_parallel_after_wait(fastq_filename_1, map_read_pair, distribution_is_ready);
                 }
 
-                //Now map all the ambiguous pairs
-                //TODO: What do we do if we haven't finalized the distribution?
-                if (!minimizer_mapper.fragment_distr_is_finalized()){
-                    cerr << "warning[vg::giraffe]: Finalizing fragment length distribution before reaching maximum sample size" << endl;
-                    cerr << "                      mapped " << minimizer_mapper.get_fragment_length_sample_size() 
-                         << " reads single ended with " << ambiguous_pair_buffer.size() << " pairs of reads left unmapped" << endl;
-                    cerr << "                      mean: " << minimizer_mapper.get_fragment_length_mean() << ", stdev: " 
-                         << minimizer_mapper.get_fragment_length_stdev() << endl;
-                    minimizer_mapper.finalize_fragment_length_distr();
-                }
+                // Now map all the ambiguous pairs
+                // Make sure fragment length distribution is finalized first.
+                require_distribution_finalized();
                 for (pair<Alignment, Alignment>& alignment_pair : ambiguous_pair_buffer) {
 
                     auto mapped_pairs = minimizer_mapper.map_paired(alignment_pair.first, alignment_pair.second);


### PR DESCRIPTION
If our buffer gets too full, we finalize the distribution as is.

If that results in a distribution that's mean 0 and ends up too short for the
reads, we will instead fall back on single-ended mapping and print warnings.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe now falls back to single-ended mapping instead of quitting when it can't learn a fragment length distribution

## Description
