### PR TITLE
Surject interval crash

### DIFF
--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -142,6 +142,8 @@ int main_autoindex(int argc, char** argv) {
     bool force_phased = false;
     int64_t target_mem_usage = IndexRegistry::get_system_memory() / 2;
     
+    string gfa_name;
+    
     int c;
     optind = 2; // force optind past command positional argument
     while (true) {
@@ -215,12 +217,7 @@ int main_autoindex(int argc, char** argv) {
                 registry.provide("Insertion Sequence FASTA", optarg);
                 break;
             case 'g':
-                if (IndexRegistry::gfa_has_haplotypes(optarg)) {
-                    registry.provide("Reference GFA w/ Haplotypes", optarg);
-                }
-                else {
-                    registry.provide("Reference GFA", optarg);
-                }
+                gfa_name = optarg;
                 break;
             case 'x':
                 registry.provide("GTF/GFF", optarg);
@@ -310,6 +307,15 @@ int main_autoindex(int argc, char** argv) {
             else {
                 registry.provide("VCF", vcf_name);
             }
+        }
+    }
+    
+    if (!gfa_name.empty()) {
+        if (IndexRegistry::gfa_has_haplotypes(gfa_name)) {
+            registry.provide("Reference GFA w/ Haplotypes", optarg);
+        }
+        else {
+            registry.provide("Reference GFA", gfa_name);
         }
     }
 

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -312,7 +312,7 @@ int main_autoindex(int argc, char** argv) {
     
     if (!gfa_name.empty()) {
         if (IndexRegistry::gfa_has_haplotypes(gfa_name)) {
-            registry.provide("Reference GFA w/ Haplotypes", optarg);
+            registry.provide("Reference GFA w/ Haplotypes", gfa_name);
         }
         else {
             registry.provide("Reference GFA", gfa_name);

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -3802,7 +3802,7 @@ using namespace std;
             
             size_t right_overhang = no_right_expansion ? 0 : (get_aligner()->longest_detectable_gap(source, path_chunk.first.second)
                                                               + (source.sequence().end() - path_chunk.first.second));
-            
+                        
             const Position& first_pos = path_chunk.second.mapping(0).position();
             if (rev_strand) {
                 size_t path_offset = (graph->get_position_of_step(ref_chunk.first)
@@ -3818,7 +3818,7 @@ using namespace std;
                     interval.first = 0;
                 }
                 else {
-                    interval.first = min(interval.first, path_offset - left_overhang);
+                    interval.first = min(min(interval.first, path_offset - left_overhang), path_length - 1);
                 }
             }
             
@@ -3834,7 +3834,7 @@ using namespace std;
                     interval.first = 0;
                 }
                 else {
-                    interval.first = min(interval.first, path_offset - right_overhang);
+                    interval.first = min(min(interval.first, path_offset - right_overhang), path_length - 1);
                 }
             }
             else {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Bug fix in `vg surject`

## Description

`vg surject` could fail an assert statement when re-aligning a read that only intersected a path on its past-the-last position. That situation was encountered because of an edge case in the `vg giraffe` alignments in which a softclip can be placed on the node adjacent to the aligned bases instead of on the same node. We may also want to handle this case better in the tail alignment routine.

This PR should make https://github.com/vgteam/vg/pull/3714 unnecessary, not that there's any harm to merging both.