### PR TITLE
Merge partially redundant MEMs in multipath alignment algorithm

### DIFF
--- a/src/mem.cpp
+++ b/src/mem.cpp
@@ -12,10 +12,7 @@ using namespace std;
 
 // construct the sequence of the MEM; useful in debugging
 string MaximalExactMatch::sequence(void) const {
-    string seq; //seq.resize(end-begin);
-    string::const_iterator c = begin;
-    while (c != end) seq += *c++;
-    return seq;
+    return string(begin, end);
 }
     
 // length of the MEM

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1066,6 +1066,7 @@ namespace vg {
         
         unordered_set<int64_t> already_merged;
         for (const auto& overlapping_pair : pairs_to_attempt) {
+            
             if (already_merged.count(overlapping_pair.first) || already_merged.count(overlapping_pair.second)) {
                 // too complicated to try to merge the same node multiple times
                 continue;
@@ -1081,7 +1082,10 @@ namespace vg {
             vector<tuple<size_t, size_t, size_t>> identical_segments;
             int64_t to_length_1 = 0, to_length_2 = 0;
             bool in_identical_segment = false;
-            for (size_t i = 0, j = 0; i < path_node_1.path.mapping_size() && path_node_2.path.mapping_size(); ) {
+            for (size_t i = 0, j = 0; i < path_node_1.path.mapping_size() && j < path_node_2.path.mapping_size(); ) {
+#ifdef debug_multipath_alignment
+                cerr << "compare mappings " << i << " and " << j << ", idx diff " << ((path_node_2.begin - path_node_1.begin) + to_length_2 - to_length_1) << ", pos " << debug_string(path_node_1.path.mapping(i).position()) << " and " << debug_string(path_node_2.path.mapping(j).position()) << endl;
+#endif
                 if (path_node_1.begin + to_length_1 > path_node_2.begin + to_length_2) {
                     in_identical_segment = false;
                     to_length_2 += mapping_to_length(path_node_2.path.mapping(j));

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1150,8 +1150,10 @@ namespace vg {
                         to_length += mapping_to_length(node_into.path.mapping().back());
                     }
                     node_into.end = original_path_node.begin + to_length;
+                    
 #ifdef debug_multipath_alignment
                     cerr << "created node in index " << idx << endl;
+                    cerr << "relative sequence interval [" << (node_into.begin - original_path_node.begin) << ", " << (node_into.end - original_path_node.begin) << endl;
                     cerr << string(node_into.begin, node_into.end) << endl;
                     cerr << debug_string(node_into.path) << endl;
 #endif
@@ -1169,7 +1171,7 @@ namespace vg {
                 int64_t to_length_1 = 0, to_length_2 = 0;
                 for (size_t i = 0; i <= identical_segments.size(); ++i) {
 #ifdef debug_multipath_alignment
-                    cerr << "segment iter " << i << " of " << identical_segments.size() << endl;
+                    cerr << "segment iter " << i << " of " << identical_segments.size() << ", to len 1 " << to_length_1 << ", to len 2 " << to_length_2 << ", replaced 1? " << replaced_1 << ", replaced 2? " << replaced_2 << endl;
 #endif
                     
                     // identify the segments (if any) between the identical segments
@@ -1211,12 +1213,16 @@ namespace vg {
                         break;
                     }
                     
+#ifdef debug_multipath_alignment
+                    cerr << "matching ranges [" << here_1 << ", " << here_1 + get<2>(identical_segments[i]) << "), [" << here_2 << ", " << here_2 + get<2>(identical_segments[i]) << ")" << endl;
+#endif
+                    
                     // add the shared segment as a path node
                     int64_t to_length_before_advancing_1 = to_length_1;
                     add_segment_path_node(original_path_node_1, here_1, here_1 + get<2>(identical_segments[i]),
                                           overlapping_pair.first, prov_1, replaced_1, to_length_1);
                     // ugly, but it works
-                    to_length_2 += (to_length_before_advancing_1 - to_length_1);
+                    to_length_2 += (to_length_1 - to_length_before_advancing_1);
                 }
                 
                 // mark these path nodes so we don't try to merge the same nodes (which have been chopped

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -635,7 +635,7 @@ namespace vg {
             // check all MEMs that traversed this node to see if this is a redundant sub-MEM
             if (node_matches.count(injected_id)) {
 #ifdef debug_multipath_alignment
-                cerr << "we need to check if this is a redundant sub MEM, there are previous that visited this hit" << endl;
+                cerr << "we need to check if this is a redundant sub MEM, there are previous paths that visited this hit" << endl;
 #endif
                 
                 for (int64_t j : node_matches[injected_id]) {
@@ -644,15 +644,15 @@ namespace vg {
                     if (begin < match_node.begin || end > match_node.end) {
 #ifdef debug_multipath_alignment
                         if (begin < match_node.begin) {
-                            cerr << "this MEM is earlier in the read than the other, so this is not redundant" << endl;
+                            cerr << "this MEM is earlier in the read than path node " << j << " by " << (match_node.begin - begin) << ", so this is not redundant" << endl;
                         }
                         else if (end > match_node.end) {
-                            cerr << "this MEM is later in the read than the other, so this is not redundant" << endl;
+                            cerr << "this MEM is later in the read than path node " << j << " by " << (end - match_node.end) << ", so this is not redundant" << endl;
                         }
 #endif
                         // the hit does not fall on the same section of the read as the other match, so
                         // it cannot be contained in it
-                        return false;
+                        continue;
                     }
                     
                     int64_t relative_offset = begin - match_node.begin;
@@ -1153,7 +1153,7 @@ namespace vg {
                     
 #ifdef debug_multipath_alignment
                     cerr << "created node in index " << idx << endl;
-                    cerr << "relative sequence interval [" << (node_into.begin - original_path_node.begin) << ", " << (node_into.end - original_path_node.begin) << endl;
+                    cerr << "relative sequence interval [" << (node_into.begin - original_path_node.begin) << ", " << (node_into.end - original_path_node.begin) << ")" << endl;
                     cerr << string(node_into.begin, node_into.end) << endl;
                     cerr << debug_string(node_into.path) << endl;
 #endif

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -990,9 +990,8 @@ namespace vg {
             }
         }
         
-        if (num_failed_walks != 0) {
-            hits.first.resize(hits.first.size() - num_failed_walks);
-        }
+        // clear out the space that we allocated for walks that failed (if any)
+        hits.first.resize(hits.first.size() - num_failed_walks);
         
         if (!filter_sub_mems_on_fly) {
             // we weren't removing redundant sub-MEMs as we made them, but now we can do it
@@ -1039,6 +1038,171 @@ namespace vg {
             if (removed_so_far) {
                 path_nodes.resize(path_nodes.size() - removed_so_far);
                 path_node_provenance.resize(path_nodes.size());
+            }
+        }
+        
+        merge_partially_redundant_match_nodes(node_matches, path_node_provenance);
+    }
+
+    void MultipathAlignmentGraph::merge_partially_redundant_match_nodes(const unordered_map<int64_t, vector<int64_t>>& node_matches,
+                                                                        vector<size_t>& path_node_provenance) {
+        
+#ifdef debug_multipath_alignment
+        cerr << "looking for MEMs with partial redundancies to merge" << endl;
+#endif
+        
+        // find the pairs that share at least one node
+        set<pair<int64_t, int64_t>> pairs_to_attempt;
+        for (const auto& match_record : node_matches) {
+            if (match_record.second.size() > 1) {
+                for (int64_t i = 1; i < match_record.second.size(); ++i) {
+                    for (int64_t j = 0; j < i; ++j) {
+                        pairs_to_attempt.emplace(j, i);
+                    }
+                }
+            }
+        }
+        
+        unordered_set<int64_t> already_merged;
+        for (const auto& overlapping_pair : pairs_to_attempt) {
+            if (already_merged.count(overlapping_pair.first) || already_merged.count(overlapping_pair.second)) {
+                // too complicated to try to merge the same node multiple times
+                continue;
+            }
+            
+            auto& path_node_1 = path_nodes[overlapping_pair.first];
+            auto& path_node_2 = path_nodes[overlapping_pair.second];
+            
+            // records of (start on 1, start on 2, length)
+            vector<tuple<size_t, size_t, size_t>> identical_segments;
+            int64_t to_length_1 = 0, to_length_2 = 0;
+            bool in_identical_segment = false;
+            for (size_t i = 0, j = 0; i < path_node_1.path.mapping_size() && path_node_2.path.mapping_size(); ) {
+                if (path_node_1.begin + to_length_1 > path_node_2.begin + to_length_2) {
+                    in_identical_segment = false;
+                    to_length_2 += mapping_to_length(path_node_2.path.mapping(j));
+                    ++j;
+                }
+                else if (path_node_1.begin + to_length_1 < path_node_2.begin + to_length_2) {
+                    in_identical_segment = false;
+                    to_length_1 += mapping_to_length(path_node_1.path.mapping(i));
+                    ++i;
+                }
+                else {
+                    if (path_node_1.path.mapping(i) == path_node_2.path.mapping(j)) {
+                        if (in_identical_segment) {
+                            ++get<2>(identical_segments.back());
+                        }
+                        else {
+                            identical_segments.emplace_back(i, j, 1);
+                            in_identical_segment = true;
+                        }
+                    }
+                    else {
+                        in_identical_segment = false;
+                    }
+                    to_length_1 += mapping_to_length(path_node_1.path.mapping(i));
+                    to_length_2 += mapping_to_length(path_node_2.path.mapping(j));
+                    ++i;
+                    ++j;
+                }
+            }
+            
+            if (!identical_segments.empty()) {
+#ifdef debug_multipath_alignment
+                cerr << "found identical segments between nodes " << overlapping_pair.first << " and " << overlapping_pair.second << endl;
+                cerr << string(path_nodes[overlapping_pair.first].begin, path_nodes[overlapping_pair.first].end) << endl;
+                cerr << debug_string(path_nodes[overlapping_pair.first].path) << endl;
+                cerr << string(path_nodes[overlapping_pair.second].begin, path_nodes[overlapping_pair.second].end) << endl;
+                cerr << debug_string(path_nodes[overlapping_pair.second].path) << endl;
+                for (const auto& segment : identical_segments) {
+                    cerr << "\t(i: " << get<0>(segment) << ", j: " << get<1>(segment) << ", len: " << get<2>(segment) << endl;
+                }
+#endif
+                
+                // add a path node for a segment, updating the tracking variables as necessary
+                auto add_segment_path_node = [&](PathNode& original_path_node, size_t seg_begin, size_t seg_end,
+                                                 size_t orig_idx, size_t prov, bool& replaced_orig, int64_t& to_length) {
+                    size_t idx;
+                    if (!replaced_orig) {
+                        idx = orig_idx;
+                        replaced_orig = true;
+                    }
+                    else {
+                        idx = path_nodes.size();
+                        path_nodes.emplace_back();
+                        path_node_provenance.emplace_back(prov);
+                    }
+                    auto& node_into = path_nodes[idx];
+                    node_into.begin = original_path_node.begin + to_length;
+                    for (size_t i = seg_begin; i < seg_end; ++i) {
+                        *node_into.path.add_mapping() = move(*original_path_node.path.mutable_mapping(i));
+                        to_length += mapping_to_length(node_into.path.mapping().back());
+                    }
+                    node_into.end = original_path_node.begin + to_length;
+#ifdef debug_multipath_alignment
+                    cerr << "created node in index " << idx << endl;
+                    cerr << string(node_into.begin, node_into.end) << endl;
+                    cerr << debug_string(node_into.path) << endl;
+#endif
+                };
+                
+                PathNode original_path_node_1 = move(path_node_1);
+                PathNode original_path_node_2 = move(path_node_2);
+                path_node_1.path.clear_mapping();
+                path_node_2.path.clear_mapping();
+                
+                size_t prov_1 = path_node_provenance[overlapping_pair.first];
+                size_t prov_2 = path_node_provenance[overlapping_pair.second];
+                
+                bool replaced_1 = false, replaced_2 = false;
+                int64_t to_length_1 = 0, to_length_2 = 0;
+                for (size_t i = 0; i <= identical_segments.size(); ++i) {
+                    // identify the segments (if any) between the identical segments
+                    size_t prev_1, prev_2;
+                    if (i == 0) {
+                        prev_1 = prev_2 = 0;
+                    }
+                    else {
+                        prev_1 = get<0>(identical_segments[i - 1]);
+                        prev_2 = get<1>(identical_segments[i - 1]);
+                    }
+                    size_t here_1, here_2;
+                    if (i < identical_segments.size()) {
+                        here_1 = get<0>(identical_segments[i]);
+                        here_2 = get<1>(identical_segments[i]);
+                    }
+                    else {
+                        here_1 = original_path_node_1.path.mapping_size();
+                        here_2 = original_path_node_2.path.mapping_size();
+                    }
+                    
+                    // add unshared portions as path nodes
+                    if (prev_1 != here_1) {
+                        add_segment_path_node(original_path_node_1, prev_1, here_1, overlapping_pair.first,
+                                              prov_1, replaced_1, to_length_1);
+                    }
+                    if (prev_2 != here_2) {
+                        add_segment_path_node(original_path_node_2, prev_2, here_2, overlapping_pair.second,
+                                              prov_2, replaced_2, to_length_2);
+                    }
+                    
+                    if (i == identical_segments.size()) {
+                        // this was the final segment past the end of the shared segments
+                        break;
+                    }
+                    
+                    // add the shared segment as a path node
+                    add_segment_path_node(original_path_node_1, here_1, here_1 + get<2>(identical_segments[i]),
+                                          overlapping_pair.first, prov_1, replaced_1, to_length_1);
+                    // because the segments are shared, the read position should end at the same place
+                    to_length_2 = to_length_1;
+                }
+                
+                // mark these path nodes so we don't try to merge the same nodes (which have been chopped
+                // up) again later
+                already_merged.insert(overlapping_pair.first);
+                already_merged.insert(overlapping_pair.second);
             }
         }
     }
@@ -3789,7 +3953,7 @@ namespace vg {
                 
                 for (auto& connecting_alignment : deduplicated) {
 #ifdef debug_multipath_alignment
-                    cerr << "translating connecting alignment: " << pb2json(connecting_alignment) << endl;
+                    cerr << "translating connecting alignment: " << debug_string(connecting_alignment.first), ", score " << connecting_alignment.second << endl;
 #endif
                     
                     auto& aligned_path = connecting_alignment.first;

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1063,7 +1063,6 @@ namespace vg {
             }
         }
         
-        
         unordered_set<int64_t> already_merged;
         for (const auto& overlapping_pair : pairs_to_attempt) {
             
@@ -1074,6 +1073,9 @@ namespace vg {
 #ifdef debug_multipath_alignment
             cerr << "checking overlapping pair " << overlapping_pair.first << ", " << overlapping_pair.second << endl;
 #endif
+            
+            // TODO: right now only focusing on overlapping mappings, we could also merge along edits
+            // and partial edits
             
             auto& path_node_1 = path_nodes[overlapping_pair.first];
             auto& path_node_2 = path_nodes[overlapping_pair.second];
@@ -1210,10 +1212,11 @@ namespace vg {
                     }
                     
                     // add the shared segment as a path node
+                    int64_t to_length_before_advancing_1 = to_length_1;
                     add_segment_path_node(original_path_node_1, here_1, here_1 + get<2>(identical_segments[i]),
                                           overlapping_pair.first, prov_1, replaced_1, to_length_1);
-                    // because the segments are shared, the read position should end at the same place
-                    to_length_2 = to_length_1;
+                    // ugly, but it works
+                    to_length_2 += (to_length_before_advancing_1 - to_length_1);
                 }
                 
                 // mark these path nodes so we don't try to merge the same nodes (which have been chopped

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -259,7 +259,9 @@ namespace vg {
                                 vector<size_t>& path_node_provenance,
                                 const MultipathMapper::match_fanouts_t* fanout_breaks);
         
-        
+        /// If path nodes partially overlap, merge the sections that overlap into a single path node
+        void merge_partially_redundant_match_nodes(const unordered_map<int64_t, vector<int64_t>>& node_matches,
+                                                   vector<size_t>& path_node_provenance);
         
         /// Identifies runs of exact matches that are sub-maximal because they hit the order of the GCSA
         /// index and merges them into a single node, assumes that match nodes are sorted by length and

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -385,6 +385,8 @@ public:
     inline const string& sequence() const;
     inline void set_sequence(const string& s);
     inline string* mutable_sequence();
+    inline bool operator==(const edit_t& other) const;
+    inline bool operator!=(const edit_t& other) const;
 private:
     int32_t _from_length;
     int32_t _to_length;
@@ -408,6 +410,8 @@ public:
     inline edit_t* mutable_edit(size_t i);
     inline edit_t* add_edit();
     inline size_t edit_size() const;
+    inline bool operator==(const path_mapping_t& other) const;
+    inline bool operator!=(const path_mapping_t& other) const;
 private:
     position_t _position;
     vector<edit_t> _edit;
@@ -428,6 +432,8 @@ public:
     inline path_mapping_t* add_mapping();
     inline void clear_mapping();
     inline size_t mapping_size() const;
+    inline bool operator==(const path_t& other) const;
+    inline bool operator!=(const path_t& other) const;
 private:
     vector<path_mapping_t> _mapping;
 };
@@ -499,6 +505,14 @@ inline void edit_t::set_sequence(const string& s) {
 inline string* edit_t::mutable_sequence() {
     return &_sequence;
 }
+inline bool edit_t::operator==(const edit_t& other) const {
+    return (_to_length == other._to_length
+            && _from_length == other._from_length
+            && _sequence == other._sequence);
+}
+inline bool edit_t::operator!=(const edit_t& other) const {
+    return !(*this == other);
+}
 
 /*
  * path_mapping_t
@@ -528,6 +542,12 @@ inline edit_t* path_mapping_t::mutable_edit(size_t i) {
 inline size_t path_mapping_t::edit_size() const {
     return _edit.size();
 }
+inline bool path_mapping_t::operator==(const path_mapping_t& other) const {
+    return (_position == other._position && _edit == other._edit);
+}
+inline bool path_mapping_t::operator!=(const path_mapping_t& other) const {
+    return !(*this == other);
+}
 
 /*
  * path_t
@@ -553,6 +573,12 @@ inline void path_t::clear_mapping() {
 }
 inline size_t path_t::mapping_size() const {
     return _mapping.size();
+}
+inline bool path_t::operator==(const path_t& other) const {
+    return _mapping == other._mapping;
+}
+inline bool path_t::operator!=(const path_t& other) const {
+    return !(*this == other);
 }
 }
 

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -34,6 +34,8 @@ public:
     inline void set_offset(int64_t o);
     inline bool is_reverse() const;
     inline void set_is_reverse(bool r);
+    inline bool operator==(const position_t& other) const;
+    inline bool operator!=(const position_t& other) const;
 private:
     int64_t _node_id;
     int64_t _offset;
@@ -81,6 +83,16 @@ inline bool position_t::is_reverse() const {
 }
 inline void position_t::set_is_reverse(bool r) {
     _is_reverse = r;
+}
+
+inline bool position_t::operator==(const position_t& other) const {
+    return (_node_id == other._node_id
+            && _is_reverse == other._is_reverse
+            && _offset == other._offset);
+}
+
+inline bool position_t::operator!=(const position_t& other) const {
+    return !(*this == other);
 }
 }
 

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -801,6 +801,15 @@ int main_mpmap(int argc, char** argv) {
         }
     }
     
+    if (optind != argc) {
+        cerr << "error:[vg mpmap] Unused positional argument(s):";
+        for (int i = optind; i < argc; ++i) {
+            cerr << " " << argv[i];
+        }
+        cerr << endl;
+        exit(1);
+    }
+    
     // normalize capitalization on preset options
     if (read_length == "Long" || read_length == "LONG") {
         read_length = "long";


### PR DESCRIPTION
## Changelog Entry

 * `vg mpmap` produces more complete multipath alignments around indels in low complexity sequences.

## Description

Leaving MEMs that were largely redundant alone in the algorithm was causing some alignments to be rejected as duplicates, which removed variation from the multipath alignment.