### PR TITLE
Bugfix for spliced surjection on complex graphs

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -3384,7 +3384,6 @@ namespace vg {
                 
                 if (i == 0 && j == 0 && !rev) {
                     // base case if the position is given for the beginning of the surjected alignment
-                    // TODO: will this work if the position is between two nodes?
                     auto step = graph.get_step_at_position(path_handle, path_pos);
 #ifdef debug_cigar
                     cerr << "got step " << graph.get_id(graph.get_handle_of_step(step)) << " " << graph.get_is_reverse(graph.get_handle_of_step(step)) << " as path pos " << graph.get_position_of_step(step) << endl;

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -109,7 +109,8 @@ using namespace std;
         
         Alignment
         realigning_surject(const PathPositionHandleGraph* graph, const Alignment& source,
-                           const path_handle_t& path_handle, const vector<path_chunk_t>& path_chunks,
+                           const path_handle_t& path_handle, bool rev_strand,
+                           const vector<path_chunk_t>& path_chunks,
                            pair<step_handle_t, step_handle_t>& path_range_out,
                            bool allow_negative_scores,
                            bool preserve_N_alignments = false,
@@ -119,7 +120,8 @@ using namespace std;
         spliced_surject(const PathPositionHandleGraph* path_position_graph,
                         const string& src_sequence, const string& src_quality,
                         const int32_t src_mapping_quality,
-                        const path_handle_t& path_handle, vector<path_chunk_t>& path_chunks,
+                        const path_handle_t& path_handle, bool rev_strand,
+                        vector<path_chunk_t>& path_chunks,
                         vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
                         vector<tuple<size_t, size_t, int32_t>>& connections,
                         pair<step_handle_t, step_handle_t>& path_range_out,
@@ -130,16 +132,16 @@ using namespace std;
         ///////////////////////
         
         /// get the chunks of the alignment path that follow the given reference paths
-        unordered_map<path_handle_t, pair<vector<path_chunk_t>, vector<pair<step_handle_t, step_handle_t>>>>
+        unordered_map<pair<path_handle_t, bool>, pair<vector<path_chunk_t>, vector<pair<step_handle_t, step_handle_t>>>>
         extract_overlapping_paths(const PathPositionHandleGraph* graph, const Alignment& source,
                                   const unordered_set<path_handle_t>& surjection_paths) const;
         
         /// same semantics except for a multipath alignment
-        unordered_map<path_handle_t, pair<vector<path_chunk_t>, vector<pair<step_handle_t, step_handle_t>>>>
+        unordered_map<pair<path_handle_t, bool>, pair<vector<path_chunk_t>, vector<pair<step_handle_t, step_handle_t>>>>
         extract_overlapping_paths(const PathPositionHandleGraph* graph,
                                   const multipath_alignment_t& source,
                                   const unordered_set<path_handle_t>& surjection_paths,
-                                  unordered_map<path_handle_t, vector<tuple<size_t, size_t, int32_t>>>& connections_out) const;
+                                  unordered_map<pair<path_handle_t, bool>, vector<tuple<size_t, size_t, int32_t>>>& connections_out) const;
         
         /// remove any path chunks and corresponding ref chunks that are identical to a longer
         /// path chunk over the region where they overlap
@@ -152,7 +154,7 @@ using namespace std;
         /// end if there are no path chunks.
         pair<size_t, size_t>
         compute_path_interval(const PathPositionHandleGraph* graph, const Alignment& source, path_handle_t path_handle,
-                              const vector<path_chunk_t>& path_chunks) const;
+                              bool rev_strand, const vector<path_chunk_t>& path_chunks) const;
         
         /// make a linear graph that corresponds to a path interval, possibly duplicating nodes in case of cycles
         unordered_map<id_t, pair<id_t, bool>>
@@ -163,7 +165,7 @@ using namespace std;
         void set_path_position(const PathPositionHandleGraph* graph, const pos_t& init_surj_pos,
                                const pos_t& final_surj_pos,
                                const step_handle_t& range_begin, const step_handle_t& range_end,
-                               string& path_name_out, int64_t& path_pos_out, bool& path_rev_out) const;
+                               bool rev_strand, string& path_name_out, int64_t& path_pos_out, bool& path_rev_out) const;
         
         ///////////////////////
         // Support methods for the spliced surject algorithm

--- a/src/unittest/surject.cpp
+++ b/src/unittest/surject.cpp
@@ -223,17 +223,19 @@ TEST_CASE("Path overlapping segments can be identified from multipath alignment"
     
     SECTION("Forward strand of path") {
         
-        unordered_map<path_handle_t, vector<tuple<size_t, size_t, int32_t>>> connections;
+        unordered_map<pair<path_handle_t, bool>, vector<tuple<size_t, size_t, int32_t>>> connections;
         
         auto overlaps = surjector.extract_overlapping_paths(&pos_graph, mp_aln,
                                                             surjection_paths,
                                                             connections);
         
-        REQUIRE(overlaps.count(p));
+        auto fp = make_pair(p, false);
+        
+        REQUIRE(overlaps.count(fp));
         REQUIRE(overlaps.size() == 1);
         REQUIRE(connections.empty());
         
-        auto& p_overlaps = overlaps[p];
+        auto& p_overlaps = overlaps[fp];
         
         REQUIRE(p_overlaps.first.size() == 1);
         REQUIRE(p_overlaps.first.front().first.first == mp_aln.sequence().begin());
@@ -259,7 +261,7 @@ TEST_CASE("Path overlapping segments can be identified from multipath alignment"
     
     SECTION("Reverse strand of path"){
         
-        unordered_map<path_handle_t, vector<tuple<size_t, size_t, int32_t>>> connections;
+        unordered_map<pair<path_handle_t, bool>, vector<tuple<size_t, size_t, int32_t>>> connections;
         
         multipath_alignment_t rev_mp_aln;
         rev_comp_multipath_alignment(mp_aln, node_length, rev_mp_aln);
@@ -268,11 +270,13 @@ TEST_CASE("Path overlapping segments can be identified from multipath alignment"
                                                             surjection_paths,
                                                             connections);
         
-        REQUIRE(overlaps.count(p));
+        auto rp = make_pair(p, true);
+            
+        REQUIRE(overlaps.count(rp));
         REQUIRE(overlaps.size() == 1);
         REQUIRE(connections.empty());
         
-        auto& p_overlaps = overlaps[p];
+        auto& p_overlaps = overlaps[rp];
         
         REQUIRE(p_overlaps.first.size() == 1);
         REQUIRE(p_overlaps.first.front().first.first == rev_mp_aln.sequence().begin());
@@ -326,24 +330,26 @@ TEST_CASE("Path overlapping segments can be identified from multipath alignment"
     
     SECTION("Connections break segments and are recorded correctly") {
         
-        unordered_map<path_handle_t, vector<tuple<size_t, size_t, int32_t>>> connections;
+        unordered_map<pair<path_handle_t, bool>, vector<tuple<size_t, size_t, int32_t>>> connections;
         
         auto overlaps = surjector.extract_overlapping_paths(&pos_graph, mp_aln,
                                                             surjection_paths,
                                                             connections);
         
-        REQUIRE(overlaps.count(p));
+        auto fp = make_pair(p, false);
+        
+        REQUIRE(overlaps.count(fp));
         REQUIRE(overlaps.size() == 1);
         
-        auto& p_overlaps = overlaps[p];
+        auto& p_overlaps = overlaps[fp];
         
         REQUIRE(p_overlaps.first.size() == 5);
         REQUIRE(p_overlaps.second.size() == 5);
         
         REQUIRE(connections.size() == 1);
-        REQUIRE(connections.count(p));
+        REQUIRE(connections.count(fp));
         
-        auto& p_connections = connections[p];
+        auto& p_connections = connections[fp];
         
         REQUIRE(p_connections.size() == 2);
         


### PR DESCRIPTION
## Description

I needed to re-architect surject a bit so that it aligns consistently to one strand of a path rather than just to a path, which is important in graphs where the two strands can reach each other. This actually led to simpler code in a lot of places.