### PR TITLE
GBZ format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -459,20 +459,20 @@ endif
 
 $(INC_DIR)/gbwt/dynamic_gbwt.h: $(LIB_DIR)/libgbwt.a
 
-$(LIB_DIR)/libgbwt.a: $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libdivsufsort.a $(LIB_DIR)/libdivsufsort64.a $(wildcard $(GBWT_DIR)/*.cpp) $(wildcard $(GBWT_DIR)/include/gbwt/*.h)
+$(LIB_DIR)/libgbwt.a: $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libdivsufsort.a $(LIB_DIR)/libdivsufsort64.a $(wildcard $(GBWT_DIR)/src/*.cpp) $(wildcard $(GBWT_DIR)/include/gbwt/*.h)
 ifeq ($(shell uname -s),Darwin)
-	+. ./source_me.sh && cp -r $(GBWT_DIR)/include/gbwt $(CWD)/$(INC_DIR)/ && cd $(GBWT_DIR) && $(MAKE) clean && AS_INTEGRATED_ASSEMBLER=1 $(MAKE) $(FILTER) && mv libgbwt.a $(CWD)/$(LIB_DIR)
+	+. ./source_me.sh && cp -r $(GBWT_DIR)/include/gbwt $(CWD)/$(INC_DIR)/ && cd $(GBWT_DIR) && $(MAKE) clean && AS_INTEGRATED_ASSEMBLER=1 $(MAKE) $(FILTER) && mv lib/libgbwt.a $(CWD)/$(LIB_DIR)
 else
-	+. ./source_me.sh && cp -r $(GBWT_DIR)/include/gbwt $(CWD)/$(INC_DIR)/ && cd $(GBWT_DIR) && $(MAKE) clean && $(MAKE) $(FILTER) && mv libgbwt.a $(CWD)/$(LIB_DIR)
+	+. ./source_me.sh && cp -r $(GBWT_DIR)/include/gbwt $(CWD)/$(INC_DIR)/ && cd $(GBWT_DIR) && $(MAKE) clean && $(MAKE) $(FILTER) && mv lib/libgbwt.a $(CWD)/$(LIB_DIR)
 endif
 
 $(INC_DIR)/gbwtgraph/gbwtgraph.h: $(LIB_DIR)/libgbwtgraph.a
 
-$(LIB_DIR)/libgbwtgraph.a: $(LIB_DIR)/libgbwt.a $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libdivsufsort.a $(LIB_DIR)/libdivsufsort64.a $(LIB_DIR)/libhandlegraph.a $(wildcard $(GBWTGRAPH_DIR)/*.cpp) $(wildcard $(GBWTGRAPH_DIR)/include/gbwtgraph/*.h)
+$(LIB_DIR)/libgbwtgraph.a: $(LIB_DIR)/libgbwt.a $(LIB_DIR)/libsdsl.a $(LIB_DIR)/libdivsufsort.a $(LIB_DIR)/libdivsufsort64.a $(LIB_DIR)/libhandlegraph.a $(wildcard $(GBWTGRAPH_DIR)/src/*.cpp) $(wildcard $(GBWTGRAPH_DIR)/include/gbwtgraph/*.h)
 ifeq ($(shell uname -s),Darwin)
-	+. ./source_me.sh && cp -r $(GBWTGRAPH_DIR)/include/gbwtgraph $(CWD)/$(INC_DIR)/ && cd $(GBWTGRAPH_DIR) && $(MAKE) clean && AS_INTEGRATED_ASSEMBLER=1 $(MAKE) $(FILTER) && mv libgbwtgraph.a $(CWD)/$(LIB_DIR)
+	+. ./source_me.sh && cp -r $(GBWTGRAPH_DIR)/include/gbwtgraph $(CWD)/$(INC_DIR)/ && cd $(GBWTGRAPH_DIR) && $(MAKE) clean && AS_INTEGRATED_ASSEMBLER=1 $(MAKE) $(FILTER) && mv lib/libgbwtgraph.a $(CWD)/$(LIB_DIR)
 else
-	+. ./source_me.sh && cp -r $(GBWTGRAPH_DIR)/include/gbwtgraph $(CWD)/$(INC_DIR)/ && cd $(GBWTGRAPH_DIR) && $(MAKE) clean && $(MAKE) $(FILTER) && mv libgbwtgraph.a $(CWD)/$(LIB_DIR)
+	+. ./source_me.sh && cp -r $(GBWTGRAPH_DIR)/include/gbwtgraph $(CWD)/$(INC_DIR)/ && cd $(GBWTGRAPH_DIR) && $(MAKE) clean && $(MAKE) $(FILTER) && mv lib/libgbwtgraph.a $(CWD)/$(LIB_DIR)
 endif
 
 $(INC_DIR)/BooPHF.h: $(BBHASH_DIR)/BooPHF.h

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -113,7 +113,7 @@ void load_gbwt(gbwt::GBWT& index, const std::string& filename, bool show_progres
     }
     std::unique_ptr<gbwt::GBWT> loaded = vg::io::VPKG::load_one<gbwt::GBWT>(filename);
     if (loaded.get() == nullptr) {
-        std::cerr << "error: [load_gbwt()] could not load compressed GBWT " << filename << std::endl;
+        std::cerr << "error: [load_gbwt()] cannot load compressed GBWT " << filename << std::endl;
         std::exit(EXIT_FAILURE);
     }
     index = std::move(*loaded);
@@ -125,7 +125,19 @@ void load_gbwt(gbwt::DynamicGBWT& index, const std::string& filename, bool show_
     }
     std::unique_ptr<gbwt::DynamicGBWT> loaded = vg::io::VPKG::load_one<gbwt::DynamicGBWT>(filename);
     if (loaded.get() == nullptr) {
-        std::cerr << "error: [load_gbwt()] could not load dynamic GBWT " << filename << std::endl;
+        std::cerr << "error: [load_gbwt()] cannot load dynamic GBWT " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    index = std::move(*loaded);
+}
+
+void load_r_index(gbwt::FastLocate& index, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Loading r-index from " << filename << std::endl;
+    }
+    std::unique_ptr<gbwt::FastLocate> loaded = vg::io::VPKG::load_one<gbwt::FastLocate>(filename);
+    if (loaded.get() == nullptr) {
+        std::cerr << "error: [load_r_index()] cannot load r-index " << filename << std::endl;
         std::exit(EXIT_FAILURE);
     }
     index = std::move(*loaded);
@@ -143,6 +155,16 @@ void save_gbwt(const gbwt::DynamicGBWT& index, const std::string& filename, bool
         std::cerr << "Saving dynamic GBWT to " << filename << std::endl;
     }
     sdsl::simple_sds::serialize_to(index, filename);
+}
+
+void save_r_index(const gbwt::FastLocate& index, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Saving r-index to " << filename << std::endl;
+    }
+    if (!sdsl::store_to_file(index, filename)) {
+        std::cerr << "error: [save_r_index()] cannot write r-index to " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -107,7 +107,7 @@ void finish_gbwt_constuction(gbwt::GBWTBuilder& builder,
 
 //------------------------------------------------------------------------------
 
-void load_gbwt(const std::string& filename, gbwt::GBWT& index, bool show_progress) {
+void load_gbwt(gbwt::GBWT& index, const std::string& filename, bool show_progress) {
     if (show_progress) {
         std::cerr << "Loading compressed GBWT from " << filename << std::endl;
     }
@@ -119,7 +119,7 @@ void load_gbwt(const std::string& filename, gbwt::GBWT& index, bool show_progres
     index = std::move(*loaded);
 }
 
-void load_gbwt(const std::string& filename, gbwt::DynamicGBWT& index, bool show_progress) {
+void load_gbwt(gbwt::DynamicGBWT& index, const std::string& filename, bool show_progress) {
     if (show_progress) {
         std::cerr << "Loading dynamic GBWT from " << filename << std::endl;
     }
@@ -130,6 +130,22 @@ void load_gbwt(const std::string& filename, gbwt::DynamicGBWT& index, bool show_
     }
     index = std::move(*loaded);
 }
+
+void save_gbwt(const gbwt::GBWT& index, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Saving compressed GBWT to " << filename << std::endl;
+    }
+    sdsl::simple_sds::serialize_to(index, filename);
+}
+
+void save_gbwt(const gbwt::DynamicGBWT& index, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Saving dynamic GBWT to " << filename << std::endl;
+    }
+    sdsl::simple_sds::serialize_to(index, filename);
+}
+
+//------------------------------------------------------------------------------
 
 void GBWTHandler::use_compressed() {
     if (this->in_use == index_compressed) {
@@ -142,7 +158,7 @@ void GBWTHandler::use_compressed() {
         this->dynamic = gbwt::DynamicGBWT();
         this->in_use = index_compressed;
     } else {
-        load_gbwt(this->filename, this->compressed, this->show_progress);
+        load_gbwt(this->compressed, this->filename, this->show_progress);
         this->in_use = index_compressed;
     }
 }
@@ -158,7 +174,7 @@ void GBWTHandler::use_dynamic() {
         this->compressed = gbwt::GBWT();
         this->in_use = index_dynamic;
     } else {
-        load_gbwt(this->filename, this->dynamic, this->show_progress);
+        load_gbwt(this->dynamic, this->filename, this->show_progress);
         this->in_use = index_dynamic;
     }
 }
@@ -180,16 +196,13 @@ void GBWTHandler::unbacked() {
 }
 
 void GBWTHandler::serialize(const std::string& new_filename) {
-    if (this->show_progress) {
-        std::cerr << "Serializing the GBWT to " << new_filename << std::endl;
-    }
     if (this->in_use == index_none) {
         std::cerr << "warning: [GBWTHandler] no GBWT to serialize" << std::endl;
         return;
     } else if (this->in_use == index_compressed) {
-        vg::io::VPKG::save(this->compressed, new_filename);
+        save_gbwt(this->compressed, new_filename, this->show_progress);
     } else {
-        vg::io::VPKG::save(this->dynamic, new_filename);
+        save_gbwt(this->dynamic, new_filename, this->show_progress);
     }
     this->filename = new_filename;
 }

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -10,6 +10,7 @@
 #include "position.hpp"
 
 #include <gbwt/dynamic_gbwt.h>
+#include <gbwt/fast_locate.h>
 #include <handlegraph/mutable_path_handle_graph.hpp>
 
 namespace vg {
@@ -75,7 +76,7 @@ void finish_gbwt_constuction(gbwt::GBWTBuilder& builder,
 //------------------------------------------------------------------------------
 
 /*
-    These are the proper ways of saving and loading GBWT indexes.
+    These are the proper ways of saving and loading GBWT structures.
     Loading with `vg::io::VPKG::load_one` is also supported.
 */
 
@@ -85,11 +86,17 @@ void load_gbwt(gbwt::GBWT& index, const std::string& filename, bool show_progres
 /// Load a dynamic GBWT from the file.
 void load_gbwt(gbwt::DynamicGBWT& index, const std::string& filename, bool show_progress = false);
 
+/// Load an r-index from the file.
+void load_r_index(gbwt::FastLocate& index, const std::string& filename, bool show_progress = false);
+
 /// Save a compressed GBWT to the file.
 void save_gbwt(const gbwt::GBWT& index, const std::string& filename, bool show_progress = false);
 
 /// Save a dynamic GBWT to the file.
 void save_gbwt(const gbwt::DynamicGBWT& index, const std::string& filename, bool show_progress = false);
+
+/// Save an r-index to the file.
+void save_r_index(const gbwt::FastLocate& index, const std::string& filename, bool show_progress = false);
 
 //------------------------------------------------------------------------------
 
@@ -191,7 +198,6 @@ unordered_map<nid_t, vector<nid_t>> load_translation_map(ifstream& input_stream)
 unordered_map<nid_t, pair<nid_t, size_t>> load_translation_back_map(HandleGraph& graph, ifstream& input_stream);
 
 //------------------------------------------------------------------------------
-
 
 } // namespace vg
 

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -74,11 +74,24 @@ void finish_gbwt_constuction(gbwt::GBWTBuilder& builder,
 
 //------------------------------------------------------------------------------
 
+/*
+    These are the proper ways of saving and loading GBWT indexes.
+    Loading with `vg::io::VPKG::load_one` is also supported.
+*/
+
 /// Load a compressed GBWT from the file.
-void load_gbwt(const std::string& filename, gbwt::GBWT& index, bool show_progress = false);
+void load_gbwt(gbwt::GBWT& index, const std::string& filename, bool show_progress = false);
 
 /// Load a dynamic GBWT from the file.
-void load_gbwt(const std::string& filename, gbwt::DynamicGBWT& index, bool show_progress = false);
+void load_gbwt(gbwt::DynamicGBWT& index, const std::string& filename, bool show_progress = false);
+
+/// Save a compressed GBWT to the file.
+void save_gbwt(const gbwt::GBWT& index, const std::string& filename, bool show_progress = false);
+
+/// Save a dynamic GBWT to the file.
+void save_gbwt(const gbwt::DynamicGBWT& index, const std::string& filename, bool show_progress = false);
+
+//------------------------------------------------------------------------------
 
 /**
  * Helper class that stores either a GBWT or a DynamicGBWT and loads them from a file

--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -42,13 +42,14 @@ void load_gbz(gbwt::GBWT& index, gbwtgraph::GBWTGraph& graph, const std::string&
     }
     index = std::move(loaded->index);
     graph = std::move(loaded->graph);
+    graph.set_gbwt(index); // We moved the GBWT out from the GBZ, so we have to update the pointer.
 }
 
 void load_gbz(gbwtgraph::GBZ& gbz, const std::string& gbwt_name, const std::string& graph_name, bool show_progress) {
     gbz = gbwtgraph::GBZ();
     load_gbwt(gbz.index, gbwt_name, show_progress);
     load_gbwtgraph(gbz.graph, graph_name, show_progress);
-    gbz.graph.set_gbwt(gbz.index);
+    gbz.graph.set_gbwt(gbz.index); // We know the GBWT index corresponding to the graph.
 }
 
 void load_minimizer(gbwtgraph::DefaultMinimizerIndex& index, const std::string& filename, bool show_progress) {

--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -1,0 +1,113 @@
+#include "gbwtgraph_helper.hpp"
+#include "gbwt_helper.hpp"
+
+#include <vg/io/vpkg.hpp>
+
+namespace vg {
+
+//------------------------------------------------------------------------------
+
+void load_gbwtgraph(gbwtgraph::GBWTGraph& graph, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Loading GBWTGraph from " << filename << std::endl;
+    }
+    std::unique_ptr<gbwtgraph::GBWTGraph> loaded = vg::io::VPKG::load_one<gbwtgraph::GBWTGraph>(filename);
+    if (loaded.get() == nullptr) {
+        std::cerr << "error: [load_gbwtgraph()] cannot load GBWTGraph " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    graph = std::move(*loaded);
+}
+
+void load_gbz(gbwtgraph::GBZ& gbz, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Loading GBZ from " << filename << std::endl;
+    }
+    std::unique_ptr<gbwtgraph::GBZ> loaded = vg::io::VPKG::load_one<gbwtgraph::GBZ>(filename);
+    if (loaded.get() == nullptr) {
+        std::cerr << "error: [load_gbz()] cannot load GBZ " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    gbz = std::move(*loaded);
+}
+
+void load_gbz(gbwt::GBWT& index, gbwtgraph::GBWTGraph& graph, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Loading GBWT and GBWTGraph from " << filename << std::endl;
+    }
+    std::unique_ptr<gbwtgraph::GBZ> loaded = vg::io::VPKG::load_one<gbwtgraph::GBZ>(filename);
+    if (loaded.get() == nullptr) {
+        std::cerr << "error: [load_gbz()] cannot load GBZ " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    index = std::move(loaded->index);
+    graph = std::move(loaded->graph);
+}
+
+void load_gbz(gbwtgraph::GBZ& gbz, const std::string& gbwt_name, const std::string& graph_name, bool show_progress) {
+    gbz = gbwtgraph::GBZ();
+    load_gbwt(gbz.index, gbwt_name, show_progress);
+    load_gbwtgraph(gbz.graph, graph_name, show_progress);
+    gbz.graph.set_gbwt(gbz.index);
+}
+
+void load_minimizer(gbwtgraph::DefaultMinimizerIndex& index, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Loading MinimizerIndex from " << filename << std::endl;
+    }
+    std::unique_ptr<gbwtgraph::DefaultMinimizerIndex> loaded = vg::io::VPKG::load_one<gbwtgraph::DefaultMinimizerIndex>(filename);
+    if (loaded.get() == nullptr) {
+        std::cerr << "error: [load_minimizer()] cannot load MinimizerIndex " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    index = std::move(*loaded);
+}
+
+void save_gbwtgraph(const gbwtgraph::GBWTGraph& graph, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Saving GBWTGraph to " << filename << std::endl;
+    }
+    graph.serialize(filename);
+}
+
+void save_gbz(const gbwtgraph::GBZ& gbz, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Saving GBZ to " << filename << std::endl;
+    }
+    sdsl::simple_sds::serialize_to(gbz, filename);
+}
+
+void save_gbz(const gbwt::GBWT& index, gbwtgraph::GBWTGraph& graph, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Saving GBWT and GBWTGraph to " << filename << std::endl;
+    }
+    std::ofstream out(filename, std::ios_base::binary);
+    if (!out) {
+        std::cerr << "error: [save_gbz()] cannot open file " << filename << " for writing" << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    gbwtgraph::GBZ::simple_sds_serialize(index, graph, out);
+    out.close();
+}
+
+void save_gbz(const gbwtgraph::GBZ& gbz, const std::string& gbwt_name, const std::string& graph_name, bool show_progress) {
+    save_gbwt(gbz.index, gbwt_name, show_progress);
+    save_gbwtgraph(gbz.graph, graph_name, show_progress);
+}
+
+void save_minimizer(const gbwtgraph::DefaultMinimizerIndex& index, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Saving MinimizerIndex to " << filename << std::endl;
+    }
+    std::ofstream out(filename, std::ios_base::binary);
+    if (!out) {
+        std::cerr << "error: [save_minimizer()] cannot open file " << filename << " for writing" << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    index.serialize(out);
+    out.close();
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace vg

--- a/src/gbwtgraph_helper.hpp
+++ b/src/gbwtgraph_helper.hpp
@@ -1,0 +1,54 @@
+#ifndef VG_GBWTGRAPH_HELPER_HPP_INCLUDED
+#define VG_GBWTGRAPH_HELPER_HPP_INCLUDED
+
+/** \file 
+ * Utility classes and functions for working with GBWTGraph.
+ */
+
+#include <gbwtgraph/gbz.h>
+#include <gbwtgraph/minimizer.h>
+
+namespace vg {
+
+//------------------------------------------------------------------------------
+
+/*
+    These are the proper ways of saving and loading GBWTGraph structures.
+    Loading with `vg::io::VPKG::load_one` is also supported.
+*/
+
+/// Load GBWTGraph from the file.
+void load_gbwtgraph(gbwtgraph::GBWTGraph& graph, const std::string& filename, bool show_progress = false);
+
+/// Load GBZ from the file.
+void load_gbz(gbwtgraph::GBZ& gbz, const std::string& filename, bool show_progress = false);
+
+/// Load GBZ from separate GBWT / GBWTGraph files.
+void load_gbz(gbwtgraph::GBZ& gbz, const std::string& gbwt_name, const std::string& graph_name, bool show_progress = false);
+
+/// Load GBWT and GBWTGraph from the GBZ file.
+void load_gbz(gbwt::GBWT& index, gbwtgraph::GBWTGraph& graph, const std::string& filename, bool show_progress = false);
+
+/// Load a minimizer index from the file.
+void load_minimizer(gbwtgraph::DefaultMinimizerIndex& index, const std::string& filename, bool show_progress = false);
+
+/// Save GBWTGraph to the file.
+void save_gbwtgraph(const gbwtgraph::GBWTGraph& graph, const std::string& filename, bool show_progress = false);
+
+/// Save GBZ to the file.
+void save_gbz(const gbwtgraph::GBZ& gbz, const std::string& filename, bool show_progress = false);
+
+/// Save GBWT and GBWTGraph to the GBZ file.
+void save_gbz(const gbwt::GBWT& index, gbwtgraph::GBWTGraph& graph, const std::string& filename, bool show_progress = false);
+
+/// Save GBZ to separate GBWT / GBWTGraph files.
+void save_gbz(const gbwtgraph::GBZ& gbz, const std::string& gbwt_name, const std::string& graph_name, bool show_progress = false);
+
+/// Save a minimizer index to the file.
+void save_minimizer(const gbwtgraph::DefaultMinimizerIndex& index, const std::string& filename, bool show_progress = false);
+
+//------------------------------------------------------------------------------
+
+} // namespace vg
+
+#endif // VG_GBWTGRAPH_HELPER_HPP_INCLUDED

--- a/src/gbwtgraph_helper.hpp
+++ b/src/gbwtgraph_helper.hpp
@@ -18,6 +18,7 @@ namespace vg {
 */
 
 /// Load GBWTGraph from the file.
+/// NOTE: Call `graph.set_gbwt()` afterwards with the appropriate GBWT index.
 void load_gbwtgraph(gbwtgraph::GBWTGraph& graph, const std::string& filename, bool show_progress = false);
 
 /// Load GBZ from the file.

--- a/src/gcsa_helper.cpp
+++ b/src/gcsa_helper.cpp
@@ -1,0 +1,55 @@
+#include "gcsa_helper.hpp"
+
+#include <vg/io/vpkg.hpp>
+
+namespace vg {
+
+//------------------------------------------------------------------------------
+
+void load_gcsa(gcsa::GCSA& index, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Loading GCSA from " << filename << std::endl;
+    }
+    std::unique_ptr<gcsa::GCSA> loaded = vg::io::VPKG::load_one<gcsa::GCSA>(filename);
+    if (loaded.get() == nullptr) {
+        std::cerr << "error: [load_gcsa()] cannot load GCSA " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    index = std::move(*loaded);
+}
+
+void load_lcp(gcsa::LCPArray& lcp, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Loading LCP from " << filename << std::endl;
+    }
+    std::unique_ptr<gcsa::LCPArray> loaded = vg::io::VPKG::load_one<gcsa::LCPArray>(filename);
+    if (loaded.get() == nullptr) {
+        std::cerr << "error: [load_lcp()] cannot load LCP " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    lcp = std::move(*loaded);
+}
+
+void save_gcsa(const gcsa::GCSA& index, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Saving GCSA to " << filename << std::endl;
+    }
+    if (!sdsl::store_to_file(index, filename)) {
+        std::cerr << "error: [save_gcsa()] cannot write GCSA to " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+}
+
+void save_lcp(const gcsa::LCPArray& lcp, const std::string& filename, bool show_progress) {
+    if (show_progress) {
+        std::cerr << "Saving LCP to " << filename << std::endl;
+    }
+    if (!sdsl::store_to_file(lcp, filename)) {
+        std::cerr << "error: [save_gcsa()] cannot write LCP to " << filename << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace vg

--- a/src/gcsa_helper.hpp
+++ b/src/gcsa_helper.hpp
@@ -1,0 +1,36 @@
+#ifndef VG_GCSA_HELPER_HPP_INCLUDED
+#define VG_GCSA_HELPER_HPP_INCLUDED
+
+/** \file 
+ * Utility classes and functions for working with GCSA.
+ */
+
+#include <gcsa/gcsa.h>
+#include <gcsa/lcp.h>
+
+namespace vg {
+
+//------------------------------------------------------------------------------
+
+/*
+    These are the proper ways of saving and loading GCSA structures.
+    Loading with `vg::io::VPKG::load_one` is also supported.
+*/
+
+/// Load GCSA from the file.
+void load_gcsa(gcsa::GCSA& index, const std::string& filename, bool show_progress = false);
+
+/// Load LCP array from the file.
+void load_lcp(gcsa::LCPArray& lcp, const std::string& filename, bool show_progress = false);
+
+/// Save GCSA to the file.
+void save_gcsa(const gcsa::GCSA& index, const std::string& filename, bool show_progress = false);
+
+/// Save LCP array to the file.
+void save_lcp(const gcsa::LCPArray& lcp, const std::string& filename, bool show_progress = false);
+
+//------------------------------------------------------------------------------
+
+} // namespace vg
+
+#endif // VG_GCSA_HELPER_HPP_INCLUDED

--- a/src/haplotypes.hpp
+++ b/src/haplotypes.hpp
@@ -622,7 +622,7 @@ int64_t GBWTScoreProvider<GBWTType>::get_haplotype_count() const {
   
   // TODO: Does this haplotype count have the same expected-count-for-fixed-path semantics that we want?
   // Or does it count fragments of haplotypes?
-  return index.metadata.haplotype_count;
+  return index.metadata.haplotypes();
 }
 
 template<class GBWTType>

--- a/src/index_manager.cpp
+++ b/src/index_manager.cpp
@@ -2,6 +2,8 @@
  * \file index_manager.cpp: implementations of common indexing functionality
  */
 
+#include "index_manager.hpp"
+
 #include <iostream>
 #include <vector>
 #include <string>
@@ -12,7 +14,6 @@
 #include <bdsg/hash_graph.hpp>
 #include <gbwtgraph/index.h> 
 
-#include "index_manager.hpp"
 #include "utility.hpp"
 #include "constructor.hpp"
 #include "cactus_snarl_finder.hpp"
@@ -395,7 +396,8 @@ void IndexManager::ensure_gbwt() {
 
         if (out.is_open()) {
             // Save it
-            vg::io::VPKG::save(*gbwt, out);
+            // TODO: It would be nicer to use file names here.
+            gbwt->simple_sds_serialize(out);
         }
     });
 }
@@ -446,7 +448,8 @@ void IndexManager::ensure_gbwtgraph() {
 
         if (out.is_open()) {
             // Save it
-            vg::io::VPKG::save(*gbwtgraph.first, out);
+            // TODO: It would be nicer to use file names here.
+            gbwtgraph.first->serialize(out);
         }
     });
 }
@@ -484,7 +487,8 @@ void IndexManager::ensure_minimizer() {
 
         if (out.is_open()) {
             // Save it
-            vg::io::VPKG::save(*minimizer, out);
+            // TODO: It would be nicer to use file names here.
+            minimizer->serialize(out);
         }
     });
 }

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -2217,7 +2217,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             
             vector<gbwt::GBWT> gbwt_indexes(gbwt_names.size());
             for (size_t i = 0; i < gbwt_names.size(); ++i) {
-                load_gbwt(gbwt_names[i], gbwt_indexes[i], IndexingParameters::verbosity >= IndexingParameters::Debug);
+                load_gbwt(gbwt_indexes[i], gbwt_names[i], IndexingParameters::verbosity >= IndexingParameters::Debug);
             }
             gbwt::GBWT merged(gbwt_indexes);
             merged.serialize(outfile);

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -40,6 +40,8 @@
 #include "haplotype_indexer.hpp"
 #include "phase_unfolder.hpp"
 #include "gbwt_helper.hpp"
+#include "gbwtgraph_helper.hpp"
+#include "gcsa_helper.hpp"
 #include "kmer.hpp"
 #include "transcriptome.hpp"
 #include "integrated_snarl_finder.hpp"
@@ -2343,7 +2345,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             
             unique_ptr<gbwt::DynamicGBWT> gbwt_index = haplotype_indexer->build_gbwt(parse_files);
             
-            vg::io::VPKG::save(*gbwt_index, gbwt_name);
+            save_gbwt(*gbwt_index, gbwt_name);
             
             gbwt_names[i] = gbwt_name;
         };
@@ -2430,7 +2432,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                                                        IndexingParameters::gbwt_sampling_interval,
                                                        IndexingParameters::verbosity >= IndexingParameters::Debug);
         
-        vg::io::VPKG::save(cover, output_name);
+        save_gbwt(cover, output_name);
         output_names.push_back(output_name);
         return all_outputs;
     });
@@ -2473,7 +2475,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                                                       IndexingParameters::gbwt_sampling_interval,
                                                       IndexingParameters::verbosity >= IndexingParameters::Debug);
         
-        vg::io::VPKG::save(cover, output_name);
+        save_gbwt(cover, output_name);
         output_names.push_back(output_name);
         return all_outputs;
     });
@@ -2607,7 +2609,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             
             // save the haplotype transcript GBWT
             gbwt_builder.finish();
-            vg::io::VPKG::save(gbwt_builder.index, gbwt_name);
+            save_gbwt(gbwt_builder.index, gbwt_name);
             
             // write transcript origin info table
             transcriptome.write_info(&info_outfile, *haplotype_index, false);
@@ -2997,8 +2999,8 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         cerr << "saving GCSA/LCP pair" << endl;
 #endif
         
-        vg::io::VPKG::save(gcsa_index, gcsa_output_name);
-        vg::io::VPKG::save(lcp_array, lcp_output_name);
+        save_gcsa(gcsa_index, gcsa_output_name);
+        save_lcp(lcp_array, lcp_output_name);
         
         gcsa_names.push_back(gcsa_output_name);
         lcp_names.push_back(lcp_output_name);
@@ -3220,7 +3222,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         // TODO: could add simplification to replace XG index with a gbwt::SequenceSource here
         gbwtgraph::GBWTGraph ggraph(*gbwt_index, *xg_index);
         
-        vg::io::VPKG::save(ggraph, output_name);
+        save_gbwtgraph(ggraph, output_name);
         
         output_names.push_back(output_name);
         return all_outputs;
@@ -3280,7 +3282,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             return MIPayload::encode(dist_index->get_minimizer_distances(pos));
         });
         
-        vg::io::VPKG::save(minimizers, output_name);
+        save_minimizer(minimizers, output_name);
         
         output_names.push_back(output_name);
         return all_outputs;

--- a/src/io/register_libvg_io.cpp
+++ b/src/io/register_libvg_io.cpp
@@ -9,6 +9,7 @@
 #include "register_loader_saver_gbwt.hpp"
 #include "register_loader_saver_r_index.hpp"
 #include "register_loader_saver_gbwtgraph.hpp"
+#include "register_loader_saver_gbz.hpp"
 #include "register_loader_saver_gcsa.hpp"
 #include "register_loader_saver_lcp.hpp"
 #include "register_loader_saver_minimizer.hpp"
@@ -34,6 +35,7 @@ bool register_libvg_io() {
     register_loader_saver_gbwt();
     register_loader_saver_r_index();
     register_loader_saver_gbwtgraph();
+    register_loader_saver_gbz();
     register_loader_saver_gcsa();
     register_loader_saver_lcp();
     register_loader_saver_minimizer();

--- a/src/io/register_loader_saver_gbwt.cpp
+++ b/src/io/register_loader_saver_gbwt.cpp
@@ -32,7 +32,7 @@ void register_loader_saver_gbwt() {
     }, [](const void* index_void, ostream& output) {
         // Cast to GBWT and serialize to the stream.
         assert(index_void != nullptr);
-        ((const gbwt::GBWT*) index_void)->serialize(output);
+        ((const gbwt::GBWT*) index_void)->simple_sds_serialize(output);
     });
     
     Registry::register_bare_loader_saver<gbwt::DynamicGBWT>("GBWT", [](istream& input) -> void* {
@@ -47,7 +47,7 @@ void register_loader_saver_gbwt() {
     }, [](const void* index_void, ostream& output) {
         // Cast to DynamicGBWT and serialize to the stream.
         assert(index_void != nullptr);
-        ((const gbwt::DynamicGBWT*) index_void)->serialize(output);
+        ((const gbwt::DynamicGBWT*) index_void)->simple_sds_serialize(output);
     });
 }
 

--- a/src/io/register_loader_saver_gbwt.cpp
+++ b/src/io/register_loader_saver_gbwt.cpp
@@ -18,9 +18,10 @@ using namespace vg::io;
 
 void register_loader_saver_gbwt() {
     // GBWT and DynamicGBWT can both load/save the same format.
-    // TODO: Should DynamicGBWT be its own file here?
+    std::uint32_t magic_number = gbwt::GBWTHeader::TAG;
+    std::string magic_string(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
 
-    Registry::register_bare_loader_saver<gbwt::GBWT>("GBWT", [](istream& input) -> void* {
+    Registry::register_bare_loader_saver_with_magic<gbwt::GBWT>("GBWT", magic_string, [](istream& input) -> void* {
         // Allocate a GBWT
         gbwt::GBWT* index = new gbwt::GBWT();
         
@@ -35,7 +36,7 @@ void register_loader_saver_gbwt() {
         ((const gbwt::GBWT*) index_void)->simple_sds_serialize(output);
     });
     
-    Registry::register_bare_loader_saver<gbwt::DynamicGBWT>("GBWT", [](istream& input) -> void* {
+    Registry::register_bare_loader_saver_with_magic<gbwt::DynamicGBWT>("GBWT", magic_string, [](istream& input) -> void* {
         // Allocate a DynamicGBWT
         gbwt::DynamicGBWT* index = new gbwt::DynamicGBWT();
         

--- a/src/io/register_loader_saver_gbwtgraph.cpp
+++ b/src/io/register_loader_saver_gbwtgraph.cpp
@@ -8,6 +8,8 @@
 
 #include <gbwtgraph/gbwtgraph.h>
 
+#include <arpa/inet.h>
+
 namespace vg {
 
 namespace io {
@@ -16,7 +18,13 @@ using namespace std;
 using namespace vg::io;
 
 void register_loader_saver_gbwtgraph() {
-    Registry::register_bare_loader_saver<gbwtgraph::GBWTGraph>("GBWTGraph", [](istream& input) -> void* {
+
+    // Use the `SerializableHandleGraph` magic number.
+    gbwtgraph::GBWTGraph empty;
+    std::uint32_t magic_number = htonl(empty.get_magic_number());
+    std::string magic_string(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
+
+    Registry::register_bare_loader_saver_with_magic<gbwtgraph::GBWTGraph>("GBWTGraph", magic_string, [](istream& input) -> void* {
         gbwtgraph::GBWTGraph* graph = new gbwtgraph::GBWTGraph();
         graph->deserialize(input);
         
@@ -24,6 +32,8 @@ void register_loader_saver_gbwtgraph() {
         return static_cast<void*>(graph);
     }, [](const void* graph_void, ostream& output) {
         assert(graph_void != nullptr);
+        // Serialize in the SDSL format, which is larger than the simple-sds format but faster to load.
+        // If we want to use the simple-sds format, we can serialize GBZ instead.
         static_cast<const gbwtgraph::GBWTGraph*>(graph_void)->serialize(output);
     });
 }

--- a/src/io/register_loader_saver_gbwtgraph.cpp
+++ b/src/io/register_loader_saver_gbwtgraph.cpp
@@ -1,6 +1,6 @@
 /**
  * \file register_loader_saver_gbwtgraph.cpp
- * Defines IO for a minimizer index from stream files.
+ * Defines IO for GBWTGraph from stream files.
  */
 
 #include <vg/io/registry.hpp>

--- a/src/io/register_loader_saver_gbz.cpp
+++ b/src/io/register_loader_saver_gbz.cpp
@@ -1,0 +1,35 @@
+/**
+ * \file register_loader_saver_gbz.cpp
+ * Defines IO for GBZ from stream files.
+ */
+
+#include <vg/io/registry.hpp>
+#include "register_loader_saver_gbz.hpp"
+
+#include <gbwtgraph/gbz.h>
+
+namespace vg {
+
+namespace io {
+
+using namespace std;
+using namespace vg::io;
+
+void register_loader_saver_gbz() {
+    std::uint32_t magic_number = gbwtgraph::GBZ::Header::TAG;
+    std::string magic_string(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
+
+    Registry::register_bare_loader_saver_with_magic<gbwtgraph::GBZ>("GBZ", magic_string, [](std::istream& input) -> void* {
+        gbwtgraph::GBZ* result = new gbwtgraph::GBZ();
+        result->simple_sds_load(input);
+        return reinterpret_cast<void*>(result);
+    }, [](const void* gbz_void, std::ostream& output) {
+        assert(gbz_void != nullptr);
+        const gbwtgraph::GBZ* gbz = reinterpret_cast<const gbwtgraph::GBZ*>(gbz_void);
+        gbz->simple_sds_serialize(output);
+    });
+}
+
+}
+
+}

--- a/src/io/register_loader_saver_gbz.hpp
+++ b/src/io/register_loader_saver_gbz.hpp
@@ -1,0 +1,21 @@
+#ifndef VG_IO_REGISTER_LOADER_SAVER_GBZ_HPP_INCLUDED
+#define VG_IO_REGISTER_LOADER_SAVER_GBZ_HPP_INCLUDED
+
+/**
+ * \file register_loader_saver_gbz.hpp
+ * Defines IO for GBZ from stream files.
+ */
+
+namespace vg {
+
+namespace io {
+
+using namespace std;
+
+void register_loader_saver_gbz();
+
+}
+
+}
+
+#endif

--- a/src/io/register_loader_saver_gcsa.cpp
+++ b/src/io/register_loader_saver_gcsa.cpp
@@ -16,7 +16,10 @@ using namespace std;
 using namespace vg::io;
 
 void register_loader_saver_gcsa() {
-    Registry::register_bare_loader_saver<gcsa::GCSA>("GCSA", [](istream& input) -> void* {
+    std::uint32_t magic_number = gcsa::GCSAHeader::TAG;
+    std::string magic_string(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
+
+    Registry::register_bare_loader_saver_with_magic<gcsa::GCSA>("GCSA", magic_string, [](istream& input) -> void* {
         // Allocate a GCSA
         gcsa::GCSA* index = new gcsa::GCSA();
         

--- a/src/io/register_loader_saver_lcp.cpp
+++ b/src/io/register_loader_saver_lcp.cpp
@@ -16,7 +16,10 @@ using namespace std;
 using namespace vg::io;
 
 void register_loader_saver_lcp() {
-    Registry::register_bare_loader_saver<gcsa::LCPArray>("LCP", [](istream& input) -> void* {
+    std::uint32_t magic_number = gcsa::LCPHeader::TAG;
+    std::string magic_string(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
+
+    Registry::register_bare_loader_saver_with_magic<gcsa::LCPArray>("LCP", magic_string, [](istream& input) -> void* {
         // Allocate an LCPArray
         gcsa::LCPArray* index = new gcsa::LCPArray();
         

--- a/src/io/register_loader_saver_minimizer.cpp
+++ b/src/io/register_loader_saver_minimizer.cpp
@@ -16,7 +16,10 @@ using namespace std;
 using namespace vg::io;
 
 void register_loader_saver_minimizer() {
-    Registry::register_bare_loader_saver<gbwtgraph::DefaultMinimizerIndex>("MinimizerIndex", [](istream& input) -> void* {
+    std::uint32_t magic_number = gbwtgraph::MinimizerHeader::TAG;
+    std::string magic_string(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
+
+    Registry::register_bare_loader_saver_with_magic<gbwtgraph::DefaultMinimizerIndex>("MinimizerIndex", magic_string, [](istream& input) -> void* {
         gbwtgraph::DefaultMinimizerIndex* index = new gbwtgraph::DefaultMinimizerIndex();
         index->deserialize(input);
         

--- a/src/io/register_loader_saver_r_index.cpp
+++ b/src/io/register_loader_saver_r_index.cpp
@@ -16,8 +16,10 @@ using namespace std;
 using namespace vg::io;
 
 void register_loader_saver_r_index() {
+    std::uint32_t magic_number = gbwt::FastLocate::Header::TAG;
+    std::string magic_string(reinterpret_cast<char*>(&magic_number), sizeof(magic_number));
 
-    Registry::register_bare_loader_saver<gbwt::FastLocate>("R-INDEX", [](istream& input) -> void* {
+    Registry::register_bare_loader_saver_with_magic<gbwt::FastLocate>("R-INDEX", magic_string, [](istream& input) -> void* {
         // Allocate an r-index
         gbwt::FastLocate* index = new gbwt::FastLocate();
 

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -19,7 +19,7 @@
 #include <vg/io/vpkg.hpp>
 
 #include <gbwt/fast_locate.h>
-#include <gbwtgraph/gbwtgraph.h>
+#include <gbwtgraph/gbz.h>
 #include <gbwtgraph/gfa.h>
 #include <gbwtgraph/path_cover.h>
 
@@ -48,6 +48,9 @@ struct GBWTConfig {
 
     // Parallel merging.
     gbwt::MergeParameters merge_parameters;
+
+    // GBWTGraph construction.
+    bool gbz_format = false;
 
     // Other parameters and flags.
     bool show_progress = false;
@@ -169,15 +172,19 @@ int main_gbwt(int argc, char** argv) {
         step_4_path_cover(gbwts, graphs, config);
     }
 
-    // Now we can serialize the GBWT.
-    if (!config.gbwt_output.empty()) {
+    // Now we can serialize the GBWT in SDSL format.
+    if (!config.gbwt_output.empty() && !config.gbz_format) {
         double start = gbwt::readTimer();
         gbwts.serialize(config.gbwt_output);
-        graphs.serialize_segment_translation(config);
         report_time_memory("GBWT serialized", start, config);
     }
 
-    // GBWTGraph construction.
+    // Serialize the segment translation if necessary.
+    if (graphs.in_use == GraphHandler::graph_source || !config.segment_translation.empty()) {
+        graphs.serialize_segment_translation(config);
+    }
+
+    // GBWTGraph construction and serialization.
     if (!config.graph_output.empty()) {
         step_5_gbwtgraph(gbwts, graphs, config);
     }
@@ -274,6 +281,7 @@ void help_gbwt(char** argv) {
     std::cerr << std::endl;
     std::cerr << "Step 5: GBWTGraph construction (requires one of { -x, -G } and one input GBWT):" << std::endl;
     std::cerr << "    -g, --graph-name FILE   build GBWTGraph and store it in FILE" << std::endl;
+    std::cerr << "        --gbz-format        serialize both GBWT and GBWTGraph in GBZ format (makes -o unnecessary)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Step 6: R-index construction (one input GBWT):" << std::endl;
     std::cerr << "    -r, --r-index FILE      build an r-index and store it in FILE" << std::endl;
@@ -344,6 +352,7 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
     constexpr int OPT_THREAD_BUFFER = 1202;
     constexpr int OPT_MERGE_BUFFERS = 1203;
     constexpr int OPT_MERGE_JOBS = 1204;
+    constexpr int OPT_GBZ_FORMAT = 1500;
 
     static struct option long_options[] =
     {
@@ -414,6 +423,7 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
 
         // GBWTGraph
         { "graph-name", required_argument, 0, 'g' },
+        { "gbz-format", no_argument, 0, OPT_GBZ_FORMAT },
 
         // R-index
         { "r-index", required_argument, 0, 'r' },
@@ -661,6 +671,9 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
         case 'g':
             config.graph_output = optarg;
             break;
+        case OPT_GBZ_FORMAT:
+            config.gbz_format = true;
+            break;
 
         // Build r-index
         case 'r':
@@ -733,8 +746,12 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
 //----------------------------------------------------------------------------
 
 void validate_gbwt_config(GBWTConfig& config) {
+    // We can either write GBWT in SDSL format to a separate file or with GBWTGraph in GBZ format.
+    // However, `--parse-only` uses `gbwt_output` for other purposes.
+    bool has_gbwt_output = !config.gbwt_output.empty() || (config.gbz_format && !config.graph_output.empty() && !config.parse_only);
+
     if (config.build != GBWTConfig::build_none) {
-        if (config.gbwt_output.empty()) {
+        if (!has_gbwt_output) {
             std::cerr << "error: [vg gbwt] GBWT construction requires output GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
         }
@@ -773,21 +790,21 @@ void validate_gbwt_config(GBWTConfig& config) {
     }
 
     if (config.merge != GBWTConfig::merge_none) {
-        if (config.input_filenames.size() < 2 || config.gbwt_output.empty()) {
+        if (config.input_filenames.size() < 2 || !has_gbwt_output) {
             std::cerr << "error: [vg gbwt] merging requires multiple input GBWTs and output GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
         }
     }
 
     if (!config.to_remove.empty()) {
-        if (!(config.input_filenames.size() == 1 || config.merge != GBWTConfig::merge_none) || config.gbwt_output.empty()) {
+        if (!(config.input_filenames.size() == 1 || config.merge != GBWTConfig::merge_none) || !has_gbwt_output) {
             std::cerr << "error: [vg gbwt] removing a sample requires one input GBWT and output GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
         }
     }
 
     if (config.path_cover != GBWTConfig::path_cover_none) {
-        if (config.gbwt_output.empty() || config.graph_name.empty()) {
+        if (!has_gbwt_output || config.graph_name.empty()) {
             std::cerr << "error: [vg gbwt] path cover options require output GBWT and a graph" << std::endl;
             std::exit(EXIT_FAILURE);
         }
@@ -1221,9 +1238,6 @@ void step_5_gbwtgraph(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& conf
     }
 
     gbwts.use_compressed();
-    if (config.show_progress) {
-        std::cerr << "Starting the construction" << std::endl;
-    }
     gbwtgraph::GBWTGraph graph;
     if (graphs.in_use == GraphHandler::graph_source) {
         graph = gbwtgraph::GBWTGraph(gbwts.compressed, *(graphs.sequence_source));
@@ -1231,10 +1245,23 @@ void step_5_gbwtgraph(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& conf
         graphs.get_graph(config);
         graph = gbwtgraph::GBWTGraph(gbwts.compressed, *(graphs.path_graph));
     }
-    if (config.show_progress) {
-        std::cerr << "Serializing GBWTGraph to " << config.graph_output << std::endl;
+    if (config.gbz_format) {
+        if (config.show_progress) {
+            std::cerr << "Serializing GBZ to " << config.graph_output << std::endl;
+        }
+        std::ofstream out(config.graph_output, std::ios_base::binary);
+        if (!out) {
+            std::cerr << "error: [vg gbwt] cannot open file " << config.graph_output << " for writing" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        gbwtgraph::GBZ::simple_sds_serialize(gbwts.compressed, graph, out);
+        out.close();
+    } else {
+        if (config.show_progress) {
+            std::cerr << "Serializing GBWTGraph to " << config.graph_output << std::endl;
+        }
+        vg::io::VPKG::save(graph, config.graph_output);
     }
-    vg::io::VPKG::save(graph, config.graph_output);
 
     report_time_memory("GBWTGraph built", start, config);
 }
@@ -1384,9 +1411,7 @@ void GraphHandler::clear() {
 }
 
 void GraphHandler::serialize_segment_translation(const GBWTConfig& config) const {
-    if (this->in_use != graph_source || config.segment_translation.empty()) {
-        return;
-    }
+    double start = gbwt::readTimer();
     if (config.show_progress) {
         std::cerr << "Serializing segment to node translation to " << config.segment_translation << std::endl;
     }
@@ -1403,6 +1428,8 @@ void GraphHandler::serialize_segment_translation(const GBWTConfig& config) const
         }
     }
     out.close();
+
+    report_time_memory("Translation serialized", start, config);
 }
 
 //----------------------------------------------------------------------------

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -172,7 +172,7 @@ int main_gbwt(int argc, char** argv) {
         step_4_path_cover(gbwts, graphs, config);
     }
 
-    // Now we can serialize the GBWT in SDSL format.
+    // Now we can serialize the GBWT to a separate file.
     if (!config.gbwt_output.empty() && !config.gbz_format) {
         double start = gbwt::readTimer();
         gbwts.serialize(config.gbwt_output);

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1,5 +1,5 @@
 /**
- * \file giraffe_main.cpp: G(ir)AF (Graph Alignment Format) Fast Emitter: a new mapper that will be *extremely* fast once we actually write it
+ * \file giraffe_main.cpp: G(ir)AF (Graph Alignment Format) Fast Emitter: a fast short-read-to-haplotypes mapper
  */
 
 #include <omp.h>

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -24,8 +24,8 @@
 #include "../min_distance.hpp"
 #include "../source_sink_overlay.hpp"
 #include "../gbwt_helper.hpp"
+#include "../gcsa_helper.hpp"
 
-#include <gcsa/gcsa.h>
 #include <gcsa/algorithms.h>
 #include <gbwt/variants.h>
 #include <bdsg/overlays/packed_subgraph_overlay.hpp>
@@ -627,17 +627,8 @@ int main_index(int argc, char** argv) {
         }
 
         // Save the indexes
-        if (show_progress) {
-            cerr << "Saving the index to disk..." << endl;
-        }
-        if (!sdsl::store_to_file(gcsa_index, gcsa_name)) {
-            std::cerr << "error: [vg index] cannot write the GCSA to " << gcsa_name << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-        if (!sdsl::store_to_file(lcp_array, gcsa_name + ".lcp")) {
-            std::cerr << "error: [vg index] cannot write the LCP array to " << gcsa_name << ".lcp" << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
+        save_gcsa(gcsa_index, gcsa_name, show_progress);
+        save_lcp(lcp_array, gcsa_name + ".lcp", show_progress);
 
         // Verify the index
         if (verify_gcsa) {

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -285,7 +285,13 @@ int main_minimizer(int argc, char** argv) {
     if (progress) {
         std::cerr << "Writing the index to " << output_name << std::endl;
     }
-    vg::io::VPKG::save(*index, output_name);
+    std::ofstream out(output_name, std::ios_base::binary);
+    if (!out) {
+        std::cerr << "error: [vg minimizer] cannot write the minimizer index to " << output_name << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    index->serialize(out);
+    out.close();
 
     if (progress) {
         double seconds = gbwt::readTimer() - start;

--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -374,7 +374,7 @@ int32_t main_rna(int32_t argc, char** argv) {
         // Finish contruction and recode index.
         gbwt_builder.finish();
 
-        vg::io::VPKG::save(gbwt_builder.index, gbwt_out_filename);
+        save_gbwt(gbwt_builder.index, gbwt_out_filename);
 
         assert(num_written_transcripts == num_added_threads || num_written_transcripts == 0);
         num_written_transcripts = num_added_threads;

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -27,7 +27,7 @@ cmp x.gbwt x2.gbwt
 is $? 0 "identical construction results with vg gbwt and vg index"
 vg gbwt -x x.vg -o parse --parse-only -v small/xy2.vcf.gz
 is $? 0 "chromosome X VCF parse"
-../deps/gbwt/build_gbwt -p -r parse_x > /dev/null 2> /dev/null
+../deps/gbwt/bin/build_gbwt -O -p -r parse_x > /dev/null 2> /dev/null
 is $? 0 "chromosome X GBWT from VCF parse"
 vg view -x GBWT x.gbwt > x.bare.gbwt
 cmp x.bare.gbwt parse_x.gbwt
@@ -161,7 +161,7 @@ rm -f xy.gbwt xy.ri
 
 # Non-empty and empty GBWTs
 vg gbwt -x x.vg -o x.gbwt -v small/xy2.vcf.gz
-../deps/gbwt/build_gbwt -e empty > /dev/null
+../deps/gbwt/bin/build_gbwt -e empty > /dev/null
 
 # Normal merging, x + empty
 vg gbwt -m -o x2.gbwt x.gbwt empty.gbwt
@@ -243,7 +243,7 @@ rm -f x.gbwt x.extract
 vg gbwt -x x.vg -g x.gg -o x.gbwt -v small/xy2.vcf.gz
 is $? 0 "GBWTGraph construction"
 vg view --extract-tag GBWTGraph x.gg > x.extracted.gg
-is $(md5sum x.extracted.gg | cut -f 1 -d\ ) 602951fad1bc68e3171ee75778b52b73 "GBWTGraph was serialized correctly"
+is $(md5sum x.extracted.gg | cut -f 1 -d\ ) 8e10d978d7303ba00ceed7837fcbd793 "GBWTGraph was serialized correctly"
 
 rm -f x.gbwt x.gg x.extracted.gg
 
@@ -252,7 +252,7 @@ rm -f x.gbwt x.gg x.extracted.gg
 vg gbwt -P -n 16 -x xy.xg -g xy.cover.gg -o xy.cover.gbwt
 is $? 0 "Path cover GBWTGraph construction"
 vg view --extract-tag GBWTGraph xy.cover.gg > xy.extracted.gg
-is $(md5sum xy.extracted.gg | cut -f 1 -d\ ) dfda13202364b838fbb61ed465e91d8f "GBWTGraph was serialized correctly"
+is $(md5sum xy.extracted.gg | cut -f 1 -d\ ) 6a2738f51472e0ba1553a815a005b157 "GBWTGraph was serialized correctly"
 is $(vg gbwt -c xy.cover.gbwt) 32 "path cover: 32 threads"
 is $(vg gbwt -C xy.cover.gbwt) 2 "path cover: 2 contigs"
 is $(vg gbwt -H xy.cover.gbwt) 16 "path cover: 16 haplotypes"
@@ -265,7 +265,7 @@ rm -f xy.cover.gg xy.cover.gbwt xy.extracted.gg
 vg gbwt -x xy-alt.xg -g xy.local.gg -l -n 16 -o xy.local.gbwt -v small/xy2.vcf.gz
 is $? 0 "Local haplotypes GBWTGraph construction"
 vg view --extract-tag GBWTGraph xy.local.gg > xy.extracted.gg
-is $(md5sum xy.extracted.gg | cut -f 1 -d\ ) 0f23148b424bf5cc2705bfa0a20cfa33 "GBWTGraph was serialized correctly"
+is $(md5sum xy.extracted.gg | cut -f 1 -d\ ) 00429586246711abcf1367a97d3c468c "GBWTGraph was serialized correctly"
 is $(vg gbwt -c xy.local.gbwt) 32 "local haplotypes: 32 threads"
 is $(vg gbwt -C xy.local.gbwt) 2 "local haplotypes: 2 contigs"
 is $(vg gbwt -H xy.local.gbwt) 16 "local haplotypes: 16 haplotypes"
@@ -279,7 +279,7 @@ vg gbwt -x x.vg -o x.gbwt -v small/xy2.vcf.gz
 vg gbwt -a -n 16 -x xy.xg -g augmented.gg -o augmented.gbwt x.gbwt
 is $? 0 "Augmented GBWTGraph construction"
 vg view --extract-tag GBWTGraph augmented.gg > augmented.extracted.gg
-is $(md5sum augmented.extracted.gg | cut -f 1 -d\ ) 0f23148b424bf5cc2705bfa0a20cfa33 "GBWTGraph was serialized correctly"
+is $(md5sum augmented.extracted.gg | cut -f 1 -d\ ) 00429586246711abcf1367a97d3c468c "GBWTGraph was serialized correctly"
 is $(vg gbwt -c augmented.gbwt) 18 "augmented: 18 threads"
 is $(vg gbwt -C augmented.gbwt) 2 "augmented: 2 contigs"
 is $(vg gbwt -H augmented.gbwt) 2 "augmented: 2 haplotypes"
@@ -296,7 +296,7 @@ rm -f x.vg y.vg x.xg xy.xg xy-alt.xg
 vg gbwt -o gfa.gbwt -G graphs/components_walks.gfa
 is $? 0 "GBWT construction from GFA"
 vg view --extract-tag GBWT gfa.gbwt > gfa.extracted.gbwt
-is $(md5sum gfa.extracted.gbwt | cut -f 1 -d\ ) 0dc7b0a99818f2fa4c79a9423e5a1e23 "GBWT was serialized correctly"
+is $(md5sum gfa.extracted.gbwt | cut -f 1 -d\ ) 68dad5b441d1d23413b4ddd42c962301 "GBWT was serialized correctly"
 is $(vg gbwt -c gfa.gbwt) 4 "gfa: 4 threads"
 is $(vg gbwt -C gfa.gbwt) 2 "gfa: 2 contigs"
 is $(vg gbwt -H gfa.gbwt) 2 "gfa: 2 haplotypes"
@@ -307,8 +307,8 @@ vg gbwt -o gfa2.gbwt -g gfa2.gg --translation gfa2.trans -G graphs/components_wa
 is $? 0 "GBWT+GBWTGraph construction from GFA"
 cmp gfa.gbwt gfa2.gbwt
 is $? 0 "Identical construction results with and without GBWTGraph"
-vg view --extract-tag GBWT gfa2.gg > gfa2.extracted.gg
-is $(md5sum gfa2.extracted.gg | cut -f 1 -d\ ) d41d8cd98f00b204e9800998ecf8427e "GBWTGraph was serialized correctly"
+vg view --extract-tag GBWTGraph gfa2.gg > gfa2.extracted.gg
+is $(md5sum gfa2.extracted.gg | cut -f 1 -d\ ) 5c1f16564c95b54f355972f065b25b4e "GBWTGraph was serialized correctly"
 is $(wc -l < gfa2.trans) 0 "no chopping: 0 translations"
 
 # Build GBWT and GBWTGraph from GFA with node chopping

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 118
+plan tests 122
 
 
 # Build vg graphs for two chromosomes
@@ -243,7 +243,12 @@ vg gbwt -x x.vg -g x.gg -o x.gbwt -v small/xy2.vcf.gz
 is $? 0 "GBWTGraph construction"
 is $(md5sum x.gg | cut -f 1 -d\ ) 8e10d978d7303ba00ceed7837fcbd793 "GBWTGraph was serialized correctly"
 
-rm -f x.gbwt x.gg
+# Build and serialize GBWTGraph in the GBZ format
+vg gbwt -x x.vg -g x.gbz --gbz-format -v small/xy2.vcf.gz
+is $? 0 "GBZ construction"
+is $(md5sum x.gbz | cut -f 1 -d\ ) 0b1850c1b479b3ac990cc24b70bf5e82 "GBZ was serialized correctly"
+
+rm -f x.gbwt x.gg x.gbz
 
 
 # Build both GBWT and GBWTGraph from a 16-path cover
@@ -304,6 +309,11 @@ is $? 0 "Identical construction results with and without GBWTGraph"
 is $(md5sum gfa2.gg | cut -f 1 -d\ ) 5c1f16564c95b54f355972f065b25b4e "GBWTGraph was serialized correctly"
 is $(wc -l < gfa2.trans) 0 "no chopping: 0 translations"
 
+# Build GBZ from GFA
+vg gbwt -g gfa2.gbz --gbz-format -G graphs/components_walks.gfa
+is $? 0 "GBZ construction from GFA"
+is $(md5sum gfa2.gbz | cut -f 1 -d\ ) 195b111e8dbb072c7486ce1cd5dca07b "GBZ was serialized correctly"
+
 # Build GBWT and GBWTGraph from GFA with node chopping
 vg gbwt -o chopping.gbwt -g chopping.gg --translation chopping.trans --max-node 2 -G graphs/chopping_walks.gfa
 is $? 0 "GBWT+GBWTGraph construction from GFA with chopping"
@@ -323,6 +333,6 @@ is $(vg gbwt -S ref_paths.gbwt) 2 "ref paths: 2 samples"
 is $(wc -l < ref_paths.trans) 0 "ref paths: 0 translations"
 
 rm -f gfa.gbwt
-rm -f gfa2.gbwt gfa2.gg gfa2.trans
+rm -f gfa2.gbwt gfa2.gg gfa2.trans gfa2.gbz
 rm -f ref_paths.gbwt ref_paths.gg ref_paths.trans
 rm -f chopping.gbwt chopping.gg chopping.trans

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -27,7 +27,7 @@ cmp x.gbwt x2.gbwt
 is $? 0 "identical construction results with vg gbwt and vg index"
 vg gbwt -x x.vg -o parse --parse-only -v small/xy2.vcf.gz
 is $? 0 "chromosome X VCF parse"
-../deps/gbwt/bin/build_gbwt -O -p -r parse_x > /dev/null 2> /dev/null
+../deps/gbwt/bin/build_gbwt -p -r parse_x > /dev/null 2> /dev/null
 is $? 0 "chromosome X GBWT from VCF parse"
 vg view -x GBWT x.gbwt > x.bare.gbwt
 cmp x.bare.gbwt parse_x.gbwt
@@ -296,7 +296,7 @@ rm -f x.vg y.vg x.xg xy.xg xy-alt.xg
 vg gbwt -o gfa.gbwt -G graphs/components_walks.gfa
 is $? 0 "GBWT construction from GFA"
 vg view --extract-tag GBWT gfa.gbwt > gfa.extracted.gbwt
-is $(md5sum gfa.extracted.gbwt | cut -f 1 -d\ ) 68dad5b441d1d23413b4ddd42c962301 "GBWT was serialized correctly"
+is $(md5sum gfa.extracted.gbwt | cut -f 1 -d\ ) be566b133e95f33402aead1af60ed1f1 "GBWT was serialized correctly"
 is $(vg gbwt -c gfa.gbwt) 4 "gfa: 4 threads"
 is $(vg gbwt -C gfa.gbwt) 2 "gfa: 2 contigs"
 is $(vg gbwt -H gfa.gbwt) 2 "gfa: 2 haplotypes"

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 122
+plan tests 126
 
 
 # Build vg graphs for two chromosomes
@@ -243,12 +243,18 @@ vg gbwt -x x.vg -g x.gg -o x.gbwt -v small/xy2.vcf.gz
 is $? 0 "GBWTGraph construction"
 is $(md5sum x.gg | cut -f 1 -d\ ) 8e10d978d7303ba00ceed7837fcbd793 "GBWTGraph was serialized correctly"
 
-# Build and serialize GBWTGraph in the GBZ format
-vg gbwt -x x.vg -g x.gbz --gbz-format -v small/xy2.vcf.gz
-is $? 0 "GBZ construction"
+# Build and serialize GBZ from an existing GBWT
+vg gbwt -x x.vg -g x.gbz --gbz-format x.gbwt
+is $? 0 "GBZ construction from GBWT"
 is $(md5sum x.gbz | cut -f 1 -d\ ) 0b1850c1b479b3ac990cc24b70bf5e82 "GBZ was serialized correctly"
 
-rm -f x.gbwt x.gg x.gbz
+# Build and serialize GBZ from VCF
+vg gbwt -x x.vg -g x2.gbz --gbz-format -v small/xy2.vcf.gz
+is $? 0 "GBZ construction from VCF"
+cmp x.gbz x2.gbz
+is $? 0 "Identical construction results from GBWT and VCF"
+
+rm -f x.gbwt x.gg x.gbz x2.gbz
 
 
 # Build both GBWT and GBWTGraph from a 16-path cover
@@ -272,7 +278,12 @@ is $(vg gbwt -C xy.local.gbwt) 2 "local haplotypes: 2 contigs"
 is $(vg gbwt -H xy.local.gbwt) 16 "local haplotypes: 16 haplotypes"
 is $(vg gbwt -S xy.local.gbwt) 16 "local haplotypes: 16 samples"
 
-rm -f xy.local.gg xy.local.gbwt
+# Build GBZ from 16 paths of local haplotypes
+vg gbwt -x xy-alt.xg -g xy.local.gbz --gbz-format -l -n 16 -v small/xy2.vcf.gz
+is $? 0 "Local haplotypes GBZ construction"
+is $(md5sum xy.local.gbz | cut -f 1 -d\ ) b2b37402cb2169ac994c42fdee94f3ec "GBZ was serialized correctly"
+
+rm -f xy.local.gg xy.local.gbwt xy.local.gbz
 
 
 # Build GBWTGraph from an augmented GBWT

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -323,7 +323,7 @@ is $(wc -l < gfa2.trans) 0 "no chopping: 0 translations"
 # Build GBZ from GFA
 vg gbwt -g gfa2.gbz --gbz-format -G graphs/components_walks.gfa
 is $? 0 "GBZ construction from GFA"
-is $(md5sum gfa2.gbz | cut -f 1 -d\ ) 195b111e8dbb072c7486ce1cd5dca07b "GBZ was serialized correctly"
+is $(md5sum gfa2.gbz | cut -f 1 -d\ ) 4cba27d74e0d5679ceb75e1ef2cb45e4 "GBZ was serialized correctly"
 
 # Build GBWT and GBWTGraph from GFA with node chopping
 vg gbwt -o chopping.gbwt -g chopping.gg --translation chopping.trans --max-node 2 -G graphs/chopping_walks.gfa

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -29,8 +29,7 @@ vg gbwt -x x.vg -o parse --parse-only -v small/xy2.vcf.gz
 is $? 0 "chromosome X VCF parse"
 ../deps/gbwt/bin/build_gbwt -p -r parse_x > /dev/null 2> /dev/null
 is $? 0 "chromosome X GBWT from VCF parse"
-vg view -x GBWT x.gbwt > x.bare.gbwt
-cmp x.bare.gbwt parse_x.gbwt
+cmp x.gbwt parse_x.gbwt
 is $? 0 "identical construction results with vg gbwt and from VCF parse"
 
 # Single chromosome: metadata for haplotypes
@@ -42,7 +41,7 @@ is $(vg gbwt -T x.gbwt | wc -l) 2 "chromosome X: 2 thread names"
 is $(vg gbwt -C -L x.gbwt | wc -l) 1 "chromosome X: 1 contig name"
 is $(vg gbwt -S -L x.gbwt | wc -l) 1 "chromosome X: 1 sample name"
 
-rm -f x.gbwt x2.gbwt x.bare.gbwt parse_x.gbwt
+rm -f x.gbwt x2.gbwt parse_x.gbwt
 rm -f parse_x parse_x_0_1
 
 
@@ -242,50 +241,46 @@ rm -f x.gbwt x.extract
 # Build and serialize GBWTGraph
 vg gbwt -x x.vg -g x.gg -o x.gbwt -v small/xy2.vcf.gz
 is $? 0 "GBWTGraph construction"
-vg view --extract-tag GBWTGraph x.gg > x.extracted.gg
-is $(md5sum x.extracted.gg | cut -f 1 -d\ ) 8e10d978d7303ba00ceed7837fcbd793 "GBWTGraph was serialized correctly"
+is $(md5sum x.gg | cut -f 1 -d\ ) 8e10d978d7303ba00ceed7837fcbd793 "GBWTGraph was serialized correctly"
 
-rm -f x.gbwt x.gg x.extracted.gg
+rm -f x.gbwt x.gg
 
 
 # Build both GBWT and GBWTGraph from a 16-path cover
 vg gbwt -P -n 16 -x xy.xg -g xy.cover.gg -o xy.cover.gbwt
 is $? 0 "Path cover GBWTGraph construction"
-vg view --extract-tag GBWTGraph xy.cover.gg > xy.extracted.gg
-is $(md5sum xy.extracted.gg | cut -f 1 -d\ ) 6a2738f51472e0ba1553a815a005b157 "GBWTGraph was serialized correctly"
+is $(md5sum xy.cover.gg | cut -f 1 -d\ ) 6a2738f51472e0ba1553a815a005b157 "GBWTGraph was serialized correctly"
 is $(vg gbwt -c xy.cover.gbwt) 32 "path cover: 32 threads"
 is $(vg gbwt -C xy.cover.gbwt) 2 "path cover: 2 contigs"
 is $(vg gbwt -H xy.cover.gbwt) 16 "path cover: 16 haplotypes"
 is $(vg gbwt -S xy.cover.gbwt) 16 "path cover: 16 samples"
 
-rm -f xy.cover.gg xy.cover.gbwt xy.extracted.gg
+rm -f xy.cover.gg xy.cover.gbwt
 
 
 # Build both GBWT and GBWTGraph from 16 paths of local haplotypes
 vg gbwt -x xy-alt.xg -g xy.local.gg -l -n 16 -o xy.local.gbwt -v small/xy2.vcf.gz
 is $? 0 "Local haplotypes GBWTGraph construction"
-vg view --extract-tag GBWTGraph xy.local.gg > xy.extracted.gg
-is $(md5sum xy.extracted.gg | cut -f 1 -d\ ) 00429586246711abcf1367a97d3c468c "GBWTGraph was serialized correctly"
+is $(md5sum xy.local.gg | cut -f 1 -d\ ) 00429586246711abcf1367a97d3c468c "GBWTGraph was serialized correctly"
 is $(vg gbwt -c xy.local.gbwt) 32 "local haplotypes: 32 threads"
 is $(vg gbwt -C xy.local.gbwt) 2 "local haplotypes: 2 contigs"
 is $(vg gbwt -H xy.local.gbwt) 16 "local haplotypes: 16 haplotypes"
 is $(vg gbwt -S xy.local.gbwt) 16 "local haplotypes: 16 samples"
 
-rm -f xy.local.gg xy.local.gbwt xy.extracted.gg
+rm -f xy.local.gg xy.local.gbwt
 
 
 # Build GBWTGraph from an augmented GBWT
 vg gbwt -x x.vg -o x.gbwt -v small/xy2.vcf.gz
 vg gbwt -a -n 16 -x xy.xg -g augmented.gg -o augmented.gbwt x.gbwt
 is $? 0 "Augmented GBWTGraph construction"
-vg view --extract-tag GBWTGraph augmented.gg > augmented.extracted.gg
-is $(md5sum augmented.extracted.gg | cut -f 1 -d\ ) 00429586246711abcf1367a97d3c468c "GBWTGraph was serialized correctly"
+is $(md5sum augmented.gg | cut -f 1 -d\ ) 00429586246711abcf1367a97d3c468c "GBWTGraph was serialized correctly"
 is $(vg gbwt -c augmented.gbwt) 18 "augmented: 18 threads"
 is $(vg gbwt -C augmented.gbwt) 2 "augmented: 2 contigs"
 is $(vg gbwt -H augmented.gbwt) 2 "augmented: 2 haplotypes"
 is $(vg gbwt -S augmented.gbwt) 17 "augmented: 17 samples"
 
-rm -f x.gbwt augmented.gg augmented.gbwt augmented.extracted.gg
+rm -f x.gbwt augmented.gg augmented.gbwt
 
 
 # Remove the graphs
@@ -295,8 +290,7 @@ rm -f x.vg y.vg x.xg xy.xg xy-alt.xg
 # Build GBWT from GFA
 vg gbwt -o gfa.gbwt -G graphs/components_walks.gfa
 is $? 0 "GBWT construction from GFA"
-vg view --extract-tag GBWT gfa.gbwt > gfa.extracted.gbwt
-is $(md5sum gfa.extracted.gbwt | cut -f 1 -d\ ) be566b133e95f33402aead1af60ed1f1 "GBWT was serialized correctly"
+is $(md5sum gfa.gbwt | cut -f 1 -d\ ) be566b133e95f33402aead1af60ed1f1 "GBWT was serialized correctly"
 is $(vg gbwt -c gfa.gbwt) 4 "gfa: 4 threads"
 is $(vg gbwt -C gfa.gbwt) 2 "gfa: 2 contigs"
 is $(vg gbwt -H gfa.gbwt) 2 "gfa: 2 haplotypes"
@@ -307,8 +301,7 @@ vg gbwt -o gfa2.gbwt -g gfa2.gg --translation gfa2.trans -G graphs/components_wa
 is $? 0 "GBWT+GBWTGraph construction from GFA"
 cmp gfa.gbwt gfa2.gbwt
 is $? 0 "Identical construction results with and without GBWTGraph"
-vg view --extract-tag GBWTGraph gfa2.gg > gfa2.extracted.gg
-is $(md5sum gfa2.extracted.gg | cut -f 1 -d\ ) 5c1f16564c95b54f355972f065b25b4e "GBWTGraph was serialized correctly"
+is $(md5sum gfa2.gg | cut -f 1 -d\ ) 5c1f16564c95b54f355972f065b25b4e "GBWTGraph was serialized correctly"
 is $(wc -l < gfa2.trans) 0 "no chopping: 0 translations"
 
 # Build GBWT and GBWTGraph from GFA with node chopping
@@ -329,7 +322,7 @@ is $(vg gbwt -H ref_paths.gbwt) 3 "ref paths: 3 haplotypes"
 is $(vg gbwt -S ref_paths.gbwt) 2 "ref paths: 2 samples"
 is $(wc -l < ref_paths.trans) 0 "ref paths: 0 translations"
 
-rm -f gfa.gbwt gfa.extracted.gbwt
-rm -f gfa2.gbwt gfa2.gg gfa2.extracted.gg gfa2.trans
+rm -f gfa.gbwt
+rm -f gfa2.gbwt gfa2.gg gfa2.trans
 rm -f ref_paths.gbwt ref_paths.gg ref_paths.trans
 rm -f chopping.gbwt chopping.gg chopping.trans

--- a/test/t/46_vg_minimizer.t
+++ b/test/t/46_vg_minimizer.t
@@ -5,12 +5,13 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 14
+plan tests 16
 
 
 # Indexing a single graph
 vg construct -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a > x.vg 2> /dev/null
-vg index -x x.xg -G x.gbwt -v small/xy2.vcf.gz x.vg
+vg index -x x.xg x.vg
+vg gbwt -x x.vg -o x.gbwt -v small/xy2.vcf.gz
 vg snarls -T x.vg > x.snarls
 vg index -s x.snarls -j x.dist -x x.xg
 
@@ -39,12 +40,18 @@ vg minimizer -t 1 -g x.gbwt -G -o x.mi x.gg
 is $? 0 "construction from GBWTGraph"
 is $(md5sum x.mi | cut -f 1 -d\ ) 58b2bd98902df9acbe416bcfde649571 "construction is deterministic"
 
+# Construction from GBZ
+vg gbwt -x x.xg -g x.gbz --gbz-format x.gbwt
+vg minimizer -t 1 -Z -o x.mi x.gbz
+is $? 0 "construction from GBZ"
+is $(md5sum x.mi | cut -f 1 -d\ ) 58b2bd98902df9acbe416bcfde649571 "construction is deterministic"
+
 # Store payload in the index
 vg minimizer -t 1 -o x.mi -g x.gbwt -d x.dist -G x.gg
 is $? 0 "construction with payload"
 is $(md5sum x.mi | cut -f 1 -d\ ) 58a6780c18921e4f6701b57fdb9c2e44 "construction is deterministic"
 
-rm -f x.vg x.xg x.gbwt x.snarls x.dist x.mi x.gg
+rm -f x.vg x.xg x.gbwt x.snarls x.dist x.mi x.gg x.gbz
 
 
 # Indexing two graphs

--- a/test/t/46_vg_minimizer.t
+++ b/test/t/46_vg_minimizer.t
@@ -15,36 +15,36 @@ vg snarls -T x.vg > x.snarls
 vg index -s x.snarls -j x.dist -x x.xg
 
 # Default construction
-vg minimizer -i x.mi -g x.gbwt x.xg
+vg minimizer -o x.mi -g x.gbwt x.xg
 is $? 0 "default parameters"
 
 # Single-threaded for deterministic results
-vg minimizer -t 1 -i x.mi -g x.gbwt x.xg
+vg minimizer -t 1 -o x.mi -g x.gbwt x.xg
 is $? 0 "single-threaded construction"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
 is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 58b2bd98902df9acbe416bcfde649571 "construction is deterministic"
 
 # Indexing syncmers
-vg minimizer -t 1 -i x.mi -b -g x.gbwt x.xg
+vg minimizer -t 1 -o x.mi -b -g x.gbwt x.xg
 is $? 0 "syncmer index"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
 is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 111bb0658db34d88a3a075f269513a36 "construction is deterministic"
 
 # Minimizer parameters
-vg minimizer -t 1 -k 7 -w 3 -i x.mi -g x.gbwt x.xg
+vg minimizer -t 1 -k 7 -w 3 -o x.mi -g x.gbwt x.xg
 is $? 0 "minimizer parameters"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
 is $(md5sum x.extracted.mi | cut -f 1 -d\ ) c69f4f2dfab192fc66055dcf2fa8a7da "setting -k -w works correctly"
 
 # Construction from GBWTGraph
 vg gbwt -x x.xg -g x.gg x.gbwt
-vg minimizer -t 1 -g x.gbwt -G -i x.mi x.gg
+vg minimizer -t 1 -g x.gbwt -G -o x.mi x.gg
 is $? 0 "construction from GBWTGraph"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
 is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 58b2bd98902df9acbe416bcfde649571 "construction is deterministic"
 
 # Store payload in the index
-vg minimizer -t 1 -i x.mi -g x.gbwt -d x.dist -G x.gg
+vg minimizer -t 1 -o x.mi -g x.gbwt -d x.dist -G x.gg
 is $? 0 "construction with payload"
 vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
 is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 58a6780c18921e4f6701b57fdb9c2e44 "construction is deterministic"
@@ -60,9 +60,9 @@ vg index -x x.xg -G x.gbwt -v small/xy2.vcf.gz x.vg
 vg index -x y.xg -G y.gbwt -v small/xy2.vcf.gz y.vg
 
 # Appending to the index
-vg minimizer -t 1 -i x.mi -g x.gbwt x.xg
+vg minimizer -t 1 -o x.mi -g x.gbwt x.xg
 is $? 0 "multiple graphs: first"
-vg minimizer -t 1 -l x.mi -i xy.mi -g y.gbwt y.xg
+vg minimizer -t 1 -l x.mi -o xy.mi -g y.gbwt y.xg
 is $? 0 "multiple graphs: second"
 vg view --extract-tag MinimizerIndex xy.mi > xy.extracted.mi
 is $(md5sum xy.extracted.mi | cut -f 1 -d\ ) 7500d106741f2dd8aa34aa178c917832 "construction is deterministic"

--- a/test/t/46_vg_minimizer.t
+++ b/test/t/46_vg_minimizer.t
@@ -21,35 +21,30 @@ is $? 0 "default parameters"
 # Single-threaded for deterministic results
 vg minimizer -t 1 -o x.mi -g x.gbwt x.xg
 is $? 0 "single-threaded construction"
-vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 58b2bd98902df9acbe416bcfde649571 "construction is deterministic"
+is $(md5sum x.mi | cut -f 1 -d\ ) 58b2bd98902df9acbe416bcfde649571 "construction is deterministic"
 
 # Indexing syncmers
 vg minimizer -t 1 -o x.mi -b -g x.gbwt x.xg
 is $? 0 "syncmer index"
-vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 111bb0658db34d88a3a075f269513a36 "construction is deterministic"
+is $(md5sum x.mi | cut -f 1 -d\ ) 111bb0658db34d88a3a075f269513a36 "construction is deterministic"
 
 # Minimizer parameters
 vg minimizer -t 1 -k 7 -w 3 -o x.mi -g x.gbwt x.xg
 is $? 0 "minimizer parameters"
-vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) c69f4f2dfab192fc66055dcf2fa8a7da "setting -k -w works correctly"
+is $(md5sum x.mi | cut -f 1 -d\ ) c69f4f2dfab192fc66055dcf2fa8a7da "setting -k -w works correctly"
 
 # Construction from GBWTGraph
 vg gbwt -x x.xg -g x.gg x.gbwt
 vg minimizer -t 1 -g x.gbwt -G -o x.mi x.gg
 is $? 0 "construction from GBWTGraph"
-vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 58b2bd98902df9acbe416bcfde649571 "construction is deterministic"
+is $(md5sum x.mi | cut -f 1 -d\ ) 58b2bd98902df9acbe416bcfde649571 "construction is deterministic"
 
 # Store payload in the index
 vg minimizer -t 1 -o x.mi -g x.gbwt -d x.dist -G x.gg
 is $? 0 "construction with payload"
-vg view --extract-tag MinimizerIndex x.mi > x.extracted.mi
-is $(md5sum x.extracted.mi | cut -f 1 -d\ ) 58a6780c18921e4f6701b57fdb9c2e44 "construction is deterministic"
+is $(md5sum x.mi | cut -f 1 -d\ ) 58a6780c18921e4f6701b57fdb9c2e44 "construction is deterministic"
 
-rm -f x.vg x.xg x.gbwt x.snarls x.dist x.mi x.extracted.mi x.gg
+rm -f x.vg x.xg x.gbwt x.snarls x.dist x.mi x.gg
 
 
 # Indexing two graphs
@@ -64,10 +59,9 @@ vg minimizer -t 1 -o x.mi -g x.gbwt x.xg
 is $? 0 "multiple graphs: first"
 vg minimizer -t 1 -l x.mi -o xy.mi -g y.gbwt y.xg
 is $? 0 "multiple graphs: second"
-vg view --extract-tag MinimizerIndex xy.mi > xy.extracted.mi
-is $(md5sum xy.extracted.mi | cut -f 1 -d\ ) 7500d106741f2dd8aa34aa178c917832 "construction is deterministic"
+is $(md5sum xy.mi | cut -f 1 -d\ ) 7500d106741f2dd8aa34aa178c917832 "construction is deterministic"
 
 rm -f x.vg y.vg
 rm -f x.xg y.xg
 rm -f x.gbwt y.gbwt
-rm -f x.mi xy.mi xy.extracted.mi
+rm -f x.mi xy.mi

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 58
+plan tests 68
 
 vg construct -r complex/c.fa -v complex/c.vcf.gz > c.vg
 cat <(vg view c.vg | grep ^S | sort) <(vg view c.vg | grep L | uniq | wc -l) <(vg paths -v c.vg -E) > c.info
@@ -228,20 +228,35 @@ vg view components.hg | grep "^S" | sort > converted.gfa
 cmp sorted.gfa converted.gfa
 is $? 0 "GFA -> GBWTGraph -> HashGraph -> GFA conversion maintains segments"
 
+# GFA to GBZ to HashGraph to GFA
+vg gbwt -g components.gbz --gbz-format -G graphs/components_walks.gfa
+vg convert -Z -a components.gbz > components.hg 2> /dev/null
+is $? 0 "GBZ to HashGraph conversion"
+vg view components.hg | grep "^S" | sort > converted.gfa
+cmp sorted.gfa converted.gfa
+is $? 0 "GFA -> GBZ -> HashGraph -> GFA conversion maintains segments"
+
 # GBWTGraph to GFA with walks
 vg convert -b components.gbwt -f components.gg > extracted.gfa
 is $? 0 "GBWTGraph to GFA conversion with walks"
 cmp extracted.gfa graphs/components_walks.gfa
 is $? 0 "GBWTGraph to GFA conversion creates the correct normalized GFA file"
 
-rm -f components.gbwt components.gg
+# GBZ to GFA with walks
+vg convert -Z -f components.gbz > extracted.gfa
+is $? 0 "GBZ to GFA conversion with walks"
+cmp extracted.gfa graphs/components_walks.gfa
+is $? 0 "GBZ to GFA conversion creates the correct normalized GFA file"
+
+rm -f components.gbwt components.gg components.gbz
 rm -f components.hg
 rm -f sorted.gfa converted.gfa
 rm -f extracted.gfa
 
 
-# GFA to GBWTGraph with paths and walks
+# GFA to GBWTGraph and GBZ with paths and walks
 vg gbwt -o components.gbwt -g components.gg -G graphs/components_paths_walks.gfa
+vg gbwt -g components.gbz --gbz-format -G graphs/components_paths_walks.gfa
 vg convert -g -a graphs/components_paths_walks.gfa > direct.hg
 vg paths -v direct.hg -A > correct_paths.gaf
 
@@ -252,6 +267,13 @@ vg paths -A -v components.hg > hg_paths.gaf
 cmp hg_paths.gaf correct_paths.gaf
 is $? 0 "GBWTGraph to HashGraph conversion creates the correct reference paths"
 
+# GBZ to HashGraph with paths and walks
+vg convert -Z -a components.gbz > components.hg
+is $? 0 "GBZ to HashGraph conversion with reference paths"
+vg paths -A -v components.hg > gbz_hg_paths.gaf
+cmp gbz_hg_paths.gaf correct_paths.gaf
+is $? 0 "GBZ to HashGraph conversion creates the correct reference paths"
+
 # GBWTGraph to XG with paths and walks
 vg convert -b components.gbwt -x components.gg > components.xg
 is $? 0 "GBWTGraph to XG conversion with reference paths"
@@ -259,17 +281,31 @@ vg paths -A -v components.xg > xg_paths.gaf
 cmp xg_paths.gaf correct_paths.gaf
 is $? 0 "GBWTGraph to XG conversion creates the correct reference paths"
 
+# GBZ to XG with paths and walks
+vg convert -Z -x components.gbz > components.xg
+is $? 0 "GBZ to XG conversion with reference paths"
+vg paths -A -v components.xg > gbz_xg_paths.gaf
+cmp gbz_xg_paths.gaf correct_paths.gaf
+is $? 0 "GBZ to XG conversion creates the correct reference paths"
+
 # GBWTGraph to GFA with paths and walks
 vg convert -b components.gbwt -f components.gg > extracted.gfa
 is $? 0 "GBWTGraph to GFA conversion with paths and walks"
 cmp extracted.gfa graphs/components_paths_walks.gfa
 is $? 0 "GBWTGraph to GFA conversion creates the correct normalized GFA file"
 
-rm -f components.gbwt components.gg
+# GBZ to GFA with paths and walks
+vg convert -Z -f components.gbz > gbz.gfa
+is $? 0 "GBZ to GFA conversion with paths and walks"
+cmp gbz.gfa graphs/components_paths_walks.gfa
+is $? 0 "GBZ to GFA conversion creates the correct normalized GFA file"
+
+rm -f components.gbwt components.gg components.gbz
 rm -f direct.hg correct_paths.gaf
-rm -f components.hg hg_paths.gaf
-rm -f components.xg xg_paths.gaf
-rm -f extracted.gfa
+rm -f components.hg hg_paths.gaf gbz_hg_paths.gaf
+rm -f components.xg xg_paths.gaf gbz_xg_paths.gaf
+rm -f extracted.gfa gbz.gfa
+
 
 # GFA Streaming
 vg convert -g tiny/tiny.gfa -p | vg convert -f - | sort > tiny.roundtrip.gfa

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -11,12 +11,12 @@ vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -G x.gbwt -v small/x.vcf.gz x.vg
 vg snarls --include-trivial x.vg > x.snarls
 vg index -s x.snarls -j x.dist x.vg
-vg minimizer -k 29 -w 11 -g x.gbwt -i x.min x.xg
+vg minimizer -k 29 -w 11 -g x.gbwt -o x.min x.xg
 
 vg giraffe -x x.xg -H x.gbwt -m x.min -d x.dist -f reads/small.middle.ref.fq > mapped1.gam
 is "${?}" "0" "a read can be mapped with all indexes specified without crashing"
 
-vg minimizer -k 29 -b -s 18 -g x.gbwt -i x.sync x.xg
+vg minimizer -k 29 -b -s 18 -g x.gbwt -o x.sync x.xg
 
 vg giraffe -x x.xg -H x.gbwt -m x.sync -d x.dist -f reads/small.middle.ref.fq > mapped.sync.gam
 is "${?}" "0" "a read can be mapped with syncmer indexes without crashing"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Support for the [GBZ format](https://github.com/jltsiren/gbwtgraph/blob/master/SERIALIZATION.md) in `vg gbwt`, `vg convert`, and `vg minimizer`.
 * `vg convert` outputs HashGraph instead of VG by default.
 * GBWT / GBWTGraph / GCSA2 structures are serialized as bare files for better compatibility with external tools.

## Description

Initial support for the [GBZ format](https://github.com/jltsiren/gbwtgraph/blob/master/SERIALIZATION.md) that combines GBWT and GBWTGraph into a single compressed file. The format is currently supported as output from `vg gbwt` and as input to `vg convert` and `vg minimizer`.

Serialize GBWT / GBWTGraph / GCSA2 structures as bare files using `save_X()` functions for better compatibility with external tools. The structures can be loaded with `VPKG::load_one()` (as before) or with `load_X()` functions.

GBWT is always serialized in the simple-sds format.