### PR TITLE
Use a Toil that can install on Pip 22

### DIFF
--- a/vgci/vgci.sh
+++ b/vgci/vgci.sh
@@ -34,7 +34,7 @@ TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@b79e340073832324e9714
 # What toil should we install?
 # Could be something like "toil[aws,mesos]==3.20.0"
 # or "git+https://github.com/DataBiosphere/toil.git@3ab74776a3adebd6db75de16985ce9d734f60743#egg=toil[aws,mesos]"
-TOIL_PACKAGE="git+https://github.com/DataBiosphere/toil.git@3ab74776a3adebd6db75de16985ce9d734f60743#egg=toil[aws,mesos]"
+TOIL_PACKAGE="git+https://github.com/DataBiosphere/toil.git@9041c54d9802add8973e31eddd8ba33529218f94#egg=toil[aws,mesos]"
 # What tests should we run?
 # Should be something like "vgci/vgci.py::VGCITest::test_sim_brca2_snp1kg_mpmap"
 # Must have the Python file in it or Pytest can't find the tests.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * CI now uses Toil compatible with Pip 22.

## Description
Toil has been installing an old yanked `futures` forever when installed with AWS. Recent `pip` has decided to refuse to do this, breaking installation of Toil.

This should use a Toil that does not have that problem and ought to install properly on current `pip`.
