### PR TITLE
Better haplotype sampling

### DIFF
--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -353,16 +353,16 @@ public:
 
     /// Multiplier to the score of a present kmer every time a haplotype with that
     /// kmer is selected.
-    constexpr static double PRESENT_DISCOUNT = 0.7;
+    constexpr static double PRESENT_DISCOUNT = 0.9;
 
     /// Adjustment to the score of a heterozygous kmer every time a haplotype with
     /// (-) or without (+) that kmer is selected.
-    constexpr static double HET_ADJUSTMENT = 0.2;
+    constexpr static double HET_ADJUSTMENT = 0.05;
 
     /// Score for getting an absent kmer right/wrong. This should be less than 1, if
     /// we assume that having the right variants in the graph is more important than
     /// keeping wrong variants out.
-    constexpr static double ABSENT_SCORE = 0.7;
+    constexpr static double ABSENT_SCORE = 0.8;
 
     /// A GBWT sequence as (sequence identifier, offset in a node).
     typedef Haplotypes::sequence_type sequence_type;

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -289,6 +289,9 @@ public:
      *
      * Haplotypes crossing each subchain are represented using minimizers with a
      * single occurrence in the graph.
+     *
+     * Throws `std::runtime_error` on error in single-threaded parts and exits
+     * with `std::exit(EXIT_FAILURE)` in multi-threaded parts.
      */
     Haplotypes partition_haplotypes(const Parameters& parameters) const;
 
@@ -530,6 +533,9 @@ public:
      * the middle of a chain create fragment breaks. If the chain starts without
      * a prefix (ends without a suffix), the haplotype chosen for the first (last)
      * subchain is used from the start (continued until the end).
+     *
+     * Throws `std::runtime_error` on error in single-threaded parts and exits
+     * with `std::exit(EXIT_FAILURE)` in multi-threaded parts.
      */
     gbwt::GBWT generate_haplotypes(const Haplotypes& haplotypes, const std::string& kff_file, const Parameters& parameters) const;
 

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -348,8 +348,8 @@ public:
     /// Number of haplotypes to be generated.
     constexpr static size_t NUM_HAPLOTYPES = 8;
 
-    /// Expected read coverage.
-    constexpr static size_t COVERAGE = 30;
+    /// Expected kmer coverage. Use 0 to estimate from kmer counts.
+    constexpr static size_t COVERAGE = 0;
 
     /// Block size (in kmers) for reading KFF files.
     constexpr static size_t KFF_BLOCK_SIZE = 1000000;
@@ -493,7 +493,7 @@ public:
         /// Number of haplotypes to be generated.
         size_t num_haplotypes = NUM_HAPLOTYPES;
 
-        /// Read coverage.
+        /// Kmer coverage. Use 0 to estimate from kmer counts.
         size_t coverage = COVERAGE;
 
         /// Buffer size (in nodes) for GBWT construction.
@@ -547,7 +547,7 @@ private:
     Statistics generate_haplotypes(const Haplotypes::TopLevelChain& chain,
         const hash_map<Haplotypes::Subchain::kmer_type, size_t>& kmer_counts,
         gbwt::GBWTBuilder& builder,
-        const Parameters& parameters) const;
+        const Parameters& parameters, double coverage) const;
 };
 
 //------------------------------------------------------------------------------

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -346,7 +346,7 @@ private:
 class Recombinator {
 public:
     /// Number of haplotypes to be generated.
-    constexpr static size_t NUM_HAPLOTYPES = 8;
+    constexpr static size_t NUM_HAPLOTYPES = 4;
 
     /// Expected kmer coverage. Use 0 to estimate from kmer counts.
     constexpr static size_t COVERAGE = 0;

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -38,6 +38,7 @@ struct SummaryStatistics {
     double mean;
     double median;
     double stdev;
+    double mode;
     size_t number_of_values;
     double max_value;
     size_t count_of_max;
@@ -46,12 +47,16 @@ struct SummaryStatistics {
 /// Returns summary statistics for a multiset of numbers.
 template<typename Number>
 SummaryStatistics summary_statistics(const std::map<Number, size_t>& values) {
-    SummaryStatistics result { 0.0, 0.0, 0.0, 0, 0.0, 0 };
+    SummaryStatistics result { 0.0, 0.0, 0.0, 0.0, 0, 0.0, 0 };
 
     double sum_of_values = 0.0;
+    size_t max_freq = 0;
     for (auto iter = values.begin(); iter != values.end(); ++iter) {
         sum_of_values += iter->first * iter->second;
         result.number_of_values += iter->second;
+        if (iter->second > max_freq) {
+            result.mode = iter->first; max_freq = iter->second;
+        }
     }
     if (result.number_of_values == 0) {
         return result;

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -188,7 +188,7 @@ void help_haplotypes(char** argv, bool developer_options) {
     std::cerr << "        --kmer-length N       kmer length for building the minimizer index (default: " << haplotypes_default_k() << ")" << std::endl;
     std::cerr << "        --window-length N     window length for building the minimizer index (default: " << haplotypes_default_w() << ")" << std::endl;
     std::cerr << "        --subchain-length N   target length (in bp) for subchains (default: " << haplotypes_default_subchain_length() << ")" << std::endl;
-    std::cerr << "        --coverage N          read coverage in the KFF file (default: " << haplotypes_default_coverage() << ")" << std::endl;
+    std::cerr << "        --coverage N          kmer coverage in the KFF file (default: " << haplotypes_default_coverage() << ")" << std::endl;
     std::cerr << "        --num-haplotypes N    generate N haplotypes (default: " << haplotypes_default_n() << ")" << std::endl;
     std::cerr << "        --present-discount F  discount scores for present kmers by factor F (default: " << haplotypes_default_discount() << ")" << std::endl;
     std::cerr << "        --het-adjustment F    adjust scores for heterozygous kmers by F (default: " << haplotypes_default_adjustment() << ")" << std::endl;
@@ -306,7 +306,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
         case OPT_COVERAGE:
             this->recombinator_parameters.coverage = parse<size_t>(optarg);
             if (this->recombinator_parameters.coverage == 0) {
-                std::cerr << "error: [vg haplotypes] read coverage cannot be 0" << std::endl;
+                std::cerr << "error: [vg haplotypes] kmer coverage cannot be 0" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             break;
@@ -320,21 +320,21 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
         case OPT_PRESENT_DISCOUNT:
             this->recombinator_parameters.present_discount = parse<double>(optarg);
             if (this->recombinator_parameters.present_discount < 0.0 || this->recombinator_parameters.present_discount > 1.0) {
-                std::cerr << "error: [vg haplotypes] discount factor must be between 0.0 and 1.0" << std::endl;
+                std::cerr << "error: [vg haplotypes] present discount must be between 0.0 and 1.0" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             break;
         case OPT_HET_ADJUSTMENT:
             this->recombinator_parameters.het_adjustment = parse<double>(optarg);
             if (this->recombinator_parameters.het_adjustment < 0.0) {
-                std::cerr << "error: [vg haplotypes] adjustment term must be non-negative" << std::endl;
+                std::cerr << "error: [vg haplotypes] het adjustment must be non-negative" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             break;
         case OPT_ABSENT_SCORE:
             this->recombinator_parameters.absent_score = parse<double>(optarg);
             if (this->recombinator_parameters.absent_score < 0.0) {
-                std::cerr << "error: [vg haplotypes] scores must be non-negative" << std::endl;
+                std::cerr << "error: [vg haplotypes] absent score must be non-negative" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             break;
@@ -1161,7 +1161,8 @@ void validate_haplotypes(const Haplotypes& haplotypes,
                 if (iter != kmers.end()) {
                     const Haplotypes::Subchain& prev = haplotypes.chains[iter->second.first].subchains[iter->second.second];
                     if (chain_id == iter->second.first && subchain_id == iter->second.second + 1 && subchain.type == Haplotypes::Subchain::prefix && prev.type == Haplotypes::Subchain::suffix) {
-                        // TODO: Maybe warn that there are shared kmers in a snarl broken into a suffix and a prefix.
+                        // A prefix subchain may overlap the preceding suffix subchain and
+                        // contain the same kmers.
                     } else {
                         std::string message = subchain.to_string() + ": kmer " + std::to_string(i) + " also found in " + subchain_to_string(iter->second.first, iter->second.second, prev);
                         validate_error_subchain(chain_id, subchain_id, message);

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -181,14 +181,14 @@ void help_haplotypes(char** argv, bool developer_options) {
     std::cerr << "Input files:" << std::endl;
     std::cerr << "    -d, --distance-index X    use this distance index (default: <basename>.dist)" << std::endl;
     std::cerr << "    -r, --r-index X           use this r-index (default: <basename>.ri)" << std::endl;
-    std::cerr << "    -i, --haplotype-input X   use this haplotype information (default: generate the information)" << std::endl;
+    std::cerr << "    -i, --haplotype-input X   use this haplotype information (default: generate)" << std::endl;
     std::cerr << "    -k, --kmer-input X        use kmer counts from this KFF file (required for --gbz-output)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Computational parameters:" << std::endl;
     std::cerr << "        --kmer-length N       kmer length for building the minimizer index (default: " << haplotypes_default_k() << ")" << std::endl;
     std::cerr << "        --window-length N     window length for building the minimizer index (default: " << haplotypes_default_w() << ")" << std::endl;
     std::cerr << "        --subchain-length N   target length (in bp) for subchains (default: " << haplotypes_default_subchain_length() << ")" << std::endl;
-    std::cerr << "        --coverage N          kmer coverage in the KFF file (default: " << haplotypes_default_coverage() << ")" << std::endl;
+    std::cerr << "        --coverage N          kmer coverage in the KFF file (default: estimate)" << std::endl;
     std::cerr << "        --num-haplotypes N    generate N haplotypes (default: " << haplotypes_default_n() << ")" << std::endl;
     std::cerr << "        --present-discount F  discount scores for present kmers by factor F (default: " << haplotypes_default_discount() << ")" << std::endl;
     std::cerr << "        --het-adjustment F    adjust scores for heterozygous kmers by F (default: " << haplotypes_default_adjustment() << ")" << std::endl;
@@ -305,10 +305,6 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
             break;
         case OPT_COVERAGE:
             this->recombinator_parameters.coverage = parse<size_t>(optarg);
-            if (this->recombinator_parameters.coverage == 0) {
-                std::cerr << "error: [vg haplotypes] kmer coverage cannot be 0" << std::endl;
-                std::exit(EXIT_FAILURE);
-            }
             break;
         case OPT_NUM_HAPLOTYPES:
             this->recombinator_parameters.num_haplotypes = parse<size_t>(optarg);

--- a/src/unittest/statistics.cpp
+++ b/src/unittest/statistics.cpp
@@ -21,6 +21,7 @@ TEST_CASE("Summary statistics", "[statistics]") {
         REQUIRE(statistics.mean == 2.5);
         REQUIRE(statistics.median == 2.0);
         REQUIRE(statistics.stdev == std::sqrt(25.5 / 6));
+        REQUIRE(statistics.mode == 1.0);
         REQUIRE(statistics.number_of_values == 6);
         REQUIRE(statistics.max_value == 6.0);
         REQUIRE(statistics.count_of_max == 1);
@@ -32,6 +33,7 @@ TEST_CASE("Summary statistics", "[statistics]") {
         REQUIRE(statistics.mean == 5.0);
         REQUIRE(statistics.median == 5.0);
         REQUIRE(statistics.stdev == std::sqrt(114.0 / 9));
+        REQUIRE(statistics.mode == 5.0);
         REQUIRE(statistics.number_of_values == 9);
         REQUIRE(statistics.max_value == 12.0);
         REQUIRE(statistics.count_of_max == 1);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Better default parameters for haplotype sampling

## Description

Haplotype sampling now uses the following defaults: `--num-haplotypes 4 --present-discount 0.9 --het-adjustment 0.05 --absent-score 0.8`. With these parameters, DeepVariant variant calling performance is generally better with reads mapped to a sampled HPRC graph than to the filtered HPRC graph.

Additionally, `vg haplotypes` now estimates kmer coverage, which should be relatively robust. The user can override this with option `--coverage`.