### PR TITLE
Don't return secondary alignments from vg mpmap --agglomerate-alns

### DIFF
--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -4443,7 +4443,7 @@ namespace vg {
     }
 
     void MultipathMapper::agglomerate_alignments(vector<multipath_alignment_t>& multipath_alns_out,
-                                                 vector<double>* multiplicities) const {
+                                                 vector<double>* multiplicities) {
         
         if (multipath_alns_out.empty()) {
             return;
@@ -4459,7 +4459,7 @@ namespace vg {
         unordered_set<pos_t> agg_start_positions, agg_end_positions;
         for (i = 0; i < multipath_alns_out.size(); ++i) {
             // is the score good enough to agglomerate?
-            if (scores[i] < min_score) {
+            if (scores[i] < min_score || likely_mismapping(multipath_alns_out[i])) {
                 // none of the following will be either
                 break;
             }
@@ -4490,7 +4490,7 @@ namespace vg {
 
     void MultipathMapper::agglomerate_alignment_pairs(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                                       vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
-                                                      vector<double>& multiplicities) const {
+                                                      vector<double>& multiplicities) {
 
         if (multipath_aln_pairs_out.empty()) {
             return;
@@ -4507,7 +4507,8 @@ namespace vg {
         unordered_set<pos_t> agg_start_positions_1, agg_end_positions_1, agg_start_positions_2, agg_end_positions_2;
         for (i = 0; i < multipath_aln_pairs_out.size(); ++i) {
             // is the score good enough to agglomerate?
-            if (scores[i] < min_score) {
+            if (scores[i] < min_score ||
+                (likely_mismapping(multipath_aln_pairs_out[i].first) && likely_mismapping(multipath_aln_pairs_out[i].second))) {
                 // none of the following will be either
                 break;
             }

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -408,13 +408,13 @@ namespace vg {
         /// Combine all of the significant alignments into one. Requires alignments to be sorted by
         /// significance already
         void agglomerate_alignments(vector<multipath_alignment_t>& multipath_alns_out,
-                                    vector<double>* multiplicities = nullptr) const;
+                                    vector<double>* multiplicities = nullptr);
         
         /// Combine all of the significant alignments into one pair. Requires alignments to be sorted by
         /// significance already
         void agglomerate_alignment_pairs(vector<pair<multipath_alignment_t, multipath_alignment_t>>& multipath_aln_pairs_out,
                                          vector<pair<pair<size_t, size_t>, int64_t>>& cluster_pairs,
-                                         vector<double>& multiplicities) const;
+                                         vector<double>& multiplicities);
         
         /// Before returning, remove alignments that are likely noise and add a placeholder
         /// for an unmapped read if necessary

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1145,6 +1145,11 @@ int main_mpmap(int argc, char** argv) {
     // we can usually ignore them
     int hard_hit_max = hard_hit_max_muliplier * hit_max;
     
+    // don't report secondaries if we're agglomerating
+    if (agglomerate_multipath_alns && max_num_mappings != 1) {
+        max_num_mappings = 1;
+    }
+    
     // check for valid parameters
     
     if (std::isnan(frag_length_mean) != std::isnan(frag_length_stddev)) {


### PR DESCRIPTION
## Description

Jonas pointed out that this behavior is somewhat confusing. I now have more sensible defaults.