### PR TITLE
Acclerate MEM-finding in mpmap (a bit)

### DIFF
--- a/src/mapper.hpp
+++ b/src/mapper.hpp
@@ -22,6 +22,7 @@
 #include "cluster.hpp"
 #include "graph.hpp"
 #include "translator.hpp"
+#include "mem_accelerator.hpp"
 // TODO: pull out ScoreProvider into its own file
 #include "haplotypes.hpp"
 #include "algorithms/subgraph.hpp"
@@ -211,9 +212,7 @@ public:
     /// Same, but loading a 4x4 substitution score matrix from a stream
     void set_alignment_scores(istream& matrix_stream, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus,
                               double haplotype_consistency_exponent = 1);
-    
-    void set_cache_size(int new_cache_size);
-    
+        
     // MEM-based mapping
     // find maximal exact matches
     // These are SMEMs by definition when shorter than the max_mem_length or GCSA2 order.
@@ -350,6 +349,11 @@ public:
                             int min_sub_mem_length,
                             vector<pair<MaximalExactMatch, vector<size_t>>>& sub_mems_out);
     
+    /// If possible, use the MEMAcclerator to get the initial range for a MEM and update the cursor
+    /// accordingly. If this is not possible, return the full GCSA2 range and leave the cursor unaltered.
+    gcsa::range_type accelerate_mem_query(string::const_iterator begin,
+                                          string::const_iterator& cursor) const;
+    
     // Use the GCSA index to look up the sequence
     set<pos_t> sequence_positions(const string& seq);
     
@@ -372,6 +376,7 @@ public:
     // GCSA index and its LCP array
     gcsa::GCSA* gcsa = nullptr;
     gcsa::LCPArray* lcp = nullptr;
+    MEMAccelerator* accelerator = nullptr;
     
     // Haplotype score provider, if any, for determining haplotype concordance
     haplo::ScoreProvider* haplo_score_provider = nullptr;

--- a/src/mem_accelerator.cpp
+++ b/src/mem_accelerator.cpp
@@ -37,8 +37,15 @@ MEMAccelerator::MEMAccelerator(const gcsa::GCSA& gcsa_index, size_t k)
             // extend the current range by the next character
             auto next = get<0>(stack.back())++;
             auto enc = (next << (2 * (stack.size() - 1))) | get<1>(stack.back());
-            auto range = gcsa_index.LF(get<2>(stack.back()),
-                                       gcsa_index.alpha.char2comp[alphabet[next]]);
+            
+            gcsa::range_type range;
+            if (!gcsa::Range::empty(get<2>(stack.back()))) {
+                range = gcsa_index.LF(get<2>(stack.back()),
+                                      gcsa_index.alpha.char2comp[alphabet[next]]);
+            }
+            else {
+                range = get<2>(stack.back());
+            }
             stack.emplace_back(0, enc, range);
         }
     }

--- a/src/mem_accelerator.cpp
+++ b/src/mem_accelerator.cpp
@@ -1,0 +1,59 @@
+/**
+ * \file mem_accelerator.hpp
+ *
+ * Implements an index for accelerating GCSA2 queries
+ */
+
+#include "mem_accelerator.hpp"
+#include <sdsl/util.hpp>
+
+namespace vg {
+
+MEMAccelerator::MEMAccelerator(const gcsa::GCSA& gcsa_index, size_t k)
+    : k(k), range_table(1 << (2 * k + 1))
+{
+    // range table is initialized to size 2^(2k + 1)
+    
+    const char alphabet[5] = "ACGT";
+    
+    // records of (next char to query, k-mer integer encoding, range)
+    vector<tuple<int64_t, int64_t, gcsa::range_type>> stack;
+    stack.emplace_back(0, 0, gcsa::range_type(0, gcsa_index.size() - 1));
+    
+    // TODO: multithread this? probably would do it single threaded
+    // to init 128 stacks or something similar
+    while (!stack.empty()) {
+        if (stack.size() == k + 1) {
+            // we've walked the full k-mers
+            range_table[2 * get<1>(stack.back())] = get<2>(stack.back()).first;
+            range_table[2 * get<1>(stack.back()) + 1] = get<2>(stack.back()).second;
+            stack.pop_back();
+        }
+        else if (get<0>(stack.back()) == 4) {
+            // we've walked all the k-mers that start with this prefix
+            stack.pop_back();
+        }
+        else {
+            // extend the current range by the next character
+            auto next = get<0>(stack.back())++;
+            auto enc = (next << (2 * (stack.size() - 1))) | get<1>(stack.back());
+            auto range = gcsa_index.LF(get<2>(stack.back()),
+                                       gcsa_index.alpha.char2comp[alphabet[next]]);
+            stack.emplace_back(0, enc, range);
+        }
+    }
+    
+    // bit compress the whole mess
+    sdsl::util::bit_compress(range_table);
+}
+
+gcsa::range_type MEMAccelerator::memoized_LF(string::const_iterator last) const {
+    int64_t enc = 0;
+    for (size_t i = 0; i < k; ++i) {
+        enc |= (encode(*last) << (i << 1));
+        --last;
+    }
+    return gcsa::range_type(range_table[enc << 1], range_table[(enc << 1) | 1]);
+}
+
+}

--- a/src/mem_accelerator.hpp
+++ b/src/mem_accelerator.hpp
@@ -1,0 +1,71 @@
+/**
+ * \file mem_accelerator.hpp
+ *
+ * Defines an index for accelerating GCSA2 queries
+ */
+
+#ifndef VG_MEM_ACCELERATOR_HPP_INCLUDED
+#define VG_MEM_ACCELERATOR_HPP_INCLUDED
+
+#include <cstdint>
+#include <string>
+#include <gcsa/gcsa.h>
+#include <sdsl/int_vector.hpp>
+
+namespace vg {
+
+using namespace std;
+
+/*
+ * An auxilliary index that accelerates the initial steps of
+ * MEM-finding in
+ */
+class MEMAccelerator {
+public:
+    
+    MEMAccelerator() = default;
+    MEMAccelerator(const gcsa::GCSA& gcsa_index, size_t k);
+    
+    // return the length of k-mers that are memoized
+    inline int64_t length() const;
+    
+    // look up the GCSA range that corresponds to a k-length
+    // string ending at the indicated position. client code
+    // is responsible for ensuring that the string being
+    // accessed is at least length k and consists only of ACGT
+    // characters
+    gcsa::range_type memoized_LF(string::const_iterator last) const;
+    
+private:
+    
+    inline int64_t encode(char c) const;
+    
+    // the size k-mer we'll index
+    const int64_t k = 1;
+    // the actual table
+    sdsl::int_vector<> range_table;
+    
+};
+
+inline int64_t MEMAccelerator::length() const {
+    return k;
+}
+
+inline int64_t MEMAccelerator::encode(char c) const {
+    switch (c) {
+        case 'A':
+            return 0;
+        case 'C':
+            return 1;
+        case 'G':
+            return 2;
+        case 'T':
+            return 3;
+        default:
+            return -1;
+    }
+}
+
+}
+
+#endif

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -265,7 +265,7 @@ int main_mpmap(int argc, char** argv) {
     vector<size_t> calibration_read_lengths{50, 100, 150, 250, 450};
     size_t order_length_repeat_hit_max = 3000;
     size_t sub_mem_count_thinning = 4;
-    size_t sub_mem_thinning_burn_in = 16;
+    size_t sub_mem_thinning_burn_in_diff = 1;
     double secondary_rescue_score_diff = 0.8;
     size_t secondary_rescue_attempts = 4;
     size_t secondary_rescue_attempts_arg = numeric_limits<size_t>::max();
@@ -299,7 +299,7 @@ int main_mpmap(int argc, char** argv) {
     int full_length_bonus_arg = std::numeric_limits<int>::min();
     int reversing_walk_length = 1;
     int min_splice_length = 20;
-    int mem_accelerator_length = 10;
+    int mem_accelerator_length = 12;
     bool no_output = false;
     string out_format = "GAMP";
 
@@ -1701,7 +1701,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.fast_reseed = true;
     multipath_mapper.fast_reseed_length_diff = reseed_diff;
     multipath_mapper.sub_mem_count_thinning = sub_mem_count_thinning;
-    multipath_mapper.sub_mem_thinning_burn_in = sub_mem_thinning_burn_in;
+    multipath_mapper.sub_mem_thinning_burn_in = int(ceil(log(total_seq_length) / log(4.0))) + sub_mem_thinning_burn_in_diff;
     multipath_mapper.order_length_repeat_hit_max = order_length_repeat_hit_max;
     multipath_mapper.min_mem_length = min_mem_length;
     multipath_mapper.stripped_match_alg_strip_length = stripped_match_alg_strip_length;

--- a/src/unittest/mem_accelerator.cpp
+++ b/src/unittest/mem_accelerator.cpp
@@ -1,0 +1,76 @@
+/// \file path_index.cpp
+///  
+/// Unit tests for the PathIndex class, which indexes paths for random access.
+///
+
+#include <iostream>
+#include <string>
+#include "../mem_accelerator.hpp"
+#include "../utility.hpp"
+#include "../build_index.hpp"
+#include "catch.hpp"
+#include "random_graph.hpp"
+
+#include <bdsg/hash_graph.hpp>
+
+namespace vg {
+namespace unittest {
+using namespace std;
+
+
+TEST_CASE("MEMAccelerator returns same ranges as direct LF queries",
+          "[mem][mapping][memaccelerator]" ) {
+    
+    int num_graphs = 5;
+    int seq_size = 100;
+    int var_count = 4;
+    int var_length = 3;
+    int memo_length = 5;
+    for (int g = 0; g < num_graphs; ++g) {
+        
+        bdsg::HashGraph graph;
+        random_graph(seq_size, var_length, var_count, &graph);
+        
+        // Configure GCSA temp directory to the system temp directory
+        gcsa::TempFile::setDirectory(temp_file::get_dir());
+        // And make it quiet
+        gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
+        
+        // Make pointers to fill in
+        gcsa::GCSA* gcsaidx = nullptr;
+        gcsa::LCPArray* lcpidx = nullptr;
+        
+        // Build the GCSA index
+        build_gcsa_lcp(graph, gcsaidx, lcpidx, 8, 2);
+        
+        MEMAccelerator accelerator(*gcsaidx, memo_length);
+        
+        // iterate over all k-mers
+        for (int k = 0; k < (1 << (2 * memo_length)); ++k) {
+            
+            string seq(memo_length, 'N');
+            for (int i = 0; i < memo_length; ++i) {
+                seq[i] = "ACGT"[(k >> i) & 3];
+            }
+            
+            // check that the memoized and direct ranges are equivalent
+            auto memo_range = accelerator.memoized_LF(seq.end() - 1);
+            auto direct_range = gcsa::range_type(0, gcsaidx->size() - 1);
+            auto cursor = seq.end() - 1;
+            while (cursor >= seq.begin()) {
+                direct_range = gcsaidx->LF(direct_range,
+                                           gcsaidx->alpha.char2comp[*cursor]);
+                --cursor;
+            }
+            
+            REQUIRE(memo_range == direct_range);
+        }
+        
+        delete gcsaidx;
+        delete lcpidx;
+    }
+}
+   
+}
+}
+        

--- a/src/unittest/mem_accelerator.cpp
+++ b/src/unittest/mem_accelerator.cpp
@@ -57,7 +57,7 @@ TEST_CASE("MEMAccelerator returns same ranges as direct LF queries",
             auto memo_range = accelerator.memoized_LF(seq.end() - 1);
             auto direct_range = gcsa::range_type(0, gcsaidx->size() - 1);
             auto cursor = seq.end() - 1;
-            while (cursor >= seq.begin()) {
+            while (cursor >= seq.begin() && !gcsa::Range::empty(direct_range)) {
                 direct_range = gcsaidx->LF(direct_range,
                                            gcsaidx->alpha.char2comp[*cursor]);
                 --cursor;


### PR DESCRIPTION
## Description

A small scale optimization for mpmap, inspired by some literature I read. The basic idea is to memoize all GCSA2 queries at some short length k so that we can replace a sequence of 2k cache misses with just 1. My back-of-the-envelope calculations suggest that this will speed mpmap up by ~1% at the expense of a few tens of MBs. The start-up costs to compute this index also seem to be minimal (~20 seconds on our servers).