### PR TITLE
Fix gaf translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,7 +470,7 @@ $(LIB_DIR)/libvg.a: $(LIBVG_DEPS)
 	
 $(LIB_DIR)/libvg.$(SHARED_SUFFIX): $(LIBVG_SHARED_DEPS)
 	rm -f $@
-	$(CXX) -shared -o $@ $(SHARED_OBJ) $(ALGORITHMS_SHARED_OBJ) $(IO_SHARED_OBJ) $(DEP_SHARED_OBJ)
+	$(CXX) -shared -o $@ $(SHARED_OBJ) $(ALGORITHMS_SHARED_OBJ) $(IO_SHARED_OBJ) $(DEP_SHARED_OBJ) $(LDFLAGS) $(LD_LIB_DIR_FLAGS) $(LD_LIB_FLAGS) $(LD_STATIC_LIB_FLAGS) $(LD_STATIC_LIB_DEPS) 
 
 # Each test set can have its own binary, and not link everything static
 $(UNITTEST_EXE): $(UNITTEST_BIN_DIR)/%: $(UNITTEST_OBJ_DIR)/%.o $(UNITTEST_SUPPORT_OBJ) $(CONFIG_OBJ) $(LIB_DIR)/libvg.$(SHARED_SUFFIX)

--- a/src/unittest/back_translate.cpp
+++ b/src/unittest/back_translate.cpp
@@ -230,116 +230,131 @@ TEST_CASE("An Alignment can be back-translated while converting to GAF", "[algor
     trans.translation[oriented_node_range_t(2, false, 2, 2)] = {oriented_node_range_t(1, false, 3, 2)};
     trans.translation[oriented_node_range_t(3, false, 0, 2)] = {oriented_node_range_t(1, false, 5, 2)};
     trans.translation[oriented_node_range_t(4, false, 0, 5)] = {oriented_node_range_t(2, false, 0, 5)};
-    trans.translation[oriented_node_range_t(3, true, 1, 1)] = {oriented_node_range_t(1, true, 1, 1)};
-    trans.translation[oriented_node_range_t(2, true, 0, 2)] = {oriented_node_range_t(1, true, 2, 2)};
     // Make sure to include reverse strand translation info for segment length sniffing.
     trans.translation[oriented_node_range_t(2, true, 0, 0)] = {oriented_node_range_t(1, true, 2, 0)};
     trans.translation[oriented_node_range_t(3, true, 0, 0)] = {oriented_node_range_t(1, true, 0, 0)};
     trans.translation[oriented_node_range_t(4, true, 0, 0)] = {oriented_node_range_t(2, true, 1, 0)};
+    trans.node_names[1] = "FirstSegment";
+    trans.node_names[2] = "SecondSegment";
+
+
+    string alignment_string = R"(
+        {
+            "name": "francine",
+            "mapping_quality": 30,
+            "sequence": "GATTACA",
+            "path": {"mapping": [
+                {
+                    "position": {"node_id": 2, "offset": 2},
+                    "edit": [
+                        {"from_length": 1, "to_length": 1},
+                        {"from_length": 1}
+                    ]
+                },
+                {
+                    "position": {"node_id": 3},
+                    "edit": [
+                        {"from_length": 1, "to_length": 1},
+                        {"to_length": 1, "sequence": "T"},
+                        {"from_length": 1, "to_length": 1}
+                    ]
+                },
+                {
+                    "position": {"node_id": 4},
+                    "edit": [
+                        {"from_length": 1, "to_length": 1},
+                        {"from_length": 2},
+                        {"from_length": 2, "to_length": 2}
+                    ]
+                }
+            ]}
+        }
+    )";
+    
+    Alignment a;
+    json2pb(a, alignment_string.c_str(), alignment_string.size());
+
+    SECTION("Translating GAF generation produces the right GAF") {
+        auto node_space = vg::io::alignment_to_gaf(g, a);
+        stringstream s;
+        s << node_space;
+        
+        // See column definitions at https://github.com/lh3/gfatools/blob/master/doc/rGFA.md#the-graph-alignment-format-gaf
+        // Alignment block length is longest involved sequence.
+        // Note that we combine adjacent duplicate operations in cs across node boundaries.
+        // Note that end position is 0-based inclusive
+        REQUIRE(s.str() == "francine\t7\t0\t7\t+\t>2>3>4\t13\t2\t10\t6\t8\t30\tcs:Z::1-G:1+T:2-CA:2");
+    }
+    
+    SECTION("Translating GAF generation with a translation produces the right GAF") {
+        auto back_translated = vg::io::alignment_to_gaf(g, a, &trans);
+        stringstream s;
+        s << back_translated;
+        
+        REQUIRE(s.str() == "francine\t7\t0\t7\t+\t>FirstSegment>SecondSegment\t15\t3\t11\t6\t8\t30\tcs:Z::1-G:1+T:2-CA:2");
+    }
+}
+
+TEST_CASE("A reverse-strand Alignment can be back-translated while converting to GAF", "[algorithms][back_translate]") {
+
+    bdsg::HashGraph g;
+    
+    handle_t h1 = g.create_handle("G");
+    handle_t h2 = g.create_handle("GGGG");
+    handle_t h3 = g.create_handle("AT");
+    handle_t h4 = g.create_handle("ACACAAA");
+    handle_t h5 = g.create_handle("A");
+    
+    g.create_edge(h1, h2);
+    g.create_edge(h2, h3);
+    g.create_edge(h3, h4);
+    g.create_edge(h4, h5);
+
+    // Define a translation back to a named node space
+    MockBackTranslation trans;
+    trans.translation[oriented_node_range_t(3, true, 1, 1)] = {oriented_node_range_t(1, true, 1, 1)};
+    trans.translation[oriented_node_range_t(2, true, 0, 2)] = {oriented_node_range_t(1, true, 2, 2)};
+    // Make sure to include reverse strand translation info for segment length sniffing.
     trans.translation[oriented_node_range_t(2, false, 0, 0)] = {oriented_node_range_t(1, false, 1, 0)};
     trans.translation[oriented_node_range_t(3, false, 0, 0)] = {oriented_node_range_t(1, false, 5, 0)};
     trans.node_names[1] = "FirstSegment";
     trans.node_names[2] = "SecondSegment";
 
-    SECTION("Forward alignment") {
 
-        string alignment_string = R"(
-            {
-                "name": "francine",
-                "mapping_quality": 30,
-                "sequence": "GATTACA",
-                "path": {"mapping": [
-                    {
-                        "position": {"node_id": 2, "offset": 2},
-                        "edit": [
-                            {"from_length": 1, "to_length": 1},
-                            {"from_length": 1}
-                        ]
-                    },
-                    {
-                        "position": {"node_id": 3},
-                        "edit": [
-                            {"from_length": 1, "to_length": 1},
-                            {"to_length": 1, "sequence": "T"},
-                            {"from_length": 1, "to_length": 1}
-                        ]
-                    },
-                    {
-                        "position": {"node_id": 4},
-                        "edit": [
-                            {"from_length": 1, "to_length": 1},
-                            {"from_length": 2},
-                            {"from_length": 2, "to_length": 2}
-                        ]
-                    }
-                ]}
-            }
-        )";
-        
-        Alignment a;
-        json2pb(a, alignment_string.c_str(), alignment_string.size());
+    string alignment_string = R"(
+        {
+            "name": "steve",
+            "mapping_quality": 30,
+            "sequence": "TCC",
+            "path": {"mapping": [
+                {
+                    "position": {"node_id": 3, "offset": 1, "is_reverse": true},
+                    "edit": [
+                        {"from_length": 1, "to_length": 1}
+                    ]
+                },
+                {
+                    "position": {"node_id": 2, "is_reverse": true},
+                    "edit": [
+                        {"from_length": 2, "to_length": 2}
+                    ]
+                }
+            ]}
+        }
+    )";
     
-        SECTION("Translating GAF generation produces the right GAF") {
-            auto node_space = vg::io::alignment_to_gaf(g, a);
-            stringstream s;
-            s << node_space;
-            
-            // See column definitions at https://github.com/lh3/gfatools/blob/master/doc/rGFA.md#the-graph-alignment-format-gaf
-            // Alignment block length is longest involved sequence.
-            // Note that we combine adjacent duplicate operations in cs across node boundaries.
-            // Note that end position is 0-based inclusive
-            REQUIRE(s.str() == "francine\t7\t0\t7\t+\t>2>3>4\t13\t2\t10\t6\t8\t30\tcs:Z::1-G:1+T:2-CA:2");
-        }
-        
-        SECTION("Translating GAF generation with a translation produces the right GAF") {
-            auto back_translated = vg::io::alignment_to_gaf(g, a, &trans);
-            stringstream s;
-            s << back_translated;
-            
-            REQUIRE(s.str() == "francine\t7\t0\t7\t+\t>FirstSegment>SecondSegment\t15\t3\t11\t6\t8\t30\tcs:Z::1-G:1+T:2-CA:2");
-        }
-    }
-
-    SECTION("Reverse alignment within one segment") {
-
-        string alignment_string = R"(
-            {
-                "name": "steve",
-                "mapping_quality": 30,
-                "sequence": "TCC",
-                "path": {"mapping": [
-                    {
-                        "position": {"node_id": 3, "offset": 1, "is_reverse": true},
-                        "edit": [
-                            {"from_length": 1, "to_length": 1}
-                        ]
-                    },
-                    {
-                        "position": {"node_id": 2, "is_reverse": true},
-                        "edit": [
-                            {"from_length": 2, "to_length": 2}
-                        ]
-                    }
-                ]}
-            }
-        )";
-        
-        Alignment a;
-        json2pb(a, alignment_string.c_str(), alignment_string.size());
-        
-        SECTION("Translating GAF generation with a translation produces the right GAF") {
-            auto back_translated = vg::io::alignment_to_gaf(g, a, &trans);
-            stringstream s;
-            s << back_translated;
-            
-            // Should be mapped to a length-7 path, at offset 1 to 4, 3 matches in a lenght 3 block.
-            REQUIRE(s.str() == "steve\t3\t0\t3\t+\t<FirstSegment\t7\t1\t4\t3\t3\t30\tcs:Z::3");
-        }
-    }
-
+    Alignment a;
+    json2pb(a, alignment_string.c_str(), alignment_string.size());
     
-
+    auto back_translated = vg::io::alignment_to_gaf(g, a, &trans);
+    stringstream s;
+    s << back_translated;
+    
+    // Should be mapped to a length-7 path, at offset 1 to 4, 3 matches in a lenght 3 block.
+    REQUIRE(s.str() == "steve\t3\t0\t3\t+\t<FirstSegment\t7\t1\t4\t3\t3\t30\tcs:Z::3");
 }
+
+    
 
 }
 }

--- a/src/unittest/back_translate.cpp
+++ b/src/unittest/back_translate.cpp
@@ -212,42 +212,6 @@ TEST_CASE("A Path can be back-translated properly when it goes around cycles", "
 
 TEST_CASE("An Alignment can be back-translated while converting to GAF", "[algorithms][back_translate]") {
 
-    string alignment_string = R"(
-        {
-            "name": "francine",
-            "mapping_quality": 30,
-            "sequence": "GATTACA",
-            "path": {"mapping": [
-                {
-                    "position": {"node_id": 2, "offset": 2},
-                    "edit": [
-                        {"from_length": 1, "to_length": 1},
-                        {"from_length": 1}
-                    ]
-                },
-                {
-                    "position": {"node_id": 3},
-                    "edit": [
-                        {"from_length": 1, "to_length": 1},
-                        {"to_length": 1, "sequence": "T"},
-                        {"from_length": 1, "to_length": 1}
-                    ]
-                },
-                {
-                    "position": {"node_id": 4},
-                    "edit": [
-                        {"from_length": 1, "to_length": 1},
-                        {"from_length": 2},
-                        {"from_length": 2, "to_length": 2}
-                    ]
-                }
-            ]}
-        }
-    )";
-    
-    Alignment a;
-    json2pb(a, alignment_string.c_str(), alignment_string.size());
-    
     bdsg::HashGraph g;
     
     handle_t h1 = g.create_handle("G");
@@ -266,35 +230,116 @@ TEST_CASE("An Alignment can be back-translated while converting to GAF", "[algor
     trans.translation[oriented_node_range_t(2, false, 2, 2)] = {oriented_node_range_t(1, false, 3, 2)};
     trans.translation[oriented_node_range_t(3, false, 0, 2)] = {oriented_node_range_t(1, false, 5, 2)};
     trans.translation[oriented_node_range_t(4, false, 0, 5)] = {oriented_node_range_t(2, false, 0, 5)};
+    trans.translation[oriented_node_range_t(3, true, 1, 1)] = {oriented_node_range_t(1, true, 1, 1)};
+    trans.translation[oriented_node_range_t(2, true, 0, 2)] = {oriented_node_range_t(1, true, 2, 2)};
     // Make sure to include reverse strand translation info for segment length sniffing.
     trans.translation[oriented_node_range_t(2, true, 0, 0)] = {oriented_node_range_t(1, true, 2, 0)};
     trans.translation[oriented_node_range_t(3, true, 0, 0)] = {oriented_node_range_t(1, true, 0, 0)};
     trans.translation[oriented_node_range_t(4, true, 0, 0)] = {oriented_node_range_t(2, true, 1, 0)};
+    trans.translation[oriented_node_range_t(2, false, 0, 0)] = {oriented_node_range_t(1, false, 1, 0)};
+    trans.translation[oriented_node_range_t(3, false, 0, 0)] = {oriented_node_range_t(1, false, 5, 0)};
     trans.node_names[1] = "FirstSegment";
     trans.node_names[2] = "SecondSegment";
-    
-    SECTION("Translating GAF generation produces the right GAF") {
-        auto node_space = vg::io::alignment_to_gaf(g, a);
-        stringstream s;
-        s << node_space;
+
+    SECTION("Forward alignment") {
+
+        string alignment_string = R"(
+            {
+                "name": "francine",
+                "mapping_quality": 30,
+                "sequence": "GATTACA",
+                "path": {"mapping": [
+                    {
+                        "position": {"node_id": 2, "offset": 2},
+                        "edit": [
+                            {"from_length": 1, "to_length": 1},
+                            {"from_length": 1}
+                        ]
+                    },
+                    {
+                        "position": {"node_id": 3},
+                        "edit": [
+                            {"from_length": 1, "to_length": 1},
+                            {"to_length": 1, "sequence": "T"},
+                            {"from_length": 1, "to_length": 1}
+                        ]
+                    },
+                    {
+                        "position": {"node_id": 4},
+                        "edit": [
+                            {"from_length": 1, "to_length": 1},
+                            {"from_length": 2},
+                            {"from_length": 2, "to_length": 2}
+                        ]
+                    }
+                ]}
+            }
+        )";
         
-        // See column definitions at https://github.com/lh3/gfatools/blob/master/doc/rGFA.md#the-graph-alignment-format-gaf
-        // Alignment block length is longest involved sequence.
-        // Note that we combine adjacent duplicate operations in cs across node boundaries.
-        // Note that end position is 0-based inclusive
-        REQUIRE(s.str() == "francine\t7\t0\t7\t+\t>2>3>4\t13\t2\t10\t6\t8\t30\tcs:Z::1-G:1+T:2-CA:2");
-    }
+        Alignment a;
+        json2pb(a, alignment_string.c_str(), alignment_string.size());
     
-    SECTION("Translating GAF generation with a translation produces the right GAF") {
-        auto back_translated = vg::io::alignment_to_gaf(g, a, &trans);
-        stringstream s;
-        s << back_translated;
+        SECTION("Translating GAF generation produces the right GAF") {
+            auto node_space = vg::io::alignment_to_gaf(g, a);
+            stringstream s;
+            s << node_space;
+            
+            // See column definitions at https://github.com/lh3/gfatools/blob/master/doc/rGFA.md#the-graph-alignment-format-gaf
+            // Alignment block length is longest involved sequence.
+            // Note that we combine adjacent duplicate operations in cs across node boundaries.
+            // Note that end position is 0-based inclusive
+            REQUIRE(s.str() == "francine\t7\t0\t7\t+\t>2>3>4\t13\t2\t10\t6\t8\t30\tcs:Z::1-G:1+T:2-CA:2");
+        }
         
-        REQUIRE(s.str() == "francine\t7\t0\t7\t+\t>FirstSegment>SecondSegment\t15\t3\t11\t6\t8\t30\tcs:Z::1-G:1+T:2-CA:2");
+        SECTION("Translating GAF generation with a translation produces the right GAF") {
+            auto back_translated = vg::io::alignment_to_gaf(g, a, &trans);
+            stringstream s;
+            s << back_translated;
+            
+            REQUIRE(s.str() == "francine\t7\t0\t7\t+\t>FirstSegment>SecondSegment\t15\t3\t11\t6\t8\t30\tcs:Z::1-G:1+T:2-CA:2");
+        }
     }
+
+    SECTION("Reverse alignment within one segment") {
+
+        string alignment_string = R"(
+            {
+                "name": "steve",
+                "mapping_quality": 30,
+                "sequence": "TCC",
+                "path": {"mapping": [
+                    {
+                        "position": {"node_id": 3, "offset": 1, "is_reverse": true},
+                        "edit": [
+                            {"from_length": 1, "to_length": 1}
+                        ]
+                    },
+                    {
+                        "position": {"node_id": 2, "is_reverse": true},
+                        "edit": [
+                            {"from_length": 2, "to_length": 2}
+                        ]
+                    }
+                ]}
+            }
+        )";
+        
+        Alignment a;
+        json2pb(a, alignment_string.c_str(), alignment_string.size());
+        
+        SECTION("Translating GAF generation with a translation produces the right GAF") {
+            auto back_translated = vg::io::alignment_to_gaf(g, a, &trans);
+            stringstream s;
+            s << back_translated;
+            
+            // Should be mapped to a length-7 path, at offset 1 to 4, 3 matches in a lenght 3 block.
+            REQUIRE(s.str() == "steve\t3\t0\t3\t+\t<FirstSegment\t7\t1\t4\t3\t3\t30\tcs:Z::3");
+        }
+    }
+
+    
 
 }
-
 
 }
 }

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -102,11 +102,12 @@ diff mut.gaf mut-back.gaf
 is "$?" 0 "vg convert gam -> gaf -> gam -> gaf makes same gaf twice in presence of indels and snps"
   
 #hand-code cg example.  this is (for reference) mut.gaf:
-printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cs:Z::13*GA*GA:8+TTT:16*GA*TA:18-AC-T-AG:16\n" > mut.cs.gaf
+# Except with the to length fixed (it is 80 bp if you decode the cs tag with https://github.com/lh3/minimap2#cs) 
+printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	102	71	80	60	AS:i:47	cs:Z::13*GA*GA:8+TTT:16*GA*TA:18-AC-T-AG:16\n" > mut.cs.gaf
 #manually convert to cg:
-printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cg:Z:13M1X1X8M3I16M1X1X18M5D16M\n" > mut.cg.gaf
+printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	102	71	80	60	AS:i:47	cg:Z:13M1X1X8M3I16M1X1X18M5D16M\n" > mut.cg.gaf
 #this is what we expect back, mut.gaf where insertions and snps are converted to Ns:
-printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	101	71	79	60	AS:i:47	cs:Z::13*GN*GN:8+NNN:16*GN*TN:18-ACTAG:16\n" > mut.cs.exp.gaf
+printf "*	78	0	78	+	>20>21>23>24>26>27>29>30>32>33>35	102	22	102	71	80	60	AS:i:47	cs:Z::13*GN*GN:8+NNN:16*GN*TN:18-ACTAG:16\n" > mut.cs.exp.gaf
 vg convert x.vg -F mut.cg.gaf -t 1 | vg convert x.vg -G - -t 1 > mut.cs.back.gaf
 diff mut.cs.back.gaf mut.cs.exp.gaf
 is "$?" 0 "vg convert cg-gaf -> gam -> cs-gaf gives expected output (snps converted to matches, insertion converted to Ns)"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GAF output should now have (more?) correct path end positions and block lengths

## Description

This should fix #3996. It turns out we just never really tested the GAF output's calculation of path end positions and block lengths, and they were wrong and also the unit tests we had were wrong.

I probably want to add more unit tests to this before we merge.
