### PR TITLE
Fix construction for variation 1bp before inversion end

### DIFF
--- a/src/constructor.hpp
+++ b/src/constructor.hpp
@@ -33,7 +33,7 @@ namespace vg {
 using namespace std;
 
 /**
- * Represents a constructed region of the graph alogn a single linear sequence.
+ * Represents a constructed region of the graph along a single linear sequence.
  * Contains the protobuf Graph holding all the created components (which may be
  * too large to serialize), a set of node IDs whose left sides need to be
  * connected to when you connect to the start of the chunk, and a set of node

--- a/src/unittest/constructor.cpp
+++ b/src/unittest/constructor.cpp
@@ -2202,7 +2202,9 @@ CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG
         unordered_map<size_t, string> expected;
         // Order is a bit weird. First part before insertion.
         expected.insert({1, "CAAATAAGG"});
-        // Replacing inserted base. TODO: Should we change this to join with the rest of the insert?
+        // Replacing inserted base. Because we aren't using flat alts, vcflib
+        // parses this as a substitution and then an insertion and we allow one
+        // but not the other in the graph.
         expected.insert({2, "G"});
         // Rest of inserted bases
         expected.insert({3, "ATTACA"});


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg construct` now properly handles the case where it is looking for the end of an inversion from 1 base before it

## Description
I used the wrong bound function and managed to not see inversion endpoints from the preceding position, when looking for places we need to break the reference.

I have fixed that and added a test. This will fix #3906.