### PR TITLE
Use P lines to improve GFA round-tripping

### DIFF
--- a/src/algorithms/gfa_to_handle.hpp
+++ b/src/algorithms/gfa_to_handle.hpp
@@ -106,7 +106,7 @@ void gfa_to_path_handle_graph(istream& in,
  * raise GFAFormatError or its subclasses if they do not like what the GFA is
  * saying. Some types of GFAFormatError can be caught internally and
  * processing of the file will continue with the next line, but *not* with the
- * next listener for that line, so the user is responsible for worring about
+ * next listener for that line, so the user is responsible for worrying about
  * what happens if some but not all listeners for something end up getting
  * called because one failed.
  */


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg GFA output should now use P lines instead of W lines when nonzero phase blocks are present, to allow them to be round-tripped.

## Description
This should fix #4240 by using P lines instead of W lines if a path has a nonzero phase block number.
