### PR TITLE
Greedy haplotype scoring

### DIFF
--- a/src/recombinator.cpp
+++ b/src/recombinator.cpp
@@ -23,6 +23,8 @@ constexpr size_t HaplotypePartitioner::APPROXIMATE_JOBS;
 constexpr size_t Recombinator::NUM_HAPLOTYPES;
 constexpr size_t Recombinator::COVERAGE;
 constexpr size_t Recombinator::KFF_BLOCK_SIZE;
+constexpr double Recombinator::PRESENT_DISCOUNT;
+constexpr double Recombinator::HET_ADJUSTMENT;
 
 //------------------------------------------------------------------------------
 
@@ -814,13 +816,6 @@ void Recombinator::Statistics::combine(const Statistics& another) {
     this->haplotypes = std::max(this->haplotypes, another.haplotypes);
     this->kmers += another.kmers;
     this->score += another.score;
-
-    if (another.score_by_rank.size() > this->score_by_rank.size()) {
-        this->score_by_rank.resize(another.score_by_rank.size(), 0.0);
-    }
-    for (size_t i = 0; i < another.score_by_rank.size(); i++) {
-        this->score_by_rank[i] += another.score_by_rank[i];
-    }
 }
 
 std::ostream& Recombinator::Statistics::print(std::ostream& out) const {
@@ -831,12 +826,6 @@ std::ostream& Recombinator::Statistics::print(std::ostream& out) const {
         out << "; used " << this->kmers << " kmers with average score " << average_score;
     }
     return out;
-}
-
-void Recombinator::Statistics::print_scores(std::ostream& out) const {
-    for (size_t i = 0; i < this->score_by_rank.size(); i++) {
-        out << i << "\t" << (this->score_by_rank[i] / this->kmers) << std::endl;
-    }
 }
 
 //------------------------------------------------------------------------------
@@ -920,10 +909,6 @@ gbwt::GBWT Recombinator::generate_haplotypes(const Haplotypes& haplotypes, const
     if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
         double seconds = gbwt::readTimer() - checkpoint;
         std::cerr << "Total: "; statistics.print(std::cerr) << std::endl;
-        if (this->verbosity >= HaplotypePartitioner::verbosity_debug) {
-            std::cerr << "Average kmer score for each sequence rank in sorted order:" << std::endl;
-            statistics.print_scores(std::cerr);
-        }
         std::cerr << "Finished the jobs in " << seconds << " seconds" << std::endl;
     }
 
@@ -986,17 +971,18 @@ Recombinator::Statistics Recombinator::generate_haplotypes(const Haplotypes::Top
             // TODO: -log prob may be the right score once we have enough haplotypes, but
             // right now +1 works better, because we don't have haplotypes with the right
             // combination of rare kmers.
-            // Determine the type of each kmer in the sample and the score for getting that
-            // kmer right.
+            // Determine the type of each kmer in the sample and the score for the kmer.
+            // A haplotype with the kmer gets +1.0 * score, while a haplotype without it
+            // gets -1.0 * score.
             std::vector<std::pair<kmer_presence, double>> kmer_types;
             size_t selected_kmers = 0;
             for (size_t kmer_id = 0; kmer_id < subchain.kmers.size(); kmer_id++) {
                 double count = kmer_counts.at(subchain.kmers[kmer_id].first);
                 if (count < absent_threshold) {
-                    kmer_types.push_back({ absent, 1.0 });
+                    kmer_types.push_back({ absent, -1.0 });
                     selected_kmers++;
                 } else if (count < heterozygous_threshold) {
-                    kmer_types.push_back({ heterozygous, 1.0 });
+                    kmer_types.push_back({ heterozygous, 0.0 });
                     selected_kmers++;
                 } else if (count < homozygous_threshold) {
                     kmer_types.push_back({ present, 1.0 });
@@ -1007,43 +993,60 @@ Recombinator::Statistics Recombinator::generate_haplotypes(const Haplotypes::Top
             }
             statistics.kmers += selected_kmers;
 
-            // Score the sequences by kmer presence and sort them by score in descending order.
-            std::vector<std::pair<size_t, double>> sequence_scores;
+            // Select the haplotypes greedily.
+            std::vector<std::pair<size_t, double>> selected_haplotypes;
+            std::vector<std::pair<size_t, double>> remaining_haplotypes;
             for (size_t sequence_id = 0; sequence_id < subchain.sequences.size(); sequence_id++) {
-                size_t offset = sequence_id * subchain.kmers.size();
-                double score = 0.0;
+                remaining_haplotypes.push_back( { sequence_id, 0.0 });
+            }
+            while (selected_haplotypes.size() < haplotypes.size() && !remaining_haplotypes.empty()) {
+                // Score the remaining haplotypes.
+                for (size_t i = 0; i < remaining_haplotypes.size(); i++) {
+                    size_t offset = remaining_haplotypes[i].first * subchain.kmers.size();
+                    double score = 0.0;
+                    for (size_t kmer_id = 0; kmer_id < subchain.kmers.size(); kmer_id++) {
+                        double multiplier = -1.0 + 2.0 * subchain.kmers_present[offset + kmer_id];
+                        score += multiplier * kmer_types[kmer_id].second;
+                    }
+                    remaining_haplotypes[i].second = score;
+                }
+
+                // Select the haplotype to use.
+                size_t selected = 0;
+                if (parameters.random_sampling) {
+                    selected = rng() % remaining_haplotypes.size();
+                } else {
+                    for (size_t i = 1; i < remaining_haplotypes.size(); i++) {
+                        if (remaining_haplotypes[i].second > remaining_haplotypes[selected].second) {
+                            selected = i;
+                        }
+                    }
+                }
+                selected_haplotypes.push_back(remaining_haplotypes[selected]);
+                remaining_haplotypes.erase(remaining_haplotypes.begin() + selected);
+
+                // Adjust kmer scores based on the selected haplotype.
+                size_t sequence_id = selected_haplotypes.back().first;
+                size_t offset = selected_haplotypes.back().first * subchain.kmers.size();
                 for (size_t kmer_id = 0; kmer_id < subchain.kmers.size(); kmer_id++) {
                     switch (kmer_types[kmer_id].first) {
-                    case absent:
-                        score += (subchain.kmers_present[offset + kmer_id] ? -kmer_types[kmer_id].second : kmer_types[kmer_id].second);
-                        break;
                     case heterozygous:
-                        score += (subchain.kmers_present[offset + kmer_id] ? kmer_types[kmer_id].second : 0);
+                        kmer_types[kmer_id].second += (subchain.kmers_present[offset + kmer_id] ? -1.0 : 1.0) * HET_ADJUSTMENT;
                         break;
                     case present:
-                        score += (subchain.kmers_present[offset + kmer_id] ? kmer_types[kmer_id].second : -kmer_types[kmer_id].second);
-                        break;
-                    default:
+                        if (subchain.kmers_present[offset + kmer_id]) {
+                            kmer_types[kmer_id].second *= PRESENT_DISCOUNT;
+                        }
                         break;
                     }
                 }
-                sequence_scores.push_back({ sequence_id, score });
-            }
-            std::sort(sequence_scores.begin(), sequence_scores.end(), [](std::pair<size_t, double> a, std::pair<size_t, double> b) -> bool {
-                return (a.second > b.second);
-            });
-            if (sequence_scores.size() > statistics.score_by_rank.size()) {
-                statistics.score_by_rank.resize(sequence_scores.size(), 0.0);
-            }
-            for (size_t i = 0; i < sequence_scores.size(); i++) {
-                statistics.score_by_rank[i] += sequence_scores[i].second;
             }
 
-            // Extend the haplotypes with the highest-scoring sequences.
+            // Extend the haplotypes with the selected sequences.
             for (size_t haplotype = 0; haplotype < haplotypes.size(); haplotype++) {
-                size_t offset = (parameters.random_sampling ? rng() : haplotype) % sequence_scores.size();
-                size_t seq_id = sequence_scores[offset].first;
-                statistics.score += sequence_scores[offset].second;
+                size_t offset = haplotype % selected_haplotypes.size();
+                size_t seq_id = selected_haplotypes[offset].first;
+                statistics.score += selected_haplotypes[offset].second;
                 haplotypes[haplotype].extend(subchain.sequences[seq_id], subchain, *this, builder);
             }
             have_haplotypes = subchain.has_end();

--- a/src/recombinator.cpp
+++ b/src/recombinator.cpp
@@ -1031,12 +1031,14 @@ Recombinator::Statistics Recombinator::generate_haplotypes(const Haplotypes::Top
                 for (size_t kmer_id = 0; kmer_id < subchain.kmers.size(); kmer_id++) {
                     switch (kmer_types[kmer_id].first) {
                     case heterozygous:
-                        kmer_types[kmer_id].second += (subchain.kmers_present[offset + kmer_id] ? -1.0 : 1.0) * HET_ADJUSTMENT;
+                        kmer_types[kmer_id].second += (subchain.kmers_present[offset + kmer_id] ? -1.0 : 1.0) * parameters.het_adjustment;
                         break;
                     case present:
                         if (subchain.kmers_present[offset + kmer_id]) {
-                            kmer_types[kmer_id].second *= PRESENT_DISCOUNT;
+                            kmer_types[kmer_id].second *= parameters.present_discount;
                         }
+                        break;
+                    default:
                         break;
                     }
                 }

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -474,6 +474,15 @@ public:
         /// Buffer size (in nodes) for GBWT construction.
         gbwt::size_type buffer_size = gbwt::DynamicGBWT::INSERT_BATCH_SIZE;
 
+        /// Multiplicative factor for discounting the scores for present kmers after
+        /// selecting a haplotype with that kmer.
+        double present_discount = PRESENT_DISCOUNT;
+
+        /// Additive term for adjusting the scores for heterozygous kmers after
+        /// each haplotype to encourage even sampling of haplotypes with and without
+        /// that kmer.
+        double het_adjustment = HET_ADJUSTMENT;
+
         /// Sample randomly instead of by score.
         bool random_sampling = false;
     };

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -344,6 +344,14 @@ public:
     /// Block size (in kmers) for reading KFF files.
     constexpr static size_t KFF_BLOCK_SIZE = 1000000;
 
+    /// Multiplier to the score of a present kmer every time a haplotype with that
+    /// kmer is selected.
+    constexpr static double PRESENT_DISCOUNT = 0.7;
+
+    /// Adjustment to the score of a heterozygous kmer every time a haplotype with
+    /// (-) or without (+) that kmer is selected.
+    constexpr static double HET_ADJUSTMENT = 0.2;
+
     /// A GBWT sequence as (sequence identifier, offset in a node).
     typedef Haplotypes::sequence_type sequence_type;
 
@@ -441,9 +449,6 @@ public:
 
         /// Total score for selected sequences.
         double score = 0.0;
-
-        /// Total score for sequences of each rank in sorted order.
-        std::vector<double> score_by_rank;
 
         /// Combines the statistics into this object.
         void combine(const Statistics& another);

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -69,6 +69,14 @@ size_t haplotypes_default_coverage() {
     return Recombinator::COVERAGE;
 }
 
+double haplotypes_default_discount() {
+    return Recombinator::PRESENT_DISCOUNT;
+}
+
+double haplotypes_default_adjustment() {
+    return Recombinator::HET_ADJUSTMENT;
+}
+
 void help_haplotypes(char** argv) {
     std::string usage = "    " + std::string(argv[0]) + " " + std::string(argv[1]) + " [options] ";
     std::cerr << "Usage:" << std::endl;
@@ -95,6 +103,8 @@ void help_haplotypes(char** argv) {
     std::cerr << "        --subchain-length N   target length (in bp) for subchains (default: " << haplotypes_default_subchain_length() << ")" << std::endl;
     std::cerr << "        --coverage N          read coverage in the KFF file (default: " << haplotypes_default_coverage() << ")" << std::endl;
     std::cerr << "        --num-haplotypes N    generate N haplotypes (default: " << haplotypes_default_n() << ")" << std::endl;
+    std::cerr << "        --present-discount F  discount scores for present kmers by factor F (default: " << haplotypes_default_discount() << ")" << std::endl;
+    std::cerr << "        --het-adjustment F    adjust scores for heterozygous kmers by F (default: " << haplotypes_default_adjustment() << ")" << std::endl;
     std::cerr << "        --random-sampling     sample randomly instead of using the kmer counts" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
@@ -162,7 +172,9 @@ int main_haplotypes(int argc, char** argv) {
     constexpr int OPT_SUBCHAIN_LENGTH = 1202;
     constexpr int OPT_COVERAGE = 1300;
     constexpr int OPT_NUM_HAPLOTYPES = 1301;
-    constexpr int OPT_RANDOM_SAMPLING = 1302;
+    constexpr int OPT_PRESENT_DISCOUNT = 1302;
+    constexpr int OPT_HET_ADJUSTMENT = 1303;
+    constexpr int OPT_RANDOM_SAMPLING = 1304;
     constexpr int OPT_VALIDATE = 1400;
 
     static struct option long_options[] =
@@ -179,6 +191,8 @@ int main_haplotypes(int argc, char** argv) {
         { "subchain-length", required_argument, 0, OPT_SUBCHAIN_LENGTH },
         { "coverage", required_argument, 0, OPT_COVERAGE },
         { "num-haplotypes", required_argument, 0, OPT_NUM_HAPLOTYPES },
+        { "present-discount", required_argument, 0, OPT_PRESENT_DISCOUNT },
+        { "het-adjustment", required_argument, 0, OPT_HET_ADJUSTMENT },
         { "random-sampling", no_argument, 0, OPT_RANDOM_SAMPLING },
         { "verbosity", required_argument, 0, 'v' },
         { "threads", required_argument, 0, 't' },
@@ -244,6 +258,20 @@ int main_haplotypes(int argc, char** argv) {
             recombinator_parameters.coverage = parse<size_t>(optarg);
             if (recombinator_parameters.coverage == 0) {
                 std::cerr << "error: [vg haplotypes] read coverage cannot be 0" << std::endl;
+                return 1;
+            }
+            break;
+        case OPT_PRESENT_DISCOUNT:
+            recombinator_parameters.present_discount = parse<double>(optarg);
+            if (recombinator_parameters.present_discount < 0.0 || recombinator_parameters.present_discount > 1.0) {
+                std::cerr << "error: [vg haplotypes] discount factor must be between 0.0 and 1.0" << std::endl;
+                return 1;
+            }
+            break;
+        case OPT_HET_ADJUSTMENT:
+            recombinator_parameters.het_adjustment = parse<double>(optarg);
+            if (recombinator_parameters.het_adjustment < 0.0) {
+                std::cerr << "error: [vg haplotypes] adjustment term must be non-negative" << std::endl;
                 return 1;
             }
             break;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * (Nothing that concerns the user.)

## Description

This PR introduces a greedy scoring model in `vg haplotypes`. After selecting a haplotype in a subchain, kmer scores are adjusted and the remaining haplotypes are rescored.

* The initial scores are +1/-1 for kmers that are present in the sample, 0/0 for heterozygous kmers, and -1/+1 for absent kmers. (For kmers that are present/absent in the haplotype.)
* If the selected haplotype contains a present kmer, the scores for that kmer are multiplied by a discount factor (default 0.7). This encourages selecting haplotypes that contain present kmers that have not been covered yet.
* If a heterozygous kmer was present in the selected haplotype, an additive adjustment (default -0.2/+0.2) is added to the score. If it was absent, the adjustment is reversed (default +0.2/-0.2). This encourages selecting haplotypes with and without the heterozygous kmer.