### PR TITLE
Improved spliced alignment accuracy

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1726,7 +1726,19 @@ namespace vg {
 
     pair<int64_t, int64_t> aligned_interval(const multipath_alignment_t& multipath_aln) {
         
-        if (multipath_aln.subpath().empty()) {
+        // check whether there are any aligned bases
+        bool empty = true;
+        for (size_t i = 0; i < multipath_aln.subpath_size() && empty; ++i) {
+            const auto& path = multipath_aln.subpath(i).path();
+            for (size_t j = 0; j < path.mapping_size() && empty; ++j) {
+                const auto& mapping = path.mapping(j);
+                for (size_t k = 0; k < mapping.edit_size() && empty; ++k) {
+                    const auto& edit = mapping.edit(k);
+                    empty = (edit.to_length() == 0 && edit.from_length() == 0);
+                }
+            }
+        }
+        if (empty) {
             return pair<int64_t, int64_t>(0, 0);
         }
         

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3531,15 +3531,8 @@ namespace vg {
                                 cerr << "will swap with current index " << multipath_aln_pairs_out.size() - 1 << ", which has original index " << original_index[multipath_aln_pairs_out.size() - 1] << endl;
 #endif
                                 
-                                cerr << "read 1 before scavenge:" << endl;
-                                cerr << debug_string(multipath_aln_pairs_out[mp_aln_candidates[i]].first) << endl;
-                                cerr << "read 2 before scavenge:" << endl;
-                                cerr << debug_string(multipath_aln_pairs_out[mp_aln_candidates[i]].second) << endl;
-                                
                                 tmp = do_read_1 ? move(multipath_aln_pairs_out[mp_aln_candidates[i]].first)
                                                 : move(multipath_aln_pairs_out[mp_aln_candidates[i]].second);
-                                cerr << "scavenged candidate:" << endl;
-                                cerr << debug_string(tmp) << endl;
                                 
                                 // replace it in the vectors and clear the final position
                                 multipath_aln_pairs_out[mp_aln_candidates[i]] = move(multipath_aln_pairs_out.back());

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -742,8 +742,9 @@ namespace vg {
         
         // put local alignment here
         Alignment aln = other_aln;
-        // in case we're realigning a GAM, get rid of the path
+        // in case we're realigning a GAM, get rid of the path and score
         aln.clear_path();
+        aln.set_score(0);
         
         aligner->align(aln, *align_dag, true);
         

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2450,7 +2450,7 @@ namespace vg {
                             
                             // TODO: enforce pairing constraints?
                             
-                            if (dist >= 0 && dist != numeric_limits<int64_t>::max() && dist < max_intron_length) {
+                            if (dist > 0 && dist != numeric_limits<int64_t>::max() && dist < max_intron_length) {
 
                                 
                                 // the positions can reach each other in under the max length, make a join

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2791,6 +2791,13 @@ namespace vg {
             // add in the soft-clips for the part of the read we trimmed off
             if (rescue_left) {
                 // the softclip should come at the beginning of the rescued alignment
+                rescued_out.mutable_sequence()->insert(rescued_out.mutable_sequence()->begin(),
+                                                       alignment.sequence().begin(), begin);
+                if (!alignment.quality().empty()) {
+                    rescued_out.mutable_quality()->insert(rescued_out.mutable_quality()->begin(),
+                                                          alignment.quality().begin(),
+                                                          alignment.quality().begin() + (begin - alignment.sequence().begin()));
+                }
                 for (auto i : rescued_out.start()) {
                     auto subpath = rescued_out.mutable_subpath(i);
                     auto mapping = subpath->mutable_path()->mutable_mapping(0);
@@ -2816,6 +2823,13 @@ namespace vg {
             }
             else {
                 // the softclip should come at the end of the rescued alignment
+                rescued_out.mutable_sequence()->insert(rescued_out.mutable_sequence()->end(),
+                                                       end, alignment.sequence().end());
+                if (!alignment.quality().empty()) {
+                    rescued_out.mutable_quality()->insert(rescued_out.mutable_quality()->end(),
+                                                          alignment.quality().begin() + (end - alignment.sequence().begin()),
+                                                          alignment.quality().end());
+                }
                 for (size_t i = 0; i < rescued_out.subpath_size(); ++i) {
                     auto subpath = rescued_out.mutable_subpath(i);
                     if (subpath->next().empty()) {

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -496,7 +496,7 @@ namespace vg {
         /// Check whether splice segment candidates can form a statistically significant spliced
         /// alignment. Returns true if a spliced alignment is made
         bool test_splice_candidates(const Alignment& alignment, bool searching_left,
-                                    multipath_alignment_t& anchor_mp_aln, double& anchor_multiplicity,
+                                    multipath_alignment_t& anchor_mp_aln, double* anchor_multiplicity_out,
                                     SpliceStrand& strand, int64_t num_candidates,
                                     const function<const multipath_alignment_t&(int64_t)>& get_candidate,
                                     const function<double(int64_t)>& get_multiplicity,
@@ -512,7 +512,7 @@ namespace vg {
         /// See if we can find a spliced alignment segment by aligning between the pair
         bool find_rescuable_spliced_alignments(const Alignment& alignment,
                                                multipath_alignment_t& splice_anchor,
-                                               double anchor_multiplicity,
+                                               double& anchor_multiplicity,
                                                SpliceStrand& strand,
                                                const multipath_alignment_t& rescue_anchor,
                                                double rescue_multiplicity,

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -165,6 +165,7 @@ namespace vg {
         double secondary_rescue_score_diff = 1.0;
         bool get_rescue_graph_from_paths = true;
         double rescue_graph_std_devs = 6.0;
+        double splice_rescue_graph_std_devs = 3.0;
         double mapq_scaling_factor = 1.0;
         bool report_group_mapq = false;
         bool report_allelic_mapq = false;
@@ -208,6 +209,7 @@ namespace vg {
         bool do_spliced_alignment = false;
         int64_t max_softclip_overlap = 8;
         int64_t max_splice_overhang = 3;
+        int64_t min_splice_rescue_matches = 6;
         // about 250k
         int64_t max_intron_length = 1 << 18;
         int64_t min_splice_ref_search_length = 6;
@@ -264,9 +266,16 @@ namespace vg {
         bool attempt_rescue(const multipath_alignment_t& multipath_aln, const Alignment& other_aln,
                             bool rescue_forward, multipath_alignment_t& rescue_multipath_aln);
         
+        /// Make an alignment to a rescue graph and translate it back to the original node space
+        /// Returns false if the alignment fails, but does not check statistical significance
+        bool do_rescue_alignment(const multipath_alignment_t& multipath_aln, const Alignment& other_aln,
+                                 bool rescue_forward, multipath_alignment_t& rescue_multipath_aln,
+                                 double rescue_mean_length, double num_std_devs) const;
+        
         /// Use the algorithm implied by the mapper settings to extract a subgraph to perform a rescue alignment against
         void extract_rescue_graph(const multipath_alignment_t& multipath_aln, const Alignment& other_aln,
-                                  bool rescue_forward, MutableHandleGraph* rescue_graph) const;
+                                  bool rescue_forward, MutableHandleGraph* rescue_graph,
+                                  double rescue_mean_length, double num_std_devs) const;
         
         /// After clustering MEMs, extracting graphs, and assigning hits to cluster graphs, perform
         /// multipath alignment.
@@ -426,7 +435,10 @@ namespace vg {
         bool find_spliced_alignments(const Alignment& alignment, vector<multipath_alignment_t>& multipath_alns_out,
                                      vector<double>& multiplicities, vector<size_t>& cluster_idxs,
                                      const vector<MaximalExactMatch>& mems, vector<clustergraph_t>& cluster_graphs,
-                                     const match_fanouts_t* fanouts = nullptr);
+                                     const match_fanouts_t* fanouts = nullptr,
+                                     const multipath_alignment_t* rescue_anchor = nullptr,
+                                     bool rescue_left = false,
+                                     double rescue_multiplicity = 1.0);
         
         /// Look for spliced alignments among the results of various stages in the mapping algorithm for pairs
         /// Returns true if any spliced alignments were made
@@ -489,6 +501,13 @@ namespace vg {
                                     const function<const multipath_alignment_t&(int64_t)>& get_candidate,
                                     const function<double(int64_t)>& get_multiplicity,
                                     const function<multipath_alignment_t&&(int64_t)>& consume_candidate);
+        
+        /// Try to rescue an anchor for a missing spliced alignment section between
+        /// the reads in a pair
+        bool attempt_rescue_for_splice_segment(const Alignment& alignment,
+                                               const pair<int64_t, int64_t>& primary_interval,
+                                               const multipath_alignment_t& rescue_anchor,
+                                               bool rescue_left, multipath_alignment_t& rescued_out) const;
         
         /// Check if any of the unpaired spliced alignments can make pairs now
         /// If any pairs are identified, can invalidate the input alignments

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -500,7 +500,7 @@ namespace vg {
                                     SpliceStrand& strand, int64_t num_candidates,
                                     const function<const multipath_alignment_t&(int64_t)>& get_candidate,
                                     const function<double(int64_t)>& get_multiplicity,
-                                    const function<multipath_alignment_t&&(int64_t)>& consume_candidate);
+                                    const function<multipath_alignment_t&&(int64_t)>& consume_candidate) const;
         
         /// Try to rescue an anchor for a missing spliced alignment section between
         /// the reads in a pair
@@ -508,6 +508,16 @@ namespace vg {
                                                const pair<int64_t, int64_t>& primary_interval,
                                                const multipath_alignment_t& rescue_anchor,
                                                bool rescue_left, multipath_alignment_t& rescued_out) const;
+        
+        /// See if we can find a spliced alignment segment by aligning between the pair
+        bool find_rescuable_spliced_alignments(const Alignment& alignment,
+                                               multipath_alignment_t& splice_anchor,
+                                               double anchor_multiplicity,
+                                               SpliceStrand& strand,
+                                               const multipath_alignment_t& rescue_anchor,
+                                               double rescue_multiplicity,
+                                               bool rescue_left,
+                                               const pair<int64_t, int64_t>& primary_interval) const;
         
         /// Check if any of the unpaired spliced alignments can make pairs now
         /// If any pairs are identified, can invalidate the input alignments

--- a/src/splicing.cpp
+++ b/src/splicing.cpp
@@ -827,7 +827,10 @@ tuple<pos_t, int64_t, int32_t> trimmed_end(const Alignment& aln, int64_t len, bo
                 get_is_rev(get<0>(return_val)) = position.is_reverse();
                 get_offset(get<0>(return_val)) = position.offset() + mapping_from_length(mapping) - from_length;
                 if (dummy_mapping) {
-                    from_proto_position(mapping.position(), *dummy_mapping->mutable_position());
+                    auto dummy_position = dummy_mapping->mutable_position();
+                    dummy_position->set_node_id(id(get<0>(return_val)));
+                    dummy_position->set_is_reverse(is_rev(get<0>(return_val)));
+                    dummy_position->set_offset(offset(get<0>(return_val)));
                 }
             }
         }
@@ -933,11 +936,13 @@ tuple<pos_t, int64_t, int32_t> trimmed_end(const Alignment& aln, int64_t len, bo
     else {
         begin = aln.sequence().begin();
     }
-#ifdef debug_trimming
-    cerr << "scoring trimmed subpath " << debug_string(dummy_path) << ", with substring " << (begin - aln.sequence().begin()) << ":" << (begin - aln.sequence().begin()) + get<1>(return_val) << endl;
-#endif
+
     
     get<2>(return_val) = aligner.score_partial_alignment(aln, graph, dummy_path, begin);
+    
+#ifdef debug_trimming
+    cerr << "scored trimmed subpath " << debug_string(dummy_path) << " with substring " << (begin - aln.sequence().begin()) << ":" << (begin - aln.sequence().begin()) + get<1>(return_val) << ": " << get<2>(return_val) << endl;
+#endif
     
     return return_val;
 }

--- a/src/splicing.hpp
+++ b/src/splicing.hpp
@@ -4,8 +4,8 @@
  * Defines splicing related objects and functions
  *
  */
-#ifndef VG_SPLICE_REGION_HPP_INCLUDED
-#define VG_SPLICE_REGION_HPP_INCLUDED
+#ifndef VG_SPLICING_HPP_INCLUDED
+#define VG_SPLICING_HPP_INCLUDED
 
 #include "dinucleotide_machine.hpp"
 #include "incremental_subgraph.hpp"
@@ -285,4 +285,4 @@ multipath_alignment_t&& fuse_spliced_alignments(const Alignment& alignment,
 
 }
 
-#endif // VG_SPLICE_REGION_HPP_INCLUDED
+#endif // VG_SPLICING_HPP_INCLUDED

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1879,7 +1879,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.agglomerate_multipath_alns = agglomerate_multipath_alns;
     
     // splicing parameters
-    int64_t min_softclip_length_for_splice = int(ceil(log(total_seq_length * 2) / log(4.0))) + 2;
+    int64_t min_softclip_length_for_splice = max<int>(int(ceil(log(total_seq_length * 2) / log(4.0))) + 2, 0);
     multipath_mapper.set_min_softclip_length_for_splice(min_softclip_length_for_splice);
     multipath_mapper.set_log_odds_against_splice(no_splice_log_odds);
     multipath_mapper.max_softclip_overlap = max_softclip_overlap;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1880,7 +1880,7 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.agglomerate_multipath_alns = agglomerate_multipath_alns;
     
     // splicing parameters
-    int64_t min_softclip_length_for_splice = max<int>(int(floor(log(total_seq_length) / log(4.0))) - max_softclip_overlap / 2, 0);
+    int64_t min_softclip_length_for_splice = max<int>(int(ceil(log(total_seq_length) / log(4.0)) - max_softclip_overlap) , 1);
     multipath_mapper.set_min_softclip_length_for_splice(min_softclip_length_for_splice);
     multipath_mapper.set_log_odds_against_splice(no_splice_log_odds);
     multipath_mapper.max_softclip_overlap = max_softclip_overlap;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -341,6 +341,7 @@ int main_mpmap(int argc, char** argv) {
     int max_softclip_overlap = 8;
     int max_splice_overhang = 2 * max_softclip_overlap;
     double no_splice_log_odds = 2.0;
+    double splice_rescue_graph_std_devs = 3.0;
     bool override_spliced_alignment = false;
     int match_score_arg = std::numeric_limits<int>::min();
     int mismatch_score_arg = std::numeric_limits<int>::min();
@@ -1879,11 +1880,12 @@ int main_mpmap(int argc, char** argv) {
     multipath_mapper.agglomerate_multipath_alns = agglomerate_multipath_alns;
     
     // splicing parameters
-    int64_t min_softclip_length_for_splice = max<int>(int(ceil(log(total_seq_length * 2) / log(4.0))) + 2, 0);
+    int64_t min_softclip_length_for_splice = max<int>(int(floor(log(total_seq_length) / log(4.0))) - max_softclip_overlap / 2, 0);
     multipath_mapper.set_min_softclip_length_for_splice(min_softclip_length_for_splice);
     multipath_mapper.set_log_odds_against_splice(no_splice_log_odds);
     multipath_mapper.max_softclip_overlap = max_softclip_overlap;
     multipath_mapper.max_splice_overhang = max_splice_overhang;
+    multipath_mapper.splice_rescue_graph_std_devs = splice_rescue_graph_std_devs;
     if (!intron_distr_name.empty()) {
         multipath_mapper.set_intron_length_distribution(intron_mixture_weights, intron_component_params);
     }

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1562,6 +1562,15 @@ using namespace std;
                     score_dp[get<0>(edge)] = extended_score;
                     backpointer[get<0>(edge)] = i;
                 }
+                else if (extended_score == score_dp[get<0>(edge)]
+                         && backpointer[get<0>(edge)] >= 0
+                         && (abs<int64_t>(graph->get_position_of_step(section_path_ranges[i].first)
+                                          - graph->get_position_of_step(section_path_ranges[get<0>(edge)].first))
+                             < abs<int64_t>(graph->get_position_of_step(section_path_ranges[backpointer[get<0>(edge)]].first)
+                                            - graph->get_position_of_step(section_path_ranges[get<0>(edge)].first)))) {
+                    // break ties in favor of the closer exon
+                    backpointer[get<0>(edge)] = i;
+                }
             }
         }
         

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -712,7 +712,7 @@ string random_sequence(size_t length) {
 string pseudo_random_sequence(size_t length, uint64_t seed) {
     static const string alphabet = "ACGT";
     mt19937_64 gen(1357908642ull * seed + 80085ull);
-    uniform_int_distribution<char> distr(0, 3);
+    vg::uniform_int_distribution<char> distr(0, 3);
     
     string seq(length, '\0');
     for (size_t i = 0; i < length; i++) {

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -615,7 +615,7 @@ class VGCITest(TestCase):
             # toil-vg map options
             # don't waste time sharding reads since we only run on one node
             single_reads_chunk = True,
-            mpmap_opts = ['-B', '-F GAM'],
+            mpmap_opts = ['-B', '-F GAM', '-n DNA'],
             more_mpmap_opts = more_mpmap_opts,
             force_outstore = self.force_outstore
         )

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -615,7 +615,7 @@ class VGCITest(TestCase):
             # toil-vg map options
             # don't waste time sharding reads since we only run on one node
             single_reads_chunk = True,
-            mpmap_opts = ['-B', '-F GAM', '-n DNA'],
+            mpmap_opts = ['-B', '-F', 'GAM', '-n', 'DNA'],
             more_mpmap_opts = more_mpmap_opts,
             force_outstore = self.force_outstore
         )


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Spliced alignment accuracy is substantially improved

## Description

I dropped the threshold for looking for a spliced alignment to better match the newly more accurate significance testing. I also fixed two bugs (one of which was longstanding) and added an algorithm to rescue spliced alignment segments that lie between paired-end reads. I will need to profile speed before doing a final merge.