### PR TITLE
Compute outside-to-outside TLENs properly

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1292,14 +1292,20 @@ pair<int32_t, int32_t> compute_template_lengths(const int64_t& pos1, const vecto
         int64_t here = pos;
         for (auto& item : cigar) {
             // Trace along the cigar
-            if (item.second == 'M') {
-                // Bases are matched. Count them in the bounds and execute the operation
-                low = min(low, here);
-                here += item.first;
-                high = max(high, here);
-            } else if (item.second == 'D') {
-                // Only other way to advance in the reference
-                here += item.first;
+            switch (item.second) {
+                case 'M':
+                case 'X':
+                case '=':
+                    // Bases are matched or mismatched. Count them in the bounds and execute the operation
+                    low = min(low, here);
+                    high = max(high, here + item.first);
+                    // Fall through.
+                case 'D':
+                case 'N':
+                    // Even for deletions/gaps, we advance on the reference.
+                    here += item.first;
+                    break;
+                // Inserts and various clips/paddings don't do anything.
             }
         }
         
@@ -1308,16 +1314,12 @@ pair<int32_t, int32_t> compute_template_lengths(const int64_t& pos1, const vecto
     
     auto bounds1 = find_bounds(pos1, cigar1);
     auto bounds2 = find_bounds(pos2, cigar2);
-    
-    // Compute the separation
-    int32_t dist = 0;
-    if (bounds1.first < bounds2.second) {
-        // The reads are in order
-        dist = bounds2.second - bounds1.first;
-    } else if (bounds2.first < bounds1.second) {
-        // The reads are out of order so the other bounds apply
-        dist = bounds1.second - bounds2.first;
-    }
+
+    // We wanted the distance between the outermost points. So find them.
+    auto min_start = std::min(bounds1.first, bounds2.first);
+    auto max_end = std::max(bounds1.second, bounds2.second);
+    // And find the distance
+    int32_t dist = max_end - min_start;
     
     if (pos1 < pos2) {
         // Count read 1 as the overall "leftmost", so its value will be positive

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1321,8 +1321,10 @@ pair<int32_t, int32_t> compute_template_lengths(const int64_t& pos1, const vecto
     // And find the distance
     int32_t dist = max_end - min_start;
     
-    if (pos1 < pos2) {
-        // Count read 1 as the overall "leftmost", so its value will be positive
+    if (bounds1.first < bounds2.first || (bounds1.first == bounds2.first && bounds1.second < bounds2.second)) {
+        // Count read 1 as the overall "leftmost" if it starts earlier or
+        // starts at the same point and ends earlier, so its value will be
+        // positive
         return make_pair(dist, -dist);
     } else {
         // Count read 2 as the overall leftmost

--- a/src/unittest/alignment.cpp
+++ b/src/unittest/alignment.cpp
@@ -283,12 +283,68 @@ TEST_CASE("simplify_cigar merges runs of adjacent operations and removes empty o
     REQUIRE(cigar[3] == make_pair(1, 'M'));
 }
 
-TEST_CASE("Inter-alignment distance computation for HTS output formats matches BWA", "[alignment]") {
+TEST_CASE("Template length for HTS output formats matches BWA", "[alignment][tlen]") {
     // See https://github.com/vgteam/vg/issues/3078. We want to match BWA on
     // these straightforward, fully-matching reads.
     auto lengths = compute_template_lengths(10206220, {{151, 'M'}}, 10206662, {{151, 'M'}});
     REQUIRE(lengths.first == 593);
     REQUIRE(lengths.second == -593);
+}
+
+TEST_CASE("Template length for HTS output formats is outermost to outermost when read 1 starts inside read 2", "[alignment][tlen]") {
+    auto lengths = compute_template_lengths(1000, {{151, 'M'}}, 900, {{151, 'M'}});
+    REQUIRE(lengths.first == -251);
+    REQUIRE(lengths.second == 251);
+}
+
+TEST_CASE("Template length for HTS output formats is outermost to outermost when read 2 starts inside read 1", "[alignment][tlen]") {
+    auto lengths = compute_template_lengths(900, {{151, 'M'}}, 1000, {{151, 'M'}});
+    REQUIRE(lengths.first == 251);
+    REQUIRE(lengths.second == -251);
+}
+
+TEST_CASE("Template length for HTS output formats is outermost to outermost when read 1 is contained in read 2", "[alignment][tlen]") {
+    auto lengths = compute_template_lengths(1000, {{10, 'M'}}, 900, {{151, 'M'}});
+    REQUIRE(lengths.first == -151); // Read 1 is the rightmost since it starts latest
+    REQUIRE(lengths.second == 151);
+}
+
+TEST_CASE("Template length for HTS output formats is outermost to outermost when read 2 is contained in read 1", "[alignment][tlen]") {
+    auto lengths = compute_template_lengths(900, {{151, 'M'}}, 1000, {{10, 'M'}});
+    REQUIRE(lengths.first == 151); // Read 1 is the leftmost since it starts earliest
+    REQUIRE(lengths.second == -151);
+}
+
+TEST_CASE("Template length for HTS output formats is outermost to outermost when read 1 is a prefix of read 2", "[alignment][tlen]") {
+    auto lengths = compute_template_lengths(1000, {{10, 'M'}}, 1000, {{151, 'M'}});
+    REQUIRE(lengths.first == 151); // Read 1 is the leftmost since it ends earliest
+    REQUIRE(lengths.second == -151);
+}
+
+TEST_CASE("Template length for HTS output formats is outermost to outermost when read 2 is a prefix of read 1", "[alignment][tlen]") {
+    auto lengths = compute_template_lengths(1000, {{151, 'M'}}, 1000, {{10, 'M'}});
+    REQUIRE(lengths.first == -151); // Read 1 is the rightmost since it ends latest
+    REQUIRE(lengths.second == 151);
+}
+
+TEST_CASE("Template length for HTS output formats is outermost to outermost when read 1 is a suffix of read 2", "[alignment][tlen]") {
+    auto lengths = compute_template_lengths(1141, {{10, 'M'}}, 1000, {{151, 'M'}});
+    REQUIRE(lengths.first == -151); // Read 1 is the rightmost since it starts latest
+    REQUIRE(lengths.second == 151);
+}
+
+TEST_CASE("Template length for HTS output formats is outermost to outermost when read 2 is a suffix of read 1", "[alignment][tlen]") {
+    auto lengths = compute_template_lengths(1000, {{151, 'M'}}, 1141, {{10, 'M'}});
+    REQUIRE(lengths.first == -151); // Read 1 is the leftmost since it starts earliest
+    REQUIRE(lengths.second == 151);
+}
+
+TEST_CASE("Template length for HTS output formats is outermost to outermost when read 1 and read 2 have identical coordinates", "[alignment][tlen]") {
+    auto lengths = compute_template_lengths(1000, {{151, 'M'}}, 1000, {{151, 'M'}});
+    // Signs are arbitrary but must be opposite
+    REQUIRE(std::abs(lengths.first) == 151);
+    REQUIRE(std::abs(lengths.second) == 151);
+    REQUIRE(lengths.first + lengths.second == 0);
 }
 
 TEST_CASE("CIGAR generation forces adjacent insertions and deletions to obey GATK's constraints", "[alignment]") {

--- a/src/unittest/alignment.cpp
+++ b/src/unittest/alignment.cpp
@@ -335,8 +335,8 @@ TEST_CASE("Template length for HTS output formats is outermost to outermost when
 
 TEST_CASE("Template length for HTS output formats is outermost to outermost when read 2 is a suffix of read 1", "[alignment][tlen]") {
     auto lengths = compute_template_lengths(1000, {{151, 'M'}}, 1141, {{10, 'M'}});
-    REQUIRE(lengths.first == -151); // Read 1 is the leftmost since it starts earliest
-    REQUIRE(lengths.second == 151);
+    REQUIRE(lengths.first == 151); // Read 1 is the leftmost since it starts earliest
+    REQUIRE(lengths.second == -151);
 }
 
 TEST_CASE("Template length for HTS output formats is outermost to outermost when read 1 and read 2 have identical coordinates", "[alignment][tlen]") {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * TLEN for read 1 starting inside read 2 will no longer be shorter than the union of the reads in `vg surject`.
 * TLEN computation handles more CIGAR operations in case we decide to use them.

## Description
Even if the reads overlap we need an outside-to-outside TLEN like the function claims to calculate.

This adds a bunch of unit tests for TLEN computation edge cases based on the SAM spec, and makes us pass them.
