### PR TITLE
Add Node setup to Mac tests

### DIFF
--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -37,6 +37,11 @@ jobs:
           
       - name: Checkout code without submodules
         uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
       
       - name: Get or restore dependencies
         run: scripts/restore-deps.sh


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Mac CI now actually installs Node

## Description

Don't just hope npm exists
