### PR TITLE
Diploid sampling

### DIFF
--- a/src/recombinator.cpp
+++ b/src/recombinator.cpp
@@ -920,6 +920,7 @@ void RecombinatorHaplotype::insert(gbwt::GBWTBuilder& builder) {
         builder.index.metadata.addSamples({ sample_name });
     }
 
+    // FIXME: Get the contig name from the graph if possible.
     std::string contig_name = "chain_" + std::to_string(this->chain);
     gbwt::size_type contig_id = builder.index.metadata.contig(contig_name);
     if (contig_id >= builder.index.metadata.contigs()) {
@@ -1251,13 +1252,13 @@ std::vector<std::pair<size_t, double>> select_diploid(
                 int64_t found = subchain.kmers_present[left_offset + kmer_id] + subchain.kmers_present[right_offset + kmer_id];
                 switch (kmer_types[kmer_id].first) {
                 case Recombinator::absent:
-                    score += 2 * (1 - found); // +2 for 0, 0 for 1, -2 for 2
+                    score += 1 - found; // +1 for 0, 0 for 1, -1 for 2
                     break;
                 case Recombinator::heterozygous:
-                    score += (found == 1 ? 2 : 0);
+                    score += (found == 1 ? 1 : 0);
                     break;
                 case Recombinator::present:
-                    score += 2 * (found - 1); // -2 for 0, 0 for 1, +2 for 2
+                    score += found - 1; // -1 for 0, 0 for 1, +1 for 2
                     break;
                 default:
                     break;
@@ -1375,7 +1376,7 @@ Recombinator::Statistics Recombinator::generate_haplotypes(const Haplotypes::Top
     size_t final_haplotypes = (parameters.diploid_sampling ? 2 : parameters.num_haplotypes);
     std::vector<RecombinatorHaplotype> haplotypes;
     for (size_t i = 0; i < final_haplotypes; i++) {
-        haplotypes.push_back({ chain.offset, i, 0, gbwt::invalid_sequence(), gbwt::invalid_edge(), {} });
+        haplotypes.push_back({ chain.offset, i + 1, 0, gbwt::invalid_sequence(), gbwt::invalid_edge(), {} });
     }
 
     Statistics statistics;

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -34,6 +34,12 @@ namespace vg {
  * may share kmers.)
  *
  * NOTE: This assumes that the top-level chains are linear, not cyclical.
+ *
+ * Versions:
+ *
+ * * Version 2: Top-level chains include a contig name. Compatible with version 1.
+ *
+ * * Version 1: Initial version.
  */
 class Haplotypes {
 public:
@@ -55,7 +61,8 @@ public:
     /// Header of the serialized file.
     struct Header {
         constexpr static std::uint32_t MAGIC_NUMBER = 0x4C504148; // "HAPL"
-        constexpr static std::uint32_t VERSION = 1;
+        constexpr static std::uint32_t VERSION = 2;
+        constexpr static std::uint32_t MIN_VERSION = 1;
         constexpr static std::uint64_t DEFAULT_K = 29;
 
         /// A magic number that identifies the file.
@@ -153,6 +160,9 @@ public:
         /// GBWT construction job for this chain.
         size_t job_id;
 
+        /// Contig name corresponding to the chain.
+        std::string contig_name;
+
         /// Subchains in the order they appear in.
         std::vector<Subchain> subchains;
 
@@ -161,6 +171,9 @@ public:
 
         /// Loads the object from a stream in the simple-sds format.
         void simple_sds_load(std::istream& in);
+
+        /// Loads the old version without a contig name.
+        void load_old(std::istream& in);
 
         /// Returns the size of the object in elements.
         size_t simple_sds_size() const;

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -117,7 +117,7 @@ public:
         /// Sequences as (GBWT sequence id, offset in the relevant node).
         std::vector<sequence_type> sequences;
 
-        // TODO: This could be compressed by removing duplicate haplotypes.
+        // TODO: This needs to be compressed for larger datasets.
         sdsl::bit_vector kmers_present;
 
         /// Returns the start node as a GBWTGraph handle.
@@ -440,6 +440,10 @@ public:
         /// the wrong variants out.
         double absent_score = ABSENT_SCORE;
 
+        /// After selecting the initial `num_haplotypes` haplotypes, choose the
+        /// highest-scoring pair out of them.
+        bool diploid_sampling = false;
+
         /// Include named and reference paths.
         bool include_reference = false;
     };
@@ -475,6 +479,9 @@ public:
         /// participates in.
         std::vector<std::pair<size_t, double>> scores;
     };
+
+    /// Kmer classification.
+    enum kmer_presence { absent, heterozygous, present, frequent };
 
     /**
      * Extracts the local haplotypes in the given subchain. In addition to the

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -514,7 +514,13 @@ void preprocess_graph(const gbwtgraph::GBZ& gbz, Haplotypes& haplotypes, Haploty
 
     // Partition the haplotypes.
     HaplotypePartitioner partitioner(gbz, r_index, distance_index, minimizer_index, config.verbosity);
-    haplotypes = partitioner.partition_haplotypes(config.partitioner_parameters);
+    try {
+        haplotypes = partitioner.partition_haplotypes(config.partitioner_parameters);
+    }
+    catch (const std::runtime_error& e) {
+        std::cerr << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
     if (config.verbosity >= Haplotypes::verbosity_basic) {
         double seconds = gbwt::readTimer() - start;
         std::cerr << "Generated haplotype information in " << seconds << " seconds" << std::endl;

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -209,6 +209,7 @@ void help_haplotypes(char** argv, bool developer_options) {
     std::cerr << "        --present-discount F  discount scores for present kmers by factor F (default: " << haplotypes_default_discount() << ")" << std::endl;
     std::cerr << "        --het-adjustment F    adjust scores for heterozygous kmers by F (default: " << haplotypes_default_adjustment() << ")" << std::endl;
     std::cerr << "        --absent-score F      score absent kmers -F/+F (default: " << haplotypes_default_absent()  << ")" << std::endl;
+    std::cerr << "        --diploid-sampling    choose the best pair from the greedily selected haplotypes" << std::endl;
     std::cerr << "        --include-reference   include named and reference paths in the output" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
@@ -237,6 +238,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
     constexpr int OPT_PRESENT_DISCOUNT = 1302;
     constexpr int OPT_HET_ADJUSTMENT = 1303;
     constexpr int OPT_ABSENT_SCORE = 1304;
+    constexpr int OPT_DIPLOID_SAMPLING = 1305;
     constexpr int OPT_INCLUDE_REFERENCE = 1306;
     constexpr int OPT_VALIDATE = 1400;
     constexpr int OPT_VCF_INPUT = 1500;
@@ -260,6 +262,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
         { "present-discount", required_argument, 0, OPT_PRESENT_DISCOUNT },
         { "het-adjustment", required_argument, 0, OPT_HET_ADJUSTMENT },
         { "absent-score", required_argument, 0, OPT_ABSENT_SCORE },
+        { "diploid-sampling", no_argument, 0, OPT_DIPLOID_SAMPLING },
         { "include-reference", no_argument, 0, OPT_INCLUDE_REFERENCE },
         { "verbosity", required_argument, 0, 'v' },
         { "threads", required_argument, 0, 't' },
@@ -352,6 +355,9 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
                 std::cerr << "error: [vg haplotypes] absent score must be non-negative" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
+            break;
+        case OPT_DIPLOID_SAMPLING:
+            this->recombinator_parameters.diploid_sampling = true;
             break;
         case OPT_INCLUDE_REFERENCE:
             this->recombinator_parameters.include_reference = true;

--- a/test/t/54_vg_haplotypes.t
+++ b/test/t/54_vg_haplotypes.t
@@ -22,7 +22,7 @@ is $? 0 "generating haplotype information"
 vg haplotypes --validate -i full.hapl -k haplotype-sampling/HG003.kff --include-reference -g indirect.gbz full.gbz
 is $? 0 "sampling from existing haplotype information"
 is $(vg gbwt -S -Z indirect.gbz) 3 "1 generated + 2 reference samples"
-is $(vg gbwt -C -Z indirect.gbz) 4 "2 generated + 2 reference contigs"
+is $(vg gbwt -C -Z indirect.gbz) 2 "2 contigs"
 is $(vg gbwt -H -Z indirect.gbz) 6 "4 generated + 2 reference haplotypes"
 
 # Sample the haplotypes directly
@@ -57,7 +57,7 @@ is $? 0 "the sampled graphs are identical"
 vg haplotypes --validate -i full.hapl -k haplotype-sampling/HG003.kff --include-reference --diploid-sampling --num-haplotypes 8 -g diploid.gbz full.gbz
 is $? 0 "diploid sampling"
 is $(vg gbwt -S -Z diploid.gbz) 3 "1 generated + 2 reference samples"
-is $(vg gbwt -C -Z diploid.gbz) 4 "2 generated + 2 reference contigs"
+is $(vg gbwt -C -Z diploid.gbz) 2 "2 contigs"
 is $(vg gbwt -H -Z diploid.gbz) 4 "2 generated + 2 reference haplotypes"
 
 # Cleanup

--- a/test/t/54_vg_haplotypes.t
+++ b/test/t/54_vg_haplotypes.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 15
+plan tests 19
 
 # The test graph consists of two subgraphs of the HPRC Minigraph-Cactus v1.1 graph:
 # - GRCh38#chr6:31498145-31511124 (micb)
@@ -32,7 +32,7 @@ cmp indirect.gbz direct.gbz
 is $? 0 "the outputs are identical"
 
 # Sample without reference
-vg haplotypes --validate --subchain-length 300 -k haplotype-sampling/HG003.kff -g no_ref.gbz full.gbz
+vg haplotypes --validate -i full.hapl -k haplotype-sampling/HG003.kff -g no_ref.gbz full.gbz
 is $? 0 "sampling without adding reference"
 is $(vg gbwt -S -Z no_ref.gbz) 1 "1 sample"
 is $(vg gbwt -C -Z no_ref.gbz) 2 "2 contigs"
@@ -53,8 +53,16 @@ is $? 0 "Giraffe integration with a specified output name"
 cmp full.HG003.gbz sampled.003HG.gbz
 is $? 0 "the sampled graphs are identical"
 
+# Diploid sampling
+vg haplotypes --validate -i full.hapl -k haplotype-sampling/HG003.kff --include-reference --diploid-sampling --num-haplotypes 8 -g diploid.gbz full.gbz
+is $? 0 "diploid sampling"
+is $(vg gbwt -S -Z diploid.gbz) 3 "1 generated + 2 reference samples"
+is $(vg gbwt -C -Z diploid.gbz) 4 "2 generated + 2 reference contigs"
+is $(vg gbwt -H -Z diploid.gbz) 4 "2 generated + 2 reference haplotypes"
+
 # Cleanup
 rm -r full.gbz full.ri full.dist full.hapl
 rm -f indirect.gbz direct.gbz no_ref.gbz
 rm -f full.HG003.gbz full.HG003.dist full.HG003.min default.gam
 rm -f sampled.003HG.gbz sampled.003HG.dist sampled.003HG.min specified.gam
+rm -f diploid.gbz


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Diploid mode for haplotype sampling: first select N haplotypes, then choose the best pair.

## Description

A quick implementation of diploid sampling in `vg haplotypes`. This mode, enabled with option `--diploid-sampling`, first generates the specified number of candidate haplotypes with the existing greedy algorithm. Then it considers all pairs of candidates and chooses the highest-scoring pair according to a simple +1/-1 scoring scheme:
* Present kmer: -1 / 0 / +1 for 0 / 1 / 2 copies in the haplotypes
* Heterozygous kmer: 0 / +1 / 0
* Absent kmer: +1 / 0 / -1

As usual, this process is repeated independently in each subchain.

Haplotype sampling now also tries to use reference contig names in the generated haplotypes. This requires rebuilding the haplotype information.