### PR TITLE
Fix mac build

### DIFF
--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -42,8 +42,12 @@ jobs:
         run: scripts/restore-deps.sh
        
       - name: Install packages
-        # We don't use artemnovichkov/action-homebrew because that's for Linux
-        run: brew bundle
+        # We don't use artemnovichkov/action-homebrew because that's for Linux.
+        # We uninstall everything we don't need in order to prevent linking
+        # conflicts with existing/outdated packages, which we can't resolve
+        # because there's no way to tell Homebrew to force-link when installing
+        # from a Brewfile.
+        run: brew bundle cleanup --force && brew bundle install
 
       - name: Run build and test
         run: |

--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -18,14 +18,6 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-      # The Homebrew Github ships as of 4/12/21 in their Mac 10.15 image uses Bintray for binaries, which is shutting down.
-      # They recommend updating Homebrew to the latest version which pulls binaries from Github Packages instead.
-      # See: https://github.com/Homebrew/discussions/discussions/691#discussioncomment-600559
-      # Remove this step when Github starts shipping a sufficiently new Homebrew
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
       - name: Use cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Mac CI Homebrew package installation is more robust

## Description

Mac CI has started failing today with complaints that `libnghttp2` conflicts with file links belonging to `libhttp2`:

```
==> Installing node dependency: libnghttp2
==> Pouring libnghttp2--1.45.1.catalina.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink include/nghttp2/nghttp2.h
Target /usr/local/include/nghttp2/nghttp2.h
is a symlink belonging to nghttp2. You can unlink it:
  brew unlink nghttp2
```

I think they're really the same package but renamed, but we can't actually do any of the forcing of linking that Homebrew recommends since we're operating through `brew bundle` and a `Brewfile`. So I'm going to try just uninstalling everything the `Brewfile` doesn't want, before installing everything it does want.