### PR TITLE
Random stuff

### DIFF
--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -26,31 +26,37 @@ using namespace vg::subcommand;
 
 #include <unistd.h>
 
-enum operation_mode { operation_none, operation_merge, operation_graph, operation_remove, operation_r_index, operation_other };
+enum merge_mode { merge_none, merge_insert, merge_fast };
 enum path_cover_mode { path_cover_none, path_cover_augment, path_cover_local, path_cover_greedy };
+enum index_type { index_none, index_compressed, index_dynamic };
+
+void load_gbwt(const std::string& filename, gbwt::GBWT& index, bool show_progress);
+void load_gbwt(const std::string& filename, gbwt::DynamicGBWT& index, bool show_progress);
+
+void get_compressed(gbwt::GBWT& compressed_index, gbwt::DynamicGBWT& dynamic_index, index_type& in_use, const std::string& filename, bool show_progress);
+void get_dynamic(gbwt::GBWT& compressed_index, gbwt::DynamicGBWT& dynamic_index, index_type& in_use, const std::string& filename, bool show_progress);
+
+void get_graph(std::unique_ptr<HandleGraph>& graph, bool& in_use, const std::string& filename, bool show_progress);
+void clear_graph(std::unique_ptr<HandleGraph>& graph, bool& in_use);
 
 void help_gbwt(char** argv) {
-    std::cerr << "usage: " << argv[0] << " [options] [args]" << std::endl;
+    std::cerr << "usage: " << argv[0] << " gbwt [options] [args]" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Manipulate GBWTs." << std::endl;
+    std::cerr << "Manipulate GBWTs. Each input arg represents one input GBWT." << std::endl;
     std::cerr << std::endl;
     std::cerr << "General options:" << std::endl;
+    std::cerr << "    -x, --xg-name FILE      read the graph from FILE" << std::endl;
     std::cerr << "    -o, --output FILE       write output GBWT to FILE" << std::endl;
     std::cerr << "    -p, --progress          show progress and statistics" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Merging (requires -o; use deps/gbwt/merge_gbwt for more options):" << std::endl;
-    std::cerr << "    -m, --merge             merge the GBWT files from the input args and write to output" << std::endl;
-    std::cerr << "    -f, --fast              fast merging algorithm (node ids must not overlap; implies -m)" << std::endl;
+    std::cerr << "Step 1: Merge multiple input GBWTs (requires -o; use deps/gbwt/merge_gbwt for more options):" << std::endl;
+    std::cerr << "    -m, --merge             use the insertion algorithm" << std::endl;
+    std::cerr << "    -f, --fast              fast merging algorithm (node ids must not overlap)" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Threads (one input GBWT):" << std::endl;
-    std::cerr << "    -c, --count-threads     print the number of threads" << std::endl;
-    std::cerr << "    -e, --extract FILE      extract threads in SDSL format to FILE" << std::endl;
+    std::cerr << "Step 2: Remove samples (requires -o and one input GBWT):" << std::endl;
+    std::cerr << "    -R, --remove-sample X   remove sample X from the index" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "GBWTGraph construction (based on one input GBWT or path cover GBWT):" << std::endl;
-    std::cerr << "    -g, --graph-name FILE   build GBWTGraph and serialize it to FILE (required)" << std::endl;
-    std::cerr << "    -x, --xg-name FILE      use the node sequences from the graph in FILE (required)" << std::endl;
-    std::cerr << std::endl;
-    std::cerr << "Path cover (for GBWTGraph construction; requires -o and one of { -a, -l, -P }):" << std::endl;
+    std::cerr << "Step 3: Path cover (requires -o, -x, and one of { -a, -l, -P }):" << std::endl;
     std::cerr << "    -a, --augment-gbwt      add a path cover of missing components (one input GBWT)" << std::endl;
     std::cerr << "    -l, --local-haplotypes  sample local haplotypes (one input GBWT)" << std::endl;
     std::cerr << "    -P, --path-cover        build a greedy path cover (no input GBWTs)" << std::endl;
@@ -59,7 +65,14 @@ void help_gbwt(char** argv) {
     std::cerr << "    -b, --buffer-size N     GBWT construction buffer size in millions of nodes (default " << (gbwt::DynamicGBWT::INSERT_BATCH_SIZE / gbwt::MILLION) << ")" << std::endl;
     std::cerr << "    -i, --id-interval N     store path ids at one out of N positions (default " << gbwt::DynamicGBWT::SAMPLE_INTERVAL << ")" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Metadata (one input GBWT; use deps/gbwt/metadata_tool to modify):" << std::endl;
+    std::cerr << "Step 4: GBWTGraph construction (requires -x and one input GBWT):" << std::endl;
+    std::cerr << "    -g, --graph-name FILE   build GBWTGraph and serialize it to FILE" << std::endl;
+    std::cerr << std::endl;
+    std::cerr << "Step 5: R-index construction (one input GBWT):" << std::endl;
+    std::cerr << "    -r, --r-index FILE      build an r-index and store it in FILE" << std::endl;
+    std::cerr << "    -t, --threads N         use N extraction threads (default " << omp_get_max_threads() << ")" << std::endl;
+    std::cerr << std::endl;
+    std::cerr << "Step 6: Metadata (one input GBWT; use deps/gbwt/metadata_tool to modify):" << std::endl;
     std::cerr << "    -M, --metadata          print basic metadata" << std::endl;
     std::cerr << "    -C, --contigs           print the number of contigs" << std::endl;
     std::cerr << "    -H, --haplotypes        print the number of haplotypes" << std::endl;
@@ -67,12 +80,9 @@ void help_gbwt(char** argv) {
     std::cerr << "    -L, --list-names        list contig/sample names (use with -C or -S)" << std::endl;
     std::cerr << "    -T, --thread-names      list thread names" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Remove sample (one input GBWT; requires -o):" << std::endl;
-    std::cerr << "    -R, --remove-sample X   remove sample X from the index" << std::endl;
-    std::cerr << std::endl;
-    std::cerr << "R-index construction (one input GBWT):" << std::endl;
-    std::cerr << "    -r, --r-index FILE      build an r-index and store it in FILE" << std::endl;
-    std::cerr << "    -t, --threads N         use N extraction threads (default " << omp_get_max_threads() << ")" << std::endl;
+    std::cerr << "Step 6: Threads (one input GBWT):" << std::endl;
+    std::cerr << "    -c, --count-threads     print the number of threads" << std::endl;
+    std::cerr << "    -e, --extract FILE      extract threads in SDSL format to FILE" << std::endl;
     std::cerr << std::endl;
 }
 
@@ -84,17 +94,21 @@ int main_gbwt(int argc, char** argv)
         std::exit(EXIT_FAILURE);
     }
 
-    // Operation modes.
-    operation_mode mode = operation_none;
+    // Requirements and modes.
+    bool produces_one_gbwt = false;
+    merge_mode merge = merge_none;
     path_cover_mode path_cover = path_cover_none;
+    bool metadata_mode = false, thread_mode = false;
 
-    bool fast_merging = false;
+    // Other parameters and flags.
     bool show_progress = false;
     bool count_threads = false;
     bool metadata = false, contigs = false, haplotypes = false, samples = false, list_names = false, thread_names = false;
     size_t num_paths = gbwtgraph::PATH_COVER_DEFAULT_N, context_length = gbwtgraph::PATH_COVER_DEFAULT_K;
     size_t buffer_size = gbwt::DynamicGBWT::INSERT_BATCH_SIZE;
     size_t id_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL;
+
+    // File/sample names.
     string gbwt_output, thread_output;
     string graph_output, xg_name;
     std::string r_index_name;
@@ -106,6 +120,7 @@ int main_gbwt(int argc, char** argv)
         static struct option long_options[] =
             {
                 // General
+                { "xg-name", required_argument, 0, 'x' },
                 { "output", required_argument, 0, 'o' },
                 { "progress",  no_argument, 0, 'p' },
 
@@ -113,13 +128,8 @@ int main_gbwt(int argc, char** argv)
                 { "merge", no_argument, 0, 'm' },
                 { "fast", no_argument, 0, 'f' },
 
-                // Threads
-                { "count-threads", no_argument, 0, 'c' },
-                { "extract", required_argument, 0, 'e' },
-
-                // GBWTGraph
-                { "graph-name", required_argument, 0, 'g' },
-                { "xg-name", required_argument, 0, 'x' },
+                // Remove sample
+                { "remove-sample", required_argument, 0, 'R' },
 
                 // Path cover
                 { "augment-gbwt", no_argument, 0, 'a' },
@@ -130,6 +140,13 @@ int main_gbwt(int argc, char** argv)
                 { "buffer-size", required_argument, 0, 'b' },
                 { "id-interval", required_argument, 0, 'i' },
 
+                // GBWTGraph
+                { "graph-name", required_argument, 0, 'g' },
+
+                // R-index
+                { "r-index", required_argument, 0, 'r' },
+                { "threads", required_argument, 0, 't' },
+
                 // Metadata
                 { "metadata", no_argument, 0, 'M' },
                 { "contigs", no_argument, 0, 'C' },
@@ -138,19 +155,16 @@ int main_gbwt(int argc, char** argv)
                 { "list-names", no_argument, 0, 'L' },
                 { "thread-names", no_argument, 0, 'T' },
 
-                // Remove sample
-                { "remove-sample", required_argument, 0, 'R' },
-
-                // R-index
-                { "r-index", required_argument, 0, 'r' },
-                { "threads", required_argument, 0, 't' },
+                // Threads
+                { "count-threads", no_argument, 0, 'c' },
+                { "extract", required_argument, 0, 'e' },
 
                 { "help", no_argument, 0, 'h' },
                 { 0, 0, 0, 0 }
             };
 
         int option_index = 0;
-        c = getopt_long(argc, argv, "o:pmfce:g:x:alPn:k:b:i:MCHSLTR:r:t:h?", long_options, &option_index);
+        c = getopt_long(argc, argv, "x:o:pmfR:alPn:k:b:i:g:r:t:MCHSLTce:h?", long_options, &option_index);
 
         /* Detect the end of the options. */
         if (c == -1)
@@ -159,6 +173,9 @@ int main_gbwt(int argc, char** argv)
         switch (c)
         {
         // General
+        case 'x':
+            xg_name = optarg;
+            break;
         case 'o':
             gbwt_output = optarg;
             break;
@@ -168,41 +185,32 @@ int main_gbwt(int argc, char** argv)
 
         // Merging
         case 'm':
-            mode = operation_merge;
+            merge = merge_insert;
+            produces_one_gbwt = true;
             break;
         case 'f':
-            mode = operation_merge;
-            fast_merging = true;
+            merge = merge_fast;
+            produces_one_gbwt = true;
             break;
 
-        // Threads
-        case 'c':
-            mode = operation_other;
-            count_threads = true;
-            break;
-        case 'e':
-            mode = operation_other;
-            thread_output = optarg;
-            break;
-
-        // GBWTGraph
-        case 'g':
-            mode = operation_graph;
-            graph_output = optarg;
-            break;
-        case 'x':
-            xg_name = optarg;
+        // Remove sample
+        case 'R':
+            to_remove = optarg;
             break;
 
         // Path cover
         case 'a':
+            assert(path_cover == path_cover_none);
             path_cover = path_cover_augment;
             break;
         case 'l':
+            assert(path_cover == path_cover_none);
             path_cover = path_cover_local;
             break;
         case 'P':
+            assert(path_cover == path_cover_none);
             path_cover = path_cover_greedy;
+            produces_one_gbwt = true;
             break;
         case 'n':
             num_paths = parse<size_t>(optarg);
@@ -217,44 +225,53 @@ int main_gbwt(int argc, char** argv)
             id_interval = parse<size_t>(optarg);
             break;
 
-        // Metadata
-        case 'M':
-            mode = operation_other;
-            metadata = true;
-            break;
-        case 'C':
-            mode = operation_other;
-            contigs = true;
-            break;
-        case 'H':
-            mode = operation_other;
-            haplotypes = true;
-            break;
-        case 'S':
-            mode = operation_other;
-            samples = true;
-            break;
-        case 'L':
-            list_names = true;
-            break;
-        case 'T':
-            mode = operation_other;
-            thread_names = true;
-            break;
-
-        // Remove sample
-        case 'R':
-            mode = operation_remove;
-            to_remove = optarg;
+        // GBWTGraph
+        case 'g':
+            graph_output = optarg;
             break;
 
         // Build r-index
         case 'r':
-            mode = operation_r_index;
             r_index_name = optarg;
             break;
         case 't':
             omp_set_num_threads(parse<int>(optarg));
+            break;
+
+        // Metadata
+        case 'M':
+            metadata = true;
+            metadata_mode = true;
+            break;
+        case 'C':
+            contigs = true;
+            metadata_mode = true;
+            break;
+        case 'H':
+            haplotypes = true;
+            metadata_mode = true;
+            break;
+        case 'S':
+            samples = true;
+            metadata_mode = true;
+            break;
+        case 'L':
+            list_names = true;
+            metadata_mode = true;
+            break;
+        case 'T':
+            thread_names = true;
+            metadata_mode = true;
+            break;
+
+        // Threads
+        case 'c':
+            count_threads = true;
+            thread_mode = true;
+            break;
+        case 'e':
+            thread_output = optarg;
+            thread_mode = true;
             break;
 
         case 'h':
@@ -268,389 +285,305 @@ int main_gbwt(int argc, char** argv)
             std::exit(EXIT_FAILURE);
         }
     }
+    int input_gbwts = argc - optind;
+    std::string gbwt_name = (input_gbwts == 0 ? "" : argv[optind]);
 
     // Sanity checks.
-    if (mode == operation_none) {
-        help_gbwt(argv);
-        std::exit(EXIT_FAILURE);
+    if (merge != merge_none) {
+        if (input_gbwts < 2 || gbwt_output.empty()) {
+            std::cerr << "error: [vg gbwt]: merging requires multiple input GBWTs and output GBWT" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
     }
+    if (!to_remove.empty()) {
+        if (input_gbwts != 1 || gbwt_output.empty()) {
+            std::cerr << "error: [vg gbwt]: removing a sample requires one input GBWT and output GBWT" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+    if (path_cover != path_cover_none) {
+        if (gbwt_output.empty() || xg_name.empty()) {
+            std::cerr << "error: [vg gbwt]: path cover options require output GBWT and a graph" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        if (path_cover == path_cover_greedy && input_gbwts != 0) {
+            std::cerr << "error: [vg gbwt]: greedy path cover does not use input GBWTs" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        if ((path_cover == path_cover_local || path_cover == path_cover_augment) && !(input_gbwts == 1 || produces_one_gbwt)) {
+            std::cerr << "error: [vg gbwt]: path cover options -a and -l require one input GBWT" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        if (num_paths == 0) {
+            std::cerr << "error: [vg gbwt] number of paths must be non-zero for path cover" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        if (context_length < gbwtgraph::PATH_COVER_MIN_K) {
+            std::cerr << "error: [vg gbwt] context length must be at least " << gbwtgraph::PATH_COVER_MIN_K << " for path cover" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        if (buffer_size == 0) {
+            std::cerr << "error: [vg gbwt] GBWT construction buffer size cannot be 0" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+    if (!graph_output.empty()) {
+        if (xg_name.empty() || !(input_gbwts == 1 || produces_one_gbwt)) {
+            std::cerr << "error: [vg gbwt]: GBWTGraph construction requires a graph and one input GBWT" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+    if (!r_index_name.empty()) {
+        if (!(input_gbwts == 1 || produces_one_gbwt)) {
+            std::cerr << "error: [vg gbwt]: r-index construction requires one input GBWT" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+    if (metadata_mode) {
+        if (!(input_gbwts == 1 || produces_one_gbwt)) {
+            std::cerr << "error: [vg gbwt]: metadata operations one input GBWT" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+    if (thread_mode) {
+        if (!(input_gbwts == 1 || produces_one_gbwt)) {
+            std::cerr << "error: [vg gbwt]: thread operations one input GBWT" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+
 
     // Let GBWT operate silently.
     gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
 
+    // This is the data we are using.
+    gbwt::GBWT compressed_index;
+    gbwt::DynamicGBWT dynamic_index;
+    index_type in_use = index_none;
+    std::unique_ptr<HandleGraph> input_graph;
+    bool graph_in_use = false;
 
-    // Merging options.
-    if (mode == operation_merge) {
 
-        // Ugly hack here. GBWT prints to stdout, and we want to direct it to stderr.
-        std::streambuf* cout_buf = std::cout.rdbuf();
-        std::cout.rdbuf(cerr.rdbuf());
-
-        size_t input_files = argc - optind;
-        size_t total_inserted = 0;
-        if (input_files <= 1) {
-            std::cerr << "error: [vg gbwt] at least two input gbwt files required to merge" << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-        if (gbwt_output.empty()) {
-            std::cerr << "error: [vg gbwt] output file must be specified with -o" << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-        if (show_progress) {
-            gbwt::printHeader("Algorithm"); std::cout << (fast_merging ? "fast" : "insert") << std::endl;
-            gbwt::printHeader("Input files"); std::cout << input_files << std::endl;
-            gbwt::printHeader("Output name"); std::cout << gbwt_output << std::endl;
-            std::cout << std::endl;
-        }
-
+    // Merge multiple input GBWTs.
+    if (merge != merge_none) {
         double start = gbwt::readTimer();
-        if(fast_merging)
-        {
-            vector<gbwt::GBWT> indexes(argc - optind);
-            for(int i = optind; i < argc; i++)
-            {
-                string input_name = argv[i];
-                
-                // Try loading the GBWT
-                std::unique_ptr<gbwt::GBWT> loaded = vg::io::VPKG::load_one<gbwt::GBWT>(input_name);
-                if (loaded.get() == nullptr) {
-                    std::cerr << "error: [vg gbwt] could not load GBWT " << input_name << std::endl;
-                    std::exit(EXIT_FAILURE);
-                }
-                
-                // Move out of the std::unique_ptr and into the vector that the GBWT library needs.
-                indexes[i - optind] = std::move(*loaded);
-                
-                if (show_progress) {
-                    gbwt::printStatistics(indexes[i - optind], input_name);
-                }
-                total_inserted += indexes[i - optind].size();
-            }
-            
-            // Merge the GBWT.
-            gbwt::GBWT merged(indexes);
-            
-            // Save to a file in VPKG-encapsulated format.
-            vg::io::VPKG::save(merged, gbwt_output);
-            if (show_progress) {
-                gbwt::printStatistics(merged, gbwt_output);
-            }
+        if (show_progress) {
+            std::string algo_name = (merge == merge_fast ? "fast" : "insertion");
+            std::cerr << "Merging " << input_gbwts << " input GBWTs (" << algo_name << " algorithm)" << std::endl;
         }
-        else
-        {
-            std::unique_ptr<gbwt::DynamicGBWT> index;
-            {
-                // Try to load the first GBWT as a dynamic one.
-                std::string input_name = argv[optind];
-                index = vg::io::VPKG::load_one<gbwt::DynamicGBWT>(input_name);
-                if (index.get() == nullptr) {
-                    std::cerr << "error: [vg gbwt] could not load dynamic GBWT " << input_name << std::endl;
-                    std::exit(EXIT_FAILURE);
-                }
-                if (show_progress) {
-                    gbwt::printStatistics(*index, input_name);
-                }
+        if (merge == merge_fast) {
+            std::vector<gbwt::GBWT> indexes(input_gbwts);
+            for (int i = optind; i < argc; i++) {
+                load_gbwt(argv[i], indexes[i - optind], show_progress);
             }
-            for (int curr = optind + 1; curr < argc; curr++)
-            {
-                std::string input_name = argv[curr];
-                std::unique_ptr<gbwt::GBWT> next = vg::io::VPKG::load_one<gbwt::GBWT>(input_name);
-                if (next.get() == nullptr) {
-                    std::cerr << "error: [vg gbwt]: could not load GBWT " << input_name << std::endl;
-                    std::exit(EXIT_FAILURE);
-                }
-                if (show_progress) {
-                    gbwt::printStatistics(*next, input_name);
-                }
-                if (next->size() > 2 * index->size()) {
-                    std::cerr << "warning: [vg gbwt] merging " << input_name << " into a substantially smaller index" << std::endl;
+            if (show_progress) {
+                std::cerr << "Merging the GBWTs" << std::endl;
+            }
+            compressed_index = gbwt::GBWT(indexes);
+            in_use = index_compressed;
+        }
+        else if (merge == merge_insert) {
+            load_gbwt(gbwt_name, dynamic_index, show_progress);
+            in_use = index_dynamic;
+            for (int curr = optind + 1; curr < argc; curr++) {
+                gbwt::GBWT next;
+                load_gbwt(argv[curr], next, show_progress);
+                if (next.size() > 2 * dynamic_index.size()) {
+                    std::cerr << "warning: [vg gbwt] merging " << argv[curr] << " into a substantially smaller index" << std::endl;
                     std::cerr << "warning: [vg gbwt] merging would be faster in another order" << std::endl;
                 }
-                index->merge(*next);
-                total_inserted += next->size();
-            }
-            
-            // Save to a file in VPKG-encapsulated format.
-            vg::io::VPKG::save(*index, gbwt_output);
-            if (show_progress) { 
-                gbwt::printStatistics(*index, gbwt_output);
-            }
-        }
-        double seconds = gbwt::readTimer() - start;
-
-        if (show_progress) {
-            std::cout << "Inserted " << total_inserted << " nodes in " << seconds << " seconds ("
-                      << (total_inserted / seconds) << " nodes/second)" << std::endl;
-            std::cout << "Memory usage " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB" << std::endl;
-            std::cout << std::endl;
-        }
-
-        // Revert the hack and exit.
-        std::cout.rdbuf(cout_buf);
-        std::exit(EXIT_SUCCESS);
-    }
-
-
-    // GBWTGraph construction.
-    if (mode == operation_graph) {
-        if (path_cover != path_cover_none) {
-            if (path_cover == path_cover_local && optind + 1 != argc) {
-                std::cerr << "error: [vg gbwt] no input GBWT given for finding local haplotypes" << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-            if (path_cover == path_cover_augment && optind + 1 != argc) {
-                std::cerr << "error: [vg gbwt] no input GBWT to augment" << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-            if (path_cover == path_cover_greedy && optind != argc) {
-                std::cerr << "error: [vg gbwt] input GBWTs are not used with greedy path cover" << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-            if (num_paths == 0) {
-                std::cerr << "error: [vg gbwt] number of paths must be non-zero for path cover" << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-            if (context_length < gbwtgraph::PATH_COVER_MIN_K) {
-                std::cerr << "error: [vg gbwt] context length must be at least " << gbwtgraph::PATH_COVER_MIN_K << " for path cover" << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-            if (buffer_size == 0) {
-                std::cerr << "error: [vg gbwt] GBWT construction buffer size cannot be 0" << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-            if (gbwt_output.empty()) {
-                std::cerr << "error: [vg gbwt] output file not specified for path cover GBWT" << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-        } else {
-            if (optind + 1 != argc) {
-                std::cerr << "error: [vg gbwt] no input GBWT given for GBWTGraph construction" << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-        }
-        if (xg_name.empty()) {
-            std::cerr << "error: [vg gbwt] GBWTGraph construction requires an input graph" << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-
-        // Load the input graph.
-        if (show_progress) {
-            std::cerr << "Loading input graph " << xg_name << std::endl;
-        }
-        std::unique_ptr<HandleGraph> handle_graph = vg::io::VPKG::load_one<HandleGraph>(xg_name);
-        if (handle_graph == nullptr) {
-            std::cerr << "error: [vg gbwt] could not load graph " << xg_name << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-
-        // Load or build GBWT.
-        std::unique_ptr<gbwt::GBWT> loaded_gbwt(nullptr);
-        gbwt::GBWT generated_gbwt;
-        if (path_cover == path_cover_greedy) {
-            if (show_progress) {
-                std::cerr << "Finding " << num_paths << "-path cover with context length " << context_length << std::endl;
-            }
-            double start = gbwt::readTimer();
-            generated_gbwt = gbwtgraph::path_cover_gbwt(*handle_graph, num_paths, context_length, buffer_size, id_interval, show_progress);
-            if (show_progress) {
-                double seconds = gbwt::readTimer() - start;
-                std::cerr << "GBWT built in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
-                std::cerr << "Serializing path cover GBWT to " << gbwt_output << std::endl;
-            }
-            vg::io::VPKG::save(generated_gbwt, gbwt_output);
-        } else if (path_cover == path_cover_augment) {
-            if (show_progress) {
-                std::cerr << "Loading GBWT " << argv[optind] << std::endl;
-            }
-            std::unique_ptr<gbwt::DynamicGBWT> input_gbwt = vg::io::VPKG::load_one<gbwt::DynamicGBWT>(argv[optind]);
-            if (input_gbwt.get() == nullptr) {
-                std::cerr << "error: [vg gbwt] could not load GBWT " << argv[optind] << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-            if (show_progress) {
-                std::cerr << "Finding " << num_paths << "-path cover with context length " << context_length << " for missing components" << std::endl;
-            }
-            double start = gbwt::readTimer();
-            gbwtgraph::augment_gbwt(*handle_graph, *input_gbwt, num_paths, context_length, buffer_size, id_interval, show_progress);
-            if (show_progress) {
-                double seconds = gbwt::readTimer() - start;
-                std::cerr << "GBWT augmented in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
-                std::cerr << "Serializing augmented GBWT to " << gbwt_output << std::endl;
-            }
-            generated_gbwt = gbwt::GBWT(*input_gbwt);
-            vg::io::VPKG::save(generated_gbwt, gbwt_output);
-        } else {
-            if (show_progress) {
-                std::cerr << "Loading GBWT " << argv[optind] << std::endl;
-            }
-            loaded_gbwt = vg::io::VPKG::load_one<gbwt::GBWT>(argv[optind]);
-            if (loaded_gbwt.get() == nullptr) {
-                std::cerr << "error: [vg gbwt] could not load GBWT " << argv[optind] << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
-            if (path_cover == path_cover_local) {
                 if (show_progress) {
-                    std::cerr << "Finding " << num_paths << "-path cover with context length " << context_length << std::endl;
+                    std::cerr << "Inserting " << next.sequences() << " sequences of total length " << next.size() << std::endl;
                 }
-                double start = gbwt::readTimer();
-                generated_gbwt = gbwtgraph::local_haplotypes(*handle_graph, *loaded_gbwt, num_paths, context_length, buffer_size, id_interval, show_progress);
-                if (show_progress) {
-                    double seconds = gbwt::readTimer() - start;
-                    std::cerr << "GBWT built in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
-                    std::cerr << "Serializing local haplotypes to " << gbwt_output << std::endl;
-                }
-                vg::io::VPKG::save(generated_gbwt, gbwt_output);
-                loaded_gbwt.reset();
+                dynamic_index.merge(next);
             }
         }
-        const gbwt::GBWT& selected_gbwt = (path_cover == path_cover_none ? *loaded_gbwt : generated_gbwt);
-
         if (show_progress) {
-            std::cerr << "Building GBWTGraph" << std::endl;
+            double seconds = gbwt::readTimer() - start;
+            std::cerr << "GBWTs merged in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+            std::cerr << std::endl;
         }
-        gbwtgraph::GBWTGraph graph(selected_gbwt, *handle_graph);
-        if (show_progress) {
-            std::cerr << "Serializing GBWTGraph to " << graph_output << std::endl;
-        }
-        vg::io::VPKG::save(graph, graph_output);
-        std::exit(EXIT_SUCCESS);
     }
 
 
     // Remove a sample from the GBWT.
-    if (mode == operation_remove) {
-        if (optind + 1 != argc) {
-            std::cerr << "error: [vg gbwt] one input GBWT is required for removing a sample" << std::endl;
-            std::exit(EXIT_FAILURE);
+    if (!to_remove.empty()) {
+        double start = gbwt::readTimer();
+        if (show_progress) {
+            std::cerr << "Removing sample " << to_remove << " from the index" << std::endl;
         }
-        if (gbwt_output.empty()) {
-            std::cerr << "error: [vg gbwt] output file not specified for removing a sample" << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-        std::unique_ptr<gbwt::DynamicGBWT> index = vg::io::VPKG::load_one<gbwt::DynamicGBWT>(argv[optind]);
-        if (index.get() == nullptr) {
-            std::cerr << "error: [vg gbwt] could not load dynamic GBWT " << argv[optind] << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-        if (!(index->hasMetadata() && index->metadata.hasPathNames() && index->metadata.hasSampleNames())) {
+        get_dynamic(compressed_index, dynamic_index, in_use, gbwt_name, show_progress);
+        if (!(dynamic_index.hasMetadata() && dynamic_index.metadata.hasPathNames() && dynamic_index.metadata.hasSampleNames())) {
             std::cerr << "error: [vg gbwt] the index does not contain metadata with thread and sample names" << std::endl;
             std::exit(EXIT_FAILURE);
         }
-        gbwt::size_type sample_id = index->metadata.sample(to_remove);
-        std::vector<gbwt::size_type> path_ids = index->metadata.removeSample(sample_id);
+        gbwt::size_type sample_id = dynamic_index.metadata.sample(to_remove);
+        std::vector<gbwt::size_type> path_ids = dynamic_index.metadata.removeSample(sample_id);
         if (path_ids.empty()) {
             std::cerr << "error: [vg gbwt] the index does not contain sample " << to_remove << std::endl;
             std::exit(EXIT_FAILURE);
         }
-        size_t foo = index->remove(path_ids);
-        std::string output = (gbwt_output.empty() ? argv[optind] : gbwt_output);
-        vg::io::VPKG::save(*index, output);
-        std::exit(EXIT_SUCCESS);
+        if (show_progress) {
+            std::cerr << "Removing " << path_ids.size() << " threads" << std::endl;
+        }
+        size_t foo = dynamic_index.remove(path_ids);
+        if (show_progress) {
+            double seconds = gbwt::readTimer() - start;
+            std::cerr << "Sample removed in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+            std::cerr << std::endl;
+        }
     }
+
+
+    // Path cover options.
+    if (path_cover != path_cover_none) {
+        double start = gbwt::readTimer();
+        if (show_progress) {
+            std::cerr << "Finding a " << num_paths << "-path cover with context length " << context_length << std::endl;
+        }
+        get_graph(input_graph, graph_in_use, xg_name, show_progress);
+        if (path_cover == path_cover_greedy) {
+            if (show_progress) {
+                std::cerr << "Algorithm: greedy" << std::endl;
+            }
+            compressed_index = gbwtgraph::path_cover_gbwt(*input_graph, num_paths, context_length, buffer_size, id_interval, show_progress);
+            in_use = index_compressed;
+        } else if (path_cover == path_cover_augment) {
+            if (show_progress) {
+                std::cerr << "Algorithm: augment" << std::endl;
+            }
+            get_dynamic(compressed_index, dynamic_index, in_use, gbwt_name, show_progress);
+            gbwtgraph::augment_gbwt(*input_graph, dynamic_index, num_paths, context_length, buffer_size, id_interval, show_progress);
+        } else {
+            if (show_progress) {
+                std::cerr << "Algorithm: local haplotypes" << std::endl;
+            }
+            get_compressed(compressed_index, dynamic_index, in_use, gbwt_name, show_progress);
+            compressed_index = gbwtgraph::local_haplotypes(*input_graph, compressed_index, num_paths, context_length, buffer_size, id_interval, show_progress);
+        }
+        if (show_progress) {
+            double seconds = gbwt::readTimer() - start;
+            std::cerr << "Path cover built in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+            std::cerr << std::endl;
+        }
+    }
+
+
+    // Now we can serialize the GBWT.
+    if (!gbwt_output.empty() && in_use != index_none) {
+        double start = gbwt::readTimer();
+        if (show_progress) {
+            std::cerr << "Serializing the GBWT to " << gbwt_output << std::endl;
+        }
+        if (in_use == index_compressed) {
+            vg::io::VPKG::save(compressed_index, gbwt_output);
+        } else if (in_use == index_dynamic) {
+            vg::io::VPKG::save(dynamic_index, gbwt_output);
+        }
+        if (show_progress) {
+            double seconds = gbwt::readTimer() - start;
+            std::cerr << "GBWT serialized in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+            std::cerr << std::endl;
+        }
+    }
+
+
+    // GBWTGraph construction.
+    if (!graph_output.empty()) {
+        double start = gbwt::readTimer();
+        if (show_progress) {
+            std::cerr << "Building GBWTGraph" << std::endl;
+        }
+        get_graph(input_graph, graph_in_use, xg_name, show_progress);
+        get_compressed(compressed_index, dynamic_index, in_use, gbwt_name, show_progress);
+        if (show_progress) {
+            std::cerr << "Starting the construction" << std::endl;
+        }
+        gbwtgraph::GBWTGraph graph(compressed_index, *input_graph);
+        if (show_progress) {
+            std::cerr << "Serializing GBWTGraph to " << graph_output << std::endl;
+        }
+        vg::io::VPKG::save(graph, graph_output);
+        if (show_progress) {
+            double seconds = gbwt::readTimer() - start;
+            std::cerr << "GBWTGraph built in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+            std::cerr << std::endl;
+        }
+    }
+
+
+    // We no longer need the graph.
+    clear_graph(input_graph, graph_in_use);
 
 
     // R-index construction.
-    if (mode == operation_r_index) {
+    if (!r_index_name.empty()) {
+        double start = gbwt::readTimer();
         if (show_progress) {
-            std::cerr << "Loading GBWT index " << argv[optind] << std::endl;
+            std::cerr << "Building r-index" << std::endl;
         }
-        std::unique_ptr<gbwt::GBWT> index = vg::io::VPKG::load_one<gbwt::GBWT>(argv[optind]);
+        get_compressed(compressed_index, dynamic_index, in_use, gbwt_name, show_progress);
         if (show_progress) {
-            std::cerr << "Building the r-index" << std::endl;
+            std::cerr << "Starting the construction" << std::endl;
         }
-        gbwt::FastLocate r_index(*index);
+        gbwt::FastLocate r_index(compressed_index);
         if (show_progress) {
-            std::cerr << "Saving the r-index to " << r_index_name << std::endl;
+            std::cerr << "Serializing the r-index to " << r_index_name << std::endl;
         }
         vg::io::VPKG::save(r_index, r_index_name);
+        if (show_progress) {
+            double seconds = gbwt::readTimer() - start;
+            std::cerr << "R-index built in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+            std::cerr << std::endl;
+        }
     }
 
 
-    // Other options.
-    if (mode == operation_other) {
-        if (optind + 1 != argc) {
-            std::cerr << "error: [vg gbwt] selected options require one input GBWT" << std::endl;
+    // Metadata options.
+    if (metadata_mode) {
+        get_compressed(compressed_index, dynamic_index, in_use, gbwt_name, show_progress);
+        if (!compressed_index.hasMetadata()) {
+            std::cerr << "error: [vg gbwt] the GBWT does not contain metadata" << std::endl;
             std::exit(EXIT_FAILURE);
         }
-        std::unique_ptr<gbwt::GBWT> index = vg::io::VPKG::load_one<gbwt::GBWT>(argv[optind]);
-        if (index.get() == nullptr) {
-            std::cerr << "error: [vg gbwt] could not load GBWT " << argv[optind] << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-
-        // Extract threads in SDSL format.
-        if (!thread_output.empty()) {
-            gbwt::size_type node_width = gbwt::bit_length(index->sigma() - 1);
-            gbwt::text_buffer_type out(thread_output, std::ios::out, gbwt::MEGABYTE, node_width);
-            for (gbwt::size_type id = 0; id < index->sequences(); id += 2) { // Ignore reverse complements.
-                gbwt::vector_type sequence = index->extract(id);
-                for (auto node : sequence) {
-                    out.push_back(node);
-                }
-                out.push_back(gbwt::ENDMARKER);
-            }
-            out.close();
-        }
-
-        // There are two sequences for each thread.
-        if (count_threads) {
-            std::cout << (index->sequences() / 2) << std::endl;
-        }
-
         if (metadata) {
-            if (index->hasMetadata()) {
-                gbwt::operator<<(std::cout, index->metadata) << std::endl;
-            }
+            gbwt::operator<<(std::cout, compressed_index.metadata) << std::endl;
         }
-
         if (contigs) {
-            if (index->hasMetadata()) {
-                if (list_names) {
-                    if (index->metadata.hasContigNames()) {
-                        for (size_t i = 0; i < index->metadata.contigs(); i++) {
-                            std::cout << index->metadata.contig(i) << std::endl;
-                        }
-                    } else {
-                        std::cerr << "error: [vg gbwt] the metadata does not contain contig names" << std::endl;
+            if (list_names) {
+                if (compressed_index.metadata.hasContigNames()) {
+                    for (size_t i = 0; i < compressed_index.metadata.contigs(); i++) {
+                        std::cout << compressed_index.metadata.contig(i) << std::endl;
                     }
                 } else {
-                    std::cout << index->metadata.contigs() << std::endl;
+                    std::cerr << "error: [vg gbwt] the metadata does not contain contig names" << std::endl;
+                    std::exit(EXIT_FAILURE);
                 }
             } else {
-                std::cout << -1 << std::endl;
+                std::cout << compressed_index.metadata.contigs() << std::endl;
             }
         }
-
         if (haplotypes) {
-            if (index->hasMetadata()) {
-                std::cout << index->metadata.haplotypes() << std::endl;
-            } else {
-                std::cout << -1 << std::endl;
-            }
+            std::cout << compressed_index.metadata.haplotypes() << std::endl;
         }
-
         if (samples) {
-            if (index->hasMetadata()) {
-                if (list_names) {
-                    if (index->metadata.hasSampleNames()) {
-                        for (size_t i = 0; i < index->metadata.samples(); i++) {
-                            std::cout << index->metadata.sample(i) << std::endl;
-                        }
-                    } else {
-                        std::cerr << "error: [vg gbwt] the metadata does not contain sample names" << std::endl;
+            if (list_names) {
+                if (compressed_index.metadata.hasSampleNames()) {
+                    for (size_t i = 0; i < compressed_index.metadata.samples(); i++) {
+                        std::cout << compressed_index.metadata.sample(i) << std::endl;
                     }
                 } else {
-                    std::cout << index->metadata.samples() << std::endl;
+                    std::cerr << "error: [vg gbwt] the metadata does not contain sample names" << std::endl;
+                    std::exit(EXIT_FAILURE);
                 }
             } else {
-                std::cout << -1 << std::endl;
+                std::cout << compressed_index.metadata.samples() << std::endl;
             }
         }
-
         if (thread_names) {
-            if (index->hasMetadata() && index->metadata.hasPathNames()) {
-                for (size_t i = 0; i < index->metadata.paths(); i++) {
-                    std::cout << thread_name(*index, i) << std::endl;
+            if (compressed_index.metadata.hasPathNames()) {
+                for (size_t i = 0; i < compressed_index.metadata.paths(); i++) {
+                    std::cout << thread_name(compressed_index, i) << std::endl;
                 }
             } else {
                 std::cerr << "error: [vg gbwt] the metadata does not contain thread names" << std::endl;
@@ -658,8 +591,133 @@ int main_gbwt(int argc, char** argv)
         }
     }
 
+    // Thread options.
+    if (thread_mode) {
+        // Extract threads in SDSL format.
+        if (!thread_output.empty()) {
+            double start = gbwt::readTimer();
+            if (show_progress) {
+                std::cerr << "Extracting threads to " << thread_output << std::endl;
+            }
+            get_compressed(compressed_index, dynamic_index, in_use, gbwt_name, show_progress);
+            gbwt::size_type node_width = gbwt::bit_length(compressed_index.sigma() - 1);
+            gbwt::text_buffer_type out(thread_output, std::ios::out, gbwt::MEGABYTE, node_width);
+            for (gbwt::size_type id = 0; id < compressed_index.sequences(); id += 2) { // Ignore reverse complements.
+                gbwt::vector_type sequence = compressed_index.extract(id);
+                for (auto node : sequence) {
+                    out.push_back(node);
+                }
+                out.push_back(gbwt::ENDMARKER);
+            }
+            out.close();
+            if (show_progress) {
+                double seconds = gbwt::readTimer() - start;
+                std::cerr << "Threads extracted in " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+                std::cerr << std::endl;
+            }
+        }
+
+        // There are two sequences for each thread.
+        if (count_threads) {
+            get_compressed(compressed_index, dynamic_index, in_use, gbwt_name, show_progress);
+            std::cout << (compressed_index.sequences() / 2) << std::endl;
+        }
+    }
+
     return 0;
 }
+
+
+//----------------------------------------------------------------------------
+
+// Utility functions
+
+void load_gbwt(const std::string& filename, gbwt::GBWT& index, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Loading " << filename << std::endl;
+    }
+    std::unique_ptr<gbwt::GBWT> loaded = vg::io::VPKG::load_one<gbwt::GBWT>(filename);
+    if (loaded.get() == nullptr) {
+        std::cerr << "error: [vg gbwt] could not load compressed GBWT " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    index = std::move(*loaded);
+}
+
+void load_gbwt(const std::string& filename, gbwt::DynamicGBWT& index, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Loading " << filename << std::endl;
+    }
+    std::unique_ptr<gbwt::DynamicGBWT> loaded = vg::io::VPKG::load_one<gbwt::DynamicGBWT>(filename);
+    if (loaded.get() == nullptr) {
+        std::cerr << "error: [vg gbwt] could not load dynamic GBWT " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    index = std::move(*loaded);
+}
+
+void get_compressed(gbwt::GBWT& compressed_index, gbwt::DynamicGBWT& dynamic_index, index_type& in_use, const std::string& filename, bool show_progress) {
+    if (in_use == index_compressed) {
+        return;
+    } else if (in_use == index_dynamic) {
+        if (show_progress) {
+            std::cerr << "Converting dynamic GBWT into compressed GBWT" << std::endl;
+        }
+        compressed_index = gbwt::GBWT(dynamic_index);
+        dynamic_index = gbwt::DynamicGBWT();
+        in_use = index_compressed;
+    } else {
+        load_gbwt(filename, compressed_index, show_progress);
+        in_use = index_compressed;
+    }
+}
+
+void get_dynamic(gbwt::GBWT& compressed_index, gbwt::DynamicGBWT& dynamic_index, index_type& in_use, const std::string& filename, bool show_progress) {
+    if (in_use == index_dynamic) {
+        return;
+    } else if (in_use == index_compressed) {
+        // FIXME in-memory conversion would be better
+        if (show_progress) {
+            std::cerr << "Converting compressed GBWT into dynamic GBWT" << std::endl;
+        }
+        std::string temp_filename = temp_file::create();
+        vg::io::VPKG::save(compressed_index, temp_filename);
+        compressed_index = gbwt::GBWT();
+        load_gbwt(temp_filename, dynamic_index, show_progress);
+        temp_file::remove(temp_filename);
+        in_use = index_dynamic;
+    } else {
+        load_gbwt(filename, dynamic_index, show_progress);
+        in_use = index_dynamic;
+    }
+}
+
+void get_graph(std::unique_ptr<HandleGraph>& graph, bool& in_use, const std::string& filename, bool show_progress) {
+    if (in_use) {
+        return;
+    } else {
+        if (show_progress) {
+            std::cerr << "Loading input graph from " << filename << std::endl;
+        }
+        graph = vg::io::VPKG::load_one<HandleGraph>(filename);
+        if (graph == nullptr) {
+            std::cerr << "error: [vg gbwt] could not load graph " << filename << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        in_use = true;
+    }
+}
+
+void clear_graph(std::unique_ptr<HandleGraph>& graph, bool& in_use) {
+    if (!in_use) {
+        return;
+    } else {
+        graph.reset();
+        in_use = false;
+    }
+}
+
+//----------------------------------------------------------------------------
 
 
 // Register subcommand

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -353,8 +353,9 @@ int main_gbwt(int argc, char** argv)
     }
 
 
-    // Let GBWT operate silently.
+    // Let GBWT operate silently and use the same temporary directory as vg.
     gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+    gbwt::TempFile::setDirectory(temp_file::get_dir());
 
     // This is the data we are using.
     gbwt::GBWT compressed_index;

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -66,7 +66,7 @@ void help_gbwt(char** argv) {
     std::cerr << "    -i, --id-interval N     store path ids at one out of N positions (default " << gbwt::DynamicGBWT::SAMPLE_INTERVAL << ")" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Step 4: GBWTGraph construction (requires -x and one input GBWT):" << std::endl;
-    std::cerr << "    -g, --graph-name FILE   build GBWTGraph and serialize it to FILE" << std::endl;
+    std::cerr << "    -g, --graph-name FILE   build GBWTGraph and store it in FILE" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Step 5: R-index construction (one input GBWT):" << std::endl;
     std::cerr << "    -r, --r-index FILE      build an r-index and store it in FILE" << std::endl;
@@ -80,7 +80,7 @@ void help_gbwt(char** argv) {
     std::cerr << "    -L, --list-names        list contig/sample names (use with -C or -S)" << std::endl;
     std::cerr << "    -T, --thread-names      list thread names" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Step 6: Threads (one input GBWT):" << std::endl;
+    std::cerr << "Step 7: Threads (one input GBWT):" << std::endl;
     std::cerr << "    -c, --count-threads     print the number of threads" << std::endl;
     std::cerr << "    -e, --extract FILE      extract threads in SDSL format to FILE" << std::endl;
     std::cerr << std::endl;
@@ -676,15 +676,11 @@ void get_dynamic(gbwt::GBWT& compressed_index, gbwt::DynamicGBWT& dynamic_index,
     if (in_use == index_dynamic) {
         return;
     } else if (in_use == index_compressed) {
-        // FIXME in-memory conversion would be better
         if (show_progress) {
             std::cerr << "Converting compressed GBWT into dynamic GBWT" << std::endl;
         }
-        std::string temp_filename = temp_file::create();
-        vg::io::VPKG::save(compressed_index, temp_filename);
+        dynamic_index = gbwt::DynamicGBWT(compressed_index);
         compressed_index = gbwt::GBWT();
-        load_gbwt(temp_filename, dynamic_index, show_progress);
-        temp_file::remove(temp_filename);
         in_use = index_dynamic;
     } else {
         load_gbwt(filename, dynamic_index, show_progress);

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -601,6 +601,9 @@ int main_gbwt(int argc, char** argv)
                 std::cerr << "Extracting threads to " << thread_output << std::endl;
             }
             get_compressed(compressed_index, dynamic_index, in_use, gbwt_name, show_progress);
+            if (show_progress) {
+                std::cerr << "Starting the extraction" << std::endl;
+            }
             gbwt::size_type node_width = gbwt::bit_length(compressed_index.sigma() - 1);
             gbwt::text_buffer_type out(thread_output, std::ios::out, gbwt::MEGABYTE, node_width);
             for (gbwt::size_type id = 0; id < compressed_index.sequences(); id += 2) { // Ignore reverse complements.

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -455,6 +455,12 @@ int main_index(int argc, char** argv) {
         file_names.push_back(file_name);
     }
 
+    // Use the same temp directory in submodules.
+    gcsa::TempFile::setDirectory(temp_file::get_dir());
+    gbwt::TempFile::setDirectory(temp_file::get_dir());
+    xg::temp_file::set_dir(temp_file::get_dir());
+
+
     if (xg_name.empty() && gbwt_name.empty() && haplotype_indexer.batch_file_prefix.empty() &&
         gcsa_name.empty() && rocksdb_name.empty() && !build_gai_index && !build_vgi_index && dist_name.empty()) {
         cerr << "error: [vg index] index type not specified" << endl;
@@ -528,6 +534,7 @@ int main_index(int argc, char** argv) {
         build_xg = false;
         std::cerr << "warning: [vg index] providing input XG with option -x is deprecated" << std::endl;
     }
+
 
     // Build XG. Include alt paths in the XG if requested with -L.
     if (build_xg) {
@@ -610,9 +617,6 @@ int main_index(int argc, char** argv) {
         if (!show_progress) {
             gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
         }
-
-        // Use the same temp directory as VG.
-        gcsa::TempFile::setDirectory(temp_file::get_dir());
 
         double start = gcsa::readTimer();
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

* Refactored `vg gbwt`.
* Fixed a rare `GaplessExtender` bug.
* Use the same temp directory for all submodules in `vg index`.

## Description

I refactored `vg gbwt` to make it easier to move GBWT construction there.

`vg index` now uses the same temp directory for vg, GBWT, GCSA2, and xg. See #2447, #2451, and #2997.

`GaplessExtender` had a rare bug where it could not always find the extension containing the seed. We could miss the right extension of the correct haplotype if we already had enough mismatches, the next node started with a mismatch, and another right extension started with a match. That would then rule out the left extension containing the seed. This was fixed by considering an extension right-maximal if we fail to find right extensions for some haplotypes. This resolves #3002.