### PR TITLE
Even more better base-level alignments when surjecting long reads

### DIFF
--- a/src/algorithms/pad_band.cpp
+++ b/src/algorithms/pad_band.cpp
@@ -12,7 +12,7 @@ namespace vg {
 namespace algorithms {
 
 
-std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk_internal(double band_padding_multiplier, size_t band_padding_memo_size,
+std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk_internal(double band_padding_multiplier, size_t band_padding_memo_size, size_t max_padding,
                                                                                           const std::function<size_t(const Alignment&, const HandleGraph&)> size_function) {
     // We're goign to capture this vector by value into the closure
     std::vector<size_t> band_padding_memo;
@@ -20,29 +20,29 @@ std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk
     // Fill it in to initialize
     band_padding_memo.resize(band_padding_memo_size);
     for (size_t i = 0; i < band_padding_memo.size(); i++) {
-        band_padding_memo[i] = size_t(band_padding_multiplier * sqrt(i)) + 1;
+        band_padding_memo[i] = std::min<size_t>(max_padding, size_t(band_padding_multiplier * sqrt(i)) + 1);
     }
     
     function<size_t(const Alignment&, const HandleGraph&)> choose_band_padding =
-        [band_padding_multiplier, band_padding_memo, size_function](const Alignment& seq, const HandleGraph& graph) {
+        [band_padding_multiplier, band_padding_memo, size_function, max_padding](const Alignment& seq, const HandleGraph& graph) {
             size_t size = size_function(seq, graph);
             return size < band_padding_memo.size() ? band_padding_memo.at(size)
-                                                   : size_t(band_padding_multiplier * sqrt(size)) + 1;
+                                                   : std::min<size_t>(max_padding, size_t(band_padding_multiplier * sqrt(size)) + 1);
     };
     
     // And return the closure which now owns the memo table.
     return choose_band_padding;
 }
 
-std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk(double band_padding_multiplier, size_t band_padding_memo_size) {
-    return pad_band_random_walk_internal(band_padding_multiplier, band_padding_memo_size,
+std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk(double band_padding_multiplier, size_t band_padding_memo_size, size_t max_padding) {
+    return pad_band_random_walk_internal(band_padding_multiplier, band_padding_memo_size, max_padding,
                                         [](const Alignment& seq, const HandleGraph&) {
         return seq.sequence().size();
     });
 }
 
-std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_min_random_walk(double band_padding_multiplier, size_t band_padding_memo_size) {
-    return pad_band_random_walk_internal(band_padding_multiplier, band_padding_memo_size,
+std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_min_random_walk(double band_padding_multiplier, size_t band_padding_memo_size, size_t max_padding) {
+    return pad_band_random_walk_internal(band_padding_multiplier, band_padding_memo_size, max_padding,
                                          [](const Alignment& seq, const HandleGraph& graph) {
         return std::min(seq.sequence().size(), graph.get_total_length());
     });

--- a/src/algorithms/pad_band.cpp
+++ b/src/algorithms/pad_band.cpp
@@ -11,8 +11,9 @@
 namespace vg {
 namespace algorithms {
 
-std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk(double band_padding_multiplier, size_t band_padding_memo_size) {
 
+std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk_internal(double band_padding_multiplier, size_t band_padding_memo_size,
+                                                                                          const std::function<size_t(const Alignment&, const HandleGraph&)> size_function) {
     // We're goign to capture this vector by value into the closure
     std::vector<size_t> band_padding_memo;
     
@@ -21,15 +22,30 @@ std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk
     for (size_t i = 0; i < band_padding_memo.size(); i++) {
         band_padding_memo[i] = size_t(band_padding_multiplier * sqrt(i)) + 1;
     }
-
-    function<size_t(const Alignment&, const HandleGraph&)> choose_band_padding = [band_padding_multiplier, band_padding_memo](const Alignment& seq, const HandleGraph& graph) {
-        size_t read_length = seq.sequence().size();
-        return read_length < band_padding_memo.size() ? band_padding_memo.at(read_length)
-                                                      : size_t(band_padding_multiplier * sqrt(read_length)) + 1;
+    
+    function<size_t(const Alignment&, const HandleGraph&)> choose_band_padding =
+        [band_padding_multiplier, band_padding_memo, size_function](const Alignment& seq, const HandleGraph& graph) {
+            size_t size = size_function(seq, graph);
+            return size < band_padding_memo.size() ? band_padding_memo.at(size)
+                                                   : size_t(band_padding_multiplier * sqrt(size)) + 1;
     };
     
     // And return the closure which now owns the memo table.
     return choose_band_padding;
+}
+
+std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk(double band_padding_multiplier, size_t band_padding_memo_size) {
+    return pad_band_random_walk_internal(band_padding_multiplier, band_padding_memo_size,
+                                        [](const Alignment& seq, const HandleGraph&) {
+        return seq.sequence().size();
+    });
+}
+
+std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_min_random_walk(double band_padding_multiplier, size_t band_padding_memo_size) {
+    return pad_band_random_walk_internal(band_padding_multiplier, band_padding_memo_size,
+                                         [](const Alignment& seq, const HandleGraph& graph) {
+        return std::min(seq.sequence().size(), graph.get_total_length());
+    });
 }
 
 std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_constant(size_t band_padding) {

--- a/src/algorithms/pad_band.hpp
+++ b/src/algorithms/pad_band.hpp
@@ -15,9 +15,14 @@ namespace algorithms {
 
 using namespace std;
 
-/// Get a band padding function that uses the expected distance of a random
+/// Get a band padding function that scales with the expected distance of a random
 /// walk, memoized out to the given length.
 std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk(double band_padding_multiplier = 1.0, size_t band_padding_memo_size = 2000);
+
+/// Get a band padding function that scales the expected distance of a random
+/// walk, memoized out to the given length, using the minimum of graph size and
+/// read size as the length.
+std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_min_random_walk(double band_padding_multiplier = 1.0, size_t band_padding_memo_size = 2000);
 
 /// Get a band padding function that uses a constant value.
 std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_constant(size_t band_padding);

--- a/src/algorithms/pad_band.hpp
+++ b/src/algorithms/pad_band.hpp
@@ -9,6 +9,7 @@
 
 #include "../handle.hpp"
 #include <vg/vg.pb.h>
+#include <limits>
 
 namespace vg {
 namespace algorithms {
@@ -17,12 +18,16 @@ using namespace std;
 
 /// Get a band padding function that scales with the expected distance of a random
 /// walk, memoized out to the given length.
-std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk(double band_padding_multiplier = 1.0, size_t band_padding_memo_size = 2000);
+std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_random_walk(double band_padding_multiplier = 1.0,
+                                                                                 size_t band_padding_memo_size = 2000,
+                                                                                 size_t max_padding = std::numeric_limits<size_t>::max());
 
 /// Get a band padding function that scales the expected distance of a random
 /// walk, memoized out to the given length, using the minimum of graph size and
 /// read size as the length.
-std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_min_random_walk(double band_padding_multiplier = 1.0, size_t band_padding_memo_size = 2000);
+std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_min_random_walk(double band_padding_multiplier = 1.0,
+                                                                                     size_t band_padding_memo_size = 2000,
+                                                                                     size_t max_padding = std::numeric_limits<size_t>::max());
 
 /// Get a band padding function that uses a constant value.
 std::function<size_t(const Alignment&, const HandleGraph&)> pad_band_constant(size_t band_padding);

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -1421,8 +1421,7 @@ void Aligner::align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_al
 }
 
 void Aligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
-                                  int32_t band_padding, bool permissive_banding,
-                                  const unordered_map<handle_t, bool>* left_align_strand) const {
+                                  int32_t band_padding, bool permissive_banding) const {
     
     if (alignment.sequence().empty()) {
         // we can save time by using a specialized deletion aligner for empty strings
@@ -1447,8 +1446,7 @@ void Aligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
                                                g,
                                                band_padding,
                                                permissive_banding,
-                                               false,
-                                               left_align_strand);
+                                               false);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else if (best_score <= numeric_limits<int16_t>::max() && worst_score >= numeric_limits<int16_t>::min()) {
@@ -1457,8 +1455,7 @@ void Aligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
                                                 g,
                                                 band_padding,
                                                 permissive_banding,
-                                                false,
-                                                left_align_strand);
+                                                false);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else if (best_score <= numeric_limits<int32_t>::max() && worst_score >= numeric_limits<int32_t>::min()) {
@@ -1467,8 +1464,7 @@ void Aligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
                                                 g,
                                                 band_padding,
                                                 permissive_banding,
-                                                false,
-                                                left_align_strand);
+                                                false);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else {
@@ -1477,16 +1473,14 @@ void Aligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
                                                 g,
                                                 band_padding,
                                                 permissive_banding,
-                                                false,
-                                                left_align_strand);
+                                                false);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     }
 }
 
 void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                        int32_t max_alt_alns, int32_t band_padding, bool permissive_banding,
-                                        const unordered_map<handle_t, bool>* left_align_strand) const {
+                                        int32_t max_alt_alns, int32_t band_padding, bool permissive_banding) const {
                               
     if (alignment.sequence().empty()) {
         // we can save time by using a specialized deletion aligner for empty strings
@@ -1511,8 +1505,7 @@ void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>&
                                                max_alt_alns,
                                                band_padding,
                                                permissive_banding,
-                                               false,
-                                               left_align_strand);
+                                               false);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else if (best_score <= numeric_limits<int16_t>::max() && worst_score >= numeric_limits<int16_t>::min()) {
@@ -1523,8 +1516,7 @@ void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>&
                                                 max_alt_alns,
                                                 band_padding,
                                                 permissive_banding,
-                                                false,
-                                                left_align_strand);
+                                                false);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else if (best_score <= numeric_limits<int32_t>::max() && worst_score >= numeric_limits<int32_t>::min()) {
@@ -1535,8 +1527,7 @@ void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>&
                                                 max_alt_alns,
                                                 band_padding,
                                                 permissive_banding,
-                                                false,
-                                                left_align_strand);
+                                                false);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else {
@@ -1547,8 +1538,7 @@ void Aligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>&
                                                 max_alt_alns,
                                                 band_padding,
                                                 permissive_banding,
-                                                false,
-                                                left_align_strand);
+                                                false);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     }
@@ -2105,8 +2095,7 @@ void QualAdjAligner::align_pinned_multi(Alignment& alignment, vector<Alignment>&
 }
 
 void QualAdjAligner::align_global_banded(Alignment& alignment, const HandleGraph& g,
-                                         int32_t band_padding, bool permissive_banding,
-                                         const unordered_map<handle_t, bool>* left_align_strand) const {
+                                         int32_t band_padding, bool permissive_banding) const {
     
     if (alignment.sequence().empty()) {
         // we can save time by using a specialized deletion aligner for empty strings
@@ -2129,8 +2118,7 @@ void QualAdjAligner::align_global_banded(Alignment& alignment, const HandleGraph
                                                g,
                                                band_padding,
                                                permissive_banding,
-                                               true,
-                                               left_align_strand);
+                                               true);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else if (best_score <= numeric_limits<int16_t>::max() && worst_score >= numeric_limits<int16_t>::min()) {
@@ -2139,8 +2127,7 @@ void QualAdjAligner::align_global_banded(Alignment& alignment, const HandleGraph
                                                 g,
                                                 band_padding,
                                                 permissive_banding,
-                                                true,
-                                                left_align_strand);
+                                                true);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else if (best_score <= numeric_limits<int32_t>::max() && worst_score >= numeric_limits<int32_t>::min()) {
@@ -2149,8 +2136,7 @@ void QualAdjAligner::align_global_banded(Alignment& alignment, const HandleGraph
                                                 g,
                                                 band_padding,
                                                 permissive_banding,
-                                                true,
-                                                left_align_strand);
+                                                true);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else {
@@ -2159,16 +2145,14 @@ void QualAdjAligner::align_global_banded(Alignment& alignment, const HandleGraph
                                                 g,
                                                 band_padding,
                                                 permissive_banding,
-                                                true,
-                                                left_align_strand);
+                                                true);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     }
 }
 
 void QualAdjAligner::align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                               int32_t max_alt_alns, int32_t band_padding, bool permissive_banding,
-                                               const unordered_map<handle_t, bool>* left_align_strand) const {
+                                               int32_t max_alt_alns, int32_t band_padding, bool permissive_banding) const {
     
     if (alignment.sequence().empty()) {
         // we can save time by using a specialized deletion aligner for empty strings
@@ -2193,8 +2177,7 @@ void QualAdjAligner::align_global_banded_multi(Alignment& alignment, vector<Alig
                                                max_alt_alns,
                                                band_padding,
                                                permissive_banding,
-                                               true,
-                                               left_align_strand);
+                                               true);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else if (best_score <= numeric_limits<int16_t>::max() && worst_score >= numeric_limits<int16_t>::min()) {
@@ -2205,8 +2188,7 @@ void QualAdjAligner::align_global_banded_multi(Alignment& alignment, vector<Alig
                                                 max_alt_alns,
                                                 band_padding,
                                                 permissive_banding,
-                                                true,
-                                                left_align_strand);
+                                                true);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else if (best_score <= numeric_limits<int32_t>::max() && worst_score >= numeric_limits<int32_t>::min()) {
@@ -2217,8 +2199,7 @@ void QualAdjAligner::align_global_banded_multi(Alignment& alignment, vector<Alig
                                                 max_alt_alns,
                                                 band_padding,
                                                 permissive_banding,
-                                                true,
-                                                left_align_strand);
+                                                true);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     } else {
@@ -2229,8 +2210,7 @@ void QualAdjAligner::align_global_banded_multi(Alignment& alignment, vector<Alig
                                                 max_alt_alns,
                                                 band_padding,
                                                 permissive_banding,
-                                                true,
-                                                left_align_strand);
+                                                true);
         
         band_graph.align(score_matrix, nt_table, gap_open, gap_extension);
     }

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -153,8 +153,7 @@ namespace vg {
         /// permissive banding auto detects the width of band needed so that paths can travel
         /// through every node in the graph
         virtual void align_global_banded(Alignment& alignment, const HandleGraph& g,
-                                         int32_t band_padding = 0, bool permissive_banding = true,
-                                         const unordered_map<handle_t, bool>* left_align_strand = nullptr) const = 0;
+                                         int32_t band_padding = 0, bool permissive_banding = true) const = 0;
         
         /// store top scoring global alignments in the vector in descending score order up to a maximum number
         /// of alternate alignments (including the optimal alignment). if there are fewer than the maximum
@@ -162,8 +161,7 @@ namespace vg {
         /// optimal alignment will be stored in both the vector and the original alignment object
         virtual void align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments,
                                                const HandleGraph& g, int32_t max_alt_alns, int32_t band_padding = 0,
-                                               bool permissive_banding = true,
-                                               const unordered_map<handle_t, bool>* left_align_strand = nullptr) const = 0;
+                                               bool permissive_banding = true) const = 0;
         /// xdrop aligner
         virtual void align_xdrop(Alignment& alignment, const HandleGraph& g, const vector<MaximalExactMatch>& mems,
                                  bool reverse_complemented, uint16_t max_gap_length = default_xdrop_max_gap_length) const = 0;
@@ -360,16 +358,14 @@ namespace vg {
         /// permissive banding auto detects the width of band needed so that paths can travel
         /// through every node in the graph
         void align_global_banded(Alignment& alignment, const HandleGraph& g,
-                                 int32_t band_padding = 0, bool permissive_banding = true,
-                                 const unordered_map<handle_t, bool>* left_align_strand = nullptr) const;
+                                 int32_t band_padding = 0, bool permissive_banding = true) const;
         
         /// store top scoring global alignments in the vector in descending score order up to a maximum number
         /// of alternate alignments (including the optimal alignment). if there are fewer than the maximum
         /// number of alignments in the return value, then the vector contains all possible alignments. the
         /// optimal alignment will be stored in both the vector and the original alignment object
         void align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                       int32_t max_alt_alns, int32_t band_padding = 0, bool permissive_banding = true,
-                                       const unordered_map<handle_t, bool>* left_align_strand = nullptr) const;
+                                       int32_t max_alt_alns, int32_t band_padding = 0, bool permissive_banding = true) const;
 
         /// xdrop aligner
         void align_xdrop(Alignment& alignment, const HandleGraph& g, const vector<MaximalExactMatch>& mems,
@@ -432,13 +428,11 @@ namespace vg {
         
         void align(Alignment& alignment, const HandleGraph& g, bool traceback_aln) const;
         void align_global_banded(Alignment& alignment, const HandleGraph& g,
-                                 int32_t band_padding = 0, bool permissive_banding = true,
-                                 const unordered_map<handle_t, bool>* left_align_strand = nullptr) const;
+                                 int32_t band_padding = 0, bool permissive_banding = true) const;
         void align_pinned(Alignment& alignment, const HandleGraph& g, bool pin_left, bool xdrop = false,
                           uint16_t xdrop_max_gap_length = default_xdrop_max_gap_length) const;
         void align_global_banded_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
-                                       int32_t max_alt_alns, int32_t band_padding = 0, bool permissive_banding = true,
-                                       const unordered_map<handle_t, bool>* left_align_strand = nullptr) const;
+                                       int32_t max_alt_alns, int32_t band_padding = 0, bool permissive_banding = true) const;
         void align_pinned_multi(Alignment& alignment, vector<Alignment>& alt_alignments, const HandleGraph& g,
                                 bool pin_left, int32_t max_alt_alns) const;
                                 

--- a/src/banded_global_aligner.hpp
+++ b/src/banded_global_aligner.hpp
@@ -60,8 +60,7 @@ namespace vg {
         ///
         BandedGlobalAligner(Alignment& alignment, const HandleGraph& g,
                             int64_t band_padding, bool permissive_banding = false,
-                            bool adjust_for_base_quality = false,
-                            const unordered_map<handle_t, bool>* left_align_strand = nullptr);
+                            bool adjust_for_base_quality = false);
         
         
         /// Initializes banded multi-alignment, which computes the top scoring alternate alignments in addition
@@ -79,8 +78,7 @@ namespace vg {
         BandedGlobalAligner(Alignment& alignment, const HandleGraph& g,
                             vector<Alignment>& alt_alignments, int64_t max_multi_alns,
                             int64_t band_padding, bool permissive_banding = false,
-                            bool adjust_for_base_quality = false,
-                            const unordered_map<handle_t, bool>* left_align_strand = nullptr);
+                            bool adjust_for_base_quality = false);
         
         ~BandedGlobalAligner();
         
@@ -135,8 +133,7 @@ namespace vg {
         BandedGlobalAligner(Alignment& alignment, const HandleGraph& g,
                             vector<Alignment>* alt_alignments, int64_t max_multi_alns,
                             int64_t band_padding, bool permissive_banding = false,
-                            bool adjust_for_base_quality = false,
-                            const unordered_map<handle_t, bool>* left_align_strand = nullptr);
+                            bool adjust_for_base_quality = false);
         
         /// Traceback through dynamic programming matrices to compute alignment
         void traceback(int8_t* score_mat, int8_t* nt_table, int8_t gap_open, int8_t gap_extend, IntType min_inf);
@@ -159,7 +156,7 @@ namespace vg {
         
     public:
         BAMatrix(Alignment& alignment, handle_t node, int64_t top_diag, int64_t bottom_diag,
-                 const vector<BAMatrix*>& seeds, int64_t cumulative_seq_len, bool left_alignment_strand);
+                 const vector<BAMatrix*>& seeds, int64_t cumulative_seq_len);
         ~BAMatrix();
         
         /// Use DP to fill the band with alignment scores
@@ -190,9 +187,7 @@ namespace vg {
         int64_t bottom_diag;
         
         handle_t node;
-        
-        bool left_alignment_strand;
-        
+                
         Alignment& alignment;
         
         /// Length of shortest sequence leading to matrix from a source node

--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -197,8 +197,7 @@ namespace vg {
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t max_gap, double pessimistic_tail_gap_multiplier, size_t max_tail_length,
                    bool simplify_topologies, size_t unmergeable_len, size_t band_padding, multipath_alignment_t& multipath_aln_out,
                    SnarlManager* cutting_snarls = nullptr, SnarlDistanceIndex* dist_index = nullptr,
-                   const function<pair<id_t, bool>(id_t)>* project = nullptr, bool allow_negative_scores = false,
-                   unordered_map<handle_t, bool>* left_align_strand = nullptr);
+                   const function<pair<id_t, bool>(id_t)>* project = nullptr, bool allow_negative_scores = false, bool align_in_reverse = false);
         
         /// Do intervening and tail alignments between the anchoring paths and
         /// store the result in a multipath_alignment_t. Reachability edges must
@@ -216,8 +215,7 @@ namespace vg {
                    size_t max_alt_alns, bool dynamic_alt_alns, size_t max_gap, double pessimistic_tail_gap_multiplier, size_t max_tail_length,
                    bool simplify_topologies, size_t unmergeable_len, const function<size_t(const Alignment&,const HandleGraph&)>& band_padding_function,
                    multipath_alignment_t& multipath_aln_out, SnarlManager* cutting_snarls = nullptr, SnarlDistanceIndex* dist_index = nullptr,
-                   const function<pair<id_t, bool>(id_t)>* project = nullptr, bool allow_negative_scores = false,
-                   unordered_map<handle_t, bool>* left_align_strand = nullptr);
+                   const function<pair<id_t, bool>(id_t)>* project = nullptr, bool allow_negative_scores = false, bool align_in_reverse = false);
         
         /// Converts a MultipathAlignmentGraph to a GraphViz Dot representation, output to the given ostream.
         /// If given the Alignment query we are working on, can produce information about subpath iterators.
@@ -336,6 +334,8 @@ namespace vg {
         static pair<path_t, int32_t> zip_alignments(vector<pair<path_t, int32_t>>& alt_alns, bool from_left,
                                                     const Alignment& alignment, const HandleGraph& align_graph,
                                                     string::const_iterator begin, const GSSWAligner* aligner);
+        
+        void reverse_alignment(Alignment& aln) const;
         
         /// Identifies regions that are shared across all of the alternative alignments, and then
         /// splits those regions out into separate alignments, dividing the set of alternative

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -318,6 +318,7 @@ int main_surject(int argc, char** argv) {
     }
     surjector.max_tail_length = max_tail_len;
     surjector.annotate_with_all_path_scores = annotate_with_all_path_scores;
+    surjector.choose_band_padding = algorithms::pad_band_min_random_walk(1.0, 2000);
 
     // Count our threads
     int thread_count = vg::get_thread_count();

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -318,7 +318,7 @@ int main_surject(int argc, char** argv) {
     }
     surjector.max_tail_length = max_tail_len;
     surjector.annotate_with_all_path_scores = annotate_with_all_path_scores;
-    surjector.choose_band_padding = algorithms::pad_band_min_random_walk(1.0, 2000);
+    surjector.choose_band_padding = algorithms::pad_band_min_random_walk(1.0, 2000, 16);
 
     // Count our threads
     int thread_count = vg::get_thread_count();

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -18,6 +18,7 @@
 #include "path.hpp"
 #include <vg/vg.pb.h>
 #include "multipath_alignment.hpp"
+#include "algorithms/pad_band.hpp"
 
 
 namespace vg {
@@ -129,8 +130,11 @@ using namespace std;
         bool prune_suspicious_anchors = false;
         int64_t max_tail_anchor_prune = 4;
         double low_complexity_p_value = .0075;
-        int64_t max_low_complexity_anchor_prune = 32;
-        int64_t pad_suspicious_anchors_to_length = 10;
+        int64_t max_low_complexity_anchor_prune = 40;
+        int64_t pad_suspicious_anchors_to_length = 12;
+        
+        // A function for computing band padding
+        std::function<size_t(const Alignment&, const HandleGraph&)> choose_band_padding;
         
         /// How many anchors (per path) will we use when surjecting using
         /// anchors?


### PR DESCRIPTION
## Changelog Entry

No new change log required.

## Description

To correct variant calling errors we've identified:
- Loosens the criteria to identify sequences as low complexity
- Uses dynamic band padding for the banded alignment in surject
- Switches to a more reliable (and cleaner) method for strand-independent left alignment
- Fixes a bug in reference sequence extraction when checking for low-complexity anchors