### PR TITLE
Fix CI use of txm and its need for a new Node

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,13 +89,16 @@ build-job:
     - docker buildx create --use --name=buildkit --platform=linux/amd64,linux/arm64 --node=buildkit-amd64 --driver=kubernetes --driver-opt="nodeselector=kubernetes.io/arch=amd64"
     # Prune down build cache to make space
     - docker buildx prune --keep-storage 80G
-    # Connect so we can upload our images
-    - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
   script:
     - make include/vg_git_version.hpp
-    - docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target run --push -t "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" -f Dockerfile .
-    # Also run the tests
+    # Build but don't push, just fill the cache
+    - docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target run -f Dockerfile .
+    # Run the tests
     - docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target test -f Dockerfile .
+    # Connect so we can upload our images
+    - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
+    # Keep trying to push until it works or we time out
+    - while [ ! docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target run --push -t "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" -f Dockerfile . ] ; do docker logout "${CI_REGISTRY}" ; sleep 30; docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}" ; done
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,6 @@
 image: quay.io/vgteam/vg_ci_prebake:latest
 
 before_script:
-  # txm markdown test runner depends on yargs which requires Node newer than current Ubuntu LTS can ship
-  - curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
   - sudo apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
   # And the CI report upload needs uuidgen from uuid-runtime

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ local-build-test-job:
     - git clone https://github.com/vgteam/sequenceTubeMap.git
     - cd sequenceTubeMap
     # Tube map expects local IPv6 but Kubernetes won't let us have it
-    - sed -i 's/^}$/,"serverBindAddress": "127.0.0.1"}/' src/config.json
+    - 'sed -i "s/^}$/,\"serverBindAddress\": \"127.0.0.1\"}/" src/config.json'
     - npm install
     - CI=true npm run test
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,9 @@ build-job:
     # Connect so we can upload our images
     - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
     # Keep trying to push until it works or we time out
-    - while [ ! docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target run --push -t "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" -f Dockerfile . ] ; do docker logout "${CI_REGISTRY}" ; sleep 30; docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}" ; done
+    - set +e
+    - docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target run --push -t "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" -f Dockerfile .
+    - while [[ "$?" != "0" ]] ; do docker logout "${CI_REGISTRY}" ; sleep 30; docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}" ; done
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,8 @@
 image: quay.io/vgteam/vg_ci_prebake:latest
 
 before_script:
+  # txm markdown test runner depends on yargs which requires Node newer than current Ubuntu LTS can ship
+  - curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
   - sudo apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
   # And the CI report upload needs uuidgen from uuid-runtime

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,6 +69,8 @@ local-build-test-job:
     # Also test as a backend for the tube map
     - git clone https://github.com/vgteam/sequenceTubeMap.git
     - cd sequenceTubeMap
+    # Tube map expects local IPv6 but Kubernetes won't let us have it
+    - sed -i 's/^}$/,"serverBindAddress": "127.0.0.1"}/' src/config.json
     - npm install
     - CI=true npm run test
   variables:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ ARG TARGETARCH
 
 RUN echo build > /stage.txt
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
-    apt-get -qq -y update && \
+RUN apt-get -qq -y update && \
     apt-get -qq -y upgrade && \
     apt-get -qq -y install sudo
 
@@ -77,7 +76,7 @@ ARG THREADS=8
 
 RUN echo test > /stage.txt
 
-RUN apt-get -qq -y install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get -qq -y install nodejs
 
 # Fail if any non-portable instructions were used
 RUN /bin/bash -e -c 'if objdump -d /vg/bin/vg | grep vperm2i128 ; then exit 1 ; else exit 0 ; fi'

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ ARG TARGETARCH
 
 RUN echo build > /stage.txt
 
-RUN apt-get -qq -y update && \
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get -qq -y update && \
     apt-get -qq -y upgrade && \
     apt-get -qq -y install sudo
 
@@ -75,6 +76,8 @@ FROM build AS test
 ARG THREADS=8
 
 RUN echo test > /stage.txt
+
+RUN apt-get -qq -y install nodejs
 
 # Fail if any non-portable instructions were used
 RUN /bin/bash -e -c 'if objdump -d /vg/bin/vg | grep vperm2i128 ; then exit 1 ; else exit 0 ; fi'

--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,7 @@ $(LIB_DIR)/libtabixpp.a: $(LIB_DIR)/libhts.a $(TABIXPP_DIR)/*.cpp $(TABIXPP_DIR)
 
 # Build vcflib. Install the library and headers but not binaries or man pages.
 $(LIB_DIR)/libvcflib.a: $(LIB_DIR)/libhts.a $(LIB_DIR)/libtabixpp.a $(VCFLIB_DIR)/src/*.cpp $(VCFLIB_DIR)/src/*.hpp $(VCFLIB_DIR)/intervaltree/*.cpp $(VCFLIB_DIR)/intervaltree/*.h
-	+. ./source_me.sh && cd $(VCFLIB_DIR) && rm -Rf build && mkdir build && cd build && PKG_CONFIG_PATH="$(CWD)/$(LIB_DIR)/pkgconfig" cmake .. && cmake --build .
+	+. ./source_me.sh && cd $(VCFLIB_DIR) && rm -Rf build && mkdir build && cd build && PKG_CONFIG_PATH="$(CWD)/$(LIB_DIR)/pkgconfig:$(PKG_CONFIG_PATH)" cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON .. && cmake --build .
 	+cp $(VCFLIB_DIR)/filevercmp/*.h* $(INC_DIR)
 	+cp $(VCFLIB_DIR)/fastahack/*.h* $(INC_DIR)
 	+cp $(VCFLIB_DIR)/smithwaterman/*.h* $(INC_DIR)

--- a/src/haplotype_indexer.cpp
+++ b/src/haplotype_indexer.cpp
@@ -57,7 +57,7 @@ std::vector<std::string> HaplotypeIndexer::parse_vcf(const std::string& filename
     // How many samples are there?
     size_t num_samples = variant_file.sampleNames.size();
     if (num_samples == 0) {
-        std::cerr << "error: [HaplotypeIndexer::parse_vcf] the variant file does not contain phasings" << std::endl;
+        std::cerr << "error: [HaplotypeIndexer::parse_vcf] variant file '" << filename << "' does not contain phasings" << std::endl;
         std::exit(EXIT_FAILURE);
     }
 

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -265,7 +265,7 @@ int main_autoindex(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "p:w:r:v:i:g:x:a:P:R:f:M:T:t:dVh",
+        c = getopt_long (argc, argv, "p:w:r:v:i:g:x:a:P:R:f:M:T:t:dV:h",
                          long_options, &option_index);
 
         // Detect the end of the options.

--- a/vgci/buildkit-deployment.yml
+++ b/vgci/buildkit-deployment.yml
@@ -34,7 +34,7 @@ spec:
       initContainers:
       - name: configure
         image: moby/buildkit:buildx-stable-1
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         # Set up to GC any container data over 80 GB.
         # In the background? See https://github.com/moby/buildkit/issues/1962
         command:
@@ -90,7 +90,7 @@ spec:
           privileged: true
       containers:
       - image: moby/buildkit:buildx-stable-1
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         command: [buildkitd, '--debug']
         name: buildkitd
         readinessProbe:


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex` now produces valid FAI indexes when the sequence name lines contain tabs.
 * `vg autoindex` has best-practices options set correctly for GBWT construction.
 *  `PKG_CONFIG_PATH` is now forwarded to vcflib build
 * Gitlab build now runs with Node 14

## Description

This pulls in #3287 and #3292 and should fix Gitlab CI by upgrading node beyond what Ubuntu LTS ships.