### PR TITLE
Exon border cycle support in vg rna

### DIFF
--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -616,15 +616,11 @@ list<EditedTranscriptPath> Transcriptome::project_transcript_gbwt(const Transcri
 
                     while (haplotype_id_index_it != haplotype_id_index_it_range.second) {
 
-                        if (haplotype_id_index_it == haplotype_id_index.end()) {
-
-                            continue;         
-                        }
-
                         if (exon_idx != haplotype_id_index_it->second.second) {
 
                             assert(haplotype_id_index_it->second.second < exon_idx);
-                            haplotype_id_index.erase(haplotype_id_index_it);
+
+                            haplotype_id_index_it = haplotype_id_index.erase(haplotype_id_index_it);
                             continue;
                         }
 
@@ -655,7 +651,8 @@ list<EditedTranscriptPath> Transcriptome::project_transcript_gbwt(const Transcri
                         
                         } else {
 
-                            haplotype_id_index.erase(haplotype_id_index_it);
+                            haplotype_id_index_it = haplotype_id_index.erase(haplotype_id_index_it);
+                            continue;
                         } 
 
                         ++haplotype_id_index_it;
@@ -1032,13 +1029,13 @@ list<EditedTranscriptPath> Transcriptome::project_transcript_embedded(const Tran
 
             while (true) {
 
+                auto border_offsets = cur_transcript.exons.at(exon_idx).border_offsets;
+
                 // Get path step at exon start if exon start node is in the current path.
                 auto haplotype_path_start_step = haplotype_path_start_it_range.first->second;
 
                 // Get path mapping at exon end if exon end node is in the current path.
                 auto haplotype_path_end_step = haplotype_path_end_it_range.first->second;
-
-                auto border_offsets = cur_transcript.exons.at(exon_idx).border_offsets;
 
                 // Swap start and end steps if in reverse order on path
                 if (graph_path_pos_overlay.get_position_of_step(haplotype_path_start_step) > graph_path_pos_overlay.get_position_of_step(haplotype_path_end_step)) {
@@ -1255,6 +1252,8 @@ list<EditedTranscriptPath> Transcriptome::project_transcript_embedded(const Tran
                     assert(haplotype_path_end_it_range.first != haplotype_path_end_it_range.second);
                     ++haplotype_path_end_it_range.first;
                 }
+
+                cerr << cur_transcript.name << " " << cur_edited_transcript_paths.size() << " " << gcsa::inGigabytes(gcsa::memoryUsage()) << endl;
             }
         }
 

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -620,7 +620,6 @@ list<EditedTranscriptPath> Transcriptome::project_transcript_gbwt(const Transcri
                 for (auto & haplotype_id: exon_haplotype.second) {
 
                     haplotype_id_index.emplace(haplotype_id, make_pair(haplotypes.size() - 1, exon_idx + 1));
-                    assert(haplotype_id_index.count(haplotype_id) == 1);
                 }
             }
             
@@ -709,18 +708,18 @@ list<EditedTranscriptPath> Transcriptome::project_transcript_gbwt(const Transcri
             assert(gbwt::Node::id(haplotype.first.at(exon_idx).front()) == exon_node_ids.at(exon_idx).first);
             assert(gbwt::Node::id(haplotype.first.at(exon_idx).back()) == exon_node_ids.at(exon_idx).second);
 
-            for (auto & exon_node: haplotype.first.at(exon_idx)) {
+            for (size_t exon_node_idx = 0; exon_node_idx < haplotype.first.at(exon_idx).size(); ++exon_node_idx) {
 
-                assert(exon_node != gbwt::ENDMARKER);
+                assert(haplotype.first.at(exon_idx).at(exon_node_idx) != gbwt::ENDMARKER);
 
-                auto node_id = gbwt::Node::id(exon_node);
+                auto node_id = gbwt::Node::id(haplotype.first.at(exon_idx).at(exon_node_idx));
                 auto node_length = _splice_graph->get_length(_splice_graph->get_handle(node_id, false));
 
                 int32_t offset = 0;
 
                 // Adjust start position from exon border (last position in upstream intron)
                 // to first position in exon. Do not adjust if first position in path.
-                if ((cur_exon.coordinates.first > 0) && (node_id == exon_node_ids.at(exon_idx).first)) {
+                if ((cur_exon.coordinates.first > 0) && (exon_node_idx == 0)) {
 
                     if (cur_exon.border_offsets.first + 1 == node_length) {
 
@@ -739,7 +738,7 @@ list<EditedTranscriptPath> Transcriptome::project_transcript_gbwt(const Transcri
 
                 // Adjust end position from exon border (first position in downstream intron)
                 // to last position in exon. Do not adjust if last position in path.
-                if ((cur_exon.coordinates.second < cur_transcript.chrom_length - 1) && (node_id == exon_node_ids.at(exon_idx).second)) {
+                if ((cur_exon.coordinates.second < cur_transcript.chrom_length - 1) && (exon_node_idx == haplotype.first.at(exon_idx).size() - 1)) {
 
                     if (cur_exon.border_offsets.second == 0) {
 

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -16,7 +16,7 @@ using namespace vg::io;
 
 using namespace std;
 
-#define transcriptome_debug
+//#define transcriptome_debug
 
 
 Transcriptome::Transcriptome(const string & graph_filename, const bool show_progress) {

--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -266,7 +266,7 @@ class Transcriptome {
 
         /// Convert a path to a vector of handles. Checks that 
         /// the path is complete (i.e. only consist of whole nodes).
-        vector<handle_t> path_to_handles(const Path & path, const EditedTranscriptPath & test) const;
+        vector<handle_t> path_to_handles(const Path & path) const;
 
         /// Checks whether transcript path only consist of 
         /// whole nodes (complete). 

--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -27,6 +27,24 @@ typedef vector<gbwt::size_type> thread_ids_t;
 /**
  * Data structure that defines a transcript annotation.
  */
+struct Exon {
+
+    /// Exon coordinates (start and end) on the chromosome/contig.
+    pair<int32_t, int32_t> coordinates;
+
+    /// Exon border node offsets (last position in upstream intron and
+    /// first position in downstream intron) on a variation graph. 
+    pair<uint32_t, uint32_t> border_offsets;
+
+    /// Exon border reference path steps (last position in upstream intron and
+    /// first position in downstream intron) on a variation graph. 
+    pair<step_handle_t, step_handle_t> border_steps;
+};
+
+
+/**
+ * Data structure that defines a transcript annotation.
+ */
 struct Transcript {
 
     /// Transcript name.
@@ -41,12 +59,8 @@ struct Transcript {
     /// Length of chromosome/contig where transcript exist.
     const uint32_t chrom_length;
 
-    /// Exon coordinates (start and end) on the chromosome/contig.
-    vector<pair<int32_t, int32_t> > exons;
-
-    /// Exon border node positions (last position in upstream intron and
-    /// first position in downstream intron) on a variation graph. 
-    vector<pair<Position, Position> > exon_border_nodes;
+    /// Transcript exons.
+    vector<Exon> exons;
 
     Transcript(const string & name_in, const bool is_reverse_in, const string & chrom_in, const uint32_t & chrom_length_in) : name(name_in), is_reverse(is_reverse_in), chrom(chrom_in), chrom_length(chrom_length_in) {
 
@@ -202,10 +216,10 @@ class Transcriptome {
         bool _splice_graph_node_updated;
 
         /// Parse BED file of introns.
-        vector<Transcript> parse_introns(istream & intron_stream) const;
+        vector<Transcript> parse_introns(istream & intron_stream, const bdsg::PositionOverlay & graph_path_pos_overlay) const;
 
         /// Parse gtf/gff3 file of transcripts.
-        vector<Transcript> parse_transcripts(istream & transcript_stream) const;
+        vector<Transcript> parse_transcripts(istream & transcript_stream, const bdsg::PositionOverlay & graph_path_pos_overlay) const;
 
         /// Returns the mean node length of the graph
         float mean_node_length() const;
@@ -220,17 +234,17 @@ class Transcriptome {
 
         /// Constructs edited transcript paths from a set of 
         /// reference transcripts. 
-        list<EditedTranscriptPath> construct_edited_transcript_paths(const vector<Transcript> & transcripts) const;
+        list<EditedTranscriptPath> construct_edited_transcript_paths(const vector<Transcript> & transcripts, const bdsg::PositionOverlay & graph_path_pos_overlay) const;
 
         /// Threaded edited transcript path construction.
-        void construct_edited_transcript_paths_callback(list<EditedTranscriptPath> * edited_transcript_paths, mutex * edited_transcript_paths_mutex, const int32_t thread_idx, const vector<Transcript> & transcripts) const;
+        void construct_edited_transcript_paths_callback(list<EditedTranscriptPath> * edited_transcript_paths, mutex * edited_transcript_paths_mutex, const bdsg::PositionOverlay & graph_path_pos_overlay, const int32_t thread_idx, const vector<Transcript> & transcripts) const;
 
         /// Constructs transcript paths by projecting transcripts onto embedded paths in
         /// a variation graph and/or haplotypes in a GBWT index. 
-        void project_and_add_transcripts(const vector<Transcript> & transcripts, const gbwt::GBWT & haplotype_index, const float mean_node_length);
+        void project_and_add_transcripts(const vector<Transcript> & transcripts, const gbwt::GBWT & haplotype_index, const bdsg::PositionOverlay & graph_path_pos_overlay, const float mean_node_length);
 
         /// Threaded transcript projecting.
-        void project_and_add_transcripts_callback(const int32_t thread_idx, const vector<Transcript> & transcripts, const gbwt::GBWT & haplotype_index, const float mean_node_length);
+        void project_and_add_transcripts_callback(const int32_t thread_idx, const vector<Transcript> & transcripts, const gbwt::GBWT & haplotype_index, const bdsg::PositionOverlay & graph_path_pos_overlay, const float mean_node_length);
 
         /// Projects transcripts onto haplotypes in a GBWT index and returns resulting transcript paths.
         list<EditedTranscriptPath> project_transcript_gbwt(const Transcript & cur_transcript, const gbwt::GBWT & haplotype_index, const float mean_node_length) const;
@@ -240,7 +254,7 @@ class Transcriptome {
         vector<pair<exon_nodes_t, thread_ids_t> > get_exon_haplotypes(const vg::id_t start_node, const vg::id_t end_node, const gbwt::GBWT & haplotype_index, const int32_t expected_length) const;
 
         /// Projects transcripts onto embedded paths in a variation graph and returns resulting transcript paths.
-        list<EditedTranscriptPath> project_transcript_embedded(const Transcript & cur_transcript, const bool reference_only) const;
+        list<EditedTranscriptPath> project_transcript_embedded(const Transcript & cur_transcript, const bdsg::PositionOverlay & graph_path_pos_overlay, const bool reference_only) const;
 
         /// Adds new transcript paths to current set. Has argument to only add unique paths.
         void append_transcript_paths(list<CompletedTranscriptPath> * completed_transcript_path, list<CompletedTranscriptPath> * new_completed_transcript_paths, const bool add_unqiue_paths_only) const;
@@ -252,7 +266,7 @@ class Transcriptome {
 
         /// Convert a path to a vector of handles. Checks that 
         /// the path is complete (i.e. only consist of whole nodes).
-        vector<handle_t> path_to_handles(const Path & path) const;
+        vector<handle_t> path_to_handles(const Path & path, const EditedTranscriptPath & test) const;
 
         /// Checks whether transcript path only consist of 
         /// whole nodes (complete). 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Support added for exon border cycles in `vg rna`

## Description

`vg rna` can now handle cycles that cover exon boundaries. Before it only handled cycles inside exons. It works on both embedded paths and haplotypes provided in a GBWT. There is still some rare cases that are not yet supported when projecting on to specific cycles on embedded paths. However, I thought I would be better to PR this now since it will handle the most common cases. Also, I am still working out what would be the best way to project on to these. 
