### PR TITLE
Faster gbz surject

### DIFF
--- a/src/subpath_overlay.hpp
+++ b/src/subpath_overlay.hpp
@@ -1,11 +1,11 @@
-#ifndef VG_SUBGRAPH_OVERLAY_HPP_INCLUDED
-#define VG_SUBGRAPH_OVERLAY_HPP_INCLUDED
+#ifndef VG_SUBPATH_OVERLAY_HPP_INCLUDED
+#define VG_SUBPATH_OVERLAY_HPP_INCLUDED
 
 /**
- * \file subgraph_overlay.hpp
+ * \file subpath_overlay.hpp
  *
- * Provides SourceSinkOverlay, a HandleGraph implementation that joins all the
- * heads and tails of a backing graph to single source and sink nodes. 
+ * Provides SubpathOverlay, a PathHandleGraph overlay that presents an subinterval
+ * of a path as a linearized graph.
  *
  */
 
@@ -104,4 +104,4 @@ protected:
 
 }
 
-#endif
+#endif // VG_SUBPATH_OVERLAY_HPP_INCLUDED


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Faster BAM output when using a GBZ format graph

## Description

This is pulling in an overlay helper that applies the new `ReferencePathOverlay` in the subcommands.