### PR TITLE
Speed up path lookup on nodes with an overlay

### DIFF
--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -21,6 +21,7 @@
 #include <vg/io/stream.hpp>
 #include <vg/io/vpkg.hpp>
 #include <bdsg/overlays/overlay_helper.hpp>
+#include <bdsg/overlays/packed_reference_path_overlay.hpp>
 #include <gbwtgraph/utils.h>
 #include <gbwtgraph/index.h>
 
@@ -196,7 +197,7 @@ int main_deconstruct(int argc, char** argv){
         return 1;
     }
 
-    bdsg::PathPositionOverlayHelper overlay_helper;
+    bdsg::OverlayHelper<PathPositionHandleGraph, bdsg::PackedReferencePathOverlay, PathHandleGraph> overlay_helper;
     PathPositionHandleGraph* graph = overlay_helper.apply(path_handle_graph);
 
     // Read the GBWT

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -21,7 +21,6 @@
 #include <vg/io/stream.hpp>
 #include <vg/io/vpkg.hpp>
 #include <bdsg/overlays/overlay_helper.hpp>
-#include <bdsg/overlays/packed_reference_path_overlay.hpp>
 #include <gbwtgraph/utils.h>
 #include <gbwtgraph/index.h>
 
@@ -171,7 +170,6 @@ int main_deconstruct(int argc, char** argv){
         }
 
     }
-
     if ((!path_sep.empty() || set_ploidy) && !path_restricted_traversals && gbwt_file_name.empty()) {
         cerr << "Error [vg deconstruct]: -H and -d can only be used with -e or -g" << endl;
         return 1;
@@ -204,7 +202,7 @@ int main_deconstruct(int argc, char** argv){
     }
 
     // We might need to apply an overlay to get good path position queries
-    bdsg::OverlayHelper<PathPositionHandleGraph, bdsg::PackedReferencePathOverlay, PathHandleGraph> overlay_helper;
+    bdsg::ReferencePathOverlayHelper overlay_helper;
     
     // Set up to time making the overlay
     clock_t overlay_start_clock = clock();

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -25,7 +25,7 @@
 #include <gbwtgraph/utils.h>
 #include <gbwtgraph/index.h>
 
-#define USE_CALLGRIND
+//#define USE_CALLGRIND
 
 #ifdef USE_CALLGRIND
 #include <valgrind/callgrind.h>
@@ -219,8 +219,8 @@ int main_deconstruct(int argc, char** argv){
     double overlay_cpu_seconds = (overlay_stop_clock - overlay_start_clock) / (double)CLOCKS_PER_SEC;
     std::chrono::duration<double> overlay_seconds = overlay_stop_time - overlay_start_time;
     
-    if (graph != dynamic_cast<PathPositionHandleGraph*>(path_handle_graph)) {
-        std::cerr << "Info [vg deconstruct]: Computed overlay in " << overlay_seconds.count() << " seconds using " << overlay_cpu_seconds << " CPU seconds." << std::endl;
+    if (show_progress && graph != dynamic_cast<PathPositionHandleGraph*>(path_handle_graph)) {
+        std::cerr << "Computed overlay in " << overlay_seconds.count() << " seconds using " << overlay_cpu_seconds << " CPU seconds." << std::endl;
     }
 
     // Read the GBWT

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -335,7 +335,7 @@ int main_filter(int argc, char** argv) {
      // If the user gave us an XG index, we probably ought to load it up.
     PathPositionHandleGraph* xindex = nullptr;
     unique_ptr<PathHandleGraph> path_handle_graph;
-    bdsg::PathPositionOverlayHelper overlay_helper;
+    bdsg::ReferencePathOverlayHelper overlay_helper;
     if (!xg_name.empty()) {
         // read the xg index
         path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -26,7 +26,6 @@
 #include "../minimizer_mapper.hpp"
 #include "../index_registry.hpp"
 #include <bdsg/overlays/overlay_helper.hpp>
-#include <bdsg/overlays/packed_reference_path_overlay.hpp>
 
 #include <gbwtgraph/gbz.h>
 #include <gbwtgraph/minimizer.h>
@@ -1190,8 +1189,8 @@ int main_giraffe(int argc, char** argv) {
     // getting offsets along ref paths.
     PathPositionHandleGraph* path_position_graph = nullptr;
     // If we need an overlay for position lookup, we might be pointing into
-    // this overlay
-    bdsg::OverlayHelper<PathPositionHandleGraph, bdsg::PackedReferencePathOverlay, PathHandleGraph> overlay_helper;
+    // this overlay. We want one that's good for reference path queries.
+    bdsg::ReferencePathOverlayHelper overlay_helper;
     // And we might load an XG
     unique_ptr<PathHandleGraph> xg_graph;
     if (track_correctness || hts_output) {

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -26,6 +26,7 @@
 #include "../minimizer_mapper.hpp"
 #include "../index_registry.hpp"
 #include <bdsg/overlays/overlay_helper.hpp>
+#include <bdsg/overlays/packed_reference_path_overlay.hpp>
 
 #include <gbwtgraph/gbz.h>
 #include <gbwtgraph/minimizer.h>
@@ -1190,7 +1191,7 @@ int main_giraffe(int argc, char** argv) {
     PathPositionHandleGraph* path_position_graph = nullptr;
     // If we need an overlay for position lookup, we might be pointing into
     // this overlay
-    bdsg::PathPositionOverlayHelper overlay_helper;
+    bdsg::OverlayHelper<PathPositionHandleGraph, bdsg::PackedReferencePathOverlay, PathHandleGraph> overlay_helper;
     // And we might load an XG
     unique_ptr<PathHandleGraph> xg_graph;
     if (track_correctness || hts_output) {

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1698,7 +1698,7 @@ int main_mpmap(int argc, char** argv) {
         cerr << "warning:[vg mpmap] Identifying rescue subgraphs using embedded paths (--path-rescue-graph) is impossible on graphs that lack embedded paths. Pair rescue will not be used on this graph, potentially hurting accuracy." << endl;
     }
     
-    bdsg::PathPositionOverlayHelper overlay_helper;
+    bdsg::ReferencePathOverlayHelper overlay_helper;
     PathPositionHandleGraph* path_position_handle_graph = overlay_helper.apply(path_handle_graph.get());
     
     // identify these before loading later data structures to reduce peak memory use

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -13,6 +13,7 @@
 #include <bdsg/hash_graph.hpp>
 #include <bdsg/overlays/path_position_overlays.hpp>
 #include <bdsg/overlays/overlay_helper.hpp>
+#include <bdsg/overlays/packed_reference_path_overlay.hpp>
 
 #include "../vg.hpp"
 #include "../xg.hpp"
@@ -227,7 +228,7 @@ int main_surject(int argc, char** argv) {
     
     PathPositionHandleGraph* xgidx = nullptr;
     unique_ptr<PathHandleGraph> path_handle_graph;
-    bdsg::PathPositionOverlayHelper overlay_helper;
+    bdsg::OverlayHelper<PathPositionHandleGraph, bdsg::PackedReferencePathOverlay, PathHandleGraph> overlay_helper;
     if (!xg_name.empty()) {
         path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);
         xgidx = overlay_helper.apply(path_handle_graph.get());

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -13,7 +13,6 @@
 #include <bdsg/hash_graph.hpp>
 #include <bdsg/overlays/path_position_overlays.hpp>
 #include <bdsg/overlays/overlay_helper.hpp>
-#include <bdsg/overlays/packed_reference_path_overlay.hpp>
 
 #include "../vg.hpp"
 #include "../xg.hpp"
@@ -228,7 +227,9 @@ int main_surject(int argc, char** argv) {
     
     PathPositionHandleGraph* xgidx = nullptr;
     unique_ptr<PathHandleGraph> path_handle_graph;
-    bdsg::OverlayHelper<PathPositionHandleGraph, bdsg::PackedReferencePathOverlay, PathHandleGraph> overlay_helper;
+    // If we add an overlay for path position queries, use one optimized for
+    // use with reference paths.
+    bdsg::ReferencePathOverlayHelper overlay_helper;
     if (!xg_name.empty()) {
         path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);
         xgidx = overlay_helper.apply(path_handle_graph.get());

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -19,6 +19,8 @@
 
 #include "bdsg/hash_graph.hpp"
 
+#include <bdsg/overlays/packed_reference_path_overlay.hpp>
+
 //#define debug_spliced_surject
 //#define debug_anchored_surject
 //#define debug_multipath_surject

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -19,8 +19,6 @@
 
 #include "bdsg/hash_graph.hpp"
 
-#include <bdsg/overlays/packed_reference_path_overlay.hpp>
-
 //#define debug_spliced_surject
 //#define debug_anchored_surject
 //#define debug_multipath_surject


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject`, `vg giraffe`, `vg mpmap`, `vg filter`, and `vg deconstruct` now accelerate paths-on-node queries with an overlay, so working from a GBZ will no longer be quite as slow relative to working from an XG
 
## Description
This pulls in the new overlay from https://github.com/vgteam/libbdsg/pull/169 to be used in `vg giraffe`, `vg surject`, and `vg deconstruct`, so that using a GBWT-based graph like GBZ can be faster.

@glennhickey gave me a test `vg deconstruct` run that was ~5.5x slower from a GBZ than from an XG and GBWT; this cuts that to more like 1.3x slower.

I'm still doing some profiling to see if I can find ways to make that better.