### PR TITLE
Statically link libvgio if we are statically linking Protobuf

### DIFF
--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -48,8 +48,9 @@ jobs:
         # because there's no way to tell Homebrew to force-link when installing
         # from a Brewfile. We also update Protobuf to make sure we have 3.21.3+
         # to avoid problems with ABI changes with/without -DNDEBUG.
+        # And we update libomp to make extra sure it will be picked up by the compiler.
         # We pre-install a pinned txm to work around https://github.com/anko/txm/issues/8
-        run: brew bundle cleanup --force && brew bundle install && brew update && brew install protobuf && npm install -g txm@7.4.5
+        run: brew bundle cleanup --force && brew bundle install && brew update && brew install protobuf && brew install libomp && npm install -g txm@7.4.5
 
       - name: Run build and test
         run: |

--- a/Makefile
+++ b/Makefile
@@ -145,9 +145,20 @@ ifeq ($(shell uname -s),Darwin)
 
         # If HOMEBREW_PREFIX is specified, libomp probably cannot be found automatically.
         ifdef HOMEBREW_PREFIX
-            $(info OMP source is Homebrew)
+            # If we have homebrew, use Homebrew
             CXXFLAGS += -I$(HOMEBREW_PREFIX)/include
             LD_LIB_DIR_FLAGS += -L$(HOMEBREW_PREFIX)/lib
+            ifeq ($(shell if [ -e $(HOMEBREW_PREFIX)/include/omp.h ]; then echo 1; else echo 0; fi), 1)
+                # libomp used to be globally installed in Homebrew
+                $(info OMP source is Homebrew libomp global install)
+            else ifeq ($(shell if [ -d $(HOMEBREW_PREFIX)/opt/libomp/include ]; then echo 1; else echo 0; fi), 1)
+                # libomp moved to these directories, recently, because it is now keg-only to not fight GCC
+                $(info OMP source is Homebrew libomop keg)
+                CXXFLAGS += -I$(HOMEBREW_PREFIX)/opt/libomp/include
+                LD_LIB_DIR_FLAGS += -L$(HOMEBREW_PREFIX)/opt/libomp/lib
+            else
+                $(error OMP is not available from Homebrew)
+            endif
         # Macports installs libomp to /opt/local/lib/libomp
         else ifeq ($(shell if [ -d /opt/local/lib/libomp ]; then echo 1; else echo 0; fi), 1)
             $(info OMP source Macports)

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,11 @@ include $(wildcard $(UNITTEST_BIN_DIR)/*.d)
 # What pkg-config-controlled system dependencies should we use compile and link flags from?
 # Use PKG_CONFIG_PATH to point the build system at the right versions of these, if they aren't picked up automatically.
 # We can't do this for our bundled, pkg-config-supporting dependencies (like htslib) because they won't be built yet.
-PKG_CONFIG_DEPS := cairo jansson libzstd
+PKG_CONFIG_DEPS := cairo libzstd
 # These are like PKG_CONFIG_DEPS but we try to always link them statically, if possible.
 # Note that we then must *always* link anything *else* that uses them statically.
-PKG_CONFIG_STATIC_DEPS := protobuf 
+# Jansson has to be in here because it has to come after libvgio, which is in the static deps.
+PKG_CONFIG_STATIC_DEPS := protobuf jansson
 
 # We don't ask for -fopenmp here because how we get it can depend on the compiler.
 # We don't ask for automatic Make dependency file (*.d) generation here because

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,15 @@ ifeq ($(shell uname -s),Darwin)
         # The compiler only needs to do the preprocessing
         CXXFLAGS += -Xpreprocessor -fopenmp
 
-        # If HOMEBREW_PREFIX is specified, libomp probably cannot be found automatically.
+        ifndef HOMEBREW_PREFIX
+            BREW_PATH=$(shell which brew 2>/dev/null)
+            $(info Homebrew would be $(BREW_PATH))
+            ifneq ($(BREW_PATH),)
+                # Get prefix from Homebrew instead of environment
+                HOMEBREW_PREFIX=$(shell brew --prefix)
+            endif
+        endif
+
         ifdef HOMEBREW_PREFIX
             # If we have homebrew, use Homebrew
             CXXFLAGS += -I$(HOMEBREW_PREFIX)/include

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Paths provide stable coordinates for graphs built in different ways from the sam
 
 ## Support 
 
-We maintain a support forum on biostars: https://www.biostars.org/t/vg/
+We maintain a support forum on biostars: https://www.biostars.org/tag/vg/
 
 ## Installation
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ void vg_help(char** argv) {
      });
      
      cerr << endl << "For more commands, type `vg help`." << endl;
-     cerr << "For technical support, please visit: https://www.biostars.org/t/vg/" << endl << endl;
+     cerr << "For technical support, please visit: https://www.biostars.org/tag/vg/" << endl << endl;
  }
 
 // We make sure to compile main for the lowest common denominator architecture.

--- a/src/subcommand/help_main.cpp
+++ b/src/subcommand/help_main.cpp
@@ -46,7 +46,7 @@ int main_help(int argc, char** argv){
          cerr << endl;
      }
      
-     cerr << "For technical support, please visit: https://www.biostars.org/t/vg/" << endl << endl;
+     cerr << "For technical support, please visit: https://www.biostars.org/tag/vg/" << endl << endl;
      
     
     return 0;

--- a/src/unittest/protobuf.cpp
+++ b/src/unittest/protobuf.cpp
@@ -1,0 +1,69 @@
+/// \file protobuf.cpp
+///  
+/// unit tests for Protobuf linking and usage
+///
+
+#include <vg/vg.pb.h>
+#include <google/protobuf/descriptor.h>
+
+#include "../version.hpp"
+
+#include "catch.hpp"
+
+#include <iostream>
+
+namespace vg {
+namespace unittest {
+using namespace std;
+
+TEST_CASE("Protobuf reflection works", "[protobuf][io]") {
+
+    std::cerr << "Testing libvgio..." << std::endl;
+    
+    // We need to actually instantiate a vg Protobuf (or otherwise depend on
+    // its symbols at link time) or the vg Protobuf symbols might not come
+    // along in the binary.
+#ifdef debug
+    std::cerr << "Creating Graph..." << std::endl;
+#endif
+    vg::Graph g;
+#ifdef debug
+    std::cerr << "Graph exists at " << &g << std::endl;
+#endif
+
+    // We also need to make sure to actually pull in something from libvg so it gets linked in if it is dynamic.
+    auto version = vg::Version::get_version();
+#ifdef debug
+    std::cerr << "libvg version: " << version << std::endl;
+#endif
+
+#ifdef debug
+    std::cerr << "Checking for Protobuf descriptor pool..." << std::endl;
+#endif
+    const google::protobuf::DescriptorPool* pool =  google::protobuf::DescriptorPool::generated_pool();
+    if (pool == nullptr) {
+        throw std::runtime_error("Cound not find Protobuf descriptor pool: is libvgio working?");
+    }
+#ifdef debug
+    std::cerr << "Found descriptor pool at " << pool << std::endl;
+#endif
+    
+    for (auto message_name : {"vg.Graph", "vg.Alignment", "vg.Position"}) {
+#ifdef debug
+        std::cerr << "Checking for Protobuf message type " << message_name << "..." << std::endl;
+#endif
+        const google::protobuf::Descriptor* descriptor = pool->FindMessageTypeByName(message_name);
+        if (descriptor == nullptr) {
+            throw std::runtime_error(std::string("Cound not find Protobuf descriptor for message type ") + message_name + ": is libvgio working?");
+        }
+#ifdef debug
+        std::cerr << "Found " << message_name << " as " << descriptor->full_name() << " at " << descriptor << std::endl;
+#endif
+    }
+
+
+}
+
+
+}
+}


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg should now only link one copy of Protobuf into the non-static build
 * vg should now build against newer libomp from Homebrew which is keg-only

## Description

Since `libvgio` has a `libvgio.so`, which transitively links against `libprotobuf.so`, but since `vg` statically links Protobuf, we were ending up with a static Protobuf in the `vg` binary and then another, dynamic Protobuf being loaded when `libvgio.so` was loaded, in non-static `vg` builds.

This would *almost* work, except somewhere between Protobuf 3.6.1 (on Ubuntu 20.04) and Protobuf 3.12.4 (on Ubuntu 22.04), this started breaking Protobuf reflection, which broke JSON IO in `vg`.

This PR fixes the problem by using the static `libvgio` in the `vg` build, just like we use the static `libprotobuf`.

It also adds a test specifically to make sure that Protobuf reflection is working.
