### PR TITLE
Warning instead of crash when unable to dijkstra across snarl

### DIFF
--- a/src/algorithms/k_widest_paths.cpp
+++ b/src/algorithms/k_widest_paths.cpp
@@ -171,6 +171,12 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
                                          edge_weight_callback, [](handle_t) {return false;},
                                          [](edge_t) {return false;}, greedy_avg));
 
+    // unable to get any kind of path.  this is either a bug in the search or the graph
+    if (best_paths.back().second.empty()) {
+        best_paths.clear();
+        return best_paths;
+    }
+
     best_spurs.push_back(0);
     
     // working path set, mapped to spur index (plus 1 -- ie next spot we want to look when finding new spurs)

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -1318,13 +1318,13 @@ bool FlowCaller::call_snarl(const Snarl& managed_snarl, int ploidy) {
             break;
         } else if (get<2>(ref_interval) == true) {
             if (!graph.has_previous_step(cur_step)) {
-                cerr << "Warning [vg call]: Unable, due to bug or corrupt path information, to trace reference path through snarl " << pb2json(snarl) << endl;
+                cerr << "Warning [vg call]: Unable, due to bug or corrupt path information, to trace reference path through snarl " << pb2json(managed_snarl) << endl;
                 return false;
             }
             cur_step = graph.get_previous_step(cur_step);
         } else {
             if (!graph.has_next_step(cur_step)) {
-                cerr << "Warning [vg call]: Unable, due to bug or corrupt path information, to trace reference path through snarl " << pb2json(snarl) << endl;
+                cerr << "Warning [vg call]: Unable, due to bug or corrupt path information, to trace reference path through snarl " << pb2json(managed_snarl) << endl;
                 return false;
             }
             cur_step = graph.get_next_step(cur_step);
@@ -1342,6 +1342,11 @@ bool FlowCaller::call_snarl(const Snarl& managed_snarl, int ploidy) {
     } else {
         // find the traversals using the generic interface
         travs = traversal_finder.find_traversals(snarl);
+    }
+
+    if (travs.empty()) {
+        cerr << "Warning [vg call]: Unable, due to bug or corrupt graph, to search for any traversals through snarl " << pb2json(managed_snarl) << endl;
+        return false;
     }
 
     // find the reference traversal in the list of results from the traversal finder


### PR DESCRIPTION
This should fix [this crash](https://github.com/vgteam/vg/issues/3209#issuecomment-784553706).  I still can't figure out what's going wrong (so sign of anything obvious like missing edges), but think time more usefully spent on merging in the nested caller than continuing to debug this.  The snarl it's happening on is so massive, I don't think there's much to be done about a VCF line for it.  
