### PR TITLE
Single node chains

### DIFF
--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -1691,12 +1691,16 @@ void IntegratedSnarlFinder::traverse_computed_decomposition(MergedAdjacencyGraph
                             // It turns out there's only one edge here.
                             // It is going to become a contained self-loop, instead of a real cycle
                             
-                            // TODO: register as part of snarl in index
+                            // Record we visited it.
                             visited.insert(graph->forward(edge));
                             
 #ifdef debug
                             cerr << "\t\tContain new self-loop " << graph->get_id(edge) << (graph->get_is_reverse(edge) ? "-" : "+") << endl;
 #endif
+
+                            // Register as part of snarl in index
+                            begin_chain(graph->forward(edge));
+                            end_chain(graph->forward(edge));
                         } else {
                             // Close the cycle we are making out of the bridge
                             // forest path.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `IntegratedSnarlFinder` properly generates single-node chains for bridge edges in the Cactus graph.

## Description

This should fix #3322. We weren't generating chain messages when a bridge edge path was just a single node, but we also weren't noticing because the current snarl manager doesn't need them. The new distance index snarl manager is going to.