### PR TITLE
Make Makefile fully responsible for finding coreutils and Macports libraries on Mac

### DIFF
--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -54,13 +54,6 @@ jobs:
 
       - name: Run build and test
         run: |
-          brew --prefix
-          export PATH="$(brew --prefix)/opt/coreutils/libexec/gnubin:/usr/local/opt/bison/bin:$(pwd)/bin:/usr/local/bin:$PATH"
-          which wc
-          wc --version
-          export LD_LIBRARY_PATH=/usr/local/lib/
-          export LIBRARY_PATH=/usr/local/lib/
-          export CFLAGS="-isystem /usr/local/include/"
           export VG_FULL_TRACEBACK=1
           echo "Build with $(nproc) threads"
           make -j$(nproc) test

--- a/README.md
+++ b/README.md
@@ -106,22 +106,6 @@ Homebrew provides another package management solution for OSX, and may be prefer
     # Install all the dependencies in the Brewfile
     brew bundle
     
-    # Use GNU versions of coreutils over Apple versions
-    export PATH="/usr/local/opt/coreutils/libexec/gnubin:/usr/local/bin:$PATH"
-
-    # Force use of new version of bison
-    brew link bison --force
-    # NOTE! If brew says that it is refusing to link Bison, follow its suggested
-    # instructions to put Bison on your PATH instead.
-
-    # Use glibtool/ize
-    export LIBTOOL=glibtool
-    export LIBTOOLIZE=glibtoolize
-
-    # Use installed libraries
-    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH;
-    export LIBRARY_PATH=$LD_LIBRARY_PATH;
-
 #### Build
 
 With dependencies installed, VG can now be built:


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Macports-based installation instructions have been simplified

## Description

It turns out `brew link --force bison` hasn't done anything for a while, and the Makefile has a much better idea where Macports stuff actually is than the README or the mac test workflow really can. So it should just be in charge of setting up the necessary flags.
