### PR TITLE
Address issue with better default behavior in vg chunk

### DIFF
--- a/src/chunker.cpp
+++ b/src/chunker.cpp
@@ -229,7 +229,7 @@ void PathChunker::extract_subgraph(const Region& region, int64_t context, int64_
         if (!mappings.begin()->is_reverse() && vg_subgraph->start_degree(start_node) != 0) {
             for (auto edge : vg_subgraph->edges_to(start_node)) {
 #ifdef debug
-#pragma omp crticial(cerr)
+#pragma omp critical(cerr)
                 {
                     cerr << "clipping out edge " << pb2json(*edge) << " in order to make path start a tip" << endl;
                 }
@@ -239,7 +239,7 @@ void PathChunker::extract_subgraph(const Region& region, int64_t context, int64_
         } else if (mappings.begin()->is_reverse() && vg_subgraph->end_degree(start_node) != 0) {
             for (auto edge : vg_subgraph->edges_from(start_node)) {
 #ifdef debug
-#pragma omp crticial(cerr)
+#pragma omp critical(cerr)
                 {
                     cerr << "clipping out edge " << pb2json(*edge) << " in order to make path start a tip" << endl;
                 }
@@ -254,7 +254,7 @@ void PathChunker::extract_subgraph(const Region& region, int64_t context, int64_
         if (!mappings.rbegin()->is_reverse() && vg_subgraph->end_degree(end_node) != 0) {
             for (auto edge : vg_subgraph->edges_from(end_node)) {
 #ifdef debug
-#pragma omp crticial(cerr)
+#pragma omp critical(cerr)
                 {
                     cerr << "clipping out edge " << pb2json(*edge) << " in order to make path end a tip" << endl;
                 }
@@ -264,7 +264,7 @@ void PathChunker::extract_subgraph(const Region& region, int64_t context, int64_
         } else if (mappings.rbegin()->is_reverse() && vg_subgraph->start_degree(end_node) != 0) {
             for (auto edge : vg_subgraph->edges_to(end_node)) {
 #ifdef debug
-#pragma omp crticial(cerr)
+#pragma omp critical(cerr)
                 {
                     cerr << "clipping out edge " << pb2json(*edge) << " in order to make path end a tip" << endl;
                 }

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -9,6 +9,7 @@
 #include <cctype>
 #include <cstdio>
 #include <cerrno>
+#include <unistd.h>
 
 #include <bdsg/hash_graph.hpp>
 #include <bdsg/packed_graph.hpp>
@@ -36,6 +37,7 @@
 #include "integrated_snarl_finder.hpp"
 #include "min_distance.hpp"
 #include "gfa.hpp"
+#include "job_schedule.hpp"
 
 #include "io/save_handle_graph.hpp"
 
@@ -87,6 +89,7 @@ int IndexingParameters::minimizer_s = 18;
 int IndexingParameters::path_cover_depth = gbwtgraph::PATH_COVER_DEFAULT_N;
 int IndexingParameters::giraffe_gbwt_downsample = gbwtgraph::LOCAL_HAPLOTYPES_DEFAULT_N;
 int IndexingParameters::downsample_context_length = gbwtgraph::PATH_COVER_DEFAULT_K;
+double IndexingParameters::max_memory_proportion = 0.75;
 bool IndexingParameters::verbose = false;
 
 // return file size in bytes
@@ -141,8 +144,7 @@ double format_multiplier() {
     }
 }
 
-// approximate the memory of a graph that would be constructed with all of these
-// inputs
+// approximate the memory of a graph that would be constructed with FASTAs and VCFs
 int64_t approx_graph_memory(const vector<string>& fasta_filenames, const vector<string>& vcf_filenames) {
 
     // compute the size of the reference and the approximate number of
@@ -166,11 +168,59 @@ int64_t approx_graph_memory(const vector<string>& fasta_filenames, const vector<
     return hash_graph_memory_usage * format_multiplier();
 }
 
+vector<int64_t> each_approx_graph_memory(const vector<string>& fasta_filenames,
+                                         const vector<string>& vcf_filenames) {
+    
+    auto n = max(fasta_filenames.size(), vcf_filenames.size());
+    assert(fasta_filenames.size() == 1 || fasta_filenames.size() == n);
+    assert(vcf_filenames.size() == 1 || vcf_filenames.size() == n);
+    
+    double total_ref_size = 0;
+    vector<double> ref_sizes(fasta_filenames.size());
+    for (int64_t i = 0; i < ref_sizes.size(); ++i) {
+        double ref_size = get_file_size(fasta_filenames[i]);
+        ref_sizes[i] = ref_size;
+        total_ref_size += ref_size;
+    }
+    double total_var_count = 0;
+    vector<int64_t> var_counts(vcf_filenames.size());
+    for (int64_t i = 0; i < vcf_filenames.size(); ++i) {
+        int64_t var_count = approx_num_vars(vcf_filenames[i]);
+        var_counts[i] = var_count;
+        total_var_count += var_count;
+    }
+    
+    vector<int64_t> approx_memories(n);
+    for (int64_t i = 0; i < n; ++i) {
+        
+        double ref_size, var_count;
+        if (vcf_filenames.size() == 1) {
+            var_count = total_var_count * (ref_sizes[i] / total_ref_size);
+        }
+        else {
+            var_count = var_counts[i];
+        }
+        if (fasta_filenames.size() == 1) {
+            ref_size = total_ref_size * (var_counts[i] / total_var_count);
+        }
+        else {
+            ref_size = ref_sizes[i];
+        }
+        
+        // TODO: repetitive with previous function, magic constants
+        double linear_memory = 30.4483 * ref_size;
+        double var_memory = 2242.90 * var_count;
+        double hash_graph_memory_usage = linear_memory + var_memory;
+        approx_memories[i] = hash_graph_memory_usage * format_multiplier();
+    }
+    return approx_memories;
+}
+
 int64_t approx_graph_memory(const string& fasta_filename, const string& vcf_filename) {
     return approx_graph_memory(vector<string>(1, fasta_filename), vector<string>(1, vcf_filename));
 }
 
-// estimate the amount of memory of a graph constructed from all of these inputs
+// estimate the amount of memory of a graph constructed GFAs
 int64_t approx_graph_memory(const vector<string>& gfa_filenames) {
     
     int64_t total_size = 0;
@@ -201,6 +251,8 @@ bool transcript_file_nonempty(const string& transcripts) {
     return false;
 }
 
+// return all of the contigs with variants in a VCF by iterating through
+// the whole damn thing (SQ lines are not required, unfortunately)
 vector<string> vcf_contigs(const string& filename) {
     
     unordered_set<string> contigs;
@@ -555,15 +607,36 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             }
         }
         
-        // TODO: allow contig renaming through Constructor::add_name_mapping
-        // TODO: actually do the chunking based on available memory and in parallel if possible
+        // are we broadcasting the transcripts from one chunk to many?
+        bool broadcasting_txs = transcripts.size() != max(ref_filenames.size(),
+                                                          vcf_filenames.size());
         
+        // TODO: this estimate should include splice edges too
+        vector<pair<int64_t, int64_t>> approx_job_requirements;
+        {
+            size_t i = 0;
+            for (auto approx_mem : each_approx_graph_memory(ref_filenames, vcf_filenames)) {
+                int64_t approx_time;
+                if (vcf_filenames.size() != 1) {
+                    approx_time = get_file_size(vcf_filenames[i]);
+                }
+                else {
+                    approx_time = get_file_size(ref_filenames[i]);
+                }
+                approx_job_requirements.emplace_back(approx_time, approx_mem);
+                ++i;
+            }
+        }
+        
+        graph_names.resize(max(ref_filenames.size(), vcf_filenames.size()));
         nid_t max_node_id = 0;
-        size_t i = 0, j = 0, k = 0;
-        while (i < ref_filenames.size() && j < vcf_filenames.size()) {
+        auto make_graph = [&](int64_t idx) {
+            
+            auto ref_filename = ref_filenames.size() == 1 ? 0 : ref_filenames[idx];
+            auto vcf_filename = vcf_filenames.size() == 1 ? 0 : vcf_filenames[idx];
             
 #ifdef debug_index_registry_recipes
-            cerr << "constructing graph with Constructor for ref " << ref_filenames[i] << " and variants " << vcf_filenames[j] << endl;
+            cerr << "constructing graph with Constructor for ref " << ref_filename << " and variants " << vcf_filename << endl;
 #endif
             
             // init and configure the constructor
@@ -576,29 +649,31 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                 // we have multiple FASTA but only 1 VCF, so we'll limit the
                 // constructor to the contigs of this FASTA for this run
                 FastaReference ref;
-                ref.open(ref_filenames[i]);
+                ref.open(ref_filename);
                 for (const string& seqname : ref.index->sequenceNames) {
                     constructor.allowed_vcf_names.insert(seqname);
                 }
             }
             else if (vcf_filenames.size() != 1 && ref_filenames.size() == 1) {
+                // we have multiple VCFs but only 1 FASTA, so we'll limit the
+                // constructor to the contigs of this VCF for this run
                 
                 // unfortunately there doesn't seem to be a good way to do this without
                 // iterating over the entire file:
-                for (const auto& contig : vcf_contigs(vcf_filenames[j])) {
+                for (const auto& contig : vcf_contigs(vcf_filename)) {
                     constructor.allowed_vcf_names.insert(contig);
                 }
             }
             
-            string output_name = plan->output_filepath(output_graph, max(i, j),
+            string output_name = plan->output_filepath(output_graph, idx,
                                                        max(ref_filenames.size(), vcf_filenames.size()));
             ofstream outfile;
             init_out(outfile, output_name);
             
             auto graph = init_mutable_graph();
             
-            vector<string> fasta(1, ref_filenames[i]);
-            vector<string> vcf(1, vcf_filenames[j]);
+            vector<string> fasta(1, ref_filename);
+            vector<string> vcf(1, vcf_filename);
             
             // do the construction
             constructor.construct_graph(fasta, vcf, insertions, graph.get());
@@ -606,20 +681,18 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
 #ifdef debug_index_registry_recipes
             cerr << "resulting graph has " << graph->get_node_count() << " nodes" << endl;
 #endif
-
+                               
             
             if (!transcripts.empty()) {
                 
+                auto transcript_filename = transcripts[transcripts.size() == 1 ? 0 : idx];
+                
 #ifdef debug_index_registry_recipes
-                cerr << "adding transcripts from " << transcripts[k] << endl;
+                cerr << "adding transcripts from " << transcript_filename << endl;
 #endif
                 
                 ifstream infile_tx;
-                init_in(infile_tx, transcripts[k]);
-                
-                // are we broadcasting the transcripts from one chunk to many?
-                bool broadcasting_txs = transcripts.size() != max(ref_filenames.size(),
-                                                                  vcf_filenames.size());
+                init_in(infile_tx, transcript_filename);
                 
                 vector<string> path_names;
                 if (broadcasting_txs) {
@@ -645,13 +718,15 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
 #endif
                 
                 if (broadcasting_txs && !path_names.empty() && transcripts_added == 0
-                    && transcript_file_nonempty(transcripts[k])) {
-                    cerr << "warning:[IndexRegistry] no matching paths from transcript file " << transcripts[k] << " were found in graph chunk containing the following paths:" << endl;
+                    && transcript_file_nonempty(transcripts[idx])) {
+                    cerr << "warning:[IndexRegistry] no matching paths from transcript file " << transcript_filename << " were found in graph chunk containing the following paths:" << endl;
                     for (const string& path_name : path_names) {
                         cerr << "\t" << path_name << endl;
                     }
                 }
                 
+                // we don't need to worry about race conditions on this, because it will
+                // be fixed when the ID spaces are joined anyway
                 max_node_id = max(max_node_id, transcriptome.splice_graph().max_node_id());
                 
                 // save the file
@@ -664,43 +739,36 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                 vg::io::save_handle_graph(graph.get(), outfile);
             }
             
-            graph_names.push_back(output_name);
-            
-            // awkward incrementation that allows 1x1, 1xN, Nx1, and NxN matching
-            // of VCFs, FASTAs, and GTF/GFFs
-            if (ref_filenames.size() == 1 && vcf_filenames.size() == 1) {
-                break;
-            }
-            if (ref_filenames.size() > 1) {
-                ++i;
-            }
-            if (vcf_filenames.size() > 1) {
-                ++j;
-            }
-            if (transcripts.size() > 1) {
-                ++k;
-            }
-        }
+            graph_names[idx] = output_name;
+        };
         
-        if (ref_filenames.size() == 1 && vcf_filenames.size() != 1) {
-            
-            // we will have added components for all of the paths that are also
-            // VCF sequences, but we may have FASTA sequences that don't
-            // correspond to any VCF sequence (e.g. unlocalized contigs of
-            // decoys)
-            
-            // TODO: how can we keep track of all of the contigs seen in the Constructor
-            // so that we know which ones to include in this component?
-            
+        // TODO: allow contig renaming through Constructor::add_name_mapping
+        
+        
+//        if (ref_filenames.size() == 1 && vcf_filenames.size() != 1) {
+//
+//            // we will have added components for all of the paths that are also
+//            // VCF sequences, but we may have FASTA sequences that don't
+//            // correspond to any VCF sequence (e.g. unlocalized contigs of
+//            // decoys)
+//
+//            // TODO: how can we keep track of all of the contigs seen in the Constructor
+//            // so that we know which ones to include in this component?
+//
 //            string output_name = (plan->prefix(constructing)
 //                                  + "." + to_string(inputs[1]->get_filenames().size())
 //                                  + "." + plan->suffix(constructing));
-            
-            // FIXME: punting on this for now
-            // FIXME: also need to add a dummy VCF, but how to add it to const index?
-            // FIXME: also need to locate these contigs in the GTF/GFF
-            // maybe i should add it as a second index, along with this graph...
-        }
+//
+//            // FIXME: punting on this for now
+//            // FIXME: also need to add a dummy VCF, but how to add it to const index?
+//            // FIXME: also need to locate these contigs in the GTF/GFF
+//            // maybe i should add it as a second index, along with this graph...
+//        }
+        
+        // construct the jobs in parallel, trying to use multithreading while also
+        // restraining memory usage
+        JobSchedule schedule(approx_job_requirements, make_graph);
+        schedule.execute(plan->target_memory_usage());
         
         if (graph_names.size() > 1) {
             // join the ID spaces
@@ -1247,7 +1315,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     });
     
     registry.register_recipe({"Haplotype-Transcript GBWT", "Spliced VG w/ Transcript Paths", "Unjoined Transcript Origin Table", },
-                             {"GTF/GFF", "Spliced GBWT", "Spliced VG", },
+                             {"GTF/GFF", "Spliced GBWT", "Spliced VG"},
                              [&](const vector<const IndexFile*>& inputs,
                                  const IndexingPlan* plan,
                                  AliasGraph& alias_graph,
@@ -2060,6 +2128,10 @@ bool IndexingPlan::is_intermediate(const IndexName& identifier) const {
     // Or if it is directly requested
     return !targets.count(identifier);
 }
+
+int64_t IndexingPlan::target_memory_usage() const {
+    return IndexingParameters::max_memory_proportion * registry->get_target_memory_usage();
+}
     
 string IndexingPlan::output_filepath(const IndexName& identifier) const {
     return output_filepath(identifier, 0, 1);
@@ -2257,15 +2329,23 @@ void IndexRegistry::register_index(const IndexName& identifier, const string& su
 
 
 void IndexRegistry::provide(const IndexName& identifier, const string& filename) {
-    if (!index_registry.count(identifier)) {
-        cerr << "error:[IndexRegistry] cannot provide unregistered index: " << identifier << endl;
-        exit(1);
-    }
     provide(identifier, vector<string>(1, filename));
 }
 
 void IndexRegistry::provide(const IndexName& identifier, const vector<string>& filenames) {
+    if (!index_registry.count(identifier)) {
+        cerr << "error:[IndexRegistry] cannot provide unregistered index: " << identifier << endl;
+        exit(1);
+    }
     get_index(identifier)->provide(filenames);
+}
+
+void IndexRegistry::set_target_memory_usage(int64_t bytes) {
+    target_memory_usage = bytes;
+}
+
+int64_t IndexRegistry::get_target_memory_usage() const {
+    return target_memory_usage;
 }
 
 vector<IndexName> IndexRegistry::completed_indexes() const {

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -628,12 +628,22 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             }
         }
         
+#ifdef debug_index_registry_recipes
+        cerr << "approximate chunk requirements:" << endl;
+        for (size_t i = 0; i < approx_job_requirements.size(); ++i) {
+            auto requirement = approx_job_requirements[i];
+            cerr << "\tchunk " << i << " -- time: " << requirement.first << ", memory: " << requirement.second << endl;
+        }
+#endif
         graph_names.resize(max(ref_filenames.size(), vcf_filenames.size()));
         nid_t max_node_id = 0;
         auto make_graph = [&](int64_t idx) {
+#ifdef debug_index_registry_recipes
+            cerr << "making graph chunk " << idx << endl;
+#endif
             
-            auto ref_filename = ref_filenames.size() == 1 ? 0 : ref_filenames[idx];
-            auto vcf_filename = vcf_filenames.size() == 1 ? 0 : vcf_filenames[idx];
+            auto ref_filename = ref_filenames.size() == 1 ? ref_filenames[0] : ref_filenames[idx];
+            auto vcf_filename = vcf_filenames.size() == 1 ? vcf_filenames[0] : vcf_filenames[idx];
             
 #ifdef debug_index_registry_recipes
             cerr << "constructing graph with Constructor for ref " << ref_filename << " and variants " << vcf_filename << endl;
@@ -3081,6 +3091,9 @@ vector<vector<string>> IndexRegistry::execute_recipe(const RecipeName& recipe_na
             assert(input->is_finished());
         }
     }
+#ifdef debug_index_registry_recipes
+    cerr << "executing recipe " << recipe_name.second << " for " << to_string(recipe_name.first) << endl;
+#endif
     return index_recipe.execute(plan, alias_graph, recipe_name.first);;
 }
 

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -105,6 +105,8 @@ struct IndexingParameters {
     static int giraffe_gbwt_downsample;
     // Jordan actually doesn't know what this one does [4]
     static int downsample_context_length;
+    // actually use this fraction of the maximum memory to give slosh for bad estmates [0.75]
+    static double max_memory_proportion;
     // whether indexing algorithms will log progress (if available) [false]
     static bool verbose;
 };
@@ -148,6 +150,9 @@ public:
     /// Returns true if the given index is to be intermediate under the given
     /// plan, and false if it is to be preserved.
     bool is_intermediate(const IndexName& identifier) const;
+    
+    /// TODO: is this where this function wants to live?
+    int64_t target_memory_usage() const;
     
 protected:
     
@@ -227,6 +232,13 @@ public:
     /// Indicate a list of serialized files that contains some identified index
     void provide(const IndexName& identifier, const vector<string>& filenames);
     
+    /// Set the maximum memory that indexing should try to consume (note: this is
+    /// not strictly adhered to due to difficulties in estimating memory use)
+    void set_target_memory_usage(int64_t bytes);
+    
+    /// Get the maximum memory we will try to consume
+    int64_t get_target_memory_usage() const;
+    
     /// Get a list of all indexes that have already been completed or provided
     vector<IndexName> completed_indexes() const;
     
@@ -291,6 +303,9 @@ protected:
     
     /// should intermediate files end up in the scratch or the output directory?
     bool keep_intermediates = false;
+    
+    /// the max memory we will *attempt* to use
+    int64_t target_memory_usage = numeric_limits<int64_t>::max();
 };
 
 /**

--- a/src/job_schedule.cpp
+++ b/src/job_schedule.cpp
@@ -1,0 +1,83 @@
+/**
+ * \file job_schedule.cpp: implements JobSchedule
+ */
+#include "job_schedule.hpp"
+
+#include <omp.h>
+#include <unistd.h>
+
+namespace vg {
+
+using namespace std;
+
+JobSchedule::JobSchedule(const vector<pair<int64_t, int64_t>>& job_requirements,
+                         const function<void(int64_t)>& job_func)
+    : job_func(job_func)
+{
+    for (int64_t i = 0; i < job_requirements.size(); ++i) {
+        queue.emplace(job_requirements[i].first,
+                      job_requirements[i].second, i);
+        
+    }
+    
+}
+
+void JobSchedule::execute(int64_t target_memory_usage) {
+    
+    int64_t jobs_ongoing = 0;
+    int64_t est_memory_usage = 0;
+    
+    auto do_job = [&](tuple<int64_t, int64_t, int64_t> job) {
+#pragma omp atomic update
+        ++jobs_ongoing;
+#pragma omp atomic update
+        est_memory_usage += get<1>(job);
+        this->job_func(get<2>(job));
+#pragma omp atomic update
+        est_memory_usage += get<1>(job);
+#pragma omp atomic update
+        --jobs_ongoing;
+    };
+    
+#pragma omp parallel default(none) shared(jobs_ongoing, est_memory_usage, do_job)
+#pragma omp single
+    {
+        
+        while (!queue.empty()) {
+            int64_t curr_mem, curr_jobs;
+#pragma omp atomic read
+            curr_mem = est_memory_usage;
+#pragma omp atomic read
+            curr_jobs = jobs_ongoing;
+            
+            // get the remaining job with the highest estimated run time
+            auto job = queue.top();
+            if (omp_get_num_threads() == 1) {
+                // single threaded, just do the job in the scheduler thread
+                queue.pop();
+                do_job(job);
+            }
+            else if (curr_jobs == 0 ||
+                     (curr_mem + get<1>(queue.top()) < target_memory_usage
+                      && curr_jobs + 1 < omp_get_num_threads())) {
+                // we have memory and threads available to do the next job
+                queue.pop();
+#pragma omp task default(none) firstprivate(job) shared(jobs_ongoing, est_memory_usage, do_job)
+                do_job(job);
+            }
+            else {
+                // TODO: it would be nice to do useful work with this thread, maybe
+                // with the smallest job?
+                // but performance could crater if this thread isn't available
+                // when other threads finish
+                
+                // wait 1 sec and try again
+                usleep(1000000);
+            }
+        }
+    }
+    
+}
+
+}
+

--- a/src/job_schedule.cpp
+++ b/src/job_schedule.cpp
@@ -39,7 +39,7 @@ void JobSchedule::execute(int64_t target_memory_usage) {
         --jobs_ongoing;
     };
     
-#pragma omp parallel default(none) shared(jobs_ongoing, est_memory_usage, do_job)
+#pragma omp parallel default(none) shared(target_memory_usage, jobs_ongoing, est_memory_usage, do_job)
 #pragma omp single
     {
         

--- a/src/job_schedule.hpp
+++ b/src/job_schedule.hpp
@@ -1,0 +1,38 @@
+#ifndef VG_JOB_SECHEDULE_HPP_INCLUDED
+#define VG_JOB_SECHEDULE_HPP_INCLUDED
+
+/** \file
+ * job_schedule.hpp: defines JobSchedule
+ */
+#include <vector>
+#include <utility>
+#include <functional>
+#include <queue>
+
+namespace vg {
+
+using namespace std;
+
+class JobSchedule {
+public:
+    
+    // job requirements are given in pairs of (time estimate, memory estimate)
+    // with the memory estimate being in bytes, and the time estimate in
+    // arbitrary units
+    // the job function should execute the i-th job when called
+    JobSchedule(const vector<pair<int64_t, int64_t>>& job_requirements,
+                const function<void(int64_t)>& job_func);
+    ~JobSchedule() = default;
+    
+    void execute(int64_t target_memory_usage);
+    
+private:
+    
+    function<void(int64_t)> job_func;
+    priority_queue<tuple<int64_t, int64_t, int64_t>> queue;
+    
+};
+
+}
+
+#endif

--- a/src/region.hpp
+++ b/src/region.hpp
@@ -14,8 +14,8 @@ using namespace std;
 // Generally regions parsed form user input will be 1-based.
 struct Region {
     string seq;
-    int64_t start;
-    int64_t end;
+    int64_t start = -1;
+    int64_t end = -1;
 };
 
 // Parse a genomic contig[:start-end] region. Outputs -1 for missing start or end.

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -132,7 +132,7 @@ void help_autoindex(char** argv) {
     << "    -T, --tmp-dir DIR      temporary directory to use for intermediate files" << endl
     << "    -t, --threads NUM      number of threads (default: all available)" << endl
     << "    -V, --verbose          log progress to stderr" << endl
-    << "    -d, --dot              print the dot-formatted graph of index recipes and exit" << endl
+    //<< "    -d, --dot              print the dot-formatted graph of index recipes and exit" << endl
     << "    -h, --help             print this help message to stderr and exit" << endl;
 }
 
@@ -215,19 +215,19 @@ int main_autoindex(int argc, char** argv) {
                 }
                 break;
             case 'r':
-                registry.provide({"Reference FASTA"}, optarg);
+                registry.provide("Reference FASTA", optarg);
                 break;
             case 'v':
                 vcf_names.push_back(optarg);
                 break;
             case 'i':
-                registry.provide({"Insertion Sequence FASTA"}, optarg);
+                registry.provide("Insertion Sequence FASTA", optarg);
                 break;
             case 'g':
-                registry.provide({"Reference GFA"}, optarg);
+                registry.provide("Reference GFA", optarg);
                 break;
             case 'x':
-                registry.provide({"GTF/GFF"}, optarg);
+                registry.provide("GTF/GFF", optarg);
                 break;
             case 'f':
                 IndexingParameters::gff_feature_name = optarg;
@@ -279,10 +279,10 @@ int main_autoindex(int argc, char** argv) {
         
         for (auto& vcf_name : vcf_names) {
             if (phased) {
-                registry.provide({"VCF w/ Phasing"}, vcf_name);
+                registry.provide("VCF w/ Phasing", vcf_name);
             }
             else {
-                registry.provide({"VCF"}, vcf_name);
+                registry.provide("VCF", vcf_name);
             }
         }
     }

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -283,18 +283,6 @@ int main_chunk(int argc, char** argv) {
         cerr << "error:[vg chunk] context cannot be specified (-c) when splitting into components (-C)" << endl;
         return 1;
     }
-    // context steps default to 1 if using id_ranges.  otherwise, force user to specify to avoid
-    // misunderstandings
-    if (context_steps < 0 && gam_split_size == 0) {
-        if (id_range) {
-            if (!context_length) {
-                context_steps = 1;
-            }
-        } else if (!components){
-            cerr << "error:[vg chunk] context expansion steps must be specified with -c/--context when chunking on paths" << endl;
-            return 1;
-        }
-    }
 
     // check the output format
     std::transform(output_format.begin(), output_format.end(), output_format.begin(), ::tolower);
@@ -470,6 +458,24 @@ int main_chunk(int argc, char** argv) {
                     regions.push_back(region);
                 }
             });
+    }
+    
+    if (context_steps >= 0 && regions.empty()) {
+        cerr << "error:[vg chunk] extracting context (-c) requires a region to take context around" << endl;
+        return 1;
+    }
+    
+    // context steps default to 1 if using id_ranges.  otherwise, force user to specify to avoid
+    // misunderstandings
+    if (context_steps < 0 && gam_split_size == 0) {
+        if (id_range) {
+            if (!context_length) {
+                context_steps = 1;
+            }
+        } else if (!components){
+            cerr << "error:[vg chunk] context expansion steps must be specified with -c/--context when chunking on paths" << endl;
+            return 1;
+        }
     }
 
     // validate and fill in sizes for regions that span entire path


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg chunk -c` will no longer crash if no paths/nodes are provided

## Description

Previously, `vg chunk` would try to load a path chunk whose start and end coordinates were uninitialized memory. This was one of the problems identified in https://github.com/vgteam/vg/issues/3214.
