### PR TITLE
Make autoindex produce valid FAI indexes

### DIFF
--- a/src/haplotype_indexer.cpp
+++ b/src/haplotype_indexer.cpp
@@ -57,7 +57,7 @@ std::vector<std::string> HaplotypeIndexer::parse_vcf(const std::string& filename
     // How many samples are there?
     size_t num_samples = variant_file.sampleNames.size();
     if (num_samples == 0) {
-        std::cerr << "error: [HaplotypeIndexer::parse_vcf] the variant file does not contain phasings" << std::endl;
+        std::cerr << "error: [HaplotypeIndexer::parse_vcf] variant file '" << filename << "' does not contain phasings" << std::endl;
         std::exit(EXIT_FAILURE);
     }
 

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -955,6 +955,12 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                     auto output_vcf_name = plan->output_filepath(output_vcf, i, buckets.size());
                     htsFile* vcf = bcf_open(output_vcf_name.c_str(), "wz");
                     bcf_hdr_t* header = bcf_hdr_init("w");
+                    // this is to satisfy HaplotypeIndexer, which doesn't like sample-less VCFs
+                    int sample_add_code = bcf_hdr_add_sample(header, "dummy");
+                    if (sample_add_code != 0) {
+                        cerr << "error:[IndexRegistry] error initializing VCF header" << endl;
+                        exit(1);
+                    }
                     int hdr_write_err_code = bcf_hdr_write(vcf, header);
                     if (hdr_write_err_code != 0) {
                         cerr << "error:[IndexRegistry] error writing VCF header to " << output_vcf_name << endl;

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -2328,6 +2328,10 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             }
             haplotype_indexer->show_progress = IndexingParameters::verbosity >= IndexingParameters::Debug;
             
+            // from the toil-vg best practices
+            haplotype_indexer->force_phasing = true;
+            haplotype_indexer->discard_overlaps = true;
+            
             vector<string> parse_files = haplotype_indexer->parse_vcf(vcf_filenames[i],
                                                                       *graph);
             

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -631,9 +631,9 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             FastaReference ref;
             ref.open(fasta_filenames[i]);
             for (const auto& idx_entry : *ref.index) {
-                seq_files[idx_entry.second.name] = i;
-                seq_lengths[idx_entry.second.name] = idx_entry.second.length;
-                seq_queue.emplace(idx_entry.second.length, idx_entry.second.name);
+                seq_files[idx_entry.first] = i;
+                seq_lengths[idx_entry.first] = idx_entry.second.length;
+                seq_queue.emplace(idx_entry.second.length, idx_entry.first);
             }
         }
         

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -265,7 +265,7 @@ int main_autoindex(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "p:w:r:v:i:g:x:a:P:R:f:M:T:t:dVh",
+        c = getopt_long (argc, argv, "p:w:r:v:i:g:x:a:P:R:f:M:T:t:dV:h",
                          long_options, &option_index);
 
         // Detect the end of the options.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex` now produces valid FAI indexes when the sequence name lines contain tabs.
 * `vg autoindex` has best-practices options set correctly for GBWT construction.

## Description

Resolves https://github.com/vgteam/vg/issues/3291. The root of the problem is that `fastahack` was writing tabs from the sequence name into the FAI index, which caused it to have the wrong number of columns.

Also resolves https://github.com/vgteam/vg/issues/3290.

Also resolves an issue where chunks of contigs that didn't receive any variants would be rejected by the `HaplotypeIndexer` as missing phasing info.