### PR TITLE
Make speed more robust in spliced surject

### DIFF
--- a/src/algorithms/component.cpp
+++ b/src/algorithms/component.cpp
@@ -83,6 +83,17 @@ void traverse_components(const HandleGraph& graph,
     });
 }
 
+size_t num_components(const HandleGraph& graph) {
+    size_t num_comps = 0;
+    function<void(void)> on_new_comp = [&]() {
+        ++num_comps;
+    };
+    function<void(handle_t)> on_node = [&](const handle_t here) { };
+    traverse_components(graph, on_new_comp, on_node);
+    return num_comps;
+}
+
+
 vector<size_t> component_sizes(const HandleGraph& graph) {
     
     vector<size_t> comp_sizes;
@@ -92,7 +103,6 @@ vector<size_t> component_sizes(const HandleGraph& graph) {
         comp_sizes.push_back(0);
     };
     
-    // add the paths of the new node
     function<void(handle_t)> on_node = [&](const handle_t here) {
         comp_sizes.back()++;
     };

--- a/src/algorithms/component.hpp
+++ b/src/algorithms/component.hpp
@@ -14,6 +14,9 @@ namespace algorithms {
 
 using namespace std;
 
+// returns the number of weakly connected components
+size_t num_components(const HandleGraph& graph);
+
 // returns the size in number of nodes of each component
 vector<size_t> component_sizes(const HandleGraph& graph);
 

--- a/src/algorithms/extract_connecting_graph.cpp
+++ b/src/algorithms/extract_connecting_graph.cpp
@@ -95,9 +95,8 @@ unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source,
     // keep track of whether we find a path or not
     bool found_target = false;
     
-    unordered_set<handle_t> skip_handles{source_handle_1};
     // mark final position for skipping so that we won't look for additional traversals
-    skip_handles.insert(source_handle_2);
+    unordered_set<handle_t> skip_handles{source_handle_1, source_handle_2};
     
     // initialize the queue
     UpdateablePriorityQueue<Traversal, handle_t> queue([](const Traversal& item) {
@@ -195,7 +194,8 @@ unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source,
     
     // add the edges we saw
     for (const edge_t& edge : observed_edges) {
-        into->create_edge(edge);
+        into->create_edge(into->get_handle(source->get_id(edge.first), source->get_is_reverse(edge.first)),
+                          into->get_handle(source->get_id(edge.second), source->get_is_reverse(edge.second)));
     }
     
 #ifdef debug_vg_algorithms

--- a/src/algorithms/extract_connecting_graph.hpp
+++ b/src/algorithms/extract_connecting_graph.hpp
@@ -35,8 +35,6 @@ namespace algorithms {
     ///  max_len                    guarantee finding walks along which pos_1 and pos_2 are this distance apart
     ///  pos_1                      start position, subgraph walks begin from here in same orientation
     ///  pos_2                      end position, subgraph walks end here in the same orientation
-    ///  detect_terminal_cycles     also find walks that include cycles involving pos_1 and/or pos_2
-    ///  only_walks                 only extract nodes and edges if they fall on some walk between pos_1 and pos_2
     ///  strict_max_len             only extract nodes and edges if they fall on some walk between pos_1 and pos_2
     ///                             that is under the maximum length (implies only_walks = true)
     unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source,

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -3437,7 +3437,7 @@ namespace vg {
                 }
                 
                 if (next_pos && next_pos->node_id() == pos.node_id() && next_pos->is_reverse() == pos.is_reverse()
-                    && next_pos->offset() == pos.offset() + from_length) {
+                    && next_pos->offset() == pos.offset() + from_length && !curr_runs.empty()) {
                     // we only care about transitions that are between nodes, this one is within a node
                     
 #ifdef debug_cigar

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1659,6 +1659,21 @@ Path trim_hanging_ends(const Path& p) {
     return r;
 }
 
+bool mappings_equivalent(const Mapping& m1, const Mapping& m2) {
+    bool equivalent = (m1.position().node_id() == m2.position().node_id()
+                       && m1.position().is_reverse() == m2.position().is_reverse()
+                       && m1.position().offset() == m2.position().offset()
+                       && m1.edit_size() == m2.edit_size());
+    for (size_t i = 0; i < m1.edit_size() && equivalent; ++i) {
+        const auto& e1 = m1.edit(i);
+        const auto& e2 = m2.edit(i);
+        equivalent = (e1.from_length() == e2.from_length()
+                      && e1.to_length() == e2.to_length()
+                      && e1.sequence() == e2.sequence());
+    }
+    return equivalent;
+}
+
 bool mapping_ends_in_deletion(const Mapping& m){
     return m.edit_size() >= 1 && edit_is_deletion(m.edit(m.edit_size()-1));
 }

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -268,6 +268,7 @@ Position first_path_position(const Path& path);
 Position last_path_position(const Path& path);
 int to_length(const Mapping& m);
 int from_length(const Mapping& m);
+bool mappings_equivalent(const Mapping& m1, const Mapping& m2);
 bool mapping_ends_in_deletion(const Mapping& m);
 bool mapping_starts_in_deletion(const Mapping& m);
 bool mapping_is_total_deletion(const Mapping& m);

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1435,17 +1435,23 @@ using namespace std;
                         }
                         size_t n = get<0>(divisions[left][0]);
                         if (n == 0) {
+                            ++left;
                             continue;
                         }
 #ifdef debug_constrictions
                         cerr << "extend left sequence " << i << " from " << string(path_chunks[i].first.first, path_chunks[i].first.second);
 #endif
                         
-                        ref_chunks[i].second = get<1>(divisions[left][0]);
                         path_chunks[i].first.second = get<3>(divisions[left][0]);
                         
 #ifdef debug_constrictions
                         cerr << " to " << string(path_chunks[i].first.first, path_chunks[i].first.second) << endl;
+                        cerr << "move left step from position " << graph->get_position_of_step(ref_chunks[i].second);
+#endif
+                        
+                        ref_chunks[i].second = get<1>(divisions[left][0]);
+#ifdef debug_constrictions
+                        cerr << " to " << graph->get_position_of_step(ref_chunks[i].second) << endl;
 #endif
                         
                         // check if we need to merge the first and last mappings
@@ -1483,17 +1489,22 @@ using namespace std;
                         size_t n = get<0>(divisions[0][right]);
                         const auto& aln = repair_alns[0][right];
                         if (n == aln.path().mapping_size()) {
+                            ++right;
                             continue;
                         }
 #ifdef debug_constrictions
                         cerr << "extend right sequence " << i << " from " << string(path_chunks[i].first.first, path_chunks[i].first.second);
 #endif
                         
-                        ref_chunks[i].first = get<1>(divisions[0][right]);
                         path_chunks[i].first.first = get<4>(divisions[0][right]);
                         
 #ifdef debug_constrictions
-                        cerr << "to " << string(path_chunks[i].first.first, path_chunks[i].first.second) << endl;
+                        cerr << " to " << string(path_chunks[i].first.first, path_chunks[i].first.second) << endl;
+                        cerr << "move right step from position " << graph->get_position_of_step(ref_chunks[i].first);
+#endif
+                        ref_chunks[i].first = get<2>(divisions[0][right]);
+#ifdef debug_constrictions
+                        cerr << " to " << graph->get_position_of_step(ref_chunks[i].first) << endl;
 #endif
                         
                         // copy the repair alignment

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1019,6 +1019,9 @@ using namespace std;
                             continue;
                         }
                         if (path_chunks[*left_it].first.second != path_chunks[i].first.first || !connected_by_edge(*left_it, i)) {
+#ifdef debug_constrictions
+                            cerr << "fail deletion along edge condition in adjacency from " << *left_it << " to " << i << " with read positions " << (path_chunks[*left_it].first.second - src_sequence.begin()) << " and " << (path_chunks[i].first.first - src_sequence.begin()) << ", connected by edge? " << connected_by_edge(*left_it, i) << endl;
+#endif
                             incompatible = true;
                             break;
                         }
@@ -1115,7 +1118,7 @@ using namespace std;
                             
                             
 #ifdef debug_constrictions
-                            cerr << "connecting graph:" << endl;
+                            cerr << "connecting graph between " << left_pos << " and " << right_pos << ":" << endl;
                             connecting.for_each_handle([&](const handle_t& handle) {
                                 cerr << connecting.get_id(handle) << " " << connecting.get_sequence(handle) << endl;
                                 connecting.follow_edges(handle, true, [&](const handle_t& prev) {
@@ -1145,21 +1148,7 @@ using namespace std;
                                 connecting.destroy_handle(handle);
                             }
                             
-#ifdef debug_constrictions
-                            cerr << "connecting graph after pruning to the path:" << endl;
-                            connecting.for_each_handle([&](const handle_t& handle) {
-                                cerr << connecting.get_id(handle) << " " << connecting.get_sequence(handle) << endl;
-                                connecting.follow_edges(handle, true, [&](const handle_t& prev) {
-                                    cerr << "\t" << connecting.get_id(prev) << " <-" << endl;
-                                });
-                                connecting.follow_edges(handle, false, [&](const handle_t& next) {
-                                    cerr << "\t-> " << connecting.get_id(next) << endl;
-                                });
-                            });
-#endif
-                            
                             // TODO: we could probably dagify, but i don't want to worry about it yet
-                            // TODO: banded aligner actually assumes single stranded too
                             if (connecting.get_node_count() == 0 || !handlealgs::is_directed_acyclic(&connecting)
                                 || algorithms::num_components(connecting) != 1) {
 #ifdef debug_constrictions
@@ -1195,6 +1184,19 @@ using namespace std;
                                                                                       connecting.get_is_reverse(handle));
                                 handle = connecting.apply_orientation(handle);
                             }
+
+#ifdef debug_constrictions
+                            cerr << "connecting graph after pruning to the path and orienting:" << endl;
+                            connecting.for_each_handle([&](const handle_t& handle) {
+                                cerr << connecting.get_id(handle) << " " << connecting.get_sequence(handle) << endl;
+                                connecting.follow_edges(handle, true, [&](const handle_t& prev) {
+                                    cerr << "\t" << connecting.get_id(prev) << " <-" << endl;
+                                });
+                                connecting.follow_edges(handle, false, [&](const handle_t& next) {
+                                    cerr << "\t-> " << connecting.get_id(next) << endl;
+                                });
+                            });
+#endif
                                                         
                             repair_alns.back().emplace_back();
                             auto& aln = repair_alns.back().back();

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -1107,7 +1107,7 @@ using namespace std;
                                 continue;
                             }
 #ifdef debug_constrictions
-                            cerr << "attempting to repair splice adjacency from " << *left_it << " to " << i << endl;
+                            cerr << "attempting to repair splice adjacency from " << *left_it << " to " << i << " with read initerval " << (path_chunks[*left_it].first.second - src_sequence.begin()) << ":" << (path_chunks[i].first.first - src_sequence.begin()) << endl;
 #endif
                             
                             auto right_pos = initial_position(path_chunks[i].second);
@@ -1200,8 +1200,8 @@ using namespace std;
                                                         
                             repair_alns.back().emplace_back();
                             auto& aln = repair_alns.back().back();
-                            aln.set_sequence(string(path_chunks[*left_side.begin()].first.second,
-                                                    path_chunks[*right_side.begin()].first.first));
+                            aln.set_sequence(string(path_chunks[*left_it].first.second,
+                                                    path_chunks[i].first.first));
                             if (!src_quality.empty()) {
                                 auto qual_begin = src_quality.begin() + (path_chunks[*left_side.begin()].first.second - src_sequence.begin());
                                 aln.set_quality(string(qual_begin, qual_begin + aln.sequence().size()));
@@ -1437,8 +1437,16 @@ using namespace std;
                         if (n == 0) {
                             continue;
                         }
+#ifdef debug_constrictions
+                        cerr << "extend left sequence " << i << " from " << string(path_chunks[i].first.first, path_chunks[i].first.second);
+#endif
+                        
                         ref_chunks[i].second = get<1>(divisions[left][0]);
                         path_chunks[i].first.second = get<3>(divisions[left][0]);
+                        
+#ifdef debug_constrictions
+                        cerr << " to " << string(path_chunks[i].first.first, path_chunks[i].first.second) << endl;
+#endif
                         
                         // check if we need to merge the first and last mappings
                         size_t k = 0;
@@ -1477,8 +1485,16 @@ using namespace std;
                         if (n == aln.path().mapping_size()) {
                             continue;
                         }
+#ifdef debug_constrictions
+                        cerr << "extend right sequence " << i << " from " << string(path_chunks[i].first.first, path_chunks[i].first.second);
+#endif
+                        
                         ref_chunks[i].first = get<1>(divisions[0][right]);
                         path_chunks[i].first.first = get<4>(divisions[0][right]);
+                        
+#ifdef debug_constrictions
+                        cerr << "to " << string(path_chunks[i].first.first, path_chunks[i].first.second) << endl;
+#endif
                         
                         // copy the repair alignment
                         Path concat_path;

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -94,10 +94,14 @@ using namespace std;
         /// How big of a graph in bp should we ever try to align against for realigning surjection?
         size_t max_subgraph_bases = 100 * 1024;
         
+        /// in spliced surject, downsample if the base-wise average coverage by chunks is this high
+        int64_t min_fold_coverage_for_downsample = 8;
+        /// while downsampling, try to get down to this coverage on each base
+        int64_t downsample_coverage = 16;
+        
         /// And have we complained about hitting it?
         mutable atomic_flag warned_about_subgraph_size = ATOMIC_FLAG_INIT;
         
-        ///
         bool prune_suspicious_anchors = false;
         int64_t max_tail_anchor_prune = 4;
         double low_complexity_p_value = .001;
@@ -197,6 +201,12 @@ using namespace std;
         void cut_anchors(bool rev_strand, vector<path_chunk_t>& path_chunks,
                          vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
                          vector<tuple<size_t, size_t, int32_t>>& connections) const;
+        
+        /// if there are too many chunks, downsample to a given level
+        void downsample_chunks(const string& src_sequence,
+                               vector<path_chunk_t>& path_chunks,
+                               vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
+                               vector<tuple<size_t, size_t, int32_t>>& connections) const;
         
         /// returns all sets of chunks such that 1) all of chunks on the left set abut all of the chunks on the right
         /// set on the read, 2) all source-to-sink paths in the connected component go through an edge between

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -89,7 +89,7 @@ using namespace std;
         int64_t dominated_path_chunk_diff = 10;
 
         /// the minimum length apparent intron that we will try to repair
-        int64_t min_splice_repair_length = 1000;
+        int64_t min_splice_repair_length = 250;
         
         /// How big of a graph in bp should we ever try to align against for realigning surjection?
         size_t max_subgraph_bases = 100 * 1024;

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -87,6 +87,9 @@ using namespace std;
         int64_t min_splice_length = 20;
         
         int64_t dominated_path_chunk_diff = 10;
+
+        /// the minimum length apparent intron that we will try to repair
+        int64_t min_splice_repair_length = 1000;
         
         /// How big of a graph in bp should we ever try to align against for realigning surjection?
         size_t max_subgraph_bases = 100 * 1024;
@@ -201,7 +204,9 @@ using namespace std;
         /// connected (i.e. form a biclique)
         vector<pair<vector<size_t>, vector<size_t>>> find_constriction_bicliques(const vector<vector<size_t>>& adj,
                                                                                  const string& src_sequence,
-                                                                                 const vector<path_chunk_t>& path_chunks,
+                                                                                 const string& src_quality,
+                                                                                 vector<path_chunk_t>& path_chunks,
+                                                                                 vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
                                                                                  const vector<tuple<size_t, size_t, int32_t>>& connections) const;
         
         void prune_unconnectable(vector<vector<size_t>>& adj,


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject -S` has more reliable run time and is better at detecting spliced alignments

## Description

Includes some improved logic for detecting when a multipath alignment contains a splice junction, and also some very mild pruning that can help when projecting from regions of the graph with very complicated local structures (e.g. STRs in HPRC graphs). 