### PR TITLE
Keep GBWT paths when subsampling

### DIFF
--- a/src/haplotype_indexer.cpp
+++ b/src/haplotype_indexer.cpp
@@ -386,6 +386,11 @@ std::unique_ptr<gbwt::DynamicGBWT> HaplotypeIndexer::build_gbwt(const std::vecto
                 std::cerr << "Indexing embedded paths" << std::endl;
             }
         }
+        
+        // TODO: Get rid of paths_as_samples and use
+        // gbwtgraph::store_named_paths to store the paths, and the metadata's
+        // dictionaries to keep track of which numbers mean which strings.
+        
         // For each path we want to add to the GBWT
         auto add_graph_path_to_gbwt = [&](path_handle_t path_handle) {
             std::string path_name = graph->get_path_name(path_handle);

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -2598,11 +2598,20 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         gbwt::GBWT cover;
         if (downsample) {
             // Downsample the haplotypes and generate a path cover of components without haplotypes.
+            
+            // We need to drop paths that are alt allele paths and not pass them
+            // through from a graph that has them to the synthesized GBWT.
+            std::function<bool(const path_handle_t&)> path_filter = [&xg_index](const path_handle_t& path) {
+                return !Paths::is_alt(xg_index->get_path_name(path));
+            };
+            
             cover = gbwtgraph::local_haplotypes(*xg_index, *gbwt_index,
                                                 IndexingParameters::giraffe_gbwt_downsample,
                                                 IndexingParameters::downsample_context_length,
                                                 IndexingParameters::gbwt_insert_batch_size, 
                                                 IndexingParameters::gbwt_sampling_interval,
+                                                true, // Also include named paths from the graph
+                                                &path_filter,
                                                 IndexingParameters::verbosity >= IndexingParameters::Debug);
         } else {
             // Augment the GBWT with a path cover of components without haplotypes.
@@ -2658,12 +2667,20 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         auto comp_sizes = algorithms::component_sizes(*xg_index);
         size_t max_comp_size = *max_element(comp_sizes.begin(), comp_sizes.end());
         
+        // We need to drop paths that are alt allele paths and not pass them
+        // through from a graph that has them to the synthesized GBWT.
+        std::function<bool(const path_handle_t&)> path_filter = [&xg_index](const path_handle_t& path) {
+            return !Paths::is_alt(xg_index->get_path_name(path));
+        };
+        
         // make a GBWT from a greedy path cover
         gbwt::GBWT cover = gbwtgraph::path_cover_gbwt(*xg_index,
                                                       IndexingParameters::path_cover_depth,
                                                       IndexingParameters::downsample_context_length,
-                                                      std::max(IndexingParameters::gbwt_insert_batch_size, 20 * max_comp_size), // buffer size recommendation from Jouni
+                                                      std::max<gbwt::size_type>(IndexingParameters::gbwt_insert_batch_size, 20 * max_comp_size), // buffer size recommendation from Jouni
                                                       IndexingParameters::gbwt_sampling_interval,
+                                                      true, // Also include named paths from the graph
+                                                      &path_filter,
                                                       IndexingParameters::verbosity >= IndexingParameters::Debug);
         
         save_gbwt(cover, output_name, IndexingParameters::verbosity == IndexingParameters::Debug);

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -2601,7 +2601,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             cover = gbwtgraph::local_haplotypes(*xg_index, *gbwt_index,
                                                 IndexingParameters::giraffe_gbwt_downsample,
                                                 IndexingParameters::downsample_context_length,
-                                                200 * gbwt::MILLION, // buffer size
+                                                IndexingParameters::gbwt_insert_batch_size, 
                                                 IndexingParameters::gbwt_sampling_interval,
                                                 IndexingParameters::verbosity >= IndexingParameters::Debug);
         } else {
@@ -2614,7 +2614,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             gbwtgraph::augment_gbwt(*xg_index, dynamic_index,
                                     IndexingParameters::path_cover_depth,
                                     IndexingParameters::downsample_context_length,
-                                    200 * gbwt::MILLION, // buffer size
+                                    IndexingParameters::gbwt_insert_batch_size, 
                                     IndexingParameters::gbwt_sampling_interval,
                                     IndexingParameters::verbosity >= IndexingParameters::Debug);
             cover = gbwt::GBWT(dynamic_index);
@@ -2662,7 +2662,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         gbwt::GBWT cover = gbwtgraph::path_cover_gbwt(*xg_index,
                                                       IndexingParameters::path_cover_depth,
                                                       IndexingParameters::downsample_context_length,
-                                                      20 * max_comp_size, // buffer size recommendation from Jouni
+                                                      std::max(IndexingParameters::gbwt_insert_batch_size, 20 * max_comp_size), // buffer size recommendation from Jouni
                                                       IndexingParameters::gbwt_sampling_interval,
                                                       IndexingParameters::verbosity >= IndexingParameters::Debug);
         

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 133
+plan tests 145
 
 
 # Build vg graphs for two chromosomes
@@ -283,6 +283,16 @@ is $(vg gbwt -S xy.cover.gbwt) 16 "path cover: 16 samples"
 
 rm -f xy.cover.gg xy.cover.gbwt
 
+# Build both GBWT and GBWTGraph from a 16-path cover, passing through named paths
+vg gbwt -P -n 16 -x xy.xg -g xy.cover.gg -o xy.cover.gbwt --pass-paths
+is $? 0 "Path cover GBWTGraph construction"
+is $(md5sum xy.cover.gg | cut -f 1 -d\ ) 6a2738f51472e0ba1553a815a005b157 "GBWTGraph was serialized correctly"
+is $(vg gbwt -c xy.cover.gbwt) 34 "path cover w/ paths: 34 threads"
+is $(vg gbwt -C xy.cover.gbwt) 2 "path cover w/ paths: 2 contigs"
+is $(vg gbwt -H xy.cover.gbwt) 17 "path cover w/ paths: 17 haplotypes"
+is $(vg gbwt -S xy.cover.gbwt) 17 "path cover w/ paths: 17 samples"
+
+rm -f xy.cover.gg xy.cover.gbwt
 
 # Build both GBWT and GBWTGraph from 16 paths of local haplotypes
 vg gbwt -x xy-alt.xg -g xy.local.gg -l -n 16 -o xy.local.gbwt -v small/xy2.vcf.gz
@@ -299,6 +309,17 @@ is $? 0 "Local haplotypes GBZ construction"
 is $(md5sum xy.local.gbz | cut -f 1 -d\ ) 65d2290f32c200ea57212cb7b71075b0 "GBZ was serialized correctly"
 
 rm -f xy.local.gg xy.local.gbwt xy.local.gbz
+
+# Build both GBWT and GBWTGraph from 16 paths of local haplotypes, passing through named paths
+vg gbwt -x xy-alt.xg -g xy.local.gg -l -n 16 -o xy.local.gbwt -v small/xy2.vcf.gz --pass-paths
+is $? 0 "Local haplotypes GBWTGraph construction"
+is $(md5sum xy.local.gg | cut -f 1 -d\ ) 6a2738f51472e0ba1553a815a005b157 "GBWTGraph was serialized correctly"
+is $(vg gbwt -c xy.local.gbwt) 34 "local haplotypes w/ paths: 34 threads"
+is $(vg gbwt -C xy.local.gbwt) 2 "local haplotypes w/ paths: 2 contigs"
+is $(vg gbwt -H xy.local.gbwt) 17 "local haplotypes w/ paths: 17 haplotypes"
+is $(vg gbwt -S xy.local.gbwt) 17 "local haplotypes w/ paths: 17 samples"
+
+rm -f xy.local.gg xy.local.gbwt
 
 
 # Build GBWTGraph from an augmented GBWT


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex` now doesn't throw out graph paths when subsampling a GBWT
 * `vg gbwt` has a `--pass-paths` option to use paths from a passed-in graph when computing a path cover or local haplotype cover GBWT.

## Description

This should fix #3542. It might really want a test that replicates #3542, though.
