### PR TITLE
Graceful error on gff3.gz files

### DIFF
--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -251,8 +251,8 @@ int32_t main_rna(int32_t argc, char** argv) {
         return 1;       
     }
 
-    // taken from https://stackoverflow.com/a/64794991/
-    for (const auto & f : {std::cref(transcript_filenames), std::cref(intron_filenames)}) {
+    for (const auto& filenames : {std::cref(transcript_filenames), std::cref(intron_filenames)}) {
+        // For each collection of filenames (see https://stackoverflow.com/a/64794991/)
 
         for (auto filename : f.get()) {
 

--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -21,6 +21,7 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+string GZ_SUFFIX = ".gz";
 
 void help_rna(char** argv) {
     cerr << "\nusage: " << argv[0] << " rna [options] graph.[vg|pg|hg|gbz] > splicing_graph.[vg|pg|hg]" << endl
@@ -92,7 +93,6 @@ int32_t main_rna(int32_t argc, char** argv) {
     string hap_gbwt_out_filename = "";
     int32_t num_threads = 1;
     bool show_progress = false;
-    string gz_suffix = ".gz";
 
     int32_t c;
     optind = 2;
@@ -254,11 +254,11 @@ int32_t main_rna(int32_t argc, char** argv) {
     for (const auto& filenames : {std::cref(transcript_filenames), std::cref(intron_filenames)}) {
         // For each collection of filenames (see https://stackoverflow.com/a/64794991/)
 
-        for (auto filename : f.get()) {
+        for (auto filename : filenames.get()) {
 
             // taken from https://stackoverflow.com/a/20446239/
-            if (filename.size() >= gz_suffix.size() &&
-                filename.compare(filename.size() - gz_suffix.size(), gz_suffix.size(), gz_suffix) == 0) {
+            if (filename.size() >= GZ_SUFFIX.size() &&
+                filename.compare(filename.size() - GZ_SUFFIX.size(), GZ_SUFFIX.size(), GZ_SUFFIX) == 0) {
 
                 cerr << "[vg rna] ERROR: Annotation file " << filename << " appears to be gzipped. Decompress it before use." << endl;    
                 return 1;

--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -251,25 +251,18 @@ int32_t main_rna(int32_t argc, char** argv) {
         return 1;       
     }
 
-    // taken from https://stackoverflow.com/a/20446239/
-    for (auto & filename: transcript_filenames) {
+    // taken from https://stackoverflow.com/a/64794991/
+    for (const auto & f : {std::cref(transcript_filenames), std::cref(intron_filenames)}) {
 
-        if (filename.size() >= gz_suffix.size() &&
-            filename.compare(filename.size() - gz_suffix.size(), gz_suffix.size(), gz_suffix) == 0) {
+        for (auto filename : f.get()) {
 
-            cerr << "[vg rna] ERROR: Transcript file " << filename << " appears to be gzipped. Decompress it before use." << endl;    
-            return 1;
-        }
-    }
+            // taken from https://stackoverflow.com/a/20446239/
+            if (filename.size() >= gz_suffix.size() &&
+                filename.compare(filename.size() - gz_suffix.size(), gz_suffix.size(), gz_suffix) == 0) {
 
-    // I wish this wasn't copy-pasted but I don't know where a function would go
-    for (auto & filename: intron_filenames) {
-
-        if (filename.size() >= gz_suffix.size() &&
-            filename.compare(filename.size() - gz_suffix.size(), gz_suffix.size(), gz_suffix) == 0) {
-
-            cerr << "[vg rna] ERROR: Intron file " << filename << " appears to be gzipped. Decompress it before use." << endl;    
-            return 1;
+                cerr << "[vg rna] ERROR: Annotation file " << filename << " appears to be gzipped. Decompress it before use." << endl;    
+                return 1;
+            }
         }
     }
 

--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -92,6 +92,7 @@ int32_t main_rna(int32_t argc, char** argv) {
     string hap_gbwt_out_filename = "";
     int32_t num_threads = 1;
     bool show_progress = false;
+    string gz_suffix = ".gz";
 
     int32_t c;
     optind = 2;
@@ -248,6 +249,28 @@ int32_t main_rna(int32_t argc, char** argv) {
 
         cerr << "[vg rna] ERROR: No transcripts or introns were given. Use --transcripts FILE and/or --introns FILE." << endl;
         return 1;       
+    }
+
+    // taken from https://stackoverflow.com/a/20446239/
+    for (auto & filename: transcript_filenames) {
+
+        if (filename.size() >= gz_suffix.size() &&
+            filename.compare(filename.size() - gz_suffix.size(), gz_suffix.size(), gz_suffix) == 0) {
+
+            cerr << "[vg rna] ERROR: Transcript file " << filename << " appears to be gzipped. Decompress it before use." << endl;    
+            return 1;
+        }
+    }
+
+    // I wish this wasn't copy-pasted but I don't know where a function would go
+    for (auto & filename: intron_filenames) {
+
+        if (filename.size() >= gz_suffix.size() &&
+            filename.compare(filename.size() - gz_suffix.size(), gz_suffix.size(), gz_suffix) == 0) {
+
+            cerr << "[vg rna] ERROR: Intron file " << filename << " appears to be gzipped. Decompress it before use." << endl;    
+            return 1;
+        }
     }
 
     if (!haplotypes_filename.empty() && gbz_format) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Since `vg rna` can't parse `.gz` files, have it give a useful error for those inputs (resolve #4459)

## Description

Currently, `.gz` files will be accepted for `vg rna`'s `--transcripts` or `--introns` flags, but when we actually try to parse them it fails. This change auto-detects such files via the `.gz` extension and gives a useful error message. This will have false positives and false negatives, since it relies on the filenames following convention, but actually reading the file and detecting compression is much more difficult.