### PR TITLE
Fetch test reads over possibly-more-reliable HTTPS

### DIFF
--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -1284,7 +1284,7 @@ class VGCITest(TestCase):
                            sim_opts='-p 570 -v 150 -S 4 -i 0.002 -I',
                            # 800k 148bp reads from Genome in a Bottle NA12878 library
                            # (placeholder while finding something better)
-                           sim_fastq='ftp://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/NA12878/NIST_NA12878_HG001_HiSeq_300x/131219_D00360_005_BH814YADXX/Project_RM8398/Sample_U5a/U5a_AGTCAA_L002_R1_007.fastq.gz')
+                           sim_fastq='https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/NA12878/NIST_NA12878_HG001_HiSeq_300x/131219_D00360_005_BH814YADXX/Project_RM8398/Sample_U5a/U5a_AGTCAA_L002_R1_007.fastq.gz')
 
     @skip("skipping test to keep runtime down")        
     @timeout_decorator.timeout(2400)


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * CI should no longer fail due to truncated FTP download

## Description

This switches the read set we've been pulling over FTP to try HTTPS instead, since sometimes it was apparently being truncated.