### PR TITLE
Add libzstd-devel to README.md Ubuntu deps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ On other distros, you will need to perform the equivalent of:
                          protobuf-compiler libprotoc-dev libprotobuf-dev libjansson-dev \
                          automake gettext autopoint libtool jq bsdmainutils bc rs parallel \
                          npm curl unzip redland-utils librdf-dev bison flex gawk lzma-dev \
-                         liblzma-dev liblz4-dev libffi-dev libcairo-dev libboost-all-dev
+                         liblzma-dev liblz4-dev libffi-dev libcairo-dev libboost-all-dev \
+                         libzstd-devel
                          
 Note that **Ubuntu 16.04** does not ship a sufficiently new Protobuf; vg requires **Protobuf 3** which will have to be manually installed.
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add libzstd-devel to README.md Ubuntu deps

## Description
Add `libzstd-devel` to README.md Ubuntu deps as `elfutils` grew a new system dependency on the libraries that implement zstd
