### PR TITLE
Try to reverse speed regression in spliced alignment

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -127,7 +127,7 @@ namespace vg {
             multipath_alns_out.back().clear_start();
         }
         
-        if (do_spliced_alignment) {
+        if (do_spliced_alignment && !likely_mismapping(multipath_alns_out.front())) {
             find_spliced_alignments(alignment, multipath_alns_out, multiplicities, cluster_idxs,
                                     mems, cluster_graphs, fanouts.get());
         }

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1432,12 +1432,17 @@ namespace vg {
             }
             
             // find splices independently, also use the mate to rescue missing splice segments
-            bool did_splice_1 = find_spliced_alignments(alignment1, multipath_alns_1, multiplicities_1, cluster_idxs_1,
-                                                        mems1, cluster_graphs1, fanouts1,
-                                                        rescue_anchor_2, true, rescue_multiplicity_2);
-            bool did_splice_2 = find_spliced_alignments(alignment2, multipath_alns_2, multiplicities_2, cluster_idxs_2,
-                                                        mems2, cluster_graphs2, fanouts2,
-                                                        rescue_anchor_1, false, rescue_multiplicity_1);
+            bool did_splice_1 = false, did_splice_2 = false;
+            if (!likely_mismapping(multipath_alns_1.front())) {
+                did_splice_1 = find_spliced_alignments(alignment1, multipath_alns_1, multiplicities_1, cluster_idxs_1,
+                                                       mems1, cluster_graphs1, fanouts1,
+                                                       rescue_anchor_2, true, rescue_multiplicity_2);
+            }
+            if (!likely_mismapping(multipath_alns_2.front())) {
+                did_splice_2 = find_spliced_alignments(alignment2, multipath_alns_2, multiplicities_2, cluster_idxs_2,
+                                                       mems2, cluster_graphs2, fanouts2,
+                                                       rescue_anchor_1, false, rescue_multiplicity_1);
+            }
             
             if (did_splice_1 || did_splice_2) {
                 // it may now be possible to identify some pairs as properly paired using the spliced alignment

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1433,12 +1433,12 @@ namespace vg {
             
             // find splices independently, also use the mate to rescue missing splice segments
             bool did_splice_1 = false, did_splice_2 = false;
-            if (!likely_mismapping(multipath_alns_1.front())) {
+            if (!multipath_alns_1.empty() && !likely_mismapping(multipath_alns_1.front())) {
                 did_splice_1 = find_spliced_alignments(alignment1, multipath_alns_1, multiplicities_1, cluster_idxs_1,
                                                        mems1, cluster_graphs1, fanouts1,
                                                        rescue_anchor_2, true, rescue_multiplicity_2);
             }
-            if (!likely_mismapping(multipath_alns_2.front())) {
+            if (!multipath_alns_2.empty() && !likely_mismapping(multipath_alns_2.front())) {
                 did_splice_2 = find_spliced_alignments(alignment2, multipath_alns_2, multiplicities_2, cluster_idxs_2,
                                                        mems2, cluster_graphs2, fanouts2,
                                                        rescue_anchor_1, false, rescue_multiplicity_1);

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2331,10 +2331,14 @@ namespace vg {
                                                          min_splice_ref_search_length,
                                                          max_splice_ref_search_length);
                 }
+                
                 if (distance_index && (dist < 0 || dist == numeric_limits<int64_t>::max())) {
                     // they're probably still reachable if they got this far, get a worse estimate of the
                     // distance from the distance index
-                    dist = distance_index->min_distance(pos_1, pos_2);
+                    int64_t min_dist = distance_index->min_distance(pos_1, pos_2);
+                    if (min_dist >= 0) {
+                        dist = min_dist;
+                    }
                 }
                 
                 if (dist != numeric_limits<int64_t>::max()) {

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -10,6 +10,7 @@
 //#define debug_report_startup_training
 //#define debug_pretty_print_alignments
 //#define debug_time_phases
+//#define debug_log_splice_align_stats
 
 #ifdef debug_time_phases
 #include <ctime>
@@ -2294,7 +2295,7 @@ namespace vg {
             
             int32_t post_align_net_score(const SpliceStats& splice_stats,
                                          const Alignment& opt) {
-                return fixed_score_components(splice_stats, opt) + connecting_aln.score();
+                return fixed_score_components(splice_stats, opt) + connecting_aln.score() + intron_score;
             }
         };
         
@@ -2500,7 +2501,6 @@ namespace vg {
                             
                             // measure the intron length
                             int64_t dist = get_reference_dist(l_pos, r_pos);
-                            
                             if (dist <= 0 || dist > max_intron_length || dist == numeric_limits<int64_t>::max()) {
 #ifdef debug_multipath_mapper
                                 cerr << "\tinconsistent intron length " << dist << ", skipping putative join" << endl;
@@ -3397,6 +3397,12 @@ namespace vg {
                                                                    strand, *rescue_anchor, rescue_multiplicity,
                                                                    rescue_left, interval);
                 }
+                
+#ifdef debug_log_splice_align_stats
+                string line = alignment.name() + '\t' + to_string(did_splice) + '\t' + to_string(interval.first) + '\t' + to_string(interval.second) + '\t' + to_string(do_left) + '\t' + to_string(mp_aln_candidates.size()) + '\t' + to_string(cluster_candidates.size()) + '\t' + to_string(hit_candidates.size()) + '\n';
+#pragma omp critical
+                cerr << line;
+#endif
                 
                 if (did_splice) {
                     // we may need to update the multiplicity based on the splicing


### PR DESCRIPTION
## Changelog Entry

No changes of interest to users

## Description

I made a few changes that should improve speed and only minimally affect output:

- Spliced alignment candidates can sometimes be filtered earlier
- Avoid intron length recomputation for nearby potential splice sites
- Don't try to find spliced alignments on mispaired, statistically insignificant mappings