### PR TITLE
deconstruct usability improvements

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -631,7 +631,9 @@ void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHand
             vector<gbwt::size_type>& thread_ids = gbwt_name_to_ids.at(refpath);
             size_t path_len = 0;
             for (gbwt::size_type thread_id : thread_ids) {
-                path_len += path_to_length(extract_gbwt_path(*graph, *gbwt, thread_id));
+                size_t offset = thread_count(*gbwt, thread_id);
+                size_t len = path_to_length(extract_gbwt_path(*graph, *gbwt, thread_id));
+                path_len = std::max(path_len, offset + len);
             }
             stream << "##contig=<ID=" << refpath << ",length=" << path_len << ">" << endl;
         }

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -283,14 +283,16 @@ Path extract_gbwt_path(const HandleGraph& graph, const gbwt::GBWT& gbwt_index, g
     return result;
 }
 
-std::string thread_name(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
+std::string thread_name(const gbwt::GBWT& gbwt_index, gbwt::size_type id, bool short_name) {
     if (!gbwt_index.hasMetadata() || !gbwt_index.metadata.hasPathNames() || id >= gbwt_index.metadata.paths()) {
         return "";
     }
 
     const gbwt::PathName& path = gbwt_index.metadata.path(id);
     std::stringstream stream;
-    stream << "_thread_";
+    if (!short_name) {
+        stream << "_thread_";
+    }
     if (gbwt_index.metadata.hasSampleNames()) {
         stream << gbwt_index.metadata.sample(path.sample);
     } else {
@@ -302,7 +304,9 @@ std::string thread_name(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
     } else {
         stream << path.contig;
     }
-    stream << "_" << path.phase << "_" << path.count;
+    if (!short_name) {
+        stream << "_" << path.phase << "_" << path.count;
+    }
     return stream.str();
 }
 
@@ -330,6 +334,14 @@ int thread_phase(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
     return path.phase;
 }
 
+int thread_count(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
+    if (!gbwt_index.hasMetadata() || !gbwt_index.metadata.hasPathNames() || id >= gbwt_index.metadata.paths()) {
+        return 0;
+    }
+    
+    const gbwt::PathName& path = gbwt_index.metadata.path(id);
+    return path.count;
+}
 
 //------------------------------------------------------------------------------
 

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -334,7 +334,7 @@ int thread_phase(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
     return path.phase;
 }
 
-int thread_count(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
+gbwt::size_type thread_count(const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
     if (!gbwt_index.hasMetadata() || !gbwt_index.metadata.hasPathNames() || id >= gbwt_index.metadata.paths()) {
         return 0;
     }

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -144,8 +144,9 @@ std::string insert_gbwt_path(MutablePathHandleGraph& graph, const gbwt::GBWT& gb
 Path extract_gbwt_path(const HandleGraph& graph, const gbwt::GBWT& gbwt_index, gbwt::size_type id);
 
 /// Get a string representation of a thread name stored in GBWT metadata.
+/// When short_name is true, return a short name made of just the sample and contig
 /// NOTE: id is a gbwt path id, not a gbwt sequence id.
-std::string thread_name(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
+std::string thread_name(const gbwt::GBWT& gbwt_index, gbwt::size_type id, bool short_name = false);
 
 /// Get a sample name of a thread stored in GBWT metadata.
 /// NOTE: id is a gbwt path id, not a gbwt sequence id.
@@ -154,6 +155,10 @@ std::string thread_sample(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
 /// Get phase of a thread stored in GBWT metadata.
 /// NOTE: id is a gbwt path id, not a gbwt sequence id.
 int thread_phase(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
+
+/// Get count of a thread stored in GBWT metadata.
+/// NOTE: id is a gbwt path id, not a gbwt sequence id.
+int thread_count(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
 
 //------------------------------------------------------------------------------
 

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -158,7 +158,7 @@ int thread_phase(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
 
 /// Get count of a thread stored in GBWT metadata.
 /// NOTE: id is a gbwt path id, not a gbwt sequence id.
-int thread_count(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
+gbwt::size_type thread_count(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
 
 //------------------------------------------------------------------------------
 

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -264,13 +264,22 @@ int main_deconstruct(int argc, char** argv){
             }
         }            
 
-        if (gbwt_index.get() && !altpath_prefixes.empty()) {
+        if (gbwt_index.get()) {
             for (size_t i = 0; i < gbwt_index->metadata.paths(); i++) {
                 string sample_name = thread_sample(*gbwt_index.get(), i);
+                // if no prefixes were specified, we add them all.  this way
+                // we make sure we only use gbwt alts.  an option could be added
+                // to incorporate graph paths by toggling this (ie only adding to
+                // the map if prefixes given)
+                bool add_prefix = altpath_prefixes.empty();
                 for (auto& prefix : altpath_prefixes) {
                     if (sample_name.compare(0, prefix.size(), prefix) == 0) {
-                        alt_path_to_prefix[sample_name] = sample_name;
+                        add_prefix = true;
+                        break;
                     }
+                }
+                if (add_prefix) { 
+                    alt_path_to_prefix[sample_name] = sample_name;
                 }
             }
         }

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -192,7 +192,7 @@ int main_deconstruct(int argc, char** argv){
         // Add GBWT threads if no reference paths found or we're running with -a
         if (gbwt_index.get() && (all_snarls || refpaths.empty())) {
             for (size_t i = 0; i < gbwt_index->metadata.paths(); i++) {
-                refpaths.push_back(thread_name(*gbwt_index, i));
+                refpaths.push_back(thread_name(*gbwt_index, i, true));
             }            
         }
     }
@@ -254,7 +254,7 @@ int main_deconstruct(int argc, char** argv){
             });
         if (gbwt_index.get()) {
             for (size_t i = 0; i < gbwt_index->metadata.paths(); i++) {
-                std::string path_name = thread_name(*gbwt_index, i);
+                std::string path_name = thread_name(*gbwt_index, i, true);
                 for (auto& prefix : refpath_prefixes) {
                     if (path_name.compare(0, prefix.size(), prefix) == 0) {
                         refpaths.push_back(path_name);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg deconstruct` can more easily use reference paths (or subpaths) from the GBWT

## Description

Add subpath support to `deconstruct` names.  So if it finds a reference path that looks like chr21[10-5000], the VCF will be written in terms of chr21 with the offset taken into account.  This goes for path selection too.  Also, reference paths can be selected from the GBWT without needing _thread_ prepended.  