### PR TITLE
Sort minimizers by score in Giraffe single-end mode

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -589,10 +589,13 @@ vector<Alignment> MinimizerMapper::map_from_extensions(Alignment& aln) {
         return aln.sequence();
     });
 
-
-    // Minimizers sorted by score in descending order.
-    std::vector<Minimizer> minimizers = this->find_minimizers(aln.sequence(), funnel);
-
+    // Minimizers sorted by position
+    std::vector<Minimizer> minimizers_in_read = this->find_minimizers(aln.sequence(), funnel);
+    // Indexes of minimizers, sorted into score order, best score first
+    std::vector<size_t> minimizer_score_order = sort_minimizers_by_score(minimizers_in_read);
+    // Minimizers sorted by best score first
+    VectorView<Minimizer> minimizers{minimizers_in_read, minimizer_score_order};
+    
     // Find the seeds and mark the minimizers that were located.
     vector<Seed> seeds = this->find_seeds(minimizers, aln, funnel);
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` in non-chaining single-end mode will again prioritize minimizers the same way as in paired-end mode

## Description

Apparently in 40bf613207369f2e35d4c5367a7199a2f3bff4ce I meant to keep the minimizers sorted by score in single-end mapping mode, but when https://github.com/vgteam/vg/pull/3810 actually merged it changed the order that find_minimizers returns results in to read order and added a score sort to the paired-end non-chaining codepath but not the single-end non-chaining codepath.

This should restore the vg 1.44.0 behavior of taking or not taking identical minimizers all across the read, and also of prioritizing minimizers to take by score, in single-end mode.
