### PR TITLE
Fix a bad parameter setting in multipath alignment graph

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -4766,7 +4766,7 @@ namespace vg {
                     
                     // figure out how far we need to try to align out to
                     int64_t tail_length = path_node.begin - alignment.sequence().begin();
-                    int64_t gap =  min(aligner->longest_detectable_gap(alignment, path_node.end), max_gap);
+                    int64_t gap =  min(aligner->longest_detectable_gap(alignment, path_node.begin), max_gap);
                     if (pessimistic_tail_gap_multiplier) {
                         gap = min(gap, pessimistic_tail_gap(tail_length, pessimistic_tail_gap_multiplier));
                     }


### PR DESCRIPTION
Contains one of the bugfixes from https://github.com/vgteam/vg/pull/3174 so I can merge it while continuing to work on the other bugfix.