### PR TITLE
Update fermi-lite

### DIFF
--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -578,7 +578,7 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
             config.segment_translation = optarg;
             break;
 
-        // Input GBWT construction: paths
+        // Input GBWT construction: Paths
         case 'E':
             assert(config.build == GBWTConfig::build_none);
             config.build = GBWTConfig::build_paths;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

## Description

Update fermi-lite to allow compiling on GCC 10. This should fix #3242.