### PR TITLE
Fix missing tails

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -775,14 +775,6 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                                                       vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer){
     if (fragment_length_distr.is_finalized()) {
 
-        if (show_work && !reported_final_distribution.test_and_set()) {
-            // We are responsible for logging the distribution
-            #pragma omp critical (cerr)
-            {
-                cerr << log_name() << "Using fragment length estimate: " << fragment_length_distr.mean() << " +/- " << fragment_length_distr.std_dev() << endl;
-            }
-        }
-
         //If we know the fragment length distribution then we just map paired ended 
         return map_paired(aln1, aln2);
     } else {

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -3701,8 +3701,8 @@ pair<Path, size_t> MinimizerMapper::get_best_alignment_against_any_tree(const ve
                 }
             }
             
-            if (deterministic_beats(current_alignment.score(), best_score, rng)) {
-                // This is a new best alignment.
+            if (current_alignment.path().mapping_size() > 0 && deterministic_beats(current_alignment.score(), best_score, rng)) {
+                // This is a new best alignment, and it is nonempty.
                 best_path = current_alignment.path();
                 
                 if (!pin_left) {

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -775,6 +775,14 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                                                       vector<pair<Alignment, Alignment>>& ambiguous_pair_buffer){
     if (fragment_length_distr.is_finalized()) {
 
+        if (show_work && !reported_final_distribution.test_and_set()) {
+            // We are responsible for logging the distribution
+            #pragma omp critical (cerr)
+            {
+                cerr << log_name() << "Using fragment length estimate: " << fragment_length_distr.mean() << " +/- " << fragment_length_distr.std_dev() << endl;
+            }
+        }
+
         //If we know the fragment length distribution then we just map paired ended 
         return map_paired(aln1, aln2);
     } else {

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -265,9 +265,16 @@ protected:
     
     /// We have a clusterer
     SnarlSeedClusterer clusterer;
-
+    
+    /// We have a distribution for read fragment lengths that takes care of
+    /// knowing when we've observed enough good ones to learn a good
+    /// distribution.
     FragmentLengthDistribution fragment_length_distr;
+    /// We may need to complain exactly once that the distribution is bad.
     atomic_flag warned_about_bad_distribution = ATOMIC_FLAG_INIT;
+    /// When reporting our work, we may need to report the finalization of the
+    /// distribution exactly once.
+    atomic_flag reported_final_distribution = ATOMIC_FLAG_INIT;
 
 //-----------------------------------------------------------------------------
 

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -272,9 +272,6 @@ protected:
     FragmentLengthDistribution fragment_length_distr;
     /// We may need to complain exactly once that the distribution is bad.
     atomic_flag warned_about_bad_distribution = ATOMIC_FLAG_INIT;
-    /// When reporting our work, we may need to report the finalization of the
-    /// distribution exactly once.
-    atomic_flag reported_final_distribution = ATOMIC_FLAG_INIT;
 
 //-----------------------------------------------------------------------------
 

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1040,26 +1040,33 @@ int main_giraffe(int argc, char** argv) {
     }
     
     // The IndexRegistry doesn't try to infer index files based on the
-    // basename, so do that here.
-    unordered_map<string, string> indexes_and_extensions = {
-        {"Giraffe GBZ", "gbz"},
-        {"XG", "xg"},
-        {"Giraffe GBWT", "gbwt"},
-        {"GBWTGraph", "gg"},
-        {"Giraffe Distance Index", "dist"},
-        {"Minimizers", "min"}
+    // basename, so do that here. We can have multiple extension options that
+    // we try in order of priority.
+    unordered_map<string, vector<string>> indexes_and_extensions = {
+        {"Giraffe GBZ", {"giraffe.gbz", "gbz"}},
+        {"XG", {"xg"}},
+        {"Giraffe GBWT", {"gbwt"}},
+        {"GBWTGraph", {"gg"}},
+        {"Giraffe Distance Index", {"dist"}},
+        {"Minimizers", {"min"}}
     };
     for (auto& completed : registry.completed_indexes()) {
         // Drop anything we already got from the list
         indexes_and_extensions.erase(completed);
     }
-    for (auto& index_and_extension : indexes_and_extensions) {
-        string inferred_filename = registry.get_prefix() + "." + index_and_extension.second;
-        if (ifstream(inferred_filename).is_open()) {
-            // A file with the appropriate name exists and we can read it
-            registry.provide(index_and_extension.first, inferred_filename);
-            // Report it because this may not be desired behavior
-            cerr << "Guessing that " << inferred_filename << " is " << index_and_extension.first << endl;
+    for (auto& index_and_extensions : indexes_and_extensions) {
+        // For each index type
+        for (auto& extension : index_and_extensions.second) {
+            // For each extension in priority order
+            string inferred_filename = registry.get_prefix() + "." + extension;
+            if (ifstream(inferred_filename).is_open()) {
+                // A file with the appropriate name exists and we can read it
+                registry.provide(index_and_extensions.first, inferred_filename);
+                // Report it because this may not be desired behavior
+                cerr << "Guessing that " << inferred_filename << " is " << index_and_extensions.first << endl;
+                // Skip other extension options for the index
+                break;
+            }
         }
     }
 

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1412,6 +1412,15 @@ int main_giraffe(int argc, char** argv) {
                     if (is_ready && !distribution_was_ready) {
                         // It has become ready now.
                         distribution_was_ready = true;
+                        
+                        if (show_progress) {
+                            // Report that it is now ready
+                            #pragma omp critical (cerr)
+                            {
+                                cerr << "Using fragment length estimate: " << minimizer_mapper.get_fragment_length_mean() << " +/- " << minimizer_mapper.get_fragment_length_stdev() << endl;
+                            }
+                        }
+                        
                         // Remember when now is.
                         all_threads_start = std::chrono::system_clock::now();
                     }
@@ -1435,7 +1444,7 @@ int main_giraffe(int argc, char** argv) {
 #ifdef __linux__
                     ensure_perf_for_thread();
 #endif
-                    
+
                     pair<vector<Alignment>, vector<Alignment>> mapped_pairs = minimizer_mapper.map_paired(aln1, aln2, ambiguous_pair_buffer);
                     if (!mapped_pairs.first.empty() && !mapped_pairs.second.empty()) {
                         //If we actually tried to map this paired end

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -99,6 +99,7 @@ using namespace std;
                 cerr << "error[Surjector::surject]: read " << source_aln->name() << " has "
                 << source_aln->sequence().size() << " sequence bases but an input alignment that aligns "
                 << source_to_length << " bases instead. This is invalid and uninterpretable; check your mapper." << endl;
+                cerr << "error[Surjector::surject]: offending alignemnt: " << pb2json(*source_aln) << endl; 
                 exit(1);
             }
         }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Tail alignments can no longer skip read sequence completely when alignment would be too large
 * Giraffe progress reports now include fragment length distribution information
 * Giraffe can now find `.giraffe.gbz` GBZ files automatically.

## Description

When I added the read equivalent placement randomization I accidentally made it so Giraffe could opt to not even include a softclip for a read tail that would be too large to align, since both options were score 0. This prevents that from happening.

It also adds the fragment length distribution to the progress logs, and fixes a bug with finding GBZ files that Giraffe generates.