### PR TITLE
Fix assertion problem in deconstruct that seems to affect PGGB graphs

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -424,28 +424,16 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
     int sample_ploidy = ploidy;
     int min_phase = 1;
     int max_phase = ploidy;
-    if (has_phasing) {
-        // override ploidy with information about all phases found in input
-        std::tie(min_phase, max_phase) = gbwt_sample_to_phase_range.at(sample_name);
-        // shift left by 1 unless min phase is 0
-        sample_ploidy = min_phase == 0 ? max_phase + 1 : max_phase;
-        assert(sample_ploidy > 0);
-        
-        set<int> used_phases;
-        for (int i = sorted_travs.size() - 1; i >= 0 && most_frequent_travs.size() < sample_ploidy; --i) {
-            int phase = gbwt_phases.at(sorted_travs[i]);
-            if (!used_phases.count(phase)) {
-                if (trav_to_allele[sorted_travs[i]] >= 0) {
-                    most_frequent_travs.push_back(sorted_travs[i]);
-                    used_phases.insert(phase);
-                }
-            } else {
-                phasing_conflict = true;
-            }
-        }
-    } else if (path_to_sample_phase) {
-        sample_ploidy = sample_ploidys.at(sample_name);
-        
+    if (has_phasing || path_to_sample_phase) {
+        if (has_phasing) {
+            // override ploidy with information about all phases found in input
+            std::tie(min_phase, max_phase) = gbwt_sample_to_phase_range.at(sample_name);
+            // shift left by 1 unless min phase is 0
+            sample_ploidy = min_phase == 0 ? max_phase + 1 : max_phase;
+            assert(sample_ploidy > 0);
+        } else {
+            sample_ploidy = sample_ploidys.at(sample_name);
+        }        
         set<int> used_phases;
         for (int i = sorted_travs.size() - 1; i >= 0 && most_frequent_travs.size() < sample_ploidy; --i) {
             int phase = gbwt_phases.at(sorted_travs[i]);

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -472,7 +472,7 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
                   [&](int t1, int t2) {return gbwt_phases.at(t1) < gbwt_phases.at(t2);});
         if (max_phase > 0) {
             // pad out by phase
-            assert(gbwt_phases.at(most_frequent_travs.back()) <= max_phase);
+            assert(most_frequent_travs.empty() || gbwt_phases.at(most_frequent_travs.back()) <= max_phase);
             assert(max_phase < 1000);
             // we normally expect to have phases 1,2,3, ...
             // in this case, we shift them all back, otherwise leave 0-based


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fix crash due to failed assertion in `vg deconstruct` that was introduced in v1.48.0 

## Description

In #3931 I cleaned up a bunch of redundant code-paths where gbz and non-gbz input were handled differently.  

This seems to have had the effect of putting non-GBZ inputs down a path that added this one assertion (but was otherwise equivalent). The problem is that this assertion fails at an (apparently uncallable?) site in the PGGB graph from #3973.  

Anyway, all this PR does is fix the assertion, which should be enough to bring back the functionality from the last release.  I won't merge it until I've compared the output of the full vcf from v1.47 and this branch.  

Resolves #3973