### PR TITLE
Test workflow docker image caching

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,6 +98,8 @@ local-build-test-job:
     - nvm use
     - npm ci
     - CI=true npm run test
+  after_script:
+    - true
   variables:
     VG_FULL_TRACEBACK: "1"
     GIT_SUBMODULE_STRATEGY: none
@@ -189,7 +191,11 @@ test-job:
   # Run in parallel, setting CI_NODE_INDEX and CI_NODE_TOTAL
   # We will find our share of tests from vgci/test-list.txt and run them
   # We ought to run one job per test, but we can wrap around.
-  parallel: 6 
+  parallel: 6
+  cache:
+    key: docker-pull-cache
+    paths:
+      - /var/lib/docker
   script:
     - docker pull "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"
     - docker tag "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" vgci-docker-vg-local
@@ -201,6 +207,12 @@ test-job:
     - export GH_TOKEN=""
     # Make sure IO to Gitlab is in blocking mode so we can't swamp it and crash
     - vgci/blockify.py bash vgci/vgci-parallel-wrapper.sh vgci/test-list.txt vgci-docker-vg-local ${CI_NODE_INDEX} ${CI_NODE_TOTAL} ./junit ./test_output
+  after_script:
+    - startdocker || true
+    # Don't leave each run's CI image laying around in the cache
+    - docker rmi "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" vgci-docker-vg-local
+    - stopdocker || true
+
   artifacts:
     # Let Gitlab see the junit report
     reports:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ production-build-job:
     # Finally, push run image to where we actually want it.
     - docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:${DOCKER_TAG} -f Dockerfile --push .
     # Tag it latest if we pushed a real release tag
-    - if [[ ! -z "${CI_COMMIT_TAG}" ]]; then --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:latest -f Dockerfile --push .; fi
+    - if [[ ! -z "${CI_COMMIT_TAG}" ]]; then docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:latest -f Dockerfile --push .; fi
     # If we wanted to run the tests under ARM emulation, we could do:
     #   docker buildx build --platform=linux/arm64 --build-arg THREADS=8 --target test -f Dockerfile .
     # But we don't, because they both don't actually pass yet on ARM and also

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -208,6 +208,8 @@ test-job:
     # Make sure IO to Gitlab is in blocking mode so we can't swamp it and crash
     - vgci/blockify.py bash vgci/vgci-parallel-wrapper.sh vgci/test-list.txt vgci-docker-vg-local ${CI_NODE_INDEX} ${CI_NODE_TOTAL} ./junit ./test_output
   after_script:
+    - stopdocker || true
+    - rm -f /var/run/docker.sock
     - startdocker || true
     # Don't leave each run's CI image laying around in the cache
     - docker rmi "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" vgci-docker-vg-local

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,7 +99,7 @@ local-build-test-job:
     - npm ci
     - CI=true npm run test
   after_script:
-    - true
+    - echo "Don't do anything"
   variables:
     VG_FULL_TRACEBACK: "1"
     GIT_SUBMODULE_STRATEGY: none

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -198,6 +198,7 @@ test-job:
     paths:
       - /var/lib/docker
   script:
+    - docker images
     - docker pull "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"
     - docker tag "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" vgci-docker-vg-local
     - mkdir -p junit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -178,9 +178,10 @@ production-build-job:
     - docker buildx build --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:${DOCKER_TAG} -f Dockerfile --push .
     # Tag it latest if we pushed a real release tag
     - if [[ ! -z "${CI_COMMIT_TAG}" ]]; then --cache-from type=local,src=${HOME}/docker-cache --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=8 --target run -t ${CI_REPO}:latest -f Dockerfile --push .; fi
-    # Also run the ARM tests (emulated!)
-    # But don't fail if they fail yet, because they don't yet actually work.
-    - docker buildx build --platform=linux/arm64 --build-arg THREADS=8 --target test -f Dockerfile . || true
+    # If we wanted to run the tests under ARM emulation, we could do:
+    #   docker buildx build --platform=linux/arm64 --build-arg THREADS=8 --target test -f Dockerfile .
+    # But we don't, because they both don't actually pass yet on ARM and also
+    # manage to hit a 6 hour timeout on our extremely slow emulators.
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
 
@@ -211,8 +212,12 @@ test-job:
     - stopdocker || true
     - rm -f /var/run/docker.sock
     - startdocker || true
+    # Don't leave containers in the cache
+    - docker ps -q -a | xargs docker rm -f || true
     # Don't leave each run's CI image laying around in the cache
     - docker rmi "quay.io/vgteam/vg:ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}" vgci-docker-vg-local
+    # Show what we are caching
+    - docker images
     - stopdocker || true
 
   artifacts:

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -1252,7 +1252,7 @@ class VGCITest(TestCase):
                            score_baseline_graph='primary',
                            sample='HG00096', acc_threshold=0.02, auc_threshold=0.02)
                            
-    @timeout_decorator.timeout(1800)
+    @timeout_decorator.timeout(2400)
     def test_sim_mhc_cactus(self):
         """ Mapping test for MHC cactus graph """
         log.info("Test start at {}".format(datetime.now()))        


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * CI test jobs now cache pulled Docker images

## Description

This tries to set up Gitlab caching for the Docker image storage in the test jobs. This will hopefully stop 4 test jobs from starting on a node and thrashing the disk by all trying to do docker pulls at the same time.
