### PR TITLE
Fix deconstruct crash

### DIFF
--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -5,6 +5,7 @@
 #include <ostream>
 #include <sstream>
 #include <algorithm>
+#include <atomic>
 #include "genotypekit.hpp"
 #include "Variant.h"
 #include "handle.hpp"
@@ -159,6 +160,9 @@ private:
 
     // should we keep conflicted genotypes or not
     bool keep_conflicted_genotypes = false;
+
+    // warn about context jaccard not working with exhaustive traversals
+    mutable atomic<bool> exhaustive_jaccard_warning;
 };
 
 // helpel for measuring set intersectiond and union size


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg deconstruct` fixed to no longer crash when combining multiple reference traversals with exhaustive (ie not path-based or gbwt-based traversal logic). Note that running `vg deconstruct` in exhaustive mode (ie without `-e`, `-g` or GBZ input remains not recommended for anything but trivial graphs).

## Description

For, I guess, reasons of backward compatibility, running `vg deconstruct` in its default mode triggers an exhaustive search of all alleles.  This is pretty useless in most cases.  More relevant is the path-based deconstruction that's used by PGGB and Minigraph-Cactus.  In the former, this is toggled on with `-e` and in the latter, it gets activated upon seeing GBZ input.  

But what happens when you pass a PGGB graph without `-e`?  Mostly nonsense or a crash, depending on the reference path that gets chosen for the site, with the crash happening if the context jaccard logic is triggered by the reference path crossing the site more than once.

In the example from #4048, it worked in v1.40.0 because it was choosing a reference path, `HG00438#1#JAHBCB010000040.1:24269348-24320210`, that does not loop twice through any sites.  In `v1.50.1` it (by default) sniffs out `chm13#chr6:31825251-31908851` as a reference, but that has self loops and causes the crash. 

This PR simply adds a block to make sure that context jaccard is never triggered with exhaustive traversals (and prints a warning suggesting `-e`).  This should ensure the crash never happens again.  

There's certainly a case to be made for making the default behaviour of `deconstruct` more user friendly, but that's not dealt with here.  So getting useful deconstruction from alignment-based graphs continues to require either `-e` or a GBZ/GBWT. 
 
Resolves #4048
