### PR TITLE
preserve secondary annotations in mp surject

### DIFF
--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -349,7 +349,7 @@ void MultipathAlignmentEmitter::convert_to_hts_unpaired(const string& name, cons
     Alignment shim;
     create_alignment_shim(name, mp_aln, shim);
     auto bam = alignment_to_bam(header, shim, ref_name, ref_pos, ref_rev, cigar);
-    add_mapq_annotations(mp_aln, bam);
+    add_annotations(mp_aln, bam);
     dest.push_back(bam);
 }
 
@@ -390,14 +390,14 @@ void MultipathAlignmentEmitter::convert_to_hts_paired(const string& name_1, cons
         }
     }
     
-    add_mapq_annotations(mp_aln_1, bam_1);
-    add_mapq_annotations(mp_aln_2, bam_2);
+    add_annotations(mp_aln_1, bam_1);
+    add_annotations(mp_aln_2, bam_2);
     
     dest.push_back(bam_1);
     dest.push_back(bam_2);
 }
 
-void MultipathAlignmentEmitter::add_mapq_annotations(const multipath_alignment_t& mp_aln, bam1_t* bam) const {
+void MultipathAlignmentEmitter::add_annotations(const multipath_alignment_t& mp_aln, bam1_t* bam) const {
     if (mp_aln.has_annotation("allelic_mapq")) {
         auto anno = mp_aln.get_annotation("allelic_mapq");
         assert(anno.first == multipath_alignment_t::Double);
@@ -409,6 +409,14 @@ void MultipathAlignmentEmitter::add_mapq_annotations(const multipath_alignment_t
         assert(anno.first == multipath_alignment_t::Double);
         int64_t group_mapq = *((double*) anno.second);
         bam_aux_update_int(bam, "GM", group_mapq);
+    }
+    if (mp_aln.has_annotation("secondary")) {
+        auto anno = mp_aln.get_annotation("secondary");
+        assert(anno.first == multipath_alignment_t::Bool);
+        bool secondary = *((bool*) anno.second);
+        if (secondary) {
+            bam->core.flag |= BAM_FSECONDARY;
+        }
     }
 }
 

--- a/src/multipath_alignment_emitter.hpp
+++ b/src/multipath_alignment_emitter.hpp
@@ -89,8 +89,8 @@ private:
                                const string& ref_name_2, bool ref_rev_2, int64_t ref_pos_2,
                                int64_t tlen_limit, bam_hdr_t* header, vector<bam1_t*>& dest) const;
     
-    /// transfer the allelic mapq annotation to a BAM record
-    void add_mapq_annotations(const multipath_alignment_t& mp_aln, bam1_t* bam) const;
+    /// transfer the allelic mapq, group mapq, and secondary annotations to a BAM record
+    void add_annotations(const multipath_alignment_t& mp_aln, bam1_t* bam) const;
     
     const PathPositionHandleGraph* graph;
     


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg mpmap`'s secondary alignment annotations are preserved by `vg surject`
