### PR TITLE
Don't generate or expect empty allele paths

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1548,16 +1548,16 @@ namespace vg {
         max_rank.clear();
         // We have this many nonempty paths at the start of the collection at
         // the start of every loop.
-        size_t nonempty_through = 0;
-        while (nonempty_through < to_return.graph.path_size()) {
-            if (to_return.graph.path(nonempty_through).mapping_size() == 0) {
+        size_t nonempty_paths = 0;
+        while (nonempty_paths < to_return.graph.path_size()) {
+            if (to_return.graph.path(nonempty_paths).mapping_size() == 0) {
                 // This is empty of mappings so swap it to the end and remove it.
-                to_return.graph.mutable_path()->SwapElements(nonempty_through, to_return.graph.path_size() - 1);
+                to_return.graph.mutable_path()->SwapElements(nonempty_paths, to_return.graph.path_size() - 1);
                 to_return.graph.mutable_path()->RemoveLast();
                 // Leave our cursor where it is; we have to check the element we swapped to here.
             } else {
                 // This is nonempty so advance the cursor.
-                nonempty_through++;
+                nonempty_paths++;
             }
         }
 

--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1047,8 +1047,7 @@ namespace vg {
                                     deletion_starts.insert(arc_start);
                                     
                                     // No alt path mappings necessary for the
-                                    // deletion; the existence of the empty
-                                    // path is sufficient.
+                                    // deletion
                                 }
 
                             }

--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1542,6 +1542,24 @@ namespace vg {
 
         // Remember to tell the caller how many IDs we used
         to_return.max_id = next_id - 1;
+        
+        // Filter out any empty variant Paths.
+        // First stop pointing to them.
+        max_rank.clear();
+        // We have this many nonempty paths at the start of the collection at
+        // the start of every loop.
+        size_t nonempty_through = 0;
+        while (nonempty_through < to_return.graph.path_size()) {
+            if (to_return.graph.path(nonempty_through).mapping_size() == 0) {
+                // This is empty of mappings so swap it to the end and remove it.
+                to_return.graph.mutable_path()->SwapElements(nonempty_through, to_return.graph.path_size() - 1);
+                to_return.graph.mutable_path()->RemoveLast();
+                // Leave our cursor where it is; we have to check the element we swapped to here.
+            } else {
+                // This is nonempty so advance the cursor.
+                nonempty_through++;
+            }
+        }
 
         return to_return;
     }

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -53,10 +53,11 @@ inline gbwt::vector_type path_to_gbwt(const Path& path) {
     return result;
 }
 
-/// Extract a path as a GBWT path.
+/// Extract a path as a GBWT path. If the path does not exist, it is treated as empty.
 gbwt::vector_type extract_as_gbwt_path(const PathHandleGraph& graph, const std::string& path_name);
 
-// Find all predecessor nodes of the path, ignoring self-loops.
+/// Find all predecessor nodes of the path, ignoring self-loops. If the path
+/// does not exist, it is treated as empty.
 gbwt::vector_type path_predecessors(const PathHandleGraph& graph, const std::string& path_name);
 
 //------------------------------------------------------------------------------

--- a/src/haplotype_indexer.cpp
+++ b/src/haplotype_indexer.cpp
@@ -165,12 +165,13 @@ std::vector<std::string> HaplotypeIndexer::parse_vcf(const std::string& filename
                 // it in the graph.
                 var.sequenceName = path_name;
             }
-
+            
             // Determine the reference nodes for the current variant and create a variant site.
             // If the variant is not an insertion, there should be a path for the ref allele.
             std::string var_name = make_variant_id(var);
             std::string ref_path_name = "_alt_" + var_name + "_0";
             gbwt::vector_type ref_path = extract_as_gbwt_path(graph, ref_path_name);
+            
             size_t ref_pos = variants.invalid_position();
             if (!ref_path.empty()) {
                 ref_pos = variants.firstOccurrence(ref_path.front());
@@ -230,11 +231,7 @@ std::vector<std::string> HaplotypeIndexer::parse_vcf(const std::string& filename
             // Add alternate alleles to the site.
             for (size_t alt_index = 1; alt_index < var.alleles.size(); alt_index++) {
                 std::string alt_path_name = "_alt_" + var_name + "_" + std::to_string(alt_index);
-                if (graph.has_path(alt_path_name)) {
-                    variants.addAllele(extract_as_gbwt_path(graph, alt_path_name));
-                } else {
-                    variants.addAllele(ref_path);
-                }
+                variants.addAllele(extract_as_gbwt_path(graph, alt_path_name));
             }
 
             // Store the phasings in PhasingInformation structures.

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -413,13 +413,7 @@ int main_mod(int argc, char** argv) {
             // Grab its id, or make one by hashing stuff if it doesn't
             // have an ID.
             string var_name = make_variant_id(variant);
-
-            if(!graph->has_path("_alt_" + var_name + "_0")) {
-                // There isn't a reference alt path for this variant. Someone messed up.
-                cerr << variant << endl;
-                throw runtime_error("Reference alt for " + var_name + " not in graph!");
-            }
-
+            
             // For now always work on sample 0. TODO: let the user specify a
             // name and find it.
             int sample_number = 0;
@@ -446,15 +440,15 @@ int main_mod(int argc, char** argv) {
                     allele_number = stoi(it->str());
                 }
 
-
-
                 // Make the name for its alt path
                 string alt_path_name = "_alt_" + var_name + "_" + to_string(allele_number);
-                
-                graph->for_each_step_in_path(graph->get_path_handle(alt_path_name), [&](const step_handle_t& s) {
-                    // Un-mark all nodes that are on this alt path, since it is used by the sample.
-                    alt_path_ids.erase(graph->get_id(graph->get_handle_of_step(s)));
-                });
+                if (graph->has_path(alt_path_name)) {
+                    // This alt path is existent and may be nonempty.
+                    graph->for_each_step_in_path(graph->get_path_handle(alt_path_name), [&](const step_handle_t& s) {
+                        // Un-mark all nodes that are on this alt path, since it is used by the sample.
+                        alt_path_ids.erase(graph->get_id(graph->get_handle_of_step(s)));
+                    });
+                }
             }
 
         };

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -102,12 +102,14 @@ vector<SnarlTraversal> PathBasedTraversalFinder::find_traversals(const Snarl& si
                 // Add the start node to the traversal
                 *fresh_trav.add_visit() = site.start();
                 // Fill in our traversal
-                for (auto h : graph.scan_path(graph.get_path_handle(a))) {
-                    int64_t n_id = graph.get_id(h);
-                    bool backward = graph.get_is_reverse(h);
-                    Visit* v = fresh_trav.add_visit();
-                    v->set_node_id(n_id);
-                    v->set_backward(backward);
+                if (graph.has_path(a)) {
+                    for (auto h : graph.scan_path(graph.get_path_handle(a))) {
+                        int64_t n_id = graph.get_id(h);
+                        bool backward = graph.get_is_reverse(h);
+                        Visit* v = fresh_trav.add_visit();
+                        v->set_node_id(n_id);
+                        v->set_backward(backward);
+                    }
                 }
                 // Add the end node to the traversal
                 *fresh_trav.add_visit() = site.end();
@@ -3063,8 +3065,6 @@ pair<SnarlTraversal, vector<edge_t>> VCFTraversalFinder::get_alt_path(vcflib::Va
                     alt_path = std::move(scan_deletion.first);
                     deletion_edges = std::move(scan_deletion.second);
                 }
-            } else {
-                assert(allele == 0);
             }
         }
     }

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -91,7 +91,7 @@ vg construct -m 1000 -r small/xy.fa -v small/xy2.vcf.gz -R x -C -a 2> /dev/null 
 vg index -x w.xg w.vg
 cat w.vg | vg paths -d -v - > part1.tmp
 vg find -x w.xg -Q alt > part2.tmp
-is $(vg combine -c part1.tmp part2.tmp | vg paths -L -v - | wc -l) 38 "pattern based path extraction works"
+is "$(vg combine -c part1.tmp part2.tmp | vg paths -L -v - | wc -l)" "$(vg view -j w.vg | jq -c '.path[] | select(.name | contains("alt"))' | wc -l)" "pattern based path extraction works"
 rm -f w.xg w.vg part1.tmp part2.tmp
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -95,7 +95,7 @@ rm -f c.vg
 # Note the math (and subsetting) only works out on a flat alleles graph
 vg construct -r small/x.fa -a -f -v small/x.vcf.gz >x.vg
 vg mod -v small/x.vcf.gz x.vg >x.sample.vg
-is $(vg stats x.sample.vg -l | cut -f 2) 1041 "subsetting a flat-alleles graph to a sample graph works"
+is "$(vg stats x.sample.vg -l | cut -f 2)" "1041" "subsetting a flat-alleles graph to a sample graph works"
 rm -f x.vg x.sample.vg 
 
 is $(vg mod -M 5 jumble/j.vg|  vg stats -s - | wc -l) 7 "removal of high-degree nodes results in the expected number of subgraphs"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg construct -a` no longer generates, and other vg tools no longer expect to see, empty paths for some variants

## Description

We used to use empty paths (I think for the `_0` reference path?) when generating alt allele paths for some indel variants. We didn't actually need those paths to be there, and now we should be able to use nonexistent paths instead of empty ones.