### PR TITLE
add libzstd to pkg_config_deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ include $(wildcard $(UNITTEST_BIN_DIR)/*.d)
 # What pkg-config-controlled system dependencies should we use compile and link flags from?
 # Use PKG_CONFIG_PATH to point the build system at the right versions of these, if they aren't picked up automatically.
 # We can't do this for our bundled, pkg-config-supporting dependencies (like htslib) because they won't be built yet.
-PKG_CONFIG_DEPS := cairo jansson 
+PKG_CONFIG_DEPS := cairo jansson libzstd
 # These are like PKG_CONFIG_DEPS but we try to always link them statically, if possible.
 PKG_CONFIG_STATIC_DEPS := protobuf 
 


### PR DESCRIPTION
`src/zstdutil` seems to need libzstd version > 1.5 in order to build.  But on Ubuntu 18.04 libzstd is capped at 1.33.  If I manually install libzstd 1.5 from source (it ends up in `/usr/local`) vg picks up the headers just fine but links against the old version leading to `zstdutil.cpp:85: undefined reference to ZSTD_compressStream2`.  No luck with `LD_LIBRARY_PATH` but adding `-L` seems to work.  

