### PR TITLE
Allow forcing a different CXX_STANDARD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -509,7 +509,8 @@ test: $(BIN_DIR)/$(EXE) $(LIB_DIR)/libvg.a test/build_graph $(BIN_DIR)/shuf $(BI
 	# Hide the compiler configuration from the doc tests, so that the ones that
 	# build code can't pick up libraries out of the bg build itself. Definitely
 	# don't source source_me.sh!
-	CFLAGS= CXXFLAGS= CPPFLAGS= LDFLAGS= INCLUDE_FLAGS= LIBRARY_PATH= LD_LIBRARY_PATH= DYLD_LIBRARY_PATH= DYLD_FALLBACK_LIBRARY_PATH= LD_INCLUDE_PATH= CC= CXX= CXX_STANDARD= doc/test-docs.sh
+	# But still supply vg on the PATH. Hope it knows where its own libraries are.
+	CFLAGS= CXXFLAGS= CPPFLAGS= LDFLAGS= INCLUDE_FLAGS= LIBRARY_PATH= LD_LIBRARY_PATH= DYLD_LIBRARY_PATH= DYLD_FALLBACK_LIBRARY_PATH= LD_INCLUDE_PATH= CC= CXX= CXX_STANDARD= PATH=$(CWD)/bin:$(PATH) doc/test-docs.sh
 
 # Somebody has been polluting the test directory with temporary files that are not deleted after the tests.
 # To make git status more useful, we delete everything that looks like a temporary file.

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ ifeq ($(shell uname -s),Darwin)
     LD_UTIL_RPATH_FLAGS=""
 
     # Homebrew installs a Protobuf that uses an Abseil that is built with C++17, so we need to build with at least C++17
-    CXX_STANDARD=17
+    CXX_STANDARD?=17
 
     # We may need libraries from Macports
     ifeq ($(shell if [ -d /opt/local/lib ];then echo 1;else echo 0;fi), 1)
@@ -221,7 +221,7 @@ else
     $(info Compiler $(CXX) is assumed to be GCC)
 
     # Linux can have some old compilers so we want to work back to C++14
-    CXX_STANDARD=14
+    CXX_STANDARD?=14
 
     # Set an rpath for vg and dependency utils to find installed libraries
     LD_UTIL_RPATH_FLAGS="-Wl,-rpath,$(CWD)/$(LIB_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -506,7 +506,10 @@ deps: $(DEPS)
 
 test: $(BIN_DIR)/$(EXE) $(LIB_DIR)/libvg.a test/build_graph $(BIN_DIR)/shuf $(BIN_DIR)/vcf2tsv $(FASTAHACK_DIR)/fastahack $(BIN_DIR)/rapper
 	. ./source_me.sh && cd test && prove -v t
-	. ./source_me.sh && doc/test-docs.sh
+	# Hide the compiler configuration from the doc tests, so that the ones that
+	# build code can't pick up libraries out of the bg build itself. Definitely
+	# don't source source_me.sh!
+	CFLAGS= CXXFLAGS= CPPFLAGS= LDFLAGS= INCLUDE_FLAGS= LIBRARY_PATH= LD_LIBRARY_PATH= DYLD_LIBRARY_PATH= DYLD_FALLBACK_LIBRARY_PATH= LD_INCLUDE_PATH= CC= CXX= CXX_STANDARD= doc/test-docs.sh
 
 # Somebody has been polluting the test directory with temporary files that are not deleted after the tests.
 # To make git status more useful, we delete everything that looks like a temporary file.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg Makefile now can take a CXX_STANDARD variable in

## Description
You should be able to e.g. `make CXX_STANDARD=20` if you have a Protobuf/Abseil that require it.
