### PR TITLE
Discourage convert -v

### DIFF
--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -253,8 +253,8 @@ int main_convert(int argc, char** argv) {
     }
 
     if (output_format.empty()) {
-        // default to HashGraph
-        output_format = "hash";
+        // default to PackedGraph
+        output_format = "packed";
     }
         
     // allocate a graph using the graph_type string to decide a class
@@ -459,9 +459,9 @@ void help_convert(char** argv) {
          << "gfa input options (use with -g):" << endl
          << "    -T, --gfa-trans FILE   write gfa id conversions to FILE" << endl
          << "output options:" << endl
-         << "    -v, --vg-out           output in VG format" << endl
-         << "    -a, --hash-out         output in HashGraph format [default]" << endl
-         << "    -p, --packed-out       output in PackedGraph format" << endl
+         << "    -v, --vg-out           output in VG's original Protobuf format [DEPRECATED: use -p instead]." << endl
+         << "    -a, --hash-out         output in HashGraph format" << endl
+         << "    -p, --packed-out       output in PackedGraph format [default]" << endl
          << "    -x, --xg-out           output in XG format" << endl
          << "    -f, --gfa-out          output in GFA format" << endl
          << "    -H, --drop-haplotypes  do not include haplotype paths in the output (useful with GBWTGraph / GBZ inputs)" << endl


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg convert` defaults to `-p` instead of `-a` if output format not specified. 

## Description

I've see a [couple](https://github.com/pangenome/pggb/issues/270#issuecomment-1443367867) of [recent](https://github.com/vgteam/vg/issues/3871#issue-1606872195) examples of people using `vg convert -v` to make `.vg` graphs.  

I don't think there's a good reason to do this other than poor documentation on vg's part.  This PR adds a note to `convert`'s help screen to use `packed graph` instead when making `.vg` files (and also switches its default mode to packed graph from hash graph).  