### PR TITLE
Keep the dagify algorithm from going too wild in mpmap

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -128,9 +128,10 @@ bool get_next_alignment_from_fastq(gzFile fp, char* buffer, size_t len, Alignmen
     alignment.Clear();
     bool is_fasta = false;
     // handle name
+    string name;
     if (0!=gzgets(fp,buffer,len)) {
         buffer[strlen(buffer)-1] = '\0';
-        string name = buffer;
+        name = buffer;
         if (name[0] == '@') {
             is_fasta = false;
         } else if (name[0] == '>') {
@@ -147,13 +148,13 @@ bool get_next_alignment_from_fastq(gzFile fp, char* buffer, size_t len, Alignmen
         buffer[strlen(buffer)-1] = '\0';
         alignment.set_sequence(buffer);
     } else {
-        cerr << "[vg::alignment.cpp] error: incomplete fastq record" << endl; exit(1);
+        cerr << "[vg::alignment.cpp] error: incomplete fastq/fasta record " << name << endl; exit(1);
     }
     // handle "+" sep
     if (!is_fasta) {
         if (0!=gzgets(fp,buffer,len)) {
         } else {
-            cerr << "[vg::alignment.cpp] error: incomplete fastq record" << endl; exit(1);
+            cerr << "[vg::alignment.cpp] error: incomplete fastq record " << name << endl; exit(1);
         }
         // handle quality
         if (0!=gzgets(fp,buffer,len)) {
@@ -162,7 +163,7 @@ bool get_next_alignment_from_fastq(gzFile fp, char* buffer, size_t len, Alignmen
             //cerr << string_quality_short_to_char(quality) << endl;
             alignment.set_quality(quality);
         } else {
-            cerr << "[vg::alignment.cpp] error: incomplete fastq record" << endl; exit(1);
+            cerr << "[vg::alignment.cpp] error: fastq record missing base quality " << name << endl; exit(1);
         }
     }
 

--- a/src/dagified_graph.cpp
+++ b/src/dagified_graph.cpp
@@ -11,7 +11,8 @@ namespace vg {
 
 using namespace std;
 
-    DagifiedGraph::DagifiedGraph(const HandleGraph* graph, size_t min_preserved_path_length) : graph(graph) {
+    DagifiedGraph::DagifiedGraph(const HandleGraph* graph, size_t min_preserved_path_length,
+                                 size_t max_num_duplications) : graph(graph) {
         
 #ifdef debug_dagify
         cerr << "constructing dagified graph" << endl;
@@ -146,7 +147,7 @@ using namespace std;
             
             // keep track of how many times we've implicitly copied
             uint64_t copy_num = 0;
-            for (; min_relaxed_dist < int64_t(min_preserved_path_length); copy_num++) {
+            for (; min_relaxed_dist < int64_t(min_preserved_path_length) && copy_num < max_num_duplications; copy_num++) {
                 
 #ifdef debug_dagify
                 cerr << "making " << copy_num << "-th copy of SCC with incoming min relaxed distance " << min_relaxed_dist << endl;

--- a/src/dagified_graph.hpp
+++ b/src/dagified_graph.hpp
@@ -18,8 +18,10 @@ using namespace std;
     class DagifiedGraph : public ExpandingOverlayGraph {
     public:
         
-        /// Expand a single-stranded graph into a DAG, preserving alll walks up to the minimum length.
-        DagifiedGraph(const HandleGraph* graph, size_t min_preserved_path_length);
+        /// Expand a single-stranded graph into a DAG, preserving all walks up to the minimum length.
+        /// If max duplications is provided, limits the number of times any node is copied.
+        DagifiedGraph(const HandleGraph* graph, size_t min_preserved_path_length, 
+                      size_t max_num_duplications = std::numeric_limits<size_t>::max());
         
         /// Default constructor -- not actually functional
         DagifiedGraph() = default;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -744,7 +744,7 @@ namespace vg {
 #ifdef debug_multipath_mapper_alignment
             cerr << "graph contains directed cycles, performing dagification" << endl;
 #endif
-            dagified = unique_ptr<DagifiedGraph>(new DagifiedGraph(&align_digraph, target_length));
+            dagified = unique_ptr<DagifiedGraph>(new DagifiedGraph(&align_digraph, target_length, max_dagify_duplications));
             align_dag = dagified.get();
         }
         
@@ -6096,7 +6096,7 @@ namespace vg {
 #endif
             
 #ifdef debug_multipath_mapper_alignment
-            cerr << "initial alignment graph:" << endl;
+            cerr << "initial alignment graph with " << graph->get_node_count() << " nodes and " << graph->get_edge_count() << ":" << endl;
             graph->for_each_handle([&](const handle_t& h) {
                 cerr << graph->get_id(h) << " " << graph->get_sequence(h) << endl;
                 graph->follow_edges(h, false, [&](const handle_t& n) {
@@ -6139,7 +6139,7 @@ namespace vg {
 #ifdef debug_multipath_mapper_alignment
                 cerr << "graph contains directed cycles, performing dagification" << endl;
 #endif
-                dagified = unique_ptr<DagifiedGraph>(new DagifiedGraph(align_digraph, target_length));
+                dagified = unique_ptr<DagifiedGraph>(new DagifiedGraph(align_digraph, target_length, max_dagify_duplications));
                 align_dag = dagified.get();
             }
             
@@ -6150,7 +6150,7 @@ namespace vg {
             };
             
 #ifdef debug_multipath_mapper_alignment
-            cerr << "final alignment graph:" << endl;
+            cerr << "final alignment graph of size " << align_dag->get_node_count() << " nodes and " << align_dag->get_edge_count() << ":" << endl;
             align_dag->for_each_handle([&](const handle_t& h) {
                 auto tr = translator(align_dag->get_id(h));
                 cerr << align_dag->get_id(h) << " (" << tr.first << (tr.second ? "-" : "+") << ") " << align_dag->get_sequence(h) << endl;

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -127,6 +127,7 @@ namespace vg {
         bool restrained_graph_extraction = false;
         size_t max_expected_dist_approx_error = 8;
         int32_t num_alt_alns = 4;
+        size_t max_dagify_duplications = 10;
         double mem_coverage_min_ratio = 0.5;
         double truncation_multiplicity_mq_limit = 7.0;
         double max_suboptimal_path_score_ratio = 2.0;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg mpmap` is faster on very complex cyclic graphs

## Description

Having an unbounded number of dagification copies was slowing `vg mpmap` down for some users trying it on PGGB graphs.