### PR TITLE
Annotate writes GAF too and fix to unwanted GAM dumping to stdout

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1798,7 +1798,7 @@ void normalize_alignment(Alignment& alignment) {
     if (doing_normalization) {
         // we found things we needed to normalize away, so we must have built the normalized
         // path, now replace the original with it
-        *alignment.mutable_path() = move(normalized);
+        *alignment.mutable_path() = std::move(normalized);
     }
 }
 

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1900,7 +1900,8 @@ pair<string, string> signature(const Alignment& aln1, const Alignment& aln2) {
 
 void parse_bed_regions(istream& bedstream,
                        const PathPositionHandleGraph* graph,
-                       vector<Alignment>* out_alignments) {
+                       vector<Alignment>* out_alignments,
+                       AlignmentEmitter* aln_emitter) {
     out_alignments->clear();
     if (!bedstream) {
         cerr << "Unable to open bed file." << endl;
@@ -2166,13 +2167,24 @@ void parse_bed_regions(istream& bedstream,
             out_alignments->push_back(alignment);
         }
 
-        vg::io::write_buffered(cout, *out_alignments, 1000); 
+        // if we do want to output alignments and we have enough, write them
+        if(aln_emitter != nullptr & out_alignments->size() > 1000){
+            aln_emitter->emit_singles(vector<Alignment>(*out_alignments));
+            // clear the buffer
+            out_alignments->clear();
+        }
+    }
+
+    // if we do want to output to alignments and we have some, write them
+    if(aln_emitter != nullptr & out_alignments->size() > 0){
+        aln_emitter->emit_singles(vector<Alignment>(*out_alignments));
     }
 }
 
 void parse_gff_regions(istream& gffstream,
                        const PathPositionHandleGraph* graph,
-                       vector<Alignment>* out_alignments) {
+                       vector<Alignment>* out_alignments,
+                       AlignmentEmitter* aln_emitter) {
     out_alignments->clear();
     if (!gffstream) {
         cerr << "Unable to open gff3/gtf file." << endl;
@@ -2448,7 +2460,16 @@ void parse_gff_regions(istream& gffstream,
             out_alignments->push_back(alignment);
         }
 
-        vg::io::write_buffered(cout, *out_alignments, 1000); 
+        // if we do want to output alignments and we have enough, write them
+        if(aln_emitter != nullptr & out_alignments->size() > 1000){
+            aln_emitter->emit_singles(vector<Alignment>(*out_alignments));
+            // clear the buffer
+            out_alignments->clear();
+        }
+        
+    }
+    if(aln_emitter != nullptr & out_alignments->size() > 0){
+        aln_emitter->emit_singles(vector<Alignment>(*out_alignments));
     }
 }
 

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -15,6 +15,7 @@
 #include <htslib/vcf.h>
 #include "handle.hpp"
 #include "vg/io/alignment_io.hpp"
+#include <vg/io/alignment_emitter.hpp>
 
 namespace vg {
 
@@ -296,8 +297,9 @@ map<id_t, int> alignment_quality_per_node(const Alignment& aln);
 /// Parse regions from the given BED file into Alignments in a vector.
 /// Reads the optional name, is_reverse, and score fields if present, and populates the relevant Alignment fields.
 /// Skips and warns about malformed or illegal BED records.
-void parse_bed_regions(istream& bedstream, const PathPositionHandleGraph* graph, vector<Alignment>* out_alignments);
-void parse_gff_regions(istream& gtfstream, const PathPositionHandleGraph* graph, vector<Alignment>* out_alignments);
+void parse_bed_regions(istream& bedstream, const PathPositionHandleGraph* graph, vector<Alignment>* out_alignments, vg::io::AlignmentEmitter* aln_emitter = nullptr);
+// void parse_bed_regions(istream& bedstream, const PathPositionHandleGraph* graph, vector<Alignment>* out_alignments);
+void parse_gff_regions(istream& gtfstream, const PathPositionHandleGraph* graph, vector<Alignment>* out_alignments, vg::io::AlignmentEmitter* aln_emitter = nullptr);
 
 Position alignment_start(const Alignment& aln);
 Position alignment_end(const Alignment& aln);Position alignment_start(const Alignment& aln);

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -297,8 +297,8 @@ map<id_t, int> alignment_quality_per_node(const Alignment& aln);
 /// Parse regions from the given BED file into Alignments in a vector.
 /// Reads the optional name, is_reverse, and score fields if present, and populates the relevant Alignment fields.
 /// Skips and warns about malformed or illegal BED records.
+/// If the optional AlignmentEmitter argument is provided, emit the alignments (and flush the vector once in a while).
 void parse_bed_regions(istream& bedstream, const PathPositionHandleGraph* graph, vector<Alignment>* out_alignments, vg::io::AlignmentEmitter* aln_emitter = nullptr);
-// void parse_bed_regions(istream& bedstream, const PathPositionHandleGraph* graph, vector<Alignment>* out_alignments);
 void parse_gff_regions(istream& gtfstream, const PathPositionHandleGraph* graph, vector<Alignment>* out_alignments, vg::io::AlignmentEmitter* aln_emitter = nullptr);
 
 Position alignment_start(const Alignment& aln);

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -485,7 +485,6 @@ int main_annotate(int argc, char** argv) {
             
             for (auto& gff_name : gff_names) {
                 get_input_file(gff_name, [&](istream& gff_stream) {
-                    // parse_bed_regions(gff_stream, xg_index, aln_emitter);
                     vector<Alignment> buffer;
                     parse_gff_regions(gff_stream, xg_index, &buffer, alignment_emitter.get());
                 });

--- a/src/subcommand/gamsort_main.cpp
+++ b/src/subcommand/gamsort_main.cpp
@@ -281,6 +281,9 @@ int main_gamsort(int argc, char **argv)
         while(opened_records.size() > 0){
             // which file will have the smallest record (i.e. to output first)
             gf = opened_records.top();
+            // remove the rk1/rk2 fields
+            gf.gaf.opt_fields.erase("rk1");
+            gf.gaf.opt_fields.erase("rk2");
             // output smallest record
             cout << gf.gaf << endl;
             opened_records.pop();


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg annotate` can output alignments in GAF.
 * When reading more than 1000 BED or GFF records, vg will no longer dump the first records to standard output and forget about them.

## Description

In  #4363, @adamnovak is fixing the bug I introduced when flushing the output buffer when `vg annotate` output alignments. I happened to have also noticed and corrected this when I added a *GAF output* option to `vg annotate`. 

Basically, I added an optional AlignmentEmitter which, when provided, will be used to write the alignments. That emitter can be set to output either GAM or GAF. In `vg annotate`, we prepare an emitter and pass it to the function that parses the regions, and it outputs the alignments (flushing every 1000 alignments). In the rest of the code, where an emitter is not passed, it will return the vector of alignments and **not** do any GAM dumping and buffer flushing.