### PR TITLE
Fix chunk -T

### DIFF
--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -285,16 +285,6 @@ int main_augment(int argc, char** argv) {
     HandleGraph* vectorizable_graph = nullptr;
     unique_ptr<Packer> packer;
     bdsg::VectorizableOverlayHelper overlay_helper;
-    // the packer's required for any kind of filtering logic -- so we use it when
-    // baseq is present as well, or n-fraction.
-    if (min_coverage > 0 || min_baseq || max_frac_n < 1.) {
-        vectorizable_graph = dynamic_cast<HandleGraph*>(overlay_helper.apply(graph.get()));
-        size_t data_width = Packer::estimate_data_width(expected_coverage);
-        size_t bin_count = Packer::estimate_bin_count(get_thread_count());
-        packer = make_unique<Packer>(vectorizable_graph, true, false, false, false, 0, bin_count, data_width);
-        // makes sure filters are activated. 
-        min_coverage = max(size_t(min_coverage), size_t(1));
-    }
     
     if (label_paths) {
         // Just add path names with extend()
@@ -320,6 +310,17 @@ int main_augment(int argc, char** argv) {
         }
     }
     else {
+        // the packer's required for any kind of filtering logic -- so we use it when
+        // baseq is present as well, or n-fraction.
+        if (min_coverage > 0 || min_baseq || max_frac_n < 1.) {
+            vectorizable_graph = dynamic_cast<HandleGraph*>(overlay_helper.apply(graph.get()));
+            size_t data_width = Packer::estimate_data_width(expected_coverage);
+            size_t bin_count = Packer::estimate_bin_count(get_thread_count());
+            packer = make_unique<Packer>(vectorizable_graph, true, false, false, false, 0, bin_count, data_width);
+            // makes sure filters are activated. 
+            min_coverage = max(size_t(min_coverage), size_t(1));
+        }
+    
         // Actually do augmentation
         vector<Translation> translation;
         if (!gam_out_file_name.empty()) {

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -651,6 +651,12 @@ int main_chunk(int argc, char** argv) {
                 for (; trace_start_step != trace_end_step; trace_start_step = graph->get_next_step(trace_start_step)) {
                     ++trace_steps;
                 }
+                // haplotype_extender is forward only.  until it's made bidirectional, try to
+                // detect backward paths and trace them backwards.  this will not cover all possible cases though.
+                if (graph->get_is_reverse(graph->get_handle_of_step(trace_start_step)) &&
+                    graph->get_is_reverse(graph->get_handle_of_step(trace_end_step))) {
+                    trace_start = graph->get_id(graph->get_handle_of_step(trace_end_step));
+                }
             }
             Graph g;
             trace_haplotypes_and_paths(*graph, *gbwt_index.get(), trace_start, trace_steps,

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -635,18 +635,23 @@ int main_chunk(int argc, char** argv) {
         // optionally trace our haplotypes
         if (trace && subgraph && gbwt_index.get() != nullptr) {
             int64_t trace_start;
-            int64_t trace_end;
+            int64_t trace_steps = 0;
             if (id_range) {
                 trace_start = output_regions[i].start;
-                trace_end = output_regions[i].end;
+                trace_steps = output_regions[i].end - trace_start;
             } else {
                 path_handle_t path_handle = graph->get_path_handle(output_regions[i].seq);
                 step_handle_t trace_start_step = graph->get_step_at_position(path_handle, output_regions[i].start);
-                trace_start = graph->get_id(graph->get_handle_of_step(trace_start_step));
                 step_handle_t trace_end_step = graph->get_step_at_position(path_handle, output_regions[i].end);
-                trace_end = graph->get_id(graph->get_handle_of_step(trace_end_step));
+                // make sure we don't loop forever in next loop
+                if (output_regions[i].start > output_regions[i].end) {
+                    swap(trace_start_step, trace_end_step);
+                }
+                trace_start = graph->get_id(graph->get_handle_of_step(trace_start_step));
+                for (; trace_start_step != trace_end_step; trace_start_step = graph->get_next_step(trace_start_step)) {
+                    ++trace_steps;
+                }
             }
-            int64_t trace_steps = trace_end - trace_start;
             Graph g;
             trace_haplotypes_and_paths(*graph, *gbwt_index.get(), trace_start, trace_steps,
                                        g, trace_thread_frequencies, false);

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -50,7 +50,11 @@ is "$(vg chunk -x x.xg -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.
 is "$(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.name != "x[0]")' | wc -l)" 2 "chunker extracts 2 local threads from a gBWT with 2 locally distinct threads in it"
 is "$(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -r '.path[] | select(.name == "thread_0") | .mapping | length')" 3 "chunker can extract a partial haplotype from a GBWT"
 
-is $(vg chunk -x x.xg -G x.gbwt -p x:50-100 -c 0 -T | vg view - | grep ^S | sort) $(vg find -x x.xg -p x:50-100 -c 0 | vg view - | grep ^S | sort) "trace consistent on path coordinates"
+vg chunk -x x.xg -G x.gbwt -p x:50-100 -c 0 -T | vg view - | grep ^S | sort > cnodes
+vg find -x x.xg -p x:50-100 -c 0 | vg view - | grep ^S | sort > fnodes
+diff cnodes fnodes
+is "$?" 0 "trace consistent on path coordinates"
+rm -f cnodes fnodes
 
 #check that n-chunking works
 # We know that it will drop _alt paths so we remake the graph without them for comparison.

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 24
+plan tests 25
 
 # Construct a graph with alt paths so we can make a GBWT and a GBZ
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz -a >x.vg
@@ -49,6 +49,8 @@ is $(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq .node | grep 
 is "$(vg chunk -x x.xg -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.name != "x[0]")' | wc -l)" 0 "chunker extracts no threads from an empty gPBWT"
 is "$(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.name != "x[0]")' | wc -l)" 2 "chunker extracts 2 local threads from a gBWT with 2 locally distinct threads in it"
 is "$(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -r '.path[] | select(.name == "thread_0") | .mapping | length')" 3 "chunker can extract a partial haplotype from a GBWT"
+
+is $(vg chunk -x x.xg -G x.gbwt -p x:50-100 -c 0 -T | vg view - | grep ^S | sort) $(vg find -x x.xg -p x:50-100 -c 0 | vg view - | grep ^S | sort) "trace consistent on path coordinates"
 
 #check that n-chunking works
 # We know that it will drop _alt paths so we remake the graph without them for comparison.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fix bug in `vg chunk -T` where input path ranges were incorrectly used to find subgraph size
 * Fix `vg augment -B` to not initialize packer object unnecessarily. 

## Description

