### PR TITLE
Fix algorithms::find_translation()

### DIFF
--- a/src/algorithms/find_translation.cpp
+++ b/src/algorithms/find_translation.cpp
@@ -15,18 +15,23 @@ const NamedNodeBackTranslation* find_translation(const HandleGraph* graph) {
         // No graph means no translation.
         return nullptr;
     }
+    if (const gbwtgraph::GBWTGraph* gg = dynamic_cast<const gbwtgraph::GBWTGraph*>(graph)) {
+        // A GBWTGraph is a NamedNodeBackTranslation, but the translation may not be present.
+        if (gg->has_segment_names()) { return gg; }
+        else { return nullptr; }
+    }
+    if (const GBZGraph* gg = dynamic_cast<const GBZGraph*>(graph)) {
+        // The same goes for a GBWTGraph contained in a GBZ graph.
+        if (gg->gbz.graph.has_segment_names()) { return &(gg->gbz.graph); }
+        else { return nullptr; }
+    }
     if (dynamic_cast<const NamedNodeBackTranslation*>(graph)) {
-        // Some graph implementations (like GBWTGraph) just are a NamedNodeBackTranslation already.
+        // Some graph implementations just are a NamedNodeBackTranslation already.
         return dynamic_cast<const NamedNodeBackTranslation*>(graph);
     }
     if (dynamic_cast<const GFAHandleGraph*>(graph)) {
         // If we loaded the graph from a GFA we would have attached this translation.
         return &dynamic_cast<const GFAHandleGraph*>(graph)->gfa_id_space;
-    }
-    if (dynamic_cast<const GBZGraph*>(graph)) {
-        // If we loaded the graph from a GBZ we can use the GBWTGraph even though the back-translation stuff isn't proxied.
-        // TODO: proxy it?
-        return &dynamic_cast<const GBZGraph*>(graph)->gbz.graph;
     }
     // Otherwise there's no applicable translation
     return nullptr;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Handle GBWTGraphs and GBZ graphs that do not contain a translation correctly when a translation is needed.

## Description

A `GBWTGraph` is a `NamedNodeBackTranslation`, but the translation is not always present. `algorithms::find_translation()` used to return a translation regardless of if it was present. That could cause issues when the translation didn't translate anything but it was expected to contain a translation for every node (as in GBWTGraph construction; see #3749).

After this fix, `algorithms::find_translation()` checks if a translation is present in a `GBWTGraph` and returns `nullptr` if there is no translation.