### PR TITLE
Stop double-counting single node chains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,7 +426,7 @@ test/build_graph: test/build_graph.cpp $(LIB_DIR)/libvg.a $(SRC_DIR)/vg.hpp
 	. ./source_me.sh && $(CXX) $(LDFLAGS) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o test/build_graph test/build_graph.cpp -lvg $(LD_LIB_DIR_FLAGS) $(LD_LIB_FLAGS) $(START_STATIC) $(LD_STATIC_LIB_FLAGS) $(END_STATIC) $(FILTER)
 
 $(LIB_DIR)/libjemalloc.a: $(JEMALLOC_DIR)/src/*.c
-	+. ./source_me.sh && cd $(JEMALLOC_DIR) && ./autogen.sh && ./configure --disable-libdl --prefix=`pwd` $(FILTER) && $(MAKE) $(FILTER) && cp -r lib/* $(CWD)/$(LIB_DIR)/ && cp -r include/* $(CWD)/$(INC_DIR)/
+	+. ./source_me.sh && rm -Rf $(CWD)/$(INC_DIR)/jemalloc && cd $(JEMALLOC_DIR) && ./autogen.sh && ./configure --disable-libdl --prefix=`pwd` $(FILTER) && $(MAKE) $(FILTER) && cp -r lib/* $(CWD)/$(LIB_DIR)/ && cp -r include/* $(CWD)/$(INC_DIR)/
 
 # Use fake patterns to tell Make that this rule generates all these files when run once.
 # Here % should always match "lib" which is a common substring.

--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -16,7 +16,7 @@
 
 namespace vg {
 
-//#define debug
+#define debug
 
 using namespace std;
 
@@ -1728,13 +1728,13 @@ void IntegratedSnarlFinder::traverse_computed_decomposition(MergedAdjacencyGraph
                             
                                 // This edge is the incoming edge for a cycle. Queue it up.
                                 frame.todo.push_back(inbound);
-                            } else if (cactus.find(graph->flip(inbound)) == cactus.find(inbound)) {
+                            } else if (cactus.find(graph->flip(inbound)) == cactus.find(inbound) && !graph->get_is_reverse(inbound)) {
                             
 #ifdef debug
                                 cerr << "\t\tInherit contained edge " << graph->get_id(inbound) << (graph->get_is_reverse(inbound) ? "-" : "+") << endl;
 #endif
                             
-                                // Count all self edges as empty chains.
+                                // Count all self edges as empty chains, but only from one side.
                                 begin_chain(inbound);
                                 end_chain(inbound);
                                 

--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -16,7 +16,7 @@
 
 namespace vg {
 
-#define debug
+//#define debug
 
 using namespace std;
 

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -4111,39 +4111,6 @@ namespace vg {
            
             IntegratedSnarlFinder snarl_finder(graph);
             
-            SECTION("events should be unique") {
-            
-                // Collect all the begins and ends shown by the snarl finder
-                vector<string> events;
-                
-                auto revfwd = [&](const handle_t h) -> std::string {
-                    return graph.get_is_reverse(h) ? "rev" : "fwd";
-                };
-                
-                snarl_finder.traverse_decomposition([&](const handle_t& here) {
-                    // Chain begun
-                    events.push_back("begin chain @ " + std::to_string(graph.get_id(here)) + " " + revfwd(here));
-                }, [&](const handle_t& here) {
-                    // Chain ended
-                    events.push_back("end chain @ " + std::to_string(graph.get_id(here)) + " " + revfwd(here));
-                }, [&](const handle_t& here) {
-                    // Snarl begun
-                    events.push_back("begin snarl @ " + std::to_string(graph.get_id(here)) + " " + revfwd(here));
-                }, [&](const handle_t& here) {
-                    // Snarl ended
-                    events.push_back("end snarl @ " + std::to_string(graph.get_id(here)) + " " + revfwd(here));
-                });
-                
-                for (auto& item : events) {
-                    std::cerr << item << std::endl;
-                }
-                
-                unordered_set<string> uniques(events.begin(), events.end());
-                
-                // There should be no duplicate messages
-                REQUIRE(events.size() == uniques.size());
-            }
-            
             SECTION("Endpoints should only be seen once") {
                 unordered_set<pair<id_t, bool>> seen_node_sides;
                 snarl_finder.traverse_decomposition(

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -3821,277 +3821,331 @@ namespace vg {
             
         }
 
-    TEST_CASE( "PathTraversalFinder works correctly",
+        TEST_CASE( "PathTraversalFinder works correctly",
                "[sites][snarls]" ) {
 
 
-        // Build a toy graph
-        const string graph_json = R"(
+            // Build a toy graph
+            const string graph_json = R"(
+            
+                {
+                    "node": [
+                        {"id": 1, "sequence": "G"},
+                        {"id": 2, "sequence": "A"},
+                        {"id": 3, "sequence": "G"},
+                        {"id": 4, "sequence": "A"},
+                        {"id": 5, "sequence": "G"},
+                        {"id": 6, "sequence": "A"},
+                        {"id": 7, "sequence": "G"},
+                        {"id": 8, "sequence": "A"},
+                        {"id": 9, "sequence": "A"},
+                        {"id": 10, "sequence": "G"},
+                        {"id": 11, "sequence": "A"}
+                    ],
+                    "edge": [
+                        {"from": 1, "to": 2},
+                        {"from": 2, "to": 3},
+                        {"from": 2, "to": 4},
+                        {"from": 3, "to": 5},
+                        {"from": 3, "to": 6},
+                        {"from": 4, "to": 5},
+                        {"from": 4, "to": 6},
+                        {"from": 5, "to": 7},
+                        {"from": 6, "to": 7},
+                        {"from": 7, "to": 8},
+                        {"from": 8, "to": 9},
+                        {"from": 8, "to": 10, "to_end": "true"},
+                        {"from": 9, "to": 10},
+                        {"from": 9, "to": 10, "from_start": "true"},
+                        {"from": 9, "to": 11, "to_end": "true"},
+                        {"from": 9, "to": 11, "from_start": "true", "to_end": "true"},
+                        {"from": 10, "to": 11, "to_end": "true"}
+                    ],
+                    "path": [
+                        {"name": "ref", "mapping": [
+                            {"position": {"node_id": 1}, "rank" : 1 },
+                            {"position": {"node_id": 2}, "rank" : 2 },
+                            {"position": {"node_id": 4}, "rank" : 3 },
+                            {"position": {"node_id": 6}, "rank" : 4 },
+                            {"position": {"node_id": 7}, "rank" : 5 },
+                            {"position": {"node_id": 8}, "rank" : 6 },
+                            {"position": {"node_id": 9}, "rank" : 7 },
+                            {"position": {"node_id": 10}, "rank" : 8 },
+                            {"position": {"node_id": 11, "is_reverse" : "true"}, "rank" : 9 }
+                        ]},
+                        {"name": "alt1", "mapping": [
+                            {"position": {"node_id": 1}, "rank" : 1 },
+                            {"position": {"node_id": 2}, "rank" : 2 },
+                            {"position": {"node_id": 3}, "rank" : 3 },
+                            {"position": {"node_id": 5}, "rank" : 4 },
+                            {"position": {"node_id": 7}, "rank" : 5 },
+                            {"position": {"node_id": 8}, "rank" : 6 },
+                            {"position": {"node_id": 10, "is_reverse" : "true"}, "rank" : 7 },
+                            {"position": {"node_id": 9}, "rank" : 8 },
+                            {"position": {"node_id": 11, "is_reverse" : "true"}, "rank" : 9 }
+                        ]},
+                        {"name": "alt1a", "mapping": [
+                            {"position": {"node_id": 2}, "rank" : 2 },
+                            {"position": {"node_id": 3}, "rank" : 3 },
+                            {"position": {"node_id": 5}, "rank" : 4 },
+                            {"position": {"node_id": 7}, "rank" : 5 }
+                        ]},
+                        {"name": "alt2", "mapping": [
+                            {"position": {"node_id": 8, "is_reverse" : "true"}, "rank" : 1 },
+                            {"position": {"node_id": 7, "is_reverse" : "true"}, "rank" : 2 },
+                            {"position": {"node_id": 6, "is_reverse" : "true"}, "rank" : 3 },
+                            {"position": {"node_id": 3, "is_reverse" : "true"}, "rank" : 4 },
+                            {"position": {"node_id": 2, "is_reverse" : "true"}, "rank" : 5 },
+                            {"position": {"node_id": 1, "is_reverse" : "true"}, "rank" : 6 }
+                        ]},
+                        {"name": "shorty", "mapping": [
+                            {"position": {"node_id": 1}, "rank" : 1 },
+                            {"position": {"node_id": 2}, "rank" : 2 },
+                            {"position": {"node_id": 3}, "rank" : 3 },
+                            {"position": {"node_id": 6}, "rank" : 4 }
+                        ]},
+                        {"name": "alt3", "mapping": [
+                            {"position": {"node_id": 11}, "rank" : 1 },
+                            {"position": {"node_id": 9}, "rank" : 2 },
+                            {"position": {"node_id": 10}, "rank" : 3 },
+                            {"position": {"node_id": 8, "is_reverse" : "true"}, "rank" : 4 },
+                            {"position": {"node_id": 7, "is_reverse" : "true"}, "rank" : 5 }
+                        ]},
+                        {"name": "alt4", "mapping": [
+                            {"position": {"node_id": 11}, "rank" : 1 },
+                            {"position": {"node_id": 10, "is_reverse" : "true"}, "rank" : 2 },
+                            {"position": {"node_id": 9, "is_reverse" : "true"}, "rank" : 3 },
+                            {"position": {"node_id": 8, "is_reverse" : "true"}, "rank" : 4 },
+                            {"position": {"node_id": 7, "is_reverse" : "true"}, "rank" : 5 }
+                        ]}
+                    ]
+                }            
+                )";
+                
+            // Make an actual graph
+            VG graph;
+            Graph chunk;
+            json2pb(chunk, graph_json.c_str(), graph_json.size());
+            graph.extend(chunk);
+            assert(graph.is_valid());
+            
+            SECTION( "PathTraversalFinder can find simple forward traversals") {
+
+                CactusSnarlFinder snarl_finder(graph);
+                SnarlManager snarl_manager = snarl_finder.find_snarls();
+                PathTraversalFinder trav_finder(graph, snarl_manager);
+
+                Snarl snarl;
+                snarl.mutable_start()->set_node_id(2);
+                snarl.mutable_end()->set_node_id(7);
+
+                auto trav_results = trav_finder.find_path_traversals(snarl);
+
+                // get a path for ref, atl1, alt1a and alt2
+                REQUIRE(trav_results.first.size() == 4);
+
+                set<string> correct_names = {"ref", "alt1", "alt1a", "alt2"};
+                for (auto step_pair : trav_results.second) {
+                    string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
+                    string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
+                    REQUIRE(name1 == name2);
+                    REQUIRE(correct_names.count(name1));
+                }
+                
+                map<string, string> true_trav_strings = {
+                    {"ref", R"({"visit":[{"node_id":"2"},{"node_id":"4"},{"node_id":"6"},{"node_id":"7"}]})"},
+                    {"alt1", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"5"},{"node_id":"7"}]})"},
+                    {"alt1a", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"5"},{"node_id":"7"}]})"},
+                    {"alt2", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"6"},{"node_id":"7"}]})"}
+                };
+                for (int i = 0; i < trav_results.first.size(); ++i) {
+                    string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));
+                    REQUIRE(true_trav_strings.count(name));
+                    SnarlTraversal true_trav;
+                    json2pb(true_trav, true_trav_strings[name]);
+                    bool trav_is_correct = trav_results.first[i] == true_trav;
+                    REQUIRE(trav_is_correct);
+                }
+            }
+
+            SECTION( "PathTraversalFinder can find simple traversals when snarl is backward") {
+
+                CactusSnarlFinder snarl_finder(graph);
+                SnarlManager snarl_manager = snarl_finder.find_snarls();
+                PathTraversalFinder trav_finder(graph, snarl_manager);
+
+                Snarl snarl;
+                snarl.mutable_start()->set_node_id(7);
+                snarl.mutable_start()->set_backward(true);
+                snarl.mutable_end()->set_node_id(2);
+                snarl.mutable_end()->set_backward(true);
+                
+                auto trav_results = trav_finder.find_path_traversals(snarl);
+
+                // get a path for ref, atl1, alt1a and alt2
+                REQUIRE(trav_results.first.size() == 4);
+
+                set<string> correct_names = {"ref", "alt1", "alt1a", "alt2"};
+                for (auto step_pair : trav_results.second) {
+                    string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
+                    string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
+                    REQUIRE(name1 == name2);
+                    REQUIRE(correct_names.count(name1));
+                }
+
+                map<string, string> true_trav_strings = {
+                    {"ref", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"6","backward":true},{"node_id":"4","backward":true},{"node_id":"2","backward":true}]})"},
+                    {"alt1", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"5","backward":true},{"node_id":"3","backward":true},{"node_id":"2","backward":true}]})"},
+                    {"alt1a", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"5","backward":true},{"node_id":"3","backward":true},{"node_id":"2","backward":true}]})"},
+                    {"alt2", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"6","backward":true},{"node_id":"3","backward":true},{"node_id":"2","backward":true}]})"}
+                };
+                for (int i = 0; i < trav_results.first.size(); ++i) {
+                    string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));                
+                    REQUIRE(true_trav_strings.count(name));
+                    SnarlTraversal true_trav;
+                    json2pb(true_trav, true_trav_strings[name]);
+                    bool trav_is_correct = trav_results.first[i] == true_trav;
+                    REQUIRE(trav_is_correct);
+                }
+            }
+
+            SECTION( "PathTraversalFinder can find forward traversals in snarl with inversion") {
+
+                CactusSnarlFinder snarl_finder(graph);
+                SnarlManager snarl_manager = snarl_finder.find_snarls();
+                PathTraversalFinder trav_finder(graph, snarl_manager);
+
+                Snarl snarl;
+                snarl.mutable_start()->set_node_id(8);
+                snarl.mutable_end()->set_node_id(11);
+                snarl.mutable_end()->set_backward(true);
+                
+                auto trav_results = trav_finder.find_path_traversals(snarl);
+
+                // get a path for ref, atl1, alt1a and alt2
+                REQUIRE(trav_results.first.size() == 4);
+
+                set<string> correct_names = {"ref", "alt1", "alt3", "alt4"};
+                for (auto step_pair : trav_results.second) {
+                    string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
+                    string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
+                    REQUIRE(name1 == name2);
+                    REQUIRE(correct_names.count(name1));
+                }
+
+                map<string, string> true_trav_strings = {
+                    {"ref", R"({"visit":[{"node_id":"8"},{"node_id":"9"},{"node_id":"10"},{"node_id":"11","backward":true}]})"},
+                    {"alt1", R"({"visit":[{"node_id":"8"},{"node_id":"10","backward":true},{"node_id":"9"},{"node_id":"11","backward":true}]})"},
+                    {"alt3", R"({"visit":[{"node_id":"8"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"11","backward":true}]})"},
+                    {"alt4", R"({"visit":[{"node_id":"8"},{"node_id":"9"},{"node_id":"10"},{"node_id":"11","backward":true}]})"}
+                };
+                for (int i = 0; i < trav_results.first.size(); ++i) {
+                    string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));                
+                    REQUIRE(true_trav_strings.count(name));
+                    SnarlTraversal true_trav;
+                    json2pb(true_trav, true_trav_strings[name]);
+                    bool trav_is_correct = trav_results.first[i] == true_trav;
+                    REQUIRE(trav_is_correct);
+                }
+            }
+
+            SECTION( "PathTraversalFinder can find traversals in backward snarl with inversion") {
+
+                CactusSnarlFinder snarl_finder(graph);
+                SnarlManager snarl_manager = snarl_finder.find_snarls();
+                PathTraversalFinder trav_finder(graph, snarl_manager);
+
+                Snarl snarl;
+                snarl.mutable_start()->set_node_id(11);
+                snarl.mutable_end()->set_node_id(8);
+                snarl.mutable_end()->set_backward(true);
+                
+                auto trav_results = trav_finder.find_path_traversals(snarl);
+
+                // get a path for ref, atl1, alt1a and alt2
+                REQUIRE(trav_results.first.size() == 4);
+
+                set<string> correct_names = {"ref", "alt1", "alt3", "alt4"};
+                for (auto step_pair : trav_results.second) {
+                    string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
+                    string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
+                    REQUIRE(name1 == name2);
+                    REQUIRE(correct_names.count(name1));
+                }
+                    
+                map<string, string> true_trav_strings = {
+                    {"ref", R"({"visit":[{"node_id":"11"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"8","backward":true}]})"},
+                    {"alt1", R"({"visit":[{"node_id":"11"},{"node_id":"9","backward":true},{"node_id":"10"},{"node_id":"8","backward":true}]})"},
+                    {"alt3", R"({"visit":[{"node_id":"11"},{"node_id":"9"},{"node_id":"10"},{"node_id":"8","backward":true}]})"},
+                    {"alt4", R"({"visit":[{"node_id":"11"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"8","backward":true}]})"}
+                };
+                for (int i = 0; i < trav_results.first.size(); ++i) {
+                    string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));                                
+                    REQUIRE(true_trav_strings.count(name));
+                    SnarlTraversal true_trav;
+                    json2pb(true_trav, true_trav_strings[name]);
+                    bool trav_is_correct = trav_results.first[i] == true_trav;
+                    REQUIRE(trav_is_correct);
+                }
+            }
+                
+        }
         
+        TEST_CASE("snarls and chains can be found in a graph with lots of root snarl connectivity", "[snarls]") {
+    
+            // Build a toy graph
+            const string graph_json = R"(
+            
             {
                 "node": [
-                    {"id": 1, "sequence": "G"},
+                    {"id": 1, "sequence": "A"},
                     {"id": 2, "sequence": "A"},
-                    {"id": 3, "sequence": "G"},
+                    {"id": 3, "sequence": "A"},
                     {"id": 4, "sequence": "A"},
-                    {"id": 5, "sequence": "G"},
-                    {"id": 6, "sequence": "A"},
-                    {"id": 7, "sequence": "G"},
-                    {"id": 8, "sequence": "A"},
-                    {"id": 9, "sequence": "A"},
-                    {"id": 10, "sequence": "G"},
-                    {"id": 11, "sequence": "A"}
+                    {"id": 5, "sequence": "A"}
                 ],
                 "edge": [
                     {"from": 1, "to": 2},
+                    {"from": 1, "from_start": true, "to": 2},
                     {"from": 2, "to": 3},
-                    {"from": 2, "to": 4},
-                    {"from": 3, "to": 5},
-                    {"from": 3, "to": 6},
+                    {"from": 3, "to": 4},
                     {"from": 4, "to": 5},
-                    {"from": 4, "to": 6},
-                    {"from": 5, "to": 7},
-                    {"from": 6, "to": 7},
-                    {"from": 7, "to": 8},
-                    {"from": 8, "to": 9},
-                    {"from": 8, "to": 10, "to_end": "true"},
-                    {"from": 9, "to": 10},
-                    {"from": 9, "to": 10, "from_start": "true"},
-                    {"from": 9, "to": 11, "to_end": "true"},
-                    {"from": 9, "to": 11, "from_start": "true", "to_end": "true"},
-                    {"from": 10, "to": 11, "to_end": "true"}
-                ],
-                "path": [
-                    {"name": "ref", "mapping": [
-                        {"position": {"node_id": 1}, "rank" : 1 },
-                        {"position": {"node_id": 2}, "rank" : 2 },
-                        {"position": {"node_id": 4}, "rank" : 3 },
-                        {"position": {"node_id": 6}, "rank" : 4 },
-                        {"position": {"node_id": 7}, "rank" : 5 },
-                        {"position": {"node_id": 8}, "rank" : 6 },
-                        {"position": {"node_id": 9}, "rank" : 7 },
-                        {"position": {"node_id": 10}, "rank" : 8 },
-                        {"position": {"node_id": 11, "is_reverse" : "true"}, "rank" : 9 }
-                    ]},
-                    {"name": "alt1", "mapping": [
-                        {"position": {"node_id": 1}, "rank" : 1 },
-                        {"position": {"node_id": 2}, "rank" : 2 },
-                        {"position": {"node_id": 3}, "rank" : 3 },
-                        {"position": {"node_id": 5}, "rank" : 4 },
-                        {"position": {"node_id": 7}, "rank" : 5 },
-                        {"position": {"node_id": 8}, "rank" : 6 },
-                        {"position": {"node_id": 10, "is_reverse" : "true"}, "rank" : 7 },
-                        {"position": {"node_id": 9}, "rank" : 8 },
-                        {"position": {"node_id": 11, "is_reverse" : "true"}, "rank" : 9 }
-                    ]},
-                    {"name": "alt1a", "mapping": [
-                        {"position": {"node_id": 2}, "rank" : 2 },
-                        {"position": {"node_id": 3}, "rank" : 3 },
-                        {"position": {"node_id": 5}, "rank" : 4 },
-                        {"position": {"node_id": 7}, "rank" : 5 }
-                    ]},
-                    {"name": "alt2", "mapping": [
-                        {"position": {"node_id": 8, "is_reverse" : "true"}, "rank" : 1 },
-                        {"position": {"node_id": 7, "is_reverse" : "true"}, "rank" : 2 },
-                        {"position": {"node_id": 6, "is_reverse" : "true"}, "rank" : 3 },
-                        {"position": {"node_id": 3, "is_reverse" : "true"}, "rank" : 4 },
-                        {"position": {"node_id": 2, "is_reverse" : "true"}, "rank" : 5 },
-                        {"position": {"node_id": 1, "is_reverse" : "true"}, "rank" : 6 }
-                    ]},
-                    {"name": "shorty", "mapping": [
-                        {"position": {"node_id": 1}, "rank" : 1 },
-                        {"position": {"node_id": 2}, "rank" : 2 },
-                        {"position": {"node_id": 3}, "rank" : 3 },
-                        {"position": {"node_id": 6}, "rank" : 4 }
-                    ]},
-                    {"name": "alt3", "mapping": [
-                        {"position": {"node_id": 11}, "rank" : 1 },
-                        {"position": {"node_id": 9}, "rank" : 2 },
-                        {"position": {"node_id": 10}, "rank" : 3 },
-                        {"position": {"node_id": 8, "is_reverse" : "true"}, "rank" : 4 },
-                        {"position": {"node_id": 7, "is_reverse" : "true"}, "rank" : 5 }
-                    ]},
-                    {"name": "alt4", "mapping": [
-                        {"position": {"node_id": 11}, "rank" : 1 },
-                        {"position": {"node_id": 10, "is_reverse" : "true"}, "rank" : 2 },
-                        {"position": {"node_id": 9, "is_reverse" : "true"}, "rank" : 3 },
-                        {"position": {"node_id": 8, "is_reverse" : "true"}, "rank" : 4 },
-                        {"position": {"node_id": 7, "is_reverse" : "true"}, "rank" : 5 }
-                    ]}
+                    {"from": 3, "to": 5},
+                    {"from": 3, "to": 3, "to_end": true}
+                    
                 ]
-            }            
+            }
+            
             )";
             
-        // Make an actual graph
-        VG graph;
-        Graph chunk;
-        json2pb(chunk, graph_json.c_str(), graph_json.size());
-        graph.extend(chunk);
-        assert(graph.is_valid());
-        
-        SECTION( "PathTraversalFinder can find simple forward traversals") {
-
-            CactusSnarlFinder snarl_finder(graph);
-            SnarlManager snarl_manager = snarl_finder.find_snarls();
-            PathTraversalFinder trav_finder(graph, snarl_manager);
-
-            Snarl snarl;
-            snarl.mutable_start()->set_node_id(2);
-            snarl.mutable_end()->set_node_id(7);
-
-            auto trav_results = trav_finder.find_path_traversals(snarl);
-
-            // get a path for ref, atl1, alt1a and alt2
-            REQUIRE(trav_results.first.size() == 4);
-
-            set<string> correct_names = {"ref", "alt1", "alt1a", "alt2"};
-            for (auto step_pair : trav_results.second) {
-                string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
-                string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
-                REQUIRE(name1 == name2);
-                REQUIRE(correct_names.count(name1));
-            }
+            // Make an actual graph
+            VG graph;
+            Graph chunk;
+            json2pb(chunk, graph_json.c_str(), graph_json.size());
+            graph.extend(chunk);
             
-            map<string, string> true_trav_strings = {
-                {"ref", R"({"visit":[{"node_id":"2"},{"node_id":"4"},{"node_id":"6"},{"node_id":"7"}]})"},
-                {"alt1", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"5"},{"node_id":"7"}]})"},
-                {"alt1a", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"5"},{"node_id":"7"}]})"},
-                {"alt2", R"({"visit":[{"node_id":"2"},{"node_id":"3"},{"node_id":"6"},{"node_id":"7"}]})"}
-            };
-            for (int i = 0; i < trav_results.first.size(); ++i) {
-                string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));
-                REQUIRE(true_trav_strings.count(name));
-                SnarlTraversal true_trav;
-                json2pb(true_trav, true_trav_strings[name]);
-                bool trav_is_correct = trav_results.first[i] == true_trav;
-                REQUIRE(trav_is_correct);
+            IntegratedSnarlFinder finder(graph);
+            
+            // Collect all the begins and ends shown by the snarl finder
+            vector<string> events;
+            
+            finder.traverse_decomposition([&](const handle_t& here) {
+                // Chain begun
+                events.push_back("begin chain " + std::to_string(graph.get_id(here)));
+            }, [&](const handle_t& here) {
+                // Chain ended
+                events.push_back("end chain " + std::to_string(graph.get_id(here)));
+            }, [&](const handle_t& here) {
+                // Snarl begun
+                events.push_back("begin snarl " + std::to_string(graph.get_id(here)));
+            }, [&](const handle_t& here) {
+                // Snarl ended
+                events.push_back("end snarl " + std::to_string(graph.get_id(here)));
+            });
+            
+            for (auto& item : events) {
+                std::cerr << item << std::endl;
             }
         }
-
-        SECTION( "PathTraversalFinder can find simple traversals when snarl is backward") {
-
-            CactusSnarlFinder snarl_finder(graph);
-            SnarlManager snarl_manager = snarl_finder.find_snarls();
-            PathTraversalFinder trav_finder(graph, snarl_manager);
-
-            Snarl snarl;
-            snarl.mutable_start()->set_node_id(7);
-            snarl.mutable_start()->set_backward(true);
-            snarl.mutable_end()->set_node_id(2);
-            snarl.mutable_end()->set_backward(true);
-            
-            auto trav_results = trav_finder.find_path_traversals(snarl);
-
-            // get a path for ref, atl1, alt1a and alt2
-            REQUIRE(trav_results.first.size() == 4);
-
-            set<string> correct_names = {"ref", "alt1", "alt1a", "alt2"};
-            for (auto step_pair : trav_results.second) {
-                string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
-                string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
-                REQUIRE(name1 == name2);
-                REQUIRE(correct_names.count(name1));
-            }
-
-            map<string, string> true_trav_strings = {
-                {"ref", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"6","backward":true},{"node_id":"4","backward":true},{"node_id":"2","backward":true}]})"},
-                {"alt1", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"5","backward":true},{"node_id":"3","backward":true},{"node_id":"2","backward":true}]})"},
-                {"alt1a", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"5","backward":true},{"node_id":"3","backward":true},{"node_id":"2","backward":true}]})"},
-                {"alt2", R"({"visit":[{"node_id":"7","backward":true},{"node_id":"6","backward":true},{"node_id":"3","backward":true},{"node_id":"2","backward":true}]})"}
-            };
-            for (int i = 0; i < trav_results.first.size(); ++i) {
-                string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));                
-                REQUIRE(true_trav_strings.count(name));
-                SnarlTraversal true_trav;
-                json2pb(true_trav, true_trav_strings[name]);
-                bool trav_is_correct = trav_results.first[i] == true_trav;
-                REQUIRE(trav_is_correct);
-            }
-        }
-
-        SECTION( "PathTraversalFinder can find forward traversals in snarl with inversion") {
-
-            CactusSnarlFinder snarl_finder(graph);
-            SnarlManager snarl_manager = snarl_finder.find_snarls();
-            PathTraversalFinder trav_finder(graph, snarl_manager);
-
-            Snarl snarl;
-            snarl.mutable_start()->set_node_id(8);
-            snarl.mutable_end()->set_node_id(11);
-            snarl.mutable_end()->set_backward(true);
-            
-            auto trav_results = trav_finder.find_path_traversals(snarl);
-
-            // get a path for ref, atl1, alt1a and alt2
-            REQUIRE(trav_results.first.size() == 4);
-
-            set<string> correct_names = {"ref", "alt1", "alt3", "alt4"};
-            for (auto step_pair : trav_results.second) {
-                string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
-                string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
-                REQUIRE(name1 == name2);
-                REQUIRE(correct_names.count(name1));
-            }
-
-            map<string, string> true_trav_strings = {
-                {"ref", R"({"visit":[{"node_id":"8"},{"node_id":"9"},{"node_id":"10"},{"node_id":"11","backward":true}]})"},
-                {"alt1", R"({"visit":[{"node_id":"8"},{"node_id":"10","backward":true},{"node_id":"9"},{"node_id":"11","backward":true}]})"},
-                {"alt3", R"({"visit":[{"node_id":"8"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"11","backward":true}]})"},
-                {"alt4", R"({"visit":[{"node_id":"8"},{"node_id":"9"},{"node_id":"10"},{"node_id":"11","backward":true}]})"}
-            };
-            for (int i = 0; i < trav_results.first.size(); ++i) {
-                string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));                
-                REQUIRE(true_trav_strings.count(name));
-                SnarlTraversal true_trav;
-                json2pb(true_trav, true_trav_strings[name]);
-                bool trav_is_correct = trav_results.first[i] == true_trav;
-                REQUIRE(trav_is_correct);
-            }
-        }
-
-        SECTION( "PathTraversalFinder can find traversals in backward snarl with inversion") {
-
-            CactusSnarlFinder snarl_finder(graph);
-            SnarlManager snarl_manager = snarl_finder.find_snarls();
-            PathTraversalFinder trav_finder(graph, snarl_manager);
-
-            Snarl snarl;
-            snarl.mutable_start()->set_node_id(11);
-            snarl.mutable_end()->set_node_id(8);
-            snarl.mutable_end()->set_backward(true);
-            
-            auto trav_results = trav_finder.find_path_traversals(snarl);
-
-            // get a path for ref, atl1, alt1a and alt2
-            REQUIRE(trav_results.first.size() == 4);
-
-            set<string> correct_names = {"ref", "alt1", "alt3", "alt4"};
-            for (auto step_pair : trav_results.second) {
-                string name1 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.first));
-                string name2 = graph.get_path_name(graph.get_path_handle_of_step(step_pair.second));
-                REQUIRE(name1 == name2);
-                REQUIRE(correct_names.count(name1));
-            }
-                
-            map<string, string> true_trav_strings = {
-                {"ref", R"({"visit":[{"node_id":"11"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"8","backward":true}]})"},
-                {"alt1", R"({"visit":[{"node_id":"11"},{"node_id":"9","backward":true},{"node_id":"10"},{"node_id":"8","backward":true}]})"},
-                {"alt3", R"({"visit":[{"node_id":"11"},{"node_id":"9"},{"node_id":"10"},{"node_id":"8","backward":true}]})"},
-                {"alt4", R"({"visit":[{"node_id":"11"},{"node_id":"10","backward":true},{"node_id":"9","backward":true},{"node_id":"8","backward":true}]})"}
-            };
-            for (int i = 0; i < trav_results.first.size(); ++i) {
-                string name = graph.get_path_name(graph.get_path_handle_of_step(trav_results.second[i].first));                                
-                REQUIRE(true_trav_strings.count(name));
-                SnarlTraversal true_trav;
-                json2pb(true_trav, true_trav_strings[name]);
-                bool trav_is_correct = trav_results.first[i] == true_trav;
-                REQUIRE(trav_is_correct);
-            }
-        }
-
-        
-            
     }
-
-   }
 }

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -4116,22 +4116,30 @@ namespace vg {
                 unordered_set<pair<id_t, bool>> seen_snarl_sides;
                 snarl_finder.traverse_decomposition(
                 [&](handle_t chain_start_handle){
+#ifdef debug
                     cerr << "Start new chain at " << graph.get_id(chain_start_handle) << (graph.get_is_reverse(chain_start_handle) ? "rev" : "fd") << endl;
+#endif
                     REQUIRE(seen_chain_sides.count(make_pair(graph.get_id(chain_start_handle), graph.get_is_reverse(chain_start_handle)))==0);
                     seen_chain_sides.emplace(graph.get_id(chain_start_handle), graph.get_is_reverse(chain_start_handle));
                 },
                 [&](handle_t chain_end_handle) {
+#ifdef debug
                     cerr << "End new chain at " << graph.get_id(chain_end_handle) << (graph.get_is_reverse(chain_end_handle) ? "rev" : "fd") << endl;
+#endif
                     REQUIRE(seen_chain_sides.count(make_pair(graph.get_id(chain_end_handle), !graph.get_is_reverse(chain_end_handle)))==0);
                     seen_chain_sides.emplace(graph.get_id(chain_end_handle), !graph.get_is_reverse(chain_end_handle));
                 },
                 [&](handle_t snarl_start_handle) {
+#ifdef debug
                     cerr << "Start new snarl at " << graph.get_id(snarl_start_handle) << (graph.get_is_reverse(snarl_start_handle) ? "rev" : "fd") << endl;
+#endif
                     REQUIRE(seen_snarl_sides.count(make_pair(graph.get_id(snarl_start_handle), graph.get_is_reverse(snarl_start_handle)))==0);
                     seen_snarl_sides.emplace(graph.get_id(snarl_start_handle), graph.get_is_reverse(snarl_start_handle));
                 },
                 [&](handle_t snarl_end_handle) {
+#ifdef debug
                     cerr << "End new snarl at " << graph.get_id(snarl_end_handle) << (graph.get_is_reverse(snarl_end_handle) ? "rev" : "fd") << endl;
+#endif
                     REQUIRE(seen_snarl_sides.count(make_pair(graph.get_id(snarl_end_handle), !graph.get_is_reverse(snarl_end_handle)))==0);
                     seen_snarl_sides.emplace(graph.get_id(snarl_end_handle), !graph.get_is_reverse(snarl_end_handle));
                 });

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -4112,27 +4112,28 @@ namespace vg {
             IntegratedSnarlFinder snarl_finder(graph);
             
             SECTION("Endpoints should only be seen once") {
-                unordered_set<pair<id_t, bool>> seen_node_sides;
+                unordered_set<pair<id_t, bool>> seen_chain_sides;
+                unordered_set<pair<id_t, bool>> seen_snarl_sides;
                 snarl_finder.traverse_decomposition(
                 [&](handle_t chain_start_handle){
                     cerr << "Start new chain at " << graph.get_id(chain_start_handle) << (graph.get_is_reverse(chain_start_handle) ? "rev" : "fd") << endl;
-                    REQUIRE(seen_node_sides.count(make_pair(graph.get_id(chain_start_handle), graph.get_is_reverse(chain_start_handle)))==0);
-                    seen_node_sides.emplace(graph.get_id(chain_start_handle), graph.get_is_reverse(chain_start_handle));
+                    REQUIRE(seen_chain_sides.count(make_pair(graph.get_id(chain_start_handle), graph.get_is_reverse(chain_start_handle)))==0);
+                    seen_chain_sides.emplace(graph.get_id(chain_start_handle), graph.get_is_reverse(chain_start_handle));
                 },
                 [&](handle_t chain_end_handle) {
                     cerr << "End new chain at " << graph.get_id(chain_end_handle) << (graph.get_is_reverse(chain_end_handle) ? "rev" : "fd") << endl;
-                    REQUIRE(seen_node_sides.count(make_pair(graph.get_id(chain_end_handle), !graph.get_is_reverse(chain_end_handle)))==0);
-                    seen_node_sides.emplace(graph.get_id(chain_end_handle), !graph.get_is_reverse(chain_end_handle));
+                    REQUIRE(seen_chain_sides.count(make_pair(graph.get_id(chain_end_handle), !graph.get_is_reverse(chain_end_handle)))==0);
+                    seen_chain_sides.emplace(graph.get_id(chain_end_handle), !graph.get_is_reverse(chain_end_handle));
                 },
                 [&](handle_t snarl_start_handle) {
                     cerr << "Start new snarl at " << graph.get_id(snarl_start_handle) << (graph.get_is_reverse(snarl_start_handle) ? "rev" : "fd") << endl;
-                    REQUIRE(seen_node_sides.count(make_pair(graph.get_id(snarl_start_handle), graph.get_is_reverse(snarl_start_handle)))==0);
-                    seen_node_sides.emplace(graph.get_id(snarl_start_handle), graph.get_is_reverse(snarl_start_handle));
+                    REQUIRE(seen_snarl_sides.count(make_pair(graph.get_id(snarl_start_handle), graph.get_is_reverse(snarl_start_handle)))==0);
+                    seen_snarl_sides.emplace(graph.get_id(snarl_start_handle), graph.get_is_reverse(snarl_start_handle));
                 },
                 [&](handle_t snarl_end_handle) {
                     cerr << "End new snarl at " << graph.get_id(snarl_end_handle) << (graph.get_is_reverse(snarl_end_handle) ? "rev" : "fd") << endl;
-                    REQUIRE(seen_node_sides.count(make_pair(graph.get_id(snarl_end_handle), !graph.get_is_reverse(snarl_end_handle)))==0);
-                    seen_node_sides.emplace(graph.get_id(snarl_end_handle), !graph.get_is_reverse(snarl_end_handle));
+                    REQUIRE(seen_snarl_sides.count(make_pair(graph.get_id(snarl_end_handle), !graph.get_is_reverse(snarl_end_handle)))==0);
+                    seen_snarl_sides.emplace(graph.get_id(snarl_end_handle), !graph.get_is_reverse(snarl_end_handle));
                 });
             }
         }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Single nodes at the end of bridge paths in the Cactus graph won't show up twice in the snarl decomposition

## Description

This will fix https://github.com/vgteam/vg/issues/3224#issuecomment-795971733 by no longer double counting single-node chains in certain cases.
