### PR TITLE
better handle orientation conflicts when find reference path thru snarl

### DIFF
--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -97,7 +97,8 @@ protected:
 
     /// get the interval of a snarl from our reference path using the PathPositionHandleGraph interface
     /// the bool is true if the snarl's backward on the path
-    tuple<size_t, size_t, bool, step_handle_t, step_handle_t> get_ref_interval(const PathPositionHandleGraph& graph, const Snarl& snarl,
+    /// first returned value -1 if no traversal found 
+    tuple<int64_t, int64_t, bool, step_handle_t, step_handle_t> get_ref_interval(const PathPositionHandleGraph& graph, const Snarl& snarl,
                                                                                const string& ref_path_name) const;
 
     /// clean up the alleles to not share common prefixes / suffixes


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fix `vg call` crash on some cylcle/reversing cases wrt threading ref paths through snarls 

## Description

The reference interval check in `vg call` made a (naive) assumption that if a reference path passed through the snarl endpoints, then it could be a valid path.  But that's not true in general as the pggb graph from #3454 shows.

This PR adds checks to reference traversal finding function  to make sure orientations are properly respected, and allows it to say no interval is found if they aren't. 

Note that while cycles will be called without crashing, there's no unfolding logic or anything -- it'll make its best diploid call on the first reference interval it finds in the cycle and that's it. 

Should resolve #3454