### PR TITLE
Recognize sample#contig paths in GFA to GBWTGraph

### DIFF
--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -12,25 +12,36 @@ gbwtgraph::GFAParsingParameters get_best_gbwtgraph_gfa_parsing_parameters() {
     // Configure GBWTGraph GFA parsing to be as close to the vg GFA parser as we can get.
     // TODO: Make it closer.
     parameters.path_name_formats.clear();
-    // Parse panSN with a fragment after it.
+
+    // Parse panSN with a fragment after it (e.g. HG002#1#chr3#1).
     parameters.path_name_formats.emplace_back(
         gbwtgraph::GFAParsingParameters::PAN_SN_REGEX + "#([0-9][0-9]*)",
         gbwtgraph::GFAParsingParameters::PAN_SN_FIELDS + "F",
         gbwtgraph::GFAParsingParameters::PAN_SN_SENSE
     );
+
     // Parse panSN with a range after it as a normal but with a fragment based
-    // on start position.
+    // on start position (e.g. HG002#1#chr3#1566235).
     parameters.path_name_formats.emplace_back(
         gbwtgraph::GFAParsingParameters::PAN_SN_REGEX + "\\[([0-9][0-9]*)(-[0-9]*)?\\]",
         gbwtgraph::GFAParsingParameters::PAN_SN_FIELDS + "F",
         gbwtgraph::GFAParsingParameters::PAN_SN_SENSE
     );
-    // Parse standard panSN as what we think that is
+
+    // Parse standard panSN as what we think that is (e.g. HG002#1#chr3).
     parameters.path_name_formats.emplace_back(
         gbwtgraph::GFAParsingParameters::PAN_SN_REGEX,
         gbwtgraph::GFAParsingParameters::PAN_SN_FIELDS,
         gbwtgraph::GFAParsingParameters::PAN_SN_SENSE
     );
+
+    // Parse path names with a sample and a contig (e.g. GRCh38#chr3).
+    parameters.path_name_formats.emplace_back(
+        "(.*)#(.*)",
+        "XSC",
+        PathSense::HAPLOTYPE
+    );
+
     // Parse paths with just a name and a range as generic paths with a contig
     // and a fragment. Sample for generic paths gets provided automatically.
     parameters.path_name_formats.emplace_back(
@@ -38,12 +49,14 @@ gbwtgraph::GFAParsingParameters get_best_gbwtgraph_gfa_parsing_parameters() {
         "XCF",
         PathSense::GENERIC
     );
+
     // Parse paths with nothing to distinguish them the default way (as generic named paths)
     parameters.path_name_formats.emplace_back(
         gbwtgraph::GFAParsingParameters::DEFAULT_REGEX,
         gbwtgraph::GFAParsingParameters::DEFAULT_FIELDS,
         gbwtgraph::GFAParsingParameters::DEFAULT_SENSE
     );
+
     return parameters;
 }
 

--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -21,7 +21,7 @@ gbwtgraph::GFAParsingParameters get_best_gbwtgraph_gfa_parsing_parameters() {
     );
 
     // Parse panSN with a range after it as a normal but with a fragment based
-    // on start position (e.g. HG002#1#chr3#[1566235] or HG002#1#chr3#[1566235-2397571]).
+    // on start position (e.g. HG002#1#chr3[1566235] or HG002#1#chr3[1566235-2397571]).
     parameters.path_name_formats.emplace_back(
         gbwtgraph::GFAParsingParameters::PAN_SN_REGEX + "\\[([0-9][0-9]*)(-[0-9]*)?\\]",
         gbwtgraph::GFAParsingParameters::PAN_SN_FIELDS + "F",

--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -21,7 +21,7 @@ gbwtgraph::GFAParsingParameters get_best_gbwtgraph_gfa_parsing_parameters() {
     );
 
     // Parse panSN with a range after it as a normal but with a fragment based
-    // on start position (e.g. HG002#1#chr3#1566235).
+    // on start position (e.g. HG002#1#chr3#[1566235] or HG002#1#chr3#[1566235-2397571]).
     parameters.path_name_formats.emplace_back(
         gbwtgraph::GFAParsingParameters::PAN_SN_REGEX + "\\[([0-9][0-9]*)(-[0-9]*)?\\]",
         gbwtgraph::GFAParsingParameters::PAN_SN_FIELDS + "F",

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -404,8 +404,7 @@ is "$(vg gbwt --tags -Z gfa3.gbz | grep reference_samples | cut -f 2)" "GRCh37 C
 rm -f gfa.gbz gfa2.gbz gfa3.gbz tags.tsv
 
 # Build a GBZ from a graph with a reference but no haplotype phase number
-# TODO: When <https://github.com/vgteam/vg/issues/4110> is fixed, actually parse this as GFA
-vg gbwt -g gfa.gbz --gbz-format -E -x graphs/gfa_two_part_reference.gfa
+vg gbwt -g gfa.gbz --gbz-format -G graphs/gfa_two_part_reference.gfa
 is "$(vg paths -M --reference-paths -x gfa.gbz | grep -v "^#" | cut -f4 | grep NO_HAPLOTYPE | wc -l)" "2" "GBZ can represent reference paths without haplotype numbers"
 
 rm -f gfa.gbz


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GBWTGraph algorithm for parsing GFA now handles P-line names of the form `sample#contig` correctly.

## Description

Function `get_best_gbwtgraph_gfa_parsing_parameters()` was missing name pattern `sample#contig`, which is sometimes used for reference paths stored as P-lines. This PR adds the pattern. When there are no W-lines in the GFA, paths with a name matching that pattern will be parsed as haplotype paths with no haplotype/phase number. They can be promoted to reference paths using tag `RS` in the header.

This resolves #4110.