### PR TITLE
Try to treat a failed Docker build as a failed job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,7 +99,7 @@ build-job:
     # Build but don't push, just fill the cache
     - docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target run -f Dockerfile .
     # Run the tests
-    - docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target test -f Dockerfile .
+    - docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target test -f Dockerfile . || exit 1
     # Connect so we can upload our images
     - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
     # Keep trying to push until it works or we time out or run out of tries


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Failed Gitlab Docker builds are detected more reliably

## Description

We want to avoid cases like https://ucsc-ci.com/vgteam/vg/-/jobs/96240#L3013 where we fail the tests but still somehow claim the job succeeded.