### PR TITLE
Deconstruct option to cluster similar alleles together 

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -350,11 +350,16 @@ void Deconstructor::get_genotypes(vcflib::Variant& v, const vector<string>& name
                 genotype += (chosen_travs[i] != -1 && (!conflict || keep_conflicted_genotypes))
                     ? std::to_string(trav_to_allele[chosen_travs[i]]) : ".";
                 if (this->cluster_threshold < 1.0) {
-                    ostringstream ss;
-                    ss.precision(3);
-                    ss << trav_to_cluster_info[chosen_travs[i]].first;
-                    v.samples[sample_name]["TS"].push_back(ss.str());
-                    v.samples[sample_name]["TL"].push_back(std::to_string(trav_to_cluster_info[chosen_travs[i]].second));
+                    if (*genotype.rbegin() == '.') {
+                        v.samples[sample_name]["TS"].push_back(".");
+                        v.samples[sample_name]["TL"].push_back(".");
+                    } else {
+                        ostringstream ss;
+                        ss.precision(3);
+                        ss << trav_to_cluster_info[chosen_travs[i]].first;
+                        v.samples[sample_name]["TS"].push_back(ss.str());
+                        v.samples[sample_name]["TL"].push_back(std::to_string(trav_to_cluster_info[chosen_travs[i]].second));
+                    }
                 }
             }
             v.samples[sample_name]["GT"] = {genotype};
@@ -920,7 +925,7 @@ string Deconstructor::get_vcf_header() {
     if (sample_to_haps.empty()) {
         cerr << "Error [vg deconstruct]: No paths found for alt alleles in the graph. Note that "
              << "exhaustive path-free traversal finding is no longer supported, and vg deconstruct "
-             << "now only works on embedded paths and GBWT threads" << endl;
+             << "now only works on embedded paths and GBWT threads." << endl;
         exit(1);
     }
 

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -1,6 +1,7 @@
 #include "deconstructor.hpp"
 #include "traversal_finder.hpp"
 #include <gbwtgraph/gbwtgraph.h>
+#include "traversal_clusters.hpp"
 
 //#define debug
 
@@ -248,7 +249,7 @@ vector<int> Deconstructor::get_alleles(vcflib::Variant& v,
                             for (auto& c : ref_contexts) {
                                 auto& ref_context = c.second;
                                 auto& ref_pos = c.first;
-                                double j = context_jaccard(ref_context, path_context);
+                                double j = jaccard_coefficient(ref_context, path_context);
                                 if (j > best_jaccard) {
                                     best_jaccard = j;
                                     best_pos = ref_pos;
@@ -487,38 +488,6 @@ pair<vector<int>, bool> Deconstructor::choose_traversals(const string& sample_na
     return make_pair(most_frequent_travs, conflict);
 }
 
-
-// todo refactor if we need to reuse elsewhere in vg
-// implemented inline for development
-// assumes sorted input
-double Deconstructor::context_jaccard(
-    const vector<nid_t>& target,
-    const vector<nid_t>& query) const {
-    size_t node_isec = 0;
-    std::set_intersection(target.begin(), target.end(),
-                          query.begin(), query.end(),
-                          count_back_inserter<nid_t>(node_isec));
-    size_t node_union = 0;
-    std::set_union(target.begin(), target.end(),
-                   query.begin(), query.end(),
-                   count_back_inserter<nid_t>(node_union));
-    return (double)node_isec / (double)node_union;
-}
-
-double Deconstructor::context_jaccard(
-    const dac_vector<>& target,
-    const vector<nid_t>& query) const {
-    size_t node_isec = 0;
-    std::set_intersection(target.begin(), target.end(),
-                          query.begin(), query.end(),
-                          count_back_inserter<nid_t>(node_isec));
-    size_t node_union = 0;
-    std::set_union(target.begin(), target.end(),
-                   query.begin(), query.end(),
-                   count_back_inserter<nid_t>(node_union));
-    return (double)node_isec / (double)node_union;
-}
-
 vector<nid_t> Deconstructor::get_context(
     step_handle_t start_step,
     step_handle_t end_step) const {
@@ -738,7 +707,7 @@ bool Deconstructor::deconstruct_site(const handle_t& snarl_start, const handle_t
             vector<pair<double, int>> ref_mappings;
             for (uint64_t j = 0; j < ref_travs.size(); ++j) {
                 ref_mappings.push_back(make_pair(
-                                           context_jaccard(
+                                           jaccard_coefficient(
                                                ref_contexts[j],
                                                context),
                                            ref_travs[j]));

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -83,7 +83,8 @@ private:
                             char prev_char, bool use_start) const;
     
     // write traversal path names as genotypes
-    void get_genotypes(vcflib::Variant& v, const vector<string>& names, const vector<int>& trav_to_allele) const;
+    void get_genotypes(vcflib::Variant& v, const vector<string>& names, const vector<int>& trav_to_allele,
+                       const vector<pair<double, int64_t>>& trav_to_cluster_info) const;
 
     // given a set of traversals associated with a particular sample, select a set of size <ploidy> for the VCF
     // the highest-frequency ALT traversal is chosen

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -96,15 +96,6 @@ private:
     vector<nid_t> get_context(
         step_handle_t start_step,
         step_handle_t end_step) const;
-
-    // compares node contexts
-    double context_jaccard(const vector<nid_t>& target,
-                           const vector<nid_t>& query) const;
-
-    // specialization for enc_vectors
-    double context_jaccard(
-        const dac_vector<>& target,
-        const vector<nid_t>& query) const;
     
     // the graph
     const PathPositionHandleGraph* graph;
@@ -156,21 +147,6 @@ private:
     bool keep_conflicted_genotypes = false;
 };
 
-// helpel for measuring set intersectiond and union size
-template <typename T>
-class count_back_inserter {
-    size_t &count;
-public:
-    typedef void value_type;
-    typedef void difference_type;
-    typedef void pointer;
-    typedef void reference;
-    typedef std::output_iterator_tag iterator_category;
-    count_back_inserter(size_t &count) : count(count) {};
-    void operator=(const T &){ ++count; }
-    count_back_inserter &operator *(){ return *this; }
-    count_back_inserter &operator++(){ return *this; }
-};
 
 }
 #endif

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -45,6 +45,7 @@ public:
                      bool keep_conflicted,
                      bool strict_conflicts,
                      bool long_ref_contig,
+                     double cluster_threshold = 1.0,
                      gbwt::GBWT* gbwt = nullptr);
     
 private:
@@ -78,7 +79,7 @@ private:
                             const vector<Traversal>& travs,
                             const vector<pair<step_handle_t, step_handle_t>>& trav_steps,
                             int ref_path_idx,
-                            const vector<bool>& use_trav,
+                            const vector<vector<int>>& trav_clusters,
                             char prev_char, bool use_start) const;
     
     // write traversal path names as genotypes
@@ -145,6 +146,11 @@ private:
 
     // should we keep conflicted genotypes or not
     bool keep_conflicted_genotypes = false;
+
+    // used to merge together similar traversals (to keep allele counts down)
+    // currently implemented as handle jaccard coefficient.  So 1 means only
+    // merge if identical (which is what deconstruct has always done)
+    double cluster_threshold = 1.0;
 };
 
 

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -51,7 +51,7 @@ void help_deconstruct(char** argv){
          << "    -K, --keep-conflicted    Retain conflicted genotypes in output." << endl
          << "    -S, --strict-conflicts   Drop genotypes when we have more than one haplotype for any given phase (set by default when using GBWT input)." << endl
          << "    -C, --contig-only-ref    Only use the CONTIG name (and not SAMPLE#CONTIG#HAPLOTYPE etc) for the reference if possible (ie there is only one reference sample)." << endl
-         << "    -L, --cluster F          Cluster traversals whose (handle) Jaccard coefficient is >= F together (default: 1.0)" << endl
+         << "    -L, --cluster F          Cluster traversals whose (handle) Jaccard coefficient is >= F together (default: 1.0) [experimental]" << endl
          << "    -t, --threads N          Use N threads" << endl
          << "    -v, --verbose            Print some status messages" << endl
          << endl;
@@ -163,7 +163,7 @@ int main_deconstruct(int argc, char** argv){
             contig_only_ref = true;
             break;
         case 'L':
-            cluster_threshold = min(0.0, max(1.0, parse<double>(optarg)));
+            cluster_threshold = max(0.0, min(1.0, parse<double>(optarg)));
             break;
         case 't':
             omp_set_num_threads(parse<int>(optarg));

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -260,13 +260,22 @@ int main_deconstruct(int argc, char** argv){
     }
     
     if (refpaths.empty() && refpath_prefixes.empty()) {
+        bool found_hap;
         // No paths specified: use them all
         graph->for_each_path_handle([&](path_handle_t path_handle) {
-                const string& name = graph->get_path_name(path_handle);
-                if (!Paths::is_alt(name) && PathMetadata::parse_sense(name) != PathSense::HAPLOTYPE) {
-                    refpaths.push_back(name);
-                }
-            });
+            const string& name = graph->get_path_name(path_handle);
+            if (!Paths::is_alt(name) && PathMetadata::parse_sense(name) != PathSense::HAPLOTYPE) {
+                refpaths.push_back(name);
+            } else {
+                found_hap = true;
+            }
+        });
+
+        if (!found_hap) {
+            cerr << "error [vg deconstruct]: All graph paths selected as references (leaving no alts). Please use -P/-p "
+                 << "to narrow down the reference to a subset of paths, or GBZ/GBWT input that contains haplotype paths" << endl;
+            return 1;
+        }        
     }
 
     // Read the translation

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -51,6 +51,7 @@ void help_deconstruct(char** argv){
          << "    -K, --keep-conflicted    Retain conflicted genotypes in output." << endl
          << "    -S, --strict-conflicts   Drop genotypes when we have more than one haplotype for any given phase (set by default when using GBWT input)." << endl
          << "    -C, --contig-only-ref    Only use the CONTIG name (and not SAMPLE#CONTIG#HAPLOTYPE etc) for the reference if possible (ie there is only one reference sample)." << endl
+         << "    -L, --cluster F          Cluster traversals whose (handle) Jaccard coefficient is >= F together (default: 1.0)" << endl
          << "    -t, --threads N          Use N threads" << endl
          << "    -v, --verbose            Print some status messages" << endl
          << endl;
@@ -77,6 +78,7 @@ int main_deconstruct(int argc, char** argv){
     int context_jaccard_window = 10000;
     bool untangle_traversals = false;
     bool contig_only_ref = false;
+    double cluster_threshold = 1.0;
     
     int c;
     optind = 2; // force optind past command positional argument
@@ -97,14 +99,15 @@ int main_deconstruct(int argc, char** argv){
                 {"all-snarls", no_argument, 0, 'a'},
                 {"keep-conflicted", no_argument, 0, 'K'},
                 {"strict-conflicts", no_argument, 0, 'S'},
-                {"contig-only-ref", no_argument, 0, 'C'},                
+                {"contig-only-ref", no_argument, 0, 'C'},
+                {"cluster", required_argument, 0, 'L'},
                 {"threads", required_argument, 0, 't'},
                 {"verbose", no_argument, 0, 'v'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hp:P:H:r:g:T:OeKSCd:c:uat:v",
+        c = getopt_long (argc, argv, "hp:P:H:r:g:T:OeKSCd:c:uaL:t:v",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -158,7 +161,10 @@ int main_deconstruct(int argc, char** argv){
             break;
         case 'C':
             contig_only_ref = true;
-            break;            
+            break;
+        case 'L':
+            cluster_threshold = min(0.0, max(1.0, parse<double>(optarg)));
+            break;
         case 't':
             omp_set_num_threads(parse<int>(optarg));
             break;
@@ -344,6 +350,7 @@ int main_deconstruct(int argc, char** argv){
                    keep_conflicted,
                    strict_conflicts,
                    !contig_only_ref,
+                   cluster_threshold,
                    gbwt_index);
     return 0;
 }

--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -2,36 +2,82 @@
 
 namespace vg {
 
+
+vector<int> get_traversal_order(const PathHandleGraph* graph,
+                                const vector<Traversal>& traversals,
+                                const vector<string>& trav_path_names,
+                                const vector<int>& ref_travs,
+                                const vector<bool>& use_traversal) {
+    set<int> ref_set(ref_travs.begin(), ref_travs.end());
+    
+    function<bool(int, int)> trav_less = [&](int i, int j) {
+        if (ref_set.count(i) && !ref_set.count(j)) {
+            return true;
+        }
+        if (!trav_path_names[i].empty() && (!trav_path_names[j].empty() || trav_path_names[i] < trav_path_names[j])) {
+            return true;
+        }
+        return false;
+    };
+
+    vector<int> sorted_travs;
+    sorted_travs.reserve(traversals.size());
+    for (int64_t i = 0; i < traversals.size(); ++i) {
+        if (use_traversal[i]) {
+            sorted_travs.push_back(i);
+        }
+    }
+    std::sort(sorted_travs.begin(), sorted_travs.end(), trav_less);
+    return sorted_travs;
+}
+
 vector<vector<int>> cluster_traversals(const PathHandleGraph* graph,
                                        const vector<Traversal>& traversals,
-                                       const vector<int64_t>& traversal_order,
+                                       const vector<int>& traversal_order,
                                        double min_jaccard) {
 
-    assert(traversal_order.size() == traversals.size());
+    assert(traversal_order.size() <= traversals.size());
     
     // the values are indexes in the input traversals vector
     // the "reference" traversal of each cluster (to which distance is computed)
     // is always its first element
     vector<vector<int>> clusters;
 
-    for (const int64_t& i : traversal_order) {
-        const Traversal& trav = traversals[i];
-        double min_jaccard = numeric_limits<double>::max();
-        int64_t min_cluster_idx = -1;
+    // need the clusters as sorted lists. we'll forget the endpoints while we're at
+    // it since they're always shared.  note we work with multisets since we want to
+    // count differences between, say, cycle copy numbers. 
+    vector<multiset<handle_t>> sorted_traversals;
+    for (const Traversal& trav : traversals) {
+        assert(trav.size() >=2 );
+        // prune snarl nodes as they're always the same
+        // todo: does jaccard properly handle empty sets?
+        int64_t first = trav.size() == 2 ? 0 : 1;
+        int64_t last = trav.size() == 2 ? trav.size() : trav.size() - 1;
+        multiset<handle_t> sorted_trav;
+        for (int64_t i = first; i < last; ++i) {
+            sorted_trav.insert(trav[i]);
+        }
+        sorted_traversals.push_back(sorted_trav);
+    } 
+
+    for (const int& i : traversal_order) {
+        const auto& trav = sorted_traversals[i];
+        double max_jaccard = 0;
+        int64_t max_cluster_idx = -1;
         for (int64_t j = 0; j < clusters.size(); ++j) {
-            const Traversal& cluster_trav = traversals[clusters[j][0]];
+            const auto& cluster_trav = sorted_traversals[clusters[j][0]];
             double jac = jaccard_coefficient(trav, cluster_trav);
-            if (jac < min_jaccard) {
-                min_jaccard = jac;
-                min_cluster_idx = j;
-                if (jac == 0) {
+            if (jac > max_jaccard) {
+                max_jaccard = jac;
+                max_cluster_idx = j;
+                if (jac == 1) {
                     break;
                 }                    
             }        
         }
-        if (min_cluster_idx >= 0) {
+        if (max_cluster_idx >= 0 && max_jaccard >= min_jaccard) {
             // we've found a suitably similar cluster, add it do that
-            clusters[min_cluster_idx].push_back(i);
+            clusters[max_cluster_idx].push_back(i);
         } else {
             // there's no cluster close enough, need to start a new one
             clusters.push_back({i});

--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -5,6 +5,31 @@
 namespace vg {
 
 
+// specialized version of jaccard_coefficient() that weights jaccard by node lenths. 
+double weighted_jaccard_coefficient(const PathHandleGraph* graph,
+                                    const multiset<handle_t>& target,
+                                    const multiset<handle_t>& query) {
+    vector<handle_t> intersection_handles;
+    std::set_intersection(target.begin(), target.end(),
+                          query.begin(), query.end(),
+                          std::back_inserter(intersection_handles));
+    vector<handle_t> union_handles;
+    std::set_union(target.begin(), target.end(),
+                   query.begin(), query.end(),
+                   std::back_inserter(union_handles));
+
+    int64_t isec_size = 0;
+    for (const handle_t& handle : intersection_handles) {
+        isec_size += graph->get_length(handle);
+    }
+    int64_t union_size = 0;
+    for (const handle_t& handle : union_handles) {
+        union_size += graph->get_length(handle);
+    }    
+    return (double)isec_size / (double)union_size;
+}
+
+
 vector<int> get_traversal_order(const PathHandleGraph* graph,
                                 const vector<Traversal>& traversals,
                                 const vector<string>& trav_path_names,
@@ -89,7 +114,7 @@ vector<vector<int>> cluster_traversals(const PathHandleGraph* graph,
         int64_t max_cluster_idx = -1;
         for (int64_t j = 0; j < clusters.size(); ++j) {
             const auto& cluster_trav = sorted_traversals[clusters[j][0]];
-            double jac = jaccard_coefficient(trav, cluster_trav);
+            double jac = weighted_jaccard_coefficient(graph, trav, cluster_trav);
             if (jac > max_jaccard) {
                 max_jaccard = jac;
                 max_cluster_idx = j;

--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -1,0 +1,45 @@
+#include "traversal_clusters.hpp"
+
+namespace vg {
+
+vector<vector<int>> cluster_traversals(const PathHandleGraph* graph,
+                                       const vector<Traversal>& traversals,
+                                       const vector<int64_t>& traversal_order,
+                                       double min_jaccard) {
+
+    assert(traversal_order.size() == traversals.size());
+    
+    // the values are indexes in the input traversals vector
+    // the "reference" traversal of each cluster (to which distance is computed)
+    // is always its first element
+    vector<vector<int>> clusters;
+
+    for (const int64_t& i : traversal_order) {
+        const Traversal& trav = traversals[i];
+        double min_jaccard = numeric_limits<double>::max();
+        int64_t min_cluster_idx = -1;
+        for (int64_t j = 0; j < clusters.size(); ++j) {
+            const Traversal& cluster_trav = traversals[clusters[j][0]];
+            double jac = jaccard_coefficient(trav, cluster_trav);
+            if (jac < min_jaccard) {
+                min_jaccard = jac;
+                min_cluster_idx = j;
+                if (jac == 0) {
+                    break;
+                }                    
+            }        
+        }
+        if (min_cluster_idx >= 0) {
+            // we've found a suitably similar cluster, add it do that
+            clusters[min_cluster_idx].push_back(i);
+        } else {
+            // there's no cluster close enough, need to start a new one
+            clusters.push_back({i});
+        }        
+    }
+
+    return clusters;
+}
+
+
+}

--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -1,5 +1,7 @@
 #include "traversal_clusters.hpp"
 
+//#define debug
+
 namespace vg {
 
 
@@ -11,10 +13,14 @@ vector<int> get_traversal_order(const PathHandleGraph* graph,
     set<int> ref_set(ref_travs.begin(), ref_travs.end());
     
     function<bool(int, int)> trav_less = [&](int i, int j) {
-        if (ref_set.count(i) && !ref_set.count(j)) {
-            return true;
+        // give reference set preference priority
+        bool iref = ref_set.count(i);
+        bool jref = ref_set.count(j);
+        if (iref != jref) {
+            return iref;
         }
-        if (!trav_path_names[i].empty() && (!trav_path_names[j].empty() || trav_path_names[i] < trav_path_names[j])) {
+        // fall back to name comparison 
+        if (!trav_path_names[i].empty() && (trav_path_names[j].empty() || trav_path_names[i] < trav_path_names[j])) {
             return true;
         }
         return false;
@@ -27,15 +33,30 @@ vector<int> get_traversal_order(const PathHandleGraph* graph,
             sorted_travs.push_back(i);
         }
     }
+#ifdef debug
+    cerr << "names:";
+    for (auto x : trav_path_names) cerr << " " << x;
+    cerr << endl << "ref set:";
+    for (auto x : ref_set) cerr << " " << x;
+    cerr << endl << "before sort:";
+    for (auto x : sorted_travs) cerr << " " << x;
+#endif
     std::sort(sorted_travs.begin(), sorted_travs.end(), trav_less);
+#ifdef debug
+    cerr << endl << "after sort:";
+    for (auto x : sorted_travs) cerr << " " << x;
+    cerr << endl;
+#endif
+    assert(ref_travs.empty() || sorted_travs.empty() || ref_set.count(sorted_travs.front()));
     return sorted_travs;
 }
 
 vector<vector<int>> cluster_traversals(const PathHandleGraph* graph,
                                        const vector<Traversal>& traversals,
                                        const vector<int>& traversal_order,
-                                       double min_jaccard) {
-
+                                       double min_jaccard,
+                                       vector<pair<double, int64_t>>& out_info) {
+    
     assert(traversal_order.size() <= traversals.size());
     
     // the values are indexes in the input traversals vector
@@ -43,6 +64,8 @@ vector<vector<int>> cluster_traversals(const PathHandleGraph* graph,
     // is always its first element
     vector<vector<int>> clusters;
 
+    out_info.resize(traversals.size(), make_pair(-1., 0));
+    
     // need the clusters as sorted lists. we'll forget the endpoints while we're at
     // it since they're always shared.  note we work with multisets since we want to
     // count differences between, say, cycle copy numbers. 
@@ -78,10 +101,39 @@ vector<vector<int>> cluster_traversals(const PathHandleGraph* graph,
         if (max_cluster_idx >= 0 && max_jaccard >= min_jaccard) {
             // we've found a suitably similar cluster, add it do that
             clusters[max_cluster_idx].push_back(i);
+            out_info[i] = make_pair(max_jaccard, 0);
         } else {
             // there's no cluster close enough, need to start a new one
             clusters.push_back({i});
+            out_info[i] = make_pair(1.0, 0);
         }        
+    }
+
+    // fill in the size deltas
+    for (vector<int>& cluster : clusters) {
+        // only non-zero for non-empty clusters
+        if (cluster.size() > 1) {
+            int64_t cluster_ref_length = -1;
+            for (int64_t i = 1; i < cluster.size(); ++i) {
+                if (out_info[cluster[i]].first < 1) {
+                    // get the cluster reference length on-demand
+                    if (cluster_ref_length == -1) {
+                        cluster_ref_length = 0;
+                        for (const handle_t& handle : traversals[cluster[0]]) {
+                            cluster_ref_length += graph->get_length(handle);
+                        }
+                    }
+                    // compute the length of the non-ref traversal
+                    int64_t length = 0;
+                    for (const handle_t& handle : traversals[cluster[i]]) {
+                        length += graph->get_length(handle);
+                    }
+                    // store the delta
+                   out_info[cluster[i]].second = length - cluster_ref_length;
+                }
+                
+            }
+        }
     }
 
     return clusters;

--- a/src/traversal_clusters.hpp
+++ b/src/traversal_clusters.hpp
@@ -66,10 +66,13 @@ vector<int> get_traversal_order(const PathHandleGraph* graph,
 ///   - if the traversal is <= min_jaccard away from the reference traversal of cluster, add to cluster
 ///   - else start a new cluster, with the given traversal as a reference
 /// note that traversal_order can specify a subset of traversals
+/// out_info are Simlarity/length-delta pairs comparing the traversal to its cluster reference
+/// (if the traversal wasn't in traversal_order, it'll get -1)
 vector<vector<int>> cluster_traversals(const PathHandleGraph* graph,
                                        const vector<Traversal>& traversals,
                                        const vector<int>& traversal_order,                                       
-                                       double min_jaccard);
+                                       double min_jaccard,
+                                       vector<pair<double, int64_t>>& out_info);
 
 //int64_t find_parent_traversal(const PathHandleGraph* graph,
 //                              const vector<Traversal>& traversals,

--- a/src/traversal_clusters.hpp
+++ b/src/traversal_clusters.hpp
@@ -1,0 +1,55 @@
+#include "handle.hpp"
+#include "traversal_finder.hpp"
+
+#pragma once
+
+
+/** \file
+* Utilities for finding and clustering similar snarl traversals
+*/
+namespace vg {
+using namespace std;
+
+// 
+template <typename T>
+class count_back_inserter {
+    size_t &count;
+public:
+    typedef void value_type;
+    typedef void difference_type;
+    typedef void pointer;
+    typedef void reference;
+    typedef std::output_iterator_tag iterator_category;
+    count_back_inserter(size_t &count) : count(count) {};
+    void operator=(const T &){ ++count; }
+    count_back_inserter &operator *(){ return *this; }
+    count_back_inserter &operator++(){ return *this; }
+};
+
+// compute the jaccard coefficient (|intersection| / |union|) of two sets
+// target and query should be sorted vectors (or something equivalent)
+template <typename T, typename U>
+inline double jaccard_coefficient(const T& target, const U& query) {
+    size_t isec_size = 0;
+    std::set_intersection(target.begin(), target.end(),
+                          query.begin(), query.end(),
+                          count_back_inserter<typename T::value_type>(isec_size));
+    size_t union_size = 0;
+    std::set_union(target.begin(), target.end(),
+                   query.begin(), query.end(),
+                   count_back_inserter<typename T::value_type>(union_size));
+    return (double)isec_size / (double)union_size;
+
+}
+
+/// cluster the traversals. The algorithm is:
+/// - visit traversals in provided order
+///   - if the traversal is <= min_jaccard away from the reference traversal of cluster, add to cluster
+///   - else start a new cluster, with the given traversal as a reference
+vector<vector<int>> cluster_traversals(const PathHandleGraph* graph,
+                                       const vector<Traversal>& traversals,
+                                       function<int64_t(int64_t)> traversal_order,
+                                       double min_jaccard);
+
+
+}

--- a/src/traversal_clusters.hpp
+++ b/src/traversal_clusters.hpp
@@ -39,8 +39,10 @@ inline double jaccard_coefficient(const T& target, const U& query) {
                    query.begin(), query.end(),
                    count_back_inserter<typename T::value_type>(union_size));
     return (double)isec_size / (double)union_size;
-
 }
+
+// specialized version that weights jaccard by node lenths. 
+double weighted_jaccard_coefficient(const PathHandleGraph* graph, const multiset<handle_t>& target, const multiset<handle_t>& query);
 
 // the information needed from the parent traversal in order to
 // genotype a child traversal

--- a/src/traversal_clusters.hpp
+++ b/src/traversal_clusters.hpp
@@ -42,14 +42,36 @@ inline double jaccard_coefficient(const T& target, const U& query) {
 
 }
 
+// the information needed from the parent traversal in order to
+// genotype a child traversal
+struct ParentGenotypeInfo {
+    Traversal ref_traversal;
+    pair<step_handle_t, step_handle_t> ref_steps;
+    unordered_map<string, int64_t> sample_to_ploidy; // to check/enforce consistency
+};
+
+
+/// sort the traversals, putting the reference first then using names
+/// traversals masked out by use_traversal will be filrtered out entirely
+/// (so the output vector may be smaller than the input...)
+vector<int> get_traversal_order(const PathHandleGraph* graph,
+                                const vector<Traversal>& traversals,
+                                const vector<string>& trav_path_names,
+                                const vector<int>& ref_travs,
+                                const vector<bool>& use_traversal);
+
+
 /// cluster the traversals. The algorithm is:
 /// - visit traversals in provided order
 ///   - if the traversal is <= min_jaccard away from the reference traversal of cluster, add to cluster
 ///   - else start a new cluster, with the given traversal as a reference
+/// note that traversal_order can specify a subset of traversals
 vector<vector<int>> cluster_traversals(const PathHandleGraph* graph,
                                        const vector<Traversal>& traversals,
-                                       function<int64_t(int64_t)> traversal_order,
+                                       const vector<int>& traversal_order,                                       
                                        double min_jaccard);
 
-
+//int64_t find_parent_traversal(const PathHandleGraph* graph,
+//                              const vector<Traversal>& traversals,
+                              
 }

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -10,7 +10,7 @@ namespace vg {
 
 using namespace std;
 
-string traversal_to_string(const PathHandleGraph* graph, const Traversal& traversal, bool max_steps) {
+string traversal_to_string(const PathHandleGraph* graph, const Traversal& traversal, int64_t max_steps) {
     string s;
     function<string(handle_t)> handle_to_string = [&](handle_t handle) {
         string ss = graph->get_is_reverse(handle) ? "<" : ">";

--- a/src/traversal_finder.hpp
+++ b/src/traversal_finder.hpp
@@ -39,7 +39,7 @@ class AugmentedGraph;
 // some Protobuf replacements
 using Traversal = vector<handle_t>;
 using PathInterval = pair<step_handle_t, step_handle_t>;
-string traversal_to_string(const PathHandleGraph* graph, const Traversal& traversal, bool max_steps = 10);
+string traversal_to_string(const PathHandleGraph* graph, const Traversal& traversal, int64_t max_steps = 10);
 // replaces pb2json(snarl)
 string graph_interval_to_string(const HandleGraph* graph, const handle_t& start_handle, const handle_t& end_handle);
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Experimental option `-L` added to `vg deconstruct` in order to cluster similar allele traversals together.  The value given is a (length-weighted) threshold for the jaccard coefficient between the oriented nodes of two traversals.  So if `-L 0.75` is given, then alleles that have >= 0.75 similarity based on their graph positions will be merged into one.  Two new FORMAT fields are added to keep track of the difference, `TS` (jaccard distance) and `TL` (length difference).  Clustering is done greedily starting with selected reference paths. 

## Description

I don't think the clustering is especially useful on its own (though it can be used to make much simpler VCFs), but it's an important part of improved multi-level vcf support (finally coming in next PR).  (it's also why I'm clustering on graph path and not the actual dna string, since only the paths themselves can be used to anchor the child snarls)


