### PR TITLE
Do not convert multiple ref alleles with deconstruct -n

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -790,7 +790,19 @@ bool Deconstructor::deconstruct_site(const handle_t& snarl_start, const handle_t
 #pragma omp critical (cerr)
         cerr << "Multiple ref traversals not yet supported with nested decomposition: removing all but first" << endl;
 #endif
-        ref_travs.resize(1);
+        size_t min_start_pos = numeric_limits<size_t>::max();
+        int64_t first_ref_trav;
+        for (int64_t i = 0; i < ref_travs.size(); ++i) {            
+            auto& ref_trav_idx = ref_travs[i];
+            step_handle_t start_step = trav_steps[ref_trav_idx].first;
+            step_handle_t end_step = trav_steps[ref_trav_idx].second;
+            size_t ref_trav_pos = min(graph->get_position_of_step(start_step), graph->get_position_of_step(end_step));
+            if (ref_trav_pos < min_start_pos) {
+                min_start_pos = ref_trav_pos;
+                first_ref_trav = i;
+            }
+        }
+        ref_travs = {ref_travs[first_ref_trav]};        
     }
 
     // XXX CHECKME this assumes there is only one reference path here, and that multiple traversals are due to cycles

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -785,6 +785,14 @@ bool Deconstructor::deconstruct_site(const handle_t& snarl_start, const handle_t
         return false;
     }
 
+    if (ref_travs.size() > 1 && this->nested_decomposition) {
+#ifdef debug
+#pragma omp critical (cerr)
+        cerr << "Multiple ref traversals not yet supported with nested decomposition: removing all but first" << endl;
+        ref_travs.resize(1);
+#endif
+    }
+
     // XXX CHECKME this assumes there is only one reference path here, and that multiple traversals are due to cycles
     
     // we collect windows around the reference traversals

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -789,8 +789,8 @@ bool Deconstructor::deconstruct_site(const handle_t& snarl_start, const handle_t
 #ifdef debug
 #pragma omp critical (cerr)
         cerr << "Multiple ref traversals not yet supported with nested decomposition: removing all but first" << endl;
-        ref_travs.resize(1);
 #endif
+        ref_travs.resize(1);
     }
 
     // XXX CHECKME this assumes there is only one reference path here, and that multiple traversals are due to cycles

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -213,7 +213,7 @@ is $(grep -v ^# nested_snp_in_nested_ins.vcf | grep LV=2 | awk '{print $8}') "AC
 rm -f nested_snp_in_nested_ins.snarls nested_snp_in_nested_ins.vcf
 
 vg deconstruct nesting/nested_snp_in_ins_cycle.gfa -P x -n > nested_snp_in_ins_cycle.vcf
-printf "A#1#y0\t6\t>2>5\tA\tT\tAC=2;AF=0.5;AN=4;AT=>2>4>5,>2>3>5;NS=2;PA=1;PL=7;PR=1;RC=x;RD=1;RL=7;RS=1;LV=1;PS=>1>6\t0|1\t0|1\n" >  nested_snp_in_ins_cycle_truth.tsv
+printf "A#1#y0\t3\t>2>5\tA\tT\tAC=2;AF=0.5;AN=4;AT=>2>4>5,>2>3>5;NS=2;PA=1;PL=7;PR=1;RC=x;RD=1;RL=7;RS=1;LV=1;PS=>1>6\t0|1\t0|1\n" >  nested_snp_in_ins_cycle_truth.tsv
 printf "x\t1\t>1>6\tC\tCAAGAAG,CATG,CAAG\tAC=1,2,1;AF=0.25,0.5,0.25;AN=4;AT=>1>6,>1>2>4>5>2>4>5>6,>1>2>3>5>6,>1>2>4>5>6;NS=2;PA=0;PL=1;PR=1;RC=x;RD=1;RL=1;RS=1;LV=0\t1|2\t3|2\n" >> nested_snp_in_ins_cycle_truth.tsv
 grep -v ^#  nested_snp_in_ins_cycle.vcf | awk '{print $1 "\t" $2 "\t" $3 "\t" $4 "\t" $5 "\t" $8 "\t" $10 "\t" $11}' > nested_snp_in_ins_cycle.tsv
 diff nested_snp_in_ins_cycle.tsv nested_snp_in_ins_cycle_truth.tsv


### PR DESCRIPTION
Most of the nesting tree-traversal logic I have on hand assumes snarl ids are unique across vcf sites.  This breaks when producing many records per snarl (as could arise with cycles).  This PR deactivates it for now (note: this only applies to the new `-n` option) -- turning it back on will require updating the ids (or tags) to carry more information. 