### PR TITLE
Allow reads to softclip at the end of a path in `vg inject`

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -2697,6 +2697,7 @@ Alignment target_alignment(const PathPositionHandleGraph* graph, const path_hand
                 Mapping* last_mapping = aln.mutable_path()->mutable_mapping(aln.path().mapping_size() - 1);
                 *last_mapping->add_edit() = edit;
                 ++edit_idx;
+                continue;
             } else {
                 // We've gone off the end of the contig with something other than a softclip
                 throw std::runtime_error("Reached unexpected end of path " + graph->get_path_name(path) +

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -2689,6 +2689,7 @@ Alignment target_alignment(const PathPositionHandleGraph* graph, const path_hand
     size_t node_pos = pos1 - graph->get_position_of_step(step);
     while (edit_idx < cigar_mapping.edit_size()) {
         if (step == graph->path_end(path)) {
+            const auto& edit = cigar_mapping.edit(edit_idx);
             if (edit.from_length() == 0 && aln.path().mapping_size() != 0) {
                 // This is a softclip off the end of the contig.
                 // We can add it to the last mapping as an edit


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg inject` can now handle reads that softclip after the end of the target path

## Description

This fixes #4379 by allowing softclip edits that happen after the whole target path has been consumed. I'm cherry-picking some commits out of the `lr-giraffe` branch.
