### PR TITLE
Add missing break to vg convert

### DIFF
--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -82,6 +82,7 @@ int main_convert(int argc, char** argv) {
             return 0;
         case 'g':
             input_gfa = true;
+            break;
         case 'v':
             output_format = "vg";
             break;


### PR DESCRIPTION
We will no longer set the output format to vg::VG when we set the input format to GFA.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg convert` calls with `-g` as the last option will now convert to the correct format, not always Protobuf 