### PR TITLE
sync with vgteam's ssw HEAD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,8 +427,8 @@ else
 	+. ./source_me.sh && cd $(SDSL_DIR) && BUILD_PORTABLE=1 CXXFLAGS="$(CPPFLAGS) $(CXXFLAGS)" ./install.sh $(CWD) $(FILTER)
 endif
 
-$(LIB_DIR)/libssw.a: $(SSW_DIR)/*.c $(SSW_DIR)/*.h
-	+. ./source_me.sh && cd $(SSW_DIR) && $(MAKE) $(FILTER) && ar rs $(CWD)/$(LIB_DIR)/libssw.a ssw.o ssw_cpp.o && cp ssw_cpp.h ssw.h $(CWD)/$(LIB_DIR)
+$(LIB_DIR)/libssw.a: $(SSW_DIR)/*.c $(SSW_DIR)/*.cpp $(SSW_DIR)/*.h
+	+. ./source_me.sh && cd $(SSW_DIR) && $(MAKE) $(FILTER) && ar rs $(CWD)/$(LIB_DIR)/libssw.a ssw.o ssw_cpp.o && cp ssw_cpp.h ssw.h $(CWD)/$(INC_DIR)
 
 # We need to hide -Xpreprocessor -fopenmp from Snappy, at least on Mac, because
 # it will drop the -Xpreprocessor and keep the -fopenmp and upset Clang.

--- a/src/ssw_aligner.cpp
+++ b/src/ssw_aligner.cpp
@@ -23,7 +23,13 @@ Alignment SSWAligner::align(const string& query, const string& ref) {
                                           gap_extension);
     StripedSmithWaterman::Filter filter;
     StripedSmithWaterman::Alignment alignment;
-    aligner.Align(query.c_str(), ref.c_str(), ref.size(), filter, &alignment);
+    
+    // We need to send out own mask length, recommended to be half the sequence length and at least 15.
+    int32_t mask_len = min(max((size_t) 15, query.size()), (size_t) numeric_limits<int32_t>::max());
+    
+    assert(ref.size() <= numeric_limits<int>::max());
+    
+    aligner.Align(query.c_str(), ref.c_str(), (int) ref.size(), filter, &alignment, mask_len);
     return ssw_to_vg(alignment, query, ref);
 }
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Smith Waterman library updated to enable cross building and non-x86 architectures.
