### PR TITLE
Improve autoindex robustness

### DIFF
--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -1467,7 +1467,12 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                                 continue;
                             }
                             
-                            int64_t chunk_idx = contig_to_idx.at(chrom);
+                            auto it = contig_to_idx.find(chrom);
+                            if (it == contig_to_idx.end()) {
+                                cerr << "error:[IndexRegistry] contig " << chrom << " from GTF/GFF " << tx_filenames[idx] << " is not found in reference" << endl;
+                                exit(1);
+                            }
+                            int64_t chunk_idx = it->second;
                             if (chunk_idx != prev_chunk_idx) {
                                 // we're transitioning between chunks, so we need to check the chunk
                                 // out for writing

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -2063,6 +2063,24 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     
     // TODO: spliced vg from GFA input
     
+    registry.register_recipe({"Spliced MaxNodeID", "Spliced VG w/ Variant Paths"},
+                             {"Chunked GTF/GFF", "Chunked Reference FASTA", "Chunked VCF w/ Phasing", "Insertion Sequence FASTA"},
+                             [construct_with_constructor](const vector<const IndexFile*>& inputs,
+                                                          const IndexingPlan* plan,
+                                                          AliasGraph& alias_graph,
+                                                          const IndexGroup& constructing) {
+        return construct_with_constructor(inputs, plan, constructing, true, true);
+    });
+    
+    registry.register_recipe({"Spliced MaxNodeID", "Spliced VG w/ Variant Paths"},
+                             {"Chunked GTF/GFF", "Chunked Reference FASTA", "Chunked VCF w/ Phasing"},
+                             [construct_with_constructor](const vector<const IndexFile*>& inputs,
+                                                          const IndexingPlan* plan,
+                                                          AliasGraph& alias_graph,
+                                                          const IndexGroup& constructing) {
+        return construct_with_constructor(inputs, plan, constructing, true, true);
+    });
+    
     registry.register_recipe({"Spliced MaxNodeID", "Spliced VG"},
                              {"Chunked GTF/GFF", "Chunked Reference FASTA", "Chunked VCF", "Insertion Sequence FASTA"},
                              [construct_with_constructor](const vector<const IndexFile*>& inputs,
@@ -2079,23 +2097,6 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                                  AliasGraph& alias_graph,
                                  const IndexGroup& constructing) {
         return construct_with_constructor(inputs, plan, constructing, false, true);
-    });
-    registry.register_recipe({"Spliced MaxNodeID", "Spliced VG w/ Variant Paths"},
-                             {"Chunked GTF/GFF", "Chunked Reference FASTA", "Chunked VCF w/ Phasing", "Insertion Sequence FASTA"},
-                             [construct_with_constructor](const vector<const IndexFile*>& inputs,
-                                 const IndexingPlan* plan,
-                                 AliasGraph& alias_graph,
-                                 const IndexGroup& constructing) {
-        return construct_with_constructor(inputs, plan, constructing, true, true);
-    });
-    
-    registry.register_recipe({"Spliced MaxNodeID", "Spliced VG w/ Variant Paths"},
-                             {"Chunked GTF/GFF", "Chunked Reference FASTA", "Chunked VCF w/ Phasing"},
-                             [construct_with_constructor](const vector<const IndexFile*>& inputs,
-                                 const IndexingPlan* plan,
-                                 AliasGraph& alias_graph,
-                                 const IndexGroup& constructing) {
-        return construct_with_constructor(inputs, plan, constructing, true, true);
     });
     
     

--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -246,8 +246,8 @@ class Transcriptome {
         /// Parse BED file of introns.
         void parse_introns(vector<Transcript> * introns, istream * intron_stream, const bdsg::PositionOverlay & graph_path_pos_overlay) const;
 
-        /// Parse gtf/gff3 file of transcripts.
-        void parse_transcripts(vector<Transcript> * transcripts, istream * transcript_stream, const bdsg::PositionOverlay & graph_path_pos_overlay, const gbwt::GBWT & haplotype_index, const bool use_haplotype_paths) const;
+        /// Parse gtf/gff3 file of transcripts. Returns the number of non-header lines in the parsed file.
+        int32_t parse_transcripts(vector<Transcript> * transcripts, istream * transcript_stream, const bdsg::PositionOverlay & graph_path_pos_overlay, const gbwt::GBWT & haplotype_index, const bool use_haplotype_paths) const;
 
         /// Parse gtf/gff3 attribute value.
         string parse_attribute_value(const string & attribute, const string & name) const;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex -w mpmap` no longer complains if some contigs don't have any transcripts.

## Description

Found a couple of small bugs that hadn't shown up in our workflows yet.