### PR TITLE
Update the mpmap interface to easily toggle between output formats

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -555,7 +555,7 @@ namespace vg {
         
     }
     
-    void MultipathMapper::attempt_unpaired_multipath_map_of_pair(const Alignment& alignment1, const Alignment& alignment2,
+    bool MultipathMapper::attempt_unpaired_multipath_map_of_pair(const Alignment& alignment1, const Alignment& alignment2,
                                                                  vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                                  vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer) {
         
@@ -654,6 +654,8 @@ namespace vg {
             cerr << endl;
         }
 #endif
+        
+        return !is_ambiguous;
     }
     
     bool MultipathMapper::attempt_rescue(const multipath_alignment_t& multipath_aln, const Alignment& other_aln,
@@ -1691,7 +1693,7 @@ namespace vg {
         }
     }
     
-    void MultipathMapper::multipath_map_paired(const Alignment& alignment1, const Alignment& alignment2,
+    bool MultipathMapper::multipath_map_paired(const Alignment& alignment1, const Alignment& alignment2,
                                                vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer) {
         
@@ -1710,9 +1712,7 @@ namespace vg {
             cerr << "no fragment length distribution yet, looking for unambiguous single ended pairs" << endl;
 #endif
             
-            attempt_unpaired_multipath_map_of_pair(alignment1, alignment2, multipath_aln_pairs_out, ambiguous_pair_buffer);
-            
-            return;
+            return attempt_unpaired_multipath_map_of_pair(alignment1, alignment2, multipath_aln_pairs_out, ambiguous_pair_buffer);
         }
         
         // the fragment length distribution has been estimated, so we can do full-fledged paired mode
@@ -1976,6 +1976,8 @@ namespace vg {
             view_multipath_alignment(cerr, multipath_aln_pair.second, *xindex);
         }
 #endif
+        
+        return proper_paired;
     }
     
     void MultipathMapper::reduce_to_single_path(const multipath_alignment_t& multipath_aln, vector<Alignment>& alns_out,

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -81,7 +81,8 @@ namespace vg {
         /// same strand of the DNA/RNA molecule. If the fragment length distribution is still being estimated
         /// and the pair cannot be mapped unambiguously, adds the reads to a buffer for ambiguous pairs and
         /// does not output any multipath alignments.
-        void multipath_map_paired(const Alignment& alignment1, const Alignment& alignment2,
+        /// Returns true if the output is properly paired, or false if it is independent end mappings.
+        bool multipath_map_paired(const Alignment& alignment1, const Alignment& alignment2,
                                   vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                   vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer);
                                   
@@ -234,7 +235,8 @@ namespace vg {
         /// Before the fragment length distribution has been estimated, look for an unambiguous mapping of
         /// the reads using the single ended routine. If we find one record the fragment length and report
         /// the pair, if we don't find one, add the read pair to a buffer instead of the output vector.
-        void attempt_unpaired_multipath_map_of_pair(const Alignment& alignment1, const Alignment& alignment2,
+        /// Returns true if we successfully find a measurable pair.
+        bool attempt_unpaired_multipath_map_of_pair(const Alignment& alignment1, const Alignment& alignment2,
                                                     vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                     vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer);
         

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -62,7 +62,7 @@ void help_mpmap(char** argv) {
     << "output:" << endl
     << "  -F, --output-fmt FMT          format to output alignments in: GAMP for multipath, GAM or GAF for single path," << endl
     << "                                SAM, CRAM, or BAM for linear reference alignments (may also require -S) [GAMP]" << endl
-    << "  -S, --ref-paths FILE          paths in the graph, one per line, to treat as reference for HTSlib output (see -F) [all paths]" << endl
+    << "  -S, --ref-paths FILE          paths in the graph, one per line, to treat as reference for HTSlib formats (see -F) [all paths]" << endl
     << "  -a, --agglomerate-alns        combine separate multipath alignments into one (possibly disconnected) alignment" << endl
     << "  -N, --sample NAME             add this sample name to output" << endl
     << "  -R, --read-group NAME         add this read group to output" << endl

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -954,7 +954,7 @@ int main_mpmap(int argc, char** argv) {
     // revisit this at some point
     if (single_path_alignment_mode &&
         (population_max_paths == 0 || (sublinearLS_name.empty() && gbwt_name.empty())) &&
-        !hts_output) {
+        !(hts_output && transcriptomic)) {
         // adjust parameters that produce irrelevant extra work single path mode
         if (!snarls_name.empty()) {
             cerr << "warning:[vg mpmap] Snarl file (-s) is ignored for single path alignment formats (-F) without multipath population scoring (--max-paths)." << endl;
@@ -1900,6 +1900,9 @@ int main_mpmap(int argc, char** argv) {
                                                                        path_lengths.get());
     emitter->set_read_group(read_group);
     emitter->set_sample_name(sample_name);
+    if (transcriptomic) {
+        emitter->set_min_splice_length(min_splice_length);
+    }
     
     // a buffer to hold read pairs that can't be unambiguously mapped before the fragment length distribution
     // is estimated

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -11,6 +11,7 @@
 
 #include <vg/io/vpkg.hpp>
 #include "../multipath_mapper.hpp"
+#include "../surjector.hpp"
 #include "../multipath_alignment_emitter.hpp"
 #include "../path.hpp"
 #include "../watchdog.hpp"
@@ -59,9 +60,10 @@ void help_mpmap(char** argv) {
     << "  -l, --read-length TYPE        read length preset: 'very-short', 'short', or 'long' (approx. <50bp, 50-500bp, and >500bp) [short]" << endl
     << "  -e, --error-rate TYPE         error rate preset: 'low' or 'high' (approx. PHRED >20 and <20) [low]" << endl
     << "output:" << endl
+    << "  -F, --output-fmt FMT          format to output alignments in: GAMP for multipath, GAM or GAF for single path," << endl
+    << "                                SAM, CRAM, or BAM for linear reference alignments (may also require -S) [GAMP]" << endl
+    << "  -S, --ref-paths FILE          paths in the graph, one per line, to treat as reference for HTSlib output (see -F) [all paths]" << endl
     << "  -a, --agglomerate-alns        combine separate multipath alignments into one (possibly disconnected) alignment" << endl
-    << "  -S, --single-path-mode        output single-path alignments (GAM or GAF) instead of multipath alignments (GAMP)" << endl
-    << "  -F, --single-path-fmt FMT     output in either 'gam' or 'gaf' format in single path mode [gam]" << endl
     << "  -N, --sample NAME             add this sample name to output" << endl
     << "  -R, --read-group NAME         add this read group to output" << endl
     << "  -p, --suppress-progress       do not report progress to stderr (slightly reduces thread contention)" << endl
@@ -170,6 +172,7 @@ int main_mpmap(int argc, char** argv) {
     string fastq_name_1;
     string fastq_name_2;
     string gam_file_name;
+    string ref_paths_name;
     int match_score = default_match;
     int mismatch_score = default_mismatch;
     int gap_open_score = default_gap_open;
@@ -296,8 +299,6 @@ int main_mpmap(int argc, char** argv) {
     int full_length_bonus_arg = std::numeric_limits<int>::min();
     int reversing_walk_length = 1;
     bool no_output = false;
-    string default_single_path_format = "GAM";
-    string single_path_format = default_single_path_format;
     string out_format = "GAMP";
 
     // default presets
@@ -327,8 +328,8 @@ int main_mpmap(int argc, char** argv) {
             {"read-group", required_argument, 0, 'R'},
             {"interleaved", no_argument, 0, 'i'},
             {"same-strand", no_argument, 0, 'T'},
-            {"single-path-mode", no_argument, 0, 'S'},
-            {"single-path-fmt", required_argument, 0, 'F'},
+            {"ref-paths", required_argument, 0, 'S'},
+            {"output-fmt", required_argument, 0, 'F'},
             {"snarls", required_argument, 0, 's'},
             {"synth-tail-anchors", no_argument, 0, OPT_SUPPRESS_TAIL_ANCHORS},
             {"suppress-suppression", no_argument, 0, OPT_SUPPRESS_SUPPRESSION},
@@ -397,7 +398,7 @@ int main_mpmap(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:iSs:vX:u:b:I:D:BP:Q:UpM:r:W:K:F:c:C:R:En:l:e:q:z:w:o:y:L:mAt:Z:a",
+        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:iS:s:vX:u:b:I:D:BP:Q:UpM:r:W:K:F:c:C:R:En:l:e:q:z:w:o:y:L:mAt:Z:a",
                          long_options, &option_index);
 
 
@@ -524,7 +525,7 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'S':
-                single_path_alignment_mode = true;
+                ref_paths_name = optarg;
                 break;
                 
             case 's':
@@ -629,7 +630,7 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'F':
-                single_path_format = optarg;
+                out_format = optarg;
                 break;
                 
             case OPT_STRIPPED_MATCH:
@@ -829,6 +830,33 @@ int main_mpmap(int argc, char** argv) {
     else if (error_rate == "High" || error_rate == "HIGH") {
         error_rate = "high";
     }
+    
+    // normalize capitalization
+    if (out_format == "gamp") {
+        out_format = "GAMP";
+    }
+    if (out_format == "gam") {
+        out_format = "GAM";
+    }
+    if (out_format == "gaf") {
+        out_format = "GAF";
+    }
+    if (out_format == "sam") {
+        out_format = "SAM";
+    }
+    if (out_format == "bam") {
+        out_format = "BAM";
+    }
+    if (out_format == "cram") {
+        out_format = "CRAM";
+    }
+    
+    bool hts_output = (out_format == "SAM" || out_format == "BAM" || out_format == "CRAM");
+    bool transcriptomic = (nt_type == "rna");
+    
+    if (out_format != "GAMP") {
+        single_path_alignment_mode = true;
+    }
         
     // set baseline parameters according to presets
     
@@ -922,33 +950,21 @@ int main_mpmap(int argc, char** argv) {
     if (single_path_alignment_mode) {
         // simplifying topologies is redundant work if we're just going to take the maximum weight path anyway
         simplify_topologies = false;
-        out_format = single_path_format;
-    }
-    
-    // normalize capitalization
-    if (out_format == "gam") {
-        out_format = "GAM";
-    }
-    if (out_format == "gamp") {
-        out_format = "GAMP";
-    }
-    if (out_format == "gaf") {
-        out_format = "GAF";
     }
     
     if (single_path_alignment_mode &&
         (population_max_paths == 0 || (sublinearLS_name.empty() && gbwt_name.empty()))) {
         // adjust parameters that produce irrelevant extra work single path mode
         if (!snarls_name.empty()) {
-            cerr << "warning:[vg mpmap] Snarl file (-s) is ignored in single path mode (-S) without multipath population scoring (--max-paths)." << endl;
+            cerr << "warning:[vg mpmap] Snarl file (-s) is ignored for single path alignment formats (-F) without multipath population scoring (--max-paths)." << endl;
         }
         
         if (snarl_cut_size != default_snarl_cut_size) {
-            cerr << "warning:[vg mpmap] Snarl cut limit (-X) is ignored in single path mode (-S) without multipath population scoring (--max-paths)." << endl;
+            cerr << "warning:[vg mpmap] Snarl cut limit (-X) is ignored for single path alignment formats (-F) without multipath population scoring (--max-paths)." << endl;
         }
         
         if (num_alt_alns != default_num_alt_alns) {
-            cerr << "warning:[vg mpmap] Number of alternate alignments (-a) is ignored in single path mode (-S) without multipath population scoring (--max-paths)." << endl;
+            cerr << "warning:[vg mpmap] Number of alternate alignments (-a) for ignored in single path alignment formats (-F) without multipath population scoring (--max-paths)." << endl;
         }
         
         // don't cut inside snarls or load the snarl manager
@@ -1059,6 +1075,11 @@ int main_mpmap(int argc, char** argv) {
     
     if (!interleaved_input && fastq_name_2.empty() && same_strand) {
         cerr << "warning:[vg mpmap] Ignoring same strand parameter (-e) because no paired end input provided." << endl;
+    }
+    
+    if (!ref_paths_name.empty() && hts_output) {
+        cerr << "warning:[vg mpmap] Reference path file (-S) is only used when output format (-F) is SAM, BAM, or CRAM." << endl;
+        ref_paths_name = "";
     }
     
     if (num_alt_alns <= 0) {
@@ -1199,12 +1220,10 @@ int main_mpmap(int argc, char** argv) {
         exit(1);
     }
     
-    if (single_path_format != default_single_path_format && !single_path_alignment_mode) {
-        cerr << "warning:[vg mpmap] Single path output format (-F) is ignored when not using single path alignment output (-S)." << endl;
-    }
-    
     if (single_path_alignment_mode && agglomerate_multipath_alns) {
-        cerr << "warning:[vg mpmap] Disconnected alignments cannot be agglomerated (-a) in single path mode (-S)." << endl;
+        // this could probably be just a warning, but it will really mess up the MAPQs
+        cerr << "error:[vg mpmap] Disconnected alignments cannot be agglomerated (-a) for single path alignment formats (-F)." << endl;
+        exit(1);
     }
     
     if (stripped_match_alg_strip_length <= 0) {
@@ -1394,6 +1413,15 @@ int main_mpmap(int argc, char** argv) {
         ls_stream.open(sublinearLS_name);
         if (!ls_stream) {
             cerr << "error:[vg mpmap] Cannot open sublinear Li & Stevens file " << sublinearLS_name << endl;
+            exit(1);
+        }
+    }
+    
+    ifstream ref_paths_stream;
+    if (!ref_paths_name.empty()) {
+        ref_paths_stream.open(ref_paths_name);
+        if (!ref_paths_stream) {
+            cerr << "error:[vg mpmap] Cannot open reference paths file " << ref_paths_name << endl;
             exit(1);
         }
     }
@@ -1607,6 +1635,62 @@ int main_mpmap(int argc, char** argv) {
         
     }
     
+    // Load structures that we need for HTS lib outputs
+    unique_ptr<map<string, int64_t>> path_lengths;
+    unordered_set<path_handle_t> surjection_paths;
+    unique_ptr<Surjector> surjector;
+    if (hts_output) {
+        // init the data structures
+        path_lengths = unique_ptr<map<string, int64_t>>(new map<string, int64_t>());
+        surjector = unique_ptr<Surjector>(new Surjector(path_position_handle_graph));
+        
+        if (ref_paths_stream.is_open()) {
+            // get reference paths from a file
+            cerr << progress_boilerplate() << "Choosing reference paths from " << ref_paths_name << endl;
+            string line;
+            while (ref_paths_stream.good()) {
+                getline(ref_paths_stream, line);
+                // trim whitespace from ends
+                line.erase(line.begin(), find_if(line.begin(), line.end(), [](char ch) {
+                    return !isspace(ch);
+                }));
+                line.erase(find_if(line.rbegin(), line.rend(), [](char ch) {
+                    return !isspace(ch);
+                }).base(), line.end());
+                if (line.empty()) {
+                    // skip blank lines
+                    continue;
+                }
+                if (!path_position_handle_graph->has_path(line)) {
+                    cerr << "error:[vg mpmap] Graph does not have a path named " << line << ", which was indicated in " << ref_paths_name << endl;
+                    exit(1);
+                }
+                path_handle_t path_handle = path_position_handle_graph->get_path_handle(line);
+                path_lengths->insert(pair<string, int64_t>(line, path_position_handle_graph->get_path_length(path_handle)));
+                surjection_paths.insert(path_handle);
+            }
+            if (path_lengths->empty()) {
+                cerr << "error:[vg mpmap] Reference path file (-S) " << ref_paths_name << " does not contain any path names" << endl;
+                exit(1);
+            }
+        }
+        else {
+            // default to using all embedded paths as
+            cerr << progress_boilerplate() << "No reference path file given. Interpreting all paths in graph as reference sequences." << endl;
+            
+            if (path_position_handle_graph->get_path_count() == 0) {
+                cerr << "error:[vg mpmap] Graph does not have embedded paths to treat as reference sequences. Cannot produces HTSlib output formats (SAM/BAM/CRAM)." << endl;
+                exit(1);
+            }
+            
+            path_position_handle_graph->for_each_path_handle([&](const path_handle_t& path_handle) {
+                surjection_paths.insert(path_handle);
+                path_lengths->insert(pair<string, int64_t>(path_position_handle_graph->get_path_name(path_handle),
+                                                           path_position_handle_graph->get_path_length(path_handle)));
+            });
+        }
+    }
+    
     // this also takes a while inside the MultipathMapper constructor, but it will only activate if we don't
     // have a distance index available for oriented distance calculations
     if (!suppress_progress && distance_index_name.empty() && path_handle_graph->get_path_count() > 0) {
@@ -1805,7 +1889,8 @@ int main_mpmap(int argc, char** argv) {
     
     // init a writer for the output
     MultipathAlignmentEmitter* emitter = new MultipathAlignmentEmitter("-", thread_count, out_format,
-                                                                       path_position_handle_graph);
+                                                                       path_position_handle_graph,
+                                                                       path_lengths.get());
     emitter->set_read_group(read_group);
     emitter->set_sample_name(sample_name);
     
@@ -1835,6 +1920,18 @@ int main_mpmap(int argc, char** argv) {
         vector<multipath_alignment_t> mp_alns;
         multipath_mapper.multipath_map(alignment, mp_alns);
         
+        vector<tuple<string, bool, int64_t>> path_positions;
+        if (hts_output) {
+            // we need to surject and compute path positions
+            path_positions.resize(mp_alns.size());
+            for (size_t i = 0; i < mp_alns.size(); ++i) {
+                auto& path_pos = path_positions[i];
+                mp_alns[i] = surjector->surject(mp_alns[i], surjection_paths,
+                                                get<0>(path_pos), get<2>(path_pos), get<1>(path_pos),
+                                                true, transcriptomic);
+            }
+        }
+        
         if (is_rna) {
             for (multipath_alignment_t& mp_aln : mp_alns) {
                 convert_Ts_to_Us(mp_aln);
@@ -1842,7 +1939,12 @@ int main_mpmap(int argc, char** argv) {
         }
         
         if (!no_output) {
-            emitter->emit_singles(alignment.name(), move(mp_alns));
+            if (!hts_output) {
+                emitter->emit_singles(alignment.name(), move(mp_alns));
+            }
+            else {
+                emitter->emit_singles(alignment.name(), move(mp_alns), &path_positions);
+            }
         }
         
         if (watchdog) {
@@ -1890,13 +1992,34 @@ int main_mpmap(int argc, char** argv) {
         size_t num_buffered = ambiguous_pair_buffer.size();
         
         vector<pair<multipath_alignment_t, multipath_alignment_t>> mp_aln_pairs;
-        multipath_mapper.multipath_map_paired(alignment_1, alignment_2, mp_aln_pairs, ambiguous_pair_buffer);
+        bool proper_paired = multipath_mapper.multipath_map_paired(alignment_1, alignment_2, mp_aln_pairs, ambiguous_pair_buffer);
         
         
         if (!same_strand) {
             for (auto& mp_aln_pair : mp_aln_pairs) {
                 rev_comp_multipath_alignment_in_place(&mp_aln_pair.second, [&](vg::id_t node_id) { return path_position_handle_graph->get_length(path_position_handle_graph->get_handle(node_id));
                 });
+            }
+        }
+        
+        vector<pair<tuple<string, bool, int64_t>, tuple<string, bool, int64_t>>> path_positions;
+        vector<int64_t> tlen_limits;
+        if (hts_output) {
+            // we need to surject and compute path positions
+            path_positions.resize(mp_aln_pairs.size());
+            // hackily either give no limit or an unattainable limit to communicate pairedness
+            tlen_limits.resize(mp_aln_pairs.size(),
+                               proper_paired ? numeric_limits<int32_t>::max() : -1);
+            
+            for (size_t i = 0; i < mp_aln_pairs.size(); ++i) {
+                auto& path_pos_1 = path_positions[i].first;
+                auto& path_pos_2 = path_positions[i].second;
+                mp_aln_pairs[i].first = surjector->surject(mp_aln_pairs[i].first, surjection_paths,
+                                                           get<0>(path_pos_1), get<2>(path_pos_1), get<1>(path_pos_1),
+                                                           true, transcriptomic);
+                mp_aln_pairs[i].second = surjector->surject(mp_aln_pairs[i].second, surjection_paths,
+                                                            get<0>(path_pos_2), get<2>(path_pos_2), get<1>(path_pos_2),
+                                                            true, transcriptomic);
             }
         }
         
@@ -1908,7 +2031,13 @@ int main_mpmap(int argc, char** argv) {
         }
         
         if (!no_output) {
-            emitter->emit_pairs(alignment_1.name(), alignment_2.name(), move(mp_aln_pairs));
+            if (!hts_output) {
+                emitter->emit_pairs(alignment_1.name(), alignment_2.name(), move(mp_aln_pairs));
+            }
+            else {
+                emitter->emit_pairs(alignment_1.name(), alignment_2.name(), move(mp_aln_pairs),
+                                    &path_positions, &tlen_limits);
+            }
         }
         
         if (watchdog) {
@@ -1966,16 +2095,40 @@ int main_mpmap(int argc, char** argv) {
         mp_alns_1.resize(min(mp_alns_1.size(), mp_alns_2.size()));
         mp_alns_2.resize(min(mp_alns_1.size(), mp_alns_2.size()));
         
-        if (!no_output) {
-            // interface expects vectors, but we'll be doing one at a time
-            vector<multipath_alignment_t> buffer;
+        vector<pair<tuple<string, bool, int64_t>, tuple<string, bool, int64_t>>> path_positions;
+        vector<int64_t> tlen_limits;
+        if (hts_output) {
+            // we need to surject and compute path positions
+            path_positions.resize(mp_alns_1.size());
+            // hackily give unattainable limit to indicate no proper pairing
+            tlen_limits.resize(mp_alns_1.size(), -1);
+            
             for (size_t i = 0; i < mp_alns_1.size(); ++i) {
-                buffer.emplace_back(move(mp_alns_1[i]));
-                emitter->emit_singles(alignment_1.name(), move(buffer));
-                buffer.clear();
-                buffer.emplace_back(move(mp_alns_2[i]));
-                emitter->emit_singles(alignment_2.name(), move(buffer));
-                buffer.clear();
+                auto& path_pos_1 = path_positions[i].first;
+                auto& path_pos_2 = path_positions[i].second;
+                mp_alns_1[i] = surjector->surject(mp_alns_1[i], surjection_paths,
+                                                  get<0>(path_pos_1), get<2>(path_pos_1), get<1>(path_pos_1),
+                                                  true, transcriptomic);
+                mp_alns_2[i] = surjector->surject(mp_alns_2[i], surjection_paths,
+                                                  get<0>(path_pos_2), get<2>(path_pos_2), get<1>(path_pos_2),
+                                                  true, transcriptomic);
+            }
+        }
+        
+        if (!no_output) {
+            // reorganize into pairs
+            vector<pair<multipath_alignment_t, multipath_alignment_t>> mp_aln_pairs;
+            mp_aln_pairs.reserve(mp_alns_1.size());
+            for (size_t i = 0; i < mp_alns_1.size(); ++i) {
+                mp_aln_pairs.emplace_back(move(mp_alns_1[i]), move(mp_alns_2[i]));
+            }
+            
+            if (!hts_output) {
+                emitter->emit_pairs(alignment_1.name(), alignment_2.name(), move(mp_aln_pairs));
+            }
+            else {
+                emitter->emit_pairs(alignment_1.name(), alignment_2.name(), move(mp_aln_pairs),
+                                    &path_positions, &tlen_limits);
             }
         }
         

--- a/test/t/33_vg_mpmap.t
+++ b/test/t/33_vg_mpmap.t
@@ -16,13 +16,13 @@ vg index -x xy2.xg -g xy2.gcsa -v small/xy2.vcf.gz --gbwt-name xy2.gbwt -k 16 xy
 # We turn off the background model calibration with -B and ignore it with -P 1
 
 # This read is part ref and part alt which matches a haplotype on X, but is possible on Y as well.
-is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa -f reads/xy2.match.fq -S | vg view -aj - | jq '.mapping_quality')" "3" "MAPQ is 50% without haplotype info"
-is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -f reads/xy2.match.fq -S | vg view -aj - | jq '.mapping_quality')" "4" "haplotype match can disambiguate"
+is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa -f reads/xy2.match.fq -F GAM | vg view -aj - | jq '.mapping_quality')" "3" "MAPQ is 50% without haplotype info"
+is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -f reads/xy2.match.fq -F GAM | vg view -aj - | jq '.mapping_quality')" "4" "haplotype match can disambiguate"
 
 # For paired end, don't do any fragment length estimation
 
-is "$(vg mpmap -B -P 1 -I 200 -D 200 -x xy2.xg -g xy2.gcsa -f reads/xy2.matchpaired.fq -i -S | vg view -aj - | head -n1 | jq '.mapping_quality')" "3" "MAPQ is 50% when paired without haplotype info"
-vg mpmap -B -P 1 -I 200 -D 200 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -f reads/xy2.matchpaired.fq -i -S > gbwt.gam
+is "$(vg mpmap -B -P 1 -I 200 -D 200 -x xy2.xg -g xy2.gcsa -f reads/xy2.matchpaired.fq -i -F GAM | vg view -aj - | head -n1 | jq '.mapping_quality')" "3" "MAPQ is 50% when paired without haplotype info"
+vg mpmap -B -P 1 -I 200 -D 200 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -f reads/xy2.matchpaired.fq -i -F GAM > gbwt.gam
 is "$(vg view -aj gbwt.gam | head -n1 | jq '.mapping_quality')" "4" "haplotype match can disambiguate paired"
 is "$(vg view -aj gbwt.gam | head -n1 | jq '.annotation.haplotype_score_used')" "true" "use of haplotype-aware mapping is recorded"
 
@@ -35,10 +35,10 @@ rm -f gbwt.gam
 # We need to use snarl cutting to actually consider the alignment as not just a single subpath
 vg snarls xy2.vg > xy2.snarls
 
-is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa -s xy2.snarls -f reads/xy2.discordant.fq -S | vg view -aj - | jq -r '.path.mapping[0].position.node_id')" "50" "Haplotype-oblivious mapping places read on the wrong contig"
-is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa -s xy2.snarls -f reads/xy2.discordant.fq -S | vg view -aj - | jq '.mapping_quality')" "3" "Haplotype-oblivious mapping places read with MAPQ of 50%"
-is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -s xy2.snarls -f reads/xy2.discordant.fq -t 1 -S | vg view -aj - | jq -r '.path.mapping[0].position.node_id')" "1" "Haplotype-aware mapping places read on the right contig"
-is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -s xy2.snarls -f reads/xy2.discordant.fq -S | vg view -aj - | jq '.mapping_quality')" "6" "Haplotype-aware mapping places read with MAPQ > 50%"
+is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa -s xy2.snarls -f reads/xy2.discordant.fq -F GAM | vg view -aj - | jq -r '.path.mapping[0].position.node_id')" "50" "Haplotype-oblivious mapping places read on the wrong contig"
+is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa -s xy2.snarls -f reads/xy2.discordant.fq -F GAM | vg view -aj - | jq '.mapping_quality')" "3" "Haplotype-oblivious mapping places read with MAPQ of 50%"
+is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -s xy2.snarls -f reads/xy2.discordant.fq -t 1 -F GAM | vg view -aj - | jq -r '.path.mapping[0].position.node_id')" "1" "Haplotype-aware mapping places read on the right contig"
+is "$(vg mpmap -B -P 1 -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -s xy2.snarls -f reads/xy2.discordant.fq -F GAM | vg view -aj - | jq '.mapping_quality')" "6" "Haplotype-aware mapping places read with MAPQ > 50%"
 
 rm -f xy2.vg xy2.xg xy2.gcsa xy2.gcsa.lcp xy2.gbwt xy2.snarls
 
@@ -46,9 +46,9 @@ rm -f xy2.vg xy2.xg xy2.gcsa xy2.gcsa.lcp xy2.gbwt xy2.snarls
 
 vg index -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -k 16 graphs/refonly-lrc_kir.vg
 
-vg mpmap -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -B -i -I 10 -D 50 -S | vg view -aj -  > temp_paired_alignment.json
-vg mpmap -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -B -i -I 100000 -D 5 -S | vg view -aj -  > temp_distant_alignment.json
-vg mpmap -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -B -i -S | vg view -aj - > temp_independent_alignment.json
+vg mpmap -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -B -i -I 10 -D 50 -F GAM | vg view -aj -  > temp_paired_alignment.json
+vg mpmap -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -B -i -I 100000 -D 5 -F GAM | vg view -aj -  > temp_distant_alignment.json
+vg mpmap -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -f reads/grch38_lrc_kir_paired.fq -B -i -F GAM | vg view -aj - > temp_independent_alignment.json
 paired_score=$(jq -r ".score" < temp_paired_alignment.json | awk '{ sum+=$1} END {print sum}')
 independent_score=$(jq -r ".score" < temp_independent_alignment.json | awk '{ sum+=$1} END {print sum}')
 is $(printf "%s\t%s\n" $paired_score $independent_score | awk '{if ($1 < $2) print 1; else print 0}') 1 "paired read alignments forced to be consistent have lower score than unrestricted alignments"
@@ -63,7 +63,7 @@ rm -f temp_paired_alignment.json temp_distant_alignment.json temp_independent_al
 
 vg sim -x graphs/refonly-lrc_kir.vg.xg -n 1000 -p 500 -l 100 -a > input.gam
 
-vg mpmap -B -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -G input.gam -I 500 -D 100 -i --single-path-mode --no-qual-adjust > output.gam
+vg mpmap -B -x graphs/refonly-lrc_kir.vg.xg -g graphs/refonly-lrc_kir.vg.gcsa -G input.gam -I 500 -D 100 -i -F GAM --no-qual-adjust > output.gam
 is "$(vg view -aj output.gam | jq -c 'select(.fragment_next == null and .fragment_prev == null)' | wc -l)" "0" "small batches are still all paired in the output"
 
 rm -f graphs/refonly-lrc_kir.vg.xg graphs/refonly-lrc_kir.vg.gcsa graphs/refonly-lrc_kir.vg.gcsa.lcp input.gam output.gam

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -603,7 +603,7 @@ class VGCITest(TestCase):
             # toil-vg map options
             # don't waste time sharding reads since we only run on one node
             single_reads_chunk = True,
-            mpmap_opts = ['-B', '-S'],
+            mpmap_opts = ['-B', '-F GAM'],
             more_mpmap_opts = more_mpmap_opts,
             force_outstore = self.force_outstore
         )

--- a/vgci/vgci.sh
+++ b/vgci/vgci.sh
@@ -30,7 +30,7 @@ KEEP_INTERMEDIATE_FILES=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@45e5e71335dd3fa5396bd746b8097704379d9637"
+TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@15bb8bbebe0429054dfa6e50d6235e003e832aca"
 # What toil should we install?
 # Could be something like "toil[aws,mesos]==3.20.0"
 # or "git+https://github.com/adamnovak/toil.git@2b696bec34fa1381afdcf187456571d2b41f3842#egg=toil[aws,mesos]"

--- a/vgci/vgci.sh
+++ b/vgci/vgci.sh
@@ -30,7 +30,7 @@ KEEP_INTERMEDIATE_FILES=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@1206fd5215defbef46ef3ede5ba51895aa5abfd1"
+TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@45e5e71335dd3fa5396bd746b8097704379d9637"
 # What toil should we install?
 # Could be something like "toil[aws,mesos]==3.20.0"
 # or "git+https://github.com/adamnovak/toil.git@2b696bec34fa1381afdcf187456571d2b41f3842#egg=toil[aws,mesos]"


### PR DESCRIPTION
## Changelog Entry

 * `vg mpmap` can now toggle between output formats (including single path and linear formats) with a single option. Some command line arguments have changed meaning.

## Description

The `vg mpmap` command line interface has been tweaked so that a single command line option toggles between GAMP, GAM, GAF, SAM, BAM, and CRAM formats. For SAM, BAM, and CRAM, the surject algorithm is applied automatically.
