### PR TITLE
Deduplicate endpoints

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2426,6 +2426,20 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
 
 //-----------------------------------------------------------------------------
 
+bool MinimizerMapper::share_terminal_positions(const Alignment& aln1, const Alignment& aln2) const {
+    if (aln1.path().mapping_size() == 0 || aln2.path().mapping_size() == 0) {
+        // One of them doesn't actually have any terminal positions
+        return false;
+    }
+    
+    // We don't care if any starts meet any ends, just if starts meet starts or
+    // ends meet ends.
+    // TODO: Maybe instead of sharing terminal positions, we really want to be
+    // deduplicating placements based on something else?
+    return (initial_position(aln1.path()) == initial_position(aln2.path()) ||
+            final_position(aln1.path()) == final_position(aln2.path()));
+}
+
 double MinimizerMapper::faster_cap(const vector<Minimizer>& minimizers, vector<size_t>& minimizers_explored,
     const string& sequence, const string& quality_bytes) {
 

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2017,20 +2017,8 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
             duplicate_endpoints_2.push_back(0);
         } else {
             // This is not the best pair, but we need to see if any read endpoints are shared
-            if (show_work) {
-                #pragma omp critical (cerr)
-                {
-                    cerr << log_name() << "Check pair " << scores.size() - 1 << " read 1 for shared endpoints with the winner" << endl;
-                }
-            }
             if (share_terminal_positions(mappings.first[0], mappings.first.back())) {
                 duplicate_endpoints_1.push_back(scores.size() - 1);
-            }
-            if (show_work) {
-                #pragma omp critical (cerr)
-                {
-                    cerr << log_name() << "Check pair " <<scores.size() - 1 << " read 2 for shared endpoints with the winner" << endl;
-                }
             }
             if (share_terminal_positions(mappings.second[0], mappings.second.back())) {
                 duplicate_endpoints_2.push_back(scores.size() - 1);
@@ -2072,20 +2060,8 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
 
         // We assume the best pair actually exists already and has its alignments recorded.
         // We need to decide whether the score we just emitted shares a read placement for either read.
-        if (show_work) {
-            #pragma omp critical (cerr)
-            {
-                cerr << log_name() << "Check discarded pair " << scores.size() - 1 << " read 1 for shared endpoints with the winner" << endl;
-            }
-        }
         if (share_terminal_positions(mappings.first[0], follow_alignment_index(index_pair.first, true))) {
             duplicate_endpoints_1.push_back(scores.size() - 1);
-        }
-        if (show_work) {
-            #pragma omp critical (cerr)
-            {
-                cerr << log_name() << "Check discarded pair " << scores.size() - 1 << " read 2 for shared endpoints with the winner" << endl;
-            }
         }
         if (share_terminal_positions(mappings.second[0], follow_alignment_index(index_pair.second, false))) {
             duplicate_endpoints_2.push_back(scores.size() - 1);
@@ -2506,13 +2482,6 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
 bool MinimizerMapper::share_terminal_positions(const Alignment& aln1, const Alignment& aln2) const {
     if (aln1.path().mapping_size() == 0 || aln2.path().mapping_size() == 0) {
         // One of them doesn't actually have any terminal positions
-        if (show_work) {
-            #pragma omp critical (cerr)
-            {
-                cerr << log_name() << "No shared endpoints because a path is empty" << endl;
-            }
-        }
-        
         return false;
     }
     
@@ -2520,47 +2489,8 @@ bool MinimizerMapper::share_terminal_positions(const Alignment& aln1, const Alig
     // ends meet ends.
     // TODO: Maybe instead of sharing terminal positions, we really want to be
     // deduplicating placements based on something else?
-    
-    pos_t s1 = initial_position(aln1.path());
-    pos_t s2 = initial_position(aln2.path());
-    
-    if (s1 == s2) {
-        if (show_work) {
-            #pragma omp critical (cerr)
-            {
-                cerr << log_name() << "Detected shared start " << s1 << endl;
-            }
-        }
-        return true;
-    } else {
-        if (show_work) {
-            #pragma omp critical (cerr)
-            {
-                cerr << log_name() << "Starts " << s1 << " and " << s2 << " are different" << endl;
-            }
-        }
-    }
-    
-    pos_t e1 = final_position(aln1.path());
-    pos_t e2 = final_position(aln2.path());
-    
-    if (e1 == e2) {
-        if (show_work) {
-            #pragma omp critical (cerr)
-            {
-                cerr << log_name() << "Detected shared end " << e1 << endl;
-            }
-        }
-        return true;
-    } else {
-        if (show_work) {
-            #pragma omp critical (cerr)
-            {
-                cerr << log_name() << "Ends " << e1 << " and " << e2 << " are different" << endl;
-            }
-        }
-    }
-    return false;
+    return (initial_position(aln1.path()) == initial_position(aln2.path()) ||
+            final_position(aln1.path()) == final_position(aln2.path()));
 }
 
 double MinimizerMapper::faster_cap(const vector<Minimizer>& minimizers, vector<size_t>& minimizers_explored,

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -352,41 +352,8 @@ protected:
     /**
      * Return true if any start or end positions are shared between the two alignments.
      */
-    bool share_terminal_positions(const Alignment& aln_1, const Alignment& aln_2) const;
+    bool share_terminal_positions(const Alignment& aln1, const Alignment& aln2) const;
 
-    /**
-     * Compute MAPQ caps based on all minimizers that are explored, for some definition of explored.
-     *
-     * Needs access to the input alignment for sequence and quality
-     * information.
-     *
-     * Returns only an "extended" cap at the moment.
-     */
-    double compute_mapq_caps(const Alignment& aln, const std::vector<Minimizer>& minimizers,
-                             const SmallBitset& explored);
-
-    /**
-     * Compute a bound on the Phred score probability of having created the
-     * agglomerations of the specified minimizers by base errors from the given
-     * sequence, which was sequenced with the given qualities.
-     *
-     * No limit is imposed if broken is empty.
-     *
-     * Takes the collection of all minimizers found, and a vector of the
-     * indices of minimizers we are interested in the agglomerations of. May
-     * modify the order of that index vector.
-     *
-     * Also takes the sequence of the read (to avoid Ns) and the quality string
-     * (interpreted as a byte array).
-     *
-     * Currently computes a lower-score-bound, upper-probability-bound,
-     * suitable for use as a mapping quality cap, by assuming the
-     * easiest-to-disrupt possible layout of the windows, and the lowest
-     * possible qualities for the disrupting bases.
-     */
-    static double window_breaking_quality(const vector<Minimizer>& minimizers, vector<size_t>& broken,
-        const string& sequence, const string& quality_bytes);
-    
     /**
      * Compute a bound on the Phred score probability of a mapping beign wrong
      * due to base errors and unlocated minimizer hits prevented us from

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -344,30 +344,15 @@ protected:
     void fix_dozeu_score(Alignment& rescued_alignment, const HandleGraph& rescue_graph,
                          const std::vector<handle_t>& topological_order) const;
 
-//-----------------------------------------------------------------------------
-
-    // Helper functions.
-
-    /**
-     * Get the distance between a pair of read alignments
-     */
-    int64_t distance_between(const Alignment& aln1, const Alignment& aln2);
-
-    /**
-     * Convert the GaplessExtension into an alignment. This assumes that the
-     * extension is a full-length alignment and that the sequence field of the
-     * alignment has been set.
-     */
-    void extension_to_alignment(const GaplessExtension& extension, Alignment& alignment) const;
-    
-    /**
-     * Set pair partner references for paired mapping results.
-     */
-    void pair_all(pair<vector<Alignment>, vector<Alignment>>& mappings) const;
-    
-
 
 //-----------------------------------------------------------------------------
+
+    // MAPQ.
+
+    /**
+     * Return true if any start or end positions are shared between the two alignments.
+     */
+    bool share_terminal_positions(const Alignment& aln_1, const Alignment& aln_2) const;
 
     /**
      * Compute MAPQ caps based on all minimizers that are explored, for some definition of explored.
@@ -485,6 +470,27 @@ protected:
         const string& sequence, const string& quality_bytes,
         const vector<size_t>::iterator& disrupt_begin, const vector<size_t>::iterator& disrupt_end,
         size_t index);
+        
+//-----------------------------------------------------------------------------
+
+    // Helper functions.
+
+    /**
+     * Get the distance between a pair of read alignments
+     */
+    int64_t distance_between(const Alignment& aln1, const Alignment& aln2);
+
+    /**
+     * Convert the GaplessExtension into an alignment. This assumes that the
+     * extension is a full-length alignment and that the sequence field of the
+     * alignment has been set.
+     */
+    void extension_to_alignment(const GaplessExtension& extension, Alignment& alignment) const;
+    
+    /**
+     * Set pair partner references for paired mapping results.
+     */
+    void pair_all(pair<vector<Alignment>, vector<Alignment>>& mappings) const;
     
     /**
      * Score the given group of gapless extensions. Determines the best score


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Mappings with shared endpoints are now treated as equivalent for MAPQ by `vg giraffe` 

## Description

This fixes @jmonlong's read where several mappings ending at the same point managed to produce a MAPQ 0.

I haven't looked at all into *why* we're having multiple alignments that nearly coincide, and I'm also not removing all the both-reads-coinciding secondaries like `vg mpmap` does, since they seem useful as `-M` output and also they *should* fall out for MAPQ purposes when grouped in just like one-read-coinciding secondaries. @jeizenga does that make statistical sense?

I haven't yet tested what the impact of this is on the DeepVariant pipeline.