### PR TITLE
Port `vg filter --exact-name` from lr-giraffe branch

### DIFF
--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -43,6 +43,8 @@ public:
     /// TODO: This should be a trie but I don't have one handy.
     /// Must be sorted for vaguely efficient search.
     vector<string> name_prefixes;
+    /// Read name must not have anything in it besides the prefix
+    bool exact_name = false;
     /// Read must not have a refpos set with a contig name containing a match to any of these
     vector<regex> excluded_refpos_contigs;
     /// Read must contain at least one of these strings as a subsequence
@@ -192,7 +194,8 @@ private:
     double get_score(const Read& read) const;
     
     /**
-     * Does the read name have one of the indicated prefixes?
+     * Does the read name have one of the indicated prefixes? If exact_name is
+     * set, only finds complete matches of a "prefix" to the whole read name.
      */
     bool matches_name(const Read& read) const;
     
@@ -712,7 +715,7 @@ bool ReadFilter<Read>::matches_name(const Read& aln) const {
             right_match++;
         }
         
-        if (left_match == name_prefixes[left_bound].size() || right_match == name_prefixes[right_bound].size()) {
+        if (!exact_name && (left_match == name_prefixes[left_bound].size() || right_match == name_prefixes[right_bound].size())) {
             // We found a match already
             found = true;
         } else {
@@ -729,7 +732,7 @@ bool ReadFilter<Read>::matches_name(const Read& aln) const {
                     center_match++;
                 }
                 
-                if (center_match == name_prefixes[center].size()) {
+                if (center_match == name_prefixes[center].size() && (!exact_name || center_match == aln.name().size())) {
                     // We found a hit!
                     found = true;
                     break;

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -715,7 +715,8 @@ bool ReadFilter<Read>::matches_name(const Read& aln) const {
             right_match++;
         }
         
-        if (!exact_name && (left_match == name_prefixes[left_bound].size() || right_match == name_prefixes[right_bound].size())) {
+        if ((left_match == name_prefixes[left_bound].size() && (!exact_name || left_match == aln.name().size())) ||
+            (right_match == name_prefixes[right_bound].size() && (!exact_name || right_match == aln.name().size()))) {
             // We found a match already
             found = true;
         } else {

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -31,7 +31,7 @@ void help_filter(char** argv) {
          << "    -M, --input-mp-alns        input is multipath alignments (GAMP) rather than GAM" << endl
          << "    -n, --name-prefix NAME     keep only reads with this prefix in their names [default='']" << endl
          << "    -N, --name-prefixes FILE   keep reads with names with one of many prefixes, one per nonempty line" << endl
-         << "    -c, --exact-name           match read names exactly instead of by prefix" << endl
+         << "    -e, --exact-name           match read names exactly instead of by prefix" << endl
          << "    -a, --subsequence NAME     keep reads that contain this subsequence" << endl
          << "    -A, --subsequences FILE    keep reads that contain one of these subsequences, one per nonempty line" << endl
          << "    -p, --proper-pairs         keep reads that are annotated as being properly paired" << endl

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -126,7 +126,7 @@ int main_filter(int argc, char** argv) {
                 {"input-mp-alns", no_argument, 0, 'M'},
                 {"name-prefix", required_argument, 0, 'n'},
                 {"name-prefixes", required_argument, 0, 'N'},
-                {"exact-name", no_argument, 0, 'c'},
+                {"exact-name", no_argument, 0, 'e'},
                 {"subsequence", required_argument, 0, 'a'},
                 {"subsequences", required_argument, 0, 'A'},
                 {"proper-pairs", no_argument, 0, 'p'},
@@ -153,14 +153,14 @@ int main_filter(int argc, char** argv) {
                 {"interleaved-all", no_argument, 0, 'I'},
                 {"min-base-quality", required_argument, 0, 'b'},
                 {"annotation", required_argument, 0, 'B'},
-                {"correctly-mapped", no_argument, 0, 'g'},
+                {"correctly-mapped", no_argument, 0, 'c'},
                 {"complement", no_argument, 0, 'U'},
                 {"threads", required_argument, 0, 't'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "Mn:N:ca:A:pPX:F:s:r:Od:e:fauo:m:Sx:vVT:q:E:D:C:d:iIb:B:gUt:",
+        c = getopt_long (argc, argv, "Mn:N:ea:A:pPX:F:s:r:Od:fauo:m:Sx:vVT:q:E:D:C:d:iIb:B:cUt:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -188,7 +188,7 @@ int main_filter(int argc, char** argv) {
                 }
             });
             break;
-        case 'c':
+        case 'e':
             exact_name = true;
             break;
         case 'a':
@@ -330,7 +330,7 @@ int main_filter(int argc, char** argv) {
         case 'B':
             annotation = optarg;
             break;
-        case 'g':
+        case 'c':
             correctly_mapped = true;
             break;
         case 'U':

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -31,6 +31,7 @@ void help_filter(char** argv) {
          << "    -M, --input-mp-alns        input is multipath alignments (GAMP) rather than GAM" << endl
          << "    -n, --name-prefix NAME     keep only reads with this prefix in their names [default='']" << endl
          << "    -N, --name-prefixes FILE   keep reads with names with one of many prefixes, one per nonempty line" << endl
+         << "    -c, --exact-name           match read names exactly instead of by prefix" << endl
          << "    -a, --subsequence NAME     keep reads that contain this subsequence" << endl
          << "    -A, --subsequences FILE    keep reads that contain one of these subsequences, one per nonempty line" << endl
          << "    -p, --proper-pairs         keep reads that are annotated as being properly paired" << endl
@@ -73,6 +74,7 @@ int main_filter(int argc, char** argv) {
     
     bool input_gam = true;
     vector<string> name_prefixes;
+    bool exact_name = false;
     vector<regex> excluded_refpos_contigs;
     unordered_set<string> excluded_features;
     vector<string> subsequences;
@@ -124,6 +126,7 @@ int main_filter(int argc, char** argv) {
                 {"input-mp-alns", no_argument, 0, 'M'},
                 {"name-prefix", required_argument, 0, 'n'},
                 {"name-prefixes", required_argument, 0, 'N'},
+                {"exact-name", no_argument, 0, 'c'},
                 {"subsequence", required_argument, 0, 'a'},
                 {"subsequences", required_argument, 0, 'A'},
                 {"proper-pairs", no_argument, 0, 'p'},
@@ -150,14 +153,14 @@ int main_filter(int argc, char** argv) {
                 {"interleaved-all", no_argument, 0, 'I'},
                 {"min-base-quality", required_argument, 0, 'b'},
                 {"annotation", required_argument, 0, 'B'},
-                {"correctly-mapped", no_argument, 0, 'c'},
+                {"correctly-mapped", no_argument, 0, 'g'},
                 {"complement", no_argument, 0, 'U'},
                 {"threads", required_argument, 0, 't'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "Mn:N:a:A:pPX:F:s:r:Od:e:fauo:m:Sx:vVT:q:E:D:C:d:iIb:B:cUt:",
+        c = getopt_long (argc, argv, "Mn:N:ca:A:pPX:F:s:r:Od:e:fauo:m:Sx:vVT:q:E:D:C:d:iIb:B:gUt:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -184,6 +187,9 @@ int main_filter(int argc, char** argv) {
                     name_prefixes.push_back(line);
                 }
             });
+            break;
+        case 'c':
+            exact_name = true;
             break;
         case 'a':
             subsequences.push_back(optarg);
@@ -324,7 +330,7 @@ int main_filter(int argc, char** argv) {
         case 'B':
             annotation = optarg;
             break;
-        case 'c':
+        case 'g':
             correctly_mapped = true;
             break;
         case 'U':
@@ -370,6 +376,7 @@ int main_filter(int argc, char** argv) {
     // template lambda to set parameters
     auto set_params = [&](auto& filter) {
         filter.name_prefixes = name_prefixes;
+        filter.exact_name = exact_name;
         filter.subsequences = subsequences;
         filter.excluded_refpos_contigs = excluded_refpos_contigs;
         filter.excluded_features = excluded_features;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg filter` now lets you require exact matches for name filters instead of prefix matches with `--exact-name`.

## Description

This ports over the `--exact-name` flag fro vg filter from the `lr-giraffe` branch. It also puts it on the actually-unused `e` flag, since `c` is taken here.

