### PR TITLE
Enforce that snarls come out in chain order by default

### DIFF
--- a/test/snarls/nested.json
+++ b/test/snarls/nested.json
@@ -1,0 +1,106 @@
+{
+  "edge": [
+    {
+      "from": 1,
+      "to": 2
+    },
+    {
+      "from": 1,
+      "to": 3
+    },
+    {
+      "from": 2,
+      "to": 44
+    },
+    {
+      "from": 44,
+      "to": 5
+    },
+    {
+      "from": 5,
+      "to": 34
+    },
+    {
+      "from": 5,
+      "to": 7
+    },
+    {
+      "from": 7,
+      "to": 77
+    },
+    {
+      "from": 77,
+      "to": 33
+    },
+    {
+      "from": 34,
+      "to": 33
+    },
+    {
+      "from": 33,
+      "to": 9
+    },
+    {
+      "from": 3,
+      "to": 10
+    },
+    {
+      "from": 10,
+      "to": 9
+    },
+    {
+      "from": 9,
+      "to": 99
+    }
+  ],
+  "node": [
+    {
+      "sequence": "AAAAAAAAAAAAAAAAAAAAAAA",
+      "id": 1
+    },
+    {
+      "sequence": "T",
+      "id": 2
+    },
+    {
+      "sequence": "C",
+      "id": 3
+    },
+    {
+      "sequence": "A",
+      "id": 44
+    },
+    {
+      "sequence": "T",
+      "id": 5
+    },
+    {
+      "sequence": "C",
+      "id": 34
+    },
+    {
+      "sequence": "A",
+      "id": 7
+    },
+    {
+      "sequence": "A",
+      "id": 77
+    },
+    {
+      "sequence": "T",
+      "id": 33
+    },
+    {
+      "sequence": "CCCCCCCCCCCCCCCCCCCCCCCC",
+      "id": 9
+    },
+    {
+      "sequence": "CCCCCCCCCCCCCCCCCCCCCCCC",
+      "id": 99
+    },
+    {
+      "sequence": "C",
+      "id": 10
+    }
+  ]
+}


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Snarls from `vg snarls` now are guaranteed to come out grouped by chain

## Description

Now when you get snarls from `vg snarls -T`, if they share a boundary node and a parent, they are part of the same chain, and all the snarls in a chain will come together in order, separated only by their children.

So you can read in snarls and build chains and child chains as you stream the snarls in, without having to do too much processing. When you see a child snarl of the last snarl you saw, start a new chain for it. When you see a sibling snarl that shares a boundary node with the previous snarl, add it to the current chain. And while the snarl you are looking at isn't any of those, finish off chains and walk back up the stack until it either comes after something in a chain or is a sibling of it that begins a new chain at that level.