### PR TITLE
WIP: Native GFA I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ cp small/x-s1337-n1.gam x.gam
 vg view -a x.gam >x.json
 ```
 
+`vg convert` provides further graph conversion options.
+
+Note that `vg` tools can generally read all supported graph formats (VG, uncompressed GFA, XG, PackedGraph, HashGraph) interchangeably, so conversion is not required.  One exception is tools that modify graphs (ex `vg mod`) will not accept the read-only XG format. Tools that ask for XG input specifically with `-x` (ex `vg map`, `vg find`) will run on any graph type, but will be faster on XG.
+
+The format of a given graph file can be retrieved with `vg stats -F`.
+
 ### Alignment
 
 As this is a small graph, you could align to it using a full-length partial order alignment:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ vg view -a x.gam >x.json
 
 Note that `vg` tools can generally read all supported graph formats (VG, uncompressed GFA, XG, PackedGraph, HashGraph) interchangeably, so conversion is not required.  One exception is tools that modify graphs (ex `vg mod`) will not accept the read-only XG format. Tools that ask for XG input specifically with `-x` (ex `vg map`, `vg find`) will run on any graph type, but will be faster on XG.
 
-The format of a given graph file can be retrieved with `vg stats -F`.
+The format of a given graph file can be retrieved with `vg stats -F`. 
 
 ### Alignment
 

--- a/src/algorithms/gfa_to_handle.hpp
+++ b/src/algorithms/gfa_to_handle.hpp
@@ -54,6 +54,24 @@ void gfa_to_path_handle_graph_in_memory(istream& in,
                                         MutablePathMutableHandleGraph* graph,
                                         int64_t max_rgfa_rank = numeric_limits<int64_t>::max());
 
+/// Operate on a stream line by line.  This can only work if the GFA is sorted.  If the GFA isn't
+/// sorted, dump it to a temp file, and fall back on gfa_to_path_handle_graph()
+void gfa_to_path_handle_graph_stream(istream& in,
+                                     MutablePathMutableHandleGraph* graph,
+                                     int64_t max_rgfa_rank = numeric_limits<int64_t>::max());
+
+
+/// gfakluge can't parse line by line, which we need for streaming
+/// ideally, it needs to be entirely replaced.  here's a bare minimum for parsing lines
+/// in the meantime.  they return the fields as strings, don't support overlaps, and
+/// optional tags get read as strings in the vectors. 
+tuple<string, string, vector<string>> parse_gfa_s_line(const string& s_line);
+tuple<string, bool, string, bool, vector<string>> parse_gfa_l_line(const string& l_line);
+/// visit_step takes {path-name, rank (-1 if path empty), step id, step reversed}
+/// and returns true if it wants to keep iterating (false means stop)
+void parse_gfa_p_line(const string& p_line,
+                      function<bool(const string&, int64_t, const string&, bool)> visit_step);
+
 
 }
 }

--- a/src/io/register_libvg_io.cpp
+++ b/src/io/register_libvg_io.cpp
@@ -18,6 +18,7 @@
 #include "register_loader_saver_packed_graph.hpp"
 #include "register_loader_saver_hash_graph.hpp"
 #include "register_loader_saver_odgi.hpp"
+#include "register_loader_saver_gfa.hpp"
 
 #include "register_libvg_io.hpp"
 
@@ -38,6 +39,7 @@ bool register_libvg_io() {
     register_loader_saver_minimizer();
     register_loader_saver_snarl_manager();
     register_loader_saver_vg();
+    register_loader_saver_gfa();
     register_loader_saver_xg();
     register_loader_saver_packed_graph();
     register_loader_saver_hash_graph();

--- a/src/io/register_loader_saver_gfa.cpp
+++ b/src/io/register_loader_saver_gfa.cpp
@@ -96,7 +96,7 @@ void register_loader_saver_gfa() {
         bdsg::PackedGraph* packed_graph = new bdsg::PackedGraph();
         
         // Load it
-        algorithms::gfa_to_path_handle_graph_in_memory(input, packed_graph);
+        algorithms::gfa_to_path_handle_graph_stream(input, packed_graph);
         
         // Return it so the caller owns it.
         return (void*) packed_graph;

--- a/src/io/register_loader_saver_gfa.cpp
+++ b/src/io/register_loader_saver_gfa.cpp
@@ -1,0 +1,113 @@
+/**
+ * \file register_loader_saver_gfa.cpp
+ */
+
+#include <vg/io/registry.hpp>
+#include "register_loader_saver_gfa.hpp"
+#include "algorithms/gfa_to_handle.hpp"
+#include "gfa.hpp"
+
+#include "handle.hpp"
+#include "bdsg/packed_graph.hpp"
+
+
+namespace vg {
+
+namespace io {
+
+using namespace std;
+using namespace vg::io;
+
+// derived from Registry::sniff_magic() in libvgio/src/registry.cpp
+// note that we have a limited number of characters to work with so
+// there's no way to do something extremely precise or general.
+// this only works when we can seek around a little bet, which the calling
+// logic in libvgio verifies...
+static bool sniff_gfa(istream& stream) {
+    if (!stream) {
+        // Can't read anything, so obviously it can't match.
+        return false;
+    }
+    
+    // Work out how many characters to try and sniff.
+    // We require that our C++ STL can do this much ungetting, even though the
+    // standard guarantees absolutely no ungetting.
+    const size_t to_sniff = 8;
+    
+    // Allocate a buffer
+    char buffer[to_sniff];
+    // Have a cursor in the buffer
+    size_t buffer_used = 0;
+
+    while (stream.peek() != EOF && buffer_used < to_sniff) {
+        // Until we fill the buffer or would hit EOF, fill the buffer
+        buffer[buffer_used] = (char) stream.get();
+        buffer_used++;
+    }
+
+    for (size_t i = 0; i < buffer_used; i++) {
+        // Now unget all the characters again.
+        // C++11 says we can unget from EOF.
+        stream.unget();
+        if (!stream) {
+            // We did something the stream disliked.
+            throw runtime_error("Ungetting failed after " + to_string(i) + " characters");
+        }
+    }
+    
+    // Now all the characters are back in the stream.
+    
+    if (!stream) {
+        // We reached EOF when sniffing the magic. We managed to unget
+        // everything (maybe the file is empty). But we need to clear errors on
+        // the stream so it is like it was when we started.
+        stream.clear();
+    }
+
+    if (buffer_used < 2) {
+        // Todo: GFAs can be empty -- may want to return true for empty files?
+        // As it stands, we require "H\n" at the very least.
+        return false;
+    }
+
+    // We are not accepting leading whitespaces.  There is no way to do this generally
+    // with our limited buffer.  Also, this check is not bulletproof, so best to sniff gfas
+    // as a last resort.
+
+    // Check for a header line
+    if (buffer[0] == 'H' &&
+        (buffer[1] == '\n' ||
+         (buffer[1] == '\t' && buffer_used >= 8 && strncmp(buffer + 2, "VN:Z:", 5) == 0))) {
+        return true;
+    }
+
+    // Check for any other type of line, looking for a <record type> <TAB> <printable char>
+    if ((buffer[0] == 'S' || buffer[0] == 'L' || buffer[0] == 'P' || buffer[0] == 'W') &&
+        buffer[1] == '\t' && buffer_used > 3 && isprint(buffer[2])) {
+        return true;
+    }
+    
+    return false;
+}
+
+void register_loader_saver_gfa() {
+    Registry::register_bare_loader_saver_with_header_check<bdsg::PackedGraph, MutablePathDeletableHandleGraph, MutablePathMutableHandleGraph, MutableHandleGraph, PathHandleGraph, HandleGraph>("GFA", sniff_gfa, [](istream& input) -> void* {
+        // Allocate a PackedGraph
+        bdsg::PackedGraph* packed_graph = new bdsg::PackedGraph();
+        
+        // Load it
+        algorithms::gfa_to_path_handle_graph_in_memory(input, packed_graph);
+        
+        // Return it so the caller owns it.
+        return (void*) packed_graph;
+    }, [](const void* packed_graph_void, ostream& output) {
+        // Cast to PackedGraph and serialize to the stream.
+        assert(packed_graph_void != nullptr);
+        graph_to_gfa((const bdsg::PackedGraph*)packed_graph_void, output);
+    });
+}
+
+}
+
+}
+

--- a/src/io/register_loader_saver_gfa.hpp
+++ b/src/io/register_loader_saver_gfa.hpp
@@ -1,0 +1,22 @@
+#ifndef VG_IO_REGISTER_LOADER_SAVER_GFA_HPP_INCLUDED
+#define VG_IO_REGISTER_LOADER_SAVER_GFA_HPP_INCLUDED
+
+/**
+ * \file register_loader_saver_gfa.hpp
+ * Defines IO for a graph in GFA format.  It's best if the GFA is "canonical"
+ * with S lines before L lines before P lines.
+ */
+
+namespace vg {
+
+namespace io {
+
+using namespace std;
+
+void register_loader_saver_gfa();
+
+}
+
+}
+
+#endif

--- a/src/io/save_handle_graph.hpp
+++ b/src/io/save_handle_graph.hpp
@@ -14,7 +14,7 @@
 #include "xg.hpp"
 #include <vg/io/stream.hpp>
 #include <vg/io/vpkg.hpp>
-
+#include "gfa.hpp"
 #include <memory>
 
 namespace vg {
@@ -39,7 +39,7 @@ inline void save_handle_graph(HandleGraph* graph, ostream& os) {
 
     if (dynamic_cast<GFAHandleGraph*>(graph) != nullptr) {
         // We loaded a GFA into a handle graph, want to write back to GFA
-        vg::io::VPKG::save(*dynamic_cast<GFAHandleGraph*>(graph), os);
+        graph_to_gfa(dynamic_cast<GFAHandleGraph*>(graph), os);
     } else if (dynamic_cast<SerializableHandleGraph*>(graph) != nullptr) {
         // SerializableHandleGraphs are all serialized bare, without VPKG framing, for libbdsg compatibility.
         dynamic_cast<SerializableHandleGraph*>(graph)->serialize(os);
@@ -54,7 +54,11 @@ inline void save_handle_graph(HandleGraph* graph, ostream& os) {
 inline void save_handle_graph(HandleGraph* graph, const string& dest_path) {
     if (dynamic_cast<GFAHandleGraph*>(graph) != nullptr) {
         // We loaded a GFA into a handle graph, want to write back to GFA
-        vg::io::VPKG::save(*dynamic_cast<GFAHandleGraph*>(graph), dest_path);
+        ofstream os(dest_path);
+        if (!os) {
+            throw runtime_error("error[save_handle_graph]: Unable to write to: " + dest_path);
+        }
+        graph_to_gfa(dynamic_cast<GFAHandleGraph*>(graph), os);
     } else if (dynamic_cast<SerializableHandleGraph*>(graph) != nullptr) {
         // SerializableHandleGraphs are all serialized bare, without VPKG framing, for libbdsg compatibility.
         dynamic_cast<SerializableHandleGraph*>(graph)->serialize(dest_path);

--- a/src/io/save_handle_graph.hpp
+++ b/src/io/save_handle_graph.hpp
@@ -72,7 +72,7 @@ inline void save_handle_graph(HandleGraph* graph, const string& dest_path) {
 
 // Check that output format specifier is a valid graph type
 inline bool valid_output_format(const string& fmt_string) {
-    return fmt_string == "vg" || fmt_string == "pg" || fmt_string == "hg";
+    return fmt_string == "vg" || fmt_string == "pg" || fmt_string == "hg" || fmt_string == "gfa";
 }
 
 // Create a new graph (of handle graph type T) where the implementation is chosen using the format string
@@ -84,6 +84,8 @@ unique_ptr<T> new_output_graph(const string& fmt_string) {
         return make_unique<bdsg::PackedGraph>();
     } else if (fmt_string == "hg") {
         return make_unique<bdsg::HashGraph>();
+    } else if (fmt_string == "gfa") {
+        return make_unique<GFAHandleGraph>();
     } else {
         return unique_ptr<T>();
     }

--- a/src/io/save_handle_graph.hpp
+++ b/src/io/save_handle_graph.hpp
@@ -19,6 +19,13 @@
 
 namespace vg {
 
+/// Use to load in GFAs and remember where they came from
+class GFAHandleGraph : public bdsg::PackedGraph {
+public:
+   GFAHandleGraph() : bdsg::PackedGraph() {}
+   virtual ~GFAHandleGraph() = default;
+};
+
 namespace io {
 
 using namespace std;
@@ -29,8 +36,11 @@ using namespace std;
  * Todo: should this be somewhere else (ie in vgio with new types registered?)
  */
 inline void save_handle_graph(HandleGraph* graph, ostream& os) {
-    
-    if (dynamic_cast<SerializableHandleGraph*>(graph) != nullptr) {
+
+    if (dynamic_cast<GFAHandleGraph*>(graph) != nullptr) {
+        // We loaded a GFA into a handle graph, want to write back to GFA
+        vg::io::VPKG::save(*dynamic_cast<GFAHandleGraph*>(graph), os);
+    } else if (dynamic_cast<SerializableHandleGraph*>(graph) != nullptr) {
         // SerializableHandleGraphs are all serialized bare, without VPKG framing, for libbdsg compatibility.
         dynamic_cast<SerializableHandleGraph*>(graph)->serialize(os);
     } else if (dynamic_cast<VG*>(graph) != nullptr) {
@@ -42,7 +52,10 @@ inline void save_handle_graph(HandleGraph* graph, ostream& os) {
 }
 
 inline void save_handle_graph(HandleGraph* graph, const string& dest_path) {
-    if (dynamic_cast<SerializableHandleGraph*>(graph) != nullptr) {
+    if (dynamic_cast<GFAHandleGraph*>(graph) != nullptr) {
+        // We loaded a GFA into a handle graph, want to write back to GFA
+        vg::io::VPKG::save(*dynamic_cast<GFAHandleGraph*>(graph), dest_path);
+    } else if (dynamic_cast<SerializableHandleGraph*>(graph) != nullptr) {
         // SerializableHandleGraphs are all serialized bare, without VPKG framing, for libbdsg compatibility.
         dynamic_cast<SerializableHandleGraph*>(graph)->serialize(dest_path);
     } else if (dynamic_cast<VG*>(graph) != nullptr) {

--- a/src/subcommand/add_main.cpp
+++ b/src/subcommand/add_main.cpp
@@ -164,11 +164,10 @@ int main_add(int argc, char** argv) {
     }
     
     // Load the graph
-    
+
     unique_ptr<handlegraph::MutablePathDeletableHandleGraph> graph;
-    get_input_file(optind, argc, argv, [&](istream& in) {
-        graph = vg::io::VPKG::load_one<handlegraph::MutablePathDeletableHandleGraph>(in);
-    });
+    string graph_filename = get_input_file_name(optind, argc, argv);
+    graph = vg::io::VPKG::load_one<handlegraph::MutablePathDeletableHandleGraph>(graph_filename);
     
     VG* vg_graph = dynamic_cast<vg::VG*>(graph.get());
     

--- a/src/subcommand/align_main.cpp
+++ b/src/subcommand/align_main.cpp
@@ -181,9 +181,8 @@ int main_align(int argc, char** argv) {
     if (ref_seq.empty()) {
         // Only look at a filename if we don't have an explicit reference
         // sequence.
-        get_input_file(optind, argc, argv, [&](istream& in) {
-            graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
-        });
+        string graph_filename = get_input_file_name(optind, argc, argv);
+        graph = vg::io::VPKG::load_one<PathHandleGraph>(graph_filename);
     }
 
     ifstream matrix_stream;

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -190,11 +190,9 @@ int main_annotate(int argc, char** argv) {
     bdsg::PathPositionOverlayHelper overlay_helper;
 
     if (!xg_name.empty()) {
-        get_input_file(xg_name, [&](istream& in) {
-            // Read in the XG index
-            path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
-            xg_index = overlay_helper.apply(path_handle_graph.get());
-        });
+        // Read in the XG index
+        path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);
+        xg_index = overlay_helper.apply(path_handle_graph.get());
     } else {
         cerr << "error [vg annotate]: no xg index provided" << endl;
         return 1;

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -280,9 +280,7 @@ int main_augment(int argc, char** argv) {
 
     // Read the graph
     unique_ptr<MutablePathMutableHandleGraph> graph;
-    get_input_file(graph_file_name, [&](istream& in) {
-            graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(in);
-        });
+    graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(graph_file_name);
     VG* vg_graph = dynamic_cast<VG*>(graph.get());
     HandleGraph* vectorizable_graph = nullptr;
     unique_ptr<Packer> packer;

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -303,9 +303,8 @@ int main_call(int argc, char** argv) {
     
     // Read the graph
     unique_ptr<PathHandleGraph> path_handle_graph;
-    get_input_file(optind, argc, argv, [&](istream& in) {
-            path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
-        });
+    string graph_filename = get_input_file_name(optind, argc, argv);
+    path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(graph_filename);
     PathHandleGraph* graph = path_handle_graph.get();
 
     // Apply overlays as necessary

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -314,8 +314,9 @@ int main_chunk(int argc, char** argv) {
             cerr << "error:[vg chunk] unable to load graph / xg index file " << xg_file << endl;
             return 1;
         }
+        in.close();
         
-        path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
+        path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_file);
         graph = overlay_helper.apply(path_handle_graph.get());
         in.close();
     }

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -72,7 +72,7 @@ void help_chunk(char** argv) {
          << "    -T, --trace              trace haplotype threads in chunks (and only expand forward from input coordinates)." << endl
          << "                             Produces a .annotate.txt file with haplotype frequencies for each chunk." << endl 
          << "    -f, --fully-contained    only return GAM alignments that are fully contained within chunk" << endl
-         << "    -O, --output-fmt         Specify output format (vg, pg, hg).  [VG]" << endl
+         << "    -O, --output-fmt         Specify output format (vg, pg, hg, gfa).  [VG]" << endl
          << "    -t, --threads N          for tasks that can be done in parallel, use this many threads [1]" << endl
          << "    -h, --help" << endl;
 }

--- a/src/subcommand/combine_main.cpp
+++ b/src/subcommand/combine_main.cpp
@@ -94,17 +94,15 @@ int main_combine(int argc, char** argv) {
     }
     
     unique_ptr<MutablePathMutableHandleGraph> first_graph;
-    get_input_file(optind, argc, argv, [&](istream& in) {
-            first_graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(in);
-        });
+    string first_graph_filename = get_input_file_name(optind, argc, argv);
+    first_graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(first_graph_filename);
     int64_t max_node_id = first_graph->max_node_id();
 
     while (optind < argc) {
 
         unique_ptr<MutablePathMutableHandleGraph> graph;
-        get_input_file(optind, argc, argv, [&](istream& in) {
-                graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(in);
-            });
+        string graph_filename = get_input_file_name(optind, argc, argv);
+        graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(graph_filename);
 
         // join the id spaces if necessary
         int64_t delta = max_node_id - graph->min_node_id();

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -196,9 +196,8 @@ int main_convert(int argc, char** argv) {
         assert(gam_to_gaf || gaf_to_gam);
 
         unique_ptr<HandleGraph> input_graph;
-        get_input_file(optind, argc, argv, [&](istream& in) {
-            input_graph = vg::io::VPKG::load_one<HandleGraph>(in);
-        });
+        string input_graph_filename = get_input_file_name(optind, argc, argv);
+        input_graph = vg::io::VPKG::load_one<HandleGraph>(input_graph_filename);
 
         unique_ptr<AlignmentEmitter> emitter = get_non_hts_alignment_emitter("-", gam_to_gaf ? "GAF" : "GAM", {}, get_thread_count(),
                                                                              input_graph.get());
@@ -300,9 +299,8 @@ int main_convert(int argc, char** argv) {
             input_gbwt = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_name);
             gbwt_graph->set_gbwt(*input_gbwt);
         } else {
-            get_input_file(optind, argc, argv, [&](istream& in) {
-                input_graph = vg::io::VPKG::load_one<HandleGraph>(in);
-            });
+            string input_graph_filename = get_input_file_name(optind, argc, argv);
+            input_graph = vg::io::VPKG::load_one<HandleGraph>(input_graph_filename);
         }
         
         PathHandleGraph* input_path_graph = dynamic_cast<PathHandleGraph*>(input_graph.get());

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -149,9 +149,8 @@ int main_deconstruct(int argc, char** argv){
 
     // Read the graph
     unique_ptr<PathHandleGraph> path_handle_graph;
-    get_input_file(optind, argc, argv, [&](istream& in) {
-            path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
-        });
+    string path_handle_graph_filename = get_input_file_name(optind, argc, argv);
+    path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(path_handle_graph_filename);
 
     bdsg::PathPositionOverlayHelper overlay_helper;
     PathPositionHandleGraph* graph = overlay_helper.apply(path_handle_graph.get());

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -168,9 +168,8 @@ int main_depth(int argc, char** argv) {
 
     // Read the graph
     unique_ptr<PathHandleGraph> path_handle_graph;
-    get_input_file(optind, argc, argv, [&](istream& in) {
-            path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
-        });
+    string path_handle_graph_filename = get_input_file_name(optind, argc, argv);
+    path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(path_handle_graph_filename);
     PathHandleGraph* graph = path_handle_graph.get();
     
     // Apply the overlay if necessary

--- a/src/subcommand/ids_main.cpp
+++ b/src/subcommand/ids_main.cpp
@@ -117,10 +117,8 @@ int main_ids(int argc, char** argv) {
 
     if (!join && mapping_name.empty()) {
         unique_ptr<MutablePathMutableHandleGraph> graph;
-        get_input_file(optind, argc, argv, [&](istream& in) {
-                graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(in);
-            });
-            
+        string graph_filename = get_input_file_name(optind, argc, argv);
+        graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(graph_filename);            
             
         if (sort || compact) {
             // We need to reassign IDs

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -498,9 +498,7 @@ int main_index(int argc, char** argv) {
 
         // Load the only input graph.
         unique_ptr<PathHandleGraph> path_handle_graph;
-        get_input_file(file_names[0], [&](istream& in) {
-                path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
-            });
+        path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(file_names[0]);
 
         std::unique_ptr<gbwt::DynamicGBWT> gbwt_index(nullptr);
         if (thread_source == thread_source_vcf) {
@@ -549,27 +547,25 @@ int main_index(int argc, char** argv) {
             } else if (!xg_name.empty()) {
                 // Get the kmers from an XG
                 
-                get_input_file(xg_name, [&](istream& xg_stream) {
-                    // Load the XG
-                    auto xg = vg::io::VPKG::load_one<xg::XG>(xg_stream);
+              // Load the XG
+              auto xg = vg::io::VPKG::load_one<xg::XG>(xg_name);
                 
-                    // Make an overlay on it to add source and sink nodes
-                    // TODO: Don't use this directly; unify this code with VGset's code.
-                    SourceSinkOverlay overlay(xg.get(), kmer_size);
+              // Make an overlay on it to add source and sink nodes
+              // TODO: Don't use this directly; unify this code with VGset's code.
+              SourceSinkOverlay overlay(xg.get(), kmer_size);
                     
-                    // Get the size limit
-                    size_t kmer_bytes = params.getLimitBytes();
+              // Get the size limit
+              size_t kmer_bytes = params.getLimitBytes();
                     
-                    // Write just the one kmer temp file
-                    dbg_names.push_back(write_gcsa_kmers_to_tmpfile(overlay, kmer_size, kmer_bytes,
-                        overlay.get_id(overlay.get_source_handle()),
-                        overlay.get_id(overlay.get_sink_handle())));
+              // Write just the one kmer temp file
+              dbg_names.push_back(write_gcsa_kmers_to_tmpfile(overlay, kmer_size, kmer_bytes,
+                                                              overlay.get_id(overlay.get_source_handle()),
+                                                              overlay.get_id(overlay.get_sink_handle())));
                         
-                    // Feed back into the size limit
-                    params.reduceLimit(kmer_bytes);
-                    delete_kmer_files = true;
+              // Feed back into the size limit
+              params.reduceLimit(kmer_bytes);
+              delete_kmer_files = true;
                 
-                });
             } else {
                 cerr << "error: [vg index] cannot generate GCSA index without either a vg or an xg" << endl;
                 exit(1);
@@ -688,8 +684,7 @@ int main_index(int argc, char** argv) {
             if (file_names.empty() && !xg_name.empty()) {
                 // We were given a -x specifically to read as XG
                 
-                ifstream xg_stream(xg_name);
-                auto xg = vg::io::VPKG::load_one<xg::XG>(xg_stream);
+                auto xg = vg::io::VPKG::load_one<xg::XG>(xg_name);
 
                 // Create the MinimumDistanceIndex
                 MinimumDistanceIndex di(xg.get(), snarl_manager);

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -686,13 +686,14 @@ int main_map(int argc, char** argv) {
             cerr << "Error[vg map]: Unable to open xg file \"" << xg_name << "\"" << endl;
             exit(1);
         }
+        xg_stream.close();
         
         // TODO: tell when the user asked for an XG vs. when we guessed one,
         // and error when the user asked for one and we can't find it.
         if(debug) {
             cerr << "Loading xg index " << xg_name << "..." << endl;
         }
-        path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_stream);
+        path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);
         xgidx = dynamic_cast<PathPositionHandleGraph*>(overlay_helper.apply(path_handle_graph.get()));
     }
 

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -364,9 +364,8 @@ int main_mod(int argc, char** argv) {
     }
 
     unique_ptr<handlegraph::MutablePathDeletableHandleGraph> graph;
-    get_input_file(optind, argc, argv, [&](istream& in) {
-        graph = vg::io::VPKG::load_one<handlegraph::MutablePathDeletableHandleGraph>(in);
-    });
+    string graph_filename = get_input_file_name(optind, argc, argv);
+    graph = vg::io::VPKG::load_one<handlegraph::MutablePathDeletableHandleGraph>(graph_filename);
 
     if (!vcf_filename.empty()) {
         // We need to throw out the parts of the graph that are on alt paths,

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1356,6 +1356,7 @@ int main_mpmap(int argc, char** argv) {
         cerr << "error:[vg mpmap] Cannot open graph file " << graph_name << endl;
         exit(1);
     }
+    graph_stream.close();
     
     ifstream gcsa_stream(gcsa_name);
     if (!gcsa_stream) {
@@ -1489,7 +1490,7 @@ int main_mpmap(int argc, char** argv) {
     if (!suppress_progress) {
         cerr << progress_boilerplate() << "Loading graph from " << graph_name << endl;
     }
-    unique_ptr<PathHandleGraph> path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(graph_stream);
+    unique_ptr<PathHandleGraph> path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(graph_name);
     
     if (!suppress_progress) {
         // let's be a friendly guide to selecting a graph

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -311,9 +311,7 @@ int main_paths(int argc, char** argv) {
         assert(vg_file.empty() || xg_file.empty());
         const string& graph_file = vg_file.empty() ? xg_file : vg_file;
         // Load the vg or xg
-        get_input_file(graph_file, [&](istream& in) {
-                graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
-            });
+        graph = vg::io::VPKG::load_one<PathHandleGraph>(graph_file);
     }
     unique_ptr<gbwt::GBWT> gbwt_index;
     if (!gbwt_file.empty()) {

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -331,9 +331,7 @@ int main_prune(int argc, char** argv) {
 
     // Handle the input.
     std::unique_ptr<MutablePathDeletableHandleGraph> graph;
-    get_input_file(vg_name, [&](std::istream& in) {
-        graph = vg::io::VPKG::load_one<MutablePathDeletableHandleGraph>(in);
-    });
+    graph = vg::io::VPKG::load_one<MutablePathDeletableHandleGraph>(vg_name);
     xg::XG xg_index;
     std::unique_ptr<gbwt::GBWT> gbwt_index;
     

--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -232,9 +232,8 @@ int32_t main_rna(int32_t argc, char** argv) {
     unique_ptr<MutablePathDeletableHandleGraph> splice_graph(nullptr);
 
     // Load variation graph.
-    get_input_file(optind, argc, argv, [&](istream& in) {
-        splice_graph = move(vg::io::VPKG::load_one<MutablePathDeletableHandleGraph>(in));
-    });
+    string splice_graph_filename = get_input_file_name(optind, argc, argv);
+    splice_graph = move(vg::io::VPKG::load_one<MutablePathDeletableHandleGraph>(splice_graph_filename));
 
     if (splice_graph == nullptr) {
         cerr << "[transcriptome] ERROR: Could not load graph." << endl;

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -184,9 +184,8 @@ int main_snarl(int argc, char** argv) {
 
     // Read the graph
     unique_ptr<PathHandleGraph> graph;
-    get_input_file(optind, argc, argv, [&](istream& in) {
-        graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
-    });
+    string graph_filename = get_input_file_name(optind, argc, argv);
+    graph = vg::io::VPKG::load_one<PathHandleGraph>(graph_filename);
     
     // The only implemented snarl finder:
     unique_ptr<SnarlFinder> snarl_finder;

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -30,6 +30,7 @@
 #include "bdsg/hash_graph.hpp"
 #include "bdsg/odgi.hpp"
 #include "../io/converted_hash_graph.hpp"
+#include "../io/save_handle_graph.hpp"
 
 using namespace std;
 using namespace vg;
@@ -379,6 +380,9 @@ int main_stats(int argc, char** argv) {
         string format_string;
         if (dynamic_cast<xg::XG*>(graph.get()) != nullptr) {
             format_string = "XG";
+        } else if (dynamic_cast<GFAHandleGraph*>(graph.get()) != nullptr) {
+            // important this check comes before PackedGraph
+            format_string = "GFA";
         } else if (dynamic_cast<bdsg::PackedGraph*>(graph.get()) != nullptr) {
             format_string = "PackedGraph";
         } else if (dynamic_cast<vg::io::ConvertedHashGraph*>(graph.get()) != nullptr) {

--- a/src/subcommand/validate_main.cpp
+++ b/src/subcommand/validate_main.cpp
@@ -82,9 +82,8 @@ int main_validate(int argc, char** argv) {
 
     // load the graph
     unique_ptr<PathHandleGraph> graph;
-    get_input_file(optind, argc, argv, [&](istream& in) {
-            graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
-        });
+    string graph_filename = get_input_file_name(optind, argc, argv);
+    graph = vg::io::VPKG::load_one<PathHandleGraph>(graph_filename);
 
     // validate the alignment if given
     bool valid_aln = true;

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -507,9 +507,7 @@ int main_view(int argc, char** argv) {
             cerr << "[vg view] error: Cannot stream a generic HandleGraph to JSON" << endl;
             exit(1);
         } else {
-            get_input_file(file_name, [&](istream& in) {
-                graph = vg::io::VPKG::load_one<PathHandleGraph>(in);
-            });
+            graph = vg::io::VPKG::load_one<PathHandleGraph>(file_name);
         }
     } else if (input_type == "gfa") {
         graph = make_unique<bdsg::HashGraph>();

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -525,7 +525,7 @@ void get_input_file(int& optind, int argc, char** argv, function<void(istream&)>
 
 }
 
-string get_input_file_name(int& optind, int argc, char** argv) {
+string get_input_file_name(int& optind, int argc, char** argv, bool test_open) {
 
     if (optind >= argc) {
         // Complain that the user didn't specify a filename
@@ -538,6 +538,13 @@ string get_input_file_name(int& optind, int argc, char** argv) {
     if (file_name.empty()) {
         cerr << "error:[get_input_file_name] specify a non-empty input filename" << endl;
         exit(1);
+    }
+
+    if (test_open && file_name != "-") {
+        ifstream file_stream(file_name);
+        if (!file_stream) {
+            cerr << "error:[get_input_file_name] unable to open input file: " << file_name << endl;
+        }
     }
     
     return file_name;

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -426,11 +426,15 @@ bool have_input_file(int& optind, int argc, char** argv);
 /// is not. Handles "-" as a filename as indicating standard input. The reference
 /// passed is guaranteed to be valid only until the callback returns. Bumps up
 /// optind to the next argument if a filename is found.
+///
+/// Warning: If you're reading a HandleGraph via VPKG::load_one (as is the pattern in vg)
+///          it is best to use get_input_file_name() below instead, and run load_one on that.
+///          This allows better GFA support because it allows memmapping the file directly
 void get_input_file(int& optind, int argc, char** argv, function<void(istream&)> callback);
 
 /// Parse out the name of an input file (i.e. the next positional argument), or
 /// throw an error. File name must be nonempty, but may be "-" or may not exist.
-string get_input_file_name(int& optind, int argc, char** argv);
+string get_input_file_name(int& optind, int argc, char** argv, bool test_open = true);
 
 /// Parse out the name of an output file (i.e. the next positional argument), or
 /// throw an error. File name must be nonempty.

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 27
+plan tests 28
 
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 is $? 0 "construction"
@@ -115,3 +115,8 @@ vg index -x x.xg x.vg
 vg index -G x.gbwt -v small/xy2.vcf.gz x.vg
 is $(vg find -p x -x x.xg -K 16 -H x.gbwt | cut -f 5 | sort | uniq -c  | tail -n 1 | awk '{ print $1 }') 1510 "we find the expected number of kmers with haplotype frequency equal to 2"
 rm -f x.vg x.xg x.gbwt
+
+vg convert -gp tiny/tiny.gfa | vg find -x - -n 1 -c 2 | vg convert -f - | vg ids -s - | sort > found1.gfa
+vg find -x tiny/tiny.gfa -n 1 -c 2| vg ids -s - | sort > found2.gfa
+diff found1.gfa found2.gfa
+is $? 0 "GFA i/o for find -n consistent with converting both ways"

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 18
+plan tests 19
 
 vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 #is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
@@ -63,7 +63,9 @@ vg convert graphs/atgc.vg -o > atgc.og
 is "$(vg stats -F atgc.og)" "format: ODGI" "vg stats -F detects format of odgi graph"
 vg index graphs/atgc.vg -x atgc.xg
 is "$(vg stats -F atgc.xg)" "format: XG" "vg stats -F detects format of xg graph"
-rm -f  atgc.vg atgc.hg atgc.pg atgc.og atgc.xg
+vg convert graphs/atgc.vg -f > atgc.gfa
+is "$(vg stats -F atgc.gfa)" "format: GFA" "vg stats -F detects format of GFA graph"
+rm -f  atgc.vg atgc.hg atgc.pg atgc.og atgc.xg atgc.gfa
 
 vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa | vg stats -D - | head -4 | tail -1 > tiny.deg
 printf "2\t12\t3\t9\t8\n" > tiny.true.deg

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -266,8 +266,8 @@ vg convert tiny/tiny.gfa -p | vg convert -f - | sort > tiny.roundtrip2.gfa
 diff tiny.roundtrip.gfa tiny.roundtrip2.gfa
 is $? 0 "No difference roundtripping a GFA if it's loaded as a GFA or HandleGraph"
 
-grep -Pv "S\t6" tiny/tiny.gfa > tiny.unsort.gfa
-grep -P "S\t6" tiny/tiny.gfa >> tiny.unsort.gfa
+grep -v "S	6" tiny/tiny.gfa > tiny.unsort.gfa
+grep "S	6" tiny/tiny.gfa >> tiny.unsort.gfa
 cat tiny.unsort.gfa | vg convert -p - 2> tiny.roundtrip3.stderr | vg convert -f - | sort > tiny.roundtrip3.gfa
 cat tiny.roundtrip3.stderr
 diff tiny.roundtrip.gfa tiny.roundtrip3.gfa

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -269,11 +269,13 @@ is $? 0 "No difference roundtripping a GFA if it's loaded as a GFA or HandleGrap
 grep -Pv "S\t6" tiny/tiny.gfa > tiny.unsort.gfa
 grep -P "S\t6" tiny/tiny.gfa >> tiny.unsort.gfa
 cat tiny.unsort.gfa | vg convert -p - 2> tiny.roundtrip3.stderr | vg convert -f - | sort > tiny.roundtrip3.gfa
+cat tiny.roundtrip3.stderr
 diff tiny.roundtrip.gfa tiny.roundtrip3.gfa
 is $? 0 "Streaming an unsorted GFA gives same output as sorted"
 is $(grep "warning:\[gfa\]" tiny.roundtrip3.stderr | wc -l) 1 "Warning given when falling back to temp GFA buffer file"
 
 cat tiny/tiny.gfa | vg convert -p - 2> tiny.roundtrip4.stderr | vg convert -f - | sort > tiny.roundtrip4.gfa
+cat tiny.roundtrip4.stderr
 diff tiny.roundtrip.gfa tiny.roundtrip4.gfa
 is $? 0 "Streaming an sorted GFA gives same output as reading from file"
 is $(cat tiny.roundtrip4.stderr | wc -l) 0 "No warnings given when streamed GFA is sorted"
@@ -286,10 +288,12 @@ cat tiny/tiny.gfa | vg mod -X 3 - | vg ids -s - | sort > tiny.chop3.2.gfa
 diff tiny.chop3.gfa tiny.chop3.2.gfa
 is $? 0 "Modding sorted GFA stream produces same output as going through convert"
 cat tiny.unsort.gfa | vg mod -X 3 - 2> tiny.chop3.3.stderr | vg ids -s - | sort > tiny.chop3.3.gfa
+cat tiny.chop3.3.stderr
 diff tiny.chop3.gfa tiny.chop3.3.gfa
 is $? 0 "Modding unsorted GFA stream produces same output as going through convert"
 is $(grep "warning:\[gfa\]" tiny.chop3.3.stderr | wc -l) 1 "Warning given when falling back to temp GFA buffer file in mod"
 vg mod -X 3 tiny.unsort.gfa 2> tiny.chop3.4.stderr | vg ids -s - | sort > tiny.chop3.4.gfa
+cat tiny.chop3.4.stderr
 diff tiny.chop3.gfa tiny.chop3.4.gfa
 is $? 0 "Modding unsorted GFA file produces same output as going through convert"
 is $(cat tiny.chop3.4.stderr | wc -l) 0 "No warnings given when input GFA file is unsorted"

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 45
+plan tests 56
 
 vg construct -r complex/c.fa -v complex/c.vcf.gz > c.vg
 cat <(vg view c.vg | grep ^S | sort) <(vg view c.vg | grep L | uniq | wc -l) <(vg paths -v c.vg -E) > c.info
@@ -259,3 +259,46 @@ rm -f direct.hg correct_paths.gaf
 rm -f components.hg hg_paths.gaf
 rm -f components.xg xg_paths.gaf
 rm -f extracted.gfa
+
+# GFA Streaming
+vg convert -g tiny/tiny.gfa -p | vg convert -f - | sort > tiny.roundtrip.gfa
+vg convert tiny/tiny.gfa -p | vg convert -f - | sort > tiny.roundtrip2.gfa
+diff tiny.roundtrip.gfa tiny.roundtrip2.gfa
+is $? 0 "No difference roundtripping a GFA if it's loaded as a GFA or HandleGraph"
+
+grep -Pv "S\t6" tiny/tiny.gfa > tiny.unsort.gfa
+grep -P "S\t6" tiny/tiny.gfa >> tiny.unsort.gfa
+cat tiny.unsort.gfa | vg convert -p - 2> tiny.roundtrip3.stderr | vg convert -f - | sort > tiny.roundtrip3.gfa
+diff tiny.roundtrip.gfa tiny.roundtrip3.gfa
+is $? 0 "Streaming an unsorted GFA gives same output as sorted"
+is $(grep "warning:\[gfa\]" tiny.roundtrip3.stderr | wc -l) 1 "Warning given when falling back to temp GFA buffer file"
+
+cat tiny/tiny.gfa | vg convert -p - 2> tiny.roundtrip4.stderr | vg convert -f - | sort > tiny.roundtrip4.gfa
+diff tiny.roundtrip.gfa tiny.roundtrip4.gfa
+is $? 0 "Streaming an sorted GFA gives same output as reading from file"
+is $(cat tiny.roundtrip4.stderr | wc -l) 0 "No warnings given when streamed GFA is sorted"
+
+vg convert -g tiny/tiny.gfa | vg mod - -X 3 | vg convert -f - | vg ids -s - | sort > tiny.chop3.gfa
+vg mod -X 3 tiny/tiny.gfa | vg ids -s - | sort > tiny.chop3.1.gfa
+diff tiny.chop3.gfa tiny.chop3.1.gfa
+is $? 0 "Modding GFA directly produces same output as going through convert"
+cat tiny/tiny.gfa | vg mod -X 3 - | vg ids -s - | sort > tiny.chop3.2.gfa
+diff tiny.chop3.gfa tiny.chop3.2.gfa
+is $? 0 "Modding sorted GFA stream produces same output as going through convert"
+cat tiny.unsort.gfa | vg mod -X 3 - 2> tiny.chop3.3.stderr | vg ids -s - | sort > tiny.chop3.3.gfa
+diff tiny.chop3.gfa tiny.chop3.3.gfa
+is $? 0 "Modding unsorted GFA stream produces same output as going through convert"
+is $(grep "warning:\[gfa\]" tiny.chop3.3.stderr | wc -l) 1 "Warning given when falling back to temp GFA buffer file in mod"
+vg mod -X 3 tiny.unsort.gfa 2> tiny.chop3.4.stderr | vg ids -s - | sort > tiny.chop3.4.gfa
+diff tiny.chop3.gfa tiny.chop3.4.gfa
+is $? 0 "Modding unsorted GFA file produces same output as going through convert"
+is $(cat tiny.chop3.4.stderr | wc -l) 0 "No warnings given when input GFA file is unsorted"
+
+rm -f tiny.roundtrip.gfa tiny.roundtrip2.gfa tiny.roundtrip3.gfa tiny.roundtrip4.gfa
+rm -f tiny.roundtrip3.stderr tiny.roundtrip4.stderr
+rm -f tiny.unsort.gfa
+rm -f tiny.chop3.gfa tiny.chop3.1.gfa  tiny.chop3.2.gfa  tiny.chop3.3.gfa tiny.chop3.4.gfa
+rm -f tiny.chop3.3.stderr tiny.chop3.4.stderr
+
+
+

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 56
+plan tests 57
 
 vg construct -r complex/c.fa -v complex/c.vcf.gz > c.vg
 cat <(vg view c.vg | grep ^S | sort) <(vg view c.vg | grep L | uniq | wc -l) <(vg paths -v c.vg -E) > c.info
@@ -299,6 +299,11 @@ rm -f tiny.roundtrip3.stderr tiny.roundtrip4.stderr
 rm -f tiny.unsort.gfa
 rm -f tiny.chop3.gfa tiny.chop3.1.gfa  tiny.chop3.2.gfa  tiny.chop3.3.gfa tiny.chop3.4.gfa
 rm -f tiny.chop3.3.stderr tiny.chop3.4.stderr
+
+vg view tiny/tiny.gfa | sort > tiny.rgfa.1
+cat tiny/tiny.gfa | vg view - | sort > tiny.rgfa.2
+diff tiny.rgfa.1 tiny.rgfa.2
+is $? 0 "rGFA handled consistently when streaming as when loaded from file"
 
 
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Uncompressed GFA files can now be directly input as graphs into all vg commands. (previously `vg convert -g` was required beforehand) 

## Description

This PR lets VPKG load up a GFA graph directly into a PackedGraph (chosen as GFAs can be big).  It works by hacking the magic number logic in libvgio to also allow it to check for GFA-like input instead of a fixed number.  

I still need to enable streaming (it's putting everything in memory now) before merging this in. As discussed, the idea will be to read sorted GFA on the fly, falling back (with a warning) onto a mem-mapped temp file if something order-breaking is detected.  Also need to wire things up so that tools that load GFA write GFA.

Preserving segment names will be left as a stretch goal for some other time. 
