### PR TITLE
Set reference

### DIFF
--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 149
+plan tests 151
 
 
 # Build vg graphs for two chromosomes
@@ -397,8 +397,11 @@ is "$(vg paths -M -S GRCh37 -x gfa2.gbz | grep -v "^#" | cut -f2 | grep HAPLOTYP
 is "$(vg paths -M -S CHM13 -x gfa2.gbz | grep -v "^#" | cut -f2 | grep REFERENCE | wc -l)" "1" "Changing reference_samples tag can make a haplotype a reference"
 vg gbwt -g gfa2.gbz --gbz-format -Z gfa.gbz --set-tag "reference_samples=GRCh38#1 CHM13" 2>/dev/null
 is $? 1 "GBZ GBWT tag modification validation works"
+vg gbwt -g gfa3.gbz --gbz-format --set-reference GRCh37 --set-reference CHM13 -Z gfa2.gbz
+is $? 0 "Samples can be direcly set as references"
+is "$(vg gbwt --tags -Z gfa3.gbz | grep reference_samples | cut -f 2)" "GRCh37 CHM13" "Direct reference assignment works"
 
-rm -f gfa.gbz gfa2.gbz tags.tsv
+rm -f gfa.gbz gfa2.gbz gfa3.gbz tags.tsv
 
 # Build a GBZ from a graph with a reference but no haplotype phase number
 # TODO: When <https://github.com/vgteam/vg/issues/4110> is fixed, actually parse this as GFA


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Set reference samples in GBWT or GBZ with option `--set-reference`.

## Description

Changing reference samples in a GBZ graph is kind of annoying. I added a convenience option `--set-reference` to `vg gbwt` to make this a bit cleaner. The following commands are now equivalent:

```
vg gbwt --set-tag "reference_samples=GRCh38 CHM13" --gbz-format -g out.gbz -Z in.gbz
vg gbwt --set-reference GRCh38 --set-reference CHM13 --gbz-format -g out.gbz -Z in.gbz
```