### PR TITLE
Update Mac CI image

### DIFF
--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -46,10 +46,10 @@ jobs:
         # We uninstall everything we don't need in order to prevent linking
         # conflicts with existing/outdated packages, which we can't resolve
         # because there's no way to tell Homebrew to force-link when installing
-        # from a Brewfile. We update/upgrade to make sure we actually have
-        # current package versions.
+        # from a Brewfile. We also update Protobuf to make sure we have 3.21.3+
+        # to avoid problems with ABI changes with/without -DNDEBUG.
         # We pre-install a pinned txm to work around https://github.com/anko/txm/issues/8
-        run: brew bundle cleanup --force && brew update && brew upgrade && brew bundle install && npm install -g txm@7.4.5
+        run: brew bundle cleanup --force && brew bundle install && brew update && brew install protobuf && npm install -g txm@7.4.5
 
       - name: Run build and test
         run: |

--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   testmac:
     name: Test on Mac
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - name: Use cache
@@ -26,14 +26,14 @@ jobs:
             lib
             include
             bin
-          key: ${{ runner.os }}-${{ github.ref }}
+          key: ${{ runner.os }}-11-${{ github.ref }}
           # Restore keys are a "list", but really only a multiline string is
           # accepted. Also we match by prefix. And the most recent cache is
           # used, not the most specific.
           # See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
           restore-keys: |
-            ${{ runner.os }}-${{ github.base_ref }}
-            ${{ runner.os }}
+            ${{ runner.os }}-11-${{ github.base_ref }}
+            ${{ runner.os }}-11
           
       - name: Checkout code without submodules
         uses: actions/checkout@v2

--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -46,9 +46,10 @@ jobs:
         # We uninstall everything we don't need in order to prevent linking
         # conflicts with existing/outdated packages, which we can't resolve
         # because there's no way to tell Homebrew to force-link when installing
-        # from a Brewfile.
+        # from a Brewfile. We update/upgrade to make sure we actually have
+        # current package versions.
         # We pre-install a pinned txm to work around https://github.com/anko/txm/issues/8
-        run: brew bundle cleanup --force && brew bundle install && npm install -g txm@7.4.5
+        run: brew bundle cleanup --force && brew update && brew upgrade && brew bundle install && npm install -g txm@7.4.5
 
       - name: Run build and test
         run: |

--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   testmac:
     name: Test on Mac
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
       - name: Use cache
@@ -26,14 +26,14 @@ jobs:
             lib
             include
             bin
-          key: ${{ runner.os }}-11-${{ github.ref }}
+          key: ${{ runner.os }}-12-${{ github.ref }}
           # Restore keys are a "list", but really only a multiline string is
           # accepted. Also we match by prefix. And the most recent cache is
           # used, not the most specific.
           # See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
           restore-keys: |
-            ${{ runner.os }}-11-${{ github.base_ref }}
-            ${{ runner.os }}-11
+            ${{ runner.os }}-12-${{ github.base_ref }}
+            ${{ runner.os }}-12
           
       - name: Checkout code without submodules
         uses: actions/checkout@v2

--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   testmac:
     name: Test on Mac
-    runs-on: macos-10.15
+    runs-on: macos-latest
 
     steps:
       - name: Use cache

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -1018,7 +1018,7 @@ public:
         auto used_bits = numeric_limits<long long unsigned int>::digits - unused_bits;
         
         // Get just that max used bit
-        OutType used_bit = 1 << (used_bits - 1);
+        OutType used_bit = OutType(1) << (used_bits - 1);
         
         // If a generated number from the RNG has this bit flag in it, it has
         // passed the largest complete power of 2 it can make and needs to be


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Mac CI now runs on MacOS 12
 * `uniform_int_distribution` unit tests no longer hang on MacOS 12

## Description

As noted in https://github.com/actions/virtual-environments#available-environments, the MacOS image we are using for Github Actions, `macos-10.15`, is deprecated. Github has started turning it off occasionally to annoy us enough to switch, and it is due to go away entirely sometime in August.

I tried `macos-11`, and ran into a Clang crash when building `aligner.cpp`, which I think we never fixed and just waited for Clang to fix it in the new Clang version that runs on MacOS 12.

On `macos-12`, I have the build successfully building, but running the unit tests appears to hang. I need to see if I can reproduce this hang on an interactive machine somewhere, so I can try to fix it.