### PR TITLE
Limit surjection work

### DIFF
--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -3917,6 +3917,17 @@ namespace vg {
         
     }
     
+    size_t MultipathAlignmentGraph::count_reachability_edges() const {
+        if (!has_reachability_edges) {
+            return 0;
+        }
+        size_t count = 0;
+        for (auto& node : path_nodes) {
+            count += node.edges.size();
+        }
+        return count;
+    }
+    
     // Kahn's algorithm
     void MultipathAlignmentGraph::topological_sort(vector<size_t>& order_out) {
         // Can only sort if edges are present.
@@ -6422,7 +6433,7 @@ void MultipathAlignmentGraph::align(const Alignment& alignment, const HandleGrap
                 auto node_id = path.mapping(j).position().node_id();
                 
                 if (!mentioned_nodes.count(node_id)) {
-                    // This graph node eneds to be made
+                    // This graph node needs to be made
                     mentioned_nodes.insert(node_id);
                     out << "g" << node_id << " [label=\"" << node_id << "\" shape=box];" << endl;
                 }

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -149,6 +149,9 @@ namespace vg {
         /// (possibly after modifying the graph).
         void clear_reachability_edges();
         
+        /// Get the number of reachability edges in the graph.
+        size_t count_reachability_edges() const;
+        
         /// Remove the ends of paths, up to a maximum length, if they cause the path
         /// to extend past a branch point in the graph.
         void trim_to_branch_points(const HandleGraph* graph, size_t max_trim_length = 1);

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -48,7 +48,7 @@ void help_surject(char** argv) {
          << "  -s, --sam-output         write SAM to stdout" << endl
          << "  -l, --subpath-local      let the multipath mapping surjection produce local (rather than global) alignments" << endl
          << "  -P, --prune-low-cplx     prune short and low complexity anchors during realignment" << endl
-         << "  -a, --max-anchors N      use no more than N anchors per target path (default: 20)" << endl
+         << "  -a, --max-anchors N      use no more than N anchors per target path (default: 200)" << endl
          << "  -S, --spliced            interpret long deletions against paths as spliced alignments" << endl
          << "  -A, --qual-adj           adjust scoring for base qualities, if they are available" << endl
          << "  -N, --sample NAME        set this sample name for all reads" << endl
@@ -98,7 +98,7 @@ int main_surject(int argc, char** argv) {
     bool subpath_global = true; // force full length alignments in mpmap resolution
     bool qual_adj = false;
     bool prune_anchors = false;
-    size_t max_anchors = 20;
+    size_t max_anchors = 200;
     bool annotate_with_all_path_scores = false;
     bool multimap = false;
     bool validate = true;

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -48,6 +48,7 @@ void help_surject(char** argv) {
          << "  -s, --sam-output         write SAM to stdout" << endl
          << "  -l, --subpath-local      let the multipath mapping surjection produce local (rather than global) alignments" << endl
          << "  -P, --prune-low-cplx     prune short and low complexity anchors during realignment" << endl
+         << "  -a, --max-anchors N      use no more than N anchors per target path (default: 20)" << endl
          << "  -S, --spliced            interpret long deletions against paths as spliced alignments" << endl
          << "  -A, --qual-adj           adjust scoring for base qualities, if they are available" << endl
          << "  -N, --sample NAME        set this sample name for all reads" << endl
@@ -97,6 +98,7 @@ int main_surject(int argc, char** argv) {
     bool subpath_global = true; // force full length alignments in mpmap resolution
     bool qual_adj = false;
     bool prune_anchors = false;
+    size_t max_anchors = 20;
     bool annotate_with_all_path_scores = false;
     bool multimap = false;
     bool validate = true;
@@ -122,6 +124,7 @@ int main_surject(int argc, char** argv) {
             {"sam-output", no_argument, 0, 's'},
             {"spliced", no_argument, 0, 'S'},
             {"prune-low-cplx", no_argument, 0, 'P'},
+            {"max-anchors", required_argument, 0, 'a'},
             {"qual-adj", no_argument, 0, 'A'},
             {"sample", required_argument, 0, 'N'},
             {"read-group", required_argument, 0, 'R'},
@@ -134,7 +137,7 @@ int main_surject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:p:F:liGmcbsN:R:f:C:t:SPALMVw:",
+        c = getopt_long (argc, argv, "hx:p:F:liGmcbsN:R:f:C:t:SPa:ALMVw:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -195,6 +198,10 @@ int main_surject(int argc, char** argv) {
                 
         case 'P':
             prune_anchors = true;
+            break;
+            
+        case 'a':
+            max_anchors = parse<size_t>(optarg);
             break;
             
         case 'A':
@@ -287,6 +294,7 @@ int main_surject(int argc, char** argv) {
     Surjector surjector(xgidx);
     surjector.adjust_alignments_for_base_quality = qual_adj;
     surjector.prune_suspicious_anchors = prune_anchors;
+    surjector.max_anchors = max_anchors;
     if (spliced) {
         surjector.min_splice_length = min_splice_length;
         // we have to bump this up to be sure to align most splice junctions

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -20,7 +20,7 @@
 #include "bdsg/hash_graph.hpp"
 
 //#define debug_spliced_surject
-#define debug_anchored_surject
+//#define debug_anchored_surject
 //#define debug_multipath_surject
 //#define debug_constrictions
 //#define debug_prune_unconnectable

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -3042,8 +3042,10 @@ using namespace std;
             mp_aln_graph.topological_sort(topological_order);
             mp_aln_graph.remove_transitive_edges(topological_order);
             
-            // Drop material that looks implausible.
-            {
+            if (!sinks_are_anchors && !sources_are_anchors) {
+                // We are allowed to create new sources and sinks.
+                
+                // Drop material that looks implausible.
                 vector<size_t> scratch(topological_order.size());
                 mp_aln_graph.prune_to_high_scoring_paths(source, get_aligner(), 2.0, topological_order, scratch);
             }

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -125,6 +125,11 @@ using namespace std;
         int64_t max_tail_anchor_prune = 4;
         double low_complexity_p_value = .001;
         
+        /// How many anchors (per path) will we use when surjecting using
+        /// anchors?
+        /// Excessive anchors will be pruned away.
+        size_t max_anchors = 20;
+        
         bool annotate_with_all_path_scores = false;
         
     protected:

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -128,7 +128,7 @@ using namespace std;
         /// How many anchors (per path) will we use when surjecting using
         /// anchors?
         /// Excessive anchors will be pruned away.
-        size_t max_anchors = 20;
+        size_t max_anchors = 200;
         
         bool annotate_with_all_path_scores = false;
         


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject` will limit itself to 200 anchors per target path segment by default; use the new `-a/--max-anchors` option to control this limit. Surjection against PGGB graphs may require `--max-anchors 20` to complete.
 * `vg surject` may be able to limit itself to considering only high-scoring surjections in some cases.

## Description

At first the plan was to call `prune_to_high_scoring_paths()` in surjection, but that broke one of the multipath alignment surjection unit tests (`vg test "Multipath alignments can be surjected"`) which expected to be able to get a surjection with a pretty negative score. I suspect it is creating sources and sinks when it shouldn't be.

So I had to guard that with some checks that I think mean it won't normally be used? @jeizenga might want to review it.

But on top of that I added a limit for total anchors feeding into the process. With both changes together, I was able to make slow but apparently steady progress through @Overcraft90's read set with his PGGB-based graph. I'm not sure if the final result here is sufficient for that, but I think it is at least necessary. 