### PR TITLE
Improve behavior of low complexity anchor pruning in surject

### DIFF
--- a/src/sequence_complexity.hpp
+++ b/src/sequence_complexity.hpp
@@ -107,7 +107,7 @@ double SeqComplexity<MaxOrder>::p_value(int order) const {
 
 template<int MaxOrder>
 double SeqComplexity<MaxOrder>::repetitiveness(int order) const {
-    return double(matches[order - 1]) / double(len - order);
+    return len > order ? double(matches[order - 1]) / double(len - order) : 0.0;
 }
 
 

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -130,6 +130,7 @@ using namespace std;
         int64_t max_tail_anchor_prune = 4;
         double low_complexity_p_value = .001;
         int64_t max_low_complexity_anchor_prune = 32;
+        int64_t pad_suspicious_anchors_to_length = 10;
         
         /// How many anchors (per path) will we use when surjecting using
         /// anchors?


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject` has improved base-level alignment accuracy with long reads

## Description

Previously, we were leaning on the anchor sequence itself to determine whether it was low complexity, and should therefore be pruned. However, for short anchors, there frequently wasn't enough evidence within the anchor to determine whether the sequence was low complexity. We now pad short anchors with some of the surrounding read sequence before testing.