### PR TITLE
Fix bug in trimming logic in spliced alignment

### DIFF
--- a/src/algorithms/component_paths.cpp
+++ b/src/algorithms/component_paths.cpp
@@ -227,7 +227,6 @@ vector<unordered_set<path_handle_t>> component_paths_parallel(const PathHandleGr
             }
         });
     }
-    // TODO: switch to unsigned ints and use 0 as the sentinel
     
     // barrier sync
     for (auto& initializer : initializers) {

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -666,7 +666,8 @@ namespace vg {
                 size_t mapping_start_idx = 0;
                 // merge mappings if they occur on the same node and same strand
                 if (curr_end_mapping->position().node_id() == next_start_mapping.position().node_id()
-                    && curr_end_mapping->position().is_reverse() == next_start_mapping.position().is_reverse()) {
+                    && curr_end_mapping->position().is_reverse() == next_start_mapping.position().is_reverse()
+                    && curr_end_mapping->position().offset() + mapping_from_length(*curr_end_mapping) == next_start_mapping.position().offset()) {
                     
                     Edit* last_edit = curr_end_mapping->mutable_edit(curr_end_mapping->edit_size() - 1);
                     const edit_t& first_edit = next_start_mapping.edit(0);

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2257,7 +2257,7 @@ namespace vg {
             int32_t max_score;
             int32_t untrimmed_score;
             size_t motif_idx;
-            // intron stats start uninitialized until measurign length
+            // intron stats start uninitialized until measuring length
             int32_t intron_score;
             int64_t estimated_intron_length;
             // these two filled out after doing alignment
@@ -2532,7 +2532,6 @@ namespace vg {
                                 // this has no chance of becoming significant, let's skip it
                                 putative_joins.pop_back();
                             }
-                            
                         }
                     }
                 }
@@ -2559,9 +2558,9 @@ namespace vg {
             
             auto& join = putative_joins.front();
             
-            size_t read_len = alignment.sequence().size();
-            size_t connect_len = join.left_clip_length + join.right_clip_length - read_len;
-            size_t connect_begin = read_len - join.left_clip_length;
+            
+            size_t connect_begin = alignment.sequence().size() - join.left_clip_length;
+            size_t connect_len = join.left_clip_length + join.right_clip_length - alignment.sequence().size();
             
             join.connecting_aln.set_sequence(alignment.sequence().substr(connect_begin, connect_len));
             if (!alignment.quality().empty()) {
@@ -2576,7 +2575,7 @@ namespace vg {
             int32_t net_score = join.post_align_net_score(splice_stats, opt);
             
 #ifdef debug_multipath_mapper
-            cerr << "next candidate spliced alignment with score bound " << join.max_score << " has net score " << net_score << ", must get " << no_splice_log_odds << " for significance"  << endl;
+            cerr << "next candidate spliced alignment with score bound " << join.max_score << " has net score " << net_score << " after realigning read interval " << connect_begin << ":" << (connect_begin + connect_len) << ", must get " << no_splice_log_odds << " for significance"  << endl;
 #endif
             
             if (net_score > no_splice_log_odds) {

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -757,7 +757,7 @@ namespace vg {
         translate_oriented_node_ids(*aln.mutable_path(), translator);
         
 #ifdef debug_multipath_mapper
-        cerr << "resecued direct alignment is" << endl;
+        cerr << "rescued direct alignment is" << endl;
         cerr << pb2json(aln) << endl;
 #endif
         
@@ -2847,11 +2847,13 @@ namespace vg {
             rescued_interval.second += (begin - alignment.sequence().begin());
             
             succeeded = (rescued_interval.first >= primary_interval.second - max_softclip_overlap
-                         && rescued_interval.second - max(rescued_interval.first, primary_interval.second) >= min_splice_rescue_matches);
+                         && rescued_interval.second - max(rescued_interval.first, primary_interval.second) >= min_splice_rescue_matches
+                         && rescued_interval.second > primary_interval.first);
         }
         else {
             succeeded = (rescued_interval.second <= primary_interval.first + max_softclip_overlap
-                         && min(rescued_interval.second, primary_interval.first) >= min_splice_rescue_matches);
+                         && min(rescued_interval.second, primary_interval.first) >= min_splice_rescue_matches
+                         && rescued_interval.first < primary_interval.first);
         }
 #ifdef debug_multipath_mapper
         cerr << "rescue candidate covers read interval " << rescued_interval.first << ":" << rescued_interval.second << " compared to primary interval " << primary_interval.first << ":" << primary_interval.second << ", considered successful? " << succeeded << endl;


### PR DESCRIPTION
## Changelog Entry

 * Fixes a crash in `vg mpmap` that could happen during spliced alignment of low quality reads

## Description

Small bug-fix.
Edit: fixed a couple more subtle but nasty bugs that came up in the course of testing the earlier bug fix.