### PR TITLE
Annotate reads with correct minimizer coverage

### DIFF
--- a/src/algorithms/count_covered.hpp
+++ b/src/algorithms/count_covered.hpp
@@ -1,0 +1,57 @@
+#ifndef VG_ALGORITHMS_COUNT_COVERED_HPP_INCLUDED
+#define VG_ALGORITHMS_COUNT_COVERED_HPP_INCLUDED
+
+/**
+ * \file count_covered.hpp
+ *
+ * Sweep-line algorithm to count the number of positions covered by a set of
+ * intervals.
+ */
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+/**
+ * Count, from begin to end, the number of positions covered by ranges in the
+ * given collection. The collection will be sorted in place.
+ *
+ * The collection must be a have a begin(), end(), and random [] access (like a
+ * vector). 
+ *
+ * No boundaries are needed because no positions can be covered without
+ * segments representing them.
+ */
+template<typename Collection>
+size_t count_covered(Collection& segments) {
+
+    if (segments.empty()) {
+        // Protect against no segments
+        return 0;
+    }
+
+    std::sort(segments.begin(), segments.end());
+    auto curr_begin = segments[0].first;
+    auto curr_end = segments[0].second;
+    
+    size_t total = 0;
+    for (size_t i = 1; i < segments.size(); i++) {
+        if (segments[i].first >= curr_end) {
+            total += (curr_end - curr_begin);
+            curr_begin = segments[i].first;
+            curr_end = segments[i].second;
+        }
+        else if (segments[i].second > curr_end) {
+            curr_end = segments[i].second;
+        }
+    }
+    total += (curr_end - curr_begin);
+    return total;
+}
+
+}
+}
+
+#endif
+

--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -216,6 +216,13 @@ bool Funnel::was_correct(size_t prev_stage_item) const {
     return prev_stage.items[prev_stage_item].correct;
 }
 
+bool Funnel::was_correct(size_t prev_stage_index, const string& prev_stage_name, size_t prev_stage_item) const {
+    assert(stages.size() > prev_stage_index);
+    auto& prev_stage = stages[prev_stage_index];
+    assert(prev_stage.name == prev_stage_name);
+    return prev_stage.items[prev_stage_item].correct;
+}
+
 string Funnel::last_correct_stage() const {
     // Just do a linear scan backward through stages
     for (auto it = stages.rbegin(); it != stages.rend(); ++it) {

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -122,6 +122,12 @@ public:
     /// Return true if the given item at the previous stage is tagged correct, or
     /// descends from an item that was tagged correct.
     bool was_correct(size_t prev_stage_item) const;
+    
+    /// Return true if the given item at the given named previous stage is
+    /// tagged correct, or descends from an item that was tagged correct.
+    /// Needs a hint about what number the stage was in the order, to make
+    /// lookup fast.
+    bool was_correct(size_t prev_stage_index, const string& prev_stage_name, size_t prev_stage_item) const;
 
     /// Get the name of the most recent stage that had a correct-tagged item
     /// survive into it, or "none" if no items were ever tagged correct.

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -3038,8 +3038,9 @@ void MinimizerMapper::annotate_with_minimizer_statistics(Alignment& target, cons
     for(auto& minimizer_number : seeded) {
         // For each minimizer with correct seeds
         auto& minimizer = minimizers[minimizer_number];
-        // Cover all consecutive instances.
-        bounds.emplace_back(minimizer.agglomeration_start, minimizer.agglomeration_start + minimizer.agglomeration_length);
+        // Cover the minimizer k-mer itself.
+        size_t start = minimizer.forward_offset();
+        bounds.emplace_back(start, start + minimizer.length);
     }
     // Then we count the positions covered
     size_t covered_count = algorithms::count_covered(bounds);

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -365,7 +365,10 @@ protected:
      */
     void pair_all(pair<vector<Alignment>, vector<Alignment>>& mappings) const;
     
-
+    /**
+     * Add annotations to an Alignment with statistics about the minimizers.
+     */
+    void annotate_with_minimizer_statistics(Alignment& target, const std::vector<Minimizer>& minimizers, const std::vector<Seed>& seeds, const Funnel& funnel) const;
 
 //-----------------------------------------------------------------------------
 

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -39,6 +39,7 @@
 #include "split_strand_graph.hpp"
 #include "dagified_graph.hpp"
 
+#include "algorithms/count_covered.hpp"
 #include "algorithms/extract_containing_graph.hpp"
 #include "algorithms/locally_expand_graph.hpp"
 #include "algorithms/jump_along_path.hpp"
@@ -6282,22 +6283,7 @@ namespace vg {
         for (auto& mem_hit : mem_hits.first) {
             mem_read_segments.emplace_back(mem_hit.first->begin, mem_hit.first->end);
         }
-        std::sort(mem_read_segments.begin(), mem_read_segments.end());
-        auto curr_begin = mem_read_segments[0].first;
-        auto curr_end = mem_read_segments[0].second;
-        
-        int64_t total = 0;
-        for (size_t i = 1; i < mem_read_segments.size(); i++) {
-            if (mem_read_segments[i].first >= curr_end) {
-                total += (curr_end - curr_begin);
-                curr_begin = mem_read_segments[i].first;
-                curr_end = mem_read_segments[i].second;
-            }
-            else if (mem_read_segments[i].second > curr_end) {
-                curr_end = mem_read_segments[i].second;
-            }
-        }
-        get<2>(cluster_graph) = total + (curr_end - curr_begin);
+        get<2>(cluster_graph) = algorithms::count_covered(mem_read_segments);
         
         stable_sort(get<1>(cluster_graph).first.begin(), get<1>(cluster_graph).first.end(), length_first_cmp);
     }

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -394,6 +394,9 @@ vector<Alignment> Sampler::alignment_pair(size_t read_length, size_t fragment_le
                                                   (function<int64_t(int64_t)>) ([&](int64_t id) {
                                                           return (int64_t)node_length(id);
                                                       }));
+    // And annotate with true positions
+    annotate_with_path_positions(aln1);
+    annotate_with_path_positions(aln2);
     return fragments;
 }
 

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 36
+plan tests 41
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
@@ -137,13 +137,24 @@ else
 fi
 is "${IN_RANGE}" "1" "unpaired reads are evenly split between equivalent mappings"
 
-vg giraffe xy.fa xy.vcf.gz -G x.gam -o SAM --track-provenance --discard
+vg giraffe xy.fa xy.vcf.gz -G x.gam --track-provenance --discard
 is $? "0" "provenance tracking succeeds for unpaired reads"
 
-vg giraffe xy.fa xy.vcf.gz -G x.gam -o SAM -i --fragment-mean 200 --fragment-stdev 10 --distance-limit 50 --track-provenance --discard
+vg giraffe xy.fa xy.vcf.gz -G x.gam --track-provenance --track-correctness -o json >xy.json
+is $? "0" "correctness tracking succeeds for unpaired reads"
+
+is "$(cat xy.json | grep "correct-minimizer-coverage" | wc -l)" "2000" "unpaired reads are annotated with minimizer coverage"
+
+vg giraffe xy.fa xy.vcf.gz -G x.gam -i --fragment-mean 200 --fragment-stdev 10 --distance-limit 50 --track-provenance --discard
 is $? "0" "provenance tracking succeeds for paired reads"
 
-rm -f x.vg xy.sam
+vg giraffe xy.fa xy.vcf.gz -G x.gam -i --fragment-mean 200 --fragment-stdev 10 --distance-limit 50 --track-provenance --track-correctness -o json >xy.json
+is $? "0" "correctness tracking succeeds for paired reads"
+
+is "$(cat xy.json | grep "correct-minimizer-coverage" | wc -l)" "2000" "paired reads are annotated with minimizer coverage"
+is "$(cat xy.json | jq '.annotation["correct-minimizer-coverage"] | select(. > 0)' | wc -l)" "2000" "paired reads all have nonzero correct minimizer coverage"
+
+rm -f x.vg xy.sam xy.json
 rm -f xy.vg xy.gbwt xy.xg xy.snarls xy.min xy.dist xy.gg xy.fa xy.fa.fai xy.vcf.gz xy.vcf.gz.tbi
 
 vg giraffe -Z xy.giraffe.gbz -G x.gam -o BAM >xy.bam


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` can now annotate reads with coverage by minimizers that gave rise to correct seeds.

## Description

@StephenHwang This should let us mark reads with a `correct-minimizer-coverage` annotation, which is the portion of the read's bases that are in mimimizer minimal k-mers, where those minimizers gave rise to located seeds that were marked as correct.

I'm not sure how we would want Giraffe Facts to display it it, since it's not associated with a filter, so I haven't added support of rreading it there. But it should be easy to pull out of the JSO,. and take e.g. the average, or the average for correct or incorrect reads, or to make some histograms.
