### PR TITLE
Prototype of an option to list all sequences that surject attempt to realign to

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1,5 +1,6 @@
 #include "alignment.hpp"
 #include "vg/io/gafkluge.hpp"
+#include "annotation.hpp"
 
 #include <sstream>
 
@@ -746,6 +747,13 @@ bam1_t* alignment_to_bam_internal(bam_hdr_t* header,
     if (!alignment.read_group().empty()) {
         bam_aux_append(bam, "RG", 'Z', alignment.read_group().size() + 1, (uint8_t*) alignment.read_group().c_str());
     }
+    
+    // this annotation comes from surject and should be retained in the BAM
+    if (has_annotation(alignment, "all_scores")) {
+        string all_scores = get_annotation<string>(alignment, "all_scores");
+        bam_aux_append(bam, "SS", 'Z', all_scores.size() + 1, (uint8_t*) all_scores.c_str());
+    }
+    
     // TODO: this does not seem to be a standardized field (https://samtools.github.io/hts-specs/SAMtags.pdf)
 //    if (!alignment.sample_name()) {
 //

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -338,7 +338,13 @@ void MultipathAlignmentEmitter::create_alignment_shim(const string& name, const 
     // hacky way to inform the conversion code that the read is mapped
     if (mapped) {
         shim.mutable_path()->add_mapping();
-    } 
+    }
+    // this tag comes from surject and is used in both
+    if (mp_aln.has_annotation("all_scores")) {
+        auto anno = mp_aln.get_annotation("all_scores");
+        assert(anno.first == multipath_alignment_t::String);
+        set_annotation(&shim, "all_scores", *((const string*) anno.second));
+    }
 }
 
 void MultipathAlignmentEmitter::convert_to_hts_unpaired(const string& name, const multipath_alignment_t& mp_aln,

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -50,6 +50,7 @@ void help_surject(char** argv) {
          << "    -N, --sample NAME       set this sample name for all reads" << endl
          << "    -R, --read-group NAME   set this read group for all reads" << endl
          << "    -f, --max-frag-len N    reads with fragment lengths greater than N will not be marked properly paired in SAM/BAM/CRAM" << endl
+         << "    -L, --list-all-paths    annotate SAM records with a list of all attempted re-alignments to paths in SS tag" << endl
          << "    -C, --compression N     level for compression [0-9]" << endl;
 }
 
@@ -75,6 +76,7 @@ int main_surject(int argc, char** argv) {
     bool subpath_global = true; // force full length alignments in mpmap resolution
     bool qual_adj = false;
     bool prune_anchors = false;
+    bool annotate_with_all_path_scores = false;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -100,12 +102,13 @@ int main_surject(int argc, char** argv) {
             {"sample", required_argument, 0, 'N'},
             {"read-group", required_argument, 0, 'R'},
             {"max-frag-len", required_argument, 0, 'f'},
+            {"list-all-paths", no_argument, 0, 'L'},
             {"compress", required_argument, 0, 'C'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:p:F:liGmcbsN:R:f:C:t:SPA",
+        c = getopt_long (argc, argv, "hx:p:F:liGmcbsN:R:f:C:t:SPAL",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -187,6 +190,10 @@ int main_surject(int argc, char** argv) {
         case 't':
             omp_set_num_threads(parse<int>(optarg));
             break;
+                
+        case 'L':
+            annotate_with_all_path_scores = true;
+            break;
 
         case 'h':
         case '?':
@@ -248,6 +255,7 @@ int main_surject(int argc, char** argv) {
     else {
         surjector.min_splice_length = numeric_limits<int64_t>::max();
     }
+    surjector.annotate_with_all_path_scores = annotate_with_all_path_scores;
     
     // Count our threads
     int thread_count = vg::get_thread_count();

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -3,11 +3,21 @@
  * surjector.cpp: implements a class that surjects alignments onto paths
  */
 
+
+#include "surjector.hpp"
+
+#include "sequence_complexity.hpp"
+#include "alignment.hpp"
+#include "utility.hpp"
+#include "memoizing_graph.hpp"
+#include "multipath_alignment_graph.hpp"
+#include "split_strand_graph.hpp"
+
 #include "algorithms/extract_connecting_graph.hpp"
 #include "algorithms/prune_to_connecting_graph.hpp"
 #include "algorithms/component.hpp"
 
-#include "surjector.hpp"
+#include "bdsg/hash_graph.hpp"
 
 //#define debug_spliced_surject
 //#define debug_anchored_surject
@@ -322,6 +332,16 @@ using namespace std;
                 best_path_strand = surjection.first;
             }
         }
+        
+        string annotation_string;
+        if (annotate_with_all_path_scores) {
+            if (aln_out) {
+                annotation_string = path_score_annotations(aln_surjections);
+            }
+            else {
+                annotation_string = path_score_annotations(mp_aln_surjections);
+            }
+        }
                 
         // find the position along the path
         
@@ -335,6 +355,10 @@ using namespace std;
             final_pos = final_position(surjection.first.path());
             path_range = surjection.second;
             *aln_out = move(surjection.first);
+            
+            if (annotate_with_all_path_scores) {
+                set_annotation(aln_out, "all_scores", annotation_string);
+            }
         }
         else {
             auto& surjection = mp_aln_surjections[best_path_strand];
@@ -342,6 +366,10 @@ using namespace std;
             final_pos = final_position(surjection.first.subpath().back().path());
             path_range = surjection.second;
             *mp_aln_out = move(surjection.first);
+            
+            if (annotate_with_all_path_scores) {
+                mp_aln_out->set_annotation("all_scores", annotation_string);
+            }
         }
         
         // use this info to set the path position
@@ -3972,6 +4000,16 @@ using namespace std;
         null.set_sequence(src_sequence);
         null.set_quality(src_quality);
         return null;
+    }
+
+
+    template<>
+    int32_t Surjector::get_score(const Alignment& aln) {
+        return aln.score();
+    }
+    template<>
+    int32_t Surjector::get_score(const multipath_alignment_t& mp_aln) {
+        return optimal_alignment_score(mp_aln);
     }
 }
 

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -8,19 +8,15 @@
 
 #include <set>
 #include <atomic>
+#include <sstream>
+#include <algorithm>
+#include <functional>
 
-#include "alignment.hpp"
 #include "aligner.hpp"
-#include "vg.hpp"
-#include "translator.hpp"
-#include "utility.hpp"
+#include "handle.hpp"
 #include <vg/vg.pb.h>
-#include "multipath_alignment_graph.hpp"
-#include "memoizing_graph.hpp"
-#include "split_strand_graph.hpp"
-#include "sequence_complexity.hpp"
+#include "multipath_alignment.hpp"
 
-#include "bdsg/hash_graph.hpp"
 
 namespace vg {
 
@@ -109,6 +105,8 @@ using namespace std;
         int64_t max_tail_anchor_prune = 4;
         double low_complexity_p_value = .001;
         
+        bool annotate_with_all_path_scores = false;
+        
     protected:
         
         void surject_internal(const Alignment* source_aln, const multipath_alignment_t* source_mp_aln,
@@ -182,6 +180,9 @@ using namespace std;
                                const step_handle_t& range_begin, const step_handle_t& range_end,
                                bool rev_strand, string& path_name_out, int64_t& path_pos_out, bool& path_rev_out) const;
         
+        template<class AlnType>
+        string path_score_annotations(const unordered_map<pair<path_handle_t, bool>, pair<AlnType, pair<step_handle_t, step_handle_t>>>& surjections) const;
+        
         ///////////////////////
         // Support methods for the spliced surject algorithm
         ///////////////////////
@@ -240,9 +241,36 @@ using namespace std;
         static multipath_alignment_t make_null_mp_alignment(const string& src_sequence,
                                                             const string& src_quality);
         
+        template<class AlnType>
+        static int32_t get_score(const AlnType& aln);
+        
         /// the graph we're surjecting onto
         const PathPositionHandleGraph* graph = nullptr;
     };
+
+
+    template<class AlnType>
+    string Surjector::path_score_annotations(const unordered_map<pair<path_handle_t, bool>, pair<AlnType, pair<step_handle_t, step_handle_t>>>& surjections) const {
+        
+        vector<tuple<int32_t, string, bool>> paths;
+        for (const auto& surjection : surjections) {
+            paths.emplace_back(get_score(surjection.second.first), graph->get_path_name(surjection.first.first), surjection.first.second);
+        }
+        sort(paths.begin(), paths.end(), greater<tuple<int32_t, string, bool>>());
+        
+        stringstream sstrm;
+        
+        for (size_t i = 0; i < paths.size(); ++i) {
+            if (i != 0) {
+                sstrm << ',';
+            }
+            sstrm << get<1>(paths[i]);
+            sstrm << (get<2>(paths[i]) ? '-' : '+') << ':';
+            sstrm << get<0>(paths[i]);
+        }
+        
+        return sstrm.str();
+    }
 }
 
 #endif

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -265,7 +265,7 @@ using namespace std;
                 sstrm << ',';
             }
             sstrm << get<1>(paths[i]);
-            sstrm << (get<2>(paths[i]) ? '-' : '+') << ':';
+            sstrm << (get<2>(paths[i]) ? '-' : '+');
             sstrm << get<0>(paths[i]);
         }
         


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject` can annotate SAM/BAM records by all of the sequences it attempted to realign to

## Description

This is a prototype feature requested by our Google friends.