### PR TITLE
Translate GAMP annotations into GAM annotations in mpmap output

### DIFF
--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -300,12 +300,41 @@ void MultipathAlignmentEmitter::convert_to_alignment(const multipath_alignment_t
     optimal_alignment(mp_aln, aln);
     if (prev_name) {
         aln.mutable_fragment_prev()->set_name(*prev_name);
+        aln.set_read_paired(true);
     }
     if (next_name) {
         aln.mutable_fragment_next()->set_name(*next_name);
+        aln.set_read_paired(true);
     }
     // at one point vg call needed these, maybe it doesn't anymore though
     aln.set_identity(identity(aln.path()));
+    
+    // transfer over annotations
+    if (mp_aln.has_annotation("secondary")) {
+        auto anno = mp_aln.get_annotation("secondary");
+        assert(anno.first == multipath_alignment_t::Bool);
+        bool secondary = *((bool*) anno.second);
+        aln.set_is_secondary(secondary);
+    }
+    if (mp_aln.has_annotation("proper_pair")) {
+        auto anno = mp_aln.get_annotation("proper_pair");
+        assert(anno.first == multipath_alignment_t::Bool);
+        bool proper_pair = *((bool*) anno.second);
+        set_annotation<bool>(aln, "proper_pair", proper_pair);
+        aln.set_read_paired(true);
+    }
+    if (mp_aln.has_annotation("group_mapq")) {
+        auto anno = mp_aln.get_annotation("group_mapq");
+        assert(anno.first == multipath_alignment_t::Double);
+        double group_mapq = *((double*) anno.second);
+        set_annotation<double>(aln, "group_mapq", group_mapq);
+    }
+    if (mp_aln.has_annotation("allelic_mapq")) {
+        auto anno = mp_aln.get_annotation("allelic_mapq");
+        assert(anno.first == multipath_alignment_t::Double);
+        double allelic_mapq = *((double*) anno.second);
+        set_annotation<double>(aln, "allelic_mapq", allelic_mapq);
+    }
 }
 
 void MultipathAlignmentEmitter::create_alignment_shim(const string& name, const multipath_alignment_t& mp_aln,

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -309,31 +309,12 @@ void MultipathAlignmentEmitter::convert_to_alignment(const multipath_alignment_t
     // at one point vg call needed these, maybe it doesn't anymore though
     aln.set_identity(identity(aln.path()));
     
-    // transfer over annotations
+    // transfer over annotation that has a special field in GAM
     if (mp_aln.has_annotation("secondary")) {
         auto anno = mp_aln.get_annotation("secondary");
         assert(anno.first == multipath_alignment_t::Bool);
         bool secondary = *((bool*) anno.second);
         aln.set_is_secondary(secondary);
-    }
-    if (mp_aln.has_annotation("proper_pair")) {
-        auto anno = mp_aln.get_annotation("proper_pair");
-        assert(anno.first == multipath_alignment_t::Bool);
-        bool proper_pair = *((bool*) anno.second);
-        set_annotation<bool>(aln, "proper_pair", proper_pair);
-        aln.set_read_paired(true);
-    }
-    if (mp_aln.has_annotation("group_mapq")) {
-        auto anno = mp_aln.get_annotation("group_mapq");
-        assert(anno.first == multipath_alignment_t::Double);
-        double group_mapq = *((double*) anno.second);
-        set_annotation<double>(aln, "group_mapq", group_mapq);
-    }
-    if (mp_aln.has_annotation("allelic_mapq")) {
-        auto anno = mp_aln.get_annotation("allelic_mapq");
-        assert(anno.first == multipath_alignment_t::Double);
-        double allelic_mapq = *((double*) anno.second);
-        set_annotation<double>(aln, "allelic_mapq", allelic_mapq);
     }
 }
 

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -48,7 +48,7 @@ double lognormal_pdf(double x, double mu, double sigma);
  * out of log space.
  */
 inline double add_log(double log_x, double log_y) {
-    return log_x > log_y ? log_x + log(1.0 + exp(log_y - log_x)) : log_y + log(1.0 + exp(log_x - log_y));
+    return log_x > log_y ? log_x + log1p(exp(log_y - log_x)) : log_y + log1p(exp(log_x - log_y));
 }
 
 /*
@@ -56,7 +56,7 @@ inline double add_log(double log_x, double log_y) {
  * them out of log space.
  */
 inline double subtract_log(double log_x, double log_y) {
-    return log_x + log(1.0 - exp(log_y - log_x));
+    return log_x + log1p(-exp(log_y - log_x));
 }
 
 /**


### PR DESCRIPTION
## Changelog Entry

 * `vg mpmap -F GAM` correctly labels secondary mappings
  
## Description

GAM has specific fields for a few specific annotations that GAMP uses the generic annotation system for. These annotations are now translated into the GAM output from `vg mpmap`.