### PR TITLE
star allele toggle for deconstruct

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -974,8 +974,10 @@ bool Deconstructor::deconstruct_site(const handle_t& snarl_start, const handle_t
             
             // add in the star alleles -- these are alleles that were genotyped in the parent but not
             // the current allele, and are treated as *'s in VCF.
-            sample_to_haps = add_star_traversals(travs, trav_path_names, trav_clusters, trav_cluster_info,
-                                                 in_nesting_info->sample_to_haplotypes);
+            if (this->star_allele) {
+                sample_to_haps = add_star_traversals(travs, trav_path_names, trav_clusters, trav_cluster_info,
+                                                     in_nesting_info->sample_to_haplotypes);
+            }
             
         }
 
@@ -1364,7 +1366,8 @@ void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHand
                                 bool long_ref_contig,
                                 double cluster_threshold,
                                 gbwt::GBWT* gbwt,
-                                bool nested_decomposition) {
+                                bool nested_decomposition,
+                                bool star_allele) {
 
     this->graph = graph;
     this->ref_paths = set<string>(ref_paths.begin(), ref_paths.end());
@@ -1380,6 +1383,7 @@ void Deconstructor::deconstruct(vector<string> ref_paths, const PathPositionHand
     this->cluster_threshold = cluster_threshold;
     this->gbwt = gbwt;
     this->nested_decomposition = nested_decomposition;
+    this->star_allele = star_allele;
 
     // the need to use nesting is due to a problem with omp tasks and shared state
     // which results in extremely high memory costs (ex. ~10x RAM for 2 threads vs. 1)

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -1025,7 +1025,7 @@ bool Deconstructor::deconstruct_site(const handle_t& snarl_start, const handle_t
             v.info["PR"].push_back(std::to_string(ref_info.parent_ref_len));            
             v.info["RC"].push_back(ref_info.lv0_ref_name);
             v.info["RS"].push_back(std::to_string(ref_info.lv0_ref_start));
-            v.info["RE"].push_back(std::to_string(ref_info.lv0_ref_len));
+            v.info["RD"].push_back(std::to_string(ref_info.lv0_ref_len));
             v.info["RL"].push_back(std::to_string(ref_info.lv0_alt_len));
         }
 
@@ -1167,9 +1167,9 @@ string Deconstructor::get_vcf_header() {
         stream << "\">" << endl;
     }
     if (path_to_sample_phase && cluster_threshold < 1) {
-        stream << "##FORMAT<ID=TS,Number=1,Type=Float,Descript=\"Similarity between the sample's actual path and its allele\">"
+        stream << "##FORMAT=<ID=TS,Number=1,Type=Float,Descript=\"Similarity between the sample's actual path and its allele\">"
                << endl;
-        stream << "##FORMAT<ID=TL,Number=1,Type=Integer,Descript=\"Length difference between the sample's actual path and its allele\">"
+        stream << "##FORMAT=<ID=TL,Number=1,Type=Integer,Descript=\"Length difference between the sample's actual path and its allele\">"
                << endl;
 
     }
@@ -1187,7 +1187,7 @@ string Deconstructor::get_vcf_header() {
         stream << "##INFO=<ID=PR,Number=1,Type=Integer,Description=\"Length of 0th allele in the Parent Snarl\">" << endl;
         stream << "##INFO=<ID=RC,Number=1,Type=String,Description=\"Reference chromosome name of top-level containing site\">" << endl;
         stream << "##INFO=<ID=RS,Number=1,Type=Integer,Description=\"Reference start position of top-level containing site\">" << endl;
-        stream << "##INFO=<ID=RE,Number=1,Type=Integer,Description=\"Reference end position name of top-level containing site\">" << endl;
+        stream << "##INFO=<ID=RD,Number=1,Type=Integer,Description=\"Reference end position name of top-level containing site\">" << endl;
         stream << "##INFO=<ID=RL,Number=1,Type=Integer,Description=\"Length of the top-level allele in which this site nests\">" << endl;
     }
     if (untangle_allele_traversals) {

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -1169,9 +1169,9 @@ string Deconstructor::get_vcf_header() {
         stream << "\">" << endl;
     }
     if (path_to_sample_phase && cluster_threshold < 1) {
-        stream << "##FORMAT=<ID=TS,Number=1,Type=Float,Descript=\"Similarity between the sample's actual path and its allele\">"
+        stream << "##FORMAT=<ID=TS,Number=1,Type=Float,Description=\"Similarity between the sample's actual path and its allele\">"
                << endl;
-        stream << "##FORMAT=<ID=TL,Number=1,Type=Integer,Descript=\"Length difference between the sample's actual path and its allele\">"
+        stream << "##FORMAT=<ID=TL,Number=1,Type=Integer,Description=\"Length difference between the sample's actual path and its allele\">"
                << endl;
 
     }

--- a/src/deconstructor.hpp
+++ b/src/deconstructor.hpp
@@ -47,7 +47,8 @@ public:
                      bool long_ref_contig,
                      double cluster_threshold = 1.0,
                      gbwt::GBWT* gbwt = nullptr,
-                     bool nested_decomposition = false);
+                     bool nested_decomposition = false,
+                     bool star_allele = false);
     
 private:
 
@@ -201,6 +202,11 @@ private:
     // (which lives in vcfoutputcaller) but with more of an effort to link
     // the parent and child snarls, as well as better support for nested insertions
     bool nested_decomposition = false;
+
+    // use *-alleles to represent spanning alleles that do not cross site but do go around it
+    // ex: a big containing deletion
+    // only works with nested_decomposition
+    bool star_allele = false;
 };
 
 

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 36
+plan tests 37
 
 vg msga -f GRCh38_alts/FASTA/HLA/V-352962.fa -t 1 -k 16 | vg mod -U 10 - | vg mod -c - > hla.vg
 vg index hla.vg -x hla.xg
@@ -155,7 +155,7 @@ is "$(tail -1 small_cluster_3.vcf | awk '{print $10}')" "0:0.333:0" "clustered d
 
 rm -f small_cluster.gfa small_cluster_0.vcf small_cluster_3.vcf
 
-vg deconstruct nesting/nested_snp_in_del.gfa -p x -n > nested_snp_in_del.vcf
+vg deconstruct nesting/nested_snp_in_del.gfa -p x -nR > nested_snp_in_del.vcf
 grep -v ^# nested_snp_in_del.vcf | awk '{print $4 "\t" $5 "\t" $10}' > nested_snp_in_del.tsv
 printf "CATG\tCAAG,C\t1|2\n" > nested_snp_in_del_truth.tsv
 printf "T\tA,*\t1|2\n" >> nested_snp_in_del_truth.tsv
@@ -163,6 +163,15 @@ diff nested_snp_in_del.tsv nested_snp_in_del_truth.tsv
 is "$?" 0 "nested deconstruction gets correct star-allele for snp inside deletion"
 
 is $(grep PA=0 nested_snp_in_del.vcf | wc -l) 2 "PA=0 correctly set at both sites of neseted deletion"
+
+rm -f nested_snp_in_del.vcf nested_snp_in_del.tsv nested_snp_in_del_truth.tsv
+
+vg deconstruct nesting/nested_snp_in_del.gfa -p x -n > nested_snp_in_del.vcf
+grep -v ^# nested_snp_in_del.vcf | awk '{print $4 "\t" $5 "\t" $10}' > nested_snp_in_del.tsv
+printf "CATG\tCAAG,C\t1|2\n" > nested_snp_in_del_truth.tsv
+printf "T\tA\t1|.\n" >> nested_snp_in_del_truth.tsv
+diff nested_snp_in_del.tsv nested_snp_in_del_truth.tsv
+is "$?" 0 "nested deconstruction gets correct allele for snp inside deletion (without -R)"
 
 rm -f nested_snp_in_del.vcf nested_snp_in_del.tsv nested_snp_in_del_truth.tsv
 
@@ -184,7 +193,7 @@ is "$?" 0 "nested deconstruction gets correct contigs in vcf header for snp insi
 
 rm -f nested_snp_in_ins.tsv nested_snp_in_ins.tsv nested_snp_in_ins_truth.tsv  nested_snp_in_ins_contigs.tsv nested_snp_in_ins_contigs_truth.tsv
 
-vg deconstruct nesting/nested_snp_in_ins2.gfa -p x -n | grep -v ^# | awk '{print $4 "\t" $5 "\t" $10 "\t" $11}' > nested_snp_in_ins2.tsv
+vg deconstruct nesting/nested_snp_in_ins2.gfa -p x -nR | grep -v ^# | awk '{print $4 "\t" $5 "\t" $10 "\t" $11}' > nested_snp_in_ins2.tsv
 printf "A\tT,*\t0|1\t0|2\n" > nested_snp_in_ins2._truth.tsv
 printf "C\tCAAG,CATG\t1|2\t1|0\n" >> nested_snp_in_ins2._truth.tsv
 diff nested_snp_in_ins2.tsv nested_snp_in_ins2._truth.tsv

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -197,15 +197,15 @@ rm -f nested_snp_in_ins2.tsv nested_snp_in_ins2._truth.tsv
 #       but seems like something that needs reviewing
 vg snarls nesting/nested_snp_in_nested_ins.gfa -A cactus > nested_snp_in_nested_ins.snarls
 vg deconstruct nesting/nested_snp_in_nested_ins.gfa -r nested_snp_in_nested_ins.snarls -P x -n > nested_snp_in_nested_ins.vcf
-is $(grep -v ^# nested_snp_in_nested_ins.vcf | grep LV=0 | awk '{print $8}') "AC=1,1;AF=0.5,0.5;AN=2;AT=>1>6,>1>2>3>31>33>34>35>5>6,>1>2>3>31>32>34>35>5>6;NS=1;PA=0;PL=1;PR=1;RC=x;RE=1;RL=1;RS=1;LV=0" "INFO tags correct for level-0 site of double-nested SNP"
-is $(grep -v ^# nested_snp_in_nested_ins.vcf | grep LV=1 | awk '{print $8}') "AC=1;AF=0.5;AN=2;AT=>2>3>31>33>34>35>5,>2>3>31>32>34>35>5;NS=1;PA=1;PL=8;PR=1;RC=x;RE=1;RL=8;RS=1;LV=1;PS=>1>6" "INFO tags correct for level-1 site of double-nested SNP"
-is $(grep -v ^# nested_snp_in_nested_ins.vcf | grep LV=2 | awk '{print $8}') "AC=1;AF=0.5;AN=2;AT=>31>33>34,>31>32>34;NS=1;PA=0;PL=5;PR=5;RC=x;RE=1;RL=8;RS=1;LV=2;PS=>2>5" "INFO tags correct for level-2 site of double-nested SNP"
+is $(grep -v ^# nested_snp_in_nested_ins.vcf | grep LV=0 | awk '{print $8}') "AC=1,1;AF=0.5,0.5;AN=2;AT=>1>6,>1>2>3>31>33>34>35>5>6,>1>2>3>31>32>34>35>5>6;NS=1;PA=0;PL=1;PR=1;RC=x;RD=1;RL=1;RS=1;LV=0" "INFO tags correct for level-0 site of double-nested SNP"
+is $(grep -v ^# nested_snp_in_nested_ins.vcf | grep LV=1 | awk '{print $8}') "AC=1;AF=0.5;AN=2;AT=>2>3>31>33>34>35>5,>2>3>31>32>34>35>5;NS=1;PA=1;PL=8;PR=1;RC=x;RD=1;RL=8;RS=1;LV=1;PS=>1>6" "INFO tags correct for level-1 site of double-nested SNP"
+is $(grep -v ^# nested_snp_in_nested_ins.vcf | grep LV=2 | awk '{print $8}') "AC=1;AF=0.5;AN=2;AT=>31>33>34,>31>32>34;NS=1;PA=0;PL=5;PR=5;RC=x;RD=1;RL=8;RS=1;LV=2;PS=>2>5" "INFO tags correct for level-2 site of double-nested SNP"
 
 rm -f nested_snp_in_nested_ins.snarls nested_snp_in_nested_ins.vcf
 
 vg deconstruct nesting/nested_snp_in_ins_cycle.gfa -P x -n > nested_snp_in_ins_cycle.vcf
-printf "A#1#y0\t6\t>2>5\tA\tT\tAC=2;AF=0.5;AN=4;AT=>2>4>5,>2>3>5;NS=2;PA=1;PL=7;PR=1;RC=x;RE=1;RL=7;RS=1;LV=1;PS=>1>6\t0|1\t0|1\n" >  nested_snp_in_ins_cycle_truth.tsv
-printf "x\t1\t>1>6\tC\tCAAGAAG,CATG,CAAG\tAC=1,2,1;AF=0.25,0.5,0.25;AN=4;AT=>1>6,>1>2>4>5>2>4>5>6,>1>2>3>5>6,>1>2>4>5>6;NS=2;PA=0;PL=1;PR=1;RC=x;RE=1;RL=1;RS=1;LV=0\t1|2\t3|2\n" >> nested_snp_in_ins_cycle_truth.tsv
+printf "A#1#y0\t6\t>2>5\tA\tT\tAC=2;AF=0.5;AN=4;AT=>2>4>5,>2>3>5;NS=2;PA=1;PL=7;PR=1;RC=x;RD=1;RL=7;RS=1;LV=1;PS=>1>6\t0|1\t0|1\n" >  nested_snp_in_ins_cycle_truth.tsv
+printf "x\t1\t>1>6\tC\tCAAGAAG,CATG,CAAG\tAC=1,2,1;AF=0.25,0.5,0.25;AN=4;AT=>1>6,>1>2>4>5>2>4>5>6,>1>2>3>5>6,>1>2>4>5>6;NS=2;PA=0;PL=1;PR=1;RC=x;RD=1;RL=1;RS=1;LV=0\t1|2\t3|2\n" >> nested_snp_in_ins_cycle_truth.tsv
 grep -v ^#  nested_snp_in_ins_cycle.vcf | awk '{print $1 "\t" $2 "\t" $3 "\t" $4 "\t" $5 "\t" $8 "\t" $10 "\t" $11}' > nested_snp_in_ins_cycle.tsv
 diff nested_snp_in_ins_cycle.tsv nested_snp_in_ins_cycle_truth.tsv
 is "$?" 0 "nested deconstruction handles cycle"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `-R` option added to `vg deconstruct` to toggle whether star-alleles are reported with `-n`.  

## Description
