### PR TITLE
Giraffe paired end fragment length

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -3291,10 +3291,10 @@ int64_t MinimizerMapper::distance_between(const Alignment& aln1, const Alignment
     crash_unless(aln1.path().mapping_size() != 0); 
     crash_unless(aln2.path().mapping_size() != 0); 
      
-    pos_t pos1 = initial_position(aln1.path()); 
-    pos_t pos2 = final_position(aln2.path());
+    pos_t pos1 = final_position(aln1.path()); 
+    pos_t pos2 = initial_position(aln2.path());
 
-    return distance_between(pos1, pos2);
+    return SnarlDistanceIndex::sum(distance_between(pos1, pos2), aln1.sequence().size() + aln2.sequence().size());
 }
 
 void MinimizerMapper::extension_to_alignment(const GaplessExtension& extension, Alignment& alignment) const {

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -293,7 +293,7 @@ public:
     
     static constexpr size_t default_max_multimaps = 1;
     size_t max_multimaps = default_max_multimaps;
-    static constexpr size_t default_distance_limit = 200;
+    static constexpr size_t default_distance_limit = 0;
     size_t distance_limit = default_distance_limit;
     
     /// If false, skip computing base-level alignments.
@@ -381,7 +381,7 @@ public:
      * Get the distance limit for the given read length
      */
     size_t get_distance_limit(size_t read_length) const {
-        return max(distance_limit, read_length + 50);
+        return max(distance_limit, (size_t) ((int)read_length * 1.5));
     }
 
     /// The information we store for each seed.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Change giraffe's measurement of distance between pairs of reads to measure between the inner edges plus the lengths of the reads

## Description

This might address #4434