### PR TITLE
Add a warning to giraffe when using minimizers without distance hints

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -598,11 +598,25 @@ vector<Alignment> MinimizerMapper::map_from_extensions(Alignment& aln) {
 
     if (seeds.size() > 0 && seeds.front().minimizer_cache == MIPayload::NO_CODE){
         //If there is no payload
-        if (!warned_about_minimizer_payload.test_and_set()) {
+        bool found_minimizer = found_minimizer_payload.test_and_set();
+        if (!found_minimizer &&
+            !warned_about_minimizer_payload.test_and_set()) {
             cerr << "warning[vg::giraffe]: Running giraffe without distance hints in the minimizers." << endl;
             cerr << "                      Mapping will be slow." << endl;
             cerr << "                      To include distance hints, rebuilt the minimizers with vg minimizer -d" << endl;
         }
+
+        //TODO: C++ 20 will let us use found_minimizer_payload.test(),
+        //which won't set the value to true.
+        //For now, check if it was false before getting set to true
+        //and reset it if necessary
+        if (!found_minimizer) {
+            found_minimizer_payload.clear();
+        }
+    } else {
+        //If we found a payload, make sure we remember it so we don't
+        //warn about it later
+        found_minimizer_payload.test_and_set();
     }
 
     // Cluster the seeds. Get sets of input seed indexes that go together.

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -596,6 +596,15 @@ vector<Alignment> MinimizerMapper::map_from_extensions(Alignment& aln) {
     // Find the seeds and mark the minimizers that were located.
     vector<Seed> seeds = this->find_seeds(minimizers, aln, funnel);
 
+    if (seeds.size() > 0 && seeds.front().minimizer_cache == MIPayload::NO_CODE){
+        //If there is no payload
+        if (!warned_about_minimizer_payload.test_and_set()) {
+            cerr << "warning[vg::giraffe]: Running giraffe without distance hints in the minimizers." << endl;
+            cerr << "                      Mapping will be slow." << endl;
+            cerr << "                      To include distance hints, rebuilt the minimizers with vg minimizer -d" << endl;
+        }
+    }
+
     // Cluster the seeds. Get sets of input seed indexes that go together.
     if (track_provenance) {
         funnel.stage("cluster");

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -596,29 +596,6 @@ vector<Alignment> MinimizerMapper::map_from_extensions(Alignment& aln) {
     // Find the seeds and mark the minimizers that were located.
     vector<Seed> seeds = this->find_seeds(minimizers, aln, funnel);
 
-    if (seeds.size() > 0 && seeds.front().minimizer_cache == MIPayload::NO_CODE){
-        //If there is no payload
-        bool found_minimizer = found_minimizer_payload.test_and_set();
-        if (!found_minimizer &&
-            !warned_about_minimizer_payload.test_and_set()) {
-            cerr << "warning[vg::giraffe]: Running giraffe without distance hints in the minimizers." << endl;
-            cerr << "                      Mapping will be slow." << endl;
-            cerr << "                      To include distance hints, rebuilt the minimizers with vg minimizer -d" << endl;
-        }
-
-        //TODO: C++ 20 will let us use found_minimizer_payload.test(),
-        //which won't set the value to true.
-        //For now, check if it was false before getting set to true
-        //and reset it if necessary
-        if (!found_minimizer) {
-            found_minimizer_payload.clear();
-        }
-    } else {
-        //If we found a payload, make sure we remember it so we don't
-        //warn about it later
-        found_minimizer_payload.test_and_set();
-    }
-
     // Cluster the seeds. Get sets of input seed indexes that go together.
     if (track_provenance) {
         funnel.stage("cluster");

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -124,18 +124,6 @@ public:
     /// If set, exclude overlapping minimizers
     static constexpr bool default_exclude_overlapping_min = false;
     bool exclude_overlapping_min = default_exclude_overlapping_min;
-
-    ///Have we complained about minimizer not including distance hints?
-    atomic_flag warned_about_minimizer_payload = ATOMIC_FLAG_INIT;
-
-    //Some minimizer payloads are too big and don't get stored, so
-    //we might encounter empty ones even though we have the rest.
-    //Remember if we've seen any payloads so we don't complain about
-    //an anomalous empty one. This isn't perfect since it might warn
-    //about empty payloads if the first one is empty, but this is 
-    //unlikely
-    ///Have we found a minimizer payload yet?
-    atomic_flag found_minimizer_payload = ATOMIC_FLAG_INIT;
     
     //////////////
     // Alignment-from-gapless-extension/short read Giraffe specific parameters:

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -124,6 +124,9 @@ public:
     /// If set, exclude overlapping minimizers
     static constexpr bool default_exclude_overlapping_min = false;
     bool exclude_overlapping_min = default_exclude_overlapping_min;
+
+    ///Have we complained about minimizer not including distance hints?
+    atomic_flag warned_about_minimizer_payload = ATOMIC_FLAG_INIT;
     
     //////////////
     // Alignment-from-gapless-extension/short read Giraffe specific parameters:

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -127,6 +127,15 @@ public:
 
     ///Have we complained about minimizer not including distance hints?
     atomic_flag warned_about_minimizer_payload = ATOMIC_FLAG_INIT;
+
+    //Some minimizer payloads are too big and don't get stored, so
+    //we might encounter empty ones even though we have the rest.
+    //Remember if we've seen any payloads so we don't complain about
+    //an anomalous empty one. This isn't perfect since it might warn
+    //about empty payloads if the first one is empty, but this is 
+    //unlikely
+    ///Have we found a minimizer payload yet?
+    atomic_flag found_minimizer_payload = ATOMIC_FLAG_INIT;
     
     //////////////
     // Alignment-from-gapless-extension/short read Giraffe specific parameters:


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add a warning to giraffe when using minimizers without distance hints

## Description
Running giraffe with minimizers that don't include the distance hints in the payload is very slow. Warn users when this happens