### PR TITLE
Handle overlapping replacements in GBWT reconstruction

### DIFF
--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -249,7 +249,7 @@ gbwt::GBWT rebuild_gbwt(const gbwt::GBWT& gbwt_index, const std::vector<std::pai
     gbwt::size_type node_width = sdsl::bits::length(gbwt_index.sigma() - 1);
     std::unordered_map<gbwt::node_type, std::vector<std::pair<gbwt::vector_type, gbwt::vector_type>>> mappings_by_first_node;
     for (auto& mapping : mappings) {
-        if (mapping.first.empty()) {
+        if (mapping.first.empty() || mapping.first == mapping.second) {
             continue;
         }
         mappings_by_first_node[mapping.first.front()].push_back(mapping);
@@ -279,8 +279,14 @@ gbwt::GBWT rebuild_gbwt(const gbwt::GBWT& gbwt_index, const std::vector<std::pai
                         j++;
                     }
                     if (j >= mapping.first.size()) {
-                        mapped.insert(mapped.end(), mapping.second.begin(), mapping.second.end());
-                        i += j;
+                        // Leave the last node unprocessed if it does not change.
+                        if (mapping.first.size() > 1 && mapping.second.size() > 0 && mapping.first.back() == mapping.second.back()) {
+                            mapped.insert(mapped.end(), mapping.second.begin(), mapping.second.end() - 1);
+                            i += mapping.first.size() - 1;
+                        } else {
+                            mapped.insert(mapped.end(), mapping.second.begin(), mapping.second.end());
+                            i += mapping.first.size();
+                        }
                         found = true;
                         break;
                     }

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -158,6 +158,14 @@ struct GBWTHandler {
 /// The mappings will be applied in both orientations. The reverse mapping replaces
 /// the reverse of the original subpath with the reverse of the new subpath.
 ///
+/// The first and the last node can be used as context. For example (aXb, aYb)
+/// can be interpreted as "replace X with Y in context a b". If both subpaths
+/// end with the same node, the cursor will point at that node after the mapping.
+/// Otherwise the cursor will be set past the original subpath.
+///
+/// NOTE: To avoid infinite loops, the cursor will proceed after a mapping of the
+/// type (a, Xa).
+///
 /// TODO: We could provide construction parameters and an option to parallelize
 /// by contig.
 gbwt::GBWT rebuild_gbwt(const gbwt::GBWT& gbwt_index, const std::vector<std::pair<gbwt::vector_type, gbwt::vector_type>>& mappings);

--- a/src/unittest/index_helpers.cpp
+++ b/src/unittest/index_helpers.cpp
@@ -88,6 +88,26 @@ TEST_CASE("GBWT reconstruction", "[index_helpers]") {
         check_paths(index, truth);
     }
 
+    SECTION("replacements with context") {
+        std::vector<gbwt::vector_type> source {
+            short_path, alt_path, short_path
+        };
+        gbwt::GBWT index = get_gbwt(source);
+        std::vector<std::pair<gbwt::vector_type, gbwt::vector_type>> mappings {
+            { { 8 }, { 6, 8 } }, // add 3 before 4; do it only once
+            { { 8 }, { 8, 24 } }, // add 12 after 4; this does not happen because 4 was already consumed
+            { { 10, 12 }, { 22, 12 } }, // replace 5 with 11 if followed by 6
+            { { 12, 16 }, { 12, 20, 16 } }, // visit 10 between 6 and 8; this works because 6 was not consumed
+        };
+        std::vector<gbwt::vector_type> truth {
+            { 2, 6, 8, 22, 12, 14, 18 },
+            { 2, 4, 6, 8, 22, 12, 20, 16, 18 },
+            { 2, 6, 8, 22, 12, 14, 18 },
+        };
+        index = rebuild_gbwt(index, mappings);
+        check_paths(index, truth);
+    }
+
     SECTION("impossible replacements") {
         std::vector<gbwt::vector_type> source {
             short_path, alt_path, short_path


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * (Nothing that concerns the user.)

## Description

Another tweak to GBWT reconstruction. Previously the reconstruction only considered non-overlapping substitutions. For example, if we had mappings (aSb, aTb) and (bXc, bYc), the second mapping would not have been applied to path aSbXc, because the first mapping already consumed node b.

After this PR, the first and the last nodes of the subpaths can be used as context. If the original subpath is longer than 1 node and both subpaths end with the same node, the cursor will be left pointing at that node after the mapping. Otherwise the cursor will move past the original subpath, as before.