### PR TITLE
Stricter positioning of splice points in mpmap

### DIFF
--- a/src/splicing.cpp
+++ b/src/splicing.cpp
@@ -1236,9 +1236,6 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
     for (const auto& pos : left_mp_aln_trace) {
         is_bridge_left[get<0>(pos)] = true;
     }
-    for (auto i : left_mp_aln.start()) {
-        to_keep_left[i] = true;
-    }
     for (int64_t i = left_mp_aln.subpath_size() - 1; i >= 0; --i) {
         if (is_bridge_left[i]) {
             to_keep_left[i] = true;
@@ -1420,9 +1417,7 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
         is_bridge_right[get<0>(pos)] = true;
     }
     for (int64_t i = 0; i < right_mp_aln.subpath_size(); ++i) {
-        if (is_bridge_right[i]) {
-            to_keep_right[i] = true;
-        }
+        to_keep_right[i] = to_keep_right[i] || is_bridge_right[i];
         for (auto j : right_mp_aln.subpath(i).next()) {
             to_keep_right[j] = to_keep_right[j] || to_keep_right[i];
         }

--- a/src/splicing.hpp
+++ b/src/splicing.hpp
@@ -242,7 +242,8 @@ tuple<pos_t, int64_t, int32_t> trimmed_end(const Alignment& aln, int64_t len, bo
                                            const HandleGraph& graph, const GSSWAligner& aligner);
 
 // remove the portion of the path either to the left or right of a given position along it,
-// described in terms of the indexes in the path object
+// described in terms of the indexes in the path object. returns true if any edits were
+// actually removed.
 bool trim_path(path_t* path, bool from_left, int64_t mapping_idx, int64_t edit_idx, int64_t base_idx);
 
 // consumes two multipath alignments and returns a spliced multipath alignment, which is connected
@@ -253,7 +254,7 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
                                                 multipath_alignment_t&& left_mp_aln, multipath_alignment_t&& right_mp_aln,
                                                 int64_t left_bridge_point, const Alignment& splice_segment,
                                                 int64_t splice_junction_idx, int32_t splice_score, const GSSWAligner& scorer,
-                                                const HandleGraph& graph);
+                                                const HandleGraph& graph);  
 
 }
 

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1381,6 +1381,7 @@ using namespace std;
             
 #ifdef debug_spliced_surject
             cerr << "surjected section " << i << " after score adjustment: " << pb2json(sections.back()) << endl;
+            cerr << "path range: " << graph->get_id(graph->get_handle_of_step(section_path_ranges.back().first)) << " " << graph->get_is_reverse(graph->get_handle_of_step(section_path_ranges.back().first)) << " " << graph->get_position_of_step(section_path_ranges.back().first) << " : " << graph->get_id(graph->get_handle_of_step(section_path_ranges.back().second)) << " " << graph->get_is_reverse(graph->get_handle_of_step(section_path_ranges.back().second)) << " " << graph->get_position_of_step(section_path_ranges.back().second) << endl;
 #endif
         }
         
@@ -2588,6 +2589,7 @@ using namespace std;
     void Surjector::set_path_position(const PathPositionHandleGraph* graph, const pos_t& init_surj_pos, const pos_t& final_surj_pos,
                                       const step_handle_t& range_begin, const step_handle_t& range_end,
                                       string& path_name_out, int64_t& path_pos_out, bool& path_rev_out) const {
+
         
         assert(graph->get_path_handle_of_step(range_begin) == graph->get_path_handle_of_step(range_end));
         
@@ -2599,6 +2601,12 @@ using namespace std;
             path_rev_out = false;
         }
         else {
+#if defined(debug_anchored_surject) || defined(debug_spliced_surject)
+            cerr << "setting position based on range:" << endl;
+            cerr << "\tbegin: " << graph->get_id(graph->get_handle_of_step(range_begin)) << " " << graph->get_is_reverse(graph->get_handle_of_step(range_begin)) << " " << graph->get_position_of_step(range_begin) << endl;
+            cerr << "\tend: " << graph->get_id(graph->get_handle_of_step(range_end)) << " " << graph->get_is_reverse(graph->get_handle_of_step(range_end)) << " " << graph->get_position_of_step(range_end) << endl;
+#endif
+            
             // the path name
             path_name_out = graph->get_path_name(graph->get_path_handle_of_step(range_begin));
             

--- a/src/unittest/multipath_alignment.cpp
+++ b/src/unittest/multipath_alignment.cpp
@@ -2370,7 +2370,6 @@ namespace vg {
         }
 
         SECTION("Paths can be traced from search positions") {
-
             Path path;
 
             Mapping* pm = path.add_mapping();
@@ -2391,8 +2390,9 @@ namespace vg {
             tie(i, j, k, l) = search.front();
             auto trace = trace_path(mp_aln, path, i, j, k, l, false, path.mapping_size());
 
-            REQUIRE(get<0>(trace.first) == 1);
-            REQUIRE(get<1>(trace.first) == 0);
+
+            REQUIRE(get<0>(trace.first) == 0);
+            REQUIRE(get<1>(trace.first) == 1);
             REQUIRE(get<2>(trace.first) == 0);
             REQUIRE(trace.second.size() == 1);
             REQUIRE(get<0>(trace.second.front()) == 0);
@@ -2408,13 +2408,13 @@ namespace vg {
             tie(i, j, k, l) = search.front();
             trace = trace_path(mp_aln, path, i, j, k, l, false, path.mapping_size());
 
-            REQUIRE(get<0>(trace.first) == 1);
-            REQUIRE(get<1>(trace.first) == 0);
+            REQUIRE(get<0>(trace.first) == 0);
+            REQUIRE(get<1>(trace.first) == 1);
             REQUIRE(get<2>(trace.first) == 0);
             REQUIRE(trace.second.size() == 1);
             REQUIRE(get<0>(trace.second.front()) == 0);
-            REQUIRE(get<1>(trace.second.front()) == 1);
-            REQUIRE(get<2>(trace.second.front()) == 0);
+            REQUIRE(get<1>(trace.second.front()) == 0);
+            REQUIRE(get<2>(trace.second.front()) == 1);
             REQUIRE(get<3>(trace.second.front()) == 0);
 
             pm->mutable_position()->set_offset(3);
@@ -2428,13 +2428,13 @@ namespace vg {
             tie(i, j, k, l) = search.front();
             trace = trace_path(mp_aln, path, i, j, k, l, false, path.mapping_size());
 
-            REQUIRE(get<0>(trace.first) == 1);
-            REQUIRE(get<1>(trace.first) == 0);
+            REQUIRE(get<0>(trace.first) == 0);
+            REQUIRE(get<1>(trace.first) == 1);
             REQUIRE(get<2>(trace.first) == 0);
             REQUIRE(trace.second.size() == 1);
             REQUIRE(get<0>(trace.second.front()) == 0);
-            REQUIRE(get<1>(trace.second.front()) == 1);
-            REQUIRE(get<2>(trace.second.front()) == 0);
+            REQUIRE(get<1>(trace.second.front()) == 0);
+            REQUIRE(get<2>(trace.second.front()) == 1);
             REQUIRE(get<3>(trace.second.front()) == 0);
             
             pm->mutable_position()->set_node_id(graph.get_id(h2));
@@ -2450,8 +2450,8 @@ namespace vg {
             tie(i, j, k, l) = search.front();
             trace = trace_path(mp_aln, path, i, j, k, l, false, path.mapping_size());
 
-            REQUIRE(get<0>(trace.first) == 1);
-            REQUIRE(get<1>(trace.first) == 0);
+            REQUIRE(get<0>(trace.first) == 0);
+            REQUIRE(get<1>(trace.first) == 1);
             REQUIRE(get<2>(trace.first) == 0);
             REQUIRE(trace.second.size() == 1);
             REQUIRE(get<0>(trace.second.front()) == 1);
@@ -2483,13 +2483,13 @@ namespace vg {
             tie(i, j, k, l) = search.front();
             trace = trace_path(mp_aln, path, i, j, k, l, false, path.mapping_size());
 
-            REQUIRE(get<0>(trace.first) == 2);
-            REQUIRE(get<1>(trace.first) == 0);
+            REQUIRE(get<0>(trace.first) == 1);
+            REQUIRE(get<1>(trace.first) == 2);
             REQUIRE(get<2>(trace.first) == 0);
             REQUIRE(trace.second.size() == 1);
             REQUIRE(get<0>(trace.second.front()) == 1);
-            REQUIRE(get<1>(trace.second.front()) == 2);
-            REQUIRE(get<2>(trace.second.front()) == 0);
+            REQUIRE(get<1>(trace.second.front()) == 1);
+            REQUIRE(get<2>(trace.second.front()) == 3);
             REQUIRE(get<3>(trace.second.front()) == 0);
 
             Edit* pe5 = pm2->add_edit();
@@ -2507,19 +2507,9 @@ namespace vg {
             REQUIRE(get<2>(trace.first) == 0);
             REQUIRE(trace.second.size() == 1);
             REQUIRE(get<0>(trace.second.front()) == 1);
-            REQUIRE(get<1>(trace.second.front()) == 2);
-            REQUIRE(get<2>(trace.second.front()) == 0);
+            REQUIRE(get<1>(trace.second.front()) == 1);
+            REQUIRE(get<2>(trace.second.front()) == 3);
             REQUIRE(get<3>(trace.second.front()) == 0);
-            
-            //   s0  s1      s2 s3
-            //   m0  m1m2    m3 m4
-            //   GA  A|TTA--|A  TT
-            // TAGA  A|T--CA|A  GG
-            // h1    h2         h3
-            
-            //cerr << i << " " << j << " " << k << " " << l << endl;
-            //cerr << "(" << get<0>(trace.first) << ", " << get<1>(trace.first) << ", " << get<2>(trace.first) << ", " << get<3>(trace.first) << "), (" << get<0>(trace.second) << ", " << get<1>(trace.second) << ", " << get<2>(trace.second) << ")" << endl;
-
         }
 
         SECTION("Paths with empty elements be traced from search positions") {
@@ -2548,13 +2538,13 @@ namespace vg {
             tie(i, j, k, l) = search.front();
             auto trace = trace_path(mp_aln, path, i, j, k, l, false, path.mapping_size());
 
-            REQUIRE(get<0>(trace.first) == 1);
-            REQUIRE(get<1>(trace.first) == 0);
+            REQUIRE(get<0>(trace.first) == 0);
+            REQUIRE(get<1>(trace.first) == 2);
             REQUIRE(get<2>(trace.first) == 0);
             REQUIRE(trace.second.size() == 1);
             REQUIRE(get<0>(trace.second.front()) == 0);
-            REQUIRE(get<1>(trace.second.front()) == 1);
-            REQUIRE(get<2>(trace.second.front()) == 0);
+            REQUIRE(get<1>(trace.second.front()) == 0);
+            REQUIRE(get<2>(trace.second.front()) == 1);
             REQUIRE(get<3>(trace.second.front()) == 0);
 
             Mapping* pm1 = path.add_mapping();
@@ -2566,15 +2556,22 @@ namespace vg {
             REQUIRE(search.size() == 1);
             tie(i, j, k, l) = search.front();
             trace = trace_path(mp_aln, path, i, j, k, l, false, path.mapping_size());
-
-            REQUIRE(get<0>(trace.first) == 2);
-            REQUIRE(get<1>(trace.first) == 0);
+            
+            REQUIRE(get<0>(trace.first) == 0);
+            REQUIRE(get<1>(trace.first) == 2);
             REQUIRE(get<2>(trace.first) == 0);
             REQUIRE(trace.second.size() == 1);
-            REQUIRE(get<0>(trace.second.front()) == 1);
+            REQUIRE(get<0>(trace.second.front()) == 0);
             REQUIRE(get<1>(trace.second.front()) == 0);
-            REQUIRE(get<2>(trace.second.front()) == 0);
+            REQUIRE(get<2>(trace.second.front()) == 1);
             REQUIRE(get<3>(trace.second.front()) == 0);
+            
+            
+            //   s0  s1      s2 s3
+            //   m0  m1m2    m3 m4
+            //   GA  A|TTA--|A  TT
+            // TAGA  A|T--CA|A  GG
+            // h1    h2         h3
         }
 
         auto add_mapping_front = [](Path& path) {
@@ -2755,9 +2752,9 @@ namespace vg {
             REQUIRE(get<2>(trace.first) == 0);
             REQUIRE(trace.second.size() == 1);
             REQUIRE(get<0>(trace.second.front()) == 1);
-            REQUIRE(get<1>(trace.second.front()) == 0);
+            REQUIRE(get<1>(trace.second.front()) == 1);
             REQUIRE(get<2>(trace.second.front()) == 0);
-            REQUIRE(get<3>(trace.second.front()) == 1);
+            REQUIRE(get<3>(trace.second.front()) == 0);
 
             pm3->mutable_position()->set_offset(0);
             pe6->set_from_length(2);
@@ -2835,8 +2832,8 @@ namespace vg {
             tie(i, j, k, l) = search.front();
             auto trace = trace_path(mp_aln, p, i, j, k, l, false, p.mapping_size());
 
-            REQUIRE(get<0>(trace.first) == 1);
-            REQUIRE(get<1>(trace.first) == 0);
+            REQUIRE(get<0>(trace.first) == 0);
+            REQUIRE(get<1>(trace.first) == 1);
             REQUIRE(get<2>(trace.first) == 0);
             REQUIRE(trace.second.size() == 1);
             REQUIRE(get<0>(trace.second.front()) == 0);


### PR DESCRIPTION
## Description

The algorithm I was using to decide what part of a pre-spliced multipath alignment should get diced up to make the spliced alignment could sometimes be fooled into adding splice edges that were invalid. The problem should be fixed now.