### PR TITLE
Selecting the number of minimzers for Giraffe based on length of aligned read

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -3323,6 +3323,7 @@ std::vector<SeedType> MinimizerMapper::find_seeds(const std::vector<Minimizer>& 
     // bit vector length of read to check for overlaps
     size_t num_minimizers = 0;
     size_t read_len = aln.sequence().size();
+    size_t num_min_by_read_len = read_len / this->num_bp_per_min;
     std::vector<bool> read_bit_vector (read_len, false);
 
     // Select the minimizers we use for seeds.
@@ -3372,10 +3373,11 @@ std::vector<SeedType> MinimizerMapper::find_seeds(const std::vector<Minimizer>& 
                 funnel.fail("any-hits", i);
             }
         } else if (  // passes reads
+              // cap minimizer at max of specified minimizers and minimizers calculated by read length
               ((minimizer.hits <= this->hit_cap) ||
               (run_hits <= this->hard_hit_cap && selected_score + minimizer.score <= target_score) ||
               (took_last && i > start)) &&
-              (num_minimizers < this->max_unique_min) &&
+              (num_minimizers < ( max(this->max_unique_min, num_min_by_read_len) )) &&
               (overlapping == false)
             ) {
             

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -99,6 +99,9 @@ public:
     /// Maximum number of distinct minimizers to take
     size_t max_unique_min = 500;
     
+    /// Number of minimzers to select based on read_len/num_min_per_bp
+    size_t num_bp_per_min = 1000;
+
     /// If set, exclude overlapping minimizers
     bool exclude_overlapping_min = false;
 

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -350,6 +350,7 @@ void help_giraffe(char** argv) {
     << "  -S, --pad-cluster-score INT   also extend clusters within INT of above threshold to get a second-best cluster [0]" << endl
     << "  -u, --cluster-coverage FLOAT  only extend clusters if they are within FLOAT of the best read coverage [0.3]" << endl
     << "  -U, --max-min INT             use at most INT minimizers [500]" << endl
+    << "  --num-bp-per-min INT          use maximum of number minimizers calculated by READ_LENGTH / INT and --max-min [1000]" << endl
     << "  -v, --extension-score INT     only align extensions if their score is within INT of the best score [1]" << endl
     << "  -w, --extension-set INT       only align extension sets if their score is within INT of the best score [20]" << endl
     << "  -O, --no-dp                   disable all gapped alignment" << endl
@@ -391,7 +392,7 @@ int main_giraffe(int argc, char** argv) {
     #define OPT_NAMED_COORDINATES 1012
     #define OPT_EXCLUDE_OVERLAPPING_MIN 1013
     #define OPT_ALIGN_FROM_CHAINS 1014
-    
+    #define OPT_NUM_BP_PER_MIN 1015
 
     // initialize parameters with their default options
     
@@ -404,6 +405,8 @@ int main_giraffe(int argc, char** argv) {
     Range<size_t> hit_cap = 10, hard_hit_cap = 500;
     Range<double> minimizer_score_fraction = 0.9;
     Range<size_t> max_unique_min = 500;
+    // number minimizers calculated by READ_LENGTH / INT
+    size_t num_bp_per_min = 1000;
     bool show_progress = false;
     // Should we exclude overlapping minimizers
     bool exclude_overlapping_min = false;
@@ -551,6 +554,7 @@ int main_giraffe(int argc, char** argv) {
             {"pad-cluster-score", required_argument, 0, 'S'},
             {"cluster-coverage", required_argument, 0, 'u'},
             {"max-min", required_argument, 0, 'U'},
+            {"num-bp-per-min", required_argument, 0, OPT_NUM_BP_PER_MIN},
             {"exclude-overlapping-min", no_argument, 0, OPT_EXCLUDE_OVERLAPPING_MIN},
             {"extension-score", required_argument, 0, 'v'},
             {"extension-set", required_argument, 0, 'w'},
@@ -935,6 +939,10 @@ int main_giraffe(int argc, char** argv) {
                 }
                 break;
 
+            case OPT_NUM_BP_PER_MIN:
+                num_bp_per_min = parse<size_t>(optarg);;
+                break;
+
             case OPT_EXCLUDE_OVERLAPPING_MIN:
                 exclude_overlapping_min = true;
                 break;
@@ -1296,6 +1304,11 @@ int main_giraffe(int argc, char** argv) {
             cerr << "--max-min " << max_unique_min << endl;
         }
         minimizer_mapper.max_unique_min = max_unique_min;
+
+        if (show_progress) {
+            cerr << "--num-bp-per-min " << num_bp_per_min << endl;
+        }
+        minimizer_mapper.num_bp_per_min = num_bp_per_min;
 
         if (show_progress) {
             cerr << "--exclude-overlapping-min " << endl;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add the flag `--num-bp-per-min` to adjust the number of selected minimizers based on the read length.

## Description
Add command line flag `--num-bp-per-min INT`
for calculating the number of minimizers to select based on `read_length / INT`. The actual number of minimizers selected is the maximum of this calculated value and the value specified by `--max-min INT`.