### PR TITLE
Set snarl distance to 0 in path normalizer now that distance index is fixed. 

### DIFF
--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -384,8 +384,7 @@ void merge_equivalent_traversals_in_graph(MutablePathHandleGraph* graph, const u
     SnarlDistanceIndex distance_index;
     {
         IntegratedSnarlFinder snarl_finder(*graph);
-        // todo: why can't I pass in 0 below -- I don't want any dinstances!
-        fill_in_distance_index(&distance_index, graph, &snarl_finder, 1);
+        fill_in_distance_index(&distance_index, graph, &snarl_finder, 0);
     }
 
     // only consider embedded paths that span snarl

--- a/test/t/11_vg_paths.t
+++ b/test/t/11_vg_paths.t
@@ -90,10 +90,10 @@ diff original.fa norm_x4.fa
 is $? 0 "path normalizer doesnt alter path sequences"
 
 # note: x3 is x4 in reverse, so we key on that
-grep x3 norm_x2.gfa | awk '{print $3}' > x4.path
-grep x3 norm_x2.gfa | awk '{print $3}' >> x4.path
-grep x3 norm_x2.gfa | awk '{print $3}'> x4.norm.path
-grep x5 norm_x2.gfa | awk '{print $3}' >> x4.norm.path
+grep x3 norm_x4.gfa | awk '{print $3}' > x4.path
+grep x3 norm_x4.gfa | awk '{print $3}' >> x4.path
+grep x3 norm_x4.gfa | awk '{print $3}'> x4.norm.path
+grep x5 norm_x4.gfa | awk '{print $3}' >> x4.norm.path
 diff x4.path x4.norm.path
 is $? 0 "path normalizere correctly snapped all equivalent paths to x4"
 


### PR DESCRIPTION
This resolves some small issues in #4396 , but can't be merged in until #4395 is.  