### PR TITLE
Improve construct errors

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1354,7 +1354,7 @@ namespace vg {
                         << inv_end_cursor << endl;
                     #endif
                     
-                    if (inv_end_cursor == inv_start) {
+                    if (inv_end_cursor != inv_start) {
                         // Make sure we did it right
                         #pragma omp critical (cerr)
                         cerr << "error:[vg::Constructor] On " << reference_path_name << " near " << reference_cursor

--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1809,7 +1809,7 @@ namespace vg {
                 // Update the mapping lengths on the mutable first node.
                 // First we find the primary path
                 Path* path = chunk.graph.mutable_path(0);
-                if (path->name() == reference_contig) {
+                if (path->name() != reference_contig) {
                     #pragma omp critical (cerr)
                     cerr << "error:[vg::Constructor] Expected path " << reference_contig
                          << " but found path " << path->name() << endl;
@@ -1865,7 +1865,7 @@ namespace vg {
 
                 // Find the primary path
                 Path* path = chunk.graph.mutable_path(0);
-                if (path->name() == reference_contig) {
+                if (path->name() != reference_contig) {
                     #pragma omp critical (cerr)
                     cerr << "error:[vg::Constructor] Expected path " << reference_contig
                          << " but found path " << path->name() << endl;

--- a/src/constructor.hpp
+++ b/src/constructor.hpp
@@ -299,11 +299,37 @@ private:
      * bound before their start, because the anchoring base isn't included.
      */
     static pair<int64_t, int64_t> get_symbolic_bounds(vcflib::Variant var);
+    
+    /**
+     * Given a sequence, get rid of all the lowercase characters and all the
+     * ambiguity codes. Warn if configured, and the sequence has a name
+     * assigned, and no warning has yet been issued for that name, or if a
+     * variant is specified.
+     *
+     * Will error if this results in a string with anything other than A, C, G,
+     * T, and N.
+     *
+     * sequence_start_offset can be set to produce useful messages if the
+     * sequence we are looking at is an excerpt from a longer sequence.
+     *
+     * Santitizing may move the stored string data in memory.
+     *
+     * Returns true if the string was modified.
+     *
+     * We need this as a function because vcflib reaches back and reads the
+     * FASTA files directly, so we can't *just* preprocess the reference and we
+     * need to constantly clean up the variants.
+     */
+    bool sanitize_sequence_in_place(string& sequence, const string* sequence_name = nullptr, size_t sequence_start_offset = 0, const vcflib::Variant* variant = nullptr) const;
+    
     /// What sequences have we warned about containing lowercase characters?
     mutable unordered_set<string> lowercase_warned_sequences;
     /// Have we given a warning yet about lowercase alt alleles?
     mutable bool lowercase_warned_alt = false;
-    
+    /// Have we given a warning yet about multiallelic SVs?
+    mutable bool multiallelic_sv_warned = false;
+    /// Have we given a warning yet about uncanonicalizable SVs?
+    mutable bool uncanonicalizable_sv_warned = false;
     /// What sequences have we warned about containing unsupported ambiguity codes?
     mutable unordered_set<string> ambiguous_warned_sequences;
     


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg construct` should no longer fail assertions and will instead report errors.
 * `vg construct` now handles IUPAC codes in the reference as Ns even if they are covered by symbolic structural variants

## Description

This removes all the asserts from constructor.cpp and adds more useful error checking.

It also revises how sequences are sanitized and related warnings an errors are reported.

This will fix #3838.