### PR TITLE
Distinguish unmapped reads from reads with MAPQ 0 in mpmap

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -518,6 +518,12 @@ namespace vg {
             }
         }
     }
+
+    void clear_alignment(multipath_alignment_t& multipath_aln) {
+        multipath_aln.set_mapping_quality(0);
+        multipath_aln.clear_subpath();
+        multipath_aln.clear_start();
+    }
     
     /// We define this struct for holding the dynamic programming problem for a
     /// multipath alignment, which we use for finding the optimal alignment,

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -146,6 +146,9 @@ namespace vg {
     /// Finds the start subpaths (i.e. the source nodes of the multipath DAG) and stores
     /// them in the 'start' field of the multipath_alignment_t
     void identify_start_subpaths(multipath_alignment_t& multipath_aln);
+
+    /// Clear all of the field associated with the alignment
+    void clear_alignment(multipath_alignment_t& multipath_aln);
     
     /// Stores the highest scoring alignment contained in the multipath_alignment_t in an Alignment
     ///

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -997,6 +997,10 @@ namespace vg {
         bool reset_strip_bonuses = strip_bonuses;
         strip_bonuses = false;
         
+        // we want to avoid returning empty alignments that indicated unmapped reads
+        bool reset_suppress_mismapping_detection = suppress_mismapping_detection;
+        suppress_mismapping_detection = true;
+        
         // and we expect small MEMs, so don't filter them out
         int reset_min_mem_length = min_mem_length;
         size_t reset_min_clustering_mem_length = min_clustering_mem_length;
@@ -1079,6 +1083,7 @@ namespace vg {
         min_mem_length = reset_min_mem_length;
         max_alt_mappings = reset_max_alt_mappings;
         suppress_p_value_memoization = false;
+        suppress_mismapping_detection = reset_suppress_mismapping_detection;
     }
 
     void MultipathMapper::determine_distance_correlation() {

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -415,6 +415,15 @@ namespace vg {
                                          vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
                                          vector<double>& multiplicities) const;
         
+        /// Before returning, remove alignments that are likely noise and add a placeholder
+        /// for an unmapped read if necessary
+        void purge_unmapped_alignments(vector<multipath_alignment_t>& multipath_alns_out);
+        
+        /// Before returning, remove alignments that are likely noise and add placeholders
+        /// for unmapped reads if necessary
+        void purge_unmapped_alignments(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
+                                       bool proper_paired);
+        
         /// The internal agglomeration procedure
         void agglomerate(size_t idx, multipath_alignment_t& agglomerating, const multipath_alignment_t& multipath_aln,
                          vector<size_t>& agglomerated_group, unordered_set<pos_t>& agg_start_positions,

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -216,6 +216,7 @@ int main_mpmap(int argc, char** argv) {
     #define OPT_REPORT_ALLELIC_MAPQ 1034
     #define OPT_RESEED_LENGTH 1035
     #define OPT_MAX_MOTIF_PAIRS 1036
+    #define OPT_SUPPRESS_MISMAPPING_DETECTION 1037
     string matrix_file_name;
     string graph_name;
     string gcsa_name;
@@ -415,6 +416,7 @@ int main_mpmap(int argc, char** argv) {
             {"agglomerate-alns", no_argument, 0, 'a'},
             {"report-group-mapq", no_argument, 0, 'U'},
             {"report-allelic-mapq", no_argument, 0, OPT_REPORT_ALLELIC_MAPQ},
+            {"suppress-mismapping", no_argument, 0, OPT_SUPPRESS_MISMAPPING_DETECTION},
             {"padding-mult", required_argument, 0, OPT_BAND_PADDING_MULTIPLIER},
             {"map-attempts", required_argument, 0, 'u'},
             {"max-paths", required_argument, 0, OPT_MAX_PATHS},
@@ -610,6 +612,10 @@ int main_mpmap(int argc, char** argv) {
                 
             case OPT_SUPPRESS_SUPPRESSION:
                 suppress_suppression = true;
+                break;
+                
+            case OPT_SUPPRESS_MISMAPPING_DETECTION:
+                suppress_mismapping_detection = true;
                 break;
                 
             case 'v':

--- a/src/unittest/mcmc_genotyper.cpp
+++ b/src/unittest/mcmc_genotyper.cpp
@@ -271,7 +271,8 @@ namespace vg {
                 xg_index.from_path_handle_graph(graph);              
 
                 // Make a multipath mapper to map against the graph.
-                MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx); 
+                MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx);
+                multipath_mapper.suppress_mismapping_detection = true;
                 
                 vector<string> reads = {"GCATCTGAGCCC"};
                 vector<Alignment> alns = {reads.size(), Alignment()};
@@ -380,7 +381,8 @@ namespace vg {
                 xg_index.from_path_handle_graph(graph);              
 
                 // Make a multipath mapper to map against the graph.
-                MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx); 
+                MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx);
+                multipath_mapper.suppress_mismapping_detection = true;
                 
                 vector<string> reads = {"GGGCCCAGCTGG"};
                 vector<Alignment> alns = {reads.size(), Alignment()};
@@ -505,7 +507,8 @@ namespace vg {
                 xg_index.from_path_handle_graph(graph);              
 
                 // Make a multipath mapper to map against the graph.
-                MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx); 
+                MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx);
+                multipath_mapper.suppress_mismapping_detection = true;
                 
                 //vector<string> reads = {"GCATCTGAGCCC","GCATCTGAGCCC","GCAGCTGAACCC","GCAGCTGAACCC"}; //TGGA
                 vector<string> reads = {"GCATCTGAGCCC","GCATCTGAGCCC","GCATCTGAACCC", "GCATCTGAACCC"};//TGTA
@@ -637,7 +640,8 @@ namespace vg {
                     xg_index.from_path_handle_graph(graph);               //xg::XG xg_index();
                     
                     // Make a multipath mapper to map against the graph.
-                    MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx); 
+                    MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx);
+                    multipath_mapper.suppress_mismapping_detection = true;
 
                     
                     vector<string> reads = {"GCATCTGAGCCC", "GCATCTGAGCCC", "GCAGCTGAACCC", "GCAGCTGAACCC","GCAGCTGAACCC", "GCAGCTGAACCC", "GCAGCTGAGCCC", "GCAGCTGAGCCC"};
@@ -795,7 +799,8 @@ namespace vg {
                 xg_index.from_path_handle_graph(graph);               //xg::XG xg_index();
                 
                 // Make a multipath mapper to map against the graph.
-                MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx); 
+                MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx);
+                multipath_mapper.suppress_mismapping_detection = true;
 
                 
                 vector<string> reads = {"GCATCTGAGCCC","GCATCTGAGCCC", "GCATCTGAGCCC", "GCAGCTGAACCC", "GCAGCTGAACCC","GCAGCTGAACCC", "GCAGCTGAACCC", "GCAGCTGAGCCC", "GCAGCTGAGCCC","GCATCTGAACCC" };
@@ -914,7 +919,8 @@ namespace vg {
                 xg_index.from_path_handle_graph(graph);               //xg::XG xg_index();
                 
                 // Make a multipath mapper to map against the graph.
-                MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx); 
+                MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx);
+                multipath_mapper.suppress_mismapping_detection = true;
 
                 
                 vector<string> reads = {"GCATCTGAGCCC", "GCATCTGAGCCC", "GCAGCTGAACCC", "GCAGCTGAACCC","GCAGCTGAACCC", "GCAGCTGAACCC", "GCAGCTGAGCCC", "GCAGCTGAGCCC"};
@@ -1070,7 +1076,8 @@ namespace vg {
             xg_index.from_path_handle_graph(graph);              
 
             // Make a multipath mapper to map against the graph.
-            MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx); 
+            MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx);
+            multipath_mapper.suppress_mismapping_detection = true;
             
             vector<string> reads = {"GGGCCCAGCTGG", "GGGCCCAGCTGGTCTGAGCCC", "GGGCCCAGCTGGTCTGAGCCC", 
                                     "GGGTACCCTGGTCTGAGCCC", "CTGGTCTGAGCCC", "GGGCCCTGCTGGGCTGAGCCC", 
@@ -1247,7 +1254,8 @@ namespace vg {
             xg_index.from_path_handle_graph(graph);              
 
             // Make a multipath mapper to map against the graph.
-            MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx); 
+            MultipathMapper multipath_mapper(&xg_index, gcsaidx, lcpidx);
+            multipath_mapper.suppress_mismapping_detection = true;
             
             vector<string> reads = {"GGGCCCAGCTGG", "GGGCCCAGCTGGTCTGAGCCC", "GGGCCCAGCTGGTCTGAGCCC", 
                                     "GGGTACCCTGGTCTGAGCCC", "CTGGTCTGAGCCC", "GGGCCCTGCTGGGCTGAGCCC", 

--- a/src/unittest/multipath_mapper.cpp
+++ b/src/unittest/multipath_mapper.cpp
@@ -301,6 +301,7 @@ TEST_CASE( "MultipathMapper can map to a one-node graph", "[multipath][mapping][
     // Lower the max mapping quality so that it thinks it can find unambiguous mappings of
     // short sequences
     mapper.max_mapping_quality = 10;
+    mapper.suppress_mismapping_detection = true;
     
     SECTION( "MultipathMapper can map a short fake read" ) {
 
@@ -451,6 +452,7 @@ TEST_CASE( "MultipathMapper can work on a bigger graph", "[multipath][mapping][m
     // Lower the max mapping quality so that it thinks it can find unambiguous mappings of
     // short sequences
     mapper.max_mapping_quality = 10;
+    mapper.suppress_mismapping_detection = true;
     
     
     SECTION( "topologically_order_subpaths works within a node" ) {    

--- a/test/t/33_vg_mpmap.t
+++ b/test/t/33_vg_mpmap.t
@@ -16,8 +16,8 @@ vg index -x xy2.xg -g xy2.gcsa -v small/xy2.vcf.gz --gbwt-name xy2.gbwt -k 16 xy
 # We turn off the background model calibration with -B and ignore it with -P 1
 
 # This read is part ref and part alt which matches a haplotype on X, but is possible on Y as well.
-is "$(vg mpmap -B -P 1 -n dna -x xy2.xg -g xy2.gcsa -f reads/xy2.match.fq -F GAM | vg view -aj - | jq '.mapping_quality')" "3" "MAPQ is 50% without haplotype info"
-is "$(vg mpmap -B -P 1 -n dna -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -f reads/xy2.match.fq -F GAM | vg view -aj - | jq '.mapping_quality')" "4" "haplotype match can disambiguate"
+is "$(vg mpmap --suppress-mismapping -B -P 1 -n dna -x xy2.xg -g xy2.gcsa -f reads/xy2.match.fq -F GAM | vg view -aj - | jq '.mapping_quality')" "3" "MAPQ is 50% without haplotype info"
+is "$(vg mpmap --suppress-mismapping -B -P 1 -n dna -x xy2.xg -g xy2.gcsa --gbwt-name xy2.gbwt -f reads/xy2.match.fq -F GAM | vg view -aj - | jq '.mapping_quality')" "4" "haplotype match can disambiguate"
 
 # For paired end, don't do any fragment length estimation
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg mpmap` now distinguishes unmapped reads from reads with MAPQ 0

## Description

It was pointed out to us that this is a meaningful distinction for RNA-seq analyses that rely on multimappings.