### PR TITLE
Add vg rna, mpmap, and autoindex to main pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,30 +327,38 @@ vg deconstruct x.xg -p x > x.vcf
 
 As with `vg call`, it is best to compute snarls separately and pass them in with `-r` when working with large graphs.
 
+### Transcriptomic analysis
+
+`vg` has a number of tools to support transcriptomic analyses with spliced graphs (i.e. graphs that have annotated splice junctions added as edges into the graph). These edges can be added into an existing graph using `vg rna`. We can then perform splice-aware mapping to these graphs using `vg mpmap`. `vg` developers have also made a tool for haplotype-aware transcript quantification based on these tools in [`rpvg`](https://github.com/jonassibbesen/rpvg). The easiest way to start this pipeline is to use the `vg autoindex` subcommand to make indexes for `vg mpmap`. `vg autoindex` creates indexes for mapping from common interchange formats like FASTA, VCF, and GTF. 
+
+More information is available in the [wiki page on transcriptomics](https://github.com/vgteam/vg/wiki/Transcriptomic-analyses).
+
 ### Command line interface
 
 A variety of commands are available:
 
+- *autoindex*: construct graphs and indexes for other tools from common interchange file formats
 - *construct*: graph construction
-- *view*: conversion (dot/protobuf/json/GFA)
 - *index*: index features of the graph in a disk-backed key/value store
-- *find*: use an index to find nodes, edges, kmers, or positions
-- *paths*: traverse paths in the graph
-- *align*: local alignment
-- *map*: global alignment (kmer-driven)
-- *stats*: metrics describing graph properties
-- *join*: combine graphs (parallel)
-- *concat*: combine graphs (serial)
-- *ids*: id manipulation
-- *kmers*: generate kmers from a graph
-- *sim*: simulate reads by walking paths in the graph
-- *mod*: various transformations of the graph
-- *surject*: force graph alignments into a linear reference space
-- *msga*: construct a graph from an assembly of multiple sequences
-- *validate*: determine if graph is valid
-- *filter*: filter reads out of an alignment
+- *map*: mapp reads to a graph
+- *giraffe*: fast, haplotype-based mapping of reads to a graph
+- *mpmap*: short read mapping and multipath alignment (optionally spliced)
+- *surject*: project graph alignments onto a linear reference
 - *augment*: adds variation from aligned reads into the graph
-- *call/genotype*: call variants from an augmented graph
+- *call*: call variants from an augmented graph
+- *rna*: spliced graph construction and indexing
+- *convert*: convert graph and alignment formats
+- *combine*: combine graphs
+- *chunk*: extract or break into subgraphs
+- *ids*: node ID manipulation
+- *sim*: simulate reads by walking paths in the graph
+- *prune*: prune graphs to restrict their path complexity
+- *snarls*: find bubble-like motifs in a graph
+- *mod*: various graph transformations
+- *filter*: filter reads out of an alignment
+- *deconstruct*: create a VCF from variation in the graph
+- *paths*: traverse paths in the graph
+- *stats*: metrics describing graph properties
 
 ## Implementation notes
 

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -431,4 +431,4 @@ int main_augment(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_augment("augment", "augment a graph from an alignment", PIPELINE, 5, main_augment);
+static Subcommand vg_augment("augment", "augment a graph from an alignment", PIPELINE, 8, main_augment);

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -315,5 +315,5 @@ int main_autoindex(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_autoindex("autoindex", "produce indexes for other subcommands", TOOLKIT, main_autoindex);
+static Subcommand vg_autoindex("autoindex", "mapping tool-oriented index construction from interchange formats", PIPELINE, 1, main_autoindex);
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -603,5 +603,5 @@ int main_call(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_call("call", "call or genotype VCF variants", PIPELINE, 7, main_call);
+static Subcommand vg_call("call", "call or genotype VCF variants", PIPELINE, 10, main_call);
 

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -332,5 +332,5 @@ int main_construct(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_construct("construct", "graph construction", PIPELINE, 1, main_construct);
+static Subcommand vg_construct("construct", "graph construction", PIPELINE, 2, main_construct);
 

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1387,4 +1387,4 @@ int main_giraffe(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_giraffe("giraffe", "fast haplotype-aware short read alignment", PIPELINE, 4, main_giraffe);
+static Subcommand vg_giraffe("giraffe", "fast haplotype-aware short read alignment", PIPELINE, 6, main_giraffe);

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -716,4 +716,4 @@ int main_index(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_construct("index", "index graphs or alignments for random access or mapping", PIPELINE, 2, main_index);
+static Subcommand vg_construct("index", "index graphs or alignments for random access or mapping", PIPELINE, 4, main_index);

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -1269,4 +1269,4 @@ int main_map(int argc, char** argv) {
 
 }
 
-static Subcommand vg_map("map", "MEM-based read alignment", PIPELINE, 3, main_map);
+static Subcommand vg_map("map", "MEM-based read alignment", PIPELINE, 5, main_map);

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -2249,6 +2249,6 @@ int main_mpmap(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_mpmap("mpmap", "multipath alignments of reads to a graph", main_mpmap);
+static Subcommand vg_mpmap("mpmap", "splice-aware multipath alignment of short reads", PIPELINE, 7, main_mpmap);
 
 

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -263,4 +263,4 @@ int main_pack(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_pack("pack", "convert alignments to a compact coverage index", PIPELINE, 6, main_pack);
+static Subcommand vg_pack("pack", "convert alignments to a compact coverage index", PIPELINE, 9, main_pack);

--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -420,5 +420,5 @@ int32_t main_rna(int32_t argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_rna("rna", "construct spliced variation graphs and transcript paths", main_rna);
+static Subcommand vg_rna("rna", "construct spliced variation graphs and transcript paths", PIPELINE, 3, main_rna);
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg rna`, `vg mpmap`, and `vg autoindex` now appear in the main pipeline in the help

## Description

I also added a transcriptomics section (very cursory) to the README and cleaned up the list of subcommands while I was in there.