### PR TITLE
Warn and skip contigs in VCF that are missing in FASTA in autoindex

### DIFF
--- a/test/t/52_vg_autoindex.t
+++ b/test/t/52_vg_autoindex.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 plan tests 21
 
-vg autoindex -p auto -w map -r tiny/tiny.fa -v tiny/tiny.vcf.gz -t 1 --force-unphased
+vg autoindex -p auto -w map -r tiny/tiny.fa -v tiny/tiny.vcf.gz --force-unphased
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg map with basic input"
 is $(ls auto.* | wc -l) 3 "autoindexing makes 3 outputs for vg map" 
 is $(ls auto.xg | wc -l) 1 "autoindexing makes an XG for vg map"
@@ -17,14 +17,14 @@ is $(echo $?) 0 "basic autoindexing results can be used by vg map"
 
 rm auto.*
 
-vg autoindex -p auto -w map -r small/x.fa -v small/x.vcf.gz -r small/y.fa -v small/y.vcf.gz -t 1
+vg autoindex -p auto -w map -r small/x.fa -v small/x.vcf.gz -r small/y.fa -v small/y.vcf.gz 
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg map with chunked input"
 vg sim -x auto.xg -n 20 -a -l 10 | vg map -d auto -t 1 -G - > /dev/null
 is $(echo $?) 0 "chunked autoindexing results can be used by vg map"
 
 rm auto.*
 
-vg autoindex -p auto -w map -r small/xy.fa -v small/xy2.vcf.gz -t 1
+vg autoindex -p auto -w map -r small/xy.fa -v small/xy2.vcf.gz
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg map with phased input"
 vg sim -x auto.xg -n 20 -a -l 10 | vg map -d auto -t 1 -G - > /dev/null
 is $(echo $?) 0 "phased autoindexing results can be used by vg map"
@@ -33,7 +33,7 @@ rm auto.*
 
 # to add: GFA construction
 
-vg autoindex -p auto -w mpmap -r tiny/tiny.fa -v tiny/tiny.vcf.gz -x tiny/tiny.gtf -t 1
+vg autoindex -p auto -w mpmap -r tiny/tiny.fa -v tiny/tiny.vcf.gz -x tiny/tiny.gtf
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with unchunked input"
 is $(ls auto.* | wc -l) 6 "autoindexing creates 6 files for mpmap/rpvg"
 vg sim -x auto.spliced.xg -n 20 -a -l 10 | vg mpmap -x auto.spliced.xg -g auto.spliced.gcsa -d auto.spliced.dist -B -t 1 -G - > /dev/null
@@ -43,23 +43,23 @@ is $(cat auto.txorigin.tsv | wc -l) 5 "transcript origin table has expected numb
 
 rm auto.*
 
-vg autoindex -p auto -w mpmap -r small/x.fa -r small/y.fa -v small/x.vcf.gz -v small/y.vcf.gz -x small/x.gtf -x small/y.gtf -t 1
+vg autoindex -p auto -w mpmap -r small/x.fa -r small/y.fa -v small/x.vcf.gz -v small/y.vcf.gz -x small/x.gtf -x small/y.gtf
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with chunked input"
 is $(ls auto.* | wc -l) 6 "autoindexing creates 6 files for mpmap/rpvg with chunked input"
 
 rm auto.*
 
-vg autoindex -p auto -w mpmap -r small/x.fa -r small/y.fa -v small/x.vcf.gz -v small/y.vcf.gz -x small/xy.gtf -t 1
+vg autoindex -p auto -w mpmap -r small/x.fa -r small/y.fa -v small/x.vcf.gz -v small/y.vcf.gz -x small/xy.gtf
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with partially chunked input"
 
 rm auto.*
 
-vg autoindex -p auto -w mpmap -r small/xy.fa -v small/x.vcf.gz -v small/y.vcf.gz -x small/xy.gtf -t 1
+vg autoindex -p auto -w mpmap -r small/xy.fa -v small/x.vcf.gz -v small/y.vcf.gz -x small/xy.gtf
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with another partially chunked input"
 
 rm auto.*
 
-vg autoindex -p auto -w giraffe -r tiny/tiny.fa -v tiny/tiny.vcf.gz -t 1
+vg autoindex -p auto -w giraffe -r tiny/tiny.fa -v tiny/tiny.vcf.gz 
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg giraffe with unchunked input"
 is $(ls auto.* | wc -l) 4 "autoindexing creates 4 inputs for vg giraffe"
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > t.vg


### PR DESCRIPTION
## Description

It occurred to me when debugging an unrelated bug that `vg autoindex` would lock if provided a VCF with a contig name that is absent in the reference. It now warns the user and skips ahead in the VCF.