### PR TITLE
Don't duplicate source GBZ in autoindex

### DIFF
--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -352,6 +352,9 @@ int main_autoindex(int argc, char** argv) {
     }
     if (!gbz_name.empty()) {
         registry.provide("GBZ", gbz_name);
+        // Also mark this as the Giraffe GBZ so if we index for Giraffe we won't duplicate it.
+        // TODO: Why are these separate?
+        registry.provide("Giraffe GBZ", gbz_name);
     }
 
 

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -202,6 +202,7 @@ is "${?}" "1" "Surjection fails when using the wrong graph for GAM"
 is "$(cat err.txt | grep 'cannot be interpreted' | wc -l)" "1" "Surjection of GAM to the wrong graph reports the problem"
 vg surject -x tiny.vg -s -t 1 -m mapped.gamp >/dev/null 2>err.txt
 is "${?}" "1" "Surjection fails when using the wrong graph for GAMP"
+cat err.txt 1>&2
 is "$(cat err.txt | grep 'cannot be interpreted' | wc -l)" "1" "Surjection of GAMP to the wrong graph reports the problem"
 
 rm x.vg x.pathdup.vg x.xg x.gcsa x.gcsa.lcp x.gam mapped.gam mapped.gamp tiny.vg err.txt


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex` will no longer duplicate input gbz as `.giraffe.gbz` when indexing for Giraffe.

## Description

This should make it easier to autoindex for Giraffe starting with a GBZ.
