### PR TITLE
add error message when -S turns up no paths

### DIFF
--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -582,6 +582,17 @@ int main_call(int argc, char** argv) {
         swap(ref_paths, ref_subpaths);
     }
 
+    // make sure we have some ref paths
+    if (ref_paths.empty()) {
+        if (!ref_sample.empty()) {
+            cerr << "error [vg call]: No paths with selected reference sample \"" << ref_sample << "\" found. "
+                 << "Try using vg paths -M to see which samples are in your graph" << endl;
+            return 1;
+        }
+        cerr << "error [vg call]: No reference paths found" << endl;
+        return 1;
+    }
+
     // build table of ploidys
     vector<int> ref_path_ploidies;
     for (const string& ref_path : ref_paths) {


### PR DESCRIPTION
As seen in #4147, if you use `-S` with `vg call` to select a sample that's not in the graph, you get a crash and a stack trace.  This patch turns that into an error message. 
