### PR TITLE
Annotate thoroughly

### DIFF
--- a/src/algorithms/alignment_path_offsets.hpp
+++ b/src/algorithms/alignment_path_offsets.hpp
@@ -19,20 +19,28 @@ using namespace std;
 /// with nearby set if it is not set on initial call and no positions are
 /// found. Respects search_limit in bp in that case. If search_limit is 0, read
 /// length is used.
+///
+/// If path_filter is set, and it returns false for a path, that path is not
+/// used to annotate the read.
 unordered_map<path_handle_t, vector<pair<size_t, bool> > >
 alignment_path_offsets(const PathPositionHandleGraph& graph,
                        const Alignment& aln,
                        bool just_min,
                        bool nearby,
-                       size_t search_limit = 0);
+                       size_t search_limit = 0,
+                       const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
 
 /// Find the position of a multipath alignment on paths. Returns the lowest offset
 /// position on a path for each contiguous stretch of the multipath alignment, but
 /// multiple positions on the same path may be returned if the multipath alignment
 /// is disconnected or fans out toward the sources or sinks.
+///
+/// If path_filter is set, and it returns false for a path, that path is not
+/// used to annotate the read.
 unordered_map<path_handle_t, vector<pair<size_t, bool> > >
 multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
-                                 const multipath_alignment_t& mp_aln);
+                                 const multipath_alignment_t& mp_aln,
+                                 const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
 
 /// Use the graph to annotate an Alignment with the first
 /// position it touches on each reference path. Thread safe.
@@ -40,7 +48,10 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
 /// search_limit gives the maximum distance to search for a path if the
 /// alignment does not actually touch any paths. If 0, the alignment's
 /// sequence length is used.
-void annotate_with_initial_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, size_t search_limit = 0);
+///
+/// If path_filter is set, and it returns false for a path, that path is not
+/// used to annotate the read.
+void annotate_with_initial_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, size_t search_limit = 0, const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
 
 /// Use the graph to annotate an Alignment with the first
 /// position it touches on each node it visits in each reference path. Thread
@@ -50,7 +61,10 @@ void annotate_with_initial_path_positions(const PathPositionHandleGraph& graph, 
 /// search_limit gives the maximum distance to search for a path if the
 /// alignment does not actually touch any paths. If 0, the alignment's
 /// sequence length is used.
-void annotate_with_node_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, size_t search_limit = 0);
+///
+/// If path_filter is set, and it returns false for a path, that path is not
+/// used to annotate the read.
+void annotate_with_node_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, size_t search_limit = 0, const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
 
 /// Use the graph to annotate an Alignment with positions on each reference
 /// path. Thread safe.
@@ -59,7 +73,10 @@ void annotate_with_node_path_positions(const PathPositionHandleGraph& graph, Ali
 /// all Mapping start positions on each path. If no positions on the path are
 /// found, looks for nearby path positions in graph space. Respects
 /// search_limit in bp in that case. If search_limit is 0, read length is used.
-void annotate_with_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, bool just_min, size_t search_limit = 0);
+///
+/// If path_filter is set, and it returns false for a path, that path is not
+/// used to annotate the read.
+void annotate_with_path_positions(const PathPositionHandleGraph& graph, Alignment& aln, bool just_min, size_t search_limit = 0, const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
 
 /// Use the graph annotate Alignments with the first position
 /// they touch on each reference path. Thread safe.
@@ -67,7 +84,10 @@ void annotate_with_path_positions(const PathPositionHandleGraph& graph, Alignmen
 /// search_limit gives the maximum distance to search for a path if the
 /// alignment does not actually touch any paths. If 0, the alignment's
 /// sequence length is used.
-void annotate_with_initial_path_positions(const PathPositionHandleGraph& graph, vector<Alignment>& aln, size_t search_limit = 0);
+///
+/// If path_filter is set, and it returns false for a path, that path is not
+/// used to annotate the read.
+void annotate_with_initial_path_positions(const PathPositionHandleGraph& graph, vector<Alignment>& aln, size_t search_limit = 0, const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
 
 
 }

--- a/src/algorithms/nearest_offsets_in_paths.cpp
+++ b/src/algorithms/nearest_offsets_in_paths.cpp
@@ -15,7 +15,8 @@ using namespace std;
 
 unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
                                                                                   const pos_t& pos,
-                                                                                  int64_t max_search) {
+                                                                                  int64_t max_search,
+                                                                                  const std::function<bool(const path_handle_t&)>* path_filter) {
     
     // init the return value
     unordered_map<path_handle_t, vector<pair<size_t, bool>>> return_val;
@@ -49,6 +50,16 @@ unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_path
 #ifdef debug
             cerr << "handle is on step at path offset " << graph->get_position_of_step(step) << endl;
 #endif
+
+            path_handle_t path_handle = graph->get_path_handle_of_step(step);
+
+            if (path_filter && !(*path_filter)(path_handle)) {
+                // We are to ignore this path
+#ifdef debug
+                cerr << "handle is on ignored path " << graph->get_name(path_handle) << endl;
+#endif
+                continue;
+            }
             
             // flip the handle back to the orientation it started in
             handle_t oriented = search_left ? graph->flip(here) : here;
@@ -69,8 +80,6 @@ unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_path
 #ifdef debug
             cerr << "after adding search distance and node offset, " << path_offset << " on strand " << rev_on_path << endl;
 #endif
-            
-            path_handle_t path_handle = graph->get_path_handle_of_step(step);
             
             // handle possible under/overflow from the search distance
             path_offset = max<int64_t>(min<int64_t>(path_offset, graph->get_path_length(path_handle)), 0);

--- a/src/algorithms/nearest_offsets_in_paths.hpp
+++ b/src/algorithms/nearest_offsets_in_paths.hpp
@@ -26,8 +26,12 @@ using namespace std;
 /// Return, for the nearest position in a path to the given position,
 /// subject to the given max search distance, a mapping from path name to
 /// all positions on each path where that pos_t occurs.
+/// Stops search when path(s) are ancountered.
+///
+/// If path_filter is set, ignores paths for which it returns false.
 unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
-                                                                                  const pos_t& pos, int64_t max_search);
+                                                                                  const pos_t& pos, int64_t max_search,
+                                                                                  const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
     
 /// Wrapper for the above to support some earlier code. Only looks for paths
 /// that directly touch the position, and returns the paths by name.

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -19,9 +19,9 @@ void AbstractReadSampler::annotate_with_path_positions(Alignment& aln) {
     // We need to annotate the alignment with the right kind of path positions
     // that we are configured for.
     if (multi_position_annotations) {
-        algorithms::annotate_with_node_path_positions(graph, aln);
+        algorithms::annotate_with_node_path_positions(graph, aln, 0, annotation_path_filter.get());
     } else {
-        algorithms::annotate_with_initial_path_positions(graph, aln);
+        algorithms::annotate_with_initial_path_positions(graph, aln, 0, annotation_path_filter.get());
     }
 }
 

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -15,6 +15,15 @@ using namespace vg::io;
 
 namespace vg {
 
+void AbstractReadSampler::annotate_with_path_positions(Alignment& aln) {
+    // We need to annotate the alignment with the right kind of path positions
+    // that we are configured for.
+    if (multi_position_annotations) {
+        algorithms::annotate_with_node_path_positions(graph, aln);
+    } else {
+        algorithms::annotate_with_initial_path_positions(graph, aln);
+    }
+}
 
 void Sampler::set_source_paths(const vector<string>& source_paths,
                                const vector<double>& source_path_ploidies,
@@ -39,7 +48,7 @@ void Sampler::set_source_paths(const vector<string>& source_paths,
         if (haplotype_transcripts.empty()) {
             for (const pair<string, double>& transcript_expression : transcript_expressions) {
                 this->source_paths.push_back(transcript_expression.first);
-                size_t tx_len = xgidx->get_path_length(xgidx->get_path_handle(transcript_expression.first));
+                size_t tx_len = graph.get_path_length(graph.get_path_handle(transcript_expression.first));
                 expression_values.push_back(transcript_expression.second * tx_len);
             }
         }
@@ -55,7 +64,7 @@ void Sampler::set_source_paths(const vector<string>& source_paths,
                 }
                 for (size_t i : haplotypes_of_transcript[transcript_expression.first]) {
                     double haplotype_expression = (transcript_expression.second * get<2>(haplotype_transcripts[i])) / total_haplotypes;
-                    size_t hp_tx_len = xgidx->get_path_length(xgidx->get_path_handle(get<0>(haplotype_transcripts[i])));
+                    size_t hp_tx_len = graph.get_path_length(graph.get_path_handle(get<0>(haplotype_transcripts[i])));
                     expression_values.push_back(haplotype_expression * hp_tx_len);
                     this->source_paths.push_back(get<0>(haplotype_transcripts[i]));
                 }
@@ -74,7 +83,7 @@ void Sampler::set_source_paths(const vector<string>& source_paths,
             double ploidy = i >= source_path_ploidies.size() ? 1.0 : source_path_ploidies[i];
             
             // Add each path, weighted by ploidy and length, to the distribution for sampling paths
-            path_weights.push_back(ploidy * xgidx->get_path_length(xgidx->get_path_handle(source_path)));
+            path_weights.push_back(ploidy * graph.get_path_length(graph.get_path_handle(source_path)));
         }
         path_sampler = vg::discrete_distribution<>(path_weights.begin(), path_weights.end());
     }
@@ -86,21 +95,21 @@ void Sampler::set_source_paths(const vector<string>& source_paths,
 
 /// We have a helper function to convert path positions and orientations to
 /// pos_t values.
-pos_t position_at(PathPositionHandleGraph* xgidx, const string& path_name, const size_t& path_offset, bool is_reverse) {
-    path_handle_t path_handle = xgidx->get_path_handle(path_name);
-    step_handle_t step = xgidx->get_step_at_position(path_handle, path_offset);
-    handle_t handle = xgidx->get_handle_of_step(step);
+pos_t position_at(PathPositionHandleGraph* graph_ptr, const string& path_name, const size_t& path_offset, bool is_reverse) {
+    path_handle_t path_handle = graph_ptr->get_path_handle(path_name);
+    step_handle_t step = graph_ptr->get_step_at_position(path_handle, path_offset);
+    handle_t handle = graph_ptr->get_handle_of_step(step);
     
     // Work out where in that mapping we should be.
-    size_t node_offset = path_offset - xgidx->get_position_of_step(step);
+    size_t node_offset = path_offset - graph_ptr->get_position_of_step(step);
 
     if (is_reverse) {
         // Flip the node offset around to be from the end and not the start
-        node_offset = xgidx->get_length(handle) - node_offset - 1;
+        node_offset = graph_ptr->get_length(handle) - node_offset - 1;
     }
 
     // Make a pos_t for where we are, on the appropriate strand
-    pos_t pos = make_pos_t(xgidx->get_id(handle), xgidx->get_is_reverse(handle) != is_reverse, node_offset);
+    pos_t pos = make_pos_t(graph_ptr->get_id(handle), graph_ptr->get_is_reverse(handle) != is_reverse, node_offset);
     
     return pos;
 }
@@ -109,11 +118,11 @@ pos_t Sampler::position(void) {
     // We sample from the entire graph sequence, 1-based.
     vg::uniform_int_distribution<size_t> xdist(1, total_seq_length);
     size_t offset = xdist(rng);
-    id_t id = dynamic_cast<VectorizableHandleGraph*>(xgidx)->node_at_vector_offset(offset);
+    id_t id = dynamic_cast<VectorizableHandleGraph*>(&graph)->node_at_vector_offset(offset);
     vg::uniform_int_distribution<size_t> flip(0, 1);
     bool rev = forward_only ? false : flip(rng);
     // 1-0 base conversion
-    size_t node_offset = offset - dynamic_cast<VectorizableHandleGraph*>(xgidx)->node_vector_offset(id) - 1;
+    size_t node_offset = offset - dynamic_cast<VectorizableHandleGraph*>(&graph)->node_vector_offset(id) - 1;
     // Ignore flipping the node offset because we're uniform over both strands
     return make_pos_t(id, rev, node_offset);
 }
@@ -347,12 +356,12 @@ Alignment Sampler::mutate(const Alignment& aln,
     mutaln.set_sequence(alignment_seq(mutaln));
     mutaln.set_name(aln.name());
     mutaln.clear_refpos();
-    algorithms::annotate_with_initial_path_positions(*xgidx, mutaln);
+    annotate_with_path_positions(mutaln);
     return mutaln;
 }
 
 string Sampler::alignment_seq(const Alignment& aln) {
-    return algorithms::path_string(*xgidx, aln.path());
+    return algorithms::path_string(graph, aln.path());
 }
 
 vector<Alignment> Sampler::alignment_pair(size_t read_length, size_t fragment_length, double fragment_std_dev, double base_error, double indel_error) {
@@ -401,8 +410,8 @@ Alignment Sampler::alignment(size_t length) {
 Alignment Sampler::alignment_to_path(const string& source_path, size_t length) {
 
     // Pick a starting point along the path and an orientation
-    path_handle_t path_handle = xgidx->get_path_handle(source_path);
-    uint64_t path_length = xgidx->get_path_length(path_handle);
+    path_handle_t path_handle = graph.get_path_handle(source_path);
+    uint64_t path_length = graph.get_path_length(path_handle);
     vg::uniform_int_distribution<size_t> xdist(0, path_length - 1);
     size_t path_offset = xdist(rng);
     vg::uniform_int_distribution<size_t> flip(0, 1);
@@ -417,7 +426,7 @@ Alignment Sampler::alignment_to_path(const string& source_path, size_t length) {
     while (seq.size() < length) {
 
         // Make a pos_t for where we are, on the appropriate strand
-        pos_t pos = position_at(xgidx, source_path, path_offset, rev);
+        pos_t pos = position_at(&graph, source_path, path_offset, rev);
 
         // Add that character to the sequence
         seq.push_back(pos_char(pos));
@@ -463,7 +472,7 @@ Alignment Sampler::alignment_to_path(const string& source_path, size_t length) {
     // And set its identity
     aln.set_identity(identity(aln.path()));
     aln.clear_refpos();
-    algorithms::annotate_with_initial_path_positions(*xgidx, aln);
+    annotate_with_path_positions(aln);
     return aln;
 }
 
@@ -515,7 +524,7 @@ Alignment Sampler::alignment_to_graph(size_t length) {
     }
     // And set its identity
     aln.set_identity(identity(aln.path()));
-    algorithms::annotate_with_initial_path_positions(*xgidx, aln);
+    annotate_with_path_positions(aln);
     return aln;
 }
 
@@ -558,20 +567,20 @@ Alignment Sampler::alignment_with_error(size_t length,
     
     // Check the alignment to make sure we didn't mess it up
     assert(is_valid(aln));
-    algorithms::annotate_with_initial_path_positions(*xgidx, aln);
+    annotate_with_path_positions(aln);
     return aln;
 }
 
 size_t Sampler::node_length(id_t id) {
-    return xgidx->get_length(xgidx->get_handle(id));
+    return graph.get_length(graph.get_handle(id));
 }
 
 char Sampler::pos_char(pos_t pos) {
-    return xgidx->get_base(xgidx->get_handle(id(pos), is_rev(pos)), offset(pos));
+    return graph.get_base(graph.get_handle(id(pos), is_rev(pos)), offset(pos));
 }
 
 map<pos_t, char> Sampler::next_pos_chars(pos_t pos) {
-    return algorithms::next_pos_chars(*xgidx, pos);
+    return algorithms::next_pos_chars(graph, pos);
 }
 
 bool Sampler::is_valid(const Alignment& aln) {
@@ -587,7 +596,7 @@ bool Sampler::is_valid(const Alignment& aln) {
         auto accounted_bases = observed_from + mapping.position().offset();
         
         // How many bases need to be accounted for?
-        auto expected_bases = xgidx->get_length(xgidx->get_handle(mapping.position().node_id()));
+        auto expected_bases = graph.get_length(graph.get_handle(mapping.position().node_id()));
         
         if (accounted_bases != expected_bases) {
             cerr << "[vg::Sampler] Warning: alignment mapping " << i << " accounts for "
@@ -623,7 +632,7 @@ NGSSimulator::NGSSimulator(PathPositionHandleGraph& graph,
                            bool retry_on_Ns,
                            bool sample_unsheared_paths,
                            uint64_t manual_seed) :
-      graph(graph)
+      AbstractReadSampler(graph)
     , sub_poly_rate(substition_polymorphism_rate)
     , indel_poly_rate(indel_polymorphism_rate)
     , indel_error_prop(indel_error_proportion)
@@ -978,7 +987,7 @@ Alignment NGSSimulator::sample_read() {
     // mask out any of the sequence that we sampled to be an 'N'
     apply_N_mask(*aln.mutable_sequence(), qual_and_masks.second);
     
-    algorithms::annotate_with_initial_path_positions(graph, aln);
+    annotate_with_path_positions(aln);
     
     register_sampled_position(aln, source_path, sampled_offset + sampled_is_reverse, sampled_is_reverse);
     return aln;
@@ -1156,8 +1165,8 @@ pair<Alignment, Alignment> NGSSimulator::sample_read_pair() {
     apply_N_mask(*aln_pair.first.mutable_sequence(), qual_and_mask_pair.first.second);
     apply_N_mask(*aln_pair.second.mutable_sequence(), qual_and_mask_pair.second.second);
         
-    algorithms::annotate_with_initial_path_positions(graph, aln_pair.first);
-    algorithms::annotate_with_initial_path_positions(graph, aln_pair.second);
+    annotate_with_path_positions(aln_pair.first);
+    annotate_with_path_positions(aln_pair.second);
     
     // take back the final base that we sampled
     register_sampled_position(aln_pair.first, source_path, sampled_offset + sampled_is_reverse, sampled_is_reverse);

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -23,17 +23,59 @@ using namespace std;
 /// orientations, into pos_ts. Remember that pos_t counts offset from the start
 /// of the reoriented node, while here we count offset from the beginning of the
 /// forward version of the path.
-pos_t position_at(PathPositionHandleGraph* xgidx, const string& path_name, const size_t& path_offset, bool is_reverse);
+pos_t position_at(PathPositionHandleGraph* graph_ptr, const string& path_name, const size_t& path_offset, bool is_reverse);
+
+/**
+ * Interface for shared functionality for things that sample reads.
+ */
+class AbstractReadSampler {
+public:
+    virtual ~AbstractReadSampler() = default;
+    
+    /// Make a new sampler using the given graph.
+    inline AbstractReadSampler(PathPositionHandleGraph& graph) :
+        graph(graph) {
+        // Graph must be vectorizable for our implementations to be able to
+        // sample positions.
+        if (!dynamic_cast<VectorizableHandleGraph*>(&graph)) {
+            throw std::logic_error("Graph is expected to be vectorizable!");
+        }
+    }
+    
+    // TODO: Add a real sampling interface when one can be factored out!
+    
+    ///////////
+    // Control fields
+    ///////////
+    
+    /// If true, annotate alignments with multiple positions along reference
+    /// paths. If false, annotate them with minimum visited positions along
+    /// reference paths.
+    bool multi_position_annotations = false;
+    
+    // TODO: Move more common fields out here. Make Sampler store at least a
+    // default error rate, etc. for the common sampling interface.
+    
+protected:
+   
+    /// The graph being simulated against.
+    PathPositionHandleGraph& graph;
+   
+    /// Annotate the given alignment with the appropriate type of path
+    /// positions.
+    void annotate_with_path_positions(Alignment& aln);
+};
+ 
+
 
 /**
  * Generate Alignments (with or without mutations, and in pairs or alone) from
  * an PathPositionHandleGraph index.
  */
-class Sampler {
+class Sampler: public AbstractReadSampler {
 
 public:
 
-    PathPositionHandleGraph* xgidx;
     // We need this so we don't re-load the node for every character we visit in
     // it.
     LRUCache<id_t, Node> node_cache;
@@ -62,7 +104,7 @@ public:
             const vector<double>& source_path_ploidies = {},
             const vector<pair<string, double>>& transcript_expressions = {},
             const vector<tuple<string, string, size_t>>& haplotype_transcripts = {})
-        : xgidx(x),
+        : AbstractReadSampler(*x),
           node_cache(100),
           edge_cache(100),
           forward_only(forward_only),
@@ -70,8 +112,8 @@ public:
           nonce(0),
           source_paths(source_paths) {
         // sum seq lengths
-        xgidx->for_each_handle([&](const handle_t& handle) {
-            total_seq_length += xgidx->get_length(handle);
+        graph.for_each_handle([&](const handle_t& handle) {
+            total_seq_length += graph.get_length(handle);
         });
         if (!seed) {
             seed = time(NULL);
@@ -79,6 +121,10 @@ public:
         rng.seed(seed);
         set_source_paths(source_paths, source_path_ploidies, transcript_expressions, haplotype_transcripts);
     }
+    
+    // AbstractReadSampler interface
+    Alignment sample_read();
+    pair<Alignment, Alignment> sample_read_pair();
 
     /// Make a path sampling distribution based on relative lengths (weighted
     /// by ploidy) or on transcript expressions. (At most one of source_paths and
@@ -112,6 +158,7 @@ public:
                                      double fragment_std_dev,
                                      double base_error,
                                      double indel_error);
+                                     
     size_t node_length(id_t id);
     char pos_char(pos_t pos);
     map<pos_t, char> next_pos_chars(pos_t pos);
@@ -148,7 +195,7 @@ public:
  * Class that simulates reads with alignments to a graph that mimic the error
  * profile of NGS sequencing data.
  */
-class NGSSimulator {
+class NGSSimulator : public AbstractReadSampler {
 public:
     /// Initialize simulator. FASTQ file will be used to train an error distribution.
     /// Most reads in the FASTQ should be the same length. Polymorphism rates apply
@@ -309,8 +356,6 @@ private:
     vector<MarkovDistribution<pair<uint8_t, bool>, pair<uint8_t, bool>>> transition_distrs_2;
     /// A distribution for the joint initial qualities of a read pair
     MarkovDistribution<pair<uint8_t, bool>, pair<pair<uint8_t, bool>, pair<uint8_t, bool>>> joint_initial_distr;
-    
-    PathPositionHandleGraph& graph;
     
     vector<mt19937_64> prngs;
     vg::discrete_distribution<> path_sampler;

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -53,6 +53,10 @@ public:
     /// reference paths.
     bool multi_position_annotations = false;
     
+    /// Set to a filter function that returns true if a given path in the graph
+    /// is allowed to be used as an annotation path.
+    std::unique_ptr<std::function<bool(const path_handle_t&)>> annotation_path_filter; 
+    
     // TODO: Move more common fields out here. Make Sampler store at least a
     // default error rate, etc. for the common sampling interface.
     

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -600,8 +600,14 @@ int main_sim(int argc, char** argv) {
         }
     }
     
-    unique_ptr<AlignmentEmitter> alignment_emitter = get_non_hts_alignment_emitter("-", json_out ? "JSON" : "GAM",
-                                                                                       map<string, int64_t>(), get_thread_count()); 
+    unique_ptr<AlignmentEmitter> alignment_emitter;
+    if (align_out) {
+        // We're writing in an alignment format
+        alignment_emitter = get_non_hts_alignment_emitter("-", json_out ? "JSON" : "GAM",
+                                                          map<string, int64_t>(), get_thread_count());
+    }
+    // Otherwise we're just dumping sequence strings; leave it null.
+    
     if (progress) {
         std::cerr << "Simulating " << (fragment_length > 0 ? "read pairs" : "reads") << std::endl;
         std::cerr << "--num-reads " << num_reads << std::endl;

--- a/test/t/13_vg_sim.t
+++ b/test/t/13_vg_sim.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 34
+plan tests 36
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 vg construct -r small/x.fa -v small/x.vcf.gz -a >x2.vg
@@ -63,26 +63,33 @@ vg index -G xy.gbwt -v small/x.vcf.gz xy.vg
 vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 --any-path >/dev/null
 is $? "0" "Sample simulation works along with --any-path"
 
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex y:0 | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "not having any regexes skips all unvisited contigs"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex candyfloss:12345 | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l | awk '{print ($0>450&&$0<550)?1:0}')" "1" "assigning a ploidy of 2 by default gives reads in a ~1-1 ratio vs. diploid covered contigs"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex y:1 | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l | awk '{print ($0>620&&$0<720)?1:0}')" "1" "assigning a ploidy of 1 by regex gives reads in a ~1-2 ratio vs. diploid covered contigs"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex y:0 | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "assigning a ploidy of 0 by regex excludes reads from that contig"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex a:5,b:10,y:0,c:6 | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "multiple regexes are interpreted"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex "[^x]:0" | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "regexes are interpreted as regexes"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex y:1E20 | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "y")' | wc -l)" "1000" "assigning a very high ploidy by regex starves out the other paths"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex y:0 | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "not having any regexes skips all unvisited contigs"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex candyfloss:12345 | jq -c 'select(.refpos[].name == "x")' | wc -l | awk '{print ($0>450&&$0<550)?1:0}')" "1" "assigning a ploidy of 2 by default gives reads in a ~1-1 ratio vs. diploid covered contigs"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex y:1 | jq -c 'select(.refpos[].name == "x")' | wc -l | awk '{print ($0>620&&$0<720)?1:0}')" "1" "assigning a ploidy of 1 by regex gives reads in a ~1-2 ratio vs. diploid covered contigs"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex y:0 | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "assigning a ploidy of 0 by regex excludes reads from that contig"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex a:5,b:10,y:0,c:6 | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "multiple regexes are interpreted"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex "[^x]:0" | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "regexes are interpreted as regexes"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex y:1E20 | jq -c 'select(.refpos[].name == "y")' | wc -l)" "1000" "assigning a very high ploidy by regex starves out the other paths"
 
 vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 --any-path -F minigiab/NA12878.chr22.tiny.fq.gz >/dev/null
 is $? "0" "Sample simulation works along with --any-path with training FASTQ"
 
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex y:0 -F minigiab/NA12878.chr22.tiny.fq.gz | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "not having any regexes skips all unvisited contigs with training FASTQ"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex candyfloss:12345 -F minigiab/NA12878.chr22.tiny.fq.gz | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l | awk '{print ($0>450&&$0<550)?1:0}')" "1" "assigning a ploidy of 2 by default gives reads in a ~1-1 ratio vs. diploid covered contigs with training FASTQ"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex y:1 -F minigiab/NA12878.chr22.tiny.fq.gz | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l | awk '{print ($0>620&&$0<720)?1:0}')" "1" "assigning a ploidy of 1 by regex gives reads in a ~1-2 ratio vs. diploid covered contigs with training FASTQ"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex y:0 -F minigiab/NA12878.chr22.tiny.fq.gz | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "assigning a ploidy of 0 by regex excludes reads from that contig with training FASTQ"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex a:5,b:10,y:0,c:6 -F minigiab/NA12878.chr22.tiny.fq.gz | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "multiple regexes are interpreted with training FASTQ"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex "[^x]:0" -F minigiab/NA12878.chr22.tiny.fq.gz | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "regexes are interpreted as regexes with training FASTQ"
-is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -a --ploidy-regex y:1E20 -F minigiab/NA12878.chr22.tiny.fq.gz | vg annotate -p -x xy.xg -a - | vg view -aj - | jq -c 'select(.refpos[].name == "y")' | wc -l)" "1000" "assigning a very high ploidy by regex starves out the other paths with training FASTQ"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex y:0 -F minigiab/NA12878.chr22.tiny.fq.gz | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "not having any regexes skips all unvisited contigs with training FASTQ"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex candyfloss:12345 -F minigiab/NA12878.chr22.tiny.fq.gz | jq -c 'select(.refpos[].name == "x")' | wc -l | awk '{print ($0>450&&$0<550)?1:0}')" "1" "assigning a ploidy of 2 by default gives reads in a ~1-1 ratio vs. diploid covered contigs with training FASTQ"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex y:1 -F minigiab/NA12878.chr22.tiny.fq.gz | jq -c 'select(.refpos[].name == "x")' | wc -l | awk '{print ($0>620&&$0<720)?1:0}')" "1" "assigning a ploidy of 1 by regex gives reads in a ~1-2 ratio vs. diploid covered contigs with training FASTQ"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex y:0 -F minigiab/NA12878.chr22.tiny.fq.gz | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "assigning a ploidy of 0 by regex excludes reads from that contig with training FASTQ"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex a:5,b:10,y:0,c:6 -F minigiab/NA12878.chr22.tiny.fq.gz | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "multiple regexes are interpreted with training FASTQ"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex "[^x]:0" -F minigiab/NA12878.chr22.tiny.fq.gz | jq -c 'select(.refpos[].name == "x")' | wc -l)" "1000" "regexes are interpreted as regexes with training FASTQ"
+is "$(vg sim -s 12345 -n 1000 -l 2 -e 0.1 -x xy.xg -g xy.gbwt --sample-name 1 -aJ --ploidy-regex y:1E20 -F minigiab/NA12878.chr22.tiny.fq.gz | jq -c 'select(.refpos[].name == "y")' | wc -l)" "1000" "assigning a very high ploidy by regex starves out the other paths with training FASTQ"
 
 rm -f xy.vg xy.xg xy.gbwt
+
+vg construct -r small/x.fa -v small/x.vcf.gz -a >x.vg
+vg index -x x.xg x.vg
+is "$(vg sim -s 12345 -n 1000 -l 64 -e 0.1 -x x.xg -aJ | jq -c 'select(.refpos | length == 1)' | wc -l)" "1000" "All reads are annotated with single reference positions by default"
+is "$(vg sim -s 12345 -n 1000 -l 64 -e 0.1 -x x.xg -aJ --multi-position | jq -c 'select(.refpos | length > 1)' | wc -l)" "1000" "All reads can be annotated with multiple reference positions when requested"
+
+rm -f x.vg x.xg
 
 vg view -Fv graphs/cactus-BRCA2.gfa >cactus-BRCA2.vg
 vg index -x cactus-BRCA2.xg cactus-BRCA2.vg


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg sim` no longer annotates reads with positions along synthesized haplotype paths
 * `vg sim` supports the `--multi-position` option of `vg annotate`, for annotating simulated reads with path positions per node.

## Description

This adjusts `vg sim` to use read true position annotations that might work a bit better for long reads. If you use `--multi-position`, it will report multiple positions on each path, one per node, instead of just taking the minimal position along each encountered path.

It's not guaranteed to reach every path from every node, but it should give a more representative view of where long reads fall, rather than just a single point from one end.

Then minimizer correctness in `vg giraffe` and GAM position comparison in `vg gamcompare` only have to look out to about the length of a node, rather than the whole length of the read, to determine if two things are close in path space.

Note that comparing multi-position-annotated GAMs with each other is going to be quadradic right now, until `vg gamcompare`'s algorithm is changed to do some sorting.

I also noticed that `vg sim` was emitting annotations using the names of synthesized haplotype paths, and that these would sometimes prevent annotations on the graph's real stored anmed paths from being created (because the haplotype paths would be hit first and search would stop). This wasn't under test, so I decided to filter those paths out and save a bunch of `vg annotate` re-processing in the tests. Now `vg annotate` should produce the same annotations that `vg sim` would.
