### PR TITLE
Fix crash in vg sim on 1 bp paths

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -2609,19 +2609,19 @@ namespace vg {
                     
                 }
                 
-                if (distance_index && dist == numeric_limits<int64_t>::max()) {
-                    // FIXME: this will still sometimes produce finite distances for reads that
-                    // can't reach each other along a surjection path in cyclic graphs
-                    // FIXME: it can also find finite distances to different strands of a path,
-                    // but this might be okay sometimes?
-                    
-                    // they're probably still reachable if they got this far, get a worse estimate of the
-                    // distance from the distance index
-                    int64_t min_dist = distance_index->min_distance(pos_1, pos_2);
-                    if (min_dist >= 0) {
-                        dist = min_dist;
-                    }
-                }
+//                if (distance_index && dist == numeric_limits<int64_t>::max()) {
+//                    // FIXME: this will still sometimes produce finite distances for reads that
+//                    // can't reach each other along a surjection path in cyclic graphs
+//                    // FIXME: it can also find finite distances to different strands of a path,
+//                    // but this might be okay sometimes?
+//                    
+//                    // they're probably still reachable if they got this far, get a worse estimate of the
+//                    // distance from the distance index
+//                    int64_t min_dist = distance_index->min_distance(pos_1, pos_2);
+//                    if (min_dist >= 0) {
+//                        dist = min_dist;
+//                    }
+//                }
                 
                 if (dist != numeric_limits<int64_t>::max()) {
                     // not memoizing unreachable distances, since distance index should

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -717,10 +717,14 @@ NGSSimulator::NGSSimulator(PathPositionHandleGraph& graph,
             // Always use accurate length for sampling start pos, even with sample_unsheared_paths
             start_pos_samplers.emplace_back(0, length - 1);
             
-            if (sample_unsheared_paths) {
+            if (length == 0) {
+                path_weights.push_back(0.0);
+            }
+            else if (sample_unsheared_paths) {
                 // sample uniformly between paths
                 path_weights.push_back(1.0);
-            } else {
+            }
+            else {
                 // Sample paths proportional to effective length and ploidy
                 double eff_path_len;
                 if (fragment_mean != numeric_limits<double>::max()) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg sim` does not crash when a path has length 1 bp

## Description

I extended the truncated normal code to handle point masses.