### PR TITLE
Fix giraffe bug

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -445,10 +445,7 @@ vector<Alignment> MinimizerMapper::map(Alignment& aln) {
 #endif
             };
             
-            // There's always a best alignment
-            observe_alignment(best_alignments[0]);
-            
-            for(auto aln_it = best_alignments.begin() + 1; aln_it != best_alignments.end() && aln_it->score() != 0 && aln_it->score() >= best_alignments[0].score() * 0.8; ++aln_it) {
+            for(auto aln_it = best_alignments.begin() ; aln_it != best_alignments.end() && aln_it->score() != 0 && aln_it->score() >= best_alignments[0].score() * 0.8; ++aln_it) {
                 //For each additional alignment with score at least 0.8 of the best score
                 observe_alignment(*aln_it);
             }
@@ -1240,10 +1237,7 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
 #endif
                 };
                 
-                // There's always a best alignment
-                observe_alignment(best_alignments[0]);
-                
-                for(auto aln_it = best_alignments.begin() + 1; aln_it != best_alignments.end() && aln_it->score() != 0 && aln_it->score() >= best_alignments[0].score() * 0.8; ++aln_it) {
+                for(auto aln_it = best_alignments.begin() ; aln_it != best_alignments.end() && aln_it->score() != 0 && aln_it->score() >= best_alignments[0].score() * 0.8; ++aln_it) {
                     //For each additional extension with score at least 0.8 of the best score
                     observe_alignment(*aln_it);
                 }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe no longer tries to keep an empty alignment

## Description
We were assuming that we'd always get at least one good alignment after gapless extention/chaining, but since we can disable chaining, that's not necessarily true
This doesn't quite issue #3002 but it stops it from crashing