### PR TITLE
Improve accuracy of mpmap's spliced alignment

### DIFF
--- a/src/algorithms/extract_containing_graph.cpp
+++ b/src/algorithms/extract_containing_graph.cpp
@@ -45,6 +45,10 @@ void extract_containing_graph(const HandleGraph* source,
     int64_t max_search_length = max(*std::max_element(forward_search_lengths.begin(), forward_search_lengths.end()),
                                     *std::max_element(backward_search_lengths.begin(), backward_search_lengths.end()));
     
+    
+#ifdef debug_vg_algorithms
+    cerr << "[extract_containing_graph] artificial offset calculated to be " << max_search_length << endl;
+#endif
     // for keeping track of all the edges we cross to add later
     //
     // we use spp because the order of the edges affects some tie-breaking behavior
@@ -73,6 +77,10 @@ void extract_containing_graph(const HandleGraph* source,
         // add a traversal for each direction
         queue.push_or_reprioritize(is_rev(pos) ? source->flip(source_handle) : source_handle, dist_forward);
         queue.push_or_reprioritize(is_rev(pos) ? source_handle : source->flip(source_handle), dist_backward);
+#ifdef debug_vg_algorithms
+        cerr << "[extract_containing_graph] init enqueue " << id(pos) << " " << is_rev(pos) << ": " << dist_forward << endl;
+        cerr << "[extract_containing_graph] init enqueue " << id(pos) << " " << !is_rev(pos) << ": " << dist_backward << endl;
+#endif
     }
     
     while (!queue.empty()) {
@@ -80,8 +88,16 @@ void extract_containing_graph(const HandleGraph* source,
         pair<handle_t, int64_t> trav = queue.top();
         queue.pop();
         
+        
+#ifdef debug_vg_algorithms
+        cerr << "[extract_containing_graph] dequeue " << source->get_id(trav.first) << " " << source->get_is_reverse(trav.first) << ": " << trav.second << endl;
+#endif
+        
         // make sure the node is in the graph
         if (!into->has_node(source->get_id(trav.first))) {
+#ifdef debug_vg_algorithms
+            cerr << "[extract_containing_graph] adding node to subgraph" << endl;
+#endif
             into->create_handle(source->get_sequence(source->forward(trav.first)), source->get_id(trav.first));
         }
         
@@ -96,6 +112,9 @@ void extract_containing_graph(const HandleGraph* source,
                 observed_edges.insert(source->edge_handle(trav.first, next));
                 // add it to the queue
                 queue.push_or_reprioritize(next, dist_thru);
+#ifdef debug_vg_algorithms
+                cerr << "[extract_containing_graph] traverse and (possibly) enqueue " << source->get_id(next) << " " << source->get_is_reverse(next) << ": " << dist_thru << endl;
+#endif
             });
         }
         
@@ -114,12 +133,18 @@ void extract_containing_graph(const HandleGraph* source,
                 
                 // add it to the queue
                 queue.push_or_reprioritize(next, max_search_length - reversing_walk_length);
+#ifdef debug_vg_algorithms
+                cerr << "[extract_containing_graph] reverse walk and (possibly) enqueue " << source->get_id(next) << " " << source->get_is_reverse(next) << ": " << max_search_length - reversing_walk_length << endl;
+#endif
             });
         }
     }
     
     // add the edges to the graph
     for (const edge_t& edge : observed_edges) {
+#ifdef debug_vg_algorithms
+        cerr << "[extract_containing_graph] adding edge " << source->get_id(edge.first) << " " << source->get_is_reverse(edge.first) << " -> " << source->get_id(edge.second) << " " << source->get_is_reverse(edge.second) << endl;
+#endif
         into->create_edge(into->get_handle(source->get_id(edge.first), source->get_is_reverse(edge.first)),
                           into->get_handle(source->get_id(edge.second), source->get_is_reverse(edge.second)));
     }

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -2688,12 +2688,12 @@ namespace vg {
         
 #ifdef debug_find_match
         cerr << "starting search for match at graph pos " << pos << ", read pos " << read_pos << ", length " << match_length << endl;
+        cerr << debug_string(multipath_aln) << endl;
 #endif
         
         // to keep track of the read interval corresponding to each subpath
         vector<int64_t> to_length(multipath_aln.subpath_size(), 0);
         for (size_t i = 0; i < multipath_aln.subpath_size(); ++i) {
-                        
             const subpath_t& subpath = multipath_aln.subpath(i);
             const path_t& path = subpath.path();
             
@@ -2747,7 +2747,7 @@ namespace vg {
 #endif
                                 
                                 const subpath_t& subpath_here = multipath_aln.subpath(di);
-                                const path_t& path_here = subpath.path();
+                                const path_t& path_here = subpath_here.path();
                                 const path_mapping_t& mapping_here = path_here.mapping(dj);
                                 const edit_t& edit_here = mapping_here.edit(dk);
                                 

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1657,6 +1657,10 @@ namespace vg {
 
     pair<int64_t, int64_t> aligned_interval(const multipath_alignment_t& multipath_aln) {
         
+        if (multipath_aln.subpath().empty()) {
+            return pair<int64_t, int64_t>(0, 0);
+        }
+        
         int64_t min_softclip_left = numeric_limits<int64_t>::max();
         int64_t min_softclip_right = numeric_limits<int64_t>::max();
         

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -3422,7 +3422,6 @@ namespace vg {
                         }
                     }
                     else {
-                        cerr << "\textending subseq end to " << connection.next() << endl;
                         subpath_read_interval[connection.next()].first = subpath_read_interval[i].second;
                     }
                 }

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -322,7 +322,6 @@ namespace vg {
     void merge_non_branching_subpaths(multipath_alignment_t& multipath_aln);
 
     /// Removes subpaths that have no aligned bases and adds in any implied edges crossing through them
-    /// Note: not updated for connections yet
     void remove_empty_subpaths(multipath_alignment_t& multipath_aln);
     
     /// Returns a vector whose elements are vectors with the indexes of the Subpaths in

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -350,6 +350,11 @@ namespace vg {
     trace_path(const multipath_alignment_t& multipath_aln, const Path& path,
                int64_t subpath_idx, int64_t mapping_idx, int64_t edit_idx, int64_t base_idx);
 
+    /// Returns true if the multipath alignment contains a match of a given length starting at the graph and
+    /// read position
+    bool contains_match(const multipath_alignment_t& multipath_aln, const pos_t& pos,
+                        int64_t read_pos, int64_t match_length);
+
     /// Convert a surjected multipath alignment into a CIGAR sequence against a path. Splicing will be allowed
     /// at connections and at any silent deletions of path sequence. Surjected multipath alignment graph must
     /// consist of a single non-branching path

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -62,21 +62,22 @@ namespace vg {
         /// Produces a graph with reachability edges. Assumes that the cluster
         /// is sorted by primarily length and secondarily lexicographically by
         /// read interval.
-        MultipathAlignmentGraph(const HandleGraph& graph, const MultipathMapper::memcluster_t& hits,
+        /// If a hit fails to be walked ouut in the graph, it is removed from hits.
+        MultipathAlignmentGraph(const HandleGraph& graph, MultipathMapper::memcluster_t& hits,
                                 const function<pair<id_t, bool>(id_t)>& project,
                                 const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans,
                                 size_t max_branch_trim_length = 0, gcsa::GCSA* gcsa = nullptr,
                                 const MultipathMapper::match_fanouts_t* fanout_breaks = nullptr);
                                 
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily.
-        MultipathAlignmentGraph(const HandleGraph& graph, const MultipathMapper::memcluster_t& hits,
+        MultipathAlignmentGraph(const HandleGraph& graph, MultipathMapper::memcluster_t& hits,
                                 const unordered_map<id_t, pair<id_t, bool>>& projection_trans,
                                 size_t max_branch_trim_length = 0, gcsa::GCSA* gcsa = nullptr,
                                 const MultipathMapper::match_fanouts_t* fanout_breaks = nullptr);
         
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
         /// using a lambda for a projector
-        MultipathAlignmentGraph(const HandleGraph& graph, const MultipathMapper::memcluster_t& hits,
+        MultipathAlignmentGraph(const HandleGraph& graph, MultipathMapper::memcluster_t& hits,
                                 const function<pair<id_t, bool>(id_t)>& project,
                                 size_t max_branch_trim_length = 0, gcsa::GCSA* gcsa = nullptr,
                                 const MultipathMapper::match_fanouts_t* fanout_breaks = nullptr);
@@ -137,7 +138,9 @@ namespace vg {
         /// Removes nodes and edges that are not part of any path that has an estimated score
         /// within some amount of the highest scoring path. Reachability edges must be present.
         void prune_to_high_scoring_paths(const Alignment& alignment, const GSSWAligner* aligner,
-                                         double max_suboptimal_score_ratio, const vector<size_t>& topological_order);
+                                         double max_suboptimal_score_ratio, const vector<size_t>& topological_order,
+                                         vector<pair<const MaximalExactMatch*, pos_t>>& cluster,
+                                         function<pair<id_t, bool>(id_t)>& translator);
         
         /// Clear reachability edges, so that add_reachability_edges can be run
         /// (possibly after modifying the graph).
@@ -244,7 +247,7 @@ namespace vg {
                                      const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans);
         
         /// Walk out MEMs into match nodes and filter out redundant sub-MEMs
-        void create_match_nodes(const HandleGraph& graph, const MultipathMapper::memcluster_t& hits,
+        void create_match_nodes(const HandleGraph& graph, MultipathMapper::memcluster_t& hits,
                                 const function<pair<id_t, bool>(id_t)>& project,
                                 const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans,
                                 const MultipathMapper::match_fanouts_t* fanout_breaks);

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1567,7 +1567,7 @@ namespace vg {
                             int64_t dist = distance_between(cluster_multipath_alns.front(), rescue_multipath_aln, true);
                             if (dist >= 0 && dist != numeric_limits<int64_t>::max()) {
                                 rescued_secondaries.emplace_back(move(cluster_multipath_alns.front()), move(rescue_multipath_aln));
-                                rescued_distances.emplace_back(make_pair(i, cluster_graphs2.size()), dist);
+                                rescued_distances.emplace_back(make_pair(i, RESCUED), dist);
                                 
                             }
                         }
@@ -1575,7 +1575,7 @@ namespace vg {
                             int64_t dist = distance_between(rescue_multipath_aln, cluster_multipath_alns.front(), true);
                             if (dist >= 0 && dist != numeric_limits<int64_t>::max()) {
                                 rescued_secondaries.emplace_back(move(rescue_multipath_aln), move(cluster_multipath_alns.front()));
-                                rescued_distances.emplace_back(make_pair(cluster_graphs1.size(), i), dist);
+                                rescued_distances.emplace_back(make_pair(RESCUED, i), dist);
                                 
                             }
                         }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2798,6 +2798,9 @@ namespace vg {
         }
          
         auto primary_interval = aligned_interval(multipath_alns_out.front());
+        if (primary_interval.first == primary_interval.second) {
+            return;
+        }
         bool search_left = primary_interval.first >= min_softclip_length_for_splice;
         bool search_right = alignment.sequence().size() - primary_interval.second >= min_softclip_length_for_splice;
         
@@ -2912,6 +2915,11 @@ namespace vg {
             
             // decide if this read looks like it could benefit from a spliced alignment
             auto primary_interval = aligned_interval(*anchor_mp_aln);
+            
+            if (primary_interval.first == primary_interval.second) {
+                continue;
+            }
+            
             bool search_left = primary_interval.first >= min_softclip_length_for_splice;
             bool search_right = aln->sequence().size() - primary_interval.second >= min_softclip_length_for_splice;
             

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1700,7 +1700,7 @@ namespace vg {
     bool MultipathMapper::multipath_map_paired(const Alignment& alignment1, const Alignment& alignment2,
                                                vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer) {
-        
+        cerr << alignment1.name() << endl;
 #ifdef debug_multipath_mapper
         cerr << "multipath mapping paired reads " << pb2json(alignment1) << " and " << pb2json(alignment2) << endl;
 #endif
@@ -4905,6 +4905,10 @@ namespace vg {
 
     vector<double> MultipathMapper::pair_mapping_likelihoods(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs,
                                                              const vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs) const {
+        
+#ifdef debug_multipath_mapper
+        cerr << "computing paired read likelihoods" << endl;
+#endif
         
         // Only do the population MAPQ if it might disambiguate two paths (since it's not
         // as cheap as just using the score), or if we set the setting to always do it.

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1700,7 +1700,7 @@ namespace vg {
     bool MultipathMapper::multipath_map_paired(const Alignment& alignment1, const Alignment& alignment2,
                                                vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer) {
-        cerr << alignment1.name() << endl;
+
 #ifdef debug_multipath_mapper
         cerr << "multipath mapping paired reads " << pb2json(alignment1) << " and " << pb2json(alignment2) << endl;
 #endif

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2201,6 +2201,13 @@ namespace vg {
             
             auto& candidate = get_candidate(i);
             
+            if (candidate.subpath().empty()) {
+#ifdef debug_multipath_mapper
+                cerr << "skipping empty candidate " << i << endl;
+#endif
+                continue;
+            }
+            
 #ifdef debug_multipath_mapper
             cerr << "extracting splice region for candidate " << i << ":" << endl;
             cerr << debug_string(candidate) << endl;
@@ -3269,7 +3276,7 @@ namespace vg {
                 auto it = new_cluster.find(hits_found_in_aln[j]);
                 if (it == new_cluster.end()) {
 #ifdef debug_multipath_mapper
-                    cerr << "making a new cluster with hits:" << endl;
+                    cerr << "making a new cluster at index " << cluster_graphs.size() << " with hits:" << endl;
                     for (auto hit_idx : hits_found_in_aln[j]) {
                         cerr << "\t" << hit_idx << endl;
                     }
@@ -3281,18 +3288,38 @@ namespace vg {
                     
                     // and now make the cluster graph itself
                     cluster_graphs.emplace_back();
-                    get<0>(cluster_graphs.back()) = new bdsg::HashGraph();
-                    algorithms::copy_handle_graph(get<0>(cluster_graphs[record.first]), get<0>(cluster_graphs.back()));
+                    auto& cluster_graph = cluster_graphs.back();
+                    get<0>(cluster_graph) = new bdsg::HashGraph();
+                    algorithms::copy_handle_graph(get<0>(cluster_graphs[record.first]), get<0>(cluster_graph));
                     
-                    for (auto i : hits_found_in_aln[j]) {
-                        get<1>(cluster_graphs.back()).first.emplace_back(get<1>(cluster_graphs[record.first]).first[i]);
+                    for (auto i : it->first) {
+                        get<1>(cluster_graph).first.emplace_back(get<1>(cluster_graphs[record.first]).first[i]);
                     }
-                    get<1>(cluster_graphs.back()).second = get<1>(cluster_graphs[record.first]).second;
+                    get<1>(cluster_graph).second = get<1>(cluster_graphs[record.first]).second;
                     
-                    get<2>(cluster_graphs.back()) = read_coverage(get<1>(cluster_graphs.back()));
+                    // sort lexicographically to compute read coverage
+                    sort(get<1>(cluster_graph).first.begin(), get<1>(cluster_graph).first.end(),
+                         [](const pair<const MaximalExactMatch*, pos_t>& hit_1,
+                            const pair<const MaximalExactMatch*, pos_t>& hit_2) {
+                        return (hit_1.first->begin < hit_2.first->begin ||
+                                (hit_1.first->begin == hit_2.first->begin && hit_1.first->end < hit_2.first->end));
+                    });
                     
+                    get<2>(cluster_graph) = read_coverage(get<1>(cluster_graph));
                     
+                    // and then sort back into length first order
+                    sort(get<1>(cluster_graph).first.begin(), get<1>(cluster_graph).first.end(),
+                         [](const pair<const MaximalExactMatch*, pos_t>& hit_1,
+                            const pair<const MaximalExactMatch*, pos_t>& hit_2) {
+                        return (hit_1.first->length() > hit_2.first->length() ||
+                                (hit_1.first->length() == hit_2.first->length() &&
+                                 (hit_1.first->begin < hit_2.first->begin ||
+                                  (hit_1.first->begin == hit_2.first->begin && hit_1.first->end < hit_2.first->end))));
+                    });
                     
+#ifdef debug_multipath_mapper
+                    cerr << "assign total coverage " << get<2>(cluster_graphs.back()) << endl;
+#endif
                     any_new_clusters = true;
                 }
                 
@@ -3313,14 +3340,62 @@ namespace vg {
                 }
             }
             
-            // any remainiing clusters aren't being used by any alignment and they can
+            // any remaining clusters aren't being used by any alignment and they can
             // have their hits released
             for (const auto& record : original_cluster) {
 #ifdef debug_multipath_mapper
                 cerr << "cluster " << record.first << " has no more assignees, unclaiming all of its hits" << endl;
 #endif
                 get<1>(cluster_graphs[record.first]).first.clear();
+                get<2>(cluster_graphs[record.first]) = 0;
             }
+            
+            
+            // reorder the clusters based on the new coverage
+            vector<size_t> order(cluster_graphs.size(), 0);
+            for (size_t i = 1; i < cluster_graphs.size(); ++i) {
+                order[i] = i;
+            }
+            
+            stable_sort(order.begin(), order.end(), [&](size_t i, size_t j) {
+                return get<2>(cluster_graphs[i]) > get<2>(cluster_graphs[j]);
+            });
+            
+            vector<size_t> index(order.size());
+            for (size_t i = 0; i < order.size(); ++i) {
+                index[order[i]] = i;
+            }
+            
+#ifdef debug_multipath_mapper
+            cerr << "reordering clusters based on coverage" << endl;
+            for (size_t i = 0; i < index.size(); ++i) {
+                cerr << "\t" << i << " -> " << index[i] << endl;
+            }
+#endif
+            
+            for (size_t* cluster_assignment : all_cluster_assignments) {
+                if (*cluster_assignment != RESCUED) {
+                    *cluster_assignment = index[*cluster_assignment];
+                }
+            }
+            
+            for (size_t i = 0; i < index.size(); ++i) {
+                while (index[i] != i) {
+                    std::swap(cluster_graphs[index[i]], cluster_graphs[i]);
+                    std::swap(index[index[i]], index[i]);
+                    
+                }
+            }
+            
+#ifdef debug_multipath_mapper
+            cerr << "new cluster ordering" << endl;
+            for (int i = 0; i < cluster_graphs.size(); i++) {
+                cerr << "cluster " << i << ", coverage " << get<2>(cluster_graphs[i]) << endl;
+                for (pair<const MaximalExactMatch*, pos_t>  hit : get<1>(cluster_graphs[i]).first) {
+                    cerr << "\t" << hit.second << " " <<  hit.first->sequence() << endl;
+                }
+            }
+#endif
         }
     }
 
@@ -5516,19 +5591,6 @@ namespace vg {
                                       haploMath::RRMemo(recombination_penalty, population_size)));
             return rr_memos.at(make_pair(recombination_penalty, population_size));
         }
-    }
-    
-    double MultipathMapper::read_coverage_z_score(int64_t coverage, const Alignment& alignment) const {
-        /* algebraically equivalent to
-         *
-         *      Coverage - ReadLen / 4
-         *  -------------------------------
-         *  sqrt(ReadLen * 1/4 * (1 - 1/4))
-         * 
-         * from the Normal approximation to a Binomal(ReadLen, 1/4)
-         */
-        double root_len = sqrt(alignment.sequence().size());
-        return 0.5773502691896258 * (4.0 * coverage / root_len - root_len);
     }
 }
 

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -382,11 +382,10 @@ namespace vg {
         /// Helper function to be called by split_multicomponent_alignments to reassign hits to the
         /// split clusters
         void reassign_split_clusters(const Alignment& alignment,
-                                     size_t begin, size_t end,
                                      vector<clustergraph_t>& cluster_graphs,
-                                     const function<const multipath_alignment_t&(size_t)>& get_mp_aln,
-                                     const function<size_t(size_t)>& get_cluster_idx,
-                                     const function<void(size_t,size_t)>& set_cluster_idx) const;
+                                     const vector<const multipath_alignment_t*>& split_mp_alns,
+                                     const vector<size_t*>& cluster_assignments,
+                                     const vector<size_t*>& all_cluster_assignments) const;
         
         /// Combine all of the significant alignments into one. Requires alignments to be sorted by
         /// significance already

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -562,9 +562,6 @@ namespace vg {
         /// Is this a consistent inter-pair distance based on the learned fragment length distribution?
         bool is_consistent(int64_t distance) const;
         
-        /// Computes the Z-score of the number of matches against an equal length random DNA string.
-        double read_coverage_z_score(int64_t coverage, const Alignment& alignment) const;
-        
         /// Return true if any of the initial positions of the source Subpaths are shared between the two
         /// multipath alignments
         bool share_terminal_positions(const multipath_alignment_t& multipath_aln_1, const multipath_alignment_t& multipath_aln_2) const;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -46,6 +46,7 @@
 #include "algorithms/reverse_complement.hpp"
 #include "algorithms/extend.hpp"
 #include "algorithms/jump_along_path.hpp"
+#include "algorithms/copy_graph.hpp"
 
 #include "bdsg/hash_graph.hpp"
 
@@ -361,6 +362,8 @@ namespace vg {
         /// Properly handles multipath_alignment_ts that are unmapped.
         /// Does not depend on or guarantee topological order in the multipath_alignment_ts.
         void split_multicomponent_alignments(vector<multipath_alignment_t>& multipath_alns_out,
+                                             const Alignment* alignment = nullptr,
+                                             vector<clustergraph_t>* cluster_graphs = nullptr,
                                              vector<size_t>* cluster_idxs = nullptr,
                                              vector<double>* multiplicities = nullptr) const;
         
@@ -369,9 +372,21 @@ namespace vg {
         /// a record to the cluster pairs vector.
         /// Properly handles multipath_alignment_ts that are unmapped.
         /// Does not depend on or guarantee topological order in the multipath_alignment_ts.
-        void split_multicomponent_alignments(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
+        void split_multicomponent_alignments(const Alignment& alignment1, const Alignment& alignment2,
+                                             vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
+                                             vector<clustergraph_t>& cluster_graphs1,
+                                             vector<clustergraph_t>& cluster_graphs2,
                                              vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                              vector<double>& multiplicities) const;
+        
+        /// Helper function to be called by split_multicomponent_alignments to reassign hits to the
+        /// split clusters
+        void reassign_split_clusters(const Alignment& alignment,
+                                     size_t begin, size_t end,
+                                     vector<clustergraph_t>& cluster_graphs,
+                                     const function<const multipath_alignment_t&(size_t)>& get_mp_aln,
+                                     const function<size_t(size_t)>& get_cluster_idx,
+                                     const function<void(size_t,size_t)>& set_cluster_idx) const;
         
         /// Combine all of the significant alignments into one. Requires alignments to be sorted by
         /// significance already
@@ -577,6 +592,8 @@ namespace vg {
         SnarlManager* snarl_manager;
         MinimumDistanceIndex* distance_index;
         PathComponentIndex* path_component_index = nullptr;
+        
+        static const size_t RESCUED;
         
         /// Memos used by population model
         static thread_local unordered_map<pair<double, size_t>, haploMath::RRMemo> rr_memos;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -332,25 +332,25 @@ namespace vg {
         /// caller must delete the VG objects produced!
         vector<clustergraph_t> query_cluster_graphs(const Alignment& alignment,
                                                     const vector<MaximalExactMatch>& mems,
-                                                    const vector<memcluster_t>& clusters);
+                                                    const vector<memcluster_t>& clusters) const;
         
         /// Return a graph (on the heap) that contains a cluster. The paired bool
         /// indicates whether the graph is known to be connected (but it is possible
         /// for the graph to be connected and have it return false)
-        pair<bdsg::HashGraph*, bool> extract_cluster_graph(const Alignment& alignment, const memcluster_t& mem_cluster);
+        pair<bdsg::HashGraph*, bool> extract_cluster_graph(const Alignment& alignment, const memcluster_t& mem_cluster) const;
         
         /// Extract a graph that is guaranteed to contain all local alignments that include
         /// the MEMs of the cluster.  The paired bool indicates whether the graph is
         /// known to be connected (but it is possible for the graph to be connected and have
         /// it return false)
-        pair<bdsg::HashGraph*, bool> extract_maximal_graph(const Alignment& alignment, const memcluster_t& mem_cluster);
+        pair<bdsg::HashGraph*, bool> extract_maximal_graph(const Alignment& alignment, const memcluster_t& mem_cluster) const;
         
         /// Extract a graph with an algorithm that tries to extract not much more than what
         /// is required to contain the cluster in a single connected component (can be slower
         /// than the maximal algorithm for alignments that require large indels),  The paired bool
         /// indicates whether the graph is known to be connected (but it is possible
         /// for the graph to be connected and have it return false)
-        pair<bdsg::HashGraph*, bool> extract_restrained_graph(const Alignment& alignment, const memcluster_t& mem_cluster);
+        pair<bdsg::HashGraph*, bool> extract_restrained_graph(const Alignment& alignment, const memcluster_t& mem_cluster) const;
         
         /// Returns the union of the intervals on the read that a cluster cover in sorted order
         vector<pair<int64_t, int64_t>> covered_intervals(const Alignment& alignment,
@@ -426,6 +426,7 @@ namespace vg {
         
         void align_to_splice_candidates(const Alignment& alignment,
                                         vector<clustergraph_t>& cluster_graphs,
+                                        const vector<MaximalExactMatch>& mems,
                                         const vector<size_t>& cluster_candidates,
                                         const vector<pair<const MaximalExactMatch*, pos_t>>& hit_candidates,
                                         const pair<int64_t, int64_t>& primary_interval,

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -540,10 +540,10 @@ namespace vg {
         bool likely_misrescue(const multipath_alignment_t& multipath_aln);
         
         /// A scaling of a score so that it approximately follows the distribution of the longest match in p-value test
-        size_t pseudo_length(const multipath_alignment_t& multipath_aln) const;
+        int64_t pseudo_length(const multipath_alignment_t& multipath_aln) const;
         
         /// The approximate p-value for a match length of the given size against the current graph
-        double random_match_p_value(size_t match_length, size_t read_length);
+        double random_match_p_value(int64_t match_length, size_t read_length);
         
         /// Reorganizes the fan-out breaks into the format that MultipathAlignmentGraph wants it in
         match_fanouts_t record_fanouts(const vector<MaximalExactMatch>& mems,
@@ -598,7 +598,7 @@ namespace vg {
         static thread_local unordered_map<pair<double, size_t>, haploMath::RRMemo> rr_memos;
         
         // a memo for the transcendental p-value function (thread local to maintain threadsafety)
-        static thread_local unordered_map<pair<size_t, size_t>, double> p_value_memo;
+        static thread_local unordered_map<pair<int64_t, size_t>, double> p_value_memo;
         
         // a memo for the transcendental restrained extraction function (thread local to maintain threadsafety)
         static thread_local unordered_map<double, vector<int64_t>> pessimistic_gap_memo;

--- a/src/splicing.cpp
+++ b/src/splicing.cpp
@@ -1036,43 +1036,21 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
     auto left_locations = search_multipath_alignment(left_mp_aln, pos_left, left_bridge_point);
     auto right_locations = search_multipath_alignment(right_mp_aln, pos_right, right_bridge_point);
     
-    // check if it would help us to reposition any left locations
-    auto it = find_if(left_locations.begin(), left_locations.end(),
+    // check for any before-the-beginning positions on the left side
+    auto it1 = find_if(left_locations.begin(), left_locations.end(),
                       [](const tuple<int64_t, int64_t, int64_t, int64_t>& loc) {
         return get<0>(loc) != 0 && get<1>(loc) == 0 && get<2>(loc) == 0 && get<3>(loc) == 0;
     });
-    bool check_unique = false;
-    if (it != left_locations.end()) {
-        // it's easier to handle before-the-first locations on the left side as
-        // past-the-last locations on their predecessors
-        vector<vector<int64_t>> prevs(left_mp_aln.subpath_size());
-        for (int64_t i = 0; i < prevs.size(); ++i) {
-            for (auto n : left_mp_aln.subpath(i).next()) {
-                prevs[n].push_back(i);
-            }
-        }
-        for (int64_t i = it - left_locations.begin(), end = left_locations.size(); i < end; ++i) {
-            auto& loc = left_locations[i];
-            if (!prevs[get<0>(loc)].empty() && get<1>(loc) == 0 && get<2>(loc) == 0 && get<3>(loc) == 0) {
-                // move this location onto all of the predecessors
-                for (auto j : prevs[get<0>(loc)]) {
-                    left_locations.emplace_back(j, left_mp_aln.subpath(j).path().mapping_size(), 0, 0);
-                }
-                left_locations[i] = left_locations.back();
-                left_locations.pop_back();
-                check_unique = true;
-            }
-        }
-    }
+    auto it2 = find_if(right_locations.begin(), right_locations.end(),
+                       [&](const tuple<int64_t, int64_t, int64_t, int64_t>& loc) {
+        return get<1>(loc) == right_mp_aln.subpath(get<0>(loc)).path().mapping_size();
+    });
+    // these tend to create empty subpaths, so keep track of whether we'll need to look for any
+    bool check_for_empty_subpaths_at_end = it1 != left_locations.end() || it2 != right_locations.end();
     
+    // make sure these are sorted by index
     sort(left_locations.begin(), left_locations.end());
     sort(right_locations.begin(), right_locations.end());
-    
-    if (check_unique) {
-        // it's possible that we created duplicate locations when repositioning the locations
-        // around subpath boundaries
-        left_locations.resize(unique(left_locations.begin(), left_locations.end()) - left_locations.begin());
-    }
     
 #ifdef debug_fusing
     cerr << "left splice locations:" << endl;
@@ -1218,7 +1196,9 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
     if (splice_segment_halves.first.first.mapping_size() != 0) {
         for (const auto& left_loc : left_locations) {
             auto i = get<0>(left_loc) - left_removed_so_far[get<0>(left_loc)];
-            left_mp_aln.mutable_subpath(i)->add_next(left_mp_aln.subpath_size());
+            if (i < left_mp_aln.subpath_size()) {
+                left_mp_aln.mutable_subpath(i)->add_next(left_mp_aln.subpath_size());
+            }
         }
         
         auto subpath = left_mp_aln.add_subpath();
@@ -1319,7 +1299,6 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
     vector<int64_t> right_removed_so_far(right_mp_aln.subpath_size() + 1, 0);
     int64_t right_loc_idx = 0;
     for (int64_t i = 0; i < right_mp_aln.subpath_size(); ++i) {
-        
         if (!to_keep_right[i]) {
             right_removed_so_far[i + 1] = right_removed_so_far[i] + 1;
             continue;
@@ -1352,9 +1331,11 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
                 // both of the splice segments were empty, connect directly to the left splice point
                 for (const auto& left_loc : left_locations) {
                     auto i = get<0>(left_loc) - left_removed_so_far[get<0>(left_loc)];
-                    auto connection = left_mp_aln.mutable_subpath(i)->add_connection();
-                    connection->set_next(left_mp_aln.subpath_size());
-                    connection->set_score(splice_score);
+                    if (i < left_subpaths_end) {
+                        auto connection = left_mp_aln.mutable_subpath(i)->add_connection();
+                        connection->set_next(left_mp_aln.subpath_size());
+                        connection->set_score(splice_score);
+                    }
                 }
             }
             else if (splice_segment_halves.second.first.mapping_size() == 0) {
@@ -1374,6 +1355,7 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
     }
     // fix up the edges on the transferred subpaths from the right alignment
     for (size_t i = right_subpaths_begin; i < left_mp_aln.subpath_size(); ++i)  {
+        
         auto subpath = left_mp_aln.mutable_subpath(i);
         size_t nexts_removed_so_far = 0;
         for (size_t j = 0; j < subpath->next_size(); ++j) {
@@ -1409,6 +1391,12 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
     // starts can change pretty drastically, so just clear and reidentify
     identify_start_subpaths(left_mp_aln);
     
+    if (check_for_empty_subpaths_at_end) {
+#ifdef debug_fusing
+        cerr << "removing any empty subpaths" << endl;
+#endif
+        remove_empty_subpaths(left_mp_aln);
+    }
     
 #ifdef debug_fusing
     cerr << "final product:" << endl;

--- a/src/splicing.cpp
+++ b/src/splicing.cpp
@@ -83,17 +83,26 @@ void SpliceMotifs::init(const vector<tuple<string, string, double>>& motifs,
     
     data.reserve(motifs.size());
     for (const auto& record : motifs) {
+        int32_t score = round(log(get<2>(record)) / scorer.log_base);
         data.emplace_back();
         get<0>(data.back()) = get<0>(record);
         // reverse the second string because it's encountered in reverse when going into
         // an intron
         get<1>(data.back()) = string(get<1>(record).rbegin(), get<1>(record).rend());
         // convert frequency to a log likelihood
-        get<2>(data.back()) = int32_t(round(log(get<2>(record)) / scorer.log_base));
-#ifdef debug_splice_region
-        cerr << "\t" << get<0>(data.back()) << "\t" << get<1>(data.back()) << "\t" << get<2>(data.back()) << endl;
-#endif
+        get<2>(data.back()) = score;
+        
+        // now do the reverse complement
+        data.emplace_back();
+        get<0>(data.back()) = reverse_complement(get<1>(record));
+        get<1>(data.back()) = reverse_complement(string(get<0>(record).rbegin(), get<0>(record).rend()));
+        get<2>(data.back()) = score;
     }
+#ifdef debug_splice_region
+    for (const auto& record : data) {
+        cerr << "\t" << get<0>(record) << "\t" << get<1>(record) << "\t" << get<2>(record) << endl;
+    }
+#endif
 }
 
 SpliceRegion::SpliceRegion(const pos_t& seed_pos, bool search_left, int64_t search_dist,

--- a/src/splicing.cpp
+++ b/src/splicing.cpp
@@ -1039,7 +1039,7 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
     // check for any before-the-beginning positions on the left side
     auto it1 = find_if(left_locations.begin(), left_locations.end(),
                       [](const tuple<int64_t, int64_t, int64_t, int64_t>& loc) {
-        return get<0>(loc) != 0 && get<1>(loc) == 0 && get<2>(loc) == 0 && get<3>(loc) == 0;
+        return get<1>(loc) == 0 && get<2>(loc) == 0 && get<3>(loc) == 0;
     });
     auto it2 = find_if(right_locations.begin(), right_locations.end(),
                        [&](const tuple<int64_t, int64_t, int64_t, int64_t>& loc) {

--- a/src/splicing.hpp
+++ b/src/splicing.hpp
@@ -23,7 +23,7 @@ using namespace std;
 class SpliceMotifs {
 public:
     // Defaults to the three canonical human splicing motifs with the frequencies
-    // reported in Burset, et al. (2000):
+    // reported in Burset, Seledstov, and Solovyev (2000):
     // - GT-AG: 0.9924
     // - GC-AG: 0.0069
     // - AT-AC: 0.0005

--- a/src/splicing.hpp
+++ b/src/splicing.hpp
@@ -39,6 +39,9 @@ public:
     // the dinucleotide motif on one side in the order that the nucleotides
     // are encountered when traversing into the intron
     const string& oriented_motif(size_t motif_num, bool left_side) const;
+    // true if the corresponding motif would be encountered on the reverse
+    // strand of a transcript
+    bool motif_is_reverse(size_t motif_num) const;
     // the dinucleotide motif on one side ins its standard representation
     string unoriented_motif(size_t motif_num, bool left_side) const;
     // the score associated with a splicing motif

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -287,8 +287,8 @@ int main_mpmap(int argc, char** argv) {
     double pessimistic_gap_multiplier = 3.0;
     bool restrained_graph_extraction = false;
     bool do_spliced_alignment = false;
-    int max_softclip_overlap = 5;
-    int max_splice_overhang = 5;
+    int max_softclip_overlap = 8;
+    int max_splice_overhang = 8;
     bool override_spliced_alignment = false;
     int match_score_arg = std::numeric_limits<int>::min();
     int mismatch_score_arg = std::numeric_limits<int>::min();

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -288,7 +288,7 @@ int main_mpmap(int argc, char** argv) {
     bool restrained_graph_extraction = false;
     bool do_spliced_alignment = false;
     int max_softclip_overlap = 8;
-    int max_splice_overhang = 8;
+    int max_splice_overhang = 2 * max_softclip_overlap;
     bool override_spliced_alignment = false;
     int match_score_arg = std::numeric_limits<int>::min();
     int mismatch_score_arg = std::numeric_limits<int>::min();

--- a/src/unittest/multipath_alignment.cpp
+++ b/src/unittest/multipath_alignment.cpp
@@ -2781,7 +2781,7 @@ namespace vg {
         }
     }
 
-    TEST_CASE("Matches can be located in a multipath alignment", "[multipath][splicing][newmultipath]") {
+    TEST_CASE("Matches can be located in a multipath alignment", "[multipath][splicing]") {
         
         bdsg::HashGraph graph;
         

--- a/src/unittest/multipath_mapper.cpp
+++ b/src/unittest/multipath_mapper.cpp
@@ -27,7 +27,6 @@ public:
     using MultipathMapper::strip_full_length_bonuses;
     using MultipathMapper::sort_and_compute_mapping_quality;
     using MultipathMapper::read_coverage;
-    using MultipathMapper::read_coverage_z_score;        
 };
 
 TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipathmapper]" ) {

--- a/src/unittest/splicing.cpp
+++ b/src/unittest/splicing.cpp
@@ -1,6 +1,6 @@
-/// \file dinucleotide_machine.cpp
+/// \file splicing.cpp
 ///  
-/// Unit tests for the DinucleotideMachine
+/// Unit tests for the splicing functions
 ///
 
 #include <iostream>

--- a/src/unittest/splicing.cpp
+++ b/src/unittest/splicing.cpp
@@ -62,8 +62,8 @@ TEST_CASE("SpliceRegion can detect a splice site on a trivial example",
     SpliceRegion splice_region(pos, search_left, search_dist, graph, machine, splice_motifs);
 
     auto m0 = splice_region.candidate_splice_sites(0);
-    auto m1 = splice_region.candidate_splice_sites(1);
-    auto m2 = splice_region.candidate_splice_sites(2);
+    auto m1 = splice_region.candidate_splice_sites(2);
+    auto m2 = splice_region.candidate_splice_sites(4);
 
     REQUIRE(m0.size() == 1);
     REQUIRE(m1.size() == 1);
@@ -102,8 +102,8 @@ TEST_CASE("SpliceRegion can detect a splice site leftward",
     SpliceRegion splice_region(pos, search_left, search_dist, graph, machine, splice_motifs);
 
     auto m0 = splice_region.candidate_splice_sites(0);
-    auto m1 = splice_region.candidate_splice_sites(1);
-    auto m2 = splice_region.candidate_splice_sites(2);
+    auto m1 = splice_region.candidate_splice_sites(2);
+    auto m2 = splice_region.candidate_splice_sites(4);
 
     REQUIRE(m0.size() == 1);
     REQUIRE(m1.size() == 0);
@@ -152,9 +152,9 @@ TEST_CASE("SpliceRegion can detect a splice sites across node boundaries",
     SpliceRegion splice_region(pos, search_left, search_dist, graph, machine, splice_motifs);
 
     auto m0 = splice_region.candidate_splice_sites(0);
-    auto m1 = splice_region.candidate_splice_sites(1);
-    auto m2 = splice_region.candidate_splice_sites(2);
-    auto m3 = splice_region.candidate_splice_sites(3);
+    auto m1 = splice_region.candidate_splice_sites(2);
+    auto m2 = splice_region.candidate_splice_sites(4);
+    auto m3 = splice_region.candidate_splice_sites(6);
 
     REQUIRE(m0.size() == 1);
     REQUIRE(m1.size() == 2);
@@ -217,7 +217,7 @@ TEST_CASE("SpliceRegion can detect a splice sites across node boundaries going l
     SpliceRegion splice_region(pos, search_left, search_dist, graph, machine, splice_motifs);
 
     auto m0 = splice_region.candidate_splice_sites(0);
-    auto m1 = splice_region.candidate_splice_sites(1);
+    auto m1 = splice_region.candidate_splice_sites(2);
 
     REQUIRE(m0.size() == 1);
     REQUIRE(m1.size() == 1);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg mpmap`'s spliced alignment is now significantly more accurate

## Description

Several changes to spliced alignment. Fixes a bug that resulted in spliced alignments never being found for the reverse strand of a transcript. Also creates logic for clusters to "un-claim" hits when subsequent steps prune them or split up the cluster. This helps the scavenging logic to identify spliced alignment candidates better.