### PR TITLE
Filter for properly paired reads

### DIFF
--- a/src/readfilter.cpp
+++ b/src/readfilter.cpp
@@ -9,7 +9,8 @@ ostream& operator<<(ostream& os, const Counts& counts) {
     os << "Total Filtered:                " << counts.counts[Counts::FilterName::filtered] << " / "
        << counts.counts[Counts::FilterName::read] << endl
        << "Read Name Filter:              " << counts.counts[Counts::FilterName::wrong_name] << endl
-       << "Subsequence Filter:              " << counts.counts[Counts::FilterName::subsequence] << endl
+       << "Subsequence Filter:            " << counts.counts[Counts::FilterName::subsequence] << endl
+       << "Proper Pair Filter:            " << counts.counts[Counts::FilterName::proper_pair] << endl
        << "refpos Contig Filter:          " << counts.counts[Counts::FilterName::wrong_refpos] << endl
        << "Feature Filter:                " << counts.counts[Counts::FilterName::excluded_feature] << endl
        << "Min Identity Filter:           " << counts.counts[Counts::FilterName::min_score] << endl

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -77,6 +77,9 @@ public:
     /// Limit defray recursion to visit this many nodes
     int defray_count = 99999;
     
+    /// Filter to proper pairs
+    bool only_proper_pairs = true;
+    
     /// Number of threads from omp
     int threads = -1;
     /// GAM output buffer size
@@ -224,6 +227,11 @@ private:
     bool get_is_paired(const Read& read) const;
     
     /**
+     * Is the read in a proper-mapped pair?
+     */
+    bool is_proper_pair(const Read& read) const;
+    
+    /**
      * Does the read contain at least one of the indicated sequences
      */
     bool contains_subsequence(const Read& read) const;
@@ -251,7 +259,7 @@ private:
 struct Counts {
     enum FilterName { read = 0, wrong_name, wrong_refpos, excluded_feature, min_score, min_sec_score, max_overhang,
         min_end_matches, min_mapq, split, repeat, defray, defray_all, random, min_base_qual, subsequence, filtered,
-        last};
+        proper_pair, last};
     vector<size_t> counts;
     Counts () : counts(FilterName::last, 0) {}
     Counts& operator+=(const Counts& other) {
@@ -432,6 +440,11 @@ Counts ReadFilter<Read>::filter_alignment(Read& read) {
             keep = false;
         }
     }
+    if ((keep || verbose) && only_proper_pairs) {
+        if (!is_proper_pair(read)) {
+            ++counts.counts[Counts::FilterName::proper_pair];
+        }
+    }
     if ((keep || verbose) && !excluded_refpos_contigs.empty()) {
         if (has_excluded_refpos(read)) {
             ++counts.counts[Counts::FilterName::wrong_refpos];
@@ -507,6 +520,7 @@ Counts ReadFilter<Read>::filter_alignment(Read& read) {
             keep = false;
         }
     }
+    
     if (!keep) {
         ++counts.counts[Counts::FilterName::filtered];
     }
@@ -1235,7 +1249,14 @@ template<>
 inline bool ReadFilter<MultipathAlignment>::get_is_paired(const MultipathAlignment& mp_aln) const {
     return !mp_aln.paired_read_name().empty();
 }
-    
+
+template<typename Read>
+bool ReadFilter<Read>::is_proper_pair(const Read& read) const {
+    if (!has_annotation(read, "proper_pair")) {
+        return false;
+    }
+    return get_annotation<bool>(read, "proper_pair");
+}
     
 template<typename Read>
 bool ReadFilter<Read>::contains_subsequence(const Read& read) const {

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -443,6 +443,7 @@ Counts ReadFilter<Read>::filter_alignment(Read& read) {
     if ((keep || verbose) && only_proper_pairs) {
         if (!is_proper_pair(read)) {
             ++counts.counts[Counts::FilterName::proper_pair];
+            keep = false;
         }
     }
     if ((keep || verbose) && !excluded_refpos_contigs.empty()) {

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -33,6 +33,7 @@ void help_filter(char** argv) {
          << "    -N, --name-prefixes FILE   keep reads with names with one of many prefixes, one per nonempty line" << endl
          << "    -a, --subsequence NAME     keep reads that contain this subsequence" << endl
          << "    -A, --subsequences FILE    keep reads that contain one of these subsequences, one per nonempty line" << endl
+         << "    -p, --proper-pairs         keep reads that are annotated as being properly paired" << endl
          << "    -X, --exclude-contig REGEX drop reads with refpos annotations on contigs matching the given regex (may repeat)" << endl
          << "    -F, --exclude-feature NAME drop reads with the given feature in the \"features\" annotation (may repeat)" << endl
          << "    -s, --min-secondary N      minimum score to keep secondary alignment" << endl
@@ -101,6 +102,7 @@ int main_filter(int argc, char** argv) {
     int min_base_quality;
     double min_base_quality_fraction;
     bool complement_filter = false;
+    bool only_proper_pairs = false;
 
     // What XG index, if any, should we load to support the other options?
     string xg_name;
@@ -115,6 +117,7 @@ int main_filter(int argc, char** argv) {
                 {"name-prefixes", required_argument, 0, 'N'},
                 {"subsequence", required_argument, 0, 'a'},
                 {"subsequences", required_argument, 0, 'A'},
+                {"proper-pairs", no_argument, 0, 'p'},
                 {"exclude-contig", required_argument, 0, 'X'},
                 {"exclude-feature", required_argument, 0, 'F'},
                 {"min-secondary", required_argument, 0, 's'},
@@ -141,7 +144,7 @@ int main_filter(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "Mn:N:a:A:X:F:s:r:Od:e:fauo:m:Sx:vVq:E:D:C:d:iIb:Ut:",
+        c = getopt_long (argc, argv, "Mn:N:a:A:pX:F:s:r:Od:e:fauo:m:Sx:vVq:E:D:C:d:iIb:Ut:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -184,6 +187,9 @@ int main_filter(int argc, char** argv) {
                     subsequences.push_back(line);
                 }
             });
+            break;
+        case 'p':
+            only_proper_pairs = true;
             break;
         case 'X':
             excluded_refpos_contigs.push_back(parse<std::regex>(optarg));
@@ -383,6 +389,7 @@ int main_filter(int argc, char** argv) {
                 filter.downsample_seed_mask = rand();
             }
         }
+        filter.only_proper_pairs = only_proper_pairs;
         filter.interleaved = interleaved;
         filter.filter_on_all = filter_on_all;
         if (set_min_base_quality) {

--- a/test/t/21_vg_filter.t
+++ b/test/t/21_vg_filter.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 10
+plan tests 12
 
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg  x.vg
@@ -64,6 +64,16 @@ is "$(vg filter -X "[w-z]" paired.annotated.gam | vg view -aj - | wc -l)" "0" "r
 is "$(vg filter -U x.gam | vg view -aj - | wc -l)" "0" "negating a non-filter results in no reads"
 
 is "$(cat <(vg filter -U -d 123.5 -t 10 paired.gam | vg view -aj -) <(vg filter -d 123.5 -t 10 paired.gam | vg view -aj -)  | wc -l)" "$(vg view -aj paired.gam | wc -l)" "a filter and its complement should form the entire file"
+
+vg index -x g.xg -g g.gcsa -k 16 graphs/refonly-lrc_kir.vg
+vg mpmap -x g.xg -g g.gcsa -f reads/grch38_lrc_kir_paired.fq -n dna -B -i -I 10 -D 50 -F GAM -t 1 > g.proper.gam
+vg mpmap -x g.xg -g g.gcsa -f reads/grch38_lrc_kir_paired.fq -n dna -B -i -I 10 -D 1 -F GAM -t 1 > g.improper.gam
+
+is "$(vg filter -p g.proper.gam | vg view -aj - | wc -l)" 2 "properly paired read passes proper filter"
+is "$(vg filter -p g.improper.gam | vg view -aj - | wc -l)" 0 "improperly paired read fails proper filter"
+
+rm g.xg g.gcsa g.gcsa.lcp g.proper.gam g.improper.gam
+
 
 is "$(echo '{"sequence": "GATTACA", "name": "read1", "annotation": {"features": ["test"]}, "fragment_next": {"name": "read2"}}{"sequence": "CATTAG", "name": "read2", "fragment_prev":{"name": "read1"}}' | vg view -JGa - | vg filter -F "test" -i - | vg view -aj - | wc -l)" "0" "read pairs can be tropped by feature"
 is "$(echo '{"sequence": "GATTACA", "name": "read1", "annotation": {"features": ["test"]}, "fragment_next": {"name": "read2"}}{"sequence": "CATTAG", "name": "read2", "fragment_prev":{"name": "read1"}}' | vg view -JGa - | vg filter -F "test" -I - | vg view -aj - | wc -l)" "2" "read pairs can be kept if only one read fails"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Properly paired reads can be extracted using `vg filter -p`

## Description

We've had a few feature requests now from people who wanted to look more at properly paired reads, so I threw this together.

Resolves https://github.com/vgteam/vg/issues/3732.