### PR TITLE
Stop producing negative MAPQs

### DIFF
--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -462,18 +462,11 @@ namespace vg {
                                     const function<const multipath_alignment_t&(int64_t)>& get_candidate,
                                     const function<multipath_alignment_t&&(int64_t)>& consume_candidate);
         
-//        void test_splice_candidates(const Alignment& alignment, bool searching_left,
-//                                    vector<multipath_alignment_t>& multipath_alns,
-//                                    vector<double>& multiplicities,
-//                                    const vector<size_t>& mp_aln_candidates,
-//                                    vector<multipath_alignment_t>& unaligned_candidates,
-//                                    const vector<double>& unaligned_multiplicities);
-        
         /// Make a multipath alignment of the read against the indicated graph and add it to
         /// the list of multimappings.
         /// Does NOT necessarily produce a multipath_alignment_t in topological order.
-        void multipath_align(const Alignment& alignment, const bdsg::HashGraph* graph,
-                             memcluster_t& graph_mems,
+        void multipath_align(const Alignment& alignment,
+                             clustergraph_t& cluster_graph,
                              multipath_alignment_t& multipath_aln_out,
                              const match_fanouts_t* fanouts) const;
         
@@ -538,7 +531,7 @@ namespace vg {
         double fragment_length_log_likelihood(int64_t length) const;
         
         /// Computes the number of read bases a cluster of MEM hits covers.
-        static int64_t read_coverage(const memcluster_t& mem_hits);
+        static void set_read_coverage(clustergraph_t& cluster_graph);
         
         /// Would an alignment this good be expected against a graph this big by chance alone
         bool likely_mismapping(const multipath_alignment_t& multipath_aln);

--- a/src/unittest/multipath_mapper.cpp
+++ b/src/unittest/multipath_mapper.cpp
@@ -26,7 +26,7 @@ public:
     using MultipathMapper::multipath_align;
     using MultipathMapper::strip_full_length_bonuses;
     using MultipathMapper::sort_and_compute_mapping_quality;
-    using MultipathMapper::read_coverage;
+    using MultipathMapper::set_read_coverage;
 };
 
 TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipathmapper]" ) {
@@ -38,15 +38,16 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
     vector<MaximalExactMatch> mems;
     
     // This will hold our MEMs and their start positions in the imaginary graph.
-    pair<vector<pair<const MaximalExactMatch*, pos_t>>, double> mem_hits;
+    MultipathMapper::clustergraph_t cluster_graph;
+    pair<vector<pair<const MaximalExactMatch*, pos_t>>, double>& mem_hits = get<1>(cluster_graph);
     mem_hits.second = 1.0;
     
     // We need a fake read
     string read("GATTACA");
     
     SECTION("No hits cover no bases") {
-        auto covered = TestMultipathMapper::read_coverage(mem_hits);
-        REQUIRE(covered == 0);
+        TestMultipathMapper::set_read_coverage(cluster_graph);
+        REQUIRE(get<2>(cluster_graph) == 0);
     }
     
     SECTION("A hit of zero length covers 0 bases") {
@@ -55,8 +56,8 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
         // Drop it on some arbitrary node
         mem_hits.first.emplace_back(&mems.back(), make_pos_t(999, false, 3));
         
-        auto covered = TestMultipathMapper::read_coverage(mem_hits);
-        REQUIRE(covered == 0);
+        TestMultipathMapper::set_read_coverage(cluster_graph);
+        REQUIRE(get<2>(cluster_graph) == 0);
     }
     
     SECTION("A hit that one-past-the-ends just after its start position covers 1 base") {
@@ -65,8 +66,8 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
         // Drop it on some arbitrary node
         mem_hits.first.emplace_back(&mems.back(), make_pos_t(999, false, 3));
         
-        auto covered = TestMultipathMapper::read_coverage(mem_hits);
-        REQUIRE(covered == 1);
+        TestMultipathMapper::set_read_coverage(cluster_graph);
+        REQUIRE(get<2>(cluster_graph) == 1);
     }
     
     SECTION("A hit that ends at the end of the string covers the string") {
@@ -75,8 +76,8 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
         // Drop it on some arbitrary node
         mem_hits.first.emplace_back(&mems.back(), make_pos_t(999, false, 3));
         
-        auto covered = TestMultipathMapper::read_coverage(mem_hits);
-        REQUIRE(covered == read.size());
+        TestMultipathMapper::set_read_coverage(cluster_graph);
+        REQUIRE(get<2>(cluster_graph) == read.size());
     }
     
     SECTION("Two overlapping hits still only cover the string once") {
@@ -90,8 +91,8 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
         mem_hits.first.emplace_back(&mems[0], make_pos_t(999, false, 3));
         mem_hits.first.emplace_back(&mems[1], make_pos_t(888, false, 3));
         
-        auto covered = TestMultipathMapper::read_coverage(mem_hits);
-        REQUIRE(covered == read.size());
+        TestMultipathMapper::set_read_coverage(cluster_graph);
+        REQUIRE(get<2>(cluster_graph) == read.size());
     }
     
     SECTION("Two abutting hits cover the string") {
@@ -104,8 +105,8 @@ TEST_CASE( "MultipathMapper::read_coverage works", "[multipath][mapping][multipa
         mem_hits.first.emplace_back(&mems[0], make_pos_t(999, false, 3));
         mem_hits.first.emplace_back(&mems[1], make_pos_t(888, false, 3));
         
-        auto covered = TestMultipathMapper::read_coverage(mem_hits);
-        REQUIRE(covered == read.size());
+        TestMultipathMapper::set_read_coverage(cluster_graph);
+        REQUIRE(get<2>(cluster_graph) == read.size());
     }
 
 }


### PR DESCRIPTION
## Description

Some of the logic I introduced in https://github.com/vgteam/vg/pull/3060 for cluster to "un-claim" MEMs could occasionally result in empty clusters, which were not handled appropriately by the multiplicity logic. This could then, in turn, lead to negative MAPQs.