### PR TITLE
Add "identity" as a TSV option

### DIFF
--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -1534,6 +1534,8 @@ inline void ReadFilter<Alignment>::emit_tsv(Alignment& read, std::ostream& out) 
             out << softclip_start(read);
         } else if (field == "softclip_end") {
             out << softclip_end(read);
+        } else if (field == "identity") {
+            out << read.identity();
         } else if (field == "mapping_quality") {
             out << get_mapq(read); 
         } else if (field == "sequence") {


### PR DESCRIPTION
I wanted this statistic for myself

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Allow selecting the `identity` field in `vg filter --tsv-out` 

## Description

This statistic is already there (or at least it's there in my files output by `vg giraffe`) and it's useful, so we might as well expose it via the `--tsv-out` interface.
