### PR TITLE
Handle homopolymer alignments better in mpmap

### DIFF
--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -2165,10 +2165,11 @@ void BandedGlobalAligner<IntType>::traceback(int8_t* score_mat, int8_t* nt_table
         }
         
         if (traceback_stack.next_is_empty()) {
+            traceback_stack.next_empty_alignment(*next_alignment);
 #ifdef debug_banded_aligner_traceback
             cerr << "[BandedGlobalAligner::traceback] taking the next full empty alignment" << endl;
+            cerr << pb2json(*next_alignment) << endl;
 #endif
-            traceback_stack.next_empty_alignment(*next_alignment);
         }
         else {
             
@@ -2257,6 +2258,9 @@ BandedGlobalAligner<IntType>::AltTracebackStack::AltTracebackStack(const HandleG
             band_stack.pop_back();
             
             if (!band_matrix) {
+#ifdef debug_banded_aligner_traceback
+                cerr << "[BandedGlobalAligner::traceback] found stack marker, pulling " << path.front() << " from path" << endl;
+#endif
                 path.pop_front();
                 continue;
             }
@@ -2274,6 +2278,12 @@ BandedGlobalAligner<IntType>::AltTracebackStack::AltTracebackStack(const HandleG
                 // whether they are sufficiently high scoring alignments to yield
                 if (source_node_matrices.count(band_matrix)) {
                     empty_full_paths.push_back(path);
+#ifdef debug_banded_aligner_traceback
+                    cerr << "[BandedGlobalAligner::traceback] found empty full path" << endl;
+                    for (auto nid : path ) {
+                        cerr << "\t" << nid << endl;
+                    }
+#endif
                     continue;
                 }
                 
@@ -2290,6 +2300,10 @@ BandedGlobalAligner<IntType>::AltTracebackStack::AltTracebackStack(const HandleG
                 int64_t node_id = graph.get_id(node);
                 int64_t read_length = band_matrix->alignment.sequence().length();
                 int64_t ncols = graph.get_length(node);
+                
+#ifdef debug_banded_aligner_traceback
+                cerr << "[BandedGlobalAligner::traceback] initializing tracebacks on node " << node_id << endl;
+#endif
                 
                 int64_t final_col = ncols - 1;
                 int64_t final_row = band_matrix->bottom_diag + ncols > read_length ? read_length - band_matrix->top_diag - ncols : band_matrix->bottom_diag - band_matrix->top_diag;

--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -1526,11 +1526,7 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
         string::const_iterator probe_string_begin = probe_string_end - min_sub_mem_length;
         
 #ifdef debug_mapper
-        cerr << "probe string is mem[" << probe_string_begin - mems[mem_idx].begin << ":" << probe_string_end - mems[mem_idx].begin << "] ";
-        for (auto iter = probe_string_begin; iter != probe_string_end; iter++) {
-            cerr << *iter;
-        }
-        cerr << endl;
+        cerr << "probe string is mem[" << probe_string_begin - mems[mem_idx].begin << ":" << probe_string_end - mems[mem_idx].begin << "] " << string(probe_string_begin, probe_string_end) << endl;
 #endif
         
         // set up LF searching
@@ -1550,6 +1546,9 @@ void BaseMapper::find_sub_mems_fast(const vector<MaximalExactMatch>& mems,
                 (relative_idx >= sub_mem_thinning_burn_in && (relative_idx - sub_mem_thinning_burn_in) % sub_mem_count_thinning == 0)) {
                 
                 if ((use_approx_sub_mem_count ? gcsa::Range::length(range) : gcsa->count(range)) <= parent_range_count) {
+#ifdef debug_mapper
+                    cerr << "partial probe only occurs in parent mem[" << cursor - mems[mem_idx].begin << ":" << probe_string_end - mems[mem_idx].begin << "] " << string(cursor, probe_string_end) << endl;
+#endif
                     probe_string_more_frequent = false;
                     break;
                 }

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1220,6 +1220,9 @@ namespace vg {
                         heap.pop_back();
                     }
                     else {
+#ifdef debug_multipath_alignment
+                        cerr << "have not yet exhausted " << overlapping_group[it->first] << ", keeping on heap" << endl;
+#endif
                         ++it;
                     }
                 }

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1107,7 +1107,7 @@ namespace vg {
             }
             make_heap(heap.begin(), heap.end(), heap_cmp);
             
-            while (!heap.empty()) {
+            while (heap.size() > 1) {
                 // move all of the path nodes whose next mapping occurs
                 // at the next sequence position into the unheaped back
                 auto heaped_end = heap.end();
@@ -1121,6 +1121,10 @@ namespace vg {
                 cerr << "next mappings are at uncentered sequence index " << seq_pos(heap.back().first) - path_nodes.front().begin << ":" << endl;
                 for (auto it = heaped_end; it != heap.end(); ++it) {
                     cerr << "\t" << overlapping_group[it->first] << ": " << it->second << " " << debug_string(next_mapping(*it)) << endl;
+                }
+                cerr << "the other heaped mappings:" << endl;
+                for (auto it = heap.begin(); it != heaped_end; ++it) {
+                    cerr << "\t" << overlapping_group[it->first] << " (seq index " << seq_pos(it->first) - path_nodes.front().begin << "): " << it->second << " " << debug_string(next_mapping(*it)) << endl;
                 }
 #endif
                 
@@ -1221,7 +1225,7 @@ namespace vg {
                     }
                     else {
 #ifdef debug_multipath_alignment
-                        cerr << "have not yet exhausted " << overlapping_group[it->first] << ", keeping on heap" << endl;
+                        cerr << "have not yet exhausted (path node index) " << overlapping_group[it->first] << ", keeping on heap with a new uncentered seq index  of " << seq_pos(it->first) - path_nodes.front().begin << endl;
 #endif
                         ++it;
                     }
@@ -1232,7 +1236,7 @@ namespace vg {
                 
                 // and restore the heap
                 while (heaped_end != heap.end()) {
-                    push_heap(heap.begin(), heaped_end++, heap_cmp);
+                    push_heap(heap.begin(), ++heaped_end, heap_cmp);
                 }
             }
         }

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "multipath_alignment_graph.hpp"
+#include "sequence_complexity.hpp"
 
 //#define debug_multipath_alignment
 

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1068,6 +1068,9 @@ namespace vg {
             
             if (already_merged.count(overlapping_pair.first) || already_merged.count(overlapping_pair.second)) {
                 // too complicated to try to merge the same node multiple times
+#ifdef debug_multipath_alignment
+                cerr << "skipping overlapping pair " << overlapping_pair.first << ", " << overlapping_pair.second << endl;
+#endif
                 continue;
             }
 #ifdef debug_multipath_alignment
@@ -4293,6 +4296,9 @@ namespace vg {
                         }
 #ifdef debug_multipath_alignment
                         cerr << "made " << alt_alignments.size() << " tail alignments" << endl;
+                        for (size_t i = 0; i < alt_alignments.size(); ++i) {
+                            cerr << i << ": " << pb2json(alt_alignments[i]) << endl;
+                        }
 #endif
                     }
                 }
@@ -4407,6 +4413,9 @@ namespace vg {
                         }
 #ifdef debug_multipath_alignment
                         cerr << "made " << alt_alignments.size() << " tail alignments" << endl;
+                        for (size_t i = 0; i < alt_alignments.size(); ++i) {
+                            cerr << i << ": " << pb2json(alt_alignments[i]) << endl;
+                        }
 #endif
                     }
                 }

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -5,7 +5,7 @@
 #include "multipath_alignment_graph.hpp"
 #include "sequence_complexity.hpp"
 
-#define debug_multipath_alignment
+//#define debug_multipath_alignment
 
 using namespace std;
 namespace vg {

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -4082,6 +4082,8 @@ namespace vg {
                      deduplicated.size() < num_alt_alns && num_alns_iter <= max_alt_alns;
                      num_alns_iter *= 2) {
                     
+                    intervening_sequence.clear_path();
+                    
                     vector<Alignment> alt_alignments;
                     if (num_alns_iter > 0) {
                         

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -4,7 +4,7 @@
 
 #include "multipath_alignment_graph.hpp"
 
-#define debug_multipath_alignment
+//#define debug_multipath_alignment
 
 using namespace std;
 namespace vg {

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -1042,6 +1042,7 @@ namespace vg {
             }
         }
         
+        
         merge_partially_redundant_match_nodes(node_matches, path_node_provenance);
     }
 
@@ -1051,6 +1052,10 @@ namespace vg {
 #ifdef debug_multipath_alignment
         cerr << "looking for MEMs with partial redundancies to merge" << endl;
 #endif
+        
+        if (path_nodes.size() <= 1) {
+            return;
+        }
         
         // find the groups that share at least one node
         structures::UnionFind union_find(path_nodes.size(), false);
@@ -1131,7 +1136,7 @@ namespace vg {
                 // split into groups that have identical next mappings
                 vector<vector<size_t>> groups;
                 for (size_t i = 0, n = (heap.end() - heaped_end); i < n; ++i) {
-                        bool found_match = false;
+                    bool found_match = false;
                     for (auto& group : groups) {
                         if (next_mapping(*(heaped_end + i)) == next_mapping(*(heaped_end + group.front()))) {
                             group.push_back(i);

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <vector>
 #include <unordered_map>
+#include <algorithm>
 
 #include "structures/rank_pairing_heap.hpp"
 

--- a/src/sequence_complexity.hpp
+++ b/src/sequence_complexity.hpp
@@ -15,7 +15,7 @@ namespace vg {
 
 using namespace std;
 
-#define debug_seq_complexity
+//#define debug_seq_complexity
 
 /*
  * Struct to compute the complexity of sequence at different orders
@@ -109,7 +109,7 @@ double SeqComplexity<MaxOrder>::p_value(int order) const {
 
 template<int MaxOrder>
 double SeqComplexity<MaxOrder>::repetitiveness(int order) const {
-    return double(matches[order - 1]) / double(len);
+    return double(matches[order - 1]) / double(len - order);
 }
 
 

--- a/src/sequence_complexity.hpp
+++ b/src/sequence_complexity.hpp
@@ -1,0 +1,118 @@
+/**
+ * \file sequence_complexity.hpp
+ *
+ * Defines and implements an algorithm to identify low-complexity sequences
+ *
+ */
+#ifndef VG_SEQUENCE_COMPLEXITY_HPP_INCLUDED
+#define VG_SEQUENCE_COMPLEXITY_HPP_INCLUDED
+
+#include <string>
+#include <cmath>
+#include <iostream>
+
+namespace vg {
+
+using namespace std;
+
+#define debug_seq_complexity
+
+/*
+ * Struct to compute the complexity of sequence at different orders
+ */
+template<int MaxOrder = 1>
+struct SeqComplexity {
+    
+    SeqComplexity(string::const_iterator begin, string::const_iterator end);
+    SeqComplexity(const string& seq);
+    
+    // The approximate p-value of the n-th order correlation between
+    // nucleotides. Only valid for 1 <= order <= MaxOrder template param.
+    double p_value(int order) const;
+    
+    // The fraction of pairs that are repeats at this order.
+    double repetitiveness(int order) const;
+    
+private:
+    
+    int len;
+    int matches[MaxOrder];
+};
+
+/*
+ * Template implementations
+ */
+
+template<int MaxOrder>
+SeqComplexity<MaxOrder>::SeqComplexity(const string& seq) : SeqComplexity(seq.begin(), seq.end()) {
+    
+}
+
+template<int MaxOrder>
+SeqComplexity<MaxOrder>::SeqComplexity(string::const_iterator begin, string::const_iterator end) {
+
+    len = end - begin;
+    
+    for (int i = 0; i < MaxOrder; ++i) {
+        matches[i] = 0;
+    }
+    
+    for (int i = 1; i < len; ++i) {
+        for (int j = max<int>(0, i - MaxOrder); j < i; ++j) {
+            matches[i - j - 1] += (*(begin + j) == *(begin + i));
+        }
+    }
+#ifdef debug_seq_complexity
+    cerr << "match table for seq of length " << len << ":" << endl;
+    for (int i = 1; i < len; ++i) {
+        cerr << i << ": " << matches[i - 1] << endl;
+    }
+#endif
+}
+
+// TODO: have GC bias instead of uniform random? maybe not since repetition
+// hurts alignment uncertainty even in biased sequencesc
+
+template<int MaxOrder>
+double SeqComplexity<MaxOrder>::p_value(int order) const {
+    if (order < len && order + 8 > len) {
+        // exact binomial CDF
+        // TODO: flip sum if is smaller?
+        int k = matches[order - 1];
+        int N = len - order;
+        double x = 1.0;
+        double y = N;
+        double term = pow(0.75, y);
+        double accum = 0.0;
+        for (int i = 0; i < k; ++i) {
+            accum += term;
+            // the ratio of successive terms in the binomial distr pmf
+            term *= 0.333333333333333333 * y / x;
+            x += 1.0;
+            y -= 1.0;
+        }
+        
+        return 1.0 - accum;
+    }
+    else if (order < len) {
+        // normal approximation to binomial
+        static const double root_pq = sqrt(0.25 * 0.75);
+        static const double root_1_2 = sqrt(0.5);
+        double z = (double(matches[order - 1]) - double(len - order) * 0.25) / (sqrt(len - order) * root_pq);
+        // the normal CDF
+        return 1.0 - 0.5 * erfc(-root_1_2 * z);
+    }
+    else {
+        return 1.0;
+    }
+}
+
+template<int MaxOrder>
+double SeqComplexity<MaxOrder>::repetitiveness(int order) const {
+    return double(matches[order - 1]) / double(len);
+}
+
+
+}
+
+#endif

--- a/src/sequence_complexity.hpp
+++ b/src/sequence_complexity.hpp
@@ -78,13 +78,11 @@ double SeqComplexity<MaxOrder>::p_value(int order) const {
     if (order < len && order + 8 > len) {
         // exact binomial CDF
         // TODO: flip sum if is smaller?
-        int k = matches[order - 1];
-        int N = len - order;
         double x = 1.0;
-        double y = N;
+        double y = len - order;
         double term = pow(0.75, y);
         double accum = 0.0;
-        for (int i = 0; i < k; ++i) {
+        for (int i = 0, k = matches[order - 1]; i < k; ++i) {
             accum += term;
             // the ratio of successive terms in the binomial distr pmf
             term *= 0.333333333333333333 * y / x;

--- a/src/unittest/sequence_complexity.cpp
+++ b/src/unittest/sequence_complexity.cpp
@@ -1,0 +1,31 @@
+///
+/// \file sequence_complexity.cpp
+///  
+/// Unit tests for SeqComplexity
+///
+
+#include "catch.hpp"
+#include "../sequence_complexity.hpp"
+#include <iostream>
+
+namespace vg {
+namespace unittest {
+
+using namespace std;
+
+TEST_CASE( "Sequence complexity can be identified", "[complexity]" ) {
+    
+    string seq = "ACGTACGTACGTACGT";
+    SeqComplexity<16> complexity(seq);
+    for (int order = 1; order <= 16; ++order) {
+        if (order % 4 == 0 && order < seq.size()) {
+            REQUIRE(complexity.p_value(order) < .01);
+        }
+        else {
+            REQUIRE(complexity.p_value(order) > .95);
+        }
+    }
+}
+
+}
+}


### PR DESCRIPTION
## Description

The multiple traceback algorithm had some failure cases in erroneous homopolymers where alignment uncertainty could mean that not all high-likelihood graph paths were explored. This PR adds some methods to detect these cases and expend some more computational effort on them.