### PR TITLE
Preload the distance index to avoid very slow initial read mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -907,7 +907,8 @@ $(UNITTEST_OBJ_DIR)/%.d: ;
 
 
 .pre-build:
-	@protoc --version >/dev/null 2>/dev/null || (echo "Error: protobuf compiler (protoc) not available!" ; exit 1)
+	# Make directories before quitting target due to missing protoc.
+	# If we run the rest of the build without these, lib and include can become files.
 	@if [ ! -d $(BIN_DIR) ]; then mkdir -p $(BIN_DIR); fi
 	@if [ ! -d $(UNITTEST_BIN_DIR) ]; then mkdir -p $(UNITTEST_BIN_DIR); fi
 	@if [ ! -d $(LIB_DIR) ]; then mkdir -p $(LIB_DIR); fi
@@ -922,6 +923,8 @@ $(UNITTEST_OBJ_DIR)/%.d: ;
 	@if [ ! -d $(UNITTEST_OBJ_DIR) ]; then mkdir -p $(UNITTEST_OBJ_DIR); fi
 	@if [ ! -d $(UNITTEST_SUPPORT_OBJ_DIR) ]; then mkdir -p $(UNITTEST_SUPPORT_OBJ_DIR); fi
 	@if [ ! -d $(INC_DIR) ]; then mkdir -p $(INC_DIR); fi
+	# Quit if no protoc. TODO: Doesn't reliably stop the build.
+	@protoc --version >/dev/null 2>/dev/null || (echo "Error: protobuf compiler (protoc) not available!" ; exit 1)
 	@if [ -e $(INC_DIR)/vg/vg.pb.h ] ; then \
 		HEADER_VER=$$(cat $(INC_DIR)/vg/vg.pb.h | grep GOOGLE_PROTOBUF_VERSION | sed 's/[^0-9]*\([0-9]*\)[^0-9]*/\1/' | head -n1); \
 		WORKDIR=$$(pwd); \
@@ -984,7 +987,7 @@ clean: clean-vcflib
 	cd $(DEP_DIR) && cd htslib && $(MAKE) clean
 	cd $(DEP_DIR) && cd tabixpp && rm -f tabix.o libtabixpp.a
 	cd $(DEP_DIR) && cd sonLib && $(MAKE) clean
-	cd $(DEP_DIR) && cd sparsehash && $(MAKE) clean
+	cd $(DEP_DIR) && cd sparsehash && $(MAKE) clean || true
 	cd $(DEP_DIR) && cd fastahack && $(MAKE) clean
 	cd $(DEP_DIR) && cd gcsa2 && $(MAKE) clean
 	cd $(DEP_DIR) && cd gbwt && $(MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -905,10 +905,10 @@ $(UNITTEST_OBJ_DIR)/%.d: ;
 ####################################
 
 
-
+# Make directories before quitting target due to missing protoc.
+# If we run the rest of the build without these, lib and include can become files.
+# TODO: quitting if no protoc doesn't reliably stop the build.
 .pre-build:
-	# Make directories before quitting target due to missing protoc.
-	# If we run the rest of the build without these, lib and include can become files.
 	@if [ ! -d $(BIN_DIR) ]; then mkdir -p $(BIN_DIR); fi
 	@if [ ! -d $(UNITTEST_BIN_DIR) ]; then mkdir -p $(UNITTEST_BIN_DIR); fi
 	@if [ ! -d $(LIB_DIR) ]; then mkdir -p $(LIB_DIR); fi
@@ -923,7 +923,6 @@ $(UNITTEST_OBJ_DIR)/%.d: ;
 	@if [ ! -d $(UNITTEST_OBJ_DIR) ]; then mkdir -p $(UNITTEST_OBJ_DIR); fi
 	@if [ ! -d $(UNITTEST_SUPPORT_OBJ_DIR) ]; then mkdir -p $(UNITTEST_SUPPORT_OBJ_DIR); fi
 	@if [ ! -d $(INC_DIR) ]; then mkdir -p $(INC_DIR); fi
-	# Quit if no protoc. TODO: Doesn't reliably stop the build.
 	@protoc --version >/dev/null 2>/dev/null || (echo "Error: protobuf compiler (protoc) not available!" ; exit 1)
 	@if [ -e $(INC_DIR)/vg/vg.pb.h ] ; then \
 		HEADER_VER=$$(cat $(INC_DIR)/vg/vg.pb.h | grep GOOGLE_PROTOBUF_VERSION | sed 's/[^0-9]*\([0-9]*\)[^0-9]*/\1/' | head -n1); \

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1967,8 +1967,6 @@ void MinimizerMapper::align_sequence_between(const pos_t& left_anchor, const pos
             std::cerr << "warning[MinimizerMapper::align_sequence_between]: Trimmed back tips " << trim_count << " times on graph between " << left_anchor << " and " << right_anchor << " leaving " <<  dagified_graph.get_node_count() << " nodes and " << tip_handles.size() << " tips" << std::endl;
         }
         
-        #pragma omp critical (cerr)
-        std::cerr << "info[MinimizerMapper::align_sequence_between]: Alignment happening!" << std::endl;
         if (!is_empty(left_anchor) && !is_empty(right_anchor)) {
             // Then align the linking bases, with global alignment so they have
             // to go from a source to a sink. Banded alignment means we can safely do big problems.
@@ -1996,13 +1994,13 @@ void MinimizerMapper::align_sequence_between(const pos_t& left_anchor, const pos
                 e->set_sequence(alignment.sequence());
                 return;
             } else {
+#ifdef debug_chaining
                 #pragma omp critical (cerr)
-                std::cerr << "info[MinimizerMapper::align_sequence_between]: Fill " << cell_count << " DP cells in tail with GSSW" << std::endl;
+                std::cerr << "debug[MinimizerMapper::align_sequence_between]: Fill " << cell_count << " DP cells in tail with GSSW" << std::endl;
+#endif
                 aligner->align_pinned(alignment, dagified_graph, !is_empty(left_anchor), false);
             }
         }
-        #pragma omp critical (cerr)
-        std::cerr << "info[MinimizerMapper::align_sequence_between]: Alignment done!" << std::endl;
         
         // And translate back into original graph space
         for (size_t i = 0; i < alignment.path().mapping_size(); i++) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` now preloads the distance index into memory before mapping any reads

## Description

This uses https://github.com/vgteam/libbdsg/pull/182 to pre-load the distance index before we let Giraffe start mapping. In the future we might want to try moving this to a thread or something.

Matteo noticed some really slow Giraffe read mapping performance on a read set of 5000 short reads. I managed to somewhat reproduce this, and decided most of the slowdown was during the mapping of the first few thousand reads. Running the same mapping command twice would make the reads map way faster the second time.

I figured what was probably happening was that the read-mapping threads (especially the initial single-threaded paired-end-distance learning thread) were getting held up waiting for memory pages from disk for the DI2 distance index.

I added some machinery in `libbdsg` to tell the kernel to either blockingly page-fault the whole index into memory, or else hint that we are going to need it and it should probably asynchronously prefetch the whole file: https://github.com/vgteam/libbdsg/pull/182

Then I hooked it up to Giraffe and tested with:

```
dd of=/public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.dist oflag=nocache conv=notrunc,fdatasync count=0
dd of=/public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.min oflag=nocache conv=notrunc,fdatasync count=0
dd of=/public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.xg oflag=nocache conv=notrunc,fdatasync count=0
dd of=/public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.gbz oflag=nocache conv=notrunc,fdatasync count=0
dd of=trash/matteo/HG002_R1sub10k.fastq oflag=nocache conv=notrunc,fdatasync count=0
dd of=trash/matteo/HG002_R2sub10k.fastq oflag=nocache conv=notrunc,fdatasync count=0
/usr/bin/time -v bin/vg giraffe -p -f trash/matteo/HG002_R1sub10k.fastq -f trash/matteo/HG002_R2sub10k.fastq -x /public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.xg -Z /public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.gbz -d /public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.dist -m /public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.min -t 16 > trash/output_hprc.gam 2>log.txt
cat log.txt | grep "Distance Index v2"
cat log.txt | grep "reads across"
/usr/bin/time -v bin/vg giraffe -p -f trash/matteo/HG002_R1sub10k.fastq -f trash/matteo/HG002_R2sub10k.fastq -x /public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.xg -Z /public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.gbz -d /public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.dist -m /public/groups/cgl/graph-genomes/anovak/data/hprc-lrgiraffe/graphs/hprc-v1.0-mc-chm13.min -t 16 > trash/output_hprc.gam 2>log2.txt
cat log2.txt | grep "Distance Index v2"
cat log2.txt | grep "reads across"
```

The `dd` commands at the beginning kick those files out of the cache, to make `giraffe` load them from disk again. The goal here is to make the first run not way slower than the second one, and lower its runtime overall. 


Without any preloading I would get:

```
Loading Distance Index v2
Mapped 5000 reads across 16 threads in 6.38193 seconds with 245.069 additional single-threaded seconds.
Loading Distance Index v2
Mapped 5000 reads across 16 threads in 1.64584 seconds with 1.59892 additional single-threaded seconds.
```

With nonblocking preloading (`MADV_WILLNEED`) I would get:

```
Loading Distance Index v2
Paging in Distance Index v2
Distance Index v2 paging: 0.000233409 seconds
Mapped 5000 reads across 16 threads in 6.18633 seconds with 249.256 additional single-threaded seconds.
Loading Distance Index v2
Paging in Distance Index v2
Distance Index v2 paging: 1.045e-05 seconds
Mapped 5000 reads across 16 threads in 1.61811 seconds with 1.59931 additional single-threaded seconds.
```

So that doesn't seem to really help.

With blocking preloading (which ought to be the new `MADV_POPULATE_READ` on this system but which always seems to fail to use that and fall back to reading a byte from every page), I got:

```
Loading Distance Index v2
Paging in Distance Index v2
Distance Index v2 paging: 15.0398 seconds
Mapped 5000 reads across 16 threads in 1.61342 seconds with 1.53084 additional single-threaded seconds.
Loading Distance Index v2
Paging in Distance Index v2
Distance Index v2 paging: 0.199802 seconds
Mapped 5000 reads across 16 threads in 1.59537 seconds with 1.47688 additional single-threaded seconds.
```

So for this use case at least, we spend 15 more seconds at startup and save the first read-mapping thread about 250 seconds of waiting for each page of the distance index one at a time, while bouncing around the graph trying to learn the paired end distribution.

This kind of defeats the point of memory-mapping the distance index, though I guess we still have it available for single queries without the full load if we want it.
