### PR TITLE
Flexible exon numbering

### DIFF
--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -647,8 +647,24 @@ int32_t Transcriptome::parse_transcripts(vector<Transcript> * transcripts, uint3
         transcript_line_ss.ignore(numeric_limits<streamsize>::max(), '\t');  
 
         string transcript_id = "";
-        getline(transcript_line_ss, attribute, ';');
-        transcript_id = parse_attribute_value(attribute, transcript_tag);
+        while (getline(transcript_line_ss, attribute, ';')) {
+
+            if (attribute.empty()) {
+
+                break;
+            }
+
+            // Parse transcript ID.
+            if (transcript_id.empty()) {
+
+                transcript_id = parse_attribute_value(attribute, transcript_tag);
+            }
+
+            if (!transcript_id.empty()) {
+
+                break;
+            }
+        }
 
         if (transcript_id.empty()) {
 

--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -295,10 +295,12 @@ class Transcriptome {
         /// are ordered in reverse.
         void reorder_exons(Transcript * transcript) const;
 
-	/// Checks whether any adjacent exons are out of (strictly increasing) order
+	/// Checks whether any adjacent exons are out of order
+	/// Assumes exons are in increasing order (to be correct)
 	bool has_incorrect_order_exons(const vector<Exon> & exons) const;
 
         /// Checks whether any adjacent exons overlap.
+	/// Assumes exons are in increasing order
         bool has_overlapping_exons(const vector<Exon> & exons) const;
 
         /// Constructs edited reference transcript paths from a set of 

--- a/src/transcriptome.hpp
+++ b/src/transcriptome.hpp
@@ -295,6 +295,9 @@ class Transcriptome {
         /// are ordered in reverse.
         void reorder_exons(Transcript * transcript) const;
 
+	/// Checks whether any adjacent exons are out of (strictly increasing) order
+	bool has_incorrect_order_exons(const vector<Exon> & exons) const;
+
         /// Checks whether any adjacent exons overlap.
         bool has_overlapping_exons(const vector<Exon> & exons) const;
 

--- a/src/unittest/transcriptome.cpp
+++ b/src/unittest/transcriptome.cpp
@@ -503,9 +503,12 @@ namespace vg {
                 transcript_stream2 << "path1\t.\texon\t2\t7\t.\t+\t.\ttranscript_id=transcript1;exon_number=1" << endl;
                 transcript_stream2 << "path1\t.\texon\t19\t21\t.\t+\t.\ttranscript_id=transcript1;exon_number=3" << endl;
                 transcript_stream2 << "path1\t.\texon\t16\t21\t.\t-\t.\tID=exon:transcript2:0;transcript_id=transcript2;" << endl;
-                transcript_stream2 << "path1\t.\texon\t2\t7\t.\t-\t.\tID=exon:transcript2:1;transcript_id=transcript2" << endl;
-                transcript_stream2 << "path1\t.\texon\t18\t21\t.\t+\t.\texon_number=2;transcript_id=transcript3" << endl;
+                transcript_stream2 << "path1\t.\texon\t8\t9\t.\t-\t.\tID=exon:transcript2:1;transcript_id=transcript2" << endl;
+                transcript_stream2 << "path1\t.\texon\t2\t7\t.\t-\t.\tID=exon:transcript2:2;transcript_id=transcript2" << endl;
                 transcript_stream2 << "path1\t.\texon\t9\t11\t.\t+\t.\texon_number=1;transcript_id=transcript3" << endl;
+                transcript_stream2 << "path1\t.\texon\t18\t21\t.\t+\t.\texon_number=2;transcript_id=transcript3" << endl;
+                transcript_stream2 << "path1\t.\texon\t8\t10\t.\t+\t.\ttranscript_id=transcript4" << endl;
+                transcript_stream2 << "path1\t.\texon\t3\t6\t.\t+\t.\ttranscript_id=transcript4" << endl;
 
                 transcriptome.add_reference_transcripts(vector<istream *>({&transcript_stream2}), empty_haplotype_index, false, false);
 

--- a/src/unittest/transcriptome.cpp
+++ b/src/unittest/transcriptome.cpp
@@ -506,7 +506,7 @@ namespace vg {
                 transcript_stream2 << "path1\t.\texon\t2\t7\t.\t-\t.\tID=exon:transcript2:1;transcript_id=transcript2" << endl;
                 transcript_stream2 << "path1\t.\texon\t8\t9\t.\t-\t.\tID=exon:transcript2:2;transcript_id=transcript2" << endl;
                 transcript_stream2 << "path1\t.\texon\t9\t11\t.\t+\t.\texon_number=1;transcript_id=transcript3" << endl;
-                transcript_stream2 << "path1\t.\texon\t18\t21\t.\t-\t.\texon_number=2;transcript_id=transcript3" << endl;
+                transcript_stream2 << "path1\t.\texon\t18\t21\t.\t+\t.\texon_number=2;transcript_id=transcript3" << endl;
                 transcript_stream2 << "path1\t.\texon\t8\t10\t.\t+\t.\ttranscript_id=transcript4" << endl;
                 transcript_stream2 << "path1\t.\texon\t3\t6\t.\t+\t.\ttranscript_id=transcript4" << endl;
 

--- a/src/unittest/transcriptome.cpp
+++ b/src/unittest/transcriptome.cpp
@@ -499,13 +499,13 @@ namespace vg {
             SECTION("Transcriptome can parse gff3 file and exclude transcripts with incorrect exon order") {
 
                 stringstream transcript_stream2;
-                transcript_stream2 << "path1\t.\texon\t2\t7\t.\t+\t.\ttranscript_id=transcript1;exon_number=2" << endl;
-                transcript_stream2 << "path1\t.\texon\t9\t10\t.\t+\t.\ttranscript_id=transcript1;exon_number=1" << endl;
+                transcript_stream2 << "path1\t.\texon\t9\t10\t.\t+\t.\ttranscript_id=transcript1;exon_number=2" << endl;
+                transcript_stream2 << "path1\t.\texon\t2\t7\t.\t+\t.\ttranscript_id=transcript1;exon_number=1" << endl;
                 transcript_stream2 << "path1\t.\texon\t19\t21\t.\t+\t.\ttranscript_id=transcript1;exon_number=3" << endl;
                 transcript_stream2 << "path1\t.\texon\t16\t21\t.\t-\t.\tID=exon:transcript2:0;transcript_id=transcript2;" << endl;
                 transcript_stream2 << "path1\t.\texon\t2\t7\t.\t-\t.\tID=exon:transcript2:1;transcript_id=transcript2" << endl;
-                transcript_stream2 << "path1\t.\texon\t9\t11\t.\t+\t.\texon_number=1;transcript_id=transcript3" << endl;
                 transcript_stream2 << "path1\t.\texon\t18\t21\t.\t+\t.\texon_number=2;transcript_id=transcript3" << endl;
+                transcript_stream2 << "path1\t.\texon\t9\t11\t.\t+\t.\texon_number=1;transcript_id=transcript3" << endl;
 
                 transcriptome.add_reference_transcripts(vector<istream *>({&transcript_stream2}), empty_haplotype_index, false, false);
 

--- a/src/unittest/transcriptome.cpp
+++ b/src/unittest/transcriptome.cpp
@@ -503,10 +503,10 @@ namespace vg {
                 transcript_stream2 << "path1\t.\texon\t2\t7\t.\t+\t.\ttranscript_id=transcript1;exon_number=1" << endl;
                 transcript_stream2 << "path1\t.\texon\t19\t21\t.\t+\t.\ttranscript_id=transcript1;exon_number=3" << endl;
                 transcript_stream2 << "path1\t.\texon\t16\t21\t.\t-\t.\tID=exon:transcript2:0;transcript_id=transcript2;" << endl;
-                transcript_stream2 << "path1\t.\texon\t8\t9\t.\t-\t.\tID=exon:transcript2:1;transcript_id=transcript2" << endl;
-                transcript_stream2 << "path1\t.\texon\t2\t7\t.\t-\t.\tID=exon:transcript2:2;transcript_id=transcript2" << endl;
+                transcript_stream2 << "path1\t.\texon\t2\t7\t.\t-\t.\tID=exon:transcript2:1;transcript_id=transcript2" << endl;
+                transcript_stream2 << "path1\t.\texon\t8\t9\t.\t-\t.\tID=exon:transcript2:2;transcript_id=transcript2" << endl;
                 transcript_stream2 << "path1\t.\texon\t9\t11\t.\t+\t.\texon_number=1;transcript_id=transcript3" << endl;
-                transcript_stream2 << "path1\t.\texon\t18\t21\t.\t+\t.\texon_number=2;transcript_id=transcript3" << endl;
+                transcript_stream2 << "path1\t.\texon\t18\t21\t.\t-\t.\texon_number=2;transcript_id=transcript3" << endl;
                 transcript_stream2 << "path1\t.\texon\t8\t10\t.\t+\t.\ttranscript_id=transcript4" << endl;
                 transcript_stream2 << "path1\t.\texon\t3\t6\t.\t+\t.\ttranscript_id=transcript4" << endl;
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * When reading a `.gff3` file with `vg rna`, validate exon ordering by base-pair position instead of number attribute. This allows reverse-strand exons to be numbered _either_ by base-pair order or transcription order.

## Description

When parsing a `.gff3` file several validation checks are done. One check is for whether the exons are out of order. This check is inflexible on exon numbering: all exons must be numbered in the order they appear in the file. This pull request relaxes the ordering requirement to only require base-pair order. Reverse-strand exons may appear in transcription order or base-pair order, as before.

**This change is backwards compatible.** All transcripts successfully parsed previously will still be parsed.

Currently, within a transcript, exons numbers (as determined by attribute) must increase as the parser reads down the file. However, genes on the reverse complement strand may have their exons numbered by order of transcription instead of position. Given a file where exons are sorted by position within a transcript (as is common), this means the parser will encounter the exons in _reverse order_, e.g. seeing exon 4, 3, 2, and 1. Such a transcript will be excluded as having "incorrect exon order". Therefore, **all reverse-strand genes using transcription-order numbering are excluded.**

A secondary, related bug affects forward-strand genes. Currently, to determine if a given exon is in order, its number attribute is compared to the total number of exons parsed so far for its transcript. This comparison must consider whether exons use 0-based or 1-based numbering. The parser decides on the numbering system by checking if the first parsed exon is number 0 or not. If not, then the file is assumed to use 1-based numbering. However, if the file uses 0-based numbering, but the first exon is from a reverse-strand transcript with multiple exons, then its exon number will be greater than 0. With the wrong numbering system, even forward-strand exon numbers will be off by exactly one. In this case, all **forward-strand genes may be excluded** on the basis of a faulty assumption.

This pull request bypasses both bugs by simply **ignoring exon number**. Correct order is still validated, but via base-pair position. Forward-strand exons must be in increasing base-pair order, whereas reverse-strand exons may be in either base-pair or transcription order. The pre-existing function `reorder_exons()` flips a list of reverse-strand exons if they are in reverse order. A new function, `has_incorrect_order_exons()`, performs the exon-order validation. Following the precedent of `has_overlapping_exons()`, this validation is performed after all transcripts have been parsed and thus all exons are known. Finally, because by the point of validation all exons may be assumed to be in increasing order (`reorder_exons()` is used before validation), the code in `has_overlapping_exons()` is simplified to only deal with the case of increasing order.