### PR TITLE
Specialized aligner for pure deletions

### DIFF
--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -17,6 +17,7 @@
 #include "utility.hpp"
 #include "statistics.hpp"
 #include "banded_global_aligner.hpp"
+#include "deletion_aligner.hpp"
 #include "dozeu_interface.hpp"
 #include "handle.hpp"
 #include "reverse_graph.hpp"
@@ -278,6 +279,7 @@ namespace vg {
         virtual int32_t remove_bonuses(const Alignment& aln, bool pinned = false, bool pin_left = false) const;
         
         // members
+        DeletionAligner deletion_aligner;
         int8_t* nt_table = nullptr;
         int8_t* score_matrix = nullptr;
         int8_t match;

--- a/src/deletion_aligner.cpp
+++ b/src/deletion_aligner.cpp
@@ -40,6 +40,7 @@ void DeletionAligner::align_multi(Alignment& aln, vector<Alignment>& alt_alns,
         trace_to_alignment(alt_alns[i], traces[i], graph);
     }
     *aln.mutable_path() = alt_alns.front().path();
+    aln.set_score(alt_alns.front().score());
 }
 
 vector<vector<handle_t>> DeletionAligner::run_dp(const HandleGraph& graph,

--- a/src/deletion_aligner.cpp
+++ b/src/deletion_aligner.cpp
@@ -1,0 +1,192 @@
+/**
+ * \file deletion_aligner.cpp
+ *
+ * Implements an aligner for global deletions
+ *
+ */
+
+#include "deletion_aligner.hpp"
+
+namespace vg {
+
+DeletionAligner::DeletionAligner(int8_t gap_open, int8_t gap_extension)
+    : gap_open(gap_open), gap_extension(gap_extension)
+{
+    
+}
+
+void DeletionAligner::align(Alignment& aln, const HandleGraph& graph) const {
+    if (!aln.sequence().empty()) {
+        cerr << "error: DeletionAligner can only be used for alignments of empty strings" << endl;
+        exit(1);
+    }
+    auto trace = move(run_dp(graph, 1).front());
+    trace_to_alignment(aln, trace, graph);
+}
+
+void DeletionAligner::align_multi(Alignment& aln, vector<Alignment>& alt_alns,
+                                  const HandleGraph& graph, int32_t max_alt_alns) const {
+    if (!aln.sequence().empty()) {
+        cerr << "error: DeletionAligner can only be used for alignments of empty strings" << endl;
+        exit(1);
+    }
+    auto traces = run_dp(graph, max_alt_alns);
+    alt_alns.resize(traces.size());
+    for (size_t i = 0; i < traces.size(); ++i) {
+        alt_alns[i].set_sequence(aln.sequence());
+        alt_alns[i].set_quality(aln.quality());
+        trace_to_alignment(alt_alns[i], traces[i], graph);
+    }
+    *aln.mutable_path() = alt_alns.front().path();
+}
+
+vector<vector<handle_t>> DeletionAligner::run_dp(const HandleGraph& graph,
+                                                 int32_t max_tracebacks) const {
+    auto order = algorithms::lazier_topological_order(&graph);
+    unordered_map<handle_t, size_t> index_of;
+    index_of.reserve(order.size());
+    for (size_t i = 0; i < order.size(); ++i) {
+        index_of[order[i]] = i;
+    }
+    vector<size_t> dists;
+    vector<pair<size_t, size_t>> sinks;
+    tie(dists, sinks) = min_dists(order, index_of, graph);
+    return traceback(order, index_of, graph, dists, sinks, max_tracebacks);
+}
+
+pair<vector<size_t>, vector<pair<size_t, size_t>>> DeletionAligner::min_dists(
+      const vector<handle_t>& order,
+      const unordered_map<handle_t, size_t>& index_of,
+      const HandleGraph& graph) const
+{
+    
+    // use dynamic programming to compute the minimum distance from a source
+    vector<size_t> dists(order.size(), numeric_limits<size_t>::max());
+    vector<pair<size_t, size_t>> sinks;
+    for (size_t i = 0; i < order.size(); ++i) {
+        if (dists[i] == numeric_limits<size_t>::max()) {
+            // nothing has replaced the starting value, must be a source
+            dists[i] = 0;
+        }
+        size_t length_thru = dists[i] + graph.get_length(order[i]);
+        bool is_sink = true;;
+        graph.follow_edges(order[i], false, [&](const handle_t& next) {
+            size_t j = index_of.at(next);
+            dists[j] = min(dists[j], length_thru);
+            is_sink = false;
+        });
+        if (is_sink) {
+            // didn't find any edges forward
+            sinks.emplace_back(i, length_thru);
+        }
+    }
+    return make_pair(dists, sinks);
+}
+
+vector<vector<handle_t>> DeletionAligner::traceback(const vector<handle_t>& order,
+                                                    const unordered_map<handle_t, size_t>& index_of,
+                                                    const HandleGraph& graph,
+                                                    const vector<size_t>& dists,
+                                                    const vector<pair<size_t, size_t>>& sinks,
+                                                    size_t max_tracebacks) const {
+
+    
+    // records of (distance, deflections (from, to))
+    structures::MinMaxHeap<pair<size_t, vector<pair<size_t, size_t>>>> heap;
+    vector<vector<handle_t>> traces;
+    
+    // check if we want to take this deviation from the optimal traceback next time
+    auto propose_deflection = [&](size_t from, size_t to, size_t dist, size_t deflxn,
+                                  const vector<pair<size_t, size_t>>& curr_deflections) {
+        if (heap.size() + traces.size() < max_tracebacks || heap.max().first > dist) {
+            // we've used all of the current deflections (so we can now propose more)
+            // and we either haven't fully populated the heap, or this is better than
+            // the worst
+            vector<pair<size_t, size_t>> deflections = curr_deflections;
+            deflections.emplace_back(from, to);
+            heap.emplace(dist, move(deflections));
+            if (heap.size() + traces.size() > max_tracebacks) {
+                heap.pop_max();
+            }
+        }
+    };
+    
+    // get the next trace, either by taking a deflection or by doing traceback,
+    // also propose deflections as needed
+    auto get_next = [&](size_t at, size_t& deflxn, size_t curr_dist,
+                        const vector<pair<size_t, size_t>>& curr_deflections) {
+        if (deflxn < curr_deflections.size()
+            && at == curr_deflections[deflxn].first) {
+            return curr_deflections[deflxn++].second;
+        }
+        else {
+            size_t next = numeric_limits<size_t>::max();
+            size_t dist_here = dists[at];
+            graph.follow_edges(order[at], true, [&](const handle_t& prev) {
+                size_t idx = index_of.at(prev);
+                size_t dist_thru = dists[idx] + graph.get_length(prev);
+                if (next == numeric_limits<size_t>::max() && dist_thru == dist_here) {
+                    next = idx;
+                }
+                else if (deflxn == curr_deflections.size()) {
+                    propose_deflection(at, idx, curr_dist - dist_here + dist_thru,
+                                       deflxn, curr_deflections);
+                }
+                // keep looking if we haven't found the trace or we're looking
+                // for deflections
+                return (next == numeric_limits<size_t>::max() ||
+                        deflxn == curr_deflections.size());
+            });
+            return next;
+        }
+    };
+    
+    // the first deflection is from a sentinel at the end to whichever
+    // sink node we'll start from, propose these deflections to init the heap
+    size_t deflxn = 0;
+    vector<pair<size_t, size_t>> deflections;
+    for (auto& sink : sinks) {
+        propose_deflection(order.size(), sink.first, sink.second,
+                           deflxn, deflections);
+    }
+    
+    traces.reserve(max_tracebacks);
+    while (!heap.empty()) {
+        // init the next traceback
+        traces.emplace_back();
+        auto& trace = traces.back();
+        size_t trace_dist;
+        tie(trace_dist, deflections) = heap.min();
+        heap.pop_min();
+        deflxn = 0;
+        
+        // start by taking deflection from the beginning sentinel
+        size_t tracer = get_next(order.size(), deflxn, trace_dist,
+                                 deflections);
+        while (tracer != numeric_limits<size_t>::max()) {
+            trace.push_back(order[tracer]);
+            tracer = get_next(tracer, deflxn, trace_dist, deflections);
+        }
+    }
+    return traces;
+}
+
+void DeletionAligner::trace_to_alignment(Alignment& aln, const vector<handle_t>& trace,
+                                         const HandleGraph& graph) const {
+    int64_t total_dist = 0;
+    auto path = aln.mutable_path();
+    // traces are constructed in reverse
+    for (int64_t i = trace.size() - 1; i >= 0; --i) {
+        handle_t handle = trace[i];
+        auto mapping = path->add_mapping();
+        auto position = mapping->mutable_position();
+        position->set_node_id(graph.get_id(handle));
+        position->set_is_reverse(graph.get_is_reverse(handle));
+        auto edit = mapping->add_edit();
+        edit->set_from_length(graph.get_length(handle));
+        total_dist += edit->from_length();
+    }
+    aln.set_score(total_dist ? gap_open + (total_dist - 1) * gap_extension : 0);
+}
+
+}

--- a/src/deletion_aligner.hpp
+++ b/src/deletion_aligner.hpp
@@ -1,0 +1,62 @@
+/**
+ * \file deletion_aligner.hpp
+ *
+ * Defines an aligner for global deletions
+ *
+ */
+#ifndef VG_DINUCLEOTIDE_MACHINE_GRAPH_HPP_INCLUDED
+#define VG_DINUCLEOTIDE_MACHINE_GRAPH_HPP_INCLUDED
+
+#include <cstdint>
+#include <vg/vg.pb.h>
+#include <structures/min_max_heap.hpp>
+
+#include "handle.hpp"
+#include "algorithms/topological_sort.hpp"
+
+namespace vg {
+
+using namespace std;
+
+/*
+ * An aligner for global deletions. Can only produce alignments
+ * for empty sequences
+ */
+class DeletionAligner {
+public:
+    DeletionAligner(int8_t gap_open, int8_t gap_extension);
+    ~DeletionAligner() = default;
+    
+    void align(Alignment& aln, const HandleGraph& graph) const;
+    
+    void align_multi(Alignment& aln, vector<Alignment>& alt_alns,
+                     const HandleGraph& graph, int32_t max_alt_alns) const;
+    
+    
+private:
+    
+    vector<vector<handle_t>> run_dp(const HandleGraph& graph,
+                                    int32_t max_tracebacks) const;
+    
+    pair<vector<size_t>, vector<pair<size_t, size_t>>> min_dists(const vector<handle_t>& order,
+                                                                 const unordered_map<handle_t, size_t>& index_of,
+                                                                 const HandleGraph& graph) const;
+    
+    vector<vector<handle_t>> traceback(const vector<handle_t>& order,
+                                       const unordered_map<handle_t, size_t>& index_of,
+                                       const HandleGraph& graph,
+                                       const vector<size_t>& dists,
+                                       const vector<pair<size_t, size_t>>& sinks,
+                                       size_t max_tracebacks) const;
+    
+    void trace_to_alignment(Alignment& aln, const vector<handle_t>& trace,
+                            const HandleGraph& graph) const;
+    
+    int32_t gap_open;
+    int32_t gap_extension;
+    
+};
+
+}
+
+#endif

--- a/src/deletion_aligner.hpp
+++ b/src/deletion_aligner.hpp
@@ -25,6 +25,7 @@ using namespace std;
 class DeletionAligner {
 public:
     DeletionAligner(int8_t gap_open, int8_t gap_extension);
+    DeletionAligner() = delete;
     ~DeletionAligner() = default;
     
     void align(Alignment& aln, const HandleGraph& graph) const;

--- a/src/deletion_aligner.hpp
+++ b/src/deletion_aligner.hpp
@@ -4,8 +4,8 @@
  * Defines an aligner for global deletions
  *
  */
-#ifndef VG_DINUCLEOTIDE_MACHINE_GRAPH_HPP_INCLUDED
-#define VG_DINUCLEOTIDE_MACHINE_GRAPH_HPP_INCLUDED
+#ifndef VG_DELETION_ALIGNER_GRAPH_HPP_INCLUDED
+#define VG_DELETION_ALIGNER_GRAPH_HPP_INCLUDED
 
 #include <cstdint>
 #include <vg/vg.pb.h>
@@ -25,24 +25,33 @@ using namespace std;
 class DeletionAligner {
 public:
     DeletionAligner(int8_t gap_open, int8_t gap_extension);
-    DeletionAligner() = delete;
+    DeletionAligner() = default;
     ~DeletionAligner() = default;
     
+    // store a global alignment of an empty sequence to this graph in the alignment
+    // crashes if alignment sequence is not empty
     void align(Alignment& aln, const HandleGraph& graph) const;
     
+    // store a global alignment of an empty sequence to this graph in the alignment
+    // also store the next highest-scoring alignments in the vector
+    // crashes if alignment sequence is not empty
     void align_multi(Alignment& aln, vector<Alignment>& alt_alns,
                      const HandleGraph& graph, int32_t max_alt_alns) const;
     
     
 private:
     
+    // do the dynamic programming and return the trace backs
     vector<vector<handle_t>> run_dp(const HandleGraph& graph,
                                     int32_t max_tracebacks) const;
     
+    // calculate min distance with DP. returns the DP table and
+    // the sink nodes in the graph, with their full DP value
     pair<vector<size_t>, vector<pair<size_t, size_t>>> min_dists(const vector<handle_t>& order,
                                                                  const unordered_map<handle_t, size_t>& index_of,
                                                                  const HandleGraph& graph) const;
     
+    // compute tracebacks using the DP table
     vector<vector<handle_t>> traceback(const vector<handle_t>& order,
                                        const unordered_map<handle_t, size_t>& index_of,
                                        const HandleGraph& graph,
@@ -50,6 +59,7 @@ private:
                                        const vector<pair<size_t, size_t>>& sinks,
                                        size_t max_tracebacks) const;
     
+    // convert a trace into an alignment path
     void trace_to_alignment(Alignment& aln, const vector<handle_t>& trace,
                             const HandleGraph& graph) const;
     

--- a/src/unittest/deletion_aligner.cpp
+++ b/src/unittest/deletion_aligner.cpp
@@ -1,0 +1,107 @@
+/// \file deletion_aligner.cpp
+///  
+/// unit tests for the DeletionAligner
+///
+
+#include <iostream>
+#include "path.hpp"
+#include "deletion_aligner.hpp"
+#include "random_graph.hpp"
+#include "catch.hpp"
+
+#include "bdsg/hash_graph.hpp"
+
+namespace vg {
+namespace unittest {
+
+TEST_CASE("Deletion aligner finds optimal deletions", "[aligner][deletionaligner]") {
+
+    bdsg::HashGraph graph;
+    
+    auto check_aln = [&](const Alignment& aln,
+                         vector<handle_t> correct_path) {
+        REQUIRE(aln.path().mapping_size() == correct_path.size());
+        int total_length = 0;
+        for (size_t i = 0; i < correct_path.size(); ++i) {
+            auto h = correct_path[i];
+            const auto& m = aln.path().mapping(i);
+            REQUIRE(m.position().node_id() == graph.get_id(h));
+            REQUIRE(m.position().is_reverse() == graph.get_is_reverse(h));
+            REQUIRE(m.position().offset() == 0);
+            REQUIRE(mapping_from_length(m) == graph.get_length(h));
+            REQUIRE(mapping_to_length(m) == 0);
+            total_length += graph.get_length(h);
+        }
+        REQUIRE(aln.score() == (total_length ? -total_length - 5 : 0));
+    };
+    
+    // scoring bubbles with powers of two makes ordered
+    // scores act like binary bits in counting order
+    auto h1 = graph.create_handle("AA");// +/- 1
+    auto h2 = graph.create_handle("A");
+    auto h3 = graph.create_handle("AAA");
+    auto h4 = graph.create_handle("A");
+    auto h5 = graph.create_handle("AAA");// +/- 2
+    auto h6 = graph.create_handle("A");
+    auto h7 = graph.create_handle("AAAA"); // +/- 4
+    auto h8 = graph.create_handle("AA");
+    auto h9 = graph.create_handle("A");
+    auto h10 = graph.create_handle("AAAAAAAAA"); // +/- 8
+    
+    graph.create_edge(h1, h3);
+    graph.create_edge(h2, h3);
+    graph.create_edge(h3, h4);
+    graph.create_edge(h3, h5);
+    graph.create_edge(h4, h6);
+    graph.create_edge(h5, h6);
+    graph.create_edge(h6, h7);
+    graph.create_edge(h6, h8);
+    graph.create_edge(h7, h8);
+    graph.create_edge(h8, h9);
+    graph.create_edge(h8, h10);
+    
+    DeletionAligner aligner(6, 1);
+    
+    Alignment aln;
+    
+    SECTION("Single traceback works") {
+        aligner.align(aln, graph);
+        check_aln(aln, {h2, h3, h4, h6, h8, h9});
+    }
+    
+    SECTION("Multi traceback works") {
+        
+        int num_alts = 15;
+        vector<Alignment> alts;
+        aligner.align_multi(aln, alts, graph, num_alts);
+        
+        
+        vector<vector<handle_t>> corrects{
+            {h2, h3, h4, h6, h8, h9},
+            {h1, h3, h4, h6, h8, h9},
+            {h2, h3, h5, h6, h8, h9},
+            {h1, h3, h5, h6, h8, h9},
+            {h2, h3, h4, h6, h7, h8, h9},
+            {h1, h3, h4, h6, h7, h8, h9},
+            {h2, h3, h5, h6, h7, h8, h9},
+            {h1, h3, h5, h6, h7, h8, h9},
+            {h2, h3, h4, h6, h8, h10},
+            {h1, h3, h4, h6, h8, h10},
+            {h2, h3, h5, h6, h8, h10},
+            {h1, h3, h5, h6, h8, h10},
+            {h2, h3, h4, h6, h7, h8, h10},
+            {h1, h3, h4, h6, h7, h8, h10},
+            {h2, h3, h5, h6, h7, h8, h10}
+        };
+        
+        REQUIRE(corrects.size() == num_alts);
+        REQUIRE(alts.size() == num_alts);
+        for (size_t i = 0; i < num_alts; ++i) {
+            check_aln(alts[i], corrects[i]);
+        }
+        
+    }
+}
+
+}
+}


### PR DESCRIPTION
## Description

I realized that many of the global alignments that mpmap does are from cutting snarls out of anchors where the snarl is a splice motif rather than a variant. In these cases, the alignment based on sequence DP is pretty inefficient because there's really no sequence to align, which makes it a roundabout shortest path algorithm. This PR adds in a narrowly-specialized aligner for global alignment of empty strings, which now back-ends the global alignment methods in the Aligner whenever it applies.