### PR TITLE
Better traversal size caps in vg call

### DIFF
--- a/src/algorithms/k_widest_paths.cpp
+++ b/src/algorithms/k_widest_paths.cpp
@@ -157,7 +157,8 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
                                                            size_t K,
                                                            function<double(const handle_t&)> node_weight_callback,
                                                            function<double(const edge_t&)> edge_weight_callback,
-                                                           bool greedy_avg) {
+                                                           bool greedy_avg,
+                                                           size_t max_path_length) {
 
     vector<pair<double, vector<handle_t>>> best_paths;
     best_paths.reserve(K);
@@ -170,6 +171,18 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
     best_paths.push_back(widest_dijkstra(g, source, sink, node_weight_callback,
                                          edge_weight_callback, [](handle_t) {return false;},
                                          [](edge_t) {return false;}, greedy_avg));
+
+    // keep track of longest path for early abort (if max_path_length set)
+    bool path_length_exceeded = false;
+    if (max_path_length != numeric_limits<size_t>::max()) {
+        size_t path_length = 0;
+        for (handle_t step : best_paths.back().second) {
+            path_length += g->get_length(step);
+        }
+        if (path_length > max_path_length) {
+            path_length_exceeded = true;
+        }
+    }
 
     // unable to get any kind of path.  this is either a bug in the search or the graph
     if (best_paths.back().second.empty()) {
@@ -186,13 +199,13 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
     multimap<double, map<vector<handle_t>, size_t>::iterator> score_to_B;
     
     // start scanning for our k-1 next-widest paths
-    for (size_t k = 1; k < K; ++k) {
+    for (size_t k = 1; k < K && !path_length_exceeded; ++k) {
 
         // we look for a "spur node" in the previous path.  the current path will be the previous path
         // up to that spur node, then a new path to the sink. (i is the index of the spur node in
         // the previous (k - 1) path
         vector<handle_t>& prev_path = best_paths[k - 1].second;
-        for (size_t i = best_spurs[k - 1]; i < prev_path.size() - 1; ++i) {
+        for (size_t i = best_spurs[k - 1]; i < prev_path.size() - 1 && !path_length_exceeded; ++i) {
             
             handle_t spur_node = prev_path[i];
             // root path = prev_path[0 : i]
@@ -299,6 +312,16 @@ vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g,
         best_spurs.push_back(best_B_it->second->second);
         B.erase(best_B_it->second);
         score_to_B.erase(best_B_it);
+
+        if (max_path_length != numeric_limits<size_t>::max()) {
+            size_t path_length = 0;
+            for (handle_t step : best_paths.back().second) {
+                path_length += g->get_length(step);
+            }
+            if (path_length > max_path_length) {
+                path_length_exceeded = true;
+            }
+        }
 
 #ifdef debug_vg_algorithms
         cerr << "adding best path (w=" << best_paths.back().first << "): ";

--- a/src/algorithms/k_widest_paths.hpp
+++ b/src/algorithms/k_widest_paths.hpp
@@ -8,6 +8,7 @@
  */
 
 #include <vector>
+#include <limits>
 
 #include "../position.hpp"
 #include "../handle.hpp"
@@ -33,11 +34,13 @@ pair<double, vector<handle_t>> widest_dijkstra(const HandleGraph* g, handle_t so
                                                bool greedy_avg = false);
 
 /// Find the k widest paths
+/// Search is aborted (and current list returned) if a path longer than max_path_length is added to the results
 vector<pair<double, vector<handle_t>>> yens_k_widest_paths(const HandleGraph* g, handle_t source, handle_t sink,
                                                            size_t K,
                                                            function<double(const handle_t&)> node_weight_callback,
                                                            function<double(const edge_t&)> edge_weight_callback,
-                                                           bool greedy_avg = false);
+                                                           bool greedy_avg = false,
+                                                           size_t max_path_length = numeric_limits<size_t>::max());
 
 }
 }

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -1612,7 +1612,7 @@ FlowCaller::FlowCaller(const PathPositionHandleGraph& graph,
                        bool gaf_output,
                        size_t trav_padding,
                        bool genotype_snarls,
-                       const pair<int64_t, int64_t>& ref_allele_length_range) :
+                       const pair<size_t, size_t>& allele_length_range) :
     GraphCaller(snarl_caller, snarl_manager),
     VCFOutputCaller(sample_name),
     GAFOutputCaller(aln_emitter, sample_name, ref_paths, trav_padding),
@@ -1622,7 +1622,7 @@ FlowCaller::FlowCaller(const PathPositionHandleGraph& graph,
     traversals_only(traversals_only),
     gaf_output(gaf_output),
     genotype_snarls(genotype_snarls),
-    ref_allele_length_range(ref_allele_length_range)
+    allele_length_range(allele_length_range)
 {
     for (int i = 0; i < ref_paths.size(); ++i) {
         ref_offsets[ref_paths[i]] = i < ref_path_offsets.size() ? ref_path_offsets[i] : 0;
@@ -1751,17 +1751,6 @@ bool FlowCaller::call_snarl(const Snarl& managed_snarl) {
     }
     assert(ref_trav.visit(0) == snarl.start() && ref_trav.visit(ref_trav.visit_size() - 1) == snarl.end());
 
-    // optional reference length clamp can, ex, avoid trying to resolve a giant snarl
-    if (ref_trav.visit_size() > 1 && ref_allele_length_range.first > 0 || ref_allele_length_range.second < numeric_limits<int64_t>::max()) {
-        size_t ref_trav_len = 0;
-        for (size_t j = 1; j < ref_trav.visit_size() - 1; ++j) {
-            ref_trav_len += graph.get_length(graph.get_handle(ref_trav.visit(j).node_id()));
-        }
-        if (ref_trav_len < ref_allele_length_range.first || ref_trav_len > ref_allele_length_range.second) {
-            return false;
-        }        
-    }
-
     vector<SnarlTraversal> travs;
     FlowTraversalFinder* flow_trav_finder = dynamic_cast<FlowTraversalFinder*>(&traversal_finder);
     if (flow_trav_finder != nullptr) {
@@ -1776,6 +1765,24 @@ bool FlowCaller::call_snarl(const Snarl& managed_snarl) {
     if (travs.empty()) {
         cerr << "Warning [vg call]: Unable, due to bug or corrupt graph, to search for any traversals through snarl " << pb2json(managed_snarl) << endl;
         return false;
+    }
+
+    // optional traversal length clamp can, ex, avoid trying to resolve a giant snarl    
+    if (allele_length_range.first > 0 || allele_length_range.second < numeric_limits<size_t>::max()) {
+        size_t max_trav_len = 0;
+        for (const SnarlTraversal & trav : travs) {
+            size_t trav_len = 0;
+            for (size_t i = 1; i < trav.visit_size() - 1; ++i) {
+                trav_len += graph.get_length(graph.get_handle(trav.visit(i).node_id()));
+            }
+            max_trav_len = max(max_trav_len, trav_len);
+            if (max_trav_len > allele_length_range.second) {
+                return false;
+            }
+        }
+        if (max_trav_len < allele_length_range.first) {
+            return false;
+        }
     }
 
     // find the reference traversal in the list of results from the traversal finder

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -371,7 +371,7 @@ public:
                bool gaf_output,
                size_t trav_padding,
                bool genotype_snarls,
-               const pair<int64_t, int64_t>& ref_allele_length_range);
+               const pair<size_t, size_t>& allele_length_range);
    
     virtual ~FlowCaller();
 
@@ -416,8 +416,11 @@ protected:
     ///  out to minimize variant size -- this turns all that off)
     bool genotype_snarls;
 
-    /// clamp calling to reference alleles of a given length range
-    pair<int64_t, int64_t> ref_allele_length_range;
+    /// clamp calling to alleles of a given length range
+    /// more specifically, a snarl is only called if
+    /// 1) its largest allele is >= allele_length_range.first and
+    /// 2) all alleles are < allele_length_range.second
+    pair<size_t, size_t> allele_length_range;
 };
 
 class SnarlGraph;

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -51,6 +51,9 @@ public:
     /// Call a given snarl, and print the output to out_stream
     virtual bool call_snarl(const Snarl& snarl) = 0;
 
+    /// toggle progress messages
+    void set_show_progress(bool show_progress);
+
 protected:
 
     /// Break up a chain into bits that we want to call using size heuristics
@@ -63,6 +66,9 @@ protected:
 
     /// Our snarls
     SnarlManager& snarl_manager;
+
+    /// Toggle progress messages
+    bool show_progress;
 };
 
 /**

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -761,7 +761,8 @@ int main_call(int argc, char** argv) {
 
             // create the flow traversal finder
             FlowTraversalFinder* flow_traversal_finder = new FlowTraversalFinder(*graph, *snarl_manager, max_yens_traversals,
-                                                                                 node_support, edge_support);
+                                                                                 node_support, edge_support,
+                                                                                 max_allele_len);
             traversal_finder = unique_ptr<TraversalFinder>(flow_traversal_finder);
         }
 

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -390,6 +390,8 @@ int main_call(int argc, char** argv) {
         if (gbz_paths) {
             if (show_progress) cerr << "[vg call]: Restricting search to GBZ haplotypes" << endl;
             gbwt_index = &gbz_graph->gbz.index;
+        } else {
+            cerr << "[vg call]: You can restrict the search to GBZ haplotypes, often to the benefict of speed and accuracy, with the -z option" << endl;
         }
     } else if (get<1>(input)) {
         path_handle_graph = std::move(get<1>(input));

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -47,8 +47,8 @@ void help_call(char** argv) {
        << "    -v, --vcf FILE          VCF file to genotype (must have been used to construct input graph with -a)" << endl
        << "    -a, --genotype-snarls   Genotype every snarl, including reference calls (use to compare multiple samples)" << endl
        << "    -A, --all-snarls        Genotype all snarls, including nested child snarls (like deconstruct -a)" << endl
-       << "    -c, --min-length N      Genotype only snarls with reference traversal length >= N" << endl
-       << "    -C, --max-length N      Genotype only snarls with reference traversal length <= N" << endl
+       << "    -c, --min-length N      Genotype only snarls with at least one traversal of length >= N" << endl
+       << "    -C, --max-length N      Genotype only snarls where all traversals have length <= N" << endl
        << "    -f, --ref-fasta FILE    Reference fasta (required if VCF contains symbolic deletions or inversions)" << endl
        << "    -i, --ins-fasta FILE    Insertions fasta (required if VCF contains symbolic insertions)" << endl
        << "    -s, --sample NAME       Sample name [default=SAMPLE]" << endl
@@ -106,8 +106,8 @@ int main_call(int argc, char** argv) {
     bool nested = false;
     bool call_chains = false;
     bool all_snarls = false;
-    int64_t min_ref_allele_len = 0;
-    int64_t max_ref_allele_len = numeric_limits<int64_t>::max();    
+    size_t min_allele_len = 0;
+    size_t max_allele_len = numeric_limits<size_t>::max();    
 
     // constants
     const size_t avg_trav_threshold = 50;
@@ -196,10 +196,10 @@ int main_call(int argc, char** argv) {
             all_snarls = true;
             break;
         case 'c':
-            min_ref_allele_len = parse<int64_t>(optarg);
+            min_allele_len = parse<size_t>(optarg);
             break;
         case 'C':
-            max_ref_allele_len = parse<int64_t>(optarg);
+            max_allele_len = parse<size_t>(optarg);
             break;
         case 'f':
             ref_fasta_filename = optarg;
@@ -359,7 +359,7 @@ int main_call(int argc, char** argv) {
         return 1;
     }
 
-    if ((min_ref_allele_len > 0 || max_ref_allele_len < numeric_limits<int64_t>::max()) && (legacy || !vcf_filename.empty() || nested)) {
+    if ((min_allele_len > 0 || max_allele_len < numeric_limits<size_t>::max()) && (legacy || !vcf_filename.empty() || nested)) {
         cerr << "error [vg call]: -c/-C no supported with -v, -l or -n" << endl;
         return 1;        
     }
@@ -787,7 +787,7 @@ int main_call(int argc, char** argv) {
                                               gaf_output,
                                               trav_padding,
                                               genotype_snarls,
-                                              make_pair(min_ref_allele_len, max_ref_allele_len)));
+                                              make_pair(min_allele_len, max_allele_len)));
         }
     }
 

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3336,12 +3336,19 @@ pair<vector<SnarlTraversal>, vector<double>> FlowTraversalFinder::find_weighted_
     
     handle_t start_handle = use_graph->get_handle(site.start().node_id(), site.start().backward());
     handle_t end_handle = use_graph->get_handle(site.end().node_id(), site.end().backward());
+
+    size_t max_path_length = max_traversal_length;
+    if (max_path_length != numeric_limits<size_t>::max()) {
+        // want to exclude snarl endpoints from path length clamp
+        max_path_length += use_graph->get_length(use_graph->get_handle(site.start().node_id())) +
+            use_graph->get_length(use_graph->get_handle(site.end().node_id()));
+    }
     
     vector<pair<double, vector<handle_t>>> widest_paths = algorithms::yens_k_widest_paths(use_graph, start_handle, end_handle, K,
                                                                                           node_weight_callback,
                                                                                           edge_weight_callback,
                                                                                           greedy_avg,
-                                                                                          max_traversal_length);
+                                                                                          max_path_length);
 
     vector<SnarlTraversal> travs;
     travs.reserve(widest_paths.size());

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -3309,12 +3309,14 @@ pair<step_handle_t, bool> VCFTraversalFinder::step_in_path(handle_t handle, path
 FlowTraversalFinder::FlowTraversalFinder(const HandleGraph& graph, SnarlManager& snarl_manager,
                                          size_t K,
                                          function<double(handle_t)> node_weight_callback,
-                                         function<double(edge_t)> edge_weight_callback) :
+                                         function<double(edge_t)> edge_weight_callback,
+                                         size_t max_traversal_length) :
     graph(graph),
     snarl_manager(snarl_manager),
     K(K),
     node_weight_callback(node_weight_callback),
-    edge_weight_callback(edge_weight_callback)  {
+    edge_weight_callback(edge_weight_callback),
+    max_traversal_length(max_traversal_length) {
     
 }
 
@@ -3338,7 +3340,8 @@ pair<vector<SnarlTraversal>, vector<double>> FlowTraversalFinder::find_weighted_
     vector<pair<double, vector<handle_t>>> widest_paths = algorithms::yens_k_widest_paths(use_graph, start_handle, end_handle, K,
                                                                                           node_weight_callback,
                                                                                           edge_weight_callback,
-                                                                                          greedy_avg);
+                                                                                          greedy_avg,
+                                                                                          max_traversal_length);
 
     vector<SnarlTraversal> travs;
     travs.reserve(widest_paths.size());

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -15,6 +15,7 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <list>
+#include <limits>
 
 #include <structures/immutable_list.hpp>
 
@@ -584,14 +585,19 @@ protected:
     /// Callbacks to get supports
     function<double(handle_t)> node_weight_callback;
     function<double(edge_t)> edge_weight_callback;
+
+    /// Call off the search as soon as a traversal of this length (bp) is encountered
+    size_t max_traversal_length;
     
 public:
     
     // if path_names not empty, only those paths will be considered
+    // if a traversal is found that exceeds max_traversal_length, then the search is called off
     FlowTraversalFinder(const HandleGraph& graph, SnarlManager& snarl_manager,
                         size_t K,
                         function<double(handle_t)> node_weight_callback,
-                        function<double(edge_t)> edge_weight_callback);
+                        function<double(edge_t)> edge_weight_callback,
+                        size_t max_traversal_length = numeric_limits<size_t>::max());
 
     /**
      * Return the K widest (most flow) traversals through the site


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg call` `-c` and `-C` options changed to limit search based on all alleles and not just reference allele.  This means these options work much better in practice to prevent `vg call` from being lost in giant snarls. 
 * `--progress` option added to `vg call`

## Description

It's come up a number of times where people try to run `vg call` on complex graphs and runs forever.  The reason being is that it gets lost trying to find traversals through enormous snarls, and there is not enough signal in the read mappings to narrow the search down to something manageable.  The min/max traversal cutoffs `-c/-C` were added to address this, but since they only filtered on reference allele length, they only helped sometimes -- it just takes a giant insertion to get around this.  This PR changes these options to take into account alt alleles as well.  So if you run `-c 50 -c 1000`, it will only try to genotype sites where at least one traversal is `>=50bp`, and it will give up on any site as soon as a single traversal `>1000bp` is found.  

