### PR TITLE
Quality adjusted full length bonuses

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1687,10 +1687,13 @@ int8_t* QualAdjAligner::qual_adjusted_bonuses(int8_t _full_length_bonus, uint32_
     int8_t* qual_adj_bonuses = (int8_t*) calloc(max_qual + 1, sizeof(int8_t));
     
     int lowest_meaningful_qual = ceil(-10.0 * log10(0.75));
+    // hack because i want the minimum qual value from illumina (2) to have zero score, but phred
+    // values are spaced out in a way to approximate this singularity well
+    ++lowest_meaningful_qual;
     
     for (int q = lowest_meaningful_qual; q <= max_qual; ++q) {
         double err = pow(10.0, -q / 10.0);
-        double score = log(((1.0 - err) * p_full_len + err * (1.0 - p_full_len)) / (1.0 - p_full_len)) / log_base;
+        double score = log(((1.0 - err * 4.0 / 3.0) * p_full_len + (err * 4.0 / 3.0) * (1.0 - p_full_len)) / (1.0 - p_full_len)) / log_base;
         qual_adj_bonuses[q] = round(score);
     }
     

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -181,6 +181,12 @@ namespace vg {
         /// Note that the return value is SIGNED, and almost certainly NEGATIVE, because mismatches are bad.
         virtual int32_t score_mismatch(string::const_iterator seq_begin, string::const_iterator seq_end,
                                        string::const_iterator base_qual_begin) const = 0;
+        
+        virtual int32_t score_full_length_bonus(bool left_side, string::const_iterator seq_begin,
+                                                string::const_iterator seq_end,
+                                                string::const_iterator base_qual_begin) const = 0;
+        
+        virtual int32_t score_full_length_bonus(bool left_side, const Alignment& alignment) const = 0;
                 
         /// Compute the score of a path against the given range of subsequence with the given qualities.
         virtual int32_t score_partial_alignment(const Alignment& alignment, const HandleGraph& graph, const Path& path,
@@ -363,6 +369,12 @@ namespace vg {
         /// Score a mismatch given just the length. Only possible since we ignore qualities.
         /// Return value is SIGNED, and almost certainly NEGATIVE
         int32_t score_mismatch(size_t length) const;
+        
+        int32_t score_full_length_bonus(bool left_side, string::const_iterator seq_begin,
+                                        string::const_iterator seq_end,
+                                        string::const_iterator base_qual_begin) const;
+        
+        int32_t score_full_length_bonus(bool left_side, const Alignment& alignment) const;
 
         int32_t score_partial_alignment(const Alignment& alignment, const HandleGraph& graph, const Path& path,
                                         string::const_iterator seq_begin, bool no_read_end_scoring = false) const;
@@ -416,7 +428,13 @@ namespace vg {
                                   string::const_iterator base_qual_begin) const;
         int32_t score_mismatch(string::const_iterator seq_begin, string::const_iterator seq_end,
                                string::const_iterator base_qual_begin) const;
-                                  
+        
+        int32_t score_full_length_bonus(bool left_side, string::const_iterator seq_begin,
+                                        string::const_iterator seq_end,
+                                        string::const_iterator base_qual_begin) const;
+        
+        int32_t score_full_length_bonus(bool left_side, const Alignment& alignment) const;
+        
         int32_t score_partial_alignment(const Alignment& alignment, const HandleGraph& graph, const Path& path,
                                         string::const_iterator seq_begin, bool no_read_end_scoring = false) const;
         

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -421,7 +421,7 @@ namespace vg {
                                         string::const_iterator seq_begin, bool no_read_end_scoring = false) const;
         
         
-    private:
+    protected:
         
         int8_t* qual_adjusted_matrix(const int8_t* score_matrix, double gc_content, uint32_t max_qual) const;
 

--- a/src/dozeu_interface.cpp
+++ b/src/dozeu_interface.cpp
@@ -144,7 +144,7 @@ DozeuInterface::graph_pos_s DozeuInterface::calculate_max_position(const Ordered
 
 pair<DozeuInterface::graph_pos_s, bool> DozeuInterface::scan_seed_position(const OrderedGraph& graph, const Alignment& alignment,
                                                                            bool direction, vector<const dz_forefront_s*>& forefronts,
-                                                                           uint16_t max_gap_length)
+                                                                           int8_t full_length_bonus, uint16_t max_gap_length)
 {
     const string& query_seq = alignment.sequence();
     const string& query_qual = alignment.quality();
@@ -158,8 +158,8 @@ pair<DozeuInterface::graph_pos_s, bool> DozeuInterface::scan_seed_position(const
     }
     
 	const dz_query_s* packed_query = (direction
-		? pack_query_reverse(pack_seq, pack_qual, scan_len)
-		: pack_query_forward(pack_seq, pack_qual, scan_len)
+		? pack_query_reverse(pack_seq, pack_qual, full_length_bonus, scan_len)
+		: pack_query_forward(pack_seq, pack_qual, full_length_bonus, scan_len)
 	);
     
     // make a root forefront
@@ -604,14 +604,15 @@ void DozeuInterface::debug_print(const Alignment& alignment, const OrderedGraph&
  * Then we extend the head seed backing-downstream, and trace that back to find the optimal alignment.
  */
 void DozeuInterface::align(Alignment& alignment, const HandleGraph& graph, const vector<MaximalExactMatch>& mems,
-                           bool reverse_complemented, uint16_t max_gap_length)
+                           bool reverse_complemented, int8_t full_length_bonus, uint16_t max_gap_length)
 {
     vector<handle_t> topological_order = algorithms::lazy_topological_order(&graph);
     return align(alignment, graph, topological_order, mems, reverse_complemented, max_gap_length);
 }
   
 void DozeuInterface::align(Alignment& alignment, const HandleGraph& graph, const vector<handle_t>& order,
-                           const vector<MaximalExactMatch>& mems, bool reverse_complemented, uint16_t max_gap_length)
+                           const vector<MaximalExactMatch>& mems, bool reverse_complemented,
+                           int8_t full_length_bonus, uint16_t max_gap_length)
 {
 
     const OrderedGraph ordered_graph(graph, order);
@@ -635,7 +636,8 @@ void DozeuInterface::align(Alignment& alignment, const HandleGraph& graph, const
         
         // scan seed position mems is empty
         bool scan_success;
-		tie(head_pos, scan_success) = scan_seed_position(ordered_graph, alignment, direction, forefronts, max_gap_length);
+		tie(head_pos, scan_success) = scan_seed_position(ordered_graph, alignment, direction, forefronts,
+                                                         full_length_bonus, max_gap_length);
         if (!scan_success) {
             // we failed to find a seed, so we will not attempt an alignment
             // clear the path just in case we're realigning a GAM
@@ -657,8 +659,8 @@ void DozeuInterface::align(Alignment& alignment, const HandleGraph& graph, const
         
         // pack query (upward)
 		const dz_query_s* packed_query_seq_up = (direction
-			? pack_query_reverse(pack_seq, pack_qual, seed_pos.query_offset)
-			: pack_query_forward(pack_seq, pack_qual, query_seq.size() - seed_pos.query_offset)
+			? pack_query_reverse(pack_seq, pack_qual, full_length_bonus, seed_pos.query_offset)
+			: pack_query_forward(pack_seq, pack_qual, full_length_bonus, query_seq.size() - seed_pos.query_offset)
 		);
 		// upward extension
 		head_pos = calculate_max_position(ordered_graph, seed_pos,
@@ -669,7 +671,7 @@ void DozeuInterface::align(Alignment& alignment, const HandleGraph& graph, const
 	// fprintf(stderr, "head_node_index(%lu), rpos(%lu, %u), qpos(%u), direction(%d)\n", head_pos.node_index, head_pos.node_index, head_pos.ref_offset, head_pos.query_offset, direction);
     
     // Now that we have determined head_pos, do the downward alignment from there, and the traceback.
-    align_downward(alignment, ordered_graph, {head_pos}, reverse_complemented, forefronts, max_gap_length);
+    align_downward(alignment, ordered_graph, {head_pos}, reverse_complemented, forefronts, full_length_bonus, max_gap_length);
     
     #ifdef DEBUG
 		if (mems.empty()) {
@@ -680,8 +682,9 @@ void DozeuInterface::align(Alignment& alignment, const HandleGraph& graph, const
     // bench_end(bench);
 }
     
-void DozeuInterface::align_downward(Alignment &alignment, const OrderedGraph& graph, const vector<graph_pos_s>& head_positions,
-                                    bool left_to_right, vector<const dz_forefront_s*>& forefronts, uint16_t max_gap_length)
+void DozeuInterface::align_downward(Alignment& alignment, const OrderedGraph& graph, const vector<graph_pos_s>& head_positions,
+                                    bool left_to_right, vector<const dz_forefront_s*>& forefronts,
+                                    int8_t full_length_bonus, uint16_t max_gap_length)
 { 
 
     // we're now allowing multiple graph start positions, but not multiple read start positions
@@ -702,8 +705,8 @@ void DozeuInterface::align_downward(Alignment &alignment, const OrderedGraph& gr
     
 	// pack query (downward)
 	const dz_query_s* packed_query_seq_dn = (left_to_right
-		? pack_query_forward(pack_seq, pack_qual, qlen - head_positions.front().query_offset)
-		: pack_query_reverse(pack_seq, pack_qual, head_positions.front().query_offset)
+		? pack_query_forward(pack_seq, pack_qual, full_length_bonus, qlen - head_positions.front().query_offset)
+		: pack_query_reverse(pack_seq, pack_qual, full_length_bonus, head_positions.front().query_offset)
 	);
 
 	// downward extension
@@ -716,7 +719,8 @@ void DozeuInterface::align_downward(Alignment &alignment, const OrderedGraph& gr
 	flush();
 }
 
-void DozeuInterface::align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left, uint16_t max_gap_length)
+void DozeuInterface::align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left,
+                                  int8_t full_length_bonus, uint16_t max_gap_length)
 {
     // Compute our own topological order
     vector<handle_t> order = algorithms::lazy_topological_order(&g);
@@ -756,7 +760,7 @@ void DozeuInterface::align_pinned(Alignment& alignment, const HandleGraph& g, bo
     vector<const dz_forefront_s*> forefronts(ordered.order.size(), nullptr);
     
     // Do the left-to-right alignment from the fixed head_pos seed, and then do the traceback.
-    align_downward(alignment, ordered, head_positions, pin_left, forefronts, max_gap_length);
+    align_downward(alignment, ordered, head_positions, pin_left, forefronts, full_length_bonus, max_gap_length);
 }
 
 /**

--- a/src/dozeu_interface.hpp
+++ b/src/dozeu_interface.hpp
@@ -90,7 +90,8 @@ public:
      * true, and the last occurrence of the first MEM otherwise.
      */
     void align(Alignment& alignment, const HandleGraph& graph, const vector<MaximalExactMatch>& mems,
-               bool reverse_complemented, uint16_t max_gap_length = default_xdrop_max_gap_length);
+               bool reverse_complemented, int8_t full_length_bonus,
+               uint16_t max_gap_length = default_xdrop_max_gap_length);
     
     /**
      * Same as above except using a precomputed topological order, which
@@ -98,8 +99,8 @@ public:
      * orientations of a handle.
      */
     void align(Alignment& alignment, const HandleGraph& graph, const vector<handle_t>& order,
-               const vector<MaximalExactMatch>& mems,  bool reverse_complemented,
-               uint16_t max_gap_length = default_xdrop_max_gap_length);
+               const vector<MaximalExactMatch>& mems, bool reverse_complemented,
+               int8_t full_length_bonus, uint16_t max_gap_length = default_xdrop_max_gap_length);
     
     /**
      * Compute a pinned alignment, where the start (pin_left=true) or end
@@ -111,7 +112,7 @@ public:
      * order; whichever comes first/last ends up being used for the pin.
      */
     void align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left,
-                      uint16_t max_gap_length = default_xdrop_max_gap_length);
+                      int8_t full_length_bonus, uint16_t max_gap_length = default_xdrop_max_gap_length);
     
 protected:
     /**
@@ -142,8 +143,10 @@ protected:
     
     // wrappers for dozeu functions that can be used to toggle between between quality
     // adjusted and standard alignments
-    virtual dz_query_s* pack_query_forward(const char* seq, const uint8_t* qual, size_t len) = 0;
-    virtual dz_query_s* pack_query_reverse(const char* seq, const uint8_t* qual, size_t len) = 0;
+    virtual dz_query_s* pack_query_forward(const char* seq, const uint8_t* qual,
+                                           int8_t full_length_bonus, size_t len) = 0;
+    virtual dz_query_s* pack_query_reverse(const char* seq, const uint8_t* qual,
+                                           int8_t full_length_bonus, size_t len) = 0;
     virtual const dz_forefront_s* scan(const dz_query_s* query, const dz_forefront_s** forefronts,
                                        size_t n_forefronts, const char* ref, int32_t rlen, uint32_t rid,
                                        uint16_t xt) = 0;
@@ -178,7 +181,7 @@ protected:
     /// If the scan failed, then the alignment should not be attempted.
     pair<graph_pos_s, bool> scan_seed_position(const OrderedGraph& graph, const Alignment& alignment,
                                                bool direction, vector<const dz_forefront_s*>& forefronts,
-                                               uint16_t max_gap_length);
+                                               int8_t full_length_bonus, uint16_t max_gap_length);
     
     /// Append an edit at the end of the current mapping array.
     /// Returns the length passed in.
@@ -234,7 +237,7 @@ protected:
     void align_downward(Alignment &alignment, const OrderedGraph& graph,
                         const vector<graph_pos_s>& head_positions,
                         bool left_to_right, vector<const dz_forefront_s*>& forefronts,
-                        uint16_t max_gap_length);
+                        int8_t full_length_bonus, uint16_t max_gap_length);
     
     
     /// The core dozeu class, which does the alignments
@@ -251,8 +254,7 @@ public:
     /// Main constructor. Expects a 4 x 4 score matrix.
     XdropAligner(const int8_t* _score_matrix,
                  int8_t _gap_open,
-                 int8_t _gap_extension,
-                 int32_t _full_length_bonus);
+                 int8_t _gap_extension);
     
     // see DozeuInterface::align and DozeuInterface::align_pinned below for alignment
     // interface
@@ -260,8 +262,8 @@ public:
 private:
     
     // implementations of virtual functions from DozeuInterface
-    dz_query_s* pack_query_forward(const char* seq, const uint8_t* qual, size_t len);
-    dz_query_s* pack_query_reverse(const char* seq, const uint8_t* qual, size_t len);
+    dz_query_s* pack_query_forward(const char* seq, const uint8_t* qual, int8_t full_length_bonus, size_t len);
+    dz_query_s* pack_query_reverse(const char* seq, const uint8_t* qual, int8_t full_length_bonus, size_t len);
     const dz_forefront_s* scan(const dz_query_s* query, const dz_forefront_s** forefronts,
                                size_t n_forefronts, const char* ref, int32_t rlen, uint32_t rid,
                                uint16_t xt);
@@ -297,8 +299,7 @@ public:
     QualAdjXdropAligner(const int8_t* _score_matrix,
                         const int8_t* _qual_adj_score_matrix,
                         int8_t _gap_open,
-                        int8_t _gap_extension,
-                        int32_t _full_length_bonus);
+                        int8_t _gap_extension);
     
     
     // see DozeuInterface::align and DozeuInterface::align_pinned below for alignment
@@ -307,8 +308,8 @@ public:
 private:
     
     // implementations of virtual functions from DozeuInterface
-    dz_query_s* pack_query_forward(const char* seq, const uint8_t* qual, size_t len);
-    dz_query_s* pack_query_reverse(const char* seq, const uint8_t* qual, size_t len);
+    dz_query_s* pack_query_forward(const char* seq, const uint8_t* qual, int8_t full_length_bonus, size_t len);
+    dz_query_s* pack_query_reverse(const char* seq, const uint8_t* qual, int8_t full_length_bonus, size_t len);
     const dz_forefront_s* scan(const dz_query_s* query, const dz_forefront_s** forefronts,
                                        size_t n_forefronts, const char* ref, int32_t rlen, uint32_t rid,
                                        uint16_t xt);

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3415,8 +3415,8 @@ namespace vg {
             PathNode& from_node = path_nodes.at(i);
             node_weights[i] = (aligner->score_exact_match(from_node.begin, from_node.end,
                                                           alignment.quality().begin() + (from_node.begin - alignment.sequence().begin()))
-                               + aligner->full_length_bonus * ((from_node.begin == alignment.sequence().begin())
-                                                               + (from_node.end == alignment.sequence().end())));
+                               + (from_node.begin == alignment.sequence().begin() ? aligner->score_full_length_bonus(true, alignment) : 0)
+                               + (from_node.end == alignment.sequence().end() ? aligner->score_full_length_bonus(false, alignment) : 0));
                         
             for (const pair<size_t, size_t>& edge : from_node.edges) {
                 PathNode& to_node = path_nodes.at(edge.first);
@@ -3570,9 +3570,9 @@ namespace vg {
                 int32_t match_score = aligner->score_exact_match(path_node.begin, path_node.end,
                                                                  alignment.quality().begin() + (path_node.begin - alignment.sequence().begin()));
                 
-                subpath->set_score(match_score + aligner->full_length_bonus *
-                                   ((path_node.begin == alignment.sequence().begin()) +
-                                    (path_node.end == alignment.sequence().end())));
+                subpath->set_score(match_score
+                                   + (path_node.begin == alignment.sequence().begin() ? aligner->score_full_length_bonus(true, alignment) : 0)
+                                   + (path_node.end == alignment.sequence().end() ? aligner->score_full_length_bonus(false, alignment) : 0));
             }
         }
         else {

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -4366,7 +4366,7 @@ namespace vg {
     void MultipathMapper::strip_full_length_bonuses(multipath_alignment_t& multipath_aln) const {
         
         // TODO: this could technically be wrong if only one read in a pair has qualities
-        int32_t full_length_bonus = get_aligner(!multipath_aln.quality().empty())->full_length_bonus;
+        const auto& aligner = *get_aligner(!multipath_aln.quality().empty());
         // strip bonus from source paths
         if (multipath_aln.start_size()) {
             // use the precomputed list of sources if we have it
@@ -4374,7 +4374,10 @@ namespace vg {
                 subpath_t* source_subpath = multipath_aln.mutable_subpath(multipath_aln.start(i));
                 const edit_t& edit = source_subpath->path().mapping(0).edit(0);
                 if (edit.to_length() != 0 && edit.from_length() != 0) {
-                    source_subpath->set_score(source_subpath->score() - full_length_bonus);
+                    source_subpath->set_score(source_subpath->score()
+                                              - aligner.score_full_length_bonus(true, multipath_aln.sequence().begin(),
+                                                                                multipath_aln.sequence().end(),
+                                                                                multipath_aln.quality().begin()));
                 }
             }
         }
@@ -4395,7 +4398,10 @@ namespace vg {
                 subpath_t* source_subpath = multipath_aln.mutable_subpath(i);
                 const edit_t& edit = source_subpath->path().mapping(0).edit(0);
                 if (edit.to_length() != 0 && edit.from_length() != 0) {
-                    source_subpath->set_score(source_subpath->score() - full_length_bonus);
+                    source_subpath->set_score(source_subpath->score()
+                                              - aligner.score_full_length_bonus(true, multipath_aln.sequence().begin(),
+                                                                                multipath_aln.sequence().end(),
+                                                                                multipath_aln.quality().begin()));
                 }
             }
         }
@@ -4406,7 +4412,10 @@ namespace vg {
                 const path_mapping_t& final_mapping = subpath->path().mapping(subpath->path().mapping_size() - 1);
                 const edit_t& edit = final_mapping.edit(final_mapping.edit_size() - 1);
                 if (edit.to_length() != 0 && edit.from_length() != 0) {
-                    subpath->set_score(subpath->score() - full_length_bonus);
+                    subpath->set_score(subpath->score()
+                                       - aligner.score_full_length_bonus(false, multipath_aln.sequence().begin(),
+                                                                         multipath_aln.sequence().end(),
+                                                                         multipath_aln.quality().begin()));
                 }
             }
         }

--- a/src/qual_adj_xdrop_aligner.cpp
+++ b/src/qual_adj_xdrop_aligner.cpp
@@ -47,8 +47,7 @@ QualAdjXdropAligner& QualAdjXdropAligner::operator=(const QualAdjXdropAligner& o
         dz = dz_qual_adj_init(other.dz->matrix,
                               qual_adj_matrix,
                               *((const uint16_t*) &other.dz->giv),
-                              *((const uint16_t*) &other.dz->gev),
-                              other.dz->bonus);
+                              *((const uint16_t*) &other.dz->gev));
         
         free(qual_adj_matrix);
     }
@@ -76,14 +75,12 @@ QualAdjXdropAligner& QualAdjXdropAligner::operator=(QualAdjXdropAligner&& other)
 
 QualAdjXdropAligner::QualAdjXdropAligner(const int8_t* _score_matrix,
                                          const int8_t* _qual_adj_score_matrix,
-                                         int8_t _gap_open, int8_t _gap_extension,
-                                         int32_t _full_length_bonus)
+                                         int8_t _gap_open, int8_t _gap_extension)
 {
     // xdrop aligner uses the parameterization where both gap open and gap extend
     // are added when opening a gap
     assert(_gap_open - _gap_extension >= 0);
     assert(_gap_extension > 0);
-    assert(_full_length_bonus >= 0);
     
     // convert the 5x5 matrices into a 4x4 like dozeu wants
     uint32_t max_qual = 255;
@@ -97,7 +94,7 @@ QualAdjXdropAligner::QualAdjXdropAligner(const int8_t* _score_matrix,
     }
     
     dz = dz_qual_adj_init(_score_matrix, qual_adj_scores_4x4, _gap_open - _gap_extension,
-                          _gap_extension, _full_length_bonus);
+                          _gap_extension);
     
     free(qual_adj_scores_4x4);
 }
@@ -107,12 +104,14 @@ QualAdjXdropAligner::~QualAdjXdropAligner(void)
     dz_destroy(dz);
 }
 
-dz_query_s* QualAdjXdropAligner::pack_query_forward(const char* seq, const uint8_t* qual, size_t len) {
-    return dz_qual_adj_pack_query_forward(dz, seq, qual, len);
+dz_query_s* QualAdjXdropAligner::pack_query_forward(const char* seq, const uint8_t* qual,
+                                                    int8_t full_length_bonus, size_t len) {
+    return dz_qual_adj_pack_query_forward(dz, seq, qual, full_length_bonus, len);
 }
 
-dz_query_s* QualAdjXdropAligner::pack_query_reverse(const char* seq, const uint8_t* qual, size_t len) {
-    return dz_qual_adj_pack_query_reverse(dz, seq, qual, len);
+dz_query_s* QualAdjXdropAligner::pack_query_reverse(const char* seq, const uint8_t* qual,
+                                                    int8_t full_length_bonus, size_t len) {
+    return dz_qual_adj_pack_query_reverse(dz, seq, qual, full_length_bonus, len);
 }
 
 const dz_forefront_s* QualAdjXdropAligner::scan(const dz_query_s* query, const dz_forefront_s** forefronts,

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -690,16 +690,19 @@ using namespace std;
             
             // remove any extraneous full length bonuses
             // TODO: technically, this can give a non-optimal alignment because it's post hoc to the dynamic programming
+            const auto& aligner = *get_aligner(!src_quality.empty());
             if (sections.back().path().mapping_size() != 0) {
                 if (read_range.first != src_sequence.begin()) {
                     if (sections.back().path().mapping(0).edit(0).from_length() > 0) {
-                        sections.back().set_score(sections.back().score() - get_aligner()->full_length_bonus);
+                        sections.back().set_score(sections.back().score()
+                                                  - aligner.score_full_length_bonus(true, section_source));
                     }
                 }
                 if (read_range.second != src_sequence.end()) {
                     const Mapping& m = sections.back().path().mapping(0);
                     if (m.edit(m.edit_size() - 1).from_length() > 0) {
-                        sections.back().set_score(sections.back().score() - get_aligner()->full_length_bonus);
+                        sections.back().set_score(sections.back().score()
+                                                  - aligner.score_full_length_bonus(false, section_source));
                     }
                 }
             }

--- a/src/unittest/pinned_alignment.cpp
+++ b/src/unittest/pinned_alignment.cpp
@@ -12,6 +12,7 @@
 #include "path.hpp"
 #include "catch.hpp"
 #include "vg/io/json2pb.h"
+#include "bdsg/hash_graph.hpp"
 
 using namespace google::protobuf;
 using namespace vg::io;
@@ -2529,6 +2530,32 @@ namespace vg {
                     alns_seen.insert(aln_string);
                 }
             }
+        }
+        
+        TEST_CASE("Quality adjusted alignment scores full length bonuses correctly",
+                  "[alignment][pinned][mapping]" ) {
+            
+            bdsg::HashGraph graph;
+            
+            handle_t h = graph.create_handle("ACGTAGTCTGAA");
+            
+            Alignment aln1;
+            aln1.set_sequence("ACGT");
+            aln1.set_quality("HHH#");
+            alignment_quality_char_to_short(aln1);
+            
+            Alignment aln2;
+            aln2.set_sequence("TGAA");
+            aln2.set_quality("#HHH");
+            alignment_quality_char_to_short(aln2);
+            
+            TestAligner aligner_source;
+            const QualAdjAligner& aligner = *aligner_source.get_qual_adj_aligner();
+            aligner.align_pinned(aln1, graph, true, false);
+            aligner.align_pinned(aln2, graph, false, false);
+            
+            REQUIRE(aln1.score() == 3);
+            REQUIRE(aln2.score() == 3);
         }
     }
 }

--- a/src/unittest/xdrop_aligner.cpp
+++ b/src/unittest/xdrop_aligner.cpp
@@ -837,6 +837,36 @@ TEST_CASE("XdropAligner pinned alignment doesn't crash when the optimal alignmen
     
     REQUIRE(aln.score() == 1 + 1 + 1 - 4 - 4 + 9);
 }
+
+
+
+TEST_CASE("QualAdjXdropAligner uses quality adjusted full length bonuses",
+          "[xdrop][alignment][mapping][pinned]") {
+
+    bdsg::HashGraph graph;
+    
+    handle_t h0 = graph.create_handle("AAGGG");
+    
+    Alignment aln1;
+    aln1.set_sequence("AA");
+    aln1.set_quality("H#");
+    alignment_quality_char_to_short(aln1);
+    
+    Alignment aln2;
+    aln2.set_sequence("GG");
+    aln2.set_quality("#H");
+    alignment_quality_char_to_short(aln2);
+    
+    TestAligner aligner_source;
+    aligner_source.set_alignment_scores(1, 4, 6, 1, 5);
+    const QualAdjAligner& aligner = *aligner_source.get_qual_adj_aligner();
+    
+    aligner.align_pinned(aln1, graph, true, true, 0);
+    aligner.align_pinned(aln2, graph, false, true, 0);
+        
+    REQUIRE(aln1.score() == 1);
+    REQUIRE(aln2.score() == 1);
+}
    
 }
 }

--- a/src/xdrop_aligner.cpp
+++ b/src/xdrop_aligner.cpp
@@ -42,8 +42,7 @@ XdropAligner& XdropAligner::operator=(const XdropAligner& other)
         }
         dz = dz_init(other.dz->matrix,
                      *((const uint16_t*) &other.dz->giv),
-                     *((const uint16_t*) &other.dz->gev),
-                     other.dz->bonus);
+                     *((const uint16_t*) &other.dz->gev));
     }
 
 	return *this;
@@ -67,15 +66,13 @@ XdropAligner& XdropAligner::operator=(XdropAligner&& other)
 	return *this;
 }
 
-XdropAligner::XdropAligner(const int8_t* _score_matrix, int8_t _gap_open, int8_t _gap_extension,
-                           int32_t _full_length_bonus)
+XdropAligner::XdropAligner(const int8_t* _score_matrix, int8_t _gap_open, int8_t _gap_extension)
 {
     // xdrop aligner uses the parameterization where both gap open and gap extend
     // are added when opening a gap
     assert(_gap_open - _gap_extension >= 0);
     assert(_gap_extension > 0);
-    assert(_full_length_bonus >= 0);
-    dz = dz_init(_score_matrix, _gap_open - _gap_extension, _gap_extension, _full_length_bonus);
+    dz = dz_init(_score_matrix, _gap_open - _gap_extension, _gap_extension);
 }
 
 XdropAligner::~XdropAligner(void)
@@ -83,12 +80,14 @@ XdropAligner::~XdropAligner(void)
     dz_destroy(dz);
 }
 
-dz_query_s* XdropAligner::pack_query_forward(const char* seq, const uint8_t* qual, size_t len) {
-    return dz_pack_query_forward(dz, seq, len);
+dz_query_s* XdropAligner::pack_query_forward(const char* seq, const uint8_t* qual,
+                                             int8_t full_length_bonus, size_t len) {
+    return dz_pack_query_forward(dz, seq, full_length_bonus, len);
 }
 
-dz_query_s* XdropAligner::pack_query_reverse(const char* seq, const uint8_t* qual, size_t len) {
-    return dz_pack_query_reverse(dz, seq, len);
+dz_query_s* XdropAligner::pack_query_reverse(const char* seq, const uint8_t* qual,
+                                             int8_t full_length_bonus, size_t len) {
+    return dz_pack_query_reverse(dz, seq, full_length_bonus, len);
 }
 
 const dz_forefront_s* XdropAligner::scan(const dz_query_s* query, const dz_forefront_s** forefronts,


### PR DESCRIPTION
## Changelog Entry

* Base quality-adjusted scoring now adjusts the full length bonus.

## Description

The adjustment is based on interpreting the full length bonus as a log-odds score. This should reduce some quality-adjusted alignment artifacts where long tails of very low-quality bases would align to an arbitrary path in order to pick up the full length bonus. Now those tails will get a reduced or 0 bonus.