### PR TITLE
Ensafen short read chaining preset

### DIFF
--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -805,7 +805,7 @@ int main_giraffe(int argc, char** argv) {
     // What GAM should we realign?
     string gam_filename;
     // What FASTQs should we align.
-    // Note: multiple FASTQs are not interpreted as paired.
+    // Multiple FASTQs are interpreted as paired.
     string fastq_filename_1;
     string fastq_filename_2;
     // Is the input interleaved/are we in paired-end mode?
@@ -1019,7 +1019,7 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("wfa-max-mismatches-per-base", 0.05)
         .add_entry<int>("wfa-max-max-mismatches", 15);
     // And a short reads with chaining preset
-    presets["sr"]
+    presets["chaining-sr"]
         .add_entry<bool>("align-from-chains", true)
         .add_entry<bool>("explored-cap", true)
         // Cap minimizers at a number we won't reach.
@@ -1549,6 +1549,12 @@ int main_giraffe(int argc, char** argv) {
     }
     if ((forced_mean || forced_stdev || forced_rescue_attempts) && (!paired)) {
         cerr << "warning:[vg giraffe] Attempting to set paired-end parameters but running in single-end mode" << endl;
+    }
+
+    if (parser->get_option_value<bool>("align-from-chains") && paired) {
+        // TODO: Implement chaining for paired-end alignment
+        cerr << "error:[vg giraffe] Paired-end alignment is not yet implemented for --align-from-chains or chaining-based presets" << endl;
+        exit(1);
     }
 
     bool haplotype_sampling = !haplotype_name.empty() & !kff_name.empty();

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 60
+plan tests 62
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
@@ -45,10 +45,15 @@ is "${?}" "0" "a read can be mapped with the fast preset"
 vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.fq -b default >/dev/null
 is "${?}" "0" "a read can be mapped with the default preset"
 
-vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.fq -b sr >/dev/null
+vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.fq -b chaining-sr >/dev/null
 is "${?}" "0" "a read can be mapped with the short read chaining preset"
 
-vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.mismatched.fq -b sr >/dev/null
+vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.fq -f reads/small.middle.ref.fq -b chaining-sr >/dev/null 2>log.txt
+is "${?}" "1" "a read pair cannot be mapped with the short read chaining preset"
+is "$(cat log.txt | grep "not yet implemented" | wc -l)" "1" "trying to map paired-end data with chaining produces an informative error"
+rm -f log.txt
+
+vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.mismatched.fq -b chaining-sr >/dev/null
 is "${?}" "0" "a read with a mismatch can be mapped with the short read chaining preset"
 
 rm -Rf grid-out


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Short read chaining preset renamed to `chaining-sr` and locked out for paired end inputs

## Description
This renames the "sr" preset so it is more clearly using chaining and not the recommended short read mode. It also stops you from accidentally using chaining presets or the chaining flag with paired-end inputs, which can't actually run on the chaining codepath.
