### PR TITLE
Switch to vgteam's vcflib, and point that to the latest htslib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vcflib"]
 	path = deps/vcflib
-	url = https://github.com/vcflib/vcflib.git
+	url = https://github.com/vgteam/vcflib.git
 [submodule "fastahack"]
 	path = deps/fastahack
 	url = https://github.com/vgteam/fastahack.git


### PR DESCRIPTION
This is an effort to get CI passing on the Mac, where autoconf/configure are failing on htslib.  

I think the better way of doing this is pointing vg at the latest vcflib release which does away with the htslib submodule.  But I promised during scrum to tackle this, and am running out of time on the day... 