### PR TITLE
Try to avoid virtual memory exhaustion and other causes of failing allocations in Giraffe aligner calls

### DIFF
--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -13,7 +13,7 @@
 //#define debug_banded_aligner_fill_matrix
 //#define debug_banded_aligner_traceback
 //#define debug_banded_aligner_print_matrices
-#define debug_jemalloc
+//#define debug_jemalloc
 
 #ifdef debug_jemalloc
 #include <jemalloc/jemalloc.h>

--- a/src/banded_global_aligner.cpp
+++ b/src/banded_global_aligner.cpp
@@ -13,6 +13,11 @@
 //#define debug_banded_aligner_fill_matrix
 //#define debug_banded_aligner_traceback
 //#define debug_banded_aligner_print_matrices
+#define debug_jemalloc
+
+#ifdef debug_jemalloc
+#include <jemalloc/jemalloc.h>
+#endif
 
 namespace vg {
 
@@ -255,6 +260,51 @@ void BandedGlobalAligner<IntType>::BAMatrix::fill_matrix(const HandleGraph& grap
     match = (IntType*) malloc(sizeof(IntType) * band_size);
     insert_col = (IntType*) malloc(sizeof(IntType) * band_size);
     insert_row = (IntType*) malloc(sizeof(IntType) * band_size);
+    if (!match || !insert_col || !insert_row) {
+        // An allocation has failed.
+        // We may have run out of virtual memory.
+        
+#ifdef debug_jemalloc
+        size_t requested_size = sizeof(IntType) * band_size;
+        size_t usable_size[3] = {0, 0, 0};
+#endif
+        
+        // Free up what we are holding, and also report how much usable mamoey jemalloc gave us for anything that passed.
+        if (match) {
+#ifdef debug_jemalloc
+            usable_size[0] = malloc_usable_size(match);
+#endif
+            free(match);
+        }
+        if (insert_col) {
+#ifdef debug_jemalloc
+            usable_size[1] = malloc_usable_size(insert_col);
+#endif
+            free(insert_col);
+        }
+        if (insert_row) {
+#ifdef debug_jemalloc
+            usable_size[2] = malloc_usable_size(insert_row);
+#endif
+            free(insert_row);
+        }
+        
+        cerr << "[BAMatrix::fill_matrix]: failed to allocate matrices of height " << band_height << " and width " << ncols << " for a total cell count of " << band_size << endl;
+#ifdef debug_jemalloc
+        cerr << "[BAMatrix::fill_matrix]: requested: " << requested_size << " actually obtained: " << usable_size[0] << " " << usable_size[1] << " " << usable_size[2] << endl;
+#endif
+        cerr << "[BAMatrix::fill_matrix]: is alignment problem too big for your virtual or physical memory?" << endl;
+        
+#ifdef debug_jemalloc
+        // Dump the stats from the allocator.
+        // TODO: skip when not building with jemalloc somehow.
+        malloc_stats_print(nullptr, nullptr, "");
+#endif
+        
+        // Bail out relatively safely
+        throw std::bad_alloc();
+    }
+    
     /* these represent a band in a matrix, but we store it as a rectangle with chopped
      * corners
      *

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2536,11 +2536,13 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         this->extender.unfold_haplotypes(rescue_nodes, haplotype_paths, align_graph);
         
         size_t rescue_subgraph_bases = align_graph.get_total_length();
-        if (rescue_subgraph_bases > max_rescue_subgraph_bases) {
-            if (!warned_about_rescue_subgraph_size.test_and_set()) {
-                cerr << "warning[vg::giraffe]: Refusing to perform very large rescue alignment against "
+        if (rescue_subgraph_bases * rescued_alignment.sequence().size() > max_dozeu_cells) {
+            if (!warned_about_rescue_size.test_and_set()) {
+                cerr << "warning[vg::giraffe]: Refusing to perform too-large rescue alignment of "
+                    << rescued_alignment.sequence().size() << " bp against "
                     << rescue_subgraph_bases << " bp haplotype subgraph for read " << rescued_alignment.name()
-                    << "; suppressing further warnings." << endl;
+                    << " which would use more than " << max_dozeu_cells
+                    << " cells and might exhaust Dozeu's allocator; suppressing further warnings." << endl;
             }
             return; 
         }
@@ -2589,11 +2591,13 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         for (auto& h : topological_order) {
             rescue_subgraph_bases += cached_graph.get_length(h);
         }
-        if (rescue_subgraph_bases > max_rescue_subgraph_bases) {
-            if (!warned_about_rescue_subgraph_size.test_and_set()) {
-                cerr << "warning[vg::giraffe]: Refusing to perform very large rescue alignment against "
+        if (rescue_subgraph_bases * rescued_alignment.sequence().size() > max_dozeu_cells) {
+            if (!warned_about_rescue_size.test_and_set()) {
+                cerr << "warning[vg::giraffe]: Refusing to perform too-large rescue alignment of "
+                    << rescued_alignment.sequence().size() << " bp against "
                     << rescue_subgraph_bases << " bp ordered subgraph for read " << rescued_alignment.name()
-                    << "; suppressing further warnings." << endl;
+                    << " which would use more than " << max_dozeu_cells
+                    << " cells and might exhaust Dozeu's allocator; suppressing further warnings." << endl;
             }
             return; 
         }
@@ -2624,15 +2628,17 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         handlealgs::dagify(&split_graph, &dagified, rescued_alignment.sequence().size());
 
     size_t rescue_subgraph_bases = dagified.get_total_length();
-    if (rescue_subgraph_bases > max_rescue_subgraph_bases) {
-        if (!warned_about_rescue_subgraph_size.test_and_set()) {
-            cerr << "warning[vg::giraffe]: Refusing to perform very large rescue alignment against "
+    if (rescue_subgraph_bases * rescued_alignment.sequence().size() > max_dozeu_cells) {
+        if (!warned_about_rescue_size.test_and_set()) {
+            cerr << "warning[vg::giraffe]: Refusing to perform too-large rescue alignment of "
+                << rescued_alignment.sequence().size() << " bp against "
                 << rescue_subgraph_bases << " bp dagified subgraph for read " << rescued_alignment.name()
-                << "; suppressing further warnings." << endl;
+                << " which would use more than " << max_dozeu_cells
+                << " cells and might exhaust Dozeu's allocator; suppressing further warnings." << endl;
         }
         return; 
     }
-
+    
     // Align to the subgraph.
     // TODO: Map the seed to the dagified subgraph.
     if (this->rescue_algorithm == rescue_dozeu) {
@@ -3649,10 +3655,12 @@ pair<Path, size_t> MinimizerMapper::get_best_alignment_against_any_tree(const ve
             }
             
             size_t tail_subgraph_bases = subgraph.get_total_length();
-            if (tail_subgraph_bases > max_tail_subgraph_bases) {
-                if (!warned_about_tail_subgraph_size.test_and_set()) {
-                    cerr << "warning[vg::giraffe]: Refusing to perform very large tail alignment against "
-                        << tail_subgraph_bases << " bp tree; suppressing further warnings." << endl;
+            if (tail_subgraph_bases * sequence.size() > max_dozeu_cells) {
+                if (!warned_about_tail_size.test_and_set()) {
+                    cerr << "warning[vg::giraffe]: Refusing to perform too-large tail alignment of "
+                        << sequence.size() << " bp against "
+                        << tail_subgraph_bases << " bp tree which would use more than " << max_dozeu_cells
+                        << " cells and might exhaust Dozeu's allocator; suppressing further warnings." << endl;
                 }
             } else {
                 // X-drop align, accounting for full length bonus.

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2536,12 +2536,12 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         this->extender.unfold_haplotypes(rescue_nodes, haplotype_paths, align_graph);
         
         size_t rescue_subgraph_bases = align_graph->get_total_length();
-        if (rescue_subgraph_bases > max_rescue_subgraph_bases &&
-            !warned_about_rescue_subgraph_size.test_and_set()) {
-            
-            cerr << "warning[vg::giraffe]: Refusing to perform very large rescue alignment against "
-                << rescue_subgraph_bases << " bp haplotype subgraph for read " << rescued_alignment.name()
-                << "; suppressing further warnings." << endl;
+        if (rescue_subgraph_bases > max_rescue_subgraph_bases) {
+            if (!warned_about_rescue_subgraph_size.test_and_set()) {
+                cerr << "warning[vg::giraffe]: Refusing to perform very large rescue alignment against "
+                    << rescue_subgraph_bases << " bp haplotype subgraph for read " << rescued_alignment.name()
+                    << "; suppressing further warnings." << endl;
+            }
             return; 
         }
 
@@ -2589,12 +2589,12 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         for (auto& h : topological_order) {
             rescue_subgraph_bases += cached_graph.get_length(h);
         }
-        if (rescue_subgraph_bases > max_rescue_subgraph_bases &&
-            !warned_about_rescue_subgraph_size.test_and_set()) {
-            
-            cerr << "warning[vg::giraffe]: Refusing to perform very large rescue alignment against "
-                << rescue_subgraph_bases << " bp ordered subgraph for read " << rescued_alignment.name()
-                << "; suppressing further warnings." << endl;
+        if (rescue_subgraph_bases > max_rescue_subgraph_bases) {
+            if (!warned_about_rescue_subgraph_size.test_and_set()) {
+                cerr << "warning[vg::giraffe]: Refusing to perform very large rescue alignment against "
+                    << rescue_subgraph_bases << " bp ordered subgraph for read " << rescued_alignment.name()
+                    << "; suppressing further warnings." << endl;
+            }
             return; 
         }
     
@@ -2624,12 +2624,12 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         handlealgs::dagify(&split_graph, &dagified, rescued_alignment.sequence().size());
 
     size_t rescue_subgraph_bases = dagified.get_total_length();
-    if (rescue_subgraph_bases > max_rescue_subgraph_bases &&
-        !warned_about_rescue_subgraph_size.test_and_set()) {
-        
-        cerr << "warning[vg::giraffe]: Refusing to perform very large rescue alignment against "
-            << rescue_subgraph_bases << " bp dagified subgraph for read " << rescued_alignment.name()
-            << "; suppressing further warnings." << endl;
+    if (rescue_subgraph_bases > max_rescue_subgraph_bases) {
+        if (!warned_about_rescue_subgraph_size.test_and_set()) {
+            cerr << "warning[vg::giraffe]: Refusing to perform very large rescue alignment against "
+                << rescue_subgraph_bases << " bp dagified subgraph for read " << rescued_alignment.name()
+                << "; suppressing further warnings." << endl;
+        }
         return; 
     }
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2535,7 +2535,7 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         bdsg::HashGraph align_graph;
         this->extender.unfold_haplotypes(rescue_nodes, haplotype_paths, align_graph);
         
-        size_t rescue_subgraph_bases = align_graph->get_total_length();
+        size_t rescue_subgraph_bases = align_graph.get_total_length();
         if (rescue_subgraph_bases > max_rescue_subgraph_bases) {
             if (!warned_about_rescue_subgraph_size.test_and_set()) {
                 cerr << "warning[vg::giraffe]: Refusing to perform very large rescue alignment against "

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -3648,10 +3648,18 @@ pair<Path, size_t> MinimizerMapper::get_best_alignment_against_any_tree(const ve
                 }
             }
             
-            // X-drop align, accounting for full length bonus.
-            // We *always* do left-pinned alignment internally, since that's the shape of trees we get.
-            // Make sure to pass through the gap length limit so we don't just get the default.
-            get_regular_aligner()->align_pinned(current_alignment, subgraph, true, true, longest_detectable_gap);
+            size_t tail_subgraph_bases = subgraph.get_total_length();
+            if (tail_subgraph_bases > max_tail_subgraph_bases) {
+                if (!warned_about_tail_subgraph_size.test_and_set()) {
+                    cerr << "warning[vg::giraffe]: Refusing to perform very large tail alignment against "
+                        << tail_subgraph_bases << " bp tree; suppressing further warnings." << endl;
+                }
+            } else {
+                // X-drop align, accounting for full length bonus.
+                // We *always* do left-pinned alignment internally, since that's the shape of trees we get.
+                // Make sure to pass through the gap length limit so we don't just get the default.
+                get_regular_aligner()->align_pinned(current_alignment, subgraph, true, true, longest_detectable_gap);
+            }
             
             if (show_work) {
                 #pragma omp critical (cerr)

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -163,6 +163,12 @@ public:
     
     /// And have we complained about hitting it?
     atomic_flag warned_about_rescue_subgraph_size = ATOMIC_FLAG_INIT;
+    
+    /// How big of a graph in bp should we ever try to align against for tail alignment?
+    size_t max_tail_subgraph_bases = 100 * 1024;
+    
+    /// And have we complained about hitting it?
+    mutable atomic_flag warned_about_tail_subgraph_size = ATOMIC_FLAG_INIT;
 
     ///What is the maximum fragment length that we accept as valid for paired-end reads?
     size_t max_fragment_length = 2000;

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -158,17 +158,18 @@ public:
     /// For paired end mapping, how many times should we attempt rescue (per read)?
     size_t max_rescue_attempts = 15;
     
-    /// How big of a graph in bp should we ever try to align against for rescue?
-    size_t max_rescue_subgraph_bases = 100 * 1024;
+    /// How big of an alignment in POA cells should we ever try to do with Dozeu?
+    /// TODO: Lift this when Dozeu's allocator is able to work with >4 MB of memory.
+    /// Each cell is 16 bits in Dozeu, and we leave some room for the query and
+    /// padding to full SSE registers. Note that a very chopped graph might
+    /// still break this!
+    size_t max_dozeu_cells = (size_t)(1.5 * 1024 * 1024);
     
-    /// And have we complained about hitting it?
-    atomic_flag warned_about_rescue_subgraph_size = ATOMIC_FLAG_INIT;
+    /// And have we complained about hitting it for rescue?
+    atomic_flag warned_about_rescue_size = ATOMIC_FLAG_INIT;
     
-    /// How big of a graph in bp should we ever try to align against for tail alignment?
-    size_t max_tail_subgraph_bases = 100 * 1024;
-    
-    /// And have we complained about hitting it?
-    mutable atomic_flag warned_about_tail_subgraph_size = ATOMIC_FLAG_INIT;
+    /// And have we complained about hitting it for tails?
+    mutable atomic_flag warned_about_tail_size = ATOMIC_FLAG_INIT;
 
     ///What is the maximum fragment length that we accept as valid for paired-end reads?
     size_t max_fragment_length = 2000;

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -157,6 +157,12 @@ public:
 
     /// For paired end mapping, how many times should we attempt rescue (per read)?
     size_t max_rescue_attempts = 15;
+    
+    /// How big of a graph in bp should we ever try to align against for rescue?
+    size_t max_rescue_subgraph_bases = 100 * 1024;
+    
+    /// And have we complained about hitting it?
+    atomic_flag warned_about_rescue_subgraph_size = ATOMIC_FLAG_INIT;
 
     ///What is the maximum fragment length that we accept as valid for paired-end reads?
     size_t max_fragment_length = 2000;

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1587,6 +1587,16 @@ using namespace std;
 #ifdef debug_anchored_surject
             cerr << "made split, linearized path graph with " << split_path_graph.get_node_count() << " nodes" << endl;
 #endif
+
+            size_t subgraph_bases = split_path_graph.get_total_length();
+            if (split_path_graph > max_subgraph_bases) {
+                if (!warned_about_subgraph_size.test_and_set()) {
+                    cerr << "warning[vg::Surjector]: Refusing to perform very large alignment against "
+                        << subgraph_bases << " bp strand split subgraph for read " << source.name()
+                        << "; suppressing further warnings." << endl;
+                }
+                return move(make_null_alignment(source)); 
+            }
             
             // compute the connectivity between the path chunks
             MultipathAlignmentGraph mp_aln_graph(split_path_graph, path_chunks, source, node_trans, !preserve_N_alignments,

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1589,7 +1589,7 @@ using namespace std;
 #endif
 
             size_t subgraph_bases = split_path_graph.get_total_length();
-            if (split_path_graph > max_subgraph_bases) {
+            if (subgraph_bases > max_subgraph_bases) {
                 if (!warned_about_subgraph_size.test_and_set()) {
                     cerr << "warning[vg::Surjector]: Refusing to perform very large alignment against "
                         << subgraph_bases << " bp strand split subgraph for read " << source.name()

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -91,7 +91,7 @@ using namespace std;
         size_t max_subgraph_bases = 100 * 1024;
         
         /// And have we complained about hitting it?
-        atomic_flag warned_about_subgraph_size = ATOMIC_FLAG_INIT;
+        mutable atomic_flag warned_about_subgraph_size = ATOMIC_FLAG_INIT;
         
     protected:
         

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -7,6 +7,7 @@
  */
 
 #include <set>
+#include <atomic>
 
 #include "alignment.hpp"
 #include "aligner.hpp"
@@ -85,6 +86,12 @@ using namespace std;
         int64_t min_splice_length = 20;
         
         int64_t dominated_path_chunk_diff = 10;
+        
+        /// How big of a graph in bp should we ever try to align against for realigning surjection?
+        size_t max_subgraph_bases = 100 * 1024;
+        
+        /// And have we complained about hitting it?
+        atomic_flag warned_about_subgraph_size = ATOMIC_FLAG_INIT;
         
     protected:
         


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg now uses a much newer `jemalloc`.
 * Alignments against subgraphs of more than 102400 bp will not be performed in surjection, to avoid extremely large memory allocations.
 * Dozeu alignment problems in Giraffe are restricted to be well below the Dozeu 4 MB memory limit.


## Description

This tries to fix #3202 by skipping over alignments against very big subgraphs in the giraffe-and-surject codepath. I'm still testing it to see if it has actually caught all of them and can run though on that example.

We might want to make the limit configurable from the command line.

@jeizenga @glennhickey @cmarkello Is 102400 bp a sensible subgraph size above which to give up?
