### PR TITLE
Simulate from HSTs in a GBWT pantranscriptome

### DIFF
--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -442,7 +442,8 @@ std::vector<gbwt::size_type> threads_for_contig(const gbwt::GBWT& gbwt_index, co
 
 std::string insert_gbwt_path(MutablePathHandleGraph& graph, const gbwt::GBWT& gbwt_index, gbwt::size_type id, std::string path_name) {
 
-    gbwt::size_type sequence_id = gbwt::Path::encode(id, false);
+    gbwt::size_type sequence_id = gbwt_index.bidirectional() ? gbwt::Path::encode(id, false) : id;
+
     if (sequence_id >= gbwt_index.sequences()) {
         std::cerr << "error: [insert_gbwt_path()] invalid path id: " << id << std::endl;
         return "";
@@ -470,7 +471,7 @@ std::string insert_gbwt_path(MutablePathHandleGraph& graph, const gbwt::GBWT& gb
 Path extract_gbwt_path(const HandleGraph& graph, const gbwt::GBWT& gbwt_index, gbwt::size_type id) {
 
     Path result;
-    gbwt::size_type sequence_id = gbwt::Path::encode(id, false);
+    gbwt::size_type sequence_id = gbwt_index.bidirectional() ? gbwt::Path::encode(id, false) : id;
     if (sequence_id >= gbwt_index.sequences()) {
         std::cerr << "error: [insert_gbwt_path()] invalid path id: " << id << std::endl;
         return result;

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -1124,7 +1124,7 @@ pair<Alignment, Alignment> NGSSimulator::sample_read_pair() {
             // we need to walk backwards from the end of the first read
             if (walk_backwards(walked_offset, is_reverse, pos, -remaining_length, source_path, aln_pair.first.path())) {
 #ifdef debug_ngs_sim
-                cerr << "rejecting because backwards walk is off path" << endl;
+                cerr << "rejecting because backwards walk is off path/graph" << endl;
 #endif
                 continue;
             }
@@ -1458,7 +1458,7 @@ bool NGSSimulator::walk_backwards_along_alignment(const Path& path, int64_t dist
             const auto& edit = mapping.edit(j);
             if (edit.to_length() < remaining_to_walk) {
                 // we can continue to walk through this edit
-                remaining_to_walk += edit.to_length();
+                remaining_to_walk -= edit.to_length();
                 walked_from_length += edit.from_length();
             }
             else {

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -120,7 +120,7 @@ pos_t Sampler::position(void) {
 
 string Sampler::sequence(size_t length) {
     pos_t pos = position();
-    cerr << pos << endl;
+
     string seq;
     while (seq.size() < length) {
         auto nextc = next_pos_chars(pos);
@@ -1036,20 +1036,24 @@ pair<Alignment, Alignment> NGSSimulator::sample_read_pair() {
     
     int64_t walked_offset;
     
+#ifdef debug_ngs_sim
+    cerr << "sampled fragment length " << fragment_length << endl;
+#endif
+    
     if (fragment_length < transition_distrs_1.size()) {
         // the fragment is shorter than the sequencing length
         qual_and_mask_pair.first.first.resize(fragment_length);
         qual_and_mask_pair.first.second.resize(fragment_length);
         qual_and_mask_pair.second.first.resize(fragment_length);
         qual_and_mask_pair.second.second.resize(fragment_length);
+#ifdef debug_ngs_sim
+        cerr << "truncating reads to fragment length" << endl;
+#endif
     }
     
     aln_pair.first.set_quality(qual_and_mask_pair.first.first);
     aln_pair.second.set_quality(qual_and_mask_pair.second.first);
     
-#ifdef debug_ngs_sim
-    cerr << "sampled fragment length " << fragment_length << endl;
-#endif
     
     // reverse the quality string so that it acts like it's reading from the opposite end
     // when we walk forward from the beginning of the first read
@@ -1065,7 +1069,7 @@ pair<Alignment, Alignment> NGSSimulator::sample_read_pair() {
         walked_offset = sampled_offset;
         bool is_reverse = sampled_is_reverse;
 #ifdef debug_ngs_sim
-        cerr << "sampled start pos " << pos << ", is reverse " << is_reverse << ", offset " << walked_offset << endl;
+        cerr << "sampled read 1 start pos " << pos << ", is reverse " << is_reverse << ", offset " << walked_offset << endl;
 #endif
         
         // align the first end at this position on the source path or graph
@@ -1105,18 +1109,18 @@ pair<Alignment, Alignment> NGSSimulator::sample_read_pair() {
                 // we hit the end of the graph trying to walk
                 continue;
             }
-        } else {
+        }
+        else {
             // we need to walk backwards from the end of the first read
-            int64_t walk_length = min<int64_t>(-remaining_length, path_from_length(aln_pair.first.path()));
-            pos = walk_backwards(aln_pair.first.path(), walk_length);
-            // Make sure to update the offset along the path as well. If offset
-            // and is_reverse aren't being used (becasue we aren't in path
-            // mode), the result won't be used either.
-            walked_offset += is_reverse ? walk_length : -walk_length;
-            
+            if (walk_backwards(walked_offset, is_reverse, pos, -remaining_length, source_path, aln_pair.first.path())) {
+#ifdef debug_ngs_sim
+                cerr << "rejecting because backwards walk is off path" << endl;
+#endif
+                continue;
+            }
 
 #ifdef debug_ngs_sim
-            cerr << "walked backwards, walk length " << walk_length << ", is rev " << is_reverse << ", walked offset " << walked_offset << endl;
+            cerr << "walked backwards, walk length " << -remaining_length << ", is rev " << is_reverse << ", walked offset " << walked_offset << endl;
 #endif
         }
 #ifdef debug_ngs_sim
@@ -1151,6 +1155,16 @@ pair<Alignment, Alignment> NGSSimulator::sample_read_pair() {
     reverse_complement_alignment_in_place(&aln_pair.second, [&](id_t node_id) {
         return graph.get_length(graph.get_handle(node_id));
     });
+    
+    for (auto aln : {&aln_pair.first, &aln_pair.second}) {
+        for (const auto& mapping : aln->path().mapping()) {
+            if (mapping.position().offset() < 0) {
+                cerr << "error: invalid alignment!" << endl;
+                cerr << pb2json(*aln) << endl;
+                exit(1);
+            }
+        }
+    }
     
     // mask out any of the sequence that we sampled to be an 'N'
     apply_N_mask(*aln_pair.first.mutable_sequence(), qual_and_mask_pair.first.second);
@@ -1336,7 +1350,7 @@ bool NGSSimulator::advance_on_graph(pos_t& pos, char& graph_char) {
 }
 
 bool NGSSimulator::advance_on_path(int64_t& offset, bool& is_reverse, pos_t& pos, char& graph_char, const string& source_path) {
-    size_t path_length = graph.get_path_length(graph.get_path_handle(source_path));
+    int64_t path_length = graph.get_path_length(graph.get_path_handle(source_path));
     if (is_reverse) {
         // Go left on the path
         offset--;
@@ -1400,21 +1414,20 @@ bool NGSSimulator::advance_on_graph_by_distance(pos_t& pos, int64_t distance) {
 bool NGSSimulator::advance_on_path_by_distance(int64_t& offset, bool& is_reverse, pos_t& pos, int64_t distance,
                                                const string& source_path) {
     
-    size_t path_length = graph.get_path_length(graph.get_path_handle(source_path));
+    int64_t path_length = graph.get_path_length(graph.get_path_handle(source_path));
     if (is_reverse) {
         // Go left on the path
         offset -= distance;
-        if (offset < 0) {
-            // We hit the beginning
-            return true;
-        }
     } else {
         // Go right on the path
         offset += distance;
-        if (offset >= path_length) {
-            // We hit the end
-            return true;
-        }
+    }
+    if (offset < 0 || offset >= path_length) {
+#ifdef debug_ngs_sim
+        cerr << "walked offset of " << offset << " after advancing " << distance << ", rev ? " << is_reverse << " is outside of path of length " << path_length << endl;
+#endif
+        // We hit the end
+        return true;
     }
     
     // Set position according to position on path
@@ -1423,77 +1436,63 @@ bool NGSSimulator::advance_on_path_by_distance(int64_t& offset, bool& is_reverse
     return false;
 }
 
-pos_t NGSSimulator::walk_backwards(const Path& path, int64_t distance) {
-    // Starting at the past-the-end of the path, walk back to the given nonzero distance.
-    // Walking back the whole path length puts you at the start of the path.
-    // walk backwards until we find the mapping it's on
-    int64_t remaining = distance;
-    int64_t mapping_idx = path.mapping_size() - 1;
-    int64_t mapping_length = mapping_to_length(path.mapping(mapping_idx));
-    while (remaining > mapping_length) {
-        remaining -= mapping_length;
-        mapping_idx--;
-        mapping_length = mapping_to_length(path.mapping(mapping_idx));
-    }
-    // Now we know the position we want is inside this mapping.
-    const Mapping& mapping = path.mapping(mapping_idx);
-    const Position& mapping_pos = mapping.position();
-    // walk forward from the beginning of the mapping, edit by edit, until we've passed where it is on the read
-    int64_t remaining_flipped = mapping_length - remaining;
-    int64_t edit_idx = 0;
-    int64_t prefix_from_length = 0;
-    int64_t prefix_to_length = 0;
-    while (prefix_to_length <= remaining_flipped) {
-        prefix_from_length += mapping.edit(edit_idx).from_length();
-        prefix_to_length += mapping.edit(edit_idx).to_length();
-        edit_idx++;
-    }
-    // Go back one edit to the edit that covers the position we want to be at
-    --edit_idx;
-    // use the mapping's position and the distance we traveled on the graph to get the offset of
-    // the beginning of this edit
-    int64_t offset = mapping_pos.offset() + prefix_from_length - mapping.edit(edit_idx).from_length();
-    if (mapping.edit(edit_idx).from_length() == mapping.edit(edit_idx).to_length()) {
-        // if the edit is a match/mismatch, we can walk part of it
-        
-        // How many extra bases did this mapping have when we got past where we wanted to be?
-        auto extra_bases = prefix_to_length - remaining_flipped;
+bool NGSSimulator::walk_backwards_along_alignment(const Path& path, int64_t distance, pos_t& pos) {
+    
+    // convert to a distance forward, which is easier to implement
+    int64_t remaining_to_walk = max<int64_t>(path_to_length(path) - distance, 0);
+    
+    for (size_t i = 0; i < path.mapping_size(); ++i) {
+        const auto& mapping = path.mapping(i);
+        int64_t walked_from_length = 0;
+        for (size_t j = 0; j < mapping.edit_size(); ++j) {
+            const auto& edit = mapping.edit(j);
+            if (edit.to_length() < remaining_to_walk) {
+                // we can continue to walk through this edit
+                remaining_to_walk += edit.to_length();
+                walked_from_length += edit.from_length();
+            }
+            else {
+                // this edit overlaps the place we want to walk to
+                if (edit.to_length() == edit.from_length()) {
+                    // this is a match/substitition, so we can walk the remaining distance
+                    walked_from_length += remaining_to_walk;
+                    remaining_to_walk = 0;
+                }
                 
-        // Take all the non-extra bases of the mapping.
-        offset += mapping.edit(edit_idx).to_length() - extra_bases;
-    } else {
-        // Otherwise it's an insert, so just land at the spot it is inserted at.
-        
-        // But we will have a problem if the insert is the last thing in its mapping
-        if (prefix_from_length == mapping_from_length(mapping)) {
-            // We are trying to put our starting position past the end of this
-            // mapping, because we are landing inside an insert that is the
-            // last thing in its mapping.
-            
-            // Note that this can happen at the end of the path, if the whole
-            // path ends in an insert. So we can't just go to the next
-            // position.
-            
-            // There's not really a quite correct thing to do here, but since
-            // we can't go right we have to go left.
-            assert(offset > 0);
-            offset--;
+                nid_t node_id = mapping.position().node_id();
+                bool rev = mapping.position().is_reverse();
+                size_t offset = mapping.position().offset() + walked_from_length;
+                if (offset == graph.get_length(graph.get_handle(node_id))) {
+                    // we're actually past-the-last on this node, which is not what we want
+                    if (i + 1 < path.mapping_size()) {
+                        // we can bump the position over to the next node
+                        const auto& next_mapping = path.mapping(i + 1);
+                        node_id = next_mapping.position().node_id();
+                        rev = next_mapping.position().is_reverse();
+                        offset = 0;
+                    }
+                    else {
+                        // there's not really a "correct" option here, so we just adjust
+                        // the offset by 1 and hope this doesn't lead to too much distortion
+                        --offset;
+                    }
+                }
+                pos = make_pos_t(node_id, rev, offset);
+                return false;
+            }
         }
     }
-    
-    // Get the length of the node we landed on
-    auto node_length = graph.get_length(graph.get_handle(mapping_pos.node_id()));
-    // The position we pick should not be past the end of the node.
-    if (offset >= node_length) {
-        cerr << pb2json(path) << endl;
-        cerr << "Covering mapping: " << pb2json(mapping) << endl;
-        cerr << "Covering edit: " << pb2json(mapping.edit(edit_idx)) << endl;
-        throw runtime_error("Could not go back " + to_string(distance) + " in path of length " +
-            to_string(path_to_length(path)) + "; hit node " + to_string(mapping_pos.node_id()) + " length " +
-            to_string(node_length) + " end at offset " + to_string(offset));
-    }
+    return true;
+}
 
-    return make_pos_t(mapping_pos.node_id(), mapping_pos.is_reverse(), offset);
+bool NGSSimulator::walk_backwards(int64_t& offset, bool& is_reverse, pos_t& pos, int64_t distance,
+                                  const string& source_path, const Path& path) {
+    if (source_path.empty()) {
+        return walk_backwards_along_alignment(path, distance, pos);
+    }
+    else {
+        return advance_on_path_by_distance(offset, is_reverse, pos, -distance, source_path);
+    }
 }
 
 void NGSSimulator::apply_aligned_base(Alignment& aln, const pos_t& pos, char graph_char,
@@ -1673,8 +1672,12 @@ pos_t NGSSimulator::sample_start_graph_pos() {
 
 tuple<int64_t, bool, pos_t> NGSSimulator::sample_start_path_pos(const size_t& source_path_idx,
                                                                 const int64_t& fragment_length) {
+    
     int64_t path_length = graph.get_path_length(graph.get_path_handle(source_paths[source_path_idx]));
     bool rev = strand_sampler(prng());
+#ifdef debug_ngs_sim
+    cerr << "sampling start position on path " << source_paths[source_path_idx] << ", strand " << rev << ", path length " << path_length << endl;
+#endif
     int64_t offset;
     if (sample_unsheared_paths || path_length < transition_distrs_1.size() ||
         (fragment_length > 0 && fragment_length >= path_length)) {
@@ -1686,8 +1689,21 @@ tuple<int64_t, bool, pos_t> NGSSimulator::sample_start_path_pos(const size_t& so
         }
     }
     else {
-        // The start pos sampler has been set up in path space, 0-based
-        offset = start_pos_samplers[source_path_idx](prng());
+        
+        // we'll not let it choose too unreasonable of a start position so that we can speed
+        // up the process of continuously resampling impractically close to the end of paths
+        bool feasible = false;
+        int64_t shortened_fragment_length = fragment_length - ceil(sqrt(fragment_length));
+        do {
+            // The start pos sampler has been set up in path space, 0-based
+            offset = start_pos_samplers[source_path_idx](prng());
+            if (rev) {
+                feasible = (offset - shortened_fragment_length >= -1);
+            }
+            else {
+                feasible = (offset + shortened_fragment_length <= path_length);
+            }
+        } while (!feasible);
     }
     pos_t pos = position_at(&graph, source_paths[source_path_idx], offset, rev);
     

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -968,7 +968,8 @@ Alignment NGSSimulator::sample_read() {
     while (!aln.has_path()) {
         // Populate the sample positions
         pos_t pos;
-        sample_start_pos(source_path_idx, -1, sampled_offset, sampled_is_reverse, pos);
+        sample_start_pos(source_path_idx, (int64_t) qual_and_masks.first.size(),
+                         sampled_offset, sampled_is_reverse, pos);
         // copy the values so that we can change them without forgetting the start location
         int64_t offset = sampled_offset;
         bool is_reverse = sampled_is_reverse;

--- a/src/sampler.hpp
+++ b/src/sampler.hpp
@@ -288,9 +288,13 @@ private:
     
     /// Mask out bases with 'N's if the mask is true
     void apply_N_mask(string& sequence, const vector<bool>& n_mask);
+        
+    /// Walk backwards either along an alignment path or a source path, updates positions
+    bool walk_backwards(int64_t& offset, bool& is_reverse, pos_t& pos, int64_t distance,
+                        const string& source_path, const Path& path);
+    /// Walk backwards along the alignment path
+    bool walk_backwards_along_alignment(const Path& path, int64_t distance, pos_t& pos);
     
-    /// Returns the position a given distance from the end of the path, walking backwards
-    pos_t walk_backwards(const Path& path, int64_t distance);
     /// Add a deletion to the alignment
     void apply_deletion(Alignment& aln, const pos_t& pos);
     /// Add an insertion to the alignment

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -174,7 +174,7 @@ int main_sim(int argc, char** argv) {
     // expression profile
     string haplotype_transcript_file_name;
     vector<tuple<string, string, size_t>> haplotype_transcripts;
-
+    
     int c;
     optind = 2; // force optind past command positional argument
     while (true) {
@@ -690,7 +690,7 @@ int main_sim(int argc, char** argv) {
         // Use the fixed error rate sampler
         
         if (unsheared_fragments) {
-            cerr << "Unsheared fragment option only available when simulating from FASTQ-trained errors" << endl;
+            cerr << "warning: Unsheared fragment option only available when simulating from FASTQ-trained errors" << endl;
         }
         
         // Make a sample to sample reads with


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg sim` can now simulate from a set of HSTs in a pantranscriptome from `vg rna`.

## Description

Also includes a bug fix where `vg sim` could produce invalid alignments that aligned past the end of a node by 1 base.
