### PR TITLE
Make the long form --parameter-preset Giraffe option work

### DIFF
--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -602,7 +602,7 @@ int main_giraffe(int argc, char** argv) {
         {"discard", no_argument, 0, 'n'},
         {"output-basename", required_argument, 0, OPT_OUTPUT_BASENAME},
         {"report-name", required_argument, 0, OPT_REPORT_NAME},
-        {"fast-mode", no_argument, 0, 'b'},
+        {"parameter-preset", required_argument, 0, 'b'},
         {"rescue-algorithm", required_argument, 0, 'A'},
         {"fragment-mean", required_argument, 0, OPT_FRAGMENT_MEAN },
         {"fragment-stdev", required_argument, 0, OPT_FRAGMENT_STDEV },


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe --parameter-preset` long-form option should now work again

## Description

We never actually set up the long form version of this option to work as documented.