### PR TITLE
Extract every snarl in region with vg chunk -S

### DIFF
--- a/src/chunker.cpp
+++ b/src/chunker.cpp
@@ -4,6 +4,7 @@
 #include "chunker.hpp"
 #include "algorithms/subgraph.hpp"
 #include "vg.hpp"
+#include "clip.hpp"
 
 //#define debug
 
@@ -296,6 +297,60 @@ void PathChunker::extract_subgraph(const Region& region, int64_t context, int64_
     out_region.seq = region.seq;
     out_region.start = input_start_pos - left_padding;
     out_region.end = input_end_pos + graph->get_length(end_handle) + right_padding - 1;
+}
+
+void PathChunker::extract_snarls(const Region& region, SnarlManager& snarl_manager, MutablePathMutableHandleGraph& subgraph) {
+
+    // copy over the path extraction code from above:
+
+    // extract our path range into the graph
+    path_handle_t path_handle = graph->get_path_handle(region.seq);
+    step_handle_t start_step = graph->get_step_at_position(path_handle, region.start);
+    handle_t start_handle = graph->get_handle_of_step(start_step);
+    step_handle_t end_step = graph->get_step_at_position(path_handle, region.end);    
+    handle_t end_handle = graph->get_handle_of_step(end_step);
+
+#ifdef debug
+#pragma omp critical(cerr)
+    {
+        cerr << "extracting subgraph range for " << region.seq << ":" << region.start << "-" << region.end
+             << ", wich maps to handle range " << graph->get_id(start_handle) << ":" << graph->get_is_reverse(start_handle) << "-"
+             << graph->get_id(end_handle) << ":" << graph->get_is_reverse(end_handle) << endl;
+    }
+#endif
+
+    step_handle_t end_plus_one_step = graph->has_next_step(end_step) ? graph->get_next_step(end_step) : graph->path_end(path_handle) ;
+    for (step_handle_t step = start_step; step != end_plus_one_step; step = graph->get_next_step(step)) {
+        handle_t step_handle = graph->get_handle_of_step(step);
+        if (graph->get_is_reverse(step_handle)) {
+            step_handle = graph->flip(step_handle);
+        }
+        if (!subgraph.has_node(graph->get_id(step_handle))) {
+            subgraph.create_handle(graph->get_sequence(step_handle), graph->get_id(step_handle));
+        }
+    }
+
+    // now fill in the snarls using the vg clip api
+    // todo: we can specifiy multiple regions here
+    visit_contained_snarls(graph, {region}, snarl_manager, false,
+                           [&](const Snarl* snarl, step_handle_t start_step, step_handle_t end_step,
+                               int64_t start_node, int64_t end_node, bool steps_reversed,
+                               const Region* containing_region) {
+
+                               pair<unordered_set<id_t>, unordered_set<edge_t> > snarl_contents = snarl_manager.deep_contents(snarl, *graph, true);
+                               for (id_t snarl_node : snarl_contents.first) {
+                                   if (!subgraph.has_node(snarl_node)) {
+                                       subgraph.create_handle(graph->get_sequence(graph->get_handle(snarl_node)), snarl_node);
+                                   }
+                               }
+                               
+                           });
+
+    // now fill in the edges
+    algorithms::add_connecting_edges_to_subgraph(*graph, subgraph);
+
+    // now fill in the paths
+    algorithms::add_subpaths_to_subgraph(*graph, subgraph, true);
 }
 
 void PathChunker::extract_path_component(const string& path_name, MutablePathMutableHandleGraph& subgraph, Region& out_region) {

--- a/src/chunker.hpp
+++ b/src/chunker.hpp
@@ -8,6 +8,7 @@
 #include "vg/io/json2pb.h"
 #include "region.hpp"
 #include "handle.hpp"
+#include "snarls.hpp"
 
 namespace vg {
 
@@ -39,6 +40,13 @@ public:
      * */
     void extract_subgraph(const Region& region, int64_t context, int64_t length, bool forward_only,
                           MutablePathMutableHandleGraph& subgraph, Region& out_region);
+
+
+    /** Extract the region along the given path, and any snarls fully contained in it. This will often 
+     * give more intuitive results than messing with context steps, which can run way 
+     * outside the region of interest */
+    void extract_snarls(const Region& region, SnarlManager& snarl_manager,
+                        MutablePathMutableHandleGraph& subgraph);
 
     /**
      * Extract a connected component containing a given path

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -15,7 +15,7 @@ using namespace std;
 // then return it (or nullptr if none found)
 // also return the snarl's interval (as pair of offsets) in the path
 // this logic is mostly lifted from deconstructor which does the same thing to get vcf coordinates.
-static tuple<const Region*, step_handle_t, step_handle_t, int64_t, int64_t, bool> get_containing_region(PathPositionHandleGraph* graph,
+static tuple<const Region*, step_handle_t, step_handle_t, int64_t, int64_t, bool> get_containing_region(const PathPositionHandleGraph* graph,
                                                                                                         PathTraversalFinder& trav_finder,
                                                                                                         const Snarl* snarl,
                                                                                                         unordered_map<string, IntervalTree<int64_t, const Region*>>& contig_to_interval_tree,
@@ -81,7 +81,7 @@ static tuple<const Region*, step_handle_t, step_handle_t, int64_t, int64_t, bool
     return make_tuple(nullptr, step_handle_t(), step_handle_t(), -1, -1, false);
 }
 
-void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>& regions, SnarlManager& snarl_manager,
+void visit_contained_snarls(const PathPositionHandleGraph* graph, const vector<Region>& regions, SnarlManager& snarl_manager,
                             bool include_endpoints,
                             function<void(const Snarl*, step_handle_t, step_handle_t, int64_t, int64_t, bool, const Region*)> visit_fn) {
 

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -21,7 +21,7 @@ using namespace std;
  * The parameters to visit_fn are: 
  *    <the snarl, start_step, end_step, steps_reversed, the containing input region>
  */
-void visit_contained_snarls(PathPositionHandleGraph* graph, const vector<Region>& regions, SnarlManager& snarl_manager,
+void visit_contained_snarls(const PathPositionHandleGraph* graph, const vector<Region>& regions, SnarlManager& snarl_manager,
                             bool include_endpoints,
                             function<void(const Snarl*, step_handle_t, step_handle_t, int64_t, int64_t, bool, const Region*)> visit_fn);
 

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -53,6 +53,7 @@ void help_chunk(char** argv) {
          << "    -P, --path-list FILE     write chunks for all path regions in (line - separated file). format" << endl
          << "                             for each as in -p (all paths chunked unless otherwise specified)" << endl
          << "    -e, --input-bed FILE     write chunks for all (0-based end-exclusive) bed regions" << endl
+         << "    -S, --snarls FILE        write given path-range(s) and all snarls fully contained in them, as alternative to -c" << endl
          << "id range chunking:" << endl
          << "    -r, --node-range N:M     write the chunk for the specified node range to standard output\n"
          << "    -R, --node-ranges FILE   write the chunk for each node range in (newline or whitespace separated) file" << endl
@@ -73,7 +74,7 @@ void help_chunk(char** argv) {
          << "    -T, --trace              trace haplotype threads in chunks (and only expand forward from input coordinates)." << endl
          << "                             Produces a .annotate.txt file with haplotype frequencies for each chunk." << endl 
          << "    -f, --fully-contained    only return GAM alignments that are fully contained within chunk" << endl
-         << "    -O, --output-fmt         Specify output format (vg, pg, hg, gfa).  [VG]" << endl
+         << "    -O, --output-fmt         Specify output format (vg, pg, hg, gfa).  [vg]" << endl
          << "    -t, --threads N          for tasks that can be done in parallel, use this many threads [1]" << endl
          << "    -h, --help" << endl;
 }
@@ -108,6 +109,7 @@ int main_chunk(int argc, char** argv) {
     string output_format = "vg";
     bool components = false;
     bool path_components = false;
+    string snarl_filename;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -124,6 +126,7 @@ int main_chunk(int argc, char** argv) {
             {"chunk-size", required_argument, 0, 's'},
             {"overlap", required_argument, 0, 'o'},
             {"input-bed", required_argument, 0, 'e'},
+            {"snarls", required_argument, 0, 'S'},
             {"output-bed", required_argument, 0, 'E'},
             {"prefix", required_argument, 0, 'b'},
             {"context", required_argument, 0, 'c'},
@@ -142,7 +145,7 @@ int main_chunk(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:G:a:gp:P:s:o:e:E:b:c:r:R:Tft:n:l:m:CMO:",
+        c = getopt_long (argc, argv, "hx:G:a:gp:P:s:o:e:S:E:b:c:r:R:Tft:n:l:m:CMO:",
                 long_options, &option_index);
 
 
@@ -188,7 +191,11 @@ int main_chunk(int argc, char** argv) {
         case 'e':
             in_bed_file = optarg;
             break;
-
+            
+        case 'S':
+            snarl_filename = optarg;
+            break;
+            
         case 'E':
             out_bed_file = optarg;
             break;
@@ -285,6 +292,15 @@ int main_chunk(int argc, char** argv) {
         return 1;
     }
 
+    if (!snarl_filename.empty() && context_steps >= 0) {
+        cerr << "error:[vg chunk] context cannot be specified (-c) when using snarls (-S)" << endl;
+        return 1;
+    }
+    if (!snarl_filename.empty() && region_strings.empty() && path_list_file.empty() && in_bed_file.empty()) {
+        cerr << "error:[vg chunk] snarl chunking can only be used with path regions (-p -P  -e)" << endl;
+        return 1;        
+    }
+
     // check the output format
     std::transform(output_format.begin(), output_format.end(), output_format.begin(), ::tolower);
     if (!vg::io::valid_output_format(output_format)) {
@@ -298,6 +314,17 @@ int main_chunk(int argc, char** argv) {
     // but we only write the subgraphs to disk if chunk_graph is true. 
     bool chunk_gam = !gam_files.empty() && gam_split_size == 0;
     bool chunk_graph = gam_and_graph || (!chunk_gam && gam_split_size == 0);
+
+    // Load the snarls
+    unique_ptr<SnarlManager> snarl_manager;
+    if (!snarl_filename.empty()) {
+        ifstream snarl_file(snarl_filename.c_str());
+        if (!snarl_file) {
+            cerr << "error:[vg chunk] Unable to load snarls file: " << snarl_filename << endl;
+            return 1;
+        }
+        snarl_manager = vg::io::VPKG::load_one<SnarlManager>(snarl_file);
+    }
 
     // Load our index
     PathPositionHandleGraph* graph = nullptr;
@@ -474,8 +501,8 @@ int main_chunk(int argc, char** argv) {
             if (!context_length) {
                 context_steps = 1;
             }
-        } else if (!components){
-            cerr << "error:[vg chunk] context expansion steps must be specified with -c/--context when chunking on paths" << endl;
+        } else if (!components && snarl_filename.empty()){
+            cerr << "error:[vg chunk] context (-c) or snarls (-S)  must be specified when chunking on paths" << endl;
             return 1;
         }
     }
@@ -614,6 +641,9 @@ int main_chunk(int argc, char** argv) {
             subgraph = vg::io::new_output_graph<MutablePathMutableHandleGraph>(output_format);
             if (components == true) {
                 chunker.extract_path_component(region.seq, *subgraph, output_regions[i]);
+            } else if (snarl_manager.get() != nullptr) {
+                chunker.extract_snarls(region, *snarl_manager, *subgraph);
+                output_regions[i] = region;                
             } else {
                 chunker.extract_subgraph(region, context_steps, context_length,
                                          trace, *subgraph, output_regions[i]);

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 27
+plan tests 28
 
 # Construct a graph with alt paths so we can make a GBWT and a GBZ
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz -a >x.vg
@@ -19,6 +19,11 @@ is $(vg chunk -x x.xg -p x -c 10| vg stats - -E) 291 "vg chunk with no options p
 
 # check a small chunk
 is $(vg chunk -x x.xg -p x:20-30 -c 0 | vg view - -j | jq -c '.path[0].mapping[].position' | jq 'select ((.node_id == "9"))' | grep node | sed s/,// | sort | uniq | wc -l) 1 "chunk has path going through node 9"
+
+# check snarl chunking
+vg snarls x.xg > x.snarls
+is $(vg chunk -x x.xg -S x.snarls -p x:10-20 | vg view - | grep ^S | awk '{print $2}' | sort -n | awk 'BEGIN { ORS = "" } {print}') 6789 "snarl chunk works on simple example"
+rm -f x.snarls
 
 # check a small chunk, but using vg input and packed graph output
 is $(vg chunk -x x.vg -p x:20-30 -c 0 -O pg | vg convert -v - | vg view - -j | jq -c '.path[0].mapping[].position' | jq 'select ((.node_id == "9"))' | grep node | sed s/,// | sort | uniq | wc -l) 1 "chunk has path going through node 9"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * New `vg chunk` option `-S` can be used to extract every snarl that is fully contained in the the given path region (ie specified with `-p`).  This can be used instead of context steps `-c`.  The advantage is that `-S` will return everything inside the region and nothing outside the region (barring the start and end nodes), which helps with the problem of pulling out massive amounts of neighbouring regions when jacking up `-c` for complex subgraphs.  The disadvantage is that if the region specified contains only parts of snarls, the results will be a misleadingly simple graph.  

## Description
