### PR TITLE
hack subpath support into surject

### DIFF
--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -17,6 +17,7 @@ MultipathAlignmentEmitter::MultipathAlignmentEmitter(const string& filename, siz
     HTSWriter(filename,
               out_format == "SAM" || out_format == "BAM" || out_format == "CRAM" ? out_format : "SAM", // just so the assert passes
               path_order_and_length ? *path_order_and_length : vector<pair<string, int64_t>>(),
+              {},
               num_threads),
     graph(graph)
 {

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -76,34 +76,6 @@ string Paths::make_subpath_name(const string& path_name, size_t offset, size_t e
     return out_name;
 }
 
-size_t Paths::get_base_length(const PathHandleGraph* graph, const string& path_name) {
-
-    size_t max_pos = 0;
-
-    // this returns the minimum length that can hold all the subpaths we find
-    // but the only way to get the true length would be to have stored it elsewhere
-    graph->for_each_path_handle([&](path_handle_t path_handle) {
-            string cur_path_name = graph->get_path_name(path_handle);
-            auto subpath_info = parse_subpath_name(cur_path_name);
-            if ((get<0>(subpath_info) && get<1>(subpath_info) == path_name) || cur_path_name == path_name) {
-                size_t end_pos = 0;
-                if (get<3>(subpath_info) > 0) {
-                    end_pos = get<3>(subpath_info) + 1; // convert inclusive end position to length
-                } else {
-                    graph->for_each_step_in_path(path_handle, [&](step_handle_t step_handle) {
-                            end_pos += graph->get_length(graph->get_handle_of_step(step_handle));
-                        });
-                    if (get<0>(subpath_info)) {
-                        end_pos += get<2>(subpath_info);
-                    }
-                }
-                max_pos = std::max(max_pos, end_pos);
-            }
-        });
-    
-    return max_pos;
-}
-
 mapping_t::mapping_t(void) : traversal(0), length(0), rank(1) { }
 
 mapping_t::mapping_t(const Mapping& m) {

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -53,8 +53,18 @@ public:
     // note: the start/end are as in BED : 0-based open-ended
     tuple<bool, string, size_t, size_t> static parse_subpath_name(const string& path_name);
 
+    // a lot of the time we just want a name
+    static inline string get_base_name(const string& path_name) {
+        auto sp = parse_subpath_name(path_name);
+        return get<0>(sp) ? get<1>(sp) : path_name;
+    }
+
     // Create a subpath name
     string static make_subpath_name(const string& path_name, size_t offset, size_t end_offset = 0);
+
+    // Estimate a base path length from the set of subpaths
+    // Todo: the only way to get the correct value is to somehow keep path lengths.
+    size_t static get_base_length(const PathHandleGraph* graph, const string& base_path_name);
 
     Paths(void);
 

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -62,10 +62,6 @@ public:
     // Create a subpath name
     string static make_subpath_name(const string& path_name, size_t offset, size_t end_offset = 0);
 
-    // Estimate a base path length from the set of subpaths
-    // Todo: the only way to get the correct value is to somehow keep path lengths.
-    size_t static get_base_length(const PathHandleGraph* graph, const string& base_path_name);
-
     Paths(void);
 
     // copy

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1349,7 +1349,7 @@ int main_giraffe(int argc, char** argv) {
         {
         
             // Look up all the paths we might need to surject to.
-            vector<path_handle_t> paths;
+            vector<tuple<path_handle_t, size_t, size_t>> paths;
             if (hts_output) {
                 // For htslib we need a non-empty list of paths.
                 assert(path_position_graph != nullptr);

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -748,7 +748,7 @@ int main_map(int argc, char** argv) {
     vector<Alignment> empty_alns;
    
     // Look up all the paths we might need to surject to.
-    vector<path_handle_t> paths;
+    vector<tuple<path_handle_t, size_t, size_t>> paths;
     if (hts_output) {
         paths = get_sequence_dictionary(ref_paths_name, *xgidx);
     }

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1640,7 +1640,6 @@ int main_mpmap(int argc, char** argv) {
     }
     
     // Load structures that we need for HTS lib outputs
-    vector<path_handle_t> paths;
     unordered_set<path_handle_t> surjection_paths;
     vector<pair<string, int64_t>> path_names_and_length;
     unique_ptr<Surjector> surjector(nullptr);
@@ -1659,11 +1658,13 @@ int main_mpmap(int argc, char** argv) {
         }
         
         // Load all the paths in the right order
-        vector<path_handle_t> paths = get_sequence_dictionary(ref_paths_name, *path_position_handle_graph);
+        vector<tuple<path_handle_t, size_t, size_t>> paths = get_sequence_dictionary(ref_paths_name, *path_position_handle_graph);
         // Make them into a set for directing surjection.
-        std::copy(paths.begin(), paths.end(), std::inserter(surjection_paths, surjection_paths.begin()));
+        for (const auto& path_info : paths) {
+            surjection_paths.insert(get<0>(path_info));
+        }
         // Copy out the metadata for making the emitter later
-        path_names_and_length = extract_path_metadata(paths, *path_position_handle_graph);
+        path_names_and_length = extract_path_metadata(paths, *path_position_handle_graph).first;
     }
     
     // this also takes a while inside the MultipathMapper constructor, but it will only activate if we don't

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -234,17 +234,15 @@ int main_surject(int argc, char** argv) {
         exit(1);
     }
 
-    // if no paths were given take all of those in the index
-    if (path_names.empty()) {
-        xgidx->for_each_path_handle([&](path_handle_t path_handle) {
-            path_names.insert(xgidx->get_path_name(path_handle));
-        });
-    }
-    
+    // add the target paths.  if there are no path names, add them all.  otherwise, take into account possible subpath names.
     unordered_set<path_handle_t> paths;
-    for (const string& path_name : path_names) {
-        paths.insert(xgidx->get_path_handle(path_name));
-    }
+    xgidx->for_each_path_handle([&](path_handle_t path_handle) {
+        if (path_names.empty() || path_names.count(Paths::get_base_name(xgidx->get_path_name(path_handle)))) {
+            paths.insert(path_handle);
+        }
+        });
+    // don't use this anymore: it's no longer updated to include all paths when none given. 
+    path_names.clear();    
 
     // Make a single thread-safe Surjector.
     Surjector surjector(xgidx);
@@ -252,7 +250,7 @@ int main_surject(int argc, char** argv) {
     surjector.min_splice_length = spliced ? min_splice_length : numeric_limits<int64_t>::max();
     
     // Get the paths to use in the HTSLib header sequence dictionary
-    vector<path_handle_t> sequence_dictionary = get_sequence_dictionary(ref_paths_name, *xgidx); 
+    vector<tuple<path_handle_t, size_t, size_t>> sequence_dictionary = get_sequence_dictionary(ref_paths_name, *xgidx); 
    
     // Count our threads
     int thread_count = get_thread_count();
@@ -365,7 +363,7 @@ int main_surject(int argc, char** argv) {
         }
     } else if (input_format == "GAMP") {
         // Working on multipath alignments. We need to set the emitter up ourselves.
-        auto path_order_and_length = extract_path_metadata(sequence_dictionary, *xgidx);
+        auto path_order_and_length = extract_path_metadata(sequence_dictionary, *xgidx).first;
         MultipathAlignmentEmitter mp_alignment_emitter("-", thread_count, output_format, xgidx, &path_order_and_length);
         mp_alignment_emitter.set_read_group(read_group);
         mp_alignment_emitter.set_sample_name(sample_name);

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -147,14 +147,14 @@ vg index j.sub.vg -g j.sub.gcsa
 vg map -x j.sub.vg -g j.sub.gcsa -s TGGAAAGAATACAAGATTTGGAGCCAGACAAATCTGGGTTCAAATCCTCACTTTGCCACATATTAGCCATGTGACTTTGA > r.sub.gam
 vg surject -x j.sub.vg r.sub.gam -s > r.sub.sam
 
-sed r.sam -e 's/LN:1001/LN:1501/g' -e 's/161/661/g' > r.manual.sam
+cat r.sam | sed -e 's/LN:1001/LN:1501/g' -e 's/161/661/g' > r.manual.sam
 diff r.manual.sam r.sub.sam
 is "$?" 0 "vg surject correctly handles subpath suffix in path name"
 
 printf "x\t2000\n" > path_info.tsv
 rm -f r.sub.sam r.manual.sam
 vg surject -x j.sub.vg r.sub.gam -s --ref-paths path_info.tsv > r.sub.sam
-sed r.sam -e 's/LN:1001/LN:2000/g' -e 's/161/661/g' > r.manual.sam
+cat r.sam | sed -e 's/LN:1001/LN:2000/g' -e 's/161/661/g' > r.manual.sam
 diff r.manual.sam r.sub.sam
 is "$?" 0 "vg surject correctly fetches base path length from input file"
 

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 33
+plan tests 35
 
 vg construct -r small/x.fa >j.vg
 vg index -x j.xg j.vg
@@ -136,5 +136,28 @@ is "$(vg sim -x m.xg -n 500 -l 150 -a -s 768594 -i 0.01 -e 0.01 -p 250 -v 50 | v
 
 rm -rf minigiab.vg* m.xg m.gcsa
 
+vg construct -r small/x.fa >j.vg
+vg index j.vg -g j.gcsa
+vg map -x j.vg -g j.gcsa -s TGGAAAGAATACAAGATTTGGAGCCAGACAAATCTGGGTTCAAATCCTCACTTTGCCACATATTAGCCATGTGACTTTGA > r.gam
+vg surject -x j.vg r.gam -s > r.sam
+
+cat small/x.fa | sed -e 's/x/x[500]/g' > x.sub.fa
+vg construct -r x.sub.fa >j.sub.vg
+vg index j.sub.vg -g j.sub.gcsa
+vg map -x j.sub.vg -g j.sub.gcsa -s TGGAAAGAATACAAGATTTGGAGCCAGACAAATCTGGGTTCAAATCCTCACTTTGCCACATATTAGCCATGTGACTTTGA > r.sub.gam
+vg surject -x j.sub.vg r.sub.gam -s > r.sub.sam
+
+sed r.sam -e 's/LN:1001/LN:1501/g' -e 's/161/661/g' > r.manual.sam
+diff r.manual.sam r.sub.sam
+is "$?" 0 "vg surject correctly handles subpath suffix in path name"
+
+printf "x\t2000\n" > path_info.tsv
+rm -f r.sub.sam r.manual.sam
+vg surject -x j.sub.vg r.sub.gam -s --ref-paths path_info.tsv > r.sub.sam
+sed r.sam -e 's/LN:1001/LN:2000/g' -e 's/161/661/g' > r.manual.sam
+diff r.manual.sam r.sub.sam
+is "$?" 0 "vg surject correctly fetches base path length from input file"
+
+rm -f h.vg h.gcsa r.gam r.sam x.sub.fa j.sub.vg j.sub.gcsa r.sub.gam r.sub.sam r.sub.sam
 
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `surject` joins `deconstruct` in supporting [vg subpath naming](https://github.com/vgteam/vg/blob/f8efd32416e973c9c8c8409499ce29e78138b267/src/path.hpp#L49-L57), but path lengths must come from `--ref-paths` in order to be valid in the output header.

## Description

Say there's a path of the form `chr1[600-800]` in the graph.  This PR changes the `HTSAlignmentEmitter` to:
* write the sequence name as just `chr1`
* add an offset of `800` to its position
* accept a length override (for the header) for chr1 from the user (via `--ref-paths`), or come up with one from the maximum coordinate encountered.

I'm hoping this will allow surjection to GRCh38 on my CHM13-based HPRC graph, which has GRCh38 centromeres clipped out.  Similar logic is already in `deconstruct` and seems to work quite well, for me at least.

