### PR TITLE
Don't add deletions twice in spliced surject conversion to CIGAR

### DIFF
--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -759,9 +759,6 @@ vector<pair<int, char>> SplicedHTSAlignmentEmitter::spliced_cigar_against_path(c
                     size_t deletion_length = (nearest_offset - curr_offset -
                                               graph.get_length(graph.get_handle_of_step(step)));
                     
-                    
-                    append_cigar_operation(deletion_length, 'N', cigar);
-                    
                     // add to the cigar
                     if (deletion_length >= min_splice_length) {
                         // long enough to be a splice


### PR DESCRIPTION
## Changelog Entry

 * CIGAR strings for spliced surjection from GAM files now have correct intron lengths

## Description

Deletions were being added twice.