### PR TITLE
-a to deconstruct all snarls instead of just top-level

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -372,7 +372,7 @@ bool Deconstructor::deconstruct_site(const Snarl* snarl) {
  * Convenience wrapper function for deconstruction of multiple paths.
  */
 void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHandleGraph* graph, SnarlManager* snarl_manager,
-                                bool path_restricted_traversals, int ploidy,
+                                bool path_restricted_traversals, int ploidy, bool include_nested,
                                 const unordered_map<string, string>* path_to_sample) {
 
     this->graph = graph;
@@ -453,7 +453,7 @@ void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHand
                     // if we can't make a variant from the snarl due to not finding
                     // paths through it, we try again on the children
                     // note: we may want to push the parallelism down a bit 
-                    if (!deconstruct_site(next_snarl)) {
+                    if (!deconstruct_site(next_snarl) || include_nested) {
                         const vector<const Snarl*>& children = snarl_manager->children_of(next_snarl);
                         next.insert(next.end(), children.begin(), children.end());
                     }

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -32,7 +32,7 @@ public:
 
     // deconstruct the entire graph to cout
     void deconstruct(vector<string> refpaths, const PathPositionHandleGraph* grpah, SnarlManager* snarl_manager,
-                     bool path_restricted_traversals, int ploidy,
+                     bool path_restricted_traversals, int ploidy, bool include_nested,
                      const unordered_map<string, string>* path_to_sample = nullptr); 
     
 private:

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -32,6 +32,7 @@ void help_deconstruct(char** argv){
          << "    -A, --alt-prefix NAME    Non-reference paths beginning with NAME get lumped together to same sample in VCF (multiple allowed).  Other non-ref paths not considered as samples." << endl
          << "    -r, --snarls FILE        Snarls file (from vg snarls) to avoid recomputing." << endl
          << "    -e, --path-traversals    Only consider traversals that correspond to paths in the grpah." << endl
+         << "    -a, --all-snarls         Process all snarls, including nested snarls (by default only top-level snarls reported)." << endl
          << "    -d, --ploidy N           Expected ploidy.  If more traversals found, they will be flagged as conflicts (default: 2)" << endl
          << "    -t, --threads N          Use N threads" << endl
          << "    -v, --verbose            Print some status messages" << endl
@@ -52,6 +53,7 @@ int main_deconstruct(int argc, char** argv){
     bool path_restricted_traversals = false;
     bool show_progress = false;
     int ploidy = 2;
+    bool all_snarls = false;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -64,7 +66,8 @@ int main_deconstruct(int argc, char** argv){
                 {"alt-prefix", required_argument, 0, 'A'},
                 {"snarls", required_argument, 0, 'r'},
                 {"path-traversals", no_argument, 0, 'e'},
-                {"ploidy", required_argument, 0, 'd'},                
+                {"ploidy", required_argument, 0, 'd'},
+                {"all-snarls", no_argument, 0, 'a'},
                 {"threads", required_argument, 0, 't'},
                 {"verbose", no_argument, 0, 'v'},
                 {0, 0, 0, 0}
@@ -72,7 +75,7 @@ int main_deconstruct(int argc, char** argv){
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hp:P:A:r:ed:t:v",
+        c = getopt_long (argc, argv, "hp:P:A:r:ed:at:v",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -98,7 +101,10 @@ int main_deconstruct(int argc, char** argv){
             break;
         case 'd':
             ploidy = parse<int>(optarg);
-            break;            
+            break;
+        case 'a':
+            all_snarls = true;
+            break;
         case 't':
             omp_set_num_threads(parse<int>(optarg));
             break;
@@ -195,7 +201,7 @@ int main_deconstruct(int argc, char** argv){
     if (show_progress) {
         cerr << "Decsontructing top-level snarls" << endl;
     }
-    dd.deconstruct(refpaths, graph, snarl_manager.get(), path_restricted_traversals, ploidy,
+    dd.deconstruct(refpaths, graph, snarl_manager.get(), path_restricted_traversals, ploidy, all_snarls,
                    !alt_path_to_prefix.empty() ? &alt_path_to_prefix : nullptr);
     return 0;
 }

--- a/src/variant_recall.cpp
+++ b/src/variant_recall.cpp
@@ -78,7 +78,7 @@ void genotype_svs(VG* graph,
         Deconstructor decon;
         CactusSnarlFinder finder(xg_index);
         SnarlManager snarl_manager = finder.find_snarls();
-        decon.deconstruct({refpath}, &xg_index, &snarl_manager, false, 1);
+        decon.deconstruct({refpath}, &xg_index, &snarl_manager, false, 1, false);
     }
     direct_ins.clear();
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg deconstruct` includes new option `-a` to process every snarl (instead of just top-level snarls)

## Description

resolves #2878