### PR TITLE
Surject onto cyclic paths

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -970,7 +970,7 @@ vector<pair<int, char>> cigar_against_path(const Alignment& alignment, bool on_r
     return cigar;
 }
 
-void consolidate_ID_runs(vector<pair<int, char>>& cigar) {
+void simiplify_cigar(vector<pair<int, char>>& cigar) {
     
     size_t removed = 0;
     for (size_t i = 0, j = 0; i < cigar.size(); ++j) {
@@ -1000,6 +1000,21 @@ void consolidate_ID_runs(vector<pair<int, char>>& cigar) {
         }
         if (j < cigar.size()) {
             cigar[j - removed] = cigar[j];
+        }
+    }
+    cigar.resize(cigar.size() - removed);
+    // do a second pass removing empty operations and consolidating non I/D operations
+    removed = 0;
+    for (size_t i = 0; i < cigar.size(); ++i) {
+        if (cigar[i].first == 0) {
+            ++removed;
+        }
+        else if (i > removed && cigar[i].second == cigar[i - removed - 1].second) {
+            cigar[i - removed - 1].first += cigar[i].first;
+            ++removed;
+        }
+        else if (removed) {
+            cigar[i - removed] = cigar[i];
         }
     }
     cigar.resize(cigar.size() - removed);

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -196,8 +196,10 @@ int32_t determine_flag(const Alignment& alignment,
 /// which is why it is passed by reference.
 vector<pair<int, char>> cigar_against_path(const Alignment& alignment, bool on_reverse_strand, int64_t& pos, size_t path_len, size_t softclip_suppress);
 
-/// Merge runs of successive I/D operations into a single I and D
-void consolidate_ID_runs(vector<pair<int, char>>& cigar);
+/// Merge runs of successive I/D operations into a single I and D, remove 0-length
+/// operations, and merge adjacent operations of the same type
+void simiplify_cigar(vector<pair<int, char>>& cigar);
+
 
 /// Translate the CIGAR in the given BAM record into mappings in the given
 /// Alignment against the given path in the given graph.

--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -1034,7 +1034,7 @@ vector<pair<int, char>> SplicedHTSAlignmentEmitter::spliced_cigar_against_path(c
         }
     }
     
-    consolidate_ID_runs(cigar);
+    simiplify_cigar(cigar);
     
     return cigar;
 }

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -4381,13 +4381,23 @@ namespace vg {
                     to_return += name;
                     break;
                 case multipath_alignment_t::Double:
-                    to_return += name + ": \"" + to_string(*((const double*) annotation)) + "\"";
+                {
+                    to_return += name + ": ";
+                    // handle the annoying lack of an integer annotation
+                    double val = *((const double*) annotation);
+                    if (trunc(val) == val) {
+                        to_return += to_string((int64_t) val);
+                    }
+                    else {
+                        to_return += to_string(val);
+                    }
                     break;
+                }
                 case multipath_alignment_t::Bool:
                     to_return += name + ": " + (*((const bool*) annotation) ? "true" : "false");
                     break;
                 case multipath_alignment_t::String:
-                    to_return += name + ": " + *((const string*) annotation);
+                    to_return += name + ": \"" + *((const string*) annotation) + "\"";
                     break;
                 default:
                     cerr << "error: unrecognized annotation type" << endl;

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -12,13 +12,14 @@
 
 //#define debug_multipath_alignment
 //#define debug_decompose_algorithm
+//#define debug_shift_pruning
 
 using namespace std;
 namespace vg {
     
     unordered_multimap<id_t, pair<id_t, bool>> MultipathAlignmentGraph::create_injection_trans(const unordered_map<id_t, pair<id_t, bool>>& projection_trans) {
         // create the injection translator, which maps a node in the original graph to every one of its occurrences
-        // in the dagified graph
+        // in the dagified graphfs
         unordered_multimap<id_t, pair<id_t, bool> > injection_trans;
         for (const auto& trans_record : projection_trans) {
 #ifdef debug_multipath_alignment
@@ -60,10 +61,10 @@ namespace vg {
                                                      const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
                                                      const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project,
                                                      const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans, bool realign_Ns,
-                                                     bool preserve_tail_anchors) {
+                                                     bool preserve_tail_anchors, vector<size_t>* path_node_provenance) {
         
         // Set up the initial multipath graph from the given path chunks.
-        create_path_chunk_nodes(graph, path_chunks, alignment, project, injection_trans);
+        create_path_chunk_nodes(graph, path_chunks, alignment, project, injection_trans, path_node_provenance);
         
         // trim indels off of nodes to make the score dynamic programmable across nodes
         trim_hanging_indels(alignment, realign_Ns, preserve_tail_anchors);
@@ -76,9 +77,10 @@ namespace vg {
     MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph,
                                                      const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
                                                      const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project, bool realign_Ns,
-                                                     bool preserve_tail_anchors) :
+                                                     bool preserve_tail_anchors, vector<size_t>* path_node_provenance) :
                                                      MultipathAlignmentGraph(graph, path_chunks, alignment, project,
-                                                                             create_injection_trans(graph, project), realign_Ns, preserve_tail_anchors) {
+                                                                             create_injection_trans(graph, project), realign_Ns, preserve_tail_anchors,
+                                                                             path_node_provenance) {
         // Nothing to do
         
     }
@@ -86,9 +88,10 @@ namespace vg {
     MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph,
                                                      const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
                                                      const Alignment& alignment, const unordered_map<id_t, pair<id_t, bool>>& projection_trans, bool realign_Ns,
-                                                     bool preserve_tail_anchors) :
+                                                     bool preserve_tail_anchors, vector<size_t>* path_node_provenance) :
                                                      MultipathAlignmentGraph(graph, path_chunks, alignment, create_projector(projection_trans),
-                                                                             create_injection_trans(projection_trans), realign_Ns, preserve_tail_anchors) {
+                                                                             create_injection_trans(projection_trans), realign_Ns, preserve_tail_anchors,
+                                                                             path_node_provenance) {
         // Nothing to do
         
     }
@@ -204,7 +207,8 @@ namespace vg {
     
     void MultipathAlignmentGraph::create_path_chunk_nodes(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
                                                           const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project,
-                                                          const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans) {
+                                                          const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans,
+                                                          vector<size_t>* path_node_provenance) {
         
         for (const auto& path_chunk : path_chunks) {
             
@@ -276,6 +280,9 @@ namespace vg {
                 }
                 
                 // now we can make a node in the subpath graph
+                if (path_node_provenance) {
+                    path_node_provenance->push_back(path_nodes.size());
+                }
                 path_nodes.emplace_back();
                 PathNode& path_node = path_nodes.back();
                 
@@ -6285,6 +6292,104 @@ void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGrap
 
     size_t MultipathAlignmentGraph::size() const {
         return path_nodes.size();
+    }
+
+    size_t MultipathAlignmentGraph::max_shift() const {
+        size_t shift = 0;
+        for (const auto& path_node : path_nodes) {
+            for (const auto& edge : path_node.edges) {
+                const auto& next_node = path_nodes[edge.first];
+                shift = max<size_t>(shift, abs<int64_t>((next_node.begin - path_node.end) - edge.second));
+            }
+        }
+        return shift;
+    }
+
+    void MultipathAlignmentGraph::prune_high_shift_edges(size_t prune_diff, bool prohibit_new_sources, bool prohibit_new_sinks) {
+        
+        vector<size_t> min_shift_fwd(path_nodes.size(), numeric_limits<size_t>::max());
+        vector<size_t> min_shift_rev(path_nodes.size(), numeric_limits<size_t>::max());
+        
+        vector<size_t> in_degree(path_nodes.size(), 0);
+        for (int64_t i = path_nodes.size() - 1; i >= 0; --i) {
+            auto& path_node = path_nodes[i];
+            if (path_node.edges.empty()) {
+                min_shift_rev[i] = 0;
+            }
+            else {
+                for (auto& edge : path_node.edges) {
+                    
+                    ++in_degree[edge.first];
+                    
+                    const auto& next_node = path_nodes[edge.first];
+                    size_t shift = abs<int64_t>((next_node.begin - path_node.end) - edge.second);
+                    
+#ifdef debug_shift_pruning
+                    cerr << "shift DP reverse " << i << " <- " << edge.first << " with shift " << shift << " for total " << min_shift_rev[edge.first] + shift << endl;
+#endif
+                    
+                    min_shift_rev[i] = min<size_t>(min_shift_rev[i], min_shift_rev[edge.first] + shift);
+                }
+            }
+        }
+        
+        size_t opt_shift = numeric_limits<size_t>::max();
+        for (size_t i = 0; i < path_nodes.size(); ++i) {
+            
+            if (in_degree[i] == 0) {
+                min_shift_fwd[i] = 0;
+            }
+            
+            auto& path_node = path_nodes[i];
+            if (path_node.edges.empty()) {
+                opt_shift = min(opt_shift, min_shift_fwd[i]);
+            }
+            else {
+                for (auto& edge : path_node.edges) {
+                    const auto& next_node = path_nodes[edge.first];
+                    size_t shift = abs<int64_t>((next_node.begin - path_node.end) - edge.second);
+#ifdef debug_shift_pruning
+                    cerr << "shift DP forward " << i << " -> " << edge.first << " with shift " << shift << " for total " << min_shift_fwd[i] + shift << endl;
+#endif
+                    min_shift_fwd[edge.first] = min<size_t>(min_shift_fwd[edge.first], min_shift_fwd[i] + shift);
+                }
+            }
+        }
+#ifdef debug_shift_pruning
+        cerr << "min forward and backward shift:" << endl;
+        for (size_t i = 0; i < path_nodes.size(); ++i) {
+            cerr << "\t" << i << ":\t" << min_shift_fwd[i] << "\t" << min_shift_rev[i] << endl;
+        }
+#endif
+        
+        for (size_t i = 0; i < path_nodes.size(); ++i) {
+            auto& path_node = path_nodes[i];
+            size_t removed = 0;
+            for (size_t j = 0; j < path_node.edges.size(); ++j) {
+                auto& edge = path_node.edges[j];
+                const auto& next_node = path_nodes[edge.first];
+                size_t shift = abs<int64_t>((next_node.begin - path_node.end) - edge.second);
+                
+                size_t min_edge_shift = min_shift_fwd[i] + shift + min_shift_rev[edge.first];
+                
+                // TODO: we might choose a sub-optimal set of these by just greedily removing edges
+                if (min_edge_shift > opt_shift + prune_diff
+                    && (!prohibit_new_sinks || removed + 1 < path_node.edges.size())
+                    && (!prohibit_new_sources || in_degree[edge.first] > 1)) {
+#ifdef debug_shift_pruning
+                    cerr << "removing edge " << i << " -> " << edge.first << " with min shift " << min_edge_shift << " compared to opt shift " << opt_shift << endl;
+#endif
+                    ++removed;
+                    --in_degree[edge.first];
+                }
+                else if (removed) {
+                    path_node.edges[j - removed] = path_node.edges[j];
+                }
+            }
+            if (removed) {
+                path_node.edges.resize(path_node.edges.size() - removed);
+            }
+        }
     }
     
     void MultipathAlignmentGraph::to_dot(ostream& out, const Alignment* alignment) const {

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -6310,6 +6310,7 @@ void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGrap
         vector<size_t> min_shift_fwd(path_nodes.size(), numeric_limits<size_t>::max());
         vector<size_t> min_shift_rev(path_nodes.size(), numeric_limits<size_t>::max());
         
+        // compute the min shift with reverse DP and also compute in degrees
         vector<size_t> in_degree(path_nodes.size(), 0);
         for (int64_t i = path_nodes.size() - 1; i >= 0; --i) {
             auto& path_node = path_nodes[i];
@@ -6333,6 +6334,7 @@ void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGrap
             }
         }
         
+        // compute the min shift the forward direction and find the optimal shift
         size_t opt_shift = numeric_limits<size_t>::max();
         for (size_t i = 0; i < path_nodes.size(); ++i) {
             
@@ -6362,6 +6364,7 @@ void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGrap
         }
 #endif
         
+        // prune edges as necessary
         for (size_t i = 0; i < path_nodes.size(); ++i) {
             auto& path_node = path_nodes[i];
             size_t removed = 0;

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -88,18 +88,18 @@ namespace vg {
         MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
                                 const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project,
                                 const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans, bool realign_Ns = true,
-                                bool preserve_tail_anchors = false);
+                                bool preserve_tail_anchors = false, vector<size_t>* path_node_provenance = nullptr);
        
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
         MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
                                 const Alignment& alignment, const unordered_map<id_t, pair<id_t, bool>>& projection_trans, bool realign_Ns = true,
-                                bool preserve_tail_anchors = false);
+                                bool preserve_tail_anchors = false, vector<size_t>* path_node_provenance = nullptr);
         
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
         /// and using a lambda for a projector
         MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
                                 const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project, bool realign_Ns = true,
-                                bool preserve_tail_anchors = false);
+                                bool preserve_tail_anchors = false, vector<size_t>* path_node_provenance = nullptr);
         
         /// Make a multipath alignment graph using the path of a single-path alignment. Only
         /// one of snarl_manager and dist_index need be supplied.
@@ -226,6 +226,12 @@ namespace vg {
         
         size_t size() const;
         
+        /// For a graph with reachability edges, identifies the largest difference between read interval and
+        /// reference distance
+        size_t max_shift() const;
+        
+        void prune_high_shift_edges(size_t prune_diff, bool prohibit_new_sources, bool prohibit_new_sinks);
+        
     protected:
         
         /// Nodes representing walked MEMs in the graph
@@ -253,7 +259,8 @@ namespace vg {
         /// Add the path chunks as nodes to the connectivity graph
         void create_path_chunk_nodes(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
                                      const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project,
-                                     const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans);
+                                     const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans,
+                                     vector<size_t>* path_node_provenance = nullptr);
         
         /// Walk out MEMs into match nodes and filter out redundant sub-MEMs
         void create_match_nodes(const HandleGraph& graph, MultipathMapper::memcluster_t& hits,

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -3497,6 +3497,7 @@ using namespace std;
             cerr << "looking for overlapping chunks for " << order[i] << endl;
             cerr << string(chunk_here.first.first, chunk_here.first.second) << " " << pb2json(chunk_here.second) << endl;
 #endif
+            
             // remove items from the heap if they are outside the window of this read interval
             while (!curr_chunks.empty() && path_chunks[curr_chunks.front()].first.second <= chunk_here.first.first) {
                 pop_heap(curr_chunks.begin(), curr_chunks.end(), cmp);
@@ -3511,14 +3512,14 @@ using namespace std;
                 }
                 // check that the reference interval is contained
                 if (path_rev) {
-                    if (graph->get_position_of_step(ref_chunks[i].first) < graph->get_position_of_step(ref_chunks[j].first)
-                        || graph->get_position_of_step(ref_chunks[i].second) > graph->get_position_of_step(ref_chunks[j].second)) {
+                    if (graph->get_position_of_step(ref_chunks[order[i]].first) > graph->get_position_of_step(ref_chunks[j].first)
+                        || graph->get_position_of_step(ref_chunks[order[i]].second) < graph->get_position_of_step(ref_chunks[j].second)) {
                         continue;
                     }
                 }
                 else {
-                    if (graph->get_position_of_step(ref_chunks[i].first) > graph->get_position_of_step(ref_chunks[j].first)
-                        || graph->get_position_of_step(ref_chunks[i].second) < graph->get_position_of_step(ref_chunks[j].second)) {
+                    if (graph->get_position_of_step(ref_chunks[order[i]].first) < graph->get_position_of_step(ref_chunks[j].first)
+                        || graph->get_position_of_step(ref_chunks[order[i]].second) > graph->get_position_of_step(ref_chunks[j].second)) {
                         continue;
                     }
                 }

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -153,7 +153,7 @@ using namespace std;
         
         /// remove any path chunks and corresponding ref chunks that are identical to a longer
         /// path chunk over the region where they overlap
-        void filter_redundant_path_chunks(vector<path_chunk_t>& path_chunks,
+        void filter_redundant_path_chunks(bool path_rev, vector<path_chunk_t>& path_chunks,
                                           vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
                                           vector<tuple<size_t, size_t, int32_t>>& connections) const;
         

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -121,6 +121,7 @@ using namespace std;
         realigning_surject(const PathPositionHandleGraph* graph, const Alignment& source,
                            const path_handle_t& path_handle, bool rev_strand,
                            const vector<path_chunk_t>& path_chunks,
+                           const vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
                            pair<step_handle_t, step_handle_t>& path_range_out,
                            bool allow_negative_scores,
                            bool preserve_N_alignments = false,
@@ -166,7 +167,9 @@ using namespace std;
         /// end if there are no path chunks.
         pair<size_t, size_t>
         compute_path_interval(const PathPositionHandleGraph* graph, const Alignment& source, path_handle_t path_handle,
-                              bool rev_strand, const vector<path_chunk_t>& path_chunks) const;
+                              bool rev_strand, const vector<path_chunk_t>& path_chunks,
+                              const vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
+                              bool no_left_expansion, bool no_right_expansion) const;
         
         /// make a linear graph that corresponds to a path interval, possibly duplicating nodes in case of cycles
         unordered_map<id_t, pair<id_t, bool>>

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -99,6 +99,9 @@ using namespace std;
         /// while downsampling, try to get down to this coverage on each base
         int64_t downsample_coverage = 16;
         
+        int64_t min_shift_for_prune = 32 * 1024;
+        int64_t shift_prune_diff = 16 * 1024;
+        
         /// And have we complained about hitting it?
         mutable atomic_flag warned_about_subgraph_size = ATOMIC_FLAG_INIT;
         
@@ -121,7 +124,8 @@ using namespace std;
                            pair<step_handle_t, step_handle_t>& path_range_out,
                            bool allow_negative_scores,
                            bool preserve_N_alignments = false,
-                           bool preserve_tail_indel_anchors = false,
+                           bool sinks_are_anchors = false,
+                           bool sources_are_anchors = false,
                            vector<pair<step_handle_t, step_handle_t>>* all_path_ranges_out = nullptr) const;
         
         multipath_alignment_t

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -121,7 +121,8 @@ using namespace std;
                            pair<step_handle_t, step_handle_t>& path_range_out,
                            bool allow_negative_scores,
                            bool preserve_N_alignments = false,
-                           bool preserve_tail_indel_anchors = false) const;
+                           bool preserve_tail_indel_anchors = false,
+                           vector<pair<step_handle_t, step_handle_t>>* all_path_ranges_out = nullptr) const;
         
         multipath_alignment_t
         spliced_surject(const PathPositionHandleGraph* path_position_graph,

--- a/src/unittest/alignment.cpp
+++ b/src/unittest/alignment.cpp
@@ -241,7 +241,7 @@ TEST_CASE("Target to alignment extraction", "[target-to-aln]") {
     
 }
 
-TEST_CASE("consolidate_ID_runs merges runs of adjacent I's and D's in cigars", "[alignment][surject]") {
+TEST_CASE("simiplify_cigar merges runs of adjacent I's and D's in cigars", "[alignment][surject]") {
     
     vector<pair<int, char>> cigar{
         make_pair(2, 'D'),
@@ -253,7 +253,7 @@ TEST_CASE("consolidate_ID_runs merges runs of adjacent I's and D's in cigars", "
         make_pair(1, 'I')
     };
 
-    consolidate_ID_runs(cigar);
+    simiplify_cigar(cigar);
     REQUIRE(cigar.size() == 5);
     bool consolidated_1 = ((cigar[0] == make_pair(6, 'D') && cigar[1] == make_pair(1, 'I'))
                            || (cigar[0] == make_pair(1, 'I') && cigar[1] == make_pair(6, 'D')));
@@ -262,6 +262,25 @@ TEST_CASE("consolidate_ID_runs merges runs of adjacent I's and D's in cigars", "
     
     REQUIRE(consolidated_1);
     REQUIRE(consolidated_2);
+}
+
+TEST_CASE("simiplify_cigar merges runs of adjacent operations and removes empty operations", "[alignment][surject]") {
+    
+    vector<pair<int, char>> cigar{
+        make_pair(2, 'S'),
+        make_pair(1, 'M'),
+        make_pair(1, 'M'),
+        make_pair(0, 'D'),
+        make_pair(1, 'I'),
+        make_pair(1, 'M')
+    };
+    
+    simiplify_cigar(cigar);
+    REQUIRE(cigar.size() == 4);
+    REQUIRE(cigar[0] == make_pair(2, 'S'));
+    REQUIRE(cigar[1] == make_pair(2, 'M'));
+    REQUIRE(cigar[2] == make_pair(1, 'I'));
+    REQUIRE(cigar[3] == make_pair(1, 'M'));
 }
 
 TEST_CASE("Inter-alignment distance computation for HTS output formats matches BWA", "[alignment]") {

--- a/src/unittest/surject.cpp
+++ b/src/unittest/surject.cpp
@@ -688,7 +688,7 @@ TEST_CASE("Duplicate path chunks can be detected", "[surject][multipath]") {
     
     vector<tuple<size_t, size_t, int32_t>> connections;
     
-    surjector.filter_redundant_path_chunks(path_chunks, ref_chunks, connections);
+    surjector.filter_redundant_path_chunks(false, path_chunks, ref_chunks, connections);
     
     REQUIRE(ref_chunks.size() == path_chunks.size());
     REQUIRE(path_chunks.size() == 2);

--- a/src/unittest/surject.cpp
+++ b/src/unittest/surject.cpp
@@ -676,15 +676,30 @@ TEST_CASE("Duplicate path chunks can be detected", "[surject][multipath]") {
     e31->set_to_length(2);
     
     bdsg::HashGraph graph;
+    handle_t h1 = graph.create_handle("AAAC");
+    handle_t h2 = graph.create_handle("GTGT");
+    handle_t h3 = graph.create_handle("GTAC");
+    
+    graph.create_edge(h1, h2);
+    graph.create_edge(h1, h3);
+    graph.create_edge(h2, h1);
+    
+    path_handle_t p = graph.create_path_handle("path");
+    
+    step_handle_t s1 = graph.append_step(p, h1);
+    step_handle_t s2 = graph.append_step(p, h2);
+    step_handle_t s3 = graph.append_step(p, h1);
+    step_handle_t s4 = graph.append_step(p, h3);
+    
     bdsg::PositionOverlay pos_graph(&graph);
     TestSurjector surjector(&pos_graph);
     
     vector<Surjector::path_chunk_t> path_chunks{chunk1, chunk2, chunk3, chunk4};
     vector<pair<step_handle_t, step_handle_t>> ref_chunks;
-    ref_chunks.emplace_back();
-    ref_chunks.emplace_back();
-    ref_chunks.emplace_back();
-    ref_chunks.emplace_back();
+    ref_chunks.emplace_back(s1, s2);
+    ref_chunks.emplace_back(s1, s1);
+    ref_chunks.emplace_back(s2, s2);
+    ref_chunks.emplace_back(s3, s4);
     
     vector<tuple<size_t, size_t, int32_t>> connections;
     


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject -S` no longer crashes when projecting to paths that contain cycles

## Description

There were several substantial bugs in `vg surject` on graphs with reference paths that cycle back onto themselves. Most of the bugs involved logic errors by which the wrong copy of a repeated section of a path could be chosen, which resulted in alignments that were not co-linear along the reference.

Re-resolves https://github.com/vgteam/vg/issues/3672.