### PR TITLE
Add error checking around writing kmer files

### DIFF
--- a/src/kmer.cpp
+++ b/src/kmer.cpp
@@ -348,7 +348,15 @@ string write_gcsa_kmers_to_tmpfile(const HandleGraph& graph, int kmer_size, size
         temp_file::remove(tmpfile);
         throw ex;
     }
+    if (!out) {
+        std::cerr << "error[write_gcsa_kmers_to_tmpfile]: I/O error while writing kmers to " << tmpfile << std::endl;
+        exit(1);
+    }
     out.close();
+    if (!out) {
+        std::cerr << "error[write_gcsa_kmers_to_tmpfile]: I/O error while closing kmer file " << tmpfile << std::endl;
+        exit(1);
+    }
     return tmpfile;
 }
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GCSA indexing now checks for I/O errors on temporary kmer files.

## Description

This might help with problems like https://github.com/vgteam/vg/issues/4404#issuecomment-2373287057 by letting us tell whether the kmer files were actually accepted by the filesystem or not.

