### PR TITLE
Log Homebrew info on CI

### DIFF
--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -50,7 +50,15 @@ jobs:
         # to avoid problems with ABI changes with/without -DNDEBUG.
         # And we update libomp to make extra sure it will be picked up by the compiler.
         # We pre-install a pinned txm to work around https://github.com/anko/txm/issues/8
-        run: brew bundle cleanup --force && brew bundle install && brew update && brew install protobuf && brew install libomp && npm install -g txm@7.4.5
+        run: |
+          brew bundle cleanup --force && \
+          brew bundle install && \
+          brew update && \
+          brew install protobuf && \
+          brew install libomp && \
+          npm install -g txm@7.4.5 && \
+          brew config && \
+          (brew doctor || echo "brew doctor is unhappy")
 
       - name: Run build and test
         run: |


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Mac CI now collect Homebrew debug info

## Description

Homebrew *really* doesn't want to take issues unless someone somewhere has run `brew config` and `brew doctor`. So we need to run them on CI so we can say we did and present the logs in case anything is broken in Homebrew.
