### PR TITLE
more messaging about not using vg-protobuf graph format

### DIFF
--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -224,6 +224,10 @@ int main_convert(int argc, char** argv) {
         cerr << "error [vg convert]: paths cannot be converted to reference sense when writing GFA output" << endl;
         return 1;
     }
+    if (output_format == "vg") {
+          cerr << "[vg convert] warning: vg-protobuf output (-v / --vg-out) is depreacted. please use -p instead." << endl;
+    }
+
     
     // with -F or -G we convert an alignment and not a graph
     if (input == input_gam || input == input_gaf) {

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -225,7 +225,7 @@ int main_convert(int argc, char** argv) {
         return 1;
     }
     if (output_format == "vg") {
-          cerr << "[vg convert] warning: vg-protobuf output (-v / --vg-out) is depreacted. please use -p instead." << endl;
+          cerr << "[vg convert] warning: vg-protobuf output (-v / --vg-out) is deprecated. please use -p instead." << endl;
     }
 
     

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -37,7 +37,7 @@ void help_view(char** argv) {
          << "    -g, --gfa                  output GFA format (default)" << endl
          << "    -F, --gfa-in               input GFA format, reducing overlaps if they occur" << endl
 
-         << "    -v, --vg                   output VG format" << endl
+         << "    -v, --vg                   output VG format [DEPRECATED, use vg convert instead]" << endl
          << "    -V, --vg-in                input VG format only" << endl
 
          << "    -j, --json                 output JSON format" << endl
@@ -473,6 +473,9 @@ int main_view(int argc, char** argv) {
     if (optind >= argc) {
         cerr << "[vg view] error: no filename given" << endl;
         exit(1);
+    }
+    if (output_type == "vg") {
+        cerr << "[vg view] warning: vg-protobuf output (-v / --v) is depreacted. please use vg convert instead." << endl;
     }
     
     string file_name = get_input_file_name(optind, argc, argv);

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -475,7 +475,7 @@ int main_view(int argc, char** argv) {
         exit(1);
     }
     if (output_type == "vg") {
-        cerr << "[vg view] warning: vg-protobuf output (-v / --v) is depreacted. please use vg convert instead." << endl;
+        cerr << "[vg view] warning: vg-protobuf output (-v / --v) is deprecated. please use vg convert instead." << endl;
     }
     
     string file_name = get_input_file_name(optind, argc, argv);

--- a/test/t/03_vg_view.t
+++ b/test/t/03_vg_view.t
@@ -48,17 +48,17 @@ is $(vg view -d ./cyclic/all.vg | wc -l) 23 "view produces the expected number o
 vg construct -r small/x.fa -v small/x.vcf.gz | vg view -v - >x.vg
 is $(cat x.vg x.vg x.vg x.vg | vg view -c - | wc -l) 4 "streaming JSON output produces the expected number of chunks"
 
-is "$(cat x.vg x.vg | vg view -vVD - 2>&1 > /dev/null | wc -l)" 0 "duplicate warnings can be suppressed when loading as vg::VG"
+is "$(cat x.vg x.vg | vg view -vVD - 2>&1 > /dev/null | grep -v deprecated | wc -l)" 0 "duplicate warnings can be suppressed when loading as vg::VG"
 
 rm x.vg
 
 vg view -Fv overlaps/two_snvs_assembly1.gfa >/dev/null 2>errors.txt
 is "${?}" "1" "gfa graphs with overlaps are rejected"
-is "$(cat errors.txt | wc -l)" "2" "GFA import produces a concise error message when overlaps are present"
+is "$(cat errors.txt | grep -v deprecated | wc -l)" "2" "GFA import produces a concise error message when overlaps are present"
 
 vg view -Fv overlaps/incorrect_overlap.gfa >/dev/null 2>errors.txt
 is "$?" "1" "GFA import rejects a GFA file with an overlap that goes beyond its sequences"
-is "$(cat errors.txt | wc -l)" "2" "GFA import produces a concise error message in that case"
+is "$(cat errors.txt | grep -v deprecated | wc -l)" "2" "GFA import produces a concise error message in that case"
 
 rm -f errors.txt
 


### PR DESCRIPTION
The protobuf-based vg format doesn't scale very well, and there's no good reason to be using it when, for example, importing gfa.  So add some warnings when people try to convert their graphs into this format. 

