### PR TITLE
Switch to vgteams's dozeu

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -78,7 +78,7 @@
 	url = https://github.com/ebiggers/libdeflate.git
 [submodule "deps/dozeu"]
 	path = deps/dozeu
-	url = https://github.com/ocxtal/dozeu.git
+	url = https://github.com/vgteam/dozeu.git
 [submodule "deps/libhandlegraph"]
 	path = deps/libhandlegraph
 	url = https://github.com/vgteam/libhandlegraph.git


### PR DESCRIPTION
As #3650 points out, vg links to upstream (ocxtal) dozeu but uses a commit that's only in the vgteam fork. I would have thought this would break the build in general, but I guess newer versions of git are clever enough to hunt in forks by themselves? (issue submitter's using a really old version of git).  

resolves #3650.

