### PR TITLE
Speed up vg surject -P on long reads

### DIFF
--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <algorithm>
 #include <functional>
+#include <limits>
 
 #include "aligner.hpp"
 #include "handle.hpp"
@@ -125,11 +126,12 @@ using namespace std;
         bool prune_suspicious_anchors = false;
         int64_t max_tail_anchor_prune = 4;
         double low_complexity_p_value = .001;
+        int64_t max_low_complexity_anchor_prune = 32;
         
         /// How many anchors (per path) will we use when surjecting using
         /// anchors?
         /// Excessive anchors will be pruned away.
-        size_t max_anchors = 200;
+        size_t max_anchors = numeric_limits<size_t>::max();
         
         bool annotate_with_all_path_scores = false;
         


### PR DESCRIPTION
## Changelog Entry

No significant user-facing effects (yet)

## Description

With long reads, the `--prune-low-cplx` option in `vg surject` let to slow run time and high memory usage because, in large STRs, it would sometimes remove very long anchors (sometimes > 1000 bp) that would then need to be realigned. This behavior also existed for short reads, but the time spent on realigning was much lower. 

This PR adds a maximum size (default 32) to the length of anchor that will be removed, which seems to be sufficient to restore the speed to nearly the same as without the `--prune-low-cplx` option.