### PR TITLE
Fast position comparison for `vg giraffe` seed correctness

### DIFF
--- a/src/algorithms/intersect_path_offsets.cpp
+++ b/src/algorithms/intersect_path_offsets.cpp
@@ -1,0 +1,103 @@
+/**
+ * \file intersect_path_offsets.cpp
+ *
+ * Contains implementation of intersect_path_offsets function
+ */
+
+#include "intersect_path_offsets.hpp"
+
+#include <algorithms>
+
+//#define debug
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+
+
+bool intersect_path_offsets(path_offset_collection_t& a_offsets,
+                            path_offset_collection_t& b_offsets,
+                            size_t maximum_distance) {
+                            
+    for (auto& kv : a_offsets) {
+        // For each path on th a side
+        path_handle_t& path = kv.first;
+        
+        auto found = b_offsets.find(path);
+        if (found == b_ffsets.end()) {
+            // Skip it if it's not also on the b side
+            continue;
+        }
+        
+        // Otherwise, find all the positions
+        vector<pair<size_t, bool>>& a_positions = kv.second;
+        vector<pair<size_t, bool>>& b_positions = found->second;
+        
+        if (a_positions.empty() || b_positions.empty()) {
+            // Stop if either side is actually empty somehow
+            continue;
+        }
+        
+        // Otherwise sort them
+        std::sort(a_positions.begin(), a_positions.end());
+        std::sort(b_positions.begin(), b_positions.end());
+        
+        // Go through both collections at the same time
+        auto a_cursor = a_positions.begin();
+        auto b_cursor = b_positions.begin();
+        
+        while (a_cursor != a_positions.end() && b_cursor != b_positions.end()) {
+            // Compute the distance of the things we are considering.
+            
+            size_t distance = (size_t) abs((int64_t)a_cursor->first - (int64_t)b_cursor->first);
+            
+            if (distance <= maximum_distance) {
+                // These two things are close enough. 
+                // Return that we found a match.
+                return true;
+            }
+            
+            // Otherwise, peek ahead on both sides, and advance whichever one
+            // exists and is earliest.
+            
+            auto a_next = a_cursor;
+            ++a_next;
+            if (a_next == a_positions.end()) {
+                // We can't advance a, so we must advance b.
+                // If we hit the end in b we will stop.
+                ++b_cursor;
+            } else {
+                // We might want to advance b instead though.
+                auto b_next = b_cusrsor;
+                ++b_next;
+                if (b_next == b_positions.end()) {
+                    // Actually we can only advance a. If we hit the end in a we will stop.
+                    a_cursor = a_next;
+                } else {
+                    // We could advance a or b, so advance whichever is soonest
+                    if (a_next->first < b_next->first) {
+                        // the next thing in a is earlier
+                        a_cursor = a_next;
+                    } else {
+                        // The next thing in b is earlier, or we are tied
+                        b_cursor = b_next;
+                    }
+                }
+            }
+            
+            // The correctness of this approach depends on being able to ignore
+            // strand, and thus rule out the existence of a match to something
+            // later if there was no match to something earlier.
+            
+            // TODO: Support depending on strand by running one set of cursors per strand?
+        }
+        
+    }
+    
+    // If we get here we found no matches on any paths.
+    return false;
+}
+
+}
+}

--- a/src/algorithms/intersect_path_offsets.hpp
+++ b/src/algorithms/intersect_path_offsets.hpp
@@ -1,0 +1,43 @@
+#ifndef VG_ALGORITHMS_INTERSECT_PATH_OFFSETS_HPP_INCLUDED
+#define VG_ALGORITHMS_INTERSECT_PATH_OFFSETS_HPP_INCLUDED
+
+/**
+ * \file intersect_path_offsets.hpp
+ *
+ * Defines algorithm for finding whether any offsets on paths in one set are
+ * near any offsets on paths in a different set.
+ */
+
+#include "../handle.hpp"
+
+#include "nearest_offsets_in_paths.hpp"
+
+namespace vg {
+namespace algorithms {
+
+using namespace std;
+    
+/**
+ * Given two maps from path handle to (position, orientation) pair vectors,
+ * determine if any positions in the two sets are on the
+ * same path, within the given maximum distance.
+ *
+ * The set expected to visit fewer paths should be passed first.
+ *
+ * Orientation is ignored.
+ *
+ * See nearest_offsets_in_paths() for a function that generates these.
+ *
+ * Needs write access to its input position collections, so it can sort them in
+ * place.
+ */
+bool intersect_path_offsets(path_offset_collection_t& a_offsets,
+                            path_offset_collection_t& b_offsets,
+                            size_t maximum_distance);
+    
+
+}
+}
+
+#endif
+

--- a/src/algorithms/intersect_path_offsets.hpp
+++ b/src/algorithms/intersect_path_offsets.hpp
@@ -19,21 +19,26 @@ using namespace std;
     
 /**
  * Given two maps from path handle to (position, orientation) pair vectors,
- * determine if any positions in the two sets are on the
- * same path, within the given maximum distance.
+ * determine if any positions in the two sets are on the same path, within the
+ * given maximum distance.
  *
- * The set expected to visit fewer paths should be passed first.
+ * The set expected to have more visits should be passed first.
  *
  * Orientation is ignored.
  *
- * See nearest_offsets_in_paths() for a function that generates these.
+ * The first set must be sorted, for binary search. We run binary search for
+ * each item in the second set, so the first set should be the larger one.
  *
- * Needs write access to its input position collections, so it can sort them in
- * place.
+ * We run in b log a time.
  */
-bool intersect_path_offsets(path_offset_collection_t& a_offsets,
-                            path_offset_collection_t& b_offsets,
+bool intersect_path_offsets(const path_offset_collection_t& a_offsets,
+                            const path_offset_collection_t& b_offsets,
                             size_t maximum_distance);
+                            
+/**
+ * Sort path offsets, so intersect_path_offsets() can use them as a target.
+ */
+void sort_path_offsets(path_offset_collection_t& offsets);
     
 
 }

--- a/src/algorithms/nearest_offsets_in_paths.cpp
+++ b/src/algorithms/nearest_offsets_in_paths.cpp
@@ -13,13 +13,14 @@ namespace algorithms {
 
 using namespace std;
 
-unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
-                                                                                  const pos_t& pos,
-                                                                                  int64_t max_search,
-                                                                                  const std::function<bool(const path_handle_t&)>* path_filter) {
+path_offset_collection_t nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
+                                                  const pos_t& pos,
+                                                  int64_t max_search,
+                                                  const std::function<bool(const path_handle_t&)>* path_filter) {
     
     // init the return value
-    unordered_map<path_handle_t, vector<pair<size_t, bool>>> return_val;
+    // This is a map from path handle, to vector of offset and orientation pairs
+    path_offset_collection_t return_val;
     
     // use greater so that we traverse in ascending order of distance
     structures::RankPairingHeap<pair<handle_t, bool>, int64_t, greater<int64_t>> queue;
@@ -123,8 +124,8 @@ map<string, vector<pair<size_t, bool>>> offsets_in_paths(const PathPositionHandl
     return named_offsets;
 }
 
-unordered_map<path_handle_t, vector<pair<size_t, bool>>> simple_offsets_in_paths(const PathPositionHandleGraph* graph, pos_t pos) {
-    unordered_map<path_handle_t, vector<pair<size_t, bool>>> positions;
+path_offset_collection_t simple_offsets_in_paths(const PathPositionHandleGraph* graph, pos_t pos) {
+    path_offset_collection_t positions;
     handle_t handle = graph->get_handle(id(pos), is_rev(pos));
     size_t handle_length = graph->get_length(handle);
     for (const step_handle_t& step : graph->steps_of_handle(handle)) {

--- a/src/algorithms/nearest_offsets_in_paths.hpp
+++ b/src/algorithms/nearest_offsets_in_paths.hpp
@@ -21,7 +21,10 @@ namespace vg {
 namespace algorithms {
 
 using namespace std;
-    
+
+/// Represents a set of positions and orientations, along a collection of paths.
+/// Positions and orientations may or may not be stored sorted.
+using path_offset_collection_t = unordered_map<path_handle_t, vector<pair<size_t, bool>>>;
     
 /// Return, for the nearest position in a path to the given position,
 /// subject to the given max search distance, a mapping from path name to
@@ -29,16 +32,16 @@ using namespace std;
 /// Stops search when path(s) are ancountered.
 ///
 /// If path_filter is set, ignores paths for which it returns false.
-unordered_map<path_handle_t, vector<pair<size_t, bool>>> nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
-                                                                                  const pos_t& pos, int64_t max_search,
-                                                                                  const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
+path_offset_collection_t nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
+                                                  const pos_t& pos, int64_t max_search,
+                                                  const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
     
 /// Wrapper for the above to support some earlier code. Only looks for paths
 /// that directly touch the position, and returns the paths by name.
 map<string, vector<pair<size_t, bool>>> offsets_in_paths(const PathPositionHandleGraph* graph, const pos_t& pos);
 
 /// A "simple" model for path position getting for debugging
-unordered_map<path_handle_t, vector<pair<size_t, bool>>> simple_offsets_in_paths(const PathPositionHandleGraph* graph, pos_t pos);
+path_offset_collection_t simple_offsets_in_paths(const PathPositionHandleGraph* graph, pos_t pos);
     
 
 }

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -12,6 +12,7 @@
 #include "subgraph.hpp"
 #include "statistics.hpp"
 #include "algorithms/count_covered.hpp"
+#include "algorithms/intersect_path_offsets.hpp"
 
 #include <bdsg/overlays/strand_split_overlay.hpp>
 #include <gbwtgraph/algorithms.h>
@@ -2983,24 +2984,27 @@ std::vector<MinimizerMapper::Seed> MinimizerMapper::find_seeds(const std::vector
         }
 
         if (aln.refpos_size() != 0) {
+            // Compose path handle to position and strand data structure for the annotated reference positions
+            algorithms::path_offset_collection_t ref_positions;
+            for (auto& true_pos : aln.refpos()) {
+               ref_positions[this->path_graph->get_path_handle(true_pos.name())].emplace_back(true_pos.offset(), true_pos.is_reverse());
+            }
+            // Make sure it is sorted
+            algorithms::sort_path_offsets(ref_positions);
+            
+            // We need to know whether each seed is correct or not, and the
+            // seeds probably have about one position each. So we look up the
+            // seeds' positions in the sorted ref positions, and take: 
+            // O(#seed positions * log(#ref positions)) 
+            
             for (size_t i = 0; i < seeds.size(); i++) {
                 // Find every seed's reference positions. This maps from path name to pairs of offset and orientation.
-                auto offsets = algorithms::nearest_offsets_in_paths(this->path_graph, seeds[i].pos, 100);
-                bool found = false;
-                for (auto& true_pos : aln.refpos()) {
-                    // For every annotated true position
-                    for (auto& hit_pos : offsets[this->path_graph->get_path_handle(true_pos.name())]) {
-                        // Look at all the hit positions on the path the read's true position is on.
-                        if (abs((int64_t)hit_pos.first - (int64_t) true_pos.offset()) < 200) {
-                            // Call this seed hit close enough to be correct
-                            funnel.tag_correct(i);
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (found) {
-                        break;
-                    }
+                algorithms::path_offset_collection_t seed_positions = algorithms::nearest_offsets_in_paths(this->path_graph, seeds[i].pos, 100);
+                // Check against the annotated truth position set
+                if (algorithms::intersect_path_offsets(ref_positions, seed_positions, 200)) {
+                    // It's within range of a truth position.
+                    // Call this seed hit close enough to be correct.
+                    funnel.tag_correct(i);
                 }
             }
         }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` correctness-tracking position comparison now has acceptable algorithmics

## Description

Previously, we've been checking every annotated truth position (of `n`) against every seed position (of `m`), to see if a seed ought to be called correct. This takes `O(m*n)` time (quadradic).

This changes things so we sort the annotated truth positions along each path, and then bang the seeds' positions against them by repeated binary search. This will take `O(m * log(n))` time for the comparisons, and `O(n * log(n))` time for the sort, which is better than quadradic.

I thought about doing a sweep line algorithm. If all we had to answer is whether the read had any correct seed, it would probably be better; we'd need to sort each side but the scan would be linear. But since we need to know if *each* seed is correct, so we know when the correct seeds are lost, we'd need to do one sweep line run per seed, which would be quadradic again. So I opted for repeated search instead.

@StephenHwang You should be able to use this to speed up your long read benchmarking. Please let me know if it somehow manages to be slower at the scale you're working at, despite the better algorithmic complexity.