### PR TITLE
Make GBZ node translation for VCF ID's opt-in instead of default

### DIFF
--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -76,7 +76,8 @@ int main_call(int argc, char** argv) {
     string snarl_filename;
     string gbwt_filename;
     bool   gbz_paths = false;
-    string translation_file_name;    
+    string translation_file_name;
+    bool   gbz_translation = false;
     string ref_fasta_filename;
     string ins_fasta_filename;
     vector<string> ref_paths;
@@ -137,7 +138,8 @@ int main_call(int argc, char** argv) {
             {"snarls", required_argument, 0, 'r'},
             {"gbwt", required_argument, 0, 'g'},
             {"gbz", no_argument, 0, 'z'},
-            {"translation", required_argument, 0, 'N'},            
+            {"translation", required_argument, 0, 'N'},
+            {"gbz-translation", no_argument, 0, 'O'},
             {"ref-path", required_argument, 0, 'p'},
             {"ref-offset", required_argument, 0, 'o'},
             {"ref-length", required_argument, 0, 'l'},
@@ -156,7 +158,7 @@ int main_call(int argc, char** argv) {
 
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "k:Be:b:m:v:aAc:C:f:i:s:r:g:zN:p:o:l:d:R:GTLM:nt:h",
+        c = getopt_long (argc, argv, "k:Be:b:m:v:aAc:C:f:i:s:r:g:zN:Op:o:l:d:R:GTLM:nt:h",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -215,6 +217,9 @@ int main_call(int argc, char** argv) {
             break;
         case 'N':
             translation_file_name = optarg;
+            break;
+        case 'O':
+            gbz_translation = true;
             break;            
         case 'p':
             ref_paths.push_back(optarg);
@@ -376,10 +381,14 @@ int main_call(int argc, char** argv) {
         cerr << "Error [vg call]: -z can only be used when input graph is in GBZ format" << endl;
         return 1;
     }
+    if (gbz_translation && !gbz_graph) {
+        cerr << "Error [vg call]: -O can only be used when input graph is in GBZ format" << endl;
+        return 1;
+    }
     
     // Read the translation
     unique_ptr<unordered_map<nid_t, pair<string, size_t>>> translation;
-    if (gbz_graph.get() != nullptr) {
+    if (gbz_graph.get() != nullptr && gbz_translation) {
         // try to get the translation from the graph
         translation = make_unique<unordered_map<nid_t, pair<string, size_t>>>();
         *translation = load_translation_back_map(gbz_graph->gbz.graph);

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -69,11 +69,11 @@ diff inv_decon.tsv inv_truth.tsv
 is "$?" 0 "deconstruct correctly handles a simple inversion when the reference contains the reversing edge"
 
 vg gbwt -G inv.gfa -g inv.chop.gbz --gbz-format --max-node 5
-vg deconstruct inv.chop.gbz -p x > inv.chop.decon
+vg deconstruct inv.chop.gbz -p x -O > inv.chop.decon
 vg gbwt -G inv.gfa -g inv.gbz --gbz-format --max-node 1025
-vg deconstruct inv.gbz -p x > inv.decon
+vg deconstruct inv.gbz -p x -O > inv.decon
 diff inv.decon inv.chop.decon
-is "$?" 0 "deconstruct automatically applies translation from gbz"
+is "$?" 0 "deconstruct applies translation from gbz with -O"
 
 rm -f inv.gfa inv.vg inv.xg inv_decon.vcf inv_decon.tsv inv_truth.tsv inv.gbz inv.chop.gbz inv.gbz inv.chop.decon inv.decon
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg call` and `vg deconstruct` now only apply node ID translation from GBZ inputs if new `-O` is used.  

## Description

Nodes get chopped down to 1024bp when converting to GBZ (or GBWT), but a mapping back to the unchopped IDs is kept around.  When working with GBWT's, `vg call` and `deconstruct` had options to pass in a translation file (written by `vg gbwt`) to write node IDs in the output VCF (ie in AT fields) in using the unchopped IDs. 

When adding support for GBZ input a few versions back, I toggled this on by default: if there was a translation in the GBZ it got used.  But this is a very confusing turn of events where you get different logic depending on the input format, with the default GBZ logic of writing node IDs in a different graph than what you're working on being extra confusing.  

So this PR just reverts back to using the chopped ID space by default -- the translation from the GBZ can be used with a new `-O` flag in both `call` and `deconstruct`. 

Resolves #3873