### PR TITLE
Better rebuild_gbwt()

### DIFF
--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -253,6 +253,10 @@ gbwt::GBWT rebuild_gbwt(const gbwt::GBWT& gbwt_index, const std::vector<std::pai
             continue;
         }
         mappings_by_first_node[mapping.first.front()].push_back(mapping);
+        std::pair<gbwt::vector_type, gbwt::vector_type> reverse;
+        gbwt::reversePath(mapping.first, reverse.first);
+        gbwt::reversePath(mapping.second, reverse.second);
+        mappings_by_first_node[reverse.first.front()].push_back(reverse);
         for (auto node : mapping.second) {
             node_width = std::max(node_width, static_cast<gbwt::size_type>(sdsl::bits::length(node)));
         }

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -154,6 +154,17 @@ struct GBWTHandler {
 /// (original subpath, new subpath). If the original subpath is empty, the
 /// mapping is ignored. If there are multiple applicable mappings, the first one
 /// will be used.
+///
+/// The mappings will be applied in both orientations. Subpaths
+///
+/// { gbwt::Node::encode(a, false), gbwt::Node::encode(b, true), gbwt::Node::encode(c, true) }
+///
+/// and
+///
+/// { gbwt::Node::encode(c, false), gbwt::Node::encode(b, false), gbwt::Node::encode(a, true) }
+///
+/// are equivalent.
+///
 /// TODO: We could provide construction parameters and an option to parallelize
 /// by contig.
 gbwt::GBWT rebuild_gbwt(const gbwt::GBWT& gbwt_index, const std::vector<std::pair<gbwt::vector_type, gbwt::vector_type>>& mappings);

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -155,15 +155,8 @@ struct GBWTHandler {
 /// mapping is ignored. If there are multiple applicable mappings, the first one
 /// will be used.
 ///
-/// The mappings will be applied in both orientations. Subpaths
-///
-/// { gbwt::Node::encode(a, false), gbwt::Node::encode(b, true), gbwt::Node::encode(c, true) }
-///
-/// and
-///
-/// { gbwt::Node::encode(c, false), gbwt::Node::encode(b, false), gbwt::Node::encode(a, true) }
-///
-/// are equivalent.
+/// The mappings will be applied in both orientations. The reverse mapping replaces
+/// the reverse of the original subpath with the reverse of the new subpath.
 ///
 /// TODO: We could provide construction parameters and an option to parallelize
 /// by contig.

--- a/src/unittest/index_helpers.cpp
+++ b/src/unittest/index_helpers.cpp
@@ -69,6 +69,25 @@ TEST_CASE("GBWT reconstruction", "[index_helpers]") {
         check_paths(index, truth);
     }
 
+    SECTION("reverse replacements") {
+        std::vector<gbwt::vector_type> source {
+            short_path, alt_path, short_path
+        };
+        gbwt::GBWT index = get_gbwt(source);
+        std::vector<std::pair<gbwt::vector_type, gbwt::vector_type>> mappings {
+            { { 9 }, { } }, // delete 4
+            { { 15, 13 }, { 15 } }, // delete 6 if followed by 7
+            { { 17, 13 }, { 17, 21, 13 } }, // visit 10 between 6 and 8
+        };
+        std::vector<gbwt::vector_type> truth {
+            { 2, 10, 14, 18 },
+            { 2, 4, 10, 12, 20, 16, 18 },
+            { 2, 10, 14, 18 },
+        };
+        index = rebuild_gbwt(index, mappings);
+        check_paths(index, truth);
+    }
+
     SECTION("impossible replacements") {
         std::vector<gbwt::vector_type> source {
             short_path, alt_path, short_path


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * (Nothing that concerns the user.)

## Description

`rebuild_gbwt()` now applies the subpath substitutions in both orientations.