### PR TITLE
Send users to the bug report URL

### DIFF
--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -184,7 +184,7 @@ void emit_stacktrace(int signalNumber, siginfo_t *signalInfo, void *signalContex
     #endif
 
     if (fullTrace == false) {
-        cerr << "ERROR: Signal "<< signalNumber << " occurred. VG has crashed. Run 'vg bugs --new' to report a bug." << endl;
+        cerr << "ERROR: Signal "<< signalNumber << " occurred. VG has crashed. Visit https://github.com/vgteam/vg/issues/new/choose to report a bug." << endl;
         // Print path for stack trace file
         cerr << "Stack trace path: "<< dirName << "/stacktrace.txt" << endl;
         cerr << "Please include the stack trace file in your bug report!" << endl;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Crash reports now direct users directly to the new issue URL

## Description

We've dropped `vg bugs` because it's not as good as a direct link.
