### PR TITLE
Make sure std::runtime_error is available

### DIFF
--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <string>
 #include <memory>
+#include <stdexcept>
 
 namespace vg {
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Build should fail less on GCC 10.2.1-1.

## Description
This should fix #3170, unless there are more problems on very new GCC.