### PR TITLE
Speed up start-up time in mpmap with multithreading

### DIFF
--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1521,7 +1521,7 @@ int main_mpmap(int argc, char** argv) {
     bool clock_init = false;
     time_t time_start;
     mutex progress_mutex;
-    auto log_progress = [&](const string& progress) {
+    auto log_progress = [&](const string progress) {
         if (!suppress_progress) {
             progress_mutex.lock();
             stringstream strm;
@@ -1567,7 +1567,6 @@ int main_mpmap(int argc, char** argv) {
         for (size_t i = 0; i < argc; ++i) {
             strm << " " << argv[i];
         }
-        strm << endl;
         log_progress(strm.str());
     }
     
@@ -1641,7 +1640,7 @@ int main_mpmap(int argc, char** argv) {
             strm << "XG format is recommended for most mapping tasks. ";
         }
         
-        strm << "See `vg convert` if you want to change graph formats." << endl;
+        strm << "See `vg convert` if you want to change graph formats.";
         log_progress(strm.str());
     }
     
@@ -1685,7 +1684,7 @@ int main_mpmap(int argc, char** argv) {
     // start at 1 for the main thread
     atomic<int> threads_active(1);
     list<thread> background_processes;
-    auto background_process = [&](const string& progress, function<void(void)>& lambda) {
+    auto background_process = [&](const string progress, function<void(void)> lambda) {
         // try to add an active thread
         int curr_thread_active = threads_active++;
         if (curr_thread_active >= thread_count) {
@@ -1696,7 +1695,7 @@ int main_mpmap(int argc, char** argv) {
         }
         else {
             // do the process in a background thread
-            background_processes.emplace_back([&]() {
+            background_processes.emplace_back([&log_progress,&lambda,&threads_active,progress]() {
                 log_progress(progress + " (in background)");
                 lambda();
                 --threads_active;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -7,6 +7,9 @@
 #include <ctime>
 #include <getopt.h>
 #include <thread>
+#include <atomic>
+#include <mutex>
+#include <list>
 
 #include "subcommand.hpp"
 
@@ -1481,9 +1484,6 @@ int main_mpmap(int argc, char** argv) {
         }
     }
     
-    // Count our threads
-    int thread_count = get_thread_count();
-    
     ifstream gbwt_stream;
     ifstream ls_stream;
     if (!gbwt_name.empty()) {
@@ -1513,53 +1513,62 @@ int main_mpmap(int argc, char** argv) {
         }
     }
     
+    // Count our threads
+    int thread_count = get_thread_count();
+    
     // a convenience function to preface a stderr log with an indicator of the command
     // and the time elapse
     bool clock_init = false;
     time_t time_start;
-    auto progress_boilerplate = [&]() {
-        stringstream strm;
-        strm << fixed;
-        strm.precision(0);
-        if (!clock_init) {
-            time(&time_start);
-            strm << 0.0 << " s";
-            clock_init = true;
-        }
-        else {
-            time_t time_now;
-            time(&time_now);
-            double secs = (double) difftime(time_now, time_start);
-            if (secs <= 60.0) {
-                strm << secs << " s";
+    mutex progress_mutex;
+    auto log_progress = [&](const string& progress) {
+        if (!suppress_progress) {
+            progress_mutex.lock();
+            stringstream strm;
+            strm << fixed;
+            strm.precision(0);
+            if (!clock_init) {
+                time(&time_start);
+                strm << 0.0 << " s";
+                clock_init = true;
             }
             else {
-                strm.precision(1);
-                double mins = secs / 60.0;
-                if (mins <= 60.0) {
-                    strm << mins << " m";
+                time_t time_now;
+                time(&time_now);
+                double secs = (double) difftime(time_now, time_start);
+                if (secs <= 60.0) {
+                    strm << secs << " s";
                 }
                 else {
-                    double hrs = mins / 60.0;
-                    if (hrs <= 24.0) {
-                        strm << hrs << " h";
+                    strm.precision(1);
+                    double mins = secs / 60.0;
+                    if (mins <= 60.0) {
+                        strm << mins << " m";
                     }
                     else {
-                        strm << (hrs / 24.0) << " d";
+                        double hrs = mins / 60.0;
+                        if (hrs <= 24.0) {
+                            strm << hrs << " h";
+                        }
+                        else {
+                            strm << (hrs / 24.0) << " d";
+                        }
                     }
                 }
             }
+            cerr << "[vg mpmap] elapsed time " << strm.str() << ": " << progress << endl;
+            progress_mutex.unlock();
         }
-        string boilerplate = "[vg mpmap] elapsed time " + strm.str() + ": ";
-        return boilerplate;
     };
     
-    if (!suppress_progress) {
-        cerr << progress_boilerplate() << "Executing command:";
+    {
+        stringstream strm;
+        strm << "Executing command:";
         for (size_t i = 0; i < argc; ++i) {
-            cerr << " " << argv[i];
+            strm << " " << argv[i];
         }
-        cerr << endl;
+        strm << endl;
+        log_progress(strm.str());
     }
     
     vector<double> intron_mixture_weights;
@@ -1572,9 +1581,7 @@ int main_mpmap(int argc, char** argv) {
     gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
     
     // Load required indexes
-    if (!suppress_progress) {
-        cerr << progress_boilerplate() << "Loading graph from " << graph_name << endl;
-    }
+    log_progress("Loading graph from " + graph_name);
     unique_ptr<PathHandleGraph> path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(graph_name);
     
     if (!suppress_progress) {
@@ -1604,37 +1611,38 @@ int main_mpmap(int argc, char** argv) {
             type = "ODGI";
         }
         
-        cerr << progress_boilerplate();
+        stringstream strm;
         if (!type.empty()) {
             // we found the type, give an appropriate message about it
-            cerr << "Graph is in " + type + " format. ";
+            strm << "Graph is in " + type + " format. ";
             
             if (type == "XG") {
-                cerr << "XG is a good graph format for most mapping use cases. PackedGraph may be selected if memory usage is too high. ";
+                strm << "XG is a good graph format for most mapping use cases. PackedGraph may be selected if memory usage is too high. ";
             }
             else if (type == "HashGraph") {
-                cerr << "HashGraph can have high memory usage. ";
+                strm << "HashGraph can have high memory usage. ";
             }
             else if (type == "PackedGraph") {
-                cerr << "PackedGraph is memory efficient, but has some slow queries. ";
+                strm << "PackedGraph is memory efficient, but has some slow queries. ";
             }
             else if (type == "ODGI") {
-                cerr << "ODGI is fairly memory efficient, but can be slow on certain queries. ";
+                strm << "ODGI is fairly memory efficient, but can be slow on certain queries. ";
             }
         }
         else {
             // probably a VG graph
-            cerr << "Graph is not in XG format. ";
+            strm << "Graph is not in XG format. ";
         }
         
         // are they using a graph combo that I don't recommend?
         if (type != "XG" && (!use_min_dist_clusterer || type == "HashGraph" || type.empty())) {
             // min dist clustering alleviates the issues with slow path queries because we don't need to do
             // so many, but I want to dissuade people from using HashGraph and VG for mapping regardless
-            cerr << "XG format is recommended for most mapping tasks. ";
+            strm << "XG format is recommended for most mapping tasks. ";
         }
         
-        cerr << "See `vg convert` if you want to change graph formats." << endl;
+        strm << "See `vg convert` if you want to change graph formats." << endl;
+        log_progress(strm.str());
     }
     
     if (path_handle_graph->get_path_count() == 0 && distance_index_name.empty()) {
@@ -1654,9 +1662,7 @@ int main_mpmap(int argc, char** argv) {
     unordered_set<path_handle_t> ref_path_handles;
     if (do_spliced_alignment) {
         // TODO: could let IO continue while doing this, but it risks increasing peak memory for some graphs...
-        if (!suppress_progress) {
-            cerr << progress_boilerplate() << "Identifying reference paths." << endl;
-        }
+        log_progress("Identifying reference paths");
         vector<unordered_set<path_handle_t>> component_path_sets = algorithms::component_paths_parallel(*path_position_handle_graph);
         for (const auto& path_set : component_path_sets) {
             // remove dependency on system hash ordering
@@ -1676,37 +1682,66 @@ int main_mpmap(int argc, char** argv) {
         }
     }
     
+    // start at 1 for the main thread
+    atomic<int> threads_active(1);
+    list<thread> background_processes;
+    auto background_process = [&](const string& progress, function<void(void)>& lambda) {
+        // try to add an active thread
+        int curr_thread_active = threads_active++;
+        if (curr_thread_active >= thread_count) {
+            // take back the increment and don't let it go multithreaded
+            --threads_active;
+            log_progress(progress);
+            lambda();
+        }
+        else {
+            // do the process in a background thread
+            background_processes.emplace_back([&]() {
+                log_progress(progress + " (in background)");
+                lambda();
+                --threads_active;
+                log_progress(progress + " (completed)");
+            });
+        }
+    };
+    
+    // for the indexes whose loading involves non-trivial computation, do them in the
+    // background to maximize IO
+    
+    unique_ptr<SnarlManager> snarl_manager;
+    if (!snarls_name.empty() && (distance_index_name.empty() || no_clustering)) {
+        function<void(void)> load_snarls = [&]() {
+            snarl_manager = vg::io::VPKG::load_one<SnarlManager>(snarl_stream);
+        };
+        background_process("Loading snarls from " + snarls_name, load_snarls);
+    }
+    
+    unique_ptr<MinimumDistanceIndex> distance_index;
+    if (!distance_index_name.empty() && !(no_clustering && !snarls_name.empty())) {
+        function<void(void)> load_distance_index = [&]() {
+            distance_index = vg::io::VPKG::load_one<MinimumDistanceIndex>(distance_index_stream);
+        };
+        background_process("Loading distance index from " + distance_index_name, load_distance_index);
+    }
+    
     // compute this once in case the backing graph doesn't have an efficient implementation
     size_t total_seq_length = path_position_handle_graph->get_total_length();
     
-    if (!suppress_progress) {
-        cerr << progress_boilerplate() << "Loading GCSA2 from " << gcsa_name << endl;
-    }
+    log_progress("Loading GCSA2 from " + gcsa_name);
     unique_ptr<gcsa::GCSA> gcsa_index = vg::io::VPKG::load_one<gcsa::GCSA>(gcsa_stream);
     
     unique_ptr<MEMAccelerator> mem_accelerator;
     unique_ptr<gcsa::LCPArray> lcp_array;
-    unique_ptr<thread> mem_accelerator_thread;
     if (!use_stripped_match_alg) {
         // don't make a huge table for a small graph
         mem_accelerator_length = min<int>(mem_accelerator_length, round(log(total_seq_length) / log(4.0)));
-        if (thread_count == 1) {
-            // don't let it go multithreaded
-            if (!suppress_progress) {
-                cerr << progress_boilerplate() << "Memoizing GCSA2 queries" << endl;
-            }
+        function<void(void)> memoize_gcsa2 = [&]() {
             mem_accelerator = unique_ptr<MEMAccelerator>(new MEMAccelerator(*gcsa_index, mem_accelerator_length));
-        }
-        else {
-            // construct the MEM accelerator in a thread, since it doesn't use IO like the rest of the load
-            mem_accelerator_thread = unique_ptr<thread>(new thread([&]() {
-                mem_accelerator = unique_ptr<MEMAccelerator>(new MEMAccelerator(*gcsa_index, mem_accelerator_length));
-            }));
-        }
+        };
+        background_process("Memoizing GCSA2 queries", memoize_gcsa2);
+        
         // The stripped algorithm doesn't use the LCP, but we aren't doing it
-        if (!suppress_progress) {
-            cerr << progress_boilerplate() << "Loading LCP from " << lcp_name << endl;
-        }
+        log_progress("Loading LCP from " + lcp_name);
         lcp_array = vg::io::VPKG::load_one<gcsa::LCPArray>(lcp_stream);
     }
     
@@ -1716,9 +1751,7 @@ int main_mpmap(int argc, char** argv) {
     haplo::linear_haplo_structure* sublinearLS = nullptr;
     haplo::ScoreProvider* haplo_score_provider = nullptr;
     if (!gbwt_name.empty()) {
-        if (!suppress_progress) {
-            cerr << progress_boilerplate() << "Loading GBWT from " << gbwt_name << endl;
-        }
+        log_progress("Loading GBWT from " + gbwt_name);
         // Load the GBWT from its container
         gbwt = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_stream);
 
@@ -1732,9 +1765,7 @@ int main_mpmap(int argc, char** argv) {
         haplo_score_provider = new haplo::GBWTScoreProvider<gbwt::GBWT>(*gbwt);
     }
     else if (!sublinearLS_name.empty()) {
-        if (!suppress_progress) {
-            cerr << progress_boilerplate() << "Loading LS index from " << sublinearLS_name << endl;
-        }
+        log_progress("Loading LS index from " + sublinearLS_name);
         
         // TODO: we only support a single ref contig, and we use these
         // hardcoded mutation and recombination likelihoods
@@ -1742,25 +1773,6 @@ int main_mpmap(int argc, char** argv) {
         sublinearLS = new linear_haplo_structure(ls_stream, -9 * 2.3, -6 * 2.3, *path_position_handle_graph,
                                                  path_position_handle_graph->get_path_handle(sublinearLS_ref_path));
         haplo_score_provider = new haplo::LinearScoreProvider(*sublinearLS);
-    }
-    
-    unique_ptr<SnarlManager> snarl_manager;
-    if (!snarls_name.empty() && (distance_index_name.empty() || no_clustering)) {
-        if (!suppress_progress) {
-            cerr << progress_boilerplate() << "Loading snarls from " << snarls_name << endl;
-        }
-        snarl_manager = vg::io::VPKG::load_one<SnarlManager>(snarl_stream);
-    }
-    
-    unique_ptr<MinimumDistanceIndex> distance_index;
-    if (!distance_index_name.empty() && !(no_clustering && !snarls_name.empty())) {
-        if (!suppress_progress) {
-            cerr << progress_boilerplate() << "Loading distance index from " << distance_index_name << endl;
-        }
-        
-        // Load the index
-        distance_index = vg::io::VPKG::load_one<MinimumDistanceIndex>(distance_index_stream);
-        
     }
     
     // Load structures that we need for HTS lib outputs
@@ -1773,12 +1785,10 @@ int main_mpmap(int argc, char** argv) {
         surjector->min_splice_length = transcriptomic ? min_splice_length : numeric_limits<int64_t>::max();
         surjector->adjust_alignments_for_base_quality = qual_adjusted;
         
-        if (!suppress_progress) {
-            if (!ref_paths_name.empty()) {
-                cerr << progress_boilerplate() << "Choosing reference paths from " << ref_paths_name << endl;
-            } else {
-                cerr << progress_boilerplate() << "No reference path file given. Interpreting all non-alt-allele paths in graph as reference sequences." << endl;
-            }
+        if (!ref_paths_name.empty()) {
+            log_progress("Choosing reference paths from " + ref_paths_name);
+        } else {
+            log_progress("No reference path file given. Interpreting all non-alt-allele paths in graph as reference sequences.");
         }
         
         // Load all the paths in the right order
@@ -1791,19 +1801,21 @@ int main_mpmap(int argc, char** argv) {
         path_names_and_length = extract_path_metadata(paths, *path_position_handle_graph).first;
     }
     
+    // barrier sync the background threads
+    for (auto& process : background_processes) {
+        process.join();
+    }
+    background_processes.clear();
+    
     // this also takes a while inside the MultipathMapper constructor, but it will only activate if we don't
     // have a distance index available for oriented distance calculations
-    if (!suppress_progress && distance_index_name.empty() && path_handle_graph->get_path_count() > 0) {
-        cerr << progress_boilerplate() << "Labeling embedded paths by their connected component" << endl;
+    if (distance_index_name.empty() && path_handle_graph->get_path_count() > 0) {
+        log_progress("Labeling embedded paths by their connected component");
     }
     
     MultipathMapper multipath_mapper(path_position_handle_graph, gcsa_index.get(), lcp_array.get(), haplo_score_provider,
         snarl_manager.get(), distance_index.get());
     // give it the MEMAccelerator
-    if (mem_accelerator_thread.get() != nullptr) {
-        // sync the thread first
-        mem_accelerator_thread->join();
-    }
     if (mem_accelerator.get() != nullptr) {
         multipath_mapper.accelerator = mem_accelerator.get();
     }
@@ -1944,9 +1956,7 @@ int main_mpmap(int argc, char** argv) {
     
     // if directed to, auto calibrate the mismapping detection to the graph
     if (auto_calibrate_mismapping_detection && !suppress_mismapping_detection) {
-        if (!suppress_progress) {
-            cerr << progress_boilerplate() << "Building null model to calibrate mismapping detection." << endl;
-        }
+        log_progress("Building null model to calibrate mismapping detection");
         multipath_mapper.calibrate_mismapping_detection(num_calibration_simulations, calibration_read_lengths);
     }
     
@@ -1992,10 +2002,7 @@ int main_mpmap(int argc, char** argv) {
 #pragma omp atomic capture
                 n = num_reads_mapped += num_mapped;
                 if (n % progress_frequency == 0) {
-#pragma omp critical
-                    {
-                        cerr << progress_boilerplate() << "Mapped " << n << (!interleaved_input && fastq_name_2.empty() ? " reads" : " read pairs") << endl;
-                    }
+                    log_progress("Mapped " + to_string(n) + (!interleaved_input && fastq_name_2.empty() ? " reads" : " read pairs"));
                 }
                 thread_num_reads_mapped[thread_num] = 0;
             }
@@ -2275,10 +2282,7 @@ int main_mpmap(int argc, char** argv) {
     
     // FASTQ input
     if (!fastq_name_1.empty()) {
-        if (!suppress_progress) {
-            
-            cerr << progress_boilerplate() << "Mapping reads from " << (fastq_name_1 == "-" ? "STDIN" : fastq_name_1) << (fastq_name_2.empty() ? "" : " and " + (fastq_name_2 == "-" ? "STDIN" : fastq_name_2)) << " using " << thread_count << " thread" << (thread_count > 1 ? "s" : "") << endl;
-        }
+        log_progress("Mapping reads from " + (fastq_name_1 == "-" ? string("STDIN") : fastq_name_1) + (fastq_name_2.empty() ? "" : " and " + (fastq_name_2 == "-" ? "STDIN" : fastq_name_2)) + " using " + to_string(thread_count) + " thread" + (thread_count > 1 ? "s" : ""));
         
         if (interleaved_input) {
             fastq_paired_interleaved_for_each_parallel_after_wait(fastq_name_1, do_paired_alignments,
@@ -2295,9 +2299,7 @@ int main_mpmap(int argc, char** argv) {
     
     // GAM input
     if (!gam_file_name.empty()) {
-        if (!suppress_progress) {
-            cerr << progress_boilerplate() << "Mapping reads from " << (gam_file_name == "-" ? "STDIN" : gam_file_name) << " using " << thread_count << " thread" << (thread_count > 1 ? "s" : "")  << endl;
-        }
+        log_progress("Mapping reads from " + (gam_file_name == "-" ? string("STDIN") : gam_file_name) + " using " + to_string(thread_count) + " thread" + (thread_count > 1 ? "s" : ""));
         
         function<void(istream&)> execute = [&](istream& gam_in) {
             if (!gam_in) {
@@ -2363,7 +2365,7 @@ int main_mpmap(int argc, char** argv) {
         for (auto uncounted_mappings : thread_num_reads_mapped) {
             num_reads_mapped += uncounted_mappings;
         }
-        cerr << progress_boilerplate() << "Mapping finished. Mapped " << num_reads_mapped << " " << (fastq_name_2.empty() && !interleaved_input ? "reads" : "read pairs") << "." << endl;
+        log_progress("Mapping finished. Mapped " + to_string(num_reads_mapped) + " " + (fastq_name_2.empty() && !interleaved_input ? "reads" : "read pairs") + ".");
     }
     
 #ifdef record_read_run_times


### PR DESCRIPTION
## Description

The index loads that involve significantly more computation than just slinging bits off of disk are now done in parallel threads, which cuts start-up time by about 1/3. This probably doesn't matter all that much to anyone but me, since the start-up time is a pain when debugging.