### PR TITLE
Convert GBWTGraph to GFA without using translation

### DIFF
--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order
 
-plan tests 102
+plan tests 106
 
 vg construct -r complex/c.fa -v complex/c.vcf.gz > c.vg
 cat <(vg view c.vg | grep ^S | sort) <(vg view c.vg | grep L | uniq | wc -l) <(vg paths -v c.vg -E) > c.info
@@ -361,6 +361,15 @@ vg convert -f components.gbz | sort > sorted.gfa
 cmp sorted.gfa correct.gfa
 is $? 0 "GBZ to GFA conversion works with multiple threads"
 
+# GFA extraction from GBZ with/without translation.
+vg gbwt --gbz-format -g chopping.gbz --max-node 2 -G graphs/chopping_walks.gfa
+vg convert -f -t 1 chopping.gbz > with-translation.gfa
+is $? 0 "GBZ to GFA with translation"
+is "$(grep -c "^S" with-translation.gfa)" "8" "8 segments"
+vg convert -f -t 1 --no-translation chopping.gbz > no-translation.gfa
+is $? 0 "GBZ to GFA without translation"
+is "$(grep -c "^S" no-translation.gfa)" "9" "9 segments"
+
 rm -f components.gbwt components.gg components.gbz
 rm -f direct.hg correct_paths.gaf correct_haplotypes.gaf
 rm -f components.hg hg_paths.gaf hg_haplotypes.gaf gbz_hg_paths.gaf gbz_hg_haplotypes.gaf
@@ -368,6 +377,7 @@ rm -f components.xg xg_paths.gaf xg_haplotypes.gaf gbz_xg_paths.gaf gbz_xg_haplo
 rm -f no_haplotypes.xg no_haplotypes.hg
 rm -f extracted.gfa gbz.gfa extracted.hg
 rm -f sorted.gfa correct.gfa
+rm -f chopping.gbz with-translation.gfa no-translation.gfa
 
 #####
 # Reference path conversion


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg convert` option `--no-translation` for converting GBWTGraph to GFA directly without using the node-to-segment translation.

## Description

GBWTGraph can store a node-to-segment translation for conversions between GFA segments (string names, arbitrary length) and nodes (integer ids, often limited to 1024 bp). When GBWTGraph is converted to GFA, this translation is used to restore the original GFA. Sometimes this is undesirable and we really want a direct conversion to a GFA graph with the same nodes as the GBWTGraph. This is now possible by using `vg convert` option `--no-translation`.