### PR TITLE
Remove extra `-headerpad` linker argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,8 +216,9 @@ ifeq ($(shell uname -s),Darwin)
     START_STATIC =
     END_STATIC =
 
-    # We need to use special flags to let us rename libraries
-    LD_RENAMEABLE_FLAGS = -Wl,-headerpad -Wl,-headerpad_max_install_names
+    # We need to use special flags to let us rename libraries.
+    # See <https://github.com/Homebrew/legacy-homebrew/issues/20233>
+    LD_RENAMEABLE_FLAGS = -Wl,-headerpad_max_install_names
 else
     # We are not running on OS X
     $(info OS is Linux)


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg mac builds no longer pass `-headerpad` without an argument to the linker.

## Description

According to the Clang 15 man page, `-headerpad` needs a size argument:

>     -headerpad size
>             Specifies the minimum space for future expansion of the load commands.  Only useful
>             if intend to run install_name_tool to alter the load commands later. Size is a
>             hexadecimal number.
>
>     -headerpad_max_install_names
>             Automatically adds space for future expansion of load commands such that all paths
>             could expand to MAXPATHLEN.  Only useful if intend to run install_name_tool to alter
>             the load commands later.
>

I don't think it does anything we need that `-headerpad_max_install_names` doesn't do. And it is causing build failures for some people (see <https://www.biostars.org/p/9598655/>) because it doesn't have an argument.
