### PR TITLE
Use cache for Docker Hub images for tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,12 +18,6 @@ before_script:
   - |
     if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then
         echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
-        DOCKER_PID=$(pidof dockerd)
-        if [[ "$?" != "1" ]] ; then
-            # Docker already running
-            echo "Reloading Docker configuration"
-            sudo kill -SIGHUP ${DOCKER_PID}
-        fi
     fi
   - startdocker || true
   - docker info

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,14 +7,14 @@
 image: quay.io/vgteam/vg_ci_prebake
 
 before_script:
-  - whoami
   - sudo apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
   # We also need Node >4 for junit merging (so we need to be on Ubuntu 18.04+)
   # And the CI report upload needs uuidgen from uuid-runtime
   - sudo apt-get -q -y install --no-upgrade docker.io python-pip python-virtualenv libcurl4-gnutls-dev python-dev npm nodejs node-gyp nodejs-dev libssl1.0-dev uuid-runtime libgnutls28-dev
   - which junit-merge || sudo npm install -g junit-merge
-  - cat /etc/hosts
+  # Configure Docker to use a mirror for Docker Hub and restart the daemon
+  - if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"]}" | sudo tee /etc/docker/daemon.json ; sudo kill -SIGHUP $(pidof dockerd) ; fi
   - startdocker || true
   - docker info
   - mkdir -p ~/.aws && cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,9 +18,13 @@ before_script:
   - |
     if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then
         echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
-        sudo kill -SIGHUP $(pidof dockerd)
+        DOCKER_PID=$(pidof dockerd)
+        if [[ "$?" != "1" ]] ; then
+            # Docker already running
+            echo "Reloading Docker configuration"
+            sudo kill -SIGHUP ${DOCKER_PID}
+        fi
     fi
-  - cat /etc/docker/daemon.json || true
   - startdocker || true
   - docker info
   - mkdir -p ~/.aws && cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,8 @@ before_script:
   - sudo apt-get -q -y install --no-upgrade docker.io python-pip python-virtualenv libcurl4-gnutls-dev python-dev npm nodejs node-gyp nodejs-dev libssl1.0-dev uuid-runtime libgnutls28-dev
   - which junit-merge || sudo npm install -g junit-merge
   # Configure Docker to use a mirror for Docker Hub and restart the daemon
-  - if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"]}" | sudo tee /etc/docker/daemon.json ; sudo kill -SIGHUP $(pidof dockerd) ; fi
+  # Set the registry as insecure because it is probably cluster-internal over plain HTTP.
+  - 'if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json ; sudo kill -SIGHUP $(pidof dockerd) ; fi'
   - startdocker || true
   - docker info
   - mkdir -p ~/.aws && cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,11 @@ before_script:
   - which junit-merge || sudo npm install -g junit-merge
   # Configure Docker to use a mirror for Docker Hub and restart the daemon
   # Set the registry as insecure because it is probably cluster-internal over plain HTTP.
-  - 'if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json ; sudo kill -SIGHUP $(pidof dockerd) ; fi'
+  - |
+    if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then
+        echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
+        sudo kill -SIGHUP $(pidof dockerd)
+    fi
   - cat /etc/docker/daemon.json || true
   - startdocker || true
   - docker info

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ before_script:
   # Configure Docker to use a mirror for Docker Hub and restart the daemon
   # Set the registry as insecure because it is probably cluster-internal over plain HTTP.
   - 'if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json ; sudo kill -SIGHUP $(pidof dockerd) ; fi'
+  - cat /etc/docker/daemon.json || true
   - startdocker || true
   - docker info
   - mkdir -p ~/.aws && cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * CI now uses a DOCKER_HUB_CACHE URL from the environment, which it expects to be insecure.

## Description

Our CI tests run Docker-in-Kubernetes, and need to pull images for Toil-VG workflows. Right now they hit Docker Hub every time and use up our image pulls. I've observed tests failing because we hit the maximum number of pulls. This makes pulls use a caching mirror first, if we have one set up.

Lon set one up for Toil in our Kubernetes cluster, so I've set the CI environment to provide the URL for it. This PR hooks it up.