### PR TITLE
Update elfutils submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -63,7 +63,7 @@
 	url = https://github.com/adamnovak/backward-cpp.git
 [submodule "deps/elfutils"]
 	path = deps/elfutils
-	url = git://sourceware.org/git/elfutils.git
+	url = https://sourceware.org/git/elfutils.git
 [submodule "deps/structures"]
 	path = deps/structures
 	url = https://github.com/vgteam/structures.git


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Changed the protocol of the `elfutils` submodule from git:// to https:// 

## Description

With this change #2491 can be resolved in some cases.