### PR TITLE
Automatically apply gbz translation in call+deconstruct

### DIFF
--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -553,16 +553,16 @@ gbwt::GBWT get_gbwt(const std::vector<gbwt::vector_type>& paths) {
 
 //------------------------------------------------------------------------------
 
-unordered_map<nid_t, vector<nid_t>> load_translation_map(ifstream& input_stream) {
+unordered_map<string, vector<nid_t>> load_translation_map(ifstream& input_stream) {
     string buffer;
     size_t line = 1;
-    unordered_map<nid_t, vector<nid_t>> translation_map;
+    unordered_map<string, vector<nid_t>> translation_map;
     try {
         while (getline(input_stream, buffer)) {
             vector<string> toks = split_delims(buffer, "\t");
             if (toks.size() == 3 && toks[0] == "T") {
                 vector<string> toks2 = split_delims(toks[2], ",");
-                nid_t segment_id = parse<nid_t>(toks[1]);
+                const string& segment_id = toks[1];
                 vector<nid_t> node_ids;
                 node_ids.reserve(toks2.size());
                 for (string& node_id_str : toks2) {
@@ -585,16 +585,16 @@ unordered_map<nid_t, vector<nid_t>> load_translation_map(ifstream& input_stream)
     return translation_map;
 }
 
-unordered_map<nid_t, pair<nid_t, size_t>> load_translation_back_map(HandleGraph& graph, ifstream& input_stream) {
+unordered_map<nid_t, pair<string, size_t>> load_translation_back_map(HandleGraph& graph, ifstream& input_stream) {
     string buffer;
     size_t line = 1;
-    unordered_map<nid_t, pair<nid_t, size_t>> translation_back_map;
+    unordered_map<nid_t, pair<string, size_t>> translation_back_map;
     try {
         while (getline(input_stream, buffer)) {
             vector<string> toks = split_delims(buffer, "\t");
             if (toks.size() == 3 && toks[0] == "T") {
                 vector<string> toks2 = split_delims(toks[2], ",");
-                nid_t segment_id = stol(toks[1]);
+                const string& segment_id = toks[1];
                 size_t offset = 0;
                 for (string& node_id_str : toks2) {
                     nid_t node_id = stol(node_id_str);

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -248,13 +248,13 @@ gbwt::GBWT get_gbwt(const std::vector<gbwt::vector_type>& paths);
 
 /// Load a translation file (created with vg gbwt --translation) and return a mapping
 /// original segment ids to a list of chopped node ids
-unordered_map<nid_t, vector<nid_t>> load_translation_map(ifstream& input_stream);
+unordered_map<string, vector<nid_t>> load_translation_map(ifstream& input_stream);
 
 /// Load a translation file (created with vg gbwt --translation) and return a backwards mapping
 /// of chopped node to original segment position (id,offset pair)
 /// NOTE: hopefully this is just a short-term hack, and we get a general interface baked into
 ///       the handlegraphs themselves
-unordered_map<nid_t, pair<nid_t, size_t>> load_translation_back_map(HandleGraph& graph, ifstream& input_stream);
+unordered_map<nid_t, pair<string, size_t>> load_translation_back_map(HandleGraph& graph, ifstream& input_stream);
 
 //------------------------------------------------------------------------------
 

--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -151,4 +151,54 @@ void save_minimizer(const gbwtgraph::DefaultMinimizerIndex& index, const std::st
 
 //------------------------------------------------------------------------------
 
+/// Return a mapping of the original segment ids to a list of chopped node ids
+/// (mimicking logic and interface from function of same name in gbwt_helper.cpp)
+unordered_map<nid_t, vector<nid_t>> load_translation_map(const gbwtgraph::GBWTGraph& graph) {
+    unordered_map<nid_t, vector<nid_t>> translation_map;
+    try {
+        graph.for_each_segment([&](const std::string& name, std::pair<nid_t, nid_t> nodes) -> bool {
+                nid_t segment_id = parse<nid_t>(name);
+                vector<nid_t>& val = translation_map[segment_id];
+                if (!val.empty()) {
+                    throw runtime_error("Segment " + name + " already in map");
+                }
+                val.reserve(nodes.second - nodes.first);
+                for (nid_t node_id = nodes.first; node_id < nodes.second; ++node_id) {
+                    val.push_back(node_id);
+                }
+                return true;
+            });
+    } catch (const std::exception& e) {
+        cerr << "[load_translation_map] warning: unable to load translation from graph: " << e.what() << endl;
+        translation_map.clear();
+    }
+    return translation_map;
+}
+
+/// Return a backwards mapping of chopped node to original segment position (id,offset pair)
+/// (mimicking logic and interface from function of same name in gbwt_helper.cpp)
+unordered_map<nid_t, pair<nid_t, size_t>> load_translation_back_map(const gbwtgraph::GBWTGraph& graph) {
+    unordered_map<nid_t, pair<nid_t, size_t>> translation_back_map;
+    try {
+        graph.for_each_segment([&](const std::string& name, std::pair<nid_t, nid_t> nodes) -> bool {
+                nid_t segment_id = parse<nid_t>(name);
+                size_t offset = 0;
+                for (nid_t node_id = nodes.first; node_id < nodes.second; ++node_id) {
+                    if (translation_back_map.count(node_id)) {
+                        throw runtime_error("Node ID " + std::to_string(node_id) + " already in map");
+                    }
+                    translation_back_map[node_id] = make_pair(segment_id, offset);
+                    offset += graph.get_length(graph.get_handle(node_id));
+                }
+                return true;
+            });
+                
+    } catch (const std::exception& e) {
+        cerr << "[load_translation_back_map] warning: unable to load back translation from graph: "  << e.what() << endl;
+        translation_back_map.clear();
+    }    
+    return translation_back_map;
+}
+
+
 } // namespace vg

--- a/src/gbwtgraph_helper.hpp
+++ b/src/gbwtgraph_helper.hpp
@@ -61,10 +61,10 @@ void save_minimizer(const gbwtgraph::DefaultMinimizerIndex& index, const std::st
 //------------------------------------------------------------------------------
 
 /// Return a mapping of the original segment ids to a list of chopped node ids
-std::unordered_map<nid_t, std::vector<nid_t>> load_translation_map(const gbwtgraph::GBWTGraph& graph);
+std::unordered_map<std::string, std::vector<nid_t>> load_translation_map(const gbwtgraph::GBWTGraph& graph);
 
 /// Return a backwards mapping of chopped node to original segment position (id,offset pair)
-std::unordered_map<nid_t, std::pair<nid_t, size_t>> load_translation_back_map(const gbwtgraph::GBWTGraph& graph);
+std::unordered_map<nid_t, std::pair<std::string, size_t>> load_translation_back_map(const gbwtgraph::GBWTGraph& graph);
 
 //------------------------------------------------------------------------------
 

--- a/src/gbwtgraph_helper.hpp
+++ b/src/gbwtgraph_helper.hpp
@@ -8,6 +8,9 @@
 #include <gbwtgraph/gfa.h>
 #include <gbwtgraph/gbz.h>
 #include <gbwtgraph/minimizer.h>
+#include "position.hpp"
+#include <unordered_map>
+#include <vector>
 
 namespace vg {
 
@@ -54,6 +57,14 @@ void save_gbz(const gbwtgraph::GBZ& gbz, const std::string& gbwt_name, const std
 
 /// Save a minimizer index to the file.
 void save_minimizer(const gbwtgraph::DefaultMinimizerIndex& index, const std::string& filename, bool show_progress = false);
+
+//------------------------------------------------------------------------------
+
+/// Return a mapping of the original segment ids to a list of chopped node ids
+std::unordered_map<nid_t, std::vector<nid_t>> load_translation_map(const gbwtgraph::GBWTGraph& graph);
+
+/// Return a backwards mapping of chopped node to original segment position (id,offset pair)
+std::unordered_map<nid_t, std::pair<nid_t, size_t>> load_translation_back_map(const gbwtgraph::GBWTGraph& graph);
 
 //------------------------------------------------------------------------------
 

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -330,7 +330,7 @@ void VCFOutputCaller::vcf_fixup(vcflib::Variant& var) const {
     }
 }
 
-void VCFOutputCaller::set_translation(const unordered_map<nid_t, pair<nid_t, size_t>>* translation) {
+void VCFOutputCaller::set_translation(const unordered_map<nid_t, pair<string, size_t>>* translation) {
     this->translation = translation;
 }
 
@@ -346,18 +346,19 @@ void VCFOutputCaller::add_allele_path_to_info(vcflib::Variant& v, int allele, co
     vector<int> nodes;
     nodes.reserve(trav.visit_size());
     const Visit* prev_visit = nullptr;
-    unordered_map<nid_t, pair<nid_t, size_t>>::const_iterator prev_trans;
+    unordered_map<nid_t, pair<string, size_t>>::const_iterator prev_trans;
     
     for (size_t i = 0; i < trav.visit_size(); ++i) {
         size_t j = !reversed ? i : trav.visit_size() - 1 - i;
         const Visit& visit = trav.visit(j);
         nid_t node_id = visit.node_id();
+        string node_name = std::to_string(node_id);
         bool skip = false;
         // todo: check one_based? (we kind of ignore that when writing the snarl name, so maybe not pertienent)
         if (translation) {
             auto i = translation->find(node_id);
             if (i == translation->end()) {
-                throw runtime_error("Error [vg deconstruct]: Unable to find node " + std::to_string(node_id) + " in translation file");
+                throw runtime_error("Error [vg deconstruct]: Unable to find node " + node_name + " in translation file");
             }
             if (prev_visit) {
                 nid_t prev_node_id = prev_visit->node_id();
@@ -368,14 +369,14 @@ void VCFOutputCaller::add_allele_path_to_info(vcflib::Variant& v, int allele, co
                     skip = true;
                 }
             }
-            node_id = i->second.first;
+            node_name = i->second.first;
             prev_trans = i;
         }
 
         if (!skip) {
             bool vrev = visit.backward() != reversed;
             trav_info[allele] += (vrev ? "<" : ">");
-            trav_info[allele] += std::to_string(node_id);
+            trav_info[allele] += node_name;
         }
         prev_visit = &visit;
     }
@@ -699,17 +700,19 @@ void VCFOutputCaller::flatten_common_allele_ends(vcflib::Variant& variant, bool 
 
 string VCFOutputCaller::print_snarl(const Snarl& snarl, bool in_brackets) const {
     // todo, should we canonicalize here by putting lexicographic lowest node first?
-    nid_t start_node = snarl.start().node_id();
-    nid_t end_node = snarl.end().node_id();
+    nid_t start_node_id = snarl.start().node_id();
+    nid_t end_node_id = snarl.end().node_id();
+    string start_node = std::to_string(start_node_id);
+    string end_node = std::to_string(end_node_id);
     if (translation) {
-        auto i = translation->find(start_node);
+        auto i = translation->find(start_node_id);
         if (i == translation->end()) {
-            throw runtime_error("Error [VCFOutputCaller]: Unable to find node " + std::to_string(start_node) + " in translation file");
+            throw runtime_error("Error [VCFOutputCaller]: Unable to find node " + start_node + " in translation file");
         }
         start_node = i->second.first;
-        i = translation->find(end_node);
+        i = translation->find(end_node_id);
         if (i == translation->end()) {
-            throw runtime_error("Error [VCFOutputCaller]: Unable to find node " + std::to_string(end_node) + " in translation file");
+            throw runtime_error("Error [VCFOutputCaller]: Unable to find node " + end_node + " in translation file");
         }
         end_node = i->second.first;
     }

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -331,7 +331,7 @@ void VCFOutputCaller::vcf_fixup(vcflib::Variant& var) const {
 }
 
 void VCFOutputCaller::set_translation(const unordered_map<nid_t, pair<nid_t, size_t>>* translation) {
-    translation = translation;
+    this->translation = translation;
 }
 
 void VCFOutputCaller::set_nested(bool nested) {

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -89,7 +89,7 @@ public:
     void vcf_fixup(vcflib::Variant& var) const;
 
     /// Add a translation map
-    void set_translation(const unordered_map<nid_t, pair<nid_t, size_t>>* translation);
+    void set_translation(const unordered_map<nid_t, pair<string, size_t>>* translation);
 
     /// Assume writing nested snarls is enabled
     void set_nested(bool nested);
@@ -150,7 +150,7 @@ protected:
     size_t max_uncalled_alleles = 5;
 
     // optional node translation to apply to snarl names in variant IDs
-    const unordered_map<nid_t, pair<nid_t, size_t>>* translation;
+    const unordered_map<nid_t, pair<string, size_t>>* translation;
 
     // need to write LV/PS info tags
     bool include_nested;

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -16,6 +16,7 @@
 #include "../integrated_snarl_finder.hpp"
 #include "../xg.hpp"
 #include "../gbzgraph.hpp"
+#include "../gbwtgraph_helper.hpp"
 #include <vg/io/stream.hpp>
 #include <vg/io/vpkg.hpp>
 #include <bdsg/overlays/overlay_helper.hpp>
@@ -374,7 +375,19 @@ int main_call(int argc, char** argv) {
     
     // Read the translation
     unique_ptr<unordered_map<nid_t, pair<nid_t, size_t>>> translation;
+    if (gbz_graph.get() != nullptr) {
+        // try to get the translation from the graph
+        translation = make_unique<unordered_map<nid_t, pair<nid_t, size_t>>>();
+        *translation = load_translation_back_map(gbz_graph->gbz.graph);
+        if (translation->empty()) {
+            // not worth keeping an empty translation
+            translation = nullptr;
+        }
+    }
     if (!translation_file_name.empty()) {
+        if (!translation->empty()) {
+            cerr << "Warning [vg call]: Using translation from -N overrides that in input GBZ (you probably don't want to use -N)" << endl;
+        }        
         ifstream translation_file(translation_file_name.c_str());
         if (!translation_file) {
             cerr << "Error [vg call]: Unable to load translation file: " << translation_file_name << endl;

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -374,10 +374,10 @@ int main_call(int argc, char** argv) {
     }
     
     // Read the translation
-    unique_ptr<unordered_map<nid_t, pair<nid_t, size_t>>> translation;
+    unique_ptr<unordered_map<nid_t, pair<string, size_t>>> translation;
     if (gbz_graph.get() != nullptr) {
         // try to get the translation from the graph
-        translation = make_unique<unordered_map<nid_t, pair<nid_t, size_t>>>();
+        translation = make_unique<unordered_map<nid_t, pair<string, size_t>>>();
         *translation = load_translation_back_map(gbz_graph->gbz.graph);
         if (translation->empty()) {
             // not worth keeping an empty translation
@@ -393,7 +393,7 @@ int main_call(int argc, char** argv) {
             cerr << "Error [vg call]: Unable to load translation file: " << translation_file_name << endl;
             return 1;
         }
-        translation = make_unique<unordered_map<nid_t, pair<nid_t, size_t>>>();
+        translation = make_unique<unordered_map<nid_t, pair<string, size_t>>>();
         *translation = load_translation_back_map(*graph, translation_file);
     }    
     

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -260,7 +260,19 @@ int main_deconstruct(int argc, char** argv){
 
     // Read the translation
     unique_ptr<unordered_map<nid_t, pair<nid_t, size_t>>> translation;
+    if (gbz_graph.get() != nullptr) {
+        // try to get the translation from the graph
+        translation = make_unique<unordered_map<nid_t, pair<nid_t, size_t>>>();
+        *translation = load_translation_back_map(gbz_graph->gbz.graph);
+        if (translation->empty()) {
+            // not worth keeping an empty translation
+            translation = nullptr;
+        }
+    }
     if (!translation_file_name.empty()) {
+        if (!translation->empty()) {
+            cerr << "Warning [vg deconstruct]: Using translation from -T overrides that in input GBZ (you probably don't want to use -T)" << endl;
+        }
         ifstream translation_file(translation_file_name.c_str());
         if (!translation_file) {
             cerr << "Error [vg deconstruct]: Unable to load translation file: " << translation_file_name << endl;

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -259,10 +259,10 @@ int main_deconstruct(int argc, char** argv){
     }
 
     // Read the translation
-    unique_ptr<unordered_map<nid_t, pair<nid_t, size_t>>> translation;
+    unique_ptr<unordered_map<nid_t, pair<string, size_t>>> translation;
     if (gbz_graph.get() != nullptr) {
         // try to get the translation from the graph
-        translation = make_unique<unordered_map<nid_t, pair<nid_t, size_t>>>();
+        translation = make_unique<unordered_map<nid_t, pair<string, size_t>>>();
         *translation = load_translation_back_map(gbz_graph->gbz.graph);
         if (translation->empty()) {
             // not worth keeping an empty translation
@@ -278,7 +278,7 @@ int main_deconstruct(int argc, char** argv){
             cerr << "Error [vg deconstruct]: Unable to load translation file: " << translation_file_name << endl;
             return 1;
         }
-        translation = make_unique<unordered_map<nid_t, pair<nid_t, size_t>>>();
+        translation = make_unique<unordered_map<nid_t, pair<string, size_t>>>();
         *translation = load_translation_back_map(*graph, translation_file);
     }
     

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -68,7 +68,7 @@ printf "y\t10\tAACTCCAGAAAATTTCCAAG\tCTTGGAAATTTTCTGGAGTT\t1\n" > inv_truth.tsv
 diff inv_decon.tsv inv_truth.tsv
 is "$?" 0 "deconstruct correctly handles a simple inversion when the reference contains the reversing edge"
 
-printf "P\ty\t1+,2+,6-,5-,4-,3-,7+,8+,9+,10+,11+\t*\n" >> inv.gfa
+printf "P\ty\t1+,2-,3+\t*\n" >> inv.gfa
 vg gbwt -G inv.gfa -g inv.chop.gbz --gbz-format --max-node 5
 vg deconstruct inv.gbz -p x > inv.chop.decon
 vg gbwt -G inv.gfa -g inv.gbz --gbz-format --max-node 1025

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -68,9 +68,8 @@ printf "y\t10\tAACTCCAGAAAATTTCCAAG\tCTTGGAAATTTTCTGGAGTT\t1\n" > inv_truth.tsv
 diff inv_decon.tsv inv_truth.tsv
 is "$?" 0 "deconstruct correctly handles a simple inversion when the reference contains the reversing edge"
 
-printf "P\ty\t1+,2-,3+\t*\n" >> inv.gfa
 vg gbwt -G inv.gfa -g inv.chop.gbz --gbz-format --max-node 5
-vg deconstruct inv.gbz -p x > inv.chop.decon
+vg deconstruct inv.chop.gbz -p x > inv.chop.decon
 vg gbwt -G inv.gfa -g inv.gbz --gbz-format --max-node 1025
 vg deconstruct inv.gbz -p x > inv.decon
 diff inv.decon inv.chop.decon

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 23
+plan tests 24
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
 vg index tiny.vg -x tiny.xg
@@ -68,7 +68,15 @@ printf "y\t10\tAACTCCAGAAAATTTCCAAG\tCTTGGAAATTTTCTGGAGTT\t1\n" > inv_truth.tsv
 diff inv_decon.tsv inv_truth.tsv
 is "$?" 0 "deconstruct correctly handles a simple inversion when the reference contains the reversing edge"
 
-rm -f inv.gfa inv.vg inv.xg inv_decon.vcf inv_decon.tsv inv_truth.tsv
+printf "P\ty\t1+,2+,6-,5-,4-,3-,7+,8+,9+,10+,11+\t*\n" >> inv.gfa
+vg gbwt -G inv.gfa -g inv.chop.gbz --gbz-format --max-node 5
+vg deconstruct inv.gbz -p x > inv.chop.decon
+vg gbwt -G inv.gfa -g inv.gbz --gbz-format --max-node 1025
+vg deconstruct inv.gbz -p x > inv.decon
+diff inv.decon inv.chop.decon
+is "$?" 0 "deconstruct automatically applies translation from gbz"
+
+rm -f inv.gfa inv.vg inv.xg inv_decon.vcf inv_decon.tsv inv_truth.tsv inv.gbz inv.chop.gbz inv.gbz inv.chop.decon inv.decon
 
 
 vg construct -v small/x.vcf.gz -r small/x.fa | vg view -g - > cyclic_small.gfa


### PR DESCRIPTION
Like  old `-T <translation file>` interface in `deconstruct` (and `-N` in `call`), but automatic from the stored map in the GBZ.  Should now work with non-integer node names as well. 