### PR TITLE
Ensure that vg rna produces unique HST names

### DIFF
--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -292,7 +292,7 @@ int32_t main_rna(int32_t argc, char** argv) {
 
         // Load GBZ file 
         unique_ptr<gbwtgraph::GBZ> gbz = vg::io::VPKG::load_one<gbwtgraph::GBZ>(graph_filename);
-
+        
         if (show_progress) { cerr << "[vg rna] Converting graph format ..." << endl; }
 
         // Convert GBWTGraph to mutable graph type (PackedGraph).
@@ -305,7 +305,7 @@ int32_t main_rna(int32_t argc, char** argv) {
             handlegraph::algorithms::copy_path(&(gbz->graph), path, graph.get());
         });
 
-        haplotype_index = make_unique<gbwt::GBWT>(gbz->index);
+        haplotype_index = make_unique<gbwt::GBWT>(std::move(gbz->index));
     }
 
     if (graph == nullptr) {
@@ -322,7 +322,7 @@ int32_t main_rna(int32_t argc, char** argv) {
     transcriptome.feature_type = feature_type;
     transcriptome.transcript_tag = transcript_tag;
     transcriptome.path_collapse_type = path_collapse_type;
-
+    
     if (show_progress) { cerr << "[vg rna] Graph " << ((!haplotype_index->empty()) ? "and GBWT index " : "") << "parsed in " << gcsa::readTimer() - time_parsing_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
 
 
@@ -354,7 +354,6 @@ int32_t main_rna(int32_t argc, char** argv) {
 
         if (show_progress) { cerr << "[vg rna] Introns parsed and graph updated in " << gcsa::readTimer() - time_intron_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
     }
-
 
     vector<istream *> transcript_streams;
 

--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -324,11 +324,12 @@ class Transcriptome {
         void project_haplotype_transcripts_callback(list<CompletedTranscriptPath> * completed_transcript_paths, spp::sparse_hash_map<handle_t, vector<CompletedTranscriptPath *> > * completed_transcript_paths_index,  mutex * completed_transcript_paths_mutex, const int32_t thread_idx, const vector<Transcript> & transcripts, const gbwt::GBWT & haplotype_index, const bdsg::PositionOverlay & graph_path_pos_overlay, const bool proj_emded_paths, const float mean_node_length);
 
         /// Projects transcripts onto haplotypes in a GBWT index and returns the resulting transcript paths.
-        list<EditedTranscriptPath> project_transcript_gbwt(const Transcript & cur_transcript, const gbwt::GBWT & haplotype_index, const float mean_node_length) const;
+        list<EditedTranscriptPath> project_transcript_gbwt(const Transcript & cur_transcript, const gbwt::GBWT & haplotype_index,
+                                                           const unordered_set<string>& reference_samples, const float mean_node_length) const;
 
         /// Extracts all unique haplotype paths between two nodes from a GBWT index and returns the 
         /// resulting paths and the corresponding haplotype ids for each path.
-        vector<pair<exon_nodes_t, thread_ids_t> > get_exon_haplotypes(const vg::id_t start_node, const vg::id_t end_node, const gbwt::GBWT & haplotype_index, const int32_t expected_length) const;
+        vector<pair<exon_nodes_t, thread_ids_t> > get_exon_haplotypes(const vg::id_t start_node, const vg::id_t end_node, const gbwt::GBWT & haplotype_index,  const unordered_set<string>& reference_samples, const int32_t expected_length) const;
 
         /// Remove redundant transcript paths and update index.
         template <class T>


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

* `vg rna` no longer projects transcripts twice onto a reference given by `RS` tag in a GFA
* `vg rna` assigns unique names to twice-projected transcripts on cyclic haplotypes

## Description

There were a few overlapping bugs having to do with `vg rna`'s projection algorithm when applied with new haplotype naming conventions. First, we were projecting reference transcripts back onto the reference whenever the reference was given as a W line with an RS tag. Second, when a transcript projected multiple times to the same haplotype (which can happen in cyclic, copy number variant genes) they were given the same identifier, which violated `rpvg`'s assumptions downstream, leading to a crash.

