### PR TITLE
Keep haplotypes in `vg chunk` that don't extend far enough

### DIFF
--- a/src/haplotype_extracter.cpp
+++ b/src/haplotype_extracter.cpp
@@ -36,6 +36,7 @@ void trace_haplotypes(const PathHandleGraph& source, const gbwt::GBWT& haplotype
   // add our haplotypes to the subgraph, naming ith haplotype "thread_i"
   for (int i = 0; i < haplotypes.size(); ++i) {
     std::string path_name = "thread_" + to_string(i);
+    out_thread_frequencies[path_name] = haplotypes[i].second.size();
     path_handle_t path_handle = out_graph.create_path_handle(path_name);
     const thread_t& thread = haplotypes[i].first;
     for (int j = 0; j < thread.size(); j++) {
@@ -262,10 +263,10 @@ vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > list_haplotypes(const 
         }
 
         if (next_handle_states.empty()) {
-            // TODO: Also handle case where some but not all haplotypes go on, and some end here.
 #ifdef debug
-            std::cerr <<  "Extend state " << last.second << " to nowhere; haplotype ends!" << std::endl;
+          cerr << "Got no results for any extension of " << last.second << "; emitting" << endl;
 #endif
+          search_results.emplace_back(std::move(last)); 
         }
 
     }

--- a/src/haplotype_extracter.hpp
+++ b/src/haplotype_extracter.hpp
@@ -26,9 +26,7 @@ using thread_t = vector<gbwt::node_type>;
 // from the GBWT index.
 // out_graph may already contain nodes and paths.
 // If stop_fn returns True, the haplotype extraction is stopped for that haplotype.
-// Haplotypes are emitted when they are stopped or when they cannot be extended any more.
-//
-// TODO: Should results be produced when some haplotypes end but others keep going?
+// Haplotypes are emitted when they are stopped or when a sample cannot be continued anymore.
 void trace_haplotypes(const PathHandleGraph& source,
                       const gbwt::GBWT& haplotype_database,
                       const handle_t& start_handle, function<bool(const vector<gbwt::node_type>&)> stop_fn,
@@ -49,11 +47,9 @@ Path path_from_thread_t(thread_t& t, const HandleGraph& source);
 // Lists all the sub-haplotypes of nodes starting at
 // start from the set of haplotypes embedded in the given GBWT
 // haplotype database.  At each step stop_fn() is called on the thread being created, and if it returns true
-// then the search stops. The search will also stop and emit a result if it runs out of places to go.
+// then the search stops. The search will also emit a result if any selected sample stops.
 //
 // No empty sub-haplotypes will be returned.
-//
-// TODO: Should results be produced when some haplotypes end but others keep going?
 vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > list_haplotypes(const HandleGraph& graph,
                                                                           const gbwt::GBWT& gbwt,
                                                                           handle_t start,

--- a/src/haplotype_extracter.hpp
+++ b/src/haplotype_extracter.hpp
@@ -24,18 +24,26 @@ using thread_t = vector<gbwt::node_type>;
 // as Paths a path with name thread_i.  Each path name (including threads) is
 // mapped to a frequency in out_thread_frequencies.  Haplotypes will be pulled
 // from the GBWT index.
-void trace_haplotypes_and_paths(const PathHandleGraph& source,
-                                const gbwt::GBWT& haplotype_database,
-                                vg::id_t start_node, int extend_distance,
-                                Graph& out_graph,
-                                map<string, int>& out_thread_frequencies,
-                                bool expand_graph = true);
+// out_graph may already contain nodes and paths.
+void trace_haplotypes(const PathHandleGraph& source,
+                      const gbwt::GBWT& haplotype_database,
+                      const handle_t& start_node, function<bool(const vector<gbwt::node_type>&)> stop_fn,
+                      MutablePathMutableHandleGraph& out_graph,
+                      map<string, int>& out_thread_frequencies);
+
+// Walk forward from a node, collecting all non-haplotype paths. Each path name is
+// mapped to frequency 1 in out_thread_frequencies. 
+// out_graph may already contain nodes and paths.
+void trace_paths(const PathHandleGraph& source,
+                 const handle_t& start_node, int extend_distance,
+                 MutablePathMutableHandleGraph& out_graph,
+                 map<string, int>& out_thread_frequencies);
 
 // Turns a (GBWT-based) thread_t into a (vg-based) Path
 Path path_from_thread_t(thread_t& t, const HandleGraph& source);
 
 // Lists all the sub-haplotypes of nodes starting at
-// node start_node from the set of haplotypes embedded in the geven GBWT
+// node start_node from the set of haplotypes embedded in the given GBWT
 // haplotype database.  At each step stop_fn() is called on the thread being created, and if it returns true
 // then the search stops and the thread is added two the list to be returned.
 vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > list_haplotypes(const HandleGraph& graph,

--- a/src/haplotype_extracter.hpp
+++ b/src/haplotype_extracter.hpp
@@ -27,7 +27,7 @@ using thread_t = vector<gbwt::node_type>;
 // out_graph may already contain nodes and paths.
 void trace_haplotypes(const PathHandleGraph& source,
                       const gbwt::GBWT& haplotype_database,
-                      const handle_t& start_node, function<bool(const vector<gbwt::node_type>&)> stop_fn,
+                      const handle_t& start_handle, function<bool(const vector<gbwt::node_type>&)> stop_fn,
                       MutablePathMutableHandleGraph& out_graph,
                       map<string, int>& out_thread_frequencies);
 
@@ -35,7 +35,7 @@ void trace_haplotypes(const PathHandleGraph& source,
 // mapped to frequency 1 in out_thread_frequencies. 
 // out_graph may already contain nodes and paths.
 void trace_paths(const PathHandleGraph& source,
-                 const handle_t& start_node, int extend_distance,
+                 const handle_t& start_handle, int extend_distance,
                  MutablePathMutableHandleGraph& out_graph,
                  map<string, int>& out_thread_frequencies);
 
@@ -43,7 +43,7 @@ void trace_paths(const PathHandleGraph& source,
 Path path_from_thread_t(thread_t& t, const HandleGraph& source);
 
 // Lists all the sub-haplotypes of nodes starting at
-// node start_node from the set of haplotypes embedded in the given GBWT
+// start from the set of haplotypes embedded in the given GBWT
 // haplotype database.  At each step stop_fn() is called on the thread being created, and if it returns true
 // then the search stops and the thread is added two the list to be returned.
 vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > list_haplotypes(const HandleGraph& graph,

--- a/src/haplotype_extracter.hpp
+++ b/src/haplotype_extracter.hpp
@@ -25,6 +25,10 @@ using thread_t = vector<gbwt::node_type>;
 // mapped to a frequency in out_thread_frequencies.  Haplotypes will be pulled
 // from the GBWT index.
 // out_graph may already contain nodes and paths.
+// If stop_fn returns True, the haplotype extraction is stopped for that haplotype.
+// Haplotypes are emitted when they are stopped or when they cannot be extended any more.
+//
+// TODO: Should results be produced when some haplotypes end but others keep going?
 void trace_haplotypes(const PathHandleGraph& source,
                       const gbwt::GBWT& haplotype_database,
                       const handle_t& start_handle, function<bool(const vector<gbwt::node_type>&)> stop_fn,
@@ -45,7 +49,11 @@ Path path_from_thread_t(thread_t& t, const HandleGraph& source);
 // Lists all the sub-haplotypes of nodes starting at
 // start from the set of haplotypes embedded in the given GBWT
 // haplotype database.  At each step stop_fn() is called on the thread being created, and if it returns true
-// then the search stops and the thread is added two the list to be returned.
+// then the search stops. The search will also stop and emit a result if it runs out of places to go.
+//
+// No empty sub-haplotypes will be returned.
+//
+// TODO: Should results be produced when some haplotypes end but others keep going?
 vector<pair<vector<gbwt::node_type>, gbwt::SearchState> > list_haplotypes(const HandleGraph& graph,
                                                                           const gbwt::GBWT& gbwt,
                                                                           handle_t start,

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -757,10 +757,12 @@ int main_chunk(int argc, char** argv) {
 
         // optionally trace our haplotypes
         if (trace && subgraph && gbwt_index) {
-            int64_t trace_start;
+            handle_t trace_start, trace_end;
             int64_t trace_steps = 0;
             if (id_range) {
-                trace_start = output_regions[i].start;
+                // Assume we want to look local forward probably
+                trace_start = graph->get_handle(output_regions[i].start, false);
+                trace_end = graph->get_handle(output_regions[i].end, false);
                 trace_steps = output_regions[i].end - trace_start;
             } else {
                 path_handle_t path_handle = graph->get_path_handle(output_regions[i].seq);
@@ -770,36 +772,41 @@ int main_chunk(int argc, char** argv) {
                 if (output_regions[i].start > output_regions[i].end) {
                     swap(trace_start_step, trace_end_step);
                 }
-                trace_start = graph->get_id(graph->get_handle_of_step(trace_start_step));
+                trace_start = graph->get_handle_of_step(trace_start_step);
+                trace_end = graph->get_handle_of_step(trace_start_step);
+                if (output_regions[i].start > output_regions[i].end) {
+                    // Actually we need to look in reverse alogn the path.
+                    trace_start = graph->flip(trace_start);
+                    trace_end = graph->flip(trace_end);
+                }
                 for (; trace_start_step != trace_end_step; trace_start_step = graph->get_next_step(trace_start_step)) {
+                    // Count the number of steps along the backbone path, which we use to limit graph expansion.
                     ++trace_steps;
                 }
-                // haplotype_extender is forward only.  until it's made bidirectional, try to
-                // detect backward paths and trace them backwards.  this will not cover all possible cases though.
-                if (graph->get_is_reverse(graph->get_handle_of_step(trace_start_step)) &&
-                    graph->get_is_reverse(graph->get_handle_of_step(trace_end_step))) {
-                    trace_start = graph->get_id(graph->get_handle_of_step(trace_end_step));
+            }
+
+            // Stop extending haplotypes when either they get too long or they arrive at the end.
+            auto stop_function = [&](const vector<gbwt::node_type>& candidate) {
+                if (candidate.size() >= trace_steps) {
+                    // If you go more steps than the backbone path, stop there.
+                    // TODO: We should add some padding here to account for insertions of manageable size.
+                    return true;
                 }
-            }
+                if (gbwt::Node::id(candidate.back()) == graph->get_id(trace_end) &&
+                    gbwt::Node::is_reverse(candidate.back()) == graph.get_is_reverse(trace_end)) {
+                    
+                    // The path being traced has reached the last node on our
+                    // extracted path region, so stop here and avoid leaving
+                    // the region.
+                    return true;
+                }
+                return false;
+            };
+
             Graph g;
-            trace_haplotypes_and_paths(*graph, *gbwt_index, trace_start, trace_steps,
-                                       g, trace_thread_frequencies, false);
-            subgraph->for_each_path_handle([&trace_thread_frequencies, &subgraph](path_handle_t path_handle) {
-                    trace_thread_frequencies[subgraph->get_path_name(path_handle)] = 1;});
-            VG* vg_subgraph = dynamic_cast<VG*>(subgraph.get());
-            if (vg_subgraph != nullptr) {
-                // our graph is in vg format, just extend it
-                vg_subgraph->extend(g);
-            } else {
-                // our graph is not in vg format.  covert it, extend it, convert it back
-                // this can eventually be avoided by handlifying the haplotype tracer
-                VG vg;
-                handlealgs::copy_path_handle_graph(subgraph.get(), &vg);
-                subgraph.reset();
-                vg.extend(g);
-                subgraph = vg::io::new_output_graph<MutablePathMutableHandleGraph>(output_format);
-                handlealgs::copy_path_handle_graph(&vg, subgraph.get());
-            }
+            trace_haplotypes(*graph, *gbwt_index, trace_start, stop_function,
+                             subgraph, trace_thread_frequencies);
+            std::cerr << "Traced " << trace_thread_frequencies.size() << " distinct threads" << std::endl;
         }
 
         ofstream out_file;

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -763,7 +763,7 @@ int main_chunk(int argc, char** argv) {
                 // Assume we want to look local forward probably
                 trace_start = graph->get_handle(output_regions[i].start, false);
                 trace_end = graph->get_handle(output_regions[i].end, false);
-                trace_steps = output_regions[i].end - trace_start;
+                trace_steps = output_regions[i].end - output_regions[i].start;
             } else {
                 path_handle_t path_handle = graph->get_path_handle(output_regions[i].seq);
                 step_handle_t trace_start_step = graph->get_step_at_position(path_handle, output_regions[i].start);
@@ -793,7 +793,7 @@ int main_chunk(int argc, char** argv) {
                     return true;
                 }
                 if (gbwt::Node::id(candidate.back()) == graph->get_id(trace_end) &&
-                    gbwt::Node::is_reverse(candidate.back()) == graph.get_is_reverse(trace_end)) {
+                    gbwt::Node::is_reverse(candidate.back()) == graph->get_is_reverse(trace_end)) {
                     
                     // The path being traced has reached the last node on our
                     // extracted path region, so stop here and avoid leaving
@@ -805,8 +805,10 @@ int main_chunk(int argc, char** argv) {
 
             Graph g;
             trace_haplotypes(*graph, *gbwt_index, trace_start, stop_function,
-                             subgraph, trace_thread_frequencies);
+                             *subgraph, trace_thread_frequencies);
+#ifdef debug
             std::cerr << "Traced " << trace_thread_frequencies.size() << " distinct threads" << std::endl;
+#endif
         }
 
         ofstream out_file;

--- a/src/subcommand/trace_main.cpp
+++ b/src/subcommand/trace_main.cpp
@@ -136,7 +136,13 @@ int main_trace(int argc, char** argv) {
   VG trace_graph;
   map<string, int> haplotype_frequences;
 
-  trace_paths(*xindex, start_node, extend_distance,
+  if (!xindex->has_node(start_node)) {
+    cerr << "error:[vg trace] unable to find node " << start_node << " in graph" << endl;
+    exit(1);
+  }
+
+  handle_t start_handle = xindex->get_handle(start_node, false);
+  trace_paths(*xindex, start_handle, extend_distance,
               trace_graph, haplotype_frequences);
   
   auto stop_haplotype = [&extend_distance](const vector<gbwt::node_type>& new_thread) {
@@ -144,7 +150,7 @@ int main_trace(int argc, char** argv) {
     return new_thread.size() >= extend_distance;
   };
 
-  trace_haplotypes(*xindex, *gbwt_index, start_node, stop_haplotype,
+  trace_haplotypes(*xindex, *gbwt_index, start_handle, stop_haplotype,
                    trace_graph, haplotype_frequences);
 
   // dump our graph to stdout

--- a/src/subcommand/trace_main.cpp
+++ b/src/subcommand/trace_main.cpp
@@ -133,18 +133,25 @@ int main_trace(int argc, char** argv) {
   }
   
   // trace out our graph and paths from the start node
-  Graph trace_graph;
+  VG trace_graph;
   map<string, int> haplotype_frequences;
-  trace_haplotypes_and_paths(*xindex, *gbwt_index, start_node, extend_distance,
-                             trace_graph, haplotype_frequences);
+
+  trace_paths(*xindex, start_node, extend_distance,
+              trace_graph, haplotype_frequences);
+  
+  auto stop_haplotype = [&extend_distance](const vector<gbwt::node_type>& new_thread) {
+    // Stop haplotypes at the given length, ignoring any possible stopping nodes.
+    return new_thread.size() >= extend_distance;
+  };
+
+  trace_haplotypes(*xindex, *gbwt_index, start_node, stop_haplotype,
+                   trace_graph, haplotype_frequences);
 
   // dump our graph to stdout
   if (json) {
-    cout << pb2json(trace_graph);
+    cout << pb2json(trace_graph.graph);
   } else {
-    VG vg_graph;
-    vg_graph.extend(trace_graph);
-    vg_graph.serialize_to_ostream(cout);
+    trace_graph.serialize_to_ostream(cout);
   }
 
   // if requested, write thread frequencies to a file


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg chunk --trace` will now produce haplotypes even if they stop before the end of the selected range

## Description

This refactors haplotype tracing and fixes a problem where haplotypes had to get stopped by the length limit to be visible in `vg chunk`.

It doesn't pick up new haplotypes that *start* in a chunk range. And it does some GBWT extensions to select stopping haplotypes that @jltsiren says can't work, and will need to be changed before we merge it.