### PR TITLE
vg clip stub remover

### DIFF
--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -1021,9 +1021,7 @@ void clip_stubs_generic(MutablePathMutableHandleGraph* graph,
     // keep doing the same thing on the neighbours until none left, using
     // handle_in_range to make sure we don't step out of bounds (in the case we're doing BED regions)           
     unordered_map<handle_t, const Region*> stub_neighbours_2;
-    size_t iterations = 1;
     while (!stub_neighbours_1.empty()) {
-        ++iterations;
         stub_neighbours_2.clear();
         swap(stub_neighbours_1, stub_neighbours_2);
         for (const auto&  neighbour_pair : stub_neighbours_2) {
@@ -1033,7 +1031,7 @@ void clip_stubs_generic(MutablePathMutableHandleGraph* graph,
     }
         
     if (verbose) {
-        cerr << "[vg-clip]: Removing " << to_delete.size() << " nodes from (non-reference) stubs in " << iterations << " iterations." << endl;
+        cerr << "[vg-clip]: Removing " << to_delete.size() << " nodes from (non-reference) stubs." << endl;
     }
 
     // cut out the nodes and chop up paths

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -930,4 +930,172 @@ void clip_deletion_edges(MutablePathMutableHandleGraph* graph, int64_t max_delet
     }
 }
 
+void clip_stubs_generic(MutablePathMutableHandleGraph* graph,
+                        function<void(function<void(handle_t, const Region*)>)> iterate_handles,
+                        function<bool(handle_t)> handle_in_range,
+                        const vector<string>& ref_prefixes,
+                        int64_t min_fragment_len,
+                        bool verbose) {
+    
+    unordered_set<nid_t> to_delete;
+
+    // just for logging
+    unordered_map<string, size_t> clip_counts;
+
+    // frontier for recursing on stub neighbours
+    unordered_map<handle_t, const Region*> stub_neighbours_1;
+
+    // test if a node is "reference" using a name check
+    function<bool(const string&)> check_prefixes = [&ref_prefixes] (const string& path_name) {
+        for (const string& ref_prefix : ref_prefixes) {
+            if (path_name.compare(0, ref_prefix.length(), ref_prefix) == 0) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // test if a node is a stub.
+    // we consider a node a stub if either (or both) sides have degree 0.
+    function<bool(const handle_t& handle)> is_stub = [&to_delete, &graph] (const handle_t& handle) {
+        size_t left_degree = 0;
+        graph->follow_edges(handle, true, [&](handle_t left) {
+            if (!to_delete.count(graph->get_id(left))) {
+                ++left_degree;
+                return false;
+            }
+            return true;
+        });
+        size_t right_degree = 1;
+        if (left_degree > 0) {
+            right_degree = 0;
+            graph->follow_edges(handle, false, [&](handle_t right) {
+                if (!to_delete.count(graph->get_id(right))) {
+                    ++right_degree;
+                    return false;
+                }
+                return true;
+            });
+        }
+        return left_degree == 0 || right_degree == 0;
+    };
+    
+    function<void(handle_t, const Region*)> visit_handle = [&](handle_t handle, const Region* region) {
+
+        if (!to_delete.count(graph->get_id(handle)) && is_stub(handle)) {
+            bool on_ref = false;
+            graph->for_each_step_on_handle(handle, [&](step_handle_t step_handle) {
+                if (!ref_prefixes.empty() || region) {
+                    // if we have a region, do exact comparison to it.
+                    // otherwise, do a prefix check against ref_prefix
+                    string path_name = graph->get_path_name(graph->get_path_handle_of_step(step_handle));
+                    if ((region && region->seq == path_name) || (!region && check_prefixes(path_name))) {
+                        on_ref = true;
+                        return false;
+                    }
+                }
+                return true;
+            });
+            if (!on_ref) {
+                to_delete.insert(graph->get_id(handle));
+
+                // remember the neighbours -- they can be new stubs!
+                graph->follow_edges(handle, true, [&](handle_t prev) {
+                    if (handle_in_range(prev) && !to_delete.count(graph->get_id(prev)) && graph->get_id(handle) != graph->get_id(prev)) {
+                        stub_neighbours_1[prev] = region;
+                    }
+                });
+                graph->follow_edges(handle, false, [&](handle_t next) {
+                    if (handle_in_range(next) && !to_delete.count(graph->get_id(next)) && graph->get_id(handle) != graph->get_id(next)) {
+                        stub_neighbours_1[next] = region;
+                    }
+                });
+            }
+        }
+    };
+       
+    // first pass: find all the stubs in iterate_handles
+    // and populate stub_neighbours_1
+    iterate_handles(visit_handle);
+
+    // keep doing the same thing on the neighbours until none left, using
+    // handle_in_range to make sure we don't step out of bounds (in the case we're doing BED regions)           
+    unordered_map<handle_t, const Region*> stub_neighbours_2;
+    size_t iterations = 1;
+    while (!stub_neighbours_1.empty()) {
+        ++iterations;
+        stub_neighbours_2.clear();
+        swap(stub_neighbours_1, stub_neighbours_2);
+        for (const auto&  neighbour_pair : stub_neighbours_2) {
+            visit_handle(neighbour_pair.first, neighbour_pair.second);
+        }
+        stub_neighbours_2.clear();
+    }
+        
+    if (verbose) {
+        cerr << "[vg-clip]: Removing " << to_delete.size() << " nodes from (non-reference) stubs in " << iterations << " iterations." << endl;
+    }
+
+    // cut out the nodes and chop up paths
+    delete_nodes_and_chop_paths(graph, to_delete, {}, min_fragment_len, verbose ? &clip_counts : nullptr);
+        
+    if (verbose) {
+        for (const auto& kv : clip_counts) {
+            cerr << "[vg-clip]: Creating " << kv.second << " fragments from path" << kv.first << endl;
+        }
+        clip_counts.clear();
+    }
+
+}
+
+void clip_stubs(MutablePathMutableHandleGraph* graph, const vector<string>& ref_prefixes, int64_t min_fragment_len, bool verbose) {
+    
+    function<void(function<void(handle_t, const Region*)>)> iterate_handles = [&] (function<void(handle_t, const Region*)> visit_handle) {
+        graph->for_each_handle([&](handle_t handle) {
+                visit_handle(handle, nullptr);
+            });        
+    };
+
+    function<bool(handle_t)> handle_in_range = [](handle_t) {
+        return true;
+    };
+
+    clip_stubs_generic(graph, iterate_handles, handle_in_range, ref_prefixes, min_fragment_len, verbose);
+}
+
+void clip_contained_stubs(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
+                          SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len, bool verbose) {
+
+    unordered_set<handle_t> all_handles;
+    function<bool(handle_t)> handle_in_range = [&all_handles](handle_t handle) {
+        return all_handles.count(handle);
+    };
+    
+    function<void(function<void(handle_t, const Region*)>)> iterate_handles = [&] (function<void(handle_t, const Region*)> visit_handle) {
+        
+        visit_contained_snarls(pp_graph, regions, snarl_manager, include_endpoints, [&](const Snarl* snarl, step_handle_t start_step, step_handle_t end_step,
+                                                                                        int64_t start_pos, int64_t end_pos,
+                                                                                        bool steps_reversed, const Region* containing_region) {
+                                   
+            pair<unordered_set<id_t>, unordered_set<edge_t> > contents = snarl_manager.deep_contents(snarl, *pp_graph, false);
+            for (id_t node_id : contents.first) {
+                visit_handle(graph->get_handle(node_id), containing_region);
+                all_handles.insert(graph->get_handle(node_id));
+            }                                   
+        });
+    };
+
+    // the edge depths are computed globally, without looking at regions.  as such, they need some notion of reference paths
+    // so we shimmy a set in from the regions
+    set<string> ref_path_set;
+    for (const Region& region : regions) {
+        ref_path_set.insert(region.seq);
+    }
+    vector<string> ref_paths_from_regions(ref_path_set.begin(), ref_path_set.end());
+
+    clip_stubs_generic(graph, iterate_handles, handle_in_range, ref_paths_from_regions, min_fragment_len, verbose);
+    
+}
+
+
 }

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -83,6 +83,15 @@ void clip_contained_low_depth_nodes_and_edges(MutablePathMutableHandleGraph* gra
 void clip_deletion_edges(MutablePathMutableHandleGraph* graph, int64_t max_deletion, int64_t context_steps,
                          const vector<string>& ref_prefixes, int64_t min_fragment_len, bool verbose);
 
+/**
+* clip out stubs
+*/
+void clip_stubs(MutablePathMutableHandleGraph* graph, const vector<string>& ref_prefixes, int64_t min_fragment_len, bool verbose);
+
+void clip_contained_stubs(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
+                          SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len, bool verbose);
+
+
 }
 
 

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -235,11 +235,11 @@ int main_clip(int argc, char** argv) {
     unique_ptr<SnarlManager> snarl_manager;
     vector<Region> bed_regions;
 
-    // need the path positions unless we're doing depth or deletion clipping without regions
-    bool need_pp = !(bed_path.empty() && (min_depth >= 0 || max_deletion >= 0));
+    // need the path positions unless we're doing depth, deletion or stub clipping without regions
+    bool need_pp = !(bed_path.empty() && (min_depth >= 0 || max_deletion >= 0 || stub_clipping));
 
     // need snarls if input regions are provided, or doing snarl based clipping
-    bool need_snarls = !bed_path.empty() || (min_depth < 0 && max_deletion < 0);
+    bool need_snarls = !bed_path.empty() || (min_depth < 0 && max_deletion < 0 && !stub_clipping);
 
     if (need_pp) {
         pp_graph = overlay_helper.apply(graph.get());

--- a/test/t/53_clip.t
+++ b/test/t/53_clip.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 13
+plan tests 15
 
 vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 -k 16 | vg mod -U 10 - | vg mod -c - > hla.vg
 
@@ -71,4 +71,21 @@ rm -f region.bed clip.vg
 
 rm -f hla.vg
 
+vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa | vg view - | sort  >  tiny.gfa
+cp tiny.gfa tiny-stubs.gfa
+printf "S\t0\tA\n" >> tiny-stubs.gfa
+printf "L\t0\t+\t1\t+\t0M\n" >> tiny-stubs.gfa
+printf "S\t100\tA\n" >> tiny-stubs.gfa
+printf "L\t0\t+\t100\t+\t0M\n" >> tiny-stubs.gfa
+printf "S\t200\tA\n" >> tiny-stubs.gfa
+printf "L\t5\t+\t200\t+\t0M\n" >> tiny-stubs.gfa
+printf "S\t300\tA\n" >> tiny-stubs.gfa
+printf "L\t200\t+\t300\t+\t0M\n" >> tiny-stubs.gfa
+vg clip tiny.gfa -s -P x | sort > tiny-nostubs.gfa
+diff tiny.gfa tiny-nostubs.gfa
+is "$?" 0 "stub clipping removed all stubs"
 
+printf "x\t5\t25\n" > region.bed
+is $(vg clip tiny-stubs.gfa -s -b region.bed | vg stats -N -) "17" "region clipping filtered out only 2 / 4 stub nodes"
+
+rm -f tiny.gfa tiny-stubs.gfa region.bed tiny-nostubs.gfa


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * New option `vg clip -s` to remove stubs (dangling nodes not on ref path)

## Description

No, I don't want no stub
A stub is a node that can't get no love from me
Hangin' off the reference path of the pangenome graph
Trying to holla at me
I don't want no stub
A stub is a node that can't get no love from me
Hangin' off the reference path of the pangenome graph
Trying to holla at me