### PR TITLE
Allow controlling Giraffe scoring parameters

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -2426,12 +2426,9 @@ void AlignerClient::set_alignment_scores(int8_t match, int8_t mismatch, int8_t g
             matrix[i] = -mismatch;
         }
     }
-    
-    qual_adj_aligner = unique_ptr<QualAdjAligner>(new QualAdjAligner(matrix, gap_open, gap_extend,
-                                                                     full_length_bonus, gc_content_estimate));
-    regular_aligner = unique_ptr<Aligner>(new Aligner(matrix, gap_open, gap_extend,
-                                                      full_length_bonus, gc_content_estimate));
-                  
+
+    this->set_alignment_scores(matrix, gap_open, gap_extend, full_length_bonus);
+
     free(matrix);
 }
 
@@ -2447,10 +2444,7 @@ void AlignerClient::set_alignment_scores(const int8_t* score_matrix, int8_t gap_
 
 void AlignerClient::set_alignment_scores(std::istream& matrix_stream, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus) {
     int8_t* score_matrix = parse_matrix(matrix_stream);
-    qual_adj_aligner = unique_ptr<QualAdjAligner>(new QualAdjAligner(score_matrix, gap_open, gap_extend,
-                                                                     full_length_bonus, gc_content_estimate));
-    regular_aligner = unique_ptr<Aligner>(new Aligner(score_matrix, gap_open, gap_extend,
-                                                      full_length_bonus, gc_content_estimate));
+    this->set_alignment_scores(score_matrix, gap_open, gap_extend, full_length_bonus);
     free(score_matrix);
 }
 

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -503,16 +503,17 @@ namespace vg {
     public:
         
         /// Set all the aligner scoring parameters and create the stored aligner instances.
-        void set_alignment_scores(int8_t match, int8_t mismatch, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);
+        virtual void set_alignment_scores(int8_t match, int8_t mismatch, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);
         
         /// Set the algner scoring parameters and create the stored aligner instances. The
         /// stream should contain a 4 x 4 whitespace-separated substitution matrix (in the
         /// order ACGT)
-        void set_alignment_scores(std::istream& matrix_stream, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);
+        virtual void set_alignment_scores(std::istream& matrix_stream, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);
         
         /// Set the algner scoring parameters and create the stored aligner instances. The
-        /// score matrix should by a 4 x 4 array in the order (ACGT)
-        void set_alignment_scores(const int8_t* score_matrix, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);
+        /// score matrix should by a 4 x 4 array in the order (ACGT).
+        /// Other overloads of set_alignment_scores all call this one.
+        virtual void set_alignment_scores(const int8_t* score_matrix, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);
         
         /// Allocates an array to hold a 4x4 substitution matrix and returns it
         static int8_t* parse_matrix(std::istream& matrix_stream);

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -52,11 +52,20 @@ MinimizerMapper::MinimizerMapper(const gbwtgraph::GBWTGraph& graph,
     distance_index(distance_index),  
     clusterer(distance_index, &graph),
     gbwt_graph(graph),
-    extender(gbwt_graph, *(get_regular_aligner())),
+    extender(new GaplessExtender(gbwt_graph, *(get_regular_aligner()))),
     fragment_length_distr(1000,1000,0.95) {
     
     // The GBWTGraph needs a GBWT
     crash_unless(graph.index != nullptr);
+}
+
+void MinimizerMapper::set_alignment_scores(const int8_t* score_matrix, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus) {
+    // Clear the extender before the aligners go away
+    extender.reset();
+    // Call the base class method and remake the aligners
+    AlignerClient::set_alignment_scores(score_matrix, gap_open, gap_extend, full_length_bonus);
+    // Remake the extender with new references
+    extender.reset(new GaplessExtender(gbwt_graph, *(get_regular_aligner())));
 }
 
 //-----------------------------------------------------------------------------
@@ -3039,7 +3048,7 @@ void MinimizerMapper::attempt_rescue(const Alignment& aligned_read, Alignment& r
     if (seeds.size() > this->rescue_seed_limit) {
         return;
     }
-    std::vector<GaplessExtension> extensions = this->extender.extend(seeds, rescued_alignment.sequence(), &cached_graph);
+    std::vector<GaplessExtension> extensions = this->extender->extend(seeds, rescued_alignment.sequence(), &cached_graph);
 
     // If we have a full-length extension, use it as the rescued alignment.
     if (GaplessExtender::full_length_extensions(extensions)) {
@@ -3703,7 +3712,7 @@ vector<GaplessExtension> MinimizerMapper::extend_cluster(const Cluster& cluster,
         }
     }
     
-    vector<GaplessExtension> cluster_extension = extender.extend(seed_matchings, sequence);
+    vector<GaplessExtension> cluster_extension = extender->extend(seed_matchings, sequence);
 
     if (show_work) {
         #pragma omp critical (cerr)

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -42,6 +42,9 @@ public:
          SnarlDistanceIndex* distance_index,
          const PathPositionHandleGraph* path_graph = nullptr);
 
+    using AlignerClient::set_alignment_scores;
+    virtual void set_alignment_scores(const int8_t* score_matrix, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);
+
     /**
      * Map the given read, and send output to the given AlignmentEmitter. May be run from any thread.
      * TODO: Can't be const because the clusterer's cluster_seeds isn't const.
@@ -471,7 +474,10 @@ protected:
     const gbwtgraph::GBWTGraph& gbwt_graph;
     
     /// We have a gapless extender to extend seed hits in haplotype space.
-    GaplessExtender extender;
+    /// Because this needs a reference to an Aligner, and because changing the
+    /// scoring parameters deletes all the alignmers, we need to keep this
+    /// somewhere we can clear out.
+    std::unique_ptr<GaplessExtender> extender;
     
     /// We have a clusterer
     SnarlDistanceIndexClusterer clusterer;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -905,24 +905,6 @@ namespace vg {
         }
     }
 
-    void MultipathMapper::set_alignment_scores(int8_t match, int8_t mismatch, int8_t gap_open, int8_t gap_extend,
-                                               int8_t full_length_bonus) {
-        AlignerClient::set_alignment_scores(match, mismatch, gap_open, gap_extend, full_length_bonus);
-        splice_stats.update_scoring(*get_regular_aligner());
-        set_min_softclip_length_for_splice(min_softclip_length_for_splice);
-        set_log_odds_against_splice(no_splice_natural_log_odds);
-        set_max_merge_supression_length();
-    }
-
-    void MultipathMapper::set_alignment_scores(std::istream& matrix_stream, int8_t gap_open, int8_t gap_extend,
-                                               int8_t full_length_bonus) {
-        AlignerClient::set_alignment_scores(matrix_stream, gap_open, gap_extend, full_length_bonus);
-        splice_stats.update_scoring(*get_regular_aligner());
-        set_min_softclip_length_for_splice(min_softclip_length_for_splice);
-        set_log_odds_against_splice(no_splice_natural_log_odds);
-        set_max_merge_supression_length();
-    }
-
     void MultipathMapper::set_alignment_scores(const int8_t* score_matrix, int8_t gap_open, int8_t gap_extend,
                                                int8_t full_length_bonus) {
         AlignerClient::set_alignment_scores(score_matrix, gap_open, gap_extend, full_length_bonus);

--- a/src/multipath_mapper.hpp
+++ b/src/multipath_mapper.hpp
@@ -81,14 +81,8 @@ namespace vg {
         /// Should be called once after construction, or any time the band padding multiplier is changed
         void init_band_padding_memo();
         
-        /// Set all the aligner scoring parameters and create the stored aligner instances.
-        void set_alignment_scores(int8_t match, int8_t mismatch, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);
-        
-        /// Set the algner scoring parameters and create the stored aligner instances. The
-        /// stream should contain a 4 x 4 whitespace-separated substitution matrix (in the
-        /// order ACGT)
-        void set_alignment_scores(std::istream& matrix_stream, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);
-        
+        using AlignerClient::set_alignment_scores;
+
         /// Set the algner scoring parameters and create the stored aligner instances. The
         /// score matrix should by a 4 x 4 array in the order (ACGT)
         void set_alignment_scores(const int8_t* score_matrix, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus);

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -61,6 +61,15 @@ struct GiraffeMainOptions {
     size_t watchdog_timeout = default_watchdog_timeout;
 };
 
+/// Options struct for scoring-related parameters. Defaults are in aligner.hpp.
+struct ScoringOptions {
+    int8_t match = default_match;
+    int8_t mismatch = default_mismatch;
+    int8_t gap_open = default_gap_open;
+    int8_t gap_extend = default_gap_extension;
+    int8_t full_length_bonus = default_full_length_bonus;
+};
+
 static GroupedOptionGroup get_options() {
     GroupedOptionGroup parser;
     
@@ -73,6 +82,39 @@ static GroupedOptionGroup get_options() {
         "complain after INT seconds working on a read or read pair"
     );
     
+    // Configure scoring
+    auto& scoring_opts = parser.add_group<ScoringOptions>("scoring options");
+    scoring_opts.add_range(
+        "match",
+        &ScoringOptions::match,
+        default_match,
+        "use this match score"
+    );
+    scoring_opts.add_range(
+        "mismatch",
+        &ScoringOptions::mismatch,
+        default_mismatch,
+        "use this mismatch penalty"
+    );
+    scoring_opts.add_range(
+        "gap-open",
+        &ScoringOptions::gap_open,
+        default_gap_open,
+        "use this gap open penalty"
+    );
+    scoring_opts.add_range(
+        "gap-extend",
+        &ScoringOptions::gap_extend,
+        default_gap_extension,
+        "use this gap extension penalty"
+    );
+    scoring_opts.add_range(
+        "full-l-bonus",
+        &ScoringOptions::full_length_bonus,
+        default_full_length_bonus,
+        "the full-length alignment bonus"
+    );
+
     // Configure output settings on the MinimizerMapper
     auto& result_opts = parser.add_group<MinimizerMapper>("result options");
     result_opts.add_range(
@@ -394,6 +436,8 @@ int main_giraffe(int argc, char** argv) {
     // Main Giraffe program options struct
     // Not really initialized until after we load all the indexes though...
     GiraffeMainOptions main_options;
+    // Scoring options struct
+    ScoringOptions scoring_options;
     // What GAM should we realign?
     string gam_filename;
     // What FASTQs should we align.
@@ -1012,6 +1056,8 @@ int main_giraffe(int argc, char** argv) {
     if (forced_mean && forced_stdev) {
         minimizer_mapper.force_fragment_length_distr(fragment_mean, fragment_stdev);
     }
+    // Apply scoring parameters
+    minimizer_mapper.set_alignment_scores(scoring_options.match, scoring_options.mismatch, scoring_options.gap_open, scoring_options.gap_extend, scoring_options.full_length_bonus);
 
     
     std::chrono::time_point<std::chrono::system_clock> init = std::chrono::system_clock::now();
@@ -1071,6 +1117,7 @@ int main_giraffe(int argc, char** argv) {
         }
         parser.apply(minimizer_mapper);
         parser.apply(main_options);
+        parser.apply(scoring_options);
         
         if (show_progress && interleaved) {
             cerr << "--interleaved" << endl;

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1056,9 +1056,6 @@ int main_giraffe(int argc, char** argv) {
     if (forced_mean && forced_stdev) {
         minimizer_mapper.force_fragment_length_distr(fragment_mean, fragment_stdev);
     }
-    // Apply scoring parameters
-    minimizer_mapper.set_alignment_scores(scoring_options.match, scoring_options.mismatch, scoring_options.gap_open, scoring_options.gap_extend, scoring_options.full_length_bonus);
-
     
     std::chrono::time_point<std::chrono::system_clock> init = std::chrono::system_clock::now();
     std::chrono::duration<double> init_seconds = init - launch;
@@ -1153,6 +1150,9 @@ int main_giraffe(int argc, char** argv) {
 
         minimizer_mapper.sample_name = sample_name;
         minimizer_mapper.read_group = read_group;
+
+        // Apply scoring parameters, after they have been parsed
+        minimizer_mapper.set_alignment_scores(scoring_options.match, scoring_options.mismatch, scoring_options.gap_open, scoring_options.gap_extend, scoring_options.full_length_bonus);
 
         // Work out the number of threads we will have
         size_t thread_count = omp_get_max_threads();

--- a/src/subcommand/options.cpp
+++ b/src/subcommand/options.cpp
@@ -58,6 +58,11 @@ const char* get_metavar<int>() {
 }
 
 template<>
+const char* get_metavar<int8_t>() {
+    return "INT";
+}
+
+template<>
 const char* get_metavar<bool>() {
     return "BOOL";
 }

--- a/src/subcommand/options.hpp
+++ b/src/subcommand/options.hpp
@@ -366,6 +366,9 @@ template<>
 const char* get_metavar<int>();
 
 template<>
+const char* get_metavar<int8_t>();
+
+template<>
 const char* get_metavar<bool>();
 
 template<>
@@ -609,10 +612,25 @@ struct ValueArgSpec : public ArgSpec<T, Receiver> {
         out << sep << get_metavar<T>();
     }
     virtual void print_value(ostream& out, const char* sep = "") const {
-        out << sep << value;
+        out << sep;
+        if (std::is_integral<T>::value) {
+            // Looks like a char, so print it as a number.
+            // See <https://stackoverflow.com/a/28414758>
+            out << +value;
+        } else {
+            out << value;
+        }
     }
     virtual void print_default(ostream& out) const {
-        out << " [" << this->default_value << "]";
+        out << " [";
+        if (std::is_integral<T>::value) {
+            // Looks like a char, so print it as a number.
+            // See <https://stackoverflow.com/a/28414758>
+            out << +(this->default_value);
+        } else {
+            out << this->default_value;
+        }
+        out << "]";
     }
     virtual struct option get_option_struct() const {
         return {this->option.c_str(), required_argument, 0, this->option_id};

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -172,7 +172,7 @@ vg autoindex -p brca -w giraffe -g graphs/cactus-BRCA2.gfa
 vg sim -s 100 -x brca.giraffe.gbz -n 200 -a > reads.gam
 vg giraffe -Z brca.giraffe.gbz -m brca.min -d brca.dist -G reads.gam --named-coordinates > mapped.gam
 is "$?" "0" "Mapping reads to named coordinates on a nontrivial graph without walks succeeds"
-is "$(vg view -aj mapped.gam | jq -r '.score' | grep -v "^0" | wc -l)" "200" "Reads are all mapped"
+is "$(vg view -aj mapped.gam | jq -r '.score' | grep -v "^0" | grep -v "null" | wc -l)" "200" "Reads are all mapped"
 is "$(vg view -aj mapped.gam | jq -r '.path.mapping[].position.name' | grep null | wc -l)" "0" "GFA segment names are all set"
 
 vg giraffe -Z brca.giraffe.gbz -m brca.min -d brca.dist -G reads.gam --named-coordinates -o gaf > mapped.gaf
@@ -192,7 +192,7 @@ vg autoindex -p 1mb1kgp -w giraffe -P "VG w/ Variant Paths:1mb1kgp.vg" -P "Giraf
 vg giraffe -Z 1mb1kgp.giraffe.gbz -f reads/1mb1kgp_longread.fq >longread.gam -U 300 --progress --track-provenance --align-from-chains
 # This is an 8001 bp read with 1 insert and 1 substitution
 is "$(vg view -aj longread.gam | jq -r '.score')" "7989" "A long read can be correctly aligned"
-is "$(vg view -aj longread.gam | jq -c '.path.mapping[].edit[] | select(.sequence)' | wc -l)" "2" "A long read hasd the correct edits found"
+is "$(vg view -aj longread.gam | jq -c '.path.mapping[].edit[] | select(.sequence)' | wc -l)" "2" "A long read has the correct edits found"
 is "$(vg view -aj longread.gam | jq -c '. | select(.annotation["filter_3_cluster-coverage_cluster_passed_size_total"] <= 300)' | wc -l)" "1" "Long read minimizer set is correctly restricted"
 
 rm -f longread.gam 1mb1kgp.dist 1mb1kgp.giraffe.gbz 1mb1kgp.min log.txt

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 45
+plan tests 47
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
@@ -37,6 +37,12 @@ vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.fq > mapped1.gam
 is "${?}" "0" "a read can be mapped with the indexes being inferred by name"
 
 is "$(vg view -aj mapped1.gam | grep 'time_used' | wc -l)" "1" "Mapping logs runtime per read"
+
+is "$(vg view -aj mapped1.gam | jq '.score')" "73" "Mapping produces the correct score"
+
+vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.fq --full-l-bonus 0 > mapped-nobonus.gam
+is "$(vg view -aj  mapped-nobonus.gam | jq '.score')" "63" "Mapping without a full length bonus produces the correct score"
+rm -f mapped-nobonus.gam
 
 vg minimizer -k 29 -b -s 18 -g x.gbwt -o x.sync x.xg
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` now has `--match`, `--mismatch`, `--gap-open`, `--gap-extend`, and `--full-l-bonus` options to control alignment scoring.

## Description

This adds options to `vg giraffe` to allow controlling the scoring parameters, including the full length bonus. This will fix #3961.