### PR TITLE
Prevent runs of consecutive ID operations in surjected cigars

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -994,11 +994,13 @@ vector<pair<int, char>> cigar_against_path(const Alignment& alignment, bool on_r
             cigar.front().second = 'S';
         }
     }
+    
+    simplify_cigar(cigar);
 
     return cigar;
 }
 
-void simiplify_cigar(vector<pair<int, char>>& cigar) {
+void simplify_cigar(vector<pair<int, char>>& cigar) {
     
     size_t removed = 0;
     for (size_t i = 0, j = 0; i < cigar.size(); ++j) {
@@ -1020,7 +1022,7 @@ void simiplify_cigar(vector<pair<int, char>>& cigar) {
                 cigar[i - removed] = make_pair(d_total, 'D');
                 cigar[i - removed + 1] = make_pair(i_total, 'I');
                 
-                // mark that we've
+                // mark that we've removed cigar operations
                 removed += j - i - 2;
             }
             // move the start of the next I/D run beyond the current operation

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -203,7 +203,7 @@ vector<pair<int, char>> cigar_against_path(const Alignment& alignment, bool on_r
 
 /// Merge runs of successive I/D operations into a single I and D, remove 0-length
 /// operations, and merge adjacent operations of the same type
-void simiplify_cigar(vector<pair<int, char>>& cigar);
+void simplify_cigar(vector<pair<int, char>>& cigar);
 
 
 /// Translate the CIGAR in the given BAM record into mappings in the given

--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -1055,7 +1055,7 @@ vector<pair<int, char>> SplicedHTSAlignmentEmitter::spliced_cigar_against_path(c
         }
     }
     
-    simiplify_cigar(cigar);
+    simplify_cigar(cigar);
     
     return cigar;
 }

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -3831,7 +3831,7 @@ namespace vg {
         cerr << "coalescing runs of I/D..." << endl;
 #endif
 
-        simiplify_cigar(cigar);
+        simplify_cigar(cigar);
         
 #ifdef debug_cigar
         cerr << "final cigar: ";

--- a/src/unittest/alignment.cpp
+++ b/src/unittest/alignment.cpp
@@ -241,7 +241,7 @@ TEST_CASE("Target to alignment extraction", "[target-to-aln]") {
     
 }
 
-TEST_CASE("simiplify_cigar merges runs of adjacent I's and D's in cigars", "[alignment][surject]") {
+TEST_CASE("simplify_cigar merges runs of adjacent I's and D's in cigars", "[alignment][surject]") {
     
     vector<pair<int, char>> cigar{
         make_pair(2, 'D'),
@@ -253,7 +253,7 @@ TEST_CASE("simiplify_cigar merges runs of adjacent I's and D's in cigars", "[ali
         make_pair(1, 'I')
     };
 
-    simiplify_cigar(cigar);
+    simplify_cigar(cigar);
     REQUIRE(cigar.size() == 5);
     bool consolidated_1 = ((cigar[0] == make_pair(6, 'D') && cigar[1] == make_pair(1, 'I'))
                            || (cigar[0] == make_pair(1, 'I') && cigar[1] == make_pair(6, 'D')));
@@ -264,7 +264,7 @@ TEST_CASE("simiplify_cigar merges runs of adjacent I's and D's in cigars", "[ali
     REQUIRE(consolidated_2);
 }
 
-TEST_CASE("simiplify_cigar merges runs of adjacent operations and removes empty operations", "[alignment][surject]") {
+TEST_CASE("simplify_cigar merges runs of adjacent operations and removes empty operations", "[alignment][surject]") {
     
     vector<pair<int, char>> cigar{
         make_pair(2, 'S'),
@@ -275,7 +275,7 @@ TEST_CASE("simiplify_cigar merges runs of adjacent operations and removes empty 
         make_pair(1, 'M')
     };
     
-    simiplify_cigar(cigar);
+    simplify_cigar(cigar);
     REQUIRE(cigar.size() == 4);
     REQUIRE(cigar[0] == make_pair(2, 'S'));
     REQUIRE(cigar[1] == make_pair(2, 'M'));


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Alignments from `vg surject` consistently prevent runs of consecutive I and D operations in CIGAR strings

## Description

This informatic technicality is expected by some tools, but the anchoring strategy in `vg surject` sometimes 'naturally' produces these CIGARs. This PR applies the CIGAR simplification that was being used for multipath alignments to standard GAM/GAF alignments.