### PR TITLE
Make `identity()` calculation ignore soft clips

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -2290,7 +2290,6 @@ double divergence(const Mapping& m) {
 }
 
 double identity(const Path& path) {
-    double ident = 0;
     size_t total_length = path_to_length(path);
     size_t matched_length = 0;
     for (size_t i = 0; i < path.mapping_size(); ++i) {
@@ -2299,6 +2298,12 @@ double identity(const Path& path) {
             auto& edit = mapping.edit(j);
             if (edit_is_match(edit)) {
                 matched_length += edit.from_length();
+            } else if (edit_is_insertion(edit)) {
+                bool is_first_edit = (i == 0) && (j == 0);
+                bool is_last_edit = (i == path.mapping_size() - 1) && (j == mapping.edit_size() - 1);
+                if (is_first_edit || is_last_edit) {
+                    total_length -= edit.to_length();
+                }
             }
         }
     }

--- a/src/path.hpp
+++ b/src/path.hpp
@@ -345,7 +345,7 @@ bool adjacent_mappings(const Mapping& m1, const Mapping& m2);
 // Return true if a mapping is a perfect match (i.e. contains no non-match edits)
 bool mapping_is_match(const Mapping& m);
 double divergence(const Mapping& m);
-// Return the identity for the path: perfect matches over total length.
+// Return the identity for the path: perfect matches over total length, ignoring soft clips.
 // For zero-length paths, returns 0.
 double identity(const Path& path);
 // compare the agreement between two alignments


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Stop `identity()` from penalizing soft clips (insertions at start/end of path) as part of the total length
 
## Description

Soft clips are internally represented as insertions at the start or end of paths. They're not really part of the mapping and thus shouldn't count against the identity score. Currently, the identity calculation is `# match bases / (# match bases + # mismatch bases + # insertion bases)`. This PR changes that to `# match bases / (# match bases + # mismatch bases + # insertion bases - # softclip bases)`. Note that deletions have never been counted against identity, and I do not propose to start using them.

Here are some descriptions of what "identity" means, according to the code:
* In [the `identity` field of a GAM](https://github.com/vgteam/libvgio/blob/7e8d6128d2b3045911a5747ef35077a1edb533b0/deps/vg.proto#L125). This would imply that only *aligned bases* should be counted as part of the total length for the denominator. Soft clips are not aligned. Arguably even regular *insertions* aren't aligned either, since they don't have bases in the reference which they correspond to.
    > Portion of aligned bases that are perfect matches, or 0 if no bases are aligned
* In [the definition of `identity()`](https://github.com/vgteam/vg/blob/834a1f69494224c180e665ac1c745dedad185fae/src/path.hpp#L348). The use of "total length" seems likely to mean "total length of the path", which would include regular insertions, but I don't think should include soft clips.
    > perfect matches over total length. For zero-length paths, returns 0

For what it's worth, if we want to stop counting *all* insertions, that's pretty easy. Here's code which would change the identity formula to `# match bases / (# match bases + # mismatch bases)`.

```
double identity(const Path& path) {
    size_t total_length = 0;
    size_t matched_length = 0;
    for (size_t i = 0; i < path.mapping_size(); ++i) {
        auto& mapping = path.mapping(i);
        for (size_t j = 0; j < mapping.edit_size(); ++j) {
            auto& edit = mapping.edit(j);
            if (edit_is_match(edit)) {
                matched_length += edit.from_length();
                total_length += edit.from_length();
            } else if (edit_is_sub(edit)) {
                total_length += edit.from_length();
            }
        }
    }
    return total_length == 0 ? 0.0 : (double) matched_length / (double) total_length;
}
```