### PR TITLE
Simple adapter checking

### DIFF
--- a/src/kmp.cpp
+++ b/src/kmp.cpp
@@ -1,0 +1,60 @@
+#include "kmp.hpp"
+
+#include <string>
+#include <iostream>
+
+namespace vg {
+
+// TODO: these functions are very similar, could possibly merge into one?
+ 
+vector<size_t> make_prefix_suffix_table(const char* pattern, size_t len) {
+    
+    vector<size_t> table(len, 0);
+    
+    for (size_t i = 1, j = 0; i < len;) {
+        if (pattern[i] == pattern[j]) {
+            ++j;
+            table[i] = j;
+            ++i;
+        }
+        else {
+            if (j != 0) {
+                j = table[j - 1];
+            }
+            else {
+                table[i] = 0;
+                ++i;
+            }
+        }
+    }
+    
+    return table;
+}
+
+size_t kmp_search(const char* text, size_t text_len,
+                  const char* pattern, size_t pattern_len,
+                  const vector<size_t>& prefix_suffix_table) {
+    if (text_len >= pattern_len) {
+        for (size_t i = 0, j = 0; i < text_len;) {
+            if (text[i] == pattern[j]) {
+                ++i;
+                ++j;
+                if (j == pattern_len) {
+                    return i - pattern_len;
+                }
+            }
+            else {
+                if (j != 0) {
+                    j = prefix_suffix_table[j - 1];
+                }
+                else {
+                    ++i;
+                }
+            }
+        }
+    }
+    return string::npos;
+}
+
+
+}

--- a/src/kmp.cpp
+++ b/src/kmp.cpp
@@ -35,7 +35,7 @@ size_t kmp_search(const char* text, size_t text_len,
                   const char* pattern, size_t pattern_len,
                   const vector<size_t>& prefix_suffix_table) {
     if (text_len >= pattern_len) {
-        for (size_t i = 0, j = 0; i < text_len;) {
+        for (size_t i = 0, j = 0, last = text_len - pattern_len; i - j <= last;) {
             if (text[i] == pattern[j]) {
                 ++i;
                 ++j;

--- a/src/kmp.hpp
+++ b/src/kmp.hpp
@@ -1,0 +1,23 @@
+#ifndef VG_KMP_HPP_INCLUDED
+#define VG_KMP_HPP_INCLUDED
+
+// kmp.hpp: Knuth-Morris-Pratt algorithm
+
+#include <vector>
+
+namespace vg {
+
+using namespace std;
+
+// preprocess search pattern
+vector<size_t> make_prefix_suffix_table(const char* pattern, size_t len);
+
+// return index of first match or string::npos if there is no match
+size_t kmp_search(const char* text, size_t text_len,
+                  const char* pattern, size_t pattern_len,
+                  const vector<size_t>& prefix_suffix_table);
+
+
+}
+
+#endif

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -5,6 +5,11 @@
 #include "multipath_alignment_graph.hpp"
 #include "sequence_complexity.hpp"
 
+#include "structures/rank_pairing_heap.hpp"
+
+#include "algorithms/extract_connecting_graph.hpp"
+#include "algorithms/extract_extending_graph.hpp"
+
 //#define debug_multipath_alignment
 //#define debug_decompose_algorithm
 

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -13,10 +13,7 @@
 #include <unordered_map>
 #include <algorithm>
 
-#include "structures/rank_pairing_heap.hpp"
-
 #include <vg/vg.pb.h>
-#include "vg.hpp"
 #include "snarls.hpp"
 #include "multipath_mapper.hpp"
 

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -12,16 +12,38 @@
 //#define debug_time_phases
 //#define debug_log_splice_align_stats
 //#define debug_output_distance_correlation
-
+//#define debug_check_primers
 
 #ifdef debug_time_phases
 #include <ctime>
 #endif
 
+#ifdef debug_check_primers
+#include "ssw_aligner.hpp"
+#endif
+
 #include "multipath_mapper.hpp"
 
-// include this here to avoid a circular dependency
 #include "multipath_alignment_graph.hpp"
+#include "kmp.hpp"
+#include "hash_map.hpp"
+#include "position.hpp"
+#include "nodeside.hpp"
+#include "path.hpp"
+#include "utility.hpp"
+#include "annotation.hpp"
+#include "statistics.hpp"
+
+#include "identity_overlay.hpp"
+#include "reverse_graph.hpp"
+#include "split_strand_graph.hpp"
+#include "dagified_graph.hpp"
+
+#include "algorithms/extract_containing_graph.hpp"
+#include "algorithms/locally_expand_graph.hpp"
+#include "algorithms/jump_along_path.hpp"
+#include "algorithms/ref_path_distance.hpp"
+#include "algorithms/component.hpp"
 
 namespace vg {
     
@@ -3797,6 +3819,12 @@ namespace vg {
             return false;
         }
         
+#ifdef debug_check_primers
+        bool attempt_1_left = false, attempt_1_right = false, attempt_2_left = false, attempt_2_right = false;
+        bool success_1_left = false, success_1_right = false, success_2_left = false, success_2_right = false;
+        bool primer_1_left = false, primer_1_right = false, primer_2_left = false, primer_2_right = false;
+#endif
+        
         // TODO: it would be better to use likelihoods rather than scores (esp. in paired)
         
         // choose the score cutoff based on the original unspliced mappings
@@ -3836,6 +3864,11 @@ namespace vg {
             cerr << "determining whether to make spliced alignment for pair at index " << current_index[j] << endl;
 #endif
             
+#ifdef debug_check_primers
+            bool attempt_1_left = false, attempt_1_right = false, attempt_2_left = false, attempt_2_right = false;
+            bool success_1_left = false, success_1_right = false, success_2_left = false, success_2_right = false;
+#endif
+            
             for (int read_num = 0; read_num < 2; ) {
                 
                 bool do_read_1 = (read_num == 0);
@@ -3861,6 +3894,16 @@ namespace vg {
                 bool search_left = left_max_score >= min_softclipped_score_for_splice;
                 bool search_right = right_max_score >= min_softclipped_score_for_splice;
                 
+#ifdef debug_check_primers
+                if (do_read_1) {
+                    attempt_1_left |= search_left;
+                    attempt_1_right |= search_right;
+                }
+                else {
+                    attempt_2_left |= search_left;
+                    attempt_2_right |= search_right;
+                }
+#endif
 #ifdef debug_multipath_mapper
                 cerr << "on read " << (do_read_1 ? 1 : 2) << " looking for spliced alignments, to left? " << search_left << ", to right? " << search_right << ", interval " << interval.first << ":" << interval.second << " with max tail scores " << left_max_score << " " << right_max_score << ", and required max score " << min_softclipped_score_for_splice << endl;
 #endif
@@ -3870,6 +3913,32 @@ namespace vg {
                 for (bool do_left : {true, false}) {
                     if ((do_left && !search_left) || (!do_left && !search_right)) {
                         continue;
+                    }
+                    // TODO: magic number
+                    // try to figure out the softclip that we're seeing looks like it could be due to readthrough
+                    // of a primer across the paired reads
+                    static int64_t primer_overlap_slosh = 2;
+                    if (do_read_1 && !do_left && !read_1_primer.empty()) {
+                        size_t begin = max<int64_t>(0, interval.second - primer_overlap_slosh);
+                        size_t pos = kmp_search(aln.sequence().c_str() + begin, aln.sequence().size() - begin,
+                                                read_1_primer.c_str(), read_1_primer.size(), read_1_primer_lps);
+                        if (pos != string::npos && pos < 2 * primer_overlap_slosh) {
+                            // this softclip is bracketed by a known primer sequence, it is much more likely
+                            // that it should be adapter trimmed rather than attempting a spliced alignment
+                            continue;
+                        }
+                    }
+                    if (!do_read_1 && do_left && !read_2_primer.empty()) {
+                        size_t end = min<size_t>(interval.first + primer_overlap_slosh, aln.sequence().size());
+                        // TODO: ideally this would search backwards, but it's not likely that this will ever cause
+                        // a problem since most primers lack long internal repeats
+                        size_t pos = kmp_search(aln.sequence().c_str(), end,
+                                                read_2_primer.c_str(), read_2_primer.size(), read_2_primer_lps);
+                        if (pos != string::npos && pos + read_2_primer.size() + primer_overlap_slosh > interval.first) {
+                            // this softclip is bracketed by a known primer sequence, it is much more likely
+                            // that it should be adapter trimmed rather than attempting a spliced alignment
+                            continue;
+                        }
                     }
                     
                     // select the candidate sources for the corresponding read
@@ -4055,6 +4124,25 @@ namespace vg {
                         pair_multiplicities[current_index[j]] = anchor_multiplicity;
                     }
                     
+#ifdef debug_check_primers
+                    if (do_read_1) {
+                        if (do_left) {
+                            success_1_left |= spliced_side;
+                        }
+                        else {
+                            success_1_right |= spliced_side;
+                        }
+                    }
+                    else {
+                        if (do_left) {
+                            success_2_left |= spliced_side;
+                        }
+                        else {
+                            success_2_right |= spliced_side;
+                        }
+                    }
+#endif
+                    
                     any_splices = any_splices || spliced_side;
                     found_splice_for_anchor = found_splice_for_anchor || spliced_side;
                     
@@ -4072,6 +4160,27 @@ namespace vg {
                     ++read_num;
                 }
             }
+            
+#ifdef debug_check_primers
+            vector<int32_t> primer_aln_scores;
+            vector<string> primers{"AGATCGGAAGAG"}; // the illumina universal adapter
+            primers.push_back(reverse_complement(primers.back()));
+            for (auto mp_aln : {multipath_aln_pairs_out[current_index[j]].first, multipath_aln_pairs_out[current_index[j]].second}) {
+                for (auto primer : primers) {
+                    primer_aln_scores.push_back(SSWAligner().align(mp_aln.sequence(), primer).score());
+                }
+            }
+            string line = (alignment1.name() +
+                           "\t" + to_string(attempt_1_left) + "\t" + to_string(attempt_1_right) +
+                           "\t" + to_string(attempt_2_left) + "\t" + to_string(attempt_2_right) +
+                           "\t" + to_string(success_1_left) + "\t" + to_string(success_1_right) +
+                           "\t" + to_string(success_2_left) + "\t" + to_string(success_2_right));
+            for (auto s : primer_aln_scores) {
+                line += (string("\t") + to_string(s));
+            }
+            line += "\n";
+            cerr << line;
+#endif
         }
         
         if (any_splices) {
@@ -7188,6 +7297,26 @@ namespace vg {
 
     void MultipathMapper::set_max_merge_supression_length() {
         max_tail_merge_supress_length = ceil(double(get_regular_aligner()->match) / double(get_regular_aligner()->mismatch));
+    }
+
+    void MultipathMapper::set_read_1_primer(const string& primer) {
+        // TODO: magic number
+        string trimmed_primer = primer;
+        if (trimmed_primer.size() > 12) {
+            trimmed_primer.resize(12);
+        }
+        read_1_primer = trimmed_primer;
+        read_1_primer_lps = make_prefix_suffix_table(read_1_primer.c_str(), read_1_primer.size());
+    }
+
+    void MultipathMapper::set_read_2_primer(const string& primer) {
+        // TODO: magic number
+        string trimmed_primer = primer;
+        if (trimmed_primer.size() > 12) {
+            trimmed_primer.resize(12);
+        }
+        read_2_primer = reverse_complement(trimmed_primer);
+        read_2_primer_lps = make_prefix_suffix_table(read_2_primer.c_str(), read_2_primer.size());
     }
 
     // make the memos live in this .o file

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -3665,8 +3665,8 @@ namespace vg {
                 if (!do_left && !read_1_adapter.empty()) {
                     size_t begin = max<int64_t>(0, interval.second - adapter_overlap_slosh);
                     size_t end = min<size_t>(begin + read_1_adapter.size() + 2 * adapter_overlap_slosh,
-                                             aln.sequence().size());
-                    size_t pos = kmp_search(aln.sequence().c_str() + begin, end - begin,
+                                             alignment.sequence().size());
+                    size_t pos = kmp_search(alignment.sequence().c_str() + begin, end - begin,
                                             read_1_adapter.c_str(), read_1_adapter.size(),
                                             read_1_adapter_lps);
                     if (pos != string::npos) {

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -106,12 +106,12 @@ namespace vg {
         /// Decide how long of a tail alignment we want before we allow its subpath to be merged
         void set_max_merge_supression_length();
         
-        /// Use primer sequences to help identify soft-clips that should not be splice-aligned, sequences
+        /// Use adapter sequences to help identify soft-clips that should not be splice-aligned, sequences
         /// should be ~12 bp presented in the orientation that a trimmable sequence is found in the
         /// sequencing data (reverse complement to the actual sequence, since it is encountered on the
         /// other read)
-        void set_read_1_primer(const string& primer);
-        void set_read_2_primer(const string& primer);
+        void set_read_1_adapter(const string& adapter);
+        void set_read_2_adapter(const string& adapter);
         
         // parameters
         
@@ -652,10 +652,10 @@ namespace vg {
         vector<MaximalExactMatch> find_mems(const Alignment& alignment,
                                             vector<deque<pair<string::const_iterator, char>>>* mem_fanout_breaks = nullptr);
         
-        string read_1_primer = "";
-        string read_2_primer = "";
-        vector<size_t> read_1_primer_lps;
-        vector<size_t> read_2_primer_lps;
+        string read_1_adapter = "";
+        string read_2_adapter = "";
+        vector<size_t> read_1_adapter_lps;
+        vector<size_t> read_2_adapter_lps;
         
         int64_t min_softclip_length_for_splice = 20;
         int64_t min_softclipped_score_for_splice = 25;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -14,36 +14,16 @@
 #include <vg/io/edit.hpp>
 #include <bdsg/hash_graph.hpp>
 
-#include "hash_map.hpp"
 #include "mapper.hpp"
 #include "aligner.hpp"
 #include "types.hpp"
 #include "multipath_alignment.hpp"
-#include "position.hpp"
-#include "nodeside.hpp"
-#include "path.hpp"
 #include "snarls.hpp"
 #include "haplotypes.hpp"
 #include "min_distance.hpp"
-#include "utility.hpp"
-#include "annotation.hpp"
 #include "path_component_index.hpp"
-#include "memoizing_graph.hpp"
-#include "statistics.hpp"
 #include "splicing.hpp"
-
-#include "identity_overlay.hpp"
-#include "reverse_graph.hpp"
-#include "split_strand_graph.hpp"
-#include "dagified_graph.hpp"
-
-#include "algorithms/extract_containing_graph.hpp"
-#include "algorithms/extract_connecting_graph.hpp"
-#include "algorithms/extract_extending_graph.hpp"
-#include "algorithms/locally_expand_graph.hpp"
-#include "algorithms/jump_along_path.hpp"
-#include "algorithms/ref_path_distance.hpp"
-#include "algorithms/component.hpp"
+#include "memoizing_graph.hpp"
 
 
 // note: only activated for single end mapping
@@ -125,6 +105,13 @@ namespace vg {
         
         /// Decide how long of a tail alignment we want before we allow its subpath to be merged
         void set_max_merge_supression_length();
+        
+        /// Use primer sequences to help identify soft-clips that should not be splice-aligned, sequences
+        /// should be ~12 bp presented in the orientation that a trimmable sequence is found in the
+        /// sequencing data (reverse complement to the actual sequence, since it is encountered on the
+        /// other read)
+        void set_read_1_primer(const string& primer);
+        void set_read_2_primer(const string& primer);
         
         // parameters
         
@@ -665,6 +652,10 @@ namespace vg {
         vector<MaximalExactMatch> find_mems(const Alignment& alignment,
                                             vector<deque<pair<string::const_iterator, char>>>* mem_fanout_breaks = nullptr);
         
+        string read_1_primer = "";
+        string read_2_primer = "";
+        vector<size_t> read_1_primer_lps;
+        vector<size_t> read_2_primer_lps;
         
         int64_t min_softclip_length_for_splice = 20;
         int64_t min_softclipped_score_for_splice = 25;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -14,6 +14,7 @@
 #include "subcommand.hpp"
 
 #include <vg/io/vpkg.hpp>
+#include "../algorithms/component.hpp"
 #include "../multipath_mapper.hpp"
 #include "../mem_accelerator.hpp"
 #include "../surjector.hpp"
@@ -349,6 +350,11 @@ int main_mpmap(int argc, char** argv) {
     double splice_rescue_graph_std_devs = 3.0;
     bool override_spliced_alignment = false;
     int max_motif_pairs = 200;
+    // the TruSeq primers, which seem to be what mostly gets used for RNA-seq
+    // (this info is only used during spliced alignment, so that should be all
+    // that matters)
+    string read_1_primer = "AGATCGGAAGAG";
+    string read_2_primer = "AGATCGGAAGAG";
     int match_score_arg = std::numeric_limits<int>::min();
     int mismatch_score_arg = std::numeric_limits<int>::min();
     int gap_open_score_arg = std::numeric_limits<int>::min();
@@ -1991,6 +1997,8 @@ int main_mpmap(int argc, char** argv) {
     if (!intron_distr_name.empty()) {
         multipath_mapper.set_intron_length_distribution(intron_mixture_weights, intron_component_params);
     }
+    multipath_mapper.set_read_1_primer(read_1_primer);
+    multipath_mapper.set_read_2_primer(read_2_primer);
 
 #ifdef mpmap_instrument_mem_statistics
     multipath_mapper._mem_stats.open(MEM_STATS_FILE);

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -350,11 +350,11 @@ int main_mpmap(int argc, char** argv) {
     double splice_rescue_graph_std_devs = 3.0;
     bool override_spliced_alignment = false;
     int max_motif_pairs = 200;
-    // the TruSeq primers, which seem to be what mostly gets used for RNA-seq
+    // the TruSeq adapters, which seem to be what mostly gets used for RNA-seq
     // (this info is only used during spliced alignment, so that should be all
     // that matters)
-    string read_1_primer = "AGATCGGAAGAG";
-    string read_2_primer = "AGATCGGAAGAG";
+    string read_1_adapter = "AGATCGGAAGAG";
+    string read_2_adapter = "AGATCGGAAGAG";
     int match_score_arg = std::numeric_limits<int>::min();
     int mismatch_score_arg = std::numeric_limits<int>::min();
     int gap_open_score_arg = std::numeric_limits<int>::min();
@@ -1997,8 +1997,8 @@ int main_mpmap(int argc, char** argv) {
     if (!intron_distr_name.empty()) {
         multipath_mapper.set_intron_length_distribution(intron_mixture_weights, intron_component_params);
     }
-    multipath_mapper.set_read_1_primer(read_1_primer);
-    multipath_mapper.set_read_2_primer(read_2_primer);
+    multipath_mapper.set_read_1_adapter(read_1_adapter);
+    multipath_mapper.set_read_2_adapter(read_2_adapter);
 
 #ifdef mpmap_instrument_mem_statistics
     multipath_mapper._mem_stats.open(MEM_STATS_FILE);

--- a/src/unittest/kmp.cpp
+++ b/src/unittest/kmp.cpp
@@ -1,0 +1,51 @@
+/// \file annotation.cpp
+///  
+/// Unit tests for the annotations system on Alignments and MultipathAlignments
+///
+
+#include <iostream>
+#include <string>
+#include "../kmp.hpp"
+#include "../utility.hpp"
+#include "catch.hpp"
+
+
+namespace vg {
+namespace unittest {
+using namespace std;
+
+TEST_CASE("Knuth-Morris-Pratt implementation produces correct results", "[kmp]") {
+    
+    // examples taken from https://www.youtube.com/watch?v=4jY57Ehc14Y
+    vector<pair<string, string>> searches;
+    searches.emplace_back("ONIONIONSPL", "ONIONS");
+    searches.emplace_back("QABCGABCABCD", "ABCD");
+    searches.emplace_back("AAAAAAAAD", "AAAD");
+    searches.emplace_back("TRAILTRAIN", "TRAIN");
+    searches.emplace_back("ABCABC", "XYZ");
+    searches.emplace_back("AABAAAC", "AAB");
+    searches.emplace_back("AABAAAC", "AAC");
+    for (size_t i = 0; i < 100; ++i) {
+        searches.emplace_back(pseudo_random_sequence(20, i),
+                              pseudo_random_sequence(5, 230897 * i + 98712));
+        searches.emplace_back(searches.back().first, searches.back().first.substr(6, 10));
+    }
+    
+    for (auto& search : searches) {
+        
+        string text, pattern;
+        tie(text, pattern) = search;
+        
+        auto table = make_prefix_suffix_table(pattern.c_str(), pattern.size());
+        size_t result = kmp_search(text.c_str(), text.size(),
+                                   pattern.c_str(), pattern.size(),
+                                   table);
+        
+        REQUIRE(result == text.find(pattern));
+    }
+    
+}
+   
+}
+}
+        


### PR DESCRIPTION
## Description

I figured out that `mpmap`'s spliced alignment routine could get significantly bogged down by adapter sequences since they cause the same alignment features that it looks for in order to trigger a spliced alignment: a moderately long soft clip of high-quality bases. It seems that just about everyone uses the same adapters for Illumina RNA-seq these days, so I was able to speed up the algorithm by about 10% by just checking for that sequence right at the putative splice junction.