### PR TITLE
Fix header parsing and splice-junction construction from introns in vg rna

### DIFF
--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -344,7 +344,7 @@ class Transcriptome {
         /// Augments the graph with transcript path exon boundaries and 
         /// splice-junctions. Updates threads in gbwt index to match the augmented graph. 
         /// Optinally adds transcript paths to the transcriptome.
-        void augment_graph(const list<EditedTranscriptPath> & edited_transcript_paths, const bool break_at_transcript_ends, unique_ptr<gbwt::GBWT> & haplotype_index, const bool update_haplotypes, const bool add_reference_transcript_paths);
+        void augment_graph(const list<EditedTranscriptPath> & edited_transcript_paths, const bool is_introns, unique_ptr<gbwt::GBWT> & haplotype_index, const bool update_haplotypes, const bool add_reference_transcript_paths);
 
         /// Update threads in gbwt index using graph translations. 
         void update_haplotype_index(unique_ptr<gbwt::GBWT> & haplotype_index, const spp::sparse_hash_map<handle_t, vector<pair<int32_t, handle_t> > > & update_index) const;

--- a/src/unittest/transcriptome.cpp
+++ b/src/unittest/transcriptome.cpp
@@ -120,6 +120,8 @@ namespace vg {
             unique_ptr<gbwt::GBWT> empty_haplotype_index(new gbwt::GBWT());
 
             stringstream transcript_stream;
+            transcript_stream << "# header 1" << endl;
+            transcript_stream << "# header      2" << endl;
             transcript_stream << "path1\t.\texon\t2\t7\t.\t+\t.\ttranscript_id \"transcript1\"; exon_number 1;" << endl;
             transcript_stream << "path1\t.\texon\t9\t10\t.\t+\t.\ttranscript_id \"transcript1\"; exon_number 2;" << endl;
             transcript_stream << "path1\t.\texon\t19\t21\t.\t+\t.\ttranscript_id \"transcript1\"; exon_number 3;" << endl;

--- a/src/unittest/transcriptome.cpp
+++ b/src/unittest/transcriptome.cpp
@@ -121,7 +121,7 @@ namespace vg {
 
             stringstream transcript_stream;
             transcript_stream << "# header 1" << endl;
-            transcript_stream << "# header      2" << endl;
+            transcript_stream << "# header\t2\t" << endl;
             transcript_stream << "path1\t.\texon\t2\t7\t.\t+\t.\ttranscript_id \"transcript1\"; exon_number 1;" << endl;
             transcript_stream << "path1\t.\texon\t9\t10\t.\t+\t.\ttranscript_id \"transcript1\"; exon_number 2;" << endl;
             transcript_stream << "path1\t.\texon\t19\t21\t.\t+\t.\ttranscript_id \"transcript1\"; exon_number 3;" << endl;
@@ -148,6 +148,20 @@ namespace vg {
                 REQUIRE(transcriptome.graph().get_step_count(transcriptome.graph().get_path_handle("path2")) == 10);
                 REQUIRE(transcriptome.graph().get_step_count(transcriptome.graph().get_path_handle("path3")) == 12);
                 REQUIRE(transcriptome.graph().get_step_count(transcriptome.graph().get_path_handle("path4")) == 10);
+
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(1)) == "A");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(2)) == "AAA");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(3)) == "CC");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(4)) == "G");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(5)) == "T");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(6)) == "T");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(7)) == "TT");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(8)) == "T");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(9)) == "TTT");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(10)) == "C");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(11)) == "CC");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(12)) == "A");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(13)) == "AAA");
 
                 auto int_ref_transcript_paths = transcript_paths_to_int_vectors(transcriptome.reference_transcript_paths());
 
@@ -721,6 +735,45 @@ namespace vg {
                     REQUIRE(seq_ref_transcript_paths.at(3) == "TTTAAAA");
                     REQUIRE(seq_ref_transcript_paths.back() == "TTTTGGAGGTTT");
                 }
+            }
+
+            SECTION("Transcriptome can parse intron BED file and add splice-junctions") {
+
+                stringstream intron_stream;
+                intron_stream << "# header 1" << endl;
+                intron_stream << "# header\t2\t" << endl;
+                intron_stream << "path1\t7\t8" << endl;
+                intron_stream << "path1\t10\t18\texon\t0" << endl;
+                intron_stream << "path1\t7\t15\texon\t0\t-" << endl;
+                intron_stream << "path1\t11\t17\texon\t0\t+\t.\t." << endl;
+
+                transcriptome.add_intron_splice_junctions(vector<istream *>({&intron_stream}), empty_haplotype_index, false);
+
+                REQUIRE(transcriptome.transcript_paths().empty());
+
+                REQUIRE(transcriptome.sort_compact_nodes());
+
+                REQUIRE(transcriptome.graph().get_node_count() == 12);
+                REQUIRE(transcriptome.graph().get_edge_count() == 17);
+                REQUIRE(transcriptome.graph().get_path_count() == 4);
+
+                REQUIRE(transcriptome.graph().get_step_count(transcriptome.graph().get_path_handle("path1")) == 11);
+                REQUIRE(transcriptome.graph().get_step_count(transcriptome.graph().get_path_handle("path2")) == 9);
+                REQUIRE(transcriptome.graph().get_step_count(transcriptome.graph().get_path_handle("path3")) == 11);
+                REQUIRE(transcriptome.graph().get_step_count(transcriptome.graph().get_path_handle("path4")) == 9);
+
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(1)) == "AAAA");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(2)) == "CC");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(3)) == "G");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(4)) == "T");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(5)) == "T");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(6)) == "TT");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(7)) == "T");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(8)) == "TTT");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(9)) == "C");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(10)) == "CC");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(11)) == "A");
+                REQUIRE(transcriptome.graph().get_sequence(transcriptome.graph().get_handle(12)) == "AAA");             
             }
         }
     }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

* `vg rna` will no longer in certain cases skip the first line when the annotation input has a header
* `vg rna` no longer crashes when adding splice-junction from a BED file with introns

## Description

Fixed two issues in `vg rna`. In certain cases the first line of the transcript annotation could be skipped when the gtf/gff file included a header. The splice-junction construction using the intron input was broken and crashed. 