### PR TITLE
Skip W lines for vg map autoindexing

### DIFF
--- a/src/algorithms/gfa_to_handle.hpp
+++ b/src/algorithms/gfa_to_handle.hpp
@@ -78,19 +78,22 @@ void gfa_to_handle_graph(istream& in,
 void gfa_to_path_handle_graph(const string& filename,
                               MutablePathMutableHandleGraph* graph,
                               GFAIDMapInfo* translation = nullptr,
-                              int64_t max_rgfa_rank = numeric_limits<int64_t>::max());
+                              int64_t max_rgfa_rank = numeric_limits<int64_t>::max(),
+                              unordered_set<PathSense>* ignore_sense = nullptr);
 
 /// Overload which serializes its translation to a file internally.
 void gfa_to_path_handle_graph(const string& filename,
                               MutablePathMutableHandleGraph* graph,
                               int64_t max_rgfa_rank,
-                              const string& translation_filename);
+                              const string& translation_filename,
+                              unordered_set<PathSense>* ignore_sense = nullptr);
                               
 /// Load a GFA from a stream (assumed not to be seekable or reopenable) into a PathHandleGraph.
 void gfa_to_path_handle_graph(istream& in,
                               MutablePathMutableHandleGraph* graph,
                               GFAIDMapInfo* translation = nullptr,
-                              int64_t max_rgfa_rank = numeric_limits<int64_t>::max());
+                              int64_t max_rgfa_rank = numeric_limits<int64_t>::max(),
+                              unordered_set<PathSense>* ignore_sense = nullptr);
 
 /**
  * Lower-level tools for parsing GFA elements.

--- a/src/phase_unfolder.cpp
+++ b/src/phase_unfolder.cpp
@@ -33,7 +33,9 @@ void PhaseUnfolder::unfold(MutableHandleGraph& graph, bool show_progress) {
 }
 
 void PhaseUnfolder::restore_paths(MutableHandleGraph& graph, bool show_progress) const {
-    this->path_graph.for_each_path_handle([&](const path_handle_t& path) {
+    // we include generic to also pick up transcript paths
+    this->path_graph.for_each_path_matching({PathSense::GENERIC, PathSense::REFERENCE}, {}, {},
+                                            [&](const path_handle_t& path) {
         handle_t prev;
         bool first = true;
         this->path_graph.for_each_step_in_path(path, [&](const step_handle_t& step) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex --workflow map` can index GFAs with many W lines 

## Description

W-line haplotypes were being handled inconsistently, which led to an inability to prune graphs for GCSA2 indexing (pruned regions would be immediately re-added). 

This PR leaves unaddressed the fact that the pruning step is very memory intensive on the clipped HPRC graphs (~200 GB). I can't think of any good reason why it should be so high.