### PR TITLE
Don't drop secondary alignment annotation on unmapped reads in surject

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -2278,6 +2278,7 @@ namespace vg {
         from.for_each_annotation([&](const string& anno_name, multipath_alignment_t::anno_type_t type, const void* value) {
             switch (type) {
                 case multipath_alignment_t::Null:
+                    to.set_annotation(anno_name);
                     break;
                 case multipath_alignment_t::Double:
                     to.set_annotation(anno_name, *((const double*) value));
@@ -4364,6 +4365,39 @@ namespace vg {
                 to_return += to_string(multipath_aln.start(i));
             }
             to_return += "]";
+        }
+        int anno_num = 0;
+        multipath_aln.for_each_annotation([&](const string& name,
+                                              multipath_alignment_t::anno_type_t type,
+                                              const void* annotation) {
+            if (anno_num == 0) {
+                to_return += ", annotations: {";
+            }
+            else {
+                to_return += ", ";
+            }
+            switch (type) {
+                case multipath_alignment_t::Null:
+                    to_return += name;
+                    break;
+                case multipath_alignment_t::Double:
+                    to_return += name + ": \"" + to_string(*((const double*) annotation)) + "\"";
+                    break;
+                case multipath_alignment_t::Bool:
+                    to_return += name + ": " + (*((const bool*) annotation) ? "true" : "false");
+                    break;
+                case multipath_alignment_t::String:
+                    to_return += name + ": " + *((const string*) annotation);
+                    break;
+                default:
+                    cerr << "error: unrecognized annotation type" << endl;
+                    exit(1);
+                    break;
+            }
+            ++anno_num;
+        });
+        if (anno_num != 0) {
+            to_return += "}";
         }
         to_return += "}";
         return to_return;

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -289,6 +289,9 @@ using namespace std;
             path_pos_out = -1;
             if (source_mp_aln) {
                 *mp_aln_out = make_null_mp_alignment(source_mp_aln->sequence(), source_mp_aln->quality());
+                // copy over annotations
+                // TODO: also redundantly copies over sequence and quality
+                transfer_read_metadata(*source_mp_aln, *mp_aln_out);
             }
             else {
                 *aln_out = make_null_alignment(*source_aln);


### PR DESCRIPTION
## Description

Previous PR that preserved secondary alignment status through surject had a gap for unmapped reads.