### PR TITLE
Don't needlessly convert to proto after gfa export in vg view

### DIFF
--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -896,6 +896,7 @@ int main_view(int argc, char** argv) {
 
     if (output_type == "gfa") {
         graph_to_gfa(graph, std::cout);
+        return 0;
     } 
 
     // Now we know graph was filled in from the input format. Spit it out in the


### PR DESCRIPTION
## Changelog Entry
* gfa export with `vg view` takes less memory

## Description

There's still much work to do to improve GFA support, but this should help with exporting in the meantime.  

Resolves #3119