### PR TITLE
choose alt when possible, even if ref more frequent

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -194,7 +194,12 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
     // count the number of times each allele comes up in a traversal
     vector<int> allele_frequencies(*max_element(trav_to_allele.begin(), trav_to_allele.end()) + 1, 0);
     for (auto trav : travs) {
-        ++allele_frequencies[trav_to_allele.at(trav)];
+        // we always want to choose alt over ref when possible in sorting logic below, so
+        // don't count refs here        
+        int allele = trav_to_allele.at(trav);
+        if (allele > 0) {
+            ++allele_frequencies[allele];
+        }        
     }
     // sort on frquency
     function<bool(int, int)> comp = [&] (int trav1, int trav2) {

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -195,9 +195,9 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
     vector<int> allele_frequencies(*max_element(trav_to_allele.begin(), trav_to_allele.end()) + 1, 0);
     for (auto trav : travs) {
         // we always want to choose alt over ref when possible in sorting logic below, so
-        // don't count refs here        
+        // cap ref frequency at 1
         int allele = trav_to_allele.at(trav);
-        if (allele > 0) {
+        if (allele > 0 || allele_frequencies[allele] == 0) {
             ++allele_frequencies[allele];
         }        
     }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg deconstruct` no longer prints sites without alts

## Description

Every now and then `vg deconstruct` can print a site with only reference alleles (and AC=0), which doesn't make much sense.  I think @ekg noticed this on his pggb output too.

I checked and what's going on is related to the heuristic used to choose a single allele for a haplotype that (due to loops) runs through multiple alleles in the snarl:  It chooses the most frequent allele and, in the case of a tie, takes the alt.  So if a haplotype goes through an alt once and the ref twice, it will choose ref and it's possible that no sample takes the alt leading to one of these sites. 

This PR changes it to always choose the alt in the event of a conflict, which I think is probably more intuitive as the alt is present in the haplotype.  

