### PR TITLE
avoid using get_edge_count() as it seems unreliable atm

### DIFF
--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -529,12 +529,11 @@ void clip_low_depth_nodes_and_edges_generic(MutablePathMutableHandleGraph* graph
     }
 
     // now do the edges
-    size_t edge_count = graph->get_edge_count();
     vector<edge_t> edges;
-    edges.reserve(edge_count);
     graph->for_each_edge([&](edge_t edge) {
             edges.push_back(edge);
         });
+    size_t edge_count = edges.size();
     boomphf::mphf<edge_t, BBEdgeHash> edge_hash(edge_count, edges, get_thread_count(), 2.0, false, false);
     edges.clear();
     bdsg::PackedVector<> edge_depths;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg clip` crash on PackedGraphs fixed. 

## Description

Work around https://github.com/vgteam/libbdsg/issues/188 where an apparent bug in PackedGraph can cause `vg clip` crashes in some graphs because it uses the wrong edge_count to make an array that's a bit too small. 