### PR TITLE
Make vg chunk and vg trace be able to get GBWT from input graph

### DIFF
--- a/src/algorithms/find_gbwt.cpp
+++ b/src/algorithms/find_gbwt.cpp
@@ -1,0 +1,39 @@
+/**
+ * \file find_gbwt.cpp
+ */
+
+#include "find_gbwt.hpp"
+#include "find_gbwtgraph.hpp"
+#include <vg/io/vpkg.hpp>
+
+#include "../gbzgraph.hpp"
+
+namespace vg {
+namespace algorithms {
+
+const gbwt::GBWT* find_gbwt(const HandleGraph* graph) {
+    const gbwtgraph::GBWTGraph* typed_graph = find_gbwtgraph(graph);
+    if (!typed_graph) {
+        return nullptr;
+    }
+    return typed_graph->index;
+}
+
+const gbwt::GBWT* find_gbwt(const HandleGraph* graph, std::unique_ptr<gbwt::GBWT>& holder, const std::string& filename) {
+    if (!filename.empty()) {
+        holder = vg::io::VPKG::load_one<gbwt::GBWT>(filename);
+
+        if (holder.get() == nullptr) {
+          // Complain if we couldn't get it but were supposed to.
+          cerr << "error:[vg::algorithms::find_gbwt] unable to load gbwt index file " << filename << endl;
+          exit(1);
+        }
+        
+        return holder.get();
+    }
+    // If we don't need to load it, try and get it from the graph.
+    return find_gbwt(graph);
+}
+
+}
+}

--- a/src/algorithms/find_gbwt.hpp
+++ b/src/algorithms/find_gbwt.hpp
@@ -1,0 +1,33 @@
+#ifndef VG_ALGORITHMS_FIND_GBWT_HPP_INCLUDED
+#define VG_ALGORITHMS_FIND_GBWT_HPP_INCLUDED
+
+/**
+ * \file find_gbwtgraph.hpp
+ *
+ * Defines an algorithm for finding the GBWTGraph associated with a handle graph, if any.
+ */
+
+#include "../handle.hpp"
+#include <gbwtgraph/gbwtgraph.h>
+
+namespace vg {
+namespace algorithms {
+using namespace std;
+
+/**
+ * Find the GBWT that is part of the given handle graph, if any exists.
+ * Works on GBWTGraphs and GBZGraphs.
+ * Returns null if no such GBWT exists.
+ */
+const gbwt::GBWT* find_gbwt(const HandleGraph* graph);
+
+/**
+ * Find a GBWT either by getting it from the given graph or loading it from the
+ * given filename into the given unique_ptr.
+ */
+const gbwt::GBWT* find_gbwt(const HandleGraph* graph, std::unique_ptr<gbwt::GBWT>& holder, const std::string& filename);
+
+}
+}
+
+#endif

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -5,12 +5,16 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 28
+plan tests 30
 
 # Construct a graph with alt paths so we can make a GBWT and a GBZ
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz -a >x.vg
-vg index -x x.xg -G x.gbwt -v small/x.vcf.gz  x.vg
-vg gbwt -x x.xg -v small/x.vcf.gz --gbz-format -g x.gbz
+vg index -x x.xg x.vg
+vg gbwt -x x.vg -v small/x.vcf.gz -o x.haps.gbwt
+vg gbwt -x x.vg -E -o x.paths.gbwt
+vg gbwt -m x.haps.gbwt x.paths.gbwt -o x.gbwt
+vg gbwt -x x.vg x.gbwt --gbz-format -g x.gbz
+
 vg view -a small/x-l100-n1000-s10-e0.01-i0.01.gam > x.gam.json
 
 # sanity check: does passing no options preserve input
@@ -19,6 +23,7 @@ is $(vg chunk -x x.xg -p x -c 10| vg stats - -E) 291 "vg chunk with no options p
 
 # check a small chunk
 is $(vg chunk -x x.xg -p x:20-30 -c 0 | vg view - -j | jq -c '.path[0].mapping[].position' | jq 'select ((.node_id == "9"))' | grep node | sed s/,// | sort | uniq | wc -l) 1 "chunk has path going through node 9"
+is $(vg chunk -x x.gbz -p x:20-30 -c 0 | vg view - -j | jq -c '.path[0].mapping[].position' | jq 'select ((.node_id == "9"))' | grep node | sed s/,// | sort | uniq | wc -l) 1 "chunk can be found from GBZ"
 
 # check snarl chunking
 vg snarls x.xg > x.snarls
@@ -58,8 +63,9 @@ is $(vg chunk -x x.xg -r 1 -c 0 | vg view - -j | jq .node | grep id | wc -l) 1 "
 # Check that traces work on a GBWT
 is $(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq .node | grep id | wc -l) 5 "id chunker traces correct chunk size"
 is "$(vg chunk -x x.xg -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.name != "x[0]")' | wc -l)" 0 "chunker extracts no threads from an empty gPBWT"
-is "$(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.name != "x[0]")' | wc -l)" 2 "chunker extracts 2 local threads from a gBWT with 2 locally distinct threads in it"
+is "$(vg chunk -x x.xg -G x.haps.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.name != "x[0]")' | wc -l)" 2 "chunker extracts 2 local threads from a gBWT with 2 locally distinct threads in it"
 is "$(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -r '.path[] | select(.name == "thread_0") | .mapping | length')" 3 "chunker can extract a partial haplotype from a GBWT"
+is "$(vg chunk -x x.gbz -r 1:1 -c 2 -T | vg view - -j | jq -r '.path[] | select(.name == "thread_0") | .mapping | length')" 3 "chunker can extract a partial haplotype from a GBZ"
 
 vg chunk -x x.xg -G x.gbwt -p x:50-100 -c 0 -T | vg view - | grep ^S | sort > cnodes
 vg find -x x.xg -p x:50-100 -c 0 | vg view - | grep ^S | sort > fnodes


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg chunk` and `vg trace` can now get haplotypes from an input GBZ file

## Description

We need this fro the tube map to work well with a GBZ file.