### PR TITLE
Connect haplotypes

### DIFF
--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -340,7 +340,7 @@ private:
 class Recombinator {
 public:
     /// Number of haplotypes to be generated.
-    constexpr static size_t NUM_HAPLOTYPES = 16;
+    constexpr static size_t NUM_HAPLOTYPES = 8;
 
     /// Expected read coverage.
     constexpr static size_t COVERAGE = 30;
@@ -381,6 +381,10 @@ public:
         /// If no original haplotype crosses a subchain, a new fragment will
         /// start after the subchain.
         size_t fragment;
+
+        /// GBWT sequence indentifier in the previous subchain, or
+        /// `gbwt::invalid_sequence()` if there was no such sequence.
+        gbwt::size_type sequence_id;
 
         /// GBWT position at the end of the latest `extend()` call.
         /// `gbwt::invalid_edge()` otherwise.
@@ -448,6 +452,9 @@ public:
         /// Number of haplotypes generated.
         size_t haplotypes = 0;
 
+        /// Number of times a haplotype was extended from a subchain to the next subchain.
+        size_t connections = 0;
+
         /// Number of reference paths included.
         size_t ref_paths = 0;
 
@@ -510,8 +517,6 @@ public:
      * the middle of a chain create fragment breaks. If the chain starts without
      * a prefix (ends without a suffix), the haplotype chosen for the first (last)
      * subchain is used from the start (continued until the end).
-     *
-     * TODO: Include reference paths?
      */
     gbwt::GBWT generate_haplotypes(const Haplotypes& haplotypes, const std::string& kff_file, const Parameters& parameters) const;
 

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -161,6 +161,10 @@ public:
     size_t k() const { return this->header.k; }
 
     Header header;
+
+    // Job ids for each cached path in the GBWTGraph, or `jobs()` if the path is empty.
+    std::vector<size_t> jobs_for_cached_paths;
+
     std::vector<TopLevelChain> chains;
 
     /**
@@ -444,6 +448,9 @@ public:
         /// Number of haplotypes generated.
         size_t haplotypes = 0;
 
+        /// Number of reference paths included.
+        size_t ref_paths = 0;
+
         /// Number of kmers selected.
         size_t kmers = 0;
 
@@ -485,6 +492,9 @@ public:
 
         /// Sample randomly instead of by score.
         bool random_sampling = false;
+
+        /// Include named and reference paths.
+        bool include_reference = false;
     };
 
     /**

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -106,6 +106,7 @@ void help_haplotypes(char** argv) {
     std::cerr << "        --present-discount F  discount scores for present kmers by factor F (default: " << haplotypes_default_discount() << ")" << std::endl;
     std::cerr << "        --het-adjustment F    adjust scores for heterozygous kmers by F (default: " << haplotypes_default_adjustment() << ")" << std::endl;
     std::cerr << "        --random-sampling     sample randomly instead of using the kmer counts" << std::endl;
+    std::cerr << "        --include-reference   include named and reference paths in the output" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
     std::cerr << "    -v, --verbosity N         verbosity level (0 = silent, 1 = basic, 2 = detailed, 3 = debug; default: 0)" << std::endl;
@@ -175,6 +176,7 @@ int main_haplotypes(int argc, char** argv) {
     constexpr int OPT_PRESENT_DISCOUNT = 1302;
     constexpr int OPT_HET_ADJUSTMENT = 1303;
     constexpr int OPT_RANDOM_SAMPLING = 1304;
+    constexpr int OPT_INCLUDE_REFERENCE = 1305;
     constexpr int OPT_VALIDATE = 1400;
 
     static struct option long_options[] =
@@ -194,6 +196,7 @@ int main_haplotypes(int argc, char** argv) {
         { "present-discount", required_argument, 0, OPT_PRESENT_DISCOUNT },
         { "het-adjustment", required_argument, 0, OPT_HET_ADJUSTMENT },
         { "random-sampling", no_argument, 0, OPT_RANDOM_SAMPLING },
+        { "include-reference", no_argument, 0, OPT_INCLUDE_REFERENCE },
         { "verbosity", required_argument, 0, 'v' },
         { "threads", required_argument, 0, 't' },
         { "validate", no_argument, 0,  OPT_VALIDATE },
@@ -284,6 +287,9 @@ int main_haplotypes(int argc, char** argv) {
             break;
         case OPT_RANDOM_SAMPLING:
             recombinator_parameters.random_sampling = true;
+            break;
+        case OPT_INCLUDE_REFERENCE:
+            recombinator_parameters.include_reference = true;
             break;
 
         case 'v':
@@ -781,6 +787,11 @@ void validate_haplotypes(const Haplotypes& haplotypes,
         if (chains_per_job[job_id] == 0) {
             validate_error("", "job " + std::to_string(job_id) + " is empty");
         }
+    }
+
+    // Cached paths.
+    if (haplotypes.jobs_for_cached_paths.size() != graph.named_paths.size()) {
+        validate_error("cached paths", expected_got(graph.named_paths.size(), haplotypes.jobs_for_cached_paths.size()));
     }
 
     // Haplotype information is valid

--- a/test/t/54_vg_haplotypes.t
+++ b/test/t/54_vg_haplotypes.t
@@ -24,6 +24,8 @@ is $? 0 "sampling the haplotypes directly"
 cmp indirect.gbz direct.gbz
 is $? 0 "the outputs are identical"
 
+# FIXME: Test --include-reference with both named and reference paths.
+
 # Cleanup
 rm -r small.vg small.gbz small.ri small.dist
 rm -f small.hapl indirect.gbz direct.gbz


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * (Still nothing that concerns the user.)

## Description

Haplotype sampling will now connect the same haplotype in adjacent subchains instead of doing arbitrary recombinations. This has a minor effect on mapping results.

When sampling 8 or 16 haplotypes from the HPRC graph, the connection rate is only ~40%. Most of the sample haplotypes are unrelated to the sequenced sample, because we are sampling a large fraction of all haplotypes.

There is also an option to include generic and reference paths in the sampled graph.
