### PR TITLE
Fix a bug in lognormal density function

### DIFF
--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -129,7 +129,7 @@ double lognormal_pdf(double x, double mu, double sigma) {
     double density;
     if (x > 0.0) {
         double z = (log(x) - mu) / sigma;
-        density = exp(-z * z / 2.0) / (sigma * x);
+        density = exp(-z * z / 2.0) / (sigma * x * root_2pi);
     }
     else {
         density = 0.0;


### PR DESCRIPTION
## Description

Fixes n arithmetic bug in the lognormal probability density function. This might have some subtle effects on splicing detection in `mpmap`, but not much.