### PR TITLE
Modest improvement to scheduler for autoindex

### DIFF
--- a/src/job_schedule.cpp
+++ b/src/job_schedule.cpp
@@ -42,6 +42,7 @@ void JobSchedule::execute(int64_t target_memory_usage) {
                 queue_lock.lock();
                 if (queue.empty()) {
                     // the queue emptied out while we were waiting
+                    queue_lock.unlock();
                     break;
                 }
                 if (est_memory_usage.load() == 0) {

--- a/src/job_schedule.hpp
+++ b/src/job_schedule.hpp
@@ -7,12 +7,17 @@
 #include <vector>
 #include <utility>
 #include <functional>
-#include <queue>
+#include <list>
 
 namespace vg {
 
 using namespace std;
 
+/*
+ * A parallel job scheduler that tries to (if possible) respect a
+ * cap on memory usage. Works best with a moderate number of
+ * relatively large jobs.
+ */
 class JobSchedule {
 public:
     
@@ -24,12 +29,13 @@ public:
                 const function<void(int64_t)>& job_func);
     ~JobSchedule() = default;
     
+    // execute the job schedule with a target maximum memory usage
     void execute(int64_t target_memory_usage);
     
 private:
     
     function<void(int64_t)> job_func;
-    priority_queue<tuple<int64_t, int64_t, int64_t>> queue;
+    list<pair<int64_t, int64_t>> queue;
     
 };
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex` now does a better job of scheduling jobs in memory-limited environments

## Description

The older scheduler burnt an entire thread to do the scheduling. In addition, it would often make threads wait until the largest-memory job could be done in available memory even when the threads could be doing smaller jobs that fit.