### PR TITLE
Make `vg viz` notice and complain when you want a PNG that is larger than Cairo can draw

### DIFF
--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -116,11 +116,14 @@ int main_viz(int argc, char** argv) {
     unique_ptr<PathHandleGraph> path_handle_graph;
     bdsg::PathPositionVectorizableOverlayHelper overlay_helper;
     if (xg_name.empty()) {
-        cerr << "No XG index given. An XG index must be provided." << endl;
+        cerr << "No input graph given. An input graph (-x) must be provided." << endl;
         exit(1);
     } else {
         path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);
+        // We know the PathPositionVectorizableOverlayHelper produces a PathPositionVectorizableOverlay which implements PathPositionHandleGraph.
+        // TODO: Make the types actually work out here.
         xgidx = dynamic_cast<PathPositionHandleGraph*>(overlay_helper.apply(path_handle_graph.get()));
+        assert(xgidx != nullptr);
     }
 
     // todo one packer per thread and merge
@@ -136,8 +139,10 @@ int main_viz(int argc, char** argv) {
         pack_names = packs_in;
     }
 
-    Viz viz(xgidx, &packs, pack_names, image_out, image_width, image_height, show_cnv, show_dna, show_paths);
-    viz.draw();
+    {
+        Viz viz(xgidx, &packs, pack_names, image_out, image_width, image_height, show_cnv, show_dna, show_paths);
+        viz.draw();
+    }
 
     return 0;
 }

--- a/src/viz.hpp
+++ b/src/viz.hpp
@@ -34,6 +34,7 @@ private:
     uint64_t id_to_rank(nid_t id);
     void set_hash_color(const string& str);
     void compute_borders_and_dimensions(void);
+    void check_status(const cairo_status_t& status, const std::string& task = "calling Cairo");
     unordered_map<nid_t, uint64_t> id_rank_map;
     PathHandleGraph* xgidx = nullptr;
     vector<Packer>* packs = nullptr;

--- a/test/t/41_vg_viz.t
+++ b/test/t/41_vg_viz.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 1
+plan tests 5
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg
 vg index -x t.xg -g t.gcsa t.vg
@@ -15,4 +15,16 @@ vg map -G <(vg sim -l 30 -n 100 -x t.xg -a) -d t | vg pack -x t.xg -o t.cx -g -
 vg viz -x t.xg -o t.svg -i t.cx -n alignments
 is $(echo $(wc -c t.svg | cut -f 1 -d\ )' > 0' | bc) 1 "vg viz runs"
 
-rm -f t.vg t.xg t.gcsa t.gcsa.lcp t.cx
+rm -f t.png
+vg viz -x t.xg -o t.png
+is "${?}" "0" "vg viz succeeds when drawing a PNG"
+stat t.png 2>/dev/null >/dev/null
+is "${?}" "0" "vg viz actually creates an output PNG"
+
+rm -f cactus.png
+vg viz -x graphs/cactus-BRCA2.gfa -o cactus.png
+is "${?}" "0" "vg viz succeeds when drawing a larger PNG from GFA"
+stat cactus.png 2>/dev/null >/dev/null
+is "${?}" "0" "vg viz actually creates a larger PNG from GFA"
+
+rm -f t.vg t.xg t.gcsa t.gcsa.lcp t.cx t.svg t.png cactus.png

--- a/test/t/41_vg_viz.t
+++ b/test/t/41_vg_viz.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 5
+plan tests 4
 
 vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz >t.vg
 vg index -x t.xg -g t.gcsa t.vg
@@ -21,10 +21,7 @@ is "${?}" "0" "vg viz succeeds when drawing a PNG"
 stat t.png 2>/dev/null >/dev/null
 is "${?}" "0" "vg viz actually creates an output PNG"
 
-rm -f cactus.png
 vg viz -x graphs/cactus-BRCA2.gfa -o cactus.png
-is "${?}" "0" "vg viz succeeds when drawing a larger PNG from GFA"
-stat cactus.png 2>/dev/null >/dev/null
-is "${?}" "0" "vg viz actually creates a larger PNG from GFA"
+is "${?}" "1" "vg viz knows when a graph is too big to draw as a PNG"
 
-rm -f t.vg t.xg t.gcsa t.gcsa.lcp t.cx t.svg t.png cactus.png
+rm -f t.vg t.xg t.gcsa t.gcsa.lcp t.cx t.svg t.png


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg viz` no longer silently fails when asked to draw a PNG that is too big for Cairo

## Description

This will fix the silent failure and apparent commend success in #3788, though it doesn't actually let you draw any PNGs that couldn't be drawn before.