### PR TITLE
New Long Read Giraffe parameters

### DIFF
--- a/src/algorithms/chain_items.cpp
+++ b/src/algorithms/chain_items.cpp
@@ -11,8 +11,8 @@
 #include <structures/immutable_list.hpp>
 #include <structures/min_max_heap.hpp>
 
-//#define debug_chaining
-//#define debug_transition
+#define debug_chaining
+#define debug_transition
 
 namespace vg {
 namespace algorithms {
@@ -317,6 +317,10 @@ transition_iterator zip_tree_transition_iterator(const std::vector<SnarlDistance
                 // For each source seed right to left
                 ZipCodeTree::seed_result_t source_seed = *source;
 
+#ifdef debug_transition
+                std::cerr << "\tSource seed S" << source_seed.seed << " " << seeds[source_seed.seed].pos << (source_seed.is_reverse ? "rev" : "") << " at distance " << source_seed.distance << "/" << max_lookback_bases;
+#endif
+
                 if (!source_seed.is_reverse && !dest_seed.is_reverse) {
                     // Both of these are in the same orientation relative to
                     // the read, and we're going through the graph in the
@@ -328,11 +332,15 @@ transition_iterator zip_tree_transition_iterator(const std::vector<SnarlDistance
                     if (found_source_anchor != seed_to_ending.end()) {
                         // We can transition between these seeds without jumping to/from the middle of an anchor.
 #ifdef debug_transition
-                        std::cerr << "\tSource seed S" << source_seed.seed << " " << seeds[source_seed.seed].pos << (source_seed.is_reverse ? "rev" : "") << " at distance " << source_seed.distance << "/" << max_lookback_bases << " is anchor #" << found_source_anchor->second << std::endl;
+                        std::cerr << " is anchor #" << found_source_anchor->second << std::endl;
                         std::cerr << "\t\tFound transition from #" << found_source_anchor->second << " to #" << found_dest_anchor->second << std::endl;
 #endif
                         all_transitions.emplace_back(found_source_anchor->second, found_dest_anchor->second, source_seed.distance);
-                    } 
+                    } else {
+#ifdef debug_transition
+                        std::cerr << " does not represent an anchor." << std::endl;
+#endif
+                    }
                 } else if (source_seed.is_reverse && dest_seed.is_reverse) {
                     // Both of these are in the same orientation but it is opposite to the read.
                     // We need to find source as an anchor *started*, and thensave them flipped for later.
@@ -342,12 +350,16 @@ transition_iterator zip_tree_transition_iterator(const std::vector<SnarlDistance
                         // Queue them up, flipped
                         
 #ifdef debug_transition
-                        std::cerr << "\tSource seed S" << source_seed.seed << " " << seeds[source_seed.seed].pos << (source_seed.is_reverse ? "rev" : "") << " at distance " << source_seed.distance << "/" << max_lookback_bases << " is anchor #" << found_source_anchor->second << std::endl;
+                        std::cerr << " is anchor #" << found_source_anchor->second << std::endl;
                         std::cerr << "\t\tFound backward transition from #" << found_dest_anchor->second << " to #" << found_source_anchor->second << std::endl;
 #endif
 
                         all_transitions.emplace_back(found_dest_anchor->second, found_source_anchor->second, source_seed.distance);
-                    } 
+                    } else {
+#ifdef debug_transition
+                        std::cerr << " is in the wrong relative orientation." << std::endl;
+#endif
+                    }
                 } else {
                     // We have a transition between different orientations relative to the read. Don't show that.
                     continue;

--- a/src/algorithms/chain_items.cpp
+++ b/src/algorithms/chain_items.cpp
@@ -11,8 +11,8 @@
 #include <structures/immutable_list.hpp>
 #include <structures/min_max_heap.hpp>
 
-#define debug_chaining
-#define debug_transition
+//#define debug_chaining
+//#define debug_transition
 
 namespace vg {
 namespace algorithms {

--- a/src/algorithms/chain_items.cpp
+++ b/src/algorithms/chain_items.cpp
@@ -197,12 +197,14 @@ transition_iterator zip_tree_transition_iterator(const std::vector<SnarlDistance
                                                  size_t max_read_lookback_bases) {
     
     // TODO: Remove seeds because we only bring it here for debugging and it complicates the dependency relationships
-    return [&seeds, &zip_code_tree, max_lookback_bases](const VectorView<Anchor>& to_chain,
-                                                        const SnarlDistanceIndex& distance_index,
-                                                        const HandleGraph& graph,
-                                                        size_t max_indel_bases,
-                                                        const transition_iteratee& callback) {
-                            
+    return [&seeds, &zip_code_tree, max_graph_lookback_bases, max_read_lookback_bases](
+        const VectorView<Anchor>& to_chain,
+        const SnarlDistanceIndex& distance_index,
+        const HandleGraph& graph,
+        size_t max_indel_bases,
+        const transition_iteratee& callback
+    ) {
+
         // We need a way to map from the seeds that zip tree thinks about to the anchors that we think about. So we need to index the anchors by leading/trailing seed.
         // TODO: Should we make someone else do the indexing so we can make the Anchor not need to remember the seed?
         std::unordered_map<size_t, size_t> seed_to_starting;

--- a/src/algorithms/chain_items.hpp
+++ b/src/algorithms/chain_items.hpp
@@ -308,9 +308,16 @@ transition_iterator lookback_transition_iterator(size_t max_lookback_bases,
                                                  size_t lookback_item_hard_cap);
 
 /**
- * Return a transition iterator that uses zip code tree iteration to select traversals.
+ * Return a transition iterator that uses zip code tree iteration to select
+ * traversals.
+ *
+ * Enumerates transitions under the max graph lookback bases, and filters them
+ * by the max read lookback bases.
  */
-transition_iterator zip_tree_transition_iterator(const std::vector<SnarlDistanceIndexClusterer::Seed>& seeds, const ZipCodeTree& zip_code_tree, size_t max_lookback_bases);
+transition_iterator zip_tree_transition_iterator(const std::vector<SnarlDistanceIndexClusterer::Seed>& seeds,
+                                                 const ZipCodeTree& zip_code_tree,
+                                                 size_t max_graph_lookback_bases,
+                                                 size_t max_read_lookback_bases);
 
 /**
  * Fill in the given DP table for the explored chain scores ending with each
@@ -323,11 +330,11 @@ transition_iterator zip_tree_transition_iterator(const std::vector<SnarlDistance
  *
  * Input items must be sorted by start position in the read.
  *
- * Takes the given per-item bonus for each item collected, and scales item scores by the given scale.
+ * Takes the given per-item bonus for each item collected, and scales item
+ * scores by the given scale.
  *
- * Uses a finite lookback in items and in read bases when checking where we can
- * come from to reach an item. Also, once a given number of good-looking
- * predecessor items have been found, stop looking back.
+ * Uses a transition iterator to enumerate where we can come from to reach an
+ * item. 
  *
  * Limits transitions to those involving indels of the given size or less, to
  * avoid very bad transitions.

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -254,12 +254,18 @@ public:
     static constexpr size_t default_gapless_extension_limit = 0;
     size_t gapless_extension_limit = default_gapless_extension_limit;
 
-    /// How many bases should we look back when making fragments?
-    static constexpr size_t default_fragment_max_lookback_bases = 300;
-    size_t fragment_max_lookback_bases = default_fragment_max_lookback_bases;
-    /// How many bases should we look back when making fragments, per base of read length?
-    static constexpr double default_fragment_max_lookback_bases_per_base = 0.03;
-    double fragment_max_lookback_bases_per_base = default_fragment_max_lookback_bases_per_base;
+    /// How many bases should we look back in the graph when making fragments?
+    static constexpr size_t default_fragment_max_graph_lookback_bases = 300;
+    size_t fragment_max_graph_lookback_bases = default_fragment_max_graph_lookback_bases;
+    /// How many bases should we look back in the graph when making fragments, per base of read length?
+    static constexpr double default_fragment_max_graph_lookback_bases_per_base = 0.03;
+    double fragment_max_graph_lookback_bases_per_base = default_fragment_max_graph_lookback_bases_per_base;
+    /// How many bases should we look back in the read when making fragments?
+    static constexpr size_t default_fragment_max_read_lookback_bases = std::numeric_limits<size_t>::max();
+    size_t fragment_max_read_lookback_bases = default_fragment_max_read_lookback_bases;
+    /// How many bases should we look back in the read when making fragments, per base of read length?
+    static constexpr double default_fragment_max_read_lookback_bases_per_base = 1.0;
+    double fragment_max_read_lookback_bases_per_base = default_fragment_max_read_lookback_bases_per_base;
     /// How many fragments should we try and make when fragmenting something?
     static constexpr size_t default_max_fragments = std::numeric_limits<size_t>::max();
     size_t max_fragments = default_max_fragments;
@@ -322,12 +328,18 @@ public:
     static constexpr size_t default_max_direct_to_chain = 0;
     size_t max_direct_to_chain = default_max_direct_to_chain;
 
-    /// How many bases should we look back when chaining?
-    static constexpr size_t default_max_lookback_bases = 3000;
-    size_t max_lookback_bases = default_max_lookback_bases;
-    /// How many bases should we look back when chaining, per base of read length?
-    static constexpr double default_max_lookback_bases_per_base = 0.3;
-    double max_lookback_bases_per_base = default_max_lookback_bases_per_base;
+    /// How many bases should we look back in the graph when chaining?
+    static constexpr size_t default_max_graph_lookback_bases = 3000;
+    size_t max_graph_lookback_bases = default_max_graph_lookback_bases;
+    /// How many bases should we look back in the graph when chaining, per base of read length?
+    static constexpr double default_max_graph_lookback_bases_per_base = 0.3;
+    double max_graph_lookback_bases_per_base = default_max_graph_lookback_bases_per_base;
+    /// How many bases should we look back in the read when chaining?
+    static constexpr size_t default_max_read_lookback_bases = std::numeric_limits<size_t>::max();
+    size_t max_read_lookback_bases = default_max_read_lookback_bases;
+    /// How many bases should we look back in the read when chaining, per base of read length?
+    static constexpr double default_max_read_lookback_bases_per_base = 1.0;
+    double max_read_lookback_bases_per_base = default_max_read_lookback_bases_per_base;
 
     /// How much of a bonus should we give to each item in
     /// fragmenting/chaining?

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1433,14 +1433,16 @@ void MinimizerMapper::do_fragmenting_on_trees(Alignment& aln, const ZipCodeFores
             
             // Compute lookback and indel limits based on read length.
             // Important since seed density goes down on longer reads.
-            size_t lookback_limit = std::max(this->fragment_max_lookback_bases, (size_t)(this->fragment_max_lookback_bases_per_base * aln.sequence().size()));
+            size_t graph_lookback_limit = std::max(this->fragment_max_graph_lookback_bases, (size_t)(this->fragment_max_graph_lookback_bases_per_base * aln.sequence().size()));
+            size_t read_lookback_limit = std::max(this->fragment_max_read_lookback_bases, (size_t)(this->fragment_max_read_lookback_bases_per_base * aln.sequence().size()));
             size_t indel_limit = std::max(this->fragment_max_indel_bases, (size_t)(this->fragment_max_indel_bases_per_base * aln.sequence().size()));
 
             // Find fragments over the seeds in the zip code tree
             algorithms::transition_iterator for_each_transition = algorithms::zip_tree_transition_iterator(
                 seeds,
                 zip_code_forest.trees[item_num],
-                lookback_limit
+                graph_lookback_limit,
+                read_lookback_limit
             ); 
             // Make a view of the anchors we will fragment over
             VectorView<algorithms::Anchor> anchor_view {anchors_to_fragment, anchor_indexes}; 
@@ -1896,14 +1898,16 @@ void MinimizerMapper::do_chaining_on_fragments(Alignment& aln, const ZipCodeFore
 
             // Compute lookback and indel limits based on read length.
             // Important since seed density goes down on longer reads.
-            size_t lookback_limit = std::max(this->max_lookback_bases, (size_t)(this->max_lookback_bases_per_base * aln.sequence().size()));
+            size_t graph_lookback_limit = std::max(this->max_graph_lookback_bases, (size_t)(this->max_graph_lookback_bases_per_base * aln.sequence().size()));
+            size_t read_lookback_limit = std::max(this->max_read_lookback_bases, (size_t)(this->max_read_lookback_bases_per_base * aln.sequence().size()));
             size_t indel_limit = std::max(this->max_indel_bases, (size_t)(this->max_indel_bases_per_base * aln.sequence().size()));
 
             // Chain up the fragments
             algorithms::transition_iterator for_each_transition = algorithms::zip_tree_transition_iterator(
                 seeds,
                 zip_code_forest.trees[tree_num],
-                lookback_limit
+                graph_lookback_limit,
+                read_lookback_limit
             );
             std::vector<std::pair<int, std::vector<size_t>>> chain_results = algorithms::find_best_chains(
                 fragment_view,
@@ -3101,19 +3105,19 @@ Alignment MinimizerMapper::find_chain_alignment(
         size_t link_start = (*here).read_end();
         size_t link_length = (*next).read_start() - link_start;
         string linking_bases = aln.sequence().substr(link_start, link_length);
-        size_t graph_length = algorithms::get_graph_distance(*here, *next, *distance_index, gbwt_graph);
+        size_t graph_dist = algorithms::get_graph_distance(*here, *next, *distance_index, gbwt_graph);
         
 #ifdef debug_chain_alignment
         if (show_work) {
             #pragma omp critical (cerr)
             {
                 cerr << log_name() << "Need to align graph from " << (*here).graph_end() << " to " << (*next).graph_start()
-                    << " separated by " << graph_length << " bp and sequence \"" << linking_bases << "\"" << endl;
+                    << " separated by ~" << graph_dist << " bp and sequence \"" << linking_bases << "\"" << endl;
             }
         }
 #endif
         
-        if (link_length == 0 && graph_length == 0) {
+        if (link_length == 0 && graph_dist == 0) {
             // These items abut in the read and the graph, so we assume we can just connect them.
             // WFAExtender::connect() can't handle an empty read sequence, and
             // our fallback method to align just against the graph can't handle
@@ -3159,7 +3163,7 @@ Alignment MinimizerMapper::find_chain_alignment(
             
             if (!link_alignment) {
                 // We couldn't align.
-                if (graph_length == 0) {
+                if (graph_dist == 0) {
                     // We had read sequence but no graph sequence.
                     // Try falling back to a pure insertion.
                     // TODO: We can be leaving the GBWT's space here!
@@ -3178,7 +3182,7 @@ Alignment MinimizerMapper::find_chain_alignment(
             } else if (link_alignment.length != linking_bases.size()) {
                 // We could align, but we didn't get the alignment we expected. This shouldn't happen for a middle piece that can't softclip.
                 stringstream ss;
-                ss << "Aligning anchored link " << linking_bases << " (" << linking_bases.size() << " bp) from " << left_anchor << " - " << (*next).graph_start() << " against graph distance " << graph_length << " produced wrong-length alignment ";
+                ss << "Aligning anchored link " << linking_bases << " (" << linking_bases.size() << " bp) from " << left_anchor << " - " << (*next).graph_start() << " against graph distance " << graph_dist << " produced wrong-length alignment ";
                 link_alignment.print(ss);
                 throw ChainAlignmentFailedError(ss.str());
             } else {
@@ -3188,6 +3192,10 @@ Alignment MinimizerMapper::find_chain_alignment(
             }
         }
         
+        // We will measure the graph distance on the link path actually found, for work-showing.
+        // This gets filled from either the WFA alignment we have already, or the BGA alignment we are about to compute.
+        size_t link_graph_path_length;
+
         if (link_alignment) {
             // We found a link alignment
             
@@ -3213,6 +3221,7 @@ Alignment MinimizerMapper::find_chain_alignment(
                     }
                 }
 #endif
+                link_graph_path_length = path_from_length(link_path);
                 append_path(composed_path, std::move(link_path));
             }
             composed_score += link_alignment.score;
@@ -3224,7 +3233,7 @@ Alignment MinimizerMapper::find_chain_alignment(
                 // This would be too long for the middle aligner(s) to handle and might overflow a score somewhere.
                 #pragma omp critical (cerr)
                 {
-                    cerr << "warning[MinimizerMapper::find_chain_alignment]: Refusing to align " << link_length << " bp connection between chain items " << to_chain.backing_index(*here_it) << " and " << to_chain.backing_index(*next_it) << " which are " << graph_length << " apart at " << (*here).graph_end() << " and " << (*next).graph_start() << " in " << aln.name() << " to avoid overflow, creating " << (aln.sequence().size() - (*here).read_end()) << " bp right tail" << endl;
+                    cerr << "warning[MinimizerMapper::find_chain_alignment]: Refusing to align " << link_length << " bp connection between chain items " << to_chain.backing_index(*here_it) << " and " << to_chain.backing_index(*next_it) << " which are " << graph_dist << " apart at " << (*here).graph_end() << " and " << (*next).graph_start() << " in " << aln.name() << " to avoid overflow, creating " << (aln.sequence().size() - (*here).read_end()) << " bp right tail" << endl;
                 }
                 // Just jump to right tail
                 break;
@@ -3235,7 +3244,7 @@ Alignment MinimizerMapper::find_chain_alignment(
             // long of a sequence to find a connecting path.
             #pragma omp critical (cerr)
             {
-                cerr << "warning[MinimizerMapper::find_chain_alignment]: Falling back to non-GBWT alignment of " << link_length << " bp connection between chain items " << to_chain.backing_index(*here_it) << " and " << to_chain.backing_index(*next_it) << " which are " << graph_length << " apart at " << (*here).graph_end() << " and " << (*next).graph_start() << " in " << aln.name() << endl;
+                cerr << "warning[MinimizerMapper::find_chain_alignment]: Falling back to non-GBWT alignment of " << link_length << " bp connection between chain items " << to_chain.backing_index(*here_it) << " and " << to_chain.backing_index(*next_it) << " which are " << graph_dist << " apart at " << (*here).graph_end() << " and " << (*next).graph_start() << " in " << aln.name() << endl;
             }
 #endif
             
@@ -3246,7 +3255,7 @@ Alignment MinimizerMapper::find_chain_alignment(
             }
             // Guess how long of a graph path we ought to allow in the alignment.
             size_t max_gap_length = std::min(this->max_middle_gap, longest_detectable_gap_in_range(aln, aln.sequence().begin() + link_start, aln.sequence().begin() + link_start + link_length, this->get_regular_aligner()));
-            size_t path_length = std::max(graph_length, link_length);
+            size_t path_length = std::max(graph_dist, link_length);
             if (stats) {
                 start_time = std::chrono::high_resolution_clock::now();
             }
@@ -3266,7 +3275,7 @@ Alignment MinimizerMapper::find_chain_alignment(
                 // TODO: Should we let the exceptions propagate up to here instead?
                 #pragma omp critical (cerr)
                 {
-                    cerr << "warning[MinimizerMapper::find_chain_alignment]: BGA alignment too big for " << link_length << " bp connection between chain items " << to_chain.backing_index(*here_it) << " and " << to_chain.backing_index(*next_it) << " which are " << graph_length << " apart at " << (*here).graph_end() << " and " << (*next).graph_start() << " in " << aln.name() << endl;
+                    cerr << "warning[MinimizerMapper::find_chain_alignment]: BGA alignment too big for " << link_length << " bp connection between chain items " << to_chain.backing_index(*here_it) << " and " << to_chain.backing_index(*next_it) << " which are " << graph_dist << " apart at " << (*here).graph_end() << " and " << (*next).graph_start() << " in " << aln.name() << endl;
                 }
 
                 // Just jump to right tail
@@ -3276,22 +3285,17 @@ Alignment MinimizerMapper::find_chain_alignment(
             // Otherwise we actually have a link alignment result.
             link_alignment_source = "align_sequence_between";
             
-            if (show_work) {
-                #pragma omp critical (cerr)
-                {
-                    cerr << log_name() << "Add link of length " << path_to_length(link_aln.path()) << " with score of " << link_aln.score() << endl;
-                }
-            }
-            
             // Then tack that path and score on
-            append_path(composed_path, link_aln.path());
+            Path link_path(link_aln.path());
+            link_graph_path_length = path_from_length(link_path);
+            append_path(composed_path, std::move(link_path));
             composed_score += link_aln.score();
         }
 
         if (show_work) {
             #pragma omp critical (cerr)
             {
-                cerr << log_name() << "Aligned and added link of " << link_length << " via " << link_alignment_source << std::endl;
+                cerr << log_name() << "Aligned and added link of " << link_length << " bp read and " << link_graph_path_length << " bp graph via " << link_alignment_source << " with score of " << link_aln.score() << std::endl;
             }
         }
         
@@ -3327,7 +3331,7 @@ Alignment MinimizerMapper::find_chain_alignment(
         here_alignment.check_lengths(gbwt_graph);
     
         // Do the final GaplessExtension itself (may be the first)
-        append_path(composed_path, here_alignment.to_path(this->gbwt_graph, aln.sequence()));
+    append_path(composed_path, here_alignment.to_path(this->gbwt_graph, aln.sequence()));
         composed_score += here_alignment.score;
     }
 

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -381,16 +381,28 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         "do gapless extension to seeds in a tree before fragmenting if the read length is less than this"
     );
     chaining_opts.add_range(
-        "fragment-max-lookback-bases",
-        &MinimizerMapper::fragment_max_lookback_bases,
-        MinimizerMapper::default_fragment_max_lookback_bases,
-        "maximum distance to look back when making fragments"
+        "fragment-max-graph-lookback-bases",
+        &MinimizerMapper::fragment_max_graph_lookback_bases,
+        MinimizerMapper::default_fragment_max_graph_lookback_bases,
+        "maximum distance to look back in the graph when making fragments"
     );
     chaining_opts.add_range(
-        "fragment-max-lookback-bases-per-base",
-        &MinimizerMapper::fragment_max_lookback_bases_per_base,
-        MinimizerMapper::default_fragment_max_lookback_bases_per_base,
-        "maximum distance to look back when making fragments, per base"
+        "fragment-max-graph-lookback-bases-per-base",
+        &MinimizerMapper::fragment_max_graph_lookback_bases_per_base,
+        MinimizerMapper::default_fragment_max_graph_lookback_bases_per_base,
+        "maximum distance to look back in the graph when making fragments, per base"
+    );
+    chaining_opts.add_range(
+        "fragment-max-read-lookback-bases",
+        &MinimizerMapper::fragment_max_read_lookback_bases,
+        MinimizerMapper::default_fragment_max_read_lookback_bases,
+        "maximum distance to look back in the read when making fragments"
+    );
+    chaining_opts.add_range(
+        "fragment-max-read-lookback-bases-per-base",
+        &MinimizerMapper::fragment_max_read_lookback_bases_per_base,
+        MinimizerMapper::default_fragment_max_read_lookback_bases_per_base,
+        "maximum distance to look back in the read when making fragments, per base"
     );
     chaining_opts.add_range(
         "max-fragments",
@@ -465,16 +477,28 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         int_is_nonnegative
     );
     chaining_opts.add_range(
-        "max-lookback-bases",
-        &MinimizerMapper::max_lookback_bases,
-        MinimizerMapper::default_max_lookback_bases,
-        "maximum distance to look back when chaining"
+        "max-graph-lookback-bases",
+        &MinimizerMapper::max_graph_lookback_bases,
+        MinimizerMapper::default_max_graph_lookback_bases,
+        "maximum distance to look back in the graph when chaining"
     );
     chaining_opts.add_range(
-        "max-lookback-bases-per-base",
-        &MinimizerMapper::max_lookback_bases_per_base,
-        MinimizerMapper::default_max_lookback_bases_per_base,
-        "maximum distance to look back when chaining, per read base"
+        "max-graph-lookback-bases-per-base",
+        &MinimizerMapper::max_graph_lookback_bases_per_base,
+        MinimizerMapper::default_max_graph_lookback_bases_per_base,
+        "maximum distance to look back in the graph when chaining, per read base"
+    );
+    chaining_opts.add_range(
+        "max-read-lookback-bases",
+        &MinimizerMapper::max_read_lookback_bases,
+        MinimizerMapper::default_max_read_lookback_bases,
+        "maximum distance to look back in the read when chaining"
+    );
+    chaining_opts.add_range(
+        "max-read-lookback-bases-per-base",
+        &MinimizerMapper::max_read_lookback_bases_per_base,
+        MinimizerMapper::default_max_read_lookback_bases_per_base,
+        "maximum distance to look back in the read when chaining, per read base"
     );
     chaining_opts.add_range(
         "max-indel-bases",
@@ -919,8 +943,8 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("zipcode-tree-scale", 2.0)
         .add_entry<size_t>("min-to-fragment", 2)
         .add_entry<size_t>("max-to-fragment", 15)
-        .add_entry<size_t>("fragment-max-lookback-bases", 500)
-        .add_entry<double>("fragment-max-lookback-bases-per-base", 0.025)
+        .add_entry<size_t>("fragment-max-graph-lookback-bases", 500)
+        .add_entry<double>("fragment-max-graph-lookback-bases-per-base", 0.025)
         .add_entry<size_t>("max-fragments", 15000)
         .add_entry<size_t>("fragment-max-indel-bases", 15000)
         .add_entry<double>("fragment-max-indel-bases-per-base", 0.1)
@@ -931,8 +955,8 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("fragment-set-score-threshold", 70.0)
         .add_entry<int>("min-chaining-problems", 6)
         .add_entry<int>("max-chaining-problems", std::numeric_limits<int>::max())
-        .add_entry<size_t>("max-lookback-bases", 20000)
-        .add_entry<double>("max-lookback-bases-per-base", 0.10501002120802233)
+        .add_entry<size_t>("max-graph-lookback-bases", 20000)
+        .add_entry<double>("max-graph-lookback-bases-per-base", 0.10501002120802233)
         .add_entry<size_t>("max-indel-bases", 5000)
         .add_entry<double>("max-indel-bases-per-base", 2.45)
         .add_entry<int>("item-bonus", 20)
@@ -981,8 +1005,8 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<size_t>("gapless-extension-limit", 0)
         .add_entry<size_t>("min-to-fragment", 2)
         .add_entry<size_t>("max-to-fragment", 15)
-        .add_entry<size_t>("fragment-max-lookback-bases", 500)
-        .add_entry<double>("fragment-max-lookback-bases-per-base", 0.025)
+        .add_entry<size_t>("fragment-max-graph-lookback-bases", 500)
+        .add_entry<double>("fragment-max-graph-lookback-bases-per-base", 0.025)
         .add_entry<size_t>("max-fragments", 15000)
         .add_entry<size_t>("fragment-max-indel-bases", 15000)
         .add_entry<double>("fragment-max-indel-bases-per-base", 0.1)
@@ -993,8 +1017,8 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("fragment-set-score-threshold", 70)
         .add_entry<int>("min-chaining-problems", 6)
         .add_entry<int>("max-chaining-problems", std::numeric_limits<int>::max())
-        .add_entry<size_t>("max-lookback-bases", 20000)
-        .add_entry<double>("max-lookback-bases-per-base", 0.10501002120802233)
+        .add_entry<size_t>("max-graph-lookback-bases", 20000)
+        .add_entry<double>("max-graph-lookback-bases-per-base", 0.10501002120802233)
         .add_entry<size_t>("max-indel-bases", 5000)
         .add_entry<double>("max-indel-bases-per-base", 2.45)
         .add_entry<int>("item-bonus", 20)
@@ -1046,8 +1070,8 @@ int main_giraffe(int argc, char** argv) {
         // And fragment them
         .add_entry<double>("fragment-gap-scale", 4.75)
         .add_entry<double>("gap-scale", 2.2)
-        .add_entry<size_t>("fragment-max-lookback-bases", 300)
-        .add_entry<double>("fragment-max-lookback-bases-per-base", 0)
+        .add_entry<size_t>("fragment-max-graph-lookback-bases", 300)
+        .add_entry<double>("fragment-max-graph-lookback-bases-per-base", 0)
         .add_entry<size_t>("fragment-max-indel-bases", 3000)
         .add_entry<double>("fragment-max-indel-bases-per-base", 0)
         // And take those to chains
@@ -1057,8 +1081,8 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("fragment-set-score-threshold", std::numeric_limits<double>::max())
         .add_entry<int>("min-chaining-problems", 7)
         .add_entry<int>("max-chaining-problems", std::numeric_limits<int>::max())
-        .add_entry<size_t>("max-lookback-bases", 1000)
-        .add_entry<double>("max-lookback-bases-per-base", 0)
+        .add_entry<size_t>("max-graph-lookback-bases", 1000)
+        .add_entry<double>("max-graph-lookback-bases-per-base", 0)
         .add_entry<size_t>("max-indel-bases", 1600)
         .add_entry<double>("max-indel-bases-per-base", 0)
         .add_entry<double>("chain-score-threshold", 100.0)
@@ -1088,14 +1112,14 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("mapq-score-scale", 1.0)
         .add_entry<size_t>("min-to-fragment", 2)
         .add_entry<size_t>("max-to-fragment", 10)
-        .add_entry<double>("fragment-max-lookback-bases-per-base", 0)
+        .add_entry<double>("fragment-max-graph-lookback-bases-per-base", 0)
         .add_entry<double>("fragment-max-indel-bases-per-base", 0)
         .add_entry<double>("fragment-score-fraction", 0.8)
         .add_entry<double>("fragment-min-score", 0)
         .add_entry<double>("fragment-set-score-threshold", std::numeric_limits<double>::max())
         .add_entry<int>("min-chaining-problems", 1)
         .add_entry<int>("max-chaining-problems", std::numeric_limits<int>::max())
-        .add_entry<double>("max-lookback-bases-per-base", 0)
+        .add_entry<double>("max-graph-lookback-bases-per-base", 0)
         .add_entry<double>("max-indel-bases-per-base", 0)
         .add_entry<int>("min-chains", 4)
         .add_entry<size_t>("max-chains-per-tree", 5)

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -920,6 +920,7 @@ int main_giraffe(int argc, char** argv) {
     presets["default"]
         // This is always on in the non-chaining codepath right now, but just to be sure...
         .add_entry<bool>("explored-cap", true);
+    
     presets["hifi"]
         .add_entry<bool>("align-from-chains", true)
         .add_entry<bool>("explored-cap", false)
@@ -962,11 +963,11 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<int>("item-bonus", 20)
         .add_entry<double>("item-scale", 1.0)
         .add_entry<double>("gap-scale", 0.2)
-        .add_entry<double>("chain-score-threshold", 100.0)
-        .add_entry<int>("min-chains", 4)
-        .add_entry<double>("min-chain-score-per-base", 0.06)
+        .add_entry<double>("chain-score-threshold", 200.0)
+        .add_entry<int>("min-chains", 2)
+        .add_entry<double>("min-chain-score-per-base", 0.1)
         .add_entry<size_t>("max-chains-per-tree", 3)
-        .add_entry<int>("max-min-chain-score", 100)
+        .add_entry<int>("max-min-chain-score", 1100)
         .add_entry<size_t>("max-skipped-bases", 1000)
         .add_entry<size_t>("max-alignments", 3)
         .add_entry<size_t>("max-chain-connection", 233)
@@ -980,6 +981,7 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<int>("wfa-max-mismatches", 2)
         .add_entry<double>("wfa-max-mismatches-per-base", 0.05)
         .add_entry<int>("wfa-max-max-mismatches", 15);
+
 
     presets["r10"]
         .add_entry<bool>("align-from-chains", true)
@@ -1018,17 +1020,19 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<int>("min-chaining-problems", 6)
         .add_entry<int>("max-chaining-problems", std::numeric_limits<int>::max())
         .add_entry<size_t>("max-graph-lookback-bases", 20000)
-        .add_entry<double>("max-graph-lookback-bases-per-base", 0.10501002120802233)
+        .add_entry<double>("max-graph-lookback-bases-per-base", 0.036)
+        .add_entry<size_t>("max-read-lookback-bases", 20000)
+        .add_entry<double>("max-read-lookback-bases-per-base", 0.036)
         .add_entry<size_t>("max-indel-bases", 5000)
         .add_entry<double>("max-indel-bases-per-base", 2.45)
         .add_entry<int>("item-bonus", 20)
         .add_entry<double>("item-scale", 1.0)
         .add_entry<double>("gap-scale", 0.06759721757973396)
-        .add_entry<double>("chain-score-threshold", 100.0)
+        .add_entry<double>("chain-score-threshold", 160.0)
         .add_entry<int>("min-chains", 2)
         .add_entry<size_t>("max-chains-per-tree", 3)
-        .add_entry<double>("min-chain-score-per-base", 0.06)
-        .add_entry<int>("max-min-chain-score", 500.0)
+        .add_entry<double>("min-chain-score-per-base", 0.052)
+        .add_entry<int>("max-min-chain-score", 1900.0)
         .add_entry<size_t>("max-skipped-bases", 1000)
         .add_entry<size_t>("max-alignments", 3)
         .add_entry<size_t>("max-chain-connection", 233)

--- a/src/unittest/minimizer_mapper.cpp
+++ b/src/unittest/minimizer_mapper.cpp
@@ -930,7 +930,7 @@ TEST_CASE("MinimizerMapper can make correct anchors from minimizers and their zi
                 std::unordered_map<std::pair<size_t, size_t>, std::pair<size_t, size_t>> all_transitions;
 
                 // Set up to get all the transitions between anchors in the zip code tree
-                auto transition_iterator = algorithms::zip_tree_transition_iterator(seeds, zip_forest.trees.at(0), std::numeric_limits<size_t>::max());
+                auto transition_iterator = algorithms::zip_tree_transition_iterator(seeds, zip_forest.trees.at(0), std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max());
                 // And get them
                 transition_iterator(anchors, distance_index, graph, std::numeric_limits<size_t>::max(), [&](size_t from_anchor, size_t to_anchor, size_t read_distance, size_t graph_distance) {
                     // And for each of them, remember them

--- a/src/zip_code.cpp
+++ b/src/zip_code.cpp
@@ -12,7 +12,7 @@ void ZipCode::fill_in_zipcode (const SnarlDistanceIndex& distance_index, const p
 
     //Put all ancestors of the node in a vector, starting from the node, and not including the root
     while (!distance_index.is_root(current_handle)) {
-        ancestors.emplace_back(current_handle);
+        ancestors.emplace_back(distance_index.start_end_traversal_of(current_handle));
         current_handle = distance_index.get_parent(current_handle);
     }
 

--- a/src/zip_code_tree.cpp
+++ b/src/zip_code_tree.cpp
@@ -8,10 +8,10 @@
 #include "minimizer_mapper.hpp"
 
 // Set for verbose logging from the zip code tree parsing logic
-#define debug_parse
+//#define debug_parse
 
 // Set to compile in assertions to check the zipcode tree parsing logic
-#define check_parse
+//#define check_parse
 
 using namespace std;
 namespace vg {

--- a/src/zip_code_tree.cpp
+++ b/src/zip_code_tree.cpp
@@ -8,10 +8,10 @@
 #include "minimizer_mapper.hpp"
 
 // Set for verbose logging from the zip code tree parsing logic
-//#define debug_parse
+#define debug_parse
 
 // Set to compile in assertions to check the zipcode tree parsing logic
-//#define check_parse
+#define check_parse
 
 using namespace std;
 namespace vg {
@@ -1661,7 +1661,7 @@ ZipCodeTree::reverse_iterator::reverse_iterator(vector<tree_item_t>::const_rever
     // As the end of the constructor, the iterator points to a seed that has been ticked and yielded, or is rend.
 #ifdef debug_parse
     if (this->it == rend) {
-        std::cerr << "Ran out of tree looking for first seed." << std::endl;
+        std::cerr << "Tree iteration halted looking for first seed." << std::endl;
     }
 #endif
 }
@@ -1707,7 +1707,7 @@ auto ZipCodeTree::reverse_iterator::operator++() -> reverse_iterator& {
     }
 #ifdef debug_parse
     if (it == rend) {
-        std::cerr << "Ran out of tree looking for next seed." << std::endl;
+        std::cerr << "Tree iteration halted looking for next seed." << std::endl;
     }
 #endif
     return *this;
@@ -1786,7 +1786,7 @@ auto ZipCodeTree::reverse_iterator::halt() -> void {
 
 auto ZipCodeTree::reverse_iterator::tick() -> bool {
 #ifdef debug_parse
-    std::cerr << "Tick for state " << current_state << " on symbol " << it->get_type() << " at " << &*it << std::endl;
+    std::cerr << "Tick for state " << current_state << " on symbol " << it->get_type() << " at entry " << (rend - it + 1) << std::endl;
 #endif
     switch (current_state) {
     case S_START:
@@ -1836,6 +1836,9 @@ auto ZipCodeTree::reverse_iterator::tick() -> bool {
                 // Running distance along chain is on stack, and will need to
                 // be added to all the stored distances.
                 // Note that there may be 0 stored distances if we are below the top-level snarl.
+#ifdef debug_parse
+                    std::cerr << "\tNever entered snarl; collect distances from zipcode tree." << std::endl;
+#endif
                 state(S_STACK_SNARL);
             } else {
                 // We did enter the parent snarl already.
@@ -1855,6 +1858,9 @@ auto ZipCodeTree::reverse_iterator::tick() -> bool {
                     // We never entered the parent snarl of this chain.
                     // So if the distance along the chain is too much, there
                     // are not going to be any results with a smaller distance.
+#ifdef debug_parse
+                    std::cerr << "Halt because adding " << it->get_value() << " bp gives distance " << top() << " > " << distance_limit << std::endl;
+#endif
                     halt();
                     // When we halt we have to return true to show the halting position.
                     return true;
@@ -1880,9 +1886,15 @@ auto ZipCodeTree::reverse_iterator::tick() -> bool {
         case EDGE:
             // We need to add this actual number to parent running distance.
             // Duplicate parent running distance
+#ifdef debug_parse
+            std::cerr << "\tStacking edge for snarl with current depth " << depth() << std::endl;
+#endif
             dup();
             // Add in the edge value to make a running distance for the thing this edge is for.
             // Account for if the edge is actually unreachable.
+#ifdef debug_parse
+            std::cerr << "\tTo current running parent distance " << top() << " add edge " << it->get_value() << std::endl;
+#endif
             top() = SnarlDistanceIndex::sum(top(), it->get_value());
             // Flip top 2 elements, so now parent running distance is on top, over edge running distance.
             swap();


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` has new `hifi` and `r10` preset parameters that improve speed, are mostly neutral on calling accuracy, but add more wrong MAPQ 60 HiFi reads.
 * Zip code ancestor orientation bugfix for `vg giraffe`: all minimizer and zipcode files will need to be re-generated to take advantage of it.

## Description
This changes the Long Read Giraffe parameters to increase speed, balance performance across the sampled and non-sampled graphs, and (sadly) add a bunch of to-be-diagnosed wrong MAPQ 60 HiFi reads.

It also has @xchang1's fix for a problem with zip code tree orientations.