### PR TITLE
Don't crash in mpmap when rescue alignments are null

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -150,7 +150,8 @@ namespace vg {
                                                      const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans) {
         
         // this can only be done on aligned sequences
-        if (!alignment.has_path()) {
+        if (!alignment.has_path() || alignment.path().mapping_size() == 0) {
+            has_reachability_edges = true;
             return;
         }
         


### PR DESCRIPTION
##  Description

`mpmap` no longer crashes when getting no alignment back from its rescue, which happens sometimes now that the full length bonus can go to 0 on extremely low quality reads.