### PR TITLE
Improve Surject Validation and Error Reporting

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -2081,7 +2081,7 @@ void alignment_set_distance_to_correct(Alignment& aln, const map<string ,vector<
     }
 }
 
-AlignmentValidity alignment_is_valid(Alignment& aln, const HandleGraph* hgraph) {
+AlignmentValidity alignment_is_valid(const Alignment& aln, const HandleGraph* hgraph) {
     for (size_t i = 0; i < aln.path().mapping_size(); ++i) {
         const Mapping& mapping = aln.path().mapping(i);
         if (!hgraph->has_node(mapping.position().node_id())) {

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -326,7 +326,7 @@ struct AlignmentValidity {
     /// The mapping in the alignment's path at which the problem was encountered.
     size_t bad_mapping_index = 0;
     /// An explanation for the problem.
-    std::string explanation = "";
+    std::string message = "";
     
     /// We are truthy if the alignment has no problem, and falsey otherwise.
     inline operator bool() const {
@@ -337,7 +337,7 @@ struct AlignmentValidity {
 /// Check to make sure edits on the alignment's path don't assume incorrect
 /// node lengths or ids. Result can be used like a bool or inspected for
 /// further details. Does not log anything itself about bad alignments.
-AlignmentValidity alignment_is_valid(Alignment& aln, const HandleGraph* hgraph);
+AlignmentValidity alignment_is_valid(const Alignment& aln, const HandleGraph* hgraph);
     
 /// Make an Alignment corresponding to a subregion of a stored path.
 /// Positions are 0-based, and pos2 is excluded.

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -310,8 +310,34 @@ map<string ,vector<pair<size_t, bool> > > alignment_refpos_to_path_offsets(const
 void alignment_set_distance_to_correct(Alignment& aln, const Alignment& base, const unordered_map<string, string>* translation = nullptr);
 void alignment_set_distance_to_correct(Alignment& aln, const map<string, vector<pair<size_t, bool>>>& base_offsets, const unordered_map<string, string>* translation = nullptr);
 
-/// check to make sure edits on the alignment's path don't assume incorrect node lengths or ids
-bool alignment_is_valid(Alignment& aln, const HandleGraph* hgraph);
+/**
+ * Represents a report on whether an alignment makes sense in the context of a graph.
+ */
+struct AlignmentValidity {
+    /// The different kinds of possible problems with alignments
+    enum Problem {
+        OK,
+        NODE_MISSING,
+        NODE_TOO_SHORT
+    };
+    
+    /// The kind of problem with the alignment.
+    Problem problem = OK;
+    /// The mapping in the alignment's path at which the problem was encountered.
+    size_t bad_mapping_index = 0;
+    /// An explanation for the problem.
+    std::string explanation = "";
+    
+    /// We are truthy if the alignment has no problem, and falsey otherwise.
+    inline operator bool() const {
+        return problem == OK;
+    }
+};
+
+/// Check to make sure edits on the alignment's path don't assume incorrect
+/// node lengths or ids. Result can be used like a bool or inspected for
+/// further details. Does not log anything itself about bad alignments.
+AlignmentValidity alignment_is_valid(Alignment& aln, const HandleGraph* hgraph);
     
 /// Make an Alignment corresponding to a subregion of a stored path.
 /// Positions are 0-based, and pos2 is excluded.

--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -201,6 +201,9 @@ vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const strin
     // and filled in later
     vector<pair<string, int64_t>> input_names_lengths;
     
+    // Should we print path subrange warnings?
+    bool print_subrange_warnings = true;
+    
     // When we get a sequence and possibly its length (or -1 if no length is
     // known), put it in the dictionary.
     // Can optionally provide a file name for error reporting.
@@ -224,18 +227,21 @@ vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const strin
                 exit(1);
             }
             
-            subrange_t subrange;
-            std::string base_path_name = Paths::strip_subrange(sequence_name, &subrange);
-            if (subrange != PathMetadata::NO_SUBRANGE) {
-                // The user is asking explicitly to surject to a path that is a
-                // subrange of some other logical path, like
-                // GRCh38#0#chr1[1000-2000]. That's weird. Warn.
-                cerr << "warning:[vg::get_sequence_dictionary] Path " << sequence_name;
-                if (filename) {
-                    // Report the source file.
-                    cerr << " from sequence dictionary in " << *filename;
+            if (print_subrange_warnings) {
+                subrange_t subrange;
+                std::string base_path_name = Paths::strip_subrange(sequence_name, &subrange);
+                if (subrange != PathMetadata::NO_SUBRANGE) {
+                    // The user is asking explicitly to surject to a path that is a
+                    // subrange of some other logical path, like
+                    // GRCh38#0#chr1[1000-2000]. That's weird. Warn.
+                    cerr << "warning:[vg::get_sequence_dictionary] Path " << sequence_name;
+                    if (filename) {
+                        // Report the source file.
+                        cerr << " from sequence dictionary in " << *filename;
+                    }
+                    cerr << " looks like part of a path. Output coordinates will be in " << base_path_name << " instead. Suppressing further warnings." << endl;
+                    print_subrange_warnings = false;
                 }
-                cerr << " looks like part of a path. Output coordinates will be in " << base_path_name << " instead." << endl;
             }
             
             // Remember the path

--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -223,6 +223,21 @@ vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const strin
                 cerr << endl;
                 exit(1);
             }
+            
+            subrange_t subrange;
+            std::string base_path_name = Paths::strip_subrange(sequence_name, &subrange);
+            if (subrange != PathMetadata::NO_SUBRANGE) {
+                // The user is asking explicitly to surject to a path that is a
+                // subrange of some other logical path, like
+                // GRCh38#0#chr1[1000-2000]. That's weird. Warn.
+                cerr << "warning:[vg::get_sequence_dictionary] Path " << sequence_name;
+                if (filename) {
+                    // Report the source file.
+                    cerr << " from sequence dictionary in " << *filename;
+                }
+                cerr << " looks like part of a path. Output coordinates will be in " << base_path_name << " instead." << endl;
+            }
+            
             // Remember the path
             base_path_to_subpaths[sequence_name].push_back(path);
         } else {
@@ -237,10 +252,10 @@ vector<tuple<path_handle_t, size_t, size_t>> get_sequence_dictionary(const strin
             });
             if (!base_path_to_subpaths.count(sequence_name)) {
                 // We didn't find any subpaths for this path as a base path either.
-                cerr << "error:[vg::get_sequence_dictionary] Graph does not have a path named " << sequence_name;
+                cerr << "error:[vg::get_sequence_dictionary] Graph does not have the entirety or any pieces of a path named " << sequence_name;
                 if (filename) {
                     // Report the source file.
-                    cerr << " which was indicated in " << filename;
+                    cerr << " which was indicated in " << *filename;
                 }
                 cerr << endl;
                 exit(1);

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -28,7 +28,7 @@ using namespace vg;
 
 struct GBWTConfig {
     // Build mode also defines the type of input args.
-    enum build_mode { build_none, build_vcf, build_gfa, build_paths, build_alignments, build_gbz };
+    enum build_mode { build_none, build_vcf, build_gfa, build_paths, build_alignments, build_gbz, build_gbwtgraph };
     enum merge_mode { merge_none, merge_insert, merge_fast, merge_parallel };
     enum path_cover_mode { path_cover_none, path_cover_augment, path_cover_local, path_cover_greedy };
 
@@ -66,6 +66,7 @@ struct GBWTConfig {
     std::vector<std::string> input_filenames;
     std::string gbwt_name; // There is a single input GBWT to load.
     std::string graph_name;
+    std::string gbwtgraph_name;
 
     // File names.
     std::string gbwt_output; // Output GBWT.
@@ -104,7 +105,7 @@ struct GBWTConfig {
 };
 
 struct GraphHandler {
-    enum graph_type { graph_none, graph_path, graph_source, graph_gbz };
+    enum graph_type { graph_none, graph_path, graph_source, graph_gbz, graph_gbwtgraph };
 
     std::unique_ptr<PathHandleGraph> path_graph = nullptr;
     std::unique_ptr<gbwtgraph::SequenceSource> sequence_source = nullptr;
@@ -123,6 +124,11 @@ struct GraphHandler {
     // graph in this handler.
     // NOTE: The graph will become invalid if the GBWT in the GBWTHandler changes.
     void load_gbz(GBWTHandler& gbwts, GBWTConfig& config);
+    
+    // Load the GBWTGraph specified in the config, store the GBWT in the
+    // GBWTHandler and the graph in this handler.
+    // NOTE: The graph will become invalid if the GBWT in the GBWTHandler changes.
+    void load_gbwtgraph(GBWTHandler& gbwts, GBWTConfig& config);
 
     void clear();
 
@@ -268,6 +274,7 @@ void help_gbwt(char** argv) {
     std::cerr << "        --translation FILE  write the segment to node translation table to FILE" << std::endl;
     std::cerr << "    -Z, --gbz-input         extract GBWT and GBWTGraph from GBZ input (one input arg)" << std::endl;
     std::cerr << "        --translation FILE  write the segment to node translation table to FILE" << std::endl;
+    std::cerr << "    -I, --gg-in FILE        load GBWTGraph from FILE and GBWT from input (one input arg) " << std::endl;
     std::cerr << "    -E, --index-paths       index the embedded non-alt paths in the graph (requires -x, no input args)" << std::endl;
     std::cerr << "    -A, --alignment-input   index the alignments in the GAF files specified in input args (requires -x)" << std::endl;
     std::cerr << "        --gam-format        the input files are in GAM format instead of GAF format" << std::endl;
@@ -428,6 +435,9 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
 
         // Input GBWT construction: GBZ
         { "gbz-input", no_argument, 0, 'Z' },
+        
+        // Input GBWT construction: GBWTGraph and GBWT
+        { "gg-in", required_argument, 0, 'I' },
 
         // Input GBWT construction: paths
         { "index-paths", no_argument, 0, 'E' },
@@ -487,7 +497,7 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
     GBWTConfig config;
     while (true) {
         int option_index = 0;
-        c = getopt_long(argc, argv, "x:o:d:pvGZEAmfbR:alPn:k:g:r:MCHSLTce:h?", long_options, &option_index);
+        c = getopt_long(argc, argv, "x:o:d:pvGZI:EAmfbR:alPn:k:g:r:MCHSLTce:h?", long_options, &option_index);
 
         /* Detect the end of the options. */
         if (c == -1)
@@ -643,6 +653,14 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
         case 'Z':
             no_multiple_input_types(config);
             config.build = GBWTConfig::build_gbz;
+            config.produces_one_gbwt = true;
+            break;
+            
+        // Input GBWT construction: GBWTGraph and GBWT
+        case 'I':
+            no_multiple_input_types(config);
+            config.build = GBWTConfig::build_gbwtgraph;
+            config.gbwtgraph_name = optarg;
             config.produces_one_gbwt = true;
             break;
 
@@ -831,8 +849,8 @@ void validate_gbwt_config(GBWTConfig& config) {
     // We have one input GBWT after steps 1-4.
     bool one_input_gbwt = config.input_filenames.size() == 1 || config.produces_one_gbwt;
 
-    // We can load a PathHandleGraph from a file, get a SequenceSource from parsing GFA, or get a GBWTGraph from GBZ.
-    bool has_graph_input = !config.graph_name.empty() || config.build == GBWTConfig::build_gfa || config.build == GBWTConfig::build_gbz;
+    // We can load a PathHandleGraph from a file, get a SequenceSource from parsing GFA, or get a GBWTGraph from GBZ or GG/GBWT.
+    bool has_graph_input = !config.graph_name.empty() || config.build == GBWTConfig::build_gfa || config.build == GBWTConfig::build_gbz || config.build == GBWTConfig::build_gbwtgraph;
 
     if (config.build == GBWTConfig::build_gbz) {
         // If we "build" a GBWT by loading it from a GBZ, we just need to make
@@ -843,6 +861,17 @@ void validate_gbwt_config(GBWTConfig& config) {
         }
         if (config.input_filenames.size() != 1) {
             std::cerr << "error: [vg gbwt] GBZ input requires one input arg" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    } else if (config.build == GBWTConfig::build_gbwtgraph) {
+        // If we "build" a GBWT by loading it from a GG and a GBWT, we just need to make
+        // sure that we know enough to actually load it.  
+        if (!config.graph_name.empty()) {
+            std::cerr << "error: [vg gbwt] GBWTGraph input does not use -x" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        if (config.input_filenames.size() != 1) {
+            std::cerr << "error: [vg gbwt] GBWTGraph input requires one input arg" << std::endl;
             std::exit(EXIT_FAILURE);
         }
     } else if (config.build != GBWTConfig::build_none) {
@@ -896,6 +925,9 @@ void validate_gbwt_config(GBWTConfig& config) {
     if (!config.to_remove.empty()) {
         if (config.build == GBWTConfig::build_gbz) {
             std::cerr << "error: [vg gbwt] the GBWT extracted from GBZ cannot have paths modified" << std::endl;
+        }
+        if (config.build == GBWTConfig::build_gbwtgraph) {
+            std::cerr << "error: [vg gbwt] the GBWT loaded with a GBWTGraph cannot have paths modified" << std::endl;
         }
         if (!(config.input_filenames.size() == 1 || config.merge != GBWTConfig::merge_none) || !has_gbwt_output) {
             std::cerr << "error: [vg gbwt] removing a sample requires one input GBWT and output GBWT" << std::endl;
@@ -1177,7 +1209,7 @@ void step_1_build_gbwts(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& co
         std::cerr << "Building input GBWTs" << std::endl;
     }
     gbwts.unbacked(); // We will build a new GBWT.
-    if (config.build != GBWTConfig::build_gfa && config.build != GBWTConfig::build_gbz) {
+    if (config.build != GBWTConfig::build_gfa && config.build != GBWTConfig::build_gbz && config.build != GBWTConfig::build_gbwtgraph) {
         graphs.get_graph(config);
     }
 
@@ -1242,6 +1274,11 @@ void step_1_build_gbwts(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& co
             std::cerr << "Input type: GBZ" << std::endl;
         }
         graphs.load_gbz(gbwts, config);
+    } else if (config.build == GBWTConfig::build_gbwtgraph) {
+        if(config.show_progress) {
+            std::cerr << "Input type: GBWTGraph" << std::endl;
+        }
+        graphs.load_gbwtgraph(gbwts, config);
     } else if (config.build == GBWTConfig::build_paths) {
         if(config.show_progress) {
             std::cerr << "Input type: embedded paths" << std::endl;
@@ -1650,6 +1687,25 @@ void GraphHandler::load_gbz(GBWTHandler& gbwts, GBWTConfig& config) {
         this->gbwt_graph = std::make_unique<gbwtgraph::GBWTGraph>(std::move(gbz.graph));
         this->gbwt_graph->set_gbwt(gbwts.compressed);
         this->in_use = graph_gbz;
+    }
+}
+
+void GraphHandler::load_gbwtgraph(GBWTHandler& gbwts, GBWTConfig& config) {
+    if (this->in_use == graph_gbwtgraph) {
+        return;
+    } else {
+        this->clear();
+        // Load the GBWT
+        gbwt::GBWT input_gbwt;
+        vg::load_gbwt(input_gbwt, config.input_filenames.front(), config.show_progress);
+        gbwts.use(input_gbwt);
+        
+        // Then load the GBWTGraph
+        this->gbwt_graph = std::make_unique<gbwtgraph::GBWTGraph>();
+        vg::load_gbwtgraph(*this->gbwt_graph, config.gbwtgraph_name, config.show_progress);
+        // And connect it
+        this->gbwt_graph->set_gbwt(gbwts.compressed);
+        this->in_use = graph_gbwtgraph;
     }
 }
 

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -1499,7 +1499,7 @@ void step_5_gbwtgraph(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& conf
     gbwtgraph::GBWTGraph graph;
     if (graphs.in_use == GraphHandler::graph_source) {
         graph = gbwtgraph::GBWTGraph(gbwts.compressed, *(graphs.sequence_source));
-    } else if (graphs.in_use == GraphHandler::graph_gbz) {
+    } else if (graphs.in_use == GraphHandler::graph_gbz || graphs.in_use == GraphHandler::graph_gbwtgraph) {
         graph = std::move(*(graphs.gbwt_graph));
         graphs.clear();
     } else {

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -64,7 +64,7 @@ static void ensure_alignment_is_for_graph(const Alignment& aln, const HandleGrap
     if (!validity) {
         #pragma omp critical (cerr)
         {
-            std::cerr << "error [vg surject]: Alignment " << aln.name() << " cannot be interpreted against this graph: " << validity.message << std::endl;
+            std::cerr << "error:[vg surject] Alignment " << aln.name() << " cannot be interpreted against this graph: " << validity.message << std::endl;
             std::cerr << "Make sure that you are using the same graph that the reads were mapped to!" << std::endl;
         }
         exit(1);

--- a/src/subcommand/validate_main.cpp
+++ b/src/subcommand/validate_main.cpp
@@ -93,10 +93,10 @@ int main_validate(int argc, char** argv) {
                         AlignmentValidity validity = alignment_is_valid(aln, graph.get());
                         if (!validity) {
                             // Complain about this alignment
-                            cerr << "Invalid Alignment:\n" << pb2json(aln) << "\n" << validity.explanation;
+                            cerr << "Invalid Alignment:\n" << pb2json(aln) << "\n" << validity.message;
                             if (validity.problem == AlignmentValidity::NODE_TOO_SHORT) {
                                 // If a node is too short, report the whole mapping again.
-                                cerr << ":\n" << pb2json(aln.path().mapping(validity.bad_mapping_index))
+                                cerr << ":\n" << pb2json(aln.path().mapping(validity.bad_mapping_index));
                             }
                             cerr << endl;
                             valid_aln = false;

--- a/src/subcommand/validate_main.cpp
+++ b/src/subcommand/validate_main.cpp
@@ -90,7 +90,15 @@ int main_validate(int argc, char** argv) {
     if (!gam_path.empty()) {
         get_input_file(gam_path, [&](istream& in) {
                 vg::io::for_each<Alignment>(in, [&](Alignment& aln) {
-                        if (!alignment_is_valid(aln, graph.get())) {
+                        AlignmentValidity validity = alignment_is_valid(aln, graph.get());
+                        if (!validity) {
+                            // Complain about this alignment
+                            cerr << "Invalid Alignment:\n" << pb2json(aln) << "\n" << validity.explanation;
+                            if (validity.problem == AlignmentValidity::NODE_TOO_SHORT) {
+                                // If a node is too short, report the whole mapping again.
+                                cerr << ":\n" << pb2json(aln.path().mapping(validity.bad_mapping_index))
+                            }
+                            cerr << endl;
                             valid_aln = false;
                         }
                     });

--- a/src/subcommand/validate_main.cpp
+++ b/src/subcommand/validate_main.cpp
@@ -27,7 +27,8 @@ void help_validate(char** argv) {
          << "options:" << endl
          << "    default: check all aspects of the graph, if options are specified do only those" << endl
          << "    -o, --orphans   verify that all nodes have edges" << endl
-         << "    -a, --gam FILE  verify that edits in the alignment fit on nodes in the graph" << endl;
+         << "    -a, --gam FILE  verify that edits in the alignment fit on nodes in the graph" << endl
+         << "    -A, --gam-only  do not verify the graph itself, only the alignment" << endl;
 }
 
 int main_validate(int argc, char** argv) {
@@ -39,6 +40,7 @@ int main_validate(int argc, char** argv) {
 
     bool check_orphans = false;
     string gam_path;
+    bool gam_only = false;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -48,11 +50,12 @@ int main_validate(int argc, char** argv) {
             {"help", no_argument, 0, 'h'},
             {"orphans", no_argument, 0, 'o'},
             {"gam", required_argument, 0, 'a'},
+            {"gam-only", no_argument, 0, 'A'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hoa:",
+        c = getopt_long (argc, argv, "hoa:A",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -67,6 +70,10 @@ int main_validate(int argc, char** argv) {
 
             case 'a':
                 gam_path = optarg;
+                break;
+                
+            case 'A':
+                gam_only = true;
                 break;
 
             case 'h':
@@ -107,14 +114,17 @@ int main_validate(int argc, char** argv) {
 
     // VG's a little less structured, so try its own logic
     bool valid_graph = true;
-    VG* vg_graph = dynamic_cast<VG*>(graph.get());
-    if (vg_graph != nullptr) {
-        if (!vg_graph->is_valid(true, true, check_orphans, true)) {
-            valid_graph = false;
+    
+    if (!gam_only) {
+        VG* vg_graph = dynamic_cast<VG*>(graph.get());
+        if (vg_graph != nullptr) {
+            if (!vg_graph->is_valid(true, true, check_orphans, true)) {
+                valid_graph = false;
+            }
         }
     }
 
-    if (valid_graph) {
+    if (!gam_only && valid_graph) {
         // I don't think this is possible with any libbdsg implementations, but check edges just in case
         graph->for_each_edge([&](const edge_t& edge) {
                 if (!graph->has_node(graph->get_id(edge.first))) {
@@ -171,7 +181,9 @@ int main_validate(int argc, char** argv) {
     if (!gam_path.empty()) {
         cerr << "alignment: " << (valid_aln ? "valid" : "invalid") << endl;
     }
-    cerr << "graph: " << (valid_graph ? "valid" : "invalid") << endl;
+    if (!gam_only) {
+        cerr << "graph: " << (valid_graph ? "valid" : "invalid") << endl;
+    }
 
     return valid_aln && valid_graph ? 0 : 1;
 }

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -3133,13 +3133,17 @@ using namespace std;
             }
             if (all_path_ranges_out) {
                 if (all_path_ranges_out->empty()) {
-                    cerr << "error: couldn't identify a path corresponding to surjected read " << source.name() << endl;
+                    cerr << "error: couldn't identify a path range corresponding to surjected read " << source.name()
+                         << " because there are no path ranges on path " << graph->get_path_name(path_handle) << endl;
+                    cerr << "Surjected read dump: " << pb2json(surjected) << endl;
                     exit(1);
                 }
                 path_range_out = all_path_ranges_out->front();
             }
             else if (mappings_matched != surj_path.mapping_size()) {
-                cerr << "error: couldn't identify a path corresponding to surjected read " << source.name() << endl;
+                cerr << "error: couldn't identify a path range corresponding to surjected read " << source.name()
+                     << " because " << mappings_matched << "/" << surj_path.mapping_size() << " mappings were matched on path " << graph->get_path_name(path_handle) << endl;
+                cerr << "Surjected read dump: " << pb2json(surjected) << endl;
                 exit(1);
             }
         }

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 145
+plan tests 147
 
 
 # Build vg graphs for two chromosomes
@@ -243,6 +243,12 @@ is $? 0 "GBZ construction from VCF"
 cmp x.gbz x2.gbz
 is $? 0 "Identical construction results from GBWT and VCF"
 
+# Build and serialize GBZ from an existing GBWT and GBWTGraph
+vg gbwt -I x.gg -g x3.gbz --gbz-format x.gbwt
+is $? 0 "GBZ construction from GBWTGraph"
+cmp x.gbz x3.gbz
+is $? 0 "Identical construction results from XG and GBWTGraph"
+
 # Extract GBWT from GBZ
 vg gbwt -o extracted.gbwt -Z x.gbz
 is $? 0 "GBWT extraction from GBZ"
@@ -257,7 +263,7 @@ is $? 0 "Identical GBWT indexes"
 cmp x.gg extracted2.gg
 is $? 0 "Identical GBWTGraphs"
 
-rm -f x.gbwt x.gg x.gbz x2.gbz
+rm -f x.gbwt x.gg x.gbz x2.gbz x3.gbz
 rm -f extracted.gbwt extracted2.gbwt extracted2.gg
 
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject` will now enforce that the reads it is surjection actually were mapped against the graph you are surjecting against. Right now it checks node IDs and lengths. You can turn this off with `-V`/`--no-validate`.
 * `vg gbwt` now accepts a `-I`/`--gg-in` option, which lets you load a `.gg` file and a `.gbwt` file and combine them into a `.gbz` graph.
 * `vg validate` now accepts a `-A`/`--gam-only` option which will validate only the provided alignment's agreement with the graph, and not the graph itself.
 * The `vg surject`/`vg giraffe` `error: couldn't identify a path corresponding to surjected read` error message has been improved to dump more information about the offending read and path.
 * When selecting paths to surject to, a warning will now be printed if the user asks for a path with a `[]`-enclosed subrange at the end. The base path name without the `[]` subrange coordinates should usually be used instead, because that is the space in which the SAM/BAM output will have its coordinates specified.
 * The `vg surject` `Graph does not have a path named` error message should now no longer print pointer values, and is extended to explain a bit more about subpaths.

## Description

This makes a bunch of small improvements to the surjection pipeline to try and make it easier to use and harder to use wrong.
