### PR TITLE
Handle splice connections in gampcompare algorithm

### DIFF
--- a/src/algorithms/alignment_path_offsets.cpp
+++ b/src/algorithms/alignment_path_offsets.cpp
@@ -140,6 +140,12 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
                 next_coverings.insert(path_handle);
             }
         }
+        for (const auto& c : mp_aln.subpath(i).connection()) {
+            auto& next_coverings = covered_fwd[c.next()];
+            for (auto path_handle : covered_fwd[i]) {
+                next_coverings.insert(path_handle);
+            }
+        }
     }
     
     // now do a backward pass for the reverse strand of paths
@@ -147,6 +153,11 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
         // find which paths are already covered in the reverse
         for (auto n : mp_aln.subpath(i).next()) {
             for (auto path_handle : covered_rev[n]) {
+                covered_rev[i].insert(path_handle);
+            }
+        }
+        for (const auto& c : mp_aln.subpath(i).connection()) {
+            for (auto path_handle : covered_rev[c.next()]) {
                 covered_rev[i].insert(path_handle);
             }
         }

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -218,7 +218,7 @@ int main_surject(int argc, char** argv) {
             });
     }
 
-    // Make a single therad-safe Surjector.
+    // Make a single thread-safe Surjector.
     Surjector surjector(xgidx);
     surjector.adjust_alignments_for_base_quality = qual_adj;
     


### PR DESCRIPTION
## Changelog Entry

 * `gampcompare` now handles spliced GAMP files correctly

## Description

The splice adjacencies are no longer ignored in the algorithm