### PR TITLE
Enable fasta-only autoindex

### DIFF
--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -582,8 +582,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         }
                         
         // boilerplate
-        assert(inputs.size() == 2 || inputs.size() == 3);
-        assert(constructing.size() == 2 || constructing.size() == 3);
+        assert(inputs.size() == 1 || inputs.size() == 2 || inputs.size() == 3);
         assert(constructing.size() == inputs.size());
         vector<string> fasta_filenames, vcf_filenames, tx_filenames;
         bool has_vcf = inputs.size() == 3 || (inputs.size() == 2 && !has_gff);
@@ -1670,6 +1669,13 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                                  AliasGraph& alias_graph,
                                  const IndexGroup& constructing) {
         return chunk_contigs(inputs, plan, alias_graph, constructing, true, false);
+    });
+    registry.register_recipe({"Chunked Reference FASTA"}, {"Reference FASTA"},
+                             [=](const vector<const IndexFile*>& inputs,
+                                 const IndexingPlan* plan,
+                                 AliasGraph& alias_graph,
+                                 const IndexGroup& constructing) {
+        return chunk_contigs(inputs, plan, alias_graph, constructing, false, false);
     });
     
     


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Linear reference indexes can be constructed from only a FASTA file in `vg autoindex`
 
## Description

Resolves https://github.com/vgteam/vg/issues/3900.

No new pipelining was necessary, just needed to add a missing recipe.
