### PR TITLE
Extend autoindex rewinding functionality to apply to GCSA2 memory use

### DIFF
--- a/src/build_index.cpp
+++ b/src/build_index.cpp
@@ -28,7 +28,7 @@ void build_gcsa_lcp(const HandleGraph& graph,
     params.reduceLimit(kmer_bytes);
 
     // set up the input graph using the kmers
-    gcsa::InputGraph input_graph({ tmpfile }, true);
+    gcsa::InputGraph input_graph({ tmpfile }, true, params);
     // run the GCSA construction
     gcsa = new gcsa::GCSA(input_graph, params);
     // and the LCP array construction

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -160,8 +160,11 @@ public:
     /// plan, and false if it is to be preserved.
     bool is_intermediate(const IndexName& identifier) const;
     
-    /// TODO: is this where this function wants to live?
+    // TODO: is this where this function wants to live?
+    /// The memory limit, with a little slosh for prediction inaccuracy
     int64_t target_memory_usage() const;
+    /// The mmeory limit with no slosh
+    int64_t literal_target_memory_usage() const;
     
     /// Returns the recipes in the plan that depend on this index, including the one in which
     /// it was created (if any)

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -599,7 +599,7 @@ int main_index(int argc, char** argv) {
         if (show_progress) {
             cerr << "Building the GCSA2 index..." << endl;
         }
-        gcsa::InputGraph input_graph(dbg_names, true, gcsa::Alphabet(), mapping_name);
+        gcsa::InputGraph input_graph(dbg_names, true, params, gcsa::Alphabet(), mapping_name);
         gcsa::GCSA gcsa_index(input_graph, params);
         gcsa::LCPArray lcp_array(input_graph, params);
         if (show_progress) {

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -625,8 +625,8 @@ int main_msga(int argc, char** argv) {
                         write_gcsa_kmers_to_tmpfile(path_graph, idx_kmer_size, limit, head_id, tail_id));
                 });
             // Make the index with the kmers
-            gcsa::InputGraph input_graph(tmpfiles, true);
-            gcsa::ConstructionParameters params;
+          gcsa::ConstructionParameters params;
+            gcsa::InputGraph input_graph(tmpfiles, true, params);
             params.setSteps(doubling_steps);
             // build the GCSA index
             gcsaidx = new gcsa::GCSA(input_graph, params);

--- a/test/t/52_vg_autoindex.t
+++ b/test/t/52_vg_autoindex.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 48
+plan tests 49
 
 rm auto.*
 

--- a/test/t/52_vg_autoindex.t
+++ b/test/t/52_vg_autoindex.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 47
+plan tests 48
 
 rm auto.*
 
@@ -149,6 +149,10 @@ is "$(echo $?)" 0 "Indexing is successful after rewinding from k-mer generation"
 
 # reduce disk limit to 2MB to trigger it during doubling steps
 is "$(vg autoindex -p auto -w map --gcsa-size-limit 2000000 -g graphs/linked_cycles.gfa 2>&1 | grep Rewind | wc -l)" 1 "Running out of room during GCSA2 indexing triggers a rewind"
+is "$(echo $?)" 0 "Indexing is successful after rewinding from GCSA2 indexing"
+
+# use the memory limit to trigger a rewide
+is "$(vg autoindex -p auto -w map -M 512M -g graphs/linked_cycles.gfa 2>&1 | grep Rewind | wc -l)" 1 "Running out of memory during GCSA2 indexing triggers a rewind"
 is "$(echo $?)" 0 "Indexing is successful after rewinding from GCSA2 indexing"
 
 rm auto.*


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GCSA2 construction in `vg autoindex` rewinds to pruning if memory is too high

## Description

Updates GCSA2 to include a memory-monitoring functionality and uses it in `vg autoindex`. The `autoindex` feature that rewinds to the pruning step when GCSA2's disk use is excessive now also applies to RAM use. 

This issue was mentioned in https://github.com/vgteam/vg/issues/4116.
