### PR TITLE
Fix mem accelerator

### DIFF
--- a/src/mem_accelerator.cpp
+++ b/src/mem_accelerator.cpp
@@ -13,16 +13,34 @@ namespace vg {
 MEMAccelerator::MEMAccelerator(const gcsa::GCSA& gcsa_index, size_t k) : k(k)
 {
     // Compute the minimum width required to express the integers.
-    // We need to be able to represent numbers up to th index size + 1, to
-    // account for empty ranges where the first number is greater than the
-    // second and the second is the index size. 
+    // We need to be able to represent numbers up to a bit over the index size,
+    // for some reason. We're not sure how much over the index size is needed.
+    // Start with a more or less arbitrary guess of the max needed value
+    size_t max_needed_value_guess = gcsa_index.size() + 100;
+    
+    // Compute the bit width needed to represent it
     uint8_t width = 0;
-    size_t log_cntr;
-    for (log_cntr = 1; log_cntr <= gcsa_index.size() + 1; log_cntr *= 2) {
+    // And the number too big to be represented
+    size_t too_big = 1;
+    while (too_big <= max_needed_value_guess) {
         ++width;
+        too_big *= 2;
     }
     
-    std::cerr << "Use " << (int)width << " bits storing values 0 through " << (log_cntr - 1) << " for an index size of " << gcsa_index.size() << std::endl;
+    // We use this accessor to set a value and expand the vector width if we need to.
+    auto set_range_table = [&](size_t offset, int64_t value) {
+        if (too_big <= value) {
+            while (too_big <= value) {
+                ++width;
+                too_big *= 2;
+            }
+            // This is weird; we should sort this out when we work out exactly
+            // what the limits on these range values really are.
+            std::cerr << "warning [vg::MEMAccelerator]: expanding vector width to hold value " << value << " for GCSA index size " << gcsa_index.size() << std::endl;
+            sdsl::util::expand_width(range_table, width);
+        }
+        range_table[offset] = value;
+    };
     
     range_table.width(max<uint8_t>(width, 1));
     // range table is initialized to size 2^(2k + 1) = 2 * 4^k
@@ -39,10 +57,8 @@ MEMAccelerator::MEMAccelerator(const gcsa::GCSA& gcsa_index, size_t k) : k(k)
     while (!stack.empty()) {
         if (stack.size() == k + 1) {
             // we've walked the full k-mers
-            assert(get<2>(stack.back()).first <= log_cntr - 1);
-            range_table[2 * get<1>(stack.back())] = get<2>(stack.back()).first;
-            assert(get<2>(stack.back()).second <= log_cntr - 1);
-            range_table[2 * get<1>(stack.back()) + 1] = get<2>(stack.back()).second;
+            set_range_table(2 * get<1>(stack.back()), get<2>(stack.back()).first);
+            set_range_table(2 * get<1>(stack.back()) + 1, get<2>(stack.back()).second);
             stack.pop_back();
         }
         else if (get<0>(stack.back()) == 4) {

--- a/src/unittest/mem_accelerator.cpp
+++ b/src/unittest/mem_accelerator.cpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <string>
+#include <sstream>
 #include "../mem_accelerator.hpp"
 #include "../utility.hpp"
 #include "../build_index.hpp"
@@ -12,10 +13,28 @@
 #include "random_graph.hpp"
 
 #include <bdsg/hash_graph.hpp>
+#include <gcsa/utils.h>
+
+namespace std {
+
+// For the output operator for ranges
+using gcsa::operator<<;
+
+/// Allow ranges to be dumped by the test asserts if they don't match properly.
+static std::string to_string(const gcsa::range_type& range) {
+    std::stringstream ss;
+    ss << range;
+    return ss.str();
+}
+
+}
 
 namespace vg {
 namespace unittest {
 using namespace std;
+
+// For the output operator for ranges
+using gcsa::operator<<;
 
 
 TEST_CASE("MEMAccelerator returns same ranges as direct LF queries",
@@ -61,6 +80,7 @@ TEST_CASE("MEMAccelerator returns same ranges as direct LF queries",
                 --cursor;
             }
             
+            std::cerr << "Kmer " << seq << " memo " << memo_range << " direct " << direct_range << std::endl;
             REQUIRE(memo_range == direct_range);
         }
         

--- a/src/unittest/mem_accelerator.cpp
+++ b/src/unittest/mem_accelerator.cpp
@@ -80,7 +80,6 @@ TEST_CASE("MEMAccelerator returns same ranges as direct LF queries",
                 --cursor;
             }
             
-            std::cerr << "Kmer " << seq << " memo " << memo_range << " direct " << direct_range << std::endl;
             REQUIRE(memo_range == direct_range);
         }
         


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `MEMAccelerator` can no longer slice bits off the numbers it is supposed to be storing

## Description

Commit 120699454c92b5fb668420ddc3322b4d29bbe14c seemed to introduce a bug on my machine where the `MEMAccelerator` tests would fail, probably because of the particular seeds/RNG behavior my machine uses to make the random graphs for the test.

The underlying problem is that the size of the GCSA index isn't the maximum number that can appear in a GCSA range. Perhaps @jltsiren can explain what the maximum number actually is guaranteed to be; I've observed the values going up to 256 in a 250-sized index.

This PR adds better logging if the test fails, and also sets up the `MEMAccelerator` build to make room for an arbitrary 100 numbers beyond the end of the GCSA index, and to increase the integer width during the build (with a warning) if it determines that it has a bigger number to store.

The hooks to do this are going to make it a little slower; we should eventually work out what the actual maximum values can be and just allocate bits to store those up front.
