### PR TITLE
Restrict sequence dictionary paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,11 +338,18 @@ ifneq ($(shell uname -s),Darwin)
     LIB_DEPS += $(LIB_DIR)/libelf.a
 endif
 
+# Control variable for allocator
+# On the command line, you can `make jemalloc=off` if you definitely don't want jemalloc.
+jemalloc = "on"
+ifeq ($(shell uname -s),Darwin)
+	jemalloc = "off"
+endif
+
 # Only depend on these files for the final linking stage.	
 # These libraries provide no headers to affect the vg build.	
 LINK_DEPS =
 
-ifneq ($(shell uname -s),Darwin)
+ifeq ($(jemalloc),on)
     # Use jemalloc at link time
 	LINK_DEPS += $(LIB_DIR)/libjemalloc.a
     # We have to use it statically or we can't get at its secret symbols.

--- a/Makefile
+++ b/Makefile
@@ -340,9 +340,9 @@ endif
 
 # Control variable for allocator
 # On the command line, you can `make jemalloc=off` if you definitely don't want jemalloc.
-jemalloc = "on"
+jemalloc = on
 ifeq ($(shell uname -s),Darwin)
-	jemalloc = "off"
+	jemalloc = off
 endif
 
 # Only depend on these files for the final linking stage.	
@@ -397,11 +397,11 @@ $(LIB_DIR)/libvg.a: $(LIBVG_DEPS)
 # For a normal dynamic build we remove the static build marker
 $(BIN_DIR)/$(EXE): $(LIB_DIR)/libvg.a $(EXE_DEPS)
 	-rm -f $(LIB_DIR)/vg_is_static
-	. ./source_me.sh && $(CXX) $(LDFLAGS) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) -lvg $(LD_LIB_DIR_FLAGS) $(LD_LIB_FLAGS) $(START_STATIC) $(LD_STATIC_LIB_FLAGS) $(END_STATIC) $(LD_STATIC_LIB_DEPS) 
+	. ./source_me.sh && $(CXX) $(LDFLAGS) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) $(LIB_DIR)/libvg.a $(LD_LIB_DIR_FLAGS) $(LD_LIB_FLAGS) $(START_STATIC) $(LD_STATIC_LIB_FLAGS) $(END_STATIC) $(LD_STATIC_LIB_DEPS) 
 # We keep a file that we touch on the last static build.
 # If the vg linkables are newer than the last static build, we do a build
 $(LIB_DIR)/vg_is_static: $(INC_DIR)/vg_environment_version.hpp $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) $(DEPS) $(LINK_DEPS)
-	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) -lvg $(STATIC_FLAGS) $(LD_LIB_DIR_FLAGS) $(LD_LIB_FLAGS) $(LD_STATIC_LIB_FLAGS) $(LD_STATIC_LIB_DEPS)
+	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) $(LIB_DIR)/libvg.a $(STATIC_FLAGS) $(LD_LIB_DIR_FLAGS) $(LD_LIB_FLAGS) $(LD_STATIC_LIB_FLAGS) $(LD_STATIC_LIB_DEPS)
 	-touch $(LIB_DIR)/vg_is_static
 
 # We don't want to always rebuild the static vg if no files have changed.

--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -112,7 +112,7 @@ static bool for_each_subpath_of(const PathPositionHandleGraph& graph, const stri
     }
     
     // Parse out the metadata of the thing we want subpaths of
-    PathSense& sense;
+    PathSense sense;
     string sample;
     string locus;
     size_t haplotype;
@@ -155,7 +155,7 @@ static string get_path_base_name(const PathPositionHandleGraph& graph, const pat
         return graph.get_path_name(path);
     } else {
         // This is a subpath, so remember what it's a subpath of, and use that.
-        return PathMetadata::create_path_name(graph.get_path_sense(path),
+        return PathMetadata::create_path_name(graph.get_sense(path),
                                               graph.get_sample_name(path),
                                               graph.get_locus_name(path),
                                               graph.get_haplotype(path),
@@ -277,7 +277,7 @@ vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const strin
                 } else {
                     // The graph doesn't have this exact path; does it have any subregions of a full path with this name?
                     // If so, remember and use those.
-                    for_each_subpath_of(graph, sequence_name, [&](const path_handle_t) {
+                    for_each_subpath_of(graph, sequence_name, [&](const path_handle_t& match) {
                         // We know this can't be an exact match, since we already checked for one. It must be a subrange.
                         // We found a subpath we're looking for.
                         base_path_to_subpaths[sequence_name].push_back(match);
@@ -377,6 +377,8 @@ vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const strin
                     // max the end offset in against all the end offsets we have seen so far.
                     base_name_and_length.second = std::max(base_name_and_length.second, (int64_t) end_offset);
                 }
+                // Keep going
+                return true;
             });
         }
         

--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -94,6 +94,76 @@ unique_ptr<AlignmentEmitter> get_alignment_emitter(const string& filename, const
     return emitter;
 }
 
+/// Run the given iteratee for each path that is either the path with the given
+/// name (if present), or a subrange of a path with the given name as the base
+/// name (otherwise).
+///
+/// If a path and subpaths both exist, only look at the full path.
+///
+/// If the name describes a subpath, look only at that subpath.
+///
+/// Iteratee returns false to stop.
+///
+/// Returns true if we reached the end, and false if asked to stop.
+static bool for_each_subpath_of(const PathPositionHandleGraph& graph, const string& path_name, const std::function<bool(const path_handle_t& path)>& iteratee) {
+    if (graph.has_path(path_name)) {
+        // Just look at the full path.
+        return iteratee(graph.get_path_handle(path_name));
+    }
+    
+    // Parse out the metadata of the thing we want subpaths of
+    PathSense& sense;
+    string sample;
+    string locus;
+    size_t haplotype;
+    size_t phase_block;
+    subrange_t subrange;
+    PathMetadata::parse_path_name(path_name,
+                                  sense,
+                                  sample,
+                                  locus,
+                                  haplotype,
+                                  phase_block,
+                                  subrange);
+                                  
+    if (subrange != PathMetadata::NO_SUBRANGE) {
+        // The path name described a subpath, and we didn't find it.
+        // Don't call the iteratee.
+        return true;
+    }
+    
+    // Look at every subpath on it
+    return graph.for_each_path_matching({sense}, {sample}, {locus}, [&](const path_handle_t& match) {
+        // TODO: There's no way to search by haplotype and phase block, we have to scan
+        if (graph.get_haplotype(match) != haplotype) {
+            // Skip this haplotype
+            return true;
+        }
+        if (graph.get_phase_block(match) != phase_block) {
+            // Skip this phase block
+            return true;
+        }
+        // Don't need to check subrange, we know we don't have one and this candidate does.
+        return iteratee(match);    
+    });
+}
+
+/// Returns the base path name for this path (i.e. the path's name without any subrange).
+static string get_path_base_name(const PathPositionHandleGraph& graph, const path_handle_t& path) {
+    if (graph.get_subrange(path) == PathMetadata::NO_SUBRANGE) {
+        // This is a full path
+        return graph.get_path_name(path);
+    } else {
+        // This is a subpath, so remember what it's a subpath of, and use that.
+        return PathMetadata::create_path_name(graph.get_path_sense(path),
+                                              graph.get_sample_name(path),
+                                              graph.get_locus_name(path),
+                                              graph.get_haplotype(path),
+                                              graph.get_phase_block(path),
+                                              PathMetadata::NO_SUBRANGE);
+    }
+}
+
 pair<vector<pair<string, int64_t>>, unordered_map<string, int64_t>> extract_path_metadata(
     const vector<tuple<path_handle_t, size_t, size_t>>& paths,  const PathPositionHandleGraph& graph,
     bool subpath_support) {
@@ -105,25 +175,28 @@ pair<vector<pair<string, int64_t>>, unordered_map<string, int64_t>> extract_path
     // Remember the actual path lengths (this is for coordinate transformations)        
     unordered_map<string, int64_t> subpath_to_length;
     for (const auto& path_info : paths) {
-        string base_path_name = subpath_support ? Paths::get_base_name(graph.get_path_name(get<0>(path_info))) : graph.get_path_name(get<0>(path_info));
+        auto& path = get<0>(path_info);
+        auto& own_length = get<1>(path_info);
+        auto& base_length = get<2>(path_info);
+        string base_path_name = subpath_support ? get_path_base_name(graph, path) : graph.get_path_name(path);
         if (!base_path_set.count(base_path_name)) {
-            path_names_and_lengths.push_back(make_pair(base_path_name, get<2>(path_info)));
+            path_names_and_lengths.push_back(make_pair(base_path_name, base_length));
             base_path_set.insert(base_path_name);
         }
-        subpath_to_length[graph.get_path_name(get<0>(path_info))] = get<1>(path_info);
+        subpath_to_length[graph.get_path_name(path)] = own_length;
     }
 
     return make_pair(path_names_and_lengths, subpath_to_length);
 }
 
 vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const string& filename, const PathPositionHandleGraph& graph) {
-    
-    // Hack in subpath support: map to paths from their base name
-    unordered_map<string, vector<path_handle_t>> base_path_to_subpaths;
-    graph.for_each_path_handle([&](path_handle_t path_handle) {
-            base_path_to_subpaths[Paths::get_base_name(graph.get_path_name(path_handle))].push_back(path_handle);
-        });
 
+    // TODO: We assume we're using the one true default path metadata <-> name mapping
+    
+    // Subpath support: map to paths from their base name without a subrange.
+    // Includes full-length paths if they exost, and subrange-bearing paths otherwise.
+    unordered_map<string, vector<path_handle_t>> base_path_to_subpaths;
+    
     // Parse the input into this list.  If length was unspecified (ie in regular text file with one column) then it will be -1
     // and filled in later
     vector<pair<string, int64_t>> input_names_lengths;
@@ -186,22 +259,38 @@ vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const strin
                     exit(1);
                 }
                 
-                if (!base_path_to_subpaths.count(sequence_name)) {
-                    cerr << "error:[vg mpmap] Graph does not have a path named " << line << ", which was indicated in " << filename << endl;
-                    exit(1);
-                }
-
-                // Bypass length check for subpaths
                 if (graph.has_path(sequence_name)) {
+                    // If the graph does have a path by this exact name, do a length check.
                     path_handle_t path = graph.get_path_handle(sequence_name);
                     size_t graph_path_length = graph.get_path_length(path);
-                    if (graph_path_length != length) {
-                        // Length doesn't match
+                    if (missing_length) {
+                        // We need to infer the length
+                        length = graph_path_length;
+                    } else if (graph_path_length != length) {
+                        // Length was given but doesn't match
                         cerr << "error:[vg mpmap] Graph contains a path " << sequence_name << " of length " << graph_path_length
                              << " but sequence dictionary in " << filename << " indicates a length of " << length << endl;
                         exit(1);
                     }
-                }
+                    // Remember the path
+                    base_path_to_subpaths[sequence_name].push_back(path);
+                } else {
+                    // The graph doesn't have this exact path; does it have any subregions of a full path with this name?
+                    // If so, remember and use those.
+                    for_each_subpath_of(graph, sequence_name, [&](const path_handle_t) {
+                        // We know this can't be an exact match, since we already checked for one. It must be a subrange.
+                        // We found a subpath we're looking for.
+                        base_path_to_subpaths[sequence_name].push_back(match);
+                        // Keep looking for more.
+                        return true;
+                    });
+                    if (!base_path_to_subpaths.count(sequence_name)) {
+                        // We didn't find any subpaths for this path as a base path either.
+                        cerr << "error:[vg mpmap] Graph does not have a path named " << line << ", which was indicated in " << filename << endl;
+                        exit(1);
+                    }
+                    // The length may still be missing.
+                } 
 
                 input_names_lengths.push_back(make_pair(sequence_name, length));
 
@@ -214,47 +303,89 @@ vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const strin
             exit(1);
         }
     } else {
+        // We got no paths in so we need to guess them.
+        // We will deduplicate their base names, without subpath info.
         unordered_set<string> base_names;
-        graph.for_each_path_handle([&](const path_handle_t& path_handle) {
-            string sequence_name = graph.get_path_name(path_handle);
-            if (!Paths::is_alt(sequence_name)) {
-                // This isn't an alt allele path, so we want it.
-                string base_name = Paths::get_base_name(sequence_name);
-                if (!base_names.count(base_name)) {
-                    input_names_lengths.push_back(make_pair(base_name, -1));
-                    base_names.insert(base_name);
-                }
+        
+        // When we find a path or subpath we want, we will keep it.
+        auto keep_path_or_subpath = [&](const path_handle_t& path) {
+            string base_name = get_path_base_name(graph, path);
+            int64_t base_length = -1;
+            if (graph.get_subrange(path) == PathMetadata::NO_SUBRANGE) {
+                // This is a full path so we can determine base length now.
+                base_length = graph.get_path_length(path);
             }
-        });
+            if (!base_names.count(base_name)) {
+                // This is the first time we have seen something on this path.
+                // Remember we need a length for it.
+                // TODO: make this a map so we can just max in here instead of doing another pass.
+                input_names_lengths.push_back(make_pair(base_name, base_length));
+                // And remember we are using it.
+                base_names.insert(base_name);
+            }
+            // Remember this path as belonging to the right base name.
+            base_path_to_subpaths[base_name].push_back(path);
+        };
+        
+        // First look for reference sense paths and their subpaths
+        graph.for_each_path_of_sense(PathSense::REFERENCE, keep_path_or_subpath);
         
         if (input_names_lengths.empty()) {
-            cerr << "error:[vg::get_sequence_dictionary] No non-alt-allele paths available in the graph!" << endl;
+            // If none of those exist, try generic sense paths and their subpaths
+            cerr << "warning:[vg::get_sequence_dictionary] No reference-sense paths available in the graph; falling back to generic paths." << endl;
+            graph.for_each_path_of_sense(PathSense::GENERIC, [&](const path_handle_t& path) {
+                if (Paths::is_alt(graph.get_path_name(path))) {
+                    // Skip this path because it is a stored allele.
+                    return;
+                }
+                // Otherwise, keep it.
+                keep_path_or_subpath(path);
+            });
+        }
+        
+        if (input_names_lengths.empty()) {
+            // No non-alt generic paths either
+            cerr << "error:[vg::get_sequence_dictionary] No reference or non-alt-allele generic paths available in the graph!" << endl;
             exit(1);
         }
     }
-
-    // fill in the missing lengths using what we can find out from the graph
-    unordered_map<string, int64_t> base_to_len;
-    graph.for_each_path_handle([&](const path_handle_t& path_handle) {
-            string path_name = graph.get_path_name(path_handle);
-            auto subpath_info = Paths::parse_subpath_name(path_name);
-            if (get<0>(subpath_info)) {
-                path_name = get<1>(subpath_info);
-            }
-            base_to_len[path_name] = max((int64_t)base_to_len[path_name], (int64_t)(get<2>(subpath_info) + graph.get_path_length(path_handle)));
-        });
-
+    
     // We fill in the "dictionary" (which is what SAM calls it; it's not a mapping for us)
     // we also store the path length (from the graph) along with the base path length (from the user if specified, from paths otherwise)
     vector<tuple<path_handle_t, size_t, size_t>> dictionary;
 
-    for (auto& name_len : input_names_lengths) {
-        if (name_len.second == -1) {
-            name_len.second = base_to_len[name_len.first];
+    for (auto& base_name_and_length : input_names_lengths) {
+        // For every base path name we have stuff on
+        
+        if (base_name_and_length.second == -1) {
+            // We need the overall length of this base path still.
+            for_each_subpath_of(graph, base_name_and_length.first, [&](const path_handle_t& path) {
+                // So scan it and all its subpaths
+                
+                subrange_t subrange = graph.get_subrange(path);
+                if (subrange == PathMetadata::NO_SUBRANGE) {
+                    // Full path, use its length.
+                    // TODO: probably we should have seen the full path's length by now if it existed.
+                    base_name_and_length.second = graph.get_path_length(path);
+                } else {
+                    // Subpath, work out where it ends and max it in
+                    auto end_offset = subrange.second;
+                    if (end_offset == PathMetadata::NO_END_POSITION) {
+                        // If there was a stored end we would just trust it, but without it we have to compute it.
+                        end_offset = subrange.first + graph.get_path_length(path);
+                    }
+                    // max the end offset in against all the end offsets we have seen so far.
+                    base_name_and_length.second = std::max(base_name_and_length.second, (int64_t) end_offset);
+                }
+            });
         }
-
-        for (path_handle_t path_handle : base_path_to_subpaths[name_len.first]) {
-            dictionary.push_back(make_tuple(path_handle, graph.get_path_length(path_handle), (size_t)name_len.second));
+        
+        // Now we have the length, so we can fill in the dictionary.
+        for (auto& path : base_path_to_subpaths[base_name_and_length.first]) {
+            // For every subpath we found on the base path (possibly just
+            // itself), remember the subpath, the subpath's length, and the
+            // base path's length
+            dictionary.push_back(make_tuple(path, graph.get_path_length(path), (size_t)base_name_and_length.second));
         }
     }
 

--- a/src/hts_alignment_emitter.hpp
+++ b/src/hts_alignment_emitter.hpp
@@ -67,11 +67,15 @@ unique_ptr<AlignmentEmitter> get_alignment_emitter(const string& filename, const
  * get_alignment_emitter_with_surjection(), by parsing a file. The file may be
  * an HTSlib-style "sequence dictionary" (consisting of SAM @SQ header lines),
  * or a plain list of sequence names (which do not start with "@SQ"). If the
- * file is not openable or contains no entries, reports an error and quits. If
- * the filename is itself an empty string, all reference-sense paths from the
- * graph will be collected in arbitrary order. If there are none, all
- * non-alt-allele generic sense paths from the graph will be collected in
- * arbitrary order.
+ * file is not openable or contains no entries, reports an error and quits.
+ *
+ * If path_names has entries, they are treated as path names that supplement
+ * those in the file, if any.
+ *
+ * If the filename is itself an empty string, and no path names are passed,
+ * then all reference-sense paths from the graph will be collected in arbitrary
+ * order. If there are none, all non-alt-allele generic sense paths from the
+ * graph will be collected in arbitrary order.
  *
  * TODO: Be able to generate the autosomes human-sort, X, Y, MT order typical
  * of references.
@@ -81,7 +85,7 @@ unique_ptr<AlignmentEmitter> get_alignment_emitter(const string& filename, const
  * This information needs to come from the user in order to be correct, but 
  * if it's not specified, it'll be guessed from the graph
  */
-vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const string& filename, const PathPositionHandleGraph& graph);                                                   
+vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const string& filename, const vector<string>& path_names, const PathPositionHandleGraph& graph);                                                   
 
 /**
  * Given a list of path handles and size info (from get_sequence_dictionary), return two things:

--- a/src/hts_alignment_emitter.hpp
+++ b/src/hts_alignment_emitter.hpp
@@ -68,8 +68,10 @@ unique_ptr<AlignmentEmitter> get_alignment_emitter(const string& filename, const
  * an HTSlib-style "sequence dictionary" (consisting of SAM @SQ header lines),
  * or a plain list of sequence names (which do not start with "@SQ"). If the
  * file is not openable or contains no entries, reports an error and quits. If
- * the filename is itself an empty string, all non-alt-allele paths from the
- * graph will be collected in arbitrary order.
+ * the filename is itself an empty string, all reference-sense paths from the
+ * graph will be collected in arbitrary order. If there are none, all
+ * non-alt-allele generic sense paths from the graph will be collected in
+ * arbitrary order.
  *
  * TODO: Be able to generate the autosomes human-sort, X, Y, MT order typical
  * of references.

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1440,7 +1440,7 @@ int main_giraffe(int argc, char** argv) {
             if (hts_output) {
                 // For htslib we need a non-empty list of paths.
                 assert(path_position_graph != nullptr);
-                paths = get_sequence_dictionary(ref_paths_name, *path_position_graph);
+                paths = get_sequence_dictionary(ref_paths_name, {}, *path_position_graph);
             }
             
             // Set up output to an emitter that will handle serialization and surjection.

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -748,7 +748,7 @@ int main_map(int argc, char** argv) {
     // Look up all the paths we might need to surject to.
     vector<tuple<path_handle_t, size_t, size_t>> paths;
     if (hts_output) {
-        paths = get_sequence_dictionary(ref_paths_name, *xgidx);
+        paths = get_sequence_dictionary(ref_paths_name, {}, *xgidx);
     }
     
     // Set up output to an emitter that will handle serialization and surjection

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1858,7 +1858,7 @@ int main_mpmap(int argc, char** argv) {
         }
         
         // Load all the paths in the right order
-        vector<tuple<path_handle_t, size_t, size_t>> paths = get_sequence_dictionary(ref_paths_name, *path_position_handle_graph);
+        vector<tuple<path_handle_t, size_t, size_t>> paths = get_sequence_dictionary(ref_paths_name, {}, *path_position_handle_graph);
         // Make them into a set for directing surjection.
         for (const auto& path_info : paths) {
             surjection_paths.insert(get<0>(path_info));

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 39
+plan tests 40
 
 vg construct -r small/x.fa >j.vg
 vg index -x j.xg j.vg
@@ -36,6 +36,16 @@ is $(vg surject -p x -x x.xg -t 1 -s j.gam | grep -v "@" | cut -f3 | grep x | wc
 
 is $(vg surject -x x.xg -t 1 -s j.gam | grep -v "@" | cut -f3 | grep x | wc -l) \
     100 "vg surject doesn't need to be told which path to use"
+    
+vg paths -X -x x.vg | vg view -aj - | jq '.name = "sample#0#x#0"' | vg view -JGa - > paths.gam
+vg paths -X -x x.vg | vg view -aj - | jq '.name = "ref#0#x[55]"' | vg view -JGa - >> paths.gam
+vg augment x.vg -i paths.gam > x.aug.vg
+vg index -x x.aug.xg x.aug.vg
+
+is $(vg surject -x x.aug.xg -t 1 -s j.gam | grep -v "@" | cut -f3 | grep "ref#0#x" | wc -l) \
+    100 "vg surject picks a reference-sense path if it is present"
+
+rm x.aug.vg x.aug.xg paths.gam
 
 is $(vg surject -p x -x x.xg -t 1 x.gam | vg view -a - | wc -l) \
     100 "vg surject works for every read simulated from a dense graph"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * BAM alignment output now tries to use reference paths, and then generic paths, but won't use haplotype paths by default

## Description

This ought to fix #3694.

I think it probably needs a test, though.