### PR TITLE
Bump libvgio and C++ standard version to work with Homebrew's current Protobuf

### DIFF
--- a/src/annotation.hpp
+++ b/src/annotation.hpp
@@ -9,6 +9,8 @@
 #include <string>
 #include <type_traits>
 #include <functional>
+#include <limits>
+#include <cmath>
 
 #include <google/protobuf/struct.pb.h>
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg now builds with C++17 on Mac, as required byu the version of Protobuf packaged in Homebrew
 * vg now deduplicates arguments from pkg-config, to limit command line length with Protobuf's 30-odd Abseil dependencies.

## Description

This should fix the Mac CI failures. It might interfere with the static builds actually using a static Protobuf.
