### PR TITLE
Make WFAExtender apply full length bonuses even though it doesn't use them internally

### DIFF
--- a/src/gbwt_extender.cpp
+++ b/src/gbwt_extender.cpp
@@ -2284,7 +2284,14 @@ WFAAlignment WFAExtender::connect(std::string sequence, pos_t from, pos_t to) co
 }
 
 WFAAlignment WFAExtender::suffix(const std::string& sequence, pos_t from) const {
-    return this->connect(sequence, from, pos_t(0, false, 0));
+    WFAAlignment result = this->connect(sequence, from, pos_t(0, false, 0));
+
+    if (!result.edits.empty() && result.length == sequence.length() && (result.edits.back().first == WFAAlignment::match || result.edits.back().first == WFAAlignment::mismatch)) {
+        // The alignment used all of the sequence and has a match/mismatch at the appropriate end
+        result.score += this->aligner->full_length_bonus; 
+    }
+
+    return result;
 }
 
 WFAAlignment WFAExtender::prefix(const std::string& sequence, pos_t to) const {
@@ -2296,6 +2303,10 @@ WFAAlignment WFAExtender::prefix(const std::string& sequence, pos_t to) const {
     to = reverse_base_pos(to, this->graph->get_length(this->graph->get_handle(id(to), is_rev(to))));
     WFAAlignment result = this->connect(reverse_complement(sequence), to, pos_t(0, false, 0));
     result.flip(*(this->graph), sequence);
+
+    if (!result.edits.empty() && result.length == sequence.length() && (result.edits.front().first == WFAAlignment::match || result.edits.front().first == WFAAlignment::mismatch)) {
+        result.score += this->aligner->full_length_bonus; 
+    }
 
     return result;
 }

--- a/src/gbwt_extender.hpp
+++ b/src/gbwt_extender.hpp
@@ -412,9 +412,11 @@ public:
      * entire sequence with an acceptable score, returns the highest-scoring
      * partial alignment, which may be empty.
      *
+     * Applies the full-length bonus if the result ends with a match or mismatch.
+     * TODO: Use the full-length bonus to determine the optimal alignment.
+     *
      * NOTE: This creates a suffix of the full alignment by aligning a
      * prefix of the sequence.
-     * TODO: Should we use full-length bonuses?
      */
     WFAAlignment suffix(const std::string& sequence, pos_t from) const;
 
@@ -424,9 +426,11 @@ public:
      * sequence with an acceptable score, returns the highest-scoring partial
      * alignment, which may be empty.
      *
+     * Applies the full-length bonus if the result begins with a match or mismatch.
+     * TODO: Use the full-length bonus to determine the optimal alignment.
+     *
      * NOTE: This creates a prefix of the full alignment by aligning a suffix
      * of the sequence.
-     * TODO: Should we use full-length bonuses?
      */
     WFAAlignment prefix(const std::string& sequence, pos_t to) const;
 

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -212,7 +212,7 @@ vg index -j 1mb1kgp.dist  1mb1kgp.vg
 vg autoindex -p 1mb1kgp -w giraffe -P "VG w/ Variant Paths:1mb1kgp.vg" -P "Giraffe Distance Index:1mb1kgp.dist" -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz
 vg giraffe -Z 1mb1kgp.giraffe.gbz -f reads/1mb1kgp_longread.fq >longread.gam -U 300 --progress --track-provenance --align-from-chains
 # This is an 8001 bp read with 1 insert and 1 substitution
-is "$(vg view -aj longread.gam | jq -r '.score')" "7989" "A long read can be correctly aligned"
+is "$(vg view -aj longread.gam | jq -r '.score')" "7999" "A long read can be correctly aligned"
 is "$(vg view -aj longread.gam | jq -c '.path.mapping[].edit[] | select(.sequence)' | wc -l)" "2" "A long read has the correct edits found"
 is "$(vg view -aj longread.gam | jq -c '. | select(.annotation["filter_3_cluster-coverage_cluster_passed_size_total"] <= 300)' | wc -l)" "1" "Long read minimizer set is correctly restricted"
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * WFAExtender alignments are now scored using the full length bonus

## Description

This makes sure to apply the full length bonus to the scoring of WFAExtender alignments. It doesn't take it into account when choosing the actual alignment path yet, though.