### PR TITLE
Add proper pair tracking to map and mpmap

### DIFF
--- a/src/annotation.hpp
+++ b/src/annotation.hpp
@@ -20,6 +20,10 @@ using namespace std;
 // API
 ////////////////////////////////////////////////////////////////////////
 
+/// Returns true if the Protobuf object has an annotation with this name
+template<typename Annotated>
+bool has_annotation(const Annotated& annotated, const string& name);
+
 /// Get the annotation with the given name and return it.
 /// If not present, returns the Protobuf default value for the annotation type.
 /// The value may be a primitive type or an entire Protobuf object.
@@ -190,6 +194,14 @@ inline google::protobuf::Value value_cast(const Container& wrap) {
     // Hand it off
     to_return.set_allocated_list_value(list);
     return to_return;
+}
+
+template<typename Annotated>
+inline bool has_annotation(const Annotated& annotated, const string& name) {
+    // Grab the whole annotation struct
+    auto annotation_struct = Annotation<Annotated>::get(annotated);
+    // Check for the annotation
+    return annotation_struct.fields().count(name);
 }
 
 // TODO: more value casts for e.g. ints and embedded messages.

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1946,9 +1946,13 @@ namespace vg {
             multipath_aln_pairs_out.resize(max_alt_mappings);
         }
         
-        for (size_t i = 1; i < multipath_aln_pairs_out.size(); ++i) {
-            multipath_aln_pairs_out[i].first.set_annotation("secondary", true);
-            multipath_aln_pairs_out[i].second.set_annotation("secondary", true);
+        for (size_t i = 0; i < multipath_aln_pairs_out.size(); ++i) {
+            multipath_aln_pairs_out[i].first.set_annotation("proper_pair", proper_paired);
+            multipath_aln_pairs_out[i].second.set_annotation("proper_pair", proper_paired);
+            if (i != 0) {
+                multipath_aln_pairs_out[i].first.set_annotation("secondary", true);
+                multipath_aln_pairs_out[i].second.set_annotation("secondary", true);
+            }
         }
         
         if (simplify_topologies) {

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -19,6 +19,7 @@
 #include "../algorithms/distance_to_tail.hpp"
 #include "../handle.hpp"
 #include "../cactus_snarl_finder.hpp"
+#include "../annotation.hpp"
 
 #include "../path.hpp"
 #include "../statistics.hpp"
@@ -543,6 +544,9 @@ int main_stats(int argc, char** argv) {
             // And softclips
             size_t total_softclips = 0;
             size_t total_softclipped_bases = 0;
+            // And pairing
+            size_t total_paired = 0;
+            size_t total_proper_paired = 0;
 
             // In verbose mode we want to report details of insertions, deletions,
             // and substitutions, and soft clips.
@@ -577,6 +581,8 @@ int main_stats(int argc, char** argv) {
                 total_substituted_bases += other.total_substituted_bases;
                 total_softclips += other.total_softclips;
                 total_softclipped_bases += other.total_softclipped_bases;
+                total_paired += other.total_paired;
+                total_proper_paired += other.total_proper_paired;
                 
                 std::copy(other.insertions.begin(), other.insertions.end(), std::back_inserter(insertions));
                 std::copy(other.deletions.begin(), other.deletions.end(), std::back_inserter(deletions));
@@ -688,6 +694,13 @@ int main_stats(int argc, char** argv) {
                     // the primary can't be unaligned if the secondary is
                     // aligned.
                     stats.total_aligned++;
+                }
+                
+                if (aln.has_fragment_next() || aln.has_fragment_prev() || has_annotation(aln, "proper_pair")) {
+                    stats.total_paired++;
+                    if (has_annotation(aln, "proper_pair") && get_annotation<bool>(aln, "proper_pair")) {
+                        stats.total_proper_paired++;
+                    }
                 }
 
                 // Which sites and alleles does this read support. TODO: if we hit
@@ -930,6 +943,8 @@ int main_stats(int argc, char** argv) {
                     << " on " << id_and_edit.first << endl;
             }
         }
+        
+        cout << "Pairing: " << combined.total_paired << " paired reads with " << combined.total_proper_paired << " with properly paired alignments" << endl;
 
         if (graph.get() != nullptr) {
             cout << "Unvisited nodes: " << unvisited_nodes << "/" << graph->get_node_count()

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -914,6 +914,8 @@ int main_stats(int argc, char** argv) {
         cout << "Total aligned: " << combined.total_aligned << endl;
         cout << "Total perfect: " << combined.total_perfect << endl;
         cout << "Total gapless (softclips allowed): " << combined.total_gapless << endl;
+        cout << "Total paired: " << combined.total_paired << endl;
+        cout << "Total properly paired: " << combined.total_proper_paired << endl;
 
         cout << "Insertions: " << combined.total_inserted_bases << " bp in " << combined.total_insertions << " read events" << endl;
         if(verbose) {
@@ -944,8 +946,6 @@ int main_stats(int argc, char** argv) {
             }
         }
         
-        cout << "Pairing: " << combined.total_paired << " paired reads with " << combined.total_proper_paired << " with properly paired alignments" << endl;
-
         if (graph.get() != nullptr) {
             cout << "Unvisited nodes: " << unvisited_nodes << "/" << graph->get_node_count()
                 << " (" << unvisited_node_bases << " bp)" << endl;

--- a/test/correct/10_vg_stats/15.txt
+++ b/test/correct/10_vg_stats/15.txt
@@ -4,6 +4,8 @@ Total secondary: 0
 Total aligned: 100
 Total perfect: 100
 Total gapless (softclips allowed): 100
+Total paired: 0
+Total properly paired: 0
 Insertions: 0 bp in 0 read events
 Deletions: 0 bp in 0 read events
 Substitutions: 0 bp in 0 read events


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg map` and `vg mpmap` now annotate properly-paired read mappings
 * `vg stats -a` reports proper pairing statistics

## Description

Resolves https://github.com/vgteam/vg/issues/3217. Adds a system to record proper pairing in `map` and `mpmap`, but not yet in `giraffe`. 