### PR TITLE
Output phased vcf when deconstructing wtih GBWT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN apt-get -qq -y update && apt-get -qq -y upgrade && apt-get -qq -y install \
     libncurses5-dev automake libtool jq bsdmainutils bc rs parallel npm samtools curl \
     unzip redland-utils librdf-dev cmake pkg-config wget gtk-doc-tools raptor2-utils \
     rasqal-utils bison flex gawk libgoogle-perftools-dev liblz4-dev liblzma-dev \
-    libcairo2-dev libpixman-1-dev libffi-dev libcairo-dev libprotobuf-dev libboost-all-dev
+    libcairo2-dev libpixman-1-dev libffi-dev libcairo-dev libprotobuf-dev libboost-all-dev \
+    tabix bcftools
 ###DEPS_END###
 
 # Prepare to build submodule dependencies

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -236,19 +236,15 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
         set<int> used_phases;
         for (int i = sorted_travs.size() - 1; i >= 0 && most_frequent_travs.size() < sample_ploidy; --i) {
             int phase = gbwt_phases.at(sorted_travs.at(i));
-            if (phase >= 0) {
-                if (!used_phases.count(phase)) {
-                    most_frequent_travs.push_back(sorted_travs.at(i));
-                    used_phases.insert(phase);
-                    sorted_travs.at(i) = -1;
-                } else {
-                    phasing_conflict = true;
-                }
+            if (!used_phases.count(phase)) {
+                most_frequent_travs.push_back(sorted_travs.at(i));
+                used_phases.insert(phase);
+            } else {
+                phasing_conflict = true;
             }
         }
-    }
-    for (int i = sorted_travs.size() - 1; i >= 0 && most_frequent_travs.size() < sample_ploidy; --i) {
-        if (sorted_travs.at(i) != -1) {
+    } else {
+        for (int i = sorted_travs.size() - 1; i >= 0 && most_frequent_travs.size() < sample_ploidy; --i) {
             most_frequent_travs.push_back(sorted_travs.at(i));
         }
     }
@@ -275,8 +271,7 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
 
     // check if there's a conflict
     size_t zero_count = std::count(allele_frequencies.begin(), allele_frequencies.end(), 0);
-    bool conflict = phasing_conflict || allele_frequencies.size() - zero_count > sample_ploidy;
-
+    bool conflict = phasing_conflict || allele_frequencies.size() - zero_count > sample_ploidy;    
     return make_pair(most_frequent_travs, conflict);
 }
     

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -202,16 +202,13 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
             return true;
         } else if (allele_frequencies.at(trav_to_allele.at(trav1)) == allele_frequencies.at(trav_to_allele.at(trav2))) {
             // prefer non-ref when possible
-            if (trav_to_allele.at(trav1) == 0 && trav_to_allele.at(trav2) != 0) {
+            if (trav_to_allele.at(trav1) < trav_to_allele.at(trav2)) {
                 return true;
-            }
-            // or break tie using lex order on path name
-            else {
+            } else if (trav_to_allele.at(trav1) == trav_to_allele.at(trav2)) {
                 return trav_to_name.at(trav1) < trav_to_name.at(trav2);
             }
-        } else {
-            return false;
-        }
+        } 
+        return false;
     };
     vector<int> sorted_travs = travs;
     std::sort(sorted_travs.begin(), sorted_travs.end(), comp);

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -194,18 +194,18 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
     // count the number of times each allele comes up in a traversal
     vector<int> allele_frequencies(*max_element(trav_to_allele.begin(), trav_to_allele.end()) + 1, 0);
     for (auto trav : travs) {
-        ++allele_frequencies.at(trav_to_allele.at(trav));
+        ++allele_frequencies[trav_to_allele.at(trav)];
     }
     // sort on frquency
     function<bool(int, int)> comp = [&] (int trav1, int trav2) {
-        if (allele_frequencies.at(trav_to_allele.at(trav1)) < allele_frequencies.at(trav_to_allele.at(trav2))) {
+        if (allele_frequencies[trav_to_allele[trav1]] < allele_frequencies[trav_to_allele[trav2]]) {
             return true;
-        } else if (allele_frequencies.at(trav_to_allele.at(trav1)) == allele_frequencies.at(trav_to_allele.at(trav2))) {
+        } else if (allele_frequencies[trav_to_allele[trav1]] == allele_frequencies[trav_to_allele[trav2]]) {
             // prefer non-ref when possible
-            if (trav_to_allele.at(trav1) < trav_to_allele.at(trav2)) {
+            if (trav_to_allele[trav1] < trav_to_allele[trav2]) {
                 return true;
-            } else if (trav_to_allele.at(trav1) == trav_to_allele.at(trav2)) {
-                return trav_to_name.at(trav1) < trav_to_name.at(trav2);
+            } else if (trav_to_allele[trav1] == trav_to_allele[trav2]) {
+                return trav_to_name[trav1] < trav_to_name[trav2];
             }
         } 
         return false;
@@ -231,9 +231,9 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
         
         set<int> used_phases;
         for (int i = sorted_travs.size() - 1; i >= 0 && most_frequent_travs.size() < sample_ploidy; --i) {
-            int phase = gbwt_phases.at(sorted_travs.at(i));
+            int phase = gbwt_phases.at(sorted_travs[i]);
             if (!used_phases.count(phase)) {
-                most_frequent_travs.push_back(sorted_travs.at(i));
+                most_frequent_travs.push_back(sorted_travs[i]);
                 used_phases.insert(phase);
             } else {
                 phasing_conflict = true;
@@ -241,7 +241,7 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
         }
     } else {
         for (int i = sorted_travs.size() - 1; i >= 0 && most_frequent_travs.size() < sample_ploidy; --i) {
-            most_frequent_travs.push_back(sorted_travs.at(i));
+            most_frequent_travs.push_back(sorted_travs[i]);
         }
     }
 

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -53,14 +53,16 @@ private:
                             char prev_char, bool use_start);
 
     // write traversal path names as genotypes
-    void get_genotypes(vcflib::Variant& v, const vector<string>& names, const vector<int>& trav_to_allele);
+    void get_genotypes(vcflib::Variant& v, const vector<string>& names, const vector<int>& trav_to_allele,
+                       const vector<gbwt::size_type>& trav_thread_ids);
 
     // given a set of traversals associated with a particular sample, select a set of size <ploidy> for the VCF
     // the highest-frequency ALT traversal is chosen
     // the bool returned is true if multiple traversals map to different alleles, more than ploidy.
-    pair<vector<int>, bool> choose_traversals(const vector<int>& travs, const vector<int>& trav_to_allele,
-                                              const vector<string>& trav_to_name);
-
+    pair<vector<int>, bool> choose_traversals(const string& sample_name,
+                                              const vector<int>& travs, const vector<int>& trav_to_allele,
+                                              const vector<string>& trav_to_name,
+                                              const vector<int>& gbwt_phases);
 
     // check to see if a snarl is too big to exhaustively traverse
     bool check_max_nodes(const Snarl* snarl);
@@ -101,6 +103,8 @@ private:
     // which makes the lru cache fairly effective
     size_t lru_size = 10; 
     vector<LRUCache<gbwt::size_type, shared_ptr<unordered_map<handle_t, size_t>>>*> gbwt_pos_caches;
+    // infer ploidys from gbwt when possible
+    unordered_map<string, pair<int, int>> gbwt_sample_to_phase_range;
 
     // the ref paths
     set<string> ref_paths;

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -321,6 +321,16 @@ std::string thread_sample(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
     return stream.str();
 }
 
+int thread_phase(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
+    if (!gbwt_index.hasMetadata() || !gbwt_index.metadata.hasPathNames() || id >= gbwt_index.metadata.paths()) {
+        return -1;
+    }
+    
+    const gbwt::PathName& path = gbwt_index.metadata.path(id);
+    return path.phase;
+}
+
+
 //------------------------------------------------------------------------------
 
 gbwt::GBWT get_gbwt(const std::vector<gbwt::vector_type>& paths) {

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -151,6 +151,10 @@ std::string thread_name(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
 /// NOTE: id is a gbwt path id, not a gbwt sequence id.
 std::string thread_sample(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
 
+/// Get phase of a thread stored in GBWT metadata.
+/// NOTE: id is a gbwt path id, not a gbwt sequence id.
+int thread_phase(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
+
 //------------------------------------------------------------------------------
 
 /// Transform the paths into a GBWT index. Primarily for testing.

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -28,8 +28,8 @@ void help_deconstruct(char** argv){
          << "Outputs VCF records for Snarls present in a graph (relative to a chosen reference path)." << endl
          << "options: " << endl
          << "    -p, --path NAME          A reference path to deconstruct against (multiple allowed)." << endl
-         << "    -P, --path-prefix NAME   All paths beginning with NAME used as reference (multiple allowed)." << endl
-         << "    -A, --alt-prefix NAME    Non-reference paths beginning with NAME get lumped together to same sample in VCF (multiple allowed)." << endl
+         << "    -P, --path-prefix NAME   All paths (and/or GBWT threads) beginning with NAME used as reference (multiple allowed)." << endl
+         << "    -A, --alt-prefix NAME    Non-reference paths (and/or GBWT threads) beginning with NAME get lumped together to same sample in VCF (multiple allowed)." << endl
          << "                             Other non-ref paths not considered as samples.  When using a GBWT, select only samples with given prefix." << endl
          << "    -r, --snarls FILE        Snarls file (from vg snarls) to avoid recomputing." << endl
          << "    -g, --gbwt FILE          only consider alt traversals that correspond to GBWT threads FILE." << endl
@@ -156,11 +156,29 @@ int main_deconstruct(int argc, char** argv){
     bdsg::PathPositionOverlayHelper overlay_helper;
     PathPositionHandleGraph* graph = overlay_helper.apply(path_handle_graph.get());
 
-    // Check our paths
-    for (const string& ref_path : refpaths) {
-        if (!graph->has_path(ref_path)) {
-            cerr << "error [vg call]: Reference path \"" << ref_path << "\" not found in graph" << endl;
+    // Read the GBWT
+    unique_ptr<gbwt::GBWT> gbwt_index;
+    if (!gbwt_file_name.empty()) {
+        gbwt_index = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_file_name);
+        if (gbwt_index.get() == nullptr) {
+            cerr << "Error [vg deconstruct]: Unable to load gbwt index file: " << gbwt_file_name << endl;
             return 1;
+        }
+    }
+
+    if (!refpaths.empty()) {
+        unordered_set<string> gbwt_paths;
+        if (gbwt_index.get()) {
+            for (size_t i = 0; i < gbwt_index->metadata.paths(); i++) {
+                gbwt_paths.insert(thread_name(*gbwt_index, i));
+            }
+        }
+        // Check our paths
+        for (const string& ref_path : refpaths) {
+            if (!graph->has_path(ref_path) && !gbwt_paths.count(ref_path)) {
+                cerr << "error [vg deconstruct]: Reference path \"" << ref_path << "\" not found in graph/gbwt" << endl;
+                return 1;
+            }
         }
     }
     
@@ -172,6 +190,12 @@ int main_deconstruct(int argc, char** argv){
                     refpaths.push_back(name);
                 }
             });
+        // Add GBWT threads if no reference paths found or we're running with -a
+        if (gbwt_index.get() && (all_snarls || refpaths.empty())) {
+            for (size_t i = 0; i < gbwt_index->metadata.paths(); i++) {
+                refpaths.push_back(thread_name(*gbwt_index, i));
+            }            
+        }
     }
 
     // Read the translation
@@ -206,15 +230,6 @@ int main_deconstruct(int argc, char** argv){
         snarl_manager = unique_ptr<SnarlManager>(new SnarlManager(std::move(finder.find_snarls_parallel())));
     }
 
-    unique_ptr<gbwt::GBWT> gbwt_index;
-    if (!gbwt_file_name.empty()) {
-        gbwt_index = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_file_name);
-        if (gbwt_index.get() == nullptr) {
-            cerr << "Error [vg deconstruct]: Unable to load gbwt index file: " << gbwt_file_name << endl;
-            return 1;
-        }
-    }
-
     // We use this to map, for example, from chromosome to genome (eg S288C.chrXVI --> S288C)
     unordered_map<string, string> alt_path_to_prefix;
     
@@ -238,6 +253,18 @@ int main_deconstruct(int argc, char** argv){
                     }
                 }
             });
+        if (gbwt_index.get()) {
+            for (size_t i = 0; i < gbwt_index->metadata.paths(); i++) {
+                std::string path_name = thread_name(*gbwt_index, i);
+                for (auto& prefix : refpath_prefixes) {
+                    if (path_name.compare(0, prefix.size(), prefix) == 0) {
+                        refpaths.push_back(path_name);
+                        break;
+                    }
+                }
+            }
+        }            
+
         if (gbwt_index.get() && !altpath_prefixes.empty()) {
             for (size_t i = 0; i < gbwt_index->metadata.paths(); i++) {
                 string sample_name = thread_sample(*gbwt_index.get(), i);
@@ -250,13 +277,7 @@ int main_deconstruct(int argc, char** argv){
         }
     }
 
-    // make sure we have at least one reference
-    bool found_refpath = false;
-    for (size_t i = 0; i < refpaths.size() && !found_refpath; ++i) {
-        found_refpath = found_refpath || graph->has_path(refpaths[i]);
-    }
-
-    if (!found_refpath) {
+    if (refpaths.empty()) {
         cerr << "Error [vg deconstruct]: No specified reference path or prefix found in graph" << endl;
         return 1;
     }

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3369,7 +3369,7 @@ GBWTTraversalFinder::~GBWTTraversalFinder() {
 }
 
 pair<vector<SnarlTraversal>, vector<vector<gbwt::size_type>>>
-GBWTTraversalFinder::find_path_traversals(const Snarl& site, bool return_paths) {
+GBWTTraversalFinder::find_gbwt_traversals(const Snarl& site, bool return_paths) {
     
     // follow all gbwt threads from start to end
     vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > forward_traversals = get_spanning_haplotypes(
@@ -3451,26 +3451,25 @@ GBWTTraversalFinder::find_path_traversals(const Snarl& site, bool return_paths) 
 }
 
 vector<SnarlTraversal> GBWTTraversalFinder::find_traversals(const Snarl& site) {
-    return find_path_traversals(site, false).first;
+    return find_gbwt_traversals(site, false).first;
 }
 
-pair<vector<SnarlTraversal>, vector<string>> GBWTTraversalFinder::find_sample_traversals(const Snarl& site) {
+pair<vector<SnarlTraversal>, vector<gbwt::size_type>> GBWTTraversalFinder::find_path_traversals(const Snarl& site) {
     // get the unique traversals
-    pair<vector<SnarlTraversal>, vector<vector<gbwt::size_type>>> path_traversals = find_path_traversals(site, true);
+    pair<vector<SnarlTraversal>, vector<vector<gbwt::size_type>>> gbwt_traversals = find_gbwt_traversals(site, true);
 
     // expand them out to one per path (this is to be consistent with PathTraversalFinder as used in deconstruct)
-    pair<vector<SnarlTraversal>, vector<string>> sample_traversals;
-    for (size_t i = 0; i < path_traversals.first.size(); ++i) {
-        SnarlTraversal& trav = path_traversals.first[i];
-        vector<gbwt::size_type>& paths = path_traversals.second[i];
+    pair<vector<SnarlTraversal>, vector<gbwt::size_type>> path_traversals;
+    for (size_t i = 0; i < gbwt_traversals.first.size(); ++i) {
+        SnarlTraversal& trav = gbwt_traversals.first[i];
+        vector<gbwt::size_type>& paths = gbwt_traversals.second[i];
         for (size_t j = 0; j < paths.size(); ++j) {
-            string sample = thread_sample(gbwt, gbwt::Path::id(paths[j]));
-            sample_traversals.first.push_back(trav);
-            sample_traversals.second.push_back(sample);
+            path_traversals.first.push_back(trav);
+            path_traversals.second.push_back(paths[j]);
         }
     }
     
-    return sample_traversals;
+    return path_traversals;
 }
 
 vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > GBWTTraversalFinder::get_spanning_haplotypes(handle_t start, handle_t end) {

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -631,16 +631,19 @@ public:
      */
     virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
 
-    /** Return the traversals, paired with their path ids in the gbwt.  The traversals are 
+    /** Return the traversals, paired with their path identifiers in the gbwt.  The traversals are 
      *  unique, but there can be more than one path along each one (hence the vector)
      */
     virtual pair<vector<SnarlTraversal>, vector<vector<gbwt::size_type>>>
-    find_path_traversals(const Snarl& site, bool return_paths = true);
+    find_gbwt_traversals(const Snarl& site, bool return_paths = true);
 
-    /** Return traversals paired with sample names from the GBWT.  The traversals are *not* unique
+    /** Return traversals paired with path identifiers from the GBWT.  The traversals are *not* unique
      * (which is consistent with PathTraversalFinder)
+     * To get the sample name from the path identifier id, use thread_sample(gbwt, gbwt::Path::id(id));
      */
-    virtual pair<vector<SnarlTraversal>, vector<string>> find_sample_traversals(const Snarl& site);
+    virtual pair<vector<SnarlTraversal>, vector<gbwt::size_type>> find_path_traversals(const Snarl& site);
+
+    const gbwt::GBWT& get_gbwt() { return gbwt; }
     
 protected:
 

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 20
+plan tests 21
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
 vg index tiny.vg -x tiny.xg
@@ -127,8 +127,17 @@ rm -f tiny_names.gfa tiny_names.vg tiny_names.xg tiny_names_decon.vcf tiny_names
 
 vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
 vg index -x x.xg -G x.gbwt -v small/x.vcf.gz x.vg
-vg deconstruct x.xg -g x.gbwt > x.decon.vcf
-# todo: something better
-is $(cat x.decon.vcf | grep ^x | wc -l) 70 "gbwt deconstruct makes reasonable sized output"
+vg deconstruct x.xg -g x.gbwt | bgzip > x.decon.vcf.gz
+tabix -f -p vcf  x.decon.vcf.gz
+cat small/x.fa |  bcftools consensus small/x.vcf.gz -s 1 -H 1 > small.s1.h1.fa
+cat small/x.fa |  bcftools consensus small/x.vcf.gz -s 1 -H 2 > small.s1.h2.fa
+cat small/x.fa |  bcftools consensus x.decon.vcf.gz -s 1 -H 1 > decon.s1.h1.fa
+cat small/x.fa |  bcftools consensus x.decon.vcf.gz -s 1 -H 2 > decon.s1.h2.fa
+diff small.s1.h1.fa decon.s1.h1.fa
+is "$?" 0 "haplotype 1 preserved when deconstructing small test with gbwt"
+diff small.s1.h2.fa decon.s1.h2.fa
+is "$?" 0 "haplotype 2 preserved when deconstructing small test with gbwt"
+
+rm -f x.vg x.xg x.gbwt x.decon.vcf.gz x.decon.vcf.gz.tbi small.s1.h1.fa small.s1.h2.fa decon.s1.h1.fa decon.s1.h2.fa
 
 


### PR DESCRIPTION
There's no excuse not to output phasing information with `vg deconstruct -g`, especially as we have the haplotype number stored in the GBWT metadata. 

This PR also adds support for off-reference sites (so bubbles inside insertions can be output in the coordinates of a contig that spans the bubble).  I think there's probably some work needed on this interface for this, but it's a start. 
