### PR TITLE
Register reference-matching edits as reference runs so they can be inverted

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -529,6 +529,9 @@ namespace vg {
                 nodes_ending_at[reference_cursor + seen_bases - 1].insert(new_nodes.back()->id());
                 
                 // Save the whole run for inversion tracing
+                #ifdef debug
+                cerr << "Create ref run ending at " << reference_cursor + seen_bases - 1 << endl;
+                #endif
                 ref_runs_by_end[reference_cursor + seen_bases - 1] = std::move(new_nodes);
 
             }
@@ -1089,6 +1092,16 @@ namespace vg {
                                         nodes_starting_at[edit_start].insert(node_run.front()->id());
                                         nodes_ending_at[edit_end].insert(node_run.back()->id());
 
+                                        if (edit.ref == edit.alt) {
+                                            // This edit is a no-op and so the node we just created is a reference run.
+                                            // These can be necessary if insertions and deletions are part of the same record.
+                                            // Remember the whole node run for inversion tracing
+                                            #ifdef debug
+                                            cerr << "Create ref run ending at " << edit_end << endl;
+                                            #endif
+                                            ref_runs_by_end[edit_end] = node_run;
+                                        }
+
                                         // Save it in case any other alts also have this edit.
                                         created_nodes[key] = node_run;
 
@@ -1310,6 +1323,9 @@ namespace vg {
                         nodes_ending_at[next_end].insert(node_run.back()->id());
                         
                         // Remember the whole node run for inversion tracing
+                        #ifdef debug
+                        cerr << "Create ref run ending at " << next_end << endl;
+                        #endif
                         ref_runs_by_end[next_end] = node_run;
                         
 
@@ -1319,6 +1335,10 @@ namespace vg {
 
                         // Save it in case any other alts also have this edit.
                         created_nodes[key] = node_run;
+                    } else {
+#ifdef debug
+                        cerr << "Reference nodes at  " << reference_cursor << " for constant " << run_sequence.size() << " bp sequence " << run_sequence << " already exist" << endl;
+#endif
                     }
 
                     for (Node* node : created_nodes[key]) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Graph construction will no longer crash when inversions overlap combination insertion-deletions

## Description

This will fix #3883. 

For variants like `CTTTTTTTTT	CTTTTTTTTTTT,C` where an insert and a delete are in the same record, we have a no-op edit of some reference bases to those same reference bases, which we can't normalize away. This makes us create a reference-matching node early in the graph construction process, while making all the alt alleles, and we were forgetting to detect that the node we had created was a reference node and register it as able to be inverted. So if a variant like this is contained in an inversion, we weren't able to find the reference node we needed to spell out the inverted allele, causing a crash.

I've now made sure to register reference nodes for the inversion code if they are created to represent a variant's alt alleles.

You still might not get good behavior from VCFs with inversion variants overlapping other variants. I don't think the haplotype generation code knows how to composite overlapping variants itself; it wants all your overlapping VCF records about the same haplotype to be combined in advance, or it will throw out variants or cut haplotypes to get something it can understand.