### PR TITLE
Stop computing infinite MAPQ caps when there are many duplicate minimizers

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -20,13 +20,13 @@
 #include <cmath>
 
 // Turn on debugging prints
-//#define debug
+#define debug
 // Turn on printing of minimizer fact tables
-//#define print_minimizer_table
+#define print_minimizer_table
 // Dump local graphs that we align against 
-//#define debug_dump_graph
+#define debug_dump_graph
 // Dump fragment length distribution information
-//#define debug_fragment_distr
+#define debug_fragment_distr
 
 namespace vg {
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2397,7 +2397,7 @@ double MinimizerMapper::get_log10_prob_of_disruption_in_interval(const vector<Mi
     }
    
     // We want an OR over all the columns, but some of the probabilities are tiny.
-    // So insteaad of NOT(AND(NOT())), which also would assume independence the
+    // So instead of NOT(AND(NOT())), which also would assume independence the
     // way we calculate AND by multiplication, we just assume independence and
     // compute OR as (p1 + p2 - (p1 * p2)).
     // Start with the first column.

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -20,13 +20,13 @@
 #include <cmath>
 
 // Turn on debugging prints
-#define debug
+//#define debug
 // Turn on printing of minimizer fact tables
-#define print_minimizer_table
+//#define print_minimizer_table
 // Dump local graphs that we align against 
-#define debug_dump_graph
+//#define debug_dump_graph
 // Dump fragment length distribution information
-#define debug_fragment_distr
+//#define debug_fragment_distr
 
 namespace vg {
 

--- a/src/unittest/minimizer_mapper.cpp
+++ b/src/unittest/minimizer_mapper.cpp
@@ -251,12 +251,38 @@ TEST_CASE("Mapping quality cap cannot be confused by excessive Gs", "[giraffe][m
     // They are all going to be explored
     vector<size_t> minimizers_explored;
     
+    string min_seq;
+    for (int i = 0; i < core_width; i++) {
+        min_seq.push_back('G');
+    }
+    auto encoded = gbwtgraph::DefaultMinimizerIndex::key_type::encode(min_seq);
+    
     for (int core_start = 0; core_start + core_width < sequence.size(); core_start++) {
         minimizers_explored.push_back(minimizers.size());
         minimizers.emplace_back();
         TestableMinimizerMapper::Minimizer& m = minimizers.back();
-        m.agglomeration_start = max(0, core_start - flank_width);
-        m.agglomeration_length = min((int)sequence.size(), core_start + core_width + flank_width) - core_start;
+        
+        if (core_start <= flank_width) {
+            // Partial left flank
+            m.agglomeration_start = 0;
+            m.agglomeration_length = core_width + flank_width + core_start;
+        } else if (sequence.size() - core_start - core_width <= flank_width) {
+            // Partial right flank
+            m.agglomeration_start = core_start - flank_width;
+            m.agglomeration_length = sequence.size() - m.agglomeration_start - 1;
+        } else {
+            // Full flanks
+            m.agglomeration_start = core_start - flank_width;
+            m.agglomeration_length = core_width + flank_width * 2;
+        }
+        cerr << "For core start at " << core_start << ", run " << m.agglomeration_start << " plus " << m.agglomeration_length << endl;
+        
+        // We need to set the key and its hash
+        m.value.key = encoded;
+        m.value.hash = m.value.key.hash();
+        m.value.offset = core_start;
+        m.value.is_reverse = false;
+        
         m.hits = 229;
         // We knowe the occurrences won't be used.
         m.occs = nullptr;

--- a/src/unittest/minimizer_mapper.cpp
+++ b/src/unittest/minimizer_mapper.cpp
@@ -275,7 +275,6 @@ TEST_CASE("Mapping quality cap cannot be confused by excessive Gs", "[giraffe][m
             m.agglomeration_start = core_start - flank_width;
             m.agglomeration_length = core_width + flank_width * 2;
         }
-        cerr << "For core start at " << core_start << ", run " << m.agglomeration_start << " plus " << m.agglomeration_length << endl;
         
         // We need to set the key and its hash
         m.value.key = encoded;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe mapping quality cap is now more numerically stable and fails assertions less

## Description

This should "fix" #3150 by fixing the problems with representing probabilities very close to 1 as floats. I'm pretty sure we can do our OR this way instead and never have to use that representation.

We still will get caps that are much too high because we're assuming independence when it isn't true, but we should no longer get so many caps that are actually infinite.
