### PR TITLE
Add joint D and I coalescing for CIGAR generation

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -815,15 +815,6 @@ string mapping_string(const string& source, const Mapping& mapping) {
     return result;
 }
 
-inline void append_cigar_operation(const int length, const char operation, vector<pair<int, char>>& cigar) {
-    if (cigar.empty() || operation != cigar.back().second) {
-        cigar.emplace_back(length, operation);
-    }
-    else {
-        cigar.back().first += length;
-    }
-}
-
 void mapping_cigar(const Mapping& mapping, vector<pair<int, char>>& cigar) {
     for (const auto& edit : mapping.edit()) {
         if (edit.from_length() && edit.from_length() == edit.to_length()) {
@@ -925,6 +916,12 @@ vector<pair<int, char>> cigar_against_path(const Alignment& alignment, bool on_r
 
     // handle soft clips, which are just insertions at the start or end
     // back
+    if (cigar.size() > 1 && cigar.back().second == 'D' && cigar[cigar.size() - 2].second == 'I') {
+        // Swap insert to the outside so it can be a softclip.
+        // When making the CIGAR we should put D before I but when flipping the
+        // strand they may switch.
+        std::swap(cigar.back(), cigar[cigar.size() - 2]);
+    }
     if (cigar.back().second == 'I') {
         // make sure we stay in the reference sequence when suppressing the softclips
         if (cigar.back().first <= softclip_suppress
@@ -935,6 +932,10 @@ vector<pair<int, char>> cigar_against_path(const Alignment& alignment, bool on_r
         }
     }
     // front
+    if (cigar.size() > 1 && cigar.front().second == 'D' && cigar[1].second == 'I') {
+        // Swap insert to the outside so it can be a softclip
+        std::swap(cigar.front(), cigar[1]);
+    }
     if (cigar.front().second == 'I') {
         // make sure we stay in the reference sequence when suppressing the softclips
         if (cigar.front().first <= softclip_suppress

--- a/src/unittest/alignment.cpp
+++ b/src/unittest/alignment.cpp
@@ -248,5 +248,47 @@ TEST_CASE("Inter-alignment distance computation for HTS output formats matches B
     REQUIRE(lengths.second == -593);
 }
 
+TEST_CASE("CIGAR generation forces adjacent insertions and deletions to obey GATK's constraints", "[alignment]") {
+    // See https://github.com/vgteam/vg/issues/3080
+    vector<pair<int, char>> cigar;
+    
+    SECTION("DID becomes DI") {
+        append_cigar_operation(1, 'D', cigar);
+        append_cigar_operation(5, 'I', cigar);
+        append_cigar_operation(2, 'D', cigar);
+        
+        REQUIRE(cigar.size() == 2);
+        REQUIRE(cigar[0].first == 3);
+        REQUIRE(cigar[0].second == 'D');
+        REQUIRE(cigar[1].first == 5);
+        REQUIRE(cigar[1].second == 'I');
+    }
+    
+    SECTION("MMIDIIDDIMM becomes MDIM") {
+        append_cigar_operation(1, 'M', cigar);
+        append_cigar_operation(1, 'M', cigar);
+        append_cigar_operation(1, 'I', cigar);
+        append_cigar_operation(1, 'D', cigar);
+        append_cigar_operation(1, 'I', cigar);
+        append_cigar_operation(1, 'I', cigar);
+        append_cigar_operation(1, 'D', cigar);
+        append_cigar_operation(1, 'D', cigar);
+        append_cigar_operation(1, 'I', cigar);
+        append_cigar_operation(1, 'M', cigar);
+        append_cigar_operation(1, 'M', cigar);
+        
+        REQUIRE(cigar.size() == 4);
+        REQUIRE(cigar[0].first == 2);
+        REQUIRE(cigar[0].second == 'M');
+        REQUIRE(cigar[1].first == 3);
+        REQUIRE(cigar[1].second == 'D');
+        REQUIRE(cigar[2].first == 4);
+        REQUIRE(cigar[2].second == 'I');
+        REQUIRE(cigar[3].first == 2);
+        REQUIRE(cigar[3].second == 'M');
+    }
+    
+}
+
 }
 }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * CIGAR strings in SAM/BAM/CRAM should now consistently coalesce runs of adjacent insertions and deletions.

## Description

This should fix #3080 by making sure that we keep no more than one insert and one delete at the end of a growing CIGAR, and that we make the appropriate one longer when a new insert or delete operation comes in.

This might get us CIGARS that don't match the scores, when they otherwise would (because of the number of gap opens changing), but it should make the alignments satisfy GATK.

@jeizenga What do you think about the scoring issue?
