### PR TITLE
[WIP] rGFA import support

### DIFF
--- a/src/algorithms/gfa_to_handle.cpp
+++ b/src/algorithms/gfa_to_handle.cpp
@@ -163,7 +163,6 @@ static bool gfa_to_handle_graph_on_disk(const string& filename, MutableHandleGra
     
     // add in all edges
     gg.for_each_edge_line_in_file(filename.c_str(), [&](gfak::edge_elem e) {
-            cerr << " e  source " << e.source_name << " e sink " << e.sink_name << endl;
         validate_gfa_edge(e);
         handle_t a = graph->get_handle(parse_gfa_sequence_id(e.source_name, id_map_info), !e.source_orientation_forward);
         handle_t b = graph->get_handle(parse_gfa_sequence_id(e.sink_name, id_map_info), !e.sink_orientation_forward);
@@ -277,7 +276,7 @@ static void gfa_to_handle_graph_add_rgfa_paths(const string filename, istream* u
             pair<int64_t, vector<pair<nid_t, int64_t>>>& val = path_map[rgfa_name];
             if (!val.second.empty()) {
                 if (val.first != rgfa_rank) {
-                    cerr << "[gfa-to-handle] warning: Ignoring rGFA tags for sequence " << s.name
+                    cerr << "warning:[gfa_to_handle_graph] Ignoring rGFA tags for sequence " << s.name
                          << " because they identify it as being on path " << rgfa_name << " with rank " << rgfa_rank
                          << " but a path with that name has already been found with a different rank (" << val.first << ")" << endl;
                 }
@@ -308,7 +307,7 @@ static void gfa_to_handle_graph_add_rgfa_paths(const string filename, istream* u
         int64_t rank = path_offsets.second.first;
         vector<pair<nid_t, int64_t>>& node_offsets = path_offsets.second.second;
         if (graph->has_path(name)) {
-            cerr << "[gfa-to-handle] warning: Ignoring rGFA tags for path " << name << " as a path with that name "
+            cerr << "warning:[gfa_to_handle_graph] Ignoring rGFA tags for path " << name << " as a path with that name "
                  << "has already been imported from a P-line" << endl;
             continue;
         }

--- a/src/algorithms/gfa_to_handle.hpp
+++ b/src/algorithms/gfa_to_handle.hpp
@@ -37,18 +37,22 @@ struct GFAFormatError : std::runtime_error {
 void gfa_to_handle_graph(const string& filename,
                          MutableHandleGraph* graph,
                          bool try_from_disk = true,
-                         bool try_id_increment_hint = false);
+                         bool try_id_increment_hint = false,
+                         const string& translation_filename = "");
 
 /// Same as gfa_to_handle_graph but also adds path elements from the GFA to the graph
 void gfa_to_path_handle_graph(const string& filename,
                               MutablePathMutableHandleGraph* graph,
                               bool try_from_disk = true,
-                              bool try_id_increment_hint = false);
+                              bool try_id_increment_hint = false,
+                              int64_t max_rgfa_rank = numeric_limits<int64_t>::max(),
+                              const string& translation_filename = "");
                               
 /// Same as above but operating on a stream. Assumed to be non-seekable; all conversion happens in memory.
 /// Always streaming. Doesn't support ID increment hints.
 void gfa_to_path_handle_graph_in_memory(istream& in,
-                                        MutablePathMutableHandleGraph* graph);
+                                        MutablePathMutableHandleGraph* graph,
+                                        int64_t max_rgfa_rank = numeric_limits<int64_t>::max());
 
 
 }

--- a/src/unittest/gfa.cpp
+++ b/src/unittest/gfa.cpp
@@ -331,7 +331,7 @@ L	1	+	2	+	5M)";
         REQUIRE_THROWS_AS(algorithms::gfa_to_path_handle_graph_in_memory(in, &graph), algorithms::GFAFormatError);
     }
     
-    SECTION("A graph that uses a non-numerical identifier is rejected with GFAFormatError") {
+    SECTION("A graph that uses a non-numerical identifier is OK") {
 
         const string graph_gfa = R"(H	VN:Z:0.1
 S	1	GATT
@@ -340,10 +340,15 @@ L	1	+	Chana	+	0M)";
         
         bdsg::HashGraph graph;
         stringstream in(graph_gfa);
-        REQUIRE_THROWS_AS(algorithms::gfa_to_path_handle_graph_in_memory(in, &graph), algorithms::GFAFormatError);
+        algorithms::gfa_to_path_handle_graph_in_memory(in, &graph);
+        REQUIRE(graph.get_node_count() == 2);
+        // Note: gfakluge will visit the nodes in lex. order when loading from memory
+        REQUIRE(graph.get_sequence(graph.get_handle(1)) == "GATT");
+        REQUIRE(graph.get_sequence(graph.get_handle(2)) == "ACA");
+        REQUIRE(graph.has_edge(graph.get_handle(1), graph.get_handle(2)));
     }
     
-    SECTION("A graph that uses a negative identifier is rejected with GFAFormatError") {
+    SECTION("A graph that uses a negative identifier is OK") {
 
         const string graph_gfa = R"(H	VN:Z:0.1
 S	1	GATT
@@ -352,10 +357,15 @@ L	1	+	-2	+	0M)";
         
         bdsg::HashGraph graph;
         stringstream in(graph_gfa);
-        REQUIRE_THROWS_AS(algorithms::gfa_to_path_handle_graph_in_memory(in, &graph), algorithms::GFAFormatError);
+        algorithms::gfa_to_path_handle_graph_in_memory(in, &graph);
+        REQUIRE(graph.get_node_count() == 2);
+        // Note: gfakluge will visit the nodes in lex. order when loading from memory
+        REQUIRE(graph.get_sequence(graph.get_handle(2)) == "GATT");
+        REQUIRE(graph.get_sequence(graph.get_handle(1)) == "ACA");
+        REQUIRE(graph.has_edge(graph.get_handle(2), graph.get_handle(1)));
     }
     
-    SECTION("A graph that uses a zero identifier is rejected with GFAFormatError") {
+    SECTION("A graph that uses a zero identifier is OK") {
 
         const string graph_gfa = R"(H	VN:Z:0.1
 S	1	GATT
@@ -364,7 +374,12 @@ L	1	+	0	+	0M)";
         
         bdsg::HashGraph graph;
         stringstream in(graph_gfa);
-        REQUIRE_THROWS_AS(algorithms::gfa_to_path_handle_graph_in_memory(in, &graph), algorithms::GFAFormatError);
+        algorithms::gfa_to_path_handle_graph_in_memory(in, &graph);
+        REQUIRE(graph.get_node_count() == 2);
+        // Note: gfakluge will visit the nodes in lex. order when loading from memory
+        REQUIRE(graph.get_sequence(graph.get_handle(2)) == "GATT");
+        REQUIRE(graph.get_sequence(graph.get_handle(1)) == "ACA");
+        REQUIRE(graph.has_edge(graph.get_handle(2), graph.get_handle(1)));
     }
 
 }

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 26
+plan tests 30
 
 vg construct -r complex/c.fa -v complex/c.vcf.gz > c.vg
 cat <(vg view c.vg | grep ^S | sort) <(vg view c.vg | grep L | uniq | wc -l) <(vg paths -v c.vg -E) > c.info
@@ -166,3 +166,24 @@ diff floating-ins.gaf floating-ins2.gaf
 is "$?" 0 "convert gam->gaf->gam->gaf makes same gaf each time of floating insertion alignment" 
 
 rm -f floating-ins.pg floating-ins.gam floating-ins.gaf gam.sequence gam2.sequence floating-ins2.gaf
+
+vg convert -g tiny/tiny.gfa | vg view - | sort > tiny.gfa.gfa
+vg convert -g tiny/tiny.rgfa | vg view - | sort > tiny.rgfa.gfa
+diff tiny.gfa.gfa tiny.rgfa.gfa
+is "$?" 0 "converting gfa and equivalent rgfa produces same output"
+
+rm -f tiny.gfa.gfa tiny.rgfa.gfa
+
+is "$(vg convert -g tiny/tiny.rgfa -r 1 | vg view - | grep y | awk '{print $1","$2","$3}')" "P,y[35],2+" "rank-1 rgfa subpath found"
+
+vg convert -g tiny/tiny.rgfa -T gfa-id-mapping.tsv > /dev/null
+grep ^S tiny/tiny.rgfa  | awk '{print $2}' | sort > rgfa_nodes
+grep ^S tiny/tiny.gfa  | awk '{print $2}' | sort > gfa_nodes
+awk '{print $2}' gfa-id-mapping.tsv | sort > rgfa_translated_nodes
+awk '{print $3}' gfa-id-mapping.tsv | sort > gfa_translated_nodes
+diff rgfa_nodes rgfa_translated_nodes
+is "$?" 0 "2nd column of gfa id translation file contains all rgfa nodes"
+diff gfa_nodes gfa_translated_nodes
+is "$?" 0 "3rd column of gfa id translation file contains all gfa nodes"
+
+rm -f  gfa-id-mapping.tsv rgfa_nodes gfa_nodes rgfa_translated_nodes gfa_translated_nodes

--- a/test/tiny/tiny.gfa
+++ b/test/tiny/tiny.gfa
@@ -1,0 +1,37 @@
+H	VN:Z:1.0
+S	5	C
+S	7	A
+S	12	ATAT
+S	8	G
+S	1	CAAATAAG
+S	4	T
+S	6	TTG
+S	15	CCAACTCTCTG
+S	2	A
+S	10	A
+S	9	AAATTTTCTGGAGTTCTAT
+S	11	T
+S	13	A
+S	14	T
+S	3	G
+P	x	1+,3+,5+,6+,8+,9+,11+,12+,14+,15+	8M,1M,1M,3M,1M,19M,1M,4M,1M,11M	
+L	5	+	6	+	0M
+L	7	+	9	+	0M
+L	12	+	13	+	0M
+L	12	+	14	+	0M
+L	8	+	9	+	0M
+L	1	+	2	+	0M
+L	1	+	3	+	0M
+L	4	+	6	+	0M
+L	6	+	7	+	0M
+L	6	+	8	+	0M
+L	2	+	4	+	0M
+L	2	+	5	+	0M
+L	10	+	12	+	0M
+L	9	+	10	+	0M
+L	9	+	11	+	0M
+L	11	+	12	+	0M
+L	13	+	15	+	0M
+L	14	+	15	+	0M
+L	3	+	4	+	0M
+L	3	+	5	+	0M

--- a/test/tiny/tiny.rgfa
+++ b/test/tiny/tiny.rgfa
@@ -1,0 +1,35 @@
+S	s1	CAAATAAG	SN:Z:x	SO:i:0	SR:i:0
+S	s2	A	SN:Z:y	SO:i:35	SR:i:1
+S	s3	G	SN:Z:x	SO:i:8	SR:i:0
+S	s4	T
+S	s5	C	SN:Z:x	SO:i:9	SR:i:0
+S	s6	TTG	SN:Z:x	SO:i:10	SR:i:0
+S	s7	A
+S	s8	G	SN:Z:x	SO:i:13	SR:i:0
+S	s9	AAATTTTCTGGAGTTCTAT	SN:Z:x	SO:i:14	SR:i:0
+S	s10	A
+S	s11	T	SN:Z:x	SO:i:33	SR:i:0
+S	12	ATAT	SN:Z:x	SO:i:34	SR:i:0
+S	s13	A
+S	s14	T	SN:Z:x	SO:i:38	SR:i:0
+S	s15	CCAACTCTCTG	SN:Z:x	SO:i:39	SR:i:0
+L	s5	+	s6	+	0M
+L	s7	+	s9	+	0M
+L	12	+	s13	+	0M
+L	12	+	s14	+	0M
+L	s8	+	s9	+	0M
+L	s1	+	s2	+	0M
+L	s1	+	s3	+	0M
+L	s4	+	s6	+	0M
+L	s6	+	s7	+	0M
+L	s6	+	s8	+	0M
+L	s2	+	s4	+	0M
+L	s2	+	s5	+	0M
+L	s10	+	12	+	0M
+L	s9	+	s10	+	0M
+L	s9	+	s11	+	0M
+L	s11	+	12	+	0M
+L	s13	+	s15	+	0M
+L	s14	+	s15	+	0M
+L	s3	+	s4	+	0M
+L	s3	+	s5	+	0M


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg convert -g` now accepts `rGFA`

## Description
* support non-numeric GFA ids (at the cost of keeping a mapping table while parsing them)
* convert rGFA SN/SO/SR tags into vg paths