### PR TITLE
GBWT / GBWTGraph extraction from GBZ

### DIFF
--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -203,12 +203,14 @@ void GBWTHandler::use_dynamic() {
 
 void GBWTHandler::use(gbwt::GBWT& new_index) {
     this->clear();
+    this->unbacked();
     this->compressed.swap(new_index);
     this->in_use = index_compressed;
 }
 
 void GBWTHandler::use(gbwt::DynamicGBWT& new_index) {
     this->clear();
+    this->unbacked();
     this->dynamic.swap(new_index);
     this->in_use = index_dynamic;
 }

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -131,9 +131,11 @@ struct GBWTHandler {
     void use_dynamic();
 
     /// Start using this compressed GBWT. Clears the index used as the argument.
+    /// The GBWT is not backed by a file.
     void use(gbwt::GBWT& new_index);
 
     /// Start using this dynamic GBWT. Clears the index used as the argument.
+    /// The GBWT is not backed by a file.
     void use(gbwt::DynamicGBWT& new_index);
 
     /// The GBWT is no longer backed by a file.

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -1069,7 +1069,7 @@ void step_1_build_gbwts(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& co
         std::cerr << "Building input GBWTs" << std::endl;
     }
     gbwts.unbacked(); // We will build a new GBWT.
-    if (config.build != GBWTConfig::build_gfa) {
+    if (config.build != GBWTConfig::build_gfa && config.build != GBWTConfig::build_gbz) {
         graphs.get_graph(config);
     }
 

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -26,13 +26,13 @@
 using namespace vg;
 
 struct GBWTConfig {
-    enum build_mode { build_none, build_vcf, build_gfa, build_paths, build_alignments };
+    // Build mode also defines the type of input args.
+    enum build_mode { build_none, build_vcf, build_gfa, build_paths, build_alignments, build_gbz };
     enum merge_mode { merge_none, merge_insert, merge_fast, merge_parallel };
     enum path_cover_mode { path_cover_none, path_cover_augment, path_cover_local, path_cover_greedy };
 
     // Requirements and modes.
     bool produces_one_gbwt = false; // Steps 1-4 eventually produce one input GBWT regardless of the number of input args.
-    bool produces_sequence_source = false; // Produces a `SequenceSource` that can be used in place of a graph in step 5.
     build_mode build = build_none;
     merge_mode merge = merge_none;
     path_cover_mode path_cover = path_cover_none;
@@ -62,7 +62,7 @@ struct GBWTConfig {
 
     // Input data.
     std::vector<std::string> input_filenames;
-    std::string gbwt_name; // Single input GBWT to load.
+    std::string gbwt_name; // There is a single input GBWT to load.
     std::string graph_name;
 
     // File/sample names.
@@ -99,10 +99,11 @@ struct GBWTConfig {
 };
 
 struct GraphHandler {
-    enum graph_type { graph_none, graph_path, graph_source };
+    enum graph_type { graph_none, graph_path, graph_source, graph_gbz };
 
     std::unique_ptr<PathHandleGraph> path_graph = nullptr;
     std::unique_ptr<gbwtgraph::SequenceSource> sequence_source = nullptr;
+    std::unique_ptr<gbwtgraph::GBWTGraph> gbwt_graph = nullptr;
     graph_type in_use = graph_none;
 
     // Load the `PathHandleGraph` specified in the config and release other graphs.
@@ -112,6 +113,11 @@ struct GraphHandler {
     // Take the ownership of the provided `SequenceSource` and store it in the handler.
     // Releases other graphs.
     void use(std::unique_ptr<gbwtgraph::SequenceSource>& source);
+
+    // Load the GBZ specified in the config, store the GBWT in the GBWTHandler and the
+    // graph in this handler.
+    // NOTE: The graph will become invalid if the GBWT in the GBWTHandler changes.
+    void load_gbz(GBWTHandler& gbwts, GBWTConfig& config);
 
     void clear();
 
@@ -216,6 +222,7 @@ void help_gbwt(char** argv) {
     std::cerr << "usage: " << argv[0] << " gbwt [options] [args]" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Manipulate GBWTs. Input GBWTs are loaded from input args or built in earlier steps." << std::endl;
+    std::cerr << "The input graph is provided with one of -x, -G, or -Z" << std::endl;
     std::cerr << std::endl;
     std::cerr << "General options:" << std::endl;
     std::cerr << "    -x, --xg-name FILE      read the graph from FILE" << std::endl;
@@ -230,7 +237,7 @@ void help_gbwt(char** argv) {
     std::cerr << "Search parameters (for -b and -r):" << std::endl;
     std::cerr << "        --num-threads N     use N parallel search threads (default " << omp_get_max_threads() << ")" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Step 1: GBWT construction (requires -o and one of { -v, -G, -E, A }):" << std::endl;
+    std::cerr << "Step 1: GBWT construction (requires -o and one of { -v, -G, -Z, -E, A }):" << std::endl;
     std::cerr << "    -v, --vcf-input         index the haplotypes in the VCF files specified in input args in parallel" << std::endl;
     std::cerr << "                            (inputs must be over different contigs; requires -x, implies -f)" << std::endl;
     std::cerr << "        --preset X          use preset X (available: 1000gp)" << std::endl;
@@ -254,6 +261,7 @@ void help_gbwt(char** argv) {
     std::cerr << "        --path-regex X      parse metadata from path names using regex X (default " << gbwtgraph::GFAParsingParameters::DEFAULT_REGEX << ")" << std::endl;
     std::cerr << "        --path-fields X     map regex submatches to these fields (default " << gbwtgraph::GFAParsingParameters::DEFAULT_FIELDS << ")" << std::endl;
     std::cerr << "        --translation FILE  write the segment to node translation table to FILE" << std::endl;
+    std::cerr << "    -Z, --gbz-input         extract GBWT and GBWTGraph from GBZ input (one input arg)" << std::endl;
     std::cerr << "    -E, --index-paths       index the embedded non-alt paths in the graph (requires -x, no input args)" << std::endl;
     std::cerr << "        --paths-as-samples  each path becomes a sample instead of a contig in the metadata" << std::endl;
     std::cerr << "    -A, --alignment-input   index the alignments in the GAF files specified in input args (requires -x)" << std::endl;
@@ -279,7 +287,7 @@ void help_gbwt(char** argv) {
     std::cerr << "    -n, --num-paths N       find N paths per component (default " << GBWTConfig::default_num_paths_local() << " for -l, " << GBWTConfig::default_num_paths() << " otherwise)" << std::endl;
     std::cerr << "    -k, --context-length N  use N-node contexts (default " << GBWTConfig::default_context_length() << ")" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Step 5: GBWTGraph construction (requires one of { -x, -G } and one input GBWT):" << std::endl;
+    std::cerr << "Step 5: GBWTGraph construction (requires an input graph and one input GBWT):" << std::endl;
     std::cerr << "    -g, --graph-name FILE   build GBWTGraph and store it in FILE" << std::endl;
     std::cerr << "        --gbz-format        serialize both GBWT and GBWTGraph in GBZ format (makes -o unnecessary)" << std::endl;
     std::cerr << std::endl;
@@ -313,6 +321,21 @@ void use_preset(std::string preset_name, GBWTConfig& config) {
         config.haplotype_indexer.discard_overlaps = true;
     } else {
         std::cerr << "error: [vg gbwt] invalid preset: " << preset_name << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+}
+
+void no_multiple_input_types(const GBWTConfig& config) {
+    if (config.build != GBWTConfig::build_none) {
+        std::cerr << "error: [vg gbwt] only one input type can be specified for step 1" << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+}
+
+void no_multiple_cover_types(const GBWTConfig& config) {
+    if (config.path_cover != GBWTConfig::path_cover_none)
+    {
+        std::cerr << "error: [vg gbwt] only one path cover type can be specified for step 4" << std::endl;
         std::exit(EXIT_FAILURE);
     }
 }
@@ -393,6 +416,9 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
         { "path-fields", required_argument, 0, OPT_PATH_FIELDS },
         { "translation", required_argument, 0, OPT_TRANSLATION },
 
+        // Input GBWT construction: GBZ
+        { "gbz-input", no_argument, 0, 'Z' },
+
         // Input GBWT construction: paths
         { "index-paths", no_argument, 0, 'E' },
         { "paths-as-samples", no_argument, 0, OPT_PATHS_AS_SAMPLES },
@@ -449,7 +475,7 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
     GBWTConfig config;
     while (true) {
         int option_index = 0;
-        c = getopt_long(argc, argv, "x:o:d:pvGEAmfbR:alPn:k:g:r:MCHSLTce:h?", long_options, &option_index);
+        c = getopt_long(argc, argv, "x:o:d:pvGZEAmfbR:alPn:k:g:r:MCHSLTce:h?", long_options, &option_index);
 
         /* Detect the end of the options. */
         if (c == -1)
@@ -487,7 +513,7 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
 
         // Input GBWT construction: VCF
         case 'v':
-            assert(config.build == GBWTConfig::build_none);
+            no_multiple_input_types(config);
             config.build = GBWTConfig::build_vcf;
             config.produces_one_gbwt = true;
             break;
@@ -570,10 +596,9 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
 
         // Input GBWT construction: GFA
         case 'G':
-            assert(config.build == GBWTConfig::build_none);
+            no_multiple_input_types(config);
             config.build = GBWTConfig::build_gfa;
             config.produces_one_gbwt = true;
-            config.produces_sequence_source = true;
             break;
         case OPT_MAX_NODE:
             config.gfa_parameters.max_node_length = parse<size_t>(optarg);
@@ -588,9 +613,16 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
             config.segment_translation = optarg;
             break;
 
+        // Input GBWT construction: GBZ
+        case 'Z':
+            no_multiple_input_types(config);
+            config.build = GBWTConfig::build_gbz;
+            config.produces_one_gbwt = true;
+            break;
+
         // Input GBWT construction: Paths
         case 'E':
-            assert(config.build == GBWTConfig::build_none);
+            no_multiple_input_types(config);
             config.build = GBWTConfig::build_paths;
             config.produces_one_gbwt = true;
             break;
@@ -600,7 +632,7 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
 
         // Input GBWT construction: GAF/GAM
         case 'A':
-            assert(config.build == GBWTConfig::build_none);
+            no_multiple_input_types(config);
             config.build = GBWTConfig::build_alignments;
             config.produces_one_gbwt = true;
             break;
@@ -644,18 +676,18 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
 
         // Path cover
         case 'a':
-            assert(config.path_cover == GBWTConfig::path_cover_none);
+            no_multiple_cover_types(config);
             config.path_cover = GBWTConfig::path_cover_augment;
             break;
         case 'l':
-            assert(config.path_cover == GBWTConfig::path_cover_none);
+            no_multiple_cover_types(config);
             config.path_cover = GBWTConfig::path_cover_local;
             if (!config.num_paths_set) {
                 config.num_paths = GBWTConfig::default_num_paths_local();
             }
             break;
         case 'P':
-            assert(config.path_cover == GBWTConfig::path_cover_none);
+            no_multiple_cover_types(config);
             config.path_cover = GBWTConfig::path_cover_greedy;
             config.produces_one_gbwt = true;
             break;
@@ -732,7 +764,10 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
     for (int arg = optind; arg < argc; arg++) {
         config.input_filenames.push_back(argv[arg]);
     }
-    config.gbwt_name = (config.input_filenames.empty() ? "" : config.input_filenames.front());
+    // We can load a single input GBWT if we did not use any build options.
+    if (config.input_filenames.size() == 1 && config.build == GBWTConfig::build_none) {
+        config.gbwt_name = config.input_filenames.front();
+    }
 
     // Copy information from primary fields to redundant fields.
     config.haplotype_indexer.show_progress = config.show_progress;
@@ -750,6 +785,12 @@ void validate_gbwt_config(GBWTConfig& config) {
     // However, `--parse-only` uses `gbwt_output` for other purposes.
     bool has_gbwt_output = !config.gbwt_output.empty() || (config.gbz_format && !config.graph_output.empty() && !config.parse_only);
 
+    // We have one input GBWT after steps 1-4.
+    bool one_input_gbwt = config.input_filenames.size() == 1 || config.produces_one_gbwt;
+
+    // We can load a PathHandleGraph from a file, get a SequenceSource from parsing GFA, or get a GBWTGraph from GBZ.
+    bool has_graph_input = !config.graph_name.empty() || config.build == GBWTConfig::build_gfa || config.build == GBWTConfig::build_gbz;
+
     if (config.build != GBWTConfig::build_none) {
         if (!has_gbwt_output) {
             std::cerr << "error: [vg gbwt] GBWT construction requires output GBWT" << std::endl;
@@ -757,7 +798,7 @@ void validate_gbwt_config(GBWTConfig& config) {
         }
         if (config.build == GBWTConfig::build_vcf) {
             if (config.graph_name.empty() || config.input_filenames.empty()) {
-                std::cerr << "error: [vg gbwt] GBWT construction from VCF files requires a graph and input args" << std::endl;
+                std::cerr << "error: [vg gbwt] GBWT construction from VCF files requires -x and input args" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             if (config.parse_only) {
@@ -765,21 +806,30 @@ void validate_gbwt_config(GBWTConfig& config) {
             }
         } else if (config.build == GBWTConfig::build_gfa) {
             if (!config.graph_name.empty()) {
-                std::cerr << "error: [vg gbwt] GBWT construction from GFA does not use a graph" << std::endl;
+                std::cerr << "error: [vg gbwt] GBWT construction from GFA does not use -x" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             if (config.input_filenames.size() != 1) {
                 std::cerr << "error: [vg gbwt] GBWT construction from GFA requires one input arg" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
+        } else if (config.build == GBWTConfig::build_gbz) {
+            if (!config.graph_name.empty()) {
+                std::cerr << "error: [vg gbwt] GBZ input does not use -x" << std::endl;
+                std::exit(EXIT_FAILURE);
+            }
+            if (config.input_filenames.size() != 1) {
+                std::cerr << "error: [vg gbwt] GBZ input requires one input arg" << std::endl;
+                std::exit(EXIT_FAILURE);
+            }
         } else if (config.build == GBWTConfig::build_alignments) {
             if (config.graph_name.empty() || config.input_filenames.empty()) {
-                std::cerr << "error: [vg gbwt] GBWT construction from alignments requires a graph and input args" << std::endl;
+                std::cerr << "error: [vg gbwt] GBWT construction from alignments requires -x and input args" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
         } else if (config.build == GBWTConfig::build_paths) {
             if (config.graph_name.empty()) {
-                std::cerr << "error: [vg gbwt] GBWT construction from embedded paths requires a graph" << std::endl;
+                std::cerr << "error: [vg gbwt] GBWT construction from embedded paths requires -x" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             if (!config.input_filenames.empty()) {
@@ -797,6 +847,9 @@ void validate_gbwt_config(GBWTConfig& config) {
     }
 
     if (!config.to_remove.empty()) {
+        if (config.build == GBWTConfig::build_gbz) {
+            std::cerr << "error: [vg gbwt] the GBWT extracted from GBZ cannot be modified" << std::endl;
+        }
         if (!(config.input_filenames.size() == 1 || config.merge != GBWTConfig::merge_none) || !has_gbwt_output) {
             std::cerr << "error: [vg gbwt] removing a sample requires one input GBWT and output GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
@@ -805,7 +858,7 @@ void validate_gbwt_config(GBWTConfig& config) {
 
     if (config.path_cover != GBWTConfig::path_cover_none) {
         if (!has_gbwt_output || config.graph_name.empty()) {
-            std::cerr << "error: [vg gbwt] path cover options require output GBWT and a graph" << std::endl;
+            std::cerr << "error: [vg gbwt] path cover options require -x and output GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
         }
         if (config.path_cover == GBWTConfig::path_cover_greedy && !config.input_filenames.empty()) {
@@ -827,28 +880,28 @@ void validate_gbwt_config(GBWTConfig& config) {
     }
 
     if (!config.graph_output.empty()) {
-        if ((config.graph_name.empty() && !config.produces_sequence_source) || !(config.input_filenames.size() == 1 || config.produces_one_gbwt)) {
-            std::cerr << "error: [vg gbwt] GBWTGraph construction requires a graph and one input GBWT or GFA input" << std::endl;
+        if (!has_graph_input || !one_input_gbwt) {
+            std::cerr << "error: [vg gbwt] GBWTGraph construction requires an input graph and and one input GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
         }
     }
 
     if (!config.r_index_name.empty()) {
-        if (!(config.input_filenames.size() == 1 || config.produces_one_gbwt)) {
+        if (!one_input_gbwt) {
             std::cerr << "error: [vg gbwt] r-index construction requires one input GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
         }
     }
 
     if (config.metadata_mode) {
-        if (!(config.input_filenames.size() == 1 || config.produces_one_gbwt)) {
+        if (!one_input_gbwt) {
             std::cerr << "error: [vg gbwt] metadata operations require one input GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
         }
     }
 
     if (config.thread_mode) {
-        if (!(config.input_filenames.size() == 1 || config.produces_one_gbwt)) {
+        if (!one_input_gbwt) {
             std::cerr << "error: [vg gbwt] thread operations require one input GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
         }
@@ -1069,13 +1122,18 @@ void step_1_build_gbwts(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& co
         if(config.show_progress) {
             std::cerr << "Input type: GFA" << std::endl;
         }
-        auto result = gbwtgraph::gfa_to_gbwt(config.gbwt_name, config.gfa_parameters);
+        auto result = gbwtgraph::gfa_to_gbwt(config.input_filenames.front(), config.gfa_parameters);
         if (result.first.get() == nullptr || result.second.get() == nullptr) {
             std::cerr << "error: [vg gbwt] GBWT construction from GFA failed" << std::endl;
             std::exit(EXIT_FAILURE);
         }
         gbwts.use(*(result.first));
         graphs.use(result.second);
+    } else if (config.build == GBWTConfig::build_gbz) {
+        if(config.show_progress) {
+            std::cerr << "Input type: GBZ" << std::endl;
+        }
+        graphs.load_gbz(gbwts, config);
     } else if (config.build == GBWTConfig::build_paths) {
         if(config.show_progress) {
             std::cerr << "Input type: embedded paths" << std::endl;
@@ -1122,6 +1180,7 @@ void step_2_merge_gbwts(GBWTHandler& gbwts, GBWTConfig& config) {
         gbwt::GBWT merged(indexes);
         gbwts.use(merged);
     } else if (config.merge == GBWTConfig::merge_insert) {
+        gbwts.filename = config.input_filenames.front();
         gbwts.use_dynamic();
         for (size_t i = 1; i < config.input_filenames.size(); i++) {
             gbwt::GBWT next;
@@ -1136,6 +1195,7 @@ void step_2_merge_gbwts(GBWTHandler& gbwts, GBWTConfig& config) {
             gbwts.dynamic.merge(next);
         }
     } else if (config.merge == GBWTConfig::merge_parallel) {
+        gbwts.filename = config.input_filenames.front();
         gbwts.use_dynamic();
         omp_set_num_threads(config.search_threads);
         for (size_t i = 1; i < config.input_filenames.size(); i++) {
@@ -1241,8 +1301,14 @@ void step_5_gbwtgraph(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& conf
     gbwtgraph::GBWTGraph graph;
     if (graphs.in_use == GraphHandler::graph_source) {
         graph = gbwtgraph::GBWTGraph(gbwts.compressed, *(graphs.sequence_source));
+    } else if (graphs.in_use == GraphHandler::graph_gbz) {
+        graph = std::move(*(graphs.gbwt_graph));
+        graphs.clear();
     } else {
         graphs.get_graph(config);
+        if (config.show_progress) {
+            std::cerr << "Starting the construction" << std::endl;
+        }
         graph = gbwtgraph::GBWTGraph(gbwts.compressed, *(graphs.path_graph));
     }
     if (config.gbz_format) {
@@ -1373,7 +1439,7 @@ void GraphHandler::get_graph(const GBWTConfig& config) {
         if (config.show_progress) {
             std::cerr << "Loading input graph from " << config.graph_name << std::endl;
         }
-        this->sequence_source.reset();
+        this->clear();
         this->path_graph = vg::io::VPKG::load_one<PathHandleGraph>(config.graph_name);
         if (this->path_graph == nullptr) {
             std::cerr << "error: [vg gbwt] cannot load graph " << config.graph_name << std::endl;
@@ -1384,14 +1450,29 @@ void GraphHandler::get_graph(const GBWTConfig& config) {
 }
 
 void GraphHandler::use(std::unique_ptr<gbwtgraph::SequenceSource>& source) {
-    this->path_graph.reset();
+    this->clear();
     this->sequence_source = std::move(source);
     this->in_use = graph_source;
+}
+
+void GraphHandler::load_gbz(GBWTHandler& gbwts, GBWTConfig& config) {
+    if (this->in_use == graph_gbz) {
+        return;
+    } else {
+        this->clear();
+        gbwtgraph::GBZ gbz;
+        vg::load_gbz(gbz, config.input_filenames.front(), config.show_progress);
+        gbwts.use(gbz.index);
+        this->gbwt_graph = std::make_unique<gbwtgraph::GBWTGraph>(std::move(gbz.graph));
+        this->gbwt_graph->set_gbwt(gbwts.compressed);
+        this->in_use = graph_gbz;
+    }
 }
 
 void GraphHandler::clear() {
     this->path_graph.reset();
     this->sequence_source.reset();
+    this->gbwt_graph.reset();
     this->in_use = graph_none;
 }
 

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 126
+plan tests 131
 
 
 # Build vg graphs for two chromosomes
@@ -254,7 +254,22 @@ is $? 0 "GBZ construction from VCF"
 cmp x.gbz x2.gbz
 is $? 0 "Identical construction results from GBWT and VCF"
 
+# Extract GBWT from GBZ
+vg gbwt -o extracted.gbwt -Z x.gbz
+is $? 0 "GBWT extraction from GBZ"
+cmp x.gbwt extracted.gbwt
+is $? 0 "Identical GBWT indexes"
+
+# Extract GBWT + GBWTGraph from GBZ
+vg gbwt -o extracted2.gbwt -g extracted2.gg -Z x.gbz
+is $? 0 "GBWT + GBWTGraph extraction from GBZ"
+cmp x.gbwt extracted2.gbwt
+is $? 0 "Identical GBWT indexes"
+cmp x.gg extracted2.gg
+is $? 0 "Identical GBWTGraphs"
+
 rm -f x.gbwt x.gg x.gbz x2.gbz
+rm -f extracted.gbwt extracted2.gbwt extracted2.gg
 
 
 # Build both GBWT and GBWTGraph from a 16-path cover


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg gbwt -Z` extracts GBWT and GBWTGraph from a `.gbz` file.

## Description

`vg gbwt` can now extract GBWT and GBWTGraph from a GBZ file. This is technically a new input type (`-Z` / `--gbz-input`) for step 1 (construction) that accepts a single input arg. The GBWT can then be serialized with option `-o` / `--output`.

* The extracted GBWT cannot be modified in step 3 (remove samples), because that would invalidate the GBWTGraph.
* Path cover options cannot be used, because a graph, a sequence source from GFA, and a GBWTGraph from GBZ are mutually exclusive.
* The GBWTGraph can be serialized in step 5.
* Steps 6-8 work normally.