### PR TITLE
Fix operator precedence bug in back-translation

### DIFF
--- a/src/flat_file_back_translation.cpp
+++ b/src/flat_file_back_translation.cpp
@@ -59,7 +59,7 @@ std::vector<oriented_node_range_t> FlatFileBackTranslation::translate_back(const
              // In the requested orientation
              std::get<1>(range),
              // Starting at the correct offset along that orientation of the segment
-             std::get<2>(range) + std::get<1>(range) ? std::get<2>(it->second) : std::get<1>(it->second),
+             std::get<2>(range) + (std::get<1>(range) ? std::get<2>(it->second) : std::get<1>(it->second)),
              // And running for the specified length
              std::get<3>(range)
            }};


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `FlatFileBackTranslation` should no longer mistake nonzero offsets for the reverse strand

## Description

@jeizenga actually reads compiler warnings and found that this was going to do + before the conditional.