### PR TITLE
Fix hanging test on macOS 12

### DIFF
--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -1018,7 +1018,7 @@ public:
         auto used_bits = numeric_limits<long long unsigned int>::digits - unused_bits;
         
         // Get just that max used bit
-        OutType used_bit = 1 << (used_bits - 1);
+        OutType used_bit = OutType(1) << (used_bits - 1);
         
         // If a generated number from the RNG has this bit flag in it, it has
         // passed the largest complete power of 2 it can make and needs to be


### PR DESCRIPTION
## Description

The hanging test seems to have been caused by a change in the bit-width of a `1` literal in the uniform integer distribution code. The integer type is now specified to be the same as the output type for the distribution.