### PR TITLE
Unslowify surject

### DIFF
--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -731,6 +731,11 @@ int main_map(int argc, char** argv) {
         });
     }
     
+    unordered_set<path_handle_t> paths;
+    for (const auto& path_name : path_names) {
+        paths.insert(xgidx->get_path_handle(path_name));
+    }
+    
     // If we need to do surjection, we will need a surjector. So set one up.
     Surjector surjector(xgidx);
 
@@ -752,12 +757,12 @@ int main_map(int argc, char** argv) {
         int tid = omp_get_thread_num();
         for (auto& aln : alns1) {
             // Surject each alignment of the first read in the pair and annotate with surjected path position
-            surjects1.push_back(surjector.surject(aln, path_names, surject_subpath_global));
+            surjects1.push_back(surjector.surject(aln, paths, surject_subpath_global));
         }
         
         for (auto& aln : alns2) {
             // Surject each alignment of the second read in the pair, if any, and annotate with surjected path position
-            surjects2.push_back(surjector.surject(aln, path_names, surject_subpath_global));
+            surjects2.push_back(surjector.surject(aln, paths, surject_subpath_global));
         }
         
         if (surjects2.empty()) {

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -231,6 +231,11 @@ int main_surject(int argc, char** argv) {
             path_names.insert(xgidx->get_path_name(path_handle));
         });
     }
+    
+    unordered_set<path_handle_t> paths;
+    for (const string& path_name : path_names) {
+        paths.insert(xgidx->get_path_handle(path_name));
+    }
 
     // Make a single thread-safe Surjector.
     Surjector surjector(xgidx);
@@ -239,9 +244,9 @@ int main_surject(int argc, char** argv) {
     
     // Get the lengths of all the paths in the XG to populate the HTS headers
     map<string, int64_t> path_length;
-    xgidx->for_each_path_handle([&](path_handle_t path_handle) {
-            path_length[xgidx->get_path_name(path_handle)] = xgidx->get_path_length(path_handle);
-        });
+    for (auto path_handle : paths) {
+        path_length[xgidx->get_path_name(path_handle)] = xgidx->get_path_length(path_handle);
+    }
    
     // Count our threads
     int thread_count = get_thread_count();
@@ -301,8 +306,8 @@ int main_surject(int argc, char** argv) {
                 set_metadata(src2);
                 
                 // Surject and emit.
-                alignment_emitter->emit_pair(surjector.surject(src1, path_names, subpath_global, spliced),
-                                             surjector.surject(src2, path_names, subpath_global, spliced),
+                alignment_emitter->emit_pair(surjector.surject(src1, paths, subpath_global, spliced),
+                                             surjector.surject(src2, paths, subpath_global, spliced),
                                              max_frag_len);
                 
             };
@@ -322,7 +327,7 @@ int main_surject(int argc, char** argv) {
                 set_metadata(src);
                 
                 // Surject and emit the single read.
-                alignment_emitter->emit_single(surjector.surject(src, path_names, subpath_global, spliced));
+                alignment_emitter->emit_single(surjector.surject(src, paths, subpath_global, spliced));
             };
             if (input_format == "GAM") {
                 get_input_file(file_name, [&](istream& in) {
@@ -379,10 +384,10 @@ int main_surject(int argc, char** argv) {
                     // surject and record path positions
                     vector<pair<tuple<string, bool, int64_t>, tuple<string, bool, int64_t>>> positions(1);
                     vector<pair<multipath_alignment_t, multipath_alignment_t>> surjected;
-                    surjected.emplace_back(surjector.surject(mp_src1, path_names, get<0>(positions.front().first),
+                    surjected.emplace_back(surjector.surject(mp_src1, paths, get<0>(positions.front().first),
                                                              get<2>(positions.front().first), get<1>(positions.front().first),
                                                              subpath_global, spliced),
-                                           surjector.surject(mp_src2, path_names, get<0>(positions.front().second),
+                                           surjector.surject(mp_src2, paths, get<0>(positions.front().second),
                                                              get<2>(positions.front().second), get<1>(positions.front().second),
                                                              subpath_global, spliced));
                     
@@ -399,7 +404,7 @@ int main_surject(int argc, char** argv) {
                     // surject and record path positions
                     vector<tuple<string, bool, int64_t>> positions(1);
                     vector<multipath_alignment_t> surjected;
-                    surjected.emplace_back(surjector.surject(mp_src, path_names, get<0>(positions.front()),
+                    surjected.emplace_back(surjector.surject(mp_src, paths, get<0>(positions.front()),
                                                              get<2>(positions.front()), get<1>(positions.front()),
                                                              subpath_global, spliced));
                     

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -108,6 +108,14 @@ using namespace std;
                                                    : extract_overlapping_paths(&memoizing_graph, *source_mp_aln,
                                                                                paths, connections);
         
+        if (source_mp_aln) {
+            // the multipath alignment anchor algorithm can produce redundant paths if
+            // the alignment's graph is not parsimonious, so we filter the shorter ones out
+            for (pair<const path_handle_t, pair<vector<path_chunk_t>, vector<pair<step_handle_t, step_handle_t>>>>& path_chunk_record : path_overlapping_anchors) {
+                filter_redundant_path_chunks(path_chunk_record.second.first, path_chunk_record.second.second);
+            }
+        }
+        
 #ifdef debug_anchored_surject
         cerr << "got path overlapping segments" << endl;
         for (const auto& surjection_record : path_overlapping_anchors) {

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1732,6 +1732,12 @@ using namespace std;
                     std::swap(index[i], index[index[i]]);
                 }
             }
+            
+            // and update the indexes of the connections
+            for (auto& connection : connections) {
+                get<0>(connection) = order[get<0>(connection)];
+                get<1>(connection) = order[get<1>(connection)];
+            }
         }
     }
     

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1708,23 +1708,29 @@ using namespace std;
         }
         
         // sort the path chunks in lexicographic order like the downstream code expects
-        for (size_t i = 0; i < path_chunks.size(); ++i) {
-            order[i] = i;
-        }
-        order.resize(path_chunks.size());
-        stable_sort(order.begin(), order.end(), [&](size_t i, size_t j) {
-            return path_chunks[i].first < path_chunks[j].first;
-        });
-        vector<size_t> index(order.size());
-        for (size_t i = 0; i < order.size(); ++i) {
-            index[order[i]] = i;
-        }
-        // co-sort the vectors into the computed indexes
-        for (size_t i = 0; i < index.size(); ++i) {
-            while (index[i] != i) {
-                std::swap(path_chunks[i], path_chunks[index[i]]);
-                std::swap(ref_chunks[i], ref_chunks[index[i]]);
-                std::swap(index[i], index[index[i]]);
+        
+        if (!is_sorted(path_chunks.begin(), path_chunks.end(),
+                       [&](path_chunk_t& a, path_chunk_t& b) { return a.first < b.first; })) {
+            
+            // compute which index the chunks should end up in
+            for (size_t i = 0; i < path_chunks.size(); ++i) {
+                order[i] = i;
+            }
+            order.resize(path_chunks.size());
+            stable_sort(order.begin(), order.end(), [&](size_t i, size_t j) {
+                return path_chunks[i].first < path_chunks[j].first;
+            });
+            vector<size_t> index(order.size());
+            for (size_t i = 0; i < order.size(); ++i) {
+                index[order[i]] = i;
+            }
+            // co-sort the vectors into the computed indexes
+            for (size_t i = 0; i < index.size(); ++i) {
+                while (index[i] != i) {
+                    std::swap(path_chunks[i], path_chunks[index[i]]);
+                    std::swap(ref_chunks[i], ref_chunks[index[i]]);
+                    std::swap(index[i], index[index[i]]);
+                }
             }
         }
     }

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -43,7 +43,7 @@ using namespace std;
         /// Also optionally leaves deletions against the reference path in the final alignment
         /// (useful for splicing).
         Alignment surject(const Alignment& source,
-                          const set<string>& path_names,
+                          const unordered_set<path_handle_t>& paths,
                           string& path_name_out,
                           int64_t& path_pos_out,
                           bool& path_rev_out,
@@ -65,7 +65,7 @@ using namespace std;
         /// Also optionally leaves deletions against the reference path in the final
         /// alignment (useful for splicing).
         Alignment surject(const Alignment& source,
-                          const set<string>& path_names,
+                          const unordered_set<path_handle_t>& paths,
                           bool allow_negative_scores = false,
                           bool preserve_deletions = false) const;
         
@@ -74,7 +74,7 @@ using namespace std;
         /// a single path, separated by splices (either from large deletions or from
         /// connections)
         multipath_alignment_t surject(const multipath_alignment_t& source,
-                                      const set<string>& path_names,
+                                      const unordered_set<path_handle_t>& paths,
                                       string& path_name_out, int64_t& path_pos_out,
                                       bool& path_rev_out,
                                       bool allow_negative_scores = false,
@@ -90,7 +90,7 @@ using namespace std;
         
         void surject_internal(const Alignment* source_aln, const multipath_alignment_t* source_mp_aln,
                               Alignment* aln_out, multipath_alignment_t* mp_aln_out,
-                              const set<string>& path_names,
+                              const unordered_set<path_handle_t>& paths,
                               string& path_name_out, int64_t& path_pos_out, bool& path_rev_out,
                               bool allow_negative_scores, bool preserve_deletions) const;
         
@@ -127,6 +127,11 @@ using namespace std;
                                   const multipath_alignment_t& source,
                                   const unordered_set<path_handle_t>& surjection_paths,
                                   unordered_map<path_handle_t, vector<tuple<size_t, size_t, int32_t>>>& connections_out) const;
+        
+        /// remove any path chunks and corresponding ref chunks that are identical to a longer
+        /// path chunk over the region where they overlap
+        void filter_redundant_path_chunks(vector<path_chunk_t>& path_chunks,
+                                          vector<pair<step_handle_t, step_handle_t>>& ref_chunks) const;
         
         /// compute the widest interval of path positions that the realigned sequence could align to
         pair<size_t, size_t>

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -131,7 +131,8 @@ using namespace std;
         /// remove any path chunks and corresponding ref chunks that are identical to a longer
         /// path chunk over the region where they overlap
         void filter_redundant_path_chunks(vector<path_chunk_t>& path_chunks,
-                                          vector<pair<step_handle_t, step_handle_t>>& ref_chunks) const;
+                                          vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
+                                          vector<tuple<size_t, size_t, int32_t>>& connections) const;
         
         /// compute the widest interval of path positions that the realigned sequence could align to
         pair<size_t, size_t>

--- a/src/unittest/surject.cpp
+++ b/src/unittest/surject.cpp
@@ -21,6 +21,7 @@ public:
     ~TestSurjector() = default;
     
     using Surjector::extract_overlapping_paths;
+    using Surjector::filter_redundant_path_chunks;
     
 };
 
@@ -72,8 +73,8 @@ TEST_CASE( "Spliced surject algorithm preserves deletions against the path", "[s
     
     read.set_score(Aligner().score_contiguous_alignment(read));
     
-    set<string> path_names{pos_graph.get_path_name(p)};
-    Alignment surjected = surjector.surject(read, path_names, true, true);
+    unordered_set<path_handle_t> paths{p};
+    Alignment surjected = surjector.surject(read, paths, true, true);
     
     vector<handle_t> surjected_path{h1, h3, h4, h6};
     
@@ -109,7 +110,7 @@ TEST_CASE( "Spliced surject algorithm preserves deletions against the path", "[s
     
     rev_read.set_score(Aligner().score_contiguous_alignment(rev_read));
     
-    Alignment rev_surjected = surjector.surject(rev_read, path_names, true, true);
+    Alignment rev_surjected = surjector.surject(rev_read, paths, true, true);
     
     REQUIRE(rev_surjected.path().mapping_size() == read_path.size());
     for (size_t i = 0; i < surjected_path.size(); ++i) {
@@ -365,8 +366,7 @@ TEST_CASE("Path overlapping segments can be identified from multipath alignment"
     }
 }
 
-TEST_CASE("Multipath alignments can be surjected",
-          "[surject][multipath][newsurject]"){
+TEST_CASE("Multipath alignments can be surjected", "[surject][multipath]") {
 
     bdsg::HashGraph graph;
     handle_t h1 = graph.create_handle("A");
@@ -480,8 +480,8 @@ TEST_CASE("Multipath alignments can be surjected",
         string path_name;
         int64_t path_pos;
         bool path_rev;
-        set<string> path_names{graph.get_path_name(p)};
-        auto surjected = surjector.surject(mp_aln, path_names, path_name,
+        unordered_set<path_handle_t> paths{p};
+        auto surjected = surjector.surject(mp_aln, paths, path_name,
                                            path_pos, path_rev, true, true);
         
         REQUIRE(path_name == graph.get_path_name(p));
@@ -522,8 +522,8 @@ TEST_CASE("Multipath alignments can be surjected",
         string path_name;
         int64_t path_pos;
         bool path_rev;
-        set<string> path_names{graph.get_path_name(p)};
-        auto surjected = surjector.surject(rc_mp_aln, path_names, path_name,
+        unordered_set<path_handle_t> paths{p};
+        auto surjected = surjector.surject(rc_mp_aln, paths, path_name,
                                            path_pos, path_rev, true, true);
         
         REQUIRE(path_name == graph.get_path_name(p));
@@ -564,8 +564,8 @@ TEST_CASE("Multipath alignments can be surjected",
         string path_name;
         int64_t path_pos;
         bool path_rev;
-        set<string> path_names{graph.get_path_name(p)};
-        auto surjected = surjector.surject(mp_aln, path_names, path_name,
+        unordered_set<path_handle_t> paths{p};
+        auto surjected = surjector.surject(mp_aln, paths, path_name,
                                            path_pos, path_rev, true, false);
         
         REQUIRE(path_name == graph.get_path_name(p));
@@ -603,6 +603,88 @@ TEST_CASE("Multipath alignments can be surjected",
         REQUIRE(surjected.subpath(1).next_size() == 0);
         REQUIRE(surjected.subpath(1).connection_size() == 0);
     }
+}
+
+TEST_CASE("Duplicate path chunks can be detected", "[surject][multipath]") {
+    
+    Alignment aln;
+    aln.set_sequence("ACGT");
+    
+    Surjector::path_chunk_t chunk1;
+    Surjector::path_chunk_t chunk2;
+    Surjector::path_chunk_t chunk3;
+    Surjector::path_chunk_t chunk4;
+    
+    chunk1.first.first = aln.sequence().begin();
+    chunk1.first.second = aln.sequence().begin() + 4;
+    auto m00 = chunk1.second.add_mapping();
+    m00->mutable_position()->set_node_id(1);
+    m00->mutable_position()->set_is_reverse(false);
+    m00->mutable_position()->set_offset(2);
+    auto e00 = m00->add_edit();
+    e00->set_from_length(2);
+    e00->set_to_length(2);
+    auto m01 = chunk1.second.add_mapping();
+    m01->mutable_position()->set_node_id(2);
+    m01->mutable_position()->set_is_reverse(false);
+    m01->mutable_position()->set_offset(0);
+    auto e01 = m01->add_edit();
+    e01->set_from_length(2);
+    e01->set_to_length(2);
+    
+    chunk2.first.first = aln.sequence().begin();
+    chunk2.first.second = aln.sequence().begin() + 2;
+    auto m10 = chunk2.second.add_mapping();
+    m10->mutable_position()->set_node_id(1);
+    m10->mutable_position()->set_is_reverse(false);
+    m10->mutable_position()->set_offset(2);
+    auto e10 = m10->add_edit();
+    e10->set_from_length(2);
+    e10->set_to_length(2);
+    
+    chunk3.first.first = aln.sequence().begin() + 2;
+    chunk3.first.second = aln.sequence().begin() + 4;
+    auto m20 = chunk3.second.add_mapping();
+    m20->mutable_position()->set_node_id(2);
+    m20->mutable_position()->set_is_reverse(false);
+    m20->mutable_position()->set_offset(0);
+    auto e20 = m20->add_edit();
+    e20->set_from_length(2);
+    e20->set_to_length(2);
+    
+    chunk4.first.first = aln.sequence().begin();
+    chunk4.first.second = aln.sequence().begin() + 4;
+    auto m30 = chunk4.second.add_mapping();
+    m30->mutable_position()->set_node_id(1);
+    m30->mutable_position()->set_is_reverse(false);
+    m30->mutable_position()->set_offset(2);
+    auto e30 = m30->add_edit();
+    e30->set_from_length(2);
+    e30->set_to_length(2);
+    auto m31 = chunk4.second.add_mapping();
+    m31->mutable_position()->set_node_id(3);
+    m31->mutable_position()->set_is_reverse(false);
+    m31->mutable_position()->set_offset(0);
+    auto e31 = m31->add_edit();
+    e31->set_from_length(2);
+    e31->set_to_length(2);
+    
+    bdsg::HashGraph graph;
+    bdsg::PositionOverlay pos_graph(&graph);
+    TestSurjector surjector(&pos_graph);
+    
+    vector<Surjector::path_chunk_t> path_chunks{chunk1, chunk2, chunk3, chunk4};
+    vector<pair<step_handle_t, step_handle_t>> ref_chunks;
+    ref_chunks.emplace_back();
+    ref_chunks.emplace_back();
+    ref_chunks.emplace_back();
+    ref_chunks.emplace_back();
+    
+    surjector.filter_redundant_path_chunks(path_chunks, ref_chunks);
+    
+    REQUIRE(ref_chunks.size() == path_chunks.size());
+    REQUIRE(path_chunks.size() == 2);
+    
 }
 }
 }

--- a/src/unittest/surject.cpp
+++ b/src/unittest/surject.cpp
@@ -680,7 +680,9 @@ TEST_CASE("Duplicate path chunks can be detected", "[surject][multipath]") {
     ref_chunks.emplace_back();
     ref_chunks.emplace_back();
     
-    surjector.filter_redundant_path_chunks(path_chunks, ref_chunks);
+    vector<tuple<size_t, size_t, int32_t>> connections;
+    
+    surjector.filter_redundant_path_chunks(path_chunks, ref_chunks, connections);
     
     REQUIRE(ref_chunks.size() == path_chunks.size());
     REQUIRE(path_chunks.size() == 2);


### PR DESCRIPTION
## Changelog Entry

* `vg surject` is now substantially faster

## Description

I redid the way surject performed `path_handle_t` to minimize interaction with the backing BWT/FM-index, which it turns out is responsible for a very large proportion of surject's run time. I also added an algorithm to filter out redundant partial paths from the GAMP surject code path, which seem to have been driving some of its higher run time.