### PR TITLE
Stop suggesting old versions of Clang that people could install

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ As with Linux, you can add `-j16` or other numbers at the end to run multiple bu
     
 **Note that static binaries cannot yet be built for Mac.**
 
-Our team has successfully built vg on Mac with GCC versions 4.9, 5.3, 6, 7, and 7.3, as well as Clang 9.0.
+The vg Mac build targets whatever the current version of Apple Clang is, and whatever version of Apple Clang is provided by our Github Actions Mac CI system. If your Clang is up to date and vg does not build for you, please open an issue.
 
 #### Mac: Run
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * README no longer interpretable as suggesting that users build with very old Clang

## Description

We managed to confuse people on BioStars <https://www.biostars.org/p/9598655/#9598658> by noting that we *had* built with Clang 9 at one time, even though it would be a bad idea to actually try and install and use that Clang to build vg on a Mac right now.

This updates the README to describe how we actually decide what Clang to build with.