### PR TITLE
Fix vg convert --drop-haplotypes

### DIFF
--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -41,7 +41,7 @@ void no_multiple_inputs(input_type input);
 // Generate an XG with nodes, edges, and paths from input.
 // Promote haplotype-sense paths for the samples in ref_samples to reference sense.
 // Copy across other haplotype-sense paths if unless drop_haplotypes is true.
-void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, const std::unordered_set<std::string>& ref_samples, bool drop_haplotypes = false);
+void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, const std::unordered_set<std::string>& ref_samples, bool drop_haplotypes);
 // Copy paths from input to output.
 // Promote haplotype-sense paths for the samples in ref_samples to reference sense.
 // Copy across other haplotype-sense paths if unless drop_haplotypes is true.
@@ -299,7 +299,7 @@ int main_convert(int argc, char** argv) {
             cerr << "warning [vg convert]: currently cannot convert GFA directly to XG; converting through another format" << endl;
             algorithms::gfa_to_path_handle_graph(input_stream_name, &intermediate,
                                                  input_rgfa_rank, gfa_trans_path);
-            graph_to_xg_adjusting_paths(&intermediate, xg_graph, ref_samples);
+            graph_to_xg_adjusting_paths(&intermediate, xg_graph, ref_samples, drop_haplotypes);
         }
         else {
             // If the GFA doesn't have forward references, we can handle it
@@ -358,7 +358,7 @@ int main_convert(int argc, char** argv) {
                 xg::XG* xg_graph = dynamic_cast<xg::XG*>(output_graph.get());
                 if (input_path_graph != nullptr) {
                     // We can convert to XG with paths, which we might adjust
-                    graph_to_xg_adjusting_paths(input_path_graph, xg_graph, ref_samples);
+                    graph_to_xg_adjusting_paths(input_path_graph, xg_graph, ref_samples, drop_haplotypes);
                 } else {
                     // No paths, just convert to xg without paths
                     xg_graph->from_handle_graph(*input_graph);
@@ -472,6 +472,7 @@ void help_convert(char** argv) {
          << "    -x, --xg-out           output in XG format" << endl
          << "    -o, --odgi-out         output in ODGI format" << endl
          << "    -f, --gfa-out          output in GFA format" << endl
+         << "    -H, --drop-haplotypes  do not include haplotype paths in the output (useful with GBWTGraph / GBZ inputs)" << endl
          << "gfa output options (use with -f):" << endl
          << "    -P, --rgfa-path STR    write given path as rGFA tags instead of lines (multiple allowed, only rank-0 supported)" << endl
          << "    -Q, --rgfa-prefix STR  write paths with given prefix as rGFA tags instead of lines (multiple allowed, only rank-0 supported)" << endl

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order
 
-plan tests 98
+plan tests 102
 
 vg construct -r complex/c.fa -v complex/c.vcf.gz > c.vg
 cat <(vg view c.vg | grep ^S | sort) <(vg view c.vg | grep L | uniq | wc -l) <(vg paths -v c.vg -E) > c.info
@@ -328,6 +328,14 @@ vg paths --sample "sample" -v components.xg -A | sort > gbz_xg_haplotypes.gaf
 cmp gbz_xg_haplotypes.gaf correct_haplotypes.gaf
 is $? 0 "GBZ to XG conversion creates the correct haplotype paths"
 
+# GBZ to HashGraph and XG while dropping haplotypes
+vg convert -x --drop-haplotypes components.gbz > no_haplotypes.xg
+is $? 0 "GBZ to XG conversion while dropping haplotypes"
+is "$(vg paths -L -x no_haplotypes.xg | wc -l)" "2" "No haplotypes in the converted graph"
+vg convert -xa --drop-haplotypes components.gbz > no_haplotypes.hg
+is $? 0 "GBZ to HashGraph conversion while dropping haplotypes"
+is "$(vg paths -L -x no_haplotypes.hg | wc -l)" "2" "No haplotypes in the converted graph"
+
 # GBWTGraph to GFA with paths and walks (needs 1 thread)
 vg convert -b components.gbwt -f -t 1 components.gg > extracted.gfa
 is $? 0 "GBWTGraph to GFA conversion with paths and walks, GBWTGraph algorithm"
@@ -365,6 +373,7 @@ rm -f components.gbwt components.gg components.gbz
 rm -f direct.hg correct_paths.gaf correct_haplotypes.gaf
 rm -f components.hg hg_paths.gaf hg_haplotypes.gaf gbz_hg_paths.gaf gbz_hg_haplotypes.gaf
 rm -f components.xg xg_paths.gaf xg_haplotypes.gaf gbz_xg_paths.gaf gbz_xg_haplotypes.gaf
+rm -f no_haplotypes.xg no_haplotypes.hg
 rm -f extracted.gfa gbz.gfa extracted.hg
 rm -f sorted.gfa correct.gfa
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg convert --drop-haplotypes` will drop haplotype paths from the output graph.

## Description

After the introduction of path senses in version 1.41.0, `vg convert` started copying all haplotype paths from the input graph to the output graph. Because GBWTGraphs and GBZ graphs may contain a large number of haplotypes, this can make the output graph unnecessarily large. There was an option `-H` / `--drop-haplotypes` to avoid copying the haplotypes, but it was hidden and did not work with XG output.

This PR reveals the option in command line help and enables it with XG output.