### PR TITLE
option for normalize to not fold reference paths

### DIFF
--- a/src/algorithms/normalize.cpp
+++ b/src/algorithms/normalize.cpp
@@ -18,7 +18,8 @@ namespace algorithms {
 
 using namespace std;
 
-void normalize(handlegraph::MutablePathDeletableHandleGraph* graph, int max_iter, bool debug) {
+void normalize(handlegraph::MutablePathDeletableHandleGraph* graph, int max_iter, bool debug,
+               function<bool(const handle_t&, const handle_t&)> can_merge) {
 
     size_t last_len = 0;
     if (max_iter > 1) {
@@ -32,7 +33,7 @@ void normalize(handlegraph::MutablePathDeletableHandleGraph* graph, int max_iter
         // combine diced/chopped nodes (subpaths with no branching)
         handlealgs::unchop(*graph);
         // Resolve forks that shouldn't be
-        simplify_siblings(graph);
+        simplify_siblings(graph, can_merge);
         
         if (max_iter > 1) {
             size_t curr_len = graph->get_total_length();

--- a/src/algorithms/normalize.hpp
+++ b/src/algorithms/normalize.hpp
@@ -15,8 +15,13 @@ using namespace std;
 /**
  * Normalize a graph, performing up to the given number of iterations.
  * Simplifies siblings and unchops runs of nodes, in a loop.
+ *
+ * if "can_merge" specified, it must return true in order for a pair of nodes to get merged
  */
-void normalize(handlegraph::MutablePathDeletableHandleGraph* graph, int max_iter = 1, bool debug = false);
+void normalize(handlegraph::MutablePathDeletableHandleGraph* graph, int max_iter = 1,
+               bool debug = false,
+               function<bool(const handle_t&, const handle_t&)> can_merge = nullptr);
+
     
 }
 }

--- a/src/algorithms/simplify_siblings.hpp
+++ b/src/algorithms/simplify_siblings.hpp
@@ -22,8 +22,12 @@ using namespace std;
  * progress and there may be more merging to do.
  *
  * Preserves paths.
+ *
+ * Optional can_merge callback will only let nodes get merged together if 
+ * this pairwise check returns true. 
  */
-bool simplify_siblings(handlegraph::MutablePathDeletableHandleGraph* graph);
+bool simplify_siblings(handlegraph::MutablePathDeletableHandleGraph* graph,
+                       function<bool(const handle_t&, const handle_t&)> can_merge = nullptr);
     
 }
 }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * New option `vg mod -z` added to ensure that normalization (`mod -U / -n`) never merges two nodes that both belong to path with given prefix.  Can be used, for example, to ensure that no kinds of cycles are added to given reference paths. 

## Description
