### PR TITLE
Build on GCC 9.3.0 with C++17

### DIFF
--- a/src/incremental_subgraph.hpp
+++ b/src/incremental_subgraph.hpp
@@ -184,7 +184,7 @@ private:
     /// end up in the same relative order in the frontier index as in the frontier
     struct IterFCmp {
         inline bool operator()(const decltype(frontier)::iterator& a,
-                               const decltype(frontier)::iterator& b) {
+                               const decltype(frontier)::iterator& b) const {
             return FCmp()(*a, *b);
         }
     };


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * VG builds on GCC 9.3.0

## Description

A couple minor changes that help satisfy a c++17 build on GCC 9.3.0. 