### PR TITLE
Bug fix in dozeu and MultipathAlignmentGraph

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -4766,7 +4766,7 @@ namespace vg {
                     
                     // figure out how far we need to try to align out to
                     int64_t tail_length = path_node.begin - alignment.sequence().begin();
-                    int64_t gap =  min(aligner->longest_detectable_gap(alignment, path_node.end), max_gap);
+                    int64_t gap =  min(aligner->longest_detectable_gap(alignment, path_node.begin), max_gap);
                     if (pessimistic_tail_gap_multiplier) {
                         gap = min(gap, pessimistic_tail_gap(tail_length, pessimistic_tail_gap_multiplier));
                     }

--- a/src/unittest/xdrop_aligner.cpp
+++ b/src/unittest/xdrop_aligner.cpp
@@ -867,6 +867,27 @@ TEST_CASE("QualAdjXdropAligner uses quality adjusted full length bonuses",
     REQUIRE(aln1.score() == 1);
     REQUIRE(aln2.score() == 1);
 }
+
+TEST_CASE("QualAdjXdropAligner doesn't crash when a traceback goes through an X-dropped vector",
+          "[xdrop][alignment][mapping][pinned]") {
+    
+    bdsg::HashGraph graph;
+    
+    handle_t h0 = graph.create_handle("ACCTACCAAATCACT");
+    
+    Alignment aln;
+    aln.set_sequence("TCCTACCTAATCA");
+    aln.set_quality(":F:F,FFF:::F,");
+    alignment_quality_char_to_short(aln);
+    
+    TestAligner aligner_source;
+    aligner_source.set_alignment_scores(1, 4, 6, 1, 20);
+    const QualAdjAligner& aligner = *aligner_source.get_qual_adj_aligner();
+    
+    aligner.align_pinned(aln, graph, true, true, 0);
+    
+    REQUIRE(path_to_length(aln.path()) == aln.sequence().size());
+}
    
 }
 }

--- a/src/unittest/xdrop_aligner.cpp
+++ b/src/unittest/xdrop_aligner.cpp
@@ -888,6 +888,38 @@ TEST_CASE("QualAdjXdropAligner doesn't crash when a traceback goes through an X-
     
     REQUIRE(path_to_length(aln.path()) == aln.sequence().size());
 }
+
+TEST_CASE("QualAdjXdropAligner doesn't crash with a long sequence",
+          "[xdrop][alignment][mapping][pinned][longsequence]") {
+    
+    bdsg::HashGraph graph;
+    
+    handle_t h0 = graph.create_handle("TC");
+    handle_t h1 = graph.create_handle("ATCATTATGTTTTTGAGTATAGTATAGTTACT");
+    handle_t h2 = graph.create_handle("TGTTTTCACTGCTTTATATACCATTGTATAAA");
+    handle_t h3 = graph.create_handle("TATACCACAATTTATCCATTCTAGTATTAATG");
+    handle_t h4 = graph.create_handle("GACATTAGGTTTGTTGTTATTACAGTGTTCCT");
+    handle_t h5 = graph.create_handle("GCAAGTAACCTTGCACATTTCTCCTGATACAC");
+    
+    graph.create_edge(h0, h1);
+    graph.create_edge(h1, h2);
+    graph.create_edge(h2, h3);
+    graph.create_edge(h3, h4);
+    graph.create_edge(h4, h5);
+    
+    Alignment aln;
+    aln.set_sequence("CTTTAGGTAATTTTAAACAAACAAAAGCTATCTCAAAATTTTTTCACACTTTTCAAACCCCTGATCCCTCATTTACTCTTTGGAGATGCCCCACCTTATCTCTTTCCAAAAACTAAGGACAACTANNNNNNNNNCNNNNTNG");
+    aln.set_quality("<0FI000F<I0FII7I77B0B00I077007<077<<I07FI0IB0FFB00FF0F<I00FIF77F<0II0<000<000<F<0B<F000000FB0BF<B7F0BBBF077000I0F00000000F000'''''''''0''''0'<");
+    alignment_quality_char_to_short(aln);
+    
+    TestAligner aligner_source;
+    aligner_source.set_alignment_scores(1, 4, 6, 1, 5);
+    const QualAdjAligner& aligner = *aligner_source.get_qual_adj_aligner();
+    
+    aligner.align_pinned(aln, graph, true, true, 9);
+    
+    REQUIRE(path_to_length(aln.path()) == aln.sequence().size());
+}
    
 }
 }

--- a/src/unittest/xdrop_aligner.cpp
+++ b/src/unittest/xdrop_aligner.cpp
@@ -889,8 +889,8 @@ TEST_CASE("QualAdjXdropAligner doesn't crash when a traceback goes through an X-
     REQUIRE(path_to_length(aln.path()) == aln.sequence().size());
 }
 
-TEST_CASE("QualAdjXdropAligner doesn't crash with a long sequence",
-          "[xdrop][alignment][mapping][pinned][longsequence]") {
+TEST_CASE("XdropAligner can align across multiple nodes",
+          "[xdrop][alignment][mapping][pinned]") {
     
     bdsg::HashGraph graph;
     
@@ -920,7 +920,39 @@ TEST_CASE("QualAdjXdropAligner doesn't crash with a long sequence",
     
     REQUIRE(path_to_length(aln.path()) == aln.sequence().size());
 }
-   
+
+TEST_CASE("XdropAligner can align to a graph where some nodes are entirely unaligned",
+          "[xdrop][alignment][mapping][pinned]") {
+    
+    bdsg::HashGraph graph;
+    
+    handle_t h0 = graph.create_handle("CTTCAGGAGGCAACATCAAGGTAACCCGAGTT");
+    handle_t h1 = graph.create_handle("TAGGGATATTCTGCAAAATAACTGGCCTGTAA");
+    handle_t h2 = graph.create_handle("ACCTCAAAATTAAGTCAAGATCATGGAACCAA");
+    handle_t h3 = graph.create_handle("GAAAACACTGAGGAATTGTTCCACACTAAAGA");
+    handle_t h4 = graph.create_handle("AGTGTGCAGAAACATGGCAACTCCATGTGGTT");
+    handle_t h5 = graph.create_handle("CATGATTCTGAATCGGCA");
+    
+    graph.create_edge(h0, h1);
+    graph.create_edge(h1, h2);
+    graph.create_edge(h2, h3);
+    graph.create_edge(h3, h4);
+    graph.create_edge(h4, h5);
+    
+    Alignment aln;
+    aln.set_sequence("CGGGGCCTTCCTCCAGTGAATATCTCTTCTAACATTGTCAATCATATCCAACAGAAGAAGAGATCGCTCCATTGGTACAAAAAGCTATAGCGCTGAATAATAGTTGGACGCTGACGGGCTATCTGAGTATGACAGAGCGCN");
+    aln.set_quality("B7FFFFFIFIBFFFIII0FIIIIIF<IIBFIIIIIFF7F0BI7IFFF07FIIF00<0B<FB7BF00B007FF<0BI0BFF000000<000<0B07F00F<0B0B0F000007000000000000000000<000000F00'");
+    alignment_quality_char_to_short(aln);
+    
+    TestAligner aligner_source;
+    aligner_source.set_alignment_scores(1, 4, 6, 1, 5);
+    const QualAdjAligner& aligner = *aligner_source.get_qual_adj_aligner();
+    
+    aligner.align_pinned(aln, graph, false, true, 10);
+    
+    REQUIRE(path_to_length(aln.path()) == aln.sequence().size());
+}
+
 }
 }
         


### PR DESCRIPTION
## Description

A bug in MultipathAlignmentGraph could lead to a bad parameterization of dozeu, which could lead to strange DP matrices that exposed a bug in dozeu. Both bugs now fixed.