### PR TITLE
Minor Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -907,7 +907,8 @@ $(UNITTEST_OBJ_DIR)/%.d: ;
 
 
 .pre-build:
-	@protoc --version >/dev/null 2>/dev/null || (echo "Error: protobuf compiler (protoc) not available!" ; exit 1)
+	# Make directories before quitting target due to missing protoc.
+	# If we run the rest of the build without these, lib and include can become files.
 	@if [ ! -d $(BIN_DIR) ]; then mkdir -p $(BIN_DIR); fi
 	@if [ ! -d $(UNITTEST_BIN_DIR) ]; then mkdir -p $(UNITTEST_BIN_DIR); fi
 	@if [ ! -d $(LIB_DIR) ]; then mkdir -p $(LIB_DIR); fi
@@ -922,6 +923,8 @@ $(UNITTEST_OBJ_DIR)/%.d: ;
 	@if [ ! -d $(UNITTEST_OBJ_DIR) ]; then mkdir -p $(UNITTEST_OBJ_DIR); fi
 	@if [ ! -d $(UNITTEST_SUPPORT_OBJ_DIR) ]; then mkdir -p $(UNITTEST_SUPPORT_OBJ_DIR); fi
 	@if [ ! -d $(INC_DIR) ]; then mkdir -p $(INC_DIR); fi
+	# Quit if no protoc. TODO: Doesn't reliably stop the build.
+	@protoc --version >/dev/null 2>/dev/null || (echo "Error: protobuf compiler (protoc) not available!" ; exit 1)
 	@if [ -e $(INC_DIR)/vg/vg.pb.h ] ; then \
 		HEADER_VER=$$(cat $(INC_DIR)/vg/vg.pb.h | grep GOOGLE_PROTOBUF_VERSION | sed 's/[^0-9]*\([0-9]*\)[^0-9]*/\1/' | head -n1); \
 		WORKDIR=$$(pwd); \
@@ -984,7 +987,7 @@ clean: clean-vcflib
 	cd $(DEP_DIR) && cd htslib && $(MAKE) clean
 	cd $(DEP_DIR) && cd tabixpp && rm -f tabix.o libtabixpp.a
 	cd $(DEP_DIR) && cd sonLib && $(MAKE) clean
-	cd $(DEP_DIR) && cd sparsehash && $(MAKE) clean
+	cd $(DEP_DIR) && cd sparsehash && $(MAKE) clean || true
 	cd $(DEP_DIR) && cd fastahack && $(MAKE) clean
 	cd $(DEP_DIR) && cd gcsa2 && $(MAKE) clean
 	cd $(DEP_DIR) && cd gbwt && $(MAKE) clean

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1967,8 +1967,6 @@ void MinimizerMapper::align_sequence_between(const pos_t& left_anchor, const pos
             std::cerr << "warning[MinimizerMapper::align_sequence_between]: Trimmed back tips " << trim_count << " times on graph between " << left_anchor << " and " << right_anchor << " leaving " <<  dagified_graph.get_node_count() << " nodes and " << tip_handles.size() << " tips" << std::endl;
         }
         
-        #pragma omp critical (cerr)
-        std::cerr << "info[MinimizerMapper::align_sequence_between]: Alignment happening!" << std::endl;
         if (!is_empty(left_anchor) && !is_empty(right_anchor)) {
             // Then align the linking bases, with global alignment so they have
             // to go from a source to a sink. Banded alignment means we can safely do big problems.
@@ -1996,13 +1994,13 @@ void MinimizerMapper::align_sequence_between(const pos_t& left_anchor, const pos
                 e->set_sequence(alignment.sequence());
                 return;
             } else {
+#ifdef debug_chaining
                 #pragma omp critical (cerr)
-                std::cerr << "info[MinimizerMapper::align_sequence_between]: Fill " << cell_count << " DP cells in tail with GSSW" << std::endl;
+                std::cerr << "debug[MinimizerMapper::align_sequence_between]: Fill " << cell_count << " DP cells in tail with GSSW" << std::endl;
+#endif
                 aligner->align_pinned(alignment, dagified_graph, !is_empty(left_anchor), false);
             }
         }
-        #pragma omp critical (cerr)
-        std::cerr << "info[MinimizerMapper::align_sequence_between]: Alignment done!" << std::endl;
         
         // And translate back into original graph space
         for (size_t i = 0; i < alignment.path().mapping_size(); i++) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Makefile should deal better with `protoc` not being installed

## Description

This fixes trouble I encountered building on our new Phoenix test system:
* Protobuf wasn't installed, which I think meant the `.pre-build` target bailed out, and the rest of the build continued, so `lib` and `include` ended up as *files* due to `cp` commands elsewhere. Now the target will not bail out until those directories exist.
* I noticed some debugging prints I thought I removed in #3836, so I am removing them.
* We need a newer Node than system Node; I just installed `nvm` in my user and then the right Node and didn't make any code changes here. The tests catch this just fine.