### PR TITLE
Fix make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -889,7 +889,7 @@ clean: clean-vcflib
 	cd $(DEP_DIR) && cd structures && $(MAKE) clean
 	cd $(DEP_DIR) && cd jemalloc && $(MAKE) clean || true
 	cd $(DEP_DIR) && cd sublinear-Li-Stephens && $(MAKE) clean
-	cd $(DEP_DIR) && cd libhandlegraph && $(MAKE) clean
+	cd $(DEP_DIR) && cd libhandlegraph && rm -Rf build CMakeCache.txt CMakeFiles
 	cd $(DEP_DIR) && cd libvgio && $(MAKE) clean 
 	cd $(DEP_DIR) && cd raptor && cd build && find . -not \( -name '.gitignore' -or -name 'pkg.m4' \) -delete
 	# lru_cache is never built because it is header-only

--- a/Makefile
+++ b/Makefile
@@ -890,7 +890,7 @@ clean: clean-vcflib
 	cd $(DEP_DIR) && cd jemalloc && $(MAKE) clean || true
 	cd $(DEP_DIR) && cd sublinear-Li-Stephens && $(MAKE) clean
 	cd $(DEP_DIR) && cd libhandlegraph && rm -Rf build CMakeCache.txt CMakeFiles
-	cd $(DEP_DIR) && cd libvgio && $(MAKE) clean 
+	cd $(DEP_DIR) && cd libvgio && rm -Rf build CMakeCache.txt CMakeFiles
 	cd $(DEP_DIR) && cd raptor && cd build && find . -not \( -name '.gitignore' -or -name 'pkg.m4' \) -delete
 	# lru_cache is never built because it is header-only
 	# bash-tap is never built either


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `make clean` now works on submodules that lack top-level Makefiles

## Description

Our `make clean` doesn't currently work with some of our CMake submodules that don't ship a top-level Makefile. Now that these ones use out-of-source builds we can just directly delete files.