### PR TITLE
[WIP] clip -D option to get rid of big deletion edges

### DIFF
--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -76,8 +76,12 @@ void clip_low_depth_nodes(MutablePathMutableHandleGraph* graph, int64_t min_dept
 void clip_contained_low_depth_nodes(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
                                     SnarlManager& snarl_manager, bool include_endpoints, int64_t min_depth, int64_t min_fragment_len, bool verbose);
 
+/**
+ * clip out deletion edges 
+ */
+void clip_deletion_edges(MutablePathMutableHandleGraph* graph, int64_t max_deletion, int64_t context_steps,
+                         const vector<string>& ref_prefixes, int64_t min_fragment_len, bool verbose);
 
-                                                      
 }
 
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `-D` option added to `vg clip` that prunes out edges that induce deletions in reference paths

## Description

Large deletions are best avoided during graph construction, but I have a released graph that I want to patch up.  This PR adds an option to `vg clip` to search out big deletions and remove them.   

It uses this (fairly naive) logic:
* expand context of reference path, annotating every discovered node with the lowest and highest position on the path that connects to it
* for every edge that touches the context, add it as a candidate deletion if its left side and right side have respective paths batch to points on the graph that would induce a big enough deletion
* for every candidate edge, walk each side back to the graph without crossing any previous candidate edges, and delete it if a big enough deletion is found.

The main problem is the reliance on a context size -- if the deletion edge is too far from the reference path it won't be caught.  

