### PR TITLE
Use ref overlay in sim and stats -a

### DIFF
--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -657,7 +657,7 @@ int main_sim(int argc, char** argv) {
         std::cerr << "Creating path position overlay" << std::endl;
     }
     
-    bdsg::PathPositionVectorizableOverlayHelper overlay_helper;
+    bdsg::ReferencePathVectorizableOverlayHelper overlay_helper;
     PathPositionHandleGraph* xgidx = dynamic_cast<PathPositionHandleGraph*>(overlay_helper.apply(path_handle_graph.get()));
     
     // We want to store the inserted paths as a set of handles, which are


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg sim` and `vg stats -a` sped up for GBZ input

## Description

The overlays aren't free to create, so while it'd be nice to just apply them everywhere it would end up slowing some tools down.  Instead I think we'll just have to do patches like this every time something takes forever of GBZ.    