### PR TITLE
Looping distance bug

### DIFF
--- a/src/snarl_distance_index.cpp
+++ b/src/snarl_distance_index.cpp
@@ -20,13 +20,13 @@ size_t maximum_distance(const SnarlDistanceIndex& distance_index, pos_t pos1, po
                                             get_id(pos2), get_is_rev(pos2), get_offset(pos2)); 
 }
 
-void fill_in_distance_index(SnarlDistanceIndex* distance_index, const HandleGraph* graph, const HandleGraphSnarlFinder* snarl_finder, size_t size_limit) {
+void fill_in_distance_index(SnarlDistanceIndex* distance_index, const HandleGraph* graph, const HandleGraphSnarlFinder* snarl_finder, size_t size_limit, bool silence_warnings) {
     distance_index->set_snarl_size_limit(size_limit);
 
     //Build the temporary distance index from the graph
     SnarlDistanceIndex::TemporaryDistanceIndex temp_index = make_temporary_distance_index(graph, snarl_finder, size_limit);
 
-    if (temp_index.use_oversized_snarls) {
+    if (!silence_warnings && temp_index.use_oversized_snarls) {
         cerr << "warning: distance index uses oversized snarls, which may make mapping slow" << endl;
         cerr << "\ttry increasing --snarl-limit when building the distance index" << endl;
     }

--- a/src/snarl_distance_index.cpp
+++ b/src/snarl_distance_index.cpp
@@ -789,14 +789,202 @@ void populate_snarl_index(
         return curr_index;
     };
 
+    //TODO: Copying the list
+    vector<pair<SnarlDistanceIndex::temp_record_t, size_t>> all_children = temp_snarl_record.children;
 
-    /*Now go through each of the children and add distances from that child to everything reachable from it
+    /*
+     * Do a topological sort of the children and re-assign ranks based on the sort
+     * TODO: Snarls aren't guaranteed to be DAGs, so ideally this will be a sort
+     *       that minimizes back edges and the number of times a node is traversed backwards
+     *       For now though, just do a topological sort and don't take any loops or reversing edges
+     */
+     if (!temp_snarl_record.is_root_snarl) {
+
+        //This will hold the new order of the children. Each value is an index into all_children, which 
+        //matches the ranks(-2) of the children 
+        vector<size_t> topological_sort_order;
+        topological_sort_order.reserve(all_children.size());
+
+        // This holds everything in the topological order, to check which nodes (and therefore edges)
+        // have already been added
+        // Unlike the topological order, this stores the orientation as well.
+        // Each node is only added once to the topological order, but the reverse orientation
+        // may still be traversed to ensure that all nodes are found
+        unordered_set<std::pair<size_t, bool>> visited_nodes;
+        visited_nodes.reserve(all_children.size());
+
+        //All nodes that have no incoming edges
+        vector<pair<size_t, bool>> source_nodes;
+
+        /* Add all sources. This will start out as the start node and any tips or nodes that
+           are only reachable from the end node
+        */
+        //unordered_set<std::pair<size_t, bool>> children_seen_from_start;
+        //vector<pair<size_t, bool>> dfs_stack_from_start
+
+        //// Look for tips and loops from the end node that never reach the start node
+        //vector<pair<size_t, bool>> dfs_stack_from_end;
+        //dfs_stack_from_end.emplace_back(std::numeric_limits<size_t>::max(), false); //To indicate end node
+        //while (dfs_stack_from_end.size() != 0) {
+        //    // Go through all nodes from the end and search for anything that is a tip or that loops without 
+        //    // reaching anything seen on from the start 
+        //}
+
+        //Add max() to indicate that we start at the start node, since the start node doesn't actually have a 
+        //rank. This gets added last so it is traversed first
+        source_nodes.emplace_back(std::numeric_limits<size_t>::max(), false);
+
+        //We'll be done sorting when everything is in the sorted vector
+        while (!source_nodes.empty()) {
+
+            //Pick a child with no incoming edges
+            pair<size_t, bool> current_child_index = source_nodes.back();
+            source_nodes.pop_back();
+
+            //Mark it as being visited
+            assert(visited_nodes.count(current_child_index) == 0);
+            visited_nodes.emplace(current_child_index);
+
+            //Get the graph handle for that child, pointing out from the end of the chain
+            handle_t current_graph_handle;
+            if (current_child_index.first == std::numeric_limits<size_t>::max()) {
+                //If the current child is the start bound, then get the start node pointing in 
+                current_graph_handle = graph->get_handle(temp_snarl_record.start_node_id,temp_snarl_record.start_node_rev);
+            } else {
+                pair<SnarlDistanceIndex::temp_record_t, size_t> current_index = all_children[current_child_index.first];
+                if (current_index.first == SnarlDistanceIndex::TEMP_NODE) {
+                    //If the current child is a node, then get the node pointing in the correct direction
+                    current_graph_handle = graph->get_handle(current_index.second, current_child_index.second);
+                } else if (current_child_index.second) {
+                    //If the current child is a chain, and we're traversing the chain backwards
+                    current_graph_handle = graph->get_handle(temp_index.temp_chain_records[current_index.second].start_node_id, 
+                                                  !temp_index.temp_chain_records[current_index.second].start_node_rev);
+                } else {
+                    //Otherwise, the current child is a chain and we're traversing the chain forwards
+                    current_graph_handle = graph->get_handle(temp_index.temp_chain_records[current_index.second].end_node_id, 
+                                                     temp_index.temp_chain_records[current_index.second].end_node_rev);
+                }
+            }
+                 
+            //Add everything reachable from the start boundary node that has no other incoming edges
+            graph->follow_edges(current_graph_handle, false, [&](const handle_t next_handle) {
+#ifdef debug_distance_indexing
+                cerr << "Following forward edges from " << graph->get_id(current_graph_handle) << " to " << graph->get_id(next_handle) << endl;
+#endif
+                if (graph->get_id(next_handle) == temp_snarl_record.start_node_id ||
+                    graph->get_id(next_handle) == temp_snarl_record.end_node_id) {
+                    //If this is trying to leave the snarl, skip it
+                    return true;
+                }
+                //Check the next_handle going in the other direction, to see if it could be a new source node. 
+                //If it reaches anything unseen, then it can't be a source node
+
+                //Get the index of next_handle
+                pair<SnarlDistanceIndex::temp_record_t, size_t> next_index = get_ancestor_of_node(make_pair(SnarlDistanceIndex::TEMP_NODE, graph->get_id(next_handle))); 
+                size_t next_rank = next_index.first == SnarlDistanceIndex::TEMP_NODE
+                            ? temp_index.temp_node_records.at(next_index.second-temp_index.min_node_id).rank_in_parent  
+                            : temp_index.temp_chain_records[next_index.second].rank_in_parent;
+                assert(all_children[next_rank-2] == next_index);
+                bool next_rev = next_index.first == SnarlDistanceIndex::TEMP_NODE || temp_index.temp_chain_records[next_index.second].is_trivial 
+                            ? graph->get_is_reverse(next_handle) 
+                            : graph->get_id(next_handle) == temp_index.temp_chain_records[next_index.second].end_node_id;
+                if (visited_nodes.count(make_pair(next_rank, next_rev)) != 0) {
+                    //If this is a loop, just skip it
+                    return true;
+                }
+
+                //Get the handle from the child represented by next_handle going the other way
+                handle_t reverse_handle = next_index.first == SnarlDistanceIndex::TEMP_NODE ? 
+                            graph->get_handle(next_index.second, !next_rev) :
+                            (next_rev ? graph->get_handle(temp_index.temp_chain_records[next_index.second].end_node_id, 
+                                                          temp_index.temp_chain_records[next_index.second].end_node_rev)
+                                      : graph->get_handle(temp_index.temp_chain_records[next_index.second].start_node_id, 
+                                                          !temp_index.temp_chain_records[next_index.second].start_node_rev));
+
+                //Does this have no unseen incoming edges? Check as we go through incoming edges
+                bool is_source = true;
+
+                //Does this have no unseen incoming edges but including nodes we've seen in the other direction?
+                //TODO: Actually do this
+                graph->follow_edges(reverse_handle, false, [&](const handle_t incoming_handle) {
+#ifdef debug_distance_indexing
+                cerr << "Getting backwards edge to " << graph->get_id(incoming_handle) << endl;
+#endif
+                    if (graph->get_id(incoming_handle) == temp_snarl_record.start_node_id ||
+                        graph->get_id(incoming_handle) == temp_snarl_record.end_node_id) {
+                        //If this is trying to leave the snarl
+                        return true;
+                    }
+                    //The index of the snarl's child that next_handle represents
+                    pair<SnarlDistanceIndex::temp_record_t, size_t> incoming_index = get_ancestor_of_node(make_pair(SnarlDistanceIndex::TEMP_NODE, graph->get_id(incoming_handle))); 
+                    size_t incoming_rank = incoming_index.first == SnarlDistanceIndex::TEMP_NODE
+                                ? temp_index.temp_node_records.at(incoming_index.second-temp_index.min_node_id).rank_in_parent  
+                                : temp_index.temp_chain_records[incoming_index.second].rank_in_parent;
+
+                    bool incoming_rev = incoming_index.first == SnarlDistanceIndex::TEMP_NODE || temp_index.temp_chain_records[incoming_index.second].is_trivial 
+                                ? graph->get_is_reverse(incoming_handle) 
+                                : graph->get_id(incoming_handle) == temp_index.temp_chain_records[incoming_index.second].end_node_id;
+                    //subtract 2 to get the index from the rank
+                    assert(incoming_rank >= 2);
+                    incoming_rank-=2;
+
+                    //If we haven't seen the incoming node before, then this isn't a source so we break out of
+                    //the loop and keep going
+                    if (visited_nodes.count(std::make_pair(incoming_rank, !incoming_rev)) == 0) {
+                        is_source = false;
+                    }
+                    //Keep going
+                    return true;
+                });
+                if (is_source) {
+                    //If this is a new source node, then add it as a source node
+
+                    //subtract 2 to get the index from the rank
+                    assert(next_rank >= 2);
+                    next_rank-=2;
+                    source_nodes.emplace_back(next_rank, next_rev);
+                }
+                return true;
+            });
+            if (current_child_index.first != std::numeric_limits<size_t>::max() &&
+                visited_nodes.count(make_pair(current_child_index.first, !current_child_index.second)) == 0) {
+                //If this node wasn't already added in the other direction, add it to the topological sort
+                topological_sort_order.emplace_back(current_child_index.first);
+            }
+        }
+
+        //TODO: Do this properly
+        // For now, we only really want a topological ordering of DAGs, and I'm going to ignore tips
+        // So if anything is only reachable from the end node, then add it in an arbitrary order
+        vector<bool> check_ranks (all_children.size(), false);
+        for (size_t x : topological_sort_order) {
+            check_ranks[x] = true;
+        }
+        //If anything wasn't in the topological order, add it now
+        for (size_t i = 0 ; i < check_ranks.size() ; i++) {
+            if (!check_ranks[i]) {
+                topological_sort_order.emplace_back(i);
+            }
+        }
+        assert(topological_sort_order.size() == all_children.size());
+
+
+        //We've finished doing to topological sort, so update every child's rank to be the new order
+        for (size_t new_rank = 0 ; new_rank < topological_sort_order.size() ; new_rank++) {
+            size_t old_rank = topological_sort_order[new_rank];
+            if (all_children[old_rank].first == SnarlDistanceIndex::TEMP_NODE) {
+                temp_index.temp_node_records.at(all_children[old_rank].second-temp_index.min_node_id).rank_in_parent = new_rank+2;
+            } else {
+                temp_index.temp_chain_records[all_children[old_rank].second].rank_in_parent = new_rank+2;
+            }
+        }
+     }
+
+    /*
+     * Now go through each of the children and add distances from that child to everything reachable from it
      * Start a dijkstra traversal from each node side in the snarl and record all distances
      */
 
-    //Add the start and end nodes to the list of children so that we include them in the traversal 
-    //TODO: Copying the list
-    vector<pair<SnarlDistanceIndex::temp_record_t, size_t>> all_children = temp_snarl_record.children;
 
     //Reserve enough space to store all possible distances
     temp_snarl_record.distances.reserve( (temp_snarl_record.node_count > size_limit || size_limit == 0) 
@@ -807,8 +995,8 @@ void populate_snarl_index(
         temp_index.use_oversized_snarls = true;
     }
 
+    //Add the start and end nodes to the list of children so that we include them in the traversal 
     if (!temp_snarl_record.is_root_snarl) {
-
         all_children.emplace_back(SnarlDistanceIndex::TEMP_NODE, temp_snarl_record.start_node_id);
         all_children.emplace_back(SnarlDistanceIndex::TEMP_NODE, temp_snarl_record.end_node_id);
     }

--- a/src/snarl_distance_index.cpp
+++ b/src/snarl_distance_index.cpp
@@ -863,10 +863,15 @@ void populate_snarl_index(
             }
             current_index=parent_index;
         }
+#ifdef debug_distance_indexing
+        if (is_reversed) {
+            cerr << "\tsnarl is reversed relative to the top-level chain" << endl;
+        }
+#endif
 
         //Where do we start the topological sort? The start or end bound
-        handle_t topological_sort_start = is_reversed ? graph->get_handle(temp_snarl_record.start_node_id,temp_snarl_record.start_node_rev)
-                                                      : graph->get_handle(temp_snarl_record.end_node_id,!temp_snarl_record.end_node_rev);
+        handle_t topological_sort_start = is_reversed ? graph->get_handle(temp_snarl_record.end_node_id,!temp_snarl_record.end_node_rev)
+                                                      : graph->get_handle(temp_snarl_record.start_node_id,temp_snarl_record.start_node_rev);
 
 
         //This will hold the new order of the children. Each value is an index into all_children, which 

--- a/src/snarl_distance_index.hpp
+++ b/src/snarl_distance_index.hpp
@@ -22,7 +22,7 @@ size_t maximum_distance(const SnarlDistanceIndex& distance_index, pos_t pos1, po
 
 //Fill in the index
 //size_limit is a limit on the number of nodes in a snarl, after which the index won't store pairwise distances
-void fill_in_distance_index(SnarlDistanceIndex* distance_index, const HandleGraph* graph, const HandleGraphSnarlFinder* snarl_finder, size_t size_limit = 50000);
+void fill_in_distance_index(SnarlDistanceIndex* distance_index, const HandleGraph* graph, const HandleGraphSnarlFinder* snarl_finder, size_t size_limit = 50000, bool silence_warnings=true);
 
 //Fill in the temporary snarl record with distances
 void populate_snarl_index(SnarlDistanceIndex::TemporaryDistanceIndex& temp_index, 

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -701,7 +701,7 @@ int main_index(int argc, char** argv) {
                 SnarlDistanceIndex distance_index;
 
                 //Fill it in
-                fill_in_distance_index(&distance_index, xg.get(), &snarl_finder, snarl_limit);
+                fill_in_distance_index(&distance_index, xg.get(), &snarl_finder, snarl_limit, false);
                 // Save it
                 distance_index.serialize(dist_name);
             } else {

--- a/src/unittest/snarl_distance_index.cpp
+++ b/src/unittest/snarl_distance_index.cpp
@@ -6906,7 +6906,7 @@ namespace vg {
             SECTION("Traversal of chain") {
                 net_handle_t chain1_6 = distance_index.get_parent(distance_index.get_node_net_handle(n1->id()));
                 distance_index.for_each_child(chain1_6, [&](const net_handle_t& child) {
-                    assert(distance_index.get_parent(child) == chain1_6);
+                    assert(distance_index.canonical(distance_index.get_parent(child)) == distance_index.canonical(chain1_6));
                 });
             }
             SECTION("Minimum distances are correct") {

--- a/src/unittest/snarl_distance_index.cpp
+++ b/src/unittest/snarl_distance_index.cpp
@@ -150,7 +150,7 @@ namespace vg {
                 REQUIRE(std::get<2>(traceback.second.back()) == -5);
             }
         }
-        TEST_CASE( "Nested chain with loop", "[snarl_distance]" ) {
+        TEST_CASE( "Nested chain with loop", "[snarl_distance][bug]" ) {
         
             VG graph;
                 
@@ -190,9 +190,9 @@ namespace vg {
             
             //get the snarls
             IntegratedSnarlFinder snarl_finder(graph); 
-            SnarlDistanceIndex distance_index;
-            fill_in_distance_index(&distance_index, &graph, &snarl_finder);
             SECTION("Traversal of chain") {
+                SnarlDistanceIndex distance_index;
+                fill_in_distance_index(&distance_index, &graph, &snarl_finder);
                 net_handle_t chain1_13 = distance_index.get_parent(distance_index.get_node_net_handle(n1->id()));
                 distance_index.for_each_child(chain1_13, [&](const net_handle_t& child) {
                     if (distance_index.is_node(child)) {
@@ -200,6 +200,8 @@ namespace vg {
                 });
             }
             SECTION("Minimum distances are correct") {
+                SnarlDistanceIndex distance_index;
+                fill_in_distance_index(&distance_index, &graph, &snarl_finder);
                 net_handle_t node2 = distance_index.get_node_net_handle(n2->id());
                 net_handle_t chain1_13 = distance_index.get_parent(node2);
                 REQUIRE(distance_index.distance_in_parent(chain1_13, distance_index.flip(node2), distance_index.flip(node2)) == 0); 
@@ -211,6 +213,8 @@ namespace vg {
                 REQUIRE(distance_index.minimum_distance(n7->id(),false, 0, n8->id(), true, 0) == 1);
             }
             SECTION("Paths are correct") {
+                SnarlDistanceIndex distance_index;
+                fill_in_distance_index(&distance_index, &graph, &snarl_finder);
 
                 size_t traversal_i = 0;
                 vector<pair<handlegraph::handle_t, size_t>> actual_path;
@@ -231,6 +235,8 @@ namespace vg {
                 //REQUIRE(traversal_i == 7);
             }
             SECTION("Path that leaves lowest common ancestor") {
+                SnarlDistanceIndex distance_index;
+                fill_in_distance_index(&distance_index, &graph, &snarl_finder);
 
                 size_t traversal_i = 0;
                 vector<pair<handlegraph::handle_t, size_t>> actual_path;
@@ -253,6 +259,10 @@ namespace vg {
                 //    return true;
                 //});
                 //REQUIRE(traversal_i == 8);
+            }
+            SECTION("Distanceless index") {
+                SnarlDistanceIndex distance_index;
+                fill_in_distance_index(&distance_index, &graph, &snarl_finder, 0);
             }
         }
         TEST_CASE( "Snarl decomposition can deal with multiple connected components",
@@ -730,9 +740,9 @@ namespace vg {
             
             //get the snarls
             IntegratedSnarlFinder snarl_finder(graph); 
-            SnarlDistanceIndex distance_index;
-            fill_in_distance_index(&distance_index, &graph, &snarl_finder);
             SECTION("Traverse the root") {
+                SnarlDistanceIndex distance_index;
+                fill_in_distance_index(&distance_index, &graph, &snarl_finder);
                 net_handle_t chain1 = distance_index.get_parent(distance_index.get_node_net_handle(n1->id()));
                 net_handle_t node2 = distance_index.get_node_net_handle(n2->id());
                 net_handle_t chain2 = distance_index.get_parent(node2);
@@ -748,6 +758,8 @@ namespace vg {
                 REQUIRE(found == 2);
             }
             SECTION("into_which_snarl") {
+                SnarlDistanceIndex distance_index;
+                fill_in_distance_index(&distance_index, &graph, &snarl_finder);
                 REQUIRE((distance_index.into_which_snarl(n4->id(), false) == std::make_tuple(4, false, true) ||
                         distance_index.into_which_snarl(n4->id(), false) == std::make_tuple(5, true, true)));
                 REQUIRE((distance_index.into_which_snarl(n5->id(), true) == std::make_tuple(4, false, true) ||
@@ -756,6 +768,10 @@ namespace vg {
                         distance_index.into_which_snarl(n5->id(), true));
                 REQUIRE((distance_index.into_which_snarl(n4->id(), true) == std::make_tuple(4, true, false) ||
                         distance_index.into_which_snarl(n4->id(), true) == std::make_tuple(2, false, false)));
+            }
+            SECTION("distanceless index") {
+                SnarlDistanceIndex distance_index;
+                fill_in_distance_index(&distance_index, &graph, &snarl_finder, 0);
             }
         }
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Update bdsg to fix distance index bugs with looping chains and distance-less indexes
 * Add a topological sort of child ranks for snarls in the distance index

## Description
Also silence warnings about oversized snarls by default