### PR TITLE
More reliable buffer selection in path cover GBWT autoindexing

### DIFF
--- a/src/algorithms/component.cpp
+++ b/src/algorithms/component.cpp
@@ -97,6 +97,8 @@ vector<size_t> component_sizes(const HandleGraph& graph) {
         comp_sizes.back()++;
     };
     
+    traverse_components(graph, on_new_comp, on_node);
+    
     return comp_sizes;
 }
 

--- a/src/algorithms/component.hpp
+++ b/src/algorithms/component.hpp
@@ -1,9 +1,9 @@
 /** \file
- * Contains an algorithm to split paths up by their connected component
+ * Contains algorithms that report per-component info
  */
 
-#ifndef VG_ALGORITHMS_COMPONENT_PATHS_HPP_INCLUDED
-#define VG_ALGORITHMS_COMPONENT_PATHS_HPP_INCLUDED
+#ifndef VG_ALGORITHMS_COMPONENT_HPP_INCLUDED
+#define VG_ALGORITHMS_COMPONENT_HPP_INCLUDED
 
 #include <structures/rank_pairing_heap.hpp>
 
@@ -13,6 +13,9 @@ namespace vg {
 namespace algorithms {
 
 using namespace std;
+
+// returns the size in number of nodes of each component
+vector<size_t> component_sizes(const HandleGraph& graph);
 
 // returns sets of path handles, one set for each component (unless the
 // component doesn't have any paths)
@@ -25,4 +28,4 @@ vector<unordered_set<path_handle_t>> component_paths_parallel(const PathHandleGr
 
 }
 
-#endif // VG_ALGORITHMS_COMPONENT_PATHS_HPP_INCLUDED
+#endif // VG_ALGORITHMS_COMPONENT_HPP_INCLUDED

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -56,6 +56,7 @@
 
 #include "algorithms/gfa_to_handle.hpp"
 #include "algorithms/prune.hpp"
+#include "algorithms/component.hpp"
 
 //#define debug_index_registry
 //#define debug_index_registry_setup
@@ -2626,11 +2627,14 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         
         auto xg_index = vg::io::VPKG::load_one<xg::XG>(infile_xg);
         
+        auto comp_sizes = algorithms::component_sizes(*xg_index);
+        size_t max_comp_size = *max_element(comp_sizes.begin(), comp_sizes.end());
+        
         // make a GBWT from a greedy path cover
         gbwt::GBWT cover = gbwtgraph::path_cover_gbwt(*xg_index,
                                                       IndexingParameters::path_cover_depth,
                                                       IndexingParameters::downsample_context_length,
-                                                      200 * gbwt::MILLION, // buffer size
+                                                      20 * max_comp_size, // buffer size recommendation from Jouni
                                                       IndexingParameters::gbwt_sampling_interval,
                                                       IndexingParameters::verbosity >= IndexingParameters::Debug);
         

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -43,7 +43,7 @@
 #include "algorithms/locally_expand_graph.hpp"
 #include "algorithms/jump_along_path.hpp"
 #include "algorithms/ref_path_distance.hpp"
-#include "algorithms/component_paths.hpp"
+#include "algorithms/component.hpp"
 
 
 // note: only activated for single end mapping

--- a/src/path_component_index.cpp
+++ b/src/path_component_index.cpp
@@ -2,7 +2,7 @@
 
 #include <queue>
 #include "sdsl/bit_vectors.hpp"
-#include "algorithms/component_paths.hpp"
+#include "algorithms/component.hpp"
 
 //#define debug_component_index
 

--- a/src/unittest/component_paths.cpp
+++ b/src/unittest/component_paths.cpp
@@ -1,6 +1,6 @@
 #include "catch.hpp"
 #include "../utility.hpp"
-#include "../algorithms/component_paths.hpp"
+#include "../algorithms/component.hpp"
 
 #include <bdsg/hash_graph.hpp>
 

--- a/src/unittest/component_paths.cpp
+++ b/src/unittest/component_paths.cpp
@@ -17,6 +17,29 @@ set<set<path_handle_t>> normalize(vector<unordered_set<path_handle_t>> result) {
     return return_val;
 }
 
+TEST_CASE("Component sizes are computed correctly", "[compsize]") {
+    
+    bdsg::HashGraph graph;
+    
+    auto h1 = graph.create_handle("A");
+    auto h2 = graph.create_handle("A");
+    auto h3 = graph.create_handle("A");
+    auto h4 = graph.create_handle("A");
+    auto h5 = graph.create_handle("A");
+    auto h6 = graph.create_handle("A");
+    
+    graph.create_edge(h1, h2);
+    graph.create_edge(h1, h3);
+    graph.create_edge(h4, h5);
+    
+    auto comp_sizes = algorithms::component_sizes(graph);
+    sort(comp_sizes.begin(), comp_sizes.end());
+    
+    vector<size_t> correct{1, 2, 3};
+    REQUIRE(comp_sizes == correct);
+    
+}
+
 TEST_CASE("Parallel component paths produces correct results", "[comppathset]") {
     
     


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Prevents buffer size errors in GBWT creation by `vg autoindex`

## Description

Buffer is now sized relative to the largest connected component for the greedy path cover code path.
