### PR TITLE
Faster surject for long and short reads with GBZ

### DIFF
--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -23,15 +23,15 @@ using namespace vg::io;
 
 namespace vg {
 
-    multipath_alignment_t::multipath_alignment_t() noexcept : _mapping_quality(0) {
+    multipath_alignment_t::multipath_alignment_t() : _mapping_quality(0) {
         // i don't understand why this is necessary, but somehow mapq is getting defaulted to 160?
     }
 
-    multipath_alignment_t::multipath_alignment_t(const multipath_alignment_t& other) noexcept {
+    multipath_alignment_t::multipath_alignment_t(const multipath_alignment_t& other) {
         *this = other;
     }
 
-    multipath_alignment_t::multipath_alignment_t(multipath_alignment_t&& other) noexcept {
+    multipath_alignment_t::multipath_alignment_t(multipath_alignment_t&& other) {
         *this = move(other);
     }
 

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -23,19 +23,19 @@ using namespace vg::io;
 
 namespace vg {
 
-    multipath_alignment_t::multipath_alignment_t() : _mapping_quality(0) {
+    multipath_alignment_t::multipath_alignment_t() noexcept : _mapping_quality(0) {
         // i don't understand why this is necessary, but somehow mapq is getting defaulted to 160?
     }
 
-    multipath_alignment_t::multipath_alignment_t(const multipath_alignment_t& other) {
+    multipath_alignment_t::multipath_alignment_t(const multipath_alignment_t& other) noexcept {
         *this = other;
     }
 
-    multipath_alignment_t::multipath_alignment_t(multipath_alignment_t&& other) {
+    multipath_alignment_t::multipath_alignment_t(multipath_alignment_t&& other) noexcept {
         *this = move(other);
     }
 
-    multipath_alignment_t& multipath_alignment_t::operator=(const multipath_alignment_t& other) {
+    multipath_alignment_t& multipath_alignment_t::operator=(const multipath_alignment_t& other) noexcept {
         _sequence = other._sequence;
         _quality = other._quality;
         _subpath = other._subpath;
@@ -64,7 +64,7 @@ namespace vg {
         return *this;
     }
 
-    multipath_alignment_t& multipath_alignment_t::operator=(multipath_alignment_t&& other) {
+    multipath_alignment_t& multipath_alignment_t::operator=(multipath_alignment_t&& other) noexcept {
         if (this != &other) {
             _sequence = move(other._sequence);
             _quality = move(other._quality);

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -35,7 +35,7 @@ namespace vg {
         *this = move(other);
     }
 
-    multipath_alignment_t& multipath_alignment_t::operator=(const multipath_alignment_t& other) noexcept {
+    multipath_alignment_t& multipath_alignment_t::operator=(const multipath_alignment_t& other) {
         _sequence = other._sequence;
         _quality = other._quality;
         _subpath = other._subpath;
@@ -64,7 +64,7 @@ namespace vg {
         return *this;
     }
 
-    multipath_alignment_t& multipath_alignment_t::operator=(multipath_alignment_t&& other) noexcept {
+    multipath_alignment_t& multipath_alignment_t::operator=(multipath_alignment_t&& other) {
         if (this != &other) {
             _sequence = move(other._sequence);
             _quality = move(other._quality);
@@ -77,7 +77,7 @@ namespace vg {
         return *this;
     }
 
-    multipath_alignment_t::~multipath_alignment_t() {
+    multipath_alignment_t::~multipath_alignment_t() noexcept {
         while (!_annotation.empty()) {
             clear_annotation(_annotation.begin()->first);
         }

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -28,12 +28,12 @@ namespace vg {
 
     class connection_t {
     public:
-        connection_t() = default;
-        connection_t(const connection_t&) = default;
-        connection_t(connection_t&&) = default;
+        connection_t() noexcept = default;
+        connection_t(const connection_t&) noexcept = default;
+        connection_t(connection_t&&) noexcept = default;
         ~connection_t() = default;
-        connection_t& operator=(const connection_t&) = default;
-        connection_t& operator=(connection_t&&) = default;
+        connection_t& operator=(const connection_t&) noexcept = default;
+        connection_t& operator=(connection_t&&) noexcept = default;
         inline int32_t next() const;
         inline void set_next(int32_t n);
         inline int32_t score() const;
@@ -48,12 +48,12 @@ namespace vg {
      */
     class subpath_t {
     public:
-        subpath_t() = default;
-        subpath_t(const subpath_t&) = default;
-        subpath_t(subpath_t&&) = default;
+        subpath_t() noexcept = default;
+        subpath_t(const subpath_t&) noexcept = default;
+        subpath_t(subpath_t&&) noexcept = default;
         ~subpath_t() = default;
-        subpath_t& operator=(const subpath_t&) = default;
-        subpath_t& operator=(subpath_t&&) = default;
+        subpath_t& operator=(const subpath_t&) noexcept = default;
+        subpath_t& operator=(subpath_t&&) noexcept = default;
         inline const path_t& path() const;
         inline path_t* mutable_path();
         inline bool has_path() const;
@@ -86,12 +86,12 @@ namespace vg {
     // TODO: the metadata could be removed and only added to the protobuf at serialization time
     class multipath_alignment_t {
     public:
-        multipath_alignment_t();
-        multipath_alignment_t(const multipath_alignment_t& other);
-        multipath_alignment_t(multipath_alignment_t&& other);
+        multipath_alignment_t() noexcept;
+        multipath_alignment_t(const multipath_alignment_t& other) noexcept;
+        multipath_alignment_t(multipath_alignment_t&& other) noexcept;
         ~multipath_alignment_t();
-        multipath_alignment_t& operator=(const multipath_alignment_t& other);
-        multipath_alignment_t& operator=(multipath_alignment_t&& other);
+        multipath_alignment_t& operator=(const multipath_alignment_t& other) noexcept;
+        multipath_alignment_t& operator=(multipath_alignment_t&& other) noexcept;
         inline const string& sequence() const;
         inline string* mutable_sequence();
         inline void set_sequence(const string& s);

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -28,10 +28,10 @@ namespace vg {
 
     class connection_t {
     public:
-        connection_t() noexcept = default;
-        connection_t(const connection_t&) noexcept = default;
-        connection_t(connection_t&&) noexcept = default;
-        ~connection_t() noexcept = default;
+        connection_t() = default;
+        connection_t(const connection_t&) = default;
+        connection_t(connection_t&&) = default;
+        ~connection_t() = default;
         connection_t& operator=(const connection_t&) = default;
         connection_t& operator=(connection_t&&) = default;
         inline int32_t next() const;
@@ -48,10 +48,10 @@ namespace vg {
      */
     class subpath_t {
     public:
-        subpath_t() noexcept = default;
-        subpath_t(const subpath_t&) noexcept = default;
-        subpath_t(subpath_t&&) noexcept = default;
-        ~subpath_t() noexcept = default;
+        subpath_t() = default;
+        subpath_t(const subpath_t&) = default;
+        subpath_t(subpath_t&&) = default;
+        ~subpath_t() = default;
         subpath_t& operator=(const subpath_t&) = default;
         subpath_t& operator=(subpath_t&&) = default;
         inline const path_t& path() const;
@@ -86,10 +86,10 @@ namespace vg {
     // TODO: the metadata could be removed and only added to the protobuf at serialization time
     class multipath_alignment_t {
     public:
-        multipath_alignment_t() noexcept;
-        multipath_alignment_t(const multipath_alignment_t& other) noexcept;
-        multipath_alignment_t(multipath_alignment_t&& other) noexcept;
-        ~multipath_alignment_t() noexcept;
+        multipath_alignment_t();
+        multipath_alignment_t(const multipath_alignment_t& other);
+        multipath_alignment_t(multipath_alignment_t&& other);
+        ~multipath_alignment_t();
         multipath_alignment_t& operator=(const multipath_alignment_t& other);
         multipath_alignment_t& operator=(multipath_alignment_t&& other);
         inline const string& sequence() const;

--- a/src/multipath_alignment.hpp
+++ b/src/multipath_alignment.hpp
@@ -31,9 +31,9 @@ namespace vg {
         connection_t() noexcept = default;
         connection_t(const connection_t&) noexcept = default;
         connection_t(connection_t&&) noexcept = default;
-        ~connection_t() = default;
-        connection_t& operator=(const connection_t&) noexcept = default;
-        connection_t& operator=(connection_t&&) noexcept = default;
+        ~connection_t() noexcept = default;
+        connection_t& operator=(const connection_t&) = default;
+        connection_t& operator=(connection_t&&) = default;
         inline int32_t next() const;
         inline void set_next(int32_t n);
         inline int32_t score() const;
@@ -51,9 +51,9 @@ namespace vg {
         subpath_t() noexcept = default;
         subpath_t(const subpath_t&) noexcept = default;
         subpath_t(subpath_t&&) noexcept = default;
-        ~subpath_t() = default;
-        subpath_t& operator=(const subpath_t&) noexcept = default;
-        subpath_t& operator=(subpath_t&&) noexcept = default;
+        ~subpath_t() noexcept = default;
+        subpath_t& operator=(const subpath_t&) = default;
+        subpath_t& operator=(subpath_t&&) = default;
         inline const path_t& path() const;
         inline path_t* mutable_path();
         inline bool has_path() const;
@@ -89,9 +89,9 @@ namespace vg {
         multipath_alignment_t() noexcept;
         multipath_alignment_t(const multipath_alignment_t& other) noexcept;
         multipath_alignment_t(multipath_alignment_t&& other) noexcept;
-        ~multipath_alignment_t();
-        multipath_alignment_t& operator=(const multipath_alignment_t& other) noexcept;
-        multipath_alignment_t& operator=(multipath_alignment_t&& other) noexcept;
+        ~multipath_alignment_t() noexcept;
+        multipath_alignment_t& operator=(const multipath_alignment_t& other);
+        multipath_alignment_t& operator=(multipath_alignment_t&& other);
         inline const string& sequence() const;
         inline string* mutable_sequence();
         inline void set_sequence(const string& s);

--- a/src/multipath_alignment_graph.cpp
+++ b/src/multipath_alignment_graph.cpp
@@ -58,7 +58,7 @@ namespace vg {
     }
     
     MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph,
-                                                     const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
+                                                     const vector<pair<pair<string::const_iterator, string::const_iterator>, path_t>>& path_chunks,
                                                      const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project,
                                                      const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans, bool realign_Ns,
                                                      bool preserve_tail_anchors, vector<size_t>* path_node_provenance) {
@@ -75,7 +75,7 @@ namespace vg {
     }
     
     MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph,
-                                                     const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
+                                                     const vector<pair<pair<string::const_iterator, string::const_iterator>, path_t>>& path_chunks,
                                                      const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project, bool realign_Ns,
                                                      bool preserve_tail_anchors, vector<size_t>* path_node_provenance) :
                                                      MultipathAlignmentGraph(graph, path_chunks, alignment, project,
@@ -86,7 +86,7 @@ namespace vg {
     }
 
     MultipathAlignmentGraph::MultipathAlignmentGraph(const HandleGraph& graph,
-                                                     const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
+                                                     const vector<pair<pair<string::const_iterator, string::const_iterator>, path_t>>& path_chunks,
                                                      const Alignment& alignment, const unordered_map<id_t, pair<id_t, bool>>& projection_trans, bool realign_Ns,
                                                      bool preserve_tail_anchors, vector<size_t>* path_node_provenance) :
                                                      MultipathAlignmentGraph(graph, path_chunks, alignment, create_projector(projection_trans),
@@ -172,8 +172,9 @@ namespace vg {
         }
         
         // shim the aligned path into the path chunks constructor to make a node for it
-        vector<pair<pair<string::const_iterator, string::const_iterator>, Path>> path_holder;
-        path_holder.emplace_back(make_pair(alignment.sequence().begin(), alignment.sequence().end()), alignment.path());
+        vector<pair<pair<string::const_iterator, string::const_iterator>, path_t>> path_holder;
+        path_holder.emplace_back(make_pair(alignment.sequence().begin(), alignment.sequence().end()), path_t());
+        from_proto_path(alignment.path(), path_holder.front().second);
         create_path_chunk_nodes(graph, path_holder, alignment, project, injection_trans);
         
         // cut the snarls out of the aligned path so we can realign through them
@@ -205,7 +206,7 @@ namespace vg {
         // Nothing to do
     }
     
-    void MultipathAlignmentGraph::create_path_chunk_nodes(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
+    void MultipathAlignmentGraph::create_path_chunk_nodes(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, path_t>>& path_chunks,
                                                           const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project,
                                                           const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans,
                                                           vector<size_t>* path_node_provenance) {
@@ -216,7 +217,7 @@ namespace vg {
             cerr << "performing DFS to walk out path " << pb2json(path_chunk.second) << endl;
 #endif
             
-            const Path& path = path_chunk.second;
+            const auto& path = path_chunk.second;
             
             auto range = injection_trans.equal_range(path.mapping(0).position().node_id());
             for (auto iter = range.first; iter != range.second; iter++) {
@@ -248,7 +249,7 @@ namespace vg {
 #endif
                     pair<id_t, bool> projected_trav = project(graph.get_id(trav));
                     
-                    const Position& pos = path.mapping(stack.size() - 1).position();
+                    const auto& pos = path.mapping(stack.size() - 1).position();
                     if (projected_trav.first == pos.node_id() &&
                         projected_trav.second == (projected_trav.second != graph.get_is_reverse(trav))) {
                         
@@ -291,8 +292,8 @@ namespace vg {
                 
                 // move over the path
                 for (size_t i = 0; i < path.mapping_size(); i++) {
-                    const Mapping& mapping = path.mapping(i);
-                    const Position& position = mapping.position();
+                    const auto& mapping = path.mapping(i);
+                    const auto& position = mapping.position();
                     
                     auto& stack_record = stack[i];
                     handle_t& trav = stack_record.second[stack_record.first - 1];
@@ -307,7 +308,7 @@ namespace vg {
                     new_position->set_offset(position.offset());
                     
                     for (int64_t j = 0; j < mapping.edit_size(); j++) {
-                        from_proto_edit(mapping.edit(j), *new_mapping->add_edit());
+                        *new_mapping->add_edit() = mapping.edit(j);
                     }
                 }
                 

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -85,19 +85,19 @@ namespace vg {
         
         /// Construct a graph of the reachability between aligned chunks in a linearized
         /// path graph. Produces a graph with reachability edges.
-        MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
+        MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, path_t>>& path_chunks,
                                 const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project,
                                 const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans, bool realign_Ns = true,
                                 bool preserve_tail_anchors = false, vector<size_t>* path_node_provenance = nullptr);
        
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
-        MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
+        MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, path_t>>& path_chunks,
                                 const Alignment& alignment, const unordered_map<id_t, pair<id_t, bool>>& projection_trans, bool realign_Ns = true,
                                 bool preserve_tail_anchors = false, vector<size_t>* path_node_provenance = nullptr);
         
         /// Same as the previous constructor, but construct injection_trans implicitly and temporarily
         /// and using a lambda for a projector
-        MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
+        MultipathAlignmentGraph(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, path_t>>& path_chunks,
                                 const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project, bool realign_Ns = true,
                                 bool preserve_tail_anchors = false, vector<size_t>* path_node_provenance = nullptr);
         
@@ -261,7 +261,7 @@ namespace vg {
                                              int64_t* removed_end_from_length = nullptr);
         
         /// Add the path chunks as nodes to the connectivity graph
-        void create_path_chunk_nodes(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, Path>>& path_chunks,
+        void create_path_chunk_nodes(const HandleGraph& graph, const vector<pair<pair<string::const_iterator, string::const_iterator>, path_t>>& path_chunks,
                                      const Alignment& alignment, const function<pair<id_t, bool>(id_t)>& project,
                                      const unordered_multimap<id_t, pair<id_t, bool>>& injection_trans,
                                      vector<size_t>* path_node_provenance = nullptr);

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -379,12 +379,22 @@ Alignment alignment_from_path(const HandleGraph& graph, const Path& path);
  */
 class edit_t {
 public:
-    edit_t() = default;
-    edit_t(const edit_t&) = default;
-    edit_t(edit_t&&) = default;
+    edit_t() noexcept : _from_length(0), _to_length(0), _sequence() {}
+    edit_t(const edit_t& other) noexcept : _from_length(other._from_length), _to_length(other._to_length), _sequence(other._sequence) {}
+    edit_t(edit_t&& other) noexcept  : _from_length(other._from_length), _to_length(other._to_length), _sequence(move(other._sequence)) {}
     ~edit_t() = default;
-    edit_t& operator=(const edit_t&) = default;
-    edit_t& operator=(edit_t&&) = default;
+    edit_t& operator=(const edit_t& other) noexcept {
+        _from_length = other._from_length;
+        _to_length = other._to_length;
+        _sequence = other._sequence;
+        return *this;
+    }
+    edit_t& operator=(edit_t&& other) noexcept {
+        _from_length = other._from_length;
+        _to_length = other._to_length;
+        _sequence = move(other._sequence);
+        return *this;
+    }
     inline int32_t from_length() const;
     inline void set_from_length(int32_t l);
     inline int32_t to_length() const;
@@ -403,12 +413,20 @@ private:
 // the mapping_t name is already taken
 class path_mapping_t {
 public:
-    path_mapping_t() noexcept = default;
-    path_mapping_t(const path_mapping_t&) noexcept = default;
-    path_mapping_t(path_mapping_t&&) noexcept = default;
+    path_mapping_t() noexcept : _position(), _edit() { }
+    path_mapping_t(const path_mapping_t& other) noexcept : _position(other._position), _edit(other._edit) {}
+    path_mapping_t(path_mapping_t&& other) noexcept : _position(move(other._position)), _edit(move(other._edit)) {}
     ~path_mapping_t() = default;
-    path_mapping_t& operator=(const path_mapping_t&) noexcept = default;
-    path_mapping_t& operator=(path_mapping_t&&) noexcept = default;
+    path_mapping_t& operator=(const path_mapping_t& other) noexcept {
+        _position = other._position;
+        _edit = other._edit;
+        return *this;
+    }
+    path_mapping_t& operator=(path_mapping_t&& other) noexcept {
+        _position = std::move(other._position);
+        _edit = std::move(other._edit);
+        return *this;
+    }
     inline const position_t& position() const;
     inline position_t* mutable_position();
     inline const vector<edit_t>& edit() const;
@@ -426,12 +444,18 @@ private:
 
 class path_t {
 public:
-    path_t() noexcept = default;
-    path_t(const path_t&) noexcept = default;
-    path_t(path_t&&) noexcept = default;
+    path_t() noexcept : _mapping() {}
+    path_t(const path_t& other) noexcept : _mapping(other._mapping) {}
+    path_t(path_t&& other) noexcept : _mapping(move(other._mapping)) {}
     ~path_t() = default;
-    path_t& operator=(const path_t&) noexcept = default;
-    path_t& operator=(path_t&&) noexcept = default;
+    path_t& operator=(const path_t& other) noexcept {
+        _mapping = other._mapping;
+        return *this;
+    }
+    path_t& operator=(path_t&& other) noexcept {
+        _mapping = move(other._mapping);
+        return *this;
+    }
     inline const vector<path_mapping_t>& mapping() const;
     inline const path_mapping_t& mapping(size_t i) const;
     inline vector<path_mapping_t>* mutable_mapping();

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -1,4 +1,4 @@
-    #ifndef VG_PATH_HPP_INCLUDED
+#ifndef VG_PATH_HPP_INCLUDED
 #define VG_PATH_HPP_INCLUDED
 
 #include <iostream>
@@ -403,12 +403,12 @@ private:
 // the mapping_t name is already taken
 class path_mapping_t {
 public:
-    path_mapping_t() = default;
-    path_mapping_t(const path_mapping_t&) = default;
-    path_mapping_t(path_mapping_t&&) = default;
+    path_mapping_t() noexcept = default;
+    path_mapping_t(const path_mapping_t&) noexcept = default;
+    path_mapping_t(path_mapping_t&&) noexcept = default;
     ~path_mapping_t() = default;
-    path_mapping_t& operator=(const path_mapping_t&) = default;
-    path_mapping_t& operator=(path_mapping_t&&) = default;
+    path_mapping_t& operator=(const path_mapping_t&) noexcept = default;
+    path_mapping_t& operator=(path_mapping_t&&) noexcept = default;
     inline const position_t& position() const;
     inline position_t* mutable_position();
     inline const vector<edit_t>& edit() const;
@@ -426,12 +426,12 @@ private:
 
 class path_t {
 public:
-    path_t() = default;
-    path_t(const path_t&) = default;
-    path_t(path_t&&) = default;
+    path_t() noexcept = default;
+    path_t(const path_t&) noexcept = default;
+    path_t(path_t&&) noexcept = default;
     ~path_t() = default;
-    path_t& operator=(const path_t&) = default;
-    path_t& operator=(path_t&&) = default;
+    path_t& operator=(const path_t&) noexcept = default;
+    path_t& operator=(path_t&&) noexcept = default;
     inline const vector<path_mapping_t>& mapping() const;
     inline const path_mapping_t& mapping(size_t i) const;
     inline vector<path_mapping_t>* mutable_mapping();

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -379,12 +379,12 @@ Alignment alignment_from_path(const HandleGraph& graph, const Path& path);
  */
 class edit_t {
 public:
-    edit_t() noexcept = default;
+    edit_t() noexcept : _from_length(0), _to_length(0), _sequence() {}
     edit_t(const edit_t& other) noexcept = default;
     edit_t(edit_t&& other) noexcept = default;
     ~edit_t() noexcept = default;
-    edit_t& operator=(const edit_t& other) noexcept = default;
-    edit_t& operator=(edit_t&& other) noexcept = default;
+    edit_t& operator=(const edit_t& other) = default;
+    edit_t& operator=(edit_t&& other) = default;
     inline int32_t from_length() const;
     inline void set_from_length(int32_t l);
     inline int32_t to_length() const;
@@ -407,8 +407,8 @@ public:
     path_mapping_t(const path_mapping_t& other) noexcept = default;
     path_mapping_t(path_mapping_t&& other) noexcept = default;
     ~path_mapping_t() noexcept = default;
-    path_mapping_t& operator=(const path_mapping_t& other) noexcept = default;
-    path_mapping_t& operator=(path_mapping_t&& other) noexcept = default;
+    path_mapping_t& operator=(const path_mapping_t& other) = default;
+    path_mapping_t& operator=(path_mapping_t&& other) = default;
     inline const position_t& position() const;
     inline position_t* mutable_position();
     inline const vector<edit_t>& edit() const;
@@ -429,9 +429,9 @@ public:
     path_t() noexcept = default;
     path_t(const path_t& other) noexcept = default;
     path_t(path_t&& other) noexcept = default;
-    ~path_t() = default;
-    path_t& operator=(const path_t& other) noexcept = default;
-    path_t& operator=(path_t&& other) noexcept = default;
+    ~path_t() noexcept = default;
+    path_t& operator=(const path_t& other) = default;
+    path_t& operator=(path_t&& other) = default;
     inline const vector<path_mapping_t>& mapping() const;
     inline const path_mapping_t& mapping(size_t i) const;
     inline vector<path_mapping_t>* mutable_mapping();

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -379,22 +379,12 @@ Alignment alignment_from_path(const HandleGraph& graph, const Path& path);
  */
 class edit_t {
 public:
-    edit_t() noexcept : _from_length(0), _to_length(0), _sequence() {}
-    edit_t(const edit_t& other) noexcept : _from_length(other._from_length), _to_length(other._to_length), _sequence(other._sequence) {}
-    edit_t(edit_t&& other) noexcept  : _from_length(other._from_length), _to_length(other._to_length), _sequence(move(other._sequence)) {}
-    ~edit_t() = default;
-    edit_t& operator=(const edit_t& other) noexcept {
-        _from_length = other._from_length;
-        _to_length = other._to_length;
-        _sequence = other._sequence;
-        return *this;
-    }
-    edit_t& operator=(edit_t&& other) noexcept {
-        _from_length = other._from_length;
-        _to_length = other._to_length;
-        _sequence = move(other._sequence);
-        return *this;
-    }
+    edit_t() noexcept = default;
+    edit_t(const edit_t& other) noexcept = default;
+    edit_t(edit_t&& other) noexcept = default;
+    ~edit_t() noexcept = default;
+    edit_t& operator=(const edit_t& other) noexcept = default;
+    edit_t& operator=(edit_t&& other) noexcept = default;
     inline int32_t from_length() const;
     inline void set_from_length(int32_t l);
     inline int32_t to_length() const;
@@ -413,20 +403,12 @@ private:
 // the mapping_t name is already taken
 class path_mapping_t {
 public:
-    path_mapping_t() noexcept : _position(), _edit() { }
-    path_mapping_t(const path_mapping_t& other) noexcept : _position(other._position), _edit(other._edit) {}
-    path_mapping_t(path_mapping_t&& other) noexcept : _position(move(other._position)), _edit(move(other._edit)) {}
-    ~path_mapping_t() = default;
-    path_mapping_t& operator=(const path_mapping_t& other) noexcept {
-        _position = other._position;
-        _edit = other._edit;
-        return *this;
-    }
-    path_mapping_t& operator=(path_mapping_t&& other) noexcept {
-        _position = std::move(other._position);
-        _edit = std::move(other._edit);
-        return *this;
-    }
+    path_mapping_t() noexcept = default;
+    path_mapping_t(const path_mapping_t& other) noexcept = default;
+    path_mapping_t(path_mapping_t&& other) noexcept = default;
+    ~path_mapping_t() noexcept = default;
+    path_mapping_t& operator=(const path_mapping_t& other) noexcept = default;
+    path_mapping_t& operator=(path_mapping_t&& other) noexcept = default;
     inline const position_t& position() const;
     inline position_t* mutable_position();
     inline const vector<edit_t>& edit() const;
@@ -444,18 +426,12 @@ private:
 
 class path_t {
 public:
-    path_t() noexcept : _mapping() {}
-    path_t(const path_t& other) noexcept : _mapping(other._mapping) {}
-    path_t(path_t&& other) noexcept : _mapping(move(other._mapping)) {}
+    path_t() noexcept = default;
+    path_t(const path_t& other) noexcept = default;
+    path_t(path_t&& other) noexcept = default;
     ~path_t() = default;
-    path_t& operator=(const path_t& other) noexcept {
-        _mapping = other._mapping;
-        return *this;
-    }
-    path_t& operator=(path_t&& other) noexcept {
-        _mapping = move(other._mapping);
-        return *this;
-    }
+    path_t& operator=(const path_t& other) noexcept = default;
+    path_t& operator=(path_t&& other) noexcept = default;
     inline const vector<path_mapping_t>& mapping() const;
     inline const path_mapping_t& mapping(size_t i) const;
     inline vector<path_mapping_t>* mutable_mapping();

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -380,9 +380,9 @@ Alignment alignment_from_path(const HandleGraph& graph, const Path& path);
 class edit_t {
 public:
     edit_t() noexcept : _from_length(0), _to_length(0), _sequence() {}
-    edit_t(const edit_t& other) noexcept = default;
-    edit_t(edit_t&& other) noexcept = default;
-    ~edit_t() noexcept = default;
+    edit_t(const edit_t& other) = default;
+    edit_t(edit_t&& other) = default;
+    ~edit_t() = default;
     edit_t& operator=(const edit_t& other) = default;
     edit_t& operator=(edit_t&& other) = default;
     inline int32_t from_length() const;
@@ -403,10 +403,10 @@ private:
 // the mapping_t name is already taken
 class path_mapping_t {
 public:
-    path_mapping_t() noexcept = default;
-    path_mapping_t(const path_mapping_t& other) noexcept = default;
-    path_mapping_t(path_mapping_t&& other) noexcept = default;
-    ~path_mapping_t() noexcept = default;
+    path_mapping_t() = default;
+    path_mapping_t(const path_mapping_t& other) = default;
+    path_mapping_t(path_mapping_t&& other) = default;
+    ~path_mapping_t() = default;
     path_mapping_t& operator=(const path_mapping_t& other) = default;
     path_mapping_t& operator=(path_mapping_t&& other) = default;
     inline const position_t& position() const;
@@ -426,10 +426,10 @@ private:
 
 class path_t {
 public:
-    path_t() noexcept = default;
-    path_t(const path_t& other) noexcept = default;
-    path_t(path_t&& other) noexcept = default;
-    ~path_t() noexcept = default;
+    path_t() = default;
+    path_t(const path_t& other) = default;
+    path_t(path_t&& other) = default;
+    ~path_t() = default;
     path_t& operator=(const path_t& other) = default;
     path_t& operator=(path_t&& other) = default;
     inline const vector<path_mapping_t>& mapping() const;

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -23,21 +23,11 @@ using namespace std;
 class position_t {
 public:
     position_t() noexcept : _node_id(0), _offset(0), _is_reverse(false) {}
-    position_t(const position_t& other) noexcept : _node_id(other._node_id), _offset(other._offset), _is_reverse(other._is_reverse) {}
-    position_t(position_t&& other) noexcept : _node_id(other._node_id), _offset(other._offset), _is_reverse(other._is_reverse) {}
-    ~position_t() = default;
-    position_t& operator=(const position_t& other) noexcept {
-        _node_id = other._node_id;
-        _offset = other._offset;
-        _offset = other._offset;
-        return *this;
-    }
-    position_t& operator=(position_t&& other) noexcept {
-        _node_id = other._node_id;
-        _offset = other._offset;
-        _offset = other._offset;
-        return *this;
-    }
+    position_t(const position_t& other) noexcept = default;
+    position_t(position_t&& other) noexcept = default;
+    ~position_t() noexcept = default;
+    position_t& operator=(const position_t& other) noexcept = default;
+    position_t& operator=(position_t&& other) noexcept = default;
     inline int64_t node_id() const;
     inline void set_node_id(int64_t i);
     inline int64_t offset() const;

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -22,12 +22,22 @@ using namespace std;
 // to refactor -- can always eliminate later
 class position_t {
 public:
-    position_t() noexcept = default;
-    position_t(const position_t&) noexcept = default;
-    position_t(position_t&&) noexcept = default;
+    position_t() noexcept : _node_id(0), _offset(0), _is_reverse(false) {}
+    position_t(const position_t& other) noexcept : _node_id(other._node_id), _offset(other._offset), _is_reverse(other._is_reverse) {}
+    position_t(position_t&& other) noexcept : _node_id(other._node_id), _offset(other._offset), _is_reverse(other._is_reverse) {}
     ~position_t() = default;
-    position_t& operator=(const position_t&) noexcept = default;
-    position_t& operator=(position_t&&) noexcept = default;
+    position_t& operator=(const position_t& other) noexcept {
+        _node_id = other._node_id;
+        _offset = other._offset;
+        _offset = other._offset;
+        return *this;
+    }
+    position_t& operator=(position_t&& other) noexcept {
+        _node_id = other._node_id;
+        _offset = other._offset;
+        _offset = other._offset;
+        return *this;
+    }
     inline int64_t node_id() const;
     inline void set_node_id(int64_t i);
     inline int64_t offset() const;

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -26,8 +26,8 @@ public:
     position_t(const position_t& other) noexcept = default;
     position_t(position_t&& other) noexcept = default;
     ~position_t() noexcept = default;
-    position_t& operator=(const position_t& other) noexcept = default;
-    position_t& operator=(position_t&& other) noexcept = default;
+    position_t& operator=(const position_t& other) = default;
+    position_t& operator=(position_t&& other) = default;
     inline int64_t node_id() const;
     inline void set_node_id(int64_t i);
     inline int64_t offset() const;

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -22,12 +22,12 @@ using namespace std;
 // to refactor -- can always eliminate later
 class position_t {
 public:
-    position_t() = default;
-    position_t(const position_t&) = default;
-    position_t(position_t&&) = default;
+    position_t() noexcept = default;
+    position_t(const position_t&) noexcept = default;
+    position_t(position_t&&) noexcept = default;
     ~position_t() = default;
-    position_t& operator=(const position_t&) = default;
-    position_t& operator=(position_t&&) = default;
+    position_t& operator=(const position_t&) noexcept = default;
+    position_t& operator=(position_t&&) noexcept = default;
     inline int64_t node_id() const;
     inline void set_node_id(int64_t i);
     inline int64_t offset() const;

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -22,10 +22,10 @@ using namespace std;
 // to refactor -- can always eliminate later
 class position_t {
 public:
-    position_t() noexcept : _node_id(0), _offset(0), _is_reverse(false) {}
-    position_t(const position_t& other) noexcept = default;
-    position_t(position_t&& other) noexcept = default;
-    ~position_t() noexcept = default;
+    position_t() : _node_id(0), _offset(0), _is_reverse(false) {}
+    position_t(const position_t& other) = default;
+    position_t(position_t&& other) = default;
+    ~position_t() = default;
     position_t& operator=(const position_t& other) = default;
     position_t& operator=(position_t&& other) = default;
     inline int64_t node_id() const;

--- a/src/subpath_overlay.cpp
+++ b/src/subpath_overlay.cpp
@@ -1,0 +1,105 @@
+#include <atomic>
+#include "subpath_overlay.hpp"
+
+#include <handlegraph/util.hpp>
+
+namespace vg {
+
+using namespace std;
+using namespace handlegraph;
+
+SubpathOverlay::SubpathOverlay(const PathHandleGraph* backing,
+                               const step_handle_t& begin, const step_handle_t& end) : backing_graph(backing) {
+    
+    for (auto step = begin; step != end; step = backing->get_next_step(step)) {
+        subpath_handles.emplace_back(backing->get_handle_of_step(step));
+    }
+}
+
+bool SubpathOverlay::has_node(nid_t node_id) const {
+    return node_id <= subpath_handles.size();
+}
+   
+handle_t SubpathOverlay::get_handle(const nid_t& node_id, bool is_reverse) const {
+    return handlegraph::number_bool_packing::pack(node_id, is_reverse);
+}
+    
+nid_t SubpathOverlay::get_id(const handle_t& handle) const {
+    return handlegraph::number_bool_packing::unpack_number(handle);
+}
+    
+bool SubpathOverlay::get_is_reverse(const handle_t& handle) const {
+    return handlegraph::number_bool_packing::unpack_bit(handle);
+}
+
+handle_t SubpathOverlay::flip(const handle_t& handle) const {
+    return handlegraph::number_bool_packing::toggle_bit(handle);
+}
+    
+size_t SubpathOverlay::get_length(const handle_t& handle) const {
+    return backing_graph->get_length(subpath_handles[get_id(handle) - 1]);
+}
+
+std::string SubpathOverlay::get_sequence(const handle_t& handle) const {
+    return backing_graph->get_sequence(get_underlying_handle(handle));
+}
+    
+size_t SubpathOverlay::get_node_count() const {
+    return subpath_handles.size();
+}
+
+nid_t SubpathOverlay::min_node_id() const {
+    return 1;
+}
+    
+nid_t SubpathOverlay::max_node_id() const {
+    return subpath_handles.size();
+}
+
+bool SubpathOverlay::follow_edges_impl(const handle_t& handle, bool go_left,
+                                       const std::function<bool(const handle_t&)>& iteratee) const {
+    if (go_left != get_is_reverse(handle)) {
+        if (get_id(handle) == 1) {
+            return true;
+        }
+        else {
+            return iteratee(get_handle(get_id(handle) - 1, get_is_reverse(handle)));
+        }
+    }
+    else {
+        if (get_id(handle) == subpath_handles.size()) {
+            return true;
+        }
+        else {
+            return iteratee(get_handle(get_id(handle) + 1, get_is_reverse(handle)));
+        }
+    }
+}
+    
+bool SubpathOverlay::for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel) const {
+
+    if (!parallel) {
+        bool keep_going = true;
+        for (size_t i = 1; keep_going && i <= subpath_handles.size(); ++i) {
+            keep_going = iteratee(get_handle(i, false));
+        }
+        return keep_going;
+    } else {
+        std::atomic<bool> keep_going(true);
+#pragma omp parallel for
+        for (size_t i = 1; i <= subpath_handles.size(); ++i) {
+            keep_going = keep_going && iteratee(get_handle(i, false));
+        }
+        return keep_going;
+    }
+}
+
+handle_t SubpathOverlay::get_underlying_handle(const handle_t& handle) const {
+    handle_t underlying = subpath_handles[get_id(handle) - 1];
+    if (get_is_reverse(handle)) {
+        underlying = backing_graph->flip(underlying);
+    }
+    return underlying;
+}
+
+}

--- a/src/subpath_overlay.hpp
+++ b/src/subpath_overlay.hpp
@@ -1,0 +1,107 @@
+#ifndef VG_SUBGRAPH_OVERLAY_HPP_INCLUDED
+#define VG_SUBGRAPH_OVERLAY_HPP_INCLUDED
+
+/**
+ * \file subgraph_overlay.hpp
+ *
+ * Provides SourceSinkOverlay, a HandleGraph implementation that joins all the
+ * heads and tails of a backing graph to single source and sink nodes. 
+ *
+ */
+
+
+#include "handle.hpp"
+
+#include <handlegraph/util.hpp>
+
+
+namespace vg {
+
+using namespace handlegraph;
+
+/**
+ * Overlay that presents a linear graph corresponding to a subinterval of a path
+ */
+class SubpathOverlay : public ExpandingOverlayGraph {
+
+public:
+    /**
+     * Construct new SubpathOverlay between two steps. The 'end' step is past-the-last.
+     */
+    SubpathOverlay(const PathHandleGraph* backing,
+                   const step_handle_t& begin, const step_handle_t& end);
+    SubpathOverlay() = default;
+
+    ~SubpathOverlay() = default;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Handle-based interface
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// Method to check if a node exists by ID
+    bool has_node(nid_t node_id) const;
+   
+    /// Look up the handle for the node with the given ID in the given orientation
+    handle_t get_handle(const nid_t& node_id, bool is_reverse = false) const;
+    
+    /// Get the ID from a handle
+    nid_t get_id(const handle_t& handle) const;
+    
+    /// Get the orientation of a handle
+    bool get_is_reverse(const handle_t& handle) const;
+    
+    /// Invert the orientation of a handle (potentially without getting its ID)
+    handle_t flip(const handle_t& handle) const;
+    
+    /// Get the length of a node
+    size_t get_length(const handle_t& handle) const;
+    
+    /// Get the sequence of a node, presented in the handle's local forward
+    /// orientation.
+    std::string get_sequence(const handle_t& handle) const;
+    
+    /// Return the number of nodes in the graph
+    size_t get_node_count() const;
+    
+    /// Return the smallest ID in the graph, or some smaller number if the
+    /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
+    nid_t min_node_id() const;
+    
+    /// Return the largest ID in the graph, or some larger number if the
+    /// largest ID is unavailable. Return value is unspecified if the graph is empty.
+    nid_t max_node_id() const;
+
+    ///////////////////////////////////
+    /// ExpandingOverlayGraph interface
+    ///////////////////////////////////
+    
+    /**
+     * Returns the handle in the underlying graph that corresponds to a handle in the
+     * overlay
+     */
+    handle_t get_underlying_handle(const handle_t& handle) const;
+    
+protected:
+    
+    /// Loop over all the handles to next/previous (right/left) nodes. Passes
+    /// them to a callback which returns false to stop iterating and true to
+    /// continue. Returns true if we finished and false if we stopped early.
+    bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
+    
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee
+    /// returns false. Can be told to run in parallel, in which case stopping
+    /// after a false return value is on a best-effort basis and iteration
+    /// order is not defined. Returns true if we finished and false if we 
+    /// stopped early.
+    bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+
+    /// the backing graph
+    const HandleGraph* backing_graph = nullptr;
+
+    std::vector<handle_t> subpath_handles;
+};
+
+}
+
+#endif

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -195,11 +195,6 @@ using namespace std;
                               const vector<pair<step_handle_t, step_handle_t>>& ref_chunks,
                               bool no_left_expansion, bool no_right_expansion) const;
         
-        /// make a linear graph that corresponds to a path interval, possibly duplicating nodes in case of cycles
-        unordered_map<id_t, pair<id_t, bool>>
-        extract_linearized_path_graph(const PathPositionHandleGraph* graph, MutableHandleGraph* into,
-                                      path_handle_t path_handle, size_t first, size_t last) const;
-        
         /// use the graph position bounds and the path range bounds to assign a path position to a surjected read
         void set_path_position(const PathPositionHandleGraph* graph, const pos_t& init_surj_pos,
                                const pos_t& final_surj_pos,

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -14,6 +14,7 @@
 
 #include "aligner.hpp"
 #include "handle.hpp"
+#include "path.hpp"
 #include <vg/vg.pb.h>
 #include "multipath_alignment.hpp"
 
@@ -97,7 +98,7 @@ using namespace std;
                                                     bool preserve_deletions = false) const;
         
         /// a local type that represents a read interval matched to a portion of the alignment path
-        using path_chunk_t = pair<pair<string::const_iterator, string::const_iterator>, Path>;
+        using path_chunk_t = pair<pair<string::const_iterator, string::const_iterator>, path_t>;
         
         /// the minimum length deletion that the spliced algorithm will interpret as a splice event
         int64_t min_splice_length = 20;

--- a/src/unittest/overlays.cpp
+++ b/src/unittest/overlays.cpp
@@ -8,7 +8,9 @@
 
 #include "vg/io/json2pb.h"
 #include "../split_strand_graph.hpp"
+#include "../subpath_overlay.hpp"
 #include "../utility.hpp"
+#include "../handle.hpp"
 #include "random_graph.hpp"
 
 #include "../vg.hpp"
@@ -21,60 +23,112 @@
 namespace vg {
 namespace unittest {
 using namespace std;
+using namespace bdsg;
 
-    TEST_CASE("StrandSplitGraph overlay produces graphs that are single stranded", "[overlay][handle]") {
+TEST_CASE("StrandSplitGraph overlay produces graphs that are single stranded", "[overlay][handle]") {
+    
+    int num_tests = 100;
+    int seq_size = 500;
+    int var_len = 10;
+    int var_count = 30;
+    
+    for (int i = 0; i < num_tests; ++i) {
         
-        int num_tests = 100;
-        int seq_size = 500;
-        int var_len = 10;
-        int var_count = 30;
-        
-        for (int i = 0; i < num_tests; ++i) {
-            
-            bdsg::HashGraph graph;
-            random_graph(seq_size, var_len, var_count, &graph);
+        bdsg::HashGraph graph;
+        random_graph(seq_size, var_len, var_count, &graph);
 
-            StrandSplitGraph split(&graph);
-            REQUIRE(handlealgs::is_single_stranded(&split));
+        StrandSplitGraph split(&graph);
+        REQUIRE(handlealgs::is_single_stranded(&split));
+        
+        REQUIRE(split.get_node_count() == 2 * graph.get_node_count());
+        
+        unordered_map<handle_t, int> node_count;
+        
+        int split_edge_trav_count = 0;
+        int graph_edge_trav_count = 0;
+        
+        split.for_each_handle([&](const handle_t& h) {
+            REQUIRE(split.get_sequence(h) == graph.get_sequence(split.get_underlying_handle(h)));
             
-            REQUIRE(split.get_node_count() == 2 * graph.get_node_count());
-            
-            unordered_map<handle_t, int> node_count;
-            
-            int split_edge_trav_count = 0;
-            int graph_edge_trav_count = 0;
-            
-            split.for_each_handle([&](const handle_t& h) {
-                REQUIRE(split.get_sequence(h) == graph.get_sequence(split.get_underlying_handle(h)));
-                
-                split.follow_edges(h, false, [&](const handle_t& n) {
-                    REQUIRE(graph.has_edge(split.get_underlying_handle(h),
-                                           split.get_underlying_handle(n)));
-                    split_edge_trav_count++;
-                });
-                split.follow_edges(h, true, [&](const handle_t& p) {
-                    REQUIRE(graph.has_edge(split.get_underlying_handle(p),
-                                           split.get_underlying_handle(h)));
-                    split_edge_trav_count++;
-                });
-                
-                node_count[split.get_underlying_handle(h)]++;
+            split.follow_edges(h, false, [&](const handle_t& n) {
+                REQUIRE(graph.has_edge(split.get_underlying_handle(h),
+                                       split.get_underlying_handle(n)));
+                split_edge_trav_count++;
+            });
+            split.follow_edges(h, true, [&](const handle_t& p) {
+                REQUIRE(graph.has_edge(split.get_underlying_handle(p),
+                                       split.get_underlying_handle(h)));
+                split_edge_trav_count++;
             });
             
-            graph.for_each_handle([&](const handle_t& h) {
-                REQUIRE(node_count[h] == 1);
-                REQUIRE(node_count[graph.flip(h)] == 1);
-                graph.follow_edges(h, false, [&](const handle_t& n) {
-                    graph_edge_trav_count++;
-                });
-                graph.follow_edges(h, true, [&](const handle_t& p) {
-                    graph_edge_trav_count++;
-                });
+            node_count[split.get_underlying_handle(h)]++;
+        });
+        
+        graph.for_each_handle([&](const handle_t& h) {
+            REQUIRE(node_count[h] == 1);
+            REQUIRE(node_count[graph.flip(h)] == 1);
+            graph.follow_edges(h, false, [&](const handle_t& n) {
+                graph_edge_trav_count++;
             });
+            graph.follow_edges(h, true, [&](const handle_t& p) {
+                graph_edge_trav_count++;
+            });
+        });
+        
+        REQUIRE(split_edge_trav_count == 2 * graph_edge_trav_count);
+    }
+}
+
+TEST_CASE("SubpathOverlay works as expected", "[overlay][handle]") {
+    
+    
+    HashGraph graph;
+    auto h1 = graph.create_handle("A");
+    auto h2 = graph.create_handle("C");
+    auto h3 = graph.create_handle("G");
+    auto h4 = graph.create_handle("T");
+    
+    graph.create_edge(h1, h2);
+    graph.create_edge(h1, h3);
+    graph.create_edge(h2, h4);
+    graph.create_edge(h3, h4);
+    
+    auto p = graph.create_path_handle("p");
+    
+    vector<step_handle_t> steps;
+    steps.push_back(graph.append_step(p, h1));
+    steps.push_back(graph.append_step(p, h2));
+    steps.push_back(graph.append_step(p, h4));
+    
+    for (size_t i = 0; i < steps.size(); ++i) {
+        for (size_t j = i; j < steps.size(); ++j) {
             
-            REQUIRE(split_edge_trav_count == 2 * graph_edge_trav_count);
+            SubpathOverlay subpath(&graph, steps[i], graph.get_next_step(steps[j]));
+            
+            REQUIRE(handlealgs::is_single_stranded(&subpath));
+            
+            REQUIRE(subpath.get_node_count() == j - i + 1);
+            size_t manual_node_count = 0;
+            subpath.for_each_handle([&](const handle_t& h) {
+                ++manual_node_count;
+            });
+            REQUIRE(manual_node_count == subpath.get_node_count());
+            
+            auto nodes = handlealgs::lazier_topological_order(&subpath);
+            
+            for (size_t k = 0; k < nodes.size(); ++k) {
+                auto s = graph.get_handle_of_step(steps[i + k]);
+                REQUIRE(subpath.get_underlying_handle(nodes[k]) == s);
+                REQUIRE(subpath.get_sequence(nodes[k]) == graph.get_sequence(s));
+                
+                REQUIRE(subpath.get_degree(nodes[k], true) == (k == 0 ? 0 : 1));
+                REQUIRE(subpath.get_degree(nodes[k], false) == (k + 1 == nodes.size() ? 0 : 1));
+            }
         }
     }
+}
+
+
 }
 }
         


### PR DESCRIPTION
## Changelog Entry

 * `vg surject` is faster when projecting onto a GBZ-format graph

## Description

I reimplemented some algorithms in `vg surject` to use operations that are relatively faster on GBZ with negligible impact on other formats. I also eliminated a graph copying step that was taking a substantial proportion of the run time and replaced it with a leaner overlay data structure. 