### PR TITLE
Watchdog for Giraffe

### DIFF
--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -21,7 +21,6 @@
 #include "../multipath_alignment_emitter.hpp"
 #include "../path.hpp"
 #include "../watchdog.hpp"
-#include "../watchdog.hpp"
 #include <bdsg/overlays/overlay_helper.hpp>
 #include <bdsg/packed_graph.hpp>
 #include <bdsg/hash_graph.hpp>


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe now uses the watchdog to detect slow reads

## Description

As @jeizenga suggested, this brings the watchdog code from mpmap over to Giraffe as well. Giraffe will now complain if a read takes more than 10 seconds to map (it's supposed to be fast!); you can adjust this with `--watchdog-timeout`.