### PR TITLE
Make vg inject use AlignmentEmitter and support GAF

### DIFF
--- a/test/t/39_vg_inject.t
+++ b/test/t/39_vg_inject.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 12
+plan tests 13
 
 vg construct -r small/x.fa > j.vg
 vg index -x j.xg j.vg
@@ -52,5 +52,7 @@ cat <(samtools view -H small/x.bam) <(printf "name\t4\t*\t0\t0\t*\t*\t0\t0\tACGT
 is "$(vg inject -x x.xg unmapped.sam | vg view -aj - | grep "path" | wc -l)" 0 "vg inject does not make an alignment for an umapped read"
 is "$(echo $?)" 0 "vg inject does not crash on an unmapped read"
 
+is $(vg inject -x x.xg small/x.bam -o GAF | wc -l) \
+    1000 "vg inject supports GAF output"
 
 rm j.vg j.xg x.vg x.gcsa x.gcsa.lcp x.xg unmapped.sam


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg inject` now supports GAF format with the new `--output-format`/`-o` option

## Description

This makes `vg inject` use the AlignmentEmitter instead of directly using Protobuf emitter stuff.

This means it should get all the fancy GAM block interleaving stuff we do for speed in the mappers. I noticed the existing implementation wasn't able to consistently keep 16 threads busy; it would run all the threads for a while, and then drain, and then do it again. I haven't tested if this actually solves that problem, but it should eliminate one potential cause. Also it gives us essentially free GAF support.