### PR TITLE
Use the right DOI for the real GBZ paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please cite:
 * [The VG Paper](https://doi.org/10.1038/nbt.4227) when using `vg`
 * [The VG Giraffe Paper](https://doi.org/10.1126/science.abg8871) when using `vg giraffe`
 * [The VG Call Paper](https://doi.org/10.1186/s13059-020-1941-7) when SV genotyping with `vg call`
-* [The GBZ Paper](https://doi.org/10.1093/bioinformatics/btad097) when using GBZ
+* [The GBZ Paper](https://doi.org/10.1093/bioinformatics/btac656) when using GBZ
 * [The HPRC Paper](https://doi.org/10.1038/s41586-023-05896-x) when using `vg deconstruct`
 * [The Snarls Paper](https://doi.org/10.1089/cmb.2017.0251) when using `vg snarls`
 * [The Personalized Pangenome Paper](https://doi.org/10.1101/2023.12.13.571553) when using `vg haplotypes` and/or `vg giraffe --haplotype-name`


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GBZ paper citation link now points to the right place

## Description

As Daniel Doerr points out, the link was to the wrong paper. We probably want the one linked from https://github.com/jltsiren/gbwtgraph/blob/de61d340695f64b8aa978816b195d6687e7fda5a/README.md#citing-gbz-file-format
