### PR TITLE
Don't output VCF lines larger than 2Gi

### DIFF
--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -1285,7 +1285,7 @@ void Deconstructor::deconstruct_graph(SnarlManager* snarl_manager) {
             queue.pop_back();
             snarls.push_back(snarl);
             const vector<const Snarl*>& children = snarl_manager->children_of(snarl);
-            snarls.insert(snarls.end(), children.begin(), children.end());
+            queue.insert(queue.end(), children.begin(), children.end());
         }
     } else {
         swap(snarls, queue);

--- a/src/deconstructor.cpp
+++ b/src/deconstructor.cpp
@@ -1069,7 +1069,15 @@ bool Deconstructor::deconstruct_site(const handle_t& snarl_start, const handle_t
         if (!std::all_of(trav_to_allele.begin(), trav_to_allele.end(), [](int i) { return (i == 0 || i == -1); })) {
             // run vcffixup to add some basic INFO like AC
             vcf_fixup(v);
-            add_variant(v);
+            bool added = add_variant(v);
+            if (!added) {
+                stringstream ss;
+                ss << v;
+                cerr << "Warning [vg deconstruct]: Skipping variant at " << v.sequenceName << ":" << v.position
+                     << " with ID=" << v.id << " because its line length of " << ss.str().length() << " exceeds vg's limit of "
+                     << VCFOutputCaller::max_vcf_line_length << endl;
+                return false;            
+            }
         }
     }
     return true;

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -243,7 +243,8 @@ void VCFOutputCaller::add_variant(vcflib::Variant& var) const {
     stringstream ss;
     ss << var;
     string dest;
-    zstdutil::CompressString(ss.str(), dest);
+    int ret = zstdutil::CompressString(ss.str(), dest);
+    assert(ret == 0);
     // the Variant object is too big to keep in memory when there are many genotypes, so we
     // store it in a zstd-compressed string
     output_variants[omp_get_thread_num()].push_back(make_pair(make_pair(var.sequenceName, var.position), dest));
@@ -265,7 +266,8 @@ void VCFOutputCaller::write_variants(ostream& out_stream, const SnarlManager* sn
         });
     for (auto v : all_variants) {
         string dest;
-        zstdutil::DecompressString(v.second, dest);
+        int ret = zstdutil::DecompressString(v.second, dest);
+        assert(ret == 0);
         out_stream << dest << endl;
     }
 }
@@ -1013,7 +1015,8 @@ void VCFOutputCaller::update_nesting_info_tags(const SnarlManager* snarl_manager
     for (auto& thread_buf : output_variants) {
         for (auto& output_variant_record : thread_buf) {
             string output_variant_string;
-            zstdutil::DecompressString(output_variant_record.second, output_variant_string);
+            int ret = zstdutil::DecompressString(output_variant_record.second, output_variant_string);
+            assert(ret == 0);
             vector<string> toks = split_delims(output_variant_string, "\t", 4);
             names_in_vcf.insert(toks[2]);
         }
@@ -1046,7 +1049,8 @@ void VCFOutputCaller::update_nesting_info_tags(const SnarlManager* snarl_manager
         auto& thread_buf = output_variants[i];
         for (auto& output_variant_record : thread_buf) {
             string output_variant_string;
-            zstdutil::DecompressString(output_variant_record.second, output_variant_string);
+            int ret = zstdutil::DecompressString(output_variant_record.second, output_variant_string);
+            assert(ret == 0);
             //string& output_variant_string = output_variant_record.second;
             vector<string> toks = split_delims(output_variant_string, "\t", 9);
             const string& name = toks[2];
@@ -1070,7 +1074,8 @@ void VCFOutputCaller::update_nesting_info_tags(const SnarlManager* snarl_manager
                 }
             }
             output_variant_record.second.clear();
-            zstdutil::CompressString(output_variant_string, output_variant_record.second);
+            int ret = zstdutil::CompressString(output_variant_string, output_variant_record.second);
+            assert(ret == 0);
         }
     }
 }

--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -238,16 +238,20 @@ string VCFOutputCaller::vcf_header(const PathHandleGraph& graph, const vector<st
     return ss.str();
 }
 
-void VCFOutputCaller::add_variant(vcflib::Variant& var) const {
+bool VCFOutputCaller::add_variant(vcflib::Variant& var) const {
     var.setVariantCallFile(output_vcf);
     stringstream ss;
     ss << var;
     string dest;
+    if (ss.str().length() > VCFOutputCaller::max_vcf_line_length) {
+        return false;
+    }         
     int ret = zstdutil::CompressString(ss.str(), dest);
     assert(ret == 0);
     // the Variant object is too big to keep in memory when there are many genotypes, so we
     // store it in a zstd-compressed string
     output_variants[omp_get_thread_num()].push_back(make_pair(make_pair(var.sequenceName, var.position), dest));
+    return true;
 }
 
 void VCFOutputCaller::write_variants(ostream& out_stream, const SnarlManager* snarl_manager) {
@@ -440,7 +444,7 @@ string VCFOutputCaller::trav_string(const HandleGraph& graph, const SnarlTravers
     return seq;    
 }
 
-void VCFOutputCaller::emit_variant(const PathPositionHandleGraph& graph, SnarlCaller& snarl_caller,
+bool VCFOutputCaller::emit_variant(const PathPositionHandleGraph& graph, SnarlCaller& snarl_caller,
                                    const Snarl& snarl, const vector<SnarlTraversal>& called_traversals,
                                    const vector<int>& genotype, int ref_trav_idx, const unique_ptr<SnarlCaller::CallInfo>& call_info,
                                    const string& ref_path_name, int ref_offset, bool genotype_snarls, int ploidy,
@@ -599,8 +603,17 @@ void VCFOutputCaller::emit_variant(const PathPositionHandleGraph& graph, SnarlCa
 #endif
 
     if (genotype_snarls || !out_variant.alt.empty()) {
-        add_variant(out_variant);
+        bool added = add_variant(out_variant);
+        if (!added) {
+            stringstream ss;
+            ss << out_variant;
+            cerr << "Warning [vg call]: Skipping variant at " << out_variant.sequenceName << ":" << out_variant.position
+                 << " with ID=" << out_variant.id << " because its line length of " << ss.str().length() << " exceeds vg's limit of "
+                 << VCFOutputCaller::max_vcf_line_length << endl;
+        }
+        return added;
     }
+    return true;
 }
 
 tuple<int64_t, int64_t, bool, step_handle_t, step_handle_t> VCFOutputCaller::get_ref_interval(
@@ -1074,7 +1087,7 @@ void VCFOutputCaller::update_nesting_info_tags(const SnarlManager* snarl_manager
                 }
             }
             output_variant_record.second.clear();
-            int ret = zstdutil::CompressString(output_variant_string, output_variant_record.second);
+            ret = zstdutil::CompressString(output_variant_string, output_variant_record.second);
             assert(ret == 0);
         }
     }
@@ -1463,10 +1476,9 @@ bool LegacyCaller::call_snarl(const Snarl& snarl) {
                                                                            path_name, make_pair(get<0>(ref_interval), get<1>(ref_interval)));
 
             // emit our vcf variant
-            emit_variant(graph, snarl_caller, snarl, called_traversals, genotype, 0, call_info, path_name, ref_offsets.find(path_name)->second, false,
+            was_called = emit_variant(graph, snarl_caller, snarl, called_traversals, genotype, 0, call_info, path_name, ref_offsets.find(path_name)->second, false,
                          ploidy);
 
-            was_called = true;
         }
     }        
     if (!is_vg) {
@@ -1876,15 +1888,16 @@ bool FlowCaller::call_snarl(const Snarl& managed_snarl) {
 
         assert(trav_genotype.empty() || trav_genotype.size() == ploidy);
 
+        bool added = true;
         if (!gaf_output) {
-            emit_variant(graph, snarl_caller, snarl, travs, trav_genotype, ref_trav_idx, trav_call_info, ref_path_name,
-                         ref_offsets[ref_path_name], genotype_snarls, ploidy);
+            added = emit_variant(graph, snarl_caller, snarl, travs, trav_genotype, ref_trav_idx, trav_call_info, ref_path_name,
+                                 ref_offsets[ref_path_name], genotype_snarls, ploidy);
         } else {
             pair<string, int64_t> pos_info = get_ref_position(graph, snarl, ref_path_name, ref_offsets[ref_path_name]);
             emit_gaf_variant(graph, print_snarl(snarl), travs, trav_genotype, ref_trav_idx, pos_info.first, pos_info.second, &support_finder);
         }
 
-        ret_val = trav_genotype.size() == ploidy;
+        ret_val = trav_genotype.size() == ploidy && added;
     }
         
     return ret_val;
@@ -2267,10 +2280,13 @@ bool NestedFlowCaller::emit_snarl_recursive(const Snarl& managed_snarl, int ploi
                 return flatten_alt_allele(allele_string, std::min(allele_ploidy-1, genotype_allele), allele_ploidy, call_table);
             }
         };
-                
+
         if (!gaf_output) {
-            emit_variant(graph, snarl_caller, managed_snarl, record.travs, genotype.first, record.ref_trav_idx, genotype.second, record.ref_path_name,
-                         ref_offsets[record.ref_path_name], genotype_snarls, ploidy, trav_to_flat_string);
+            bool added = emit_variant(graph, snarl_caller, managed_snarl, record.travs, genotype.first, record.ref_trav_idx, genotype.second, record.ref_path_name,
+                                 ref_offsets[record.ref_path_name], genotype_snarls, ploidy, trav_to_flat_string);
+            if (!added) {
+                return false;
+            }
         } else {
             // todo:
             //    emit_gaf_variant(graph, snarl, travs, trav_genotype);

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -85,7 +85,8 @@ public:
                               const vector<size_t>& contig_length_overrides) const;
 
     /// Add a variant to our buffer
-    void add_variant(vcflib::Variant& var) const;
+    /// Returns false if the variant line length exceeds VCFOutputCaller::max_vcf_line_length
+    bool add_variant(vcflib::Variant& var) const;
 
     /// Sort then write variants in the buffer
     /// snarl_manager needed if include_nested is true
@@ -113,7 +114,8 @@ protected:
     string trav_string(const HandleGraph& graph, const SnarlTraversal& trav) const;
     
     /// print a vcf variant
-    void emit_variant(const PathPositionHandleGraph& graph, SnarlCaller& snarl_caller,
+    /// return value is taken from add_variant (see above)
+    bool emit_variant(const PathPositionHandleGraph& graph, SnarlCaller& snarl_caller,
                       const Snarl& snarl, const vector<SnarlTraversal>& called_traversals,
                       const vector<int>& genotype, int ref_trav_idx, const unique_ptr<SnarlCaller::CallInfo>& call_info,
                       const string& ref_path_name, int ref_offset, bool genotype_snarls, int ploidy,
@@ -166,6 +168,9 @@ protected:
 
     // need to write LV/PS info tags
     bool include_nested;
+
+    // prevent giant variants
+    static const int64_t max_vcf_line_length = 2000000000;
 };
 
 /**


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `deconstruct/call` can write giant VCF lines.  This happens in, say, large svs with lots of samples that each get their own allele due to nested variation (hopefully `deconstruct -L` can mitigate this via merging). Giant `AT` fields for each allele don't help. bcf apparently has a [2 gig line limit](https://github.com/samtools/bcftools/issues/1614#issuecomment-972850885), and there's a case of `deconstruct` seemingly [truncating](https://github.com/ComparativeGenomicsToolkit/cactus/issues/1402) large records.  `vg deconstruct / call` are now modified to drop (with a warning) any lines `>2Gb` to avoid these issues.  

## Description
