### PR TITLE
Make better multipath alignments in mpmap

### DIFF
--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -134,7 +134,10 @@ namespace vg {
         /// end of the alignment sequence.
         void trim_hanging_indels(const Alignment& alignment, bool trim_Ns = true, bool preserve_tail_anchors = false);
         
-        /// Removes all transitive edges from graph (reduces to minimum equivalent graph).
+        /// Removes all transitive edges from graph (reduces to minimum equivalent graph),
+        /// except for edges between path nodes that abut either on the graph or read. These
+        /// edges often correspond to overlap breaks in low complexity sequence, so retaining
+        /// them improves alignment in low-complexity regions like STR expansions.
         /// Note: reorders internal representation of adjacency lists.
         /// Reachability edges must be in the graph.
         void remove_transitive_edges(const vector<size_t>& topological_order);


### PR DESCRIPTION
## Description

Fixes one bug and handles one edge cases, both of which would occasionally result in multipath alignments that were missing some path completeness around challenging repetitive regions.