### PR TITLE
Snarl stats

### DIFF
--- a/src/min_distance.cpp
+++ b/src/min_distance.cpp
@@ -2315,17 +2315,12 @@ void MinimumDistanceIndex::print_snarl_stats() {
     //Print out stats bout the snarl
     //
 
-    cout << "Distance index has " << snarl_indexes.size() << " snarls and " << chain_indexes.size() << " chains" << endl;
+    cout << "#Distance index has " << snarl_indexes.size() << " snarls and " << chain_indexes.size() << " chains" << endl;
+    cout << "#snarl_size\tsnarl_depth" << endl;
    
-    cout << "Node count of snarls: " << endl;
     for (auto snarls : snarl_indexes) {
-       cout << snarls.num_nodes << "\t"; 
+       cout << snarls.num_nodes << "\t" << snarls.depth << endl; 
     }
-    cout << endl << "Snarl count of chains: " << endl;
-    for (auto chains : chain_indexes) {
-        cout << chains.loop_fd.size() << "\t";
-    }
-    cout << endl;
 }
 
 void MinimumDistanceIndex::add_nodes_in_range(const HandleGraph* super_graph, int64_t min_distance, int64_t max_distance, 
@@ -2755,7 +2750,7 @@ tuple<bool, size_t, size_t, bool, size_t, size_t, size_t, size_t, bool> MinimumD
         return tuple<bool, size_t, size_t, bool, size_t, size_t, size_t, size_t, bool>(true, component, offset + node_offset,
             false, MIPayload::NO_VALUE, MIPayload::NO_VALUE, MIPayload::NO_VALUE, MIPayload::NO_VALUE, false);
 
-    } else if (component != 0 && snarl_index.depth == 0 && snarl_index.in_chain && snarl_index.is_simple_snarl) {
+    } else if (component != 0 && snarl_index.depth == 0 && snarl_index.in_chain && snarl_index.is_simple_snarl && !chain_indexes[get_chain_assignment(snarl_index.id_in_parent)].is_looping_chain ) {
         //This node is on a top-level simple snarl
 
         size_t chain_rank = get_chain_rank(snarl_index.id_in_parent);

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -241,7 +241,7 @@ int main_stats(int argc, char** argv) {
             break;
         case 'b':
             distance_index_filename = optarg;
-
+            break;
         case 'p':
         {
             int num_threads = parse<int>(optarg);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg stats` can now print snarl stats from a distance index

## Description
`vg stats -b` takes a distance index and prints out snarl stats. For each snarl, it will print the depth and size (number of nodes in the netgraph) of the snarl

@glennhickey These are the stats that I was looking at, let me know if there's anything else I should add