### PR TITLE
Make vg map -h do help again

### DIFF
--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -586,10 +586,11 @@ int main_map(int argc, char** argv) {
             xdrop_alignment = true;
             break;
 
-        case 'h':
         case '^':
             log_time = true;
             break;
+
+        case 'h':
         case '?':
             /* getopt_long already printed an error message. */
             help_map(argv);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg map -h` should now print help again

## Description

Somehow `-h` started turning on time logging.