### PR TITLE
Convert GBWTGraph to other graph formats

### DIFF
--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -12,6 +12,8 @@
 #include "bdsg/hash_graph.hpp"
 #include "bdsg/odgi.hpp"
 
+#include <gbwtgraph/gbwtgraph.h>
+
 #include <unistd.h>
 #include <getopt.h>
 
@@ -23,7 +25,8 @@ void help_convert(char** argv) {
     cerr << "usage: " << argv[0] << " convert [options] <input-graph>" << endl
          << "input options:" << endl
          << "    -g, --gfa-in           input in GFA format" << endl
-         << "    -r, --in-rgfa-rank N   import rgfa tags with rank <= N as paths [default=0]"
+         << "    -r, --in-rgfa-rank N   import rgfa tags with rank <= N as paths [default=0]" << endl
+         << "    -b, --gbwt-in FILE     input graph is a GBWTGraph using the GBWT in FILE" << endl
          << "output options:" << endl
          << "    -v, --vg-out           output in VG format [default]" << endl
          << "    -a, --hash-out         output in HashGraph format" << endl
@@ -45,6 +48,7 @@ int main_convert(int argc, char** argv) {
     int64_t input_rgfa_rank = 0;
     string gfa_trans_path;
     string input_aln;
+    string gbwt_name;
     bool gam_to_gaf = false;
     bool gaf_to_gam = false;
 
@@ -61,6 +65,7 @@ int main_convert(int argc, char** argv) {
             {"help", no_argument, 0, 'h'},
             {"gfa-in", no_argument, 0, 'g'},
             {"in-rgfa-rank", required_argument, 0, 'r'},
+            {"gbwt-in", required_argument, 0, 'b'},
             {"vg-out", no_argument, 0, 'v'},
             {"hash-out", no_argument, 0, 'a'},
             {"packed-out", no_argument, 0, 'p'},
@@ -74,7 +79,7 @@ int main_convert(int argc, char** argv) {
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hgr:vxapxoT:G:F:t:",
+        c = getopt_long (argc, argv, "hgr:b:vxapxoT:G:F:t:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -93,6 +98,9 @@ int main_convert(int argc, char** argv) {
             break;
         case 'r':
             input_rgfa_rank = stol(optarg);
+            break;
+        case 'b':
+            gbwt_name = optarg;
             break;
         case 'v':
             output_format = "vg";
@@ -240,9 +248,25 @@ int main_convert(int argc, char** argv) {
     }
     else {
         unique_ptr<HandleGraph> input_graph;
-        get_input_file(optind, argc, argv, [&](istream& in) {
-            input_graph = vg::io::VPKG::load_one<HandleGraph>(in);
-        });
+        unique_ptr<gbwt::GBWT> input_gbwt;
+
+        // Load a GBWTGraph or another HandleGraph.
+        if (!gbwt_name.empty()) {
+            get_input_file(optind, argc, argv, [&](istream& in) {
+                input_graph = vg::io::VPKG::load_one<gbwtgraph::GBWTGraph>(in);
+            });
+            gbwtgraph::GBWTGraph* gbwt_graph = dynamic_cast<gbwtgraph::GBWTGraph*>(input_graph.get());
+            if (gbwt_graph == nullptr) {
+                cerr << "error [vg convert]: input graph is not a GBWTGraph" << endl;
+                exit(1);
+            }
+            input_gbwt = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_name);
+            gbwt_graph->set_gbwt(*input_gbwt);
+        } else {
+            get_input_file(optind, argc, argv, [&](istream& in) {
+                input_graph = vg::io::VPKG::load_one<HandleGraph>(in);
+            });
+        }
         
         PathHandleGraph* input_path_graph = dynamic_cast<PathHandleGraph*>(input_graph.get());
         

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 30
+plan tests 32
 
 vg construct -r complex/c.fa -v complex/c.vcf.gz > c.vg
 cat <(vg view c.vg | grep ^S | sort) <(vg view c.vg | grep L | uniq | wc -l) <(vg paths -v c.vg -E) > c.info
@@ -187,3 +187,17 @@ diff gfa_nodes gfa_translated_nodes
 is "$?" 0 "3rd column of gfa id translation file contains all gfa nodes"
 
 rm -f  gfa-id-mapping.tsv rgfa_nodes gfa_nodes rgfa_translated_nodes gfa_translated_nodes
+
+
+# GFA to GBWTGraph to HashGraph to GFA
+vg gbwt -o components.gbwt -g components.gg -G graphs/components_walks.gfa
+vg convert -b components.gbwt -a components.gg > components.hg
+is $? 0 "GBWTGraph to HashGraph conversion"
+grep "^S" graphs/components_walks.gfa | sort > sorted.gfa
+vg view components.hg | grep "^S" | sort > converted.gfa
+cmp sorted.gfa converted.gfa
+is $? 0 "GFA -> GBWTGraph -> HashGraph -> GFA conversion maintains segments"
+
+rm -f components.gbwt components.gg
+rm -f components.hg
+rm -f sorted.gfa converted.gfa


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg convert` can convert GBWTGraph to other graph formats.

## Description

Convert GBWTGraph to other graph formats using `vg convert`. The GBWT index must be provided with option `-b`.