### PR TITLE
support --no-output as long version of -V

### DIFF
--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -143,6 +143,7 @@ int main_filter(int argc, char** argv) {
                 {"drop-split",  no_argument, 0, 'S'},
                 {"xg-name", required_argument, 0, 'x'},
                 {"verbose",  no_argument, 0, 'v'},
+                {"no-output", no_argument, 0, 'V'},
                 {"tsv-out",  no_argument, 0, 'T'},
                 {"min-mapq", required_argument, 0, 'q'},
                 {"repeat-ends", required_argument, 0, 'E'},


### PR DESCRIPTION
Documentation says that --no-output is the verbose form of -V, but it wasn't recognized by vg filter.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Update `vg filter` to accept `--no-output` as well as `-V`, as the documentation/help already says

## Description
