### PR TITLE
Don't extract nodes in ranges that didn't actually exist in the source graph

### DIFF
--- a/src/algorithms/subgraph.cpp
+++ b/src/algorithms/subgraph.cpp
@@ -265,7 +265,7 @@ void extract_context(const HandleGraph& source, MutableHandleGraph& subgraph, co
 
 void extract_id_range(const HandleGraph& source, const nid_t& id1, const nid_t& id2, MutableHandleGraph& subgraph) {
     for (nid_t i = id1; i <= id2; ++i) {
-        if (!subgraph.has_node(i)) {
+        if (!subgraph.has_node(i) && source.has_node(i)) {
             subgraph.create_handle(source.get_sequence(source.get_handle(i)), i);
         }
     }

--- a/src/chunker.hpp
+++ b/src/chunker.hpp
@@ -63,6 +63,9 @@ public:
 
     /**
      * Like above, but use (inclusive) id range instead of region on path.
+     *
+     * Skips nodes in the ID range that do not actually exist in the source
+     * graph, or that already exist in the target graph.
      */
     void extract_id_range(vg::id_t start, vg::id_t end, int64_t context, int64_t length, bool forward_only,
                           MutablePathMutableHandleGraph& subgraph, Region& out_region);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg find -r` will no longer include empty nodes for nonexistent node IDs in the range being extracted

## Description

I noticed that if there are holes in the node ID range, we were trying to extract those nodes anyway, and ending up with empty floating nodes in the final graph. This fixes that.