### PR TITLE
Add path-based simplification logic to vg simplify

### DIFF
--- a/src/subcommand/simplify_main.cpp
+++ b/src/subcommand/simplify_main.cpp
@@ -202,7 +202,7 @@ int main_simplify(int argc, char** argv) {
         }
 
         simplify_graph_using_traversals(dynamic_cast<MutablePathMutableHandleGraph*>(graph.get()),
-                                        ref_path_prefix, min_size, 0, 100000);
+                                        ref_path_prefix, min_size, cluster_threshold, 100000);
 
         handlealgs::unchop(*graph);
         

--- a/src/subcommand/simplify_main.cpp
+++ b/src/subcommand/simplify_main.cpp
@@ -30,7 +30,7 @@ void help_simplify(char** argv) {
          << "    -b, --bed-in           read in the given BED file in the cordinates of the original paths" << endl
          << "    -B, --bed-out          output transformed features in the coordinates of the new paths" << endl
          << "path snarl simplifier options:" << endl
-         << "    -m, --min-size N       flatten sites (to reference) whose maximum traversal has <= N bp (default: 10)" << endl
+         << "    -m, --min-size N       flatten sites (to reference) whose maximum traversal has < N bp (default: 10)" << endl
          << "    -L, --cluster F        cluster traversals whose (handle) Jaccard coefficient is >= F together (default: 1.0)" << endl
          << "    -P, --path-prefix S    all paths whose names begins with S selected as reference paths (default: all reference-sense paths)" << endl
          << "small snarl simplifier options:" << endl
@@ -85,12 +85,14 @@ int main_simplify(int argc, char** argv) {
                 {"vcf", required_argument, 0, 'v'},
                 {"min-freq", required_argument, 0, 'f'},
                 {"min-count", required_argument, 0, 'c'},
+                {"cluster", required_argument, 0, 'L'},
+                {"path-prefix", required_argument, 0, 'P'},
                 {"help", no_argument, 0, 'h'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "a:pt:b:B:m:i:v:f:c:h?",
+        c = getopt_long (argc, argv, "a:pt:b:B:m:i:v:f:c:L:P:h?",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -200,7 +202,7 @@ int main_simplify(int argc, char** argv) {
         }
 
         simplify_graph_using_traversals(dynamic_cast<MutablePathMutableHandleGraph*>(graph.get()),
-                                        ref_path_prefix, min_size, 0, 1000);
+                                        ref_path_prefix, min_size, 0, 100000);
 
         handlealgs::unchop(*graph);
         

--- a/src/subcommand/simplify_main.cpp
+++ b/src/subcommand/simplify_main.cpp
@@ -224,6 +224,8 @@ int main_simplify(int argc, char** argv) {
             exit(1);
         }
 
+        nid_t min_id = graph->min_node_id();
+        
         simplify_graph_using_traversals(dynamic_cast<MutablePathMutableHandleGraph*>(graph.get()),
                                         ref_path_prefix, min_size, cluster_threshold, max_iterations, 100000);
 
@@ -238,6 +240,11 @@ int main_simplify(int argc, char** argv) {
         }
         
         handlealgs::unchop(*graph);
+
+        if (graph->min_node_id() < min_id) {
+            // we want chromosome graphs to keep disjoint node ids, so we preserve the min_id            
+            graph->increment_node_ids(min_id - graph->min_node_id());
+        }
         
     } else if (algorithm == "small") {
         if (!vcf_filename.empty()) {

--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -475,9 +475,9 @@ static void simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
     vector<bool> trav_reversed(path_travs.size());
     vector<int64_t> trav_lengths(path_travs.size(), 0);
 
-//#ifdef debug
+#ifdef debug
     cerr << "snarl " << graph_interval_to_string(graph, start_handle, end_handle) << endl;
-//#endif
+#endif
 
     // fill out traversal information (copied from merge_equivalent_traversals_in_snarl() above)
     // and find the reference traversal
@@ -492,13 +492,13 @@ static void simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
         trav_reversed[i] = graph->get_is_reverse(graph->get_handle_of_step(path_intervals[i].first)) !=
             graph->get_is_reverse(start_handle);
 
-//#ifdef debug
+#ifdef debug
         cerr << "trav " << i << ": "
              << "n=" << trav_names[i] << " "
              << "i=" << graph_interval_to_string(graph, graph->get_handle_of_step(path_intervals[i].first),
                                                  graph->get_handle_of_step(path_intervals[i].second))
              << " t=" << traversal_to_string(graph, trav, 100) << endl;
-//#endif
+#endif
 
         // note: we are excluding snarl boundaries from length calc here
         for (int64_t j = 1; j < trav.size() - 1; ++j) {
@@ -613,7 +613,7 @@ static void simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
             for (int i = 0; i < trav_clusters.size(); ++i) {            
                 const Traversal& cluster_ref_trav = path_travs[trav_clusters[i][0]];
                 if (i > 0) {
-                    for (int64_t j = 0; i < cluster_ref_trav.size(); ++j) {
+                    for (int64_t j = 0; j < cluster_ref_trav.size(); ++j) {
                         ref_nodes.insert(graph->get_id(cluster_ref_trav[j]));
                         if (j > 0) {
                             ref_edges.insert(graph->edge_handle(cluster_ref_trav[j-1], cluster_ref_trav[j]));

--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -464,7 +464,7 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
     for (int64_t i = 0; i < ref_paths.size(); ++i) {
         ref_path_to_rank[ref_paths[i]] = i;
     }
-    out_ref_paths.clear();
+    out_ref_paths = ref_paths;
     
     // find the path traversals through the snarl
     vector<Traversal> path_travs;
@@ -599,7 +599,6 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
 
     // do the length simplification
     if (max_trav_length < min_snarl_length) {
-        out_ref_paths.push_back(ref_paths[ref_trav_rank]);
         simplify = true;
     } else if (level == 0) {
         // do snarl-clustering simplification. note this is only done
@@ -620,8 +619,7 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
             }
         }
 
-        // sort off-reference paths
-        map<string, path_handle_t> name_to_path;
+        unordered_set<path_handle_t> path_set(ref_paths.begin(), ref_paths.end());
         
         // some clustering was done, we flag all cluster references to keep, and remove everything else
         assert(trav_clusters[0][0] == ref_trav_indexes[0]); // we've already added ref cluster
@@ -635,12 +633,10 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
                     }
                 }
             }
-            name_to_path[trav_names[trav_clusters[i][0]]] = trav_paths[trav_clusters[i][0]];
-        }
-
-        out_ref_paths.push_back(ref_paths[ref_trav_rank]);
-        for (const auto& name_path : name_to_path) {
-            out_ref_paths.push_back(name_path.second);
+            if (!path_set.count(trav_paths[trav_clusters[i][0]])) {
+                out_ref_paths.push_back(trav_paths[trav_clusters[i][0]]);
+                path_set.insert(trav_paths[trav_clusters[i][0]]);
+            }
         }
     }
 

--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -450,21 +450,13 @@ void merge_equivalent_traversals_in_graph(MutablePathHandleGraph* graph, const u
 
 static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph, PathTraversalFinder& path_trav_finder,
                                             const handle_t& start_handle, const handle_t& end_handle,
-                                            const vector<path_handle_t>& ref_paths,
+                                            unordered_map<path_handle_t, int64_t>& ref_path_to_rank,
                                             int64_t level,
-                                            int64_t min_snarl_length,
+                                            int64_t max_snarl_length,
                                             double min_jaccard,
                                             int64_t min_fragment_length,
                                             unordered_set<nid_t>& nodes_to_remove,
-                                            unordered_set<edge_t>& edges_to_remove,
-                                            vector<path_handle_t>& out_ref_paths) {
-
-    // index the references    
-    unordered_map<path_handle_t, int64_t> ref_path_to_rank;
-    for (int64_t i = 0; i < ref_paths.size(); ++i) {
-        ref_path_to_rank[ref_paths[i]] = i;
-    }
-    out_ref_paths = ref_paths;
+                                            unordered_set<edge_t>& edges_to_remove) {
     
     // find the path traversals through the snarl
     vector<Traversal> path_travs;
@@ -472,7 +464,6 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
     std::tie(path_travs, path_intervals) = path_trav_finder.find_path_traversals(start_handle, end_handle);
     vector<string> trav_names(path_travs.size());
     vector<path_handle_t> trav_paths(path_travs.size());
-    vector<bool> trav_reversed(path_travs.size());
     vector<int64_t> trav_lengths(path_travs.size(), 0);
 
 #ifdef debug
@@ -486,16 +477,13 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
 
     // fill out traversal information (copied from merge_equivalent_traversals_in_snarl() above)
     // and find the reference traversal
-    int64_t ref_trav_rank = ref_paths.size();
-    
+    int64_t min_rank = numeric_limits<int64_t>::max();
     int64_t alphabetically_first_ref_trav_idx = -1;
     int64_t max_trav_length = 0;
     for (int64_t i = 0; i < path_travs.size(); ++i) {
         const Traversal& trav = path_travs[i];
         trav_paths[i] = graph->get_path_handle_of_step(path_intervals[i].first);
         trav_names[i] = graph->get_path_name(trav_paths[i]);
-        trav_reversed[i] = graph->get_is_reverse(graph->get_handle_of_step(path_intervals[i].first)) !=
-            graph->get_is_reverse(start_handle);
 
 #ifdef debug
         cerr << "trav " << i << ": "
@@ -510,39 +498,40 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
             trav_lengths[i] += graph->get_length(trav[j]);
         }
         max_trav_length = max(max_trav_length, trav_lengths[i]);
-        // find the first reference path (in ref_paths input var) that appears in the traversal
-        // it will be our reference path
+
+        // determine level of path (ie are we seeing it now or was it found at a lower
+        // snarl level)
+        int64_t path_rank = level;
         if (ref_path_to_rank.count(trav_paths[i])) {
-            int64_t rank = ref_path_to_rank.at(trav_paths[i]);
-            if (rank < ref_trav_rank) {
-                ref_trav_rank = rank;
-            }
+            path_rank = ref_path_to_rank[trav_paths[i]];
+        } else {
+            ref_path_to_rank[trav_paths[i]] = path_rank;                
         }
-        
-        if (alphabetically_first_ref_trav_idx == -1 || trav_names[i] < trav_names[alphabetically_first_ref_trav_idx]) {
-            alphabetically_first_ref_trav_idx = i;
-        }
+        min_rank = min(min_rank, path_rank);
     }
 
-    // remember all traversals for first available ref_path
-    vector<int64_t> ref_trav_indexes;
-    if (ref_trav_rank < ref_paths.size()) {
-        for (int64_t i = 0; i < path_travs.size(); ++i) {
-            if (trav_paths[i] == ref_paths[ref_trav_rank]) {
-                ref_trav_indexes.push_back(i);
-            }
+    // choose the reference path
+    // the heuristic is used is minimum rank (ie path that spans the top-level snarl)
+    // which will be the given reference if available since that comes in with rank 0
+    // ties are broken with lexicograph order
+    // then choosing the bigger path.
+    vector<int64_t> ref_trav_candidates;
+    for (int64_t i = 0; i < path_travs.size(); ++i) {
+        if (ref_path_to_rank[trav_paths[i]] == min_rank) {
+            ref_trav_candidates.push_back(i);
         }
     }
-
-    // revert to not snapping to reference path. because it can happen that there
-    // are huge nested snarls that due to clipping don't have any path. 
-    if (ref_trav_indexes.empty() && level > 0 && alphabetically_first_ref_trav_idx >= 0) {
-        ref_trav_indexes.push_back(alphabetically_first_ref_trav_idx);
-    }
+    sort(ref_trav_candidates.begin(), ref_trav_candidates.end(), [&](int64_t i, int64_t j) {
+        if (trav_names[i] == trav_names[j]) {
+            return trav_lengths[i] > trav_lengths[j];
+        } else {
+            return trav_names[i] < trav_names[j];
+        }
+    });
 
     // if there are no reference paths, we bail
     // todo: we could relax this by using the alphabetical path
-    if (ref_trav_indexes.empty()) {
+    if (ref_trav_candidates.empty()) {
 #ifdef debug
         cerr << "Level-" << level << " Snarl " << graph_interval_to_string(graph, start_handle, end_handle)
              << " has no reference path in {";
@@ -591,27 +580,30 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
     // these are the nodes we want to keep
     unordered_set<nid_t> ref_nodes;
     unordered_set<edge_t> ref_edges;
-    for (int64_t ref_trav_idx : ref_trav_indexes) {
-        const Traversal& ref_trav = path_travs[ref_trav_idx];
-        for (int64_t i = 0; i < ref_trav.size(); ++i) {
-            ref_nodes.insert(graph->get_id(ref_trav[i]));
-            if (i > 0) {
-                ref_edges.insert(graph->edge_handle(ref_trav[i-1], ref_trav[i]));
-            }
+    const Traversal& ref_trav = path_travs[ref_trav_candidates[0]];
+    for (int64_t i = 0; i < ref_trav.size(); ++i) {
+        ref_nodes.insert(graph->get_id(ref_trav[i]));
+        if (i > 0) {
+            ref_edges.insert(graph->edge_handle(ref_trav[i-1], ref_trav[i]));
         }
     }
-
+    
     bool simplify = false;
 
     // do the length simplification
-    if (max_trav_length < min_snarl_length) {
+    if (max_trav_length < max_snarl_length) {
         simplify = true;
-    } else if (level == 0) {
+    } else if (min_jaccard < 1.0) {
         // do snarl-clustering simplification. note this is only done
-        // at the top level.  doing it nested can cause all sorts of weird conflicts. 
-        vector<int> traversal_order = {(int)ref_trav_indexes[0]};
+        // at the top level.  doing it nested can cause all sorts of weird conflicts.
+        set<int64_t> ref_set;
+        vector<int> traversal_order;
+        for (const int64_t& rc: ref_trav_candidates) {
+            traversal_order.push_back((int)rc);
+            ref_set.insert(rc);
+        }
         for (int i = 0; i < path_travs.size(); ++i) {
-            if (i != ref_trav_indexes[0]) {
+            if (!ref_set.count(i)) {
                 traversal_order.push_back(i);
             }
         }
@@ -625,10 +617,8 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
             }
         }
 
-        unordered_set<path_handle_t> path_set(ref_paths.begin(), ref_paths.end());
-        
         // some clustering was done, we flag all cluster references to keep, and remove everything else
-        assert(trav_clusters[0][0] == ref_trav_indexes[0]); // we've already added ref cluster
+        assert(trav_clusters[0][0] == ref_trav_candidates[0]); // we've already added ref cluster
         for (int i = 1; i < trav_clusters.size(); ++i) {            
             const Traversal& cluster_ref_trav = path_travs[trav_clusters[i][0]];
             if (simplify) {
@@ -638,10 +628,6 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
                         ref_edges.insert(graph->edge_handle(cluster_ref_trav[j-1], cluster_ref_trav[j]));
                     }
                 }
-            }
-            if (!path_set.count(trav_paths[trav_clusters[i][0]])) {
-                out_ref_paths.push_back(trav_paths[trav_clusters[i][0]]);
-                path_set.insert(trav_paths[trav_clusters[i][0]]);
             }
         }
     }
@@ -653,17 +639,6 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
         for (const nid_t& node_id : snarl_nodes) {
             if (!ref_nodes.count(node_id)) {
                 nodes_to_remove.insert(node_id);
-/*                graph->for_each_step_on_handle(graph->get_handle(node_id), [&](step_handle_t step) {
-                    string path_name = graph->get_path_name(graph->get_path_handle_of_step(step));
-                    if (path_name.compare(0, ref_path_prefix.length(), ref_path_prefix) == 0) {
-                        cerr << "about no remove reference node " << node_id << endl;
-                        cerr << "trav names " << endl;
-                        for (const auto& xx : trav_names) {
-                            cerr << xx << endl;
-                        }
-                    }
-                    assert (path_name.compare(0, ref_path_prefix.length(), ref_path_prefix) != 0);
-                    });*/
                 ++node_removed_count;
             }
         }
@@ -682,11 +657,11 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
     }
 #endif
 
-    return true;
+    return simplify;
 }
 
 void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const string& ref_path_prefix,
-                                     int64_t min_snarl_length,
+                                     int64_t max_snarl_length,
                                      double min_jaccard,
                                      int64_t max_iterations,
                                      int64_t min_fragment_length) {
@@ -694,10 +669,10 @@ void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const
     PathTraversalFinder path_trav_finder(*graph);
 
     // load up the reference paths
-    vector<path_handle_t> ref_paths;
+    unordered_map<path_handle_t, int64_t> ref_paths;
     graph->for_each_path_handle([&](path_handle_t path_handle) {
         if (graph->get_path_name(path_handle).compare(0, ref_path_prefix.length(), ref_path_prefix) == 0) {
-            ref_paths.push_back(path_handle);
+            ref_paths[path_handle] = 0;
         }
     });
 
@@ -708,7 +683,29 @@ void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const
         exit(1);
     }
 
+    // both types of normalization selected. we're going to double the iterations
+    // and alternate between them
+    int64_t input_max_snarl_length = max_snarl_length;
+    int64_t input_min_jaccard = min_jaccard;
+    int64_t empty_count = 0;
+    bool alternate = max_snarl_length > 0 && min_jaccard < 1.0;
+    if (alternate) {
+        max_iterations *= 2;        
+    }
+    
     for (int64_t iteration = 0; iteration < max_iterations; ++iteration) {
+
+        // both types of normalization selected. we're going to double the iterations
+        // and alternate between them        
+        if (alternate) {
+            if (iteration % 2 == 0) {
+                max_snarl_length = input_max_snarl_length;
+                min_jaccard = 1;
+            } else {
+                max_snarl_length = 0;
+                min_jaccard = input_min_jaccard;
+            }
+        }
 
         // compute the distance index
         SnarlDistanceIndex distance_index;
@@ -722,7 +719,7 @@ void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const
         // snarl, then again by a child.  could refactor to be more clever, but I don't yet know
         // if it would save much time in practice. 
         net_handle_t root = distance_index.get_root();
-        deque<tuple<net_handle_t, int64_t, vector<path_handle_t>>> queue = {make_tuple(root, -1, ref_paths)};
+        deque<tuple<net_handle_t, int64_t, unordered_map<path_handle_t, int64_t>>> queue = {make_tuple(root, -1, ref_paths)};
         // we remove all the nodes in one batch to avoid collisions / unececssary path updates
         // todo: does this also need streamlining? also: this setup allows us to work in parallel
         // which could be a possible speedup.    
@@ -732,29 +729,21 @@ void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const
         while (!queue.empty()) {
             net_handle_t net_handle;
             int64_t level;
-            vector<path_handle_t> cur_ref_paths;
+            unordered_map<path_handle_t, int64_t> cur_ref_paths;
             std::tie(net_handle, level, cur_ref_paths) = queue.front();
             queue.pop_front();
+            bool was_simplified = false;
             if (distance_index.is_snarl(net_handle)) {
                 net_handle_t start_bound = distance_index.get_bound(net_handle, false, true);
                 net_handle_t end_bound = distance_index.get_bound(net_handle, true, false);
                 handle_t start_handle = distance_index.get_handle(start_bound, graph);
                 handle_t end_handle = distance_index.get_handle(end_bound, graph);
-                vector<path_handle_t> out_ref_paths;
-                bool ret = simplify_snarl_using_traversals(graph, path_trav_finder, start_handle, end_handle, cur_ref_paths, level,
-                                                           min_snarl_length, min_jaccard, min_fragment_length, nodes_to_remove,
-                                                           edges_to_remove, out_ref_paths);
-                // hack so that top-level snarls can fail and it will try below
-                // but note: this code will only have a chance of working properly if the snarl tree is rooted
-                // on the reference path. 
-                if (level == 0 && ret == false) {
-                    --level;
-                }
-                if (ret == true) {
-                    cur_ref_paths = out_ref_paths;
-                }
+                was_simplified = simplify_snarl_using_traversals(graph, path_trav_finder, start_handle, end_handle,
+                                                                 cur_ref_paths, level, max_snarl_length, min_jaccard,
+                                                                 min_fragment_length, nodes_to_remove, edges_to_remove);
             }        
-            if (net_handle == root || distance_index.is_snarl(net_handle) || distance_index.is_chain(net_handle)) {
+            if (!was_simplified && (
+                    net_handle == root || distance_index.is_snarl(net_handle) || distance_index.is_chain(net_handle))) {
                 distance_index.for_each_child(net_handle, [&](net_handle_t child_handle) {
                     int64_t next_level = distance_index.is_snarl(child_handle) ? level + 1 : level;
                     queue.push_back(make_tuple(child_handle, next_level, cur_ref_paths));
@@ -763,11 +752,21 @@ void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const
         }
 
         if (!nodes_to_remove.empty() || !edges_to_remove.empty()) {
-            cerr << "iteration " << iteration << ": deleting " << nodes_to_remove.size() << " nodes and "
+            cerr << "iteration " << iteration;
+            if (max_snarl_length > 0) {
+                cerr << " (filter snarls < " << max_snarl_length;
+            } else {
+                cerr << " (merging traversals with similarity > " << min_jaccard;
+            }
+            cerr << "): deleting " << nodes_to_remove.size() << " nodes and "
                  << edges_to_remove.size() << " edges" << endl;
             // delete the nodes
             delete_nodes_and_chop_paths(graph, nodes_to_remove, edges_to_remove, min_fragment_length);
+            empty_count = 0;
         } else {
+            ++empty_count;
+        }
+        if ((alternate && empty_count > 1) || (!alternate && empty_count > 0)) {
             break;
         }
     }

--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -534,6 +534,12 @@ static bool simplify_snarl_using_traversals(MutablePathMutableHandleGraph* graph
         }
     }
 
+    // revert to not snapping to reference path. because it can happen that there
+    // are huge nested snarls that due to clipping don't have any path. 
+    if (ref_trav_indexes.empty() && level > 0 && alphabetically_first_ref_trav_idx >= 0) {
+        ref_trav_indexes.push_back(alphabetically_first_ref_trav_idx);
+    }
+
     // if there are no reference paths, we bail
     // todo: we could relax this by using the alphabetical path
     if (ref_trav_indexes.empty()) {

--- a/src/traversal_clusters.hpp
+++ b/src/traversal_clusters.hpp
@@ -110,6 +110,7 @@ void merge_equivalent_traversals_in_graph(MutablePathHandleGraph* graph, const u
 void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const string& ref_path_prefix,
                                      int64_t min_snarl_length,
                                      double min_jaccard,
+                                     int64_t max_iterations,
                                      int64_t min_fragment_length);
 
 

--- a/src/traversal_clusters.hpp
+++ b/src/traversal_clusters.hpp
@@ -104,4 +104,13 @@ vector<vector<int>> assign_child_snarls_to_traversals(const PathHandleGraph* gra
 void merge_equivalent_traversals_in_graph(MutablePathHandleGraph* graph, const unordered_set<path_handle_t>& selected_paths,
                                           bool use_snarl_manager=false);
 
+
+/// for every snarl, bottom up, compute all the traversals through it.  choose a reference traversal
+/// (using the prefix where possible), then if 
+void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const string& ref_path_prefix,
+                                     int64_t min_snarl_length,
+                                     double min_jaccard,
+                                     int64_t min_fragment_length);
+
+
 }

--- a/test/t/43_vg_simplify.t
+++ b/test/t/43_vg_simplify.t
@@ -5,15 +5,19 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 5
+plan tests 7
 
 vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
 
 # Make sure to discard all the warnings about having removed alt paths.
 vg simplify --algorithm small x.vg > x.small.vg 2>/dev/null
 is "${?}" "0" "vg simplify runs through when popping small bubbles"
-
 is "$(vg paths -d -v x.small.vg | vg mod --unchop - | vg stats -N -)" "1" "simplification pops all the bubbles in a simple graph"
+
+# Same test but new path simplifier logic
+vg simplify --algorithm small x.vg -P x > x.small.vg 2>/dev/null
+is "${?}" "0" "vg path simplify runs through when popping small bubbles"
+is "$(vg paths -d -v x.small.vg | vg mod --unchop - | vg stats -N -)" "1" "path simplification pops all the bubbles in a simple graph"
 
 vg simplify --algorithm rare --min-count 2 -v small/x.vcf.gz x.vg > x.rare.vg
 is "${?}" "0" "vg simplify runs through when removing rare variants"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg simplify -P` option added to perform simplification based on a given set of reference paths.  Snarls are "popped" if the maximum path traversal through them is `<m`.  Larger snarls can be simplified by merging together similar traversals (threshold set with `-L` -- similar to `deconstruct`).  Unlike the prior `vg simplify` logic (which remains here unchanged), `-P` scales to large graphs and supports non-protobuf input. 

## Description

I wrote this to help visualize MC graphs at chromosome / genome scale in BandageNG.  