### PR TITLE
Load GBZ or HandleGraph depending on what filetype is passed

### DIFF
--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -81,7 +81,6 @@ void help_index(char** argv) {
          << "snarl distance index options" << endl
          << "    -s  --snarl-name FILE  load snarls from FILE (snarls must include trivial snarls)" << endl
          << "    -j  --dist-name FILE   use this file to store a snarl-based distance index" << endl
-         << "        --gbz-format       the input graph is in GBZ format" << endl
          << "    -w  --max_dist N       cap beyond which the maximum distance is no longer accurate. If this is not included or is 0, don't build maximum distance index" << endl;
 }
 
@@ -101,7 +100,6 @@ int main_index(int argc, char** argv) {
     #define OPT_BUILD_VGI_INDEX  1000
     #define OPT_RENAME_VARIANTS  1001
     #define OPT_PATHS_AS_SAMPLES 1002
-    #define OPT_GBZ_FORMAT       1003
 
     // Which indexes to build.
     bool build_xg = false, build_gbwt = false, build_gcsa = false, build_dist = false;
@@ -136,7 +134,6 @@ int main_index(int argc, char** argv) {
     //Distance index
     int cap = -1;
     bool include_maximum = false;
-    bool gbz_format = false;
 
     // Include alt paths in xg
     bool xg_alts = false;
@@ -194,7 +191,6 @@ int main_index(int argc, char** argv) {
             //Snarl distance index
             {"snarl-name", required_argument, 0, 's'},
             {"dist-name", required_argument, 0, 'j'},
-            {"gbz-format", no_argument, 0, OPT_GBZ_FORMAT},
             {"max-dist", required_argument, 0, 'w'},
             {0, 0, 0, 0}
         };
@@ -382,9 +378,6 @@ int main_index(int argc, char** argv) {
         case 'j':
             build_dist = true;
             dist_name = optarg;
-            break;
-        case OPT_GBZ_FORMAT:
-            gbz_format = true;
             break;
         case 'w':
             build_dist = true;

--- a/src/unittest/vpkg.cpp
+++ b/src/unittest/vpkg.cpp
@@ -9,6 +9,7 @@
 
 #include <vg/io/vpkg.hpp>
 #include <bdsg/hash_graph.hpp>
+#include <bdsg/packed_graph.hpp>
 #include "xg.hpp"
 #include "../vg.hpp"
 #include "../seed_clusterer.hpp"
@@ -33,7 +34,7 @@ TEST_CASE("We can serialize and re-read an empty GCSA", "[vpkg][gcsa]") {
     // There should be some data
     REQUIRE(ss.str().size() != 0);
 
-    tuple<unique_ptr<gcsa::GCSA>> loaded = vg::io::VPKG::load_all<gcsa::GCSA>(ss);
+    tuple<unique_ptr<gcsa::GCSA>> loaded = vg::io::VPKG::try_load_first<gcsa::GCSA>(ss);
     
     // We should get something allocated
     REQUIRE(get<0>(loaded).get() != nullptr);
@@ -107,14 +108,20 @@ TEST_CASE("We can read and write XG", "[vpkg][handlegraph][xg]") {
     }
 }
 
-TEST_CASE("We can read a VG from an empty file", "[vpkg][vg][empty]") {
+TEST_CASE("We cannot read a vg::VG from an empty file", "[vpkg][vg][empty]") {
     stringstream ss;
     unique_ptr<vg::VG> loaded = vg::io::VPKG::try_load_one<vg::VG>(ss);
     
-    // It should be empty but exist because this type is default constructible
-    REQUIRE(std::is_default_constructible<vg::VG>::value);
-    REQUIRE(loaded.get() != nullptr);
-    REQUIRE(loaded->get_node_count() == 0);
+    REQUIRE(loaded.get() == nullptr);
+}
+
+TEST_CASE("We cannot read a HandleGraph from an empty file", "[vpkg][handlegraph][empty]") {
+    stringstream ss;
+    unique_ptr<bdsg::HandleGraph> loaded = vg::io::VPKG::try_load_one<bdsg::HandleGraph>(ss);
+    
+    // We used to be able to load vg::VG graphs from empty files but we can't
+    // really know that when loading a handle graph and picking the type.
+    REQUIRE(loaded.get() == nullptr);
 }
 
 TEST_CASE("We cannot read a SnarlSeedClusterer from an empty file", "[vpkg][snarlseedclusterer][empty]") {
@@ -225,6 +232,41 @@ TEST_CASE("We can read an empty VG as a HandleGraph", "[vpkg][handlegraph][vg][e
     
     // Make sure it is the thing we saved
     REQUIRE(loaded->get_node_count() == 0);
+}
+
+TEST_CASE("We prefer to read a graph as the first provided type that matches", "[vpkg]") {
+    string graph_json = R"(
+    {"node":[{"id":1,"sequence":"GATT"},
+    {"id":2,"sequence":"ACA"}],
+    "edge":[{"to":2,"from":1}]}
+    )";
+    
+    // Load the JSON
+    Graph proto_graph;
+    json2pb(proto_graph, graph_json.c_str(), graph_json.size());
+    
+    // Build the VG
+    vg::VG vg_graph(proto_graph);
+    
+    // Save it
+    stringstream ss;
+    vg::io::VPKG::save(vg_graph, ss);
+    
+    // There should be some data
+    REQUIRE(ss.str().size() != 0);
+    
+    // We use PackedGraph as a distractor here; HashGraph and VG can load from
+    // vg Protobuf but PackedGraph can't as of this writing.
+    auto loaded = vg::io::VPKG::try_load_first<bdsg::PackedGraph, HandleGraph, vg::VG>(ss);
+    
+    // Make sure we got the right thing
+    REQUIRE(get<0>(loaded).get() == nullptr);
+    REQUIRE(get<1>(loaded).get() != nullptr);
+    REQUIRE(get<2>(loaded).get() == nullptr);
+    
+    // Make sure it is the thing we saved
+    REQUIRE(get<1>(loaded)->get_node_count() == 2);
+    REQUIRE(get<1>(loaded)->get_sequence(get<1>(loaded)->get_handle(1, false)) == "GATT");
 }
 
 }

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="en_US.utf8" # force ekg's favorite sort order
 
-plan tests 52
+plan tests 55
 
 # Single graph without haplotypes
 vg construct -r small/x.fa -v small/x.vcf.gz > x.vg
@@ -251,6 +251,12 @@ is $? 0 "snarl finding with trivial snarls"
 vg index -s snarls.pb -j distIndex -w 100 x.vg
 is $? 0 "building a distance index of a graph"
 
+vg convert -v x.vg | vg index -s snarls.pb -j distIndex -w 100 -
+is $? 0 "building a distance index of a piped vg graph"
+
+vg convert -p x.vg | vg index -s snarls.pb -j distIndex -w 100 -
+is $? 0 "building a distance index of a piped PackedGraph"
+
 vg index -s snarls.pb -j distIndex x.vg
 is $? 0 "building a distance index of a graph without maximum index"
 
@@ -259,7 +265,10 @@ rm -f x.vg distIndex snarls.pb
 # Test distance index with GBZ
 vg gbwt -g graph.gbz --gbz-format -G graphs/components_walks.gfa
 vg snarls -T -Z graph.gbz > graph.snarls
-vg index -s graph.snarls -j graph.dist --gbz-format graph.gbz
+vg index -s graph.snarls -j graph.dist graph.gbz
 is $? 0 "distance index construction from GBZ"
+
+cat graph.gbz | vg index -s graph.snarls -j graph.dist -
+is $? 0 "distance index construction from piped GBZ"
 
 rm -f graph.gbz graph.snarls graph.dist

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -7,9 +7,10 @@ PATH=../bin:$PATH # for vg
 
 plan tests 24
 
-# Construct a graph with alt paths so we can make a gPBWT and later a GBWT
+# Construct a graph with alt paths so we can make a GBWT and a GBZ
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz -a >x.vg
 vg index -x x.xg -G x.gbwt -v small/x.vcf.gz  x.vg
+vg gbwt -x x.xg -v small/x.vcf.gz --gbz-format -g x.gbz
 vg view -a small/x-l100-n1000-s10-e0.01-i0.01.gam > x.gam.json
 
 # sanity check: does passing no options preserve input
@@ -59,7 +60,7 @@ vg chunk -x x.xg -n 5 -b x.chunk/
 is $(cat x.chunk/*vg | vg view -V - | grep -v P 2>/dev/null | sort |  md5sum | cut -f 1 -d\ ) $(vg view x.vg | grep -v P | sort  | md5sum | cut -f 1 -d\ ) "n-chunking works and chunks over the full graph"
 
 rm -rf x.sorted.gam x.sorted.gam.gai _chunk_test_bed.bed _chunk_test* x.chunk
-rm -f x.vg x.xg x.gbwt x.gam.json filter_chunk*.gam chunks.bed
+rm -f x.vg x.xg x.gbwt x.gbz x.gam.json filter_chunk*.gam chunks.bed
 rm -f chunk_*.annotate.txt
 
 vg construct -r small/xy.fa -v small/xy.vcf.gz > xy.vg


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg index` can load GBZ without a distinguishing option

## Description

This PR throws out the `load_all` that we never really used, and replaces it with `vg::io::VPKG::try_load_first`, which takes any number of types and loads whichever one was passed in. First it tries all the magic number/sniffing loaders, and if none of those work it tries to read it as type-tagged messages.

Most of the real changes are in libvgio.
