### PR TITLE
add gbwt option to vg deconstruct

### DIFF
--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -33,7 +33,8 @@ public:
     // deconstruct the entire graph to cout
     void deconstruct(vector<string> refpaths, const PathPositionHandleGraph* grpah, SnarlManager* snarl_manager,
                      bool path_restricted_traversals, int ploidy, bool include_nested,
-                     const unordered_map<string, string>* path_to_sample = nullptr); 
+                     const unordered_map<string, string>* path_to_sample = nullptr,
+                     gbwt::GBWT* gbwt = nullptr); 
     
 private:
 
@@ -81,6 +82,8 @@ private:
     unique_ptr<PathTraversalFinder> path_trav_finder;
     // we optionally use another (exhaustive for now) traversal finder if we don't want to rely on paths
     unique_ptr<TraversalFinder> trav_finder;
+    // we can also use a gbwt for traversals
+    unique_ptr<GBWTTraversalFinder> gbwt_trav_finder;
 
     // the ref paths
     set<string> ref_paths;
@@ -92,7 +95,7 @@ private:
     const unordered_map<string, string>* path_to_sample;
 
     // upper limit of degree-2+ nodes for exhaustive traversal
-    int max_nodes_for_exhaustive = 100;    
+    int max_nodes_for_exhaustive = 100;
 };
 
 }

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -96,6 +96,9 @@ private:
 
     // upper limit of degree-2+ nodes for exhaustive traversal
     int max_nodes_for_exhaustive = 100;
+
+    // recurse on child snarls
+    bool include_nested = false;
 };
 
 }

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -306,6 +306,21 @@ std::string thread_name(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
     return stream.str();
 }
 
+std::string thread_sample(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
+    if (!gbwt_index.hasMetadata() || !gbwt_index.metadata.hasPathNames() || id >= gbwt_index.metadata.paths()) {
+        return "";
+    }
+    
+    const gbwt::PathName& path = gbwt_index.metadata.path(id);
+    std::stringstream stream;
+    if (gbwt_index.metadata.hasSampleNames()) {
+        stream << gbwt_index.metadata.sample(path.sample);
+    } else {
+        stream << path.sample;
+    }
+    return stream.str();
+}
+
 //------------------------------------------------------------------------------
 
 gbwt::GBWT get_gbwt(const std::vector<gbwt::vector_type>& paths) {

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -147,6 +147,10 @@ Path extract_gbwt_path(const HandleGraph& graph, const gbwt::GBWT& gbwt_index, g
 /// NOTE: id is a gbwt path id, not a gbwt sequence id.
 std::string thread_name(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
 
+/// Get a sample name of a thread stored in GBWT metadata.
+/// NOTE: id is a gbwt path id, not a gbwt sequence id.
+std::string thread_sample(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
+
 //------------------------------------------------------------------------------
 
 /// Transform the paths into a GBWT index. Primarily for testing.

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <memory>
 #include <stdexcept>
+#include <limits>
 
 namespace vg {
 

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -29,7 +29,8 @@ void help_deconstruct(char** argv){
          << "options: " << endl
          << "    -p, --path NAME          A reference path to deconstruct against (multiple allowed)." << endl
          << "    -P, --path-prefix NAME   All paths beginning with NAME used as reference (multiple allowed)." << endl
-         << "    -A, --alt-prefix NAME    Non-reference paths beginning with NAME get lumped together to same sample in VCF (multiple allowed).  Other non-ref paths not considered as samples." << endl
+         << "    -A, --alt-prefix NAME    Non-reference paths beginning with NAME get lumped together to same sample in VCF (multiple allowed)." << endl
+         << "                             Other non-ref paths not considered as samples.  When using a GBWT, select only samples with given prefix." << endl
          << "    -r, --snarls FILE        Snarls file (from vg snarls) to avoid recomputing." << endl
          << "    -g, --gbwt FILE          only consider alt traversals that correspond to GBWT threads FILE." << endl
          << "    -e, --path-traversals    Only consider traversals that correspond to paths in the graph." << endl
@@ -219,6 +220,16 @@ int main_deconstruct(int argc, char** argv){
                     }
                 }
             });
+        if (gbwt_index.get() && !altpath_prefixes.empty()) {
+            for (size_t i = 0; i < gbwt_index->metadata.paths(); i++) {
+                string sample_name = thread_sample(*gbwt_index.get(), i);
+                for (auto& prefix : altpath_prefixes) {
+                    if (sample_name.compare(0, prefix.size(), prefix) == 0) {
+                        alt_path_to_prefix[sample_name] = sample_name;
+                    }
+                }
+            }
+        }
     }
 
     // make sure we have at least one reference

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -31,7 +31,8 @@ void help_deconstruct(char** argv){
          << "    -P, --path-prefix NAME   All paths beginning with NAME used as reference (multiple allowed)." << endl
          << "    -A, --alt-prefix NAME    Non-reference paths beginning with NAME get lumped together to same sample in VCF (multiple allowed).  Other non-ref paths not considered as samples." << endl
          << "    -r, --snarls FILE        Snarls file (from vg snarls) to avoid recomputing." << endl
-         << "    -e, --path-traversals    Only consider traversals that correspond to paths in the grpah." << endl
+         << "    -g, --gbwt FILE          only consider alt traversals that correspond to GBWT threads FILE." << endl
+         << "    -e, --path-traversals    Only consider traversals that correspond to paths in the graph." << endl
          << "    -a, --all-snarls         Process all snarls, including nested snarls (by default only top-level snarls reported)." << endl
          << "    -d, --ploidy N           Expected ploidy.  If more traversals found, they will be flagged as conflicts (default: 2)" << endl
          << "    -t, --threads N          Use N threads" << endl
@@ -50,9 +51,11 @@ int main_deconstruct(int argc, char** argv){
     vector<string> altpath_prefixes;
     string graphname;
     string snarl_file_name;
+    string gbwt_file_name;
     bool path_restricted_traversals = false;
     bool show_progress = false;
     int ploidy = 2;
+    bool set_ploidy = false;
     bool all_snarls = false;
     
     int c;
@@ -65,6 +68,7 @@ int main_deconstruct(int argc, char** argv){
                 {"path-prefix", required_argument, 0, 'P'},
                 {"alt-prefix", required_argument, 0, 'A'},
                 {"snarls", required_argument, 0, 'r'},
+                {"gbwt", required_argument, 0, 'g'},                
                 {"path-traversals", no_argument, 0, 'e'},
                 {"ploidy", required_argument, 0, 'd'},
                 {"all-snarls", no_argument, 0, 'a'},
@@ -75,7 +79,7 @@ int main_deconstruct(int argc, char** argv){
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hp:P:A:r:ed:at:v",
+        c = getopt_long (argc, argv, "hp:P:A:r:g:ed:at:v",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -96,11 +100,15 @@ int main_deconstruct(int argc, char** argv){
         case 'r':
             snarl_file_name = optarg;
             break;
+        case 'g':
+            gbwt_file_name = optarg;
+            break;            
         case 'e':
             path_restricted_traversals = true;
             break;
         case 'd':
             ploidy = parse<int>(optarg);
+            set_ploidy = true;
             break;
         case 'a':
             all_snarls = true;
@@ -122,13 +130,14 @@ int main_deconstruct(int argc, char** argv){
 
     }
 
-    if (refpaths.empty() && refpath_prefixes.empty()) {
-        cerr << "Error [vg deconstruct]: Reference path(s) and/or prefix(es) must be given with -p and/or -P" << endl;
+    if ((!altpath_prefixes.empty() || set_ploidy) && !path_restricted_traversals) {
+        cerr << "Error [vg deconstruct]: -A and -d can only be used with -e" << endl;
         return 1;
     }
 
-    if (!altpath_prefixes.empty() && !path_restricted_traversals) {
-        cerr << "Error [vg decontruct]: -A can only be used with -e" << endl;
+    if (!gbwt_file_name.empty() && path_restricted_traversals) {
+        cerr << "Error [vg deconstruct]: -e cannot be used with -g" << endl;
+        return 1;
     }
 
     // Read the graph
@@ -139,6 +148,24 @@ int main_deconstruct(int argc, char** argv){
 
     bdsg::PathPositionOverlayHelper overlay_helper;
     PathPositionHandleGraph* graph = overlay_helper.apply(path_handle_graph.get());
+
+    // Check our paths
+    for (const string& ref_path : refpaths) {
+        if (!graph->has_path(ref_path)) {
+            cerr << "error [vg call]: Reference path \"" << ref_path << "\" not found in graph" << endl;
+            return 1;
+        }
+    }
+    
+    if (refpaths.empty() && refpath_prefixes.empty()) {
+        // No paths specified: use them all
+        graph->for_each_path_handle([&](path_handle_t path_handle) {
+                const string& name = graph->get_path_name(path_handle);
+                if (!Paths::is_alt(name)) {
+                    refpaths.push_back(name);
+                }
+            });
+    }
     
     // Load or compute the snarls
     unique_ptr<SnarlManager> snarl_manager;    
@@ -158,6 +185,15 @@ int main_deconstruct(int argc, char** argv){
             cerr << "Finding snarls" << endl;
         }
         snarl_manager = unique_ptr<SnarlManager>(new SnarlManager(std::move(finder.find_snarls_parallel())));
+    }
+
+    unique_ptr<gbwt::GBWT> gbwt_index;
+    if (!gbwt_file_name.empty()) {
+        gbwt_index = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_file_name);
+        if (gbwt_index.get() == nullptr) {
+            cerr << "Error [vg deconstruct]: Unable to load gbwt index file: " << gbwt_file_name << endl;
+            return 1;
+        }
     }
 
     // We use this to map, for example, from chromosome to genome (eg S288C.chrXVI --> S288C)
@@ -202,7 +238,7 @@ int main_deconstruct(int argc, char** argv){
         cerr << "Decsontructing top-level snarls" << endl;
     }
     dd.deconstruct(refpaths, graph, snarl_manager.get(), path_restricted_traversals, ploidy, all_snarls,
-                   !alt_path_to_prefix.empty() ? &alt_path_to_prefix : nullptr);
+                   !alt_path_to_prefix.empty() ? &alt_path_to_prefix : nullptr, gbwt_index.get());
     return 0;
 }
 

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -130,8 +130,8 @@ int main_deconstruct(int argc, char** argv){
 
     }
 
-    if ((!altpath_prefixes.empty() || set_ploidy) && !path_restricted_traversals) {
-        cerr << "Error [vg deconstruct]: -A and -d can only be used with -e" << endl;
+    if ((!altpath_prefixes.empty() || set_ploidy) && !path_restricted_traversals && gbwt_file_name.empty()) {
+        cerr << "Error [vg deconstruct]: -A and -d can only be used with -e or -g" << endl;
         return 1;
     }
 

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3377,9 +3377,12 @@ GBWTTraversalFinder::find_path_traversals(const Snarl& site, bool return_paths) 
         graph.get_handle(site.end().node_id(), site.end().backward()));
 
     // follow all gbwt threads from end to start
-    vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > backward_traversals = get_spanning_haplotypes(
-        graph.get_handle(site.end().node_id(), !site.end().backward()),
-        graph.get_handle(site.start().node_id(), !site.start().backward()));
+    vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > backward_traversals;
+    if (!gbwt.bidirectional()) {
+        backward_traversals = get_spanning_haplotypes(
+            graph.get_handle(site.end().node_id(), !site.end().backward()),
+            graph.get_handle(site.start().node_id(), !site.start().backward()));
+    }
 
     // store them all as snarltraversals
     vector<SnarlTraversal> traversals;
@@ -3461,10 +3464,9 @@ pair<vector<SnarlTraversal>, vector<string>> GBWTTraversalFinder::find_sample_tr
         SnarlTraversal& trav = path_traversals.first[i];
         vector<gbwt::size_type>& paths = path_traversals.second[i];
         for (size_t j = 0; j < paths.size(); ++j) {
-            string sample = thread_sample(gbwt, paths[j]);
+            string sample = thread_sample(gbwt, gbwt::Path::id(paths[j]));
             sample_traversals.first.push_back(trav);
             sample_traversals.second.push_back(sample);
-            
         }
     }
     

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -627,16 +627,28 @@ public:
     
     virtual ~GBWTTraversalFinder();
 
+    /* Return a traversal for every gbwt thread through the snarl 
+     */
     virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
 
+    /** Return the traversals, paired with their path ids in the gbwt.  The traversals are 
+     *  unique, but there can be more than one path along each one (hence the vector)
+     */
+    virtual pair<vector<SnarlTraversal>, vector<vector<gbwt::size_type>>>
+    find_path_traversals(const Snarl& site, bool return_paths = true);
+
+    /** Return traversals paired with sample names from the GBWT.  The traversals are *not* unique
+     * (which is consistent with PathTraversalFinder)
+     */
+    virtual pair<vector<SnarlTraversal>, vector<string>> find_sample_traversals(const Snarl& site);
+    
 protected:
 
     /**
      * Breadth first search from the start to the end, only branching if there's a haplotype 
      * in the GBWT, and returning all unique haplotypes found. 
      */
-    vector<vector<gbwt::node_type>> get_spanning_haplotypes(handle_t start, handle_t end);
-    
+    vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > get_spanning_haplotypes(handle_t start, handle_t end);    
 };
 
 }

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 19
+plan tests 20
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
 vg index tiny.vg -x tiny.xg
@@ -124,4 +124,11 @@ diff tiny_names_decon.vcf tiny_names_decon_vg.vcf
 is "$?" 0 "deconstructing vg graph gives same output as xg graph"
 
 rm -f tiny_names.gfa tiny_names.vg tiny_names.xg tiny_names_decon.vcf tiny_names_decon_vg.vcf
+
+vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
+vg index -x x.xg -G x.gbwt -v small/x.vcf.gz x.vg
+vg deconstruct x.xg -g x.gbwt > x.decon.vcf
+# todo: something better
+is $(cat x.decon.vcf | grep ^x | wc -l) 70 "gbwt deconstruct makes reasonable sized output"
+
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GBWT index can now be used to find alt alleles in `vg deconstruct` with `-g`

## Description

`-g` will add every gbwt thread that spans a snarl as an alt in the VCF output.  Note that the reference path(s) must still be an embedded graph path. 
