### PR TITLE
Make duplicate GFA paths a warning to fix #3726

### DIFF
--- a/src/io/register_loader_saver_gfa.cpp
+++ b/src/io/register_loader_saver_gfa.cpp
@@ -118,8 +118,7 @@ void register_loader_saver_gfa() {
             } else {
                 cerr << "stream";
             }
-            cerr << " is corrupt and cannot be loaded." << endl;
-            cerr << e.what() << endl;
+            cerr << " cannot be loaded: " << e.what() << endl;
             exit(1);
         }
         

--- a/src/unittest/gfa.cpp
+++ b/src/unittest/gfa.cpp
@@ -289,7 +289,7 @@ S	1	GATTACA)";
 
 }
 
-TEST_CASE("Can reject graphs that have duplicate paths", "[gfa]") {
+TEST_CASE("Can accept graphs that have duplicate paths by default", "[gfa]") {
 
     const string graph_gfa = R"(H	VN:Z:1.0
 P	x	1+,3+	8M,1M
@@ -302,8 +302,9 @@ L	1	+	3	+	0M)";
 
     bdsg::HashGraph graph;
     stringstream in(graph_gfa);
-    REQUIRE_THROWS_AS(algorithms::gfa_to_path_handle_graph(in, &graph), algorithms::GFAFormatError);
-
+    algorithms::gfa_to_path_handle_graph(in, &graph);
+    REQUIRE(graph.has_path("x"));
+    // TODO: Expose the flag to require no duplicate paths
 }
 
 TEST_CASE("Can reject graphs that have conflicting paths and walks", "[gfa]") {

--- a/test/graphs/components_paths_rgfa.gfa
+++ b/test/graphs/components_paths_rgfa.gfa
@@ -1,0 +1,27 @@
+H	VN:Z:1.1
+S	11	G	SN:Z:GRCh38.chr1	SO:i:0	SR:i:0
+S	12	A	SN:Z:GRCh38.chr1	SO:i:1	SR:i:0
+S	13	T
+S	14	T	SN:Z:GRCh38.chr1	SO:i:2	SR:i:0
+S	15	A	SN:Z:GRCh38.chr1	SO:i:3	SR:i:0
+S	16	C
+S	17	A	SN:Z:GRCh38.chr1	SO:i:4	SR:i:0
+S	21	G
+S	22	A
+S	23	T
+S	24	T
+S	25	A
+L	11	+	12	+	*
+L	11	+	13	+	*
+L	12	+	14	+	*
+L	13	+	14	+	*
+L	14	+	15	+	*
+L	14	+	16	+	*
+L	15	+	17	+	*
+L	16	+	17	+	*
+L	21	+	22	+	*
+L	21	+	23	+	*
+L	22	+	24	+	*
+L	23	+	24	-	*
+L	24	+	25	+	*
+P	GRCh38.chr1	11+,12+,14+,15+,17+	*

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order
 
-plan tests 96
+plan tests 98
 
 vg construct -r complex/c.fa -v complex/c.vcf.gz > c.vg
 cat <(vg view c.vg | grep ^S | sort) <(vg view c.vg | grep L | uniq | wc -l) <(vg paths -v c.vg -E) > c.info
@@ -404,8 +404,14 @@ vg paths -M -x extracted.gfa | sort >paths.gfa.txt
 cmp paths.gfa.txt paths.truth.txt
 is "${?}" "0" "rGFA -> HashGraph -> GBZ -> GFA conversion preserves path metadata"
 
+# We should be able to handle GFA where the P lines and rGFA tags are redundant
+# and cover the same paths, like in HPRC release graphs.
+vg convert -a graphs/components_paths_rgfa.gfa > components_paths_rgfa.hg
+is "${?}" "0" "GFA -> HashGraph conversion works with redundant paths"
+is "$(vg paths --list -x components_paths_rgfa.hg | wc -l)" "1" "GFA -> HashGraph conversion with redundant paths keeps one copy of the redundant path"
+
 rm -f paths.truth.txt paths.gbz.txt paths.gfa.txt paths.hg.txt
-rm -f gfa_with_reference.gbz rgfa_with_reference.gbz gfa_with_reference.hg rgfa_with_reference.hg extracted.gfa
+rm -f gfa_with_reference.gbz rgfa_with_reference.gbz gfa_with_reference.hg components_paths_rgfa.hg rgfa_with_reference.hg extracted.gfa 
 
 #####
 # GFA Streaming


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg main GFA loader can now handle HPRC-style GFAs where the same path exists as rGFA tags and P lines.

## Description

It turns out that we can't just reject GFA files that have the same path twice, because the HPRC release graphs do that (as do new Minigraph-Cactus graphs) and we need to support those.

So this downgrades the duplicate path error to a warning.