### PR TITLE
Fix convert -w to cut at most 2 separators

### DIFF
--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -185,7 +185,7 @@ bool is_w_line(const PathHandleGraph* graph, const string& wline_sep,
 void write_w_line(const PathHandleGraph* graph, ostream& out, const string& wline_sep,
                   path_handle_t path_handle) {
     string path_name = graph->get_path_name(path_handle);
-    vector<string> toks = split_delims(path_name, wline_sep);
+    vector<string> toks = split_delims(path_name, wline_sep, 2);
     string& sample = toks[0];
     size_t hap_index = stol(toks[1]);
     auto subpath_parse = Paths::parse_subpath_name(toks[2]);

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -147,14 +147,16 @@ void choose_good_thread_count() {
     }
 }
 
-std::vector<std::string> &split_delims(const std::string &s, const std::string& delims, std::vector<std::string> &elems) {
+std::vector<std::string> &split_delims(const std::string &s, const std::string& delims, std::vector<std::string> &elems, size_t max_cuts) {
     size_t start = string::npos;
+    size_t cuts = 0;
     for (size_t i = 0; i < s.size(); ++i) {
-        if (delims.find(s[i]) != string::npos) {
+        if (delims.find(s[i]) != string::npos && cuts < max_cuts) {
             if (start != string::npos && i > start) {
                 elems.push_back(s.substr(start, i - start));
             }
             start = string::npos;
+            ++cuts;
         } else if (start == string::npos) {
             start = i;
         }
@@ -165,9 +167,9 @@ std::vector<std::string> &split_delims(const std::string &s, const std::string& 
     return elems;
 }
 
-std::vector<std::string> split_delims(const std::string &s, const std::string& delims) {
+std::vector<std::string> split_delims(const std::string &s, const std::string& delims, size_t max_cuts) {
     std::vector<std::string> elems;
-    return split_delims(s, delims, elems);
+    return split_delims(s, delims, elems, max_cuts);
 }
 
 bool starts_with(const std::string& value, const std::string& prefix) {

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -45,8 +45,11 @@ string wrap_text(const string& str, size_t width);
 bool is_number(const string& s);
 
 // split a string on any character found in the string of delimiters (delims)
-std::vector<std::string>& split_delims(const std::string &s, const std::string& delims, std::vector<std::string> &elems);
-std::vector<std::string> split_delims(const std::string &s, const std::string& delims);
+// if max_cuts specified, only split at the first <max_cuts> delimiter occurrences
+std::vector<std::string>& split_delims(const std::string &s, const std::string& delims, std::vector<std::string> &elems,
+                                       size_t max_cuts = numeric_limits<size_t>::max());
+std::vector<std::string> split_delims(const std::string &s, const std::string& delims,
+                                      size_t max_cuts = numeric_limits<size_t>::max());
 
 /// Check if a string starts with another string
 bool starts_with(const std::string& value, const std::string& prefix);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg convert -w` can now handle separator tokens in contig names

## Description
