### PR TITLE
Make spliced surject more accurate

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -2539,6 +2539,17 @@ namespace vg {
             return end ? end_node_id(idx) : start_node_id(idx);
         };
         
+        auto non_empty_from_length = [&](size_t idx) {
+            for (const auto& mapping : path_nodes[idx].path.mapping()) {
+                for (const auto& edit : mapping.edit()) {
+                    if (edit.from_length()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        };
+        
         // record the start and end node ids of every path
         // Maps from node ID to the list of MEM numbers that start on that node.
         unordered_map<id_t, vector<size_t>> path_starts;
@@ -2664,10 +2675,10 @@ namespace vg {
                 size_t curr_end_offset = end_offset(ends[end_range_begin]);
                 size_t prev_offset = 0;
                 
-                while (end_range_end == ends.size() ? false : end_offset(ends[end_range_end]) == curr_end_offset) {
+                while (end_range_end != ends.size() && end_offset(ends[end_range_end]) == curr_end_offset) {
                     end_range_end++;
                 }
-                while (start_range_end == starts.size() ? false : start_offset(starts[start_range_end]) == curr_start_offset) {
+                while (start_range_end != starts.size() && start_offset(starts[start_range_end]) == curr_start_offset) {
                     start_range_end++;
                 }
                 
@@ -2741,7 +2752,7 @@ namespace vg {
                 prev_offset = *curr_offset;
                 if (*range_begin != endpoints->size()) {
                     *curr_offset = endpoint_offset(endpoints->at(*range_begin), at_end);
-                    while (*range_end == endpoints->size() ? false : endpoint_offset(endpoints->at(*range_end), at_end) == *curr_offset) {
+                    while (*range_end != endpoints->size() && endpoint_offset(endpoints->at(*range_end), at_end) == *curr_offset) {
                         (*range_end)++;
                     }
                 }
@@ -2817,7 +2828,7 @@ namespace vg {
                     prev_offset = *curr_offset;
                     if (*range_begin != endpoints->size()) {
                         *curr_offset = endpoint_offset(endpoints->at(*range_begin), at_end);
-                        while (*range_end == endpoints->size() ? false : endpoint_offset(endpoints->at(*range_end), at_end) == *curr_offset) {
+                        while (*range_end != endpoints->size() && endpoint_offset(endpoints->at(*range_end), at_end) == *curr_offset) {
                             (*range_end)++;
                         }
                     }
@@ -2901,7 +2912,7 @@ namespace vg {
                     
                     if (*range_begin != endpoints->size()) {
                         *curr_offset = endpoint_offset(endpoints->at(*range_begin), at_end);
-                        while (*range_end == endpoints->size() ? false : endpoint_offset(endpoints->at(*range_end), at_end) == *curr_offset) {
+                        while (*range_end != endpoints->size() && endpoint_offset(endpoints->at(*range_end), at_end) == *curr_offset) {
                             (*range_end)++;
                         }
                     }
@@ -3196,7 +3207,7 @@ namespace vg {
                     
                     while (!start_queue.empty() || !end_queue.empty()) {
                         // is the next item on the queues a start or an end?
-                        if (start_queue.empty() ? false : (end_queue.empty() ? true : start_queue.top().second < end_queue.top().second)) {
+                        if (!start_queue.empty() && (end_queue.empty() || start_queue.top().second < end_queue.top().second)) {
                             
                             // the next closest endpoint is a start, traverse through it to find ends (which is what we really want)
                             
@@ -3241,7 +3252,7 @@ namespace vg {
                             // if we get this far, the two paths are colinear or overlap-colinear, so we won't add it to the
                             // non-colinear shell. now we need to decide whether to keep searching backward. we'll check a
                             // few conditions that will guarantee that the rest of the search is redundant
-                            
+
                             // TODO: this actually isn't a full set of criteria, we don't just want to know if there is an
                             // edge, we want to know if it is reachable along any series of edges...
                             // at least this will only cause a few false positive edges that we can remove later with
@@ -3346,8 +3357,12 @@ namespace vg {
                             
                             if (candidate_end_node.end <= start_node.begin) {
                                 // these MEMs are read colinear and graph reachable
-                                if (start != candidate_end) {
-                                    // and they are not the same path node, so add an edge
+                                if (candidate_dist != 0
+                                    || candidate_end_node.end != candidate_end_node.begin
+                                    || start_node.end != start_node.begin
+                                    || non_empty_from_length(start)
+                                    || non_empty_from_length(candidate_end)) {
+                                    // and they are not empty nodes at the exact same position, so add an edge
                                     // (this is almost always the case, but some code paths will add empty read sequences
                                     // to anchor to specific locations, which slightly confuses the reachability logic)
                                     candidate_end_node.edges.emplace_back(start, candidate_dist);

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3927,18 +3927,15 @@ namespace vg {
     void MultipathAlignmentGraph::reorder_adjacency_lists(const vector<size_t>& order) {
         vector<vector<pair<size_t, size_t>>> reverse_graph(path_nodes.size());
         for (size_t i = 0; i < path_nodes.size(); i++) {
-            for (const pair<size_t, size_t>& edge : path_nodes.at(i).edges) {
+            auto& edges = path_nodes[i].edges;
+            for (const pair<size_t, size_t>& edge : edges) {
                 reverse_graph[edge.first].emplace_back(i, edge.second);
             }
-        }
-        for (PathNode& path_node : path_nodes) {
-            size_t out_degree = path_node.edges.size();
-            path_node.edges.clear();
-            path_node.edges.reserve(out_degree);
+            edges.clear();
         }
         for (size_t i : order) {
             for (const pair<size_t, size_t>& edge : reverse_graph[i]) {
-                path_nodes.at(edge.first).edges.emplace_back(i, edge.second);
+                path_nodes[edge.first].edges.emplace_back(i, edge.second);
             }
         }
     }
@@ -3947,9 +3944,10 @@ namespace vg {
         // We can only remove edges when the edges are present
         assert(has_reachability_edges);
         
-        // algorithm assumes edges are also sorted in topological order, which guarantees that we will
-        // traverse a path that reveals an edge as transitive before actually traversing the transitive edge
-        reorder_adjacency_lists(topological_order);
+        // records of (incoming index, length of edge) indicating the index of the nearest node
+        // that an edge of exactly the expected length to this node, which is a strong sign
+        // that the edge is a correct connection that we want to keep
+        vector<pair<size_t, size_t>> shortest_exact_src;
         
         for (size_t i : topological_order) {
             vector<pair<size_t, size_t>>& edges = path_nodes[i].edges;
@@ -3958,6 +3956,33 @@ namespace vg {
             // (this optimization covers most cases)
             if (edges.size() <= 1) {
                 continue;
+            }
+            
+            // we don't do these linear pre-compute steps unless there is actual ambiguity in the MEMs
+            // in order to save compute in the typical case that there is none
+            // TODO: not very readable
+            if (shortest_exact_src.empty()) {
+                
+                // algorithm assumes edges are also sorted in topological order, which guarantees that we will
+                // traverse a path that reveals an edge as transitive before actually traversing the transitive edge
+                reorder_adjacency_lists(topological_order);
+                
+                // compute the shortest incoming edge that achieves exactly the expected distance for each node
+                shortest_exact_src.resize(path_nodes.size(), make_pair(numeric_limits<size_t>::max(),
+                                                                       numeric_limits<size_t>::max()));
+                
+                for (size_t i = 0; i < path_nodes.size(); ++i) {
+                    auto& path_node = path_nodes[i];
+                    for (auto& edge : path_node.edges) {
+                        if (edge.second == (path_nodes[edge.first].begin - path_node.end)) {
+                            auto& rec = shortest_exact_src[edge.first];
+                            if (edge.second < rec.second) {
+                                // this is the shortest exact edge we've seen to this node
+                                rec = make_pair(i, edge.second);
+                            }
+                        }
+                    }
+                }
             }
             
             vector<bool> keep(edges.size(), true);
@@ -3969,7 +3994,13 @@ namespace vg {
                     path_nodes[i].end != path_nodes[edge.first].begin) {
                     // we can reach the target of this edge by another path, so it is transitive
                     // and the path nodes don't abut on either the read or graph
-                    keep[j] = false;
+                    
+                    // we also spare the shortest edge with exact distance from being removed, since
+                    // it is probably correct even if it is transitive (which sometimes happens across
+                    // incorrect splice junctions or deletions)
+                    if (i != shortest_exact_src[edge.first].first) {
+                        keep[j] = false;
+                    }
                     continue;
                 }
                 

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -126,7 +126,9 @@ using namespace std;
         cerr << "got path overlapping segments" << endl;
         for (const auto& surjection_record : path_overlapping_anchors) {
             cerr << "path " << graph->get_path_name(surjection_record.first.first) << ", rev? " << surjection_record.first.second << endl;
-            for (auto& anchor : surjection_record.second.first) {
+            
+            for (size_t i = 0; i < surjection_record.second.first.size(); ++i) {
+                auto& anchor = surjection_record.second.first[i];
                 if (source_aln) {
                     cerr << "\tread[" << (anchor.first.first - source_aln->sequence().begin()) << ":" << (anchor.first.second - source_aln->sequence().begin()) << "] : ";
                 }
@@ -137,6 +139,7 @@ using namespace std;
                     cerr << *iter;
                 }
                 cerr << endl;
+                cerr << "\tpath interval " << graph->get_position_of_step(surjection_record.second.second[i].first) << " - " << graph->get_position_of_step(surjection_record.second.second[i].second) << endl;
                 cerr << "\t" << pb2json(anchor.second) << endl;
             }
             if (connections.count(surjection_record.first)) {
@@ -952,7 +955,6 @@ using namespace std;
                     deletion_chunks.push_back(i);
                 }
             }
-            //unordered_set<size_t> deletion_chunk_set(deletion_chunks.begin(), deletion_chunks.end());
             
             // deletion chunks can go on either end, so we try all combinations
             // TODO: magic number to prevent explosion
@@ -1129,6 +1131,203 @@ using namespace std;
         return return_val;
     }
 
+    void Surjector::cut_anchors(bool rev_strand, vector<path_chunk_t>& path_chunks,
+                                vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
+                                vector<tuple<size_t, size_t, int32_t>>& connections) const {
+        
+        // TODO: this is very repetitive with the similar function in the main spliced surject
+        
+        // distance along the path from end of chunk 1 to some mapping on chunk 2
+        auto path_distance = [&](size_t chunk_idx_1,
+                                 size_t chunk_idx_2, size_t mapping_idx_2) {
+            
+            step_handle_t step_1 = ref_chunks[chunk_idx_1].second;
+            // move right from the beginning of the second chunk if necessary
+            step_handle_t step_2 = ref_chunks[chunk_idx_2].first;
+            for (size_t i = 0; i < chunk_idx_2; ++i) {
+                step_2 = rev_strand ? graph->get_previous_step(step_2) : graph->get_next_step(step_2);
+            }
+            
+            // get the distance component that is on the two mappings
+            const auto& mapping_1 = *path_chunks[chunk_idx_1].second.mapping().rbegin();
+            const auto& mapping_2 = path_chunks[chunk_idx_2].second.mapping(mapping_idx_2);
+            int64_t dist = mapping_2.position().offset() - mapping_1.position().offset() - mapping_from_length(mapping_1);
+            
+            // get the distance component that is along the path
+            if (rev_strand) {
+                dist += (graph->get_position_of_step(step_1)
+                         + graph->get_length(graph->get_handle_of_step(step_1))
+                         - graph->get_position_of_step(step_2)
+                         - graph->get_length(graph->get_handle_of_step(step_2)));
+            }
+            else {
+                dist += (graph->get_position_of_step(step_2)
+                         - graph->get_position_of_step(step_1));
+            }
+            return dist;
+        };
+        
+        // put the input in lexicographic order by read interval
+        vector<size_t> order = range_vector(path_chunks.size());
+        stable_sort(order.begin(), order.end(), [&](size_t i, size_t j) {
+            const auto& interval_1 = path_chunks[i].first;
+            const auto& interval_2 = path_chunks[j].first;
+            return (interval_1.first < interval_2.first ||
+                    (interval_1.first == interval_2.first && interval_1.second < interval_2.second));
+        });
+        vector<size_t> index(order.size());
+        for (size_t i = 0; i < order.size(); i++) {
+            index[order[i]] = i;
+        }
+        // update the connection indexes
+        for (auto& connection : connections) {
+            get<0>(connection) = index[get<0>(connection)];
+            get<1>(connection) = index[get<1>(connection)];
+        }
+
+        // swap the order
+        for (size_t i = 0; i < path_chunks.size(); ++i) {
+            while (index[i] != i) {
+#ifdef debug_spliced_surject
+                cerr << "reordering chunks, swapping " << i << " and " << index[i] << endl;
+#endif
+                std::swap(path_chunks[index[i]], path_chunks[i]);
+                std::swap(ref_chunks[index[i]], ref_chunks[i]);
+                std::swap(index[index[i]], index[i]);
+            }
+        }
+        
+        // find any overlaps we want to break
+        vector<pair<size_t, size_t>> overlaps;
+        for (size_t i = 0; i < path_chunks.size(); ++i) {
+            auto i_end = path_chunks[i].first.second;
+            for (size_t j = i + 1; j < path_chunks.size() && path_chunks[j].first.first < i_end; ++j) {
+                if (i_end < path_chunks[j].first.second) {
+                    // the first chunk overlaps the second (note: this check depends on sorting order)
+                    
+                    // figure out how far we have to go down the second chunk to get past the overlap
+                    int64_t to_walk = i_end - path_chunks[j].first.first;
+                    int64_t walked = 0;
+                    size_t k = 0;
+                    for (; k < path_chunks[j].second.mapping_size() && walked < to_walk; ++k) {
+                        walked += mapping_to_length(path_chunks[j].second.mapping(k));
+                    }
+                    if (k < path_chunks[j].second.mapping_size() && path_distance(i, j, k) >= 0) {
+                        // we didn't walk off the end of the of second chunk and they're colinear along the path
+                        // so we record an overlap
+                        overlaps.emplace_back(j, k);
+#ifdef debug_spliced_surject
+                        cerr << "path chunk " << i << " overlaps " << j << " by " << to_walk << " on read, marking an overlap to split before mapping " << k << " at " << pb2json(path_chunks[j].second.mapping(k)) << endl;
+#endif
+                    }
+                }
+            }
+        }
+        
+        if (!overlaps.empty()) {
+            
+            sort(overlaps.begin(), overlaps.end());
+            overlaps.resize(unique(overlaps.begin(), overlaps.end()) - overlaps.begin());
+            
+#ifdef debug_spliced_surject
+            cerr << "performing overlap splits: " << endl;
+            for (auto overlap : overlaps) {
+                cerr << "\t" << overlap.first << ", " << overlap.second << endl;
+            }
+#endif
+            
+            vector<path_chunk_t> split_path_chunks;
+            split_path_chunks.reserve(path_chunks.size() + overlaps.size());
+            vector<pair<step_handle_t, step_handle_t>> split_ref_chunks;
+            split_ref_chunks.reserve(ref_chunks.size() + overlaps.size());
+            
+            vector<size_t> added_before(path_chunks.size(), 0);
+            for (size_t i = 0, j = 0; i < path_chunks.size(); ++i) {
+                if (i > 0) {
+                    added_before[i] = added_before[i - 1];
+                }
+                
+                if (j < overlaps.size() && overlaps[j].first == i) {
+                    // find out how many overlap splits we need to perform
+                    size_t n = 1;
+                    while (j + n < overlaps.size() && overlaps[j + n].first == i) {
+                        ++n;
+                    }
+#ifdef debug_spliced_surject
+                    cerr << "path chunk " << i << " has " << n << " overlap splits" << endl;
+#endif
+                    // we'll walk along the ref path and the read intervals as we go
+                    step_handle_t step = ref_chunks[i].first;
+                    auto read_begin = path_chunks[i].first.first;
+                    
+                    for (size_t k = 0; k <= n; ++k) {
+                        // figure out the bounds of mappings we'll move over
+                        size_t begin_idx = (k == 0 ? 0 : overlaps[j + k - 1].second);
+                        size_t end_idx = (k == n ? path_chunks[i].second.mapping_size() : overlaps[j + k].second);
+                        
+                        // add the mappings
+                        split_path_chunks.emplace_back();
+                        auto& path_chunk = split_path_chunks.back();
+                        for (size_t l = begin_idx; l < end_idx; ++l) {
+                            auto mapping = path_chunk.second.add_mapping();
+                            *mapping = path_chunks[i].second.mapping(l);
+                            mapping->set_rank(l - begin_idx + 1);
+                        }
+                        // identify the read interval
+                        path_chunk.first.first = read_begin;
+                        path_chunk.first.second = path_chunk.first.first + path_to_length(path_chunk.second);
+                        read_begin = path_chunk.first.second;
+                        
+                        // walk the reference path steps
+                        split_ref_chunks.emplace_back();
+                        auto& ref_chunk = split_ref_chunks.back();
+                        ref_chunk.first = step;
+                        for (size_t l = begin_idx + 1; l < end_idx; ++l) {
+                            step = rev_strand ? graph->get_previous_step(step) : graph->get_next_step(step);
+                        }
+                        ref_chunk.second = step;
+                        // set up the step for the next iteration
+                        step = rev_strand ? graph->get_previous_step(step) : graph->get_next_step(step);
+#ifdef debug_spliced_surject
+                        cerr << "next split for chunk " << i << " as " << split_path_chunks.size() - 1 << ", consisting of " << endl;
+                        cerr << "\t" << string(path_chunk.first.first, path_chunk.first.second) << endl;
+                        cerr << "\t" << pb2json(path_chunk.second) << endl;
+                        cerr << "\t" << graph->get_position_of_step(ref_chunk.first) << " : " << graph->get_position_of_step(ref_chunk.second) << endl;
+#endif
+                    }
+                    j += n;
+                    added_before[i] += n;
+                }
+                else {
+#ifdef debug_spliced_surject
+                    cerr << "no splits on chunk " << i << ", add as " << split_path_chunks.size() << endl;
+                    cerr << "\t" << string(path_chunks[i].first.first, path_chunks[i].first.second) << endl;
+                    cerr << "\t" << pb2json(path_chunks[i].second) << endl;
+                    cerr << "\t" << graph->get_position_of_step(ref_chunks[i].first) << " : " << graph->get_position_of_step(ref_chunks[i].second) << endl;
+#endif
+                    split_path_chunks.emplace_back(move(path_chunks[i]));
+                    split_ref_chunks.emplace_back(move(ref_chunks[i]));
+                    
+                }
+            }
+            
+            // replace the original path chunks and ref chunks with the split ones
+            path_chunks = move(split_path_chunks);
+            ref_chunks = move(split_ref_chunks);
+            
+            // and update the indexes of the connections
+            for (auto& connection : connections) {
+                // edges out should be updated for the splits added in that iteration because
+                // the come out of the last split segment
+                get<0>(connection) += added_before[get<0>(connection)];
+                // edges in should only be updated for the splits that happened in earlier
+                // iterations (also, these should never be in index 0, would violate
+                // colinearity)
+                get<1>(connection) += added_before[get<1>(connection) - 1];
+            }
+        }
+    }
+
     multipath_alignment_t Surjector::spliced_surject(const PathPositionHandleGraph* path_position_graph,
                                                      const string& src_sequence, const string& src_quality,
                                                      const int32_t src_mapping_quality,
@@ -1141,8 +1340,7 @@ using namespace std;
                 
         assert(path_chunks.size() == ref_chunks.size());
         
-        // assumes that i and j are on the same strand
-        auto path_distance = [&](size_t i, size_t j) {
+        function<int64_t(size_t,size_t)> path_distance = [&](size_t i, size_t j) {
             const auto& final_mapping = *path_chunks[i].second.mapping().rbegin();
             int64_t dist = (path_chunks[j].second.mapping(0).position().offset()
                             - final_mapping.position().offset()
@@ -1215,25 +1413,24 @@ using namespace std;
         
 #ifdef debug_spliced_surject
         cerr << "removed " << insertions_removed.back() << " chunks" << endl;
-        cerr << "making colinearity graph for " << path_chunks.size() << " path chunks" << endl;
+        cerr << "checking for need to cut anchors" << endl;
 #endif
         
-        // by construction, the path chunks are ordered by initial index on aln path, but not necessarily second index
-
-        vector<vector<size_t>> colinear_adj(path_chunks.size());
+        cut_anchors(rev_strand, path_chunks, ref_chunks, connections);
+        
+#ifdef debug_spliced_surject
+        cerr << "making colinearity graph for " << path_chunks.size() << " path chunks" << endl;
+#endif
+         vector<vector<size_t>> colinear_adj(path_chunks.size());
         
         for (size_t i = 0; i < path_chunks.size(); ++i) {
-                        
             for (size_t j = i + 1; j < path_chunks.size(); ++j) {
-                                
-                if (path_chunks[j].first.first < path_chunks[i].first.second
-                    || path_distance(i, j) < 0) {
-                    // these two path chunks are not colinear
-                    continue;
+                if (path_chunks[i].first.second <= path_chunks[j].first.first
+                    && path_distance(i, j) >= 0) {
+                    // the second one is further along both the read and the path, so it is colinear
+                    colinear_adj[i].push_back(j);
                 }
                 
-                // the second one is further along both the read and the path, so it is colinear
-                colinear_adj[i].push_back(j);
             }
         }
         

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -190,6 +190,11 @@ using namespace std;
                                                        vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
                                                        vector<tuple<size_t, size_t, int32_t>>& connections) const;
         
+        /// if any anchors overlap each other, cut the second at the implied overlap position
+        void cut_anchors(bool rev_strand, vector<path_chunk_t>& path_chunks,
+                         vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
+                         vector<tuple<size_t, size_t, int32_t>>& connections) const;
+        
         /// returns all sets of chunks such that 1) all of chunks on the left set abut all of the chunks on the right
         /// set on the read, 2) all source-to-sink paths in the connected component go through an edge between
         /// the left and right sides, 3) all of the chunks that do not have a connection between them are fully


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject -S` produces more accurate spliced BAMs

## Description

I was trying to improve accuracy on spliced HPRC graphs, but most of the problems I was seeing were actually caused by weaknesses in the spliced surject algorithm. This PR contains several tune ups.
