### PR TITLE
mpmap estimates realistic fragment length distributions with --agglomerate-alns

### DIFF
--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -338,8 +338,11 @@ namespace vg {
     /// Removes all subpaths and edges whose optimal full length alignment is less than the given difference
     /// from the highest-scoring full length alignment
     void remove_low_scoring_sections(multipath_alignment_t& multipath_aln, int32_t max_score_diff);
+
+    /// Returns the number of connected components in the multipath alignment.
+    size_t num_connected_components(const multipath_alignment_t& multipath_aln);
     
-    /// Returns a vector whose elements are vectors with the indexes of the Subpaths in
+    /// Returns a vector whose elements are vectors with the indexes of the subpath_t's in
     /// each connected component. An unmapped multipath_alignment_t with no subpaths produces an empty vector.
     vector<vector<int64_t>> connected_components(const multipath_alignment_t& multipath_aln);
     

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -584,7 +584,9 @@ namespace vg {
             
             // are these reads unambiguously mapped and well-aligned?
             // TODO: i don't like having constants floating around in here
-            if (multipath_aln_1.mapping_quality() >= min(max_mapping_quality, 45)
+            if (num_connected_components(multipath_aln_1) == 1
+                && num_connected_components(multipath_aln_2) == 1
+                && multipath_aln_1.mapping_quality() >= min(max_mapping_quality, 45)
                 && multipath_aln_2.mapping_quality() >= min(max_mapping_quality, 45)
                 && optimal_alignment_score(multipath_aln_1) >= .8 * max_score_1
                 && optimal_alignment_score(multipath_aln_2) >= .8 * max_score_2) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg mpmap --agglomerate-alns` runs faster and is more accurate with paired-end reads

## Description

The logic for estimating the fragment length distribution in `vg mpmap` was based on MAPQ, but with disconnected alignments, the MAPQ can be high even though they are not uniquely aligned. It now also requires that alignments be connected before they are used for estimating the distribution parameters.