### PR TITLE
Ship real time binary in vg image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,7 @@ RUN ls -lah /vg && \
     linux-tools-common \
     linux-tools-generic \
     perl \
+    time \
     && apt-get -qq -y clean
     
 COPY --from=build /vg/bin/vg /vg/bin/


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Docker containers now have `/usr/bin/time` for profiling

## Description

We weren't shipping a real `time` binary in the containers, which caused trouble when wanting to do things like measure memory usage.