### PR TITLE
Use GBZ in Giraffe

### DIFF
--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -24,6 +24,7 @@
 #include <gbwt/variants.h>
 #include <gbwtgraph/index.h>
 #include <gbwtgraph/gbwtgraph.h>
+#include <gbwtgraph/gbz.h>
 #include <gbwtgraph/path_cover.h>
 #include <vg/io/vpkg.hpp>
 #include <gcsa/gcsa.h>
@@ -378,6 +379,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     registry.register_index("Spliced Distance Index", "spliced.dist");
     
     registry.register_index("GBWTGraph", "gg");
+    registry.register_index("Giraffe GBZ", "giraffe.gbz");
     
     registry.register_index("Minimizers", "min");
     
@@ -2391,6 +2393,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     });
     
     // Giraffe will prefer to use a downsampled haplotype GBWT if possible
+    // FIXME Augment instead of downsampling if there are not too many haplotypes
     registry.register_recipe({"Giraffe GBWT"}, {"GBWT", "XG"},
                              [&](const vector<const IndexFile*>& inputs,
                                  const IndexingPlan* plan,
@@ -3184,16 +3187,49 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     });
     
     ////////////////////////////////////
-    // GBWTGraph Recipes
+    // GBZ Recipes
     ////////////////////////////////////
-    
-    registry.register_recipe({"GBWTGraph"}, {"Giraffe GBWT", "XG"},
+
+    registry.register_recipe({"Giraffe GBZ"}, {"GBWTGraph", "Giraffe GBWT"},
                              [&](const vector<const IndexFile*>& inputs,
                                  const IndexingPlan* plan,
                                  AliasGraph& alias_graph,
                                  const IndexGroup& constructing) {
         if (IndexingParameters::verbosity != IndexingParameters::None) {
-            cerr << "[IndexRegistry]: Constructing GBWTGraph." << endl;
+            cerr << "[IndexRegistry]: Combining Giraffe GBWT and GBWTGraph into GBZ." << endl;
+        }
+
+        assert(inputs.size() == 2);
+        auto gbwt_filenames = inputs[1]->get_filenames();
+        auto gg_filenames = inputs[0]->get_filenames();
+        assert(gbwt_filenames.size() == 1);
+        assert(gg_filenames.size() == 1);
+        auto gbwt_filename = gbwt_filenames.front();
+        auto gg_filename = gg_filenames.front();
+
+        assert(constructing.size() == 1);
+        vector<vector<string>> all_outputs(constructing.size());
+        auto gbz_output = *constructing.begin();
+        auto& output_names = all_outputs[0];
+
+        gbwtgraph::GBZ gbz;
+        load_gbz(gbz, gbwt_filename, gg_filename);
+
+        string output_name = plan->output_filepath(gbz_output);
+        save_gbz(gbz, output_name);
+
+        output_names.push_back(output_name);
+        return all_outputs;
+    });
+
+    // This used to be a GBWTGraph recipe, but we don't want to produce GBWTGraphs anymore.
+    registry.register_recipe({"Giraffe GBZ"}, {"Giraffe GBWT", "XG"},
+                             [&](const vector<const IndexFile*>& inputs,
+                                 const IndexingPlan* plan,
+                                 AliasGraph& alias_graph,
+                                 const IndexGroup& constructing) {
+        if (IndexingParameters::verbosity != IndexingParameters::None) {
+            cerr << "[IndexRegistry]: Constructing GBZ." << endl;
         }
         
         assert(inputs.size() == 2);
@@ -3206,33 +3242,32 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         
         assert(constructing.size() == 1);
         vector<vector<string>> all_outputs(constructing.size());
-        auto gbwtgraph_output = *constructing.begin();
+        auto gbz_output = *constructing.begin();
         auto& output_names = all_outputs[0];
         
-        ifstream infile_gbwt, infile_xg;
-        init_in(infile_gbwt, gbwt_filename);
+        ifstream infile_xg;
         init_in(infile_xg, xg_filename);
-        string output_name = plan->output_filepath(gbwtgraph_output);
-        ofstream outfile;
-        init_out(outfile, output_name);
-        
-        auto gbwt_index = vg::io::VPKG::load_one<gbwt::GBWT>(infile_gbwt);
         auto xg_index = vg::io::VPKG::load_one<xg::XG>(infile_xg);
-        
+
+        gbwtgraph::GBZ gbz;
+        load_gbwt(gbz.index, gbwt_filename);
         // TODO: could add simplification to replace XG index with a gbwt::SequenceSource here
-        gbwtgraph::GBWTGraph ggraph(*gbwt_index, *xg_index);
-        
-        save_gbwtgraph(ggraph, output_name);
-        
+        gbz.graph = gbwtgraph::GBWTGraph(gbz.index, *xg_index);
+
+        string output_name = plan->output_filepath(gbz_output);
+        save_gbz(gbz, output_name);
+
         output_names.push_back(output_name);
         return all_outputs;
     });
-        
+
     ////////////////////////////////////
     // Minimizers Recipes
     ////////////////////////////////////
-    
-    registry.register_recipe({"Minimizers"}, {"Distance Index", "GBWTGraph", "Giraffe GBWT"},
+
+    // FIXME We may not always want to store the minimizer index. Rebuilding the index may be
+    // faster than loading it from a network drive.
+    registry.register_recipe({"Minimizers"}, {"Distance Index", "Giraffe GBZ"},
                              [&](const vector<const IndexFile*>& inputs,
                                  const IndexingPlan* plan,
                                  AliasGraph& alias_graph,
@@ -3243,34 +3278,26 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         
         // TODO: should the distance index input be a joint simplification to avoid serializing it?
         
-        assert(inputs.size() == 3);
+        assert(inputs.size() == 2);
         auto dist_filenames = inputs[0]->get_filenames();
-        auto ggraph_filenames = inputs[1]->get_filenames();
-        auto gbwt_filenames = inputs[2]->get_filenames();
+        auto gbz_filenames = inputs[1]->get_filenames();
         assert(dist_filenames.size() == 1);
-        assert(gbwt_filenames.size() == 1);
-        assert(ggraph_filenames.size() == 1);
+        assert(gbz_filenames.size() == 1);
         auto dist_filename = dist_filenames.front();
-        auto gbwt_filename = gbwt_filenames.front();
-        auto ggraph_filename = ggraph_filenames.front();
+        auto gbz_filename = gbz_filenames.front();
                 
         assert(constructing.size() == 1);
         vector<vector<string>> all_outputs(constructing.size());
         auto minimizer_output = *constructing.begin();
         auto& output_names = all_outputs[0];
         
-        ifstream infile_gbwt, infile_ggraph, infile_dist;
+        ifstream infile_dist;
         init_in(infile_dist, dist_filename);
-        init_in(infile_gbwt, gbwt_filename);
-        init_in(infile_ggraph, ggraph_filename);
-        string output_name = plan->output_filepath(minimizer_output);
-        ofstream outfile;
-        init_out(outfile, output_name);
-                
-        auto gbwt_index = vg::io::VPKG::load_one<gbwt::GBWT>(infile_gbwt);
-        auto ggraph_index = vg::io::VPKG::load_one<gbwtgraph::GBWTGraph>(infile_ggraph);
-        ggraph_index->set_gbwt(*gbwt_index);
         auto dist_index = vg::io::VPKG::load_one<MinimumDistanceIndex>(infile_dist);
+
+        ifstream infile_gbz;
+        init_in(infile_gbz, gbz_filename);
+        auto gbz = vg::io::VPKG::load_one<gbwtgraph::GBZ>(infile_gbz);
                 
         gbwtgraph::DefaultMinimizerIndex minimizers(IndexingParameters::minimizer_k,
                                                     IndexingParameters::use_bounded_syncmers ?
@@ -3278,10 +3305,11 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                                                         IndexingParameters::minimizer_w,
                                                     IndexingParameters::use_bounded_syncmers);
                 
-        gbwtgraph::index_haplotypes(*ggraph_index, minimizers, [&](const pos_t& pos) -> gbwtgraph::payload_type {
+        gbwtgraph::index_haplotypes(gbz->graph, minimizers, [&](const pos_t& pos) -> gbwtgraph::payload_type {
             return MIPayload::encode(dist_index->get_minimizer_distances(pos));
         });
         
+        string output_name = plan->output_filepath(minimizer_output);
         save_minimizer(minimizers, output_name);
         
         output_names.push_back(output_name);
@@ -3314,8 +3342,7 @@ vector<IndexName> VGIndexes::get_default_mpmap_indexes() {
 
 vector<IndexName> VGIndexes::get_default_giraffe_indexes() {
     vector<IndexName> indexes{
-        "Giraffe GBWT",
-        "GBWTGraph",
+        "Giraffe GBZ",
         "Distance Index",
         "Minimizers"
     };

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -105,8 +105,10 @@ struct IndexingParameters {
     static int path_cover_depth;
     // the number of haplotypes to downsample to in giraffe's GBWT [64]
     static int giraffe_gbwt_downsample;
-    // Jordan actually doesn't know what this one does [4]
+    // sample subpaths of this length (in nodes) [4]
     static int downsample_context_length;
+    // augment the existing GBWT instead of downsampling it if the number of haplotypes is < this * giraffe_gbwt_downsample [3]
+    static int downsample_threshold;
     // actually use this fraction of the maximum memory to give slosh for bad estmates [0.75]
     static double max_memory_proportion;
     // aim to have X timese as many chunks as threads [2]

--- a/test/t/52_vg_autoindex.t
+++ b/test/t/52_vg_autoindex.t
@@ -61,10 +61,10 @@ rm auto.*
 
 vg autoindex -p auto -w giraffe -r tiny/tiny.fa -v tiny/tiny.vcf.gz 
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg giraffe with unchunked input"
-is $(ls auto.* | wc -l) 4 "autoindexing creates 4 inputs for vg giraffe"
+is $(ls auto.* | wc -l) 3 "autoindexing creates 3 inputs for vg giraffe"
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > t.vg
 vg index -x t.xg t.vg
-vg sim -x t.xg -n 20 -a -l 10 | vg giraffe -g auto.gg -H auto.giraffe.gbwt -m auto.min -d auto.dist -G - > /dev/null
+vg sim -x t.xg -n 20 -a -l 10 | vg giraffe -Z auto.giraffe.gbz -m auto.min -d auto.dist -G - > /dev/null
 is $(echo $?) 0 "basic autoindexing results can be used by vg giraffe"
 
 rm auto.*


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex --workflow giraffe` outputs GBZ instead of GBWT and GBWTGraph.
 * Giraffe can read GBWT + GBWTGraph from a GBZ file.

## Description

Giraffe now understands (only) GBZ format. If it gets separate GBWT and graph files as input, it will use `IndexManager` to combine them in a GBZ file. `vg autoindex` also produces GBZ instead of GBWT + GBWTGraph for Giraffe.

The `IndexManager` recipe for `Giraffe GBWT` has been updated. If downsampling would create `n` (default 64) haplotypes and the number of original haplotypes is less than `m` (default 3) times that, the original haplotypes will not be downsampled. The recipe will only augment the original GBWT with a path cover of graph components with no haplotypes.