### PR TITLE
Resolve some limitations in mpmap's spliced alignment algorithm

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2801,6 +2801,7 @@ namespace vg {
         for (int64_t i = 1; i < multipath_alns_out.size(); ++i) {
             index[i] = i;
         }
+        vector<int64_t> order = index;
         
         // we'll keep track of whether any spliced alignments succeeded
         bool any_splices = false;
@@ -2900,8 +2901,14 @@ namespace vg {
                         cluster_idxs.pop_back();
                         
                         // do the bookkeeping to track the original indexes
-                        index[multipath_alns_out.size()] = mp_aln_candidates[i];
-                        index[mp_aln_candidates[i]] = -1;
+                        int64_t consuming_original_index = order[mp_aln_candidates[i]];
+                        int64_t moving_original_index = order[multipath_alns_out.size()];
+                        
+                        index[moving_original_index] = multipath_alns_out.size();
+                        index[consuming_original_index] = -1;
+                        
+                        order[mp_aln_candidates[i]] = moving_original_index;
+                        order[multipath_alns_out.size()] = -1;
                         
                         // TODO: also do bookkeeping on the clusters to claim the hits
                         
@@ -2909,6 +2916,10 @@ namespace vg {
                         cerr << "indexes are now:" << endl;
                         for (size_t i = 0; i < index.size(); ++i) {
                             cerr << "\t" << i << " " << index[i] << endl;
+                        }
+                        cerr << "orders are now:" << endl;
+                        for (size_t i = 0; i < order.size(); ++i) {
+                            cerr << "\t" << i << " " << order[i] << endl;
                         }
 #endif
                         
@@ -2964,6 +2975,7 @@ namespace vg {
         for (int64_t i = 1; i < multipath_aln_pairs_out.size(); ++i) {
             index[i] = i;
         }
+        vector<int64_t> order = index;
         
         // we'll keep track of whether any spliced alignments succeeded
         bool any_splices = false;
@@ -3106,8 +3118,17 @@ namespace vg {
                                 cluster_pairs.pop_back();
                                 
                                 // do the bookkeeping to track the original indexes
-                                index[multipath_aln_pairs_out.size()] = mp_aln_candidates[i];
-                                index[mp_aln_candidates[i]] = -1;
+                                int64_t consuming_original_index = order[mp_aln_candidates[i]];
+                                int64_t moving_original_index = order[multipath_aln_pairs_out.size()];
+                                
+                                index[moving_original_index] = multipath_aln_pairs_out.size();
+                                index[consuming_original_index] = -1;
+                                
+                                order[mp_aln_candidates[i]] = moving_original_index;
+                                order[multipath_aln_pairs_out.size()] = -1;
+                                
+                                // TODO: also do bookkeeping on the clusters to claim the hits
+                                
                             }
                             else {
                                 // we don't want to mess up pairs, so just copy it out
@@ -3119,6 +3140,10 @@ namespace vg {
                             cerr << "pair indexes are now:" << endl;
                             for (size_t i = 0; i < index.size(); ++i) {
                                 cerr << "\t" << i << " " << index[i] << endl;
+                            }
+                            cerr << "pair orders are now:" << endl;
+                            for (size_t i = 0; i < order.size(); ++i) {
+                                cerr << "\t" << i << " " << order[i] << endl;
                             }
 #endif
                             

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -896,18 +896,21 @@ namespace vg {
                                                int8_t full_length_bonus) {
         AlignerClient::set_alignment_scores(match, mismatch, gap_open, gap_extend, full_length_bonus);
         splice_motifs.update_scoring(*get_regular_aligner());
+        set_min_softclip_length_for_splice(min_softclip_length_for_splice);
     }
 
     void MultipathMapper::set_alignment_scores(std::istream& matrix_stream, int8_t gap_open, int8_t gap_extend,
                                                int8_t full_length_bonus) {
         AlignerClient::set_alignment_scores(matrix_stream, gap_open, gap_extend, full_length_bonus);
         splice_motifs.update_scoring(*get_regular_aligner());
+        set_min_softclip_length_for_splice(min_softclip_length_for_splice);
     }
 
     void MultipathMapper::set_alignment_scores(const int8_t* score_matrix, int8_t gap_open, int8_t gap_extend,
                                                int8_t full_length_bonus) {
         AlignerClient::set_alignment_scores(score_matrix, gap_open, gap_extend, full_length_bonus);
         splice_motifs.update_scoring(*get_regular_aligner());
+        set_min_softclip_length_for_splice(min_softclip_length_for_splice);
     }
 
     
@@ -2789,84 +2792,140 @@ namespace vg {
         if (multipath_alns_out.empty()) {
             return;
         }
-         
-        auto primary_interval = aligned_interval(multipath_alns_out.front());
-        bool search_left = primary_interval.first >= min_softclip_length_for_splice;
-        bool search_right = alignment.sequence().size() - primary_interval.second >= min_softclip_length_for_splice;
         
-        if (!(search_left || search_right)) {
-#ifdef debug_multipath_mapper
-            cerr << "soft clips are not sufficiently large to look for spliced alignment on interval " << primary_interval.first << ":" << primary_interval.second << endl;
-#endif
-            return;
+        // TODO: it would be better to use likelihoods rather than scores (esp. in paired)
+        
+        // choose the score cutoff based on the original unspliced mappings
+        int32_t min_score_to_attempt = (optimal_alignment_score(multipath_alns_out.front())
+                                        - get_aligner()->mapping_quality_score_diff(max_mapping_quality));
+        
+        vector<int64_t> index(multipath_alns_out.size(), 0);
+        for (int64_t i = 1; i < multipath_alns_out.size(); ++i) {
+            index[i] = i;
         }
         
-#ifdef debug_multipath_mapper
-        cerr << "looking for spliced alignments, to left? " << search_left << ", to right? " << search_right << ", interval: " << primary_interval.first << " " << primary_interval.second << endl;
-#endif
+        // we'll keep track of whether any spliced alignments succeeded
+        bool any_splices = false;
         
-        for (bool do_left : {true, false}) {
-            if ((do_left && !search_left) || (!do_left && !search_right)) {
+        for (size_t i = 0; i < index.size(); ) {
+            if (index[i] < 0) {
+                // this alignment has been consumed as a splice candidate
                 continue;
             }
             
-            vector<size_t> mp_aln_candidates;
-            unordered_set<size_t> clusters_used;
-            vector<size_t> cluster_candidates;
-            vector<pair<const MaximalExactMatch*, pos_t>> hit_candidates;
-            identify_aligned_splice_candidates(alignment, do_left, primary_interval,
-                                               multipath_alns_out, cluster_idxs, clusters_used,
-                                               mp_aln_candidates);
-            identify_unaligned_splice_candidates(alignment, do_left, primary_interval, mems,
-                                                 cluster_graphs, clusters_used, cluster_candidates,
-                                                 hit_candidates);
-            vector<multipath_alignment_t> unaligned_candidates;
-            vector<double> unaligned_multiplicities;
-            align_to_splice_candidates(alignment, cluster_graphs, mems, cluster_candidates, hit_candidates,
-                                       primary_interval, do_left, unaligned_candidates, unaligned_multiplicities);
+#ifdef debug_multipath_mapper
+            cerr << "deciding whether to look for spliced alignments on mp aln " << index[i] << endl;
+#endif
             
-            function<const multipath_alignment_t&(int64_t)> get_candidate = [&](int64_t i) -> const multipath_alignment_t& {
-                return i < mp_aln_candidates.size() ? multipath_alns_out[mp_aln_candidates[i]]
-                                                    : unaligned_candidates[i - mp_aln_candidates.size()];
-            };
+            multipath_alignment_t& splice_anchor = multipath_alns_out[index[i]];
             
-            // TODO: this solution is kinda ugly
-            multipath_alignment_t tmp;
-            function<multipath_alignment_t&&(int64_t)> consume_candidate = [&](int64_t i) -> multipath_alignment_t&& {
-                if (i < 0) {
-                    // consume the primary
-                    return move(multipath_alns_out.front());
-                }
-                else if (i < mp_aln_candidates.size()) {
-                    // TODO: this will need to change if I start allowing multiple splices in one alignment
-                    // because indexes will need to stay stable
-                    
-                    // pull the alignment out
-                    tmp = move(multipath_alns_out[mp_aln_candidates[i]]);
-                    
-                    // replace it in the vectors and clear the final position
-                    multipath_alns_out[mp_aln_candidates[i]] = move(multipath_alns_out.back());
-                    multiplicities[mp_aln_candidates[i]] = multiplicities.back();
-                    cluster_idxs[mp_aln_candidates[i]] = cluster_idxs.back();
-                    multipath_alns_out.pop_back();
-                    multiplicities.pop_back();
-                    cluster_idxs.pop_back();
-                    
-                    return move(tmp);
-                }
-                else {
-                    return move(unaligned_candidates[i - mp_aln_candidates.size()]);
-                }
-            };
-            
-            bool did_splice = test_splice_candidates(alignment, do_left, multipath_alns_out.front(), multiplicities.front(),
-                                                     mp_aln_candidates.size() + unaligned_candidates.size(),
-                                                     get_candidate, consume_candidate);
-            
-            if (did_splice) {
-                sort_and_compute_mapping_quality(multipath_alns_out, mapping_quality_method,
-                                                 &cluster_idxs, &multiplicities);
+            if (optimal_alignment_score(splice_anchor) < min_score_to_attempt) {
+                // the rest of the alignments are too low-scoring to look at
+                break;
             }
+            
+            auto interval = aligned_interval(splice_anchor);
+            // TODO: repetitive with paired version
+            auto alnr = get_aligner(!alignment.quality().empty());
+            int64_t left_max_score = (alnr->score_exact_match(alignment, 0, interval.first)
+                                      + alnr->score_full_length_bonus(true, alignment));
+            int64_t right_max_score = (alnr->score_exact_match(alignment, interval.second,
+                                                               alignment.sequence().size() - interval.second)
+                                       + alnr->score_full_length_bonus(false, alignment));
+            bool search_left = left_max_score >= min_softclipped_score_for_splice;
+            bool search_right = right_max_score >= min_softclipped_score_for_splice;
+            
+            if (!(search_left || search_right)) {
+#ifdef debug_multipath_mapper
+                cerr << "soft clips are not sufficiently large to look for spliced alignment on interval " << interval.first << ":" << primary_interval.second << endl;
+#endif
+                continue;
+            }
+            
+#ifdef debug_multipath_mapper
+            cerr << "looking for spliced alignments, to left? " << search_left << ", to right? " << search_right << ", interval: " << primary_interval.first << " " << primary_interval.second << endl;
+#endif
+            
+            bool found_splice_for_anchor = false;
+            
+            for (bool do_left : {true, false}) {
+                if ((do_left && !search_left) || (!do_left && !search_right)) {
+                    continue;
+                }
+                
+                vector<size_t> mp_aln_candidates;
+                unordered_set<size_t> clusters_used;
+                vector<size_t> cluster_candidates;
+                vector<pair<const MaximalExactMatch*, pos_t>> hit_candidates;
+                identify_aligned_splice_candidates(alignment, do_left, interval,
+                                                   multipath_alns_out, cluster_idxs, clusters_used,
+                                                   mp_aln_candidates);
+                identify_unaligned_splice_candidates(alignment, do_left, interval, mems,
+                                                     cluster_graphs, clusters_used, cluster_candidates,
+                                                     hit_candidates);
+                vector<multipath_alignment_t> unaligned_candidates;
+                vector<double> unaligned_multiplicities;
+                align_to_splice_candidates(alignment, cluster_graphs, mems, cluster_candidates, hit_candidates,
+                                           interval, do_left, unaligned_candidates, unaligned_multiplicities);
+                
+                function<const multipath_alignment_t&(int64_t)> get_candidate = [&](int64_t i) -> const multipath_alignment_t& {
+                    return i < mp_aln_candidates.size() ? multipath_alns_out[mp_aln_candidates[i]]
+                                                        : unaligned_candidates[i - mp_aln_candidates.size()];
+                };
+                
+                // TODO: this solution is kinda ugly
+                multipath_alignment_t tmp;
+                function<multipath_alignment_t&&(int64_t)> consume_candidate = [&](int64_t i) -> multipath_alignment_t&& {
+                    if (i < 0) {
+                        // consume the anchor
+                        return move(splice_anchor);
+                    }
+                    else if (i < mp_aln_candidates.size()) {
+                        // TODO: this will need to change if I start allowing multiple splices in one alignment
+                        // because indexes will need to stay stable
+                        
+                        // pull the alignment out
+                        tmp = move(multipath_alns_out[mp_aln_candidates[i]]);
+                        
+                        // replace it in the vectors and clear the final position
+                        multipath_alns_out[mp_aln_candidates[i]] = move(multipath_alns_out.back());
+                        multiplicities[mp_aln_candidates[i]] = multiplicities.back();
+                        cluster_idxs[mp_aln_candidates[i]] = cluster_idxs.back();
+                        multipath_alns_out.pop_back();
+                        multiplicities.pop_back();
+                        cluster_idxs.pop_back();
+                        
+                        // do the bookkeeping to track the original indexes
+                        index[multipath_alns_out.size()] = mp_aln_candidates[i];
+                        index[mp_aln_candidates[i]] = -1;
+                        
+                        // TODO: also do bookkeeping on the clusters to claim the hits
+                        
+                        return move(tmp);
+                    }
+                    else {
+                        return move(unaligned_candidates[i - mp_aln_candidates.size()]);
+                    }
+                };
+                
+                bool did_splice = test_splice_candidates(alignment, do_left, splice_anchor, multiplicities[index[i]],
+                                                         mp_aln_candidates.size() + unaligned_candidates.size(),
+                                                         get_candidate, consume_candidate);
+                
+                any_splices = any_splices || did_splice;
+                found_splice_for_anchor = found_splice_for_anchor || did_splice;
+            }
+            
+            if (!found_splice_for_anchor) {
+                // there's no mor splicing to be found for this anchor alignment
+                ++i;
+            }
+        }
+        
+        if (any_splices) {
+            // we'll need
+            sort_and_compute_mapping_quality(multipath_alns_out, mapping_quality_method,
+                                             &cluster_idxs, &multiplicities);
         }
     }
 
@@ -2881,103 +2940,181 @@ namespace vg {
         if (multipath_aln_pairs_out.empty()) {
             return;
         }
+        
+        // TODO: it would be better to use likelihoods rather than scores (esp. in paired)
+        
+        // choose the score cutoff based on the original unspliced mappings
+        int32_t min_score_to_attempt_1 = (optimal_alignment_score(multipath_aln_pairs_out.front().first)
+                                          - get_aligner()->mapping_quality_score_diff(max_mapping_quality));
+        int32_t min_score_to_attempt_2 = (optimal_alignment_score(multipath_aln_pairs_out.front().second)
+                                          - get_aligner()->mapping_quality_score_diff(max_mapping_quality));
+        
+        vector<int64_t> index(multipath_aln_pairs_out.size(), 0);
+        for (int64_t i = 1; i < multipath_aln_pairs_out.size(); ++i) {
+            index[i] = i;
+        }
+        
+        // we'll keep track of whether any spliced alignments succeeded
+        bool any_splices = false;
+        
+        for (size_t i = 0; i < index.size(); ) {
+            if (index[i] < 0) {
+                // this alignment has been consumed as a splice candidate
+                continue;
+            }
+            
+            auto& splice_anchor_pair = multipath_aln_pairs_out[index[i]];
+            if (optimal_alignment_score(splice_anchor_pair.first) < min_score_to_attempt_1
+                && optimal_alignment_score(splice_anchor_pair.second) < min_score_to_attempt_2) {
+                // the rest of the alignments are too low scoring to consider
+                break;
+            }
+            
+            for (int read_num = 0; read_num < 2; ) {
                 
-        bool did_splice = false;
-        for (bool do_read_1 : {true, false}) {
-            
-            // select the candidate sources for the corresponding read
-            multipath_alignment_t* anchor_mp_aln;
-            const Alignment* aln;
-            const vector<MaximalExactMatch>* mems;
-            vector<clustergraph_t>* cluster_graphs;
-            if (do_read_1) {
-                anchor_mp_aln = &multipath_aln_pairs_out.front().first;
-                aln = &alignment1;
-                mems = &mems1;
-                cluster_graphs = &cluster_graphs1;
-            }
-            else {
-                anchor_mp_aln = &multipath_aln_pairs_out.front().second;
-                aln = &alignment2;
-                mems = &mems2;
-                cluster_graphs = &cluster_graphs2;
-            }
-            
-            // decide if this read looks like it could benefit from a spliced alignment
-            auto primary_interval = aligned_interval(*anchor_mp_aln);
-            bool search_left = primary_interval.first >= min_softclip_length_for_splice;
-            bool search_right = aln->sequence().size() - primary_interval.second >= min_softclip_length_for_splice;
-            
-#ifdef debug_multipath_mapper
-            cerr << "on read " << (do_read_1 ? 1 : 2) << " looking for spliced alignments, to left? " << search_left << ", to right? " << search_right << ", interval: " << primary_interval.first << " " << primary_interval.second << endl;
-#endif
-            
-            for (bool do_left : {true, false}) {
-                if ((do_left && !search_left) || (!do_left && !search_right)) {
-                    continue;
+                bool do_read_1 = (read_num == 0);
+                
+                // select the candidate sources for the corresponding read
+                multipath_alignment_t* anchor_mp_aln;
+                const Alignment* aln;
+                const vector<MaximalExactMatch>* mems;
+                vector<clustergraph_t>* cluster_graphs;
+                if (do_read_1) {
+                    anchor_mp_aln = &splice_anchor_pair.first;
+                    aln = &alignment1;
+                    mems = &mems1;
+                    cluster_graphs = &cluster_graphs1;
+                }
+                else {
+                    anchor_mp_aln = &splice_anchor_pair.second;
+                    aln = &alignment2;
+                    mems = &mems2;
+                    cluster_graphs = &cluster_graphs2;
                 }
                 
-                // identify the splice candidate
-                vector<size_t> mp_aln_candidates;
-                unordered_set<size_t> clusters_used;
-                vector<size_t> cluster_candidates;
-                vector<pair<const MaximalExactMatch*, pos_t>> hit_candidates;
-                identify_aligned_splice_candidates(*aln, do_read_1, do_left, primary_interval,
-                                                   multipath_aln_pairs_out, cluster_pairs, clusters_used,
-                                                   mp_aln_candidates);
-                identify_unaligned_splice_candidates(*aln, do_left, primary_interval, *mems,
-                                                     *cluster_graphs, clusters_used, cluster_candidates,
-                                                     hit_candidates);
-                // align splice candidates that haven't been aligned yet
-                vector<multipath_alignment_t> unaligned_candidates;
-                vector<double> unaligned_multiplicities;
-                align_to_splice_candidates(*aln, *cluster_graphs, *mems, cluster_candidates, hit_candidates,
-                                            primary_interval, do_left, unaligned_candidates, unaligned_multiplicities);
+                // decide if this read looks like it could benefit from a spliced alignment
+                auto interval = aligned_interval(*anchor_mp_aln);
+                auto alnr = get_aligner(!aln->quality().empty());
+                int64_t left_max_score = (alnr->score_exact_match(*aln, 0, interval.first)
+                                          + alnr->score_full_length_bonus(true, *aln));
+                int64_t right_max_score = (alnr->score_exact_match(*aln, interval.second,
+                                                                   aln->sequence().size() - interval.second)
+                                           + alnr->score_full_length_bonus(false, *aln));
+                bool search_left = left_max_score >= min_softclipped_score_for_splice;
+                bool search_right = right_max_score >= min_softclipped_score_for_splice;
                 
+#ifdef debug_multipath_mapper
+                cerr << "on read " << (do_read_1 ? 1 : 2) << " looking for spliced alignments, to left? " << search_left << ", to right? " << search_right << ", interval: " << primary_interval.first << " " << primary_interval.second << endl;
+#endif
                 
-                function<const multipath_alignment_t&(int64_t)> get_candidate = [&](int64_t i) -> const multipath_alignment_t& {
-                    if (i < mp_aln_candidates.size()) {
-                        if (do_read_1) {
-                            return multipath_aln_pairs_out[mp_aln_candidates[i]].first;
+                bool found_splice_for_anchor = false;
+                
+                for (bool do_left : {true, false}) {
+                    if ((do_left && !search_left) || (!do_left && !search_right)) {
+                        continue;
+                    }
+                    
+                    // identify the splice candidate
+                    vector<size_t> mp_aln_candidates;
+                    unordered_set<size_t> clusters_used;
+                    vector<size_t> cluster_candidates;
+                    vector<pair<const MaximalExactMatch*, pos_t>> hit_candidates;
+                    identify_aligned_splice_candidates(*aln, do_read_1, do_left, interval,
+                                                       multipath_aln_pairs_out, cluster_pairs, clusters_used,
+                                                       mp_aln_candidates);
+                    identify_unaligned_splice_candidates(*aln, do_left, interval, *mems,
+                                                         *cluster_graphs, clusters_used, cluster_candidates,
+                                                         hit_candidates);
+                    // align splice candidates that haven't been aligned yet
+                    vector<multipath_alignment_t> unaligned_candidates;
+                    vector<double> unaligned_multiplicities;
+                    align_to_splice_candidates(*aln, *cluster_graphs, *mems, cluster_candidates, hit_candidates,
+                                               interval, do_left, unaligned_candidates, unaligned_multiplicities);
+                    
+                    
+                    function<const multipath_alignment_t&(int64_t)> get_candidate = [&](int64_t i) -> const multipath_alignment_t& {
+                        if (i < mp_aln_candidates.size()) {
+                            if (do_read_1) {
+                                return multipath_aln_pairs_out[mp_aln_candidates[i]].first;
+                            }
+                            else {
+                                return multipath_aln_pairs_out[mp_aln_candidates[i]].second;
+                            }
                         }
                         else {
-                            return multipath_aln_pairs_out[mp_aln_candidates[i]].second;
+                            return unaligned_candidates[i - mp_aln_candidates.size()];
                         }
-                    }
-                    else {
-                        return unaligned_candidates[i - mp_aln_candidates.size()];
-                    }
-                };
+                    };
+                    
+                    // TODO: this solution is kinda ugly
+                    multipath_alignment_t tmp;
+                    function<multipath_alignment_t&&(int64_t)> consume_candidate = [&](int64_t i) -> multipath_alignment_t&& {
+                        if (i < 0) {
+                            // consume the primary
+                            return move(*anchor_mp_aln);
+                        }
+                        else if (i < mp_aln_candidates.size()) {
+                            
+                            // look to see if the opposite side of this pair exists in multiple pairs
+                            size_t opposite_cluster = do_read_1 ? cluster_pairs[mp_aln_candidates[i]].first.second
+                                                                : cluster_pairs[mp_aln_candidates[i]].first.first;
+                            bool opposite_duplicated = false;
+                            if (opposite_cluster != RESCUED) {
+                                // we don't want to count rescued alignments as the same cluster as each other
+                                for (size_t j = 0; j < cluster_pairs.size() && !opposite_duplicated; ++j) {
+                                    opposite_duplicated = (j != mp_aln_candidates[i] &&
+                                                           ((do_read_1 && cluster_pairs[j].first.second == opposite_cluster)
+                                                            || (!do_read_1 && cluster_pairs[j].first.first == opposite_cluster)));
+                                }
+                            }
+                            
+                            if (opposite_duplicated) {
+                                // the other side will continue to live in its other pair, so we can scavenge
+                                // this multipath alignment
+                                tmp = do_read_1 ? move(multipath_aln_pairs_out[mp_aln_candidates[i]].first)
+                                                : move(multipath_aln_pairs_out[mp_aln_candidates[i]].second);
+                                
+                                // replace it in the vectors and clear the final position
+                                multipath_aln_pairs_out[mp_aln_candidates[i]] = move(multipath_aln_pairs_out.back());
+                                pair_multiplicities[mp_aln_candidates[i]] = pair_multiplicities.back();
+                                cluster_pairs[mp_aln_candidates[i]] = cluster_pairs.back();
+                                multipath_aln_pairs_out.pop_back();
+                                pair_multiplicities.pop_back();
+                                cluster_pairs.pop_back();
+                                
+                                // do the bookkeeping to track the original indexes
+                                index[multipath_aln_pairs_out.size()] = mp_aln_candidates[i];
+                                index[mp_aln_candidates[i]] = -1;
+                            }
+                            else {
+                                // we don't want to mess up pairs, so just copy it out
+                                tmp = do_read_1 ? multipath_aln_pairs_out[mp_aln_candidates[i]].first
+                                                : multipath_aln_pairs_out[mp_aln_candidates[i]].second;
+                            }
+                            
+                            return move(tmp);
+                        }
+                        else {
+                            return move(unaligned_candidates[i - mp_aln_candidates.size()]);
+                        }
+                    };
+                    
+                    // see if we can actually make spliced alignments
+                    bool spliced_side = test_splice_candidates(*aln, do_left, *anchor_mp_aln, pair_multiplicities.front(),
+                                                               mp_aln_candidates.size() + unaligned_candidates.size(),
+                                                               get_candidate, consume_candidate);
+                    any_splices = any_splices || spliced_side;
+                    found_splice_for_anchor = found_splice_for_anchor || spliced_side;
+                }
                 
-                // TODO: this solution is kinda ugly
-                multipath_alignment_t tmp;
-                function<multipath_alignment_t&&(int64_t)> consume_candidate = [&](int64_t i) -> multipath_alignment_t&& {
-                    if (i < 0) {
-                        // consume the primary
-                        return move(*anchor_mp_aln);
-                    }
-                    else if (i < mp_aln_candidates.size()) {
-                        
-                        // we don't want to mess up pairs, so just copy it out
-                        tmp = do_read_1 ? multipath_aln_pairs_out[mp_aln_candidates[i]].first
-                                        : multipath_aln_pairs_out[mp_aln_candidates[i]].second;
-                        
-                        return move(tmp);
-                    }
-                    else {
-                        return move(unaligned_candidates[i - mp_aln_candidates.size()]);
-                    }
-                };
-                
-                // see if we can actually make spliced alignments
-                bool spliced_side = test_splice_candidates(*aln, do_left, *anchor_mp_aln, pair_multiplicities.front(),
-                                                           mp_aln_candidates.size() + unaligned_candidates.size(),
-                                                           get_candidate, consume_candidate);
-                did_splice = did_splice || spliced_side;
+                if (!found_splice_for_anchor) {
+                    // there are no more splices to be found for this read end
+                    ++read_num;
+                }
             }
         }
         
-        if (did_splice) {
+        if (any_splices) {
             sort_and_compute_mapping_quality(multipath_aln_pairs_out, cluster_pairs, nullptr, &pair_multiplicities);
         }
     }
@@ -5501,6 +5638,28 @@ namespace vg {
     
     void MultipathMapper::set_automatic_min_clustering_length(double random_mem_probability) {
         min_clustering_mem_length = max<int>(log(1.0 - pow(random_mem_probability, 1.0 / total_seq_length)) / log(0.25), 1);
+    }
+
+    void MultipathMapper::set_min_softclip_length_for_splice(size_t length) {
+        min_softclip_length_for_splice = length;
+        
+        // find the lowest score that could correspond to a high quality match of this length
+        // TODO: kinda ugly, but whatever
+        string dummy_a(length, 'A');
+        string dummy_c(length, 'C');
+        string dummy_g(length, 'G');
+        string dummy_t(length, 'T');
+        string dummy_qual(length, char(40));
+        int32_t score_a = get_regular_aligner()->score_exact_match(dummy_a);
+        int32_t score_c = get_regular_aligner()->score_exact_match(dummy_c);
+        int32_t score_g = get_regular_aligner()->score_exact_match(dummy_g);
+        int32_t score_t = get_regular_aligner()->score_exact_match(dummy_t);
+        int32_t lowest_score = min(score_a, min(score_c, min(score_g, score_t)));
+        
+        // add in the full length bonus, this is the criterion we will actually check against
+        min_softclipped_score_for_splice = lowest_score + get_regular_aligner()->score_full_length_bonus(false, dummy_a.begin(),
+                                                                                                         dummy_a.end(),
+                                                                                                         dummy_qual.begin());
     }
             
     // make the memos live in this .o file

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1,6 +1,6 @@
-`//
+//
 //  multipath_mapper.cpp
-//  
+//
 //
 //
 
@@ -1585,7 +1585,7 @@ namespace vg {
                     } else {
 #ifdef debug_multipath_mapper
                         cerr << "rescue failed" << endl;
-#endif 
+#endif
                     }
                 } else {
 #ifdef debug_multipath_mapper
@@ -1992,7 +1992,7 @@ namespace vg {
     
 #ifdef debug_multipath_mapper
         cerr << "linearizing multipath alignment to assess positional diversity" << endl;
-#endif        
+#endif
         // Compute a few optimal alignments using disjoint sets of subpaths.
         // This hopefully gives us a feel for the positional diversity of the MultipathMapping.
         // But we still may have duplicates or overlaps in vg node space.
@@ -2042,7 +2042,7 @@ namespace vg {
             }
             
 #ifdef debug_multipath_mapper
-            cerr << "found suboptimal mapping overlapping " << overlapped << "/" << alns[i].path().mapping_size() << " with score " 
+            cerr << "found suboptimal mapping overlapping " << overlapped << "/" << alns[i].path().mapping_size() << " with score "
                 << alns[i].score() << endl;
             cerr << "\t" << pb2json(alns[i]) << endl;
 #endif
@@ -2069,7 +2069,7 @@ namespace vg {
             cerr << " with best score " << alns_out[1].score();
         }
         cerr << endl;
-#endif   
+#endif
        
         if (mapping_quality_method != None) {
             // Now compute the MAPQ for the best alignment
@@ -5602,7 +5602,7 @@ namespace vg {
         }
         sort_shuffling_ties(order.begin(), order.end(),
             [&](const size_t i, const size_t j) {
-                return scores[i] > scores[j]; 
+                return scores[i] > scores[j];
             },
             [&](const size_t seed_source) {
                 return multipath_aln_pairs[seed_source].first.sequence() + multipath_aln_pairs[seed_source].second.sequence();

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1,4 +1,4 @@
-//
+`//
 //  multipath_mapper.cpp
 //  
 //
@@ -2540,6 +2540,7 @@ namespace vg {
                                                              const pair<int64_t, int64_t>& primary_interval,
                                                              const vector<multipath_alignment_t>& multipath_alns,
                                                              const vector<size_t>& cluster_idxs,
+                                                             const vector<int64_t>& current_index, int64_t anchor,
                                                              unordered_set<size_t>& clusters_used_out,
                                                              vector<size_t>& mp_aln_candidates_out) const {
         // TODO: should i generalize this to look for alignments of not only the primary?
@@ -2547,7 +2548,12 @@ namespace vg {
         // don't look at the primary again
         clusters_used_out.insert(cluster_idxs.front());
         
-        for (size_t i = 1; i < multipath_alns.size(); ++i) {
+        for (size_t idx = anchor + 1; idx < current_index.size(); ++idx) {
+            
+            int64_t i = current_index[idx];
+            if (i < 0) {
+                continue;
+            }
             
             // check that the alignment is mostly disjoint of the primary and that
             // that the independent aligned portion is significant to call this a potential splice alignment
@@ -2588,6 +2594,7 @@ namespace vg {
                                                              const pair<int64_t, int64_t>& primary_interval,
                                                              const vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs,
                                                              const vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                                             const vector<int64_t>& current_index, int64_t anchor,
                                                              unordered_set<size_t>& clusters_used_out,
                                                              vector<size_t>& mp_aln_candidates_out) const {
         
@@ -2596,7 +2603,12 @@ namespace vg {
         // don't look at the primary again
         clusters_used_out.insert(read_1 ? cluster_pairs.front().first.first : cluster_pairs.front().first.second);
         
-        for (size_t i = 1; i < multipath_aln_pairs.size(); ++i) {
+        for (size_t idx = anchor + 1; idx < current_index.size(); ++idx) {
+            
+            int64_t i = current_index[idx];
+            if (i < 0) {
+                continue;
+            }
             
             const multipath_alignment_t& mp_aln = read_1 ? multipath_aln_pairs[i].first : multipath_aln_pairs[i].second;
             
@@ -2869,9 +2881,8 @@ namespace vg {
                 unordered_set<size_t> clusters_used;
                 vector<size_t> cluster_candidates;
                 vector<pair<const MaximalExactMatch*, pos_t>> hit_candidates;
-                identify_aligned_splice_candidates(alignment, do_left, interval,
-                                                   multipath_alns_out, cluster_idxs, clusters_used,
-                                                   mp_aln_candidates);
+                identify_aligned_splice_candidates(alignment, do_left, interval, multipath_alns_out, cluster_idxs,
+                                                   index, i, clusters_used, mp_aln_candidates);
                 identify_unaligned_splice_candidates(alignment, do_left, interval, mems,
                                                      cluster_graphs, clusters_used, cluster_candidates,
                                                      hit_candidates);
@@ -3063,9 +3074,8 @@ namespace vg {
                     unordered_set<size_t> clusters_used;
                     vector<size_t> cluster_candidates;
                     vector<pair<const MaximalExactMatch*, pos_t>> hit_candidates;
-                    identify_aligned_splice_candidates(*aln, do_read_1, do_left, interval,
-                                                       multipath_aln_pairs_out, cluster_pairs, clusters_used,
-                                                       mp_aln_candidates);
+                    identify_aligned_splice_candidates(*aln, do_read_1, do_left, interval, multipath_aln_pairs_out, cluster_pairs,
+                                                       index, i, clusters_used, mp_aln_candidates);
                     identify_unaligned_splice_candidates(*aln, do_left, interval, *mems,
                                                          *cluster_graphs, clusters_used, cluster_candidates,
                                                          hit_candidates);
@@ -5819,3 +5829,4 @@ namespace vg {
 
 
 
+`

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -5829,4 +5829,4 @@ namespace vg {
 
 
 
-`
+

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -422,6 +422,7 @@ namespace vg {
                                                 const pair<int64_t, int64_t>& primary_interval,
                                                 const vector<multipath_alignment_t>& multipath_alns,
                                                 const vector<size_t>& cluster_idxs,
+                                                const vector<int64_t>& current_index, int64_t anchor,
                                                 unordered_set<size_t>& clusters_used_out,
                                                 vector<size_t>& mp_aln_candidates_out) const;
 
@@ -429,6 +430,7 @@ namespace vg {
                                                 const pair<int64_t, int64_t>& primary_interval,
                                                 const vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs,
                                                 const vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
+                                                const vector<int64_t>& current_index, int64_t anchor,
                                                 unordered_set<size_t>& clusters_used_out,
                                                 vector<size_t>& mp_aln_candidates_out) const;
 

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -117,6 +117,9 @@ namespace vg {
         /// score matrix should by a 4 x 4 array in the order (ACGT)
         void set_alignment_scores(const int8_t* score_matrix, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);
         
+        /// How big of a softclip should lead us to attempt spliced alignment?
+        void set_min_softclip_length_for_splice(size_t length);
+        
         // parameters
         
         size_t max_branch_trim_length = 1;
@@ -200,7 +203,6 @@ namespace vg {
         size_t max_alignment_gap = 5000;
         bool suppress_mismapping_detection = false;
         bool do_spliced_alignment = false;
-        int64_t min_softclip_length_for_splice = 16;
         int64_t max_softclip_overlap = 8;
         int64_t max_splice_overhang = 3;
         // about 250k
@@ -585,6 +587,10 @@ namespace vg {
         /// return a vector of their breaks.
         vector<MaximalExactMatch> find_mems(const Alignment& alignment,
                                             vector<deque<pair<string::const_iterator, char>>>* mem_fanout_breaks = nullptr);
+        
+        
+        int64_t min_softclip_length_for_splice = 20;
+        int64_t min_softclipped_score_for_splice = 25;
         
         DinucleotideMachine dinuc_machine;
         SpliceMotifs splice_motifs;

--- a/src/splicing.cpp
+++ b/src/splicing.cpp
@@ -1374,7 +1374,7 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
         for (size_t j = 0; j < subpath->connection_size(); ++j) {
             auto connection = subpath->mutable_connection(j);
             if (to_keep_right[connection->next()]) {
-                connection->set_next(connection->next() - right_removed_so_far[connection->next()]);
+                connection->set_next(connection->next() - right_removed_so_far[connection->next()] + right_subpaths_begin);
                 if (connections_removed_so_far) {
                     *subpath->mutable_connection(j - connections_removed_so_far) = *connection;
                 }

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -60,8 +60,8 @@ void help_mpmap(char** argv) {
     << "  -l, --read-length TYPE      read length preset: 'very-short', 'short', or 'long' (approx. <50bp, 50-500bp, and >500bp) [short]" << endl
     << "  -e, --error-rate TYPE       error rate preset: 'low' or 'high' (approx. PHRED >20 and <20) [low]" << endl
     << "output:" << endl
-    << "  -F, --output-fmt TYPE       format to output alignments in: 'GAMP for' multipath alignments, 'GAM' or 'GAF' for single-path," << endl
-    << "                              alignments, 'SAM', 'BAM', or 'CRAM 'for linear reference alignments (may also require -S) [GAMP]" << endl
+    << "  -F, --output-fmt TYPE       format to output alignments in: 'GAMP for' multipath alignments, 'GAM' or 'GAF' for single-path" << endl
+    << "                              alignments, 'SAM', 'BAM', or 'CRAM' for linear reference alignments (may also require -S) [GAMP]" << endl
     << "  -S, --ref-paths FILE        paths in the graph, one per line or HTSlib .dict, to treat as reference for HTSlib formats (see -F) [all paths]" << endl
     << "  -N, --sample NAME           add this sample name to output" << endl
     << "  -R, --read-group NAME       add this read group to output" << endl

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1761,7 +1761,10 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.simplify_topologies = simplify_topologies;
     multipath_mapper.max_suboptimal_path_score_ratio = suboptimal_path_exponent;
     multipath_mapper.agglomerate_multipath_alns = agglomerate_multipath_alns;
-    multipath_mapper.min_softclip_length_for_splice = int(ceil(log(path_position_handle_graph->get_total_length()) / log(4.0))) + 2;
+    
+    // splicing parameters
+    int64_t min_softclip_length_for_splice = int(ceil(log(path_position_handle_graph->get_total_length() * 2) / log(4.0))) + 2;
+    multipath_mapper.set_min_softclip_length_for_splice(min_softclip_length_for_splice);
     multipath_mapper.max_softclip_overlap = max_softclip_overlap;
     multipath_mapper.max_splice_overhang = max_splice_overhang;
 


### PR DESCRIPTION
## Description

Previously the spiced alignment algorithm wouldn't perform multiple spliced alignments on the same read, and it wouldn't look for spliced aligments on secondary mappings. This PR adds those capabilities and changes the criterion for looking for spliced alignments to be based on alignment scores instead of softclip lengths.