### PR TITLE
Always dump funnels when showing work and tracking provenance

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -27,8 +27,6 @@
 //#define print_minimizer_table
 // Dump local graphs that we align against 
 //#define debug_dump_graph
-// Dump the funnel information about where candidates were lost
-//#define debug_dump_funnel
 // Dump fragment length distribution information
 //#define debug_fragment_distr
 
@@ -743,10 +741,13 @@ vector<Alignment> MinimizerMapper::map(Alignment& aln) {
     }
 #endif
 
-#ifdef debug_dump_funnel
-    // Dump the funnel info graph.
-    funnel.to_dot(cerr);
-#endif
+    if (track_provenance && show_work) {
+        // Dump the funnel info graph.
+        #pragma omp critical (cerr)
+        {
+            funnel.to_dot(cerr);
+        }
+    }
 
     return mappings;
 }
@@ -2220,11 +2221,14 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
     }
 #endif
 
-#ifdef debug_dump_funnel
-    // Dump the funnel info graph.
-    funnels[0].to_dot(cerr);
-    funnels[1].to_dot(cerr);
-#endif
+    if (track_provenance && show_work) {
+        // Dump the funnel info graph.
+        #pragma omp critical (cerr)
+        {
+            funnels[0].to_dot(cerr);
+            funnels[1].to_dot(cerr);
+        }
+    }
 
     // Ship out all the aligned alignments
     return mappings;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe dumps funnel dots if tracking provenance and explaining itself

## Description

@cmarkello wanted to see the funnel plots. With this, you should get them if you pass `--show-work` and `--track-provenance` to Giraffe. You still need to copy-paste them into Graphviz or [WebGraphViz](http://webgraphviz.com/) yourself.
