### PR TITLE
ID Clang even if its version is not on the first line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ ifeq ($(strip $(shell $(CXX) -latomic /dev/null -o/dev/null 2>&1 | grep latomic 
     LD_LIB_FLAGS += -latomic
 endif
 
-COMPILER_ID=$(strip $(shell $(CXX) --version 2>&1 | head -n1))
+COMPILER_ID=$(strip $(shell $(CXX) --version 2>&1))
 ifeq ($(shell uname -s),Darwin)
     $(info OS is Mac)
     # Don't try and set an rpath on any dependency utilities because that's not
@@ -145,9 +145,9 @@ ifeq ($(shell uname -s),Darwin)
     endif
 
     # Our compiler might be Apple clang, which doesn't have -fopenmp.
-    ifeq ($(strip $(shell echo "$(COMPILER_ID)" | grep -i clang | wc -l)), 1)
+    ifneq ($(strip $(shell echo "$(COMPILER_ID)" | grep -i clang | wc -l)), 0)
         # This is Clang.
-        $(info Compiler $(COMPILER_ID) is Clang)
+        $(info Compiler $(CXX) is Clang)
 
         # We need to use the hard way of getting OpenMP not bundled with the compiler.
         # The compiler only needs to do the preprocessing
@@ -173,7 +173,7 @@ ifeq ($(shell uname -s),Darwin)
         # We also need to link it
         LD_LIB_FLAGS += -lomp
     else
-        $(info Compiler $(COMPILER_ID) is GCC)
+        $(info Compiler $(CXX) is GCC)
         # The compiler is (probably?) GNU GCC
         # On Mac, we need to make sure to configure it to use libc++ like
         # Clang, and not GNU libstdc++.
@@ -210,7 +210,7 @@ ifeq ($(shell uname -s),Darwin)
 else
     # We are not running on OS X
     $(info OS is Linux)
-    $(info Compiler $(COMPILER_ID) is GCC)
+    $(info Compiler $(CXX) is assumed to be GCC)
 
     # Set an rpath for vg and dependency utils to find installed libraries
     LD_UTIL_RPATH_FLAGS="-Wl,-rpath,$(CWD)/$(LIB_DIR)"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg Mac build now works even if `g++ --version` doesn't actually have the version string on the first line

## Description

`g++ --version` (now?) starts with a line about configuration options on Mac when Clang is providing the compiler via the `g++` alias. We need to handle this properly in order to build vg without making the user set `$CC`/`$CXX` themselves.
