### PR TITLE
compute haplotype frequency of kmers found in vg find subgraphs

### DIFF
--- a/src/algorithms/kmer.cpp
+++ b/src/algorithms/kmer.cpp
@@ -50,10 +50,6 @@ void for_each_kmer(const HandleGraph& graph, size_t k, size_t edge_max,
                         auto& kmer = *q;
                         // did we reach our target length?
                         if (kmer.seq.size() == k) {
-                            // TODO here check if we are at the beginning of the reverse head or the beginning of the forward tail and would need special handling
-                            // establish the context
-                            handle_t end_handle = graph.get_handle(id(kmer.end), is_rev(kmer.end));
-                            size_t end_length = graph.get_length(end_handle);
                             // now pass the kmer to our callback
                             lambda(kmer);
                             q = kmers.erase(q);

--- a/src/algorithms/kmer.hpp
+++ b/src/algorithms/kmer.hpp
@@ -37,7 +37,7 @@ struct kmer_t {
 /// Iterate over all the kmers in the graph, running lambda on each
 void for_each_kmer(const HandleGraph& graph, size_t k, size_t edge_max,
                    const std::function<void(const kmer_t&)>& lambda);
-    
+
 /// Print a kmer_t to a stream.
 std::ostream& operator<<(std::ostream& out, const kmer_t& kmer);
 

--- a/src/algorithms/walk.cpp
+++ b/src/algorithms/walk.cpp
@@ -110,6 +110,27 @@ std::ostream& operator<<(std::ostream& out, const walk_t& walk) {
     return out;
 }
 
+uint64_t walk_haplotype_frequency(const HandleGraph& graph,
+                                  const gbwt::GBWT& haplotypes,
+                                  const walk_t& walk) {
+    if (walk.path.empty()) {
+        return 0;
+    }
+    auto& first_step = walk.path.front();
+    gbwt::node_type start_node = gbwt::Node::encode(graph.get_id(first_step), graph.get_is_reverse(first_step));
+    gbwt::SearchState search_state = haplotypes.find(start_node);
+    for (uint64_t i = 1; i < walk.path.size(); ++i) {
+        auto& next = walk.path[i];
+        gbwt::node_type next_node = gbwt::Node::encode(graph.get_id(next), graph.get_is_reverse(next));
+        search_state = haplotypes.extend(search_state, next_node);
+        if (search_state.empty()) {
+            break;
+        }
+    }
+    return search_state.size();
+}
+
+
 }
 
 }

--- a/src/algorithms/walk.hpp
+++ b/src/algorithms/walk.hpp
@@ -5,6 +5,7 @@
 #include <list>
 #include <handlegraph/util.hpp>
 #include <handlegraph/handle_graph.hpp>
+#include <gbwt/gbwt.h>
 #include "position.hpp"
 
 /** \file 
@@ -39,9 +40,13 @@ struct walk_t {
 /// Iterate over all the walks in the graph, running lambda on each
 void for_each_walk(const HandleGraph& graph, size_t k, size_t edge_max,
                    const std::function<void(const walk_t&)>& lambda);
-    
+
 /// Print a walk_t to a stream.
 std::ostream& operator<<(std::ostream& out, const walk_t& walk);
+
+uint64_t walk_haplotype_frequency(const HandleGraph& graph,
+                                  const gbwt::GBWT& haplotypes,
+                                  const walk_t& walk);
 
 }
 

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 28
+plan tests 29
 
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 is $? 0 "construction"
@@ -114,3 +114,9 @@ is $((vg view q.x:10:20.vg; vg view q.x:30:35.vg) | md5sum | cut -f 1 -d\ ) $((v
 is $(vg find -x t.xg -E -p x:30-35 -p x:10-20 -K 5 | wc -l) 36 "we see the expected number of kmers in the given targets"
 
 rm -f t.xg t.vg t.x:30:35.vg t.x:10:20.vg q.x:30:35.vg q.x:10:20.vg t.bed
+
+vg construct -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a > x.vg 2> /dev/null
+vg index -x x.xg x.vg
+vg index -G x.gbwt -v small/xy2.vcf.gz x.vg
+is $(vg find -p x -x x.xg -K 16 -H x.gbwt | cut -f 5 | sort | uniq -c  | tail -n 1 | awk '{ print $1 }') 1510 "we find the expected number of kmers with haplotype frequency equal to 2"
+rm -f x.vg x.xg x.gbwt


### PR DESCRIPTION
This is relevant for GRAFIMO's use.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add haplotype frequency output to subgraph kmer enumeration in vg find.

## Description

When enumerating kmers in a subgraph defined by a path range, and a GBWT index has been provided, we can compute the frequency of the kmers in the underlying haplotypes.