### PR TITLE
Don't upgrade apt packages if already available

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ before_script:
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
   # We also need Node >4 for junit merging (so we need to be on Ubuntu 18.04+)
   # And the CI report upload needs uuidgen from uuid-runtime
-  - sudo apt-get -q -y install docker.io python-pip python-virtualenv libcurl4-gnutls-dev python-dev npm nodejs node-gyp nodejs-dev libssl1.0-dev uuid-runtime libgnutls28-dev
+  - sudo apt-get -q -y install --no-upgrade docker.io python-pip python-virtualenv libcurl4-gnutls-dev python-dev npm nodejs node-gyp nodejs-dev libssl1.0-dev uuid-runtime libgnutls28-dev
   - which junit-merge || sudo npm install -g junit-merge
   - cat /etc/hosts
   - startdocker || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . /vg
 # make get-deps to make sure it isn't missing something
 RUN apt-get -qq -y update && \
     apt-get -qq -y upgrade && \
-    apt-get -qq -y install \
+    apt-get -qq -y install --no-upgrade \
     make \
     sudo \
     git
@@ -57,7 +57,7 @@ RUN echo test > /stage.txt
 # No clean necessary since we aren't shipping this
 RUN apt-get -qq -y update && \
     apt-get -qq -y upgrade && \
-    apt-get -qq -y install \
+    apt-get -qq -y install --no-upgrade \
     bwa \
     pigz \
     dstat \
@@ -94,7 +94,7 @@ COPY deps/FlameGraph /vg/deps/FlameGraph
 RUN ls -lah /vg && \
     apt-get -qq -y update && \
     apt-get -qq -y upgrade && \
-    apt-get -qq -y install \
+    apt-get -qq -y install --no-upgrade \
     curl \
     wget \
     pigz \

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -16,7 +16,7 @@ ENV DEBCONF_NONINTERACTIVE_SEEN true
 # Install dependencies for scripts
 RUN apt-get -qq -y update && \
     apt-get -qq -y upgrade && \
-    apt-get -qq -y install \
+    apt-get -qq -y install --no-upgrade \
     numactl \
     python3-matplotlib \
     python3-numpy \

--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ $(LIB_DIR)/libvg.a: $(OBJ) $(ALGORITHMS_OBJ) $(IO_OBJ) $(DEP_OBJ) $(DEPS)
 
 # We have system-level deps to install
 get-deps:
-	sudo apt-get install -qq -y build-essential git protobuf-compiler libprotoc-dev libjansson-dev libbz2-dev libncurses5-dev automake libtool jq rs samtools curl unzip redland-utils librdf-dev cmake pkg-config wget bc gtk-doc-tools raptor2-utils rasqal-utils bison flex gawk libgoogle-perftools-dev liblz4-dev liblzma-dev libcairo2-dev libpixman-1-dev libffi-dev libcairo-dev libprotobuf-dev 
+	sudo apt-get install -qq -y --no-upgrade build-essential git protobuf-compiler libprotoc-dev libjansson-dev libbz2-dev libncurses5-dev automake libtool jq rs samtools curl unzip redland-utils librdf-dev cmake pkg-config wget bc gtk-doc-tools raptor2-utils rasqal-utils bison flex gawk libgoogle-perftools-dev liblz4-dev liblzma-dev libcairo2-dev libpixman-1-dev libffi-dev libcairo-dev libprotobuf-dev 
 
 # And we have submodule deps to build
 deps: $(DEPS)


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Dependency retrieval no longer upgrades already-installed packages

## Description

This should hopefully make CI faster by not installing stuff already installed in the base CI image just because Ubuntu updated it.
