### PR TITLE
Enable CI to work outside AWS/Kubernetes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,6 +105,11 @@ local-build-test-job:
 build-job:
   stage: build
   script:
+    - CI_REPO=${CI_REGISTRY}/vgteam/vg
+    - CACHE_TAG="cache-$(echo ${CI_COMMIT_BRANCH}${CI_COMMIT_TAG} | tr '/' '-')"
+    - MAINLINE_CACHE_TAG="cache-master"
+    - PLATFORMS=linux/amd64
+    - DOCKER_TAG=ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}
     - make include/vg_git_version.hpp
     - cat include/vg_git_version.hpp
     # Build but don't push, just fill the cache
@@ -113,9 +118,23 @@ build-job:
     - docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target test -f Dockerfile .
     # Connect so we can upload our images
     - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
-    # Keep trying to push until it works or we time out or run out of tries
-    - COUNT=0
-    - while ! docker buildx build --platform=linux/amd64 --build-arg THREADS=8 --target run --push -t "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" -f Dockerfile . ; do docker logout "${CI_REGISTRY}" ; sleep 30; docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}" ; sleep 30; ((COUNT+=1)); if [[ ${COUNT} == 10 ]] ; then exit 1; fi; done
+    # Note that A LOCAL CACHE CAN ONLY HOLD ONE TAG/TARGET AT A TIME!
+    # And Quay can't use mode=max registry caching to cache the intermediate targets with the final image, just inline caching.
+    # So we have to do the Complicated Cache Shuffle.
+    # Build base image from branch and mainline base caches to local cache
+    - docker buildx build --cache-from type=registry,ref=${CI_REPO}:${MAINLINE_CACHE_TAG}-base --cache-from type=registry,ref=${CI_REPO}:${CACHE_TAG}-base --cache-to type=local,dest=${HOME}/docker-cache --platform="${PLATFORMS}" --build-arg THREADS=8 --target base -t ${CI_REPO}:${CACHE_TAG}-base -f Dockerfile .
+    # Push base image from local cache to registry cache for branch.
+    - docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target base -t ${CI_REPO}:${CACHE_TAG}-base -f Dockerfile --push .
+    # Build build image from local base cache and branch and mainline build caches to local cache
+    - docker buildx build --cache-from type=registry,ref=${CI_REPO}:${MAINLINE_CACHE_TAG}-build --cache-from type=registry,ref=${CI_REPO}:${CACHE_TAG}-build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=local,dest=${HOME}/docker-cache --platform="${PLATFORMS}" --build-arg THREADS=8 --target build -t ${CI_REPO}:${CACHE_TAG}-build -f Dockerfile .
+    # Push build image to registry cache for branch
+    - docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target build -t ${CI_REPO}:${CACHE_TAG}-build -f Dockerfile --push .
+    # Build run image from local build cache and branch and mainline run caches to local cache
+    - docker buildx build --cache-from type=registry,ref=${CI_REPO}:${MAINLINE_CACHE_TAG}-run --cache-from type=registry,ref=${CI_REPO}:${CACHE_TAG}-run --cache-from type=local,src=${HOME}/docker-cache --cache-to type=local,dest=${HOME}/docker-cache --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:${CACHE_TAG}-run -f Dockerfile .
+    # Push run image to registry cache for branch
+    - docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:${CACHE_TAG}-run -f Dockerfile --push .
+    # Finally, push run image to where we actually want it.
+    - docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:${DOCKER_TAG} -f Dockerfile --push .
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
 
@@ -130,15 +149,35 @@ production-build-job:
     - master
     - tags
   script:
-    - make include/vg_git_version.hpp
+    - CI_REPO=${CI_REGISTRY}/vgteam/vg
+    - CACHE_TAG="cache-$(echo ${CI_COMMIT_BRANCH}${CI_COMMIT_TAG} | tr '/' '-')"
+    - MAINLINE_CACHE_TAG="cache-master"
+    - PLATFORMS=linux/amd64,linux/arm64
     # Determine what we should be tagging vg Dockers as. If we're running on a Git tag we want to use that. Otherwise push over the tag we made already.
-    - if [[ ! -z "${CI_COMMIT_TAG}" ]]; then VG_DOCKER_TAG="${CI_COMMIT_TAG}" ; else VG_DOCKER_TAG="ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"; fi
+    - if [[ ! -z "${CI_COMMIT_TAG}" ]]; then DOCKER_TAG="${CI_COMMIT_TAG}" ; else DOCKER_TAG="ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"; fi
+    - make include/vg_git_version.hpp
     # Make sure ARM emulation is available.
     - if [[ "${CI_BUILDKIT_DRIVER}" != "kubernetes" ]] ; then docker run --privileged --rm tonistiigi/binfmt --install all || true ; fi
-    # Build the container for all architectures.
-    - docker buildx build --platform=linux/amd64,linux/arm64 --build-arg THREADS=8 --target run --push -t "quay.io/vgteam/vg:${VG_DOCKER_TAG}" -f Dockerfile .
+    # TODO: deduplicate this code with normal build above
+    # Note that A LOCAL CACHE CAN ONLY HOLD ONE TAG/TARGET AT A TIME!
+    # And Quay can't use mode=max registry caching to cache the intermediate targets with the final image, just inline caching.
+    # So we have to do the Complicated Cache Shuffle.
+    # Build base image from branch and mainline base caches to local cache
+    - docker buildx build --cache-from type=registry,ref=${CI_REPO}:${MAINLINE_CACHE_TAG}-base --cache-from type=registry,ref=${CI_REPO}:${CACHE_TAG}-base --cache-to type=local,dest=${HOME}/docker-cache --platform="${PLATFORMS}" --build-arg THREADS=8 --target base -t ${CI_REPO}:${CACHE_TAG}-base -f Dockerfile .
+    # Push base image from local cache to registry cache for branch.
+    - docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target base -t ${CI_REPO}:${CACHE_TAG}-base -f Dockerfile --push .
+    # Build build image from local base cache and branch and mainline build caches to local cache
+    - docker buildx build --cache-from type=registry,ref=${CI_REPO}:${MAINLINE_CACHE_TAG}-build --cache-from type=registry,ref=${CI_REPO}:${CACHE_TAG}-build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=local,dest=${HOME}/docker-cache --platform="${PLATFORMS}" --build-arg THREADS=8 --target build -t ${CI_REPO}:${CACHE_TAG}-build -f Dockerfile .
+    # Push build image to registry cache for branch
+    - docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target build -t ${CI_REPO}:${CACHE_TAG}-build -f Dockerfile --push .
+    # Build run image from local build cache and branch and mainline run caches to local cache
+    - docker buildx build --cache-from type=registry,ref=${CI_REPO}:${MAINLINE_CACHE_TAG}-run --cache-from type=registry,ref=${CI_REPO}:${CACHE_TAG}-run --cache-from type=local,src=${HOME}/docker-cache --cache-to type=local,dest=${HOME}/docker-cache --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:${CACHE_TAG}-run -f Dockerfile .
+    # Push run image to registry cache for branch
+    - docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:${CACHE_TAG}-run -f Dockerfile --push .
+    # Finally, push run image to where we actually want it.
+    - docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:${DOCKER_TAG} -f Dockerfile --push .
     # Tag it latest if we pushed a real release tag
-    - if [[ ! -z "${CI_COMMIT_TAG}" ]]; then docker buildx build --platform=linux/amd64,linux/arm64 --build-arg THREADS=8 --target run --push -t "quay.io/vgteam/vg:latest" -f Dockerfile .; fi
+    - if [[ ! -z "${CI_COMMIT_TAG}" ]]; then --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:latest -f Dockerfile --push .; fi
     # Also run the ARM tests (emulated!)
     # But don't fail if they fail yet, because they don't yet actually work.
     - docker buildx build --platform=linux/arm64 --build-arg THREADS=8 --target test -f Dockerfile . || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,17 @@ before_script:
       fi
     fi
   - startdocker || true
+  # Get buildx
+  - mkdir -p ~/.docker/cli-plugins/ ; curl -L https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 >  ~/.docker/cli-plugins/docker-buildx ; chmod u+x ~/.docker/cli-plugins/docker-buildx
+  # Connect to the Kubernetes-based builder "buildkit" if appropriate
+  # See vgci/buildkit-deployment.yml
+  - if [[ "${CI_BUILDKIT_DRIVER}" == "kubernetes" ]] ; then docker buildx create --use --name=buildkit --platform=linux/amd64,linux/arm64 --node=buildkit-amd64 --driver=kubernetes --driver-opt="nodeselector=kubernetes.io/arch=amd64" ; else docker buildx create --use --name=container-builder --driver=docker-container ; fi
+  # Report on the builders, and make sure they exist.
+  - docker buildx inspect --bootstrap || (echo "Docker builder deployment can't be found! Are we on the right Gitlab runner?" && exit 1)
+  # Prune down build cache to make space. This will hang if the builder isn't findable.
+  - (echo "y" | docker buildx prune --keep-storage 80G) || true
+  # Connect so we can upload our images
+  - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
   - docker info
   - mkdir -p ~/.aws && cp "$GITLAB_SECRET_FILE_AWS_CREDENTIALS" ~/.aws/credentials
 
@@ -93,18 +104,6 @@ local-build-test-job:
 # We define one job to do the Docker container build
 build-job:
   stage: build
-  before_script:
-    # Don't bother starting the Docker daemon or installing much
-    - which docker || (sudo apt-get -q -y update && sudo apt-get -q -y install --no-upgrade docker.io)
-    # Get buildx
-    - mkdir -p ~/.docker/cli-plugins/ ; curl -L https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 >  ~/.docker/cli-plugins/docker-buildx ; chmod u+x ~/.docker/cli-plugins/docker-buildx
-    # Connect to the Kubernetes-based builder "buildkit"
-    # See vgci/buildkit-deployment.yml
-    - docker buildx create --use --name=buildkit --platform=linux/amd64,linux/arm64 --node=buildkit-amd64 --driver=kubernetes --driver-opt="nodeselector=kubernetes.io/arch=amd64"
-    # Report on the builders, and make sure they exist.
-    - docker buildx inspect --bootstrap || (echo "Docker builder deployment can't be found in our Kubernetes namespace! Are we on the right Gitlab runner?" && exit 1)
-    # Prune down build cache to make space. This will hang if the builder isn't findable.
-    - (echo "y" | docker buildx prune --keep-storage 80G) || true
   script:
     - make include/vg_git_version.hpp
     - cat include/vg_git_version.hpp
@@ -130,24 +129,12 @@ production-build-job:
     - /^arm/
     - master
     - tags
-  before_script:
-    # Don't bother starting the Docker daemon or installing much
-    - which docker || (sudo apt-get -q -y update && sudo apt-get -q -y install --no-upgrade docker.io)
-    # Get buildx
-    - mkdir -p ~/.docker/cli-plugins/ ; curl -L https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 >  ~/.docker/cli-plugins/docker-buildx ; chmod u+x ~/.docker/cli-plugins/docker-buildx
-    # Connect to the Kubernetes-based builder "buildkit"
-    # See vgci/buildkit-deployment.yml
-    - docker buildx create --use --name=buildkit --platform=linux/amd64,linux/arm64 --node=buildkit-amd64 --driver=kubernetes --driver-opt="nodeselector=kubernetes.io/arch=amd64"
-    # Report on the builders, and make sure they exist.
-    - docker buildx inspect --bootstrap || (echo "Docker builder deployment can't be found in our Kubernetes namespace! Are we on the right Gitlab runner?" && exit 1)
-    # Prune down build cache to make space. This will hang if the builder isn't findable.
-    - docker buildx prune --keep-storage 80G
-    # Connect so we can upload our images
-    - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
   script:
     - make include/vg_git_version.hpp
     # Determine what we should be tagging vg Dockers as. If we're running on a Git tag we want to use that. Otherwise push over the tag we made already.
     - if [[ ! -z "${CI_COMMIT_TAG}" ]]; then VG_DOCKER_TAG="${CI_COMMIT_TAG}" ; else VG_DOCKER_TAG="ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"; fi
+    # Make sure ARM emulation is available.
+    - if [[ "${CI_BUILDKIT_DRIVER}" != "kubernetes" ]] ; then docker run --privileged --rm tonistiigi/binfmt --install all || true ; fi
     # Build the container for all architectures.
     - docker buildx build --platform=linux/amd64,linux/arm64 --build-arg THREADS=8 --target run --push -t "quay.io/vgteam/vg:${VG_DOCKER_TAG}" -f Dockerfile .
     # Tag it latest if we pushed a real release tag


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg's CI can now run on local Gitlab runners

## Description

This decouples the vg CI from our Kubernetes setup so we can move it elsewhere.

It involves moving the Docker builds into the CI container, and storing caches in images on Quay instead of in the Kubernetes Buildkit deployment.