### PR TITLE
Fix chunk extraction and subsequent GBWT generation

### DIFF
--- a/src/algorithms/subgraph.cpp
+++ b/src/algorithms/subgraph.cpp
@@ -305,10 +305,7 @@ void add_subpaths_to_subgraph(const PathPositionHandleGraph& source, MutablePath
     // subrange metadata when we just have all of a path.
     std::unordered_map<base_metadata_t, std::pair<size_t, bool>> full_path_info;
 
-    size_t subgraph_handles = 0;
-
     subgraph.for_each_handle([&](const handle_t& h) {
-            subgraph_handles++;
             handlegraph::nid_t id = subgraph.get_id(h);
             if (source.has_node(id)) {
                 handle_t handle = source.get_handle(id);

--- a/src/algorithms/subgraph.cpp
+++ b/src/algorithms/subgraph.cpp
@@ -305,7 +305,10 @@ void add_subpaths_to_subgraph(const PathPositionHandleGraph& source, MutablePath
     // subrange metadata when we just have all of a path.
     std::unordered_map<base_metadata_t, std::pair<size_t, bool>> full_path_info;
 
+    size_t subgraph_handles = 0;
+
     subgraph.for_each_handle([&](const handle_t& h) {
+            subgraph_handles++;
             handlegraph::nid_t id = subgraph.get_id(h);
             if (source.has_node(id)) {
                 handle_t handle = source.get_handle(id);

--- a/src/algorithms/subgraph.hpp
+++ b/src/algorithms/subgraph.hpp
@@ -34,13 +34,15 @@ void extract_id_range(const HandleGraph& source, const nid_t& id1, const nid_t& 
 /// if end < 0, then it will walk to the end of the path
 void extract_path_range(const PathPositionHandleGraph& source, path_handle_t path_handle, int64_t start, int64_t end, MutableHandleGraph& subgraph);
 
-/// add subpaths to the subgraph, providing a concatenation of subpaths that are discontiguous over the subgraph
-/// based on their order in the path position index provided by the source graph
-/// will clear any path found in both graphs before writing the new steps into it
-/// if subpath_naming is true, a suffix will be added to each path in the subgraph denoting its offset
-/// in the source graph (unless the subpath was not cut up at all)
-void add_subpaths_to_subgraph(const PathPositionHandleGraph& source, MutablePathHandleGraph& subgraph,
-                              bool subpath_naming = false);
+/// Add subpaths to the subgraph for all paths visiting its nodes in the source
+/// graph.
+///
+/// Always generates correct path metadata, and a path for each contiguous
+/// fragment of any base path. Assumes the source graph does not contain any
+/// overlapping path fragments on a given base path, and that the subgraph does
+/// not already contain any paths on a base path also present in the source
+/// graph.
+void add_subpaths_to_subgraph(const PathPositionHandleGraph& source, MutablePathHandleGraph& subgraph);
 
 /// We can accumulate a subgraph without accumulating all the edges between its nodes
 /// this helper ensures that we get the full set

--- a/src/chunker.hpp
+++ b/src/chunker.hpp
@@ -49,14 +49,14 @@ public:
                         MutablePathMutableHandleGraph& subgraph);
 
     /**
-     * Extract a connected component containing a given path
+     * Extract a connected component containing a given path. Processes path metadata and creates subpaths.
      */
     void extract_path_component(const string& path_name, MutablePathMutableHandleGraph& subgraph, Region& out_region);
    
     /**
-     * Extract a connected component starting from an id set
+     * Extract a connected component starting from an id set. Processes path metadata and creates subpaths.
      */
-    void extract_component(const unordered_set<nid_t>& node_ids, MutablePathMutableHandleGraph& subgraph, bool subpath_naming);   
+    void extract_component(const unordered_set<nid_t>& node_ids, MutablePathMutableHandleGraph& subgraph);   
 
     /**
      * Like above, but use (inclusive) id range instead of region on path.

--- a/src/chunker.hpp
+++ b/src/chunker.hpp
@@ -31,9 +31,12 @@ public:
 
     /** Extract subgraph corresponding to given path region into its 
      * own vg graph, and send it to out_stream.  The boundaries of the
-     * extracted graph (which can be different because we expand context and don't
-     * cut nodes) are written to out_region.  If forward_only set, context
-     * is only expanded in the forward direction
+     * extracted region of the target path (which can be different because we
+     * expand context and don't cut nodes) are written to out_region. If the
+     * target path goes through the extracted region multiple times, only the
+     * extended bounds of the visit containing the target region are produced.
+     *
+     * If forward_only set, context is only expanded in the forward direction
      *
      * NOTE: we follow convention of Region coordinates being 0-based 
      * inclusive. 

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -726,7 +726,7 @@ int main_chunk(int argc, char** argv) {
         map<string, int> trace_thread_frequencies;
         if (!component_ids.empty()) {
             subgraph = vg::io::new_output_graph<MutablePathMutableHandleGraph>(output_format);
-            chunker.extract_component(component_ids[i], *subgraph, false);
+            chunker.extract_component(component_ids[i], *subgraph);
             output_regions[i] = region;
         }
         else if (id_range == false) {

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -1,4 +1,5 @@
 #include "subcommand.hpp"
+#include "../crash.hpp"
 #include "../utility.hpp"
 #include "../mapper.hpp"
 #include <vg/io/stream.hpp>
@@ -683,8 +684,9 @@ int main_find(int argc, char** argv) {
                     ofstream out(s.str().c_str());
                     vg::io::save_handle_graph(&graph, out);
                     out.close();
-                    // reset our graph
-                    dynamic_cast<DeletableHandleGraph&>(graph).clear();
+                    // reset our graph so it has no nodes or paths anymore
+                    graph.clear();
+                    crash_unless(graph.get_path_count() == 0);
                 }
                 if (subgraph_k) {
                     prep_graph(); // don't forget to prep the graph, or the kmer set will be wrong[

--- a/src/unittest/chunker.cpp
+++ b/src/unittest/chunker.cpp
@@ -186,10 +186,28 @@ TEST_CASE("basic graph chunking", "[chunk]") {
         VG subgraph;
         Region out_region;        
         chunker.extract_subgraph(region, 1, 0, false, subgraph, out_region);
+
+        // We include node 4 in the cycle, and also node 3 which is 1 away, so
+        // we include all the loops arounf the cycle and need to start the
+        // extracted path region where it enters node 3 at base 6.
         
         REQUIRE(subgraph.node_count() == 7);
         REQUIRE(subgraph.edge_count() == 9);
+        REQUIRE(out_region.start == 6);
+        
+    }
+
+    SECTION("Partial graph via cyclic path, 0 expansion") {
+        
+        Region region = {"z", 35, 36};
+        VG subgraph;
+        Region out_region;        
+        chunker.extract_subgraph(region, 0, 0, false, subgraph, out_region);
+
+        REQUIRE(subgraph.node_count() == 1);
+        REQUIRE(subgraph.edge_count() == 0);
         REQUIRE(out_region.start == 31);
+        REQUIRE(out_region.end == 36); // End is inclusive
         
     }
 

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -631,6 +631,7 @@ void VG::destroy_edge(const handle_t& left, const handle_t& right) {
 }
     
 void VG::clear() {
+    clear_paths();
     graph.mutable_node()->Clear();
     graph.mutable_edge()->Clear();
     clear_indexes();

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -90,7 +90,9 @@ printf "P\ty\t1+,3+,5+,6+,8+,9+,11+,12+,9+,10+,12+,14+,15+\t8M,1M,1M,3M,1M,19M,1
 vg view -Fv cyclic_tiny.gfa > cyclic_tiny.vg
 vg index cyclic_tiny.vg -x cyclic_tiny.xg
 vg find -x cyclic_tiny.xg  -n 10 -n 11 -n 12 -n 13 -n 14 -n 15 -c 1 > cycle.vg
-vg index cycle.vg -x cycle.xg
+# TODO: Make deconstruct see through subpaths to the base path
+vg view cycle.vg | sed 's/\([xy]\)\[[-0-9]*\]/\1/g' >cycle-asfullpaths.gfa
+vg index cycle-asfullpaths.gfa -x cycle.xg
 vg deconstruct cycle.xg -p y -e -t 1 > cycle_decon.vcf
 is $(grep -v "#" cycle_decon.vcf | wc -l) 1 "cyclic reference deconstruction has correct number of variants"
 grep -v "#" cycle_decon.vcf | grep 20 | awk '{print $1 "\t" $2 "\t" $4 "\t" $5 "\t" $10}' > cycle_decon.tsv

--- a/test/t/30_vg_chunk.t
+++ b/test/t/30_vg_chunk.t
@@ -66,8 +66,8 @@ is $(vg chunk -x x.xg -r 1:1 -c 2 -T | vg view - -j | jq .node | grep id | wc -l
 
 # Check that traces work on a GBWT
 is $(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq .node | grep id | wc -l) 5 "id chunker traces correct chunk size"
-is "$(vg chunk -x x.xg -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.name != "x[0]")' | wc -l)" 0 "chunker extracts no threads from an empty gPBWT"
-is "$(vg chunk -x x.xg -G x.haps.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.name != "x[0]")' | wc -l)" 2 "chunker extracts 2 local threads from a gBWT with 2 locally distinct threads in it"
+is "$(vg chunk -x x.xg -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.name | startswith("x[0") | not)' | wc -l)" 0 "chunker extracts no threads from an empty gPBWT"
+is "$(vg chunk -x x.xg -G x.haps.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -c '.path[] | select(.name | startswith("x[0") | not)' | wc -l)" 2 "chunker extracts 2 local threads from a gBWT with 2 locally distinct threads in it"
 is "$(vg chunk -x x.xg -G x.gbwt -r 1:1 -c 2 -T | vg view - -j | jq -r '.path[] | select(.name == "thread_0") | .mapping | length')" 3 "chunker can extract a partial haplotype from a GBWT"
 is "$(vg chunk -x x.gbz -r 1:1 -c 2 -T | vg view - -j | jq -r '.path[] | select(.name == "thread_0") | .mapping | length')" 3 "chunker can extract a partial haplotype from a GBZ"
 is "$(vg chunk -x x.gbz -r 1:1 -c 2 -T --no-embedded-haplotypes | vg view - -j | jq -r '.path[] | select(.name == "thread_0") | .mapping | length')" "" "chunker doesn't see haplotypes in the GBZ if asked not to"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg chunk` and `vg find` now generate subpaths with subrange metadata when cutting up paths.
 * `vg gbwt` will accept subranges on fragment 0 and discard the fragment number.

## Description

This should let you do:
```
wget https://s3-us-west-2.amazonaws.com/human-pangenomics/pangenomes/freeze/freeze1/minigraph-cactus/hprc-v1.1-mc-chm13/hprc-v1.1-mc-chm13.chroms/chr20.d9.vg
vg snarls -t8 -a chr20.d9.vg > chr20.d9.snarls # get snarls
vg chunk -x chr20.d9.vg -p CHM13#chr20:5000-15000 --snarls chr20.d9.snarls > chr20_10k.vg # get the subgraph
vg gbwt -E -x chr20_10k.vg -o chr20_10k.gbwt
```

But it changes a lot of how chunk extraction on reference paths names things, so it might break a bunch of CLI tests. And it needs some unit tests to make sure that subpath start offsets are accurately computed.