### PR TITLE
Write deconstruct LV/PS tags according to levels preent in VCF (as opposed to graph)

### DIFF
--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -88,6 +88,9 @@ private:
 
     // get a snarl name, using trnaslation if availabe
     string snarl_name(const Snarl* snarl) const;
+
+    // update the PS and LV tags in the output buffer (call just before write_variants)
+    void update_nesting_info_tags();
     
     // toggle between exhaustive and path restricted traversal finder
     bool path_restricted = false;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg deconstruct -a` now writes `LV` and `PS` takes according to only the sites present in the VCF

## Description

`deconstruct -a` embeds nesting information from the snarl tree in the `LV` (level) and `PS` (parent snarl) tags.  Previously, it was taking this information directly from the snarl manager.  But it could be misleading in cases where the parent snarl did not end up as a site in the VCF (ex because no ref path anchors or no alt travesals found).  Someone using `grep LV=0` for instance may miss huge swaths of the graph if there are a bunch of child sites whose parent didn't make it into the VCF.

To avoid such confusion, this PR changes these tags to only reflect what's in the VCF.  If a snarl has a parent in the graph but not in the VCF, it will be LV=0 and its children LV=1 etc.

Because snarls are no longer written top-down, this correction is done as a second pass on the output buffer, essentially applying [this correction](https://github.com/glennhickey/pg-stuff/blob/98c9e2e3bb1a87a06033b928176127e9e87ff18b/fix-nested.py) to the PS tags (and adding LV tags).

I opted not to keep the graph-based tags around (with new names?) to avoid confusion, but they obviously could get easily added back if anyone really needed them.  