### PR TITLE
Change Dockerfile to use Google's Docker Hub mirror to avoid Quay build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # Multi-container Dockerfile for build and run containers for vg
-FROM ubuntu:20.04 AS base
+
+# Use Google's non-rate-limited mirror of Docker Hub to get our base image.
+# This helps automated Quay builds because Quay hasn't built a caching system
+# and exposes pull rate limits to users.
+FROM mirror.gcr.io/library/ubuntu:20.04 AS base
 MAINTAINER vgteam
 
 RUN echo base > /stage.txt


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Docker base images are now pulled through Google's cache

## Description

When we do the release builds through Quay's automated process, sometimes they fail because Quay hasn't figured out how to do a cache in front of their infrastructure and exposes Docker Hub pull rate limits to user builds.

This makes the Dockerfile use Google's public pull-through cache of Docker Hub to fetch the base Ubuntu image. Canonical doesn't seem to host their own official registry, and I couldn't find an official-ish Ubuntu that lives on Quay.

