### PR TITLE
Giraffe rescue seed limit

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2499,6 +2499,9 @@ double MinimizerMapper::get_prob_of_disruption_in_column(const vector<Minimizer>
 
 void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& rescued_alignment, const std::vector<Minimizer>& minimizers, bool rescue_forward ) {
 
+    // Get rid of the old path.
+    rescued_alignment.clear_path();
+
     if (this->rescue_algorithm == rescue_none) { return; }
 
     // We are traversing the same small subgraph repeatedly, so it's better to use a cache.
@@ -2533,11 +2536,11 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
         }
     }
 
-    // Get rid of the old path.
-    rescued_alignment.clear_path();
-
     // Find all seeds in the subgraph and try to get a full-length extension.
     GaplessExtender::cluster_type seeds = this->seeds_in_subgraph(minimizers, rescue_nodes);
+    if (seeds.size() > this->rescue_seed_limit) {
+        return;
+    }
     std::vector<GaplessExtension> extensions = this->extender.extend(seeds, rescued_alignment.sequence(), &cached_graph);
 
     // If we have a full-length extension, use it as the rescued alignment.

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -155,6 +155,9 @@ public:
     ///How many stdevs from the mean do we extract a subgraph from?
     double rescue_subgraph_stdevs = 4.0;
 
+    /// Do not attempt rescue if there are more seeds in the rescue subgraph.
+    size_t rescue_seed_limit = 100;
+
     /// For paired end mapping, how many times should we attempt rescue (per read)?
     size_t max_rescue_attempts = 15;
     

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -358,6 +358,7 @@ void help_giraffe(char** argv) {
     << "  --fragment-stdev FLOAT        force the fragment length distribution to have this standard deviation (requires --fragment-mean)" << endl
     << "  --paired-distance-limit FLOAT cluster pairs of read using a distance limit FLOAT standard deviations greater than the mean [2.0]" << endl
     << "  --rescue-subgraph-size FLOAT  search for rescued alignments FLOAT standard deviations greater than the mean [4.0]" << endl
+    << "  --rescue-seed-limit INT       attempt rescue with at most INT seeds [100]" << endl
     << "  --track-provenance            track how internal intermediate alignment candidates were arrived at" << endl
     << "  --track-correctness           track if internal intermediate alignment candidates are correct (implies --track-provenance)" << endl
     << "  -t, --threads INT             number of mapping threads to use" << endl;
@@ -380,8 +381,9 @@ int main_giraffe(int argc, char** argv) {
     #define OPT_FRAGMENT_STDEV 1006
     #define OPT_CLUSTER_STDEV 1007
     #define OPT_RESCUE_STDEV 1008
-    #define OPT_REF_PATHS 1009
-    #define OPT_SHOW_WORK 1010
+    #define OPT_RESCUE_SEED_LIMIT 1009
+    #define OPT_REF_PATHS 1010
+    #define OPT_SHOW_WORK 1011
     
 
     // initialize parameters with their default options
@@ -441,6 +443,8 @@ int main_giraffe(int argc, char** argv) {
     double cluster_stdev = 2.0;
     //How many stdevs do we look out when rescuing? 
     double rescue_stdev = 4.0;
+    // Attempt rescue with up to this many seeds.
+    size_t rescue_seed_limit = 100;
     // How many pairs should we be willing to buffer before giving up on fragment length estimation?
     size_t MAX_BUFFERED_PAIRS = 100000;
     // What sample name if any should we apply?
@@ -535,6 +539,7 @@ int main_giraffe(int argc, char** argv) {
             {"rescue-algorithm", required_argument, 0, 'A'},
             {"paired-distance-limit", required_argument, 0, OPT_CLUSTER_STDEV },
             {"rescue-subgraph-size", required_argument, 0, OPT_RESCUE_STDEV },
+            {"rescue-seed-limit", required_argument, 0, OPT_RESCUE_SEED_LIMIT},
             {"max-fragment-length", required_argument, 0, 'L' },
             {"fragment-mean", required_argument, 0, OPT_FRAGMENT_MEAN },
             {"fragment-stdev", required_argument, 0, OPT_FRAGMENT_STDEV },
@@ -903,6 +908,10 @@ int main_giraffe(int argc, char** argv) {
 
             case OPT_RESCUE_STDEV:
                 rescue_stdev = parse<double>(optarg);
+                break;
+
+            case OPT_RESCUE_SEED_LIMIT:
+                rescue_seed_limit = parse<size_t>(optarg);
                 break;
 
             case OPT_TRACK_PROVENANCE:
@@ -1274,12 +1283,14 @@ int main_giraffe(int argc, char** argv) {
             }
             cerr << "--paired-distance-limit " << cluster_stdev << endl;
             cerr << "--rescue-subgraph-size " << rescue_stdev << endl;
+            cerr << "--rescue-seed-limit " << rescue_seed_limit << endl;
             cerr << "--rescue-attempts " << rescue_attempts << endl;
             cerr << "--rescue-algorithm " << algorithm_names[rescue_algorithm] << endl;
         }
         minimizer_mapper.max_fragment_length = fragment_length;
         minimizer_mapper.paired_distance_stdevs = cluster_stdev;
         minimizer_mapper.rescue_subgraph_stdevs = rescue_stdev;
+        minimizer_mapper.rescue_seed_limit = rescue_seed_limit;
         minimizer_mapper.max_rescue_attempts = rescue_attempts;
         minimizer_mapper.rescue_algorithm = rescue_algorithm;
 

--- a/test/t/40_vg_gamcompare.t
+++ b/test/t/40_vg_gamcompare.t
@@ -6,10 +6,12 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 5
+plan tests 7
 
 vg construct -r small/x.fa -v small/x.vcf.gz >s.vg
 vg index -x s.xg -g s.gcsa s.vg
+vg snarls -T s.vg > s.snarls
+vg index -s s.snarls -j s.dist s.vg
 vg sim -n 1000 -l 100 -e 0.01 -i 0.005 -x s.xg -a >s.sim
 
 is $(vg map -x s.xg -g s.gcsa -G s.sim --surject-to sam | vg inject -x s.xg - | vg gamcompare - s.sim | vg view -a - | wc -l) 1000 "gamcompare completes"
@@ -25,9 +27,11 @@ vg annotate -a read2.gam -p -x s.xg > read2.single.gam
 vg annotate -a read2.gam -m -x s.xg > read2.multi.gam
 
 is "$(vg gamcompare -r 30 read1.single.gam read2.single.gam | vg view -aj - | jq -c 'select(.correctly_mapped)' | wc -l)" "1" "Reads annotated with leftmost position only are close enough at a long distance"
+is "$(vg gamcompare -r 30 -d s.dist read1.gam read2.gam | vg view -aj - | jq -c 'select(.correctly_mapped)' | wc -l)" "1" "Reads are close enough at a long distance with a distance index"
 is "$(vg gamcompare -r 10 read1.single.gam read2.single.gam | vg view -aj - | jq -c 'select(.correctly_mapped)' | wc -l)" "0" "Reads annotated with leftmost position only are too far apart at a short distance"
+is "$(vg gamcompare -r 10 -d s.dist read1.gam read2.gam | vg view -aj - | jq -c 'select(.correctly_mapped)' | wc -l)" "0" "Reads are too far apart at a short distance with a distance index"
 is "$(vg gamcompare -r 10 read1.multi.gam read2.multi.gam | vg view -aj - | jq -c 'select(.correctly_mapped)' | wc -l)" "1" "Reads annotated with multiple positions only are close enough at a short distance"
 
 rm -f read1.gam read1.single.gam read1.multi.gam read2.gam read2.single.gam read2.multi.gam 
 
-rm -f s.vg s.xg s.gcsa s.gcsa.lcp s.sim
+rm -f s.vg s.xg s.gcsa s.gcsa.lcp s.sim s.snarls s.dist


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe does not attempt rescue if it would be too slow.
 * `vg gamcompare` can use distances from a distance index instead of path position annotations.

## Description

Added a rescue seed limit (default 100) to Giraffe. Rescue will not be attempted if there are too many seeds in the rescue subgraph. This improves paired-end mapping speed in the latest HPRC graphs by 2x to 3x with minimal loss of accuracy.

Also added an option for using a distance index to determine alignment correctness in `vg gamcompare`. The new distance algorithm breaks the read into maximal intervals that correspond to a gapless alignment between the read and a node both in the true alignment and the candidate alignment. The distance used is the minimum over all intervals. This is essential with HPRC graphs, where some regions do not have reference paths anywhere nearby.