### PR TITLE
Add translation support to deconstruct

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -588,7 +588,8 @@ string Deconstructor::snarl_name(const Snarl* snarl) {
         }
         end_node = i->second.first;
     }
-    return std::to_string(start_node) + "_" + std::to_string(end_node);
+    return (snarl->start().backward() ? "<" : ">") + std::to_string(start_node) +
+        (snarl->end().backward() ? "<" : ">") + std::to_string(end_node);
 }
 
 }

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -326,7 +326,7 @@ bool Deconstructor::deconstruct_site(const Snarl* snarl) {
         const SnarlTraversal& ref_trav = path_travs.first[ref_trav_idx];
         
         vcflib::Variant v;
-        v.quality = 23;
+        v.quality = 60;
 
         // write variant's sequenceName (VCF contig)
         v.sequenceName = ref_trav_name;

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -387,6 +387,10 @@ bool Deconstructor::deconstruct_site(const Snarl* snarl) {
 
         // we only bother printing out sites with at least 1 non-reference allele
         if (!std::all_of(trav_to_allele.begin(), trav_to_allele.end(), [](int i) { return i == 0; })) {
+            if (path_restricted || gbwt_trav_finder.get()) {
+                // run vcffixup to add some basic INFO like AC
+                vcf_fixup(v);
+            }
             add_variant(v);
         }
     }    
@@ -521,11 +525,6 @@ void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHand
                 next.clear();
             }
         });
-
-    if (path_restricted || gbwt_trav_finder.get()) {
-        // run vcffixup to add some basic INFO like AC
-        vcf_fixup();
-    }
     
     // write variants in sorted order
     write_variants(cout);

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -34,7 +34,8 @@ public:
     void deconstruct(vector<string> refpaths, const PathPositionHandleGraph* grpah, SnarlManager* snarl_manager,
                      bool path_restricted_traversals, int ploidy, bool include_nested,
                      const unordered_map<string, string>* path_to_sample = nullptr,
-                     gbwt::GBWT* gbwt = nullptr); 
+                     gbwt::GBWT* gbwt = nullptr,
+                     const unordered_map<nid_t, pair<nid_t, size_t>>* translation = nullptr); 
     
 private:
 
@@ -62,6 +63,9 @@ private:
     // get traversals from the exhaustive finder.  if they have nested visits, fill them in (exhaustively)
     // with node visits
     vector<SnarlTraversal> explicit_exhaustive_traversals(const Snarl* snarl);
+
+    // get a snarl name, using trnaslation if availabe
+    string snarl_name(const Snarl* snarl);
     
     // output vcf object
     vcflib::VariantCallFile outvcf;
@@ -99,6 +103,9 @@ private:
 
     // recurse on child snarls
     bool include_nested = false;
+
+    // optional node translation to apply to snarl names in variant IDs
+    const unordered_map<nid_t, pair<nid_t, size_t>>* translation;
 };
 
 }

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -9,6 +9,7 @@
 #include "handle.hpp"
 #include "genotypekit.hpp"
 #include "traversal_finder.hpp"
+#include "graph_caller.hpp"
 
 /** \file
 * Deconstruct is getting rewritten.
@@ -24,7 +25,10 @@
 namespace vg{
 using namespace std;
 
-class Deconstructor{
+// note: added VCFOutputCaller parent class from vg call bring in sorted vcf output.  it would
+//       be nice to re-use more of the VCFOutputCaller code, much of which is still duplicated in
+//       Deconstructor
+class Deconstructor : public VCFOutputCaller {
 public:
 
     Deconstructor();
@@ -66,9 +70,6 @@ private:
 
     // get a snarl name, using trnaslation if availabe
     string snarl_name(const Snarl* snarl);
-    
-    // output vcf object
-    vcflib::VariantCallFile outvcf;
     
     // toggle between exhaustive and path restricted traversal finder
     bool path_restricted = false;

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -158,6 +158,19 @@ gbwt::GBWT get_gbwt(const std::vector<gbwt::vector_type>& paths);
 
 //------------------------------------------------------------------------------
 
+/// Load a translation file (created with vg gbwt --translation) and return a mapping
+/// original segment ids to a list of chopped node ids
+unordered_map<nid_t, vector<nid_t>> load_translation_map(ifstream& input_stream);
+
+/// Load a translation file (created with vg gbwt --translation) and return a backwards mapping
+/// of chopped node to original segment position (id,offset pair)
+/// NOTE: hopefully this is just a short-term hack, and we get a general interface baked into
+//        the handlegraphs themselves
+unordered_map<nid_t, pair<nid_t, size_t>> load_translation_back_map(HandleGraph& graph, ifstream& input_stream);
+
+//------------------------------------------------------------------------------
+
+
 } // namespace vg
 
 #endif // VG_GBWT_HELPER_HPP_INCLUDED

--- a/src/genotyper.hpp
+++ b/src/genotyper.hpp
@@ -17,7 +17,6 @@
 #include <vg/vg.pb.h>
 #include "vg.hpp"
 #include "translator.hpp"
-#include "deconstructor.hpp"
 #include "srpe.hpp"
 #include "hash_map.hpp"
 #include "utility.hpp"

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -81,7 +81,7 @@ public:
     void write_variants(ostream& out_stream) const;
 
     /// Run vcffixup from vcflib
-    void vcf_fixup() const;
+    void vcf_fixup(vcflib::Variant& var) const;
     
 protected:
 
@@ -120,7 +120,8 @@ protected:
     string sample_name;
 
     /// output buffers (1/thread) (for sorting)
-    mutable vector<vector<vcflib::Variant>> output_variants;
+    /// variants stored as strings (and position key pairs) because vcflib::Variant in-memory struct so huge
+    mutable vector<vector<pair<pair<string, size_t>, string>>> output_variants;
 
     /// print up to this many uncalled alleles when doing ref-genotpes in -a mode
     size_t max_uncalled_alleles = 5;

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -79,6 +79,9 @@ public:
 
     /// Sort then write variants in the buffer
     void write_variants(ostream& out_stream) const;
+
+    /// Run vcffixup from vcflib
+    void vcf_fixup() const;
     
 protected:
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -571,6 +571,14 @@ int main_call(int argc, char** argv) {
         }
     }
 
+    string header;
+    if (!gaf_output) {
+        // Init The VCF       
+        VCFOutputCaller* vcf_caller = dynamic_cast<VCFOutputCaller*>(graph_caller.get());
+        assert(vcf_caller != nullptr);
+        header = vcf_caller->vcf_header(*graph, ref_paths, ref_path_lengths);
+    }
+
     // Call the graph
     if (!traversals_only) {
 
@@ -587,7 +595,7 @@ int main_call(int argc, char** argv) {
         // Output VCF
         VCFOutputCaller* vcf_caller = dynamic_cast<VCFOutputCaller*>(graph_caller.get());
         assert(vcf_caller != nullptr);
-        cout << vcf_caller->vcf_header(*graph, ref_paths, ref_path_lengths) << flush;
+        cout << header << flush;
         vcf_caller->write_variants(cout);
     }
     


### PR DESCRIPTION
I just realized that if we're sharing GFA/VCF pairs from either end of a GFA->GBWT->XG->VCF pipeline, the node ids in the VCF ID fields will not match node ids in the GFA.  @jeizenga has visions of adding a layer to our graph api that would take care of stuff like this behind the scenes.  But until that's further along, I've hacked in an option (`-T`) in `deconstruct` to take a translation file as output by `vg gbwt --translation` and use it to produce snarl names in the original id space.  
