### PR TITLE
Ensure read input is in uppercase in mpmap and giraffe

### DIFF
--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1458,6 +1458,8 @@ int main_giraffe(int argc, char** argv) {
 #ifdef __linux__
                     ensure_perf_for_thread();
 #endif
+                    toUppercaseInPlace(*aln1.mutable_sequence());
+                    toUppercaseInPlace(*aln2.mutable_sequence());
 
                     pair<vector<Alignment>, vector<Alignment>> mapped_pairs = minimizer_mapper.map_paired(aln1, aln2, ambiguous_pair_buffer);
                     if (!mapped_pairs.first.empty() && !mapped_pairs.second.empty()) {
@@ -1533,6 +1535,7 @@ int main_giraffe(int argc, char** argv) {
 #ifdef __linux__
                     ensure_perf_for_thread();
 #endif
+                    toUppercaseInPlace(*aln.mutable_sequence());
                 
                     // Map the read with the MinimizerMapper.
                     minimizer_mapper.map(aln, *alignment_emitter);

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1986,6 +1986,8 @@ int main_mpmap(int argc, char** argv) {
             watchdog->check_in(thread_num, alignment.name());
         }
         
+        toUppercaseInPlace(*alignment.mutable_sequence());
+        
         bool is_rna = uses_Us(alignment);
         if (is_rna) {
             convert_Us_to_Ts(alignment);
@@ -2048,6 +2050,9 @@ int main_mpmap(int argc, char** argv) {
         if (watchdog) {
             watchdog->check_in(thread_num, alignment_1.name());
         }
+        
+        toUppercaseInPlace(*alignment_1.mutable_sequence());
+        toUppercaseInPlace(*alignment_2.mutable_sequence());
         
         bool is_rna = (uses_Us(alignment_1) || uses_Us(alignment_2));
         if (is_rna) {

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <fstream>
 #include <iostream>
+#include <cctype>
 
 
 // For setting the temporary directory in submodules.
@@ -282,6 +283,12 @@ string toUppercase(const string& s) {
         }
     }
     return n;
+}
+
+void toUppercaseInPlace(string& s) {
+    for (int i = 0; i < s.size(); ++i) {
+        s[i] = toupper(s[i]);
+    }
 }
 
 void write_fasta_sequence(const std::string& name, const std::string& sequence, ostream& os, size_t width) {

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -67,6 +67,7 @@ string nonATGCNtoN(const string& s);
 string allAmbiguousToN(const string& s);
 // Convert ASCII-encoded DNA to upper case
 string toUppercase(const string& s);
+void toUppercaseInPlace(string& s);
 
 // write a fasta sqeuence
 void write_fasta_sequence(const std::string& name, const std::string& sequence, ostream& os, size_t width=80);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` and `vg mpmap` no longer crash when reads are in lowercase

## Description

Resolves https://github.com/vgteam/vg/issues/3448

Lowercase input was already handled in `vg map`.
