### PR TITLE
Fail better

### DIFF
--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -85,9 +85,18 @@ static void start_vg_link(const std::string& file_path, int line) {
         // File exists to link to!
         url_path = abspath;
         
+        size_t host_length_limit;
+        #if defined(HOST_NAME_MAX)
+            host_length_limit = HOST_NAME_MAX;
+        #elif defined(_POSIX_HOST_NAME_MAX)
+            host_length_limit = _POSIX_HOST_NAME_MAX;
+        #else
+            host_length_limit = 256;
+        #endif
+        
         // The link probably needs a hostname
-        char host_buffer[HOST_NAME_MAX + 1];
-        if (gethostname(host_buffer, HOST_NAME_MAX) == 0) {
+        char host_buffer[host_length_limit + 1];
+        if (gethostname(host_buffer, host_length_limit) == 0) {
             url_host = host_buffer;
         }
         // And we have to pick a protocol depending on if we are local or not

--- a/src/crash.hpp
+++ b/src/crash.hpp
@@ -6,16 +6,39 @@
  *
  * Implementation for crash handling to create a stack trace when VG crashes.
  * To use the crash handling system, call enable_crash_handling() early on in the program.
- * When a crash occurs, you will recieve an error message with the path to the 
- * stack trace file. To get the full stack trace on standard error, you need to
- * set the environment variable 'VG_FULL_TRACEBACK=1'. 
+ * When a crash occurs, you will recieve an error message with the stack trace.
+ * To get just a filename, you need to set the environment variable
+ * 'VG_FULL_TRACEBACK=0'. 
  *
  */
+
+#include <functional>
+#include <string>
 
 namespace vg {
 
 /// Main should call this to turn on our stack tracing support.
 void enable_crash_handling();
+
+/// User code should call this when it has context for a failure in its thread.
+void set_crash_context(const std::string& message);
+
+/// User code should call this when it wants to clear context for a failure in its thread.
+void clear_crash_context();
+
+/// User code should call this to get all its exceptions handled.
+void with_exception_handling(const std::function<void(void)>& body);
+
+/// User code should call this if it catches an exception it doesn't know what
+/// to do with.
+void report_exception(const std::exception& ex);
+
+/// User code should call this instead of assert
+#define crash_unless(condition) crash_unless_impl((condition), #condition, __FILE__, __LINE__, __func__); 
+
+/// crash_unless calls into this function for a real implementation.
+void crash_unless_impl(bool condition, const std::string& condition_string, const std::string& file, int line, const std::string& function);
+
 
 }
 #endif

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -5,6 +5,7 @@
 
 #include "minimizer_mapper.hpp"
 
+#include "crash.hpp"
 #include "annotation.hpp"
 #include "path_subgraph.hpp"
 #include "multipath_alignment.hpp"
@@ -55,7 +56,7 @@ MinimizerMapper::MinimizerMapper(const gbwtgraph::GBWTGraph& graph,
     fragment_length_distr(1000,1000,0.95) {
     
     // The GBWTGraph needs a GBWT
-    assert(graph.index != nullptr);
+    crash_unless(graph.index != nullptr);
 }
 
 //-----------------------------------------------------------------------------
@@ -1014,7 +1015,7 @@ vector<Alignment> MinimizerMapper::map_from_extensions(Alignment& aln) {
     }, [&](size_t alignment_num) {
         // This alignment does not have a sufficiently good score
         // Score threshold is 0; this should never happen
-        assert(false);
+        crash_unless(false);
     });
     
     if (track_provenance) {
@@ -1030,7 +1031,7 @@ vector<Alignment> MinimizerMapper::map_from_extensions(Alignment& aln) {
         }
     }
 
-    assert(!mappings.empty());
+    crash_unless(!mappings.empty());
     // Compute MAPQ if not unmapped. Otherwise use 0 instead of the 50% this would give us.
     // Use exact mapping quality 
     double mapq = (mappings.front().path().mapping_size() == 0) ? 0 : 
@@ -1128,7 +1129,7 @@ vector<Alignment> MinimizerMapper::map_from_extensions(Alignment& aln) {
              << minimizer.hits << "\t"
              << minimizer_extensions_count[i];
          if (minimizer_extensions_count[i]>0) {
-             assert(minimizer.hits<=hard_hit_cap) ;
+             crash_unless(minimizer.hits<=hard_hit_cap) ;
          }
     }
     cerr << "\t" << uncapped_mapq << "\t" << mapq_explored_cap << "\t"  << mappings.front().mapping_quality() << "\t";
@@ -1547,7 +1548,7 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
     }
 #ifdef debug
     for (size_t count : better_cluster_count) {
-        assert(count >= 1);
+        crash_unless(count >= 1);
     }
 #endif
 
@@ -2382,7 +2383,7 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
     }, [&](size_t alignment_num) {
         // This alignment does not have a sufficiently good score
         // Score threshold is 0; this should never happen
-        assert(false);
+        crash_unless(false);
     });
 
     if (track_provenance) {
@@ -2625,7 +2626,7 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                  << minimizer.hits << "\t"
                  << minimizer_explored_by_read[r].contains(i);
              if (minimizer_explored_by_read[r].contains(i)) {
-                 assert(minimizer.hits<=hard_hit_cap) ;
+                 crash_unless(minimizer.hits<=hard_hit_cap) ;
              }
         }
         cerr << "\t" << uncapped_mapq << "\t" << fragment_cluster_cap << "\t" << mapq_score_groups[0] << "\t" 
@@ -2638,9 +2639,9 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
             }
 
             int64_t dist = distances[i];
-            assert(dist == distance_between(paired_alignments[0], paired_alignments[1])); 
+            crash_unless(dist == distance_between(paired_alignments[0], paired_alignments[1])); 
 
-            assert(scores[i] == score_alignment_pair(paired_alignments[0], paired_alignments[1], dist));
+            crash_unless(scores[i] == score_alignment_pair(paired_alignments[0], paired_alignments[1], dist));
 
             double multiplicity = paired_multiplicities.size() == scores.size() ? paired_multiplicities[i] : 1.0;
 
@@ -2826,7 +2827,7 @@ void MinimizerMapper::for_each_agglomeration_interval(const VectorView<Minimizer
         // Handle no item case
         return;
     }
-
+    
     // Items currently being iterated over
     list<const Minimizer*> stack = {&minimizers[minimizer_indices.front()]};
     // The left end of an item interval
@@ -3208,8 +3209,8 @@ int64_t MinimizerMapper::unoriented_distance_between(const pos_t& pos1, const po
 }
 
 int64_t MinimizerMapper::distance_between(const Alignment& aln1, const Alignment& aln2) {
-    assert(aln1.path().mapping_size() != 0); 
-    assert(aln2.path().mapping_size() != 0); 
+    crash_unless(aln1.path().mapping_size() != 0); 
+    crash_unless(aln2.path().mapping_size() != 0); 
      
     pos_t pos1 = initial_position(aln1.path()); 
     pos_t pos2 = final_position(aln2.path());
@@ -4275,7 +4276,7 @@ void MinimizerMapper::find_optimal_tail_alignments(const Alignment& aln, const v
                 // If we have a nonzero offset in our mapping, and we follow
                 // something, we must be continuing on from a previous mapping to
                 // the node.
-                assert(mapping.position().node_id() == best.path().mapping(best.path().mapping_size() - 1).position().node_id());
+                crash_unless(mapping.position().node_id() == best.path().mapping(best.path().mapping_size() - 1).position().node_id());
 
                 // Find that previous mapping
                 auto* prev_mapping = best.mutable_path()->mutable_mapping(best.path().mapping_size() - 1);
@@ -4302,7 +4303,7 @@ void MinimizerMapper::find_optimal_tail_alignments(const Alignment& aln, const v
                 // If we have a nonzero offset in our mapping, and we follow
                 // something, we must be continuing on from a previous mapping to
                 // the node.
-                assert(mapping.position().node_id() == second_best.path().mapping(second_best.path().mapping_size() - 1).position().node_id());
+                crash_unless(mapping.position().node_id() == second_best.path().mapping(second_best.path().mapping_size() - 1).position().node_id());
 
                 // Find that previous mapping
                 auto* prev_mapping = second_best.mutable_path()->mutable_mapping(second_best.path().mapping_size() - 1);

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -27,6 +27,7 @@
 #include "../minimizer_mapper.hpp"
 #include "../index_registry.hpp"
 #include "../watchdog.hpp"
+#include "../crash.hpp"
 #include <bdsg/overlays/overlay_helper.hpp>
 
 #include <gbwtgraph/gbz.h>
@@ -1267,50 +1268,59 @@ int main_giraffe(int argc, char** argv) {
                 
                 // Define how to align and output a read pair, in a thread.
                 auto map_read_pair = [&](Alignment& aln1, Alignment& aln2) {
-                    auto thread_num = omp_get_thread_num();
-#ifdef __linux__
-                    ensure_perf_for_thread();
-#endif
-                    
-                    if (watchdog) {
-                        watchdog->check_in(thread_num, aln1.name() + ", " + aln2.name());
-                    }
-                    
-                    toUppercaseInPlace(*aln1.mutable_sequence());
-                    toUppercaseInPlace(*aln2.mutable_sequence());
-
-                    pair<vector<Alignment>, vector<Alignment>> mapped_pairs = minimizer_mapper.map_paired(aln1, aln2, ambiguous_pair_buffer);
-                    if (!mapped_pairs.first.empty() && !mapped_pairs.second.empty()) {
-                        //If we actually tried to map this paired end
+                    try {
+                        set_crash_context(aln1.name() + ", " + aln2.name());
                         
-                        // Work out whether it could be properly paired or not, if that is relevant.
-                        // If we're here, let the read be properly paired in
-                        // HTSlib terms no matter how far away it is in linear
-                        // space (on the same contig), because it went into
-                        // pair distribution estimation.
-                        // TODO: The semantics are weird here. 0 means
-                        // "properly paired at any distance" and
-                        // numeric_limits<int64_t>::max() doesn't.
-                        int64_t tlen_limit = 0;
-                        if (hts_output && minimizer_mapper.fragment_distr_is_finalized()) {
-                             tlen_limit = minimizer_mapper.get_fragment_length_mean() + 6 * minimizer_mapper.get_fragment_length_stdev();
+                        auto thread_num = omp_get_thread_num();
+#ifdef __linux__
+                        ensure_perf_for_thread();
+#endif
+                        
+                        if (watchdog) {
+                            watchdog->check_in(thread_num, aln1.name() + ", " + aln2.name());
                         }
-                        // Emit it
-                        alignment_emitter->emit_mapped_pair(std::move(mapped_pairs.first), std::move(mapped_pairs.second), tlen_limit);
-                        // Record that we mapped a read.
-                        reads_mapped_by_thread.at(thread_num) += 2;
-                    }
-                    
-                    if (!minimizer_mapper.fragment_distr_is_finalized() && ambiguous_pair_buffer.size() >= MAX_BUFFERED_PAIRS) {
-                        // We risk running out of memory if we keep this up.
-                        cerr << "warning[vg::giraffe]: Encountered " << ambiguous_pair_buffer.size() << " ambiguously-paired reads before finding enough" << endl
-                             << "                      unambiguously-paired reads to learn fragment length distribution. Are you sure" << endl
-                             << "                      your reads are paired and your graph is not a hairball?" << endl;
-                        require_distribution_finalized();
-                    }
-                    
-                    if (watchdog) {
-                        watchdog->check_out(thread_num);
+                        
+                        toUppercaseInPlace(*aln1.mutable_sequence());
+                        toUppercaseInPlace(*aln2.mutable_sequence());
+
+                        pair<vector<Alignment>, vector<Alignment>> mapped_pairs = minimizer_mapper.map_paired(aln1, aln2, ambiguous_pair_buffer);
+                        if (!mapped_pairs.first.empty() && !mapped_pairs.second.empty()) {
+                            //If we actually tried to map this paired end
+                            
+                            // Work out whether it could be properly paired or not, if that is relevant.
+                            // If we're here, let the read be properly paired in
+                            // HTSlib terms no matter how far away it is in linear
+                            // space (on the same contig), because it went into
+                            // pair distribution estimation.
+                            // TODO: The semantics are weird here. 0 means
+                            // "properly paired at any distance" and
+                            // numeric_limits<int64_t>::max() doesn't.
+                            int64_t tlen_limit = 0;
+                            if (hts_output && minimizer_mapper.fragment_distr_is_finalized()) {
+                                 tlen_limit = minimizer_mapper.get_fragment_length_mean() + 6 * minimizer_mapper.get_fragment_length_stdev();
+                            }
+                            // Emit it
+                            alignment_emitter->emit_mapped_pair(std::move(mapped_pairs.first), std::move(mapped_pairs.second), tlen_limit);
+                            // Record that we mapped a read.
+                            reads_mapped_by_thread.at(thread_num) += 2;
+                        }
+                        
+                        if (!minimizer_mapper.fragment_distr_is_finalized() && ambiguous_pair_buffer.size() >= MAX_BUFFERED_PAIRS) {
+                            // We risk running out of memory if we keep this up.
+                            cerr << "warning[vg::giraffe]: Encountered " << ambiguous_pair_buffer.size() << " ambiguously-paired reads before finding enough" << endl
+                                 << "                      unambiguously-paired reads to learn fragment length distribution. Are you sure" << endl
+                                 << "                      your reads are paired and your graph is not a hairball?" << endl;
+                            require_distribution_finalized();
+                        }
+                        
+                        if (watchdog) {
+                            watchdog->check_out(thread_num);
+                        }
+                        
+                        clear_crash_context();
+                            
+                    } catch (const std::exception& ex) {
+                        report_exception(ex);
                     }
                 };
 
@@ -1334,17 +1344,22 @@ int main_giraffe(int argc, char** argv) {
                 // Make sure fragment length distribution is finalized first.
                 require_distribution_finalized();
                 for (pair<Alignment, Alignment>& alignment_pair : ambiguous_pair_buffer) {
-
-                    auto mapped_pairs = minimizer_mapper.map_paired(alignment_pair.first, alignment_pair.second);
-                    // Work out whether it could be properly paired or not, if that is relevant.
-                    int64_t tlen_limit = 0;
-                    if (hts_output && minimizer_mapper.fragment_distr_is_finalized()) {
-                         tlen_limit = minimizer_mapper.get_fragment_length_mean() + 6 * minimizer_mapper.get_fragment_length_stdev();
+                    try {
+                        set_crash_context(alignment_pair.first.name() + ", " + alignment_pair.second.name());
+                        auto mapped_pairs = minimizer_mapper.map_paired(alignment_pair.first, alignment_pair.second);
+                        // Work out whether it could be properly paired or not, if that is relevant.
+                        int64_t tlen_limit = 0;
+                        if (hts_output && minimizer_mapper.fragment_distr_is_finalized()) {
+                             tlen_limit = minimizer_mapper.get_fragment_length_mean() + 6 * minimizer_mapper.get_fragment_length_stdev();
+                        }
+                        // Emit the read
+                        alignment_emitter->emit_mapped_pair(std::move(mapped_pairs.first), std::move(mapped_pairs.second), tlen_limit);
+                        // Record that we mapped a read.
+                        reads_mapped_by_thread.at(omp_get_thread_num()) += 2;
+                        clear_crash_context();
+                    } catch (const std::exception& ex) {
+                        report_exception(ex);
                     }
-                    // Emit the read
-                    alignment_emitter->emit_mapped_pair(std::move(mapped_pairs.first), std::move(mapped_pairs.second), tlen_limit);
-                    // Record that we mapped a read.
-                    reads_mapped_by_thread.at(omp_get_thread_num()) += 2;
                 }
             } else {
                 // Map single-ended
@@ -1354,23 +1369,29 @@ int main_giraffe(int argc, char** argv) {
             
                 // Define how to align and output a read, in a thread.
                 auto map_read = [&](Alignment& aln) {
-                    auto thread_num = omp_get_thread_num();
+                    try {
+                        set_crash_context(aln.name());
+                        auto thread_num = omp_get_thread_num();
 #ifdef __linux__
-                    ensure_perf_for_thread();
+                        ensure_perf_for_thread();
 #endif
-                    if (watchdog) {
-                        watchdog->check_in(thread_num, aln.name());
-                    }
+                        if (watchdog) {
+                            watchdog->check_in(thread_num, aln.name());
+                        }
+                        
+                        toUppercaseInPlace(*aln.mutable_sequence());
                     
-                    toUppercaseInPlace(*aln.mutable_sequence());
-                
-                    // Map the read with the MinimizerMapper.
-                    minimizer_mapper.map(aln, *alignment_emitter);
-                    // Record that we mapped a read.
-                    reads_mapped_by_thread.at(thread_num)++;
-                    
-                    if (watchdog) {
-                        watchdog->check_out(thread_num);
+                        // Map the read with the MinimizerMapper.
+                        minimizer_mapper.map(aln, *alignment_emitter);
+                        // Record that we mapped a read.
+                        reads_mapped_by_thread.at(thread_num)++;
+                        
+                        if (watchdog) {
+                            watchdog->check_out(thread_num);
+                        }
+                        clear_crash_context();
+                    } catch (const std::exception& ex) {
+                        report_exception(ex);
                     }
                 };
                     

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -22,6 +22,7 @@
 #include "../surjector.hpp"
 #include "../hts_alignment_emitter.hpp"
 #include "../multipath_alignment_emitter.hpp"
+#include "../crash.hpp"
 
 
 using namespace std;
@@ -315,98 +316,103 @@ int main_surject(int argc, char** argv) {
             // GAM input is paired, and for HTS output reads need to know their pair partners' mapping locations.
             // TODO: We don't preserve order relationships (like primary/secondary) beyond the interleaving.
             function<void(Alignment&, Alignment&)> lambda = [&](Alignment& src1, Alignment& src2) {
-                // Make sure that the alignments are actually paired with each other
-                // (proper fragment_prev/fragment_next). We want to catch people giving us
-                // un-interleaved GAMs as interleaved.
-                // TODO: Integrate into for_each_interleaved_pair_parallel when running on Alignments.
-                if (src1.has_fragment_next()) {
-                    // Alignment 1 comes first in fragment
-                    if (src1.fragment_next().name() != src2.name() ||
-                        !src2.has_fragment_prev() ||
-                        src2.fragment_prev().name() != src1.name()) {
-                        
+                try {
+                    set_crash_context(src1.name() + ", " + src2.name());
+                    // Make sure that the alignments are actually paired with each other
+                    // (proper fragment_prev/fragment_next). We want to catch people giving us
+                    // un-interleaved GAMs as interleaved.
+                    // TODO: Integrate into for_each_interleaved_pair_parallel when running on Alignments.
+                    if (src1.has_fragment_next()) {
+                        // Alignment 1 comes first in fragment
+                        if (src1.fragment_next().name() != src2.name() ||
+                            !src2.has_fragment_prev() ||
+                            src2.fragment_prev().name() != src1.name()) {
+                            
+#pragma omp critical (cerr)
+                            cerr << "[vg surject] error: alignments " << src1.name()
+                            << " and " << src2.name() << " are adjacent but not paired" << endl;
+                            
+                            exit(1);
+                            
+                        }
+                    } else if (src2.has_fragment_next()) {
+                        // Alignment 2 comes first in fragment
+                        if (src2.fragment_next().name() != src1.name() ||
+                            !src1.has_fragment_prev() ||
+                            src1.fragment_prev().name() != src2.name()) {
+                            
+#pragma omp critical (cerr)
+                            cerr << "[vg surject] error: alignments " << src1.name()
+                            << " and " << src2.name() << " are adjacent but not paired" << endl;
+                            
+                            exit(1);
+                            
+                        }
+                    } else {
+                        // Alignments aren't paired up at all
 #pragma omp critical (cerr)
                         cerr << "[vg surject] error: alignments " << src1.name()
                         << " and " << src2.name() << " are adjacent but not paired" << endl;
                         
                         exit(1);
-                        
-                    }
-                } else if (src2.has_fragment_next()) {
-                    // Alignment 2 comes first in fragment
-                    if (src2.fragment_next().name() != src1.name() ||
-                        !src1.has_fragment_prev() ||
-                        src1.fragment_prev().name() != src2.name()) {
-                        
-#pragma omp critical (cerr)
-                        cerr << "[vg surject] error: alignments " << src1.name()
-                        << " and " << src2.name() << " are adjacent but not paired" << endl;
-                        
-                        exit(1);
-                        
-                    }
-                } else {
-                    // Alignments aren't paired up at all
-#pragma omp critical (cerr)
-                    cerr << "[vg surject] error: alignments " << src1.name()
-                    << " and " << src2.name() << " are adjacent but not paired" << endl;
-                    
-                    exit(1);
-                }
-                
-                if (validate) {
-                    ensure_alignment_is_for_graph(src1, *xgidx);
-                    ensure_alignment_is_for_graph(src2, *xgidx);
-                }
-                
-                // Preprocess read to set metadata before surjection
-                set_metadata(src1);
-                set_metadata(src2);
-                
-                // Surject and emit.
-                if (multimap) {
-                    
-                    auto surjected1 = surjector.multi_surject(src1, paths, subpath_global, spliced);
-                    auto surjected2 = surjector.multi_surject(src2, paths, subpath_global, spliced);
-                    
-                    // we have to pair these up manually
-                    unordered_map<pair<string, bool>, size_t> strand_idx1, strand_idx2;
-                    for (size_t i = 0; i < surjected1.size(); ++i) {
-                        const auto& pos = surjected1[i].refpos(0);
-                        strand_idx1[make_pair(pos.name(), pos.is_reverse())] = i;
-                    }
-                    for (size_t i = 0; i < surjected2.size(); ++i) {
-                        const auto& pos = surjected2[i].refpos(0);
-                        strand_idx2[make_pair(pos.name(), pos.is_reverse())] = i;
                     }
                     
-                    for (size_t i = 0; i < surjected1.size(); ++i) {
-                        const auto& pos = surjected1[i].refpos(0);
-                        auto it = strand_idx2.find(make_pair(pos.name(), !pos.is_reverse()));
-                        if (it != strand_idx2.end()) {
-                            // the alignments are paired on this strand
-                            alignment_emitter->emit_pair(move(surjected1[i]), move(surjected2[it->second]), max_frag_len);
+                    if (validate) {
+                        ensure_alignment_is_for_graph(src1, *xgidx);
+                        ensure_alignment_is_for_graph(src2, *xgidx);
+                    }
+                    
+                    // Preprocess read to set metadata before surjection
+                    set_metadata(src1);
+                    set_metadata(src2);
+                    
+                    // Surject and emit.
+                    if (multimap) {
+                        
+                        auto surjected1 = surjector.multi_surject(src1, paths, subpath_global, spliced);
+                        auto surjected2 = surjector.multi_surject(src2, paths, subpath_global, spliced);
+                        
+                        // we have to pair these up manually
+                        unordered_map<pair<string, bool>, size_t> strand_idx1, strand_idx2;
+                        for (size_t i = 0; i < surjected1.size(); ++i) {
+                            const auto& pos = surjected1[i].refpos(0);
+                            strand_idx1[make_pair(pos.name(), pos.is_reverse())] = i;
                         }
-                        else {
-                            // this strand's surjection is unpaired
-                            alignment_emitter->emit_single(move(surjected1[i]));
+                        for (size_t i = 0; i < surjected2.size(); ++i) {
+                            const auto& pos = surjected2[i].refpos(0);
+                            strand_idx2[make_pair(pos.name(), pos.is_reverse())] = i;
+                        }
+                        
+                        for (size_t i = 0; i < surjected1.size(); ++i) {
+                            const auto& pos = surjected1[i].refpos(0);
+                            auto it = strand_idx2.find(make_pair(pos.name(), !pos.is_reverse()));
+                            if (it != strand_idx2.end()) {
+                                // the alignments are paired on this strand
+                                alignment_emitter->emit_pair(move(surjected1[i]), move(surjected2[it->second]), max_frag_len);
+                            }
+                            else {
+                                // this strand's surjection is unpaired
+                                alignment_emitter->emit_single(move(surjected1[i]));
+                            }
+                        }
+                        for (size_t i = 0; i < surjected2.size(); ++i) {
+                            const auto& pos = surjected2[i].refpos(0);
+                            if (!strand_idx1.count(make_pair(pos.name(), !pos.is_reverse()))) {
+                                // this strand's surjection is unpaired
+                                alignment_emitter->emit_single(move(surjected2[i]));
+                            }
                         }
                     }
-                    for (size_t i = 0; i < surjected2.size(); ++i) {
-                        const auto& pos = surjected2[i].refpos(0);
-                        if (!strand_idx1.count(make_pair(pos.name(), !pos.is_reverse()))) {
-                            // this strand's surjection is unpaired
-                            alignment_emitter->emit_single(move(surjected2[i]));
-                        }
+                    else {
+                        // FIXME: these aren't forced to be on the same path, which could be fucky
+                        alignment_emitter->emit_pair(surjector.surject(src1, paths, subpath_global, spliced),
+                                                     surjector.surject(src2, paths, subpath_global, spliced),
+                                                     max_frag_len);
                     }
+                    clear_crash_context();
+                } catch (const std::exception& ex) {
+                    report_exception(ex);
                 }
-                else {
-                    // FIXME: these aren't forced to be on the same path, which could be fucky
-                    alignment_emitter->emit_pair(surjector.surject(src1, paths, subpath_global, spliced),
-                                                 surjector.surject(src2, paths, subpath_global, spliced),
-                                                 max_frag_len);
-                }
-                
             };
             if (input_format == "GAM") {
                 get_input_file(file_name, [&](istream& in) {
@@ -424,20 +430,25 @@ int main_surject(int argc, char** argv) {
             // We can just surject each Alignment by itself.
             // TODO: We don't preserve order relationships (like primary/secondary).
             function<void(Alignment&)> lambda = [&](Alignment& src) {
-                
-                if (validate) {
-                    ensure_alignment_is_for_graph(src, *xgidx);
-                }
-                
-                // Preprocess read to set metadata before surjection
-                set_metadata(src);
-                
-                // Surject and emit the single read.
-                if (multimap) {
-                    alignment_emitter->emit_singles(surjector.multi_surject(src, paths, subpath_global, spliced));
-                }
-                else {
-                    alignment_emitter->emit_single(surjector.surject(src, paths, subpath_global, spliced));
+                try {
+                    set_crash_context(src.name());
+                    if (validate) {
+                        ensure_alignment_is_for_graph(src, *xgidx);
+                    }
+                    
+                    // Preprocess read to set metadata before surjection
+                    set_metadata(src);
+                    
+                    // Surject and emit the single read.
+                    if (multimap) {
+                        alignment_emitter->emit_singles(surjector.multi_surject(src, paths, subpath_global, spliced));
+                    }
+                    else {
+                        alignment_emitter->emit_single(surjector.surject(src, paths, subpath_global, spliced));
+                    }
+                    clear_crash_context();
+                } catch (const std::exception& ex) {
+                    report_exception(ex);
                 }
             };
             if (input_format == "GAM") {
@@ -467,148 +478,161 @@ int main_surject(int argc, char** argv) {
                 // GAMP input is paired, and for HTS output reads need to know their pair partners' mapping locations.
                 // TODO: We don't preserve order relationships (like primary/secondary) beyond the interleaving.
                 vg::io::for_each_interleaved_pair_parallel<MultipathAlignment>(in, [&](MultipathAlignment& src1, MultipathAlignment& src2) {
+                    try {
+                        set_crash_context(src1.name() + ", " + src2.name());
                     
-                    // Make sure that the alignments are actually paired with each other
-                    // (proper fragment_prev/fragment_next). We want to catch people giving us
-                    // un-interleaved GAMs as interleaved.
-                    // TODO: Integrate into for_each_interleaved_pair_parallel when running on Alignments.
-                    if (src1.paired_read_name() != src2.name() || src2.paired_read_name() != src1.name()) {
-                        
+                        // Make sure that the alignments are actually paired with each other
+                        // (proper fragment_prev/fragment_next). We want to catch people giving us
+                        // un-interleaved GAMs as interleaved.
+                        // TODO: Integrate into for_each_interleaved_pair_parallel when running on Alignments.
+                        if (src1.paired_read_name() != src2.name() || src2.paired_read_name() != src1.name()) {
+                            
 #pragma omp critical (cerr)
-                        cerr << "[vg surject] error: alignments " << src1.name()
-                        << " and " << src2.name() << " are adjacent but not paired" << endl;
-                        
-                        exit(1);
-                        
-                    }
-                    else if (src1.paired_read_name().empty() || src2.paired_read_name().empty()) {
-                        // Alignments aren't paired up at all
+                            cerr << "[vg surject] error: alignments " << src1.name()
+                            << " and " << src2.name() << " are adjacent but not paired" << endl;
+                            
+                            exit(1);
+                            
+                        }
+                        else if (src1.paired_read_name().empty() || src2.paired_read_name().empty()) {
+                            // Alignments aren't paired up at all
 #pragma omp critical (cerr)
-                        cerr << "[vg surject] error: alignments " << src1.name()
-                        << " and " << src2.name() << " are adjacent but not paired" << endl;
-                        
-                        exit(1);
-                    }
-                    
-                    // convert out of protobuf
-                    multipath_alignment_t mp_src1, mp_src2;
-                    from_proto_multipath_alignment(src1, mp_src1);
-                    from_proto_multipath_alignment(src2, mp_src2);
-                    
-                    
-                    vector<pair<tuple<string, bool, int64_t>, tuple<string, bool, int64_t>>> positions;
-                    vector<pair<multipath_alignment_t, multipath_alignment_t>> surjected;
-                    
-                    vector<tuple<string, bool, int64_t>> positions_unpaired1, positions_unpaired2;
-                    vector<multipath_alignment_t> surjected_unpaired1, surjected_unpaired2;
-                    
-                    // surject and record path positions
-                    if (multimap) {
-                        
-                        // TODO: highly repetitive with the version above for Alignments
-                        
-                        vector<tuple<string, int64_t, bool>> positions1, positions2;
-                        auto surjected1 = surjector.multi_surject(mp_src1, paths, positions1, subpath_global, spliced);
-                        auto surjected2 = surjector.multi_surject(mp_src2, paths, positions2, subpath_global, spliced);
-                        
-                        // we have to pair these up manually
-                        unordered_map<pair<string, bool>, size_t> strand_idx1, strand_idx2;
-                        for (size_t i = 0; i < surjected1.size(); ++i) {
-                            strand_idx1[make_pair(get<0>(positions1[i]), get<2>(positions1[i]))] = i;
+                            cerr << "[vg surject] error: alignments " << src1.name()
+                            << " and " << src2.name() << " are adjacent but not paired" << endl;
+                            
+                            exit(1);
                         }
-                        for (size_t i = 0; i < surjected2.size(); ++i) {
-                            strand_idx2[make_pair(get<0>(positions2[i]), get<2>(positions2[i]))] = i;
-                        }
-                                                
-                        for (size_t i = 0; i < surjected1.size(); ++i) {
-                            auto it = strand_idx2.find(make_pair(get<0>(positions1[i]), !get<2>(positions1[i])));
-                            if (it != strand_idx2.end()) {
-                                // the alignments are paired on this strand
-                                size_t j = it->second;
-                                surjected.emplace_back(move(surjected1[i]), move(surjected2[j]));
-                                
-                                // reorder the positions to deal with the mismatch in the interfaces
-                                positions.emplace_back();
-                                get<0>(positions.back().first) = get<0>(positions1[i]);
-                                get<1>(positions.back().first) = get<2>(positions1[i]);
-                                get<2>(positions.back().first) = get<1>(positions1[i]);
-                                get<0>(positions.back().second) = get<0>(positions2[j]);
-                                get<1>(positions.back().second) = get<2>(positions2[j]);
-                                get<2>(positions.back().second) = get<1>(positions2[j]);
+                        
+                        // convert out of protobuf
+                        multipath_alignment_t mp_src1, mp_src2;
+                        from_proto_multipath_alignment(src1, mp_src1);
+                        from_proto_multipath_alignment(src2, mp_src2);
+                        
+                        
+                        vector<pair<tuple<string, bool, int64_t>, tuple<string, bool, int64_t>>> positions;
+                        vector<pair<multipath_alignment_t, multipath_alignment_t>> surjected;
+                        
+                        vector<tuple<string, bool, int64_t>> positions_unpaired1, positions_unpaired2;
+                        vector<multipath_alignment_t> surjected_unpaired1, surjected_unpaired2;
+                        
+                        // surject and record path positions
+                        if (multimap) {
+                            
+                            // TODO: highly repetitive with the version above for Alignments
+                            
+                            vector<tuple<string, int64_t, bool>> positions1, positions2;
+                            auto surjected1 = surjector.multi_surject(mp_src1, paths, positions1, subpath_global, spliced);
+                            auto surjected2 = surjector.multi_surject(mp_src2, paths, positions2, subpath_global, spliced);
+                            
+                            // we have to pair these up manually
+                            unordered_map<pair<string, bool>, size_t> strand_idx1, strand_idx2;
+                            for (size_t i = 0; i < surjected1.size(); ++i) {
+                                strand_idx1[make_pair(get<0>(positions1[i]), get<2>(positions1[i]))] = i;
                             }
-                            else {
-                                // this strand's surjection is unpaired
-                                surjected_unpaired1.emplace_back(move(surjected1[i]));
-                                
-                                // reorder the position to deal with the mismatch in the interfaces
-                                positions_unpaired1.emplace_back();
-                                get<0>(positions_unpaired1.back()) = move(get<0>(positions1[i]));
-                                get<1>(positions_unpaired1.back()) = get<2>(positions1[i]);
-                                get<2>(positions_unpaired1.back()) = get<1>(positions1[i]);
+                            for (size_t i = 0; i < surjected2.size(); ++i) {
+                                strand_idx2[make_pair(get<0>(positions2[i]), get<2>(positions2[i]))] = i;
+                            }
+                                                    
+                            for (size_t i = 0; i < surjected1.size(); ++i) {
+                                auto it = strand_idx2.find(make_pair(get<0>(positions1[i]), !get<2>(positions1[i])));
+                                if (it != strand_idx2.end()) {
+                                    // the alignments are paired on this strand
+                                    size_t j = it->second;
+                                    surjected.emplace_back(move(surjected1[i]), move(surjected2[j]));
+                                    
+                                    // reorder the positions to deal with the mismatch in the interfaces
+                                    positions.emplace_back();
+                                    get<0>(positions.back().first) = get<0>(positions1[i]);
+                                    get<1>(positions.back().first) = get<2>(positions1[i]);
+                                    get<2>(positions.back().first) = get<1>(positions1[i]);
+                                    get<0>(positions.back().second) = get<0>(positions2[j]);
+                                    get<1>(positions.back().second) = get<2>(positions2[j]);
+                                    get<2>(positions.back().second) = get<1>(positions2[j]);
+                                }
+                                else {
+                                    // this strand's surjection is unpaired
+                                    surjected_unpaired1.emplace_back(move(surjected1[i]));
+                                    
+                                    // reorder the position to deal with the mismatch in the interfaces
+                                    positions_unpaired1.emplace_back();
+                                    get<0>(positions_unpaired1.back()) = move(get<0>(positions1[i]));
+                                    get<1>(positions_unpaired1.back()) = get<2>(positions1[i]);
+                                    get<2>(positions_unpaired1.back()) = get<1>(positions1[i]);
+                                }
+                            }
+                            for (size_t i = 0; i < surjected2.size(); ++i) {
+                                if (!strand_idx1.count(make_pair(get<0>(positions2[i]), !get<2>(positions2[i])))) {
+                                    // this strand's surjection is unpaired
+                                    surjected_unpaired2.emplace_back(move(surjected2[i]));
+                                    
+                                    // reorder the position to deal with the mismatch in the interfaces
+                                    positions_unpaired2.emplace_back();
+                                    get<0>(positions_unpaired2.back()) = move(get<0>(positions2[i]));
+                                    get<1>(positions_unpaired2.back()) = get<2>(positions2[i]);
+                                    get<2>(positions_unpaired2.back()) = get<1>(positions2[i]);
+                                }
                             }
                         }
-                        for (size_t i = 0; i < surjected2.size(); ++i) {
-                            if (!strand_idx1.count(make_pair(get<0>(positions2[i]), !get<2>(positions2[i])))) {
-                                // this strand's surjection is unpaired
-                                surjected_unpaired2.emplace_back(move(surjected2[i]));
-                                
-                                // reorder the position to deal with the mismatch in the interfaces
-                                positions_unpaired2.emplace_back();
-                                get<0>(positions_unpaired2.back()) = move(get<0>(positions2[i]));
-                                get<1>(positions_unpaired2.back()) = get<2>(positions2[i]);
-                                get<2>(positions_unpaired2.back()) = get<1>(positions2[i]);
-                            }
+                        else {
+                            
+                            // FIXME: these aren't required to be on the same path...
+                            positions.emplace_back();
+                            surjected.emplace_back(surjector.surject(mp_src1, paths, get<0>(positions.front().first),
+                                                                     get<2>(positions.front().first), get<1>(positions.front().first),
+                                                                     subpath_global, spliced),
+                                                   surjector.surject(mp_src2, paths, get<0>(positions.front().second),
+                                                                     get<2>(positions.front().second), get<1>(positions.front().second),
+                                                                     subpath_global, spliced));
                         }
-                    }
-                    else {
+                                            
+                        // write to output
+                        vector<int64_t> tlen_limits(surjected.size(), max_frag_len);
+                        mp_alignment_emitter.emit_pairs(src1.name(), src2.name(), move(surjected), &positions, &tlen_limits);
+                        mp_alignment_emitter.emit_singles(src1.name(), move(surjected_unpaired1), &positions_unpaired1);
+                        mp_alignment_emitter.emit_singles(src2.name(), move(surjected_unpaired2), &positions_unpaired2);
                         
-                        // FIXME: these aren't required to be on the same path...
-                        positions.emplace_back();
-                        surjected.emplace_back(surjector.surject(mp_src1, paths, get<0>(positions.front().first),
-                                                                 get<2>(positions.front().first), get<1>(positions.front().first),
-                                                                 subpath_global, spliced),
-                                               surjector.surject(mp_src2, paths, get<0>(positions.front().second),
-                                                                 get<2>(positions.front().second), get<1>(positions.front().second),
-                                                                 subpath_global, spliced));
+                        clear_crash_context();
+                    } catch (const std::exception& ex) {
+                        report_exception(ex);
                     }
-                                        
-                    // write to output
-                    vector<int64_t> tlen_limits(surjected.size(), max_frag_len);
-                    mp_alignment_emitter.emit_pairs(src1.name(), src2.name(), move(surjected), &positions, &tlen_limits);
-                    mp_alignment_emitter.emit_singles(src1.name(), move(surjected_unpaired1), &positions_unpaired1);
-                    mp_alignment_emitter.emit_singles(src2.name(), move(surjected_unpaired2), &positions_unpaired2);
                 });
             } else {
                 // TODO: We don't preserve order relationships (like primary/secondary).
                 vg::io::for_each_parallel<MultipathAlignment>(in, [&](MultipathAlignment& src) {
+                    try {
+                        set_crash_context(src.name());
 
-                    multipath_alignment_t mp_src;
-                    from_proto_multipath_alignment(src, mp_src);
-                    
-                    // surject and record path positions
-                    vector<tuple<string, bool, int64_t>> positions;
-                    vector<multipath_alignment_t> surjected;
-                    
-                    if (multimap) {
+                        multipath_alignment_t mp_src;
+                        from_proto_multipath_alignment(src, mp_src);
                         
-                        vector<tuple<string, int64_t, bool>> multi_positions;
-                        surjected = surjector.multi_surject(mp_src, paths, multi_positions, subpath_global, spliced);
+                        // surject and record path positions
+                        vector<tuple<string, bool, int64_t>> positions;
+                        vector<multipath_alignment_t> surjected;
                         
-                        // positions are in different orders in these two interfaces
-                        for (auto& position : multi_positions) {
-                            positions.emplace_back(move(get<0>(position)), get<2>(position), get<1>(position));
+                        if (multimap) {
+                            
+                            vector<tuple<string, int64_t, bool>> multi_positions;
+                            surjected = surjector.multi_surject(mp_src, paths, multi_positions, subpath_global, spliced);
+                            
+                            // positions are in different orders in these two interfaces
+                            for (auto& position : multi_positions) {
+                                positions.emplace_back(move(get<0>(position)), get<2>(position), get<1>(position));
+                            }
                         }
-                    }
-                    else {
-                        positions.emplace_back();
-                        surjected.emplace_back(surjector.surject(mp_src, paths, get<0>(positions.front()),
-                                                                 get<2>(positions.front()), get<1>(positions.front()),
-                                                                 subpath_global, spliced));
-                    }
+                        else {
+                            positions.emplace_back();
+                            surjected.emplace_back(surjector.surject(mp_src, paths, get<0>(positions.front()),
+                                                                     get<2>(positions.front()), get<1>(positions.front()),
+                                                                     subpath_global, spliced));
+                        }
+                        
+                        // write to output
+                        mp_alignment_emitter.emit_singles(src.name(), move(surjected), &positions);
                     
-                    // write to output
-                    mp_alignment_emitter.emit_singles(src.name(), move(surjected), &positions);
-                    
+                        clear_crash_context();
+                    } catch (const std::exception& ex) {
+                        report_exception(ex);
+                    }
                 });
             }
         });


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Crashes now include the stack trace by default; set `VG_FULL_TRACEBACK=0` to suppress it to a file.
 * `vg surject` and `vg giraffe` should now include relevant read name hints when crashing in many cases.
 * Added `crash_unless()` as an alternative to `assert()` that reports these hints. We eventually want to use it everywhere.
 * Crash reports now have cool hyperlinks. 

## Description

I got tired of getting stack traces that just said `map::at()` threw an exception at some random place. `at()` is no help if the whole stack unwinds and the stack trace points nowhere useful and we have no idea of the problem read.

This adds some more error handling to Giraffe and `vg surject`, and a way of recording what we were up to in each thread where we can get it if something goes wrong.

We'll still have to annoy people into sending us their graph and read, but this should hopefully make reports a little more useful.
