### PR TITLE
Fix support for chopped ref paths in deconstruct

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -630,7 +630,6 @@ bool Deconstructor::deconstruct_site(const Snarl* snarl) const {
                  << " trav=" << pb2json(path_travs.first[i]) << endl;
         }
 #endif
-        path_trav_name = Paths::strip_subrange(path_trav_name);
         if (ref_paths.count(path_trav_name) &&
             (ref_trav_name.empty() || path_trav_name < ref_trav_name)) {
             ref_trav_name = path_trav_name;
@@ -652,7 +651,7 @@ bool Deconstructor::deconstruct_site(const Snarl* snarl) const {
             path_handle_t path_handle = graph->get_path_handle_of_step(path_travs.second[i].first);
             string path_trav_name = graph->get_path_name(path_handle);            
             subrange_t subrange ;
-            path_trav_name = Paths::strip_subrange(path_trav_name, &subrange);
+            Paths::strip_subrange(path_trav_name, &subrange);
             int64_t sub_offset = subrange == PathMetadata::NO_SUBRANGE ? 0 : subrange.first;
             if (path_trav_name == ref_trav_name) {
                 ref_travs.push_back(i);

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -805,8 +805,23 @@ bool Deconstructor::deconstruct_site(const Snarl* snarl) const {
 
             // in VCF we usually just want the contig
             string contig_name = PathMetadata::parse_locus_name(ref_trav_name);
+            if (contig_name == PathMetadata::NO_LOCUS_NAME) {
+                contig_name = ref_trav_name;
+            } else {
+                string sample_name = PathMetadata::parse_sample_name(ref_trav_name);
+                if (sample_name != PathMetadata::NO_SAMPLE_NAME && (ref_samples.size() > 0 || sample_ploidys.at(sample_name) > 1)) {
+                    // the sample name isn't unique enough, so put a full ugly name in the vcf
+                    contig_name = PathMetadata::create_path_name(PathSense::REFERENCE,
+                                                                 sample_name,
+                                                                 contig_name,
+                                                                 PathMetadata::parse_haplotype(ref_trav_name),
+                                                                 PathMetadata::NO_PHASE_BLOCK,
+                                                                 PathMetadata::NO_SUBRANGE);
+                }
+            }
+            
             // write variant's sequenceName (VCF contig)
-            v.sequenceName = contig_name != PathMetadata::NO_LOCUS_NAME ? contig_name : ref_trav_name;
+            v.sequenceName = contig_name;
 
             // Map our snarl endpoints to oriented positions in the embedded path in the graph
             handle_t first_path_handle;

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -306,6 +306,10 @@ void Deconstructor::get_genotypes(vcflib::Variant& v, const vector<string>& name
     vector<int> gbwt_phases(trav_to_allele.size(), -1);
     for (int i = 0; i < names.size(); ++i) {
         string sample_name = PathMetadata::parse_sample_name(names[i]);
+        // for backward compatibility
+        if (sample_name.empty()) {
+            sample_name = names[i];
+        }
         auto phase = PathMetadata::parse_haplotype(names[i]);
         if (!sample_name.empty() && phase == PathMetadata::NO_HAPLOTYPE) {
             // THis probably won't fit in an int. Use 0 instead.
@@ -935,7 +939,11 @@ void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHand
         string path_name = graph->get_path_name(path_handle);
         if (!this->ref_paths.count(path_name)) {
             string sample_name = graph->get_sample_name(path_handle);
-            if (sample_name != PathMetadata::NO_SAMPLE_NAME && !ref_samples.count(sample_name)) {
+            // for backward compatibility
+            if (sample_name == PathMetadata::NO_SAMPLE_NAME) {
+                sample_name = path_name;
+            }
+            if (!ref_samples.count(sample_name)) {
                 size_t haplotype = graph->get_haplotype(path_handle);
                 if (haplotype == PathMetadata::NO_HAPLOTYPE) {
                     haplotype = 0;

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -45,8 +45,6 @@ public:
                      bool untangle_traversals,
                      bool keep_conflicted,
                      bool strict_conflicts,
-                     const unordered_map<string, pair<string, int>>* path_to_sample_phase = nullptr,
-                     const unordered_map<string, int>* sample_ploidy = nullptr,
                      gbwt::GBWT* gbwt = nullptr);
     
 private:
@@ -64,8 +62,7 @@ private:
                             char prev_char, bool use_start) const;
     
     // write traversal path names as genotypes
-    void get_genotypes(vcflib::Variant& v, const vector<string>& names, const vector<int>& trav_to_allele,
-                       const vector<gbwt::size_type>& trav_thread_ids) const;
+    void get_genotypes(vcflib::Variant& v, const vector<string>& names, const vector<int>& trav_to_allele) const;
 
     // given a set of traversals associated with a particular sample, select a set of size <ploidy> for the VCF
     // the highest-frequency ALT traversal is chosen
@@ -143,6 +140,9 @@ private:
     // the ref paths
     set<string> ref_paths;
 
+    // keep track of reference samples
+    set<string> ref_samples;
+    
     // keep track of the non-ref paths as they will be our samples
     set<string> sample_names;
 
@@ -150,7 +150,7 @@ private:
     const unordered_map<string, pair<string, int>>* path_to_sample_phase;
 
     // the sample ploidys given in the phases in our path names
-    const unordered_map<string, int>* sample_ploidys;
+    unordered_map<string, int> sample_ploidys;
 
     // upper limit of degree-2+ nodes for exhaustive traversal
     int max_nodes_for_exhaustive = 100;

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -142,6 +142,9 @@ private:
 
     // keep track of reference samples
     set<string> ref_samples;
+
+    // do we need to write metadata for reference contigs
+    bool long_ref_contig = false;
     
     // keep track of the non-ref paths as they will be our samples
     set<string> sample_names;

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -79,11 +79,6 @@ private:
     // with node visits
     vector<SnarlTraversal> explicit_exhaustive_traversals(const Snarl* snarl) const;
 
-    // get the path location of a given traversal out of the gbwt
-    // this will be much slower than doing the same using the PathPositionGraph interface as there's no
-    // underlying index. 
-    tuple<bool, handle_t, size_t> get_gbwt_path_position(const SnarlTraversal& trav, const gbwt::size_type& thread) const;
-
     // gets a sorted node id context for a given path
     vector<nid_t> get_context(
         const pair<vector<SnarlTraversal>,
@@ -124,16 +119,7 @@ private:
     unique_ptr<GBWTTraversalFinder> gbwt_trav_finder;
     // When using the gbwt we need some precomputed information to ask about stored paths.
     unordered_set<string> gbwt_reference_samples;
-    // hacky path position index for alts in the gbwt
-    // we map from gbwt path id -> { map of handle -> offset } for every handle in the path
-    // because child snarls are done in series, we often hit the same non-ref path consecutively
-    // which makes the lru cache fairly effective
-    size_t lru_size = 10; 
-    vector<LRUCache<gbwt::size_type, shared_ptr<unordered_map<handle_t, size_t>>>*> gbwt_pos_caches;
-    /// We need to keep track of what OMP parallelism level we made the cache
-    /// list for, so we can make sure to bail out if we end up trying to use
-    /// the wrong level's thread numbers.
-    size_t gbwt_pos_caches_level = std::numeric_limits<size_t>::max();
+    
     // infer ploidys from gbwt when possible
     unordered_map<string, pair<int, int>> gbwt_sample_to_phase_range;
 

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -520,12 +520,12 @@ std::string compose_short_path_name(const gbwt::GBWT& gbwt_index, gbwt::size_typ
     auto& metadata = gbwt_index.metadata;
     const gbwt::PathName& path = metadata.path(id);
 
-    // We want a name with just sample and contig.
+    // We want a name with just sample and contig and haplotype.
     // Spit out a name in reference sense format, which should suffice.
     return PathMetadata::create_path_name(PathSense::REFERENCE,
                                           gbwtgraph::get_path_sample_name(metadata, path, PathSense::REFERENCE),
                                           gbwtgraph::get_path_locus_name(metadata, path, PathSense::REFERENCE),
-                                          PathMetadata::NO_HAPLOTYPE,
+                                          gbwtgraph::get_path_haplotype(metadata, path, PathSense::REFERENCE),
                                           PathMetadata::NO_PHASE_BLOCK,
                                           PathMetadata::NO_SUBRANGE);
 }

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -235,7 +235,7 @@ std::string insert_gbwt_path(MutablePathHandleGraph& graph, const gbwt::GBWT& gb
 Path extract_gbwt_path(const HandleGraph& graph, const gbwt::GBWT& gbwt_index, gbwt::size_type id);
 
 /// Get a short version of a string representation of a thread name stored in
-/// GBWT metadata, made of just the sample and contig.
+/// GBWT metadata, made of just the sample and contig and haplotype.
 /// NOTE: id is a gbwt path id, not a gbwt sequence id.
 std::string compose_short_path_name(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
 

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -210,6 +210,14 @@ int main_deconstruct(int argc, char** argv){
         return 1;
     }
 
+    if (!gbwt_file_name.empty() || !gbz_graph) {
+        // context jaccard depends on having steps for each alt traversal, which is
+        // not something we have on hand when getting traversals from the GBWT/GBZ
+        // so we toggle it off in this case to prevent outputting invalid VCFs (GTs go missing)
+        // at sites with multiple reference paths
+        context_jaccard_window = 0;
+    }
+
     // We might need to apply an overlay to get good path position queries
     bdsg::ReferencePathOverlayHelper overlay_helper;
     

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -210,7 +210,7 @@ int main_deconstruct(int argc, char** argv){
         return 1;
     }
 
-    if (!gbwt_file_name.empty() || !gbz_graph) {
+    if (!gbwt_file_name.empty() || gbz_graph) {
         // context jaccard depends on having steps for each alt traversal, which is
         // not something we have on hand when getting traversals from the GBWT/GBZ
         // so we toggle it off in this case to prevent outputting invalid VCFs (GTs go missing)


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg deconstruct` fixed to work again on subpath fragments with `-P`

## Description

There's a sorely needed refactor in light of path metadata and gbz path handle interfaces etc.  This PR doesn't do that [edit: it does a fair bit of that], but it should fix a regression in the meantime where subpath suffixes weren't being handled right on references. 