### PR TITLE
WIP: vg clip

### DIFF
--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -310,7 +310,7 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
     
     if (verbose) {
         for (const auto& kv : clip_counts) {
-            cerr << "[vg-clip]: Creating " << kv.second << " fragments from path" << kv.first << endl;
+            cerr << "[vg-clip]: Creating " << kv.second << " fragments from path " << kv.first << endl;
         }
         clip_counts.clear();
     }

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -1,0 +1,273 @@
+#include "clip.hpp"
+#include "traversal_finder.hpp"
+#include <unordered_map>
+#include <IntervalTree.h>
+
+//#define debug
+
+namespace vg {
+
+using namespace std;
+
+// find the snarl's spanning interval on every reference path traversal through it
+// as soon as one of these intervals is found that is contained within an interval in the input index
+// then return it (or nullptr if none found)
+// also return the snarl's interval (as pair of offsets) in the path
+// this logic is mostly lifted from deconstructor which does the same thing to get vcf coordinates.
+static pair<const Region*, pair<step_handle_t, step_handle_t>> get_containing_region(PathPositionHandleGraph* graph,
+                                                                                     PathTraversalFinder& trav_finder,
+                                                                                     const Snarl* snarl,
+                                                                                     unordered_map<string, IntervalTree<int64_t, const Region*>>& contig_to_interval_tree,
+                                                                                     bool include_endpoints) {
+
+    // every path through the snarl
+    pair<vector<SnarlTraversal>, vector<pair<step_handle_t, step_handle_t> > > travs = trav_finder.find_path_traversals(*snarl);
+
+    // check each one against the interval tree
+    for (size_t i = 0; i < travs.first.size(); ++i) {
+        auto& step_pair = travs.second[i];
+        auto& ref_trav = travs.first[i];
+
+        path_handle_t path_handle = graph->get_path_handle_of_step(step_pair.first);
+        string path_name = graph->get_path_name(path_handle);
+        int64_t path_offset = 0;
+        auto sp_parse = Paths::parse_subpath_name(path_name);
+        if (get<0>(sp_parse)) {
+            path_name = get<1>(sp_parse);
+            path_offset = get<2>(sp_parse);
+        }
+
+        IntervalTree<int64_t, const Region*>& interval_tree = contig_to_interval_tree.at(path_name);
+
+        // first_path_pos computation copied from deconstructor.cpp (it does not include the start node)
+        step_handle_t start_step = step_pair.first;
+        step_handle_t end_step = step_pair.second;
+        handle_t start_handle = graph->get_handle_of_step(start_step);
+        handle_t end_handle = graph->get_handle_of_step(end_step);
+        size_t start_pos = graph->get_position_of_step(start_step);
+        size_t end_pos = graph->get_position_of_step(end_step);
+        bool use_start = start_pos < end_pos;
+        handle_t first_path_handle = use_start ? start_handle : end_handle;
+        int64_t first_path_pos = use_start ? start_pos : end_pos;
+        // Get the first visit of our snarl traversal
+        const Visit& first_trav_visit = use_start ? ref_trav.visit(0) : ref_trav.visit(ref_trav.visit_size() - 1);
+        if ((use_start && first_trav_visit.backward() == graph->get_is_reverse(first_path_handle)) ||
+            (!use_start && first_trav_visit.backward() != graph->get_is_reverse(first_path_handle))) {
+            // Our path and traversal have consistent orientation.  leave off the end of the start node going forward
+            first_path_pos += graph->get_length(first_path_handle);
+        }
+
+        size_t length_from_start = 0;
+        for (size_t j = 1; j < ref_trav.visit_size() - 1; ++j) {
+            length_from_start += graph->get_length(graph->get_handle(ref_trav.visit(j).node_id()));
+        }
+
+        if (include_endpoints) {
+            first_path_pos -= graph->get_length(first_path_handle);
+            length_from_start += graph->get_length(graph->get_handle(ref_trav.visit(ref_trav.visit_size() - 1).node_id()));
+        }
+        int64_t last_path_pos = length_from_start == 0 ? first_path_pos : first_path_pos + length_from_start - 1;
+        auto overlapping_intervals = interval_tree.findOverlapping(first_path_pos, last_path_pos);
+        for (auto& interval : overlapping_intervals) {
+            if (interval.start <= first_path_pos && interval.stop >= last_path_pos) {
+                return make_pair(interval.value, make_pair(start_step, end_step));
+            }
+        }
+                                                                                                                     
+    }
+    return make_pair(nullptr, make_pair(step_handle_t(), step_handle_t()));
+}
+
+void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>& regions, SnarlManager& snarl_manager,
+                            bool include_endpoints,
+                            function<void(const Snarl*, const step_handle_t&, const step_handle_t&, const Region*)> visit_fn) {
+
+    // make an interval tree of regions for each contig
+    unordered_map<string, vector<IntervalTree<int64_t, const Region*>::interval>> region_intervals;
+    for (const Region & region : regions) {
+        vector<IntervalTree<int64_t, const Region*>::interval>& intervals = region_intervals[region.seq];
+        intervals.push_back(IntervalTree<int64_t, const Region*>::interval(region.start, region.end, &region));
+    }
+    unordered_map<string, IntervalTree<int64_t, const Region*>> contig_to_interval_tree;
+    for (auto seq_intervals : region_intervals) {
+        IntervalTree<int64_t, const Region*> interval_tree(std::move(seq_intervals.second));
+        contig_to_interval_tree[seq_intervals.first] = std::move(interval_tree);
+    }
+    region_intervals.clear();
+    
+    // make a path traversal finder for all affected reference paths taking into account
+    // subpaths in the graph
+    unordered_set<string> path_name_set;
+    for (const Region& region : regions) {
+        path_name_set.insert(region.seq);
+    }
+    unordered_set<string> graph_path_name_set;
+    graph->for_each_path_handle([&](path_handle_t path_handle) {
+            string path_name = graph->get_path_name(path_handle);
+            auto sp_parse = Paths::parse_subpath_name(path_name);
+            if (get<0>(sp_parse)) {
+                path_name = get<1>(sp_parse);
+            }
+            if (path_name_set.count(path_name)) {
+                graph_path_name_set.insert(path_name);
+            }
+        });
+    vector<string> path_names;
+    for (const string& path_name : path_name_set) {
+        path_names.push_back(path_name);
+    }
+    path_name_set.clear();
+    graph_path_name_set.clear();
+    PathTraversalFinder trav_finder(*graph, snarl_manager, path_names);
+    
+    // Do the top-level snarls, the recurse as needed (framework copied from deconstructor.cpp)
+    snarl_manager.for_each_top_level_snarl([&](const Snarl* snarl) {
+            vector<const Snarl*> todo(1, snarl);
+            vector<const Snarl*> next;
+            while (!todo.empty()) {
+                for (auto next_snarl : todo) {
+                    auto containing_region_info = get_containing_region(graph, trav_finder, next_snarl, contig_to_interval_tree, include_endpoints);
+                    if (containing_region_info.first != nullptr) {
+                        visit_fn(next_snarl, containing_region_info.second.first, containing_region_info.second.second, containing_region_info.first);
+                    } else {
+                        const vector<const Snarl*>& children = snarl_manager.children_of(next_snarl);
+                        next.insert(next.end(), children.begin(), children.end());
+                    }
+                }
+                swap(todo, next);
+                next.clear();
+            }
+        });
+}
+
+// note: end_step is after the subpath
+//       end_offset is also one-past the interval
+static path_handle_t create_path_fragment(MutablePathMutableHandleGraph* graph, const string& base_name, step_handle_t first_step,
+                                          step_handle_t end_step, int64_t start_offset, int64_t end_offset) {
+    assert(end_offset > start_offset);
+    string subpath_name = Paths::make_subpath_name(base_name, start_offset, end_offset - 1);
+#ifdef debug
+    cerr << "making fragment " << subpath_name << endl;
+#endif
+    path_handle_t subpath_handle = graph->create_path_handle(subpath_name);
+    for (step_handle_t step = first_step; step != end_step; step = graph->get_next_step(step)) {
+        graph->append_step(subpath_handle, graph->get_handle_of_step(step));
+    }
+    return subpath_handle;
+}
+
+void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
+                           SnarlManager& snarl_manager, bool include_endpoints, bool verbose) {
+
+    // find all nodes in the snarl that are not on the reference interval (reference path name from containing interval)
+    unordered_set<nid_t> to_delete;
+
+    // just for logging
+    unordered_map<string, size_t> clip_counts;
+    
+    visit_contained_snarls(pp_graph, regions, snarl_manager, include_endpoints, [&](const Snarl* snarl, const step_handle_t& start_step, const step_handle_t& end_step, const Region* containing_region) {
+
+#ifdef debug
+            cerr << "Clipping snarl " << pb2json(*snarl) << " because it lies in region "
+                 << containing_region->seq << ":" << containing_region->start << "-" << containing_region->end << endl;
+#endif
+
+            unordered_set<nid_t> whitelist;
+            step_handle_t past_end_step = pp_graph->get_next_step(end_step);            
+            for (step_handle_t step = start_step ; step != past_end_step; step = graph->get_next_step(step)) {
+                whitelist.insert(pp_graph->get_id(pp_graph->get_handle_of_step(step)));
+            }
+
+            pair<unordered_set<id_t>, unordered_set<edge_t> > contents = snarl_manager.deep_contents(snarl, *pp_graph, false);
+            for (id_t node_id : contents.first) {
+                if (!whitelist.count(node_id)) {
+                    to_delete.insert(node_id);
+                    ++clip_counts[containing_region->seq];
+                }
+            }
+            
+        });
+
+    if (verbose) {
+        for (const auto& kv : clip_counts) {
+            cerr << "[vg-clip]: Removing " << kv.second << " nodes due to intervals on path " << kv.first << endl;
+        }
+        clip_counts.clear();
+    }
+    
+    // chop the paths    
+    vector<path_handle_t> path_handles;
+    graph->for_each_path_handle([&](path_handle_t path_handle) {
+            path_handles.push_back(path_handle);
+        });    
+    for (path_handle_t& path_handle : path_handles) {
+
+        string path_name = graph->get_path_name(path_handle);
+#ifdef debug
+        cerr << "processing path " << path_name << endl;
+#endif
+        int64_t path_offset = 0;
+        auto sp_parse = Paths::parse_subpath_name(path_name);
+        if (get<0>(sp_parse)) {
+            path_name = get<1>(sp_parse);
+            path_offset = get<2>(sp_parse);
+        }
+
+        int64_t cur_step_offset = path_offset;
+        step_handle_t start_step = graph->path_begin(path_handle);
+        int64_t start_step_offset = cur_step_offset;
+        step_handle_t prev_step;
+        step_handle_t end_step = graph->path_end(path_handle);
+        bool in_path = !to_delete.count(graph->get_id(graph->get_handle_of_step(start_step)));
+        bool was_chopped = false;
+        for (step_handle_t cur_step = start_step; cur_step != end_step; cur_step = graph->get_next_step(cur_step)) {
+            handle_t cur_handle = graph->get_handle_of_step(cur_step);
+            nid_t cur_id = graph->get_id(cur_handle);
+            bool step_deleted = to_delete.count(cur_id);
+            if (in_path && step_deleted && cur_step_offset > start_step_offset) {
+                // we hit a deleted node: make a path fragment for eveything to it
+                create_path_fragment(graph, path_name, start_step, cur_step, start_step_offset, cur_step_offset);
+                ++clip_counts[path_name];
+            }
+            if (!in_path && !step_deleted) {
+                // we hit the first undeleted node after a run of deleteions, start a new fragment
+                start_step_offset = cur_step_offset;
+                start_step = cur_step;
+            }
+            in_path = !step_deleted;
+            cur_step_offset += graph->get_length(cur_handle);
+            prev_step = cur_step;
+            was_chopped = was_chopped || step_deleted;
+        }
+
+        if (was_chopped && in_path && cur_step_offset > start_step_offset) {
+            // get that last fragment
+            create_path_fragment(graph, path_name, start_step, graph->path_end(path_handle), start_step_offset, cur_step_offset);
+            ++clip_counts[path_name];
+        }
+
+        if (was_chopped) {
+            graph->destroy_path(path_handle);                
+        }
+    }
+
+    if (verbose) {
+        for (const auto& kv : clip_counts) {
+            cerr << "[vg-clip]: Creating " << kv.second << " fragments from path" << kv.first << endl;
+        }
+        clip_counts.clear();
+    }
+
+    // finally, delete the nodes
+    DeletableHandleGraph* del_graph = dynamic_cast<DeletableHandleGraph*>(graph);
+    for (nid_t node_id : to_delete) {
+        handle_t handle = graph->get_handle(node_id);
+        assert(graph->steps_of_handle(handle).empty());
+        dynamic_cast<DeletableHandleGraph*>(graph)->destroy_handle(handle);
+    }    
+}
+
+
+
+
+}

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -52,9 +52,25 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
  * Clip out nodes that don't pass depth threshold (depth < min_depth).  
  * "depth" is the number of paths that step on the node. 
  * Nodes on path with given prefix ignored (todo: should really switch to regex or something)
+ * iterate_handles is a hack to generalize this function to whole graphs or snarls
+ */
+void clip_low_depth_nodes_generic(MutablePathMutableHandleGraph* graph, function<void(function<void(handle_t, const Region*)>)> iterate_handles,
+                                  int64_t min_depth, const string& ref_prefix,
+                                  int64_t min_fragment_len, bool verbose);
+
+
+/**
+ * Run above function on graph
  */
 void clip_low_depth_nodes(MutablePathMutableHandleGraph* graph, int64_t min_depth, const string& ref_prefix,
-                          int64_t min_fragment_len, bool verbose);    
+                          int64_t min_fragment_len, bool verbose);
+
+/**
+ * Or on contained snarls
+ */
+void clip_contained_low_depth_nodes(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
+                                    SnarlManager& snarl_manager, bool include_endpoints, int64_t min_depth, int64_t min_fragment_len, bool verbose);
+
 
                                                       
 }

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -19,11 +19,11 @@ using namespace std;
  * Visit each snarl if it is fully contained in at least one region from the input set.
  * Only the top-most snarl is visited.
  * The parameters to visit_fn are: 
- *    <the snarl, start_step, end_step, the containing input region>
+ *    <the snarl, start_step, end_step, steps_reversed, the containing input region>
  */
 void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>& regions, SnarlManager& snarl_manager,
                             bool include_endpoints,
-                            function<void(const Snarl*, const step_handle_t&, const step_handle_t&, const Region*)> visit_fn);
+                            function<void(const Snarl*, step_handle_t, step_handle_t, bool, const Region*)> visit_fn);
 
 /*
  * Cut nodes out of a graph, and chop up any paths that contain them, using (and resolving) supbath
@@ -31,7 +31,9 @@ void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>
  * If a chopped path has a fragment with length < min_fragment_len, don't bother writing the new path
  * The fragments_per_path map is optional, and will collect some stats if present
  */
-void delete_nodes_and_chop_paths(MutablePathMutableHandleGraph* graph, unordered_set<nid_t> to_delete,
+void delete_nodes_and_chop_paths(MutablePathMutableHandleGraph* graph,
+                                 const unordered_set<nid_t>& nodes_to_delete,
+                                 const unordered_set<edge_t>& edges_to_delete,
                                  int64_t min_fragment_len,
                                  unordered_map<string, size_t>* fragments_per_path = nullptr);
 

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -25,6 +25,16 @@ void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>
                             bool include_endpoints,
                             function<void(const Snarl*, const step_handle_t&, const step_handle_t&, const Region*)> visit_fn);
 
+/*
+ * Cut nodes out of a graph, and chop up any paths that contain them, using (and resolving) supbath
+ * naming conventions from Paths class in path.hpp
+ * If a chopped path has a fragment with length < min_fragment_len, don't bother writing the new path
+ * The fragments_per_path map is optional, and will collect some stats if present
+ */
+void delete_nodes_and_chop_paths(MutablePathMutableHandleGraph* graph, unordered_set<nid_t> to_delete,
+                                 int64_t min_fragment_len,
+                                 unordered_map<string, size_t>* fragments_per_path = nullptr);
+
 
 /**
  * If a given bed region spans a snarl (overlaps its end nodes, and forms a traversal)
@@ -33,9 +43,16 @@ void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>
  * IMPORTANT: for any given snarl, the first region that contains it is used.  
  */
 void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
-                           SnarlManager& snarl_manager, bool include_endpoints, bool verbose);
+                           SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len, bool verbose);
 
 
+/**
+ * Clip out nodes that don't pass depth threshold (depth < min_depth).  
+ * "depth" is the number of paths that step on the node. 
+ * Nodes on path with given prefix ignored (todo: should really switch to regex or something)
+ */
+void clip_low_depth_nodes(MutablePathMutableHandleGraph* graph, int64_t min_depth, const string& ref_prefix,
+                          int64_t min_fragment_len, bool verbose);    
 
                                                       
 }

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -1,0 +1,44 @@
+#ifndef VG_CLIP_HPP_INCLUDED
+#define VG_CLIP_HPP_INCLUDED
+
+/**
+ * \file clip.hpp
+ *
+ * Clip regions out of a graph
+ */
+
+#include "handle.hpp"
+#include "snarls.hpp"
+#include "region.hpp"
+
+namespace vg {
+
+using namespace std;
+
+/**
+ * Visit each snarl if it is fully contained in at least one region from the input set.
+ * Only the top-most snarl is visited.
+ * The parameters to visit_fn are: 
+ *    <the snarl, start_step, end_step, the containing input region>
+ */
+void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>& regions, SnarlManager& snarl_manager,
+                            bool include_endpoints,
+                            function<void(const Snarl*, const step_handle_t&, const step_handle_t&, const Region*)> visit_fn);
+
+
+/**
+ * If a given bed region spans a snarl (overlaps its end nodes, and forms a traversal)
+ * then clip out all other nodes (ie nodes that don't lie on the traversal)
+ *
+ * IMPORTANT: for any given snarl, the first region that contains it is used.  
+ */
+void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
+                           SnarlManager& snarl_manager, bool include_endpoints, bool verbose);
+
+
+
+                                                      
+}
+
+
+#endif

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -1,0 +1,169 @@
+#include "subcommand.hpp"
+#include "../vg.hpp"
+#include "../utility.hpp"
+#include "../integrated_snarl_finder.hpp"
+#include "../io/save_handle_graph.hpp"
+#include <vg/io/stream.hpp>
+#include <vg/io/vpkg.hpp>
+#include <vg/io/alignment_emitter.hpp>
+#include "../clip.hpp"
+#include <bdsg/overlays/overlay_helper.hpp>
+
+#include <unistd.h>
+#include <getopt.h>
+
+using namespace vg;
+using namespace vg::subcommand;
+using namespace vg::io;
+
+void help_clip(char** argv) {
+  cerr << "usage: " << argv[0] << " [options] <graph>" << endl
+       << "Chop out path intervals from a vg graph" << endl
+       << endl
+       << "bed clipping options: " << endl
+       << "    -b, --bed FILE            Clip out alt-alleles in snarls that are contained in a region from given BED file" << endl
+       << "depth clipping options: " << endl
+       << "    -d, --depth N             Clip out alt-alleles with average depth below N" << endl
+       << "    -P, --path-prefix STRING  Do not clip out alleles on paths beginning with given prefix." << endl
+       << "general options: " << endl
+       << "    -r, --snarls FILE         Snarls (from vg snarls) to avoid recomputing " << endl
+       << "    -t, --threads N           number of threads to use (only used to computing snarls) [default: all available]" << endl
+       << "    -v, --verbose             Print some logging messages" << endl
+       << endl;
+}    
+
+int main_clip(int argc, char** argv) {
+
+    string bed_path;
+    string snarls_path;
+    string ref_prefix;
+    int64_t min_depth = 0;
+    bool verbose = false;
+    int input_count = 0;
+
+    if (argc == 2) {
+        help_clip(argv);
+        return 1;
+    }
+    
+    int c;
+    optind = 2; // force optind past command positional argument
+    while (true) {
+        static struct option long_options[] =
+        {
+            {"help", no_argument, 0, 'h'},
+            {"bed", required_argument, 0, 'b'},
+            {"depth", required_argument, 0, 'd'},
+            {"path-prefix", required_argument, 0, 'P'},
+            {"snarls", required_argument, 0, 'r'},
+            {"threads", required_argument, 0, 't'},
+            {"verbose", required_argument, 0, 'v'},
+            {0, 0, 0, 0}
+
+        };
+        int option_index = 0;
+        c = getopt_long (argc, argv, "hb:d:P:r:t:v",
+                long_options, &option_index);
+
+        // Detect the end of the options.
+        if (c == -1)
+            break;
+
+        switch (c)
+        {
+
+        case '?':
+        case 'h':
+            help_clip(argv);
+            return 0;
+        case 'b':
+            bed_path = optarg;
+            ++input_count;
+            break;
+        case 'd':
+            min_depth = stol(optarg);
+            ++input_count;
+            break;
+        case 'P':
+            ref_prefix = optarg;
+            break;            
+        case 'r':
+            snarls_path = optarg;
+            break;
+        case 'v':
+            verbose = true;
+            break;
+        case 't':
+        {
+            int num_threads = parse<int>(optarg);
+            if (num_threads <= 0) {
+                cerr << "error:[vg clip] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                exit(1);
+            }
+            omp_set_num_threads(num_threads);
+            break;
+        }            
+        default:
+            abort();
+        }
+    }
+
+    if (input_count != 1) {
+        cerr << "error:[vg clip] Exactly one of -b or -d must be specified to select what to clip" << endl;
+        return 1;
+    }
+
+    // load the graph
+    string graph_path = get_input_file_name(optind, argc, argv);
+    unique_ptr<MutablePathMutableHandleGraph> graph = vg::io::VPKG::load_one<MutablePathMutableHandleGraph>(graph_path);
+
+    // Load or compute the snarls
+    unique_ptr<SnarlManager> snarl_manager;
+    if (!snarls_path.empty()) {
+        ifstream snarl_file(snarls_path.c_str());
+        if (!snarl_file) {
+            cerr << "Error [vg clip]: Unable to load snarls file: " << snarls_path << endl;
+            return 1;
+        }
+        snarl_manager = vg::io::VPKG::load_one<SnarlManager>(snarl_file);
+        if (verbose) {
+            cerr << "[vg clip]: Loaded " << snarl_manager->num_snarls() << " snarls" << endl;
+        }
+    } else {
+        IntegratedSnarlFinder finder(*graph);
+        snarl_manager = unique_ptr<SnarlManager>(new SnarlManager(std::move(finder.find_snarls_parallel())));
+        if (verbose) {
+            cerr << "[vg clip]: Computed " << snarl_manager->num_snarls() << " snarls" << endl;
+        }
+    }
+
+    if (!bed_path.empty()) {
+        // load the bed file
+        vector<Region> bed_regions;
+        parse_bed_regions(bed_path, bed_regions);
+        if (verbose) {
+            cerr << "[vg clip]: Loaded " << bed_regions.size() << " BED regions" << endl;
+        }
+
+        // need path positions
+        bdsg::PathPositionOverlayHelper overlay_helper;
+        PathPositionHandleGraph* pp_graph = overlay_helper.apply(graph.get());
+
+        // run the clipping
+        clip_contained_snarls(graph.get(), pp_graph, bed_regions, *snarl_manager, false, verbose);
+    }
+
+    if (min_depth > 0) {
+        // run the clipping
+        //clip_low_depth_traversals(graph.get(), min_depth, *snarl_manager, hardmask);
+    }
+        
+    // write the graph
+    vg::io::save_handle_graph(graph.get(), std::cout);
+    
+    return 0;
+}
+
+
+// Register subcommand
+static Subcommand vg_clip("clip", "remove BED regions (other other nodes from their snarls) from a graph", main_clip);

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -22,10 +22,10 @@ void help_clip(char** argv) {
        << endl
        << "input options: " << endl
        << "    -b, --bed FILE            BED regions corresponding to path intervals of the graph to target" << endl
-       << "    -r, --snarls FILE         Snarls from vg snarls (recomputed if not given).  Snarls used to identify subgraphs within target intervals" << endl
+       << "    -r, --snarls FILE         Snarls from vg snarls (recomputed if not given; only needed with -b). Snarls used to identify subgraphs to clip within target intervals" << endl
        << "depth clipping options: " << endl
-       << "    -d, --depth N             Clip out nodes with average depth below N" << endl
-       << "    -P, --path-prefix STRING  Do not clip out alleles on paths beginning with given prefix (references must be specified either with -P or -b). " << endl
+       << "    -d, --depth N             Clip out nodes with path depth below N" << endl
+       << "    -P, --path-prefix STRING  Do not clip out alleles on paths beginning with given prefix (such references must be specified either with -P or -b). " << endl
        << "general options: " << endl
        << "    -m, --min-fragment-len N  Don't write novel path fragment if it less than N bp long" << endl
        << "    -t, --threads N           number of threads to use (only used to computing snarls) [default: all available]" << endl

--- a/test/t/53_clip.t
+++ b/test/t/53_clip.t
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 7
+
+vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 -k 16 | vg mod -U 10 - | vg mod -c - > hla.vg
+
+#flatten it to one path
+printf "gi|568815551:1054737-1055734\t0\t1000\n" > region.bed
+vg clip hla.vg -b region.bed > clip_flat.vg
+vg validate clip_flat.vg
+is "$?" 0 "clipped graph is valid"
+for i in `vg view clip_flat.vg | grep '^S' | awk '{print $1}'` ; do vg view clip_flat.vg -n $i | grep ^P | grep "gi|568815551:1054737-1055734"; done | wc -l > step_count
+vg view clip_flat.vg | grep ^S | wc -l > node_count
+diff step_count node_count
+is "$?" 0 "every step in clipped graph belongs to reference path"
+is $(vg paths -Ev hla.vg -Q "gi|568815551:1054737-1055734" | awk '{ print $2 }') $(vg stats -l clip_flat.vg | awk '{ print $2 }') "clipped graph has same length as ref path"
+
+rm -f region.bed step_count node_count
+
+#clip out one snarl
+printf "gi|157734152:29563108-29564082\t90\t92\n" > region.bed
+vg clip hla.vg -b region.bed > clip.vg
+vg validate clip.vg
+is "$?" 0 "clipped graph is valid"
+is $(vg view clip.vg | grep ^S | wc -l) "49" "Just one node filtered"
+
+rm -f region.bed clip.vg
+
+# clip out one edge
+printf "gi|568815564:1054403-1055400\t150\t153\n" > region.bed
+vg clip hla.vg -b region.bed > clip.vg
+vg validate clip.vg
+is "$?" 0 "clipped graph is valid"
+is $(vg view clip.vg | grep ^L | wc -l) "65" "Just one edge filtered"
+
+rm -f region.bed clip.vg
+
+# clip out low coverage node
+vg clip hla.vg -d 4 > clip.vg
+vg validate clip.vg
+is "$?" 0 "clipped graph is valid"
+is $(vg view clip.vg | grep ^S | wc -l) "49" "Just one node filtered"
+
+rm -f clip.vg
+
+rm -f hla.vg
+
+


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg clip` added to remove alt alleles in bed regions  or low-path-depth alleles from the graph

## Description

Exploring ways of removing stuff to help index and map to complex graphs.   Was previously using [clip-vg](https://github.com/ComparativeGenomicsToolkit/hal2vg/blob/master/clip-vg.cpp) which can exactly cut out bed regions and / or cut low-depth stuff, but wanted to use snarls which is easier in vg. 

Two modes so far:
* `vg clip -b`  For any snarl completely contained in a BED interval, remove all nodes that don't lie on the BED interval.  
* `vg clip -d` Remove all nodes that don't get stepped on by at least the given number of paths

In both cases, in addition to removing nodes, paths are chopped up and given suffixes of the form `[start-end]` to reflect their positions in the original paths.  In addition to `vg clip`, these suffixes are understood by `deconstruct`.  

