### PR TITLE
Refactor deconstruct to use less protobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,14 +396,6 @@ vg index hla.vg -x hla.xg
 vg deconstruct hla.xg -e -p "gi|568815592:29791752-29792749" > hla_variants.vcf
 ```
 
-Variants can also be inferred strictly from topology by not using `-e`, though unlike the above example, cycles are not supported.  "Deconstruct" the VCF variants that were used to construct the graph. The output will be similar but identical to `small/x.vcf.gz` as `vg construct` can add edges between adjacent alts and/or do some normalization:
-
-<!-- !test check Deconstruct from construct -->
-```sh
-# using the same graph from the `map` example
-vg deconstruct x.xg -p x > x.vcf
-```
-
 Haplotype paths from `.gbz` or `.gbwt` indexes input can be considered using `-z` and `-g', respectively.
 
 As with `vg call`, it is best to compute snarls separately and pass them in with `-r` when working with large graphs.

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -135,7 +135,7 @@ void visit_contained_snarls(const PathPositionHandleGraph* graph, const vector<R
     }
     path_name_set.clear();
     graph_path_name_set.clear();
-    PathTraversalFinder trav_finder(*graph, snarl_manager, path_names);
+    PathTraversalFinder trav_finder(*graph, path_names);
     
     // Do the top-level snarls, the recurse as needed (framework copied from deconstructor.cpp)
     snarl_manager.for_each_top_level_snarl([&](const Snarl* snarl) {

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -1104,8 +1104,7 @@ void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHand
 
     // create the traversal finder
     map<string, const Alignment*> reads_by_name;
-    path_trav_finder = unique_ptr<PathTraversalFinder>(new PathTraversalFinder(*graph,
-                                                                               *snarl_manager));
+    path_trav_finder = unique_ptr<PathTraversalFinder>(new PathTraversalFinder(*graph));
     
     if (!path_restricted && !gbwt) {
         trav_finder = unique_ptr<TraversalFinder>(new ExhaustiveTraversalFinder(*graph,

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -51,20 +51,20 @@ private:
 
     // write a vcf record for the given site.  returns true if a record was written
     // (need to have a path going through the site)
-    bool deconstruct_site(const Snarl* site) const;
+    bool deconstruct_site(const handle_t& snarl_start, const handle_t& snarl_end) const;
 
     // get the traversals for a given site
     // this returns a combination of embedded path traversals and gbwt traversals
     // the embedded paths come first, and only they get trav_steps.
     // so you can use trav_steps.size() to find the index of the first gbwt traversal...
-    void get_traversals(const Snarl* site,
-                        vector<SnarlTraversal>& out_travs,
+    void get_traversals(const handle_t& snarl_start, const handle_t& snarl_end,
+                        vector<Traversal>& out_travs,
                         vector<string>& out_trav_path_names,
                         vector<pair<step_handle_t, step_handle_t>>& out_trav_steps) const;
 
     // convert traversals to strings.  returns mapping of traversal (offset in travs) to allele
     vector<int> get_alleles(vcflib::Variant& v,
-                            const vector<SnarlTraversal>& travs,
+                            const vector<Traversal>& travs,
                             const vector<pair<step_handle_t, step_handle_t>>& trav_steps,
                             int ref_path_idx,
                             const vector<bool>& use_trav,

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -39,8 +39,6 @@ public:
     // deconstruct the entire graph to cout.
     // Not even a little bit thread safe.
     void deconstruct(vector<string> refpaths, const PathPositionHandleGraph* grpah, SnarlManager* snarl_manager,
-                     bool path_restricted_traversals,
-                     int ploidy,
                      bool include_nested,
                      int context_jaccard_window,
                      bool untangle_traversals,
@@ -74,13 +72,6 @@ private:
                                               const vector<string>& trav_to_name,
                                               const vector<int>& gbwt_phases) const;
 
-    // check to see if a snarl is too big to exhaustively traverse
-    bool check_max_nodes(const Snarl* snarl) const;
-
-    // get traversals from the exhaustive finder.  if they have nested visits, fill them in (exhaustively)
-    // with node visits
-    vector<SnarlTraversal> explicit_exhaustive_traversals(const Snarl* snarl) const;
-
     // gets a sorted node id context for a given path
     vector<nid_t> get_context(
         const pair<vector<SnarlTraversal>,
@@ -101,12 +92,6 @@ private:
         const dac_vector<>& target,
         const vector<nid_t>& query) const;
     
-    // toggle between exhaustive and path restricted traversal finder
-    bool path_restricted = false;
-
-    // the max ploidy we expect.
-    int ploidy;
-
     // the graph
     const PathPositionHandleGraph* graph;
 
@@ -115,8 +100,6 @@ private:
 
     // the traversal finders. we always use a path traversal finder to get the reference path
     unique_ptr<PathTraversalFinder> path_trav_finder;
-    // we optionally use another (exhaustive for now) traversal finder if we don't want to rely on paths
-    unique_ptr<TraversalFinder> trav_finder;
     // we can also use a gbwt for traversals
     unique_ptr<GBWTTraversalFinder> gbwt_trav_finder;
     // When using the gbwt we need some precomputed information to ask about stored paths.
@@ -143,9 +126,6 @@ private:
     // the sample ploidys given in the phases in our path names
     unordered_map<string, int> sample_ploidys;
 
-    // upper limit of degree-2+ nodes for exhaustive traversal
-    int max_nodes_for_exhaustive = 100;
-
     // target window size for determining the correct reference position for allele traversals with path jaccard
     int path_jaccard_window = 10000;
 
@@ -160,9 +140,6 @@ private:
 
     // should we keep conflicted genotypes or not
     bool keep_conflicted_genotypes = false;
-
-    // warn about context jaccard not working with exhaustive traversals
-    mutable atomic<bool> exhaustive_jaccard_warning;
 };
 
 // helpel for measuring set intersectiond and union size

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -38,7 +38,7 @@ public:
 
     // deconstruct the entire graph to cout.
     // Not even a little bit thread safe.
-    void deconstruct(vector<string> refpaths, const PathPositionHandleGraph* grpah, SnarlManager* snarl_manager,
+    void deconstruct(vector<string> refpaths, const PathPositionHandleGraph* graph, SnarlManager* snarl_manager,
                      bool include_nested,
                      int context_jaccard_window,
                      bool untangle_traversals,
@@ -53,10 +53,19 @@ private:
     // (need to have a path going through the site)
     bool deconstruct_site(const Snarl* site) const;
 
+    // get the traversals for a given site
+    // this returns a combination of embedded path traversals and gbwt traversals
+    // the embedded paths come first, and only they get trav_steps.
+    // so you can use trav_steps.size() to find the index of the first gbwt traversal...
+    void get_traversals(const Snarl* site,
+                        vector<SnarlTraversal>& out_travs,
+                        vector<string>& out_trav_path_names,
+                        vector<pair<step_handle_t, step_handle_t>>& out_trav_steps) const;
+
     // convert traversals to strings.  returns mapping of traversal (offset in travs) to allele
     vector<int> get_alleles(vcflib::Variant& v,
-                            const pair<vector<SnarlTraversal>,
-                                       vector<pair<step_handle_t, step_handle_t>>>& path_travs,
+                            const vector<SnarlTraversal>& travs,
+                            const vector<pair<step_handle_t, step_handle_t>>& trav_steps,
                             int ref_path_idx,
                             const vector<bool>& use_trav,
                             char prev_char, bool use_start) const;
@@ -71,12 +80,6 @@ private:
                                               const vector<int>& travs, const vector<int>& trav_to_allele,
                                               const vector<string>& trav_to_name,
                                               const vector<int>& gbwt_phases) const;
-
-    // gets a sorted node id context for a given path
-    vector<nid_t> get_context(
-        const pair<vector<SnarlTraversal>,
-                   vector<pair<step_handle_t, step_handle_t>>>& path_travs,
-        const int& trav_idx) const;
 
     // the underlying context-getter
     vector<nid_t> get_context(

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -52,8 +52,14 @@ private:
     // initialize the vcf and get the header 
     string get_vcf_header();
 
+    // deconstruct all snarls in parallel (ie nesting relationship ignored)
     void deconstruct_graph(SnarlManager* snarl_manager);
-    
+
+    // deconstruct all top-level snarls in parallel
+    // nested snarls are processed after their parents in the same thread
+    // (same logic as vg call)
+    void deconstruct_graph_top_down(SnarlManager* snarl_manager);
+
     // write a vcf record for the given site.  returns true if a record was written
     // (need to have a path going through the site)
     bool deconstruct_site(const handle_t& snarl_start, const handle_t& snarl_end) const;

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -51,6 +51,8 @@ private:
 
     // initialize the vcf and get the header 
     string get_vcf_header();
+
+    void deconstruct_graph(SnarlManager* snarl_manager);
     
     // write a vcf record for the given site.  returns true if a record was written
     // (need to have a path going through the site)
@@ -100,9 +102,6 @@ private:
     
     // the graph
     const PathPositionHandleGraph* graph;
-
-    // the snarl manager
-    SnarlManager* snarl_manager;
 
     // the gbwt
     gbwt::GBWT* gbwt;

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -49,6 +49,9 @@ public:
     
 private:
 
+    // initialize the vcf and get the header 
+    string get_vcf_header();
+    
     // write a vcf record for the given site.  returns true if a record was written
     // (need to have a path going through the site)
     bool deconstruct_site(const handle_t& snarl_start, const handle_t& snarl_end) const;
@@ -100,6 +103,9 @@ private:
 
     // the snarl manager
     SnarlManager* snarl_manager;
+
+    // the gbwt
+    gbwt::GBWT* gbwt;
 
     // the traversal finders. we always use a path traversal finder to get the reference path
     unique_ptr<PathTraversalFinder> path_trav_finder;

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -366,6 +366,17 @@ void VCFOutputCaller::set_nested(bool nested) {
     include_nested = nested;
 }
 
+void VCFOutputCaller::add_allele_path_to_info(const HandleGraph* graph, vcflib::Variant& v, int allele, const Traversal& trav,
+                                              bool reversed, bool one_based) const {
+    SnarlTraversal proto_trav;
+    for (const handle_t& handle : trav) {
+        Visit* visit = proto_trav.add_visit();
+        visit->set_node_id(graph->get_id(handle));
+        visit->set_backward(graph->get_is_reverse(handle));
+    }
+    this->add_allele_path_to_info(v, allele, proto_trav, reversed, one_based);
+}
+
 void VCFOutputCaller::add_allele_path_to_info(vcflib::Variant& v, int allele, const SnarlTraversal& trav,
                                               bool reversed, bool one_based) const {
     auto& trav_info = v.info["AT"];
@@ -724,6 +735,18 @@ void VCFOutputCaller::flatten_common_allele_ends(vcflib::Variant& variant, bool 
             variant.alt[i - 1] = variant.alleles[i];
         }
     }
+}
+
+string VCFOutputCaller::print_snarl(const HandleGraph* graph, const handle_t& snarl_start,
+                                    const handle_t& snarl_end, bool in_brackets) const {
+    Snarl snarl;
+    Visit* start = snarl.mutable_start();
+    start->set_node_id(graph->get_id(snarl_start));
+    start->set_backward(graph->get_is_reverse(snarl_start));
+    Visit* end = snarl.mutable_end();
+    end->set_node_id(graph->get_id(snarl_end));
+    end->set_backward(graph->get_is_reverse(snarl_end));
+    return this->print_snarl(snarl, in_brackets);
 }
 
 string VCFOutputCaller::print_snarl(const Snarl& snarl, bool in_brackets) const {

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -103,7 +103,11 @@ public:
 protected:
 
     /// add a traversal to the VCF info field in the format of a GFA W-line or GAF path
+    void add_allele_path_to_info(const HandleGraph* graph, vcflib::Variant& v, int allele,
+                                 const Traversal& trav, bool reversed, bool one_based) const;
+    /// legacy version of above
     void add_allele_path_to_info(vcflib::Variant& v, int allele, const SnarlTraversal& trav, bool reversed, bool one_based) const;
+    
     
     /// convert a traversal into an allele string
     string trav_string(const HandleGraph& graph, const SnarlTraversal& trav) const;
@@ -131,6 +135,8 @@ protected:
 
     /// print a snarl in a consistent form like >3435<12222
     /// if in_brackets set to true,  do (>3435<12222) instead (this is only used for nested caller)
+    string print_snarl(const HandleGraph* grpah, const handle_t& snarl_start, const handle_t& snarl_end, bool in_brackets = false) const;
+    /// legacy version of above
     string print_snarl(const Snarl& snarl, bool in_brackets = false) const;
 
     /// do the opposite of above

--- a/src/mcmc_caller.cpp
+++ b/src/mcmc_caller.cpp
@@ -96,7 +96,7 @@ namespace vg {
             return false;
         }
         
-        PathTraversalFinder trav_finder(*path_position_handle_graph, snarl_manager, ref_paths);
+        PathTraversalFinder trav_finder(*path_position_handle_graph, ref_paths);
         auto trav_results = trav_finder.find_path_traversals(snarl);
         vector<SnarlTraversal> ref_path = trav_results.first;
 

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -42,12 +42,10 @@ void help_deconstruct(char** argv){
          << "    -P, --path-prefix NAME   All paths [excluding GBWT threads / non-reference GBZ paths] beginning with NAME used as reference (multiple allowed)." << endl
          << "                             Other non-ref paths not considered as samples. " << endl
          << "    -r, --snarls FILE        Snarls file (from vg snarls) to avoid recomputing." << endl
-         << "    -g, --gbwt FILE          only consider alt traversals that correspond to GBWT threads FILE (not needed for GBZ graph input)." << endl
+         << "    -g, --gbwt FILE          consider alt traversals that correspond to GBWT haplotypes in FILE (not needed for GBZ graph input)." << endl
          << "    -T, --translation FILE   Node ID translation (as created by vg gbwt --translation) to apply to snarl names and AT fields in output" << endl
          << "    -O, --gbz-translation    Use the ID translation from the input gbz to apply snarl names to snarl names and AT fields in output" << endl
-         << "    -e, --path-traversals    Only consider traversals that correspond to paths in the graph." << endl
          << "    -a, --all-snarls         Process all snarls, including nested snarls (by default only top-level snarls reported)." << endl
-         << "    -d, --ploidy N           Expected ploidy.  If more traversals found, they will be flagged as conflicts (default: 2)" << endl
          << "    -c, --context-jaccard N  Set context mapping size used to disambiguate alleles at sites with multiple reference traversals (default: 10000)." << endl
          << "    -u, --untangle-travs     Use context mapping to determine the reference-relative positions of each step in allele traversals (AP INFO field)." << endl
          << "    -K, --keep-conflicted    Retain conflicted genotypes in output." << endl
@@ -73,8 +71,6 @@ int main_deconstruct(int argc, char** argv){
     bool gbz_translation = false;
     bool path_restricted_traversals = false;
     bool show_progress = false;
-    int ploidy = 2;
-    bool set_ploidy = false;
     bool all_snarls = false;
     bool keep_conflicted = false;
     bool strict_conflicts = false;
@@ -96,7 +92,6 @@ int main_deconstruct(int argc, char** argv){
                 {"translation", required_argument, 0, 'T'},
                 {"gbz-translation", no_argument, 0, 'O'},                
                 {"path-traversals", no_argument, 0, 'e'},
-                {"ploidy", required_argument, 0, 'd'},
                 {"context-jaccard", required_argument, 0, 'c'},
                 {"untangle-travs", no_argument, 0, 'u'},
                 {"all-snarls", no_argument, 0, 'a'},
@@ -140,12 +135,12 @@ int main_deconstruct(int argc, char** argv){
             gbz_translation = true;
             break;                        
         case 'e':
-            path_restricted_traversals = true;
+            cerr << "Warning [vg deconstruct]: -e is deprecated as it's now on default" << endl;
             break;
         case 'd':
-            ploidy = parse<int>(optarg);
-            set_ploidy = true;
+            cerr << "Warning [vg deconstruct]: -d is deprecated - ploidy now inferred from haplotypes in path names" << endl;
             break;
+            break;            
         case 'c':
             context_jaccard_window = parse<int>(optarg);
             break;
@@ -204,16 +199,6 @@ int main_deconstruct(int argc, char** argv){
 
     if (!gbz_graph && gbz_translation) {
         cerr << "Error [vg deconstruct]: -O can only be used when input graph is in GBZ format" << endl;
-    }
-
-    if (set_ploidy && !path_restricted_traversals && gbwt_file_name.empty() && !gbz_graph) {
-        cerr << "Error [vg deconstruct]: -d can only be used with -e or -g or GBZ input" << endl;
-        return 1;
-    }
-
-    if ((!gbwt_file_name.empty() || gbz_graph) && path_restricted_traversals && !gbz_graph) {
-        cerr << "Error [vg deconstruct]: -e cannot be used with -g or GBZ input" << endl;
-        return 1;
     }
 
     if (!gbwt_file_name.empty() || gbz_graph) {
@@ -352,7 +337,7 @@ int main_deconstruct(int argc, char** argv){
     }
     dd.set_translation(translation.get());
     dd.set_nested(all_snarls);
-    dd.deconstruct(refpaths, graph, snarl_manager.get(), path_restricted_traversals, ploidy,
+    dd.deconstruct(refpaths, graph, snarl_manager.get(),
                    all_snarls,
                    context_jaccard_window,
                    untangle_traversals,

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -299,7 +299,7 @@ int main_snarl(int argc, char** argv) {
 
     if (path_traversals) {
         // Limit traversals to embedded paths
-        trav_finder.reset(new PathTraversalFinder(*graph, snarl_manager));
+        trav_finder.reset(new PathTraversalFinder(*graph));
     } else if (vcf_filename.empty()) {
         // This finder works with any backing graph
         trav_finder.reset(new ExhaustiveTraversalFinder(*graph, snarl_manager));

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -10,6 +10,36 @@ namespace vg {
 
 using namespace std;
 
+string traversal_to_string(const PathHandleGraph* graph, const Traversal& traversal, bool max_steps) {
+    string s;
+    function<string(handle_t)> handle_to_string = [&](handle_t handle) {
+        string ss = graph->get_is_reverse(handle) ? "<" : ">";
+        return ss + std::to_string(graph->get_id(handle));
+    };
+    if (traversal.size() <= max_steps) {
+        for (const handle_t& handle : traversal) {
+            s += handle_to_string(handle);
+        }
+    } else {
+        for (int64_t i = 0; i < max_steps / 2; ++i) {
+            s += handle_to_string(traversal[i]);
+        }
+        s += "...";
+        for (int64_t i = 0; i < max_steps / 2; ++i) {
+            s += handle_to_string(traversal[traversal.size() - 1 - i]);
+        }
+    }
+    return s;
+}
+
+string graph_interval_to_string(const HandleGraph* graph, const handle_t& start_handle, const handle_t& end_handle) {
+    function<string(handle_t)> handle_to_string = [&](handle_t handle) {
+        string ss = graph->get_is_reverse(handle) ? "<" : ">";
+        return ss + std::to_string(graph->get_id(handle));
+    };
+    return handle_to_string(start_handle) + handle_to_string(end_handle);
+}
+
 PathBasedTraversalFinder::PathBasedTraversalFinder(const PathHandleGraph& g, SnarlManager& sm) : graph(g), snarlmanager(sm){
 }
 

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -36,6 +36,9 @@ using namespace std;
 
 class AugmentedGraph;
 
+using Traversal = vector<handle_t>;
+using PathInterval = pair<step_handle_t, step_handle_t>;
+
 /**
  * Represents a strategy for finding traversals of (nested) sites. Polymorphic
  * base class/interface.
@@ -44,7 +47,12 @@ class TraversalFinder {
 public:
     virtual ~TraversalFinder() = default;
     
-    virtual vector<SnarlTraversal> find_traversals(const Snarl& site) = 0;        
+    virtual vector<SnarlTraversal> find_traversals(const Snarl& site) = 0;
+
+    // new, protobuf-free interface. hope is to eventually deprecate the old one.  for now it is only supported in a few places
+    virtual vector<Traversal> find_traversals(const handle_t& snarl_start, const handle_t& snarl_end) {
+        assert(false); return{};
+    }
 };
 
 class ExhaustiveTraversalFinder : public TraversalFinder {
@@ -201,25 +209,25 @@ protected:
     // our graph with indexed path positions
     const PathHandleGraph& graph;
     
-    SnarlManager& snarl_manager;
-
     // restrict to these paths
     unordered_set<path_handle_t> paths;
     
 public:
     // if path_names not empty, only those paths will be considered
-    PathTraversalFinder(const PathHandleGraph& graph, SnarlManager& snarl_manager,
+    PathTraversalFinder(const PathHandleGraph& graph,
                         const vector<string>& path_names = {});
 
     /**
      * Return all traversals through the site that are sub-paths of embedded paths in the graph
      */
     virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
+    virtual vector<Traversal> find_traversals(const handle_t& snarl_start, const handle_t& snarl_end);
 
     /**
     * Like above, but return the path steps for the for the traversal endpoints
     */
-    virtual pair<vector<SnarlTraversal>, vector<pair<step_handle_t, step_handle_t> > > find_path_traversals(const Snarl& site);
+    virtual pair<vector<SnarlTraversal>, vector<PathInterval>> find_path_traversals(const Snarl& site);
+    virtual pair<vector<Traversal>, vector<PathInterval>> find_path_traversals(const handle_t& snarl_start, const handle_t& snarl_end);
 
 };    
     
@@ -636,18 +644,22 @@ public:
     /* Return a traversal for every gbwt thread through the snarl 
      */
     virtual vector<SnarlTraversal> find_traversals(const Snarl& site);
+    virtual vector<Traversal> find_traversals(const handle_t& snarl_start, const handle_t& snarl_end);
 
     /** Return the traversals, paired with their path identifiers in the gbwt.  The traversals are 
      *  unique, but there can be more than one path along each one (hence the vector)
      */
     virtual pair<vector<SnarlTraversal>, vector<vector<gbwt::size_type>>>
     find_gbwt_traversals(const Snarl& site, bool return_paths = true);
+    virtual pair<vector<Traversal>, vector<vector<gbwt::size_type>>>
+    find_gbwt_traversals(const handle_t& snarl_start, const handle_t& snarl_end, bool return_paths = true);
 
     /** Return traversals paired with path identifiers from the GBWT.  The traversals are *not* unique
      * (which is consistent with PathTraversalFinder)
      * To get the sample name from the path identifier id, use gbwtgraph::get_path_sample_name();
      */
     virtual pair<vector<SnarlTraversal>, vector<gbwt::size_type>> find_path_traversals(const Snarl& site);
+    virtual pair<vector<Traversal>, vector<gbwt::size_type>> find_path_traversals(const handle_t& snarl_start, const handle_t& snarl_end);
 
     const gbwt::GBWT& get_gbwt() { return gbwt; }
     

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -36,8 +36,12 @@ using namespace std;
 
 class AugmentedGraph;
 
+// some Protobuf replacements
 using Traversal = vector<handle_t>;
 using PathInterval = pair<step_handle_t, step_handle_t>;
+string traversal_to_string(const PathHandleGraph* graph, const Traversal& traversal, bool max_steps = 10);
+// replaces pb2json(snarl)
+string graph_interval_to_string(const HandleGraph* graph, const handle_t& start_handle, const handle_t& end_handle);
 
 /**
  * Represents a strategy for finding traversals of (nested) sites. Polymorphic

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -3933,7 +3933,7 @@ namespace vg {
 
                 CactusSnarlFinder snarl_finder(graph);
                 SnarlManager snarl_manager = snarl_finder.find_snarls();
-                PathTraversalFinder trav_finder(graph, snarl_manager);
+                PathTraversalFinder trav_finder(graph);
 
                 Snarl snarl;
                 snarl.mutable_start()->set_node_id(2);
@@ -3972,7 +3972,7 @@ namespace vg {
 
                 CactusSnarlFinder snarl_finder(graph);
                 SnarlManager snarl_manager = snarl_finder.find_snarls();
-                PathTraversalFinder trav_finder(graph, snarl_manager);
+                PathTraversalFinder trav_finder(graph);
 
                 Snarl snarl;
                 snarl.mutable_start()->set_node_id(7);
@@ -4013,7 +4013,7 @@ namespace vg {
 
                 CactusSnarlFinder snarl_finder(graph);
                 SnarlManager snarl_manager = snarl_finder.find_snarls();
-                PathTraversalFinder trav_finder(graph, snarl_manager);
+                PathTraversalFinder trav_finder(graph);
 
                 Snarl snarl;
                 snarl.mutable_start()->set_node_id(8);
@@ -4053,7 +4053,7 @@ namespace vg {
 
                 CactusSnarlFinder snarl_finder(graph);
                 SnarlManager snarl_manager = snarl_finder.find_snarls();
-                PathTraversalFinder trav_finder(graph, snarl_manager);
+                PathTraversalFinder trav_finder(graph);
 
                 Snarl snarl;
                 snarl.mutable_start()->set_node_id(11);

--- a/src/variant_recall.cpp
+++ b/src/variant_recall.cpp
@@ -82,7 +82,7 @@ void genotype_svs(VG* graph,
         Deconstructor decon;
         CactusSnarlFinder finder(xg_index);
         SnarlManager snarl_manager = finder.find_snarls();
-        decon.deconstruct({refpath}, &xg_index, &snarl_manager, false, 1, false, 10000, false, false, false, false);
+        decon.deconstruct({refpath}, &xg_index, &snarl_manager, false, 10000, false, false, false, false);
     }
     direct_ins.clear();
 

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -5,22 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 24
-
-vg construct -r tiny/tiny.fa -v tiny/tiny.vcf.gz > tiny.vg
-vg index tiny.vg -x tiny.xg
-vg deconstruct tiny.xg -p x -t 1 > tiny_decon.vcf
-# we pop out that GC allele because it gets invented by the adjacent snps in the graph
-gzip -dc tiny/tiny.vcf.gz | tail -3 | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' > tiny_orig.tsv
-cat tiny_decon.vcf | grep -v "#" | grep -v GC | awk '{print $1 "\t" $2 "\t" $4 "\t" $5}' > tiny_dec.tsv
-diff tiny_orig.tsv tiny_dec.tsv
-is "$?" 0 "deconstruct retrieved original VCF (modulo adjacent snp allele)"
-grep '>1>6' tiny_decon.vcf | awk '{print $8}' > allele_travs
-printf "AT=>1>3>5>6,>1>3>4>6,>1>2>5>6,>1>2>4>6\n" > expected_allele_travs
-diff allele_travs expected_allele_travs
-is "$?" 0 "deconstruct produced expected AT field"
-
-rm -f tiny.vg tiny.xg tiny_decon.vcf tiny_orig.tsv tiny_dec.tsv allele_travs expected_allele_travs
+plan tests 22
 
 vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 -k 16 | vg mod -U 10 - | vg mod -c - > hla.vg
 vg index hla.vg -x hla.xg

--- a/vgci/vgci.sh
+++ b/vgci/vgci.sh
@@ -340,12 +340,14 @@ then
 
     # Dependencies for running tests.  Need numpy, scipy and sklearn for
     # running toil-vg mapeval, and dateutils and reqests for
-    # ./mins_since_last_build.py. Make sure to get the giant buildable modules
-    # as binaries only to avoid wasting CI time building some slightly nicer
-    # version Pip prefers.
-    pip3 install pytest timeout_decorator requests dateutils
+    # ./mins_since_last_build.py. Need exactly the right version of requests
+    # for the Python Docker API to work (see
+    # <https://github.com/docker/docker-py/issues/3256>).
+    pip3 install pytest timeout_decorator 'requests==2.31.0' dateutils
     # TODO: To upgrade to Numpy 1.24+, we need to remove usages of `numpy.int`
     # AKA `np.int` from toil-vg. See <https://stackoverflow.com/a/74946903>
+    # Make sure to get the giant buildable modules as binaries only to avoid
+    # wasting CI time building some slightly nicer version Pip prefers.
     pip3 install 'numpy==1.23.5' scipy scikit-learn --only-binary :all:
 
     # Install Toil


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 *  `vg deconstruct` now does path-based (formerly `-e`) deconstruction by default.  Old default behaviour of exhaustively processing (tiny) sites is deprecated.  
 * if `-a` is *not* used, `vg deconstruct` will recursive on child snarls of snarls it failed to process (like `vg call`) - functionality that was, I think, dropped a while back.    

## Description

This refactor 
* makes the code a bit more modular
* cuts out everything protobuf except for snarl enumeration. which is now confined to a little function.  so upgrading to the new distance-index-based format is now pretty trivial, but probably doesn't make sense until other tools like `call` are ready...
* the exhaustive traversal support complicates the logic a bunch and is very proto dependent and I don't think used in practice, so I dropped it.  if we really need something like this, I think a better approach would be going through some kind of path cover then doing a path deconstruction.

The whole point of doing this is to add better nesting support, but my branch for that is a mess so I'm breaking it into smaller PRs... 