### PR TITLE
Parallel execution in vg autoindex

### DIFF
--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -108,6 +108,8 @@ struct IndexingParameters {
     static int downsample_context_length;
     // actually use this fraction of the maximum memory to give slosh for bad estmates [0.75]
     static double max_memory_proportion;
+    // aim to have X timese as many chunks as threads [2]
+    static double thread_chunk_inflation_factor;
     // whether indexing algorithms will log progress (if available) [false]
     static bool verbose;
 };

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -22,13 +22,12 @@ using namespace vg::subcommand;
 bool vcf_is_phased(const string& filepath) {
     
     if (IndexingParameters::verbose) {
-        cerr << "[IndexRegistry]: Checking for phasing in VCF." << endl;
+        cerr << "[IndexRegistry]: Checking for phasing in VCF(s)." << endl;
     }
     
     // check about 30k variants before concluding that the VCF isn't phased
     // TODO: will there be contig ordering biases that make this a bad assumption?
     constexpr int vars_to_check = 1 << 15;
-    
     
     htsFile* file = hts_open(filepath.c_str(), "rb");
     bcf_hdr_t* hdr = bcf_hdr_read(file);

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -326,6 +326,14 @@ int main_autoindex(int argc, char** argv) {
         }
     }
     
+    if (IndexingParameters::verbose) {
+        cerr << "[vg autoindex] Excecuting command:";
+        for (int i = 0; i < argc; ++i) {
+            cerr << " " << argv[i];
+        }
+        cerr << endl;
+    }
+    
     assert(!(force_phased && force_unphased));
     
     // we have special logic for VCFs to make it friendly to both phased
@@ -353,14 +361,6 @@ int main_autoindex(int argc, char** argv) {
         // don't index, just visualize the plan
         cout << registry.to_dot(targets);
         return 0;
-    }
-    
-    if (IndexingParameters::verbose) {
-        cerr << "[vg autoindex] Excecuting command:";
-        for (int i = 0; i < argc; ++i) {
-            cerr << argv[i] << " ";
-        }
-        cerr << endl;
     }
     
     registry.set_target_memory_usage(target_mem_usage);

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -355,6 +355,14 @@ int main_autoindex(int argc, char** argv) {
         return 0;
     }
     
+    if (IndexingParameters::verbose) {
+        cerr << "[vg autoindex] Excecuting command:";
+        for (int i = 0; i < argc; ++i) {
+            cerr << argv[i] << " ";
+        }
+        cerr << endl;
+    }
+    
     registry.set_target_memory_usage(target_mem_usage);
     
     if (targets.empty()) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex` now executes in parallel

## Description

I went the route of bucketing contigs at the outset and using the buckets for parallel execution throughout. That turned out to be a bit of an operation in the case of VCFs, but I'm pretty happy with the results. It seems to make pretty effective use of the resources available in a medium-large to larger compute server, which is the hardware I'm targeting.