### PR TITLE
Add ref-path stubbification option -S to vg clip

### DIFF
--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -93,6 +93,11 @@ void clip_contained_stubs(MutablePathMutableHandleGraph* graph, PathPositionHand
                           SnarlManager& snarl_manager, bool include_endpoints, int64_t min_fragment_len, bool verbose);
 
 
+/**
+ * stubbify reference
+ */
+void stubbify_ref_paths(MutablePathMutableHandleGraph* graph, const vector<string>& ref_prefixes, int64_t min_fragment_len, bool verbose);
+
 }
 
 

--- a/test/t/53_clip.t
+++ b/test/t/53_clip.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 15
+plan tests 17
 
 vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 -k 16 | vg mod -U 10 - | vg mod -c - > hla.vg
 
@@ -87,5 +87,11 @@ is "$?" 0 "stub clipping removed all stubs"
 
 printf "x\t5\t25\n" > region.bed
 is $(vg clip tiny-stubs.gfa -s -b region.bed | vg stats -N -) "17" "region clipping filtered out only 2 / 4 stub nodes"
+
+printf "L\t100\t+\t2\t-\t0M\n" >> tiny-stubs.gfa
+printf "L\t15\t+\t13\t-\t0M\n" >> tiny-stubs.gfa
+is $(vg clip tiny-stubs.gfa -sS -P x | vg stats -HT - | sort -nk 2 | awk '{print $2}' | head -1) "1" "Correct head after path stubbification"
+is $(vg clip tiny-stubs.gfa -sS -P x | vg stats -HT - | sort -nk 2 | awk '{print $2}' | tail -1) "15" "Correct tail after path stubbification"
+
 
 rm -f tiny.gfa tiny-stubs.gfa region.bed tiny-nostubs.gfa


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add ref-path stubbification option -S to vg clip

## Description

The end of `chr4` in a recent 16-drosophila graph is a big tangle, and we get an edge (from another haplotype) coming out the end of it:

```
vg stats -HT chunk_4.vg
heads	7134050 
tails	
```

This has the effect of leaving the graph with only one tip, which in this case causes it to have 4 top level chains.  This in turn causes `vg haplotypes` to crash (#4060) since `vg haplotypes` assumes one top-level chain per component. 

This PR adds a `-S` option to `vg clip` that, for every reference path, makes sure that both of its endpoints are on tips in the graph.  When used in conjunction with the usual stub remover (so `-Ss`), it will make sure there are exactly two tips per reference path per component in the graph.  

If the graph has overlapping reference paths, then they will be chopped up by eachother, so probably best to avoid using in this case!! 

