### PR TITLE
Bring HTS output formats to Giraffe

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -94,11 +94,22 @@ bam_hdr_t* hts_file_header(string& filename, string& header) {
 }
 
 bam_hdr_t* hts_string_header(string& header,
-                             map<string, int64_t>& path_length,
-                             map<string, string>& rg_sample) {
+                             const map<string, int64_t>& path_length,
+                             const map<string, string>& rg_sample) {
+    
+    // Copy the map into a vecotr in its own order
+    vector<pair<string, int64_t>> path_order_and_length(path_length.begin(), path_length.end());
+    
+    // Make header in that order.
+    return hts_string_header(header, path_order_and_length, rg_sample);
+}
+
+bam_hdr_t* hts_string_header(string& header,
+                             const vector<pair<string, int64_t>>& path_order_and_length,
+                             const map<string, string>& rg_sample) {
     stringstream hdr;
     hdr << "@HD\tVN:1.5\tSO:unknown\n";
-    for (auto& p : path_length) {
+    for (auto& p : path_order_and_length) {
         hdr << "@SQ\tSN:" << p.first << "\t" << "LN:" << p.second << "\n";
     }
     for (auto& s : rg_sample) {

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -56,8 +56,11 @@ size_t fastq_paired_two_files_for_each_parallel_after_wait(const string& file1, 
 
 bam_hdr_t* hts_file_header(string& filename, string& header);
 bam_hdr_t* hts_string_header(string& header,
-                             map<string, int64_t>& path_length,
-                             map<string, string>& rg_sample);
+                             const map<string, int64_t>& path_length,
+                             const map<string, string>& rg_sample);
+bam_hdr_t* hts_string_header(string& header,
+                             const vector<pair<string, int64_t>>& path_order_and_length,
+                             const map<string, string>& rg_sample);
 void write_alignment_to_file(const Alignment& aln, const string& filename);
 
 void mapping_cigar(const Mapping& mapping, vector<pair<int, char> >& cigar);

--- a/src/hts_alignment_emitter.hpp
+++ b/src/hts_alignment_emitter.hpp
@@ -38,7 +38,7 @@ using namespace vg::io;
 ///
 /// See also: get_alignment_emitter_with_surjection()
 unique_ptr<AlignmentEmitter> get_alignment_emitter(const string& filename, const string& format, 
-                                                   const map<string, int64_t>& path_length, size_t max_threads,
+                                                   const vector<pair<string, int64_t>>& path_order_and_length, size_t max_threads,
                                                    const HandleGraph* graph = nullptr);
 
 /*
@@ -47,12 +47,12 @@ unique_ptr<AlignmentEmitter> get_alignment_emitter(const string& filename, const
 class HTSWriter {
 public:
     /// Create an HTSWriter writing to the given file (or "-") in the
-    /// given HTS format ("SAM", "BAM", "CRAM"). path_length must map from
-    /// contig name to length to include in the header. Sample names and read
+    /// given HTS format ("SAM", "BAM", "CRAM"). path_order_and_length must give each
+    /// contig name and length to include in the header. Sample names and read
     /// groups for the header will be guessed from the first reads. HTSlib
     /// positions will be read from the alignments' refpos, and the alignments
     /// must be surjected.
-    HTSWriter(const string& filename, const string& format, const map<string, int64_t>& path_length, size_t max_threads);
+    HTSWriter(const string& filename, const string& format, const vector<pair<string, int64_t>>& path_order_and_length, size_t max_threads);
     
     /// Tear down an HTSWriter and destroy HTSlib structures.
     ~HTSWriter();
@@ -77,8 +77,10 @@ protected:
     /// This holds our format name, for later error messages.
     string format;
     
-    /// Store the path length map until the header can be made.
-    map<string, int64_t> path_length;
+    /// Store the path names and lengths in the order to put them in the header.
+    vector<pair<string, int64_t>> path_order_and_length;
+    /// Index into that by path name
+    map<string, vector<pair<string, int64_t>>::iterator> path_index;
     
     /// To back our samFile*s, we need the hFILE* objects wrapping our C++
     /// streams. We need to manually flush these after HTS headers are written,
@@ -142,13 +144,13 @@ protected:
 class HTSAlignmentEmitter : public AlignmentEmitter, public HTSWriter {
 public:
     /// Create an HTSAlignmentEmitter writing to the given file (or "-") in the
-    /// given HTS format ("SAM", "BAM", "CRAM"). path_length must map from
-    /// contig name to length to include in the header. Sample names and read
-    /// groups for the header will be guessed from the first reads. HTSlib
-    /// positions will be read from the alignments' refpos, and the alignments
-    /// must be surjected.
+    /// given HTS format ("SAM", "BAM", "CRAM"). path_order_and_length must give
+    /// contig names and lengths to include in the header, in order. Sample
+    /// names and read groups for the header will be guessed from the first
+    /// reads. HTSlib positions will be read from the alignments' refpos, and
+    /// the alignments must be surjected.
     HTSAlignmentEmitter(const string& filename, const string& format,
-                        const map<string, int64_t>& path_length, size_t max_threads);
+                        const vector<pair<string, int64_t>>& path_order_and_length, size_t max_threads);
     
     /// Tear down an HTSAlignmentEmitter and destroy HTSlib structures.
     ~HTSAlignmentEmitter() = default;
@@ -196,7 +198,7 @@ class SplicedHTSAlignmentEmitter : public HTSAlignmentEmitter {
 public:
     
     SplicedHTSAlignmentEmitter(const string& filename, const string& format,
-                               const map<string, int64_t>& path_length,
+                               const vector<pair<string, int64_t>>& path_order_and_length,
                                const PathPositionHandleGraph& graph,
                                size_t max_threads);
     

--- a/src/hts_alignment_emitter.hpp
+++ b/src/hts_alignment_emitter.hpp
@@ -35,6 +35,8 @@ using namespace vg::io;
 /// the graph can be provided in order to form spliced CIGAR strings for the HTSlib
 /// formats. Note: it must be castable to PathPositionHandleGraph to be used for splicing
 /// Other output formats except GAF (for which it's required) ignore the graph.
+///
+/// See also: get_alignment_emitter_with_surjection()
 unique_ptr<AlignmentEmitter> get_alignment_emitter(const string& filename, const string& format, 
                                                    const map<string, int64_t>& path_length, size_t max_threads,
                                                    const HandleGraph* graph = nullptr);

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -13,10 +13,10 @@ namespace vg {
 using namespace std;
 
 MultipathAlignmentEmitter::MultipathAlignmentEmitter(const string& filename, size_t num_threads, const string out_format,
-                                                     const PathPositionHandleGraph* graph, const map<string, int64_t>* path_length) :
+                                                     const PathPositionHandleGraph* graph, const vector<pair<string, int64_t>>* path_order_and_length) :
     HTSWriter(filename,
               out_format == "SAM" || out_format == "BAM" || out_format == "CRAM" ? out_format : "SAM", // just so the assert passes
-              path_length ? *path_length : map<string, int64_t>(),
+              path_order_and_length ? *path_order_and_length : vector<pair<string, int64_t>>(),
               num_threads),
     graph(graph)
 {

--- a/src/multipath_alignment_emitter.hpp
+++ b/src/multipath_alignment_emitter.hpp
@@ -37,7 +37,7 @@ public:
     ///  already be surjected. If alignments have connections, requires a graph
     MultipathAlignmentEmitter(const string& filename, size_t num_threads, const string out_format = "GAMP",
                               const PathPositionHandleGraph* graph = nullptr,
-                              const map<string, int64_t>* path_length = nullptr);
+                              const vector<pair<string, int64_t>>* path_order_and_length = nullptr);
     ~MultipathAlignmentEmitter();
     
     /// Choose a read group to apply to all emitted alignments

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -21,7 +21,7 @@
 #include "../annotation.hpp"
 #include <vg/io/vpkg.hpp>
 #include <vg/io/stream.hpp>
-#include "../hts_alignment_emitter.hpp"
+#include "../surjecting_alignment_emitter.hpp"
 #include "../gapless_extender.hpp"
 #include "../minimizer_mapper.hpp"
 #include "../index_manager.hpp"
@@ -304,7 +304,7 @@ void help_giraffe(char** argv) {
     << "  -M, --max-multimaps INT       produce up to INT alignments for each read [1]" << endl
     << "  -N, --sample NAME             add this sample name" << endl
     << "  -R, --read-group NAME         add this read group" << endl
-    << "  -o, --output-format NAME      output the alignments in NAME format (gam / gaf / json / tsv) [gam]" << endl
+    << "  -o, --output-format NAME      output the alignments in NAME format (gam / gaf / json / tsv / SAM / BAM / CRAM) [gam]" << endl
     << "  -n, --discard                 discard all output alignments (for profiling)" << endl
     << "  --output-basename NAME        write output to a GAM file beginning with the given prefix for each setting combination" << endl
     << "  --report-name NAME            write a TSV of output file and mapping speed to the given file" << endl
@@ -440,7 +440,7 @@ int main_giraffe(int argc, char** argv) {
 
     // Formats for alignment output.
     std::string output_format = "GAM";
-    std::set<std::string> output_formats = { "GAM", "GAF", "JSON", "TSV" };
+    std::set<std::string> output_formats = { "GAM", "GAF", "JSON", "TSV", "SAM", "BAM", "CRAM" };
 
     // Map algorithm names to rescue algorithms
     std::map<std::string, MinimizerMapper::RescueAlgorithm> rescue_algorithms = {
@@ -889,6 +889,9 @@ int main_giraffe(int argc, char** argv) {
         rescue_attempts = 0;
         rescue_algorithm = MinimizerMapper::rescue_none;
     }
+    
+    // Determine if we are surjecting
+    bool surjecting = (output_format == "SAM" || output_format == "BAM" || output_format == "CRAM");
 
     // Now all the arguments are parsed, so see if they make sense
     if (!indexes.can_get_gbwtgraph() && !indexes.can_get_graph()) {
@@ -898,6 +901,11 @@ int main_giraffe(int argc, char** argv) {
     
     if (track_correctness && !indexes.can_get_graph()) {
         cerr << "error:[vg giraffe] Tracking correctness requires a normal graph (-x)" << endl;
+        exit(1);
+    }
+    
+    if (surjecting && !indexes.can_get_graph()) {
+        cerr << "error:[vg giraffe] Mapping to a linear format requires a normal graph (-x)" << endl;
         exit(1);
     }
     
@@ -945,16 +953,16 @@ int main_giraffe(int argc, char** argv) {
     
     // If we are tracking correctness, we will fill this in with a graph for
     // getting offsets along ref paths.
-    PathPositionHandleGraph* positional_graph = nullptr;
+    PathPositionHandleGraph* path_position_graph = nullptr;
     // One of these will actually own it
     bdsg::PathPositionOverlayHelper overlay_helper;
     shared_ptr<PathHandleGraph> graph;
-    if (track_correctness) {
+    if (track_correctness || surjecting) {
         // Load the base graph
         graph = indexes.get_graph();
         // And make sure it has path position support.
         // Overlay is owned by the overlay_helper, if one is needed.
-        positional_graph = overlay_helper.apply(graph.get());
+        path_position_graph = overlay_helper.apply(graph.get());
     }
 
     vector<unique_ptr<gbwtgraph::DefaultMinimizerIndex>> minimizer_index_owner;
@@ -989,7 +997,7 @@ int main_giraffe(int argc, char** argv) {
     if (show_progress) {
         cerr << "Initializing MinimizerMapper" << endl;
     }
-    MinimizerMapper minimizer_mapper(*gbwt_graph, minimizer_indexes, *distance_index, positional_graph);
+    MinimizerMapper minimizer_mapper(*gbwt_graph, minimizer_indexes, *distance_index, path_position_graph);
     if (forced_mean && forced_stdev) {
         minimizer_mapper.force_fragment_length_distr(fragment_mean, fragment_stdev);
     }
@@ -1163,12 +1171,22 @@ int main_giraffe(int argc, char** argv) {
         std::chrono::time_point<std::chrono::system_clock> all_threads_start;
         
         {
-            // Set up output to an emitter that will handle serialization
-            // Discard alignments if asked to. Otherwise spit them out in the selected format.
+        
+            // Look up all the paths we might need to surject to.
+            vector<path_handle_t> surjection_paths;
+            if (surjecting) {
+                path_position_graph->for_each_path_handle([&](path_handle_t path_handle) {
+                    surjection_paths.push_back(path_handle);
+                });
+            }
+            
+            // Set up output to an emitter that will handle serialization and surjection.
+            // Unless we want to discard all the alignments in which case do that.
+            // We send along the positional graph when we have it, and otherwise we send the GBWTGraph which is sufficient for GAF output.
             unique_ptr<AlignmentEmitter> alignment_emitter = discard_alignments ?
                 make_unique<NullAlignmentEmitter>() :
-                get_alignment_emitter(output_filename, output_format, {}, thread_count, gbwt_graph.get());
-
+                get_alignment_emitter_with_surjection("-", output_format, surjection_paths, thread_count, path_position_graph ? (const HandleGraph*)path_position_graph : (const HandleGraph*)gbwt_graph.get());
+            
 #ifdef USE_CALLGRIND
             // We want to profile the alignment, not the loading.
             CALLGRIND_START_INSTRUMENTATION;
@@ -1219,8 +1237,18 @@ int main_giraffe(int argc, char** argv) {
                     pair<vector<Alignment>, vector<Alignment>> mapped_pairs = minimizer_mapper.map_paired(aln1, aln2, ambiguous_pair_buffer);
                     if (!mapped_pairs.first.empty() && !mapped_pairs.second.empty()) {
                         //If we actually tried to map this paired end
-
-                        alignment_emitter->emit_mapped_pair(std::move(mapped_pairs.first), std::move(mapped_pairs.second));
+                        
+                        // Work out whether it could be properly paired or not, if that is relevant.
+                        // If we're here, let the read be properly paired in
+                        // HTSlib terms no matter how far away it is in linear
+                        // space (on the same contig), because it went into
+                        // pair distribution estimation.
+                        int64_t tlen_limit = numeric_limits<int64_t>::max();
+                        if (surjecting && minimizer_mapper.fragment_distr_is_finalized()) {
+                             tlen_limit = minimizer_mapper.get_fragment_length_mean() + 6 * minimizer_mapper.get_fragment_length_stdev();
+                        }
+                        // Emit it
+                        alignment_emitter->emit_mapped_pair(std::move(mapped_pairs.first), std::move(mapped_pairs.second), tlen_limit);
                         // Record that we mapped a read.
                         reads_mapped_by_thread.at(omp_get_thread_num()) += 2;
                     }
@@ -1256,7 +1284,13 @@ int main_giraffe(int argc, char** argv) {
                 for (pair<Alignment, Alignment>& alignment_pair : ambiguous_pair_buffer) {
 
                     auto mapped_pairs = minimizer_mapper.map_paired(alignment_pair.first, alignment_pair.second);
-                    alignment_emitter->emit_mapped_pair(std::move(mapped_pairs.first), std::move(mapped_pairs.second));
+                    // Work out whether it could be properly paired or not, if that is relevant.
+                    int64_t tlen_limit = 0;
+                    if (surjecting && minimizer_mapper.fragment_distr_is_finalized()) {
+                         tlen_limit = minimizer_mapper.get_fragment_length_mean() + 6 * minimizer_mapper.get_fragment_length_stdev();
+                    }
+                    // Emit the read
+                    alignment_emitter->emit_mapped_pair(std::move(mapped_pairs.first), std::move(mapped_pairs.second), tlen_limit);
                     // Record that we mapped a read.
                     reads_mapped_by_thread.at(omp_get_thread_num()) += 2;
                 }

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1243,7 +1243,10 @@ int main_giraffe(int argc, char** argv) {
                         // HTSlib terms no matter how far away it is in linear
                         // space (on the same contig), because it went into
                         // pair distribution estimation.
-                        int64_t tlen_limit = numeric_limits<int64_t>::max();
+                        // TODO: The semantics are weird here. 0 means
+                        // "properly paired at any distance" and
+                        // numeric_limits<int64_t>::max() doesn't.
+                        int64_t tlen_limit = 0;
                         if (surjecting && minimizer_mapper.fragment_distr_is_finalized()) {
                              tlen_limit = minimizer_mapper.get_fragment_length_mean() + 6 * minimizer_mapper.get_fragment_length_stdev();
                         }

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -238,9 +238,9 @@ int main_surject(int argc, char** argv) {
     surjector.min_splice_length = spliced ? min_splice_length : numeric_limits<int64_t>::max();
     
     // Get the lengths of all the paths in the XG to populate the HTS headers
-    map<string, int64_t> path_length;
+    vector<pair<string, int64_t>> path_order_and_length;
     xgidx->for_each_path_handle([&](path_handle_t path_handle) {
-            path_length[xgidx->get_path_name(path_handle)] = xgidx->get_path_length(path_handle);
+            path_order_and_length.emplace_back(xgidx->get_path_name(path_handle), xgidx->get_path_length(path_handle));
         });
    
     // Count our threads
@@ -249,7 +249,7 @@ int main_surject(int argc, char** argv) {
     if (input_format == "GAM" || input_format == "GAF") {
         
         // Set up output to an emitter that will handle serialization
-        unique_ptr<AlignmentEmitter> alignment_emitter = get_alignment_emitter("-", output_format, path_length, thread_count,
+        unique_ptr<AlignmentEmitter> alignment_emitter = get_alignment_emitter("-", output_format, path_order_and_length, thread_count,
                                                                                spliced ? xgidx : nullptr);
 
         if (interleaved) {
@@ -334,7 +334,7 @@ int main_surject(int argc, char** argv) {
         }
     } else if (input_format == "GAMP") {
 
-        MultipathAlignmentEmitter mp_alignment_emitter("-", thread_count, output_format, xgidx, &path_length);
+        MultipathAlignmentEmitter mp_alignment_emitter("-", thread_count, output_format, xgidx, &path_order_and_length);
         mp_alignment_emitter.set_read_group(read_group);
         mp_alignment_emitter.set_sample_name(sample_name);
         mp_alignment_emitter.set_min_splice_length(spliced ? min_splice_length : numeric_limits<int64_t>::max());

--- a/src/surjecting_alignment_emitter.cpp
+++ b/src/surjecting_alignment_emitter.cpp
@@ -1,0 +1,117 @@
+/**
+ * \file surjecting_alignment_emitter.cpp
+ * Implementation for SurjectingAlignmentEmitter
+ */
+
+
+#include "surjecting_alignment_emitter.hpp"
+#include "hts_alignment_emitter.hpp"
+
+#include <map>
+
+namespace vg {
+
+using namespace std;
+
+unique_ptr<AlignmentEmitter> get_alignment_emitter_with_surjection(const string& filename, const string& format, 
+                                                                   const vector<path_handle_t> paths_in_dict_order, size_t max_threads,
+                                                                   const HandleGraph* graph) {
+    
+    // Build a path length map by name
+    // TODO: be able to pass along dict order!
+    map<string, int64_t> path_length;
+    if (format == "SAM" || format == "BAM" || format == "CRAM") {
+        // Make sure we actually have a PathPositionalHandleGraph
+        const PathPositionHandleGraph* path_graph = dynamic_cast<const PathPositionHandleGraph*>(graph);
+        if (path_graph == nullptr) {
+            cerr << "error[vg::get_alignment_emitter_with_surjection]: Graph does not contain paths to surject into." << endl;
+            exit(1);
+        }
+    
+        // We will actually use it, so fill it in.
+        for (auto& path_handle : paths_in_dict_order) {
+            path_length[path_graph->get_path_name(path_handle)] = path_graph->get_path_length(path_handle);
+        }
+    }
+    
+    // Get the non-surjecting emitter
+    unique_ptr<AlignmentEmitter> emitter = get_alignment_emitter(filename, format, path_length, max_threads, graph);
+    
+    if (format == "SAM" || format == "BAM" || format == "CRAM") {
+        // Need to surject
+        
+        // Make sure (again) we actually have a PathPositionalHandleGraph
+        const PathPositionHandleGraph* path_graph = dynamic_cast<const PathPositionHandleGraph*>(graph);
+        assert(path_graph != nullptr);
+        
+        // Make a set of the path handles to surject into
+        unordered_set<path_handle_t> target_paths(paths_in_dict_order.begin(), paths_in_dict_order.end());
+        // Interpose a surjecting AlignmentEmitter
+        emitter = make_unique<SurjectingAlignmentEmitter>(path_graph, target_paths, std::move(emitter));
+    }
+    
+    return emitter;
+}
+
+SurjectingAlignmentEmitter::SurjectingAlignmentEmitter(const PathPositionHandleGraph* graph, unordered_set<path_handle_t> paths,
+    unique_ptr<AlignmentEmitter>&& backing) : surjector(graph), paths(paths), backing(std::move(backing)) {
+    
+    // Nothing to do!
+    
+}
+
+void SurjectingAlignmentEmitter::surject_alignments_in_place(vector<Alignment>& alns) const {
+    for (auto& aln : alns) {
+        // Surject each alignment and annotate with surjected path position
+        aln = surjector.surject(aln, paths, surject_subpath_global);
+    }
+}
+
+void SurjectingAlignmentEmitter::emit_singles(vector<Alignment>&& aln_batch) {
+    // Intercept the batch on its way
+    vector<Alignment> aln_batch_caught(aln_batch);
+    // Surject it in place
+    surject_alignments_in_place(aln_batch_caught);
+    // Forward it along
+    backing->emit_singles(std::move(aln_batch_caught));
+}
+
+void SurjectingAlignmentEmitter::emit_mapped_singles(vector<vector<Alignment>>&& alns_batch) {
+    // Intercept the batch on its way
+    vector<vector<Alignment>> alns_batch_caught(alns_batch);
+    for (auto& mappings : alns_batch_caught) {
+        // Surject all mappings in place
+        surject_alignments_in_place(mappings);
+    }
+    // Forward it along
+    backing->emit_mapped_singles(std::move(alns_batch_caught));
+}
+
+void SurjectingAlignmentEmitter::emit_pairs(vector<Alignment>&& aln1_batch, vector<Alignment>&& aln2_batch, vector<int64_t>&& tlen_limit_batch) {
+    // Intercept the batch on its way
+    vector<Alignment> aln1_batch_caught(aln1_batch);
+    vector<Alignment> aln2_batch_caught(aln2_batch);
+    // Surject it in place
+    surject_alignments_in_place(aln1_batch_caught);
+    surject_alignments_in_place(aln2_batch_caught);
+    // Forward it along
+    backing->emit_pairs(std::move(aln1_batch_caught), std::move(aln2_batch_caught), std::move(tlen_limit_batch));
+}
+
+void SurjectingAlignmentEmitter::emit_mapped_pairs(vector<vector<Alignment>>&& alns1_batch, vector<vector<Alignment>>&& alns2_batch, vector<int64_t>&& tlen_limit_batch) {
+    // Intercept the batch on its way
+    vector<vector<Alignment>> alns1_batch_caught(alns1_batch);
+    vector<vector<Alignment>> alns2_batch_caught(alns2_batch);
+    for (auto& mappings : alns1_batch_caught) {
+        // Surject all mappings in place
+        surject_alignments_in_place(mappings);
+    }
+    for (auto& mappings : alns2_batch_caught) {
+        // Surject all mappings in place
+        surject_alignments_in_place(mappings);
+    }
+    // Forward it along
+    backing->emit_mapped_pairs(std::move(alns1_batch_caught), std::move(alns2_batch_caught), std::move(tlen_limit_batch));
+}
+
+}

--- a/src/surjecting_alignment_emitter.cpp
+++ b/src/surjecting_alignment_emitter.cpp
@@ -19,7 +19,7 @@ unique_ptr<AlignmentEmitter> get_alignment_emitter_with_surjection(const string&
     
     // Build a path length map by name
     // TODO: be able to pass along dict order!
-    map<string, int64_t> path_length;
+    vector<pair<string, int64_t>> path_names_and_lengths;
     if (format == "SAM" || format == "BAM" || format == "CRAM") {
         // Make sure we actually have a PathPositionalHandleGraph
         const PathPositionHandleGraph* path_graph = dynamic_cast<const PathPositionHandleGraph*>(graph);
@@ -30,12 +30,12 @@ unique_ptr<AlignmentEmitter> get_alignment_emitter_with_surjection(const string&
     
         // We will actually use it, so fill it in.
         for (auto& path_handle : paths_in_dict_order) {
-            path_length[path_graph->get_path_name(path_handle)] = path_graph->get_path_length(path_handle);
+            path_names_and_lengths.emplace_back(path_graph->get_path_name(path_handle), path_graph->get_path_length(path_handle));
         }
     }
     
     // Get the non-surjecting emitter
-    unique_ptr<AlignmentEmitter> emitter = get_alignment_emitter(filename, format, path_length, max_threads, graph);
+    unique_ptr<AlignmentEmitter> emitter = get_alignment_emitter(filename, format, path_names_and_lengths, max_threads, graph);
     
     if (format == "SAM" || format == "BAM" || format == "CRAM") {
         // Need to surject

--- a/src/surjecting_alignment_emitter.hpp
+++ b/src/surjecting_alignment_emitter.hpp
@@ -1,0 +1,91 @@
+#ifndef VG_SURJECTING_ALIGNMENT_EMITTER_HPP_INCLUDED
+#define VG_SURJECTING_ALIGNMENT_EMITTER_HPP_INCLUDED
+
+/** \file
+ *
+ * Holds a surjecting wrapper AlignmentEmitter, and an entry point for getting AlignmentEmitters that can use it.
+ */
+
+
+#include "surjector.hpp"
+#include "vg/io/alignment_emitter.hpp"
+#include "handle.hpp"
+
+#include <unordered_set>
+#include <string>
+#include <vector>
+
+namespace vg {
+
+using namespace std;
+
+/**
+ * Get an AlignmentEmitter that emits in the given format.
+ * Supported formats are: GAF, GAM, SAM, BAM, CRAM, JSON.
+ * When emitting in linear formats (SAM/BAM/CRAM), automatically surjects, and uses spliced alignment output.
+ * When surjecting, surjects into the paths in the given vector, with the order
+ * used to define the order of names in the SAM/BAM/CRAM header.
+ * When surjecting, graph must be a PahtPositionalHandleGraph.
+ */
+unique_ptr<vg::io::AlignmentEmitter> get_alignment_emitter_with_surjection(const string& filename, const string& format, 
+                                                                           const vector<path_handle_t> paths_in_dict_order, size_t max_threads,
+                                                                           const HandleGraph* graph);
+
+/**
+ * An AlignmentEmitter implementation that surjects alignments before emitting them via a backing AlignmentEmitter, which it owns.
+ */
+class SurjectingAlignmentEmitter : public vg::io::AlignmentEmitter {
+public:
+    
+    /**
+     * Surject alignments using the given graph, into the given paths, and send them to the given AlignmentEmitter.
+     * Takes ownership of the AlignmentEmitter.
+     * Copies the set of paths.
+     */
+    SurjectingAlignmentEmitter(const PathPositionHandleGraph* graph, unordered_set<path_handle_t> paths, unique_ptr<AlignmentEmitter>&& backing);
+   
+    ///  Force full length alignment in surjection resolution 
+    bool surject_subpath_global = true;
+    
+    
+    /// Emit a batch of Alignments
+    virtual void emit_singles(vector<Alignment>&& aln_batch);
+    /// Emit batch of Alignments with secondaries. All secondaries must have is_secondary set already.
+    virtual void emit_mapped_singles(vector<vector<Alignment>>&& alns_batch);
+    /// Emit a batch of pairs of Alignments. The tlen_limit_batch, if
+    /// specified, is the maximum pairing distance for ewch pair to flag
+    /// properly paired, if the output format cares about such things. TODO:
+    /// Move to a properly paired annotation that runs with the Alignment.
+    virtual void emit_pairs(vector<Alignment>&& aln1_batch, vector<Alignment>&& aln2_batch,
+        vector<int64_t>&& tlen_limit_batch);
+    /// Emit the mappings of a batch of pairs of Alignments. All secondaries
+    /// must have is_secondary set already. The tlen_limit_batch, if specified,
+    /// is the maximum pairing distance for each pair to flag properly paired,
+    /// if the output format cares about such things. TODO: Move to a properly
+    /// paired annotation that runs with the Alignment.
+    ///
+    /// Both ends of each pair must have the same number of mappings.
+    virtual void emit_mapped_pairs(vector<vector<Alignment>>&& alns1_batch,
+        vector<vector<Alignment>>&& alns2_batch, vector<int64_t>&& tlen_limit_batch);
+    
+protected:
+    /// Surjector used to do the surjection
+    Surjector surjector;
+
+    /// Paths to surject into
+    unordered_set<path_handle_t> paths;
+    
+    /// AlignmentEmitter to emit to once done
+    unique_ptr<AlignmentEmitter> backing;
+    
+    /// Surject alignments in place.
+    void surject_alignments_in_place(vector<Alignment>& alns) const;
+    
+    
+    
+    
+};
+
+}
+
+#endif

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -43,7 +43,7 @@ using namespace std;
         /// Also optionally leaves deletions against the reference path in the final alignment
         /// (useful for splicing).
         Alignment surject(const Alignment& source,
-                          const set<string>& path_names,
+                          const unordered_set<path_handle_t>& path_handles,
                           string& path_name_out,
                           int64_t& path_pos_out,
                           bool& path_rev_out,
@@ -65,6 +65,57 @@ using namespace std;
         /// Also optionally leaves deletions against the reference path in the final
         /// alignment (useful for splicing).
         Alignment surject(const Alignment& source,
+                          const unordered_set<path_handle_t>& path_handles,
+                          bool allow_negative_scores = false,
+                          bool preserve_deletions = false) const;
+                          
+        /// Same semantics as with alignments except that connections are always
+        /// preserved as splices. The output consists of a multipath alignment with
+        /// a single path, separated by splices (either from large deletions or from
+        /// connections)
+        multipath_alignment_t surject(const multipath_alignment_t& source,
+                                      const unordered_set<path_handle_t>& path_handles,
+                                      string& path_name_out, int64_t& path_pos_out,
+                                      bool& path_rev_out,
+                                      bool allow_negative_scores = false,
+                                      bool preserve_deletions = false) const;
+        
+        /// Extract the portions of an alignment that are on a chosen set of paths and try to
+        /// align realign the portions that are off of the chosen paths to the intervening
+        /// path segments to obtain an alignment that is fully restricted to the paths.
+        ///
+        /// Also returns the path name, position, and strand of the new alignment.
+        ///
+        /// Optionally either allow softclips so that the alignment has a nonnegative score on
+        /// the path or require the full-length alignment, possibly creating a negative score.
+        ///
+        /// Also optionally leaves deletions against the reference path in the final alignment
+        /// (useful for splicing).
+        [[deprecated("Use handle-based path specification instead")]] 	
+        Alignment surject(const Alignment& source,
+                          const set<string>& path_names,
+                          string& path_name_out,
+                          int64_t& path_pos_out,
+                          bool& path_rev_out,
+                          bool allow_negative_scores = false,
+                          bool preserve_deletions = false) const;
+                          
+        /// Extract the portions of an alignment that are on a chosen set of
+        /// paths and try to align realign the portions that are off of the
+        /// chosen paths to the intervening path segments to obtain an
+        /// alignment that is fully restricted to the paths.
+        ///
+        /// Replaces the alignment's refpos with the path name, position, and
+        /// strand the alignment has been surjected to.
+        ///
+        /// Optionally either allow softclips so that the alignment has a
+        /// nonnegative score on the path or require the full-length alignment,
+        /// possibly creating a negative score.
+        ///
+        /// Also optionally leaves deletions against the reference path in the final
+        /// alignment (useful for splicing).
+        [[deprecated("Use handle-based path specification instead")]]
+        Alignment surject(const Alignment& source,
                           const set<string>& path_names,
                           bool allow_negative_scores = false,
                           bool preserve_deletions = false) const;
@@ -73,6 +124,7 @@ using namespace std;
         /// preserved as splices. The output consists of a multipath alignment with
         /// a single path, separated by splices (either from large deletions or from
         /// connections)
+        [[deprecated("Use handle-based path specification instead")]]
         multipath_alignment_t surject(const multipath_alignment_t& source,
                                       const set<string>& path_names,
                                       string& path_name_out, int64_t& path_pos_out,
@@ -90,7 +142,7 @@ using namespace std;
         
         void surject_internal(const Alignment* source_aln, const multipath_alignment_t* source_mp_aln,
                               Alignment* aln_out, multipath_alignment_t* mp_aln_out,
-                              const set<string>& path_names,
+                              const unordered_set<path_handle_t>& path_handles,
                               string& path_name_out, int64_t& path_pos_out, bool& path_rev_out,
                               bool allow_negative_scores, bool preserve_deletions) const;
         

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 6
+plan tests 16
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -G x.gbwt -v small/x.vcf.gz x.vg
@@ -49,6 +49,22 @@ is "$(vg view -aj single.gam | jq -c 'select((.fragment_next | not) and (.fragme
 vg giraffe x.fa x.vcf.gz -f small/x.fa_1.fastq -f small/x.fa_1.fastq --fragment-mean 300 --fragment-stdev 100 > paired.gam
 is "$(vg view -aj paired.gam | jq -c 'select((.fragment_next | not) and (.fragment_prev | not))' | wc -l)" "0" "paired reads have cross-references"
 
-rm -f x.vg x.gbwt x.gg x.snarls x.min x.dist x.gg x.fa x.fa.fai x.vcf.gz x.vcf.gz.tbi single.gam paired.gam
+# Test paired surjected mapping
+vg giraffe x.fa x.vcf.gz -iG <(vg view -a small/x-s13241-n1-p500-v300.gam | sed 's%_1%/1%' | sed 's%_2%/2%' | vg view -JaG - ) --output-format SAM >surjected.sam
+is "$(cat surjected.sam | grep -v '^@' | sort -k4 | cut -f 4)" "$(printf '321\n762')" "surjection of paired reads to SAM yields correct positions"
+is "$(cat surjected.sam | grep -v '^@' | sort -k4 | cut -f 8)" "$(printf '762\n321')" "surjection of paired reads to SAM yields correct pair partner positions"
+is "$(cat surjected.sam | grep -v '^@' | cut -f 1 | sort | uniq | wc -l)" "1" "surjection of paired reads to SAM yields properly matched QNAMEs"
+is "$(cat surjected.sam | grep -v '^@' | cut -f 7)" "$(printf '=\n=')" "surjection of paired reads to SAM produces correct pair partner contigs"
+is "$(cat surjected.sam | grep -v '^@' | sort -k4 | cut -f 2)" "$(printf '163\n83')" "surjection of paired reads to SAM produces correct flags"
+
+# And unpaired surjected mapping
+vg giraffe x.fa x.vcf.gz -G <(vg view -a small/x-s13241-n1-p500-v300.gam | sed 's%_1%/1%' | sed 's%_2%/2%' | vg view -JaG - ) --output-format SAM >surjected.sam
+is "$(cat surjected.sam | grep -v '^@' | sort -k4 | cut -f 4)" "$(printf '321\n762')" "surjection of unpaired reads to SAM yields correct positions"
+is "$(cat surjected.sam | grep -v '^@' | sort -k4 | cut -f 8)" "$(printf '0\n0')" "surjection of unpaired reads to SAM yields correct pair partner positions"
+is "$(cat surjected.sam | grep -v '^@' | cut -f 1 | sort | uniq | wc -l)" "2" "surjection of unpaired reads to SAM yields distinct QNAMEs"
+is "$(cat surjected.sam | grep -v '^@' | cut -f 7)" "$(printf '*\n*')" "surjection of unpaired reads to SAM produces absent partner contigs"
+is "$(cat surjected.sam | grep -v '^@' | sort -k4 | cut -f 2)" "$(printf '0\n16')" "surjection of unpaired reads to SAM produces correct flags"
+
+rm -f x.vg x.gbwt x.gg x.snarls x.min x.dist x.gg x.fa x.fa.fai x.vcf.gz x.vcf.gz.tbi single.gam paired.gam surjected.sam
 
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` can now output to SAM/BAM/CRAM directly

## Description

When a non-GBWTGraph graph is available, `vg giraffe` can surject when you tell it e.g. `--output-format BAM`.

This will fix #3029 (although not with the `--surject-to` option specifically).

Giraffe and map surjection are mostly unified now, using a `SurjectingAlignmentEmitter` wrapper and a new alignment emitter factory function that sets up surjection. Some of the groundwork for sequence dict order support has been laid, and the comments lie about it being there already. I want to finish pulling that through at least on the backend before we merge this.
