### PR TITLE
gfa w-line output option

### DIFF
--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -1,12 +1,18 @@
 #include "gfa.hpp"
 #include <gfakluge.hpp>
+#include "utility.hpp"
+#include "path.hpp"
 
 namespace vg {
 
 using namespace std;
 using namespace gfak;
 
-void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>& rgfa_paths) {
+static bool write_w_line(const PathHandleGraph* graph, ostream& out, const string& wline_sep,
+                         path_handle_t path_handle);
+
+void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>& rgfa_paths,
+                  const string& wline_sep) {
     GFAKluge gg;
     gg.set_version(1.0);
     for (auto h : gg.get_header()){
@@ -59,19 +65,22 @@ void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>&
         path_elem p_elem;
         p_elem.name = graph->get_path_name(h);
         if (!rgfa_paths.count(p_elem.name)) {
-            graph->for_each_step_in_path(h, [&](const step_handle_t& ph) {
-                    
+            bool wrote_w_line = write_w_line(graph, out, wline_sep, h);
+            if (!wrote_w_line) {
+                graph->for_each_step_in_path(h, [&](const step_handle_t& ph) {
+            
                     handle_t step_handle = graph->get_handle_of_step(ph);
 
                     p_elem.segment_names.push_back( std::to_string(graph->get_id(step_handle)) );
                     p_elem.orientations.push_back( !graph->get_is_reverse(step_handle) );
                     return true;
                 });
-            p_elem.overlaps.push_back("*");
-            //gg.add_path(p_elem.name, p_elem);
-            out << p_elem.to_string_1() << endl;
+                p_elem.overlaps.push_back("*");
+                //gg.add_path(p_elem.name, p_elem);
+                out << p_elem.to_string_1() << endl;
+            }
         }
-        });
+    });
 
     graph->for_each_edge([&](const edge_t& h) {
         edge_elem ee;
@@ -110,6 +119,55 @@ void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>&
         //gg.add_link(l.source_name, l);
     }, false);
     //gg.output_to_stream(cout);
+}
+
+bool write_w_line(const PathHandleGraph* graph, ostream& out, const string& wline_sep,
+                  path_handle_t path_handle) {
+    if (wline_sep.empty()) {
+        return false;
+    }
+    string path_name = graph->get_path_name(path_handle);
+    vector<string> toks = split_delims(path_name, wline_sep);
+    if (toks.size() < 3) {
+        return false;
+    }
+    string& sample = toks[0];
+    size_t hap_index;
+    try {
+        hap_index = stol(toks[1]);
+    } catch(...) {
+        return false;
+    }
+    auto subpath_parse = Paths::parse_subpath_name(toks[2]);
+    string contig;
+    size_t start_offset = 0;
+    size_t end_offset = 0;
+    if (get<0>(subpath_parse) == true) {
+        contig = get<1>(subpath_parse);
+        start_offset = get<2>(subpath_parse);
+        end_offset = get<3>(subpath_parse);
+    } else {
+        contig = toks[2];
+    }
+
+    size_t path_length = 0 ;
+    graph->for_each_step_in_path(path_handle, [&](step_handle_t step_handle) {
+            path_length += graph->get_length(graph->get_handle_of_step(step_handle));
+        });
+
+    if (end_offset != 0 && start_offset + path_length != end_offset) {
+        cerr << "[gfa] warning: incorrect end offset (" << end_offset << ") extracted from from path name " << path_name
+             << ", using " << (start_offset + path_length) << " instead" << endl;
+    }
+
+    out << "W\t" << sample << "\t" << hap_index << "\t" << contig << "\t" << start_offset << "\t" << (start_offset + path_length) << "\t";
+
+    graph->for_each_step_in_path(path_handle, [&](step_handle_t step_handle) {
+            handle_t handle = graph->get_handle_of_step(step_handle);
+            out << (graph->get_is_reverse(handle) ? "<" : ">") << graph->get_id(handle);
+        });
+    out << endl;
+    return true;
 }
 
 }

--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -12,7 +12,7 @@ static bool write_w_line(const PathHandleGraph* graph, ostream& out, const strin
                          path_handle_t path_handle);
 
 void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>& rgfa_paths,
-                  const string& wline_sep) {
+                  bool rgfa_pline, const string& wline_sep) {
     GFAKluge gg;
     gg.set_version(1.0);
     for (auto h : gg.get_header()){
@@ -64,7 +64,7 @@ void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>&
     graph->for_each_path_handle([&](const path_handle_t& h) {
         path_elem p_elem;
         p_elem.name = graph->get_path_name(h);
-        if (!rgfa_paths.count(p_elem.name)) {
+        if (rgfa_pline || !rgfa_paths.count(p_elem.name)) {
             bool wrote_w_line = write_w_line(graph, out, wline_sep, h);
             if (!wrote_w_line) {
                 graph->for_each_step_in_path(h, [&](const step_handle_t& ph) {

--- a/src/gfa.hpp
+++ b/src/gfa.hpp
@@ -18,7 +18,8 @@ namespace vg {
 using namespace std;
 
 /// Export the given VG graph to the given GFA file.
-void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>& rgfa_paths = {});
+void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>& rgfa_paths = {},
+                  const string& wline_sep = "");
 
 
 }

--- a/src/gfa.hpp
+++ b/src/gfa.hpp
@@ -18,9 +18,10 @@ namespace vg {
 using namespace std;
 
 /// Export the given VG graph to the given GFA file.
-void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>& rgfa_paths = {},
+void graph_to_gfa(const PathHandleGraph* graph, ostream& out,
+                  const set<string>& rgfa_paths = {},
+                  bool rgfa_pline = false,
                   const string& wline_sep = "");
-
 
 }
 

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -46,12 +46,15 @@ public:
     // We used to use a regex but that's a very slow way to check a prefix.
     const static function<bool(const string&)> is_alt;
 
-    // Check if using subpath naming scheme.  If it is return true,
-    // the root path name, and the offset (false otherwise)
-    tuple<bool, string, size_t> static parse_subpath_name(const string& path_name);
+    // look for suffix of form [offset] or [offset-end_offset] and parse it. ex:
+    // chr1 would return <false, "", 0, 0>
+    // chr1[10] would return <true, chr1, 10, 0>
+    // chr1[10-20] would return <true, chr1, 10, 20>
+    // note: the start/end are as in BED : 0-based open-ended
+    tuple<bool, string, size_t, size_t> static parse_subpath_name(const string& path_name);
 
     // Create a subpath name
-    string static make_subpath_name(const string& path_name, size_t offset);
+    string static make_subpath_name(const string& path_name, size_t offset, size_t end_offset = 0);
 
     Paths(void);
 

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -43,6 +43,7 @@ int main_convert(int argc, char** argv) {
     bool gaf_to_gam = false;
     set<string> rgfa_paths;
     vector<string> rgfa_prefixes;
+    bool rgfa_pline = false;
     string wline_sep;
 
     if (argc == 2) {
@@ -70,6 +71,7 @@ int main_convert(int argc, char** argv) {
             {"gfa-out", no_argument, 0, 'f'},
             {"rgfa-path", required_argument, 0, 'P'},
             {"rgfa-prefix", required_argument, 0, 'Q'},
+            {"rgfa-pline", no_argument, 0, 'B'},
             {"gfa-trans", required_argument, 0, 'T'},
             {"wline-sep", required_argument, 0, 'w'},
             {"gam-to-gaf", required_argument, 0, 'G'},
@@ -79,7 +81,7 @@ int main_convert(int argc, char** argv) {
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hgr:b:vxapxofP:Q:T:w:G:F:t:",
+        c = getopt_long (argc, argv, "hgr:b:vxapxofP:Q:BT:w:G:F:t:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -128,6 +130,9 @@ int main_convert(int argc, char** argv) {
             break;
         case 'Q':
             rgfa_prefixes.push_back(optarg);
+            break;
+        case 'B':
+            rgfa_pline = true;
             break;
         case 'T':
             gfa_trans_path = optarg;
@@ -359,7 +364,7 @@ int main_convert(int argc, char** argv) {
                     }
                 }
             });
-        graph_to_gfa(graph_to_write, std::cout, rgfa_paths, wline_sep);
+        graph_to_gfa(graph_to_write, std::cout, rgfa_paths, rgfa_pline, wline_sep);
     }
     // Serialize the output graph.
     else {
@@ -388,6 +393,7 @@ void help_convert(char** argv) {
          << "gfa options:" << endl
          << "    -P, --rgfa-path STR    write given path as rGFA tags instead of P-line (use with -f, multiple allowed, only rank-0 supported)" << endl
          << "    -Q, --rgfa-prefix STR  write paths with given prefix as rGFA tags instead of P-lines (use with -f, multiple allowed, only rank-0 supported)" << endl
+         << "    -B, --rgfa-pline       paths written as rGFA tags also written as P-lines (or W-lines if selected by -w)" << endl
          << "    -T, --gfa-trans FILE   write gfa id conversions to FILE (use with -g)" << endl
          << "    -w, --wline-sep SEP    write paths with names that can be parsed as <sample><SEP><hap><SEP><contig> as GFA W-lines. (use with -f)" << endl
          << "                           suffixes of the form [start] or [start-end] will be converted into start and end coordinates if found." << endl

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -43,6 +43,7 @@ int main_convert(int argc, char** argv) {
     bool gaf_to_gam = false;
     set<string> rgfa_paths;
     vector<string> rgfa_prefixes;
+    string wline_sep;
 
     if (argc == 2) {
         help_convert(argv);
@@ -70,6 +71,7 @@ int main_convert(int argc, char** argv) {
             {"rgfa-path", required_argument, 0, 'P'},
             {"rgfa-prefix", required_argument, 0, 'Q'},
             {"gfa-trans", required_argument, 0, 'T'},
+            {"wline-sep", required_argument, 0, 'w'},
             {"gam-to-gaf", required_argument, 0, 'G'},
             {"gaf-to-gam", required_argument, 0, 'F'},
             {"threads", required_argument, 0, 't'},
@@ -77,7 +79,7 @@ int main_convert(int argc, char** argv) {
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hgr:b:vxapxofP:Q:T:G:F:t:",
+        c = getopt_long (argc, argv, "hgr:b:vxapxofP:Q:T:w:G:F:t:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -130,6 +132,9 @@ int main_convert(int argc, char** argv) {
         case 'T':
             gfa_trans_path = optarg;
             break;
+        case 'w':
+            wline_sep = optarg;
+            break;
         case 'G':
             input_aln = optarg;
             gam_to_gaf = true;
@@ -157,8 +162,8 @@ int main_convert(int argc, char** argv) {
         cerr << "error [vg convert]: -T can only be used with -g" << endl;
         return 1;
     }
-    if (output_format != "gfa" && (!rgfa_paths.empty() || !rgfa_prefixes.empty())) {
-        cerr << "error [vg convert]: -P and -Q can only be used with -f" << endl;
+    if (output_format != "gfa" && (!rgfa_paths.empty() || !rgfa_prefixes.empty() || !wline_sep.empty())) {
+        cerr << "error [vg convert]: -P, -Q, -w and -H can only be used with -f" << endl;
         return 1;
     }
 
@@ -354,7 +359,7 @@ int main_convert(int argc, char** argv) {
                     }
                 }
             });
-        graph_to_gfa(graph_to_write, std::cout, rgfa_paths);
+        graph_to_gfa(graph_to_write, std::cout, rgfa_paths, wline_sep);
     }
     // Serialize the output graph.
     else {
@@ -380,9 +385,14 @@ void help_convert(char** argv) {
          << "    -x, --xg-out           output in XG format" << endl
          << "    -o, --odgi-out         output in ODGI format" << endl
          << "    -f, --gfa-out          output in GFA format" << endl
+         << "gfa options:" << endl
          << "    -P, --rgfa-path STR    write given path as rGFA tags instead of P-line (use with -f, multiple allowed, only rank-0 supported)" << endl
          << "    -Q, --rgfa-prefix STR  write paths with given prefix as rGFA tags instead of P-lines (use with -f, multiple allowed, only rank-0 supported)" << endl
          << "    -T, --gfa-trans FILE   write gfa id conversions to FILE (use with -g)" << endl
+         << "    -w, --wline-sep SEP    write paths with names that can be parsed as <sample><SEP><hap><SEP><contig> as GFA W-lines. (use with -f)" << endl
+         << "                           suffixes of the form [start] or [start-end] will be converted into start and end coordinates if found." << endl
+         << "                           ex: using \"-w .\" will convert path HG00735.1.chr1[10000-20000] to \"W HG00735 1 chr1 10000 20000\n" << endl
+         << "                           multiple characters allowed (they will all be treated as separators)" << endl
          << "alignment options:" << endl
          << "    -G, --gam-to-gaf FILE  convert GAM FILE to GAF" << endl
          << "    -F, --gaf-to-gam FILE  convert GAF FILE to GAM" << endl


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg convert` can output vg paths (that adhere to certain naming conventions) to GFA `W-lines` with the `-w` option.

## Description

This adds fairly minimal logic to get W-lines out of vg graph *paths* and into GFA via `vg convert -f`.  The user provides one or more separator characters with `-w` and any paths that can be parsed into `Sample / Haplotype / Contig` will get converted into W lines, otherwise they are left as P-lines. 

This is important for the Cactus Pangenome workflow which goes from `hal` -> `vg` -> `GFA`, and relies on naming conventions to keep track of the various W-line fields at different points.  
