### PR TITLE
GBWT reconstruction with subpath substitutions

### DIFF
--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -4,6 +4,7 @@
 #include <vg/io/vpkg.hpp>
 
 #include <sstream>
+#include <unordered_map>
 
 namespace vg {
 
@@ -235,6 +236,68 @@ void GBWTHandler::clear() {
     this->compressed = gbwt::GBWT();
     this->dynamic = gbwt::DynamicGBWT();
     this->in_use = index_none;
+}
+
+//------------------------------------------------------------------------------
+
+gbwt::GBWT rebuild_gbwt(const gbwt::GBWT& gbwt_index, const std::vector<std::pair<gbwt::vector_type, gbwt::vector_type>>& mappings) {
+    if (gbwt_index.empty() || mappings.empty()) {
+        return gbwt_index;
+    }
+
+    // Partition the mappings by the first node and determine node width.
+    gbwt::size_type node_width = sdsl::bits::length(gbwt_index.sigma() - 1);
+    std::unordered_map<gbwt::node_type, std::vector<std::pair<gbwt::vector_type, gbwt::vector_type>>> mappings_by_first_node;
+    for (auto& mapping : mappings) {
+        if (mapping.first.empty()) {
+            continue;
+        }
+        mappings_by_first_node[mapping.first.front()].push_back(mapping);
+        for (auto node : mapping.second) {
+            node_width = std::max(node_width, static_cast<gbwt::size_type>(sdsl::bits::length(node)));
+        }
+    }
+
+    // Build the new GBWT.
+    gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+    gbwt::GBWTBuilder builder(node_width);
+    for (gbwt::size_type id = 0; id < gbwt_index.sequences(); id += 2) {
+        gbwt::vector_type path = gbwt_index.extract(id);
+        gbwt::vector_type mapped;
+        size_t i = 0;
+        while (i < path.size()) {
+            auto iter = mappings_by_first_node.find(path[i]);
+            bool found = false;
+            if (iter != mappings_by_first_node.end()) {
+                for (auto& mapping : iter->second) {
+                    size_t j = 1;
+                    while (j < mapping.first.size() && i + j < path.size() && mapping.first[j] == path[i + j]) {
+                        j++;
+                    }
+                    if (j >= mapping.first.size()) {
+                        mapped.insert(mapped.end(), mapping.second.begin(), mapping.second.end());
+                        i += j;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if (!found) {
+                mapped.push_back(path[i]);
+                i++;
+            }
+        }
+        builder.insert(mapped, true);
+    }
+    builder.finish();
+
+    // Copy the metadata.
+    if (gbwt_index.hasMetadata()) {
+        builder.index.addMetadata();
+        builder.index.metadata = gbwt_index.metadata;
+    }
+
+    return gbwt::GBWT(builder.index);
 }
 
 //------------------------------------------------------------------------------

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -150,6 +150,16 @@ struct GBWTHandler {
 
 //------------------------------------------------------------------------------
 
+/// Rebuild the GBWT by applying all provided mappings. Each mapping is a pair
+/// (original subpath, new subpath). If the original subpath is empty, the
+/// mapping is ignored. If there are multiple applicable mappings, the first one
+/// will be used.
+/// TODO: We could provide construction parameters and an option to parallelize
+/// by contig.
+gbwt::GBWT rebuild_gbwt(const gbwt::GBWT& gbwt_index, const std::vector<std::pair<gbwt::vector_type, gbwt::vector_type>>& mappings);
+
+//------------------------------------------------------------------------------
+
 /// Return the list of thread ids / gbwt path ids for the given sample.
 std::vector<gbwt::size_type> threads_for_sample(const gbwt::GBWT& gbwt_index, const std::string& sample_name);
 
@@ -196,7 +206,7 @@ unordered_map<nid_t, vector<nid_t>> load_translation_map(ifstream& input_stream)
 /// Load a translation file (created with vg gbwt --translation) and return a backwards mapping
 /// of chopped node to original segment position (id,offset pair)
 /// NOTE: hopefully this is just a short-term hack, and we get a general interface baked into
-//        the handlegraphs themselves
+///       the handlegraphs themselves
 unordered_map<nid_t, pair<nid_t, size_t>> load_translation_back_map(HandleGraph& graph, ifstream& input_stream);
 
 //------------------------------------------------------------------------------

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -52,10 +52,9 @@ void help_minimizer(char** argv) {
     std::cerr << std::endl;
     std::cerr << "Builds a (w, k)-minimizer index or a (k, s)-syncmer index of the threads in the GBWT" << std::endl;
     std::cerr << "index. The graph can be any HandleGraph, which will be transformed into a GBWTGraph." << std::endl;
-    std::cerr << "The transformation can be avoided by providing a GBWTGraph and using option -G or -Z." << std::endl;
+    std::cerr << "The transformation can be avoided by providing a GBWTGraph or a GBZ graph." << std::endl;
     std::cerr << std::endl;
     std::cerr << "Required options:" << std::endl;
-    std::cerr << "    -g, --gbwt-name X       use the GBWT index in file X (or specify -Z)" << std::endl;
     std::cerr << "    -o, --output-name X     store the index to file X" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Minimizer options:" << std::endl;
@@ -67,8 +66,8 @@ void help_minimizer(char** argv) {
     std::cerr << "Other options:" << std::endl;
     std::cerr << "    -d, --distance-index X  annotate the hits with positions in this distance index" << std::endl;
     std::cerr << "    -l, --load-index X      load the index from file X and insert the new kmers into it" << std::endl;
-    std::cerr << "                            (overrides -k, -w, -b, and -s)" << std::endl;
-    std::cerr << "    -G, --gbwt-graph        the input graph is a GBWTGraph" << std::endl;
+    std::cerr << "                            (overrides minimizer options)" << std::endl;
+    std::cerr << "    -g, --gbwt-name X       use the GBWT index in file X (required with a non-GBZ graph)" << std::endl;
     std::cerr << "    -p, --progress          show progress information" << std::endl;
     std::cerr << "    -t, --threads N         use N threads for index construction (default " << get_default_threads() << ")" << std::endl;
     std::cerr << "                            (using more than " << DEFAULT_MAX_THREADS << " threads rarely helps)" << std::endl;
@@ -103,7 +102,7 @@ int main_minimizer(int argc, char** argv) {
             { "smer-length", required_argument, 0, 's' },
             { "distance-index", required_argument, 0, 'd' },
             { "load-index", required_argument, 0, 'l' },
-            { "gbwt-graph", no_argument, 0, 'G' },
+            { "gbwt-graph", no_argument, 0, 'G' }, // deprecated
             { "progress", no_argument, 0, 'p' },
             { "threads", required_argument, 0, 't' },
             { 0, 0, 0, 0 }
@@ -122,7 +121,7 @@ int main_minimizer(int argc, char** argv) {
             output_name = optarg;
             break;
         case 'i':
-            std::cerr << "warning: [vg minimizer] --index-name is deprecated, use --output-name instead" << std::endl;
+            std::cerr << "[vg minimizer] warning: --index-name is deprecated, use --output-name instead" << std::endl;
             output_name = optarg;
             break;
         case 'k':
@@ -132,7 +131,7 @@ int main_minimizer(int argc, char** argv) {
             IndexingParameters::minimizer_w = parse<size_t>(optarg);
             break;
         case 'b':
-            std::cerr << "warning: [vg minimizer] --bounded-syncmers is deprecated, use --closed-syncmers instead" << std::endl;
+            std::cerr << "[vg minimizer] warning: --bounded-syncmers is deprecated, use --closed-syncmers instead" << std::endl;
             use_syncmers = true;
             break;
         case 'c':
@@ -148,7 +147,7 @@ int main_minimizer(int argc, char** argv) {
             load_index = optarg;
             break;
         case 'G':
-            std::cerr << "warning: [vg minimizer] --gbwt-graph is deprecated, graph format is now autodetected" << std::endl;
+            std::cerr << "[vg minimizer] warning: --gbwt-graph is deprecated, graph format is now autodetected" << std::endl;
             break;
         case 'p':
             progress = true;
@@ -168,7 +167,7 @@ int main_minimizer(int argc, char** argv) {
         }
     }
     if (output_name.empty()) {
-        std::cerr << "[vg minimizer]: option --output-name is required" << std::endl;
+        std::cerr << "[vg minimizer] error: option --output-name is required" << std::endl;
         return 1;
     }
     if (optind + 1 != argc) {
@@ -197,7 +196,7 @@ int main_minimizer(int argc, char** argv) {
         gbz->graph = std::move(*get<1>(input));
         
         if (gbwt_name.empty()) {
-            std::cerr << "[vg minimizer]: option --gbwt-name is required when using a GBWTGraph" << std::endl;
+            std::cerr << "[vg minimizer] error: option --gbwt-name is required when using a GBWTGraph" << std::endl;
             return 1;
         }
         
@@ -209,7 +208,7 @@ int main_minimizer(int argc, char** argv) {
         // We got a normal HandleGraph
         
         if (gbwt_name.empty()) {
-            std::cerr << "[vg minimizer]: option --gbwt-name is required when using a HandleGraph" << std::endl;
+            std::cerr << "[vg minimizer] error: option --gbwt-name is required when using a HandleGraph" << std::endl;
             return 1;
         }
         
@@ -222,7 +221,7 @@ int main_minimizer(int argc, char** argv) {
         }
         gbz.reset(new gbwtgraph::GBZ(gbwt_index, *get<2>(input)));
     } else {
-        std::cerr << "[vg minimizer]: input graph is not a GBZ, GBWTGraph, or HandleGraph." << std::endl;
+        std::cerr << "[vg minimizer] error: input graph is not a GBZ, GBWTGraph, or HandleGraph." << std::endl;
         return 1;
     }
 

--- a/src/unittest/index_helpers.cpp
+++ b/src/unittest/index_helpers.cpp
@@ -1,0 +1,90 @@
+/** \file
+ *
+ * Unit tests for utility classes and functions for working with GBWT, GBWTGraph, and GCSA2.
+ */
+
+#include "../gbwt_helper.hpp"
+
+#include "catch.hpp"
+
+
+
+namespace vg {
+
+namespace unittest {
+
+//------------------------------------------------------------------------------
+
+namespace {
+
+gbwt::vector_type alt_path {
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(1, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(2, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(4, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(5, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(6, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(8, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(9, false))
+};
+
+gbwt::vector_type short_path {
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(1, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(4, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(5, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(6, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(7, false)),
+    static_cast<gbwt::vector_type::value_type>(gbwt::Node::encode(9, false))
+};
+
+void check_paths(const gbwt::GBWT& index, const std::vector<gbwt::vector_type>& truth) {
+    REQUIRE(index.sequences() == 2 * truth.size());
+    for (gbwt::size_type i = 0; i < index.sequences(); i += 2) {
+        gbwt::vector_type path = index.extract(i);
+        REQUIRE(path == truth[i / 2]);
+    }
+}
+
+} // anonymous namespace
+
+//------------------------------------------------------------------------------
+
+TEST_CASE("GBWT reconstruction", "[index_helpers]") {
+
+    SECTION("simple replacements") {
+        std::vector<gbwt::vector_type> source {
+            short_path, alt_path, short_path
+        };
+        gbwt::GBWT index = get_gbwt(source);
+        std::vector<std::pair<gbwt::vector_type, gbwt::vector_type>> mappings {
+            { { 8 }, { } }, // delete 4
+            { { 12, 14 }, { 14 } }, // delete 6 if followed by 7
+            { { 12, 16 }, { 12, 20, 16 } }, // visit 10 between 6 and 8
+        };
+        std::vector<gbwt::vector_type> truth {
+            { 2, 10, 14, 18 },
+            { 2, 4, 10, 12, 20, 16, 18 },
+            { 2, 10, 14, 18 },
+        };
+        index = rebuild_gbwt(index, mappings);
+        check_paths(index, truth);
+    }
+
+    SECTION("impossible replacements") {
+        std::vector<gbwt::vector_type> source {
+            short_path, alt_path, short_path
+        };
+        gbwt::GBWT index = get_gbwt(source);
+        std::vector<std::pair<gbwt::vector_type, gbwt::vector_type>> mappings {
+            { { 6 }, { } }, // delete 3
+            { { 4, 10 }, { 10 } }, // delete 2 if followed by 5
+            { { 18, 20 }, { 18, 10, 20 } }, // visit 5 between 9 and 10
+        };
+        index = rebuild_gbwt(index, mappings);
+        check_paths(index, source);
+    }
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -264,7 +264,7 @@ rm -f x.vg distIndex snarls.pb
 
 # Test distance index with GBZ
 vg gbwt -g graph.gbz --gbz-format -G graphs/components_walks.gfa
-vg snarls -T -Z graph.gbz > graph.snarls
+vg snarls -T graph.gbz > graph.snarls
 vg index -s graph.snarls -j graph.dist graph.gbz
 is $? 0 "distance index construction from GBZ"
 

--- a/test/t/46_vg_minimizer.t
+++ b/test/t/46_vg_minimizer.t
@@ -13,7 +13,7 @@ vg construct -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a > x.vg 2> /dev/null
 vg index -x x.xg x.vg
 vg gbwt -x x.vg -o x.gbwt -v small/xy2.vcf.gz
 vg snarls -T x.vg > x.snarls
-vg index -s x.snarls -j x.dist -x x.xg
+vg index -s x.snarls -j x.dist x.xg
 
 # Default construction
 vg minimizer -o x.mi -g x.gbwt x.xg
@@ -36,7 +36,7 @@ is $(md5sum x.mi | cut -f 1 -d\ ) c69f4f2dfab192fc66055dcf2fa8a7da "setting -k -
 
 # Construction from GBWTGraph
 vg gbwt -x x.xg -g x.gg x.gbwt
-vg minimizer -t 1 -g x.gbwt -G -o x.mi x.gg
+vg minimizer -t 1 -g x.gbwt -o x.mi x.gg
 is $? 0 "construction from GBWTGraph"
 is $(md5sum x.mi | cut -f 1 -d\ ) 58b2bd98902df9acbe416bcfde649571 "construction is deterministic"
 
@@ -47,7 +47,7 @@ is $? 0 "construction from GBZ"
 is $(md5sum x.mi | cut -f 1 -d\ ) 58b2bd98902df9acbe416bcfde649571 "construction is deterministic"
 
 # Store payload in the index
-vg minimizer -t 1 -o x.mi -g x.gbwt -d x.dist -G x.gg
+vg minimizer -t 1 -o x.mi -g x.gbwt -d x.dist x.gg
 is $? 0 "construction with payload"
 is $(md5sum x.mi | cut -f 1 -d\ ) 58a6780c18921e4f6701b57fdb9c2e44 "construction is deterministic"
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Nothing that concerns the user

## Description

Added function `rebuild_gbwt(gbwt_index, mappings)`, which rebuilds the GBWT with the subpath substitutions specified in `mappings`. This is a proof-of-concept implementation. Instead of using something like Aho-Corasick, I simply partition the substitutions by the first node of the original subpath and naively try to match each possible substitution. This should not matter, as the heavyweight operation is the GBWT construction, which happens in a background thread.

For 1000GP-scale GBWTs, this should be partitioned by chromosome.