### PR TITLE
Reference vg-data at its new home

### DIFF
--- a/scripts/mcmc_Makefile
+++ b/scripts/mcmc_Makefile
@@ -85,10 +85,10 @@ clean:
 	rm -r $(TOIL_OS) 
 
 CHR21.fa:
-	wget https://courtyard.gi.ucsc.edu/~anovak/vg-data/bakeoff/CHR21.fa
+	wget https://public.gi.ucsc.edu/~anovak/vg-data/bakeoff/CHR21.fa
 
 1kg_hg19-CHR21.vcf.gz:
-	wget https://courtyard.gi.ucsc.edu/~anovak/vg-data/bakeoff/1kg_hg19-CHR21.vcf.gz
+	wget https://public.gi.ucsc.edu/~anovak/vg-data/bakeoff/1kg_hg19-CHR21.vcf.gz
 
 1kg_hg19-CHR21.vcf.gz.tbi:
-	wget https://courtyard.gi.ucsc.edu/~anovak/vg-data/bakeoff/1kg_hg19-CHR21.vcf.gz.tbi
+	wget https://public.gi.ucsc.edu/~anovak/vg-data/bakeoff/1kg_hg19-CHR21.vcf.gz.tbi

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -54,8 +54,8 @@ class VGCITest(TestCase):
         # when moving to a more inclusive reference?
         self.worse_threshold = 0.005
         # /public/groups/vg/vg-data on Courtyard is served as
-        # https://courtyard.gi.ucsc.edu/~anovak/vg-data/
-        self.vg_data = 'https://courtyard.gi.ucsc.edu/~anovak/vg-data'
+        # https://public.gi.ucsc.edu/~anovak/vg-data/
+        self.vg_data = 'https://public.gi.ucsc.edu/~anovak/vg-data'
         self.input_store = self.vg_data + '/bakeoff'
         self.vg_docker = None
         self.container = None # Use default in toil-vg, which is Docker


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg CI can now find its test data again

## Description

`courtyard`'s URL apparently was never meant to be stable; `public.gi.ucsc.edu` is meant to be stable and should stick around.