### PR TITLE
allow colon in pathname in region range parsing

### DIFF
--- a/src/region.cpp
+++ b/src/region.cpp
@@ -8,18 +8,18 @@ namespace vg {
 void parse_region(const string& target, string& name, int64_t& start, int64_t& end) {
     start = -1;
     end = -1;
-    size_t foundFirstColon = target.find(":");
+    size_t foundLastColon = target.rfind(":");
     // we only have a single string, use the whole sequence as the target
-    if (foundFirstColon == string::npos) {
+    if (foundLastColon == string::npos) {
         name = target;
     } else {
-        name = target.substr(0, foundFirstColon);
-	    size_t foundRangeDash = target.find("-", foundFirstColon);
+        name = target.substr(0, foundLastColon);
+	    size_t foundRangeDash = target.find("-", foundLastColon);
         if (foundRangeDash == string::npos) {
-            start = atoi(target.substr(foundFirstColon + 1).c_str());
+            start = atoi(target.substr(foundLastColon + 1).c_str());
             end = start;
         } else {
-            start = atoi(target.substr(foundFirstColon + 1, foundRangeDash - foundRangeDash - 1).c_str());
+            start = atoi(target.substr(foundLastColon + 1, foundRangeDash - foundRangeDash - 1).c_str());
             end = atoi(target.substr(foundRangeDash + 1).c_str());
         }
     }

--- a/src/unittest/chunker.cpp
+++ b/src/unittest/chunker.cpp
@@ -217,6 +217,17 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         REQUIRE(subrange == PathMetadata::NO_SUBRANGE);
         REQUIRE(name == "path]");
     }
+
+    SECTION("Range extraction") {
+        string name;
+        int64_t start = -1;
+        int64_t end = -1;
+        parse_region("x:y:1-2", name, start, end);
+
+        REQUIRE(name == "x:y");
+        REQUIRE(start == 1);
+        REQUIRE(end == 2);
+    }
 }
 
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `:` character now allowed in path name during `contig:start-end` range extraction from command line options (ie in `vg chunk`). 

## Description

Apparently was causing trouble for someone using Tube Maps...