### PR TITLE
Better handling of multiple ref traversals during snarl clipping

### DIFF
--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -317,8 +317,7 @@ static bool snarl_is_complex(PathPositionHandleGraph* graph, const Snarl* snarl,
     return !filter_on || (complex_nodes && complex_edges && complex_nodes_shallow && complex_edges_shallow && complex_degree);
 }
 
-void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph,
-                           const vector<Region>& regions, const vector<string>& ref_prefixes,
+void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions, 
                            SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len,
                            size_t max_nodes, size_t max_edges, size_t max_nodes_shallow, size_t max_edges_shallow,
                            double max_avg_degree, double max_reflen_prop, size_t max_reflen,
@@ -332,6 +331,12 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
 
     // just for logging
     unordered_map<string, size_t> clip_counts;
+
+    // for making the whitelist
+    unordered_set<string> ref_prefixes;
+    for (const Region& region : regions) {
+        ref_prefixes.insert(region.seq);
+    }
     
     visit_contained_snarls(pp_graph, regions, snarl_manager, include_endpoints, [&](const Snarl* snarl, step_handle_t start_step, step_handle_t end_step,
                                                                                     int64_t start_pos, int64_t end_pos,

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -381,10 +381,10 @@ void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHan
                             for (const string& ref_prefix : ref_prefixes) {
                                 if (path_name.compare(0, ref_prefix.length(), ref_prefix) == 0) {
                                     whitelist.insert(node_id);
-                                    return true;
+                                    return false;
                                 }
                             }
-                            return false;
+                            return true;
                         });
                     }
                 }

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -42,11 +42,13 @@ void delete_nodes_and_chop_paths(MutablePathMutableHandleGraph* graph,
  * If a given bed region spans a snarl (overlaps its end nodes, and forms a traversal)
  * then clip out all other nodes (ie nodes that don't lie on the traversal)
  *
- * IMPORTANT: for any given snarl, the first region that contains it is used.  
+ * IMPORTANT: for any given snarl, the first region that contains it is used.
+ *            (but other reference paths now whitelisted via ref_prefixes)
  *
  * Update: now accepts some snarl complexity thresholds to ignore simple enough snarls
  */
-void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions,
+void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph,
+                           const vector<Region>& regions, const vector<string>& ref_prefixes,
                            SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len,
                            size_t max_nodes, size_t max_edges, size_t max_nodes_shallow, size_t max_edges_shallow,
                            double max_avg_degree, double max_reflen_prop, size_t max_reflen,

--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -47,8 +47,7 @@ void delete_nodes_and_chop_paths(MutablePathMutableHandleGraph* graph,
  *
  * Update: now accepts some snarl complexity thresholds to ignore simple enough snarls
  */
-void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph,
-                           const vector<Region>& regions, const vector<string>& ref_prefixes,
+void clip_contained_snarls(MutablePathMutableHandleGraph* graph, PathPositionHandleGraph* pp_graph, const vector<Region>& regions, 
                            SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len,
                            size_t max_nodes, size_t max_edges, size_t max_nodes_shallow, size_t max_edges_shallow,
                            double max_avg_degree, double max_reflen_prop, size_t max_reflen,

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -348,7 +348,7 @@ int main_clip(int argc, char** argv) {
         }        
     }else {
         // run the alt-allele clipping
-        clip_contained_snarls(graph.get(), pp_graph, bed_regions, ref_prefixes, *snarl_manager, false, min_fragment_len,
+        clip_contained_snarls(graph.get(), pp_graph, bed_regions, *snarl_manager, false, min_fragment_len,
                               max_nodes, max_edges, max_nodes_shallow, max_edges_shallow, max_avg_degree, max_reflen_prop, max_reflen, out_bed, verbose);
     }
 

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -348,7 +348,7 @@ int main_clip(int argc, char** argv) {
         }        
     }else {
         // run the alt-allele clipping
-        clip_contained_snarls(graph.get(), pp_graph, bed_regions, *snarl_manager, false, min_fragment_len,
+        clip_contained_snarls(graph.get(), pp_graph, bed_regions, ref_prefixes, *snarl_manager, false, min_fragment_len,
                               max_nodes, max_edges, max_nodes_shallow, max_edges_shallow, max_avg_degree, max_reflen_prop, max_reflen, out_bed, verbose);
     }
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Snarl clipping bug in `vg clip` fixed so that when there are multiple different reference traversals in a snarl (common in PGGB output), then none of them are chopped.

## Description

This adds two things:
* reference traversals chosen based on <length-of-reference, length-of-interval> (in that order) rather than arbitrarily.  This should give more meaningful interplay with the length filters `-l` and `-L` which use these values.
* when clippings snarls, all nodes that touch a reference path are now whitelisted (previously it was just those on the reference path traversal). This will fix the issue of chopped reference paths in the output. 

resolves #3941
