### PR TITLE
hack ref interval assertion fail into warning

### DIFF
--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -2737,6 +2737,9 @@ using namespace std;
             *surjected.mutable_path() = path_chunks.front().second;
             surjected.set_score(get_aligner(!source.quality().empty())->score_contiguous_alignment(surjected));
             
+        } else if (ref_path_interval.first > ref_path_interval.second) {
+            // this is a hack to avoid the assertion below
+            cerr << "skipping instead of failing with ref interval " << ref_path_interval.first << ":" << ref_path_interval.second << " on path of length " << path_position_graph->get_path_length(path_handle) << endl;
         }
         else {
             // we're going to have to realign some portions


### PR DESCRIPTION
This changes a (very rare) assertion failure into a (cryptic) message, allowing HG005 to be run on the CHM13-based year-1 HPRC graph.  

This is probably not the idea fix, but is better than a crash.  
