### PR TITLE
Distance one node

### DIFF
--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -86,7 +86,7 @@ void help_index(char** argv) {
          << "    -D, --dump             print the contents of the db to stdout" << endl
          << "    -C, --compact          compact the index into a single level (improves performance)" << endl
          << "snarl distance index options" << endl
-         << "    -s  --snarl-name FILE  load snarls from FILE" << endl
+         << "    -s  --snarl-name FILE  load snarls from FILE (snarls must include trivial snarls)" << endl
          << "    -j  --dist-name FILE   use this file to store a snarl-based distance index" << endl
          << "    -w  --max_dist N       cap beyond which the maximum distance is no longer accurate. If this is not included or is 0, don't build maximum distance index" << endl;
 }

--- a/src/unittest/min_distance.cpp
+++ b/src/unittest/min_distance.cpp
@@ -116,6 +116,30 @@ int64_t min_distance(VG* graph, pos_t pos1, pos_t pos2){
     return shortestDistance == -1 ? -1 : shortestDistance-1;
 };
 
+    TEST_CASE( "One node",
+                   "[min_dist]" ) {
+        VG graph;
+
+        Node* n1 = graph.create_node("GCATGGAGCGTTGAGTGCGGGTG");
+
+        CactusSnarlFinder bubble_finder(graph);
+        SnarlManager snarl_manager = bubble_finder.find_snarls(); 
+
+
+        
+        SECTION( "Create distance index" ) {
+
+            MinimumDistanceIndex di (&graph, &snarl_manager);
+#ifdef print
+            di.print_self();
+#endif
+
+            REQUIRE(di.min_distance(make_pos_t(1, false, 0),
+                                   make_pos_t(1, false, 3) ) == 3);
+
+        }
+
+    }
     TEST_CASE( "Create min distance index for simple nested snarl",
                    "[min_dist]" ) {
         VG graph;

--- a/src/unittest/random_graph.cpp
+++ b/src/unittest/random_graph.cpp
@@ -14,241 +14,262 @@ using namespace std;
 
 void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                   MutablePathMutableHandleGraph* graph) {
+    vector<int64_t> seq_sizes = {seq_size};
+    return random_graph(seq_sizes, variant_len, variant_count, graph);
+}
     
-            
+ 
+void random_graph(vector<int64_t> seq_sizes, int64_t variant_len, int64_t total_variant_count,
+                  MutablePathMutableHandleGraph* graph) {           
 #ifdef debug
     cerr << "Make random graph of " << seq_size << " bp with " << variant_count << " ~" << variant_len << "-bp large variants" << endl;
 #endif
-    
-    //Create a random graph for a sequence of length seq_size
-    //variant_len is the mean length of a larger variation and variationCount
-    //is the number of variations in the graph
 
-    map<size_t, id_t> index_to_id;
-                  //Index of original sequence to node that starts at that index
-    
-    //Get random number generator for lengths and variation types
-    default_random_engine generator(test_seed_source());
-    
-    uniform_int_distribution<int> base_distribution(0, 3);
-    poisson_distribution<size_t> length_distribution(variant_len);
-    uniform_int_distribution<int> variant_distribution(0, 4);
-    uniform_int_distribution<int> index_distribution(0, seq_size-1);
-    
-    // Init the string with placeholder bases
-    string seq(seq_size, 'A');
-    // Set the string to random bases
-    string alphabet = "ACGT";
-    for (size_t i = 0; i < seq.size(); i++) {
-        seq[i] = alphabet[base_distribution(generator)];
+    //How many variants for each component?
+    size_t total_sequence_length = 0;
+    for (int64_t len : seq_sizes) {
+        total_sequence_length += len;
     }
-    
-    handle_t h = graph->create_handle(seq);
-    
-    path_handle_t p = graph->create_path_handle("path");
-    graph->append_step(p, h);
-    
-    index_to_id[0] = graph->get_id(h);
+    vector<int64_t> variant_counts;
+    for (int64_t len : seq_sizes) {
+        variant_counts.emplace_back(round((len / total_sequence_length) * total_variant_count));
+    }
 
-    auto do_split = [&] (size_t index) -> pair<handle_t, handle_t> {
-        //Split graph at index and update the path index
-        
-#ifdef debug
-        cerr << "Split original sequence at base " << index << "/" << seq_size << endl;
-#endif
-        
-        // Make sure we aren't trying to split out of bounds
-        assert(index < seq_size);
-        
-        auto n = --index_to_id.upper_bound(index); //orig node containing pos
-        size_t first_index = n->first;               //Index of first node
-        handle_t first_handle = graph->get_handle(n->second);    //handle of first node
-        
-#ifdef debug
-        cerr << "\tFalls in node " << graph->get_id(first_handle) << " length " << graph->get_length(first_handle) << " at " << first_index << endl;
-#endif
-        
-        pair<handle_t, handle_t> return_val;
-        
-        if (index > first_index) {
-            // it's in the middle of a node, do a split
-            
-            size_t split_length = index - first_index;
-            
-#ifdef debug
-            cerr << "\t\tSplit at " << split_length << " along node" << endl;
-#endif
-            
-            return_val = graph->divide_handle(first_handle, split_length);
-            
-#ifdef debug
-            cerr << "\t\t\tCreate " << graph->get_id(return_val.first) << " at " << first_index << endl;
-            cerr << "\t\t\tCreate " << graph->get_id(return_val.second) << " at " << index << endl;
-#endif
-            
-            index_to_id[first_index] = graph->get_id(return_val.first);
-            index_to_id[index] = graph->get_id(return_val.second);
+    for (size_t i = 0 ; i < seq_sizes.size() ; i++) {
 
-        }
-        else {
-            return_val.second = first_handle;
-            --n;
-            return_val.first = graph->get_handle(n->second);
-            
+        int64_t seq_size = seq_sizes[i];
+        int64_t variant_count = variant_counts[i];
+
+        //Create a random graph for a sequence of length seq_size
+        //variant_len is the mean length of a larger variation and variationCount
+        //is the number of variations in the graph
+
+        map<size_t, id_t> index_to_id;
+                      //Index of original sequence to node that starts at that index
+        
+        //Get random number generator for lengths and variation types
+        default_random_engine generator(test_seed_source());
+        
+        uniform_int_distribution<int> base_distribution(0, 3);
+        poisson_distribution<size_t> length_distribution(variant_len);
+        uniform_int_distribution<int> variant_distribution(0, 4);
+        uniform_int_distribution<int> index_distribution(0, seq_size-1);
+        
+        // Init the string with placeholder bases
+        string seq(seq_size, 'A');
+        // Set the string to random bases
+        string alphabet = "ACGT";
+        for (size_t i = 0; i < seq.size(); i++) {
+            seq[i] = alphabet[base_distribution(generator)];
         }
         
-        return return_val;
-    };
+        handle_t h = graph->create_handle(seq);
+        
+        path_handle_t p = graph->create_path_handle("path");
+        graph->append_step(p, h);
+        
+        index_to_id[0] = graph->get_id(h);
 
-    enum VariationType {SNP = 0, POINT_INDEL = 1, STRUCTURAL_INDEL = 2,
-                        CNV = 3, INVERSION = 4};
-
-    for (int j = 0; j < variant_count; j++) {
-        //add variants
-        int start_index = index_distribution(generator);
-        VariationType variation_type = (VariationType) variant_distribution(generator);
-
-        switch (variation_type) {
-            case SNP:
-            {
+        auto do_split = [&] (size_t index) -> pair<handle_t, handle_t> {
+            //Split graph at index and update the path index
+            
+#ifdef debug
+            cerr << "Split original sequence at base " << index << "/" << seq_size << endl;
+#endif
+            
+            // Make sure we aren't trying to split out of bounds
+            assert(index < seq_size);
+            
+            auto n = --index_to_id.upper_bound(index); //orig node containing pos
+            size_t first_index = n->first;               //Index of first node
+            handle_t first_handle = graph->get_handle(n->second);    //handle of first node
+            
+#ifdef debug
+            cerr << "\tFalls in node " << graph->get_id(first_handle) << " length " << graph->get_length(first_handle) << " at " << first_index << endl;
+#endif
+            
+            pair<handle_t, handle_t> return_val;
+            
+            if (index > first_index) {
+                // it's in the middle of a node, do a split
                 
-                if (start_index == 0) {
+                size_t split_length = index - first_index;
+                
+#ifdef debug
+                cerr << "\t\tSplit at " << split_length << " along node" << endl;
+#endif
+                
+                return_val = graph->divide_handle(first_handle, split_length);
+                
+#ifdef debug
+                cerr << "\t\t\tCreate " << graph->get_id(return_val.first) << " at " << first_index << endl;
+                cerr << "\t\t\tCreate " << graph->get_id(return_val.second) << " at " << index << endl;
+#endif
+                
+                index_to_id[first_index] = graph->get_id(return_val.first);
+                index_to_id[index] = graph->get_id(return_val.second);
 
-                    handle_t new_node = graph->create_handle(string(1, alphabet[base_distribution(generator)]));
-                    
-                    pair<handle_t, handle_t> end_nodes = do_split(start_index+1);
-                    graph->create_edge(new_node, end_nodes.second);
-                    
-                }
-                else if (start_index < seq_size - 2) {
-                    
-                    handle_t new_node = graph->create_handle(string(1, alphabet[base_distribution(generator)]));
-                    
-                    pair<handle_t, handle_t> start_nodes = do_split(start_index);
-                    pair<handle_t, handle_t> end_nodes = do_split(start_index+1);
-                    
-                    graph->create_edge(start_nodes.first, new_node);
-                    graph->create_edge(new_node, end_nodes.second);
-                    
-                }
-                else if (start_index == seq_size - 2) {
-                    
-                    handle_t new_node = graph->create_handle(string(1, alphabet[base_distribution(generator)]));
-                    
-                    pair<handle_t, handle_t> start_nodes = do_split(start_index);
-                    
-                    graph->create_edge(start_nodes.first, new_node);
-                    
-                }
-                break;
             }
+            else {
+                return_val.second = first_handle;
+                --n;
+                return_val.first = graph->get_handle(n->second);
                 
-            case POINT_INDEL:
-            {
-                if (start_index > 0 && start_index < seq_size-1) {
-                    pair<handle_t, handle_t> start_nodes = do_split(start_index);
-                    pair<handle_t, handle_t> end_nodes = do_split(start_index+1);
-                    
-                    graph->create_edge(start_nodes.first, end_nodes.second);
-                    
-                }
-                break;
             }
-                
-            case STRUCTURAL_INDEL:
-            {
-                //long indel
-                size_t length = length_distribution(generator);
-                
-                if (length > 0 && start_index > 0 && length + start_index < seq_size-1) {
+            
+            return return_val;
+        };
+
+        enum VariationType {SNP = 0, POINT_INDEL = 1, STRUCTURAL_INDEL = 2,
+                            CNV = 3, INVERSION = 4};
+
+        for (int j = 0; j < variant_count; j++) {
+            //add variants
+            int start_index = index_distribution(generator);
+            VariationType variation_type = (VariationType) variant_distribution(generator);
+
+            switch (variation_type) {
+                case SNP:
+                {
                     
-                    pair<handle_t, handle_t> start_nodes = do_split(start_index);
-                    pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
-                    
-                    graph->create_edge(start_nodes.first, end_nodes.second);
-                    
-                }
-                break;
-            }
-                
-            case CNV:
-            {
-                //Copy number variation
-                size_t length = length_distribution(generator);
-                
-                if (length > 0) {
-                    if (start_index == 0 && length + start_index < seq_size - 1) {
-                        // Very first base is involved, but very last base isn't (we don't handle that case)
-                        pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
+                    if (start_index == 0) {
+
+                        handle_t new_node = graph->create_handle(string(1, alphabet[base_distribution(generator)]));
                         
-                        auto node_pair = index_to_id.begin();//first node
-                        handle_t first_handle = graph->get_handle(node_pair->second);
-                        
-                        graph->create_edge(end_nodes.first, first_handle);
+                        pair<handle_t, handle_t> end_nodes = do_split(start_index+1);
+                        graph->create_edge(new_node, end_nodes.second);
                         
                     }
-                    else if (length + start_index < seq_size - 1) {
-                        // Only interior bases are involved
-                        pair<handle_t, handle_t> start_nodes = do_split(start_index);
-                        pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
-                        // hack: this won't redo the split since it's already there, but it
-                        // will get the second handle again, which may have been invalidated
-                        // if we split the second node
-                        start_nodes = do_split(start_index);
+                    else if (start_index < seq_size - 2) {
                         
-                        graph->create_edge(end_nodes.first, start_nodes.second);
+                        handle_t new_node = graph->create_handle(string(1, alphabet[base_distribution(generator)]));
+                        
+                        pair<handle_t, handle_t> start_nodes = do_split(start_index);
+                        pair<handle_t, handle_t> end_nodes = do_split(start_index+1);
+                        
+                        graph->create_edge(start_nodes.first, new_node);
+                        graph->create_edge(new_node, end_nodes.second);
                         
                     }
-                    else if (length + start_index == seq_size - 1) {
-                        // Very last base is involved (but not very first)
+                    else if (start_index == seq_size - 2) {
+                        
+                        handle_t new_node = graph->create_handle(string(1, alphabet[base_distribution(generator)]));
+                        
                         pair<handle_t, handle_t> start_nodes = do_split(start_index);
                         
-                        //last node
-                        auto node_pair = --index_to_id.end();
-                        handle_t last_handle = graph->get_handle(node_pair->second);
+                        graph->create_edge(start_nodes.first, new_node);
                         
-                        graph->create_edge(last_handle, start_nodes.second);
                     }
+                    break;
                 }
-                break;
-            }
-                
-            case INVERSION:
-            {
-                //Inversion
-                size_t length = length_distribution(generator);
-                if (length > 0) {
-                    if (start_index == 0 && length + start_index < seq_size - 1) {
-                        // Very first base is involved, but very last base isn't (we don't handle that case)
-                        pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
-                        
-                        graph->create_edge(graph->flip(end_nodes.first), end_nodes.second);
-                        
-                        
-                    } else if (length + start_index < seq_size-1) {
-                        // Only interior bases are involved
+                    
+                case POINT_INDEL:
+                {
+                    if (start_index > 0 && start_index < seq_size-1) {
                         pair<handle_t, handle_t> start_nodes = do_split(start_index);
-                        pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
-                        // hack: this won't redo the split since it's already there, but it
-                        // will get the second handle again, which may have been invalidated
-                        // if we split the second node
-                        start_nodes = do_split(start_index);
+                        pair<handle_t, handle_t> end_nodes = do_split(start_index+1);
                         
-                        graph->create_edge(start_nodes.first, graph->flip(end_nodes.first));
-                        graph->create_edge(graph->flip(start_nodes.second), end_nodes.second);
+                        graph->create_edge(start_nodes.first, end_nodes.second);
                         
-                    } else if (length + start_index == seq_size - 1) {
-                        // Very last base is involved (but not very first)
-                        pair<handle_t, handle_t> start_nodes = do_split(start_index);
-                        
-                        graph->create_edge(start_nodes.first, graph->flip(start_nodes.second));
                     }
+                    break;
                 }
-                break;
+                    
+                case STRUCTURAL_INDEL:
+                {
+                    //long indel
+                    size_t length = length_distribution(generator);
+                    
+                    if (length > 0 && start_index > 0 && length + start_index < seq_size-1) {
+                        
+                        pair<handle_t, handle_t> start_nodes = do_split(start_index);
+                        pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
+                        
+                        graph->create_edge(start_nodes.first, end_nodes.second);
+                        
+                    }
+                    break;
+                }
+                    
+                case CNV:
+                {
+                    //Copy number variation
+                    size_t length = length_distribution(generator);
+                    
+                    if (length > 0) {
+                        if (start_index == 0 && length + start_index < seq_size - 1) {
+                            // Very first base is involved, but very last base isn't (we don't handle that case)
+                            pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
+                            
+                            auto node_pair = index_to_id.begin();//first node
+                            handle_t first_handle = graph->get_handle(node_pair->second);
+                            
+                            graph->create_edge(end_nodes.first, first_handle);
+                            
+                        }
+                        else if (length + start_index < seq_size - 1) {
+                            // Only interior bases are involved
+                            pair<handle_t, handle_t> start_nodes = do_split(start_index);
+                            pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
+                            // hack: this won't redo the split since it's already there, but it
+                            // will get the second handle again, which may have been invalidated
+                            // if we split the second node
+                            start_nodes = do_split(start_index);
+                            
+                            graph->create_edge(end_nodes.first, start_nodes.second);
+                            
+                        }
+                        else if (length + start_index == seq_size - 1) {
+                            // Very last base is involved (but not very first)
+                            pair<handle_t, handle_t> start_nodes = do_split(start_index);
+                            
+                            //last node
+                            auto node_pair = --index_to_id.end();
+                            handle_t last_handle = graph->get_handle(node_pair->second);
+                            
+                            graph->create_edge(last_handle, start_nodes.second);
+                        }
+                    }
+                    break;
+                }
+                    
+                case INVERSION:
+                {
+                    //Inversion
+                    size_t length = length_distribution(generator);
+                    if (length > 0) {
+                        if (start_index == 0 && length + start_index < seq_size - 1) {
+                            // Very first base is involved, but very last base isn't (we don't handle that case)
+                            pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
+                            
+                            graph->create_edge(graph->flip(end_nodes.first), end_nodes.second);
+                            
+                            
+                        } else if (length + start_index < seq_size-1) {
+                            // Only interior bases are involved
+                            pair<handle_t, handle_t> start_nodes = do_split(start_index);
+                            pair<handle_t, handle_t> end_nodes = do_split(start_index+length);
+                            // hack: this won't redo the split since it's already there, but it
+                            // will get the second handle again, which may have been invalidated
+                            // if we split the second node
+                            start_nodes = do_split(start_index);
+                            
+                            graph->create_edge(start_nodes.first, graph->flip(end_nodes.first));
+                            graph->create_edge(graph->flip(start_nodes.second), end_nodes.second);
+                            
+                        } else if (length + start_index == seq_size - 1) {
+                            // Very last base is involved (but not very first)
+                            pair<handle_t, handle_t> start_nodes = do_split(start_index);
+                            
+                            graph->create_edge(start_nodes.first, graph->flip(start_nodes.second));
+                        }
+                    }
+                    break;
+                }
+                    
+                default:
+                    break;
             }
-                
-            default:
-                break;
         }
     }
 };

--- a/src/unittest/random_graph.hpp
+++ b/src/unittest/random_graph.hpp
@@ -12,6 +12,11 @@ namespace unittest{
 /// is the number of variations added to the graph
 void random_graph(int64_t seq_size, int64_t variant_len, int64_t variant_count,
                   MutablePathMutableHandleGraph* graph);
+
+/// Create a random graph with multiple connected components. 
+/// Each connected component created with a sequence length in seq_sizes
+void random_graph(vector<int64_t> seq_sizes, int64_t variant_len, int64_t total_variant_count,
+                  MutablePathMutableHandleGraph* graph);
                   
               
 /// Create a random undirected graph over numbered nodes.

--- a/src/unittest/seed_clusterer.cpp
+++ b/src/unittest/seed_clusterer.cpp
@@ -7,6 +7,7 @@
 #include "catch.hpp"
 #include "../snarls.hpp"
 #include "../cactus_snarl_finder.hpp"
+#include "../integrated_snarl_finder.hpp"
 #include "../genotypekit.hpp"
 #include "random_graph.hpp"
 #include "../seed_clusterer.hpp"
@@ -1813,14 +1814,15 @@ namespace unittest {
             // For each random graph
             
             default_random_engine generator(time(NULL));
+            uniform_int_distribution<int> variant_count(5, 500);
+            uniform_int_distribution<int> chrom_len(10, 2000);
 
-            uniform_int_distribution<int> variant_count(5, 200);
-
+            //Make a random graph with three chromosomes of random lengths
             VG graph;
-            random_graph(1000, 30, variant_count(generator), &graph);
+            random_graph({chrom_len(generator), chrom_len(generator), chrom_len(generator)}, 30, variant_count(generator), &graph);
 
 
-            CactusSnarlFinder bubble_finder(graph);
+            IntegratedSnarlFinder bubble_finder(graph);
 
             SnarlManager snarl_manager = bubble_finder.find_snarls();
             MinimumDistanceIndex dist_index (&graph, &snarl_manager);
@@ -1846,7 +1848,7 @@ namespace unittest {
                 int64_t read_lim = 30;// Distance between read clusters
                 int64_t fragment_lim = 50;// Distance between fragment clusters
                 for (size_t read = 0 ; read < 2 ; read ++) {
-                    uniform_int_distribution<int> randPosCount(1, 50);
+                    uniform_int_distribution<int> randPosCount(1, 100);
                     for (int j = 0; j < randPosCount(generator); j++) {
                         //Check clusters of j random positions 
  

--- a/src/unittest/seed_clusterer.cpp
+++ b/src/unittest/seed_clusterer.cpp
@@ -1191,6 +1191,8 @@ namespace unittest {
         Node* n12 = graph.create_node("G");
         Node* n13 = graph.create_node("CTGA");
 
+        Node* n14 = graph.create_node("AGCCGTGTGC");
+
         Edge* e1 = graph.create_edge(n1, n2);
         Edge* e2 = graph.create_edge(n1, n3);
         Edge* e3 = graph.create_edge(n2, n3);
@@ -1297,6 +1299,47 @@ namespace unittest {
 
             REQUIRE( clusters.size() == 2);
             REQUIRE( clusters[0].size() == 2);
+            REQUIRE( clusters[1].size() == 2);
+            REQUIRE( clusters[0][0].fragment != clusters[0][1].fragment);
+            REQUIRE( clusters[1][0].fragment != clusters[1][1].fragment);
+
+            REQUIRE(( clusters[0][0].fragment == clusters[1][0].fragment || clusters[0][0].fragment == clusters[1][1].fragment));
+            REQUIRE(( clusters[0][1].fragment == clusters[1][0].fragment || clusters[0][1].fragment == clusters[1][1].fragment));
+
+
+        }
+        SECTION("Disconnected node") {
+
+            vector<id_t> ids({1, 3, 11, 14, 14});
+            vector<SnarlSeedClusterer::Seed> seeds;
+            for (id_t n : ids) {
+                pos_t pos = make_pos_t(n, false, 0);
+                std::tuple<bool, size_t, size_t, bool, size_t, size_t, size_t, size_t, bool> chain_info = dist_index.get_minimizer_distances(pos);
+                seeds.push_back({ pos, 0, std::get<0>(chain_info), std::get<1>(chain_info), std::get<2>(chain_info),
+                   std::get<3>(chain_info), std::get<4>(chain_info), std::get<5>(chain_info), std::get<6>(chain_info), std::get<7>(chain_info), std::get<8>(chain_info)});
+            }
+            vector<id_t> ids1({5, 13});
+            vector<SnarlSeedClusterer::Seed> seeds1;
+            for (id_t n : ids1) {
+                pos_t pos = make_pos_t(n, false, 0);
+                std::tuple<bool, size_t, size_t, bool, size_t, size_t, size_t, size_t, bool> chain_info = dist_index.get_minimizer_distances(pos);
+                seeds1.push_back({ pos, 0, std::get<0>(chain_info), std::get<1>(chain_info), std::get<2>(chain_info),
+                   std::get<3>(chain_info), std::get<4>(chain_info), std::get<5>(chain_info), std::get<6>(chain_info), std::get<7>(chain_info), std::get<8>(chain_info)});
+            }
+            //Clusters are 
+            //Read 1: {1, 3} in a fragment cluster with Read 2: {5}
+            //Read 1: {11} in a fragment cluster with Read 2: {13}
+            //Read 1 : {14, 14}
+            vector<vector<SnarlSeedClusterer::Seed>> all_seeds;
+            all_seeds.emplace_back(seeds);
+            all_seeds.emplace_back(seeds1);
+
+
+            vector<vector<SnarlSeedClusterer::Cluster>> clusters =  clusterer.cluster_seeds(all_seeds, 5, 10); 
+
+
+            REQUIRE( clusters.size() == 2);
+            REQUIRE( clusters[0].size() == 3);
             REQUIRE( clusters[1].size() == 2);
             REQUIRE( clusters[0][0].fragment != clusters[0][1].fragment);
             REQUIRE( clusters[1][0].fragment != clusters[1][1].fragment);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * The distance index can now handle a graph with single node connected components

## Description
The snarl finders don't add single node connected components to the snarl tree, so the distance index couldn't find them. This adds those nodes to the distance index 