### PR TITLE
Add node chopping to graph construction from GFA in autoindex

### DIFF
--- a/src/algorithms/normalize.cpp
+++ b/src/algorithms/normalize.cpp
@@ -30,7 +30,7 @@ void normalize(handlegraph::MutablePathDeletableHandleGraph* graph, int max_iter
         // for all handle graphs, or an obstacle to normality.
         
         // combine diced/chopped nodes (subpaths with no branching)
-        handlealgs::unchop(graph);
+        handlealgs::unchop(*graph);
         // Resolve forks that shouldn't be
         simplify_siblings(graph);
         
@@ -47,7 +47,7 @@ void normalize(handlegraph::MutablePathDeletableHandleGraph* graph, int max_iter
     
     // there may now be some cut nodes that can be simplified
     // This won't change the length.
-    handlealgs::unchop(graph);
+    handlealgs::unchop(*graph);
 }
 
 

--- a/src/handle.hpp
+++ b/src/handle.hpp
@@ -35,7 +35,7 @@
 #include <handlegraph/algorithms/split_strands.hpp>
 #include <handlegraph/algorithms/strongly_connected_components.hpp>
 #include <handlegraph/algorithms/topological_sort.hpp>
-#include <handlegraph/algorithms/unchop.hpp>
+#include <handlegraph/algorithms/chop.hpp>
 #include <handlegraph/algorithms/weakly_connected_components.hpp>
 
 

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -1615,7 +1615,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             exit(1);
         }
         
-        handlealgs::chop(graph.get(), IndexingParameters::max_node_size);
+        handlealgs::chop(*graph, IndexingParameters::max_node_size);
         
         // save the graph
         vg::io::save_handle_graph(graph.get(), outfile);

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -2014,36 +2014,40 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     cerr << "registering XG recipes" << endl;
 #endif
     
-    registry.register_recipe({"XG"}, {"Reference GFA"},
-                             [&](const vector<const IndexFile*>& inputs,
-                                 const IndexingPlan* plan,
-                                 AliasGraph& alias_graph,
-                                 const IndexGroup& constructing) {
-        if (IndexingParameters::verbosity != IndexingParameters::None) {
-            cerr << "[IndexRegistry]: Constructing XG graph from GFA input." << endl;
-        }
-        assert(constructing.size() == 1);
-        vector<vector<string>> all_outputs(constructing.size());
-        auto output_index = *constructing.begin();
-        auto gfa_names = inputs.front()->get_filenames();
-        if (gfa_names.size() > 1) {
-            cerr << "error:[IndexRegistry] Graph construction does not support multiple GFAs at this time." << endl;
-            exit(1);
-        }
-        
-        string output_name = plan->output_filepath(output_index);
-        ofstream outfile;
-        init_out(outfile, output_name);
-        
-        xg::XG xg_index;
-        xg_index.from_gfa(gfa_names.front());
-        
-        vg::io::save_handle_graph(&xg_index, outfile);
-        
-        // return the filename
-        all_outputs[0].emplace_back(output_name);
-        return all_outputs;
-    });
+    // TODO: currently disabling this to ensure, but I'd prefer to make a separate
+    // semantic XG for a node-chopped variety and handle the pipeline differences
+    // with simplifications
+    
+//    registry.register_recipe({"XG"}, {"Reference GFA"},
+//                             [&](const vector<const IndexFile*>& inputs,
+//                                 const IndexingPlan* plan,
+//                                 AliasGraph& alias_graph,
+//                                 const IndexGroup& constructing) {
+//        if (IndexingParameters::verbosity != IndexingParameters::None) {
+//            cerr << "[IndexRegistry]: Constructing XG graph from GFA input." << endl;
+//        }
+//        assert(constructing.size() == 1);
+//        vector<vector<string>> all_outputs(constructing.size());
+//        auto output_index = *constructing.begin();
+//        auto gfa_names = inputs.front()->get_filenames();
+//        if (gfa_names.size() > 1) {
+//            cerr << "error:[IndexRegistry] Graph construction does not support multiple GFAs at this time." << endl;
+//            exit(1);
+//        }
+//
+//        string output_name = plan->output_filepath(output_index);
+//        ofstream outfile;
+//        init_out(outfile, output_name);
+//
+//        xg::XG xg_index;
+//        xg_index.from_gfa(gfa_names.front());
+//
+//        vg::io::save_handle_graph(&xg_index, outfile);
+//
+//        // return the filename
+//        all_outputs[0].emplace_back(output_name);
+//        return all_outputs;
+//    });
     
     auto make_xg_from_graph = [&](const vector<const IndexFile*>& inputs,
                                   const IndexingPlan* plan,

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -1615,6 +1615,8 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             exit(1);
         }
         
+        handlealgs::chop(graph.get(), IndexingParameters::max_node_size);
+        
         // save the graph
         vg::io::save_handle_graph(graph.get(), outfile);
         // and the max id

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -4559,7 +4559,8 @@ const char* InsufficientInputException::what() const throw () {
         ss << "\t" << input << endl;
     }
     ss << "are insufficient to create target index " << target << endl;
-    return ss.str().c_str();
+    string msg = ss.str();
+    return msg.c_str();
 }
 
 }

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -601,7 +601,7 @@ int main_mod(int argc, char** argv) {
     }
 
     if (unchop) {
-        handlealgs::unchop(graph.get());
+        handlealgs::unchop(*graph);
     }
 
     if (simplify_graph) {
@@ -713,7 +713,7 @@ int main_mod(int argc, char** argv) {
             chop_graph = vg_graph;
         }
         
-        handlealgs::chop(chop_graph, chop_to);
+        handlealgs::chop(*chop_graph, chop_to);
         
         if (chop_graph == vg_graph) {
             vg_graph->paths.compact_ranks();

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -518,7 +518,7 @@ int main_msga(int argc, char** argv) {
     if (graph->empty()) {
         auto build_graph = [&graph,&node_max](const string& seq, const string& name) {
             graph->create_node(seq);
-            handlealgs::chop(graph, node_max);
+            handlealgs::chop(*graph, node_max);
             graph->sort();
             graph->compact_ids();
             // the graph will have a single embedded path in it
@@ -766,7 +766,7 @@ int main_msga(int argc, char** argv) {
             //if (!graph->is_valid()) cerr << "invalid after edit" << endl;
             //graph->serialize_to_file(name + "-immed-post-edit.vg");
             if (normalize) algorithms::normalize(graph, 10, debug);
-            handlealgs::chop(graph, node_max);
+            handlealgs::chop(*graph, node_max);
             //if (!graph->is_valid()) cerr << "invalid after dice" << endl;
             //graph->serialize_to_file(name + "-post-dice.vg");
             if (debug) cerr << name << ": sorting and compacting ids" << endl;
@@ -853,7 +853,7 @@ int main_msga(int argc, char** argv) {
             graph->remove_non_path();
         }
         algorithms::normalize(graph);
-        handlealgs::chop(graph, node_max);
+        handlealgs::chop(*graph, node_max);
         graph->sort();
         graph->compact_ids();
         if (!graph->is_valid()) {

--- a/src/unittest/variant_adder.cpp
+++ b/src/unittest/variant_adder.cpp
@@ -241,7 +241,7 @@ ref	5	rs1337	AAAAAAAAAAAAAAAAAAAAA	A	29	PASS	.	GT	0/1
     
     SECTION ("should work when the graph is atomized") {
     
-        handlealgs::chop(&graph, 1);
+        handlealgs::chop(graph, 1);
         graph.paths.compact_ranks();
     
         // Make a VariantAdder

--- a/src/unittest/variant_adder.cpp
+++ b/src/unittest/variant_adder.cpp
@@ -334,6 +334,9 @@ TEST_CASE( "The smart aligner works on very large inserts", "[variantadder]" ) {
     
     // Make a VariantAdder
     VariantAdder adder(graph);
+    vector<handle_t> order = handlealgs::topological_order(&adder.get_graph());
+    NodeSide front(adder.get_graph().get_id(order.front()), false);
+    NodeSide back(adder.get_graph().get_id(order.back()), true);
     
     // Make a really long insert
     stringstream s;
@@ -343,8 +346,7 @@ TEST_CASE( "The smart aligner works on very large inserts", "[variantadder]" ) {
     }
     s << "AAAAAAAAAAGCGC";
     
-    auto endpoints = make_pair(NodeSide(1, false), NodeSide(1, true));
-    Alignment aligned = adder.smart_align(graph, endpoints, s.str(), 10000 + graph.length());
+    Alignment aligned = adder.smart_align(graph, make_pair(front, back), s.str(), 10000 + graph.length());
     
     SECTION("the resulting alignment should have the input string") {
         REQUIRE(aligned.sequence() == s.str());
@@ -412,12 +414,15 @@ TEST_CASE( "The smart aligner should use mapping offsets on huge deletions", "[v
     
     // Make a VariantAdder
     VariantAdder adder(graph);
+    vector<handle_t> order = handlealgs::topological_order(&adder.get_graph());
+    NodeSide front(adder.get_graph().get_id(order.front()), false);
+    NodeSide back(adder.get_graph().get_id(order.back()), true);
     
     // Make a deleted version (only 21 As)
     string deleted = "GCGCAAAAAAAAAAAAAAAAAAAAAGCGC";
     
     // Align between 1 and 3
-    auto endpoints = make_pair(NodeSide(1, false), NodeSide(3, true));
+    auto endpoints = make_pair(front, back);
     Alignment aligned = adder.smart_align(graph, endpoints, deleted, graph.length());
     
     SECTION("the resulting alignment should have the input string") {
@@ -451,14 +456,14 @@ TEST_CASE( "The smart aligner should use mapping offsets on huge deletions", "[v
             }
             
             SECTION("the first mapping should be at the start of the first node") {
-                REQUIRE(m1.position().node_id() == 1);
+                REQUIRE(m1.position().node_id() == front.node);
                 REQUIRE(m1.position().offset() == 0);
                 REQUIRE(m1.position().is_reverse() == false);
             }
             
             SECTION("the second mapping should be at the end of the last node") {
-                REQUIRE(m2.position().node_id() == 3);
-                REQUIRE(m2.position().offset() == graph.get_node(3)->sequence().size() - match2.from_length());
+                REQUIRE(m2.position().node_id() == back.node);
+                REQUIRE(m2.position().offset() == adder.get_graph().get_length(order.back()) - mapping_from_length(m2));
                 REQUIRE(m2.position().is_reverse() == false);
             }
         }
@@ -497,12 +502,15 @@ TEST_CASE( "The smart aligner should find existing huge deletions", "[variantadd
     
     // Make a VariantAdder
     VariantAdder adder(graph);
+    vector<handle_t> order = handlealgs::topological_order(&adder.get_graph());
+    NodeSide front(adder.get_graph().get_id(order.front()), false);
+    NodeSide back(adder.get_graph().get_id(order.back()), true);
     
     // Make a deleted version (only 21 As)
     string deleted = "GCGCAAAAAAAAAAAAAAAAAAAAAGCGC";
     
     // Align it between 1 and 3
-    auto endpoints = make_pair(NodeSide(1, false), NodeSide(3, true));
+    auto endpoints = make_pair(front, back);
     Alignment aligned = adder.smart_align(graph, endpoints, deleted, graph.length());
     
     SECTION("the resulting alignment should have the input string") {
@@ -535,15 +543,15 @@ TEST_CASE( "The smart aligner should find existing huge deletions", "[variantadd
                 REQUIRE(match1.from_length() + match2.from_length() == deleted.size());
             }
             
-            SECTION("the first mapping should be at the start of node 1") {
-                REQUIRE(m1.position().node_id() == 1);
+            SECTION("the first mapping should be at the start of the first node") {
+                REQUIRE(m1.position().node_id() == front.node);
                 REQUIRE(m1.position().offset() == 0);
                 REQUIRE(m1.position().is_reverse() == false);
             }
             
-            SECTION("the second mapping should be at the end of node 3") {
-                REQUIRE(m2.position().node_id() == 3);
-                REQUIRE(m2.position().offset() == graph.get_node(3)->sequence().size() - match2.from_length());
+            SECTION("the second mapping should be at the end of the last node") {
+                REQUIRE(m2.position().node_id() == back.node);
+                REQUIRE(m2.position().offset() == adder.get_graph().get_length(order.back()) - mapping_from_length(m2));
                 REQUIRE(m2.position().is_reverse() == false);
             }
         }

--- a/src/unittest/vg_algorithms.cpp
+++ b/src/unittest/vg_algorithms.cpp
@@ -4785,7 +4785,7 @@ TEST_CASE("simplify_siblings() can actually merge some siblings", "[algorithms][
     REQUIRE(!worked);
     
     // Unchop to normalize
-    handlealgs::unchop(&graph);
+    handlealgs::unchop(graph);
     
     // Make sure we have the right shape (just a SNP left).
     REQUIRE(graph.get_node_count() == 4);

--- a/src/variant_adder.cpp
+++ b/src/variant_adder.cpp
@@ -12,7 +12,7 @@ using namespace vg::io;
 
 VariantAdder::VariantAdder(VG& graph) : graph(graph), sync([&](VG& g) -> VG& {
         // Dice nodes in the graph for GCSA indexing *before* constructing the synchronizer.
-        handlealgs::chop(&g, max_node_size);
+        handlealgs::chop(g, max_node_size);
         g.paths.compact_ranks();
         return g;
     }(this->graph)) {

--- a/src/variant_adder.cpp
+++ b/src/variant_adder.cpp
@@ -31,6 +31,10 @@ VariantAdder::VariantAdder(VG& graph) : graph(graph), sync([&](VG& g) -> VG& {
     aligner.full_length_bonus = 5;
 }
 
+const VG& VariantAdder::get_graph() const {
+    return graph;
+}
+
 void VariantAdder::add_variants(vcflib::VariantCallFile* vcf) {
     
 #ifdef debug

--- a/src/variant_adder.hpp
+++ b/src/variant_adder.hpp
@@ -44,7 +44,7 @@ public:
     void add_variants(vcflib::VariantCallFile* vcf);
     
     /**
-     * Align the given string to the given graph, wetween the given endpoints,
+     * Align the given string to the given graph, between the given endpoints,
      * using the most appropriate alignment method, depending on the relative
      * sizes involved and whether a good alignment exists. max_span gives the
      * maximum length in the graph that we expect our string to possibly align
@@ -142,6 +142,8 @@ public:
     /// Should we print out periodic updates about the variants we have
     /// processed?
     bool print_updates = false;
+    
+    const VG& get_graph() const;
     
 protected:
     /// The graph we are modifying


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex` now chops nodes when constructing graphs from GFA

## Description

Before it was possible to make graphs that were unindexable by GCSA2.