### PR TITLE
Mask non-ACGT characters in GaplessExtender

### DIFF
--- a/src/gapless_extender.hpp
+++ b/src/gapless_extender.hpp
@@ -167,12 +167,15 @@ public:
      * case, the extensions are sorted by read interval.
      * Use full_length_extensions() to determine the type of the returned
      * extension set.
+     * The sequence that will be aligned is passed by value. All non-ACGT
+     * characters are masked with character X, which should not match any
+     * character in the graph.
      * Allow any number of mismatches in the initial node, at least
      * max_mismatches mismatches in the entire extension, and at least
      * max_mismatches / 2 mismatches on each flank.
      * Use the provided CachedGBWTGraph or allocate a new one.
      */
-    std::vector<GaplessExtension> extend(cluster_type& cluster, const std::string& sequence, const gbwtgraph::CachedGBWTGraph* cache = nullptr, size_t max_mismatches = MAX_MISMATCHES, double overlap_threshold = OVERLAP_THRESHOLD) const;
+    std::vector<GaplessExtension> extend(cluster_type& cluster, std::string sequence, const gbwtgraph::CachedGBWTGraph* cache = nullptr, size_t max_mismatches = MAX_MISMATCHES, double overlap_threshold = OVERLAP_THRESHOLD) const;
 
     /**
      * Determine whether the extension set contains non-overlapping
@@ -197,6 +200,12 @@ public:
 
     const gbwtgraph::GBWTGraph* graph;
     const Aligner*   aligner;
+
+    std::vector<char> mask;
+
+private:
+    void init_mask();
+    void mask_sequence(std::string& sequence) const;
 };
 
 //------------------------------------------------------------------------------

--- a/src/unittest/gapless_extender.cpp
+++ b/src/unittest/gapless_extender.cpp
@@ -843,6 +843,42 @@ TEST_CASE("Local alignments", "[gapless_extender]") {
 
 //------------------------------------------------------------------------------
 
+TEST_CASE("Non-ACGT characters do not match", "[gapless_extender]") {
+
+    // Create a single-node GBWTGraph.
+    bdsg::HashGraph graph;
+    graph.create_handle("NNNGATTACANNN", 1);
+    std::vector<gbwt::vector_type> paths = {
+        { static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(1, false)) }
+    };
+    gbwt::GBWT gbwt_index = get_gbwt(paths);
+    gbwtgraph::GBWTGraph gbwt_graph(gbwt_index, graph);
+
+
+    // Wrap it in a GaplessExtender with an Aligner.
+    Aligner aligner;
+    GaplessExtender extender(gbwt_graph, aligner);
+
+    SECTION("exact matching") {
+        std::vector<std::pair<pos_t, size_t>> seeds {
+            { make_pos_t(1, false, 5), 4 }
+        };
+        std::string read = "NNGATTACANN";
+        std::vector<std::vector<std::pair<pos_t, std::string>>> correct_extensions {
+            {
+                { make_pos_t(1, false, 3), "7" }
+            }
+        };
+        std::vector<size_t> correct_offsets {
+            static_cast<size_t>(2)
+        };
+        size_t error_bound = 0;
+        partial_matches(seeds, read, correct_extensions, correct_offsets, extender, error_bound);
+    }
+}
+
+//------------------------------------------------------------------------------
+
 TEST_CASE("Haplotype unfolding", "[gapless_extender]") {
 
     // Build a GBWT with three threads including a duplicate.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GaplessExtender no longer matches non-ACGT characters.

## Description

Mask non-ACGT characters in the read before extending the seeds with GaplessExtender. Ns in the read are no longer aligned to Ns in the graph, which confused downstream algorithms. This fixes #3061.