### PR TITLE
Slow clustering

### DIFF
--- a/src/snarl_distance_index.hpp
+++ b/src/snarl_distance_index.hpp
@@ -22,7 +22,7 @@ size_t maximum_distance(const SnarlDistanceIndex& distance_index, pos_t pos1, po
 
 //Fill in the index
 //size_limit is a limit on the number of nodes in a snarl, after which the index won't store pairwise distances
-void fill_in_distance_index(SnarlDistanceIndex* distance_index, const HandleGraph* graph, const HandleGraphSnarlFinder* snarl_finder, size_t size_limit = 10000);
+void fill_in_distance_index(SnarlDistanceIndex* distance_index, const HandleGraph* graph, const HandleGraphSnarlFinder* snarl_finder, size_t size_limit = 50000);
 
 //Fill in the temporary snarl record with distances
 void populate_snarl_index(SnarlDistanceIndex::TemporaryDistanceIndex& temp_index, 

--- a/src/snarl_distance_index.hpp
+++ b/src/snarl_distance_index.hpp
@@ -22,7 +22,7 @@ size_t maximum_distance(const SnarlDistanceIndex& distance_index, pos_t pos1, po
 
 //Fill in the index
 //size_limit is a limit on the number of nodes in a snarl, after which the index won't store pairwise distances
-void fill_in_distance_index(SnarlDistanceIndex* distance_index, const HandleGraph* graph, const HandleGraphSnarlFinder* snarl_finder, size_t size_limit = 5000);
+void fill_in_distance_index(SnarlDistanceIndex* distance_index, const HandleGraph* graph, const HandleGraphSnarlFinder* snarl_finder, size_t size_limit = 10000);
 
 //Fill in the temporary snarl record with distances
 void populate_snarl_index(SnarlDistanceIndex::TemporaryDistanceIndex& temp_index, 

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -79,7 +79,7 @@ void help_index(char** argv) {
          << "    --index-sorted-vg      input is ID-sorted .vg format graph chunks, store a VGI index of the sorted vg in INPUT.vg.vgi" << endl
          << "snarl distance index options" << endl
          << "    -j  --dist-name FILE   use this file to store a snarl-based distance index" << endl
-         << "        --snarl-limit N    don't store snarl distances for snarls with more than N nodes (default 5000)" << endl;
+         << "        --snarl-limit N    don't store snarl distances for snarls with more than N nodes (default 10000)" << endl;
 }
 
 void multiple_thread_sources() {
@@ -134,7 +134,7 @@ int main_index(int argc, char** argv) {
     bool xg_alts = false;
 
     //Distance index
-    size_t snarl_limit = 5000;
+    size_t snarl_limit = 10000;
 
     int c;
     optind = 2; // force optind past command positional argument

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -134,7 +134,7 @@ int main_index(int argc, char** argv) {
     bool xg_alts = false;
 
     //Distance index
-    size_t snarl_limit = 10000;
+    size_t snarl_limit = 50000;
 
     int c;
     optind = 2; // force optind past command positional argument


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Change the default size-limit for distance indexing to include bigger snarls in the index

## Description
