### PR TITLE
Pass $DEBIAN_FRONTEND through make get-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -521,7 +521,7 @@ static-docker: static scripts/*
 # We have system-level deps to install
 # We want the One True Place for them to be in the Dockerfile.
 get-deps:
-	sudo apt-get install -qq -y --no-upgrade $(shell cat Dockerfile | sed -n '/^###DEPS_BEGIN###/,$${p;/^###DEPS_END###/q}' | grep -v '^ *#' | grep -v "^RUN" | tr '\n' ' ' | tr -d '\\')
+	sudo DEBIAN_FRONTEND=$(DEBIAN_FRONTEND) apt-get install -qq -y --no-upgrade $(shell cat Dockerfile | sed -n '/^###DEPS_BEGIN###/,$${p;/^###DEPS_END###/q}' | grep -v '^ *#' | grep -v "^RUN" | tr '\n' ' ' | tr -d '\\')
 
 # And we have submodule deps to build
 deps: $(DEPS)


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `make get-deps` can no longer demand you set a timezone even when `DEBIAN_FRONTEND=noninteractive` in the calling shell.

## Description

This lets you stop `make get-deps` from demanding your timezone. This would happen sometimes in fresh Docker containers. We need to explicitly pass the variable through since `sudo` does not preserve the environment.
