### PR TITLE
Fix rescue

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -36,6 +36,8 @@
 //#define debug_fragment_distr
 //Do a brute force check that clusters are correct
 //#define debug_validate_clusters
+// Make sure by-index references are correct
+//#define debug_validate_index_references
 
 namespace vg {
 
@@ -1280,6 +1282,8 @@ struct read_alignment_index_t {
         return a[fragment][read][alignment]; 
     }
     
+    /// Make sure that this index actually points to an alignment of the given
+    /// read in the given structure. Throws if not.
     template<typename NestedArray>
     void check_for_read_in(bool read, NestedArray& a) const {
         a.at(fragment).at(read).at(alignment); 
@@ -1968,10 +1972,12 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                     for (auto r : {0, 1}) {
                         paired_alignments.back()[r] = read_alignment_index_t {fragment_num, aln_index[r]};
                     }
+#ifdef debug_validate_index_references
                     for (auto r : {0, 1}) {
                         // Make sure we refer to things that exist.
                         paired_alignments.back().at(r).check_for_read_in(r, alignments);
                     }
+#endif
                     
                     paired_scores.emplace_back(score);
                     fragment_distances.emplace_back(fragment_distance);
@@ -2122,10 +2128,12 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                     paired_alignments.back()[r] = best_index[r].without_read();
                     winners[r] = &best_index[r].lookup_in(alignments);
                 }
+#ifdef debug_validate_index_references
                 for (auto r : {0, 1}) {
                     // Make sure we refer to things that exist.
                     paired_alignments.back().at(r).check_for_read_in(r, alignments);
                 }
+#endif
                 
                 //Assume the distance between them is infinite
                 double pair_score = score_alignment_pair(*winners[0], *winners[1], std::numeric_limits<int64_t>::max());
@@ -2202,10 +2210,12 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                     index_pair[1 - index.read] = rescued_index;
                     
                     paired_alignments.emplace_back(std::move(index_pair));
+#ifdef debug_validate_index_references
                     for (auto r : {0, 1}) {
                         // Make sure we refer to things that exist.
                         paired_alignments.back().at(r).check_for_read_in(r, alignments);
                     }
+#endif
                     
                     paired_scores.emplace_back(score);
                     fragment_distances.emplace_back(fragment_dist);

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2191,11 +2191,11 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                     //add the new alignment to the list of alignments 
                     //(in a separate "fragment cluster" vector for rescued alignments) and keep track of its index
                     //
-                    read_alignment_index_t mapped_index {index.read, index.alignment}; 
+                    read_alignment_index_t mapped_index = index.without_read();
                     read_alignment_index_t rescued_index {alignments.size() - 1, alignments.back()[1 - index.read].size()};
                     alignments.back()[1 - index.read].emplace_back(std::move(rescued_aln));
                     rescued_count[index.read]++;
-
+                    
                     alignment_groups.back()[1 - index.read].emplace_back();
                     std::array<read_alignment_index_t, 2> index_pair;
                     index_pair[index.read] = mapped_index;

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -1263,7 +1263,9 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
     }
 }
 
-// For paired-end alignment we use a bunch of structures indexed by clustering fragment, then read, then alignment of the read. So we define some insex types and lookup functions to deal with these.
+// For paired-end alignment we use a bunch of structures indexed by clustering
+// fragment, then read, then alignment of the read. So we define some index
+// types and lookup functions to deal with these.
 // TODO: Make these local classes when C++ learns to let you use template members in local classes.
 
 /// Type to point to an alignment of a known read
@@ -1276,6 +1278,11 @@ struct read_alignment_index_t {
     template<typename NestedArray>
     auto lookup_for_read_in(bool read, NestedArray& a) const -> typename std::add_lvalue_reference<decltype(a[0][0][0])>::type {
         return a[fragment][read][alignment]; 
+    }
+    
+    template<typename NestedArray>
+    void check_for_read_in(bool read, NestedArray& a) const {
+        a.at(fragment).at(read).at(alignment); 
     }
     
     // Allow comparison
@@ -1961,6 +1968,10 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                     for (auto r : {0, 1}) {
                         paired_alignments.back()[r] = read_alignment_index_t {fragment_num, aln_index[r]};
                     }
+                    for (auto r : {0, 1}) {
+                        // Make sure we refer to things that exist.
+                        paired_alignments.back().at(r).check_for_read_in(r, alignments);
+                    }
                     
                     paired_scores.emplace_back(score);
                     fragment_distances.emplace_back(fragment_distance);
@@ -2111,6 +2122,10 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                     paired_alignments.back()[r] = best_index[r].without_read();
                     winners[r] = &best_index[r].lookup_in(alignments);
                 }
+                for (auto r : {0, 1}) {
+                    // Make sure we refer to things that exist.
+                    paired_alignments.back().at(r).check_for_read_in(r, alignments);
+                }
                 
                 //Assume the distance between them is infinite
                 double pair_score = score_alignment_pair(*winners[0], *winners[1], std::numeric_limits<int64_t>::max());
@@ -2187,6 +2202,11 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                     index_pair[1 - index.read] = rescued_index;
                     
                     paired_alignments.emplace_back(std::move(index_pair));
+                    for (auto r : {0, 1}) {
+                        // Make sure we refer to things that exist.
+                        paired_alignments.back().at(r).check_for_read_in(r, alignments);
+                    }
+                    
                     paired_scores.emplace_back(score);
                     fragment_distances.emplace_back(fragment_dist);
                     pair_types.push_back(index.read == 0 ? rescued_from_first : rescued_from_second); 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Rescue alignment in `vg giraffe` paired-end mode should no longer decide it rescued off of the wrong alignments 

## Description

When I refactored the way the paired-end mapping system in Giraffe deals with referring to candidate alignments, I broke rescue by mis-generating the index-based references to the alignments they were rescued off of. We didn't notice this immediately because I was always using the read number (0 or 1) instead of the fragment number (likely much larger), and the alignment number would tend to be small because the alignment was used for rescue.

Jean caught it in #3826 because it managed to refer to a supposed rescue source fragment with *no* alignments.

This should fix #3826. We might want to do a v1.45.1 patch release because I think rescue is going to give wrong answers without this.