### PR TITLE
[WIP] More path coverage stats

### DIFF
--- a/src/algorithms/coverage_depth.hpp
+++ b/src/algorithms/coverage_depth.hpp
@@ -64,6 +64,18 @@ pair<double, double> sample_mapping_depth(const HandleGraph& graph, const string
 /// As above, but read a vector instead of a stream
 pair<double, double> sample_mapping_depth(const HandleGraph& graph, const vector<Alignment>& alignments, size_t max_nodes, size_t random_seed, size_t min_coverage, size_t min_mapq);
 
+/// print path-name offset base-coverage for every base on a path (just like samtools depth)
+/// ignoring things below min_coverage.  offsets are 1-based in output stream
+/// coverage here is the number of steps from (unique) other paths
+void path_depths(const PathHandleGraph& graph, const string& path_name, size_t min_coverage, ostream& out_stream);
+
+/// like packed_depth_of_bin (above), but use paths (as in path_depths) for measuring coverage
+pair<double, double> path_depth_of_bin(const PathHandleGraph& graph, step_handle_t start_step, step_handle_t end_plus_one_step,
+                                         size_t min_coverage);
+
+vector<tuple<size_t, size_t, double, double>> binned_path_depth(const PathHandleGraph& graph, const string& path_name, size_t bin_size,
+                                                                size_t min_coverage);
+
 }
 }
 

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -27,9 +27,9 @@ size_t Packer::estimate_bin_count(size_t num_threads) {
     return pow(2, log2(num_threads) + 14);
 }
 
-Packer::Packer(void) : graph(nullptr), data_width(8), cov_bin_size(0), edge_cov_bin_size(0), num_bases_dynamic(0), base_locks(nullptr), num_edges_dynamic(0), edge_locks(nullptr), node_quality_locks(nullptr), tmpfstream_locks(nullptr) { }
+Packer::Packer(const HandleGraph* graph) : graph(graph), data_width(8), cov_bin_size(0), edge_cov_bin_size(0), num_bases_dynamic(0), base_locks(nullptr), num_edges_dynamic(0), edge_locks(nullptr), node_quality_locks(nullptr), tmpfstream_locks(nullptr) { }
 
-Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t coverage_bins, size_t data_width, bool record_bases, bool record_edges, bool record_edits, bool record_qualities) :
+Packer::Packer(const HandleGraph* graph, bool record_bases, bool record_edges, bool record_edits, bool record_qualities, size_t bin_size, size_t coverage_bins, size_t data_width) :
     graph(graph), data_width(data_width), bin_size(bin_size), record_bases(record_bases), record_edges(record_edges), record_edits(record_edits), record_qualities(record_qualities) {
     // get the size of the base coverage counter
     num_bases_dynamic = 0;
@@ -39,9 +39,9 @@ Packer::Packer(const HandleGraph* graph, size_t bin_size, size_t coverage_bins, 
     // get the size of the edge coverage counter
     num_edges_dynamic = 0;
     if (record_edges) {
+        const VectorizableHandleGraph* vec_graph = dynamic_cast<const VectorizableHandleGraph*>(graph);
+        assert(vec_graph != nullptr);      
         graph->for_each_edge([&](const edge_t& edge) {
-                const VectorizableHandleGraph* vec_graph = dynamic_cast<const VectorizableHandleGraph*>(graph);
-                assert(vec_graph != nullptr);
                 auto edge_index = vec_graph->edge_index(edge);
 #ifdef debug
                 cerr << "Observed edge at index " << edge_index << endl;

--- a/src/packer.hpp
+++ b/src/packer.hpp
@@ -35,19 +35,22 @@ public:
     static size_t estimate_data_width(size_t expected_coverage);
     static size_t estimate_batch_size(size_t num_threads);
     static size_t estimate_bin_count(size_t num_threads);
+
+    /// Create a Packer (to read from a file)
+    Packer(const HandleGraph* graph = nullptr);
     
-    Packer(void);
-    /// Create a Packer
+    /// Create a Packer (to write to)
     /// graph : Must implement the VectorizableHandleGraph interface
+    /// record_bases : Store the base coverage
+    /// record_edges : Store the edge coverage
+    /// record_edits : Store the edits
+    /// record_qualities : Store the average MAPQ for each node rank    
     /// bin_size : Bin coverage into bins
     /// coverage_bins : Use this many coverage objects.  Using one / thread allows faster merge
     /// coverage_locks : Number of mutexes to use for each of node and edge coverage.
     /// data_width : Number of bits per entry in the dynamic coverage vector.  Higher values get stored in a map
-    /// record_bases : Store the base coverage
-    /// record_edges : Store the edge coverage
-    /// record_edits : Store the edits
-    /// record_qualities : Store the average MAPQ for each node rank
-    Packer(const HandleGraph* graph, size_t bin_size = 0, size_t coverage_bins = 1, size_t data_width = 8, bool record_bases = true, bool record_edges = true, bool record_edits = true, bool record_qualities = true);
+    Packer(const HandleGraph* graph, bool record_bases, bool record_edges, bool record_edits, bool record_qualities,
+           size_t bin_size = 0, size_t coverage_bins = 1, size_t data_width = 8);
     ~Packer();
     void clear();
 

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -293,7 +293,7 @@ int main_augment(int argc, char** argv) {
         vectorizable_graph = dynamic_cast<HandleGraph*>(overlay_helper.apply(graph.get()));
         size_t data_width = Packer::estimate_data_width(expected_coverage);
         size_t bin_count = Packer::estimate_bin_count(get_thread_count());
-        packer = make_unique<Packer>(vectorizable_graph, 0, bin_count, data_width, true, false, false);
+        packer = make_unique<Packer>(vectorizable_graph, true, false, false, false, 0, bin_count, data_width);
         // makes sure filters are activated. 
         min_coverage = max(size_t(min_coverage), size_t(1));
     }

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -210,7 +210,7 @@ int main_pack(int argc, char** argv) {
     size_t bin_count = Packer::estimate_bin_count(num_threads);
 
     // create our packer
-    Packer packer(graph, bin_size, bin_count, data_width, true, true, record_edits);
+    Packer packer(graph, true, true, record_edits, true, bin_size, bin_count, data_width);
     
     // todo one packer per thread and merge
     if (packs_in.size() == 1) {

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -43,6 +43,7 @@ void help_paths(char** argv) {
          << "    -E, --lengths            print a list of path names (as with -L) but paired with their lengths" << endl
          << "    -C, --cyclicity          print a list of path names (as with -L) but paired with flag denoting the cyclicity" << endl
          << "    -F, --extract-fasta      print the paths in FASTA format" << endl
+         << "    -c, --coverage           print the coverage stats for selected paths" << endl
          << "  path selection:" << endl
          << "    -p, --paths-file FILE    select the paths named in a file (one per line)" << endl
          << "    -Q, --paths-by STR       select the paths with the given name prefix" << endl
@@ -99,6 +100,8 @@ int main_paths(int argc, char** argv) {
     size_t output_formats = 0, selection_criteria = 0;
     size_t input_formats = 0;
     bool list_cyclicity = false;
+    bool coverage = false;
+    const size_t coverage_bins = 10;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -122,6 +125,7 @@ int main_paths(int argc, char** argv) {
             {"sample", required_argument, 0, 'S'},
             {"variant-paths", no_argument, 0, 'a'},
             {"cyclicity", no_argument, 0, 'C'},
+            {"coverage", no_argument, 0, 'c'},            
 
             // Hidden options for backward compatibility.
             {"threads", no_argument, 0, 'T'},
@@ -131,7 +135,7 @@ int main_paths(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hLXv:x:g:Q:VEFAS:Tq:drap:C",
+        c = getopt_long (argc, argv, "hLXv:x:g:Q:VEFAS:Tq:drap:Cc",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -223,6 +227,11 @@ int main_paths(int argc, char** argv) {
             output_formats++;
             break;
 
+        case 'c':
+            coverage = true;
+            output_formats++;
+            break;
+
         case 'T':
             std::cerr << "warning: [vg paths] option --threads is obsolete and unnecessary" << std::endl;
             break;
@@ -266,7 +275,7 @@ int main_paths(int argc, char** argv) {
         }
     } 
     if (output_formats != 1) {
-        std::cerr << "error: [vg paths] one output format (-X, -A, -V, -d, -r, -L, -F, -E or -C) must be specified" << std::endl;
+        std::cerr << "error: [vg paths] one output format (-X, -A, -V, -d, -r, -L, -F, -E, -C or -c) must be specified" << std::endl;
         std::exit(EXIT_FAILURE);
     }
     if (selection_criteria > 1) {
@@ -283,6 +292,10 @@ int main_paths(int argc, char** argv) {
     }
     if ((drop_paths || retain_paths) && !gbwt_file.empty()) {
         std::cerr << "error: [vg paths] dropping or retaining paths only works on embedded VG/XG paths, not GBWT threads" << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    if (coverage && !gbwt_file.empty()) {
+        std::cerr << "error: [vg paths] coverage option -c only works on embedded VG/XG paths, not GBWT threads" << std::endl;
         std::exit(EXIT_FAILURE);
     }
     
@@ -452,7 +465,83 @@ int main_paths(int argc, char** argv) {
             // output the graph
             dynamic_cast<SerializableHandleGraph*>(graph.get())->serialize(cout);
         }
-        else {
+        else if (coverage) {
+            // for every node, count the number of unique paths.  then add the coverage count to each one
+            // (we're doing the whole graph here, which could be inefficient in the case the user is selecting
+            //  a small path)
+            unordered_map<path_handle_t, vector<int64_t>> coverage_map;
+            size_t max_coverage = 0;
+            graph->for_each_handle([&](handle_t handle) {
+                    vector<step_handle_t> steps = graph->steps_of_handle(handle);
+                    unordered_set<path_handle_t> unique_paths;
+                    for (auto step_handle : steps) {
+                        unique_paths.insert(graph->get_path_handle_of_step(step_handle));
+                    }
+                    for (auto path_handle : unique_paths) {
+                        vector<int64_t>& cov = coverage_map[path_handle];
+                        if (cov.size() < unique_paths.size()) {
+                            cov.resize(unique_paths.size(), 0);
+                        }
+                        cov[unique_paths.size() - 1] += graph->get_length(graph->get_handle_of_step(steps[0]));
+                        max_coverage = std::max(max_coverage, unique_paths.size() - 1);                            
+                    }
+                });
+            // figure out the bin size
+            int64_t bin_size = 1;
+            if (max_coverage > coverage_bins) {
+                // reserve the first 2 bins for coverage = 0 and 1 no matter 1
+                bin_size = (max_coverage - 2) / (coverage_bins - 2);
+                if ((max_coverage - 2) % (coverage_bins - 2)) {
+                    ++bin_size;
+                }
+            }
+            // compute cumulative coverage
+            for (auto& path_cov : coverage_map) {
+                int64_t cum_cov = 0;
+                vector<int64_t>& cov = path_cov.second;
+                cov.resize(max_coverage + 1, 0);
+                // bin it up if necessary
+                if (cov.size() > coverage_bins) {
+                    vector<int64_t> binned_cov(coverage_bins, 0);
+                    // reserve the first 2 bins for coverage = 0 and 1 no matter 1
+                    binned_cov[0] = cov[0];
+                    binned_cov[1] = cov[1];
+                    // remaining bins
+                    for (size_t bin = 0; bin < coverage_bins - 2; ++bin) {
+                        for (size_t i = 0; i < bin_size && (bin * bin_size + i < cov.size()); ++i) {
+                            binned_cov[2 + bin] += cov[bin * bin_size + i];
+                        }
+                    }
+                    swap(cov, binned_cov);
+                }
+                // accumulate
+                for (auto cov_it = path_cov.second.rbegin(); cov_it != path_cov.second.rend(); ++cov_it) {
+                    cum_cov += *cov_it;
+                    *cov_it = cum_cov;
+                }
+            }
+            cout << "PathName";
+            for (size_t cov = 0; cov <= min(max_coverage, coverage_bins); ++cov) {
+                cout << "\t";
+                if (cov < 2 || bin_size == 1) {
+                    cout << cov;
+                } else {
+                    cout << (cov * bin_size) << "-" << (cov * bin_size + bin_size - 1);
+                } 
+            }
+            cout << endl;
+            graph->for_each_path_handle([&](path_handle_t path_handle) {
+                    string path_name = graph->get_path_name(path_handle);
+                    if (check_path_name(path_name)) {
+                        cout << path_name;
+                        auto& path_cov = coverage_map[path_handle];
+                        for (size_t cov = 0; cov < path_cov.size(); ++cov) {
+                            cout << "\t" << path_cov[cov];
+                        }
+                        cout << endl;
+                    }
+                });
+        } else {            
             graph->for_each_path_handle([&](path_handle_t path_handle) {
                 string path_name = graph->get_path_name(path_handle);
                 if (check_path_name(path_name)) {

--- a/test/t/49_vg_depth.t
+++ b/test/t/49_vg_depth.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 4
+plan tests 6
 
 vg construct -m 10 -r tiny/tiny.fa >flat.vg
 vg view flat.vg| sed 's/CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG/CAAATAAGGCTTGGAAATTTTCTGGAGATCTATTATACTCCAACTCTCTG/' | vg view -Fv - >2snp.vg
@@ -19,4 +19,7 @@ is $(vg depth flat.xg -k 2snp.gam.cx -b 100000 | awk '{print int($4)}') 18 "vg d
 is $(vg depth flat.xg -k 2snp.gam.cx -b 10 | wc -l) 5 "vg depth gets correct number of bins"
 vg convert flat.vg -G 2snp.gam | gzip > 2snp.gaf.gz
 is $(vg depth flat.vg -a 2snp.gaf.gz | awk '{print $1}') 18 "vg depth gets correct depth from gaf"
-rm -f flat.vg flat.gcsa flat.xg 2snp.vg 2snp.sim 2snp.gam 2snp.gam.cx 2snp.gaf.gz
+vg augment flat.vg 2snp.gam -i > flat-aug.vg
+is $(vg depth flat-aug.vg | awk '{print $1}' | uniq | wc -l) $(vg paths -Lv flat-aug.vg | wc -l) "vg depth of paths reports all paths"
+is $(vg depth flat-aug.vg -P x | awk '{print $1}' | uniq | wc -l) 1 "vg depth of paths reports just path with selected prefix"
+rm -f flat.vg flat.gcsa flat.xg 2snp.vg 2snp.sim 2snp.gam 2snp.gam.cx 2snp.gaf.gz flat-aug.vg


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg paths -c` option added to compute path coverage (how many other paths overlap given path)
 * `vg depth` will now compute coverage based on overlap with embedded paths if no pack/gam options given

## Description

Add a couple options to get some simple measures of how different paths overlap.  `vg paths -c` can help find paths that are relatively well or poorly aligned, whereas `vg depth` can now do the same for regions within a path. 
