### PR TITLE
Snarls from GBZ

### DIFF
--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -30,7 +30,7 @@ void help_snarl(char** argv) {
          << "       By default, a list of protobuf Snarls is written" << endl
          << "options:" << endl
          << "    -A, --algorithm NAME   compute snarls using 'cactus' or 'integrated' algorithms (default: integrated)" << endl
-         << "    -Z, --gbz-in           the graph is in GBZ format (GBWT + GBWTGraph)" << endl
+         << "    -Z, --gbz-format       the graph is in GBZ format (GBWT + GBWTGraph)" << endl
          << "    -p, --pathnames        output variant paths as SnarlTraversals to STDOUT" << endl
          << "    -r, --traversals FILE  output SnarlTraversals for ultrabubbles." << endl
          << "    -e, --path-traversals  only consider traversals that correspond to paths in the graph. (-m ignored)" << endl
@@ -68,7 +68,7 @@ int main_snarl(int argc, char** argv) {
     string ref_fasta_filename;
     string ins_fasta_filename;
     bool path_traversals = false;
-    bool gbz_in = false;
+    bool gbz_format = false;
         
     int c;
     optind = 2; // force optind past command positional argument
@@ -76,7 +76,7 @@ int main_snarl(int argc, char** argv) {
         static struct option long_options[] =
             {
                 {"algorithm", required_argument, 0, 'A'},
-                {"gbz-in", no_argument, 0, 'Z'},
+                {"gbz-format", no_argument, 0, 'Z'},
                 {"traversals", required_argument, 0, 'r'},
                 {"pathnames", no_argument, 0, 'p'},
                 {"leaf-only", no_argument, 0, 'l'},
@@ -110,7 +110,7 @@ int main_snarl(int argc, char** argv) {
             break;
 
         case 'Z':
-            gbz_in = true;
+            gbz_format = true;
             break;
 
         case 'r':
@@ -180,7 +180,7 @@ int main_snarl(int argc, char** argv) {
     }
 
     // GBZ input does not work with all options.
-    if (gbz_in) {
+    if (gbz_format) {
         if (algorithm == "cactus") {
             cerr << "error: [vg snarls] the cactus algorithm does not work with GBZ graphs" << endl;
             return 1;
@@ -207,7 +207,7 @@ int main_snarl(int argc, char** argv) {
     unique_ptr<gbwtgraph::GBZ> gbz;
     HandleGraph* handle_graph = nullptr;
     string graph_filename = get_input_file_name(optind, argc, argv);
-    if (gbz_in) {
+    if (gbz_format) {
         gbz = vg::io::VPKG::load_one<gbwtgraph::GBZ>(graph_filename);
         handle_graph = &(gbz->graph);
     } else {

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="en_US.utf8" # force ekg's favorite sort order
 
-plan tests 51
+plan tests 52
 
 # Single graph without haplotypes
 vg construct -r small/x.fa -v small/x.vcf.gz > x.vg
@@ -255,3 +255,11 @@ vg index -s snarls.pb -j distIndex x.vg
 is $? 0 "building a distance index of a graph without maximum index"
 
 rm -f x.vg distIndex snarls.pb
+
+# Test distance index with GBZ
+vg gbwt -g graph.gbz --gbz-format -G graphs/components_walks.gfa
+vg snarls -T -Z graph.gbz > graph.snarls
+vg index -s graph.snarls -j graph.dist --gbz-format graph.gbz
+is $? 0 "distance index construction from GBZ"
+
+rm -f graph.gbz graph.snarls graph.dist

--- a/test/t/32_vg_snarls.t
+++ b/test/t/32_vg_snarls.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 9
+plan tests 11
 
 vg view -J -v snarls/snarls.json > snarls.vg
 is $(vg snarls snarls.vg -r st.pb | vg view -R - | wc -l) 3 "vg snarls made right number of protobuf Snarls"
@@ -63,4 +63,10 @@ is $(vg snarls xy.vg | vg view -R - | wc -l) $(vg view -R xy.snarls | wc -l) "sa
 rm -f xy.vg xy.snarls
 
 
+# Find trivial snarls from a GBZ
+vg gbwt -g graph.gbz --gbz-format -G graphs/components_walks.gfa
+vg snarls -T -Z graph.gbz > graph.snarls
+is $? 0 "GBZ graphs can be used for finding snarls"
+is $(vg view -R graph.snarls | wc -l) 5 "correct number of snarls in the GFA W-line example"
 
+rm -f graph.gbz graph.snarls


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg snarls` and `vg index -j` can now use GBZ graphs.

## Description

With GBZ support in snarl finding and GBZ extraction, we can now take a GFA/GBZ file and build all the indexes Giraffe needs without using other graph types.