### PR TITLE
Magically pick up Slurm CPU limits via SLURM_JOB_CPUS_PER_NODE

### DIFF
--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -118,7 +118,7 @@ void choose_good_thread_count() {
     if (count == 0) {
         // First priority: OMP_NUM_THREADS
         const char* value = getenv("OMP_NUM_THREADS");
-        if (value) {
+        if (value && *value != '\0') {
             // Read the value. Throws if it isn't a legit number.
             count = std::stoi(value);
         }
@@ -141,6 +141,15 @@ void choose_good_thread_count() {
                 // May come out to 0, in which case it is ignored.
                 count = (int) ceil(quota / (double) period);
             }
+        }
+    }
+
+    if (count == 0) {
+        // Next priority: SLURM_JOB_CPUS_PER_NODE
+        const char* value = getenv("SLURM_JOB_CPUS_PER_NODE");
+        if (value && *value != '\0') {
+            // Read the value. Throws if it isn't a legit number.
+            count = std::stoi(value);
         }
     }
 

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -38,8 +38,9 @@ double get_fraction_of_ns(const string& seq);
 /// TODO: Assumes that this is the same for every parallel section.
 int get_thread_count(void);
 /// Decide on and apply a sensible OMP thread count. Pay attention to
-/// OMP_NUM_THREADS if set, the "hardware concurrency", and container limit
-/// information that may be available in /proc.
+/// OMP_NUM_THREADS and SLURM_JOB_CPUS_PER_NODE if set, the "hardware
+/// concurrency", and container limit information that may be available in
+/// /proc.
 void choose_good_thread_count();
 string wrap_text(const string& str, size_t width);
 bool is_number(const string& s);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg now tries to limit itself to a good number of threads for the number of CPUs in any enclosing Slurm job, via `SLURM_JOB_CPUS_PER_NODE` and CPU affinity masks.

## Description

This should prevent vg from using hundreds of threads on small Slurm jobs run on large machines, without the user needing to remember to manually pass `-t` in their Slurm script.
