### PR TITLE
Runtime stats

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -697,9 +697,10 @@ vector<Alignment> MinimizerMapper::map(Alignment& aln) {
     // Stop this alignment
     funnel.stop();
     
+    // Annotate with whatever's in the funnel
+    funnel.annotate_mapped_alignment(mappings[0], track_correctness);
+    
     if (track_provenance) {
-        funnel.annotate_mapped_alignment(mappings[0], track_correctness);
-        
         // Annotate with parameters used for the filters.
         set_annotation(mappings[0], "param_hit-cap", (double) hit_cap);
         set_annotation(mappings[0], "param_hard-hit-cap", (double) hard_hit_cap);
@@ -1683,10 +1684,10 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                 funnels[0].stop();
                 funnels[1].stop();
                 
-                if (track_provenance) {
-                    funnels[0].annotate_mapped_alignment(paired_mappings.first[0], track_correctness);
-                    funnels[0].annotate_mapped_alignment(paired_mappings.second[0], track_correctness);
-                }
+                // Annotate with whatever's in the funnel
+                funnels[0].annotate_mapped_alignment(paired_mappings.first[0], track_correctness);
+                funnels[0].annotate_mapped_alignment(paired_mappings.second[0], track_correctness);
+                
                 return paired_mappings;
             } else if (best_score_1 != 0 and best_score_2 != 0) {
                 //We are attempting rescue, but we still want to keep the best alignments as a potential (unpaired) pair 
@@ -2129,10 +2130,11 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
     funnels[0].stop();
     funnels[1].stop();
     
+    // Annotate with whatever's in the funnel.
+    funnels[0].annotate_mapped_alignment(mappings.first[0], track_correctness);
+    funnels[1].annotate_mapped_alignment(mappings.second[0], track_correctness);
+    
     if (track_provenance) {
-        funnels[0].annotate_mapped_alignment(mappings.first[0], track_correctness);
-        funnels[1].annotate_mapped_alignment(mappings.second[0], track_correctness);
-        
         // Annotate with parameters used for the filters.
         set_annotation(mappings.first[0] , "param_hit-cap", (double) hit_cap);
         set_annotation(mappings.first[0] , "param_hard-hit-cap", (double) hard_hit_cap);

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -247,6 +247,11 @@ protected:
         }
     };
     
+    /// Convert an integer distance, with limits standing for no distance, to a
+    /// double annotation that can safely be parsed back from JSON into an
+    /// integer if it is integral.
+    double distance_to_annotation(int64_t distance) const;
+    
     /// The information we store for each seed.
     typedef SnarlSeedClusterer::Seed Seed;
 

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 26
+plan tests 27
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
@@ -32,6 +32,8 @@ is "${?}" "0" "a read can be mapped with the minimizer index being regenerated"
 vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.fq > mapped1.gam
 is "${?}" "0" "a read can be mapped with the indexes being inferred by name"
 
+is "$(vg view -aj mapped1.gam | grep 'time_used' | wc -l)" "1" "Mapping logs runtime per read"
+
 vg minimizer -k 29 -b -s 18 -g x.gbwt -o x.sync x.xg
 
 vg giraffe -x x.xg -H x.gbwt -m x.sync -d x.dist -f reads/small.middle.ref.fq > mapped.sync.gam
@@ -50,9 +52,10 @@ is "${?}" "0" "a read can be mapped with just FASTA and VCF without crashing"
 
 # These files can differ as serialized and still represent the same data, due to protobuf field order not being specified.
 # Tripping through JSON will sort all the keys.
-vg view -aj mapped1.gam >mapped1.json
-vg view -aj mapped2.gam >mapped2.json
-vg view -aj mapped.sync.gam >mapped.sync.json
+# Make sure to also remove time info
+vg view -aj mapped1.gam | jq -c '.time_used = null' >mapped1.json
+vg view -aj mapped2.gam | jq -c '.time_used = null' >mapped2.json
+vg view -aj mapped.sync.gam | jq -c '.time_used = null' >mapped.sync.json
 
 # Make sure at least one file converted successfully
 SIZE="$(wc -c mapped2.json | cut -f1 -d' ')"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe records read and pair mapping wall clock times
 * Giraffe can no longer output fragment length annotations too large to convert from JSON to GAM

## Description

This adds runtime stats on mapping time per read to Giraffe.

Times are a bit weird for paired-end reads, since both reads' clocks are running at the same time, so the times don't really represent thread-seconds consumed to map the read.
