### PR TITLE
Automatically resize GBWT construction buffer

### DIFF
--- a/src/recombinator.cpp
+++ b/src/recombinator.cpp
@@ -23,6 +23,7 @@ constexpr size_t HaplotypePartitioner::SUBCHAIN_LENGTH;
 constexpr size_t HaplotypePartitioner::APPROXIMATE_JOBS;
 
 constexpr size_t Recombinator::NUM_HAPLOTYPES;
+constexpr size_t Recombinator::NUM_CANDIDATES;
 constexpr size_t Recombinator::COVERAGE;
 constexpr size_t Recombinator::KFF_BLOCK_SIZE;
 constexpr double Recombinator::PRESENT_DISCOUNT;

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -364,6 +364,9 @@ public:
     /// Number of haplotypes to be generated.
     constexpr static size_t NUM_HAPLOTYPES = 4;
 
+    /// A reasonable number of candidates for diploid sampling.
+    constexpr static size_t NUM_CANDIDATES = 32;
+
     /// Expected kmer coverage. Use 0 to estimate from kmer counts.
     constexpr static size_t COVERAGE = 0;
 
@@ -430,7 +433,8 @@ public:
 
     /// Parameters for `generate_haplotypes()`.
     struct Parameters {
-        /// Number of haplotypes to be generated.
+        /// Number of haplotypes to be generated, or the number of candidates
+        /// for diploid sampling.
         size_t num_haplotypes = NUM_HAPLOTYPES;
 
         /// Kmer coverage. Use 0 to estimate from kmer counts.

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -51,6 +51,10 @@ constexpr size_t haplotypes_default_n() {
     return Recombinator::NUM_HAPLOTYPES;
 }
 
+constexpr size_t haplotypes_default_candidates() {
+    return Recombinator::NUM_CANDIDATES;
+}
+
 constexpr size_t haplotypes_default_coverage() {
     return Recombinator::COVERAGE;
 }
@@ -211,6 +215,7 @@ void help_haplotypes(char** argv, bool developer_options) {
     std::cerr << "Options for sampling haplotypes:" << std::endl;
     std::cerr << "        --coverage N          kmer coverage in the KFF file (default: estimate)" << std::endl;
     std::cerr << "        --num-haplotypes N    generate N haplotypes (default: " << haplotypes_default_n() << ")" << std::endl;
+    std::cerr << "                              sample from N candidates (with --diploid-sampling; default: " << haplotypes_default_candidates() << ")" << std::endl;
     std::cerr << "        --present-discount F  discount scores for present kmers by factor F (default: " << haplotypes_default_discount() << ")" << std::endl;
     std::cerr << "        --het-adjustment F    adjust scores for heterozygous kmers by F (default: " << haplotypes_default_adjustment() << ")" << std::endl;
     std::cerr << "        --absent-score F      score absent kmers -F/+F (default: " << haplotypes_default_absent()  << ")" << std::endl;
@@ -282,6 +287,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
     // Process the arguments.
     int c;
     optind = 2; // force optind past command positional argument
+    bool num_haplotypes_set = false;
     while (true) {
         int option_index = 0;
         c = getopt_long(argc, argv, "g:H:d:r:i:k:v:t:h", long_options, &option_index);
@@ -335,6 +341,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
             break;
         case OPT_NUM_HAPLOTYPES:
             this->recombinator_parameters.num_haplotypes = parse<size_t>(optarg);
+            num_haplotypes_set = true;
             if (this->recombinator_parameters.num_haplotypes == 0) {
                 std::cerr << "error: [vg haplotypes] number of haplotypes cannot be 0" << std::endl;
                 std::exit(EXIT_FAILURE);
@@ -442,6 +449,11 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
     if (this->mode == mode_invalid) {
         help_haplotypes(argv, false);
         std::exit(EXIT_FAILURE);
+    }
+
+    // Use conditional defaults if the user did not override them.
+    if (this->recombinator_parameters.diploid_sampling && !num_haplotypes_set) {
+        this->recombinator_parameters.num_haplotypes = haplotypes_default_candidates();
     }
 }
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GBWT construction automatically increases buffer size if the paths are too long.
 * Default number of candidate haplotypes for diploid sampling is now 32.

## Description

GBWT construction will now resize the buffer automatically if the paths are too long to fit in. This fixes #4167. For best performabce, buffer size should be set manually when building large GBWTs. Automatic resizing likely means that the paths will be inserted one at a time.

The default number of candidate haplotypes for diploid sampling is also increased to 32.