### PR TITLE
Allow simplification of automatic indexing plans

### DIFF
--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -768,7 +768,7 @@ void IndexRegistry::make_indexes(const vector<IndexName>& identifiers) {
             index_prefix = get_work_dir() + "/" + sha1sum(to_string(index->get_identifier()));
         }
         
-        index->execute_recipe(step.second, index_prefix);
+        index->execute_recipe(step.second, this, is_intermediate);
     }
     
     // clean up intermediate files
@@ -1299,13 +1299,13 @@ bool IndexFile::was_provided_directly() const {
     return provided_directly;
 }
 
-void IndexFile::execute_recipe(size_t recipe_priority, const string& prefix) {
+void IndexFile::execute_recipe(size_t recipe_priority, const IndexRegistry* registry) {
     assert(recipe_priority < recipes.size());
     auto& recipe = recipes[recipe_priority];
     for (auto input : recipe.inputs) {
         assert(input->is_finished());
     }
-    filenames = recipe.execute(prefix, this->suffix);
+    filenames = recipe.execute(registry);
 }
 
 RecipeName IndexFile::add_recipe(const vector<const IndexFile*>& inputs,
@@ -1321,8 +1321,8 @@ IndexRecipe::IndexRecipe(const vector<const IndexFile*>& inputs,
     // nothing more to do
 }
 
-vector<string> IndexRecipe::execute(const string& prefix, const string& suffix) {
-    return exec(inputs, prefix, suffix);
+vector<string> IndexRecipe::execute(const IndexRegistry* registry) {
+    return exec(inputs, registry);
 }
 
 InsufficientInputException::InsufficientInputException(const IndexName& target,

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -35,6 +35,23 @@
 //#define debug_index_registry
 //#define debug_index_registry_path_state
 
+namespace std {
+    
+/// Convert IndexNames to strings, without defining it for all things sharing
+/// the same underlying type.
+static string to_string(const vg::IndexName& name) {
+    stringstream ss;
+    for (auto it = name.begin(); it != name.end(); ++it) {
+        if (it != name.begin()) {
+            ss << " + ";
+        }
+        ss << *it;
+    }
+    return ss.str();
+}
+    
+}
+
 namespace vg {
 
 IndexingParameters::MutableGraphImplementation IndexingParameters::mut_graph_impl = HashGraph;
@@ -56,23 +73,23 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
      ***********************/
     
     /// Data files
-    registry.register_index("Reference FASTA", "fasta");
-    registry.register_index("VCF", "vcf");
-    registry.register_index("Phased VCF", "phased.vcf");
-    registry.register_index("Insertion Sequence FASTA", "insertions.fasta");
-    registry.register_index("Reference GFA", "gfa");
+    registry.register_index({"Reference FASTA"}, "fasta");
+    registry.register_index({"VCF"}, "vcf");
+    registry.register_index({"Phased VCF"}, "phased.vcf");
+    registry.register_index({"Insertion Sequence FASTA"}, "insertions.fasta");
+    registry.register_index({"Reference GFA"}, "gfa");
     
     /// True indexes
-    registry.register_index("VG + Variant Paths", "varpaths.vg");
+    registry.register_index({"VG + Variant Paths"}, "varpaths.vg");
     //registry.register_index("VG + NodeMapping", "vg_mapping");
     //registry.register_index("VG + Variant Paths + NodeMapping", "vg_mapping");
-    registry.register_index("VG", "vg");
-    registry.register_index("XG", "xg");
-    registry.register_index("GBWT", "gbwt");
-    registry.register_index("NodeMapping", "mapping");
-    registry.register_index("Pruned VG", "pruned.vg");
-    registry.register_index("Haplotype-Pruned VG + NodeMapping", "haplopruned.vg");
-    registry.register_index("GCSA + LCP", "gcsa");
+    registry.register_index({"VG"}, "vg");
+    registry.register_index({"XG"}, "xg");
+    registry.register_index({"GBWT"}, "gbwt");
+    registry.register_index({"NodeMapping"}, "mapping");
+    registry.register_index({"Pruned VG"}, "pruned.vg");
+    registry.register_index({"Haplotype-Pruned VG", "NodeMapping"}, "haplopruned.vg");
+    registry.register_index({"GCSA", "LCP"}, "gcsa");
     
     /*********************
      * A few handy lambda functions
@@ -137,7 +154,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
 #endif
     
     // alias a phased VCF as an unphased one
-    registry.register_recipe("VCF", {"Phased VCF"},
+    registry.register_recipe({"VCF"}, {{"Phased VCF"}},
                              [](const vector<const IndexFile*>& inputs,
                                 const string& prefix, const string& suffix) {
         return inputs.front()->get_filenames();
@@ -159,7 +176,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
 //    });
     
     // strip alt allele paths from a graph that has them
-    registry.register_recipe("VG", {"VG + Variant Paths"},
+    registry.register_recipe({"VG"}, {{"VG + Variant Paths"}},
                              [&](const vector<const IndexFile*>& inputs,
                                 const string& prefix, const string& suffix) {
         if (IndexingParameters::verbose) {
@@ -231,7 +248,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         return vector<string>(1, output_name);
     };
     
-    registry.register_recipe("VG", {"Reference GFA"},
+    registry.register_recipe({"VG"}, {{"Reference GFA"}},
                              [&](const vector<const IndexFile*>& inputs,
                                  const string& prefix, const string& suffix) {
         return construct_from_gfa(inputs, prefix, suffix, nullptr);
@@ -287,22 +304,22 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     };
     
     // the specific instantiations of the meta-recipe above
-    registry.register_recipe("VG", {"Reference FASTA", "VCF", "Insertion Sequence FASTA"},
+    registry.register_recipe({"VG"}, {{"Reference FASTA"}, {"VCF"}, {"Insertion Sequence FASTA"}},
                              [&](const vector<const IndexFile*>& inputs,
                                 const string& prefix, const string& suffix) {
         return construct_with_constructor(inputs, prefix, suffix, false, nullptr);
     });
-    registry.register_recipe("VG", {"Reference FASTA", "VCF"},
+    registry.register_recipe({"VG"}, {{"Reference FASTA"}, {"VCF"}},
                              [&](const vector<const IndexFile*>& inputs,
                                 const string& prefix, const string& suffix) {
         return construct_with_constructor(inputs, prefix, suffix, false, nullptr);
     });
-    registry.register_recipe("VG + Variant Paths", {"Reference FASTA", "Phased VCF", "Insertion Sequence FASTA"},
+    registry.register_recipe({"VG + Variant Paths"}, {{"Reference FASTA"}, {"Phased VCF"}, {"Insertion Sequence FASTA"}},
                              [&](const vector<const IndexFile*>& inputs,
                                 const string& prefix, const string& suffix) {
         return construct_with_constructor(inputs, prefix, suffix, true, nullptr);
     });
-    registry.register_recipe("VG + Variant Paths", {"Reference FASTA", "Phased VCF"},
+    registry.register_recipe({"VG + Variant Paths"}, {{"Reference FASTA"}, {"Phased VCF"}},
                              [&](const vector<const IndexFile*>& inputs,
                                 const string& prefix, const string& suffix) {
         return construct_with_constructor(inputs, prefix, suffix, true, nullptr);
@@ -333,7 +350,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     cerr << "registering XG recipes" << endl;
 #endif
     
-    registry.register_recipe("XG", {"Reference GFA"},
+    registry.register_recipe({"XG"}, {{"Reference GFA"}},
                              [&](const vector<const IndexFile*>& inputs,
                                  const string& prefix, const string& suffix) {
         if (IndexingParameters::verbose) {
@@ -352,7 +369,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         return vector<string>(1, output_name);
     });
     
-    registry.register_recipe("XG", {"VG"},
+    registry.register_recipe({"XG"}, {{"VG"}},
                              [&](const vector<const IndexFile*>& inputs,
                                  const string& prefix, const string& suffix) {
         if (IndexingParameters::verbose) {
@@ -392,7 +409,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     cerr << "registering NodeMapping recipes" << endl;
 #endif
     
-    registry.register_recipe("NodeMapping", {"VG"},
+    registry.register_recipe({"NodeMapping"}, {{"VG"}},
                              [&](const vector<const IndexFile*>& inputs,
                                  const string& prefix, const string& suffix) {
         if (IndexingParameters::verbose) {
@@ -422,7 +439,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     cerr << "registering GBWT recipes" << endl;
 #endif
     
-    registry.register_recipe("GBWT", {"VG + Variant Paths", "Phased VCF"},
+    registry.register_recipe({"GBWT"}, {{"VG + Variant Paths"}, {"Phased VCF"}},
                              [&](const vector<const IndexFile*>& inputs,
                                  const string& prefix, const string& suffix) {
         if (IndexingParameters::verbose) {
@@ -541,7 +558,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         }
     };
     
-    registry.register_recipe("Pruned VG", {"VG", "XG"},
+    registry.register_recipe({"Pruned VG"}, {{"VG"}, {"XG"}},
                              [&](const vector<const IndexFile*>& inputs,
                                  const string& prefix, const string& suffix) {
         if (IndexingParameters::verbose) {
@@ -551,7 +568,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         return prune_graph(inputs, prefix, suffix);
     });
     
-    registry.register_recipe("Haplotype-Pruned VG + NodeMapping", {"VG", "XG", "GBWT", "NodeMapping"},
+    registry.register_recipe({"Haplotype-Pruned VG", "NodeMapping"}, {{"VG"}, {"XG"}, {"GBWT"}, {"NodeMapping"}},
                              [&](const vector<const IndexFile*>& inputs,
                                  const string& prefix, const string& suffix) {
         if (IndexingParameters::verbose) {
@@ -635,14 +652,14 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         return vector<string>{gcsa_output_name, lcp_output_name};
     };
     
-    registry.register_recipe("GCSA + LCP", {"Haplotype-Pruned VG + NodeMapping"},
+    registry.register_recipe({"GCSA", "LCP"}, {{"Haplotype-Pruned VG"}, {"NodeMapping"}},
                             [&](const vector<const IndexFile*>& inputs,
                                 const string& prefix, const string& suffix) {
         // execute meta recipe
         return construct_gcsa(inputs, prefix, suffix);
     });
     
-    registry.register_recipe("GCSA + LCP", {"Pruned VG"},
+    registry.register_recipe({"GCSA", "LCP"}, {{"Pruned VG"}},
                              [&](const vector<const IndexFile*>& inputs,
                                  const string& prefix, const string& suffix) {
         // execute meta recipe
@@ -652,30 +669,30 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     return registry;
 }
 
-vector<string> VGIndexes::get_default_map_indexes() {
-    vector<string> indexes{
-        "XG",
-        "GCSA + LCP"
+vector<IndexName> VGIndexes::get_default_map_indexes() {
+    vector<IndexName> indexes{
+        {"XG"},
+        {"GCSA", "LCP"}
     };
     return indexes;
 }
 
-vector<string> VGIndexes::get_default_mpmap_indexes() {
-    vector<string> indexes{
-        "Spliced XG",
-        "Spliced Distance",
-        "Spliced GCSA + LCP",
-        "Haplotype-Transcript GBWT"
+vector<IndexName> VGIndexes::get_default_mpmap_indexes() {
+    vector<IndexName> indexes{
+        {"Spliced XG"},
+        {"Spliced Distance"},
+        {"Spliced GCSA", "Spliced LCP"},
+        {"Haplotype-Transcript GBWT"}
     };
     return indexes;
 }
 
-vector<string> VGIndexes::get_default_giraffe_indexes() {
-    vector<string> indexes{
-        "GBWT",
-        "GBWTGraph",
-        "Distance",
-        "Minimizer"
+vector<IndexName> VGIndexes::get_default_giraffe_indexes() {
+    vector<IndexName> indexes{
+        {"GBWT"},
+        {"GBWTGraph"},
+        {"Distance"},
+        {"Minimizer"}
     };
     return indexes;
 }
@@ -720,7 +737,7 @@ void IndexRegistry::set_intermediate_file_keeping(bool keep_intermediates) {
     this->keep_intermediates = keep_intermediates;
 }
 
-void IndexRegistry::make_indexes(const vector<string>& identifiers) {
+void IndexRegistry::make_indexes(const vector<IndexName>& identifiers) {
     
     // utility function, checks if an index is neither directly requested
     // or provided as input
@@ -748,7 +765,7 @@ void IndexRegistry::make_indexes(const vector<string>& identifiers) {
         }
         else {
             // we're not saving this file, make it
-            index_prefix = get_work_dir() + "/" + sha1sum(index->get_identifier());
+            index_prefix = get_work_dir() + "/" + sha1sum(to_string(index->get_identifier()));
         }
         
         index->execute_recipe(step.second, index_prefix);
@@ -758,11 +775,11 @@ void IndexRegistry::make_indexes(const vector<string>& identifiers) {
     if (!keep_intermediates) {
         // collect the names of everything we want to keep (i.e. considered non-
         // intermediate by at least one index)
-        unordered_set<string> to_keep;
+        unordered_set<string> filenames_to_keep;
         for (const auto& registered_index : registry) {
             if (!is_intermediate(registered_index.second.get())) {
                 for (auto& filename : registered_index.second->get_filenames()) {
-                    to_keep.insert(filename);
+                    filenames_to_keep.insert(filename);
                 }
             }
         }
@@ -770,7 +787,7 @@ void IndexRegistry::make_indexes(const vector<string>& identifiers) {
         // delete everything else
         for (const auto& registered_index : registry) {
             for (auto& filename : registered_index.second->get_filenames()) {
-                if (!to_keep.count(filename)) {
+                if (!filenames_to_keep.count(filename)) {
                     std::remove(filename.c_str());
                 }
             }
@@ -778,7 +795,7 @@ void IndexRegistry::make_indexes(const vector<string>& identifiers) {
     }
 }
 
-void IndexRegistry::register_index(const string& identifier, const string& suffix) {
+void IndexRegistry::register_index(const IndexName& identifier, const string& suffix) {
     // Add this index to the registry
     if (identifier.empty()) {
         cerr << "error:[IndexRegistry] indexes must have a non-empty identifier" << endl;
@@ -789,7 +806,7 @@ void IndexRegistry::register_index(const string& identifier, const string& suffi
         exit(1);
     }
     if (registry.count(identifier)) {
-        cerr << "error:[IndexRegistry] index registry contains a duplicated identifier: " << identifier << endl;
+        cerr << "error:[IndexRegistry] index registry contains a duplicated identifier: " << to_string(identifier) << endl;
         exit(1);
     }
     if (registered_suffixes.count(suffix)) {
@@ -801,16 +818,16 @@ void IndexRegistry::register_index(const string& identifier, const string& suffi
 }
 
 
-void IndexRegistry::provide(const string& identifier, const string& filename) {
+void IndexRegistry::provide(const IndexName& identifier, const string& filename) {
     provide(identifier, vector<string>(1, filename));
 }
 
-void IndexRegistry::provide(const string& identifier, const vector<string>& filenames) {
+void IndexRegistry::provide(const IndexName& identifier, const vector<string>& filenames) {
     get_index(identifier)->provide(filenames);
 }
 
-vector<string> IndexRegistry::completed_indexes() const {
-    vector<string> indexes;
+vector<IndexName> IndexRegistry::completed_indexes() const {
+    vector<IndexName> indexes;
     for (const auto& index : registry) {
         if (index.second->is_finished()) {
             indexes.push_back(index.first);
@@ -819,8 +836,8 @@ vector<string> IndexRegistry::completed_indexes() const {
     return indexes;
 }
 
-void IndexRegistry::register_recipe(const string& identifier,
-                                    const vector<string>& input_identifiers,
+void IndexRegistry::register_recipe(const IndexName& identifier,
+                                    const vector<IndexName>& input_identifiers,
                                     const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec) {
     vector<const IndexFile*> inputs;
     for (const auto& input_identifier : input_identifiers) {
@@ -829,11 +846,11 @@ void IndexRegistry::register_recipe(const string& identifier,
     get_index(identifier)->add_recipe(inputs, exec);
 }
 
-IndexFile* IndexRegistry::get_index(const string& identifier) {
+IndexFile* IndexRegistry::get_index(const IndexName& identifier) {
     return registry.at(identifier).get();
 }
 
-const IndexFile* IndexRegistry::get_index(const string& identifier) const {
+const IndexFile* IndexRegistry::get_index(const IndexName& identifier) const {
     return registry.at(identifier).get();
 }
 
@@ -845,15 +862,15 @@ string IndexRegistry::get_work_dir() {
     return work_dir;
 }
 
-vector<string> IndexRegistry::dependency_order() const {
+vector<IndexName> IndexRegistry::dependency_order() const {
     
 #ifdef debug_index_registry
     cerr << "finding topological order in dependency graph" << endl;
 #endif
     
     // assign each index file an index in a vector (arbitrarily)
-    unordered_map<string, size_t> graph_idx;
-    vector<string> graph_label;
+    map<IndexName, size_t> graph_idx;
+    vector<IndexName> graph_label;
     for (const auto& idx_file : registry) {
         graph_idx[idx_file.first] = graph_label.size();
         graph_label.push_back(idx_file.first);
@@ -910,7 +927,7 @@ vector<string> IndexRegistry::dependency_order() const {
     }
     
     // convert to return format
-    vector<string> ordered_identifiers(order.size());
+    vector<IndexName> ordered_identifiers(order.size());
     for (size_t i = 0; i < order.size(); ++i) {
         ordered_identifiers[i] = graph_label[order[i]];
     }
@@ -924,7 +941,7 @@ vector<string> IndexRegistry::dependency_order() const {
     return ordered_identifiers;
 }
 
-vector<pair<string, size_t>> IndexRegistry::make_plan(const vector<string>& end_products) const {
+vector<pair<IndexName, size_t>> IndexRegistry::make_plan(const vector<IndexName>& end_products) const {
     
 #ifdef debug_index_registry
     cerr << "generating plan for indexes:" << endl;
@@ -934,14 +951,14 @@ vector<pair<string, size_t>> IndexRegistry::make_plan(const vector<string>& end_
 #endif
     
     // get the dependency ordering of the indexes
-    vector<string> identifier_order = dependency_order();
-    unordered_map<string, size_t> dep_order_of_identifier;
+    vector<IndexName> identifier_order = dependency_order();
+    map<IndexName, size_t> dep_order_of_identifier;
     for (size_t i = 0; i < identifier_order.size(); ++i) {
         dep_order_of_identifier[identifier_order[i]] = i;
     }
     
     // TODO: I'm sure there's a more elegant implementation of this algorithm
-    unordered_set<pair<string, size_t>> plan_elements;
+    set<pair<IndexName, size_t>> plan_elements;
     for (const auto& product : end_products) {
 #ifdef debug_index_registry
         cerr << "making a plan for end product " << product << endl;
@@ -959,11 +976,11 @@ vector<pair<string, size_t>> IndexRegistry::make_plan(const vector<string>& end_
 #ifdef debug_index_registry_path_state
             cerr << "new iteration, path:" << endl;
             for (auto pe : plan_path) {
-                cerr << "\t" << identifier_order[get<0>(pe)] << ", requester: " << (get<1>(pe) == identifier_order.size() ? string("PLAN TARGET") : identifier_order[get<1>(pe)]) << ", recipe " << get<2>(pe) << endl;
+                cerr << "\t" << identifier_order[get<0>(pe)] << ", requester: " << (get<1>(pe) == identifier_order.size() ? string("PLAN TARGET") : to_string(identifier_order[get<1>(pe)])) << ", recipe " << get<2>(pe) << endl;
             }
             cerr << "state of queue:" << endl;
             for (auto q : queue) {
-                cerr << "\t" << identifier_order[q.first] << ", requester: " << (q.second.first == identifier_order.size() ? string("PLAN TARGET") : identifier_order[q.second.first]) << ", num requesters " << q.second.second << endl;
+                cerr << "\t" << identifier_order[q.first] << ", requester: " << (q.second.first == identifier_order.size() ? string("PLAN TARGET") : to_string(identifier_order[q.second.first])) << ", num requesters " << q.second.second << endl;
             }
 #endif
             
@@ -973,7 +990,7 @@ vector<pair<string, size_t>> IndexRegistry::make_plan(const vector<string>& end_
             plan_path.emplace_back(it->first, it->second.first, 0);
             
 #ifdef debug_index_registry
-            cerr << "dequeue " << identifier_order[it->first] << " requested from " << (it->second.first == identifier_order.size() ? string("PLAN TARGET") : identifier_order[it->second.first]) << " and " << (it->second.second - 1) << " other indexes" << endl;
+            cerr << "dequeue " << to_string(identifier_order[it->first]) << " requested from " << (it->second.first == identifier_order.size() ? string("PLAN TARGET") : to_string(identifier_order[it->second.first])) << " and " << (it->second.second - 1) << " other indexes" << endl;
 #endif
             queue.erase(it);
             
@@ -991,7 +1008,7 @@ vector<pair<string, size_t>> IndexRegistry::make_plan(const vector<string>& end_
 #ifdef debug_index_registry
                 cerr << "index can be made by a recipe requiring";
                 for (auto input : recipe.inputs) {
-                    cerr << " " << input->get_identifier();
+                    cerr << " " << to_string(input->get_identifier());
                 }
                 cerr << endl;
 #endif
@@ -1025,7 +1042,7 @@ vector<pair<string, size_t>> IndexRegistry::make_plan(const vector<string>& end_
                     // this one
                     size_t requester = get<1>(plan_path.back());
 #ifdef debug_index_registry
-                    cerr << "pruning path to previous requester: " << (requester == identifier_order.size() ? "PLAN TARGET" : identifier_order[requester]) << endl;
+                    cerr << "pruning path to previous requester: " << (requester == identifier_order.size() ? "PLAN TARGET" : to_string(identifier_order[requester])) << endl;
 #endif
                     while (!plan_path.empty() && get<0>(plan_path.back()) != requester) {
                         
@@ -1081,7 +1098,7 @@ vector<pair<string, size_t>> IndexRegistry::make_plan(const vector<string>& end_
                     const auto& recipe = get_index(identifier_order[get<0>(plan_path.back())])->get_recipes()[get<2>(plan_path.back())];
                     
 #ifdef debug_index_registry
-                    cerr << "advancing to recipe " << get<2>(plan_path.back()) << " for index " << identifier_order[get<0>(plan_path.back())] << ", which requires";
+                    cerr << "advancing to recipe " << get<2>(plan_path.back()) << " for index " << to_string(identifier_order[get<0>(plan_path.back())]) << ", which requires";
                     for (auto input : recipe.inputs) {
                         cerr << " " << input->get_identifier();
                     }
@@ -1108,7 +1125,7 @@ vector<pair<string, size_t>> IndexRegistry::make_plan(const vector<string>& end_
 #ifdef debug_index_registry
         cerr << "final plan path for index " << product << ":" << endl;
         for (auto path_elem : plan_path) {
-            cerr << "\t" << identifier_order[get<0>(path_elem)] << ", from " << (get<1>(path_elem) == identifier_order.size() ? "PLAN START" : identifier_order[get<1>(path_elem)]) << ", recipe " << get<2>(path_elem) << endl;
+            cerr << "\t" << identifier_order[get<0>(path_elem)] << ", from " << (get<1>(path_elem) == identifier_order.size() ? "PLAN START" : to_string(identifier_order[get<1>(path_elem)])) << ", recipe " << get<2>(path_elem) << endl;
         }
 #endif
         
@@ -1124,8 +1141,8 @@ vector<pair<string, size_t>> IndexRegistry::make_plan(const vector<string>& end_
     }
     
     // convert the aggregated plan elements into a forward ordered plan
-    vector<pair<string, size_t>> plan(plan_elements.begin(), plan_elements.end());
-    sort(plan.begin(), plan.end(), [&](const pair<string, size_t>& a, const pair<string, size_t>& b) {
+    vector<pair<IndexName, size_t>> plan(plan_elements.begin(), plan_elements.end());
+    sort(plan.begin(), plan.end(), [&](const pair<IndexName, size_t>& a, const pair<IndexName, size_t>& b) {
         return dep_order_of_identifier[a.first] < dep_order_of_identifier[b.first];
     });
 #ifdef debug_index_registry
@@ -1136,27 +1153,27 @@ vector<pair<string, size_t>> IndexRegistry::make_plan(const vector<string>& end_
 #endif
     
     // and remove the input data from the plan
-    plan.resize(remove_if(plan.begin(), plan.end(), [&](const pair<string, size_t>& recipe_choice) {
+    plan.resize(remove_if(plan.begin(), plan.end(), [&](const pair<IndexName, size_t>& recipe_choice) {
         return get_index(recipe_choice.first)->is_finished();
     }) - plan.begin());
     return plan;
 }
 
 string IndexRegistry::to_dot() const {
-    return to_dot(vector<string>());
+    return to_dot(vector<IndexName>());
 }
 
-string IndexRegistry::to_dot(const vector<string>& targets) const {
+string IndexRegistry::to_dot(const vector<IndexName>& targets) const {
     
     
     stringstream strm;
     strm << "digraph recipegraph {" << endl;
     
-    unordered_set<string> plan_targets(targets.begin(), targets.end());
-    unordered_set<pair<string, size_t>> plan_elements;
-    unordered_set<string> plan_indexes;
+    set<IndexName> plan_targets(targets.begin(), targets.end());
+    set<pair<IndexName, size_t>> plan_elements;
+    set<IndexName> plan_indexes;
     if (!targets.empty()) {
-        vector<pair<string, size_t>> plan;
+        vector<pair<IndexName, size_t>> plan;
         try {
             plan = make_plan(targets);
         }
@@ -1170,12 +1187,12 @@ string IndexRegistry::to_dot(const vector<string>& targets) const {
         }
     }
     
-    unordered_map<string, string> index_to_dot_id;
+    map<IndexName, string> index_to_dot_id;
     size_t index_idx = 0;
     for (const auto& index_file : registry) {
         index_to_dot_id[index_file.first] = "I" + to_string(index_idx);
         ++index_idx;
-        strm << index_to_dot_id[index_file.first] << "[label=\"" << index_file.first << "\" shape=box";
+        strm << index_to_dot_id[index_file.first] << "[label=\"" << to_string(index_file.first) << "\" shape=box";
         if (index_file.second->is_finished()) {
             strm << " style=\"filled,bold\" fillcolor=lightgray";
         }
@@ -1216,7 +1233,7 @@ string IndexRegistry::to_dot(const vector<string>& targets) const {
     return strm.str();
 }
 
-IndexFile::IndexFile(const string& identifier, const string& suffix) : identifier(identifier), suffix(suffix) {
+IndexFile::IndexFile(const IndexName& identifier, const string& suffix) : identifier(identifier), suffix(suffix) {
     // nothing more to do
 }
 
@@ -1224,7 +1241,7 @@ bool IndexFile::is_finished() const {
     return !filenames.empty();
 }
 
-const string& IndexFile::get_identifier() const {
+const IndexName& IndexFile::get_identifier() const {
     return identifier;
 }
 
@@ -1270,9 +1287,9 @@ vector<string> IndexRecipe::execute(const string& prefix, const string& suffix) 
     return exec(inputs, prefix, suffix);
 }
 
-InsufficientInputException::InsufficientInputException(const string& target,
+InsufficientInputException::InsufficientInputException(const IndexName& target,
                                                        const IndexRegistry& registry) :
-    runtime_error("Insufficient input to create " + target), target(target), inputs(registry.completed_indexes())
+    runtime_error("Insufficient input to create " + to_string(target)), target(target), inputs(registry.completed_indexes())
 {
     // nothing else to do
 }
@@ -1281,9 +1298,9 @@ const char* InsufficientInputException::what() const throw () {
     stringstream ss;
     ss << "Inputs" << endl;
     for (const auto& input : inputs) {
-        ss << "\t" << input << endl;
+        ss << "\t" << to_string(input) << endl;
     }
-    ss << "are insufficient to create target index " << target << endl;
+    ss << "are insufficient to create target index " << to_string(target) << endl;
     return ss.str().c_str();
 }
 

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -853,7 +853,7 @@ void IndexRegistry::register_joint_recipe(const set<IndexName>& identifier,
     for (const auto& input_identifier : input_identifiers) {
         inputs.push_back(get_index(input_identifier));
     }
-    get_index(identifier)->add_recipe(inputs, exec);
+    // TODO: storage?
 }
 
 IndexFile* IndexRegistry::get_index(const IndexName& identifier) {
@@ -1287,33 +1287,14 @@ void IndexFile::add_recipe(const vector<const IndexFile*>& inputs,
 }
 
 IndexRecipe::IndexRecipe(const vector<const IndexFile*>& inputs,
-                         const function<vector<vector<string>>(const vector<const IndexFile*>&,const vector<string>&,const vector<string>&)>& exec) :
+                         const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec) :
     exec(exec), inputs(inputs)
 {
     // nothing more to do
 }
 
-IndexRecipe::IndexRecipe(const vector<const IndexFile*>& inputs,
-                         const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec) :
-    exec([&](const vector<const IndexFile*>& inputs, const vector<string>& prefixes, const vector<string>& suffixes) {
-        if (prefixes.size() != 1 || suffixes.size() != 1) {
-            throw runtime_error("Passed too many arguments to single-index recipe");
-        }
-        
-        vector<vector<string>> results =  {std::move(exec(inputs, prefixes.front, suffixes.front))};
-        
-        return results;
-    }, inputs(inputs)
-{
-    // nothing more to do
-}
-
-vector<vector<string>> IndexRecipe::execute(const vector<string>& prefixes, const vector<string>& suffixes) {
-    return exec(inputs, prefixes, suffixes);
-}
-
 vector<string> IndexRecipe::execute(const string& prefix, const string& suffix) {
-    return exec(inputs, {prefix}, {suffix}).at(0);
+    return exec(inputs, prefix, suffix);
 }
 
 InsufficientInputException::InsufficientInputException(const IndexName& target,

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -33,17 +33,17 @@ using RecipeName = pair<IndexName, size_t>;
 
 /**
  * Is a recipe to create the files (returned by name) associated with some
- * index, from a series of input indexes, a file name prefix, and a file name
- * suffix.
+ * index, from a series of input indexes, given the registry it is being
+ * generated for, and a function to tell if an index is intermediate.
  */
-using RecipeFunc = function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>;
+using RecipeFunc = function<vector<string>(const vector<const IndexFile*>&,const IndexRegistry*,const function<bool(const IndexName&)>&)>;
 
 /**
  * Is a recipe to create the files (returned by name) associated with some
- * indexes, from a series of input indexes, a some name prefixes, and some file
- * name suffixes.
+ * indexes, from a series of input indexes, given the registry they are being
+ * generated for, and a function to tell if an index is intermediate.
  */
-using JointRecipeFunc = function<vector<vector<string>>(const vector<const IndexFile*>&,const vector<string>&,const vector<string>&)>;
+using JointRecipeFunc = function<vector<vector<string>>(const vector<const IndexFile*>&,const IndexRegistry*, const function<bool(const IndexName&)>&)>;
 
 /**
  * A struct namespace for global handling of parameters used by
@@ -225,8 +225,10 @@ public:
     /// Returns true if the index has already been built or provided
     bool is_finished() const;
     
-    /// Build the index using the recipe with the provided priority
-    void execute_recipe(size_t recipe_priority, const string& prefix);
+    /// Build the index using the recipe with the provided priority.
+    /// Expose the registry so we can query where the index (or other
+    /// co-generated indexes) needs to go.
+    void execute_recipe(size_t recipe_priority, const IndexRegistry* registry);
     
     /// Returns true if the index was provided through provide method
     bool was_provided_directly() const;
@@ -256,7 +258,7 @@ struct IndexRecipe {
     IndexRecipe(const vector<const IndexFile*>& inputs,
                 const RecipeFunc& exec);
     // execute the recipe and return the filename(s) of the indexes created
-    vector<string> execute(const string& prefix, const string& suffix);
+    vector<string> execute(const IndexRegistry* registry);
     vector<const IndexFile*> inputs;
     RecipeFunc exec;
 };

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -32,6 +32,20 @@ using IndexName = set<string>;
 using RecipeName = pair<IndexName, size_t>;
 
 /**
+ * Is a recipe to create the files (returned by name) associated with some
+ * index, from a series of input indexes, a file name prefix, and a file name
+ * suffix.
+ */
+using RecipeFunc = function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>;
+
+/**
+ * Is a recipe to create the files (returned by name) associated with some
+ * indexes, from a series of input indexes, a some name prefixes, and some file
+ * name suffixes.
+ */
+using JointRecipeFunc = function<vector<vector<string>>(const vector<const IndexFile*>&,const vector<string>&,const vector<string>&)>;
+
+/**
  * A struct namespace for global handling of parameters used by
  * the IndexRegistry
  */
@@ -110,7 +124,7 @@ public:
     /// or input files. Also takes a for output as input
     RecipeName register_recipe(const IndexName& identifier,
                                const vector<IndexName>& input_identifiers,
-                               const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec);
+                               const RecipeFunc& exec);
                         
     /// Register a recipe to produce multiple indexes.
     /// Individual index recipes must still be registered; this recipe will be
@@ -121,7 +135,7 @@ public:
     /// higher priority than other recipes.
     void register_joint_recipe(const vector<IndexName>& identifiers,
                                const vector<IndexName>& input_identifiers,
-                               const function<vector<vector<string>>(const vector<const IndexFile*>&,const vector<string>&,const vector<string>&)>& exec);
+                               const JointRecipeFunc& exec);
     
     /// Indicate a serialized file that contains some identified index
     void provide(const IndexName& identifier, const string& filename);
@@ -206,7 +220,7 @@ public:
     ///
     /// Returns the name assigned to the recipe.
     RecipeName add_recipe(const vector<const IndexFile*>& inputs,
-                          const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec);
+                          const RecipeFunc& exec);
     
     /// Returns true if the index has already been built or provided
     bool is_finished() const;
@@ -240,11 +254,11 @@ private:
  */
 struct IndexRecipe {
     IndexRecipe(const vector<const IndexFile*>& inputs,
-                const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec);
+                const RecipeFunc& exec);
     // execute the recipe and return the filename(s) of the indexes created
     vector<string> execute(const string& prefix, const string& suffix);
     vector<const IndexFile*> inputs;
-    function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)> exec;
+    RecipeFunc exec;
 };
 
 

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -71,6 +71,18 @@ public:
     /// Constructor
     IndexRegistry() = default;
     
+    /// Destructor to clean up temp files.
+    ~IndexRegistry();
+    
+    // Because we own temporary files and unique pointers, we should not be copied.
+    IndexRegistry(const IndexRegistry& other) = delete;
+    IndexRegistry& operator=(const IndexRegistry& other) = delete;
+    
+    // And we need to be moved carefully
+    IndexRegistry(IndexRegistry&& other);
+    IndexRegistry& operator=(IndexRegistry&& other);
+    
+    
     /// Prefix for all saved outputs
     void set_prefix(const string& prefix);
     
@@ -121,10 +133,16 @@ protected:
     /// access const index file
     const IndexFile* get_index(const string& identifier) const;
     
+    /// Function to get and/or initialize the temporary directory in which indexes will live
+    string get_work_dir();
+    
     /// the storage struct for named indexes
     unordered_map<string, unique_ptr<IndexFile>> registry;
     
     unordered_set<string> registered_suffixes;
+    
+    /// Temporary directory in which indexes will live
+    string work_dir;
     
     /// filepath that will prefix all saved output
     string output_prefix = "index";

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -108,13 +108,17 @@ public:
     
     /// Register a recipe to produce an index using other indexes
     /// or input files. Also takes a for output as input
-    void register_recipe(const IndexName& identifier,
-                         const vector<IndexName>& input_identifiers,
-                         const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec);
+    RecipeName register_recipe(const IndexName& identifier,
+                               const vector<IndexName>& input_identifiers,
+                               const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec);
                         
     /// Register a recipe to produce multiple indexes.
     /// Individual index recipes must still be registered; this recipe will be
-    /// used to simplify the plan.
+    /// used to simplify the plan when the individual recipes with the same
+    /// input set are all called.
+    ///
+    /// Joint recipes may also be used to generate single indexes if they have
+    /// higher priority than other recipes.
     void register_joint_recipe(const vector<IndexName>& identifiers,
                                const vector<IndexName>& input_identifiers,
                                const function<vector<vector<string>>(const vector<const IndexFile*>&,const vector<string>&,const vector<string>&)>& exec);
@@ -161,8 +165,9 @@ protected:
     
     unordered_set<string> registered_suffixes;
     
-    /// All recipes that can simplify the generation of multiple indexes
-    map<set<IndexName>, vector<IndexRecipe>> simplifications;
+    /// Record that, when the given input indexes are available, this
+    /// collection of recipes is efficient to run together.
+    vector<pair<vector<IndexName>, vector<RecipeName>>> simplifications;
     
     /// Temporary directory in which indexes will live
     string work_dir;
@@ -198,8 +203,10 @@ public:
     /// Describe a recipe with a lower preference order than all existing recipes
     /// for creating this index, if there are any (i.e., recipes must be added in
     /// preference order). Recipes should return the filepath(s) to their output.
-    void add_recipe(const vector<const IndexFile*>& inputs,
-                    const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec);
+    ///
+    /// Returns the name assigned to the recipe.
+    RecipeName add_recipe(const vector<const IndexFile*>& inputs,
+                          const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec);
     
     /// Returns true if the index has already been built or provided
     bool is_finished() const;

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -94,7 +94,12 @@ struct VGIndexes {
  * A plan for producing indexes, which knows what should be saved and what should be ephemeral.
  * Wants to be nested inside IndexRegistry, but you can't forward-declare a nested class.
  */
-struct IndexingPlan {
+class IndexingPlan {
+
+public:
+    // The IndexRegistry is responsible for setting us up.
+    friend class IndexRegistry;
+
     /// Returns true if the given index is to be intermediate under the given
     /// plan, and false if it is to be preserved.
     bool is_intermediate(const IndexName& identifier) const;
@@ -106,13 +111,14 @@ struct IndexingPlan {
     /// Get the suffix with which to save the given index's files.
     string suffix(const IndexName& identifier) const;
     
-    /// The indexes to create as outputs.
-    set<IndexName> targets;
-    
     /// The steps to be invoked in the plan. May be empty before the plan is
     /// actually planned.
     vector<RecipeName> steps;
-
+    
+private:
+    /// The indexes to create as outputs.
+    set<IndexName> targets;
+    
     /// The registry that the plan is using.
     /// The registry must not move while the plan is in use.
     /// Can't be const because we need to get_work_dir() on it, which may
@@ -169,6 +175,10 @@ public:
     ///
     /// Joint recipes may also be used to generate single indexes if they have
     /// higher priority than other recipes.
+    ///
+    /// All output identifiers must be distinct, and there must be at least
+    /// one. Only one multi-index recipe can be applied to simplify the
+    /// production of any given index in a plan.
     void register_joint_recipe(const vector<IndexName>& identifiers,
                                const vector<IndexName>& input_identifiers,
                                const JointRecipeFunc& exec);

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -229,21 +229,15 @@ private:
 };
 
 /**
- * struct that indicates a method to produce and serialize one or more indexes
+ * struct that indicates a method to produce and serialize an index
  */
 struct IndexRecipe {
-    /// Make an IndexRecipe for one or more indexes
-    IndexRecipe(const vector<const IndexFile*>& inputs,
-                const function<vector<vector<string>>(const vector<const IndexFile*>&,const vector<string>&,const vector<string>&)>& exec);
-    /// Make an IndexRecipe for a single index
     IndexRecipe(const vector<const IndexFile*>& inputs,
                 const function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)>& exec);
-    /// execute the recipe and return the filename(s) of the indexes created, grouped by index
-    vector<vector<string>> execute(const vector<string>& prefixes, const vector<string>& suffixes);
-    /// Assuming the recipe produces a single index, execute the recipe and return the filename(s) of the index created
+    // execute the recipe and return the filename(s) of the indexes created
     vector<string> execute(const string& prefix, const string& suffix);
     vector<const IndexFile*> inputs;
-    function<vector<vector<string>>(const vector<const IndexFile*>&,const vector<string>&,const vector<string>&)> exec;
+    function<vector<string>(const vector<const IndexFile*>&,const string&,const string&)> exec;
 };
 
 

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -35,9 +35,9 @@ using RecipeName = pair<IndexName, size_t>;
 /**
  * Is a recipe to create the files (returned by name) associated with some
  * index, from a series of input indexes, given the plan it is being
- * generated for.
+ * generated for and the index being generated.
  */
-using RecipeFunc = function<vector<string>(const vector<const IndexFile*>&,const IndexingPlan*)>;
+using RecipeFunc = function<vector<string>(const vector<const IndexFile*>&,const IndexingPlan*,const IndexName&)>;
 
 /**
  * Is a recipe to create the files (returned by name) associated with some
@@ -296,7 +296,7 @@ struct IndexRecipe {
     IndexRecipe(const vector<const IndexFile*>& inputs,
                 const RecipeFunc& exec);
     // execute the recipe and return the filename(s) of the indexes created
-    vector<string> execute(const IndexingPlan* plan);
+    vector<string> execute(const IndexingPlan* plan, const IndexName& constructing);
     vector<const IndexFile*> inputs;
     RecipeFunc exec;
 };

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -111,7 +111,7 @@ int main_autoindex(int argc, char** argv) {
     // load the registry
     IndexRegistry registry = VGIndexes::get_vg_index_registry();
     bool print_dot = false;
-    vector<string> targets;
+    vector<IndexName> targets;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -164,21 +164,21 @@ int main_autoindex(int argc, char** argv) {
                 }
                 break;
             case 'r':
-                registry.provide("Reference FASTA", optarg);
+                registry.provide({"Reference FASTA"}, optarg);
                 break;
             case 'v':
                 if (vcf_is_phased(optarg)) {
-                    registry.provide("Phased VCF", optarg);
+                    registry.provide({"Phased VCF"}, optarg);
                 }
                 else {
-                    registry.provide("VCF", optarg);
+                    registry.provide({"VCF"}, optarg);
                 }
                 break;
             case 'i':
-                registry.provide("Insertion Sequence FASTA", optarg);
+                registry.provide({"Insertion Sequence FASTA"}, optarg);
                 break;
             case 'g':
-                registry.provide("Reference GFA", optarg);
+                registry.provide({"Reference GFA"}, optarg);
                 break;
             case 'T':
                 temp_file::set_dir(optarg);

--- a/src/unittest/index_registry.cpp
+++ b/src/unittest/index_registry.cpp
@@ -37,61 +37,71 @@ TEST_CASE("IndexRegistry can make plans on a dummy recipe graph", "[indexregistr
     // make some dummy recipes that don't actually do anything
     registry.register_recipe({"VG"}, {{"FASTA"}, {"VCF"}},
                              [&] (const vector<const IndexFile*>& inputs,
-                                  const IndexingPlan* plan) {
+                                  const IndexingPlan* plan,
+                                  const IndexName& constructing) {
         vector<string> filename(1, "vg-file");
         return filename;
     });
     registry.register_recipe({"VG"}, {{"GFA"}},
                              [&] (const vector<const IndexFile*>& inputs,
-                                  const IndexingPlan* plan) {
+                                  const IndexingPlan* plan,
+                                  const IndexName& constructing) {
         vector<string> filename(1, "vg-file");
         return filename;
     });
     registry.register_recipe({"XG"}, {{"GFA"}},
                              [&] (const vector<const IndexFile*>& inputs,
-                                  const IndexingPlan* plan) {
+                                  const IndexingPlan* plan,
+                                  const IndexName& constructing) {
         vector<string> filename(1, "xg-file");
         return filename;
     });
     registry.register_recipe({"XG"}, {{"VG"}},
                              [&] (const vector<const IndexFile*>& inputs,
-                                  const IndexingPlan* plan) {
+                                  const IndexingPlan* plan,
+                                  const IndexName& constructing) {
         vector<string> filename(1, "xg-file");
         return filename;
     });
     registry.register_recipe({"Pruned VG"}, {{"VG"}},
                              [&] (const vector<const IndexFile*>& inputs,
-                                  const IndexingPlan* plan) {
+                                  const IndexingPlan* plan,
+                                  const IndexName& constructing) {
         vector<string> filenames{"pruned-vg-file"};
         return filenames;
     });
     registry.register_recipe({"GCSA", "LCP"}, {{"Pruned VG"}},
                              [&] (const vector<const IndexFile*>& inputs,
-                                  const IndexingPlan* plan) {
+                                  const IndexingPlan* plan,
+                                  const IndexName& constructing) {
         vector<string> filenames{"gcsa-file", "lcp-file"};
         return filenames;
     });
     registry.register_recipe({"Trivial Snarls"}, {{"XG"}},
                              [&] (const vector<const IndexFile*>& inputs,
-                                  const IndexingPlan* plan) {
+                                  const IndexingPlan* plan,
+                                  const IndexName& constructing) {
         vector<string> filenames(1, "snarls-file");
         return filenames;
     });
     registry.register_recipe({"Trivial Snarls"}, {{"VG"}},
                              [&] (const vector<const IndexFile*>& inputs,
-                                  const IndexingPlan* plan) {
+                                  const IndexingPlan* plan,
+                                  const IndexName& constructing) {
         vector<string> filenames(1, "snarls-file");
         return filenames;
     });
     registry.register_recipe({"Distance"}, {{"XG"}, {"Trivial Snarls"}},
                              [&] (const vector<const IndexFile*>& inputs,
-                                  const IndexingPlan* plan) {
+                                  const IndexingPlan* plan,
+                                  const IndexName& constructing) {
         vector<string> filenames(1, "dist-file");
         return filenames;
     });
     registry.register_recipe({"Distance"}, {{"VG"}, {"Trivial Snarls"}},
                              [&] (const vector<const IndexFile*>& inputs,
-                                  const IndexingPlan* plan) {
+                                  const IndexingPlan* plan,
+                                  const IndexName& constructing) {
         vector<string> filenames(1, "dist-file");
         return filenames;
     });

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -288,27 +288,76 @@ string temp_dir;
 /// Because the names are in a static object, we can delete them when
 /// std::exit() is called.
 struct Handler {
-    set<string> filenames;
+    /// What temp files have we handed out?
+    unordered_set<string> filenames;
+    
+    /// What temp directories have we handed out
+    unordered_set<string> dirnames;
+    
+    /// Place where all temporary files for this vg invocation live.
     string parent_directory;
+    
+    /// Make sure the parent directory for all our temporary files and
+    /// directories exists.
+    void ensure_parent_directory() {
+        if (parent_directory.empty()) {
+            // Make a parent directory for our temp files
+            string tmpdirname = get_dir() + "/vg-XXXXXX";
+            auto got = mkdtemp(&tmpdirname[0]);
+            if (got != nullptr) {
+                // Save the directory we got
+                parent_directory = got;
+            } else {
+                cerr << "[vg utility.cpp]: couldn't create temp directory: " << tmpdirname << endl;
+                exit(1);
+            }
+        }
+    }
+    
+    /// Delete a directory and all files in it.
+    static void remove_directory(const string& name) {
+        // Open it up to get the files
+        auto directory = opendir(name.c_str());
+        
+        dirent* dp;
+        while ((dp = readdir(directory)) != nullptr) {
+            // For every item still in it
+            
+            // Compute the full path
+            string path = name + "/" + dp->d_name;
+            
+            struct stat dp_stat;
+            stat(path.c_str(), &dp_stat);
+            if (S_ISDIR(dp_stat.st_mode) && !S_ISLNK(dp_stat.st_mode)) {
+                // It's a directory and may have stuff in it.
+                // It isn't a link to some other random place (unless the
+                // current user is tampering with their own temp files to
+                // delete their own stuff).
+                // Clear it out.
+                remove_directory(path);
+            } else {
+                // Normal file or symlink.
+                // Delete just it.
+                std::remove(path.c_str());
+            }
+        }
+        closedir(directory);
+        
+        // Delete the directory itself
+        std::remove(name.c_str());
+    }
+    
     ~Handler() {
         // No need to lock in static destructor
         for (auto& filename : filenames) {
             std::remove(filename.c_str());
         }
+        for (auto& dirname : dirnames) {
+            remove_directory(dirname);
+        }
         if (!parent_directory.empty()) {
             // There may be extraneous files in the directory still (like .fai files)
-            auto directory = opendir(parent_directory.c_str());
-            
-            dirent* dp;
-            while ((dp = readdir(directory)) != nullptr) {
-                // For every item still in it, delete it.
-                // TODO: Maybe eventually recursively delete?
-                std::remove((parent_directory + "/" + dp->d_name).c_str());
-            }
-            closedir(directory);
-            
-            // Delete the directory itself
-            std::remove(parent_directory.c_str());
+            remove_directory(parent_directory);
         }
     }
 } handler;
@@ -316,18 +365,7 @@ struct Handler {
 string create(const string& base) {
     lock_guard<recursive_mutex> lock(monitor);
 
-    if (handler.parent_directory.empty()) {
-        // Make a parent directory for our temp files
-        string tmpdirname = get_dir() + "/vg-XXXXXX";
-        auto got = mkdtemp(&tmpdirname[0]);
-        if (got != nullptr) {
-            // Save the directory we got
-            handler.parent_directory = got;
-        } else {
-            cerr << "[vg utility.cpp]: couldn't create temp directory: " << tmpdirname << endl;
-            exit(1);
-        }
-    }
+    handler.ensure_parent_directory(); 
 
     string tmpname = handler.parent_directory + "/" + base + "XXXXXX";
     // hack to use mkstemp to get us a safe temporary file name
@@ -349,11 +387,35 @@ string create() {
     return create("vg-");
 }
 
+string create_directory() {
+    lock_guard<recursive_mutex> lock(monitor);
+    
+    handler.ensure_parent_directory(); 
+
+    string tmpname = handler.parent_directory + "/dir-XXXXXX";
+    auto got = mkdtemp(&tmpname[0]);
+    if (got != nullptr) {
+        // Save the directory we got
+        handler.dirnames.insert(got);
+        return got;
+    } else {
+        cerr << "[vg utility.cpp]: couldn't create temp directory: " << tmpname << endl;
+        exit(1);
+    }
+}
+
 void remove(const string& filename) {
     lock_guard<recursive_mutex> lock(monitor);
     
-    std::remove(filename.c_str());
-    handler.filenames.erase(filename);
+    if (handler.filenames.count(filename)) {
+        std::remove(filename.c_str());
+        handler.filenames.erase(filename);
+    } else if (handler.dirnames.count(filename)) {
+        handler.remove_directory(filename);
+        handler.dirnames.erase(filename);
+    } else {
+        throw runtime_error("Temporary file system asked to remove " + filename + " which is not its responsibility");
+    }
 }
 
 void set_dir(const string& new_temp_dir) {

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -407,14 +407,16 @@ string create_directory() {
 void remove(const string& filename) {
     lock_guard<recursive_mutex> lock(monitor);
     
-    if (handler.filenames.count(filename)) {
-        std::remove(filename.c_str());
-        handler.filenames.erase(filename);
-    } else if (handler.dirnames.count(filename)) {
+    if (handler.dirnames.count(filename)) {
         handler.remove_directory(filename);
         handler.dirnames.erase(filename);
+    } else if (handler.filenames.count(filename)) {
+        std::remove(filename.c_str());
+        handler.filenames.erase(filename);
     } else {
-        throw runtime_error("Temporary file system asked to remove " + filename + " which is not its responsibility");
+        // Probably e.g. a .fai file. Just remove it and fail if it's a
+        // nonempty directory.
+        std::remove(filename.c_str());
     }
 }
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -323,6 +323,11 @@ struct Handler {
         while ((dp = readdir(directory)) != nullptr) {
             // For every item still in it
             
+            if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0) {
+                // This is a special here or up entry, so skip it.
+                continue;
+            }
+            
             // Compute the full path
             string path = name + "/" + dp->d_name;
             

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -125,10 +125,11 @@ typename Collection::value_type sum(const Collection& collection) {
 
 
 /**
- * Temporary files. Create with create() and remove with remove(). All
- * temporary files will be deleted when the program exits normally or with
- * std::exit(). The files will be created in a directory determined from
- * environment variables, though this can be overridden with set_dir().
+ * Temporary files and directories. Create with create() or create_directory()
+ * and remove with remove(). All temporary files and directories will be
+ * deleted when the program exits normally or with std::exit(). The files will
+ * be created in a directory determined from environment variables, though this
+ * can be overridden with set_dir().
  * The interface is thread-safe.
  */
 namespace temp_file {
@@ -138,14 +139,19 @@ namespace temp_file {
 
     /// Create a temporary file
     string create();
+    
+    /// Create a temporary directory
+    string create_directory();
 
-    /// Remove a temporary file
+    /// Remove a temporary file or directory. File or directory must have been
+    /// created by create() or create_directory() and not any other means.
     void remove(const string& filename);
 
-    /// Set a temp dir, overriding system defaults and environment variables.
+    /// Set a directory for placing temporary files and directories in,
+    /// overriding system defaults and environment variables.
     void set_dir(const string& new_temp_dir);
 
-    /// Get the current temp dir
+    /// Get the current location for temporary files and directories.
     string get_dir();
 
 } // namespace temp_file


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex` can now simplify plans with joint recipes
 * `IndexRegistry` uses per-instance temp directories

## Description

You can now `register_joint_recipe()` on the `IndexRegistry` and give it a recipe that will produce multiple indexes from a shared set of inputs. If it ever makes a plan that generates all those indexes, and the given inputs are available before the first of the indexes is generated, then the joint recipe will be subbed in to simplify the plan.

I don't actually have any joint index recipes added outside the tests, but I think I changed around the prefix/suffix determining system in a way that makes writing them feasible. You can pull the prefixes and suffices to use for an index from the `IndexingPlan` that gets passed to the recipe.

This also includes fixes to temp directories for the `IndexRegistry`; each instance gets its own temp directory that will get cleaned up when it is destroyed.
