### PR TITLE
Multi-surjecting alignments

### DIFF
--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -431,8 +431,6 @@ int main_surject(int argc, char** argv) {
         // TODO: largely repetitive with GAM
         get_input_file(file_name, [&](istream& in) {
             if (interleaved) {
-                // we can reuse this
-                vector<int64_t> tlen_limits(1, max_frag_len);
                 
                 // GAMP input is paired, and for HTS output reads need to know their pair partners' mapping locations.
                 // TODO: We don't preserve order relationships (like primary/secondary) beyond the interleaving.
@@ -542,6 +540,7 @@ int main_surject(int argc, char** argv) {
                     }
                                         
                     // write to output
+                    vector<int64_t> tlen_limits(surjected.size(), max_frag_len);
                     mp_alignment_emitter.emit_pairs(src1.name(), src2.name(), move(surjected), &positions, &tlen_limits);
                     mp_alignment_emitter.emit_singles(src1.name(), move(surjected_unpaired1), &positions_unpaired1);
                     mp_alignment_emitter.emit_singles(src2.name(), move(surjected_unpaired2), &positions_unpaired2);

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -33,25 +33,26 @@ void help_surject(char** argv) {
          << "Transforms alignments to be relative to particular paths." << endl
          << endl
          << "options:" << endl
-         << "    -x, --xg-name FILE      use this graph or xg index (required)" << endl
-         << "    -t, --threads N         number of threads to use" << endl
-         << "    -p, --into-path NAME    surject into this path or its subpaths (many allowed, default: reference, then non-alt generic)" << endl
-         << "    -F, --into-paths FILE   surject into path names listed in HTSlib sequence dictionary or path list FILE" << endl
-         << "    -l, --subpath-local     let the multipath mapping surjection produce local (rather than global) alignments" << endl
-         << "    -i, --interleaved       GAM is interleaved paired-ended, so when outputting HTS formats, pair reads" << endl
-         << "    -G, --gaf-input         input file is GAF instead of GAM" << endl
-         << "    -m, --gamp-input        input file is GAMP instead of GAM" << endl
-         << "    -c, --cram-output       write CRAM to stdout" << endl
-         << "    -b, --bam-output        write BAM to stdout" << endl
-         << "    -s, --sam-output        write SAM to stdout" << endl
-         << "    -P, --prune-low-cplx    prune short and low complexity anchors during realignment" << endl
-         << "    -S, --spliced           interpret long deletions against paths as spliced alignments" << endl
-         << "    -A, --qual-adj          adjust scoring for base qualities, if they are available" << endl
-         << "    -N, --sample NAME       set this sample name for all reads" << endl
-         << "    -R, --read-group NAME   set this read group for all reads" << endl
-         << "    -f, --max-frag-len N    reads with fragment lengths greater than N will not be marked properly paired in SAM/BAM/CRAM" << endl
-         << "    -L, --list-all-paths    annotate SAM records with a list of all attempted re-alignments to paths in SS tag" << endl
-         << "    -C, --compression N     level for compression [0-9]" << endl;
+         << "  -x, --xg-name FILE      use this graph or xg index (required)" << endl
+         << "  -t, --threads N         number of threads to use" << endl
+         << "  -p, --into-path NAME    surject into this path or its subpaths (many allowed, default: reference, then non-alt generic)" << endl
+         << "  -F, --into-paths FILE   surject into path names listed in HTSlib sequence dictionary or path list FILE" << endl
+         << "  -i, --interleaved       GAM is interleaved paired-ended, so when outputting HTS formats, pair reads" << endl
+         << "  -M, --multimap          include secondary alignments to all overlapping paths instead of just primary" << endl
+         << "  -G, --gaf-input         input file is GAF instead of GAM" << endl
+         << "  -m, --gamp-input        input file is GAMP instead of GAM" << endl
+         << "  -c, --cram-output       write CRAM to stdout" << endl
+         << "  -b, --bam-output        write BAM to stdout" << endl
+         << "  -s, --sam-output        write SAM to stdout" << endl
+         << "  -l, --subpath-local     let the multipath mapping surjection produce local (rather than global) alignments" << endl
+         << "  -P, --prune-low-cplx    prune short and low complexity anchors during realignment" << endl
+         << "  -S, --spliced           interpret long deletions against paths as spliced alignments" << endl
+         << "  -A, --qual-adj          adjust scoring for base qualities, if they are available" << endl
+         << "  -N, --sample NAME       set this sample name for all reads" << endl
+         << "  -R, --read-group NAME   set this read group for all reads" << endl
+         << "  -f, --max-frag-len N    reads with fragment lengths greater than N will not be marked properly paired in SAM/BAM/CRAM" << endl
+         << "  -L, --list-all-paths    annotate SAM records with a list of all attempted re-alignments to paths in SS tag" << endl
+         << "  -C, --compression N     level for compression [0-9]" << endl;
 }
 
 int main_surject(int argc, char** argv) {
@@ -77,6 +78,7 @@ int main_surject(int argc, char** argv) {
     bool qual_adj = false;
     bool prune_anchors = false;
     bool annotate_with_all_path_scores = false;
+    bool multimap = false;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -91,6 +93,7 @@ int main_surject(int argc, char** argv) {
             {"ref-paths", required_argument, 0, 'F'}, // Now an alias for --into-paths
             {"subpath-local", required_argument, 0, 'l'},
             {"interleaved", no_argument, 0, 'i'},
+            {"multimap", no_argument, 0, 'M'},
             {"gaf-input", no_argument, 0, 'G'},
             {"gamp-input", no_argument, 0, 'm'},
             {"cram-output", no_argument, 0, 'c'},
@@ -108,7 +111,7 @@ int main_surject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:p:F:liGmcbsN:R:f:C:t:SPAL",
+        c = getopt_long (argc, argv, "hx:p:F:liGmcbsN:R:f:C:t:SPALM",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -136,6 +139,10 @@ int main_surject(int argc, char** argv) {
 
         case 'i':
             interleaved = true;
+            break;
+                
+        case 'M':
+            multimap = true;
             break;
 
         case 'G':
@@ -329,9 +336,48 @@ int main_surject(int argc, char** argv) {
                 set_metadata(src2);
                 
                 // Surject and emit.
-                alignment_emitter->emit_pair(surjector.surject(src1, paths, subpath_global, spliced),
-                                             surjector.surject(src2, paths, subpath_global, spliced),
-                                             max_frag_len);
+                if (multimap) {
+                    
+                    auto surjected1 = surjector.multi_surject(src1, paths, subpath_global, spliced);
+                    auto surjected2 = surjector.multi_surject(src2, paths, subpath_global, spliced);
+                    
+                    // we have to pair these up manually
+                    unordered_map<pair<string, bool>, size_t> strand_idx1, strand_idx2;
+                    for (size_t i = 0; i < surjected1.size(); ++i) {
+                        const auto& pos = surjected1[i].refpos(0);
+                        strand_idx1[make_pair(pos.name(), pos.is_reverse())] = i;
+                    }
+                    for (size_t i = 0; i < surjected2.size(); ++i) {
+                        const auto& pos = surjected2[i].refpos(0);
+                        strand_idx1[make_pair(pos.name(), pos.is_reverse())] = i;
+                    }
+                    
+                    for (size_t i = 0; i < surjected1.size(); ++i) {
+                        const auto& pos = surjected1[i].refpos(0);
+                        auto it = strand_idx2.find(make_pair(pos.name(), pos.is_reverse()));
+                        if (it != strand_idx2.end()) {
+                            // the alignments are paired on this strand
+                            alignment_emitter->emit_pair(move(surjected1[i]), move(surjected2[it->second]), max_frag_len);
+                        }
+                        else {
+                            // this strand's surjection is unpaired
+                            alignment_emitter->emit_single(move(surjected1[i]));
+                        }
+                    }
+                    for (size_t i = 0; i < surjected2.size(); ++i) {
+                        const auto& pos = surjected2[i].refpos(0);
+                        if (!strand_idx1.count(make_pair(pos.name(), pos.is_reverse()))) {
+                            // this strand's surjection is unpaired
+                            alignment_emitter->emit_single(move(surjected2[i]));
+                        }
+                    }
+                }
+                else {
+                    // FIXME: these aren't forced to be on the same path, which could be fucky
+                    alignment_emitter->emit_pair(surjector.surject(src1, paths, subpath_global, spliced),
+                                                 surjector.surject(src2, paths, subpath_global, spliced),
+                                                 max_frag_len);
+                }
                 
             };
             if (input_format == "GAM") {
@@ -355,7 +401,12 @@ int main_surject(int argc, char** argv) {
                 set_metadata(src);
                 
                 // Surject and emit the single read.
-                alignment_emitter->emit_single(surjector.surject(src, paths, subpath_global, spliced));
+                if (multimap) {
+                    alignment_emitter->emit_singles(surjector.multi_surject(src, paths, subpath_global, spliced));
+                }
+                else {
+                    alignment_emitter->emit_single(surjector.surject(src, paths, subpath_global, spliced));
+                }
             };
             if (input_format == "GAM") {
                 get_input_file(file_name, [&](istream& in) {
@@ -414,18 +465,87 @@ int main_surject(int argc, char** argv) {
                     from_proto_multipath_alignment(src1, mp_src1);
                     from_proto_multipath_alignment(src2, mp_src2);
                     
-                    // surject and record path positions
-                    vector<pair<tuple<string, bool, int64_t>, tuple<string, bool, int64_t>>> positions(1);
+                    
+                    vector<pair<tuple<string, bool, int64_t>, tuple<string, bool, int64_t>>> positions;
                     vector<pair<multipath_alignment_t, multipath_alignment_t>> surjected;
-                    surjected.emplace_back(surjector.surject(mp_src1, paths, get<0>(positions.front().first),
-                                                             get<2>(positions.front().first), get<1>(positions.front().first),
-                                                             subpath_global, spliced),
-                                           surjector.surject(mp_src2, paths, get<0>(positions.front().second),
-                                                             get<2>(positions.front().second), get<1>(positions.front().second),
-                                                             subpath_global, spliced));
+                    
+                    vector<tuple<string, bool, int64_t>> positions_unpaired1, positions_unpaired2;
+                    vector<multipath_alignment_t> surjected_unpaired1, surjected_unpaired2;
+                    
+                    // surject and record path positions
+                    if (multimap) {
+                        
+                        // TODO: highly repetitive with the version above for Alignments
+                        
+                        vector<tuple<string, int64_t, bool>> positions1, positions2;
+                        auto surjected1 = surjector.multi_surject(mp_src1, paths, positions1, subpath_global, spliced);
+                        auto surjected2 = surjector.multi_surject(mp_src2, paths, positions2, subpath_global, spliced);
+                        
+                        // we have to pair these up manually
+                        unordered_map<pair<string, bool>, size_t> strand_idx1, strand_idx2;
+                        for (size_t i = 0; i < surjected1.size(); ++i) {
+                            strand_idx1[make_pair(get<0>(positions1[i]), get<2>(positions1[i]))] = i;
+                        }
+                        for (size_t i = 0; i < surjected2.size(); ++i) {
+                            strand_idx2[make_pair(get<0>(positions2[i]), get<2>(positions2[i]))] = i;
+                        }
+                                                
+                        for (size_t i = 0; i < surjected1.size(); ++i) {
+                            auto it = strand_idx2.find(make_pair(get<0>(positions1[i]), get<2>(positions1[i])));
+                            if (it != strand_idx2.end()) {
+                                // the alignments are paired on this strand
+                                size_t j = it->second;
+                                surjected.emplace_back(move(surjected1[i]), move(surjected2[j]));
+                                
+                                // reorder the positions to deal with the mismatch in the interfaces
+                                positions.emplace_back();
+                                get<0>(positions.back().first) = move(get<0>(positions1[i]));
+                                get<1>(positions.back().first) = get<2>(positions1[i]);
+                                get<2>(positions.back().first) = get<1>(positions1[i]);
+                                get<0>(positions.back().second) = move(get<0>(positions2[i]));
+                                get<1>(positions.back().second) = get<2>(positions2[i]);
+                                get<2>(positions.back().second) = get<1>(positions2[i]);
+                            }
+                            else {
+                                // this strand's surjection is unpaired
+                                surjected_unpaired1.emplace_back(move(surjected1[i]));
+                                
+                                // reorder the position to deal with the mismatch in the interfaces
+                                positions_unpaired1.emplace_back();
+                                get<0>(positions_unpaired1.back()) = move(get<0>(positions1[i]));
+                                get<1>(positions_unpaired1.back()) = get<2>(positions1[i]);
+                                get<2>(positions_unpaired1.back()) = get<1>(positions1[i]);
+                            }
+                        }
+                        for (size_t i = 0; i < surjected2.size(); ++i) {
+                            if (!strand_idx1.count(make_pair(get<0>(positions2[i]), get<2>(positions2[i])))) {
+                                // this strand's surjection is unpaired
+                                surjected_unpaired2.emplace_back(move(surjected2[i]));
+                                
+                                // reorder the position to deal with the mismatch in the interfaces
+                                positions_unpaired2.emplace_back();
+                                get<0>(positions_unpaired2.back()) = move(get<0>(positions2[i]));
+                                get<1>(positions_unpaired2.back()) = get<2>(positions2[i]);
+                                get<2>(positions_unpaired2.back()) = get<1>(positions2[i]);
+                            }
+                        }
+                    }
+                    else {
+                        
+                        // FIXME: these aren't required to be on the same path...
+                        positions.emplace_back();
+                        surjected.emplace_back(surjector.surject(mp_src1, paths, get<0>(positions.front().first),
+                                                                 get<2>(positions.front().first), get<1>(positions.front().first),
+                                                                 subpath_global, spliced),
+                                               surjector.surject(mp_src2, paths, get<0>(positions.front().second),
+                                                                 get<2>(positions.front().second), get<1>(positions.front().second),
+                                                                 subpath_global, spliced));
+                    }
                     
                     // write to output
                     mp_alignment_emitter.emit_pairs(src1.name(), src2.name(), move(surjected), &positions, &tlen_limits);
+                    mp_alignment_emitter.emit_singles(src1.name(), move(surjected_unpaired1), &positions_unpaired1);
+                    mp_alignment_emitter.emit_singles(src2.name(), move(surjected_unpaired2), &positions_unpaired2);
                 });
             } else {
                 // TODO: We don't preserve order relationships (like primary/secondary).
@@ -435,11 +555,25 @@ int main_surject(int argc, char** argv) {
                     from_proto_multipath_alignment(src, mp_src);
                     
                     // surject and record path positions
-                    vector<tuple<string, bool, int64_t>> positions(1);
+                    vector<tuple<string, bool, int64_t>> positions;
                     vector<multipath_alignment_t> surjected;
-                    surjected.emplace_back(surjector.surject(mp_src, paths, get<0>(positions.front()),
-                                                             get<2>(positions.front()), get<1>(positions.front()),
-                                                             subpath_global, spliced));
+                    
+                    if (multimap) {
+                        
+                        vector<tuple<string, int64_t, bool>> multi_positions;
+                        surjected = surjector.multi_surject(mp_src, paths, multi_positions, subpath_global, spliced);
+                        
+                        // positions are in different orders in these two interfaces
+                        for (auto& position : multi_positions) {
+                            positions.emplace_back(move(get<0>(position)), get<2>(position), get<1>(position));
+                        }
+                    }
+                    else {
+                        positions.emplace_back();
+                        surjected.emplace_back(surjector.surject(mp_src, paths, get<0>(positions.front()),
+                                                                 get<2>(positions.front()), get<1>(positions.front()),
+                                                                 subpath_global, spliced));
+                    }
                     
                     // write to output
                     mp_alignment_emitter.emit_singles(src.name(), move(surjected), &positions);

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -86,6 +86,9 @@ using namespace std;
         vector<tuple<string, int64_t, bool>> position;
         surject_internal(&source, nullptr, &surjected, nullptr, paths, position,
                          false, allow_negative_scores, preserve_deletions);
+        path_name_out = get<0>(position.front());
+        path_pos_out = get<1>(position.front());
+        path_rev_out = get<2>(position.front());
         return move(surjected.front());
     }
 

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -45,6 +45,13 @@ using namespace std;
                           bool& path_rev_out,
                           bool allow_negative_scores = false,
                           bool preserve_deletions = false) const;
+        
+        /// Same as above, but include alignments to all paths instead of only the optimal one
+        vector<Alignment> multi_surject(const Alignment& source,
+                                        const unordered_set<path_handle_t>& paths,
+                                        vector<tuple<string, int64_t, bool>>& positions_out,
+                                        bool allow_negative_scores = false,
+                                        bool preserve_deletions = false) const;
                           
         /// Extract the portions of an alignment that are on a chosen set of
         /// paths and try to align realign the portions that are off of the
@@ -65,6 +72,12 @@ using namespace std;
                           bool allow_negative_scores = false,
                           bool preserve_deletions = false) const;
         
+        /// Same as above, but include alignments to all paths instead of only the optimal one
+        vector<Alignment> multi_surject(const Alignment& source,
+                                        const unordered_set<path_handle_t>& paths,
+                                        bool allow_negative_scores = false,
+                                        bool preserve_deletions = false) const;
+        
         /// Same semantics as with alignments except that connections are always
         /// preserved as splices. The output consists of a multipath alignment with
         /// a single path, separated by splices (either from large deletions or from
@@ -75,6 +88,13 @@ using namespace std;
                                       bool& path_rev_out,
                                       bool allow_negative_scores = false,
                                       bool preserve_deletions = false) const;
+        
+        /// Same as above, but include alignments to all paths instead of only the optimal one
+        vector<multipath_alignment_t> multi_surject(const multipath_alignment_t& source,
+                                                    const unordered_set<path_handle_t>& paths,
+                                                    vector<tuple<string, int64_t, bool>>& positions_out,
+                                                    bool allow_negative_scores = false,
+                                                    bool preserve_deletions = false) const;
         
         /// a local type that represents a read interval matched to a portion of the alignment path
         using path_chunk_t = pair<pair<string::const_iterator, string::const_iterator>, Path>;
@@ -110,9 +130,9 @@ using namespace std;
     protected:
         
         void surject_internal(const Alignment* source_aln, const multipath_alignment_t* source_mp_aln,
-                              Alignment* aln_out, multipath_alignment_t* mp_aln_out,
+                              vector<Alignment>* alns_out, vector<multipath_alignment_t>* mp_alns_out,
                               const unordered_set<path_handle_t>& paths,
-                              string& path_name_out, int64_t& path_pos_out, bool& path_rev_out,
+                              vector<tuple<string, int64_t, bool>>& positions_out, bool all_paths,
                               bool allow_negative_scores, bool preserve_deletions) const;
         
         Alignment

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 40
+plan tests 44
 
 vg construct -r small/x.fa >j.vg
 vg index -x j.xg j.vg
@@ -180,4 +180,17 @@ is "$(cat perpendicular.sam | grep -v "^@" | cut -f2)" "4" "vg surject leaves a 
 
 rm -f perpendicular.sam
 
+vg construct -r small/x.fa > x.vg
+cat <(vg view x.vg) <(vg view x.vg | grep P | sed 's/P\tx/P\ty/') | vg convert -g - > x.pathdup.vg
+vg index -x x.xg -g x.gcsa x.pathdup.vg
+vg sim -x x.xg -n 20 -l 40 -p 60 -v 10 -a > x.gam
+vg mpmap -x x.xg -g x.gcsa -n dna --suppress-mismapping -B -G x.gam -i -F GAM -I 60 -D 10 > mapped.gam
+vg mpmap -x x.xg -g x.gcsa -n dna --suppress-mismapping -B -G x.gam -i -F GAMP -I 60 -D 10 > mapped.gamp
+
+is "$(vg surject -x x.xg -s -t 1 mapped.gam | grep -v '@' | wc -l)" 40 "GAM surject can return only primaries"
+is "$(vg surject -x x.xg -M -s -t 1 mapped.gam | grep -v '@' | wc -l)" 80 "GAM surject can return multimappings"
+is "$(vg surject -x x.xg -s -m -t 1 mapped.gamp | grep -v '@' | wc -l)" 40 "GAMP surject can return only primaries"
+is "$(vg surject -x x.xg -M -m -s -t 1 mapped.gamp | grep -v '@' | wc -l)" 80 "GAMP surject can return multimappings"
+
+rm x.vg rm x.pathdup.vg x.xg x.gcsa x.gcsa.lcp x.gam mapped.gam mapped.gamp
 

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 44
+plan tests 46
 
 vg construct -r small/x.fa >j.vg
 vg index -x j.xg j.vg
@@ -189,8 +189,10 @@ vg mpmap -x x.xg -g x.gcsa -n dna --suppress-mismapping -B -G x.gam -i -F GAMP -
 
 is "$(vg surject -x x.xg -s -t 1 mapped.gam | grep -v '@' | wc -l)" 40 "GAM surject can return only primaries"
 is "$(vg surject -x x.xg -M -s -t 1 mapped.gam | grep -v '@' | wc -l)" 80 "GAM surject can return multimappings"
+is "$(vg surject -x x.xg -M -i -s -t 1 mapped.gam | grep -v '@' | wc -l)" 80 "GAM surject can return paired multimappings"
 is "$(vg surject -x x.xg -s -m -t 1 mapped.gamp | grep -v '@' | wc -l)" 40 "GAMP surject can return only primaries"
 is "$(vg surject -x x.xg -M -m -s -t 1 mapped.gamp | grep -v '@' | wc -l)" 80 "GAMP surject can return multimappings"
+is "$(vg surject -x x.xg -M -m -s -i -t 1 mapped.gamp | grep -v '@' | wc -l)" 80 "GAMP surject can return multimappings"
 
-rm x.vg rm x.pathdup.vg x.xg x.gcsa x.gcsa.lcp x.gam mapped.gam mapped.gamp
+rm x.vg x.pathdup.vg x.xg x.gcsa x.gcsa.lcp x.gam mapped.gam mapped.gamp
 


### PR DESCRIPTION
## Changelog Entry

 * `vg surject` can report secondary alignments to partially-overlapping paths with `-M`

## Description

This feature was motivated by some transcriptomic analyses in which it's beneficial to get multimappings to all transcripts, but it could potentially have other uses as well.