### PR TITLE
Pad out fallback pair alignments

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -1364,6 +1364,14 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
         
         // Map single-ended and bail
         std::array<vector<Alignment>, 2> mapped_pair = {map(aln1), map(aln2)};
+        // We have no way to know which mapping ought to go with each other, so pad out
+        // the shorter list with copies of the first item, so we can report all mappings
+        // we got.
+        for (size_t index = 0; index < 2; index++) {
+            while (mapped_pair[index].size() < mapped_pair[1 - index].size()) {
+                mapped_pair[index].push_back(mapped_pair[index].first());
+            }
+        }
         pair_all(mapped_pair);
         return {std::move(mapped_pair[0]), std::move(mapped_pair[1])};
     }

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -1369,7 +1369,7 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
         // we got.
         for (size_t index = 0; index < 2; index++) {
             while (mapped_pair[index].size() < mapped_pair[1 - index].size()) {
-                mapped_pair[index].push_back(mapped_pair[index].first());
+                mapped_pair[index].push_back(mapped_pair[index].front());
             }
         }
         pair_all(mapped_pair);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` should no longer crash when mapping paired-end reads and reporting secondaries without a fragment length distribution

## Description
This should fix #4315

