### PR TITLE
Get rid of apparently looping softclips at the ends of reads

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -4281,7 +4281,7 @@ void MinimizerMapper::find_optimal_tail_alignments(const Alignment& aln, const v
                 auto* prev_mapping = target->mutable_mapping(target->mapping_size() - 1);
 
                 if (mapping.position().node_id() == prev_mapping->position().node_id() && 
-                    (mapping.position().offset() != 0 || mapping_from_length(*prev_mapping) == 0 || mapping_from_length(mapping) == 0)) {
+                    (mapping.position().offset() != 0 || mapping_is_total_insertion(*prev_mapping) || mapping_is_total_insertion(mapping))) {
                     // Previous mapping is to the same node, and either the new
                     // mapping doesn't start at 0, or one mapping takes up no
                     // space on the node (i.e. is a pure insert).

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -4270,64 +4270,51 @@ void MinimizerMapper::find_optimal_tail_alignments(const Alignment& aln, const v
     best.set_score(winning_score);
     second_best.set_score(second_score);
 
-    // Concatenate the paths. We know there must be at least an edit boundary
+    // Concatenate the paths.
+    // We need a helper function that cna merge softclips in propelry.
+    auto add_to_path = [](Path* target, Path* to_append) {
+        for (auto& mapping : *to_append->mutable_mapping()) {
+            // For each mapping to append
+            if (target->mapping_size() > 0) {
+                // There is an existing mapping on the path.
+                // Find that previous mapping.
+                auto* prev_mapping = target->mutable_mapping(target->mapping_size() - 1);
+
+                if (mapping.position().node_id() == prev_mapping->position().node_id() && 
+                    (mapping.position().offset() != 0 || mapping_from_length(*prev_mapping) == 0 || mapping_from_length(mapping) == 0)) {
+                    // Previous mapping is to the same node, and either the new
+                    // mapping doesn't start at 0, or one mapping takes up no
+                    // space on the node (i.e. is a pure insert).
+                    //
+                    // So we want to combine the mappings.
+                    for (auto& edit : *mapping.mutable_edit()) {
+                        // Move over all the edits in this mapping onto the end of that one.
+                        *prev_mapping->add_edit() = std::move(edit);
+                    }
+
+                    continue;
+                }
+            }
+            // If we don't combine the mappings, we need to just move the whole mapping
+            *target->add_mapping() = std::move(mapping);
+        }
+    };
+
+
+    // We know there must be at least an edit boundary
     // between each part, because the maximal extension doesn't end in a
     // mismatch or indel and eats all matches.
     // We also don't need to worry about jumps that skip intervening sequence.
     *best.mutable_path() = std::move(winning_left);
-
-    for (auto* to_append : {&winning_middle, &winning_right}) {
-        // For each path to append
-        for (auto& mapping : *to_append->mutable_mapping()) {
-            // For each mapping to append
-            
-            if (mapping.position().offset() != 0 && best.path().mapping_size() > 0) {
-                // If we have a nonzero offset in our mapping, and we follow
-                // something, we must be continuing on from a previous mapping to
-                // the node.
-                crash_unless(mapping.position().node_id() == best.path().mapping(best.path().mapping_size() - 1).position().node_id());
-
-                // Find that previous mapping
-                auto* prev_mapping = best.mutable_path()->mutable_mapping(best.path().mapping_size() - 1);
-                for (auto& edit : *mapping.mutable_edit()) {
-                    // Move over all the edits in this mapping onto the end of that one.
-                    *prev_mapping->add_edit() = std::move(edit);
-                }
-            } else {
-                // If we start at offset 0 or there's nothing before us, we need to just move the whole mapping
-                *best.mutable_path()->add_mapping() = std::move(mapping);
-            }
-        }
-    }
+    add_to_path(best.mutable_path(), &winning_middle);
+    add_to_path(best.mutable_path(), &winning_right);
+    // Compute the identity from the path.
     best.set_identity(identity(best.path()));
+    
     //Do the same for the second best
     *second_best.mutable_path() = std::move(second_left);
-
-    for (auto* to_append : {&second_middle, &second_right}) {
-        // For each path to append
-        for (auto& mapping : *to_append->mutable_mapping()) {
-            // For each mapping to append
-            
-            if (mapping.position().offset() != 0 && second_best.path().mapping_size() > 0) {
-                // If we have a nonzero offset in our mapping, and we follow
-                // something, we must be continuing on from a previous mapping to
-                // the node.
-                crash_unless(mapping.position().node_id() == second_best.path().mapping(second_best.path().mapping_size() - 1).position().node_id());
-
-                // Find that previous mapping
-                auto* prev_mapping = second_best.mutable_path()->mutable_mapping(second_best.path().mapping_size() - 1);
-                for (auto& edit : *mapping.mutable_edit()) {
-                    // Move over all the edits in this mapping onto the end of that one.
-                    *prev_mapping->add_edit() = std::move(edit);
-                }
-            } else {
-                // If we start at offset 0 or there's nothing before us, we need to just move the whole mapping
-                *second_best.mutable_path()->add_mapping() = std::move(mapping);
-            }
-        }
-    }
-
-    // Compute the identity from the path.
+    add_to_path(second_best.mutable_path(), &second_middle);
+    add_to_path(second_best.mutable_path(), &second_right);
     second_best.set_identity(identity(second_best.path()));
 }
 

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1665,6 +1665,10 @@ bool mapping_is_total_deletion(const Mapping& m) {
     return m.edit_size() == 1 && edit_is_deletion(m.edit(0));
 }
 
+bool mapping_is_total_insertion(const Mapping& m) {
+    return m.edit_size() == 1 && edit_is_insertion(m.edit(0));
+}
+
 bool mapping_is_simple_match(const Mapping& m) {
     return m.edit_size() == 1 && edit_is_match(m.edit(0));
 }

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -262,6 +262,7 @@ int from_length(const Mapping& m);
 bool mappings_equivalent(const Mapping& m1, const Mapping& m2);
 bool mapping_ends_in_deletion(const Mapping& m);
 bool mapping_starts_in_deletion(const Mapping& m);
+bool mapping_is_total_insertion(const Mapping& m);
 bool mapping_is_total_deletion(const Mapping& m);
 bool mapping_is_simple_match(const Mapping& m);
 bool path_is_simple_match(const Path& p);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe should no longer put softclips off the ends of graphs into their own mappings.
 
## Description

The NYGC team ran Giraffe on some subgraphs, and reads that went off the ends of the graph were showing as looping around on the end nodes int eh Tube Map.

It turns out this is because we were putting the softclip edits into different mappings than the rest of the terminal visits to the graph's bounding nodes.

This fixes how we paste the alignment paths together so that that shouldn't happen anymore.