### PR TITLE
Undrepcate, handlify and generalize vg combine (and deprecate vg concat)

### DIFF
--- a/src/subcommand/combine_main.cpp
+++ b/src/subcommand/combine_main.cpp
@@ -30,10 +30,14 @@ void help_combine(char** argv) {
          << "Node IDs will be modified as needed to resolve conflicts (in same manner as vg ids -j)." << endl
          << endl
          << "Options:" << endl
-         << "    -p, --concat-paths    Add edges necessary to connect paths with the same name present in different graphs." << endl
-         << "                          ex: If path x is present in graphs N-1 and N, then an edge connecting the last node of x in N-1 "
+         << "    -c, --cat-proto       Merge graphs by converting each to Protobuf (if not already) and catting the results."
+         << "                          Node IDs not modified [DEPRECATED]" << endl
+         << "    -p, --connect-paths   Add edges necessary to connect paths with the same name present in different graphs." << endl
+         << "                          ex: If path x is present in graphs N-1 and N, then an edge connecting the last node of x in N-1 " << endl
          << "                          and the first node of x in N will be added." << endl;
 }
+
+static int cat_proto_graphs(int argc, char** argv);
 
 int main_combine(int argc, char** argv) {
 
@@ -42,7 +46,8 @@ int main_combine(int argc, char** argv) {
         return 1;
     }
 
-    bool concat_paths = false;
+    bool connect_paths = false;
+    bool cat_proto = false;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -50,12 +55,13 @@ int main_combine(int argc, char** argv) {
         static struct option long_options[] =
         {
             {"help", no_argument, 0, 'h'},
-            {"concat-paths", no_argument, 0, 'p'},
+            {"connect-paths", no_argument, 0, 'p'},
+            {"cat-proto", no_argument, 0, 'c'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hp",
+        c = getopt_long (argc, argv, "hpc",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -65,8 +71,11 @@ int main_combine(int argc, char** argv) {
         switch (c)
         {
         case 'p':
-            concat_paths = true;
-            break;            
+            connect_paths = true;
+            break;
+        case 'c':
+            cat_proto = true;
+            break;
         case 'h':
         case '?':
             help_combine(argv);
@@ -78,6 +87,12 @@ int main_combine(int argc, char** argv) {
         }
     }
 
+    if (cat_proto) {
+        if (connect_paths) 
+        cerr << "warning [vg combine]: --cat-proto/-c option is deprecated and will be removed in a future version of vg." << endl;
+        return cat_proto_graphs(argc, argv);
+    }
+    
     unique_ptr<MutablePathMutableHandleGraph> first_graph;
     get_input_file(optind, argc, argv, [&](istream& in) {
             first_graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(in);
@@ -98,13 +113,13 @@ int main_combine(int argc, char** argv) {
         }
         max_node_id = graph->max_node_id();
 
-        if (concat_paths) {
+        if (connect_paths) {
             handlealgs::append_path_handle_graph(graph.get(), first_graph.get(), true);
         } else {
             graph->for_each_path_handle([&](path_handle_t path_handle) {
                     string path_name = graph->get_path_name(path_handle);
                     if (first_graph->has_path(path_name)) {
-                        cerr << "Error [vg combine]: Paths with name \"" << path_name << "\" found in multiple input graphs. If they are consecutive subpath ranges, they can be connected by using the -p option." << endl;
+                        cerr << "error [vg combine]: Paths with name \"" << path_name << "\" found in multiple input graphs. If they are consecutive subpath ranges, they can be connected by using the -p option." << endl;
                         exit(1);
                     }
                 });
@@ -121,3 +136,98 @@ int main_combine(int argc, char** argv) {
 // Register subcommand
 static Subcommand vg_combine("combine", "merge multiple graph files together", main_combine);
 
+
+// This is the original vg combine logic, which itself mimics using "cat" to join up protobuf files
+// Since it relies on the Protobuf format itself, particular the ability to stream together chunks that
+// would otherwise be invalid individually, it is probably never going to be ported to the handle graph
+// api, which is why it's been relegated to the deprecated bin
+int cat_proto_graphs(int argc, char** argv) {
+    
+    while (optind < argc) {
+        get_input_file(optind, argc, argv, [&](istream& in) {
+            // We're producing output in uncompressed, "VG"-type-tagged, VPKG Protobuf format.
+            // We will check if this file is uncompressed or compressed VG-type-tagged data.
+            
+            if (vg::io::BlockedGzipInputStream::SmellsLikeGzip(in)) {
+                // It is compressed.
+                
+                // Save our start position
+                auto start = in.tellg();
+                
+                {
+                    // Try decompressing.
+                    vg::io::BlockedGzipInputStream decompressed(in);
+                    if (decompressed.IsBGZF() && vg::io::MessageIterator::sniff_tag(decompressed) == "VG") {
+                        // We have Blocked GZIP which we can potentially just forward.
+                        // It looks like compressed VG Protobuf data.
+                        
+                        // Decompress it all to stdout, using the ZeroCopyInputStream API.
+                        char* buffer = nullptr;
+                        int bytes = 0;
+                        while (cout && decompressed.Next((const void**) &buffer, &bytes)) {
+                            // Each time we get bytes, write them to stdout.
+                            cout.write(buffer, bytes);
+                        }
+                        
+                        if (!cout) {
+                            cerr << "error [vg combine]: Could not write decompressed data to output stream." << endl;
+                            exit(1);
+                        }
+                        
+                        // Do the next input file
+                        return;
+                    }
+                }
+                
+                // We may have hit EOF.
+                in.clear();
+                
+                // If we get here, it wasn't compressed VG Protobuf.
+                // So we need to go back to the start of the file, since the decompressor read some.
+                in.seekg(start);
+                
+            } else if (vg::io::MessageIterator::sniff_tag(in) == "VG") {
+                // It isn't compressed, but it looks like uncompressed VG Protobuf.
+                // Send the uncompressed data to stdout.
+                cout << in.rdbuf();
+                
+                if (!cout) {
+                    cerr << "error [vg combine]: Could not write raw data to output stream." << endl;
+                    exit(1);
+                }
+                
+                // Do the next input file
+                return;
+            }
+            
+            // If we get here, it isn't compressed or uncompressed VG protobuf.
+            // Read it as a PathHandleGraph
+            unique_ptr<PathHandleGraph> graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
+            
+            // Convert to vg::VG
+            VG* vg_graph = dynamic_cast<vg::VG*>(graph.get());
+            if (vg_graph == nullptr) {
+                vg_graph = new vg::VG();
+                handlealgs::copy_path_handle_graph(graph.get(), vg_graph);
+                // Give the unique_ptr ownership and delete the graph we loaded.
+                graph.reset(vg_graph);
+                // Make sure the paths are all synced up
+                vg_graph->paths.to_graph(vg_graph->graph);
+            }
+            
+            {
+                // Save to stdout, uncompressed
+                vg::io::ProtobufEmitter<Graph> emitter(cout, false);
+                vg_graph->serialize_to_emitter(emitter);
+                // Make sure the emitter goes away and writes before we check on the stream.
+            }
+            
+            if (!cout) {
+                cerr << "error [vg combine]: Could not write converted graph to output stream." << endl;
+                exit(1);
+            }
+            
+        });
+    }
+    return 0;
+}

--- a/src/subcommand/concat_main.cpp
+++ b/src/subcommand/concat_main.cpp
@@ -106,5 +106,5 @@ int main_concat(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_concat("concat", "concatenate graphs tail-to-head", main_concat);
+static Subcommand vg_concat("concat", "concatenate graphs tail-to-head", DEPRECATED, main_concat);
 

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -97,6 +97,7 @@ int main_paths(int argc, char** argv) {
     bool select_alt_paths = false;
     bool list_lengths = false;
     size_t output_formats = 0, selection_criteria = 0;
+    size_t input_formats = 0;
     bool list_cyclicity = false;
 
     int c;
@@ -142,14 +143,17 @@ int main_paths(int argc, char** argv) {
 
         case 'v':
             vg_file = optarg;
+            ++input_formats;
             break;
 
         case 'x':
             xg_file = optarg;
+            ++input_formats;
             break;
 
         case 'g':
             gbwt_file = optarg;
+            ++input_formats;
             break;
 
         case 'V':
@@ -244,10 +248,14 @@ int main_paths(int argc, char** argv) {
         std::cerr << "error: [vg paths] cannot read input from multiple sources" << std::endl;
         std::exit(EXIT_FAILURE);
     }
+    if (input_formats != 1 && input_formats != 2) {
+        std::cerr << "error: [vg paths] at least one input format (-v, -x, -g) must be specified" << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
     if (!gbwt_file.empty()) {
-        bool need_graph = (extract_as_gam || extract_as_gaf || extract_as_vg || list_lengths || extract_as_fasta || list_cyclicity);
+        bool need_graph = (extract_as_gam || extract_as_gaf || extract_as_vg || drop_paths || retain_paths || extract_as_fasta);
         if (need_graph && xg_file.empty() && vg_file.empty()) {
-            std::cerr << "error: [vg paths] an XG index or vg graph needed for extracting threads in -X, -A, -V, -d, -r, -E or -F format" << std::endl;
+            std::cerr << "error: [vg paths] an XG index or vg graph needed for extracting threads in -X, -A, -V, -d, -r or -F format" << std::endl;
             std::exit(EXIT_FAILURE);
         }
         if (!need_graph && (!xg_file.empty() || !vg_file.empty())) {
@@ -256,7 +264,7 @@ int main_paths(int argc, char** argv) {
             //std::exit(EXIT_FAILURE);
             std::cerr << "warning: [vg paths] XG index and/or vg graph  unnecessary for listing GBWT threads" << std::endl;
         }
-    }
+    } 
     if (output_formats != 1) {
         std::cerr << "error: [vg paths] one output format (-X, -A, -V, -d, -r, -L, -F, -E or -C) must be specified" << std::endl;
         std::exit(EXIT_FAILURE);
@@ -331,7 +339,7 @@ int main_paths(int argc, char** argv) {
         // Open up a GAM/GAF output stream
         aln_emitter = vg::io::get_non_hts_alignment_emitter("-", extract_as_gaf ? "GAF" : "GAM", {}, get_thread_count(),
                                                             graph.get());
-    } else if (extract_as_vg || drop_paths || retain_paths) {
+    } else if (extract_as_vg) {
         // Open up a VG Graph chunk output stream
         graph_emitter = unique_ptr<vg::io::ProtobufEmitter<Graph>>(new vg::io::ProtobufEmitter<Graph>(cout));
     }
@@ -436,22 +444,20 @@ int main_paths(int argc, char** argv) {
         };
 
         if (drop_paths || retain_paths) {
-            
-            VG new_graph;
-            
-            // copy the nodes and edges
-            handlealgs::copy_handle_graph(&(*graph), &new_graph);
-            
-            // copy the indicated paths
+
+            vector<string> to_destroy;
             graph->for_each_path_handle([&](const path_handle_t& path_handle) {
-                string name = graph->get_path_name(path_handle);
-                if (check_path_name(name) != drop_paths) {
-                    handlealgs::copy_path(&(*graph), path_handle, &new_graph);
+                    string name = graph->get_path_name(path_handle);
+                    if (check_path_name(name) == drop_paths) {
+                        to_destroy.push_back(name);
                 }
             });
+            for (string& path_name : to_destroy) {
+                dynamic_cast<MutablePathMutableHandleGraph*>(graph.get())->destroy_path(graph->get_path_handle(path_name));
+            }
             
             // output the graph
-            new_graph.serialize(cout);
+            dynamic_cast<SerializableHandleGraph*>(graph.get())->serialize(cout);
         }
         else {
             graph->for_each_path_handle([&](path_handle_t path_handle) {

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -91,7 +91,7 @@ vg construct -m 1000 -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a 2> /dev/null 
 vg index -x w.xg w.vg
 cat w.vg | vg paths -d -v - > part1.tmp
 vg find -x w.xg -Q alt > part2.tmp
-is $(vg combine part1.tmp part2.tmp | vg paths -L -v - | wc -l) 38 "pattern based path extraction works"
+is $(vg combine -c part1.tmp part2.tmp | vg paths -L -v - | wc -l) 38 "pattern based path extraction works"
 rm -f w.xg w.vg part1.tmp part2.tmp
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg

--- a/test/t/51_vg_combine.t
+++ b/test/t/51_vg_combine.t
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 10
+
+vg construct -r small/x.fa -v small/x.vcf.gz  >  x.vg
+vg construct -r small/x.fa -v small/x.vcf.gz | vg paths -d -v - > y.vg
+vg construct -r small/x.fa -v small/x.vcf.gz | vg paths -d -v - > z.vg
+
+vg combine x.vg y.vg z.vg > xyz.vg
+
+is $(vg stats -z xyz.vg | grep nodes | awk '{print $2}') 645 "combined graph as correct total nodes"
+is $(vg stats -z xyz.vg | grep edges | awk '{print $2}') 888 "combined graph as correct total edges"
+vg paths -Ev x.vg > x.paths
+vg paths -Ev xyz.vg > xyz.paths
+diff x.paths xyz.paths
+is $? 0  "combined graph has same input path"
+
+rm -f x.vg y.vg z.vg xyz.vg x.paths xyz.paths
+
+vg construct -r small/x.fa -v small/x.vcf.gz | vg convert -p - >  x.vg
+vg construct -r small/x.fa -v small/x.vcf.gz | vg paths -d -v - | vg convert -a - > y.vg
+vg construct -r small/x.fa -v small/x.vcf.gz | vg paths -d -v - | vg convert -o - > z.vg
+
+vg combine x.vg y.vg z.vg > xyz.vg
+
+is $(vg stats -z xyz.vg | grep nodes | awk '{print $2}') 645 "combined handle graph as correct total nodes"
+is $(vg stats -z xyz.vg | grep edges | awk '{print $2}') 888 "combined handle graph as correct total edges"
+vg paths -Ev x.vg > x.paths
+vg paths -Ev xyz.vg > xyz.paths
+diff x.paths xyz.paths
+is $? 0  "combined handle graph has same input path"
+
+rm -f x.vg y.vg z.vg xyz.vg x.paths xyz.paths
+
+vg construct -r small/x.fa -v small/x.vcf.gz | vg convert -p - >  x.vg
+vg construct -r small/x.fa -v small/x.vcf.gz | vg convert -a - > y.vg
+vg construct -r small/x.fa -v small/x.vcf.gz | vg convert -o - > z.vg
+
+vg combine -p x.vg y.vg z.vg > xyz.vg
+
+is $(vg stats -z xyz.vg | grep nodes | awk '{print $2}') 645 "path combined graph as correct total nodes"
+is $(vg stats -z xyz.vg | grep edges | awk '{print $2}') 890 "path combined path graph as correct total edges"
+is $(vg paths -Ev xyz.vg | wc -l) 1 "path combined graph as correct number of paths"
+is $(vg paths -Ev xyz.vg | awk '{print $2}') 3003 "combined path has correct size"
+
+rm -f x.vg y.vg z.vg xyz.vg
+
+

--- a/vgci/vgci.sh
+++ b/vgci/vgci.sh
@@ -30,7 +30,7 @@ KEEP_INTERMEDIATE_FILES=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@15bb8bbebe0429054dfa6e50d6235e003e832aca"
+TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@0edfa8f1d59cc309264fc725e6ddd0f1aadae188"
 # What toil should we install?
 # Could be something like "toil[aws,mesos]==3.20.0"
 # or "git+https://github.com/adamnovak/toil.git@2b696bec34fa1381afdcf187456571d2b41f3842#egg=toil[aws,mesos]"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg combine` no longer loads graphs as, and writes graph to, protobuf.  Also fixed to join id spaces if necessary.

## Description

In the old days, we could merge together graphs by using `cat`.  This changed at some point due to the vpkg wrapper, so `vg combine` was added to do more or less the same thing that `cat` did.  It still worked by appending protobuf though.  So giving it a list of, say, hashgraphs, would convert them to protobuf in memory, then output the catted protobuf to disk.

This PR changes it to just work on handle graphs directly.  If the input is protobuf, it will use more memory than needed, but that's not our primary use case anymore.  

It will also join IDs as needed (equivalent to running `vg ids -j` first).

The `-p` option is added that will connect paths end-to-end if the same path name is found more than once.  This is equivalent to the old `vg concat -p` option (as `vg concat` is now deprecated).  If the `-p` option is not used, and the same path name is found in more than one input, then it will exit with an error. 

  