### PR TITLE
add warning for unsurjectable GAFs

### DIFF
--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <memory>
 #include <stdexcept>
+#include <limits>
 
 namespace vg {
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject` now gives a helpful warning if you try to use an unsurjectable GAF, rather than just crashing

## Description

Related to https://github.com/vgteam/vg/issues/3214. Not all GAFs contain sufficient information to reconstruct the read sequences. They can't be surjected, but we used to just crash on them. Now we check for them and bail out with an informative message.