### PR TITLE
Fix bug in spliced surject in graphs that contain cycles

### DIFF
--- a/src/algorithms/extract_connecting_graph.hpp
+++ b/src/algorithms/extract_connecting_graph.hpp
@@ -17,17 +17,12 @@
 namespace vg {
 namespace algorithms {
     
-    /// Fills a DeletableHandleGraph with the subgraph of a HandleGraph that connects two positions. The nodes that
-    /// contain the two positions will be 'cut' at the position and will be tips in the returned graph. By default,
-    /// the algorithm provides only one guarantee:
-    ///   - 'into' contains all walks between pos_1 and pos_2 under the maximum length except walks that include
-    ///     a cycle involving either position
-    /// Cutting the nodes containing the two positions breaks cycles containing those nodes, so these nodes may
-    /// optinally be duplicated so that cycles involving the two positions are maintained. No other nodes will be
-    /// duplicated. The algorithm optionally provides additional guarantees at the expense of increased computational
-    /// cost, but no increase in asymptotic complexity (the guarantees are described below). If no walk between the
-    /// two positions under the maximum length exists, 'into' will be left empty. An error is thrown if 'into' is
-    /// not empty when passed to function.
+    /// Fills a DeletableHandleGraph with the subgraph of a HandleGraph that connects two positions. The nodes
+    /// that contain the two positions will be 'cut' at the position and will be tips in the returned graph. The
+    /// algorithm guarantees that 'into' contains all walks between pos_1 and pos_2 under the maximum length
+    /// except walks that include a cycle involving either position If no walk between the two positions under
+    /// the maximum length exists, 'into' will be left empty. An error is thrown if 'into' is not empty when
+    /// passed to function.
     ///
     /// Args:
     ///  source                     graph to extract subgraph from
@@ -36,7 +31,7 @@ namespace algorithms {
     ///  pos_1                      start position, subgraph walks begin from here in same orientation
     ///  pos_2                      end position, subgraph walks end here in the same orientation
     ///  strict_max_len             only extract nodes and edges if they fall on some walk between pos_1 and pos_2
-    ///                             that is under the maximum length (implies only_walks = true)
+    ///                             that is under the maximum length
     unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source,
                                                        DeletableHandleGraph* into,
                                                        int64_t max_len,

--- a/src/algorithms/prune_to_connecting_graph.cpp
+++ b/src/algorithms/prune_to_connecting_graph.cpp
@@ -1,0 +1,71 @@
+#include "algorithms/prune_to_connecting_graph.hpp"
+
+#include <unordered_set>
+#include <queue>
+
+//#define debug
+
+namespace vg {
+namespace algorithms {
+
+void prune_to_connecting_graph(DeletableHandleGraph& graph,
+                               const handle_t& from, const handle_t& to) {
+    
+    // we use these to remember which hanndles were reached
+    unordered_set<handle_t> forward, backward;
+    
+    // do BFS from both positions
+    for (bool fwd : {true, false}) {
+        
+        auto& reached = fwd ? forward : backward;
+        handle_t start = fwd ? from : to;
+        
+        queue<handle_t> bfs_queue;
+        reached.emplace(start);
+        bfs_queue.emplace(start);
+                
+        while (!bfs_queue.empty()) {
+            
+            handle_t here = bfs_queue.front();
+            bfs_queue.pop();
+            
+#ifdef debug
+            cerr << "BFS in direction fwd? " << fwd << " at " << graph.get_id(here) << " " << graph.get_is_reverse(here) << endl;
+#endif
+            
+            graph.follow_edges(here, !fwd, [&](const handle_t& next) {
+#ifdef debug
+                cerr << "follow edge to " << graph.get_id(next) << " " << graph.get_is_reverse(next) << endl;
+#endif
+                if (!reached.count(next)) {
+                    reached.emplace(next);
+                    bfs_queue.emplace(next);
+#ifdef debug
+                    cerr << "add to queue" << endl;
+#endif
+                }
+            });
+        }
+    }
+    
+    // check that each node is on some path between the two handles
+    vector<handle_t> to_delete;
+    graph.for_each_handle([&](const handle_t& handle) {
+        auto flipped = graph.flip(handle);
+        if (!((forward.count(handle) && backward.count(handle))
+              || (forward.count(flipped) && backward.count(flipped)))) {
+#ifdef debug
+            cerr << "mark " << graph.get_id(handle) << " for deletion" << endl;
+#endif
+            to_delete.push_back(handle);
+        }
+    });
+    
+    // delete the handles that failed the test
+    for (auto handle : to_delete) {
+        graph.destroy_handle(handle);
+    }
+}
+
+}
+}

--- a/src/algorithms/prune_to_connecting_graph.hpp
+++ b/src/algorithms/prune_to_connecting_graph.hpp
@@ -1,0 +1,15 @@
+#ifndef VG_ALGORITHMS_PRUNE_TO_CONNECTING_GRAPH_HPP_INCLUDED
+#define VG_ALGORITHMS_PRUNE_TO_CONNECTING_GRAPH_HPP_INCLUDED
+
+#include "../handle.hpp"
+
+namespace vg {
+namespace algorithms {
+
+/// Remove all parts of the graph that are not on some path between the two handles
+void prune_to_connecting_graph(DeletableHandleGraph& graph,
+                               const handle_t& from, const handle_t& to);
+}
+}
+
+#endif

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "algorithms/extract_connecting_graph.hpp"
+#include "algorithms/prune_to_connecting_graph.hpp"
 #include "algorithms/component.hpp"
 
 #include "surjector.hpp"
@@ -1204,6 +1205,25 @@ using namespace std;
 
 #ifdef debug_constrictions
                             cerr << "connecting graph after pruning to the path and orienting:" << endl;
+                            connecting.for_each_handle([&](const handle_t& handle) {
+                                cerr << connecting.get_id(handle) << " " << connecting.get_sequence(handle) << endl;
+                                connecting.follow_edges(handle, true, [&](const handle_t& prev) {
+                                    cerr << "\t" << connecting.get_id(prev) << " <-" << endl;
+                                });
+                                connecting.follow_edges(handle, false, [&](const handle_t& next) {
+                                    cerr << "\t-> " << connecting.get_id(next) << endl;
+                                });
+                            });
+#endif
+                            
+                            // make sure everything is still reachable after pruning
+                            // TODO: might be cheaper to not do the work for strict max length in extraction since
+                            // we duplicate it here, but also this code path is rare, so whatever
+                            algorithms::prune_to_connecting_graph(connecting, connecting.get_handle(id(left_pos)),
+                                                                  connecting.get_handle(id(right_pos)));
+                            
+#ifdef debug_constrictions
+                            cerr << "connecting graph after pruning for reachability:" << endl;
                             connecting.for_each_handle([&](const handle_t& handle) {
                                 cerr << connecting.get_id(handle) << " " << connecting.get_sequence(handle) << endl;
                                 connecting.follow_edges(handle, true, [&](const handle_t& prev) {


### PR DESCRIPTION
## Description

The splice repair routine in surject could sometimes end up in situations where it was re-aligning between path positions that could not reach each other due to a logic bug, which this PR fixes.