### PR TITLE
Stop node reuse

### DIFF
--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -1266,7 +1266,7 @@ void IntegratedSnarlFinder::traverse_computed_decomposition(MergedAdjacencyGraph
     // Now, keep a set of all the edges that have found a place in the decomposition.
     // Ignore handle orientation.
     // Because we don't want to mess up orientations, we only access the set through accessors.
-    HandleGraphNodeSet visited;
+    HandleGraphNodeSet visited(graph);
     
 #ifdef debug
     cerr << "Traversing cactus graph..." << endl;

--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -1254,7 +1254,6 @@ public:
     }
 };
 
-#define debug
 void IntegratedSnarlFinder::traverse_computed_decomposition(MergedAdjacencyGraph& cactus,
     const MergedAdjacencyGraph& forest,
     vector<pair<size_t, vector<handle_t>>>& longest_paths,
@@ -1842,7 +1841,6 @@ void IntegratedSnarlFinder::traverse_computed_decomposition(MergedAdjacencyGraph
     }
     
 }
-#undef debug
 
 SnarlManager IntegratedSnarlFinder::find_snarls_parallel() {
 

--- a/src/integrated_snarl_finder.cpp
+++ b/src/integrated_snarl_finder.cpp
@@ -1215,7 +1215,8 @@ void IntegratedSnarlFinder::traverse_decomposition(const function<void(handle_t)
                                     begin_snarl,
                                     end_snarl);
 }
-  
+
+#define debug
 void IntegratedSnarlFinder::traverse_computed_decomposition(MergedAdjacencyGraph& cactus,
     const MergedAdjacencyGraph& forest,
     vector<pair<size_t, vector<handle_t>>>& longest_paths,
@@ -1801,6 +1802,7 @@ void IntegratedSnarlFinder::traverse_computed_decomposition(MergedAdjacencyGraph
     }
     
 }
+#undef debug
 
 SnarlManager IntegratedSnarlFinder::find_snarls_parallel() {
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `IntegratedSnarlFinder` properly tracks whether cycles and bridge edge paths have been reached regardless of orientation

## Description

This fixes #3355 by fixing some orientation accounting that was wrong.