### PR TITLE
Run edge filter as well in vg clip

### DIFF
--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -485,6 +485,7 @@ void clip_low_depth_nodes_and_edges_generic(MutablePathMutableHandleGraph* graph
                     handle_t handle = graph->get_handle_of_step(step_handle);
                     if (!first) {
                         edge_t edge = graph->edge_handle(prev_handle, handle);
+                        size_t edge_rank = edge_hash.lookup(edge);
                         int64_t edge_depth = edge_depths.get(edge_rank);
                         if (edge_depth < min_depth) {
                             if (is_ref_path) {

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -59,21 +59,22 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
  * Nodes on path with given prefix ignored (todo: should really switch to regex or something)
  * iterate_handles is a hack to generalize this function to whole graphs or snarls
  */
-void clip_low_depth_nodes_generic(MutablePathMutableHandleGraph* graph, function<void(function<void(handle_t, const Region*)>)> iterate_handles,
-                                  int64_t min_depth, const vector<string>& ref_prefixes,
-                                  int64_t min_fragment_len, bool verbose);
-
+void clip_low_depth_nodes_and_edges_generic(MutablePathMutableHandleGraph* graph,
+                                            function<void(function<void(handle_t, const Region*)>)> iterate_handles,
+                                            function<void(function<void(edge_t, const Region*)>)> iterate_edges,
+                                            int64_t min_depth, const vector<string>& ref_prefixes,
+                                            int64_t min_fragment_len, bool verbose);
 
 /**
  * Run above function on graph
  */
-void clip_low_depth_nodes(MutablePathMutableHandleGraph* graph, int64_t min_depth, const vector<string>& ref_prefixes,
+void clip_low_depth_nodes_and_edges(MutablePathMutableHandleGraph* graph, int64_t min_depth, const vector<string>& ref_prefixes,
                           int64_t min_fragment_len, bool verbose);
 
 /**
  * Or on contained snarls
  */
-void clip_contained_low_depth_nodes(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
+void clip_contained_low_depth_nodes_and_edges(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
                                     SnarlManager& snarl_manager, bool include_endpoints, int64_t min_depth, int64_t min_fragment_len, bool verbose);
 
 /**

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -24,7 +24,7 @@ void help_clip(char** argv) {
        << "    -b, --bed FILE            BED regions corresponding to path intervals of the graph to target" << endl
        << "    -r, --snarls FILE         Snarls from vg snarls (recomputed if not given unless -d and -P used)." << endl
        << "depth clipping options: " << endl
-       << "    -d, --depth N             Clip out nodes with path depth below N" << endl
+       << "    -d, --depth N             Clip out nodes and edges with path depth below N" << endl
        << "snarl complexity clipping options: [default mode]" << endl
        << "    -n, --max-nodes N         Only clip out snarls with > N nodes" << endl
        << "    -e, --max-edges N         Only clip out snarls with > N edges" << endl
@@ -41,7 +41,7 @@ void help_clip(char** argv) {
        << "    -m, --min-fragment-len N  Don't write novel path fragment if it is less than N bp long" << endl
        << "    -B, --output-bed          Write BED-style file of affected intervals instead of clipped graph. " << endl
        << "                              Columns 4-9 are: snarl node-count edge-count shallow-node-count shallow-edge-count avg-degree" << endl
-       << "    -t, --threads N           number of threads to use (used only for computing snarls) [default: all available]" << endl
+       << "    -t, --threads N           number of threads to use [default: all available]" << endl
        << "    -v, --verbose             Print some logging messages" << endl
        << endl;
 }    
@@ -315,10 +315,10 @@ int main_clip(int argc, char** argv) {
         // run the depth clipping       
         if (bed_path.empty()) {            
             // do the whole graph
-            clip_low_depth_nodes(graph.get(), min_depth, ref_prefixes, min_fragment_len, verbose);
+            clip_low_depth_nodes_and_edges(graph.get(), min_depth, ref_prefixes, min_fragment_len, verbose);
         } else {
             // do the contained snarls
-            clip_contained_low_depth_nodes(graph.get(), pp_graph, bed_regions, *snarl_manager, false, min_depth, min_fragment_len, verbose);
+            clip_contained_low_depth_nodes_and_edges(graph.get(), pp_graph, bed_regions, *snarl_manager, false, min_depth, min_fragment_len, verbose);
         }
         
     } else if (max_deletion >= 0) {

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -717,16 +717,22 @@ int main_paths(int argc, char** argv) {
                         }
                     }
                     if (list_cyclicity) {
-                        bool cyclic = false;
+                        bool directed_cyclic = false; // same node visited twice in same orientation
+                        bool undirected_cyclic = false; // same not visited twice in any orientation
                         unordered_set<handle_t> visits;
                         graph->for_each_step_in_path(path_handle, [&](step_handle_t step_handle) {
-                                pair<unordered_set<handle_t>::iterator, bool> ret = visits.insert(graph->get_handle_of_step(step_handle));
-                                if (ret.second == false) {
-                                    cyclic = true;
+                                handle_t handle = graph->get_handle_of_step(step_handle);
+                                if (visits.count(handle)) {
+                                    directed_cyclic = true;
+                                    undirected_cyclic = false;
+                                } else if (visits.count(graph->flip(handle))) {
+                                    undirected_cyclic = true;
                                 }
-                                return !cyclic;
+                                visits.insert(handle);
+                                return !directed_cyclic || !undirected_cyclic;
                             });
-                        cout << "\t" << (cyclic ? "cyclic" : "acyclic");
+                        cout << "\t" << (directed_cyclic ? "directed-cyclic" : "directed-acyclic")
+                             << "\t" << (undirected_cyclic ? "undirected-cyclic" : "undirected-acyclic");
                     }
                     cout << endl;
                 } else {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg clip -d` now removes *edges* not meeting the depth threshold, in addition to nodes
 * `vg paths -C` reports both undirected and directed cyclicity

