### PR TITLE
Make giraffe keep the best unpaired cluster

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -1087,7 +1087,16 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
 
         // Retain clusters only if their score is better than this, in addition to the coverage cutoff
         double cluster_score_cutoff = 0.0, cluster_coverage_cutoff = 0.0, second_best_cluster_score = 0.0;
+
+        //The score and coverage of the best cluster, "best" is determined first by coverage then score
+        pair<double, double> best_cluster_coverage_score (0.0, 0.0);
         for (auto& cluster : clusters) {
+
+            if (cluster.coverage > best_cluster_coverage_score.first) {
+                best_cluster_coverage_score.first = cluster.coverage;
+                best_cluster_coverage_score.second = std::max(best_cluster_coverage_score.second, cluster.score);
+            }
+
             cluster_coverage_cutoff = std::max(cluster_coverage_cutoff, cluster.coverage);
 
             if (cluster.score > cluster_score_cutoff) {
@@ -1148,8 +1157,8 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                 // Handle sufficiently good clusters 
                 Cluster& cluster = clusters[cluster_num];
                 if (!found_paired_cluster || fragment_cluster_has_pair[cluster.fragment] || 
-                    (cluster.coverage == cluster_coverage_cutoff + cluster_coverage_threshold &&
-                           cluster.score == cluster_score_cutoff + cluster_score_threshold)) { 
+                    (cluster.coverage == best_cluster_coverage_score.first &&
+                     cluster.score    == best_cluster_coverage_score.second)) { 
                     //If this cluster has a pair or if we aren't looking at pairs
                     //Or if it is the best cluster
                     

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -1093,7 +1093,11 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
         for (auto& cluster : clusters) {
 
             if (cluster.coverage > best_cluster_coverage_score.first) {
+                //If this is the new best coverage, update both best coverage and best score
                 best_cluster_coverage_score.first = cluster.coverage;
+                best_cluster_coverage_score.second = cluster.score;
+            } else if (cluster.coverage ==  best_cluster_coverage_score.first) {
+                //If this is the same as the best coverage, get best score
                 best_cluster_coverage_score.second = std::max(best_cluster_coverage_score.second, cluster.score);
             }
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe will keep the best cluster it finds, even if it isn't in a fragment cluster with minimizers for both read

## Description
Giraffe was almost doing this, but only if the best cluster had both the best score and the best coverage.
This fixes one of the problem reads that @cmarkello found
The mapq is 0 though so this might need some adjustment