### PR TITLE
Allow using Giraffe on read-only distance index

### DIFF
--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 44
+plan tests 45
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
@@ -42,6 +42,10 @@ vg minimizer -k 29 -b -s 18 -g x.gbwt -o x.sync x.xg
 
 vg giraffe -x x.xg -H x.gbwt -m x.sync -d x.dist -f reads/small.middle.ref.fq > mapped.sync.gam
 is "${?}" "0" "a read can be mapped with syncmer indexes without crashing"
+
+chmod 400 x.dist
+vg giraffe -x x.xg -H x.gbwt -m x.min -d x.dist -f reads/small.middle.ref.fq >/dev/null 
+is "${?}" "0" "a read can be mapped when the distance index is not writable"
 
 rm -f x.vg x.xg x.gbwt x.snarls x.min x.sync x.dist x.gg
 rm -f x.giraffe.gbz


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` should no longer crash if the distance index is read-only.

## Description
This takes https://github.com/vgteam/libbdsg/pull/184 to allow loading distance indexes that are in read-only files.

Not having a read-write distance index means we have to turn off some of the pointer optimizations, but the fast path, with a read/write distance index, *shouldn't* be any slower with this change.