### PR TITLE
Faster GFA writing

### DIFF
--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -63,7 +63,7 @@ void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>&
                 << "\t" << "SO:i:" << it->second.second
                 << "\t" << "SR:i:0"; // todo: support non-zero ranks?
         }
-        out << endl;
+        out << "\n"; // Writing `std::endl` would flush the buffer.
         return true;
     });
     
@@ -114,7 +114,7 @@ void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>&
             ee.sink_orientation_forward = !ee.sink_orientation_forward;
         }
         
-        out << ee.to_string_1() << endl;;
+        out << ee.to_string_1() << "\n"; // Writing `std::endl` would flush the buffer.
         return true;
         //gg.add_edge(ee.source_name, ee);
         //link_elem l;

--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -84,7 +84,7 @@ void graph_to_gfa(const PathHandleGraph* graph, ostream& out, const set<string>&
                 });
                 p_elem.overlaps.push_back("*");
                 //gg.add_path(p_elem.name, p_elem);
-                out << p_elem.to_string_1() << endl;
+                out << p_elem.to_string_1() << "\n";
             }
         }
     });
@@ -173,7 +173,7 @@ bool write_w_line(const PathHandleGraph* graph, ostream& out, const string& wlin
             handle_t handle = graph->get_handle_of_step(step_handle);
             out << (graph->get_is_reverse(handle) ? "<" : ">") << graph->get_id(handle);
         });
-    out << endl;
+    out << "\n";
     return true;
 }
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Faster graph to GFA conversion.

## Description

Converting graphs to GFA with `vg convert` was very slow. `graph_to_gfa()` wrote `std::endl` after each line, which flushed the buffer. Replacing it with `\n` made GFA writing much faster.