### PR TITLE
Prevent mis-tagging GBZ files and fix a surject bug

### DIFF
--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 147
+plan tests 148
 
 
 # Build vg graphs for two chromosomes
@@ -395,5 +395,7 @@ vg gbwt -g gfa2.gbz --gbz-format -Z gfa.gbz --set-tag "reference_samples=GRCh38 
 is $? 0 "GBZ GBWT tag modification works"
 is "$(vg paths -M -S GRCh37 -x gfa2.gbz | grep -v "^#" | grep HAPLOTYPE | wc -l)" "1" "Changing reference_samples tag can make a reference a haplotype"
 is "$(vg paths -M -S CHM13 -x gfa2.gbz | grep -v "^#" | grep REFERENCE | wc -l)" "1" "Changing reference_samples tag can make a haplotype a reference"
+vg gbwt -g gfa2.gbz --gbz-format -Z gfa.gbz --set-tag "reference_samples=GRCh38#1 CHM13" 2>/dev/null
+is $? 1 "GBZ GBWT tag modification validation works"
 
 rm -f gfa.gbz gfa2.gbz tags.tsv


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg gbwt` will now refuse to add reference sample names with `#` in them, and will try and advise on what the tags are supposed to be like
 * `vg surject` can project to paths that intersect themselves in the reverse orientation

## Description

I noticed that it's easy for a user to accidentally set a reference sample tag like `HG002#1#`, which kind of looks right given the path names but which actually vg won't be able to understand. This adds some checks and hints to prevent that sort of string being added as a reference path name in a GBZ, from the command line.

It still could sneak in through a GFA file; validating (and complaining about the non-presence of) the `RS` GFA tag is still something we should do.

(Edit, Jordan): We also uncovered, tested, and fixed a bug in surject.