### PR TITLE
Better error messages from vg haplotypes

### DIFF
--- a/src/kff.hpp
+++ b/src/kff.hpp
@@ -84,7 +84,7 @@ public:
     typedef gbwtgraph::Key64::value_type kmer_type;
 
     /// Creates a new reader for the given file. Throws `std::runtime_error` if the
-    /// sanity checks fail.
+    /// file cannot be opened or the sanity checks fail.
     ParallelKFFReader(const std::string& filename);
 
     /// Reads the next `n` kmers and counts from the file. This can be called safely


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Better error messages from `vg haplotypes`.

## Description

Better error messages from `vg haplotypes`, particularly when the KFF file or the haplotype information file cannot be opened. Also try to catch more exceptions and report the errors without the garbage surrounding uncaught exceptions.