### PR TITLE
WIP: add snarl complexity filtering to vg clip

### DIFF
--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -14,11 +14,11 @@ using namespace std;
 // then return it (or nullptr if none found)
 // also return the snarl's interval (as pair of offsets) in the path
 // this logic is mostly lifted from deconstructor which does the same thing to get vcf coordinates.
-static tuple<const Region*, step_handle_t, step_handle_t, bool> get_containing_region(PathPositionHandleGraph* graph,
-                                                                                      PathTraversalFinder& trav_finder,
-                                                                                      const Snarl* snarl,
-                                                                                      unordered_map<string, IntervalTree<int64_t, const Region*>>& contig_to_interval_tree,
-                                                                                      bool include_endpoints) {
+static tuple<const Region*, step_handle_t, step_handle_t, int64_t, int64_t, bool> get_containing_region(PathPositionHandleGraph* graph,
+                                                                                                        PathTraversalFinder& trav_finder,
+                                                                                                        const Snarl* snarl,
+                                                                                                        unordered_map<string, IntervalTree<int64_t, const Region*>>& contig_to_interval_tree,
+                                                                                                        bool include_endpoints) {
     
     // every path through the snarl
     pair<vector<SnarlTraversal>, vector<pair<step_handle_t, step_handle_t> > > travs = trav_finder.find_path_traversals(*snarl);
@@ -72,17 +72,17 @@ static tuple<const Region*, step_handle_t, step_handle_t, bool> get_containing_r
             auto overlapping_intervals = interval_tree.findOverlapping(first_path_pos, last_path_pos);
             for (auto& interval : overlapping_intervals) {
                 if (interval.start <= first_path_pos && interval.stop >= last_path_pos) {
-                    return make_tuple(interval.value, start_step, end_step, !use_start);
+                    return make_tuple(interval.value, start_step, end_step, first_path_pos, last_path_pos, !use_start);
                 }
             }
         }
     }
-    return make_tuple(nullptr, step_handle_t(), step_handle_t(), false);
+    return make_tuple(nullptr, step_handle_t(), step_handle_t(), -1, -1, false);
 }
 
 void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>& regions, SnarlManager& snarl_manager,
                             bool include_endpoints,
-                            function<void(const Snarl*, step_handle_t, step_handle_t, bool, const Region*)> visit_fn) {
+                            function<void(const Snarl*, step_handle_t, step_handle_t, int64_t, int64_t, bool, const Region*)> visit_fn) {
 
     // make an interval tree of regions for each contig
     unordered_map<string, vector<IntervalTree<int64_t, const Region*>::interval>> region_intervals;
@@ -130,7 +130,8 @@ void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>
                 for (auto next_snarl : todo) {
                     auto containing_region_info = get_containing_region(graph, trav_finder, next_snarl, contig_to_interval_tree, include_endpoints);
                     if (get<0>(containing_region_info)  != nullptr) {
-                        visit_fn(next_snarl, get<1>(containing_region_info), get<2>(containing_region_info), get<3>(containing_region_info), get<0>(containing_region_info));
+                        visit_fn(next_snarl, get<1>(containing_region_info), get<2>(containing_region_info), get<3>(containing_region_info),
+                                 get<4>(containing_region_info), get<5>(containing_region_info), get<0>(containing_region_info));
                     } else {
                         const vector<const Snarl*>& children = snarl_manager.children_of(next_snarl);
                         next.insert(next.end(), children.begin(), children.end());
@@ -262,7 +263,8 @@ static bool snarl_is_complex(PathPositionHandleGraph* graph, const Snarl* snarl,
         double ref_prop = (double)ref_interval_length / (double)graph->get_path_length(graph->get_path_handle(region.seq));
         if (ref_prop > max_reflen_prop) {
 #ifdef debug
-            cerr << "skipping snarl " << pb2json(*snarl) << " because its ref_prop is " << ref_prop << endl;
+            cerr << "skipping snarl " << pb2json(*snarl) << " with interval length " << ref_interval_length
+                 << " because its ref_prop of " << region.seq << " is " << ref_prop << " which is greater than " << max_reflen_prop << endl;
 #endif
             return false;
         }
@@ -300,7 +302,7 @@ static bool snarl_is_complex(PathPositionHandleGraph* graph, const Snarl* snarl,
 void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
                            SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len,
                            size_t max_nodes, size_t max_edges, double max_avg_degree, double max_reflen_prop,
-                           bool verbose) {
+                           bool out_bed, bool verbose) {
 
     // find all nodes in the snarl that are not on the reference interval (reference path name from containing interval)
     unordered_set<nid_t> nodes_to_delete;
@@ -312,6 +314,7 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
     unordered_map<string, size_t> clip_counts;
     
     visit_contained_snarls(pp_graph, regions, snarl_manager, include_endpoints, [&](const Snarl* snarl, step_handle_t start_step, step_handle_t end_step,
+                                                                                    int64_t start_pos, int64_t end_pos,
                                                                                     bool steps_reversed, const Region* containing_region) {
 
 #ifdef debug
@@ -340,22 +343,26 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
 
             pair<unordered_set<id_t>, unordered_set<edge_t> > contents = snarl_manager.deep_contents(snarl, *pp_graph, false);
             if (snarl_is_complex(pp_graph, snarl, contents, ref_interval_length, *containing_region, max_nodes, max_edges, max_avg_degree, max_reflen_prop)) {
-                for (id_t node_id : contents.first) {
-                    if (!whitelist.count(node_id)) {
-                        nodes_to_delete.insert(node_id);
-                        ++clip_counts[containing_region->seq];
+                if (out_bed) {
+                    cout << containing_region->seq << "\t" << start_pos << "\t" << (end_pos + 1) << "\t" << pb2json(*snarl) << "\n";
+                } else {
+                    for (id_t node_id : contents.first) {
+                        if (!whitelist.count(node_id)) {
+                            nodes_to_delete.insert(node_id);
+                            ++clip_counts[containing_region->seq];
+                        }
                     }
-                }
-                // since we're deleting all alt alleles, the only edge that could be left is a snarl-spanning deletion
-                edge_t deletion_edge = graph->edge_handle(graph->get_handle(snarl->start().node_id(), snarl->start().backward()),
-                                                          graph->get_handle(snarl->end().node_id(), snarl->end().backward()));
-                if (graph->has_edge(deletion_edge)) {
-                    edges_to_delete.insert(deletion_edge);
+                    // since we're deleting all alt alleles, the only edge that could be left is a snarl-spanning deletion
+                    edge_t deletion_edge = graph->edge_handle(graph->get_handle(snarl->start().node_id(), snarl->start().backward()),
+                                                              graph->get_handle(snarl->end().node_id(), snarl->end().backward()));
+                    if (graph->has_edge(deletion_edge)) {
+                        edges_to_delete.insert(deletion_edge);
+                    }
                 }
             }
         });
 
-    if (verbose) {
+    if (verbose && !out_bed) {
         if (clip_counts.size() > 1) {
             for (const auto& kv : clip_counts) {
                 cerr << "[vg-clip]: Removing " << kv.second << " nodes due to intervals on path " << kv.first << endl;
@@ -366,13 +373,14 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
     }
     
     // cut out the nodes and chop up paths
-    delete_nodes_and_chop_paths(graph, nodes_to_delete, edges_to_delete, min_fragment_len, verbose ? &clip_counts : nullptr);
-    
-    if (verbose) {
-        for (const auto& kv : clip_counts) {
-            cerr << "[vg-clip]: Creating " << kv.second << " fragments from path " << kv.first << endl;
+    if (!out_bed) {        
+        delete_nodes_and_chop_paths(graph, nodes_to_delete, edges_to_delete, min_fragment_len, verbose ? &clip_counts : nullptr);
+        if (verbose) {
+            for (const auto& kv : clip_counts) {
+                cerr << "[vg-clip]: Creating " << kv.second << " fragments from path " << kv.first << endl;
+            }
+            clip_counts.clear();
         }
-        clip_counts.clear();
     }
 }
 
@@ -477,6 +485,7 @@ void clip_contained_low_depth_nodes(MutablePathMutableHandleGraph* graph, PathPo
     function<void(function<void(handle_t, const Region*)>)> iterate_handles = [&] (function<void(handle_t, const Region*)> visit_handle) {
         
         visit_contained_snarls(pp_graph, regions, snarl_manager, include_endpoints, [&](const Snarl* snarl, step_handle_t start_step, step_handle_t end_step,
+                                                                                        int64_t start_pos, int64_t end_pos,
                                                                                         bool steps_reversed, const Region* containing_region) {
                                    
                                    pair<unordered_set<id_t>, unordered_set<edge_t> > contents = snarl_manager.deep_contents(snarl, *pp_graph, false);

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -274,8 +274,8 @@ static bool snarl_is_complex(PathPositionHandleGraph* graph, const Snarl* snarl,
 
     // check the stats
     bool filter_on = max_nodes > 0 || max_edges > 0 | max_avg_degree > 0.;
-    bool complex_nodes = max_nodes > contents.first.size();
-    bool complex_edges = max_edges > contents.second.size();
+    bool complex_nodes = contents.first.size() > max_nodes;
+    bool complex_edges = contents.second.size() > max_edges;
     bool complex_degree = true;
     size_t total_degree = 0;
     for (id_t node_id : contents.first) {
@@ -286,8 +286,7 @@ static bool snarl_is_complex(PathPositionHandleGraph* graph, const Snarl* snarl,
     out_avg_degree = (double)total_degree / (2. *(double)contents.first.size());
     complex_degree = out_avg_degree > max_avg_degree;        
     
-    // todo: we could look at doing an AND instead of OR here?
-    return !filter_on || complex_nodes || complex_edges || complex_degree;
+    return !filter_on || (complex_nodes && complex_edges && complex_degree);
 }
 
 void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -360,6 +360,9 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
                     }
                 }
             }
+#ifdef debug
+            cerr << "snarl was not deemed complex enough to clip" << endl;
+#endif
         });
 
     if (verbose && !out_bed) {

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -330,6 +330,7 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
                     whitelist.insert(pp_graph->get_id(pp_graph->get_handle_of_step(step)));
                 }
             }
+            bool deletion_on_whitellist = (include_endpoints && whitelist.size() == 2) || (!include_endpoints && whitelist.size() == 0);
             size_t ref_interval_length = 0;
             for (nid_t node_id : whitelist) {
                 // don't count snarl ends here. todo: should this be an option?
@@ -358,10 +359,12 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
                         }
                     }
                     // since we're deleting all alt alleles, the only edge that could be left is a snarl-spanning deletion
-                    edge_t deletion_edge = graph->edge_handle(graph->get_handle(snarl->start().node_id(), snarl->start().backward()),
-                                                              graph->get_handle(snarl->end().node_id(), snarl->end().backward()));
-                    if (graph->has_edge(deletion_edge)) {
-                        edges_to_delete.insert(deletion_edge);
+                    if (!deletion_on_whitellist) {
+                        edge_t deletion_edge = graph->edge_handle(graph->get_handle(snarl->start().node_id(), snarl->start().backward()),
+                                                                  graph->get_handle(snarl->end().node_id(), snarl->end().backward()));
+                        if (graph->has_edge(deletion_edge)) {
+                            edges_to_delete.insert(deletion_edge);
+                        }
                     }
                 }
             }

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -23,7 +23,7 @@ using namespace std;
  */
 void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>& regions, SnarlManager& snarl_manager,
                             bool include_endpoints,
-                            function<void(const Snarl*, step_handle_t, step_handle_t, bool, const Region*)> visit_fn);
+                            function<void(const Snarl*, step_handle_t, step_handle_t, int64_t, int64_t, bool, const Region*)> visit_fn);
 
 /*
  * Cut nodes out of a graph, and chop up any paths that contain them, using (and resolving) supbath
@@ -49,7 +49,7 @@ void delete_nodes_and_chop_paths(MutablePathMutableHandleGraph* graph,
 void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
                            SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len,
                            size_t max_nodes, size_t max_edges, double max_avg_degree, double max_reflen_prop,
-                           bool verbose);
+                           bool out_bed, bool verbose);
 
 
 /**

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -43,9 +43,13 @@ void delete_nodes_and_chop_paths(MutablePathMutableHandleGraph* graph,
  * then clip out all other nodes (ie nodes that don't lie on the traversal)
  *
  * IMPORTANT: for any given snarl, the first region that contains it is used.  
+ *
+ * Update: now accepts some snarl complexity thresholds to ignore simple enough snarls
  */
 void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
-                           SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len, bool verbose);
+                           SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len,
+                           size_t max_nodes, size_t max_edges, double max_avg_degree, double max_reflen_prop,
+                           bool verbose);
 
 
 /**

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -48,7 +48,8 @@ void delete_nodes_and_chop_paths(MutablePathMutableHandleGraph* graph,
  */
 void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
                            SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len,
-                           size_t max_nodes, size_t max_edges, double max_avg_degree, double max_reflen_prop,
+                           size_t max_nodes, size_t max_edges, size_t max_nodes_shallow, size_t max_edges_shallow,
+                           double max_avg_degree, double max_reflen_prop, size_t max_reflen,
                            bool out_bed, bool verbose);
 
 

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -49,9 +49,9 @@ int main_clip(int argc, char** argv) {
     bool verbose = false;
     bool depth_clipping = false;
 
-    size_t max_nodes = numeric_limits<size_t>::max();
-    size_t max_edges = numeric_limits<size_t>::max();
-    double max_avg_degree = numeric_limits<double>::max();
+    size_t max_nodes = 0;
+    size_t max_edges = 0;
+    double max_avg_degree = 0.;
     double max_reflen_prop = numeric_limits<double>::max();
     bool out_bed = false;
     bool snarl_option = false;

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -33,7 +33,7 @@ void help_clip(char** argv) {
        << "general options: " << endl
        << "    -P, --path-prefix STRING  Do not clip out alleles on paths beginning with given prefix (such references must be specified either with -P or -b). " << endl
        << "    -m, --min-fragment-len N  Don't write novel path fragment if it less than N bp long" << endl
-       << "    -B, --output-bed          Write BED file of affected intervals instead of clipped graph (currently only supported by snarl complexity clipping)" << endl
+       << "    -B, --output-bed          Write BED-style file of affected intervals instead of clipped graph. Columns 4-8 are: snarl, node-count, edge-count, avg-degree" << endl
        << "    -t, --threads N           number of threads to use (only used to computing snarls) [default: all available]" << endl
        << "    -v, --verbose             Print some logging messages" << endl
        << endl;

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -25,9 +25,15 @@ void help_clip(char** argv) {
        << "    -r, --snarls FILE         Snarls from vg snarls (recomputed if not given; only needed with -b). Snarls used to identify subgraphs to clip within target intervals" << endl
        << "depth clipping options: " << endl
        << "    -d, --depth N             Clip out nodes with path depth below N" << endl
-       << "    -P, --path-prefix STRING  Do not clip out alleles on paths beginning with given prefix (such references must be specified either with -P or -b). " << endl
+       << "snarl complexity clipping options: [default mode]" << endl
+       << "    -n, --max-nodes N         Clip out snarls with > N nodes" << endl
+       << "    -e, --max-edges N         Clip out snarls with > N edges" << endl
+       << "    -a, --max-avg-degree N    Clip out snarls with average degree > N" << endl
+       << "    -l, --max-reflen-prop F   Ignore snarls whose reference traversal spans more than F (0<=F<=1) of the whole reference path" << endl  
        << "general options: " << endl
+       << "    -P, --path-prefix STRING  Do not clip out alleles on paths beginning with given prefix (such references must be specified either with -P or -b). " << endl
        << "    -m, --min-fragment-len N  Don't write novel path fragment if it less than N bp long" << endl
+       << "    -B, --output-bed FILE     Write BED file of affected intervals instead of clipping graph (currently only supported by snarl complexity clipping)" << endl
        << "    -t, --threads N           number of threads to use (only used to computing snarls) [default: all available]" << endl
        << "    -v, --verbose             Print some logging messages" << endl
        << endl;
@@ -43,6 +49,13 @@ int main_clip(int argc, char** argv) {
     bool verbose = false;
     bool depth_clipping = false;
 
+    size_t max_nodes = numeric_limits<size_t>::max();
+    size_t max_edges = numeric_limits<size_t>::max();
+    double max_avg_degree = numeric_limits<double>::max();
+    double max_reflen_prop = numeric_limits<double>::max();
+    string out_bed_path;
+    bool snarl_option = false;
+
     if (argc == 2) {
         help_clip(argv);
         return 1;
@@ -56,16 +69,21 @@ int main_clip(int argc, char** argv) {
             {"help", no_argument, 0, 'h'},
             {"bed", required_argument, 0, 'b'},
             {"depth", required_argument, 0, 'd'},
+            {"max-nodes", required_argument, 0, 'n'},
+            {"max-edges", required_argument, 0, 'e'},
+            {"max-avg-degree", required_argument, 0, 'a'},
+            {"max-reflen-prop", required_argument, 0, 'l'},
             {"path-prefix", required_argument, 0, 'P'},
             {"snarls", required_argument, 0, 'r'},
             {"min-fragment-len", required_argument, 0, 'm'},
+            {"output-bed", required_argument, 0, 'B'},
             {"threads", required_argument, 0, 't'},
             {"verbose", required_argument, 0, 'v'},
             {0, 0, 0, 0}
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hb:d:P:r:m:t:v",
+        c = getopt_long (argc, argv, "hb:d:n:e:a:l:P:r:m:B:t:v",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -85,6 +103,22 @@ int main_clip(int argc, char** argv) {
         case 'd':
             min_depth = parse<size_t>(optarg);
             break;
+        case 'n':
+            max_nodes = parse<size_t>(optarg);
+            snarl_option = true;
+            break;
+        case 'e':
+            max_edges = parse<size_t>(optarg);
+            snarl_option = true;
+            break;
+        case 'a':
+            max_avg_degree = parse<double>(optarg);
+            snarl_option = true;
+            break;
+        case 'l':
+            max_reflen_prop = parse<double>(optarg);
+            snarl_option = true;
+            break;
         case 'P':
             ref_prefix = optarg;
             break;            
@@ -93,6 +127,9 @@ int main_clip(int argc, char** argv) {
             break;
         case 'm':
             min_fragment_len = parse<int>(optarg);
+            break;
+        case 'B':
+            out_bed_path = optarg;
             break;
         case 'v':
             verbose = true;
@@ -112,13 +149,13 @@ int main_clip(int argc, char** argv) {
         }
     }
 
-    if (min_depth >= 0) {
-        if (bed_path.empty() == ref_prefix.empty()) {
-            cerr << "error:[vg-clip] Depth clipping (-d) requires reference intervals specified with one of -b or -P" << endl;
-            return 1;
-        }
-    } else if (bed_path.empty()) {
-        cerr << "error:[vg-clip] BED intervals must be specified with -b" << endl;
+    if (bed_path.empty() == ref_prefix.empty()) {
+        cerr << "error:[vg-clip] Reference intervals must be specified with one of -b or -P" << endl;
+        return 1;
+    }
+
+    if (min_depth >= 0 && (snarl_option || !out_bed_path.empty())) {
+        cerr << "error:[vg-clip] bed output (-B) and snarl complexity options (-n, -e, -a, -l) cannot be used with -d" << endl;
         return 1;
     }
 
@@ -133,7 +170,7 @@ int main_clip(int argc, char** argv) {
     unique_ptr<SnarlManager> snarl_manager;
     vector<Region> bed_regions;
     
-    if (!bed_path.empty()) {
+    if (!bed_path.empty() || min_depth <= 0) {
         // need path positions to intersect with regions
         pp_graph = overlay_helper.apply(graph.get());
         
@@ -157,25 +194,40 @@ int main_clip(int argc, char** argv) {
         }
         
         // load the bed file
-        parse_bed_regions(bed_path, bed_regions);
-        if (verbose) {
-            cerr << "[vg clip]: Loaded " << bed_regions.size() << " BED regions" << endl;
-        }
-        vector<Region> bed_regions_in_graph;
-        for (const Region& region : bed_regions) {
-            if (graph->has_path(region.seq)) {
-                bed_regions_in_graph.push_back(region);
-            }
-        }
-        if (bed_regions_in_graph.size() != bed_regions.size()) {
+        if (!bed_path.empty()) {
+            parse_bed_regions(bed_path, bed_regions);
             if (verbose) {
-                cerr << "[vg clip]: Dropped " << (bed_regions.size() - bed_regions_in_graph.size()) << " BED regions whose sequence names do not correspond to paths in the graph" << endl;
+                cerr << "[vg clip]: Loaded " << bed_regions.size() << " BED regions" << endl;
             }
-            if (bed_regions_in_graph.empty()) {
-                cerr << "warning:[vg-clip] No BED region found that lies on path in graph (use vg paths -Lv to list paths that are in the graph)" << endl;
+            vector<Region> bed_regions_in_graph;
+            for (const Region& region : bed_regions) {
+                if (graph->has_path(region.seq)) {
+                    bed_regions_in_graph.push_back(region);
+                }
+            }
+            if (bed_regions_in_graph.size() != bed_regions.size()) {
+                if (verbose) {
+                    cerr << "[vg clip]: Dropped " << (bed_regions.size() - bed_regions_in_graph.size()) << " BED regions whose sequence names do not correspond to paths in the graph" << endl;
+                }
+                if (bed_regions_in_graph.empty()) {
+                    cerr << "warning:[vg-clip] No BED region found that lies on path in graph (use vg paths -Lv to list paths that are in the graph)" << endl;
+                }
+            }
+            swap(bed_regions, bed_regions_in_graph);
+        } else {
+            assert(!ref_prefix.empty());
+            // load the bed regions from the reference path prefix
+            pp_graph->for_each_path_handle([&](path_handle_t path_handle) {
+                    string path_name = pp_graph->get_path_name(path_handle);
+                    if (path_name.compare(0, ref_prefix.length(), ref_prefix) == 0) {
+                        Region region = {path_name, 0, (int64_t)pp_graph->get_path_length(path_handle) - 1};
+                        bed_regions.push_back(region);
+                    }
+                });
+            if (verbose) {
+                cerr << "[vg clip]: Inferred " << bed_regions.size() << " BED regions from paths in the graph" << endl;
             }
         }
-        swap(bed_regions, bed_regions_in_graph);
     }
 
     if (min_depth >= 0) {
@@ -190,7 +242,8 @@ int main_clip(int argc, char** argv) {
         
     } else {
         // run the alt-allele clipping
-        clip_contained_snarls(graph.get(), pp_graph, bed_regions, *snarl_manager, false, min_fragment_len, verbose);
+        clip_contained_snarls(graph.get(), pp_graph, bed_regions, *snarl_manager, false, min_fragment_len,
+                              max_nodes, max_edges, max_avg_degree, max_reflen_prop, verbose);
     }
         
     // write the graph


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * snarl complexity filters and bed output option added to `vg clip`

## Description

(when not clipping by coverage), `vg clip` relied on given bed intervals.  This PR adds the option to find its own bed intervals based on snalr complexity (and a reference path prefix).  

The current metrics are really simple: node count, edge count and average degree.  Will see how they work in practice before adding anything more complicated.