### PR TITLE
GFA-based autoindex pipeline for vg mpmap and rpvg

### DIFF
--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -3003,7 +3003,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         assert(constructing.size() == 4 || constructing.size() == 2);
         bool making_hsts = constructing.size() == 4;
         assert(inputs.size() == 2 || inputs.size() == 3);
-        bool projecting_transcripts = (inputs.size() == 3);
+        bool projecting_transcripts = (inputs.size() == 2);
         
         if (IndexingParameters::verbosity != IndexingParameters::None) {
             if (making_hsts) {

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -412,7 +412,7 @@ bool execute_in_fork(const function<void(void)>& exec) {
     } else {
         // This is the parent
         if (IndexingParameters::verbosity != IndexingParameters::None) {
-            cerr << "[IndexRegistry] forked child " << pid << endl;
+            cerr << "[IndexRegistry]: Forked into child process with PID " << pid << "." << endl;
         }
     }
     
@@ -422,7 +422,7 @@ bool execute_in_fork(const function<void(void)>& exec) {
     
     // pass through signal-based exits
     if (WIFSIGNALED(child_stat)) {
-        cerr << "error:[IndexRegistry] child process " << pid << " signaled with status " << child_stat << " representing signal " << WTERMSIG(child_stat) << endl;
+        cerr << "error:[IndexRegistry] Dhild process " << pid << " signaled with status " << child_stat << " representing signal " << WTERMSIG(child_stat) << endl;
         if (raise(WTERMSIG(child_stat)) == 0) {
             // TODO: on Mac, raise isn't guaranteed to not return before the handler if it succeeds.
             // Also the signal might not be one that necessarily kills us.
@@ -436,7 +436,7 @@ bool execute_in_fork(const function<void(void)>& exec) {
     assert(WIFEXITED(child_stat));
     
     if (WEXITSTATUS(child_stat) != 0) {
-        cerr << "warning:[IndexRegistry] child process " << pid << " failed with status " << child_stat << " representing exit code " << WEXITSTATUS(child_stat) << endl;
+        cerr << "warning:[IndexRegistry] Child process " << pid << " failed with status " << child_stat << " representing exit code " << WEXITSTATUS(child_stat) << endl;
         return false;
     }
     
@@ -461,12 +461,14 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     registry.register_index("Reference GFA", "gfa");
     registry.register_index("Reference GFA w/ Haplotypes", "haplo.gfa");
     registry.register_index("GTF/GFF", "gff");
+    registry.register_index("Haplotype GTF/GFF", "haplo.gff");
     
     /// Chunked inputs
     registry.register_index("Chunked Reference FASTA", "chunked.fasta");
     registry.register_index("Chunked VCF", "chunked.vcf.gz");
     registry.register_index("Chunked VCF w/ Phasing", "phased.chunked.vcf.gz");
     registry.register_index("Chunked GTF/GFF", "chunked.gff");
+    registry.register_index("Chunked Haplotype GTF/GFF", "haplo.chunked.gff");
     
     /// True indexes
     registry.register_index("VG", "vg");
@@ -506,6 +508,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     registry.register_index("Spliced Distance Index", "spliced.dist");
     
     registry.register_index("GBWTGraph", "gg");
+    registry.register_index("GBZ", "gbz");
     registry.register_index("Giraffe GBZ", "giraffe.gbz");
     
     registry.register_index("Minimizers", "min");
@@ -2992,11 +2995,230 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         return all_outputs;
     };
     
+    // TODO: somewhat repetitive with non-GBZ pipeline, but also some notable differences...
+    auto gbz_vg_rna = [](const vector<const IndexFile*>& inputs,
+                         const IndexingPlan* plan,
+                         AliasGraph& alias_graph,
+                         const IndexGroup& constructing) {
+        
+        assert(constructing.size() == 4 || constructing.size() == 2);
+        bool making_hsts = constructing.size() == 4;
+        assert(inputs.size() == 2 || inputs.size() == 3);
+        bool projecting_transcripts = (inputs.size() == 2);
+        
+        if (IndexingParameters::verbosity != IndexingParameters::None) {
+            if (making_hsts) {
+                cerr << "[IndexRegistry]: Constructing haplotype-transcript GBWT and spliced graph from GBZ-format graph." << endl;
+            }
+            else {
+                cerr << "[IndexRegistry]: Adding splice junctions to GBZ-format graph." << endl;
+            }
+            if (IndexingParameters::verbosity >= IndexingParameters::Debug) {
+                gbwt::Verbosity::set(gbwt::Verbosity::BASIC);
+            }
+        }
+        else {
+            gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+        }
+        
+        vector<vector<string>> all_outputs(constructing.size());
+        IndexName output_haplo_tx, output_tx_table, output_tx_graph, output_max_id;
+        if (making_hsts) {
+            int i = 0;
+            for (auto output_index : constructing) {
+                if (i == 0) {
+                    output_haplo_tx = output_index;
+                }
+                else if (i == 1) {
+                    output_max_id = output_index;
+                }
+                else if (i == 2) {
+                    output_tx_graph = output_index;
+                }
+                else {
+                    output_tx_table = output_index;
+                }
+                ++i;
+            }
+        }
+        else {
+            output_max_id = *constructing.begin();
+            output_tx_graph = *constructing.rbegin();
+        }
+        //auto& haplo_tx_gbwt_names = all_outputs[0];
+        auto& max_id_names = all_outputs[making_hsts ? 1 : 0];
+        auto& tx_graph_names = all_outputs[making_hsts ? 2 : 1];
+        //auto& tx_table_names = all_outputs[2];
+        
+        auto tx_filenames = inputs[0]->get_filenames();
+        auto gbz_filenames = inputs[1]->get_filenames();
+        vector<string> haplo_tx_filenames;
+        if (projecting_transcripts) {
+            haplo_tx_filenames = inputs[2]->get_filenames();
+        }
+        assert(gbz_filenames.size() == 1);
+        auto gbz_filename = gbz_filenames.front();
+        
+        vector<ifstream> infiles_tx, infiles_haplo_tx;
+        for (auto& tx_filename : tx_filenames) {
+            infiles_tx.emplace_back();
+            init_in(infiles_tx.back(), tx_filename);
+        }
+        for (auto& haplo_tx_filename : haplo_tx_filenames) {
+            infiles_haplo_tx.emplace_back();
+            init_in(infiles_haplo_tx.back(), haplo_tx_filename);
+        }
+        
+        string max_id_name = plan->output_filepath(output_max_id);
+        ofstream max_id_outfile;
+        init_out(max_id_outfile, max_id_name);
+        
+        string tx_graph_name = plan->output_filepath(output_tx_graph);
+        ofstream tx_graph_outfile;
+        init_out(tx_graph_outfile, tx_graph_name);
+        
+        // load, convert, and discard the GBZ
+        unique_ptr<gbwt::GBWT> haplotype_index;
+        auto tx_graph = init_mutable_graph();
+        {
+            unique_ptr<gbwtgraph::GBZ> gbz = vg::io::VPKG::load_one<gbwtgraph::GBZ>(gbz_filename);
+            // copy topology
+            handlealgs::copy_handle_graph(&(gbz->graph), tx_graph.get());
+            // copy ref paths
+            gbz->graph.for_each_path_matching({PathSense::GENERIC, PathSense::REFERENCE}, {}, {}, [&](const path_handle_t& path) {
+                handlegraph::algorithms::copy_path(&(gbz->graph), path, tx_graph.get());
+            });
+            // copy the gbwt
+            haplotype_index = make_unique<gbwt::GBWT>(gbz->index);
+        }
+        
+        // hand over the graph
+        Transcriptome transcriptome(move(tx_graph));
+        transcriptome.error_on_missing_path = true;
+        transcriptome.feature_type = IndexingParameters::gff_feature_name;
+        transcriptome.transcript_tag = IndexingParameters::gff_transcript_tag;
+        
+        // gather the GTF file pointers
+        vector<istream *> tx_file_ptrs;
+        for (auto& tx_file : infiles_tx) {
+            tx_file_ptrs.push_back(&tx_file);
+        }
+        for (auto& tx_file : infiles_haplo_tx) {
+            tx_file_ptrs.push_back(&tx_file);
+        }
+        
+        // add the splice edges and ref transcript paths
+        size_t transcripts_added = transcriptome.add_reference_transcripts(tx_file_ptrs, haplotype_index,
+                                                                           !projecting_transcripts, // use haplotypes as refs for GTF?
+                                                                           projecting_transcripts); // update the GBWT for the new node IDs?
+        
+        if (making_hsts) {
+            auto& gbwt_names = all_outputs.front();
+            auto& info_table_names = all_outputs.back();
+            
+            string gbwt_name = plan->output_filepath(output_haplo_tx);
+            
+            // add edges on other haplotypes
+            if (projecting_transcripts) {
+                
+                // go back to the beginning of the transcripts
+                for (auto& tx_file : infiles_tx) {
+                    tx_file.clear();
+                    tx_file.seekg(0);
+                }
+                for (auto& tx_file : infiles_haplo_tx) {
+                    tx_file.clear();
+                    tx_file.seekg(0);
+                }
+                
+                transcriptome.add_haplotype_transcripts(tx_file_ptrs, *haplotype_index, false);
+            }
+            
+            // init the haplotype transcript GBWT
+            size_t node_width = gbwt::bit_length(gbwt::Node::encode(transcriptome.graph().max_node_id(), true));
+            bool success = execute_in_fork([&]() {
+                gbwt::GBWTBuilder gbwt_builder(node_width,
+                                               IndexingParameters::gbwt_insert_batch_size,
+                                               IndexingParameters::gbwt_sampling_interval);
+                // actually build it
+                transcriptome.add_transcripts_to_gbwt(&gbwt_builder, IndexingParameters::bidirectional_haplo_tx_gbwt, false);
+                
+                // save the haplotype transcript GBWT
+                gbwt_builder.finish();
+                save_gbwt(gbwt_builder.index, gbwt_name, IndexingParameters::verbosity == IndexingParameters::Debug);
+            });
+            if (!success) {
+                IndexingParameters::gbwt_insert_batch_size *= IndexingParameters::gbwt_insert_batch_size_increase_factor;
+                throw RewindPlanException("[IndexRegistry]: Exceeded GBWT insert buffer size, expanding and reattempting.",
+                                          {"Haplotype-Transcript GBWT"});
+            }
+            
+            // write transcript origin info table
+            string info_table_name = plan->output_filepath(output_tx_table);
+            ofstream info_outfile;
+            init_out(info_outfile, info_table_name);
+            transcriptome.write_transcript_info(&info_outfile, *haplotype_index, false);
+            
+            gbwt_names.push_back(gbwt_name);
+            info_table_names.push_back(info_table_name);
+        }
+        
+        
+        // save the graph with the transcript paths added
+        transcriptome.write_graph(&tx_graph_outfile);
+        tx_graph_names.push_back(tx_graph_name);
+        
+        // write the max ID as well
+        max_id_outfile << transcriptome.graph().max_node_id();
+        max_id_names.push_back(max_id_name);
+        
+        return all_outputs;
+    };
+    
+    
+    auto vg_rna_gbz_graph_only =
+    registry.register_recipe({"Spliced MaxNodeID", "Spliced VG w/ Transcript Paths"}, {"GBZ", "GTF/GFF", "Haplotype GTF/GFF"},
+                             [gbz_vg_rna](const vector<const IndexFile*>& inputs,
+                                          const IndexingPlan* plan,
+                                          AliasGraph& alias_graph,
+                                          const IndexGroup& constructing) {
+        return gbz_vg_rna(inputs, plan, alias_graph, constructing);
+    });
+    
+    auto vg_rna_gbz_liftover_graph_only =
+    registry.register_recipe({"Spliced MaxNodeID", "Spliced VG w/ Transcript Paths"}, {"GBZ", "GTF/GFF"},
+                             [gbz_vg_rna](const vector<const IndexFile*>& inputs,
+                                          const IndexingPlan* plan,
+                                          AliasGraph& alias_graph,
+                                          const IndexGroup& constructing) {
+        return gbz_vg_rna(inputs, plan, alias_graph, constructing);
+    });
+    
+    auto vg_rna_gbz_full =
+    registry.register_recipe({"Haplotype-Transcript GBWT", "Spliced MaxNodeID", "Spliced VG w/ Transcript Paths", "Unjoined Transcript Origin Table"},
+                             {"GBZ", "GTF/GFF", "Haplotype GTF/GFF"},
+                             [gbz_vg_rna](const vector<const IndexFile*>& inputs,
+                                          const IndexingPlan* plan,
+                                          AliasGraph& alias_graph,
+                                          const IndexGroup& constructing) {
+        return gbz_vg_rna(inputs, plan, alias_graph, constructing);
+    });
+    
+    auto vg_rna_gbz_liftover_full =
+    registry.register_recipe({"Haplotype-Transcript GBWT", "Spliced MaxNodeID", "Spliced VG w/ Transcript Paths", "Unjoined Transcript Origin Table"},
+                             {"GBZ", "GTF/GFF"},
+                             [gbz_vg_rna](const vector<const IndexFile*>& inputs,
+                                          const IndexingPlan* plan,
+                                          AliasGraph& alias_graph,
+                                          const IndexGroup& constructing) {
+        return gbz_vg_rna(inputs, plan, alias_graph, constructing);
+    });
+    
     auto vg_rna_graph_only =
     registry.register_recipe({"Spliced VG w/ Transcript Paths"},
                              {"Chunked GTF/GFF", "Spliced VG"},
                              [do_vg_rna](const vector<const IndexFile*>& inputs,
-                                    const IndexingPlan* plan,
+                                         const IndexingPlan* plan,
                                          AliasGraph& alias_graph,
                                          const IndexGroup& constructing) {
    
@@ -3016,6 +3238,8 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     
     // if both the full and graph-only are required, only do the full
     registry.register_generalization(vg_rna_full, vg_rna_graph_only);
+    registry.register_generalization(vg_rna_gbz_full, vg_rna_gbz_graph_only);
+    registry.register_generalization(vg_rna_gbz_liftover_full, vg_rna_gbz_liftover_graph_only);
     
     ////////////////////////////////////
     // Info Table Recipes
@@ -3603,7 +3827,16 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     // GBZ Recipes
     ////////////////////////////////////
     
-    registry.register_recipe({"Giraffe GBZ"}, {"Reference GFA w/ Haplotypes"},
+    registry.register_recipe({"Giraffe GBZ"}, {"GBZ"},
+                             [](const vector<const IndexFile*>& inputs,
+                                const IndexingPlan* plan,
+                                AliasGraph& alias_graph,
+                                const IndexGroup& constructing) {
+        alias_graph.register_alias(*constructing.begin(), inputs[0]);
+        return vector<vector<string>>(1, inputs.front()->get_filenames());
+    });
+    
+    registry.register_recipe({"GBZ"}, {"Reference GFA w/ Haplotypes"},
                              [](const vector<const IndexFile*>& inputs,
                                 const IndexingPlan* plan,
                                 AliasGraph& alias_graph,

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -3004,7 +3004,6 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         bool making_hsts = constructing.size() == 4;
         assert(inputs.size() == 2 || inputs.size() == 3);
         bool projecting_transcripts = (inputs.size() == 2);
-        
         if (IndexingParameters::verbosity != IndexingParameters::None) {
             if (making_hsts) {
                 cerr << "[IndexRegistry]: Constructing haplotype-transcript GBWT and spliced graph from GBZ-format graph." << endl;
@@ -3053,7 +3052,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         auto gbz_filenames = inputs[0]->get_filenames();
         auto tx_filenames = inputs[1]->get_filenames();
         vector<string> haplo_tx_filenames;
-        if (projecting_transcripts) {
+        if (!projecting_transcripts) {
             haplo_tx_filenames = inputs[2]->get_filenames();
         }
         assert(gbz_filenames.size() == 1);

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -411,7 +411,7 @@ bool execute_in_fork(const function<void(void)>& exec) {
         exit(0);
     } else {
         // This is the parent
-        if (IndexingParameters::verbosity != IndexingParameters::None) {
+        if (IndexingParameters::verbosity >= IndexingParameters::Debug) {
             cerr << "[IndexRegistry]: Forked into child process with PID " << pid << "." << endl;
         }
     }
@@ -422,7 +422,7 @@ bool execute_in_fork(const function<void(void)>& exec) {
     
     // pass through signal-based exits
     if (WIFSIGNALED(child_stat)) {
-        cerr << "error:[IndexRegistry] Dhild process " << pid << " signaled with status " << child_stat << " representing signal " << WTERMSIG(child_stat) << endl;
+        cerr << "error:[IndexRegistry] Child process " << pid << " signaled with status " << child_stat << " representing signal " << WTERMSIG(child_stat) << endl;
         if (raise(WTERMSIG(child_stat)) == 0) {
             // TODO: on Mac, raise isn't guaranteed to not return before the handler if it succeeds.
             // Also the signal might not be one that necessarily kills us.
@@ -3050,8 +3050,8 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         auto& tx_graph_names = all_outputs[making_hsts ? 2 : 1];
         //auto& tx_table_names = all_outputs[2];
         
-        auto tx_filenames = inputs[0]->get_filenames();
-        auto gbz_filenames = inputs[1]->get_filenames();
+        auto gbz_filenames = inputs[0]->get_filenames();
+        auto tx_filenames = inputs[1]->get_filenames();
         vector<string> haplo_tx_filenames;
         if (projecting_transcripts) {
             haplo_tx_filenames = inputs[2]->get_filenames();
@@ -3105,6 +3105,13 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         }
         for (auto& tx_file : infiles_haplo_tx) {
             tx_file_ptrs.push_back(&tx_file);
+        }
+        
+        if (IndexingParameters::verbosity >= IndexingParameters::Debug) {
+            gbwt::Verbosity::set(gbwt::Verbosity::BASIC);
+        }
+        else {
+            gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
         }
         
         // add the splice edges and ref transcript paths
@@ -3842,7 +3849,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                                 AliasGraph& alias_graph,
                                 const IndexGroup& constructing) {
         if (IndexingParameters::verbosity != IndexingParameters::None) {
-            cerr << "[IndexRegistry]: Combining Giraffe GBWT and GBWTGraph into GBZ." << endl;
+            cerr << "[IndexRegistry]: Constructing a GBZ from GFA input." << endl;
         }
         
         assert(inputs.size() == 1);

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -468,7 +468,6 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
     registry.register_index("Chunked VCF", "chunked.vcf.gz");
     registry.register_index("Chunked VCF w/ Phasing", "phased.chunked.vcf.gz");
     registry.register_index("Chunked GTF/GFF", "chunked.gff");
-    registry.register_index("Chunked Haplotype GTF/GFF", "haplo.chunked.gff");
     
     /// True indexes
     registry.register_index("VG", "vg");
@@ -3004,7 +3003,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         assert(constructing.size() == 4 || constructing.size() == 2);
         bool making_hsts = constructing.size() == 4;
         assert(inputs.size() == 2 || inputs.size() == 3);
-        bool projecting_transcripts = (inputs.size() == 2);
+        bool projecting_transcripts = (inputs.size() == 3);
         
         if (IndexingParameters::verbosity != IndexingParameters::None) {
             if (making_hsts) {
@@ -3020,7 +3019,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         else {
             gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
         }
-        
+                
         vector<vector<string>> all_outputs(constructing.size());
         IndexName output_haplo_tx, output_tx_table, output_tx_graph, output_max_id;
         if (making_hsts) {
@@ -3045,6 +3044,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             output_max_id = *constructing.begin();
             output_tx_graph = *constructing.rbegin();
         }
+
         //auto& haplo_tx_gbwt_names = all_outputs[0];
         auto& max_id_names = all_outputs[making_hsts ? 1 : 0];
         auto& tx_graph_names = all_outputs[making_hsts ? 2 : 1];
@@ -3091,7 +3091,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             // copy the gbwt
             haplotype_index = make_unique<gbwt::GBWT>(gbz->index);
         }
-        
+                
         // hand over the graph
         Transcriptome transcriptome(move(tx_graph));
         transcriptome.error_on_missing_path = true;

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -110,6 +110,7 @@ void help_autoindex(char** argv) {
     << "    -i, --ins-fasta FILE   FASTA file with sequences of INS variants from -v" << endl
     << "    -g, --gfa FILE         GFA file to make a graph from" << endl
     << "    -x, --tx-gff FILE      GTF/GFF file with transcript annotations (may repeat)" << endl
+    << "    -H, --hap-tx-gff FILE  GTF/GFF file with transcript annotations of a named haplotype (may repeat)" << endl
     << "  configuration:" << endl
     << "    -f, --gff-feature STR  GTF/GFF feature type (col. 3) to add to graph (default: " << IndexingParameters::gff_feature_name << ")" << endl
     << "    -a, --gff-tx-tag STR   GTF/GFF tag (in col. 9) for transcript ID (default: " << IndexingParameters::gff_transcript_tag << ")" << endl
@@ -163,6 +164,7 @@ int main_autoindex(int argc, char** argv) {
             {"ins-fasta", required_argument, 0, 'i'},
             {"gfa", required_argument, 0, 'g'},
             {"tx-gff", required_argument, 0, 'x'},
+            {"hap-tx-gff", required_argument, 0, 'H'},
             {"gff-feature", required_argument, 0, 'f'},
             {"gff-tx-tag", required_argument, 0, 'a'},
             {"provide", required_argument, 0, 'P'},
@@ -182,7 +184,7 @@ int main_autoindex(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "p:w:r:v:i:g:x:a:P:R:f:M:T:t:dV:h",
+        c = getopt_long (argc, argv, "p:w:r:v:i:g:x:H:a:P:R:f:M:T:t:dV:h",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -234,6 +236,9 @@ int main_autoindex(int argc, char** argv) {
                 break;
             case 'x':
                 registry.provide("GTF/GFF", optarg);
+                break;
+            case 'H':
+                registry.provide("Haplotype GTF/GFF", optarg);
                 break;
             case 'f':
                 IndexingParameters::gff_feature_name = optarg;

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -498,7 +498,7 @@ void Transcriptome::parse_introns(vector<Transcript> * introns, istream * intron
 
             if (error_on_missing_path) {
 
-                cerr << "\tERROR: Chromomsome path \"" << chrom << "\" not found in graph (line " << line_number << ")." << endl;
+                cerr << "\tERROR: Chromosome path \"" << chrom << "\" not found in graph (line " << line_number << ")." << endl;
                 exit(1);
             
             } else {
@@ -611,7 +611,7 @@ int32_t Transcriptome::parse_transcripts(vector<Transcript> * transcripts, uint3
 
             if (error_on_missing_path) {
 
-                cerr << "\tERROR: Chromomsome path \"" << chrom << "\" not found in graph or haplotypes index (line " << line_number << ")." << endl;
+                cerr << "\tERROR: Chromosome path \"" << chrom << "\" not found in graph or haplotypes index (line " << line_number << ")." << endl;
                 exit(1);
             
             } else {

--- a/test/graphs/gfa_with_w_lines.gtf
+++ b/test/graphs/gfa_with_w_lines.gtf
@@ -1,0 +1,10 @@
+##description: 
+##format: gtf
+alt1	SOURCE	gene	2	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1";
+alt1	SOURCE	transcript	2	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1";
+alt1	SOURCE	exon	2	4	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1"; exon_number 1;
+alt1	SOURCE	exon	8	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1"; exon_number 2;
+short	SOURCE	gene	3	8	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1";
+short	SOURCE	transcript	3	8	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE2"; transcript_id "transcript2";
+short	SOURCE	exon	3	4	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE2"; transcript_id "transcript2"; exon_number 1;
+short	SOURCE	exon	6	8	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE2"; transcript_id "transcript2"; exon_number 2;

--- a/test/graphs/gfa_with_w_lines_haplo.gtf
+++ b/test/graphs/gfa_with_w_lines_haplo.gtf
@@ -1,0 +1,6 @@
+##description: 
+##format: gtf
+alt	SOURCE	gene	2	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1";
+alt	SOURCE	transcript	2	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1";
+alt	SOURCE	exon	2	4	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1"; exon_number 1;
+alt	SOURCE	exon	8	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1"; exon_number 2;

--- a/test/graphs/gfa_with_w_lines_haplo.gtf
+++ b/test/graphs/gfa_with_w_lines_haplo.gtf
@@ -1,6 +1,6 @@
 ##description: 
 ##format: gtf
-alt	SOURCE	gene	2	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1";
-alt	SOURCE	transcript	2	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1";
-alt	SOURCE	exon	2	4	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1"; exon_number 1;
-alt	SOURCE	exon	8	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1"; exon_number 2;
+alt#0#chr	SOURCE	gene	2	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1";
+alt#0#chr	SOURCE	transcript	2	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1";
+alt#0#chr	SOURCE	exon	2	4	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1"; exon_number 1;
+alt#0#chr	SOURCE	exon	8	9	.	+	.	gene_id "gene"; gene_type "protein_coding"; gene_name "GENE1"; transcript_id "transcript1"; exon_number 2;

--- a/test/t/52_vg_autoindex.t
+++ b/test/t/52_vg_autoindex.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 34
+plan tests 47
 
 rm auto.*
 
@@ -33,8 +33,6 @@ is $(echo $?) 0 "phased autoindexing results can be used by vg map"
 
 rm auto.*
 
-# to add: GFA construction
-
 vg autoindex -p auto -w mpmap -w rpvg -r tiny/tiny.fa -v tiny/tiny.vcf.gz -x tiny/tiny.gtf
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with unchunked input"
 is $(ls auto.* | wc -l) 6 "autoindexing creates 6 files for mpmap/rpvg"
@@ -45,15 +43,33 @@ is $(cat auto.txorigin.tsv | wc -l) 7 "transcript origin table has expected numb
 
 rm auto.*
 
+vg autoindex -p auto -w mpmap  -r tiny/tiny.fa -v tiny/tiny.vcf.gz -x tiny/tiny.gtf --force-unphased
+is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with unchunked, unphased input"
+is $(ls auto.* | wc -l) 4 "autoindexing creates 4 files for mpmap/rpvg"
+vg sim -x auto.spliced.xg -n 20 -a -l 10 | vg mpmap -x auto.spliced.xg -g auto.spliced.gcsa -d auto.spliced.dist -B -t 1 -G - > /dev/null
+is $(echo $?) 0 "basic unphased autoindexing results can be used by vg mpmap"
+
+rm auto.*
+
 vg autoindex -p auto -w mpmap -r tiny/tiny.fa -x tiny/tiny.gtf
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap without variants"
-is $(ls auto.* | wc -l) 4 "autoindexing creates 4 files for mpmap/rpvg without variants"
+is $(ls auto.* | wc -l) 4 "autoindexing creates 4 files for mpmap without variants"
+vg sim -x auto.spliced.xg -n 20 -a -l 10 | vg mpmap -x auto.spliced.xg -g auto.spliced.gcsa -d auto.spliced.dist -B -t 1 -G - > /dev/null
+is $(echo $?) 0 "autoindexing results with no variants can be used by vg mpmap"
 
 rm auto.*
 
 vg autoindex -p auto -w mpmap -w rpvg -r small/x.fa -r small/y.fa -v small/x.vcf.gz -v small/y.vcf.gz -x small/x.gtf -x small/y.gtf
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with chunked input"
 is $(ls auto.* | wc -l) 6 "autoindexing creates 6 files for mpmap/rpvg with chunked input"
+
+rm auto.*
+
+vg autoindex -p auto -w mpmap -r small/x.fa -r small/y.fa -v small/x.vcf.gz -v small/y.vcf.gz -x small/x.gtf -x small/y.gtf --force-unphased
+is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with unphased chunked input"
+is $(ls auto.* | wc -l) 4 "autoindexing creates 4 files for mpmap/rpvg with chunked input"
+vg sim -x auto.spliced.xg -n 20 -a -l 10 | vg mpmap -x auto.spliced.xg -g auto.spliced.gcsa -d auto.spliced.dist -B -t 1 -G - > /dev/null
+is $(echo $?) 0 "autoindexing results with chunked unphased input can be used by vg mpmap"
 
 rm auto.*
 
@@ -64,6 +80,30 @@ rm auto.*
 
 vg autoindex -p auto -w mpmap -w rpvg -r small/xy.fa -v small/x.vcf.gz -v small/y.vcf.gz -x small/xy.gtf
 is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with another partially chunked input"
+
+rm auto.*
+
+vg autoindex -p auto -w mpmap -g graphs/gfa_with_w_lines.gfa -x graphs/gfa_with_w_lines.gtf
+is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with GFA input"
+vg sim -x auto.spliced.xg -n 20 -a -l 5 | vg mpmap -x auto.spliced.xg -g auto.spliced.gcsa -d auto.spliced.dist -B -t 1 -G - > /dev/null
+is $(echo $?) 0 "autoindexing results with GFA input can be used by vg mpmap"
+
+rm auto.*
+
+vg autoindex -p auto -w mpmap -g graphs/gfa_with_w_lines.gfa -x graphs/gfa_with_w_lines.gtf -H graphs/gfa_with_w_lines_haplo.gtf
+is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap with GFA input and a haplotype GTF"
+vg sim -x auto.spliced.xg -n 20 -a -l 5 | vg mpmap -x auto.spliced.xg -g auto.spliced.gcsa -d auto.spliced.dist -B -t 1 -G - > /dev/null
+is $(echo $?) 0 "autoindexing results with GFA input and a haplotype GTF can be used by vg mpmap"
+
+rm auto.*
+
+vg autoindex -p auto -w rpvg -w mpmap -g graphs/gfa_with_w_lines.gfa -x graphs/gfa_with_w_lines.gtf
+is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap and rpvg with GFA input"
+
+rm auto.*
+
+vg autoindex -p auto -w rpvg -w mpmap -g graphs/gfa_with_w_lines.gfa -x graphs/gfa_with_w_lines.gtf -H graphs/gfa_with_w_lines_haplo.gtf
+is $(echo $?) 0 "autoindexing successfully completes indexing for vg mpmap and rpvg with GFA input and a haplotype GTF"
 
 rm auto.*
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex --workflow mpmap` can now index from GFA-based graph input

## Description

Resolves https://github.com/vgteam/vg/issues/3886

The autoindex pipeline largely recapitulates the GBZ-handling from `vg rna`.