### PR TITLE
Pad libdeflate for renaming on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ ifeq ($(shell uname -s),Darwin)
     END_STATIC =
 
     # We need to use special flags to let us rename libraries
-    LD_RENAMEABLE_FLAGS = -headerpad -headerpad_max_install_names
+    LD_RENAMEABLE_FLAGS = -Wl,-headerpad -Wl,-headerpad_max_install_names
 else
     # We are not running on OS X
     $(info OS is Linux)

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,9 @@ ifeq ($(shell uname -s),Darwin)
     # We don't actually do any static linking on Mac, so we leave this empty.
     START_STATIC =
     END_STATIC =
+
+    # We need to use special flags to let us rename libraries
+    LD_RENAMEABLE_FLAGS = -headerpad -headerpad_max_install_names
 else
     # We are not running on OS X
     $(info OS is Linux)
@@ -252,7 +255,8 @@ else
     # Note that END_STATIC is only safe to use in a mostly-dynamic build, and has to appear or we will try to statically link secret trailing libraries.
     END_STATIC = -Wl,-Bdynamic
 
-
+    # We don't need any flags because we don't need to rename libraries with install_name_tool
+    LD_RENAMEABLE_FLAGS =
 endif
 
 # Set the C++ standard we are using
@@ -656,7 +660,7 @@ ifeq ($(shell uname -s),Darwin)
 endif
 
 $(LIB_DIR)/libdeflate.a: $(LIBDEFLATE_DIR)/*.h $(LIBDEFLATE_DIR)/lib/*.h $(LIBDEFLATE_DIR)/lib/*/*.h $(LIBDEFLATE_DIR)/lib/*.c $(LIBDEFLATE_DIR)/lib/*/*.c
-	+. ./source_me.sh && cd $(LIBDEFLATE_DIR) && V=1 $(MAKE) $(FILTER) && cp libdeflate.a $(CWD)/$(LIB_DIR) && cp libdeflate.h $(CWD)/$(INC_DIR)
+	+. ./source_me.sh && cd $(LIBDEFLATE_DIR) && V=1 LDFLAGS="$(LDFLAGS) $(LD_RENAMEABLE_FLAGS)" $(MAKE) $(FILTER) && cp libdeflate.a $(CWD)/$(LIB_DIR) && cp libdeflate.h $(CWD)/$(INC_DIR)
 
 # We build htslib after libdeflate so it can use libdeflate.
 # We need to do some wizardry to get it to pick up the right build and target system types on modern autotools.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `libdeflate` build should now have more space to be renamed

## Description

This should fix #4257

