### PR TITLE
Make multipath alignment tails more decomposable

### DIFF
--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -319,7 +319,9 @@ namespace vg {
     void transfer_proto_metadata(const MultipathAlignment& from, Alignment& to);
 
     /// Merges non-branching paths in a multipath alignment in place
-    void merge_non_branching_subpaths(multipath_alignment_t& multipath_aln);
+    /// Does not assume topological order among subpaths
+    void merge_non_branching_subpaths(multipath_alignment_t& multipath_aln,
+                                      const unordered_set<size_t>* prohibited_merges = nullptr);
 
     /// Removes all edit, mappings, and subpaths that have no aligned bases, and introduces transitive edges
     /// to preserve connectivity through any completely removed subpaths

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -146,7 +146,6 @@ namespace vg {
         /// within some amount of the highest scoring path. Reachability edges must be present.
         void prune_to_high_scoring_paths(const Alignment& alignment, const GSSWAligner* aligner,
                                          double max_suboptimal_score_ratio, const vector<size_t>& topological_order,
-                                         function<pair<id_t, bool>(id_t)>& translator,
                                          vector<size_t>& path_node_provenance);
         
         /// Clear reachability edges, so that add_reachability_edges can be run
@@ -196,7 +195,9 @@ namespace vg {
         /// with topologically_order_subpaths() before trying to run DP on it.
         void align(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t max_gap, double pessimistic_tail_gap_multiplier, bool simplify_topologies,
-                   size_t unmergeable_len, size_t band_padding, multipath_alignment_t& multipath_aln_out, bool allow_negative_scores = false);
+                   size_t unmergeable_len, size_t band_padding, multipath_alignment_t& multipath_aln_out, SnarlManager* cutting_snarls = nullptr,
+                   MinimumDistanceIndex* dist_index = nullptr, const function<pair<id_t, bool>(id_t)>* project = nullptr,
+                   bool allow_negative_scores = false);
         
         /// Do intervening and tail alignments between the anchoring paths and
         /// store the result in a multipath_alignment_t. Reachability edges must
@@ -213,7 +214,8 @@ namespace vg {
         void align(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner, bool score_anchors_as_matches,
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t max_gap, double pessimistic_tail_gap_multiplier, bool simplify_topologies,
                    size_t unmergeable_len, function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,
-                   multipath_alignment_t& multipath_aln_out, bool allow_negative_scores = false);
+                   multipath_alignment_t& multipath_aln_out, SnarlManager* cutting_snarls = nullptr, MinimumDistanceIndex* dist_index = nullptr,
+                   const function<pair<id_t, bool>(id_t)>* project = nullptr, bool allow_negative_scores = false);
         
         /// Converts a MultipathAlignmentGraph to a GraphViz Dot representation, output to the given ostream.
         /// If given the Alignment query we are working on, can produce information about subpath iterators.
@@ -291,11 +293,9 @@ namespace vg {
         bool into_cutting_snarl(id_t node_id, bool is_rev,
                                 SnarlManager* snarl_manager, MinimumDistanceIndex* dist_index) const;
         
-        /// Returns the intervals of mapping indexes that are either 1) outside snarls, or 2)
-        /// inside a snarl and also align more than a maximum length of read sequence.
-        /// Vector is left empty if the entire path is a keep segment
-        vector<pair<size_t, size_t>> get_keep_segments(path_t& path, SnarlManager* cutting_snarls, MinimumDistanceIndex* dist_index,
-                                                       const function<pair<id_t, bool>(id_t)>& project, int64_t max_snarl_cut_size) const;
+        /// Returns the intervals of the path that lie inside of snarls
+        vector<pair<size_t, size_t>> get_cut_segments(path_t& path, SnarlManager* cutting_snarls, MinimumDistanceIndex* dist_index,
+                                                      const function<pair<id_t, bool>(id_t)>& project, int64_t max_snarl_cut_size) const;
         
         /// Generate alignments of the tails of the query sequence, beyond the
         /// sources and sinks. The Alignment passed *must* be the one that owns

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -195,8 +195,8 @@ namespace vg {
         /// order, even if this MultipathAlignmentGraph is. You MUST sort it
         /// with topologically_order_subpaths() before trying to run DP on it.
         void align(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner, bool score_anchors_as_matches,
-                   size_t max_alt_alns, bool dynamic_alt_alns, size_t max_gap, double pessimistic_tail_gap_multiplier, size_t band_padding,
-                   multipath_alignment_t& multipath_aln_out, bool allow_negative_scores = false);
+                   size_t max_alt_alns, bool dynamic_alt_alns, size_t max_gap, double pessimistic_tail_gap_multiplier, bool simplify_topologies,
+                   size_t unmergeable_len, size_t band_padding, multipath_alignment_t& multipath_aln_out, bool allow_negative_scores = false);
         
         /// Do intervening and tail alignments between the anchoring paths and
         /// store the result in a multipath_alignment_t. Reachability edges must
@@ -211,8 +211,8 @@ namespace vg {
         /// order, even if this MultipathAlignmentGraph is. You MUST sort it
         /// with topologically_order_subpaths() before trying to run DP on it.
         void align(const Alignment& alignment, const HandleGraph& align_graph, const GSSWAligner* aligner, bool score_anchors_as_matches,
-                   size_t max_alt_alns, bool dynamic_alt_alns, size_t max_gap, double pessimistic_tail_gap_multiplier,
-                   function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,
+                   size_t max_alt_alns, bool dynamic_alt_alns, size_t max_gap, double pessimistic_tail_gap_multiplier, bool simplify_topologies,
+                   size_t unmergeable_len, function<size_t(const Alignment&,const HandleGraph&)> band_padding_function,
                    multipath_alignment_t& multipath_aln_out, bool allow_negative_scores = false);
         
         /// Converts a MultipathAlignmentGraph to a GraphViz Dot representation, output to the given ostream.
@@ -289,7 +289,13 @@ namespace vg {
         
         /// Returns true if we're pointing into a snarl that we want to cut out of paths
         bool into_cutting_snarl(id_t node_id, bool is_rev,
-                                SnarlManager* snarl_manager, MinimumDistanceIndex* dist_index);
+                                SnarlManager* snarl_manager, MinimumDistanceIndex* dist_index) const;
+        
+        /// Returns the intervals of mapping indexes that are either 1) outside snarls, or 2)
+        /// inside a snarl and also align more than a maximum length of read sequence.
+        /// Vector is left empty if the entire path is a keep segment
+        vector<pair<size_t, size_t>> get_keep_segments(path_t& path, SnarlManager* cutting_snarls, MinimumDistanceIndex* dist_index,
+                                                       const function<pair<id_t, bool>(id_t)>& project, int64_t max_snarl_cut_size) const;
         
         /// Generate alignments of the tails of the query sequence, beyond the
         /// sources and sinks. The Alignment passed *must* be the one that owns

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -5160,7 +5160,7 @@ namespace vg {
                 // prune this graph down the paths that have reasonably high likelihood
                 size_t size_before_prune = multi_aln_graph.size();
                 multi_aln_graph.prune_to_high_scoring_paths(alignment, aligner, max_suboptimal_path_score_ratio,
-                                                            topological_order, translator, hit_provenance);
+                                                            topological_order, hit_provenance);
                 
                 if (multi_aln_graph.size() != size_before_prune && do_spliced_alignment) {
                     // we pruned away some path nodes, so let's check if we pruned away any entire hits
@@ -5235,13 +5235,14 @@ namespace vg {
             function<size_t(const Alignment&, const HandleGraph&)> choose_band_padding = [&](const Alignment& seq, const HandleGraph& graph) {
                 size_t read_length = seq.sequence().size();
                 return read_length < band_padding_memo.size() ? band_padding_memo.at(read_length)
-                : size_t(band_padding_multiplier * sqrt(read_length)) + 1;
+                                                              : size_t(band_padding_multiplier * sqrt(read_length)) + 1;
             };
             
             // do the connecting alignments and fill out the multipath_alignment_t object
             multi_aln_graph.align(alignment, *align_dag, aligner, true, num_alt_alns, dynamic_max_alt_alns, max_alignment_gap,
                                   use_pessimistic_tail_alignment ? pessimistic_gap_multiplier : 0.0, simplify_topologies,
-                                  max_tail_merge_supress_length, choose_band_padding, multipath_aln_out);
+                                  max_tail_merge_supress_length, choose_band_padding, multipath_aln_out, snarl_manager,
+                                  distance_index, &translator);
             
             // Note that we do NOT topologically order the multipath_alignment_t. The
             // caller has to do that, after it is finished breaking it up into

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -5120,7 +5120,7 @@ namespace vg {
             }
             
             // a function to translate from the transformed graphs ID space to the original graph's
-            function<pair<id_t, bool>(id_t)> translator = [&](const id_t& node_id) {
+            function<pair<id_t, bool>(id_t)> translator = [&](const id_t node_id) {
                 handle_t original = align_digraph->get_underlying_handle(align_dag->get_underlying_handle(align_dag->get_handle(node_id)));
                 return make_pair(graph->get_id(original), graph->get_is_reverse(original));
             };

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -112,11 +112,15 @@ namespace vg {
         /// How big of a softclip should lead us to attempt spliced alignment?
         void set_min_softclip_length_for_splice(size_t length);
         
+        /// Decide how long of a tail alignment we want before we allow its subpath to be merged
+        void set_max_merge_supression_length();
+        
         // parameters
         
         size_t max_branch_trim_length = 1;
         bool agglomerate_multipath_alns = false;
         int64_t max_snarl_cut_size = 5;
+        size_t max_tail_merge_supress_length = 4;
         bool suppress_tail_anchors = false;
         size_t min_tail_anchor_length = 3;
         double band_padding_multiplier = 1.0;

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1614,8 +1614,16 @@ using namespace std;
             
             // align the intervening segments and store the result in a multipath alignment
             multipath_alignment_t mp_aln;
-            mp_aln_graph.align(source, split_path_graph, get_aligner(), false, 1, false, numeric_limits<int64_t>::max(),
-                               false, 1, mp_aln, allow_negative_scores);
+            mp_aln_graph.align(source, split_path_graph, get_aligner(),
+                               false,                                    // anchors as matches
+                               1,                                        // max alt alns
+                               false,                                    // dynamic alt alns
+                               numeric_limits<int64_t>::max(),           // max gap
+                               0.0,                                      // pessimistic tail gap multiplier
+                               false,                                    // simplify topologies
+                               0,                                        // unmergeable len
+                               1,                                        // band padding
+                               mp_aln, allow_negative_scores);
             topologically_order_subpaths(mp_aln);
             
             if (preserve_tail_indel_anchors) {

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1623,7 +1623,11 @@ using namespace std;
                                false,                                    // simplify topologies
                                0,                                        // unmergeable len
                                1,                                        // band padding
-                               mp_aln, allow_negative_scores);
+                               mp_aln,                                   // output
+                               nullptr,                                  // snarl manager
+                               nullptr,                                  // distance index
+                               nullptr,                                  // projector
+                               allow_negative_scores);
             topologically_order_subpaths(mp_aln);
             
             if (preserve_tail_indel_anchors) {

--- a/src/unittest/multipath_alignment.cpp
+++ b/src/unittest/multipath_alignment.cpp
@@ -1905,6 +1905,60 @@ namespace vg {
                 
                 REQUIRE(mpaln.subpath(2).next_size() == 0);
             }
+            
+            SECTION("Non-branching paths can be merged in non-topologically ordered multipath alignment") {
+                
+                multipath_alignment_t mpaln;
+                
+                mpaln.add_subpath();
+                mpaln.add_subpath();
+                subpath_t* sp1 = mpaln.mutable_subpath(0);
+                subpath_t* sp2 = mpaln.mutable_subpath(1);
+                
+                path_mapping_t* m11 = sp1->mutable_path()->add_mapping();
+                position_t* p11 = m11->mutable_position();
+                p11->set_node_id(1);
+                
+                edit_t* e111 = m11->add_edit();
+                e111->set_from_length(1);
+                e111->set_to_length(1);
+                
+                path_mapping_t* m21 = sp2->mutable_path()->add_mapping();
+                position_t* p21 = m21->mutable_position();
+                p21->set_node_id(2);
+                
+                edit_t* e211 = m21->add_edit();
+                e211->set_from_length(2);
+                e211->set_to_length(2);
+                
+                sp2->add_next(0);
+                
+                merge_non_branching_subpaths(mpaln);
+                
+                REQUIRE(mpaln.subpath_size() == 1);
+                
+                REQUIRE(mpaln.subpath(0).path().mapping_size() == 2);
+                
+                REQUIRE(mpaln.subpath(0).path().mapping(0).position().node_id() == 2);
+                REQUIRE(mpaln.subpath(0).path().mapping(0).position().is_reverse() == false);
+                REQUIRE(mpaln.subpath(0).path().mapping(0).position().offset() == 0);
+                
+                REQUIRE(mpaln.subpath(0).path().mapping(0).edit_size() == 1);
+                REQUIRE(mpaln.subpath(0).path().mapping(0).edit(0).from_length() == 2);
+                REQUIRE(mpaln.subpath(0).path().mapping(0).edit(0).to_length() == 2);
+                REQUIRE(mpaln.subpath(0).path().mapping(0).edit(0).sequence() == "");
+                
+                REQUIRE(mpaln.subpath(0).path().mapping(1).position().node_id() == 1);
+                REQUIRE(mpaln.subpath(0).path().mapping(1).position().is_reverse() == false);
+                REQUIRE(mpaln.subpath(0).path().mapping(1).position().offset() == 0);
+                
+                REQUIRE(mpaln.subpath(0).path().mapping(1).edit_size() == 1);
+                REQUIRE(mpaln.subpath(0).path().mapping(1).edit(0).from_length() == 1);
+                REQUIRE(mpaln.subpath(0).path().mapping(1).edit(0).to_length() == 1);
+                REQUIRE(mpaln.subpath(0).path().mapping(1).edit(0).sequence() == "");
+                
+                REQUIRE(mpaln.subpath(0).next_size() == 0);
+            }
         }
         
         TEST_CASE( "Single path alignments with disjoint subpaths can be found", "[alignment][multipath]") {

--- a/src/unittest/multipath_alignment_graph.cpp
+++ b/src/unittest/multipath_alignment_graph.cpp
@@ -197,7 +197,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
                                          MultipathAlignmentGraph::create_projector(identity), 5);
             
             // Make it align, with alignments per gap/tail
-            mpg.align(query, vg, &aligner, true, 2, false, 100, 0.0, 5, out);
+            mpg.align(query, vg, &aligner, true, 2, false, 100, 0.0, false, 0, 5, out);
             
             // Make sure to topologically sort the resulting alignment. TODO: Should
             // the MultipathAlignmentGraph guarantee this for us by construction?
@@ -233,7 +233,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         
         SECTION("Handles tails when anchors for them are not generated") {
             // Make it align, with alignments per gap/tail
-            mpg.align(query, vg, &aligner, true, 2, false, 100, 0.0, 5, out);
+            mpg.align(query, vg, &aligner, true, 2, false, 100, 0.0, false, 0, 5, out);
             
             // Make sure to topologically sort the resulting alignment. TODO: Should
             // the MultipathAlignmentGraph guarantee this for us by construction?
@@ -290,7 +290,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
                                          MultipathAlignmentGraph::create_projector(identity), 5);
             
             // Make it align, with alignments per gap/tail
-            mpg.align(query, vg, &aligner, true, 2, false, 100, 0.0, 5, out);
+            mpg.align(query, vg, &aligner, true, 2, false, 100, 0.0, false, 0, 5, out);
             
             // Make sure to topologically sort the resulting alignment. TODO: Should
             // the MultipathAlignmentGraph guarantee this for us by construction?
@@ -327,7 +327,7 @@ TEST_CASE( "MultipathAlignmentGraph::align handles tails correctly", "[multipath
         
         SECTION("Handles tails when anchors for them are not generated") {
             // Make it align, with alignments per gap/tail
-            mpg.align(query, vg, &aligner, true, 2, false, 100, 0.0, 5, out);
+            mpg.align(query, vg, &aligner, true, 2, false, 100, 0.0, false, 0, 5, out);
             
             // Make sure to topologically sort the resulting alignment. TODO: Should
             // the MultipathAlignmentGraph guarantee this for us by construction?


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Multipath alignments from `vg mpmap` are more decomposable in tails near soft clips

## Description

Usually, `mpmap` merges non-branching subpaths into a single subpath. This PR prevents that from occurring when it's possible that we might collapse over a branch whose alignment was soft-clipped.
