### PR TITLE
Handle unmapped reads in vg inject

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1250,7 +1250,7 @@ Alignment bam_to_alignment(const bam1_t *b,
         
     }
     
-    if (graph != nullptr && bh != nullptr) {
+    if (graph != nullptr && bh != nullptr && b->core.tid >= 0) {
         alignment.set_mapping_quality(b->core.qual);
         // Look for the path handle this is against.
         auto found = tid_path_handle.find(b->core.tid);

--- a/src/subcommand/inject_main.cpp
+++ b/src/subcommand/inject_main.cpp
@@ -26,7 +26,7 @@ void help_inject(char** argv) {
     cerr << "usage: " << argv[0] << " inject [options] input.[bam|sam|cram] >output.gam" << endl
          << endl
          << "options:" << endl
-         << "    -x, --xg-name FILE       use this graph or xg index (required)" << endl
+         << "    -x, --xg-name FILE       use this graph or xg index (required, non-XG formats also accepted)" << endl
          << "    -t, --threads N          number of threads to use" << endl;
 }
 

--- a/test/t/39_vg_inject.t
+++ b/test/t/39_vg_inject.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 10
+plan tests 12
 
 vg construct -r small/x.fa > j.vg
 vg index -x j.xg j.vg
@@ -47,3 +47,10 @@ is "$(vg inject -x x.xg small/i.bam | vg view -a - | wc -l)" 470 "vg inject pres
 
 is "$(vg inject -x x.xg small/i.bam | vg view -a - | jq .path.mapping[0].position.is_reverse | grep -v true | wc -l)" \
     0 "vg inject works perfectly for the reads flagged as is_reverse"
+
+cat <(samtools view -H small/x.bam) <(printf "name\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGTACGT\tHHHHHHHHHHHH\n") > unmapped.sam
+is "$(vg inject -x x.xg unmapped.sam | vg view -aj - | grep "path" | wc -l)" 0 "vg inject does not make an alignment for an umapped read"
+is "$(echo $?)" 0 "vg inject does not crash on an unmapped read"
+
+
+rm j.vg j.xg x.vg x.gcsa x.gcsa.lcp x.xg unmapped.sam


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg inject` can read BAM files with unmapped reads

## Description

Resolves https://github.com/vgteam/vg/issues/3955