### PR TITLE
Allow non-exons to have bad chromosomes

### DIFF
--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -604,6 +604,15 @@ int32_t Transcriptome::parse_transcripts(vector<Transcript> * transcripts, uint3
 
         auto chrom_lengths_it = chrom_lengths.find(chrom);
 
+        transcript_line_ss.ignore(numeric_limits<streamsize>::max(), '\t');         
+        assert(getline(transcript_line_ss, feature, '\t'));
+
+        // Select only relevant feature types.
+        if (feature != feature_type && !feature_type.empty()) {
+
+            continue;
+        }
+	
         if (chrom_lengths_it == chrom_lengths.end()) {
 
             if (error_on_missing_path) {
@@ -616,15 +625,6 @@ int32_t Transcriptome::parse_transcripts(vector<Transcript> * transcripts, uint3
                 // Seek to the end of the line.
                 continue;
             }
-        }
-
-        transcript_line_ss.ignore(numeric_limits<streamsize>::max(), '\t');         
-        assert(getline(transcript_line_ss, feature, '\t'));
-
-        // Select only relevant feature types.
-        if (feature != feature_type && !feature_type.empty()) {
-
-            continue;
         }
 
         // Parse start and end exon position and convert to 0-base.


### PR DESCRIPTION
Some GFF3 features aren't used by default, e.g. `region` or other non-gene things. However, if their chromosomes aren't in the graph, that causes a program-halting error. 

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Have `vg rna` gracefully ignore features with bad chromosome names if they're not included in `--feature-type` and thus won't be parsed anyways

## Description

This change moves the check for whether the chromosome is valid to after the check for whether the feature is relevant, allowing graceful ignorance when possible. The program will still error in any situation where the chromosome is important.