### PR TITLE
Set all temp directories

### DIFF
--- a/src/haplotype_indexer.cpp
+++ b/src/haplotype_indexer.cpp
@@ -21,9 +21,6 @@ using namespace std;
 namespace vg {
 
 HaplotypeIndexer::HaplotypeIndexer() {
-    // Use the same temp directory as VG for GBWT temp files.
-    gbwt::TempFile::setDirectory(temp_file::get_dir());
-
     // Build the GBWTs silently.
     gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
 }

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -3024,8 +3024,6 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         init_out(outfile_gcsa, gcsa_output_name);
         init_out(outfile_lcp, lcp_output_name);
         
-        // configure GCSA to use scratch in the general temp directory
-        gcsa::TempFile::setDirectory(temp_file::get_dir());
         if (IndexingParameters::verbosity >= IndexingParameters::Debug) {
             gcsa::Verbosity::set(gcsa::Verbosity::BASIC);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,7 +63,10 @@ int main(int argc, char *argv[]) {
 
     // Determine a sensible default number of threads and apply it.
     choose_good_thread_count();
-    
+
+    // Determine temp directory from environment variables.
+    temp_file::set_system_dir();
+
     // Tell the IO library about libvg types.
     // TODO: Make a more generic libvg startup function?
     if (!vg::io::register_libvg_io()) {

--- a/src/subcommand/add_main.cpp
+++ b/src/subcommand/add_main.cpp
@@ -141,9 +141,6 @@ int main_add(int argc, char** argv) {
     // Configure GCSA2 verbosity so it doesn't spit out loads of extra info
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
-    // Configure its temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    
     // Turn on nested parallelism, so we can parallelize over VCFs and over alignment bands
     omp_set_nested(1);
     

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -788,9 +788,6 @@ int main_find(int argc, char** argv) {
         // Configure GCSA2 verbosity so it doesn't spit out loads of extra info
         gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
         
-        // Configure its temp directory to the system temp directory
-        gcsa::TempFile::setDirectory(temp_file::get_dir());
-        
         // Open it
         auto gcsa_index = vg::io::VPKG::load_one<gcsa::GCSA>(gcsa_in);
         // default LCP is the gcsa base name +.lcp

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -148,9 +148,8 @@ int main_gbwt(int argc, char** argv) {
     GBWTConfig config = parse_gbwt_config(argc, argv);
     validate_gbwt_config(config);
 
-    // Let GBWT operate silently and use the same temporary directory as vg.
+    // Let GBWT operate silently.
     gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-    gbwt::TempFile::setDirectory(temp_file::get_dir());
 
     // This is the data we are using.
     GBWTHandler gbwts;

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -401,11 +401,6 @@ int main_index(int argc, char** argv) {
         file_names.push_back(file_name);
     }
 
-    // Use the same temp directory in submodules.
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    gbwt::TempFile::setDirectory(temp_file::get_dir());
-    xg::temp_file::set_dir(temp_file::get_dir());
-
 
     if (xg_name.empty() && gbwt_name.empty() &&
         gcsa_name.empty() && !build_gai_index && !build_vgi_index && dist_name.empty()) {

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -661,9 +661,6 @@ int main_map(int argc, char** argv) {
 
     // Configure GCSA2 verbosity so it doesn't spit out loads of extra info
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
-    
-    // Configure its temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
 
     // Load up our indexes.
     PathPositionHandleGraph* xgidx = nullptr;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1567,9 +1567,6 @@ int main_mpmap(int argc, char** argv) {
     // Configure GCSA2 verbosity so it doesn't spit out loads of extra info
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
-    // Configure its temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    
     // Load required indexes
     if (!suppress_progress) {
         cerr << progress_boilerplate() << "Loading graph from " << graph_name << endl;

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -555,9 +555,6 @@ int main_msga(int argc, char** argv) {
     gcsa::LCPArray* lcpidx = nullptr;
     xg::XG* xgidx = nullptr;
     size_t iter = 0;
-    
-    // Configure GCSA temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
 
     auto rebuild = [&](VG* graph, int name_idx) {
         delete mapper;
@@ -588,9 +585,6 @@ int main_msga(int argc, char** argv) {
         if (debug) cerr << "building GCSA2 index" << endl;
         // Configure GCSA2 verbosity so it doesn't spit out loads of extra info
         if(!debug) gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
-        
-        // Configure its temp directory to the system temp directory
-        gcsa::TempFile::setDirectory(temp_file::get_dir());
 
         // Replace "graph" with a subsetted graph, and use it below when creating
         // the GCSA index.

--- a/src/subcommand/vectorize_main.cpp
+++ b/src/subcommand/vectorize_main.cpp
@@ -195,9 +195,6 @@ int main_vectorize(int argc, char** argv){
 
     // Configure GCSA2 verbosity so it doesn't spit out loads of extra info
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
-    
-    // Configure its temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
 
     unique_ptr<gcsa::GCSA> gcsa_index;
     unique_ptr<gcsa::LCPArray> lcp_index;

--- a/src/unittest/mapper.cpp
+++ b/src/unittest/mapper.cpp
@@ -34,9 +34,7 @@ TEST_CASE( "Mapper can map to a one-node graph", "[mapping][mapper]" ) {
     VG graph;
     graph.extend(proto_graph);
     
-    // Configure GCSA temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    // And make it quiet
+    // Make GCSA quiet
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
     // Make pointers to fill in
@@ -256,9 +254,7 @@ TEST_CASE( "Mapper finds optimal mapping for read starting with node-border MEM"
     VG graph;
     graph.extend(proto_graph);
     
-    // Configure GCSA temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    // And make it quiet
+    // Make GCSA quiet
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
     // Make pointers to fill in
@@ -324,9 +320,7 @@ TEST_CASE( "Mapper can annotate positions correctly on both strands", "[mapper][
     VG graph;
     graph.extend(proto_graph);
     
-    // Configure GCSA temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    // And make it quiet
+    // Make GCSA quiet
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
     // Make pointers to fill in
@@ -560,9 +554,7 @@ TEST_CASE( "Mapper can walk paths from fan-out MEM algorithm", "[mapping][mapper
     graph.create_edge(h4, h10);
     graph.create_edge(h5, h11);
     
-    // Configure GCSA temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    // And make it quiet
+    // Make GCSA quiet
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
     // Make pointers to fill in

--- a/src/unittest/mcmc_genotyper.cpp
+++ b/src/unittest/mcmc_genotyper.cpp
@@ -255,10 +255,7 @@ namespace vg {
                 IntegratedSnarlFinder bubble_finder(graph);
                 SnarlManager snarl_manager = bubble_finder.find_snarls_parallel();
 
-                // Configure GCSA temp directory to the system temp directory
-                gcsa::TempFile::setDirectory(temp_file::get_dir());
-                
-                // And make it quiet
+                // Make GCSA quiet
                 gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
                 
                 // Make pointers to fill in
@@ -368,9 +365,7 @@ namespace vg {
                 CactusSnarlFinder bubble_finder(graph);
                 SnarlManager snarl_manager = bubble_finder.find_snarls();
 
-                // Configure GCSA temp directory to the system temp directory
-                gcsa::TempFile::setDirectory(temp_file::get_dir());
-                // And make it quiet
+                // Make GCSA quiet
                 gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
                 
                 // Make pointers to fill in
@@ -493,9 +488,7 @@ namespace vg {
 				IntegratedSnarlFinder bubble_finder(graph);
                 SnarlManager snarl_manager = bubble_finder.find_snarls_parallel();
 
-                // Configure GCSA temp directory to the system temp directory
-                gcsa::TempFile::setDirectory(temp_file::get_dir());
-                // And make it quiet
+                // Make GCSA quiet
                 gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
                 
                 // Make pointers to fill in
@@ -627,9 +620,7 @@ namespace vg {
                     IntegratedSnarlFinder bubble_finder(graph);
                     SnarlManager snarl_manager = bubble_finder.find_snarls_parallel();
 
-                    // Configure GCSA temp directory to the system temp directory
-                    gcsa::TempFile::setDirectory(temp_file::get_dir());
-                    // And make it quiet
+                    // Make GCSA quiet
                     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
                     
                     // Make pointers to fill in
@@ -787,9 +778,7 @@ namespace vg {
                 IntegratedSnarlFinder bubble_finder(graph);
                 SnarlManager snarl_manager = bubble_finder.find_snarls_parallel();
 
-                // Configure GCSA temp directory to the system temp directory
-                gcsa::TempFile::setDirectory(temp_file::get_dir());
-                // And make it quiet
+                // Make GCSA quiet
                 gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
                 
                 // Make pointers to fill in
@@ -908,9 +897,7 @@ namespace vg {
 				IntegratedSnarlFinder bubble_finder(graph);
                 SnarlManager snarl_manager = bubble_finder.find_snarls_parallel();
 
-                // Configure GCSA temp directory to the system temp directory
-                gcsa::TempFile::setDirectory(temp_file::get_dir());
-                // And make it quiet
+                // Make GCSA quiet
                 gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
                 
                 // Make pointers to fill in
@@ -1068,9 +1055,7 @@ namespace vg {
             IntegratedSnarlFinder bubble_finder(graph);
             SnarlManager snarl_manager = bubble_finder.find_snarls_parallel();
 
-            // Configure GCSA temp directory to the system temp directory
-            gcsa::TempFile::setDirectory(temp_file::get_dir());
-            // And make it quiet
+            // Make GCSA quiet
             gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
             
             // Make pointers to fill in
@@ -1247,9 +1232,7 @@ namespace vg {
             IntegratedSnarlFinder bubble_finder(graph);
             SnarlManager snarl_manager = bubble_finder.find_snarls_parallel();
 
-            // Configure GCSA temp directory to the system temp directory
-            gcsa::TempFile::setDirectory(temp_file::get_dir());
-            // And make it quiet
+            // Make GCSA quiet
             gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
             
             // Make pointers to fill in

--- a/src/unittest/mem_accelerator.cpp
+++ b/src/unittest/mem_accelerator.cpp
@@ -31,9 +31,7 @@ TEST_CASE("MEMAccelerator returns same ranges as direct LF queries",
         bdsg::HashGraph graph;
         random_graph(seq_size, var_length, var_count, &graph);
         
-        // Configure GCSA temp directory to the system temp directory
-        gcsa::TempFile::setDirectory(temp_file::get_dir());
-        // And make it quiet
+        // Make GCSA quiet
         gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
         
         // Make pointers to fill in

--- a/src/unittest/multipath_mapper.cpp
+++ b/src/unittest/multipath_mapper.cpp
@@ -130,9 +130,7 @@ TEST_CASE( "MultipathMapper::query_cluster_graphs works", "[multipath][mapping][
     VG graph;
     graph.extend(proto_graph);
     
-    // Configure GCSA temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    // And make it quiet
+    // Make GCSA quiet
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
     // Make pointers to fill in
@@ -285,9 +283,7 @@ TEST_CASE( "MultipathMapper can map to a one-node graph", "[multipath][mapping][
     VG graph;
     graph.extend(proto_graph);
     
-    // Configure GCSA temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    // And make it quiet
+    // Make GCSA quiet
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
     // Make pointers to fill in
@@ -437,9 +433,7 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
     VG graph;
     graph.extend(proto_graph);
     
-    // Configure GCSA temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    // And make it quiet
+    // Make GCSA quiet
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
     // Make pointers to fill in

--- a/src/unittest/splicing.cpp
+++ b/src/unittest/splicing.cpp
@@ -1644,9 +1644,7 @@ TEST_CASE("MultipathMapper can make splice alignments from different candidates"
     graph.append_step(ph, h4);
     graph.append_step(ph, h5);
     
-    // Configure GCSA temp directory to the system temp directory
-    gcsa::TempFile::setDirectory(temp_file::get_dir());
-    // And make it quiet
+    // Make GCSA quiet
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
     // Make pointers to fill in

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -134,6 +134,8 @@ typename Collection::value_type sum(const Collection& collection) {
  * be created in a directory determined from environment variables, though this
  * can be overridden with set_dir().
  * The interface is thread-safe.
+ *
+ * The temporary directory will be propagated to submodules (gbwt, gcsa2, xg).
  */
 namespace temp_file {
 
@@ -153,6 +155,10 @@ namespace temp_file {
     /// Set a directory for placing temporary files and directories in,
     /// overriding system defaults and environment variables.
     void set_dir(const string& new_temp_dir);
+
+    /// Reset the temporary directory back to the default based on environment
+    /// variables and system defaults.
+    void set_system_dir();
 
     /// Get the current location for temporary files and directories.
     string get_dir();


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * VG should now fully honor temporary directory settings.

## Description

GCSA2, GBWT, and XG all use their own temporary directories, and some subcommands did not propagate the VG temp directory to them (see #3450 for an example). After this PR, `temp_file::set_dir()` also sets the directory for submodules, and all temporary directories are initialized from environment variables in `main()`.