### PR TITLE
Allow CI registry mirror to be secure, with Google mirror fallback

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,10 +18,10 @@ before_script:
     if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then
       if [[ "${DOCKER_HUB_MIRROR}" == https* ]] ; then
         # Set up a secure mirror
-        echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"]}\"]}" | sudo tee /etc/docker/daemon.json
+        echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\", \"https://mirror.gcr.io\"]}\"]}" | sudo tee /etc/docker/daemon.json
       else
         # Set up an insecure mirror
-        echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
+        echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\", \"https://mirror.gcr.io\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
       fi
     fi
   - startdocker || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,10 +14,15 @@ before_script:
   - sudo apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev npm nodejs node-gyp uuid-runtime libgnutls28-dev doxygen
   - which junit-merge || sudo npm install -g junit-merge
   # Configure Docker to use a mirror for Docker Hub and restart the daemon
-  # Set the registry as insecure because it is probably cluster-internal over plain HTTP.
   - |
     if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then
+      if [[ "${DOCKER_HUB_MIRROR}" == https* ]] ; then
+        # Set up a secure mirror
+        echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"]}\"]}" | sudo tee /etc/docker/daemon.json
+      else
+        # Set up an insecure mirror
         echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
+      fi
     fi
   - startdocker || true
   - docker info


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * CI now supports secure Docker Hub mirrors, and has Google GCR fallback

## Description
We've been running out of Docker Hub pulls since our CI can't see our own mirror we run in the `toil` Kubernetes namespace anymore. This lets us use secure mirrors like `https://mirror.gcr.io`, and also hardcodes that mirror as a fallback.

This will fix #3475.