### PR TITLE
Skip * allele variants ourselves

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -767,9 +767,17 @@ namespace vg {
                         last_edit_end = max(last_edit_end, bounds.second);
                     }
                 }
+                
+                if (skipped.size() == clump.size()) {
+                    // We skipped all the variants in the clump. Kick back up
+                    // to clump building.
+                    clump.clear();
+                    clump_end = 0;
+                    continue;
+                }
 
-                // We have to have some non-ref material in the clump, even if it
-                // occupies 0 reference space.
+                // Otherwise, we have to have some non-ref material in the
+                // clump, even if it occupies 0 reference space.
                 assert(last_edit_end != -1);
                 assert(first_edit_start != numeric_limits<int64_t>::max());
 

--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -511,10 +511,10 @@ namespace vg {
                 int64_t first_edit_start = numeric_limits<int64_t>::max();
                 int64_t last_edit_end = -1;
 
-                // We'll fill this with any duplicate variants that should be
-                // ignored, out of the clump. This is better than erasing out of a
+                // We'll fill this with any variants that should be ignored,
+                // out of the clump. This is better than erasing out of a
                 // vector.
-                set<vcflib::Variant*> duplicates;
+                set<vcflib::Variant*> skipped;
                 
                 for (size_t var_num = 0; var_num < clump.size(); var_num++) {
                     // For each variant in the clump
@@ -529,7 +529,10 @@ namespace vg {
                     // If variants have SVTYPE set, though, we will still use that info instead of the base-level sequence.
 
                     // Since we make the fasta reference uppercase, we do the VCF too (otherwise vcflib get mad)
+                    // We set this if we modify the variant and vcflib needs to reindex it.
                     bool reindex = false;
+                    // We set this if we skipped the variant
+                    bool skip_variant = false;
                     for (auto& alt : variant->alt) {
                         string upper_case_alt = toUppercase(alt);
                         if (alt != upper_case_alt) {
@@ -544,6 +547,18 @@ namespace vg {
                             swap(alt, upper_case_alt);
                             reindex = true;
                         }
+                        if (alt == "*") {
+                            // This is a newer VCF feature we don't support,
+                            // but not a broken file.
+                            #pragma omp critical (cerr)
+                            {
+                                cerr << "warning:[vg::Constructor] Unsupported allele \"*\" found in "
+                                     << "variant, skipping variant:\n" << *variant << endl;
+                            }
+                            skipped.insert(variant);
+                            skip_variant = true;
+                            break;
+                        }
                         if (!allATGCN(alt)) {
                             // We don't know what to do with gaps or IUPAC ambiguity codes, and
                             // we want to catch complete garbage.
@@ -554,6 +569,10 @@ namespace vg {
                                 exit(1);
                             }
                         }
+                    }
+                    if (skip_variant) {
+                        // Move to the next variant
+                        continue;
                     }
                     for (auto& allele : variant->alleles) {
                         allele = toUppercase(allele);
@@ -589,7 +608,7 @@ namespace vg {
                         #pragma omp critical (cerr)
                         cerr << "warning:[vg::Constructor] Skipping duplicate variant with hash " << variant_name
                             << " at " << variant->sequenceName << ":" << variant->position << endl;
-                        duplicates.insert(variant);
+                        skipped.insert(variant);
                         continue;
                     }
 
@@ -1192,7 +1211,7 @@ namespace vg {
                         if (alt_paths) {
                             for (vcflib::Variant* variant : clump) {
                                 // For each variant we might also be part of the ref allele of
-                                if (!duplicates.count(variant) &&
+                                if (!skipped.count(variant) &&
                                         variable_bounds.count(variant) &&
                                         reference_cursor >= variable_bounds[variant].first &&
                                         reference_cursor <= variable_bounds[variant].second) {

--- a/test/t/02_vg_construct.t
+++ b/test/t/02_vg_construct.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order 
 
-plan tests 28
+plan tests 29
 
 is $(vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz | vg stats -z - | grep nodes | cut -f 2) 210 "construction produces the right number of nodes"
 
@@ -106,9 +106,11 @@ is "$(vg construct -r sv/x.fa -v sv/x.inv.vcf -S | vg view - | sort | md5sum | c
 
 is "$(vg construct -r tiny/tiny.fa -v tiny/dots.vcf | vg mod -u - | vg stats -z - | grep nodes | cut -f2)" "1" "vg construct skips variants with . ALTs"
 
-vg construct -r small/x.fa -v small/x.v4.3.vcf.gz >x.vg
-is $? 1  "VCF with * alleles is rejected"
-rm -f x.vg
+vg construct -r small/x.fa -v small/x.v4.3.vcf.gz >x.vg 2>log.txt
+is $? 0  "VCF with * alleles is accepted"
+grep "skipping variant" log.txt >/dev/null
+is $? 0  "VCF record with * allele is rejected"
+rm -f x.vg log.txt
 
 vg construct -r tiny/ambiguous.fa >tiny.vg
 is $? 0 "Reference with ambiguity codes has them coerced to Ns"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * VCF files with `*` alleles are now accepted by `vg construct`, and only the particular variant records with `*` alleles are rejected and warned about

## Description

The unphased NYGC calls on high-coverage resequencing of the 1KG samples (and others) have `*` alleles, and I can't be bothered to pull them out and explain another preprocessing step in the manuscript.