### PR TITLE
allow use of path traversals with GBWT

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -605,22 +605,7 @@ void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHand
     
     // Keep track of the non-reference paths in the graph.  They'll be our sample names
     sample_names.clear();
-    graph->for_each_path_handle([&](const path_handle_t& path_handle) {
-            string path_name = graph->get_path_name(path_handle);
-            if (!this->ref_paths.count(path_name)) {
-                // rely on the given map.  if a path isn't in it, it'll be ignored
-                if (path_to_sample) {
-                    if (path_to_sample->count(path_name)) {
-                        sample_names.insert(path_to_sample->find(path_name)->second);
-                    }
-                    // if we have the map, we only consider paths there-in
-                }
-                else {
-                    // no name mapping, just use every path as is
-                    sample_names.insert(path_name);
-                }
-            }
-        });
+    // prefer the GBWT sample names
     if (gbwt) {
         // add in sample names from the gbwt
         for (size_t i = 0; i < gbwt->metadata.paths(); i++) {
@@ -638,6 +623,23 @@ void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHand
                 }
             }
         }
+    } else {
+        graph->for_each_path_handle([&](const path_handle_t& path_handle) {
+            string path_name = graph->get_path_name(path_handle);
+            if (!this->ref_paths.count(path_name)) {
+                // rely on the given map.  if a path isn't in it, it'll be ignored
+                if (path_to_sample) {
+                    if (path_to_sample->count(path_name)) {
+                        sample_names.insert(path_to_sample->find(path_name)->second);
+                    }
+                    // if we have the map, we only consider paths there-in
+                }
+                else {
+                    // no name mapping, just use every path as is
+                    sample_names.insert(path_name);
+                }
+            }
+        });
     }
     
     // print the VCF header

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -142,10 +142,14 @@ int main_deconstruct(int argc, char** argv){
         return 1;
     }
 
+    /*
+    // this appears to be overly-restrictive, as deconstruction functions fine
+    // in the case that the GBWT and XG are equivalent
     if (!gbwt_file_name.empty() && path_restricted_traversals) {
         cerr << "Error [vg deconstruct]: -e cannot be used with -g" << endl;
         return 1;
     }
+    */
 
     // Read the graph
     unique_ptr<PathHandleGraph> path_handle_graph;

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -142,14 +142,10 @@ int main_deconstruct(int argc, char** argv){
         return 1;
     }
 
-    /*
-    // this appears to be overly-restrictive, as deconstruction functions fine
-    // in the case that the GBWT and XG are equivalent
     if (!gbwt_file_name.empty() && path_restricted_traversals) {
         cerr << "Error [vg deconstruct]: -e cannot be used with -g" << endl;
         return 1;
     }
-    */
 
     // Read the graph
     unique_ptr<PathHandleGraph> path_handle_graph;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * allow seeding path traversals from XG path set even when we are using GBWT input

## Description

This seems to be overly-restrictive limitation. @glennhickey @jltsiren what could go wrong by allowing both at the same time?

Testing on v1.33.0, without specifying `-e -a`, I see _many_ AC=0 sites. Is that expected? My input should be very standard except that I am only relying on the sample and haplotype assignment in the GBWT.

```
input=$1
ref=$2
workdir=$3
threads=$4

prefix=$(basename $input .gfa.gz)
echo "input is $input"
mkdir -p $workdir
cd $workdir

echo "unzipping $input to $gfa"
gfa=$prefix.gfa
# fixme: hack; add "haplotype identifiers" to the reference paths                                                                                                           
# so that all paths can be loaded into the GBWT with sample annotations                                                                                                     
zcat $input | sed 's/chm13#/chm13#1#/g' | sed 's/grch38#/grch38#1#/g' >$gfa
echo "building the XG index for $gfa"
xg=$prefix.xg
TEMPDIR=$(pwd) vg convert -t $threads -g $gfa -x >$xg

echo "building the GBWT index for $gfa"
gbwt=$prefix.gbwt
TEMPDIR=$(pwd) vg gbwt --num-threads $threads -G $gfa -o $gbwt --path-regex '(.+?)#(.+?)#(.+?)' --path-fields 'CSH'

echo "building VCF from $xg and $gbwt"
vcf=$prefix.vcf
TEMPDIR=$(pwd) vg deconstruct -P $ref -g $gbwt -t $threads $xg >$vcf

echo "gzipping"
pigz *.xg *.gfa *.vcf *.gbwt

echo "done"
```

In the output, I see sites like this:

```chm13#1#chr6:28385000-33300000  27297   >753>756        G       T       60      .       AC=1;AF=0.0111111;AN=90;LV=0;NS=46      GT      0|0     0|0     0|0     0|0     0|0
chm13#1#chr6:28385000-33300000  27480   >756>759        T       A       60      .       AC=1;AF=0.0111111;AN=90;LV=0;NS=46      GT      0|0     0|0     0|0     0|0     0|0
chm13#1#chr6:28385000-33300000  27500   >759>762        A       T       60      .       AC=4;AF=0.0444444;AN=90;LV=0;NS=46      GT      0|0     0|0     0|0     0|1     0|0
chm13#1#chr6:28385000-33300000  28688   >762>765        C       T       60      .       AC=0;AF=0;AN=1;LV=0;NS=1        GT      .|.     .|.     .|.     .|.     .|.     .|.
chm13#1#chr6:28385000-33300000  29151   >765>768        G       A       60      .       AC=0;AF=0;AN=0;LV=0;NS=0        GT      .|.     .|.     .|.     .|.     .|.     .|.
chm13#1#chr6:28385000-33300000  29319   >768>771        T       C       60      .       AC=0;AF=0;AN=0;LV=0;NS=0        GT      .|.     .|.     .|.     .|.     .|.     .|.
chm13#1#chr6:28385000-33300000  29771   >771>773        T       TA      60      .       AC=0;AF=0;AN=0;LV=0;NS=0        GT      .|.     .|.     .|.     .|.     .|.     .|.
chm13#1#chr6:28385000-33300000  29826   >773>776        C       T       60      .       AC=0;AF=0;AN=0;LV=0;NS=0        GT      .|.     .|.     .|.     .|.     .|.     .|.
chm13#1#chr6:28385000-33300000  29837   >776>779        A       G       60      .       AC=0;AF=0;AN=0;LV=0;NS=0        GT      .|.     .|.     .|.     .|.     .|.     .|.
chm13#1#chr6:28385000-33300000  30012   >779>782        G       C       60      .       AC=0;AF=0;AN=3;LV=0;NS=3        GT      .|.     .|.     .|.     .|.     .|.     .|.
chm13#1#chr6:28385000-33300000  30087   >782>785        C       T       60      .       AC=0;AF=0;AN=7;LV=0;NS=7        GT      .|.     .|.     .|.     .|.     .|.     .|.
chm13#1#chr6:28385000-33300000  30256   >785>788        C       T       60      .       AC=0;AF=0;AN=0;LV=0;NS=0        GT      .|.     .|.     .|.     .|.     .|.     .|.
```

Why are these sites AC=0?