### PR TITLE
Unified parallel GBWT construction

### DIFF
--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -532,6 +532,38 @@ std::string compose_short_path_name(const gbwt::GBWT& gbwt_index, gbwt::size_typ
 
 //------------------------------------------------------------------------------
 
+void copy_reference_samples(const gbwt::GBWT& source, gbwt::GBWT& destination) {
+    if (source.tags.contains(gbwtgraph::REFERENCE_SAMPLE_LIST_GBWT_TAG)) {
+        // Reference samples tag is not copied automatically.
+        destination.tags.set(
+            gbwtgraph::REFERENCE_SAMPLE_LIST_GBWT_TAG,
+            source.tags.get(gbwtgraph::REFERENCE_SAMPLE_LIST_GBWT_TAG)
+        );
+    }
+}
+
+void copy_reference_samples(const PathHandleGraph& source, gbwt::GBWT& destination) {
+    std::vector<std::string> reference_samples;
+    source.for_each_path_of_sense(PathSense::REFERENCE, [&](const path_handle_t& path) {
+        std::string sample_name = source.get_sample_name(path);
+        if (sample_name != PathMetadata::NO_SAMPLE_NAME) {
+            reference_samples.push_back(sample_name);
+        }
+    });
+
+    if (!reference_samples.empty()) {
+        std::string reference_samples_tag = reference_samples.front();
+        for (size_t i = 1; i < reference_samples.size(); i++) {
+            reference_samples_tag += gbwtgraph::REFERENCE_SAMPLE_LIST_SEPARATOR + reference_samples[i];
+        }
+        destination.tags.set(
+            gbwtgraph::REFERENCE_SAMPLE_LIST_GBWT_TAG, reference_samples_tag
+        );
+    }
+}
+
+//------------------------------------------------------------------------------
+
 gbwt::GBWT get_gbwt(const std::vector<gbwt::vector_type>& paths) {
     gbwt::size_type node_width = 1, total_length = 0;
     for (auto& path : paths) {

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -182,6 +182,7 @@ struct RebuildParameters {
     gbwt::size_type sample_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL;
 };
 
+// TODO: Use the new parallelization scheme.
 /// Rebuild the GBWT by applying all provided mappings. Each mapping is a pair
 /// (original subpath, new subpath). If the original subpath is empty, the
 /// mapping is ignored. If there are multiple applicable mappings, the first one
@@ -238,6 +239,16 @@ Path extract_gbwt_path(const HandleGraph& graph, const gbwt::GBWT& gbwt_index, g
 /// GBWT metadata, made of just the sample and contig and haplotype.
 /// NOTE: id is a gbwt path id, not a gbwt sequence id.
 std::string compose_short_path_name(const gbwt::GBWT& gbwt_index, gbwt::size_type id);
+
+//------------------------------------------------------------------------------
+
+/// Copies the reference sample tag from the source GBWT index to the destination GBWT index.
+void copy_reference_samples(const gbwt::GBWT& source, gbwt::GBWT& destination);
+
+/// Copies reference samples from the source graph to the destination GBWT index.
+/// Every sample with at least one reference path in the source graph is considered
+/// a reference sample.
+void copy_reference_samples(const PathHandleGraph& source, gbwt::GBWT& destination);
 
 //------------------------------------------------------------------------------
 

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -182,7 +182,6 @@ struct RebuildParameters {
     gbwt::size_type sample_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL;
 };
 
-// TODO: Use the new parallelization scheme.
 /// Rebuild the GBWT by applying all provided mappings. Each mapping is a pair
 /// (original subpath, new subpath). If the original subpath is empty, the
 /// mapping is ignored. If there are multiple applicable mappings, the first one
@@ -210,6 +209,9 @@ struct RebuildParameters {
 ///
 /// NOTE: Threads may be reordered if there are multiple jobs. Old thread ids are
 /// no longer valid after rebuilding the GBWT.
+///
+/// NOTE: This could use the ConstructionJob / MetadataBuilder scheme for
+/// parallelization, but it would change the interface.
 gbwt::GBWT rebuild_gbwt(const gbwt::GBWT& gbwt_index,
                         const std::vector<RebuildJob>& jobs,
                         const std::unordered_map<nid_t, size_t>& node_to_job,

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -341,7 +341,7 @@ vector<string> vcf_contigs(const string& filename) {
 size_t guess_parallel_gbwt_jobs(size_t node_count, size_t haplotype_count, size_t available_memory, size_t batch_size) {
 
     // Memory usage of the GBWT construction itself.
-    size_t bytes_per_node = 100 * std::max(std::log10(haplotype_count + 1), 1.0);
+    size_t bytes_per_node = 135 * std::max(std::log10(haplotype_count + 1), 1.0);
     // Construction buffers typically use 3-4 bytes per node, and the builder has two buffers.
     size_t bytes_per_job = batch_size * 8;
 
@@ -3909,9 +3909,10 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         params.sample_interval = IndexingParameters::gbwt_sampling_interval;
         params.max_node_length = IndexingParameters::max_node_size;
         // TODO: Here we assume that the GFA file contains 100 haplotypes. If there are more,
-        // we could safely launch more jobs.
+        // we could safely launch more jobs. Using 600 as the divisor would be a better
+        // estimate of the number of segments, but we chop long segments to 32 bp nodes.
         params.parallel_jobs = guess_parallel_gbwt_jobs(
-            std::max(get_file_size(gfa_filename) / 600, std::int64_t(1)),
+            std::max(get_file_size(gfa_filename) / 300, std::int64_t(1)),
             100,
             plan->target_memory_usage(),
             params.batch_size

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -2742,6 +2742,9 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                 parameters.batch_size
             );
             parameters.show_progress = (IndexingParameters::verbosity >= IndexingParameters::Debug);
+            if (IndexingParameters::verbosity >= IndexingParameters::Debug) {
+                std::cerr << "[IndexRegistry]: Running " << parameters.parallel_jobs << " jobs in parallel" << std::endl;
+            }
             cover = std::move(gbwtgraph::local_haplotypes(*xg_index, *gbwt_index, parameters, true, &path_filter));
             // Reference samples tag is not copied automatically.
             copy_reference_samples(*gbwt_index, cover);
@@ -2824,6 +2827,9 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             parameters.batch_size
         );
         parameters.show_progress = (IndexingParameters::verbosity >= IndexingParameters::Debug);
+        if (IndexingParameters::verbosity >= IndexingParameters::Debug) {
+            std::cerr << "[IndexRegistry]: Running " << parameters.parallel_jobs << " jobs in parallel" << std::endl;
+        }
         gbwt::GBWT cover = gbwtgraph::path_cover_gbwt(*xg_index, parameters, true, &path_filter);
         // Determine reference samples from reference paths.
         copy_reference_samples(*xg_index, cover);
@@ -3918,7 +3924,10 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             params.batch_size
         );
         params.show_progress = IndexingParameters::verbosity == IndexingParameters::Debug;
-        
+        if (IndexingParameters::verbosity >= IndexingParameters::Debug) {
+            std::cerr << "[IndexRegistry]: Running " << params.parallel_jobs << " jobs in parallel" << std::endl;
+        }
+
         // jointly generate the GBWT and record sequences
         unique_ptr<gbwt::GBWT> gbwt_index;
         unique_ptr<gbwtgraph::SequenceSource> seq_source;

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -2692,9 +2692,9 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                 return !Paths::is_alt(xg_index->get_path_name(path));
             };
 
-            // TODO: Determine the number of parallel jobs.
+            // FIXME: Determine the number of parallel jobs and set parameters.parallel_jobs.
             gbwtgraph::PathCoverParameters parameters;
-            parameters.num_paths = IndexingParameters::path_cover_depth;
+            parameters.num_paths = IndexingParameters::giraffe_gbwt_downsample;
             parameters.context = IndexingParameters::downsample_context_length;
             // TODO: See path cover for handling graphs with large components.
             parameters.batch_size = IndexingParameters::gbwt_insert_batch_size;
@@ -2712,6 +2712,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             
             gbwt::DynamicGBWT dynamic_index(*gbwt_index);
             gbwt_index.reset();
+            // Note that augmenting a GBWT is always single-threaded.
             gbwtgraph::PathCoverParameters parameters;
             parameters.num_paths = IndexingParameters::path_cover_depth;
             parameters.context = IndexingParameters::downsample_context_length;
@@ -2768,7 +2769,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         };
         
         // make a GBWT from a greedy path cover
-        // TODO: Determine the number of parallel jobs.
+        // FIXME: Determine the number of parallel jobs and set parameters.parallel_jobs.
         gbwtgraph::PathCoverParameters parameters;
         parameters.num_paths = IndexingParameters::path_cover_depth;
         parameters.context = IndexingParameters::downsample_context_length;
@@ -3854,6 +3855,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         string output_name = plan->output_filepath(gbz_output);
         
         gbwtgraph::GFAParsingParameters params = get_best_gbwtgraph_gfa_parsing_parameters();
+        // FIXME: Determine the number of parallel jobs and set params.parallel_jobs.
         // TODO: there's supposedly a heuristic to set batch size that could perform better than this global param,
         // but it would be kind of a pain to update it like we do the global param
         params.batch_size = IndexingParameters::gbwt_insert_batch_size;

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -521,7 +521,7 @@ private:
     // Generate haplotypes for the given chain.
     Statistics generate_haplotypes(const Haplotypes::TopLevelChain& chain,
         const hash_map<Haplotypes::Subchain::kmer_type, size_t>& kmer_counts,
-        gbwt::GBWTBuilder& builder,
+        gbwt::GBWTBuilder& builder, gbwtgraph::MetadataBuilder& metadata,
         const Parameters& parameters, double coverage) const;
 };
 

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -491,7 +491,7 @@ void help_convert(char** argv) {
          << "                           Not compatible with other GFA output options or non-GBWT graphs." << endl
          << "    --vg-algorithm         Always use the VG GFA algorithm. Works with all options and graph types," << endl
          << "                           but can't preserve original GFA coordinates." << endl
-         << "    --no-translation       When using the GBWTGraph algorith, convert the graph directly to GFA." << endl
+         << "    --no-translation       When using the GBWTGraph algorithm, convert the graph directly to GFA." << endl
          << "                           Do not use the translation to preserve original coordinates." << endl
          << "alignment options:" << endl
          << "    -G, --gam-to-gaf FILE  convert GAM FILE to GAF" << endl

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -123,6 +123,10 @@ struct GraphHandler {
     std::unique_ptr<gbwtgraph::GBWTGraph> gbwt_graph = nullptr;
     graph_type in_use = graph_none;
 
+    // Returns a pointer to any stored `PathHandleGraph` or loads one according to
+    // the config if there is no such graph.
+    const PathHandleGraph* get_any_graph(const GBWTConfig& config);
+
     // Load the `PathHandleGraph` specified in the config and release other graphs.
     // No effect if the handler already contains a `PathHandleGraph`.
     void get_graph(const GBWTConfig& config);
@@ -305,7 +309,7 @@ void help_gbwt(char** argv) {
     std::cerr << "        --set-tag K=V       set a GBWT tag (may repeat)" << std::endl;
     std::cerr << "        --set-reference X   set sample X as the reference (may repeat)" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Step 4: Path cover GBWT construction (requires -o, -x, and one of { -a, -l, -P }):" << std::endl;
+    std::cerr << "Step 4: Path cover GBWT construction (requires an input graph, -o, and one of { -a, -l, -P }):" << std::endl;
     std::cerr << "    -a, --augment-gbwt      add a path cover of missing components (one input GBWT)" << std::endl;
     std::cerr << "    -l, --local-haplotypes  sample local haplotypes (one input GBWT)" << std::endl;
     std::cerr << "    -P, --path-cover        build a greedy path cover (no input GBWTs)" << std::endl;
@@ -1013,8 +1017,11 @@ void validate_gbwt_config(GBWTConfig& config) {
     }
 
     if (config.path_cover != GBWTConfig::path_cover_none) {
-        if (!has_gbwt_output || config.graph_name.empty()) {
-            std::cerr << "error: [vg gbwt] path cover options require -x and output GBWT" << std::endl;
+        if (!has_gbwt_output || (config.graph_name.empty() && config.build != GBWTConfig::build_gbz && config.build != GBWTConfig::build_gbwtgraph)) {
+            // Path cover options needs a graph. We can use the provided graph or the GBZ/GBWTGraph
+            // we took as an input. In the latter case, we know that the corresponding GBWT has not
+            // been modified and the graph is hence safe to use.
+            std::cerr << "error: [vg gbwt] path cover options require an input graph and output GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
         }
         if (config.path_cover == GBWTConfig::path_cover_greedy && !config.input_filenames.empty()) {
@@ -1502,13 +1509,14 @@ void step_4_path_cover(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& con
     if (config.show_progress) {
         std::cerr << "Finding a " << config.num_paths << "-path cover with context length " << config.context_length << std::endl;
     }
-    
-    graphs.get_graph(config);
+
+    // Select the appropriate graph.
+    const PathHandleGraph* graph = graphs.get_any_graph(config);
     
     // We need to drop paths that are alt allele paths and not pass them
     // through from a graph that has them to the synthesized GBWT.
-    std::function<bool(const path_handle_t&)> path_filter = [&graphs](const path_handle_t& path) {
-        return !Paths::is_alt(graphs.path_graph->get_path_name(path));
+    std::function<bool(const path_handle_t&)> path_filter = [&graph](const path_handle_t& path) {
+        return !Paths::is_alt(graph->get_path_name(path));
     };
     
     if (config.path_cover == GBWTConfig::path_cover_greedy) {
@@ -1516,24 +1524,24 @@ void step_4_path_cover(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& con
             std::cerr << "Algorithm: greedy" << std::endl;
         }
         gbwt::GBWT cover = gbwtgraph::path_cover_gbwt(
-            *(graphs.path_graph), config.path_cover_parameters(),
+            *graph, config.path_cover_parameters(),
             config.include_named_paths, &path_filter
         );
-        copy_reference_samples(*(graphs.path_graph), cover);
+        copy_reference_samples(*graph, cover);
         gbwts.use(cover);
     } else if (config.path_cover == GBWTConfig::path_cover_augment) {
         if (config.show_progress) {
             std::cerr << "Algorithm: augment" << std::endl;
         }
         gbwts.use_dynamic();
-        gbwtgraph::augment_gbwt(*(graphs.path_graph), gbwts.dynamic, config.path_cover_parameters());
+        gbwtgraph::augment_gbwt(*graph, gbwts.dynamic, config.path_cover_parameters());
     } else {
         if (config.show_progress) {
             std::cerr << "Algorithm: local haplotypes" << std::endl;
         }
         gbwts.use_compressed();
         gbwt::GBWT cover = gbwtgraph::local_haplotypes(
-            *(graphs.path_graph), gbwts.compressed, config.path_cover_parameters(),
+            *graph, gbwts.compressed, config.path_cover_parameters(),
             config.include_named_paths, &path_filter
         );
         copy_reference_samples(gbwts.compressed, cover);
@@ -1709,6 +1717,15 @@ void step_8_threads(GBWTHandler& gbwts, GBWTConfig& config) {
 }
 
 //----------------------------------------------------------------------------
+
+const PathHandleGraph* GraphHandler::get_any_graph(const GBWTConfig& config) {
+    if (this->in_use == GraphHandler::graph_gbz || this->in_use == GraphHandler::graph_gbwtgraph) {
+        return this->gbwt_graph.get();
+    } else {
+        this->get_graph(config);
+        return this->path_graph.get();
+    }
+}
 
 void GraphHandler::get_graph(const GBWTConfig& config) {
     if (this->in_use == graph_path) {

--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -14,9 +14,9 @@
 #include <bdsg/overlays/path_position_overlays.hpp>
 #include <sparsepp/spp.h>
 
-#include "../vg.hpp"
-#include "../types.hpp"
-#include "../gbwt_helper.hpp"
+#include "vg.hpp"
+#include "types.hpp"
+#include "gbwt_helper.hpp"
 
 namespace vg {
 

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 151
+plan tests 159
 
 
 # Build vg graphs for two chromosomes
@@ -298,9 +298,14 @@ is $(vg gbwt -C xy.local.gbwt) 2 "local haplotypes: 2 contigs"
 is $(vg gbwt -H xy.local.gbwt) 16 "local haplotypes: 16 haplotypes"
 is $(vg gbwt -S xy.local.gbwt) 16 "local haplotypes: 16 samples"
 
-# Build GBZ from 16 paths of local haplotypes
-vg gbwt -x xy-alt.xg -g xy.local.gbz --gbz-format -l -n 16 -v small/xy2.vcf.gz
-is $? 0 "Local haplotypes GBZ construction"
+# Build GBZ from 16 paths of local haplotypes with a single job
+vg gbwt -x xy-alt.xg -g xy.local.gbz --gbz-format -l -n 16 --num-jobs 1 -v small/xy2.vcf.gz
+is $? 0 "Local haplotypes GBZ construction (single job)"
+is $(md5sum xy.local.gbz | cut -f 1 -d\ ) b6540312514c4e70aa45fc65b4bd762c "GBZ was serialized correctly"
+
+# As above, but with two parallel jobs
+vg gbwt -x xy-alt.xg -g xy.local.gbz --gbz-format -l -n 16 --num-jobs 2 -v small/xy2.vcf.gz
+is $? 0 "Local haplotypes GBZ construction (two jobs)"
 is $(md5sum xy.local.gbz | cut -f 1 -d\ ) b6540312514c4e70aa45fc65b4bd762c "GBZ was serialized correctly"
 
 rm -f xy.local.gg xy.local.gbwt xy.local.gbz
@@ -315,6 +320,18 @@ is $(vg gbwt -H xy.local.gbwt) 17 "local haplotypes w/ paths: 17 haplotypes"
 is $(vg gbwt -S xy.local.gbwt) 17 "local haplotypes w/ paths: 17 samples"
 
 rm -f xy.local.gg xy.local.gbwt
+
+# Build GBZ from a GFA and then build a local haplotype cover with reference paths from the GBZ
+vg gbwt -G haplotype-sampling/micb-kir3dl1.gfa -g large.gbz --gbz-format
+vg gbwt -Z large.gbz -l -n 16 --pass-paths -o large.local.gbwt
+is $? 0 "Local haplotypes with reference paths from a larger GBZ"
+is $(vg gbwt -c large.local.gbwt) 36 "local haplotypes w/ paths: 36 threads"
+is $(vg gbwt -C large.local.gbwt) 2 "local haplotypes w/ paths: 2 contigs"
+is $(vg gbwt -H large.local.gbwt) 18 "local haplotypes w/ paths: 18 haplotypes"
+is $(vg gbwt -S large.local.gbwt) 18 "local haplotypes w/ paths: 18 samples"
+is $(vg gbwt --tags large.local.gbwt | grep -c reference_samples) 1 "local haplotypes w/ paths: reference_samples set"
+
+rm -f large.gbz large.local.gbwt
 
 
 # Build GBWTGraph from an augmented GBWT
@@ -383,7 +400,7 @@ is $(wc -l < ref_paths.trans) 0 "ref paths: 0 translations"
 rm -f gfa.gbwt
 rm -f gfa2.gbwt gfa2.gg gfa2.trans gfa2.gbz
 rm -f ref_paths.gbwt ref_paths.gg ref_paths.trans
-rm -f chopping.gbwt chopping.gg chopping.trans from_gbz.trans
+rm -f chopping.gbwt chopping.gg chopping.gbz chopping.trans from_gbz.trans
 
 # Build a GBZ from a graph with a reference
 vg gbwt -g gfa.gbz --gbz-format -G graphs/gfa_with_reference.gfa

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -301,7 +301,7 @@ is $(vg gbwt -S xy.local.gbwt) 16 "local haplotypes: 16 samples"
 # Build GBZ from 16 paths of local haplotypes
 vg gbwt -x xy-alt.xg -g xy.local.gbz --gbz-format -l -n 16 -v small/xy2.vcf.gz
 is $? 0 "Local haplotypes GBZ construction"
-is $(md5sum xy.local.gbz | cut -f 1 -d\ ) 65d2290f32c200ea57212cb7b71075b0 "GBZ was serialized correctly"
+is $(md5sum xy.local.gbz | cut -f 1 -d\ ) b6540312514c4e70aa45fc65b4bd762c "GBZ was serialized correctly"
 
 rm -f xy.local.gg xy.local.gbwt xy.local.gbz
 
@@ -324,7 +324,7 @@ is $? 0 "Augmented GBWTGraph construction"
 is $(md5sum augmented.gg | cut -f 1 -d\ ) 00429586246711abcf1367a97d3c468c "GBWTGraph was serialized correctly"
 is $(vg gbwt -c augmented.gbwt) 18 "augmented: 18 threads"
 is $(vg gbwt -C augmented.gbwt) 2 "augmented: 2 contigs"
-is $(vg gbwt -H augmented.gbwt) 2 "augmented: 2 haplotypes"
+is $(vg gbwt -H augmented.gbwt) 18 "augmented: 18 haplotypes"
 is $(vg gbwt -S augmented.gbwt) 17 "augmented: 17 samples"
 
 rm -f x.gbwt augmented.gg augmented.gbwt


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Multithreaded path cover / local haplotypes GBWT construction.

## Description

This PR updates GBWTGraph to include unified support for multithreaded GBWT construction (see jltsiren/gbwtgraph#36). The main idea is to partition the graph into GBWT construction jobs using `gbwt_construction_jobs()`, create the final metadata with `MetadataBuilder`, pass reference paths with `assign_paths()` and `insert_paths()`, build partial GBWTs for the jobs in parallel, merge the GBWTs, and add metadata from `MetadataBuilder`.

* Path cover / local haplotypes GBWT construction uses this now, both in `vg gbwt` and `vg autoindex`. As a byproduct, we get parallelization for them.
* GBWT/GBZ construction from GFA already used this.
* Haplotype sampling in `vg haplotypes` uses this to the extent possible.
* `rebuild_gbwt()` still uses the old parallelization scheme, as it's built into the interface.