### PR TITLE
Fix TLEN in HTS output formats

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -972,7 +972,7 @@ pair<int32_t, int32_t> compute_template_lengths(const int64_t& pos1, const vecto
                 // Bases are matched. Count them in the bounds and execute the operation
                 low = min(low, here);
                 here += item.first;
-                high = max(high, here - 1);
+                high = max(high, here);
             } else if (item.second == 'D') {
                 // Only other way to advance in the reference
                 here += item.first;

--- a/src/unittest/alignment.cpp
+++ b/src/unittest/alignment.cpp
@@ -240,5 +240,13 @@ TEST_CASE("Target to alignment extraction", "[target-to-aln]") {
     
 }
 
+TEST_CASE("Inter-alignment distance computation for HTS output formats matches BWA", "[alignment]") {
+    // See https://github.com/vgteam/vg/issues/3078. We want to match BWA on
+    // these straightforward, fully-matching reads.
+    auto lengths = compute_template_lengths(10206220, {{151, 'M'}}, 10206662, {{151, 'M'}});
+    REQUIRE(lengths.first == 593);
+    REQUIRE(lengths.second == -593);
+}
+
 }
 }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * SAM/BAM/CRAM TLENs should now match BWA's for identical alignments

## Description
This should fix #3078 by not subtracting 1 off the right side coordinates when computing TLENs.