### PR TITLE
Allow SAM-style flags to be passed through to output from FASTQ comments

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -908,15 +908,43 @@ bam1_t* alignment_to_bam_internal(bam_hdr_t* header,
                     }
                     bam_aux_append(bam, tag_id, tag_type, sizeof(char), (uint8_t*) &tag_val[0]);
                     break;
+                case 'c':
+                {
+                    int8_t val = parse<int8_t>(tag_val);
+                    bam_aux_append(bam, tag_id, tag_type, sizeof(int8_t), (uint8_t*) &val);
+                    break;
+                }
+                case 'C':
+                {
+                    uint8_t val = parse<uint8_t>(tag_val);
+                    bam_aux_append(bam, tag_id, tag_type, sizeof(uint8_t), (uint8_t*) &val);
+                    break;
+                }
+                case 's':
+                {
+                    int16_t val = parse<int16_t>(tag_val);
+                    bam_aux_append(bam, tag_id, tag_type, sizeof(int16_t), (uint8_t*) &val);
+                    break;
+                }
+                case 'S':
+                {
+                    uint16_t val = parse<uint16_t>(tag_val);
+                    bam_aux_append(bam, tag_id, tag_type, sizeof(uint16_t), (uint8_t*) &val);
+                    break;
+                }
                 case 'i':
-                    // integer
                 {
                     int32_t val = parse<int32_t>(tag_val);
                     bam_aux_append(bam, tag_id, tag_type, sizeof(int32_t), (uint8_t*) &val);
                     break;
                 }
+                case 'I':
+                {
+                    uint32_t val = parse<uint32_t>(tag_val);
+                    bam_aux_append(bam, tag_id, tag_type, sizeof(uint32_t), (uint8_t*) &val);
+                    break;
+                }
                 case 'f':
-                    // float
                 {
                     float val = parse<float>(tag_val);
                     bam_aux_append(bam, tag_id, tag_type, sizeof(float), (uint8_t*) &val);

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -27,37 +27,42 @@ int hts_for_each(string& filename, function<void(Alignment&)> lambda,
                  const PathPositionHandleGraph* graph);
 int hts_for_each_parallel(string& filename, function<void(Alignment&)> lambda,
                           const PathPositionHandleGraph* graph);
-int fastq_for_each(string& filename, function<void(Alignment&)> lambda);
 
-// fastq
-bool get_next_alignment_from_fastq(gzFile fp, char* buffer, size_t len, Alignment& alignment);
-bool get_next_interleaved_alignment_pair_from_fastq(gzFile fp, char* buffer, size_t len, Alignment& mate1, Alignment& mate2);
-bool get_next_alignment_pair_from_fastqs(gzFile fp1, gzFile fp2, char* buffer, size_t len, Alignment& mate1, Alignment& mate2);
+// parsing a FASTQ record, optionally intepreting the comment as SAM-style tags
+bool get_next_alignment_from_fastq(gzFile fp, char* buffer, size_t len, Alignment& alignment, bool comment_as_tags);
+bool get_next_interleaved_alignment_pair_from_fastq(gzFile fp, char* buffer, size_t len, Alignment& mate1, Alignment& mate2, bool comment_as_tags);
+bool get_next_alignment_pair_from_fastqs(gzFile fp1, gzFile fp2, char* buffer, size_t len, Alignment& mate1, Alignment& mate2, bool comment_as_tags);
 
-size_t fastq_unpaired_for_each(const string& filename, function<void(Alignment&)> lambda);
-size_t fastq_paired_interleaved_for_each(const string& filename, function<void(Alignment&, Alignment&)> lambda);
-size_t fastq_paired_two_files_for_each(const string& file1, const string& file2, function<void(Alignment&, Alignment&)> lambda);
+// parsing a FASTQ or FASTA file, optionally interpreting comments as SAM-style tags
+size_t fastq_unpaired_for_each(const string& filename, function<void(Alignment&)> lambda, bool comment_as_tags = false);
+size_t fastq_paired_interleaved_for_each(const string& filename, function<void(Alignment&, Alignment&)> lambda, bool comment_as_tags = false);
+size_t fastq_paired_two_files_for_each(const string& file1, const string& file2, function<void(Alignment&, Alignment&)> lambda, bool comment_as_tags = false);
 // parallel versions of above
 size_t fastq_unpaired_for_each_parallel(const string& filename,
                                         function<void(Alignment&)> lambda,
+                                        bool comment_as_tags = false,
                                         uint64_t batch_size = vg::io::DEFAULT_PARALLEL_BATCHSIZE);
     
 size_t fastq_paired_interleaved_for_each_parallel(const string& filename,
                                                   function<void(Alignment&, Alignment&)> lambda,
+                                                  bool comment_as_tags = false,
                                                   uint64_t batch_size = vg::io::DEFAULT_PARALLEL_BATCHSIZE);
     
 size_t fastq_paired_interleaved_for_each_parallel_after_wait(const string& filename,
                                                              function<void(Alignment&, Alignment&)> lambda,
                                                              function<bool(void)> single_threaded_until_true,
+                                                             bool comment_as_tags = false,
                                                              uint64_t batch_size = vg::io::DEFAULT_PARALLEL_BATCHSIZE);
     
 size_t fastq_paired_two_files_for_each_parallel(const string& file1, const string& file2,
                                                 function<void(Alignment&, Alignment&)> lambda,
+                                                bool comment_as_tags = false,
                                                 uint64_t batch_size = vg::io::DEFAULT_PARALLEL_BATCHSIZE);
     
 size_t fastq_paired_two_files_for_each_parallel_after_wait(const string& file1, const string& file2,
                                                            function<void(Alignment&, Alignment&)> lambda,
                                                            function<bool(void)> single_threaded_until_true,
+                                                           bool comment_as_tags = false,
                                                            uint64_t batch_size = vg::io::DEFAULT_PARALLEL_BATCHSIZE);
 
 bam_hdr_t* hts_file_header(string& filename, string& header);

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -781,13 +781,11 @@ vector<Alignment> MinimizerMapper::map_from_extensions(Alignment& aln) {
     alignments_to_source.reserve(cluster_extensions.size());
 
     // Create a new alignment object to get rid of old annotations.
-    {
-      Alignment temp;
-      temp.set_sequence(aln.sequence());
-      temp.set_name(aln.name());
-      temp.set_quality(aln.quality());
-      aln = std::move(temp);
-    }
+    aln.clear_refpos();
+    aln.clear_path();
+    aln.set_score(0);
+    aln.set_identity(0);
+    aln.set_mapping_quality(0);
 
     // Annotate the read with metadata
     if (!sample_name.empty()) {

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -246,7 +246,7 @@ public:
     size_t min_lookback_items = default_min_lookback_items;
     /// How many chaining sources should we allow ourselves to consider ever?
     static constexpr size_t default_lookback_item_hard_cap = 15;
-    size_t lookback_item_hard_cap = lookback_item_hard_cap;
+    size_t lookback_item_hard_cap = default_lookback_item_hard_cap;
     /// How many bases should we try to look back initially when chaining?
     static constexpr size_t default_initial_lookback_threshold = 10;
     size_t initial_lookback_threshold = default_initial_lookback_threshold;

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -2180,6 +2180,16 @@ namespace vg {
         });
     }
 
+    // TODO: our proto annotation system actually doesn't seem to allow null annotations...
+    template<class ProtoAlignment1, class ProtoAlignment2>
+    void transfer_between_proto_annotation(const ProtoAlignment1& from, ProtoAlignment2& to) {
+        for_each_basic_annotation(from,
+                                  [&to](const string& name) { return; },
+                                  [&to](const string& name, double value) { set_annotation(to, name, value); },
+                                  [&to](const string& name, bool value) { set_annotation(to, name, value); },
+                                  [&to](const string& name, const string& value) { set_annotation(to, name, value); });
+    }
+
     // transfers the metadata that is shared across all formats
     template<class Alignment1, class Alignment2>
     void transfer_uniform_metadata(const Alignment1& from, Alignment2& to) {

--- a/src/multipath_alignment.cpp
+++ b/src/multipath_alignment.cpp
@@ -2180,16 +2180,6 @@ namespace vg {
         });
     }
 
-    // TODO: our proto annotation system actually doesn't seem to allow null annotations...
-    template<class ProtoAlignment1, class ProtoAlignment2>
-    void transfer_between_proto_annotation(const ProtoAlignment1& from, ProtoAlignment2& to) {
-        for_each_basic_annotation(from,
-                                  [&to](const string& name) { return; },
-                                  [&to](const string& name, double value) { set_annotation(to, name, value); },
-                                  [&to](const string& name, bool value) { set_annotation(to, name, value); },
-                                  [&to](const string& name, const string& value) { set_annotation(to, name, value); });
-    }
-
     // transfers the metadata that is shared across all formats
     template<class Alignment1, class Alignment2>
     void transfer_uniform_metadata(const Alignment1& from, Alignment2& to) {
@@ -2320,6 +2310,7 @@ namespace vg {
             auto annotation = from.get_annotation("secondary");
             assert(annotation.first == multipath_alignment_t::Bool);
             to.set_is_secondary(*((bool*) annotation.second));
+            clear_annotation(to, "secondary");
         }
     }
 

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -313,8 +313,7 @@ void MultipathAlignmentEmitter::convert_to_alignment(const multipath_alignment_t
 void MultipathAlignmentEmitter::create_alignment_shim(const string& name, const multipath_alignment_t& mp_aln,
                                                       Alignment& shim, const string* prev_name, const string* next_name) const {
     
-    shim.set_sequence(mp_aln.sequence());
-    shim.set_quality(mp_aln.quality());
+    transfer_read_metadata(mp_aln, shim);
     shim.set_name(name);
     if (prev_name) {
         shim.mutable_fragment_prev()->set_name(*prev_name);
@@ -344,12 +343,6 @@ void MultipathAlignmentEmitter::create_alignment_shim(const string& name, const 
         shim.set_score(optimal_alignment_score(mp_aln, true));
     }
     
-    // this tag comes from surject and is used in both
-    if (mp_aln.has_annotation("all_scores")) {
-        auto anno = mp_aln.get_annotation("all_scores");
-        assert(anno.first == multipath_alignment_t::String);
-        set_annotation(&shim, "all_scores", *((const string*) anno.second));
-    }
 }
 
 void MultipathAlignmentEmitter::convert_to_hts_unpaired(const string& name, const multipath_alignment_t& mp_aln,

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -390,7 +390,8 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, bool full_help) {
     << "input options:" << endl
     << "  -G, --gam-in FILE             read and realign GAM-format reads from FILE" << endl
     << "  -f, --fastq-in FILE           read and align FASTQ-format reads from FILE (two are allowed, one for each mate)" << endl
-    << "  -i, --interleaved             GAM/FASTQ input is interleaved pairs, for paired-end alignment" << endl;
+    << "  -i, --interleaved             GAM/FASTQ input is interleaved pairs, for paired-end alignment" << endl
+    << "  --comments-as-tags            intepret comments in name lines as SAM-style tags and annotate alignments with them" << endl;
 
     cerr
     << "haplotype sampling:" << endl
@@ -464,6 +465,7 @@ int main_giraffe(int argc, char** argv) {
     constexpr int OPT_HAPLOTYPE_NAME = 1100;
     constexpr int OPT_KFF_NAME = 1101;
     constexpr int OPT_INDEX_BASENAME = 1102;
+    constexpr int OPT_COMMENTS_AS_TAGS = 1103;
 
     // initialize parameters with their default options
     
@@ -497,8 +499,10 @@ int main_giraffe(int argc, char** argv) {
     bool interleaved = false;
     // True if fastq_filename_2 or interleaved is set.
     bool paired = false;
+    // True if the FASTQ's name line comments are SAM-style tags that we want to preserve
+    bool comments_as_tags = false;
     string param_preset = "default";
-    //Attempt up to this many rescues of reads with no pairs
+    // Attempt up to this many rescues of reads with no pairs
     bool forced_rescue_attempts = false;
     // Which rescue algorithm do we use?
     MinimizerMapper::RescueAlgorithm rescue_algorithm = MinimizerMapper::rescue_dozeu;
@@ -592,6 +596,7 @@ int main_giraffe(int argc, char** argv) {
         {"gam-in", required_argument, 0, 'G'},
         {"fastq-in", required_argument, 0, 'f'},
         {"interleaved", no_argument, 0, 'i'},
+        {"comments-as-tags", no_argument, 0, OPT_COMMENTS_AS_TAGS},
         {"max-multimaps", required_argument, 0, 'M'},
         {"sample", required_argument, 0, 'N'},
         {"read-group", required_argument, 0, 'R'},
@@ -773,6 +778,10 @@ int main_giraffe(int argc, char** argv) {
             case 'i':
                 interleaved = true;
                 paired = true;
+                break;
+                
+            case OPT_COMMENTS_AS_TAGS:
+                comments_as_tags = true;
                 break;
                 
             case 'N':
@@ -1462,12 +1471,12 @@ int main_giraffe(int argc, char** argv) {
                     });
                 } else if (!fastq_filename_2.empty()) {
                     //A pair of FASTQ files to map
-                    fastq_paired_two_files_for_each_parallel_after_wait(fastq_filename_1, fastq_filename_2, map_read_pair, distribution_is_ready, batch_size);
+                    fastq_paired_two_files_for_each_parallel_after_wait(fastq_filename_1, fastq_filename_2, map_read_pair, distribution_is_ready, comments_as_tags, batch_size);
 
 
                 } else if ( !fastq_filename_1.empty()) {
                     // An interleaved FASTQ file to map, map all its pairs in parallel.
-                    fastq_paired_interleaved_for_each_parallel_after_wait(fastq_filename_1, map_read_pair, distribution_is_ready, batch_size);
+                    fastq_paired_interleaved_for_each_parallel_after_wait(fastq_filename_1, map_read_pair, distribution_is_ready, comments_as_tags, batch_size);
                 }
 
                 // Now map all the ambiguous pairs
@@ -1535,7 +1544,7 @@ int main_giraffe(int argc, char** argv) {
                 
                 if (!fastq_filename_1.empty()) {
                     // FASTQ file to map, map all its reads in parallel.
-                    fastq_unpaired_for_each_parallel(fastq_filename_1, map_read, batch_size);
+                    fastq_unpaired_for_each_parallel(fastq_filename_1, map_read, comments_as_tags, batch_size);
                 }
             }
         

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -427,6 +427,9 @@ using namespace std;
                 if (annotate_with_all_path_scores) {
                     mp_alns_out->back().set_annotation("all_scores", annotation_string);
                 }
+#ifdef debug_anchored_surject
+                cerr << "outputting surjected mp aln: " << debug_string(mp_alns_out->back()) << endl;
+#endif
             }
             
             // use this info to set the path position

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -861,6 +861,14 @@ bool parse(const string& arg, double& dest) {
 }
 
 template<>
+bool parse(const string& arg, float& dest) {
+    size_t after;
+    dest = std::stof(arg, &after);
+    return(after == arg.size());
+}
+
+
+template<>
 bool parse(const string& arg, std::regex& dest) {
     // This throsw std::regex_error if it can't parse.
     // That contains a kind of useless error code that we can't turn itno a string without switching on all the values.

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -865,9 +865,11 @@ bool parse(const string& arg, typename enable_if<sizeof(Result) <= sizeof(unsign
     return(after == arg.size());    
 }              
 
-// We also have an implementation for doubles (defined in the cpp)
+// We also have an implementation for doubles and floats (defined in the cpp)
 template<>
 bool parse(const string& arg, double& dest);
+template<>
+bool parse(const string& arg, float& dest);
 
 // And one for regular expressions
 template<>

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -44,6 +44,8 @@ void choose_good_thread_count();
 string wrap_text(const string& str, size_t width);
 bool is_number(const string& s);
 
+// all whitespace characters
+const std::string whitespace = " \t\n\v\f\r";
 // split a string on any character found in the string of delimiters (delims)
 // if max_cuts specified, only split at the first <max_cuts> delimiter occurrences
 std::vector<std::string>& split_delims(const std::string &s, const std::string& delims, std::vector<std::string> &elems,

--- a/test/t/07_vg_map.t
+++ b/test/t/07_vg_map.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 59
+plan tests 60
 
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg -g x.gcsa -k 11 x.vg
@@ -203,13 +203,15 @@ vg index -x x.xg -g x.gcsa -k 16 x.vg
 printf "@read1\tT1:A:t T2:i:1\t T3:f:3.5e-7\nCACCGTGATCTTCAAGTTTGAAAATTGCATCTCAAATCTAAGACCCAGAGGGCTCACCCAGAGTCGAGGCTCAAGGACAG\n+\nHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH\n" > tagged1.fq
 printf "@read2 T4:Z:str T5:H:FF00\tT6:B:S,0,10 T7:B:f,8.0,5.0\nCACCGTGATCTTCAAGTTTGAAAATTGCATCTCAAATCTAAGACCCAGAGGGCTCACCCAGAGTCGAGGCTCAAGGACAG\n+\nHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH\n" > tagged2.fq
 vg map -x x.xg  -g x.gcsa --comments-as-tags -f tagged1.fq --surject-to bam > t1.bam
+vg map -x x.xg  -g x.gcsa --comments-as-tags -f tagged1.fq --surject-to sam > t1.sam
 vg map -x x.xg  -g x.gcsa --comments-as-tags -f tagged2.fq --surject-to bam > t2.bam
 vg map -x x.xg  -g x.gcsa --comments-as-tags -f tagged1.fq -f tagged2.fq --surject-to bam > t3.bam
 
-is "$(samtools view t1.bam | grep T1 | grep T2 | grep T3 | wc -l | sed 's/^[[:space:]]*//')" "1" "SAM tags are preserved on read 1"
-is "$(samtools view t2.bam | grep T4 | grep T5 | grep T6 | wc -l | sed 's/^[[:space:]]*//')" "1" "SAM tags are preserved on read 2"
-is "$(samtools view t3.bam | grep T1 | grep T2 | grep T3 | grep read1 | wc -l | sed 's/^[[:space:]]*//')" "1" "SAM tags are preserved on paired read 1"
-is "$(samtools view t3.bam | grep T4 | grep T5 | grep T6 | grep read2 | wc -l | sed 's/^[[:space:]]*//')" "1" "SAM tags are preserved on paired read 2"
+is "$(samtools view t1.bam | grep T1 | grep T2 | grep T3 | wc -l | sed 's/^[[:space:]]*//')" "1" "BAM tags are preserved on read 1"
+is "$(samtools view t2.bam | grep T4 | grep T5 | grep T6 | wc -l | sed 's/^[[:space:]]*//')" "1" "BAM tags are preserved on read 2"
+is "$(samtools view t3.bam | grep T1 | grep T2 | grep T3 | grep read1 | wc -l | sed 's/^[[:space:]]*//')" "1" "BAM tags are preserved on paired read 1"
+is "$(samtools view t3.bam | grep T4 | grep T5 | grep T6 | grep read2 | wc -l | sed 's/^[[:space:]]*//')" "1" "BAM tags are preserved on paired read 2"
+is "$(samtools view t1.sam | grep T1 | grep T2 | grep T3 | wc -l | sed 's/^[[:space:]]*//')" "1" "SAM tags are preserved on read 1"
 
-rm tagged1.fq tagged2.fq t1.bam t2.bam t3.bam
+rm tagged1.fq tagged2.fq t1.bam t2.bam t3.bam t1.sam
 rm -f x.vg x.xg x.gcsa x.gcsa.lcp


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg map`, `vg mpmap`, and `vg giraffe` can now annotate output with SAM-style flags from FASTQ comments with `--comments-as-tags`

## Description

Resolves https://github.com/vgteam/vg/issues/4370.

The tags get stored in the annotation field of the GAM and then interpreted in the BAM and GAF output.

I ended up not pulling in the full up-to-date master branch of libvgio because there's a recent PR in there that introduced a progress option, which leads to all sorts of crashes in the integration tests. I don't exactly know what's causing it, but @adamnovak might want to take a look. 