### PR TITLE
More informative error for missing fasta contig in construct

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -2243,7 +2243,10 @@ namespace vg {
 
                     // Decide what FASTA contig that is and make sure we have it
                     string fasta_contig = vcf_to_fasta(vcf_contig);
-                    assert(reference_for.count(fasta_contig));
+                    if (!reference_for.count(fasta_contig)) {
+                        cerr << "[vg::Constructor] Error: Reference contig \"" << vcf_contig << "\" in VCF not found in FASTA." << endl;
+                        exit(1);
+                    }
                     auto* reference = reference_for[fasta_contig];
 
                     // Construct on it with the appropriate FastaReference for that contig


### PR DESCRIPTION
`vg construct` failing with a cryptic ` Assertion reference_for.count(fasta_contig)' ` when a reference in the VCF isn't found in the fasta trips a lot of folks up.  This replaces the assertion with an error message about which contig is missing.  

Resolves #3834