### PR TITLE
vg stats option to print snarl contents

### DIFF
--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -64,6 +64,7 @@ void help_stats(char** argv) {
          << "                          multiple allowed; limit comparison to those provided" << endl
          << "    -O, --overlap-all     print overlap table for the cartesian product of paths" << endl
          << "    -R, --snarls          print statistics for each snarl" << endl
+         << "        --snarl-contents  print out a table of <snarl, depth, parent, contained node ids>" << endl
          << "    -C, --chains          print statistics for each chain" << endl
          << "    -F, --format          graph format from {VG-Protobuf, PackedGraph, HashGraph, XG}. " <<
         "Can't detect Protobuf if graph read from stdin" << endl
@@ -104,9 +105,13 @@ int main_stats(int argc, char** argv) {
     bool overlap_all_paths = false;
     bool snarl_stats = false;
     bool chain_stats = false;
+    bool snarl_contents = false;
     bool format = false;
     bool degree_dist = false;
     string distance_index_filename;
+
+    // Long options with no corresponding short options.
+    constexpr int OPT_SNARL_CONTENTS = 1000;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -134,6 +139,7 @@ int main_stats(int argc, char** argv) {
             {"overlap", no_argument, 0, 'o'},
             {"overlap-all", no_argument, 0, 'O'},
             {"snarls", no_argument, 0, 'R'},
+            {"snarl-contents", no_argument, 0, OPT_SNARL_CONTENTS},
             {"chains", no_argument, 0, 'C'},            
             {"format", no_argument, 0, 'F'},
             {"degree-dist", no_argument, 0, 'D'},
@@ -232,6 +238,10 @@ int main_stats(int argc, char** argv) {
             snarl_stats = true;
             break;
 
+        case OPT_SNARL_CONTENTS:
+            snarl_contents = true;
+            break;
+            
         case 'C':
             chain_stats = true;
             break;
@@ -297,7 +307,6 @@ int main_stats(int argc, char** argv) {
             exit(1);
         }
     };
-    
 
     if (stats_size) {
         require_graph();
@@ -1100,7 +1109,7 @@ int main_stats(int argc, char** argv) {
     // We will track depth for each snarl (used for both snarl and chains stats)
     unordered_map<const Snarl*, size_t> depth;
     
-    if (snarl_stats || chain_stats) {
+    if (snarl_stats || chain_stats || snarl_contents) {
         // We will go through all the snarls and compute stats.
         
         require_graph();
@@ -1181,6 +1190,35 @@ int main_stats(int argc, char** argv) {
                 // Internal connectivity not important, we just want the size.
                 auto netGraph = manager.net_graph_of(snarl, graph, false);
                 cout << netGraph.get_node_count() << endl;
+            }
+
+            if (snarl_contents) {
+                pair<unordered_set<vg::id_t>, unordered_set<vg::edge_t> > contents = manager.deep_contents(snarl, *graph, false);
+                contents.second.clear();
+                set<vg::id_t> sorted_nodes(contents.first.begin(), contents.first.end());
+                // don't bother with trivial snarls
+                if (!sorted_nodes.empty()) {
+                    cout << (snarl->start().backward() ? "<" : ">") << snarl->start().node_id()
+                         << (snarl->end().backward() ? "<" : ">") << snarl->end().node_id() << "\t"
+                         << depth[snarl] << "\t";
+                    if (parent) {
+                        cout << (parent->start().backward() ? "<" : ">") << parent->start().node_id()
+                             << (parent->end().backward() ? "<" : ">") << parent->end().node_id() << "\t";
+                    } else {
+                        cout << ".\t";
+                    }
+
+                    bool first = true;
+                    for (vg::id_t node_id : sorted_nodes) {
+                        if (first) {
+                            first = false;
+                        } else {
+                            cout << ",";
+                        }
+                        cout << node_id;
+                    }
+                    cout << "\n";
+                }
             }
         });
         


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg stats --snarl-contents` added to print a table of `snarl` / `depth` / `parent` / `nested node ids`

## Description

quick and dirty. as requested by @lh3 since VCF AT field do not always exactly represent the graph (because equivalent alleles with different paths get merged) and I don't think there's any existing way of getting snarl contents from the CLI.  