### PR TITLE
Specify GAM-format alignment output in help.

### DIFF
--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -92,7 +92,7 @@ void help_sim(char** argv) {
          << "    -l, --read-length N         simulate reads of length N" << endl
          << "    -r, --progress              show progress information" << endl
          << "output options:" << endl
-         << "    -a, --align-out             generate true alignments on stdout rather than reads" << endl
+         << "    -a, --align-out             write alignments in GAM-format" << endl
          << "    -J, --json-out              write alignments in json" << endl
          << "simulation parameters:" << endl
          << "    -F, --fastq FILE            match the error profile of NGS reads in FILE, repeat for paired reads (ignores -l,-f)" << endl


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Specified `--align-out` parameter in `vg sim` as GAM-format output

## Description
Matches `--json-out` help section style while specifying exact output format.