### PR TITLE
Pre-index non-alt paths to fix #3054

### DIFF
--- a/src/variant_adder.cpp
+++ b/src/variant_adder.cpp
@@ -8,7 +8,13 @@ namespace vg {
 using namespace std;
 using namespace vg::io;
 
-VariantAdder::VariantAdder(VG& graph) : graph(graph), sync(graph) {
+VariantAdder::VariantAdder(VG& graph) : graph(graph), sync([&](VG& g) -> VG& {
+        // Dice nodes in the graph for GCSA indexing *before* constructing the synchronizer.
+        g.dice_nodes(max_node_size);
+        return g;
+    }(this->graph)) {
+    
+    
     graph.paths.for_each_name([&](const string& name) {
         // Save the names of all the graph paths, so we don't need to lock the
         // graph to check them.
@@ -17,10 +23,6 @@ VariantAdder::VariantAdder(VG& graph) : graph(graph), sync(graph) {
     
     // Show progress if the graph does.
     show_progress = graph.show_progress;
-    
-    // Make sure to dice nodes to 1024 or smaller, the max size that GCSA2
-    // supports, in case we need to GCSA-index part of the graph.
-    graph.dice_nodes(max_node_size);
     
     // Configure the aligner to use a full length bonus
     aligner.full_length_bonus = 5;

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -4004,7 +4004,7 @@ void VG::divide_node(Node* node, vector<int>& positions, vector<Node*>& parts) {
 #ifdef debug_divide
 
 #pragma omp critical (cerr)
-            cerr << omp_get_thread_num() << ": dividing mapping " << pb2json(*m) << endl;
+            cerr << omp_get_thread_num() << ": dividing mapping " << *m << endl;
 #endif
 
             string path_name = paths.mapping_path_name(m);
@@ -4077,7 +4077,7 @@ void VG::divide_node(Node* node, vector<int>& positions, vector<Node*>& parts) {
 #pragma omp critical (cerr)
             cerr << omp_get_thread_num() << ": produced mappings:" << endl;
             for(auto mapping : mapping_parts) {
-                cerr << "\t" << pb2json(mapping) << endl;
+                cerr << "\t" << mapping << endl;
             }
 #endif
         }

--- a/test/add/multi.json
+++ b/test/add/multi.json
@@ -1,0 +1,24 @@
+{
+    "node": [
+        {"id": 1, "sequence": "CTTAAAATGATCGGGACTTTTCAAATCTTATTT"}
+    ],
+    "edge": [
+    ],
+    "path": [
+        {"name": "ref", "mapping": [
+            {"rank": 1, "edit": [
+                {"from_length": 33, "to_length": 33}
+            ], "position": {"node_id": 1, "offset": 0, "is_reverse": true}}
+        ]},
+        {"name": "ref2", "mapping": [
+            {"rank": 1, "edit": [
+                {"from_length": 33, "to_length": 33}
+            ], "position": {"node_id": 1, "offset": 0}}
+        ]},
+        {"name": "ref3", "mapping": [
+            {"rank": 1, "edit": [
+                {"from_length": 33, "to_length": 33}
+            ], "position": {"node_id": 1, "offset": 0, "is_reverse": true}}
+        ]}
+    ]
+}

--- a/test/add/multi.vcf
+++ b/test/add/multi.vcf
@@ -1,0 +1,15 @@
+##fileformat=VCFv4.0
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=1000GenomesPilot-NCBI36
+##phasing=partial
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3	SAMPLE4
+ref	18	.	TC	T	100	PASS	.	GT	1/0	0/0	0|0	././1
+ref	21	.	CGA	GAC	100	PASS	.	GT	0/1	0/0	./1	./1/.
+ref	23	.	A	AC	100	PASS	.	GT	0/0	1/0	.	./0
+ref3	18	.	TC	T	100	PASS	.	GT	1/0	0/0	0|0	././1
+ref3	21	.	CGA	GAC	100	PASS	.	GT	0/1	0/0	./1	./1/.
+ref3	23	.	A	AC	100	PASS	.	GT	0/0	1/0	.	./0

--- a/test/t/31_vg_add.t
+++ b/test/t/31_vg_add.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 11
+plan tests 12
 
 vg construct -r add/ref.fa > ref.vg
 vg add -v add/benedict.vcf ref.vg > benedict.vg
@@ -43,6 +43,8 @@ is "$?" "0" "vg add can create a slightly larger graph"
 is "$(vg view -c x.vg | jq -c '.path[].mapping[] | select(.rank | not)' | wc -l)" "0" "ranks are calculated for emitted paths"
 
 is "$(vg view -Jv add/backward.json | vg add -v add/benedict.vcf - | vg mod --unchop - | vg stats -N -)" "5" "graphs with backward nodes can be added to"
+
+is "$(vg view -Jv add/multi.json | vg add -v add/multi.vcf - | vg mod --unchop - | vg stats -N -)" "5" "graphs with multiple overlapping paths nodes can be added to"
 
 is "$(vg view -Jv add/backward_and_forward.json | vg add -v add/benedict.vcf - | vg mod --unchop - | vg stats -N -)" "5" "graphs with backward and forward nodes can be added to"
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg add` now supports overlapping reference paths, as in Cactus graphs

## Description

We assumed in `vg add` that modifications based on one reference path wouldn't make it impossible to safely position-index a different reference path later. That turns out not to be true, so we need to build all our position indexes before we modify any paths.

This will fix #3054. 
