### PR TITLE
Emit raw HandleGraphs that libbdsg can read.

### DIFF
--- a/src/io/converted_hash_graph.hpp
+++ b/src/io/converted_hash_graph.hpp
@@ -1,0 +1,23 @@
+#ifndef VG_IO_CONVERTED_HASH_GRAPH_HPP_INCLUDED
+#define VG_IO_CONVERTED_HASH_GRAPH_HPP_INCLUDED
+
+#include <bdsg/hash_graph.hpp>
+
+namespace vg {
+
+namespace io {
+
+/**
+ * Define a type that inherits HashGraph so we can tell the difference between
+ * a real HashGraph and a HashGraph converted at load time. We care about this
+ * so that vg stats can tell you the original input file format.
+ */
+class ConvertedHashGraph : public bdsg::HashGraph {
+    using bdsg::HashGraph::HashGraph;
+};
+
+}
+
+}
+
+#endif

--- a/src/io/register_loader_saver_hash_graph.cpp
+++ b/src/io/register_loader_saver_hash_graph.cpp
@@ -6,6 +6,7 @@
 #include <vg/io/registry.hpp>
 #include "register_loader_saver_hash_graph.hpp"
 #include "load_proto_to_graph.hpp"
+#include "converted_hash_graph.hpp"
 
 #include "../handle.hpp"
 #include <bdsg/hash_graph.hpp>
@@ -48,8 +49,9 @@ void register_loader_saver_hash_graph() {
         vector<string>{"VG", ""},
         [](const message_sender_function_t& for_each_message) -> void* {
     
-        // Allocate a HashGraph
-        bdsg::HashGraph* hash_graph = new bdsg::HashGraph();
+        // Allocate a HashGraph that's really a ConvertedHashGraph, to mark
+        // that we converted form Protobuf.
+        bdsg::HashGraph* hash_graph = new vg::io::ConvertedHashGraph();
         
         // Load into it
         load_proto_to_graph(hash_graph, for_each_message);

--- a/src/io/save_handle_graph.hpp
+++ b/src/io/save_handle_graph.hpp
@@ -6,6 +6,7 @@
  * Use vpkg to serialize a HandleGraph object
  */
 
+#include <handlegraph/serializable_handle_graph.hpp>
 #include "bdsg/packed_graph.hpp"
 #include "bdsg/hash_graph.hpp"
 #include "bdsg/odgi.hpp"
@@ -24,36 +25,29 @@ using namespace std;
 
 
 /**
- * Save a handle graph using the VPKG::save() function. 
+ * Save a handle graph. 
  * Todo: should this be somewhere else (ie in vgio with new types registered?)
  */
 inline void save_handle_graph(HandleGraph* graph, ostream& os) {
-    if (dynamic_cast<VG*>(graph) != nullptr) {
+    
+    if (dynamic_cast<SerializableHandleGraph*>(graph) != nullptr) {
+        // SerializableHandleGraphs are all serialized bare, without VPKG framing, for libbdsg compatibility.
+        dynamic_cast<SerializableHandleGraph*>(graph)->serialize(os);
+    } else if (dynamic_cast<VG*>(graph) != nullptr) {
+        // vg::VG doesn't use a magic number and isn't a SerializableHandleGraph
         vg::io::VPKG::save(*dynamic_cast<VG*>(graph), os);
-    } else if (dynamic_cast<bdsg::HashGraph*>(graph) != nullptr) {
-        vg::io::VPKG::save(*dynamic_cast<bdsg::HashGraph*>(graph), os);
-    } else if (dynamic_cast<bdsg::PackedGraph*>(graph) != nullptr) {
-        vg::io::VPKG::save(*dynamic_cast<bdsg::PackedGraph*>(graph), os);
-    } else if (dynamic_cast<bdsg::ODGI*>(graph) != nullptr) {
-        vg::io::VPKG::save(*dynamic_cast<bdsg::ODGI*>(graph), os);
-    } else if (dynamic_cast<xg::XG*>(graph) != nullptr) {
-        vg::io::VPKG::save(*dynamic_cast<xg::XG*>(graph), os);
     } else {
         throw runtime_error("Internal error: unable to serialize graph");
     }
 }
 
 inline void save_handle_graph(HandleGraph* graph, const string& dest_path) {
-    if (dynamic_cast<VG*>(graph) != nullptr) {
+    if (dynamic_cast<SerializableHandleGraph*>(graph) != nullptr) {
+        // SerializableHandleGraphs are all serialized bare, without VPKG framing, for libbdsg compatibility.
+        dynamic_cast<SerializableHandleGraph*>(graph)->serialize(dest_path);
+    } else if (dynamic_cast<VG*>(graph) != nullptr) {
+        // vg::VG doesn't use a magic number and isn't a SerializableHandleGraph
         vg::io::VPKG::save(*dynamic_cast<VG*>(graph), dest_path);
-    } else if (dynamic_cast<bdsg::HashGraph*>(graph) != nullptr) {
-        vg::io::VPKG::save(*dynamic_cast<bdsg::HashGraph*>(graph), dest_path);
-    } else if (dynamic_cast<bdsg::PackedGraph*>(graph) != nullptr) {
-        vg::io::VPKG::save(*dynamic_cast<bdsg::PackedGraph*>(graph), dest_path);
-    } else if (dynamic_cast<bdsg::ODGI*>(graph) != nullptr) {
-        vg::io::VPKG::save(*dynamic_cast<bdsg::ODGI*>(graph), dest_path);
-    } else if (dynamic_cast<xg::XG*>(graph) != nullptr) {
-        vg::io::VPKG::save(*dynamic_cast<xg::XG*>(graph), dest_path);
     } else {
         throw runtime_error("Internal error: unable to serialize graph");
     }    

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -33,6 +33,7 @@
 #include "bdsg/packed_graph.hpp"
 #include "bdsg/hash_graph.hpp"
 #include "bdsg/odgi.hpp"
+#include "../io/converted_hash_graph.hpp"
 
 using namespace std;
 using namespace vg;
@@ -384,27 +385,15 @@ int main_stats(int argc, char** argv) {
             format_string = "XG";
         } else if (dynamic_cast<bdsg::PackedGraph*>(graph.get()) != nullptr) {
             format_string = "PackedGraph";
+        } else if (dynamic_cast<vg::io::ConvertedHashGraph*>(graph.get()) != nullptr) {
+            // Was Protobuf but we're using a HashGraph internally
+            format_string = "VG-Protobuf";
         } else if (dynamic_cast<bdsg::HashGraph*>(graph.get()) != nullptr) {
             format_string = "HashGraph";
         } else if (dynamic_cast<bdsg::ODGI*>(graph.get()) != nullptr) {
             format_string = "ODGI";
         } else {
             format_string = "Unknown";
-        }
-        if (graph_file_name != "-" && format_string == "HashGraph") {
-            // Maybe vpkg loaded a protobuf graph into a different handle graph format
-            // (it currently uses HashGraph)
-            try {
-                ifstream graph_stream(graph_file_name);
-                vg::io::MessageIterator message_it(graph_stream);
-                if (message_it.has_current()) {
-                    string msg_tag = message_it.take().first;
-                    // older protobufs are untagged, newer ones are tagged "VG"
-                    if (msg_tag.empty() || msg_tag == "VG") {
-                        format_string = "VG-Protobuf";
-                    }
-                }
-            } catch(...) {}
         }
         cout << "format: " << format_string << endl;
     }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Now vg outputs raw handle graph files readable by libbdsg without the need for `vg view -x/--extract-tag`.

## Description

This changes vg to output HashGraph, PackedGraph, and ODGI graphs without any VPKG framing, so that libbdsg can read them. It also switches over to a libvgio that can read them from standard input (by buffering standard input enough that we are guaranteed to be able to unget enough characters to sniff the format safely).