### PR TITLE
Track and transfer read annotations more consistently in multipath alignment conversions

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -826,7 +826,6 @@ namespace vg {
 
         // transfer read information over to alignment
         transfer_read_metadata(multipath_aln, aln_out);
-        aln_out.set_mapping_quality(multipath_aln.mapping_quality());
         
         // do dynamic programming and traceback the optimal alignment
         int32_t score = optimal_alignment_internal(multipath_aln, &aln_out, subpath_global);
@@ -1102,7 +1101,6 @@ namespace vg {
                 // Set up read info and MAPQ
                 // TODO: MAPQ on secondaries?
                 transfer_read_metadata(multipath_aln, aln_out);
-                aln_out.set_mapping_quality(multipath_aln.mapping_quality());
                 
                 // Populate path
                 populate_path_from_traceback(multipath_aln, problem, basis.begin(), basis.end(), aln_out.mutable_path());
@@ -1342,8 +1340,7 @@ namespace vg {
                     
                     // Set up read info and MAPQ
                     // TODO: MAPQ on secondaries?
-                    transfer_read_metadata(multipath_aln, aln_out);
-                    aln_out.set_mapping_quality(multipath_aln.mapping_quality());
+                    transfer_read_metadata(multipath_aln, aln_out);\
                     
                     // Populate path
                     populate_path_from_traceback(multipath_aln, problem, basis.begin(), basis.end(), aln_out.mutable_path());
@@ -1813,7 +1810,6 @@ namespace vg {
                 // Set up read info and MAPQ
                 // TODO: MAPQ on secondaries?
                 transfer_read_metadata(multipath_aln, aln_out);
-                aln_out.set_mapping_quality(multipath_aln.mapping_quality());
                 
                 // Populate path
                 populate_path_from_traceback(multipath_aln, problem, basis.begin(), basis.end(), aln_out.mutable_path());
@@ -2152,82 +2148,6 @@ namespace vg {
         convert_multipath_alignment_char(multipath_aln, 'T', 'U');
     }
 
-    void to_proto_multipath_alignment(const multipath_alignment_t& multipath_aln,
-                                      MultipathAlignment& proto_multipath_aln_out) {
-        proto_multipath_aln_out.clear_subpath();
-        proto_multipath_aln_out.clear_start();
-        transfer_read_metadata(multipath_aln, proto_multipath_aln_out);
-        proto_multipath_aln_out.set_mapping_quality(multipath_aln.mapping_quality());
-        for (const auto& subpath : multipath_aln.subpath()) {
-            auto subpath_copy = proto_multipath_aln_out.add_subpath();
-            subpath_copy->set_score(subpath.score());
-            for (auto next : subpath.next()) {
-                subpath_copy->add_next(next);
-            }
-            for (const auto& connection : subpath.connection()) {
-                auto connection_copy = subpath_copy->add_connection();
-                connection_copy->set_next(connection.next());
-                connection_copy->set_score(connection.score());
-            }
-            if (subpath.has_path()) {
-                const auto& path = subpath.path();
-                auto path_copy = subpath_copy->mutable_path();
-                to_proto_path(path, *path_copy);
-            }
-        }
-        for (auto start : multipath_aln.start()) {
-            proto_multipath_aln_out.add_start(start);
-        }
-    }
-
-    void from_proto_multipath_alignment(const MultipathAlignment& proto_multipath_aln,
-                                        multipath_alignment_t& multipath_aln_out) {
-        multipath_aln_out.clear_subpath();
-        multipath_aln_out.clear_start();
-        transfer_read_metadata(proto_multipath_aln, multipath_aln_out);
-        multipath_aln_out.set_mapping_quality(proto_multipath_aln.mapping_quality());
-        for (auto subpath : proto_multipath_aln.subpath()) {
-            auto subpath_copy = multipath_aln_out.add_subpath();
-            subpath_copy->set_score(subpath.score());
-            for (auto next : subpath.next()) {
-                subpath_copy->add_next(next);
-            }
-            for (const auto& connection : subpath.connection()) {
-                auto connection_copy = subpath_copy->add_connection();
-                connection_copy->set_next(connection.next());
-                connection_copy->set_score(connection.score());
-            }
-            if (subpath.has_path()) {
-                auto path = subpath.path();
-                auto path_copy = subpath_copy->mutable_path();
-                from_proto_path(path, *path_copy);
-            }
-        }
-        
-        for (auto start : proto_multipath_aln.start()) {
-            multipath_aln_out.add_start(start);
-        }
-    }
-    
-    void to_multipath_alignment(const Alignment& aln, multipath_alignment_t& multipath_aln_out) {
-        
-        // clear repeated fields
-        multipath_aln_out.clear_subpath();
-        multipath_aln_out.clear_start();
-        
-        // transfer read and alignment metadata
-        transfer_read_metadata(aln, multipath_aln_out);
-        multipath_aln_out.set_mapping_quality(aln.mapping_quality());
-        
-        // transfer alignment and score
-        if (aln.has_path() || aln.score()) {
-            subpath_t* subpath = multipath_aln_out.add_subpath();
-            subpath->set_score(aln.score());
-            from_proto_path(aln.path(), *subpath->mutable_path());
-        }
-        identify_start_subpaths(multipath_aln_out);
-    }
-
     template<class ProtoAlignment>
     void transfer_from_proto_annotation(const ProtoAlignment& from, multipath_alignment_t& to) {
         for_each_basic_annotation(from,
@@ -2260,21 +2180,109 @@ namespace vg {
         });
     }
 
-    void transfer_read_metadata(const MultipathAlignment& from, multipath_alignment_t& to) {
+    // TODO: our proto annotation system actually doesn't seem to allow null annotations...
+    template<class ProtoAlignment1, class ProtoAlignment2>
+    void transfer_between_proto_annotation(const ProtoAlignment1& from, ProtoAlignment2& to) {
+        for_each_basic_annotation(from,
+                                  [&to](const string& name) { return; },
+                                  [&to](const string& name, double value) { set_annotation(to, name, value); },
+                                  [&to](const string& name, bool value) { set_annotation(to, name, value); },
+                                  [&to](const string& name, const string& value) { set_annotation(to, name, value); });
+    }
+
+    // transfers the metadata that is shared across all formats
+    template<class Alignment1, class Alignment2>
+    void transfer_uniform_metadata(const Alignment1& from, Alignment2& to) {
         to.set_sequence(from.sequence());
         to.set_quality(from.quality());
+        to.set_mapping_quality(from.mapping_quality());
+    }
+
+    void to_proto_multipath_alignment(const multipath_alignment_t& multipath_aln,
+                                      MultipathAlignment& proto_multipath_aln_out) {
+        proto_multipath_aln_out.clear_subpath();
+        proto_multipath_aln_out.clear_start();
+        transfer_read_metadata(multipath_aln, proto_multipath_aln_out);
+        for (const auto& subpath : multipath_aln.subpath()) {
+            auto subpath_copy = proto_multipath_aln_out.add_subpath();
+            subpath_copy->set_score(subpath.score());
+            for (auto next : subpath.next()) {
+                subpath_copy->add_next(next);
+            }
+            for (const auto& connection : subpath.connection()) {
+                auto connection_copy = subpath_copy->add_connection();
+                connection_copy->set_next(connection.next());
+                connection_copy->set_score(connection.score());
+            }
+            if (subpath.has_path()) {
+                const auto& path = subpath.path();
+                auto path_copy = subpath_copy->mutable_path();
+                to_proto_path(path, *path_copy);
+            }
+        }
+        for (auto start : multipath_aln.start()) {
+            proto_multipath_aln_out.add_start(start);
+        }
+    }
+
+    void from_proto_multipath_alignment(const MultipathAlignment& proto_multipath_aln,
+                                        multipath_alignment_t& multipath_aln_out) {
+        multipath_aln_out.clear_subpath();
+        multipath_aln_out.clear_start();
+        transfer_read_metadata(proto_multipath_aln, multipath_aln_out);
+        for (auto subpath : proto_multipath_aln.subpath()) {
+            auto subpath_copy = multipath_aln_out.add_subpath();
+            subpath_copy->set_score(subpath.score());
+            for (auto next : subpath.next()) {
+                subpath_copy->add_next(next);
+            }
+            for (const auto& connection : subpath.connection()) {
+                auto connection_copy = subpath_copy->add_connection();
+                connection_copy->set_next(connection.next());
+                connection_copy->set_score(connection.score());
+            }
+            if (subpath.has_path()) {
+                auto path = subpath.path();
+                auto path_copy = subpath_copy->mutable_path();
+                from_proto_path(path, *path_copy);
+            }
+        }
+        
+        for (auto start : proto_multipath_aln.start()) {
+            multipath_aln_out.add_start(start);
+        }
+    }
+    
+    void to_multipath_alignment(const Alignment& aln, multipath_alignment_t& multipath_aln_out) {
+        
+        // clear repeated fields
+        multipath_aln_out.clear_subpath();
+        multipath_aln_out.clear_start();
+        
+        // transfer read and alignment metadata
+        transfer_read_metadata(aln, multipath_aln_out);
+        
+        // transfer alignment and score
+        if (aln.has_path() || aln.score()) {
+            subpath_t* subpath = multipath_aln_out.add_subpath();
+            subpath->set_score(aln.score());
+            from_proto_path(aln.path(), *subpath->mutable_path());
+        }
+        identify_start_subpaths(multipath_aln_out);
+    }
+
+    void transfer_read_metadata(const MultipathAlignment& from, multipath_alignment_t& to) {
+        transfer_uniform_metadata(from, to);
         transfer_from_proto_annotation(from, to);
     }
 
     void transfer_read_metadata(const multipath_alignment_t& from, MultipathAlignment& to) {
-        to.set_sequence(from.sequence());
-        to.set_quality(from.quality());
+        transfer_uniform_metadata(from, to);
         transfer_to_proto_annotation(from, to);
     }
     
     void transfer_read_metadata(const multipath_alignment_t& from, multipath_alignment_t& to) {
-        to.set_sequence(from.sequence());
-        to.set_quality(from.quality());
+        transfer_uniform_metadata(from, to);
         from.for_each_annotation([&](const string& anno_name, multipath_alignment_t::anno_type_t type, const void* value) {
             switch (type) {
                 case multipath_alignment_t::Null:
@@ -2298,25 +2306,33 @@ namespace vg {
     }
     
     void transfer_read_metadata(const Alignment& from, multipath_alignment_t& to) {
-        to.set_sequence(from.sequence());
-        to.set_quality(from.quality());
+        transfer_uniform_metadata(from, to);
         transfer_from_proto_annotation(from, to);
+        if (from.is_secondary()) {
+            to.set_annotation("secondary", true);
+        }
     }
     
     void transfer_read_metadata(const multipath_alignment_t& from, Alignment& to) {
-        to.set_sequence(from.sequence());
-        to.set_quality(from.quality());
+        transfer_uniform_metadata(from, to);
         transfer_to_proto_annotation(from, to);
+        if (from.has_annotation("secondary")) {
+            auto annotation = from.get_annotation("secondary");
+            assert(annotation.first == multipath_alignment_t::Bool);
+            to.set_is_secondary(*((bool*) annotation.second));
+        }
     }
 
     void transfer_read_metadata(const Alignment& from, Alignment& to) {
-        to.set_sequence(from.sequence());
-        to.set_quality(from.quality());
-        // TODO: do I still care about these fields now that they're taken out
-        // of multipath_alignment_t?
+        transfer_uniform_metadata(from, to);
+        
         to.set_read_group(from.read_group());
         to.set_name(from.name());
         to.set_sample_name(from.sample_name());
+        to.set_is_secondary(from.is_secondary());
+        
+        transfer_between_proto_annotation(from, to);
+        
         if (from.has_fragment_prev()) {
             *to.mutable_fragment_prev() = from.fragment_prev();
         }
@@ -2326,28 +2342,6 @@ namespace vg {
         if (from.has_annotation()) {
             *to.mutable_annotation() = from.annotation();
         }
-    }
-
-    void transfer_proto_metadata(const Alignment& from, MultipathAlignment& to) {
-        // transfer over the fields that are included only in the protobuf object
-        to.set_name(from.name());
-        to.set_read_group(from.read_group());
-        to.set_sample_name(from.sample_name());
-        if (from.has_fragment_prev()) {
-            to.set_paired_read_name(from.fragment_prev().name());
-        }
-        else if (from.has_fragment_next()) {
-            to.set_paired_read_name(from.fragment_next().name());
-        }
-    }
-
-    void transfer_proto_metadata(const MultipathAlignment& from, Alignment& to) {
-        // transfer over the fields that are included only in the protobuf object
-        to.set_name(from.name());
-        to.set_read_group(from.read_group());
-        to.set_sample_name(from.sample_name());
-        
-        // not doing paired name because need extra logic to decide if it's prev or next
     }
     
     void merge_non_branching_subpaths(multipath_alignment_t& multipath_aln,

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -2343,6 +2343,28 @@ namespace vg {
             *to.mutable_annotation() = from.annotation();
         }
     }
+
+    void transfer_proto_metadata(const Alignment& from, MultipathAlignment& to) {
+        // transfer over the fields that are included only in the protobuf object
+        to.set_name(from.name());
+        to.set_read_group(from.read_group());
+        to.set_sample_name(from.sample_name());
+        if (from.has_fragment_prev()) {
+            to.set_paired_read_name(from.fragment_prev().name());
+        }
+        else if (from.has_fragment_next()) {
+            to.set_paired_read_name(from.fragment_next().name());
+        }
+    }
+
+    void transfer_proto_metadata(const MultipathAlignment& from, Alignment& to) {
+        // transfer over the fields that are included only in the protobuf object
+        to.set_name(from.name());
+        to.set_read_group(from.read_group());
+        to.set_sample_name(from.sample_name());
+        
+        // not doing paired name because need extra logic to decide if it's prev or next
+    }
     
     void merge_non_branching_subpaths(multipath_alignment_t& multipath_aln,
                                       const unordered_set<size_t>* prohibited_merges) {

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -1340,7 +1340,7 @@ namespace vg {
                     
                     // Set up read info and MAPQ
                     // TODO: MAPQ on secondaries?
-                    transfer_read_metadata(multipath_aln, aln_out);\
+                    transfer_read_metadata(multipath_aln, aln_out);
                     
                     // Populate path
                     populate_path_from_traceback(multipath_aln, problem, basis.begin(), basis.end(), aln_out.mutable_path());

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -322,10 +322,6 @@ namespace vg {
 
     void transfer_read_metadata(const multipath_alignment_t& from, MultipathAlignment& to);
 
-    void transfer_proto_metadata(const Alignment& from, MultipathAlignment& to);
-
-    void transfer_proto_metadata(const MultipathAlignment& from, Alignment& to);
-
     /// Merges non-branching paths in a multipath alignment in place
     /// Does not assume topological order among subpaths
     void merge_non_branching_subpaths(multipath_alignment_t& multipath_aln,

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -286,41 +286,23 @@ namespace vg {
     
     // TODO: these metadata functions should also transfer annotations
 
-    /// Copies metadata from an Alignment object and transfers it to a multipath_alignment_t
-    ///
-    ///  Args:
-    ///    from    copy metadata from this
-    ///    to      into this
-    ///
+    /// All functions of this form transfer:
+    /// - sequence
+    /// - base quality
+    /// - mapping quality
+    /// - read annotations (including multiple encodings of secondary)
     void transfer_read_metadata(const Alignment& from, multipath_alignment_t& to);
-    
-    /// Copies metadata from an multipath_alignment_t object and transfers it to a Alignment
-    ///
-    ///  Args:
-    ///    from    copy metadata from this
-    ///    to      into this
-    ///
     void transfer_read_metadata(const multipath_alignment_t& from, Alignment& to);
-    
-    /// Copies metadata from an multipath_alignment_t object and transfers it to another multipath_alignment_t
-    ///
-    ///  Args:
-    ///    from    copy metadata from this
-    ///    to      into this
-    ///
     void transfer_read_metadata(const multipath_alignment_t& from, multipath_alignment_t& to);
-    
-    /// Copies metadata from an Alignment object and transfers it to another Alignment
-    ///
-    ///  Args:
-    ///    from    copy metadata from this
-    ///    to      into this
-    ///
     void transfer_read_metadata(const Alignment& from, Alignment& to);
-
     void transfer_read_metadata(const MultipathAlignment& from, multipath_alignment_t& to);
-
     void transfer_read_metadata(const multipath_alignment_t& from, MultipathAlignment& to);
+
+    /// Transfer the annotations that are carried with the Protobuf formats but not
+    /// the internal multipath_alignment_t (and which therefore get lost when using
+    /// it as an intermediate format).
+    void transfer_proto_metadata(const Alignment& from, MultipathAlignment& to);
+    void transfer_proto_metadata(const MultipathAlignment& from, Alignment& to);
 
     /// Merges non-branching paths in a multipath alignment in place
     /// Does not assume topological order among subpaths

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -308,14 +308,6 @@ void MultipathAlignmentEmitter::convert_to_alignment(const multipath_alignment_t
     }
     // at one point vg call needed these, maybe it doesn't anymore though
     aln.set_identity(identity(aln.path()));
-    
-    // transfer over annotation that has a special field in GAM
-    if (mp_aln.has_annotation("secondary")) {
-        auto anno = mp_aln.get_annotation("secondary");
-        assert(anno.first == multipath_alignment_t::Bool);
-        bool secondary = *((bool*) anno.second);
-        aln.set_is_secondary(secondary);
-    }
 }
 
 void MultipathAlignmentEmitter::create_alignment_shim(const string& name, const multipath_alignment_t& mp_aln,

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -758,7 +758,7 @@ int main_stats(int argc, char** argv) {
 
             // Now do all the non-mapping stats
             stats.total_alignments++;
-            if(aln.is_secondary()) {
+            if(aln.is_secondary() || (has_annotation(aln, "secondary") && get_annotation<bool>(aln, "secondary"))) {
                 stats.total_secondary++;
             } else {
                 stats.total_primary++;

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -605,7 +605,6 @@ int main_view(int argc, char** argv) {
                     to_multipath_alignment(aln, mp_aln);
                     buf.emplace_back();
                     to_proto_multipath_alignment(mp_aln, buf.back());
-                    transfer_proto_metadata(aln, buf.back());
                     vg::io::write_buffered(cout, buf, 1000);
                 };
                 get_input_file(file_name, [&](istream& in) {
@@ -631,7 +630,6 @@ int main_view(int argc, char** argv) {
                     to_multipath_alignment(aln, mp_aln);
                     buf.emplace_back();
                     to_proto_multipath_alignment(mp_aln, buf.back());
-                    transfer_proto_metadata(aln, buf.back());
                     vg::io::write_buffered(std::cout, buf, 1000);
                 }
                 vg::io::write_buffered(cout, buf, 0);
@@ -687,7 +685,6 @@ int main_view(int argc, char** argv) {
                     from_proto_multipath_alignment(proto_mp_aln, mp_aln);
                     buf.emplace_back();
                     optimal_alignment(mp_aln, buf.back());
-                    transfer_proto_metadata(proto_mp_aln, buf.back());
                     if (!proto_mp_aln.paired_read_name().empty()) {
                         // alternate using next/prev
                         if (which_read_in_pair) {
@@ -753,7 +750,6 @@ int main_view(int argc, char** argv) {
                     from_proto_multipath_alignment(proto_mp_aln, mp_aln);
                     buf.emplace_back();
                     optimal_alignment(mp_aln, buf.back());
-                    transfer_proto_metadata(proto_mp_aln, buf.back());
                     vg::io::write_buffered(cout, buf, 1000);
                 };
                 get_input_file(file_name, [&](istream& in) {

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -605,6 +605,7 @@ int main_view(int argc, char** argv) {
                     to_multipath_alignment(aln, mp_aln);
                     buf.emplace_back();
                     to_proto_multipath_alignment(mp_aln, buf.back());
+                    transfer_proto_metadata(aln, buf.back());
                     vg::io::write_buffered(cout, buf, 1000);
                 };
                 get_input_file(file_name, [&](istream& in) {
@@ -685,6 +686,7 @@ int main_view(int argc, char** argv) {
                     from_proto_multipath_alignment(proto_mp_aln, mp_aln);
                     buf.emplace_back();
                     optimal_alignment(mp_aln, buf.back());
+                    transfer_proto_metadata(proto_mp_aln, buf.back());
                     if (!proto_mp_aln.paired_read_name().empty()) {
                         // alternate using next/prev
                         if (which_read_in_pair) {
@@ -750,6 +752,7 @@ int main_view(int argc, char** argv) {
                     from_proto_multipath_alignment(proto_mp_aln, mp_aln);
                     buf.emplace_back();
                     optimal_alignment(mp_aln, buf.back());
+                    transfer_proto_metadata(proto_mp_aln, buf.back());
                     vg::io::write_buffered(cout, buf, 1000);
                 };
                 get_input_file(file_name, [&](istream& in) {

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -346,7 +346,6 @@ using namespace std;
                     aln_surjections[surj_record.first] = make_pair(Alignment(), path_range);
                     auto& surjected_aln = aln_surjections[surj_record.first].first;
                     optimal_alignment(surjection, surjected_aln, allow_negative_scores);
-                    transfer_read_metadata(*source_aln, surjected_aln);
                 }
             }
             else {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GAMP files no longer lose the "secondary" annotation when converted to GAM

## Description

The functions I used to convert between alignment formats were messy and didn't handle annotations in a consistent way. I've simplified the interface and used it more consistently.

Resolves https://github.com/vgteam/vg/issues/3672 