### PR TITLE
Fix sampled translation

### DIFF
--- a/src/recombinator.cpp
+++ b/src/recombinator.cpp
@@ -46,7 +46,12 @@ find_kmer(hash_map<Haplotypes::Subchain::kmer_type, size_t>& counts, Haplotypes:
     return (forward != counts.end() ? forward : reverse);
 }
 
-hash_map<Haplotypes::Subchain::kmer_type, size_t> Haplotypes::kmer_counts(const std::string& kff_file, bool verbose) const {
+hash_map<Haplotypes::Subchain::kmer_type, size_t> Haplotypes::kmer_counts(const std::string& kff_file, Verbosity verbosity) const {
+    double start = gbwt::readTimer();
+    if (verbosity >= verbosity_basic) {
+        std::cerr << "Reading kmer counts" << std::endl;
+    }
+
     // Open and validate the kmer count file.
     ParallelKFFReader reader(kff_file);
 
@@ -63,7 +68,7 @@ hash_map<Haplotypes::Subchain::kmer_type, size_t> Haplotypes::kmer_counts(const 
             }
         }
     }
-    if (verbose) {
+    if (verbosity >= verbosity_detailed) {
         double seconds = gbwt::readTimer() - checkpoint;
         std::cerr << "Initialized the hash map with " << result.size() << " kmers in " << seconds << " seconds" << std::endl;
     }
@@ -97,11 +102,15 @@ hash_map<Haplotypes::Subchain::kmer_type, size_t> Haplotypes::kmer_counts(const 
             }
         }
     }
-    if (verbose) {
+    if (verbosity >= verbosity_detailed) {
         double seconds = gbwt::readTimer() - checkpoint;
         std::cerr << "Read " << kmer_count << " kmers in " << seconds << " seconds" << std::endl;
     }
 
+    if (verbosity >= verbosity_basic) {
+        double seconds = gbwt::readTimer() - start;
+        std::cerr << "Read the kmer counts in " << seconds << " seconds" << std::endl;
+    }
     return result;
 }
 
@@ -279,7 +288,7 @@ Haplotypes HaplotypePartitioner::partition_haplotypes(const Parameters& paramete
 
     // Determine top-level chains and assign them to jobs.
     double start = gbwt::readTimer();
-    if (this->verbosity >= verbosity_basic) {
+    if (this->verbosity >= Haplotypes::verbosity_basic) {
         std::cerr << "Determining construction jobs" << std::endl;
     }
     size_t size_bound = this->gbz.graph.get_node_count() / parameters.approximate_jobs;
@@ -317,13 +326,13 @@ Haplotypes HaplotypePartitioner::partition_haplotypes(const Parameters& paramete
     }
 
     jobs = gbwtgraph::ConstructionJobs(); // Save memory.
-    if (this->verbosity >= verbosity_basic) {
+    if (this->verbosity >= Haplotypes::verbosity_basic) {
         double seconds = gbwt::readTimer() - start;
         std::cerr << "Partitioned " << result.components() << " components into " << result.jobs() << " jobs in " << seconds << " seconds" << std::endl;
     }
 
     // Determine the subchains and sequences for each top-level chain.
-    if (verbosity >= verbosity_basic) {
+    if (verbosity >= Haplotypes::verbosity_basic) {
         std::cerr << "Running " << omp_get_max_threads() << " jobs in parallel" << std::endl;
     }
     start = gbwt::readTimer();
@@ -347,12 +356,12 @@ Haplotypes HaplotypePartitioner::partition_haplotypes(const Parameters& paramete
         {
             result.header.total_subchains += total_subchains;
             result.header.total_kmers += total_kmers;
-            if (this->verbosity >= verbosity_detailed) {
+            if (this->verbosity >= Haplotypes::verbosity_detailed) {
                 std::cerr << "Finished job " << job << " with " << chains.size() << " chains, " << total_subchains << " subchains, and " << total_kmers << " kmers" << std::endl;
             }
         }
     }
-    if (verbosity >= verbosity_basic) {
+    if (verbosity >= Haplotypes::verbosity_basic) {
         double seconds = gbwt::readTimer() - start;
         std::cerr << "Finished the jobs in " << seconds << " seconds" << std::endl;
     }
@@ -711,7 +720,85 @@ void HaplotypePartitioner::build_subchains(const gbwtgraph::TopLevelChain& chain
 
 //------------------------------------------------------------------------------
 
-void Recombinator::Haplotype::extend(sequence_type sequence, const Haplotypes::Subchain& subchain, const Recombinator& recombinator, gbwt::GBWTBuilder& builder) {
+/*
+ * A haplotype beging generated as a GBWT path.
+ *
+ * GBWT metadata will be set as following:
+ *
+ * * Sample name is "recombination".
+ * * Contig name is "chain_X", where X is the chain identifier.
+ * * Haplotype identifier is set during construction.
+ * * Fragment identifier is set as necessary.
+ */
+struct RecombinatorHaplotype {
+    typedef Recombinator::sequence_type sequence_type;
+
+    // Contig identifier in GBWT metadata.
+    // Offset of the top-level chain in the children of the root snarl.
+    size_t chain;
+
+    // Haplotype identifier in GBWT metadata.
+    size_t id;
+
+    // Fragment identifier in GBWT metadata.
+    // If no original haplotype crosses a subchain, a new fragment will
+    // start after the subchain.
+    size_t fragment;
+
+    // GBWT sequence indentifier in the previous subchain, or
+    // `gbwt::invalid_sequence()` if there was no such sequence.
+    gbwt::size_type sequence_id;
+
+    // GBWT position at the end of the latest `extend()` call.
+    // `gbwt::invalid_edge()` otherwise.
+    gbwt::edge_type position;
+
+    // The path being generated.
+    gbwt::vector_type path;
+
+    /*
+     * Extends the haplotype over the given subchain by using the given
+     * original haplotype.
+     *
+     * This assumes that the original haplotype crosses the subchain.
+     *
+     * If `extend()` has been called for this fragment, there must be a
+     * unary path connecting the subchains, which will be used in the
+     * generated haplotype.
+     *
+     * If `extend()` has not been called, the generated haplotype will
+     * take the prefix of the original original haplotype until the start
+     * of the subchain.
+     */
+    void extend(sequence_type sequence, const Haplotypes::Subchain& subchain, const Recombinator& recombinator, gbwt::GBWTBuilder& builder);
+
+    // Takes an existing haplotype from the GBWT index and inserts it into
+    /// the builder. This is intended for fragments that do not contain
+    /// subchains crossed by the original haplotypes. The call will fail if
+    /// `extend()` has been called.
+    void take(gbwt::size_type sequence_id, const Recombinator& recombinator, gbwt::GBWTBuilder& builder);
+
+    // Extends the original haplotype from the latest `extend()` call until
+    // the end, inserts it into the builder, and starts a new fragment.
+    // The call will fail if `extend()` has not been called for this
+    // fragment.
+    void finish(const Recombinator& recombinator, gbwt::GBWTBuilder& builder);
+
+private:
+    // Extends the haplotype over a unary path from a previous subchain.
+    void connect(gbwt::node_type until, const gbwtgraph::GBWTGraph& graph);
+
+    // Takes a prefix of a sequence.
+    void prefix(gbwt::size_type sequence_id, gbwt::node_type until, const gbwt::GBWT& index);
+
+    // Extends the haplotype from the previous subchain until the end.
+    void suffix(const gbwt::GBWT& index);
+
+    // Inserts the current fragment into the builder.
+    void insert(gbwt::GBWTBuilder& builder);
+};
+
+void RecombinatorHaplotype::extend(sequence_type sequence, const Haplotypes::Subchain& subchain, const Recombinator& recombinator, gbwt::GBWTBuilder& builder) {
     if (subchain.type == Haplotypes::Subchain::full_haplotype) {
         throw std::runtime_error("Haplotype::extend(): cannot extend a full haplotype");
     }
@@ -754,7 +841,7 @@ void Recombinator::Haplotype::extend(sequence_type sequence, const Haplotypes::S
     this->position = curr;
 }
 
-void Recombinator::Haplotype::take(gbwt::size_type sequence_id, const Recombinator& recombinator, gbwt::GBWTBuilder& builder) {
+void RecombinatorHaplotype::take(gbwt::size_type sequence_id, const Recombinator& recombinator, gbwt::GBWTBuilder& builder) {
     if (!this->path.empty()) {
         throw std::runtime_error("Haplotype::take(): the current fragment is not empty");
     }
@@ -769,7 +856,7 @@ void Recombinator::Haplotype::take(gbwt::size_type sequence_id, const Recombinat
     this->path.clear();
 }
 
-void Recombinator::Haplotype::finish(const Recombinator& recombinator, gbwt::GBWTBuilder& builder) {
+void RecombinatorHaplotype::finish(const Recombinator& recombinator, gbwt::GBWTBuilder& builder) {
     if (this->position == gbwt::invalid_edge()) {
         throw std::runtime_error("Haplotype::finish(): there is no current position");
     }
@@ -781,7 +868,7 @@ void Recombinator::Haplotype::finish(const Recombinator& recombinator, gbwt::GBW
     this->path.clear();
 }
 
-void Recombinator::Haplotype::connect(gbwt::node_type until, const gbwtgraph::GBWTGraph& graph) {
+void RecombinatorHaplotype::connect(gbwt::node_type until, const gbwtgraph::GBWTGraph& graph) {
     handle_t curr = gbwtgraph::GBWTGraph::node_to_handle(this->position.first);
     handle_t end = gbwtgraph::GBWTGraph::node_to_handle(until);
     this->position = gbwt::invalid_edge();
@@ -805,7 +892,7 @@ void Recombinator::Haplotype::connect(gbwt::node_type until, const gbwtgraph::GB
     }
 }
 
-void Recombinator::Haplotype::prefix(gbwt::size_type sequence_id, gbwt::node_type until, const gbwt::GBWT& index) {
+void RecombinatorHaplotype::prefix(gbwt::size_type sequence_id, gbwt::node_type until, const gbwt::GBWT& index) {
     this->position = gbwt::invalid_edge();
     if (sequence_id >= index.sequences()) {
         throw std::runtime_error("Haplotype::prefix(): invalid GBWT sequence id " + std::to_string(sequence_id));
@@ -821,13 +908,13 @@ void Recombinator::Haplotype::prefix(gbwt::size_type sequence_id, gbwt::node_typ
     throw std::runtime_error("Haplotype::prefix(): GBWT sequence " + std::to_string(sequence_id) + " did not reach GBWT node " + std::to_string(until));
 }
 
-void Recombinator::Haplotype::suffix(const gbwt::GBWT& index) {
+void RecombinatorHaplotype::suffix(const gbwt::GBWT& index) {
     for (gbwt::edge_type curr = index.LF(this->position); curr.first != gbwt::ENDMARKER; curr = index.LF(curr)) {
         this->path.push_back(curr.first);
     }
 }
 
-void Recombinator::Haplotype::insert(gbwt::GBWTBuilder& builder) {
+void RecombinatorHaplotype::insert(gbwt::GBWTBuilder& builder) {
     std::string sample_name = "recombination";
     gbwt::size_type sample_id = builder.index.metadata.sample(sample_name);
     if (sample_id >= builder.index.metadata.samples()) {
@@ -877,7 +964,7 @@ std::ostream& Recombinator::Statistics::print(std::ostream& out) const {
 
 //------------------------------------------------------------------------------
 
-Recombinator::Recombinator(const gbwtgraph::GBZ& gbz, HaplotypePartitioner::Verbosity verbosity) :
+Recombinator::Recombinator(const gbwtgraph::GBZ& gbz, Verbosity verbosity) :
     gbz(gbz), verbosity(verbosity)
 {
 }
@@ -908,71 +995,72 @@ void add_path(const gbwt::GBWT& source, gbwt::size_type path_id, gbwt::GBWTBuild
 
 //------------------------------------------------------------------------------
 
-gbwt::GBWT Recombinator::generate_haplotypes(const Haplotypes& haplotypes, const std::string& kff_file, const Parameters& parameters) const {
-
-    // Sanity checks.
+void recombinator_sanity_checks(const Recombinator::Parameters& parameters) {
     if (parameters.num_haplotypes == 0) {
-        std::string msg = "Recombinator::generate_haplotypes(): number of haplotypes cannot be 0";
+        std::string msg = "recombinator_sanity_checks(): number of haplotypes cannot be 0";
         throw std::runtime_error(msg);
     }
     if (parameters.present_discount < 0.0 || parameters.present_discount > 1.0) {
-        std::string msg = "Recombinator::generate_haplotypes(): present discount must be between 0.0 and 1.0";
+        std::string msg = "recombinator_sanity_checks(): present discount must be between 0.0 and 1.0";
         throw std::runtime_error(msg);
     }
     if (parameters.het_adjustment < 0.0) {
-        std::string msg = "Recombinator::generate_haplotypes(): het adjustment must be non-negative";
+        std::string msg = "recombinator_sanity_checks(): het adjustment must be non-negative";
         throw std::runtime_error(msg);
     }
     if (parameters.absent_score < 0.0) {
-        std::string msg = "Recombinator::generate_haplotypes(): absent score must be non-negative";
+        std::string msg = "recombinator_sanity_checks(): absent score must be non-negative";
         throw std::runtime_error(msg);
     }
+}
 
-    // Get kmer counts.
+double get_or_estimate_coverage(
+    const hash_map<Haplotypes::Subchain::kmer_type, size_t>& counts,
+    const Recombinator::Parameters& parameters,
+    Haplotypes::Verbosity verbosity) {
+    if (parameters.coverage > 0) {
+        return parameters.coverage;
+    }
+
     double start = gbwt::readTimer();
-    if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
-        std::cerr << "Reading kmer counts" << std::endl;
+    if (verbosity >= Haplotypes::verbosity_basic) {
+        std::cerr << "Estimating kmer coverage" << std::endl;
     }
-    hash_map<Haplotypes::Subchain::kmer_type, size_t> counts;
-    // This may throw.
-    counts = haplotypes.kmer_counts(kff_file, this->verbosity >= HaplotypePartitioner::verbosity_detailed);
-    if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
+    std::map<size_t, size_t> count_to_frequency;
+    for (auto iter = counts.begin(); iter != counts.end(); ++iter) {
+        // We are only interested in kmers with multiple occurrences, as unique
+        // kmers are likely sequencing errors.
+        if (iter->second > 1) {
+            count_to_frequency[iter->second]++;
+        }
+    }
+    auto statistics = summary_statistics(count_to_frequency);
+    double coverage = std::max(statistics.median, statistics.mode);
+    if (verbosity >= Haplotypes::verbosity_detailed) {
+        std::cerr << "Coverage: median " << statistics.median
+            << ", mean " << statistics.mean
+            << ", stdev " << statistics.stdev
+            << ", mode " << statistics.mode
+            << "; using " << coverage << std::endl;
+    }
+    if (verbosity >= Haplotypes::verbosity_basic) {
         double seconds = gbwt::readTimer() - start;
-        std::cerr << "Read the kmer counts in " << seconds << " seconds" << std::endl;
+        std::cerr << "Estimated kmer coverage in " << seconds << " seconds" << std::endl;
     }
+    return coverage;
+}
 
-    // TODO: What is the right estimate?
-    double coverage = parameters.coverage;
-    if (coverage == 0.0) {
-        start = gbwt::readTimer();
-        if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
-            std::cerr << "Estimating kmer coverage" << std::endl;
-        }
-        std::map<size_t, size_t> count_to_frequency;
-        for (auto iter = counts.begin(); iter != counts.end(); ++iter) {
-            // We are only interested in kmers with multiple occurrences, as unique
-            // kmers are likely sequencing errors.
-            if (iter->second > 1) {
-                count_to_frequency[iter->second]++;
-            }
-        }
-        auto statistics = summary_statistics(count_to_frequency);
-        coverage = std::max(statistics.median, statistics.mode);
-        if (this->verbosity >= HaplotypePartitioner::verbosity_detailed) {
-            std::cerr << "Coverage: median " << statistics.median
-                << ", mean " << statistics.mean
-                << ", stdev " << statistics.stdev
-                << ", mode " << statistics.mode
-                << "; using " << coverage << std::endl;
-        }
-        if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
-            double seconds = gbwt::readTimer() - start;
-            std::cerr << "Estimated kmer coverage in " << seconds << " seconds" << std::endl;
-        }
-    }
+gbwt::GBWT Recombinator::generate_haplotypes(const Haplotypes& haplotypes, const std::string& kff_file, const Parameters& parameters) const {
 
-    start = gbwt::readTimer();
-    if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
+    // Sanity checks (may throw).
+    recombinator_sanity_checks(parameters);
+
+    // Get kmer counts (may throw) and determine coverage.
+    hash_map<Haplotypes::Subchain::kmer_type, size_t> counts = haplotypes.kmer_counts(kff_file, this->verbosity);
+    double coverage = get_or_estimate_coverage(counts, parameters, this->verbosity);
+
+    double start = gbwt::readTimer();
+    if (this->verbosity >= Haplotypes::verbosity_basic) {
         if (parameters.random_sampling) {
             std::cerr << "Building GBWT (random sampling)" << std::endl;
         } else {
@@ -1001,7 +1089,7 @@ gbwt::GBWT Recombinator::generate_haplotypes(const Haplotypes& haplotypes, const
 
     // Build partial indexes.
     double checkpoint = gbwt::readTimer();
-    if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
+    if (this->verbosity >= Haplotypes::verbosity_basic) {
         std::cerr << "Running " << omp_get_max_threads() << " GBWT construction jobs in parallel" << std::endl;
     }
     std::vector<gbwt::GBWT> indexes(jobs.size());
@@ -1030,13 +1118,13 @@ gbwt::GBWT Recombinator::generate_haplotypes(const Haplotypes& haplotypes, const
         indexes[job] = builder.index;
         #pragma omp critical
         {
-            if (this->verbosity >= HaplotypePartitioner::verbosity_detailed) {
+            if (this->verbosity >= Haplotypes::verbosity_detailed) {
                 std::cerr << "Job " << job << ": "; job_statistics.print(std::cerr) << std::endl;
             }
             statistics.combine(job_statistics);
         }
     }
-    if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
+    if (this->verbosity >= Haplotypes::verbosity_basic) {
         double seconds = gbwt::readTimer() - checkpoint;
         std::cerr << "Total: "; statistics.print(std::cerr) << std::endl;
         std::cerr << "Finished the jobs in " << seconds << " seconds" << std::endl;
@@ -1044,7 +1132,7 @@ gbwt::GBWT Recombinator::generate_haplotypes(const Haplotypes& haplotypes, const
 
     // Merge the partial indexes.
     checkpoint = gbwt::readTimer();
-    if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
+    if (this->verbosity >= Haplotypes::verbosity_basic) {
         std::cerr << "Merging the partial indexes" << std::endl;
     }
     gbwt::GBWT merged(indexes);
@@ -1055,12 +1143,12 @@ gbwt::GBWT Recombinator::generate_haplotypes(const Haplotypes& haplotypes, const
             merged.tags.set(gbwtgraph::REFERENCE_SAMPLE_LIST_GBWT_TAG, reference_samples);
         }
     }
-    if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
+    if (this->verbosity >= Haplotypes::verbosity_basic) {
         double seconds = gbwt::readTimer() - checkpoint;
         std::cerr << "Merged the indexes in " << seconds << " seconds" << std::endl;
     }
 
-    if (this->verbosity >= HaplotypePartitioner::verbosity_basic) {
+    if (this->verbosity >= Haplotypes::verbosity_basic) {
         double seconds = gbwt::readTimer() - start;
         std::cerr << "Built the GBWT in " << seconds << " seconds" << std::endl;
     }
@@ -1079,7 +1167,7 @@ Recombinator::Statistics Recombinator::generate_haplotypes(const Haplotypes::Top
     double heterozygous_threshold = coverage / std::log(4.0);
     double homozygous_threshold = coverage * 2.5;
 
-    std::vector<Haplotype> haplotypes;
+    std::vector<RecombinatorHaplotype> haplotypes;
     for (size_t i = 0; i < parameters.num_haplotypes; i++) {
         haplotypes.push_back({ chain.offset, i, 0, gbwt::invalid_sequence(), gbwt::invalid_edge(), {} });
     }
@@ -1234,6 +1322,49 @@ Recombinator::Statistics Recombinator::generate_haplotypes(const Haplotypes::Top
     }
 
     return statistics;
+}
+
+//------------------------------------------------------------------------------
+
+std::vector<Recombinator::LocalHaplotype> Recombinator::extract_sequences(const Haplotypes& haplotypes,
+    const std::string& kff_file,
+    size_t chain_id, size_t subchain_id) const {
+
+    if (chain_id >= haplotypes.chains.size()) {
+        std::string msg = "Recombinator::extract_sequences(): invalid chain id " + std::to_string(chain_id);
+        throw std::runtime_error(msg);
+    }
+    if (subchain_id >= haplotypes.chains[chain_id].subchains.size()) {
+        std::string msg = "Recombinator::extract_sequences(): invalid subchain id " + std::to_string(subchain_id) +
+            " in chain " + std::to_string(chain_id);
+        throw std::runtime_error(msg);
+    }
+
+    // Extract the haplotypes.
+    const Haplotypes::Subchain& subchain = haplotypes.chains[chain_id].subchains[subchain_id];
+    std::vector<LocalHaplotype> result(subchain.sequences.size());
+    for (size_t i = 0; i < subchain.sequences.size(); i++) {
+        size_t path_id = gbwt::Path::id(subchain.sequences[i].first);
+        path_handle_t path_handle = this->gbz.graph.path_to_handle(path_id);
+        result[i].name = this->gbz.graph.get_path_name(path_handle);
+
+        gbwt::edge_type pos;
+        if (subchain.has_start()) {
+            pos = gbwt::edge_type(subchain.start, subchain.sequences[i].second);
+        } else {
+            pos = this->gbz.index.start(subchain.sequences[i].first);
+        }
+        handle_t until = gbwtgraph::GBWTGraph::node_to_handle(subchain.end);
+        size_t limit = std::numeric_limits<size_t>::max();
+        result[i].sequence = generate_haplotype(pos, until, limit, limit, this->gbz.graph);
+    }
+
+    // FIXME: Score the haplotypes.
+    // 1. read kmer counts
+    // 2. estimate coverage
+    // 3. "Select the haplotypes greedily" loop
+
+    return result;
 }
 
 //------------------------------------------------------------------------------

--- a/src/recombinator.cpp
+++ b/src/recombinator.cpp
@@ -1306,6 +1306,10 @@ Recombinator::Statistics Recombinator::generate_haplotypes(const Haplotypes::Top
 
             // Try to match the existing haplotypes with the selected sequences based on
             // GBWT sequence id.
+            // TODO: There are often many equally good haplotypes, and because we choose
+            // a different subset of them in each subchain, we often cannot connect the
+            // same haplotype from subchain to subchain, even when it would be one of the
+            // top ones in each of them.
             std::vector<size_t> haplotype_to_selected(haplotypes.size(), haplotypes.size());
             sdsl::bit_vector selected_in_use(haplotypes.size(), 0);
             for (size_t haplotype = 0; haplotype < haplotypes.size(); haplotype++) {

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -440,9 +440,6 @@ public:
         /// the wrong variants out.
         double absent_score = ABSENT_SCORE;
 
-        /// Sample randomly instead of by score.
-        bool random_sampling = false;
-
         /// Include named and reference paths.
         bool include_reference = false;
     };
@@ -488,7 +485,10 @@ public:
      *
      * Throws `std::runtime_error` on error.
      */
-    std::vector<LocalHaplotype> extract_sequences(const Haplotypes& haplotypes, const std::string& kff_file, size_t chain_id, size_t subchain_id) const;
+    std::vector<LocalHaplotype> extract_sequences(
+        const Haplotypes& haplotypes, const std::string& kff_file,
+        size_t chain_id, size_t subchain_id, const Parameters& parameters
+    ) const;
 
     const gbwtgraph::GBZ& gbz;
     Verbosity verbosity;

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -37,6 +37,21 @@ namespace vg {
  */
 class Haplotypes {
 public:
+    /// The amount of progress information that should be printed to stderr.
+    enum Verbosity : size_t {
+        /// No progress information.
+        verbosity_silent = 0,
+
+        /// Basic information.
+        verbosity_basic = 1,
+
+        /// Basic information and detailed statistics.
+        verbosity_detailed = 2,
+
+        /// Basic information, detailed statistics, and debug information.
+        verbosity_debug = 3
+    };
+
     /// Header of the serialized file.
     struct Header {
         constexpr static std::uint32_t MAGIC_NUMBER = 0x4C504148; // "HAPL"
@@ -175,7 +190,7 @@ public:
       * the file cannot be opened and throws `std::runtime_error` if the kmer
       * counts cannot be used.
      */
-    hash_map<Subchain::kmer_type, size_t> kmer_counts(const std::string& kff_file, bool verbose) const;
+    hash_map<Subchain::kmer_type, size_t> kmer_counts(const std::string& kff_file, Verbosity verbosity) const;
 
     /// Serializes the object to a stream in the simple-sds format.
     void simple_sds_serialize(std::ostream& out) const;
@@ -203,19 +218,7 @@ public:
     constexpr static size_t APPROXIMATE_JOBS = 32;
 
     /// The amount of progress information that should be printed to stderr.
-    enum Verbosity : size_t {
-        /// No progress information.
-        verbosity_silent = 0,
-
-        /// Basic information.
-        verbosity_basic = 1,
-
-        /// Basic information and detailed statistics.
-        verbosity_detailed = 2,
-
-        /// Basic information, detailed statistics, and debug information.
-        verbosity_debug = 3
-    };
+    typedef Haplotypes::Verbosity Verbosity;
 
     /// A GBWT sequence as (sequence identifier, offset in a node).
     typedef Haplotypes::sequence_type sequence_type;
@@ -367,84 +370,11 @@ public:
     /// keeping wrong variants out.
     constexpr static double ABSENT_SCORE = 0.8;
 
+    /// The amount of progress information that should be printed to stderr.
+    typedef Haplotypes::Verbosity Verbosity;
+
     /// A GBWT sequence as (sequence identifier, offset in a node).
     typedef Haplotypes::sequence_type sequence_type;
-
-    /**
-     * A haplotype beging generated as a GBWT path.
-     *
-     * GBWT metadata will be set as following:
-     *
-     * * Sample name is "recombination".
-     * * Contig name is "chain_X", where X is the chain identifier.
-     * * Haplotype identifier is set during construction.
-     * * Fragment identifier is set as necessary.
-     */
-    struct Haplotype {
-        /// Contig identifier in GBWT metadata.
-        /// Offset of the top-level chain in the children of the root snarl.
-        size_t chain;
-
-        /// Haplotype identifier in GBWT metadata. 
-        size_t id;
-
-        /// Fragment identifier in GBWT metadata.
-        /// If no original haplotype crosses a subchain, a new fragment will
-        /// start after the subchain.
-        size_t fragment;
-
-        /// GBWT sequence indentifier in the previous subchain, or
-        /// `gbwt::invalid_sequence()` if there was no such sequence.
-        gbwt::size_type sequence_id;
-
-        /// GBWT position at the end of the latest `extend()` call.
-        /// `gbwt::invalid_edge()` otherwise.
-        gbwt::edge_type position;
-
-        /// The path being generated.
-        gbwt::vector_type path;
-
-        /**
-         * Extends the haplotype over the given subchain by using the given
-         * original haplotype.
-         *
-         * This assumes that the original haplotype crosses the subchain.
-         *
-         * If `extend()` has been called for this fragment, there must be a
-         * unary path connecting the subchains, which will be used in the
-         * generated haplotype.
-         *
-         * If `extend()` has not been called, the generated haplotype will
-         * take the prefix of the original original haplotype until the start
-         * of the subchain.
-         */
-        void extend(sequence_type sequence, const Haplotypes::Subchain& subchain, const Recombinator& recombinator, gbwt::GBWTBuilder& builder);
-
-        /// Takes an existing haplotype from the GBWT index and inserts it into
-        /// the builder. This is intended for fragments that do not contain
-        /// subchains crossed by the original haplotypes. The call will fail if
-        /// `extend()` has been called.
-        void take(gbwt::size_type sequence_id, const Recombinator& recombinator, gbwt::GBWTBuilder& builder);
-
-        /// Extends the original haplotype from the latest `extend()` call until
-        /// the end, inserts it into the builder, and starts a new fragment.
-        /// The call will fail if `extend()` has not been called for this
-        /// fragment.
-        void finish(const Recombinator& recombinator, gbwt::GBWTBuilder& builder);
-
-    private:
-        // Extends the haplotype over a unary path from a previous subchain.
-        void connect(gbwt::node_type until, const gbwtgraph::GBWTGraph& graph);
-
-        // Takes a prefix of a sequence.
-        void prefix(gbwt::size_type sequence_id, gbwt::node_type until, const gbwt::GBWT& index);
-
-        // Extends the haplotype from the previous subchain until the end.
-        void suffix(const gbwt::GBWT& index);
-
-        // Inserts the current fragment into the builder.
-        void insert(gbwt::GBWTBuilder& builder);
-    };
 
     /// Statistics on the generated haplotypes.
     struct Statistics {
@@ -480,13 +410,10 @@ public:
 
         /// Prints the statistics and returns the output stream.
         std::ostream& print(std::ostream& out) const;
-
-        /// Prints the average score per kmer for each sequence rank in sorted order.
-        void print_scores(std::ostream& out) const;
     };
 
     /// Creates a new `Recombinator`.
-    Recombinator(const gbwtgraph::GBZ& gbz, HaplotypePartitioner::Verbosity verbosity);
+    Recombinator(const gbwtgraph::GBZ& gbz, Verbosity verbosity);
 
     /// Parameters for `generate_haplotypes()`.
     struct Parameters {
@@ -539,8 +466,32 @@ public:
      */
     gbwt::GBWT generate_haplotypes(const Haplotypes& haplotypes, const std::string& kff_file, const Parameters& parameters) const;
 
+    /// A local haplotype sequence within a single subchain.
+    struct LocalHaplotype {
+        /// Name of the haplotype.
+        std::string name;
+
+        /// Sequence in forward orientation.
+        std::string sequence;
+
+        /// (rank, score) in each round of haplotype selection this haplotype
+        /// participates in.
+        std::vector<std::pair<size_t, double>> scores;
+    };
+
+    /**
+     * Extracts the local haplotypes in the given subchain. In addition to the
+     * haplotype sequence, this also reports the name of the corresponding path
+     * as well as (rank, score) for the haplotype in each round of haplotype
+     * selection. The number of rounds is `parameters.num_haplotyeps`, but if
+     * the haplotype is selected earlier, it will not get further scores.
+     *
+     * Throws `std::runtime_error` on error.
+     */
+    std::vector<LocalHaplotype> extract_sequences(const Haplotypes& haplotypes, const std::string& kff_file, size_t chain_id, size_t subchain_id) const;
+
     const gbwtgraph::GBZ& gbz;
-    HaplotypePartitioner::Verbosity verbosity;
+    Verbosity verbosity;
 
 private:
     // Generate haplotypes for the given chain.

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -206,7 +206,6 @@ void help_haplotypes(char** argv, bool developer_options) {
     std::cerr << "        --present-discount F  discount scores for present kmers by factor F (default: " << haplotypes_default_discount() << ")" << std::endl;
     std::cerr << "        --het-adjustment F    adjust scores for heterozygous kmers by F (default: " << haplotypes_default_adjustment() << ")" << std::endl;
     std::cerr << "        --absent-score F      score absent kmers -F/+F (default: " << haplotypes_default_absent()  << ")" << std::endl;
-    std::cerr << "        --random-sampling     sample randomly instead of using the kmer counts" << std::endl;
     std::cerr << "        --include-reference   include named and reference paths in the output" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
@@ -234,7 +233,6 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
     constexpr int OPT_PRESENT_DISCOUNT = 1302;
     constexpr int OPT_HET_ADJUSTMENT = 1303;
     constexpr int OPT_ABSENT_SCORE = 1304;
-    constexpr int OPT_RANDOM_SAMPLING = 1305;
     constexpr int OPT_INCLUDE_REFERENCE = 1306;
     constexpr int OPT_VALIDATE = 1400;
     constexpr int OPT_VCF_INPUT = 1500;
@@ -257,7 +255,6 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
         { "present-discount", required_argument, 0, OPT_PRESENT_DISCOUNT },
         { "het-adjustment", required_argument, 0, OPT_HET_ADJUSTMENT },
         { "absent-score", required_argument, 0, OPT_ABSENT_SCORE },
-        { "random-sampling", no_argument, 0, OPT_RANDOM_SAMPLING },
         { "include-reference", no_argument, 0, OPT_INCLUDE_REFERENCE },
         { "verbosity", required_argument, 0, 'v' },
         { "threads", required_argument, 0, 't' },
@@ -349,9 +346,6 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
                 std::cerr << "error: [vg haplotypes] absent score must be non-negative" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
-            break;
-        case OPT_RANDOM_SAMPLING:
-            this->recombinator_parameters.random_sampling = true;
             break;
         case OPT_INCLUDE_REFERENCE:
             this->recombinator_parameters.include_reference = true;
@@ -844,7 +838,10 @@ void extract_haplotypes(const gbwtgraph::GBZ& gbz, const Haplotypes& haplotypes,
     }
 
     Recombinator recombinator(gbz, config.verbosity);
-    auto result = recombinator.extract_sequences(haplotypes, config.kmer_input, config.chain_id, config.subchain_id);
+    auto result = recombinator.extract_sequences(
+        haplotypes, config.kmer_input,
+        config.chain_id, config.subchain_id, config.recombinator_parameters
+    );
     if (config.verbosity >= Haplotypes::verbosity_detailed) {
         std::cerr << "Found " << result.size() << " haplotypes" << std::endl;
     }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Haplotype sampling now copies the vg node to GFA segment translation correctly from the original graph.

## Description

Graphs created using `GBWTGraph::subgraph()` did not copy the node-to-segment translation correctly from the supergraph. This affected the sampled graphs from `vg haplotypes`. When the translation was used, such as when extracting the GFA from the GBZ, segments got empty and/or incorrect names. This PR fixes the issue and resolves #4016.

There are also some developer tools for investigating the behavior of haplotype sampling at the level of an individual variant / subchain.
