### PR TITLE
Extract segment translation from GBZ

### DIFF
--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -47,7 +47,8 @@ jobs:
         # conflicts with existing/outdated packages, which we can't resolve
         # because there's no way to tell Homebrew to force-link when installing
         # from a Brewfile.
-        run: brew bundle cleanup --force && brew bundle install
+        # We pre-install a pinned txm to work around https://github.com/anko/txm/issues/8
+        run: brew bundle cleanup --force && brew bundle install && npm install -g txm@7.4.5
 
       - name: Run build and test
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ ARG THREADS=8
 
 RUN echo test > /stage.txt
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get -qq -y install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get -qq -y install nodejs && npm install txm@7.4.5
 
 # Fail if any non-portable instructions were used
 RUN /bin/bash -e -c 'if objdump -d /vg/bin/vg | grep vperm2i128 ; then exit 1 ; else exit 0 ; fi'

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ ARG THREADS=8
 
 RUN echo test > /stage.txt
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get -qq -y install nodejs && npm install txm@7.4.5
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get -qq -y install nodejs && npm install -g txm@7.4.5
 
 # Fail if any non-portable instructions were used
 RUN /bin/bash -e -c 'if objdump -d /vg/bin/vg | grep vperm2i128 ; then exit 1 ; else exit 0 ; fi'

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -261,6 +261,7 @@ void help_gbwt(char** argv) {
     std::cerr << "        --path-fields X     map regex submatches to these fields (default " << gbwtgraph::GFAParsingParameters::DEFAULT_FIELDS << ")" << std::endl;
     std::cerr << "        --translation FILE  write the segment to node translation table to FILE" << std::endl;
     std::cerr << "    -Z, --gbz-input         extract GBWT and GBWTGraph from GBZ input (one input arg)" << std::endl;
+    std::cerr << "        --translation FILE  write the segment to node translation table to FILE" << std::endl;
     std::cerr << "    -E, --index-paths       index the embedded non-alt paths in the graph (requires -x, no input args)" << std::endl;
     std::cerr << "        --paths-as-samples  each path becomes a sample instead of a contig in the metadata" << std::endl;
     std::cerr << "    -A, --alignment-input   index the alignments in the GAF files specified in input args (requires -x)" << std::endl;

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 131
+plan tests 133
 
 
 # Build vg graphs for two chromosomes
@@ -349,6 +349,12 @@ is $(vg gbwt -H chopping.gbwt) 3 "chopping: 3 haplotypes"
 is $(vg gbwt -S chopping.gbwt) 2 "chopping: 2 samples"
 is $(wc -l < chopping.trans) 9 "chopping: 9 translations"
 
+# Build a GBZ with node chopping and extract the translation
+vg gbwt -g chopping.gbz --gbz-format --max-node 2 -G graphs/chopping_walks.gfa
+vg gbwt -Z chopping.gbz -o /dev/null --translation from_gbz.trans
+is $? 0 "Translation can be extracted from GBZ"
+is $(wc -l < from_gbz.trans) 8 "from GBZ: 8 translations"
+
 # Build GBWT and GBWTGraph from GFA with both paths and walks
 vg gbwt -o ref_paths.gbwt -g ref_paths.gg --translation ref_paths.trans -G graphs/components_paths_walks.gfa
 is $? 0 "GBWT+GBWTGraph construction from GFA with reference paths"
@@ -361,4 +367,5 @@ is $(wc -l < ref_paths.trans) 0 "ref paths: 0 translations"
 rm -f gfa.gbwt
 rm -f gfa2.gbwt gfa2.gg gfa2.trans gfa2.gbz
 rm -f ref_paths.gbwt ref_paths.gg ref_paths.trans
-rm -f chopping.gbwt chopping.gg chopping.trans
+rm -f chopping.gbwt chopping.gg chopping.trans from_gbz.trans
+


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * The segment translation table can be extracted from a GBZ file with `vg gbwt`.

## Description

Until now, we could only output the segment translation table when building GBWT from a GFA file. Now it's also possible to extract it from a GBZ file with `vg gbwt` options `-Z` / `--gbz-input` and `--translation`. There is also a check that the input type is valid when trying to extract the translation table.