### PR TITLE
Add GBZ format support to vg rna

### DIFF
--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -13,6 +13,9 @@
 #include <vg/io/vpkg.hpp>
 #include <vg/io/stream.hpp>
 #include "../gbwt_helper.hpp"
+#include "bdsg/packed_graph.hpp"
+#include <gbwtgraph/gbz.h>
+#include <gbwtgraph/utils.h>
 
 using namespace std;
 using namespace vg;
@@ -20,7 +23,7 @@ using namespace vg::subcommand;
 
 
 void help_rna(char** argv) {
-    cerr << "\nusage: " << argv[0] << " rna [options] graph.[vg|pg|hg|og] > splicing_graph.[vg|pg|hg|og]" << endl
+    cerr << "\nusage: " << argv[0] << " rna [options] graph.[vg|pg|hg|gfa|gbz] > splicing_graph.[vg|pg|hg|gfa|gbz]" << endl
 
          << "\nGeneral options:" << endl
 
@@ -35,6 +38,7 @@ void help_rna(char** argv) {
          << "    -y, --feature-type NAME    parse only this feature type in the gtf/gff (parses all if empty) [exon]" << endl
          << "    -s, --transcript-tag NAME  use this attribute tag in the gtf/gff file(s) as id [transcript_id]" << endl
          << "    -l, --haplotypes FILE      project transcripts onto haplotypes in GBWT index file" << endl
+         << "    -z, --gbz-format           input graph is in GBZ format (contains both a graph and haplotypes (GBWT index))" << endl
 
          << "\nConstruction options:" << endl
 
@@ -70,6 +74,7 @@ int32_t main_rna(int32_t argc, char** argv) {
     string feature_type = "exon";
     string transcript_tag = "transcript_id";
     string haplotypes_filename;
+    bool gbz_format = false;
     bool use_hap_ref = false;
     bool proj_emded_paths = false;
     string path_collapse_type = "haplotype";
@@ -97,6 +102,7 @@ int32_t main_rna(int32_t argc, char** argv) {
                 {"feature-type",  no_argument, 0, 'y'},
                 {"transcript-tag",  no_argument, 0, 's'},
                 {"haplotypes",  no_argument, 0, 'l'},
+                {"gbz-format",  no_argument, 0, 'z'},
                 {"use-hap-ref",  no_argument, 0, 'j'},
                 {"proj-embed-paths",  no_argument, 0, 'e'},
                 {"path-collapse",  no_argument, 0, 'c'},
@@ -118,7 +124,7 @@ int32_t main_rna(int32_t argc, char** argv) {
             };
 
         int32_t option_index = 0;
-        c = getopt_long(argc, argv, "n:m:y:s:l:jec:k:dorab:f:i:uqgt:ph?", long_options, &option_index);
+        c = getopt_long(argc, argv, "n:m:y:s:l:zjec:k:dorab:f:i:uqgt:ph?", long_options, &option_index);
 
         /* Detect the end of the options. */
         if (c == -1)
@@ -145,6 +151,10 @@ int32_t main_rna(int32_t argc, char** argv) {
 
         case 'l':
             haplotypes_filename = optarg;
+            break;
+
+        case 'z':
+            gbz_format = true;
             break;
 
         case 'j':
@@ -233,6 +243,12 @@ int32_t main_rna(int32_t argc, char** argv) {
         return 1;       
     }
 
+    if (!haplotypes_filename.empty() && gbz_format) {
+
+        cerr << "[vg rna] ERROR: Only one set of haplotypes can be provided (GBZ file contains both a graph and haplotypes). Use either --haplotypes or --gbz-format." << endl;
+        return 1;       
+    }
+
     if (remove_non_transcribed_nodes && !add_reference_transcript_paths && !add_projected_transcript_paths) {
 
         cerr << "[vg rna] WARNING: Reference paths are deleted when removing intergenic and intronic regions. Consider adding transcripts as embedded paths using --add-ref-paths and/or --add-hap-paths." << endl;
@@ -247,11 +263,50 @@ int32_t main_rna(int32_t argc, char** argv) {
     double time_parsing_start = gcsa::readTimer();
     if (show_progress) { cerr << "[vg rna] Parsing graph file ..." << endl; }
 
-    unique_ptr<MutablePathDeletableHandleGraph> graph(nullptr);
-
-    // Load variation graph.
     string graph_filename = get_input_file_name(optind, argc, argv);
-    graph = move(vg::io::VPKG::load_one<MutablePathDeletableHandleGraph>(graph_filename));
+
+    unique_ptr<MutablePathDeletableHandleGraph> graph(nullptr);
+    unique_ptr<gbwt::GBWT> haplotype_index;
+
+    if (!gbz_format) {
+
+        // Load pangenome graph.
+        graph = move(vg::io::VPKG::load_one<MutablePathDeletableHandleGraph>(graph_filename));
+    
+        if (!haplotypes_filename.empty()) {
+
+            // Load haplotype GBWT index.
+            if (show_progress) { cerr << "[vg rna] Parsing haplotype GBWT index file ..." << endl; }
+            haplotype_index = vg::io::VPKG::load_one<gbwt::GBWT>(haplotypes_filename);
+            assert(haplotype_index->bidirectional());
+
+        } else {
+
+            // Construct empty GBWT index if non is given. 
+            haplotype_index = unique_ptr<gbwt::GBWT>(new gbwt::GBWT());
+        }
+
+    } else {
+
+        graph = unique_ptr<MutablePathDeletableHandleGraph>(new bdsg::PackedGraph());
+
+        // Load GBZ file 
+        unique_ptr<gbwtgraph::GBZ> gbz = vg::io::VPKG::load_one<gbwtgraph::GBZ>(graph_filename);
+
+        if (show_progress) { cerr << "[vg rna] Converting graph format ..." << endl; }
+
+        // Convert GBWTGraph to mutable graph type (PackedGraph).
+        graph->set_id_increment(gbz->graph.min_node_id());
+        handlealgs::copy_handle_graph(&(gbz->graph), graph.get());
+
+        // Copy reference and generic paths to new graph.
+        gbz->graph.for_each_path_matching({PathSense::GENERIC, PathSense::REFERENCE}, {}, {}, [&](const path_handle_t& path) {
+            
+            handlegraph::algorithms::copy_path(&(gbz->graph), path, graph.get());
+        });
+
+        haplotype_index = make_unique<gbwt::GBWT>(gbz->index);
+    }
 
     if (graph == nullptr) {
         cerr << "[transcriptome] ERROR: Could not load graph." << endl;
@@ -261,21 +316,6 @@ int32_t main_rna(int32_t argc, char** argv) {
     // Construct transcriptome and parse graph.
     Transcriptome transcriptome(move(graph));
     assert(graph == nullptr);
-
-    unique_ptr<gbwt::GBWT> haplotype_index;
-
-    if (!haplotypes_filename.empty()) {
-
-        // Load haplotype GBWT index.
-        if (show_progress) { cerr << "[vg rna] Parsing haplotype GBWT index file ..." << endl; }
-        haplotype_index = vg::io::VPKG::load_one<gbwt::GBWT>(haplotypes_filename);
-        assert(haplotype_index->bidirectional());
-
-    } else {
-
-        // Construct empty GBWT index if no is given. 
-        haplotype_index = unique_ptr<gbwt::GBWT>(new gbwt::GBWT());
-    }
 
     transcriptome.show_progress = show_progress;
     transcriptome.num_threads = num_threads;

--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -23,7 +23,7 @@ using namespace vg::subcommand;
 
 
 void help_rna(char** argv) {
-    cerr << "\nusage: " << argv[0] << " rna [options] graph.[vg|pg|hg|gfa|gbz] > splicing_graph.[vg|pg|hg|gfa]" << endl
+    cerr << "\nusage: " << argv[0] << " rna [options] graph.[vg|pg|hg|gbz] > splicing_graph.[vg|pg|hg]" << endl
 
          << "\nGeneral options:" << endl
 

--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -23,7 +23,7 @@ using namespace vg::subcommand;
 
 
 void help_rna(char** argv) {
-    cerr << "\nusage: " << argv[0] << " rna [options] graph.[vg|pg|hg|gfa|gbz] > splicing_graph.[vg|pg|hg|gfa|gbz]" << endl
+    cerr << "\nusage: " << argv[0] << " rna [options] graph.[vg|pg|hg|gfa|gbz] > splicing_graph.[vg|pg|hg|gfa]" << endl
 
          << "\nGeneral options:" << endl
 

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -2341,8 +2341,6 @@ void Transcriptome::update_haplotype_index(unique_ptr<gbwt::GBWT> & haplotype_in
         for (auto & node: cur_gbwt_thread) {
 
             auto handle = gbwt_to_handle(*_graph, node);
-            assert(_graph->get_is_reverse(handle) == 0);
-
             auto update_index_it = update_index.find(handle);
 
             if (update_index_it != update_index.end()) {
@@ -2357,7 +2355,7 @@ void Transcriptome::update_haplotype_index(unique_ptr<gbwt::GBWT> & haplotype_in
                 // Add new nodes.
                 for (auto & new_node: update_index_it->second) {
 
-                    assert(_graph->get_is_reverse(new_node.second) == 0);
+                    assert(_graph->get_is_reverse(handle) == _graph->get_is_reverse(new_node.second));
                     new_gbwt_threads.emplace_back(handle_to_gbwt(*_graph, new_node.second));
                 }
 

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -1370,7 +1370,7 @@ void Transcriptome::construct_reference_transcript_paths_gbwt_callback(list<Edit
                 // Delete transcripts with exon overlapping haplotype break.
                 if (get<2>(incomplete_transcript_paths_it->second)) {
 
-                    excluded_transcripts_local++;
+                    ++excluded_transcripts_local;
                     incomplete_transcript_paths_it = incomplete_transcript_paths.erase(incomplete_transcript_paths_it);
                 
                 } else {
@@ -1396,11 +1396,14 @@ void Transcriptome::construct_reference_transcript_paths_gbwt_callback(list<Edit
                     if (cur_transcript.exons.front().coordinates.first >= node_start_pos && cur_transcript.exons.front().coordinates.first < node_start_pos + node_length) {
 
                         incomplete_transcript_paths.emplace_back(EditedTranscriptPath(cur_transcript.name, gbwt::Path::id(haplotype_idx.second), true, false), make_tuple(transcript_idx, 0, false));
-                    } 
-
-                    if (node_start_pos + node_length <= cur_transcript.exons.front().coordinates.first) {
+                    
+                    } else if (node_start_pos + node_length <= cur_transcript.exons.front().coordinates.first) {
 
                         break;
+                    
+                    } else {
+
+                        ++excluded_transcripts_local;
                     }
 
                     ++transcript_idx;
@@ -1507,6 +1510,11 @@ void Transcriptome::construct_reference_transcript_paths_gbwt_callback(list<Edit
         }
 
         excluded_transcripts_local += incomplete_transcript_paths.size();
+
+        assert(transcript_idx <= transcript_set.first + transcript_set.second);
+        excluded_transcripts_local += (transcript_set.first + transcript_set.second - transcript_idx);
+
+        assert(thread_edited_transcript_paths.size() == transcript_set.second - excluded_transcripts_local);
 
         edited_transcript_paths_mutex->lock();
 

--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -273,7 +273,7 @@ class Transcriptome {
         void parse_introns(vector<Transcript> * introns, istream * intron_stream, const bdsg::PositionOverlay & graph_path_pos_overlay) const;
 
         /// Parse gtf/gff3 file of transcripts. Returns the number of non-header lines in the parsed file.
-        int32_t parse_transcripts(vector<Transcript> * transcripts, istream * transcript_stream, const bdsg::PositionOverlay & graph_path_pos_overlay, const gbwt::GBWT & haplotype_index, const bool use_haplotype_paths) const;
+        int32_t parse_transcripts(vector<Transcript> * transcripts, uint32_t * number_of_excluded_transcripts, istream * transcript_stream, const bdsg::PositionOverlay & graph_path_pos_overlay, const gbwt::GBWT & haplotype_index, const bool use_haplotype_paths) const;
 
         /// Parse gtf/gff3 attribute value.
         string parse_attribute_value(const string & attribute, const string & name) const;
@@ -292,6 +292,9 @@ class Transcriptome {
         /// are ordered in reverse.
         void reorder_exons(Transcript * transcript) const;
 
+        /// Checks whether any adjacent exons overlap.
+        bool has_overlapping_exons(const vector<Exon> & exons) const;
+
         /// Constructs edited reference transcript paths from a set of 
         /// transcripts using embedded graph paths.
         list<EditedTranscriptPath> construct_reference_transcript_paths_embedded(const vector<Transcript> & transcripts, const bdsg::PositionOverlay & graph_path_pos_overlay) const;
@@ -307,7 +310,7 @@ class Transcriptome {
         list<EditedTranscriptPath> construct_reference_transcript_paths_gbwt(const vector<Transcript> & transcripts, const gbwt::GBWT & haplotype_index) const;
 
         /// Threaded reference transcript path construction using GBWT haplotype paths.
-        void construct_reference_transcript_paths_gbwt_callback(list<EditedTranscriptPath> * edited_transcript_paths, spp::sparse_hash_map<handle_t, vector<EditedTranscriptPath *> > * edited_transcript_paths_index, mutex * edited_transcript_paths_mutex, const int32_t thread_idx, const vector<pair<uint32_t, uint32_t> > & chrom_transcript_sets, const vector<Transcript> & transcripts, const gbwt::GBWT & haplotype_index, const spp::sparse_hash_map<string, map<uint32_t, uint32_t> > & haplotype_name_index) const;
+        void construct_reference_transcript_paths_gbwt_callback(list<EditedTranscriptPath> * edited_transcript_paths, spp::sparse_hash_map<handle_t, vector<EditedTranscriptPath *> > * edited_transcript_paths_index, uint32_t * excluded_transcripts, mutex * edited_transcript_paths_mutex, const int32_t thread_idx, const vector<pair<uint32_t, uint32_t> > & chrom_transcript_sets, const vector<Transcript> & transcripts, const gbwt::GBWT & haplotype_index, const spp::sparse_hash_map<string, map<uint32_t, uint32_t> > & haplotype_name_index) const;
 
         /// Constructs haplotype transcript paths by projecting transcripts onto
         /// embedded paths in a graph and/or haplotypes in a GBWT index. 

--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -275,6 +275,9 @@ class Transcriptome {
         /// Parse gtf/gff3 file of transcripts. Returns the number of non-header lines in the parsed file.
         int32_t parse_transcripts(vector<Transcript> * transcripts, uint32_t * number_of_excluded_transcripts, istream * transcript_stream, const bdsg::PositionOverlay & graph_path_pos_overlay, const gbwt::GBWT & haplotype_index, const bool use_haplotype_paths) const;
 
+        /// Returns gbwt path name without phaseblock and subrange. 
+        string get_base_gbwt_path_name(const gbwt::GBWT & haplotype_index, const size_t path_id, const unordered_set<string> & gbwt_reference_samples) const;
+
         /// Parse gtf/gff3 attribute value.
         string parse_attribute_value(const string & attribute, const string & name) const;
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg rna` now supports the GBZ format for the input graph and haplotypes (new option `--gbz-format`). 

## Description

Added support for the GBZ format in `vg rna` and updated the code to use the new path metadata model (and naming scheme). In addition, transcripts are now excluded if exons overlap or exons are in incorrect order. Before `vg rna` would crash or exit in these cases. 
