### PR TITLE
Bug fix for obscure issue with dozeu

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -363,7 +363,7 @@ double GSSWAligner::recover_log_base(const int8_t* score_matrix, double gc_conte
     
     // arbitrary starting point greater than zero
     double lambda = 1.0;
-    // search for a window containing lambda where total probability is 1
+    // exponential search for a window containing lambda where total probability is 1
     double partition = alignment_score_partition_function(lambda, score_matrix, nt_freqs);
     if (partition < 1.0) {
         lower_bound = lambda;
@@ -1352,7 +1352,7 @@ void Aligner::align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_
         // wrap the graph so that empty pinning points are handled correctly
         DozeuPinningOverlay overlay(&g, !pin_left);
         
-        if (overlay.get_node_count() == 0 && g.get_node_count() > 0) {
+        if (overlay.get_node_count() == 0 && g.get_node_count() != 0) {
             // the only nodes in the graph are empty nodes for pinning, which got masked.
             // we can still infer a pinned alignment based purely on the pinning point but
             // dozeu won't handle this correctly
@@ -2026,7 +2026,7 @@ void QualAdjAligner::align_pinned(Alignment& alignment, const HandleGraph& g, bo
         
         // wrap the graph so that empty pinning points are handled correctly
         DozeuPinningOverlay overlay(&g, !pin_left);
-        if (overlay.get_node_count() == 0 && g.get_node_count() > 0) {
+        if (overlay.get_node_count() == 0 && g.get_node_count() != 0) {
             // the only nodes in the graph are empty nodes for pinning, which got masked.
             // we can still infer a pinned alignment based purely on the pinning point but
             // dozeu won't handle this correctly

--- a/src/qual_adj_xdrop_aligner.cpp
+++ b/src/qual_adj_xdrop_aligner.cpp
@@ -1,7 +1,6 @@
 /**
  * \file qual_adj_xdrop_aliigner.cpp: contains implementation of QualAdjXdropAligner
  */
-
 #include "dozeu_interface.hpp"
 
 // Configure dozeu:
@@ -51,7 +50,6 @@ QualAdjXdropAligner& QualAdjXdropAligner::operator=(const QualAdjXdropAligner& o
         
         free(qual_adj_matrix);
     }
-
 	return *this;
 }
 
@@ -82,13 +80,14 @@ QualAdjXdropAligner::QualAdjXdropAligner(const int8_t* _score_matrix,
     assert(_gap_open - _gap_extension >= 0);
     assert(_gap_extension > 0);
     
-    // convert the 5x5 matrices into a 4x4 like dozeu wants
+    // convert the 5x5 matrices into a 4x4 like dozeu wants, and also transpose
+    // the matrix so that the read error probabilities are where dozeu expects
     uint32_t max_qual = 255;
     int8_t* qual_adj_scores_4x4 = (int8_t*) malloc(16 * (max_qual + 1));
-    for (int q = 0; q < max_qual; ++q) {
+    for (int q = 0; q <= max_qual; ++q) {
         for (int i = 0; i < 4; ++i) {
             for (int j = 0; j < 4; ++j) {
-                qual_adj_scores_4x4[q * 16 + i * 4 + j] = _qual_adj_score_matrix[q * 25 + i * 5 + j];
+                qual_adj_scores_4x4[q * 16 + i * 4 + j] = _qual_adj_score_matrix[q * 25 + j * 5 + i];
             }
         }
     }

--- a/src/unittest/test_aligner.hpp
+++ b/src/unittest/test_aligner.hpp
@@ -13,7 +13,8 @@ namespace unittest {
 /// We define a child class to expose all the protected stuff for testing
 class TestAligner : public AlignerClient {
 public:
-    using AlignerClient::AlignerClient;
+    TestAligner(double gc_content) : AlignerClient(gc_content) {}
+    TestAligner() : AlignerClient() {}
     using AlignerClient::set_alignment_scores;
     using AlignerClient::get_qual_adj_aligner;
     using AlignerClient::get_regular_aligner;


### PR DESCRIPTION
## Description

This is a fix for a rare and subtle bug that I encountered as a discrepancy between GSSW and dozeu alignments. It turned out to be that dozeu's quality adjustments were applying read qualities to the reference sequence. This occasionally has asymmetric effects on the score when it's in a GC-biased reference.