### PR TITLE
Stop producing invalid alignments in vg inject

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -2675,7 +2675,10 @@ Alignment target_alignment(const PathPositionHandleGraph* graph, const path_hand
     size_t offset_in_edit = 0;
     size_t node_pos = pos1 - graph->get_position_of_step(step);
     while (edit_idx < cigar_mapping.edit_size()) {
-
+        if (step == graph->path_end(path)) {
+            cerr << "error: walked to end of path before exhausting CIGAR on read:" << endl;
+            cerr << pb2json(cigar_mapping) << endl;
+        }
         handle_t h = graph->get_handle_of_step(step);
         string seq = graph->get_sequence(h);
 

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -2678,6 +2678,7 @@ Alignment target_alignment(const PathPositionHandleGraph* graph, const path_hand
         if (step == graph->path_end(path)) {
             cerr << "error: walked to end of path before exhausting CIGAR on read:" << endl;
             cerr << pb2json(cigar_mapping) << endl;
+            exit(1);
         }
         handle_t h = graph->get_handle_of_step(step);
         string seq = graph->get_sequence(h);

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -2525,7 +2525,8 @@ void alignment_set_distance_to_correct(Alignment& aln, const map<string ,vector<
     }
 }
 
-AlignmentValidity alignment_is_valid(const Alignment& aln, const HandleGraph* hgraph) {
+AlignmentValidity alignment_is_valid(const Alignment& aln, const HandleGraph* hgraph, bool check_sequence) {
+    size_t read_idx = 0;
     for (size_t i = 0; i < aln.path().mapping_size(); ++i) {
         const Mapping& mapping = aln.path().mapping(i);
         if (!hgraph->has_node(mapping.position().node_id())) {
@@ -2548,6 +2549,60 @@ AlignmentValidity alignment_is_valid(const Alignment& aln, const HandleGraph* hg
                 i,
                 ss.str()
             };
+        }
+        if (check_sequence) {
+            size_t node_idx = mapping.position().offset();
+            auto node_seq = hgraph->get_sequence(hgraph->get_handle(mapping.position().node_id(),
+                                                                    mapping.position().is_reverse()));
+            for (size_t j = 0; j < mapping.edit_size(); ++j) {
+                const auto& edit = mapping.edit(j);
+                if (edit.to_length() == edit.from_length() && edit.from_length() != 0) {
+                    assert(edit.sequence().size() == edit.to_length() || edit.sequence().empty());
+                    for (size_t k = 0; k < edit.to_length(); ++k) {
+                        // check match/mismatch state between read and ref
+                        if ((aln.sequence()[read_idx + k] == node_seq[node_idx + k]) != edit.sequence().empty()) {
+                            std::stringstream ss;
+                            ss << "Edit erroneously claims " << (edit.sequence().empty() ? "match" : "mismatch") << " on node " << mapping.position().node_id() << " between node position " << (node_idx + k) << " and edit " << j << ", position " << k << " on " << (mapping.position().is_reverse() ? "reverse" : "forward") << " strand";
+                            return {
+                                AlignmentValidity::SEQ_DOES_NOT_MATCH,
+                                i,
+                                ss.str()
+                            };
+                        }
+                        if (!edit.sequence().empty() && edit.sequence()[k] != aln.sequence()[read_idx + k]) {
+                            // compare mismatched sequence to the read
+                            std::stringstream ss;
+                            ss << "Edit sequence (" << edit.sequence() << ") at position " << k << " does not match read sequence (" << aln.sequence() << ") at position " << (read_idx + k);
+                            return {
+                                AlignmentValidity::SEQ_DOES_NOT_MATCH,
+                                i,
+                                ss.str()
+                            };
+                        }
+                    }
+                }
+                else if (edit.from_length() == 0 && edit.to_length() != 0) {
+                    // compare inserted sequence to read
+                    assert(edit.sequence().size() == edit.to_length());
+                    for (size_t k = 0; k < edit.to_length(); ++k) {
+                        if (edit.sequence()[k] != aln.sequence()[read_idx + k]) {
+                            std::stringstream ss;
+                            ss << "Read sequence (" << aln.sequence() << ") at position " << (read_idx + k) << " does not match insert sequence of edit (" << edit.sequence() << ") at position " << k;
+                            return {
+                                AlignmentValidity::SEQ_DOES_NOT_MATCH,
+                                i,
+                                ss.str()
+                            };
+                        }
+                    }
+                }
+                else {
+                    assert(edit.from_length() != 0 && edit.to_length() == 0);
+                }
+                
+                node_idx += edit.from_length();
+                read_idx += edit.to_length();
+            }
         }
     }
     return {AlignmentValidity::OK};
@@ -2615,118 +2670,82 @@ Alignment target_alignment(const PathPositionHandleGraph* graph, const path_hand
     }
     
     step_handle_t step = graph->get_step_at_position(path, pos1);
-    size_t step_start = graph->get_position_of_step(step);
-    handle_t handle = graph->get_handle_of_step(step);
     
-    int64_t trim_start = pos1 - step_start;
-    {
-        Mapping* first_mapping = aln.mutable_path()->add_mapping();
-        first_mapping->mutable_position()->set_node_id(graph->get_id(handle));
-        first_mapping->mutable_position()->set_is_reverse(graph->get_is_reverse(handle));
-        first_mapping->mutable_position()->set_offset(trim_start);
-        
-        auto mappings = cut_mapping_offset(cigar_mapping, graph->get_length(handle)-trim_start);
-        first_mapping->clear_edit();
-        
-        string from_seq = graph->get_sequence(handle);
-        int from_pos = trim_start;
-        for (size_t j = 0; j < mappings.first.edit_size(); ++j) {
-            if (mappings.first.edit(j).to_length() == mappings.first.edit(j).from_length()) {// if (mappings.first.edit(j).sequence() != nullptr) {
-                // do the sequences match?
-                // emit a stream of "SNPs" and matches
-                int last_start = from_pos;
-                int k = 0;
-                Edit* edit;
-                for (int to_pos = 0 ; to_pos < mappings.first.edit(j).to_length() ; ++to_pos, ++from_pos) {
-                    //cerr << h << ":" << k << " " << from_seq[h] << " " << to_seq[k] << endl;
-                    if (from_seq[from_pos] != mappings.first.edit(j).sequence()[to_pos]) {
-                        // emit the last "match" region
-                        if (from_pos - last_start > 0) {
-                            edit = first_mapping->add_edit();
-                            edit->set_from_length(from_pos-last_start);
-                            edit->set_to_length(from_pos-last_start);
-                        }
-                        // set up the SNP
-                        edit = first_mapping->add_edit();
-                        edit->set_from_length(1);
-                        edit->set_to_length(1);
-                        edit->set_sequence(from_seq.substr(to_pos,1));
-                        last_start = from_pos+1;
+    size_t edit_idx = 0;
+    size_t offset_in_edit = 0;
+    size_t node_pos = pos1 - graph->get_position_of_step(step);
+    while (edit_idx < cigar_mapping.edit_size()) {
+
+        handle_t h = graph->get_handle_of_step(step);
+        string seq = graph->get_sequence(h);
+
+        auto mapping = aln.mutable_path()->add_mapping();
+
+        mapping->mutable_position()->set_node_id(graph->get_id(h));
+        mapping->mutable_position()->set_is_reverse(graph->get_is_reverse(h));
+        mapping->mutable_position()->set_offset(node_pos);
+        mapping->set_rank(aln.path().mapping_size());
+
+        while (edit_idx < cigar_mapping.edit_size() && node_pos < seq.size()) {
+
+            const auto& edit = cigar_mapping.edit(edit_idx);
+
+            if (edit.from_length() == edit.to_length()) {
+                // match/mismatch -- need to check
+
+                // end at the sooner of 1) the end of the edit and 2) the end of the node
+                size_t node_aln_len = min<size_t>(edit.from_length() - offset_in_edit, seq.size() - node_pos);
+
+                // iterate through node and edit up to the limit
+                Edit* new_edit = nullptr;
+                for (size_t i = 0; i < node_aln_len; ++i, ++offset_in_edit, ++node_pos) {
+
+                    bool match = (edit.sequence()[offset_in_edit] == seq[node_pos]);
+                    if (!new_edit || match != new_edit->sequence().empty()) {
+                        // current edit is of the wrong type or doesn't exist
+                        new_edit = mapping->add_edit();
+                    }
+                    new_edit->set_from_length(new_edit->from_length() + 1);
+                    new_edit->set_to_length(new_edit->to_length() + 1);
+                    if (!match) {
+                        new_edit->mutable_sequence()->push_back(edit.sequence()[offset_in_edit]);
                     }
                 }
-                // handles the match at the end or the case of no SNP
-                if (from_pos - last_start > 0) {
-                    edit = first_mapping->add_edit();
-                    edit->set_from_length(from_pos-last_start);
-                    edit->set_to_length(from_pos-last_start);
+                if (offset_in_edit == edit.from_length()) {
+                    ++edit_idx;
+                    offset_in_edit = 0;
                 }
-                // to_pos += length;
-                // from_pos += length;
-            } else {
-                // Edit* edit = first_mapping->add_edit();
-                // *edit = mappings.first.edit(j);
-                *first_mapping->add_edit() = mappings.first.edit(j);
-                from_pos += mappings.first.edit(j).from_length();
+            }
+            else if (edit.from_length() == 0) {
+                // insertion
+                assert(offset_in_edit == 0);
+                *mapping->add_edit() = edit;
+                ++edit_idx;
+            }
+            else {
+                // deletion
+                auto new_edit = mapping->add_edit();
+                size_t edit_remaining = edit.from_length() - offset_in_edit;
+                size_t node_remaining = seq.size() - node_pos;
+                if (edit_remaining <= node_remaining) {
+                    // we hit the end of the edit before the end of the node
+                    new_edit->set_from_length(edit_remaining);
+                    ++edit_idx;
+                    offset_in_edit = 0;
+                }
+                else {
+                    // we hit the end of the node before the end of the edit
+                    new_edit->set_from_length(node_remaining);
+                    offset_in_edit += new_edit->from_length();
+                }
+                node_pos += new_edit->from_length();
             }
         }
-        cigar_mapping = mappings.second;
-    }
-    // get p to point to the next step (or past it, if we're a feature on a single node)
-    int64_t p = step_start + graph->get_length(handle);
-    step = graph->get_next_step(step);
-    while (p < pos2) {
-        handle = graph->get_handle_of_step(step);
-        
-        auto mappings = cut_mapping_offset(cigar_mapping, graph->get_length(handle));
-        
-        Mapping m;
-        m.mutable_position()->set_node_id(graph->get_id(handle));
-        m.mutable_position()->set_is_reverse(graph->get_is_reverse(handle));
-        
-        string from_seq = graph->get_sequence(handle);
-        int from_pos = 0;
-        for (size_t j = 0 ; j < mappings.first.edit_size(); ++j) {
-            if (mappings.first.edit(j).to_length() == mappings.first.edit(j).from_length()) {
-                // do the sequences match?
-                // emit a stream of "SNPs" and matches
-                int last_start = from_pos;
-                int k = 0;
-                Edit* edit;
-                for (int to_pos = 0 ; to_pos < mappings.first.edit(j).to_length() ; ++to_pos, ++from_pos) {
-                    //cerr << h << ":" << k << " " << from_seq[h] << " " << to_seq[k] << endl;
-                    if (from_seq[from_pos] != mappings.first.edit(j).sequence()[to_pos]) {
-                        // emit the last "match" region
-                        if (from_pos - last_start > 0) {
-                            edit = m.add_edit();
-                            edit->set_from_length(from_pos-last_start);
-                            edit->set_to_length(from_pos-last_start);
-                        }
-                        // set up the SNP
-                        edit = m.add_edit();
-                        edit->set_from_length(1);
-                        edit->set_to_length(1);
-                        edit->set_sequence(from_seq.substr(to_pos,1));
-                        last_start = from_pos+1;
-                    }
-                }
-                // handles the match at the end or the case of no SNP
-                if (from_pos - last_start > 0) {
-                    edit = m.add_edit();
-                    edit->set_from_length(from_pos-last_start);
-                    edit->set_to_length(from_pos-last_start);
-                }
-                // to_pos += length;
-                // from_pos += length;
-            } else {
-                *m.add_edit() = mappings.first.edit(j);
-                from_pos += mappings.first.edit(j).from_length();
-            }
-        }
-        cigar_mapping = mappings.second;
-        *aln.mutable_path()->add_mapping() = m;
-        p += mapping_from_length(aln.path().mapping(aln.path().mapping_size()-1));
+
         step = graph->get_next_step(step);
+        node_pos = 0;
     }
+    
     aln.set_name(feature);
     if (is_reverse) {
         reverse_complement_alignment_in_place(&aln, [&](vg::id_t node_id) { return graph->get_length(graph->get_handle(node_id)); });

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -318,7 +318,8 @@ struct AlignmentValidity {
     enum Problem {
         OK,
         NODE_MISSING,
-        NODE_TOO_SHORT
+        NODE_TOO_SHORT,
+        SEQ_DOES_NOT_MATCH
     };
     
     /// The kind of problem with the alignment.
@@ -337,7 +338,7 @@ struct AlignmentValidity {
 /// Check to make sure edits on the alignment's path don't assume incorrect
 /// node lengths or ids. Result can be used like a bool or inspected for
 /// further details. Does not log anything itself about bad alignments.
-AlignmentValidity alignment_is_valid(const Alignment& aln, const HandleGraph* hgraph);
+AlignmentValidity alignment_is_valid(const Alignment& aln, const HandleGraph* hgraph, bool check_sequence = false);
     
 /// Make an Alignment corresponding to a subregion of a stored path.
 /// Positions are 0-based, and pos2 is excluded.

--- a/src/subcommand/validate_main.cpp
+++ b/src/subcommand/validate_main.cpp
@@ -26,9 +26,10 @@ void help_validate(char** argv) {
          << endl
          << "options:" << endl
          << "    default: check all aspects of the graph, if options are specified do only those" << endl
-         << "    -o, --orphans   verify that all nodes have edges" << endl
-         << "    -a, --gam FILE  verify that edits in the alignment fit on nodes in the graph" << endl
-         << "    -A, --gam-only  do not verify the graph itself, only the alignment" << endl;
+         << "    -o, --orphans    verify that all nodes have edges" << endl
+         << "    -a, --gam FILE   verify that edits in the alignment fit on nodes in the graph" << endl
+         << "    -A, --gam-only   do not verify the graph itself, only the alignment" << endl
+         << "    -c, --check-seq  check that the edits in the alignment correctly report matches" << endl;
 }
 
 int main_validate(int argc, char** argv) {
@@ -41,6 +42,7 @@ int main_validate(int argc, char** argv) {
     bool check_orphans = false;
     string gam_path;
     bool gam_only = false;
+    bool check_sequence = true;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -51,11 +53,12 @@ int main_validate(int argc, char** argv) {
             {"orphans", no_argument, 0, 'o'},
             {"gam", required_argument, 0, 'a'},
             {"gam-only", no_argument, 0, 'A'},
+            {"check-seq", no_argument, 0, 'c'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hoa:A",
+        c = getopt_long (argc, argv, "hoa:Ac",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -74,6 +77,10 @@ int main_validate(int argc, char** argv) {
                 
             case 'A':
                 gam_only = true;
+                break;
+                
+            case 'c':
+                check_sequence = true;
                 break;
 
             case 'h':
@@ -97,7 +104,7 @@ int main_validate(int argc, char** argv) {
     if (!gam_path.empty()) {
         get_input_file(gam_path, [&](istream& in) {
                 vg::io::for_each<Alignment>(in, [&](Alignment& aln) {
-                        AlignmentValidity validity = alignment_is_valid(aln, graph.get());
+                        AlignmentValidity validity = alignment_is_valid(aln, graph.get(), check_sequence);
                         if (!validity) {
                             // Complain about this alignment
                             cerr << "Invalid Alignment:\n" << pb2json(aln) << "\n" << validity.message;

--- a/test/t/39_vg_inject.t
+++ b/test/t/39_vg_inject.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 13
+plan tests 14
 
 vg construct -r small/x.fa > j.vg
 vg index -x j.xg j.vg
@@ -55,4 +55,7 @@ is "$(echo $?)" 0 "vg inject does not crash on an unmapped read"
 is $(vg inject -x x.xg small/x.bam -o GAF | wc -l) \
     1000 "vg inject supports GAF output"
 
-rm j.vg j.xg x.vg x.gcsa x.gcsa.lcp x.xg unmapped.sam
+samtools cat small/x.bam small/i.bam > all.bam
+is "$(vg inject -x x.xg all.bam | vg validate -A -c -a - x.xg 2>&1 | wc -l)" 0 "vg inject produces valid alignments of the read and reference"
+
+rm j.vg j.xg x.vg x.gcsa x.gcsa.lcp x.xg unmapped.sam all.bam

--- a/test/t/39_vg_inject.t
+++ b/test/t/39_vg_inject.t
@@ -56,6 +56,6 @@ is $(vg inject -x x.xg small/x.bam -o GAF | wc -l) \
     1000 "vg inject supports GAF output"
 
 samtools cat small/x.bam small/i.bam > all.bam
-is "$(vg inject -x x.xg all.bam | vg validate -A -c -a - x.xg 2>&1 | wc -l)" 0 "vg inject produces valid alignments of the read and reference"
+is "$(vg inject -x x.xg all.bam | vg validate -A -c -a - x.xg 2>&1 | grep invalid | wc -l)" 0 "vg inject produces valid alignments of the read and reference"
 
 rm j.vg j.xg x.vg x.gcsa x.gcsa.lcp x.xg unmapped.sam all.bam


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg inject` no longer reports invalid alignments

## Description

Resolves https://github.com/vgteam/vg/issues/4324

I reimplemented a good chunk of the algorithm that converted BAMs into GAMs, which was both a) quadratic and b) wrong. The new algorithm is linear and appears to be working. I also powered up `vg validate` so that it can check for consistency between the edits reported in an alignment and the read/reference.