### PR TITLE
Account for score_mismatch scoring negative

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -807,7 +807,7 @@ int32_t GSSWAligner::score_discontiguous_alignment(const Alignment& aln, const f
                 score += score_exact_match(aln, read_offset, edit.to_length());
                 last_was_deletion = false;
             } else if (edit_is_sub(edit)) {
-                score -= score_mismatch(aln.sequence().begin() + read_offset,
+                score += score_mismatch(aln.sequence().begin() + read_offset,
                                         aln.sequence().begin() + read_offset + edit.to_length(),
                                         aln.quality().begin() + read_offset);
                 last_was_deletion = false;

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -167,7 +167,9 @@ namespace vg {
         /// Qualities may be ignored by some implementations.
         virtual int32_t score_exact_match(string::const_iterator seq_begin, string::const_iterator seq_end,
                                           string::const_iterator base_qual_begin) const = 0;
-        
+        /// Compute the score of a mismatch of the given range of sequence with the given qualities.
+        /// Qualities may be ignored by some implementations.
+        /// Note that the return value is SIGNED, and almost certainly NEGATIVE, because mismatches are bad.
         virtual int32_t score_mismatch(string::const_iterator seq_begin, string::const_iterator seq_end,
                                        string::const_iterator base_qual_begin) const = 0;
                 
@@ -350,6 +352,7 @@ namespace vg {
                                string::const_iterator base_qual_begin) const;
         
         /// Score a mismatch given just the length. Only possible since we ignore qualities.
+        /// Return value is SIGNED, and almost certainly NEGATIVE
         int32_t score_mismatch(size_t length) const;
 
         int32_t score_partial_alignment(const Alignment& alignment, const HandleGraph& graph, const Path& path,


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Mismatches are now recognized as bad byu alignment rescoring

## Description

This should fix #3001, I think.
