### PR TITLE
Fix build on Ubuntu 24.04.1 / GCC 13.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,7 +57,7 @@
 	url = https://github.com/jltsiren/gbwt.git
 [submodule "deps/sublinear-Li-Stephens"]
 	path = deps/sublinear-Li-Stephens
-	url = https://github.com/glennhickey/sublinear-Li-Stephens.git
+	url = https://github.com/yoheirosen/sublinear-Li-Stephens.git
 [submodule "deps/backward-cpp"]
 	path = deps/backward-cpp
 	url = https://github.com/adamnovak/backward-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -57,7 +57,7 @@
 	url = https://github.com/jltsiren/gbwt.git
 [submodule "deps/sublinear-Li-Stephens"]
 	path = deps/sublinear-Li-Stephens
-	url = https://github.com/yoheirosen/sublinear-Li-Stephens.git
+	url = https://github.com/glennhickey/sublinear-Li-Stephens.git
 [submodule "deps/backward-cpp"]
 	path = deps/backward-cpp
 	url = https://github.com/adamnovak/backward-cpp.git

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
         vg_help(argv);
         return 1;
     }
-    
+
     auto* subcommand = vg::subcommand::Subcommand::get(argc, argv);
     if (subcommand != nullptr) {
         // We found a matching subcommand, so run it
@@ -85,7 +85,12 @@ int main(int argc, char *argv[]) {
         return (*subcommand)(argc, argv);
     } else {
         // No subcommand found
-        string command = argv[1];
+        string command;
+        // note: doing argv[1] = string is producing totally bizarre "error: inlining failed in call to ‘always_inline’ ..."
+        // error when upgrading to Ubuntu 24.04.1 / GCC 13.2.  Doing the base-by-base copy seems to work around it...
+        for (size_t i = 0; i < strlen(argv[1]); ++i) {
+            command += argv[1][i];
+        }
         cerr << "error:[vg] command " << command << " not found" << endl;
         vg_help(argv);
         return 1;

--- a/src/multipath_mapper.cpp
+++ b/src/multipath_mapper.cpp
@@ -1836,8 +1836,10 @@ namespace vg {
                     std::swap(rescued_secondaries[i], rescued_secondaries[end - 1]);
                     std::swap(rescued_distances[i], rescued_distances[end - 1]);
                     std::swap(rescued_multiplicities[i], rescued_multiplicities[end - 1]);
-                    std::swap(duplicate[i], duplicate[end - 1]);
-                    
+                    // nb: cant std::swap bool vectors in new c++
+                    bool dupe_i = duplicate[i];
+                    duplicate[i] = duplicate[end - 1];
+                    duplicate[end - 1] = dupe_i;
                     end--;
                 }
                 else {


### PR DESCRIPTION
My video drivers bugged out and I ended up just re-installing Ubuntu from scratch instead of wasting more time trying to fix it.  This put me on Ubuntu 24.04.1 with GCC 13.2.0,  seeming to give rise to a situation I always try to avoid: me being the first developer to build on a new compiler release....

This PR fixes the usual issues like GCC  getting stricter about which standard headers you can expect to include others, but also one on `string command = argv[1]` error in `main.cpp` that I still don't understand (but smells like a gcc bug).  

Ideally I'll hold off merging until @yoheirosen merges [this pr](https://github.com/yoheirosen/sublinear-Li-Stephens/pull/11), to avoid switching to repo to my fork as done currently... 