### PR TITLE
Giraffe speed test script

### DIFF
--- a/scripts/giraffe-speed.sh
+++ b/scripts/giraffe-speed.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # giraffe-speed.sh: evaluate Giraffe mapping speed.
-# Suggested to run on an AWS
+# Suggested to run on an AWS r5.4xlarge, with 100 GB disk, the "vg-data-user" IAM role and Ubuntu 20.04 
 # Partially based on https://github.com/vgteam/giraffe-sv-paper/blob/566573b708878d8854acb088a0a8f7c920b120eb/scripts/giraffe/speed_giraffe.sh
 set -e
 

--- a/scripts/giraffe-speed.sh
+++ b/scripts/giraffe-speed.sh
@@ -1,7 +1,42 @@
 #!/usr/bin/env bash
+#
 # giraffe-speed.sh: evaluate Giraffe mapping speed.
-# Suggested to run on an AWS r5.4xlarge, with 100 GB disk, the "vg-data-user" IAM role and Ubuntu 20.04 
-# Partially based on https://github.com/vgteam/giraffe-sv-paper/blob/566573b708878d8854acb088a0a8f7c920b120eb/scripts/giraffe/speed_giraffe.sh
+#
+# Although CPU instruction counting doesn't work in this configuration for some
+# reason, you can run on an AWS r5.4xlarge, with 100 GB disk, the
+# "vg-data-user" IAM role and Ubuntu 20.04:
+#
+# git clone https://github.com/vgteam/vg.git
+# cd vg
+# git checkout <commit to test>
+# git submodule update --init --recursive
+# sudo apt update
+# sudo apt install -y build-essential awscli
+# make get-deps
+# make -j16
+# ./scripts/giraffe-speed.sh
+#
+# In this configuration, a mapping speed of 3520.61 reads per second per
+# thread, or 3527.4 reads per CPU-second (including output), is typical.
+# Significant reductions may indicate a performance regression.
+#
+# Or, run in Docker or on Kubernetes using the Docker build of the version of
+# vg you want to evaluate. Allocate at least 50 GB memory, 16 hyperthreads, and
+# 100 GB of disk. The script dependencies should already be available.
+#
+# In this configuration, speed will vary with the machine type, and the load on
+# the host, but a mapping speed of 3836.3 reads per CPU-second (including
+# output) has been observed in a heavily loaded Kubernetes pod, and 5333.43
+# reads per CPU-second (including output) in a lightly loaded one, on the GI
+# Kubernetes cluster. In all cases, 0.918424 M instructions per read is a
+# typical value for GI Kubernetes's CPUs; significant changes from that
+# indicate that more or less work is now required to map each read.
+#
+# We expect to be root, or to be able to sudo, so Giraffe can evaluate its
+# instruction execution speed.
+#
+# Partially based on
+# https://github.com/vgteam/giraffe-sv-paper/blob/566573b708878d8854acb088a0a8f7c920b120eb/scripts/giraffe/speed_giraffe.sh
 set -e
 
 THREAD_COUNT=16
@@ -33,6 +68,9 @@ fetch "${GRAPH_BASE}.${GBWT}.min" "./${GRAPH}.${GBWT}.min"
 cat ./reads.fq.gz ./reads.fq.gz ./reads.fq.gz ./reads.fq.gz ./reads.fq.gz ./reads.fq.gz ./reads.fq.gz ./reads.fq.gz ./reads.fq.gz ./reads.fq.gz >./many-reads.fq.gz
 
 SUDO=$(which sudo 2>/dev/null || true)
+VG=$(which vg 2>/dev/null || echo "bin/vg")
 
-${SUDO} timeout -k1 1h bash -c "vg giraffe -x '${GRAPH}.xg' -H '${GRAPH}.${GBWT}.gbwt' -g '${GRAPH}.${GBWT}.gg' -m '${GRAPH}.${GBWT}.min' -d '${GRAPH}.dist' -f './many-reads.fq.gz' -i -t '${THREAD_COUNT}' -p 2>log.txt >mapped.gam" || true
+timeout -k1 1h bash -c "${SUDO} ${VG} giraffe -x ${GRAPH}.xg -H ${GRAPH}.${GBWT}.gbwt -g ${GRAPH}.${GBWT}.gg -m ${GRAPH}.${GBWT}.min -d ${GRAPH}.dist -f ./many-reads.fq.gz -i -t ${THREAD_COUNT} -p 2>log.txt >mapped.gam" || true
+
+cat log.txt
 

--- a/scripts/giraffe-speed.sh
+++ b/scripts/giraffe-speed.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# giraffe-speed.sh: evaluate Giraffe mapping speed.
+# Suggested to run on an AWS
+# Partially based on https://github.com/vgteam/giraffe-sv-paper/blob/566573b708878d8854acb088a0a8f7c920b120eb/scripts/giraffe/speed_giraffe.sh
+set -e
+
+THREAD_COUNT=16
+
+#2million real reads
+READS=s3://vg-k8s/profiling/reads/real/NA19239/novaseq6000-ERR3239454-shuffled-1m.fq.gz
+
+# The HGSVC graph is smaller and faster to load so we use that here.
+GRAPH=hgsvc
+GRAPH_BASE=s3://vg-k8s/profiling/graphs/v2/for-NA19240/hgsvc/hs38d1/HGSVC_hs38d1
+# sampled.64 isn't much bigger than the base GBWT for HGSVC
+GBWT="sampled.64"
+
+function fetch() {
+    # Download a URL to a file, if it isn't there already
+    if [ ! -e "${2}" ] ; then
+        # For now we only do S3 URLs
+        aws s3 cp "${1}" "${2}"
+    fi
+}
+
+fetch "${READS}" "./reads.fq.gz"
+fetch "${GRAPH_BASE}.xg" "./${GRAPH}.xg"
+fetch "${GRAPH_BASE}.dist" "./${GRAPH}.dist"
+fetch "${GRAPH_BASE}.${GBWT}.gbwt" "./${GRAPH}.${GBWT}.gbwt"
+fetch "${GRAPH_BASE}.${GBWT}.gg" "./${GRAPH}.${GBWT}.gg"
+fetch "${GRAPH_BASE}.${GBWT}.min" "./${GRAPH}.${GBWT}.min"
+
+/usr/bin/time -v timeout -k1 1h bash -c "vg giraffe -x '${GRAPH}.xg' -H '${GRAPH}.${GBWT}.gbwt' -g '${GRAPH}.${GBWT}.gg' -m '${GRAPH}.${GBWT}.min' -d '${GRAPH}.dist' -f '${READS}.fq.gz' -i -t '${THREAD_COUNT}' -p 2>log.txt >mapped.gam" 2> time-log.txt || true
+

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1477,7 +1477,7 @@ int main_giraffe(int argc, char** argv) {
                 << " reads per second per thread" << endl;
             
             cerr << "Used " << cpu_seconds << " CPU-seconds (including output)." << endl;
-            cerr << "Mapping speed: " << reads_per_cpu_second
+            cerr << "Achieved " << reads_per_cpu_second
                 << " reads per CPU-second (including output)" << endl;
             
             if (total_instructions != 0) {

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1206,8 +1206,8 @@ int main_giraffe(int argc, char** argv) {
         // We also time in terms of CPU time
         clock_t cpu_time_before;
         
-        // We may also have access to perf stats
-        int perf_fd = 0;
+        // We may also have access to perf stats.
+        vector<int> perf_fds;
         
 #ifdef __linux__
         // Set up a counter for executed instructions.
@@ -1217,18 +1217,42 @@ int main_giraffe(int argc, char** argv) {
         perf_config.type = PERF_TYPE_HARDWARE;
         perf_config.size = sizeof(struct perf_event_attr);
         perf_config.config = PERF_COUNT_HW_INSTRUCTIONS;
-        // Start disabled
-        perf_config.disabled = 1;
         perf_config.exclude_kernel = 1;
         perf_config.exclude_hv = 1;
-        perf_fd = perf_event_open(&perf_config, 0, -1, -1, 0);
-        // TODO: check errno/strerror here. May not work if not root!
+        
+        perf_fds.resize(thread_count);
+        
+        perf_fds[omp_get_thread_num()] = perf_event_open(&perf_config, 0, -1, -1, 0);
+        if (show_progress && perf_fds[omp_get_thread_num()] == -1) {
+            int problem = errno;
+            cerr << "Not counting CPU instructions because perf events are unavailable: " << strerror(problem) << endl;
+            perf_fds.clear();
+        }
+        
+        // Each OMP thread will call this to make sure perf is on.
+        auto ensure_perf_for_thread = [&]() {
+            if (!perf_fds.empty() && perf_fds[omp_get_thread_num()] == 0) {
+                perf_fds[omp_get_thread_num()] = perf_event_open(&perf_config, 0, -1, -1, 0);
+            }
+        };
+        
+        // Main thread will call this to turn it off
+        auto stop_perf_for_thread = [&]() {
+            if (!perf_fds.empty() && perf_fds[omp_get_thread_num()] != 0) {
+                ioctl(perf_fds[omp_get_thread_num()], PERF_EVENT_IOC_DISABLE, 0);
+            }
+        };
+        
+        // Main thread will call this when mapping starts to reset the counter.
+        auto reset_perf_for_thread = [&]() {
+            if (!perf_fds.empty() && perf_fds[omp_get_thread_num()] != 0) {
+                ioctl(perf_fds[omp_get_thread_num()], PERF_EVENT_IOC_RESET, 0);
+            }
+        };
+        
+        // TODO: we won't count the output thread, but it will appear in CPU time!
 #endif
 
-
-        cerr << "Profiling with fd " << perf_fd << endl;
-        assert(perf_fd != 0 && paef_fd != -1);
-        
         {
         
             // Look up all the paths we might need to surject to.
@@ -1256,10 +1280,7 @@ int main_giraffe(int argc, char** argv) {
             cpu_time_before = clock();
             
 #ifdef __linux__
-            if (perf_fd) {
-                ioctl(perf_fd, PERF_EVENT_IOC_RESET, 0);
-                ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
-            }
+            reset_perf_for_thread();
 #endif
 
             if (interleaved || !fastq_filename_2.empty()) {
@@ -1300,6 +1321,9 @@ int main_giraffe(int argc, char** argv) {
                 
                 // Define how to align and output a read pair, in a thread.
                 auto map_read_pair = [&](Alignment& aln1, Alignment& aln2) {
+#ifdef __linux__
+                    ensure_perf_for_thread();
+#endif
                     
                     pair<vector<Alignment>, vector<Alignment>> mapped_pairs = minimizer_mapper.map_paired(aln1, aln2, ambiguous_pair_buffer);
                     if (!mapped_pairs.first.empty() && !mapped_pairs.second.empty()) {
@@ -1372,6 +1396,10 @@ int main_giraffe(int argc, char** argv) {
             
                 // Define how to align and output a read, in a thread.
                 auto map_read = [&](Alignment& aln) {
+#ifdef __linux__
+                    ensure_perf_for_thread();
+#endif
+                
                     // Map the read with the MinimizerMapper.
                     minimizer_mapper.map(aln, *alignment_emitter);
                     // Record that we mapped a read.
@@ -1398,9 +1426,7 @@ int main_giraffe(int argc, char** argv) {
         std::chrono::time_point<std::chrono::system_clock> end = std::chrono::system_clock::now();
         clock_t cpu_time_after = clock();
 #ifdef __linux__
-        if (perf_fd) {
-            ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0);
-        }
+        stop_perf_for_thread();
 #endif
         
         // Compute wall clock elapsed
@@ -1412,16 +1438,21 @@ int main_giraffe(int argc, char** argv) {
         
         // Compute instructions used
         long long total_instructions = 0;
-        if (perf_fd) {
-            if (read(perf_fd, &total_instructions, sizeof(long long)) != sizeof(long long)) {
-                // Read failed for some reason.
-                cerr << "Could not count instructions" << endl;
-                total_instructions = 0;
+        for (auto& perf_fd : perf_fds) {
+            if (perf_fd > 0) {
+                long long thread_instructions;
+                if (read(perf_fd, &thread_instructions, sizeof(long long)) != sizeof(long long)) {
+                    // Read failed for some reason.
+                    cerr << "warning:[vg giraffe] Could not count CPU instructions executed" << endl;
+                    thread_instructions = 0;
+                }
+                if (close(perf_fd)) {
+                    int problem = errno;
+                    cerr << "warning:[vg giraffe] Error closing perf event instruction counter: " << strerror(problem) << endl;
+                }
+                total_instructions += thread_instructions;
             }
-            close(perf_fd);
         }
-        
-        cerr << "Total instructions: " << total_instructions << endl;
         
         // How many reads did we map?
         size_t total_reads_mapped = 0;
@@ -1433,8 +1464,8 @@ int main_giraffe(int argc, char** argv) {
         double reads_per_second_per_thread = total_reads_mapped / (all_threads_seconds.count() * thread_count + first_thread_additional_seconds.count());
         // And per CPU second (including any IO threads)
         double reads_per_cpu_second = total_reads_mapped / cpu_seconds;
-        double instructions_per_read = total_instructions / (double)total_reads_mapped;
-        double instructions_per_second = total_instructions / cpu_seconds;
+        double mega_instructions_per_read = total_instructions / (double)total_reads_mapped / 1E6;
+        double mega_instructions_per_second = total_instructions / cpu_seconds / 1E6;
         
         if (show_progress) {
             // Log to standard error
@@ -1442,16 +1473,18 @@ int main_giraffe(int argc, char** argv) {
                 << thread_count << " threads in "
                 << all_threads_seconds.count() << " seconds with " 
                 << first_thread_additional_seconds.count() << " additional single-threaded seconds." << endl;
-            cerr << "Used " << cpu_seconds << " CPU-seconds." << endl;
-            
             cerr << "Mapping speed: " << reads_per_second_per_thread
                 << " reads per second per thread" << endl;
+            
+            cerr << "Used " << cpu_seconds << " CPU-seconds (including output)." << endl;
             cerr << "Mapping speed: " << reads_per_cpu_second
-                << " reads per CPU-second" << endl;
+                << " reads per CPU-second (including output)" << endl;
+            
             if (total_instructions != 0) {
-                cerr << "Mapping slowness: " << instructions_per_read
-                    << " instructions per read at " << instructions_per_second
-                    << " instructions per CPU-second" << endl;
+                cerr << "Used " << total_instructions << " CPU instructions (not including output)." << endl;
+                cerr << "Mapping slowness: " << mega_instructions_per_read
+                    << " M instructions per read at " << mega_instructions_per_second
+                    << " M mapping instructions per inclusive CPU-second" << endl;
             }
 
             cerr << "Memory footprint: " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB" << endl;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe self-profiling is improved and a standardized speed test script is included

## Description

This adds a script that @jmonlong wanted to test Giraffe speed. You can run it in a controlled environment and look at the reads per wall-clock second, or on GI Kubernetes and focus on the instructions per read.

Here's a Kubernetes pod template to get an environment to test in. I couldn't get the instruction counting to work on AWS (maybe it's their hypervisor/running on a shared multi-tenant machine?), but on Kubernetes instructions-per-read is very stable and might be the right performance metric to monitor for regressions. 

```
kubectl delete pod adamnovak-pod ; kubectl apply -f - <<'EOF'
apiVersion: v1
kind: Pod
metadata:
  name: adamnovak-pod
spec:
  containers:
  - name: anovak-container
    image: quay.io/vgteam/vg:YOUR_TAG_HERE
    imagePullPolicy: Always
    env:
    args: ["sleep", "infinity"]
    resources:
      limits:
        cpu: 16000m
        memory: "50Gi"
        ephemeral-storage: "100Gi"
    volumeMounts:
      - mountPath: /scratch
        name: scratch
      - mountPath: /root/.aws
        name: s3-credentials
  restartPolicy: Never
  volumes:
  - name: scratch
    emptyDir: {}
  - name: s3-credentials
    secret:
      secretName: shared-s3-credentials
  serviceAccountName: vg-svc
EOF
    
kubectl exec -ti adamnovak-pod -- /bin/bash
``` 

Then you can `scripts/giraffe-speed.sh`.