### PR TITLE
Gaf support for cg cigars

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cp small/x-s1337-n1.gam x.gam
 vg view -a x.gam >x.json
 ```
 
-`vg convert` provides further graph conversion options.
+`vg convert` provides further graph and alignment conversion options.
 
 Note that `vg` tools can generally read all supported graph formats (VG, uncompressed GFA, XG, PackedGraph, HashGraph) interchangeably, so conversion is not required.  One exception is tools that modify graphs (ex `vg mod`) will not accept the read-only XG format. Tools that ask for XG input specifically with `-x` (ex `vg map`, `vg find`) will run on any graph type, but will be faster on XG.
 

--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -5,6 +5,7 @@
 #include "augment.hpp"
 #include "alignment.hpp"
 #include "packer.hpp"
+#include "annotation.hpp"
 //#define debug
 
 using namespace vg::io;
@@ -196,6 +197,14 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
             if (aln.mapping_quality() < min_mapq || (filter_out_of_graph_alignments && !check_in_graph(aln.path(), graph))) {
                 return;
             }
+
+            if (aln_format == "GAF" && has_annotation(aln, "from_cg") && get_annotation<bool>(aln, "from_cg")) {
+#pragma omp critical (cerr)
+                {
+                    cerr << "[vg augment] error: GAF with cg cigars contains insufficient information for augmenting: cs cigars required." << endl;
+                }
+                exit(1);
+            }                    
 
             if (remove_softclips) {
                 softclip_trim(aln);

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 57
+plan tests 58
 
 vg construct -r complex/c.fa -v complex/c.vcf.gz > c.vg
 cat <(vg view c.vg | grep ^S | sort) <(vg view c.vg | grep L | uniq | wc -l) <(vg paths -v c.vg -E) > c.info
@@ -107,6 +107,15 @@ is "$?" 0 "vg convert gam -> gaf -> gam preserves sequence"
 vg convert x.vg -G mut-back.gam -t 1 > mut-back.gaf
 diff mut.gaf mut-back.gaf
 is "$?" 0 "vg convert gam -> gaf -> gam -> gaf makes same gaf twice in presence of indels and snps"
+  
+#hand-code some cg example
+printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cs:Z::13*GA*GA:8+TTT:16*GA*TA:18-AC-T-AG:16\n" > mut.cs.gaf
+printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cg:Z:13M1X1X8M3I16M1X1X18M2D1D2D16M\n" > mut.cg.gaf
+printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	75	79	60	AS:i:47	cs:Z::23+NNN:36-AC-T-AG:16\n" > mut.cs.exp.gaf
+vg convert x.vg -F mut.cg.gaf -t 1 | vg convert x.vg -G - -t 1 > mut.cs.back.gaf
+diff mut.cs.back.gaf mut.cs.exp.gaf
+is "$?" 0 "vg convert cg-gaf -> gam -> cs-gaf gives expected output (snps converted to matches, insertion converted to Ns)"
+rm -f mut.cs.gaf mut.cg.gaf mut.cs.exp.gaf
 
 rm -f x.vg x.gcsa sim.gam sim-rm.gam sim-rm.gaf sim-rm2.gaf sim-rm2-mt-sort.gaf sim-rm2-mtbg-sort.gaf sim-rm2-sort.gaf mut.gam mut-back.gam mut.gaf mut-back.gaf mut.path mut-back.path mut.seq mut-back.seq
 

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -110,7 +110,7 @@ is "$?" 0 "vg convert gam -> gaf -> gam -> gaf makes same gaf twice in presence 
   
 #hand-code some cg example
 printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cs:Z::13*GA*GA:8+TTT:16*GA*TA:18-AC-T-AG:16\n" > mut.cs.gaf
-printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cg:Z:13M1X1X8M3I16M1X1X18M2D1D2D16M\n" > mut.cg.gaf
+printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cg:Z:13M1X1X8M3I16M1X1X18M5D16M\n" > mut.cg.gaf
 printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	75	79	60	AS:i:47	cs:Z::23+NNN:36-AC-T-AG:16\n" > mut.cs.exp.gaf
 vg convert x.vg -F mut.cg.gaf -t 1 | vg convert x.vg -G - -t 1 > mut.cs.back.gaf
 diff mut.cs.back.gaf mut.cs.exp.gaf

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -108,10 +108,12 @@ vg convert x.vg -G mut-back.gam -t 1 > mut-back.gaf
 diff mut.gaf mut-back.gaf
 is "$?" 0 "vg convert gam -> gaf -> gam -> gaf makes same gaf twice in presence of indels and snps"
   
-#hand-code some cg example
+#hand-code cg example.  this is (for reference) mut.gaf:
 printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cs:Z::13*GA*GA:8+TTT:16*GA*TA:18-AC-T-AG:16\n" > mut.cs.gaf
+#manually convert to cg:
 printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cg:Z:13M1X1X8M3I16M1X1X18M5D16M\n" > mut.cg.gaf
-printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	75	79	60	AS:i:47	cs:Z::23+NNN:36-AC-T-AG:16\n" > mut.cs.exp.gaf
+#this is what we expect back, mut.gaf where insertions and snps are converted to Ns:
+printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cs:Z::13*GN*GN:8+NNN:16*GN*TN:18-AC-T-AG:16\n" > mut.cs.exp.gaf
 vg convert x.vg -F mut.cg.gaf -t 1 | vg convert x.vg -G - -t 1 > mut.cs.back.gaf
 diff mut.cs.back.gaf mut.cs.exp.gaf
 is "$?" 0 "vg convert cg-gaf -> gam -> cs-gaf gives expected output (snps converted to matches, insertion converted to Ns)"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg pack` can now handle GAFs with cg cigars (ie from GraphMap)

## Description

It's come up a few times that people were not getting the expected behaviour when passing GAFs from GraphAligner into vg.  This is because vg relies on having cs cigars and GraphAligner writes cg cigars.  This PR lets vg to fall back on cg cigars if cs cigars are not available.   All tools that read GAF will do this automatically now.  Except `vg augment` which really needs edits.  It will abort with an error message right away 