### PR TITLE
Test vg against sequenceTubeMap to avoid breaking it

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,6 +66,11 @@ local-build-test-job:
     - echo Full Testing
     - make test
     - make static -j8
+    # Also test as a backend for the tube map
+    - git clone https://github.com/vgteam/sequenceTubeMap.git
+    - cd sequenceTubeMap
+    - npm install
+    - CI=true npm run test
   variables:
     VG_FULL_TRACEBACK: "1"
     GIT_SUBMODULE_STRATEGY: none


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * CI now tests with `sequenceTubeMap`

## Description
This runs the `sequenceTubeMap` tests against each CI version of vg to see if we break it.