### PR TITLE
Fix incorrect alignments in Giraffe when a tail doubles back onto the anchor node

### DIFF
--- a/src/dozeu_interface.cpp
+++ b/src/dozeu_interface.cpp
@@ -419,21 +419,18 @@ void DozeuInterface::calculate_and_save_alignment(Alignment &alignment, const Or
     // didn't traceback from the very last base of the query, or if we didn't
     // pack the whole query because of an offset.
     
-    // Add a mapping to node at index _id. Only the first mapping will be
-    // allowed to use offset. Also consults (and clears) ref_offset
-    #define _push_mapping(_id) ({ \
-        handle_t n = graph.order[(_id)]; \
-        Mapping *mapping = path->add_mapping(); \
-        size_t s = path->mapping_size(); \
-        mapping->set_rank(s); \
-        Position *position = mapping->mutable_position(); \
-        position->set_node_id(graph.graph.get_id(n)); \
+    // Add a mapping to node at index _id.
+    // Also consults (and clears) ref_offset
+	#define _push_mapping(_id) ({ \
+		handle_t n = graph.order[(_id)]; \
+		Mapping *mapping = path->add_mapping(); \
+		mapping->set_rank(path->mapping_size()); \
+		Position *position = mapping->mutable_position(); \
+		position->set_node_id(graph.graph.get_id(n)); \
         position->set_is_reverse(graph.graph.get_is_reverse(n)); \
-        if (s != 1 && ref_offset > 0) { mapping->add_edit()->set_from_length(ref_offset); } \
-        else { position->set_offset(ref_offset); } \
-        ref_offset = 0; \
-        mapping; \
-    })
+		position->set_offset(ref_offset); ref_offset = 0; \
+		mapping; \
+	})
 	#define _push_op(_m, _op, _len) { \
 		query_offset += push_edit(_m, (_op), &query[query_offset], (_len)); \
 	}

--- a/src/dozeu_interface.cpp
+++ b/src/dozeu_interface.cpp
@@ -418,17 +418,22 @@ void DozeuInterface::calculate_and_save_alignment(Alignment &alignment, const Or
     // aln->query_length can be shorter than alignment.sequence().size() if we
     // didn't traceback from the very last base of the query, or if we didn't
     // pack the whole query because of an offset.
-
-	#define _push_mapping(_id) ({ \
-		handle_t n = graph.order[(_id)]; \
-		Mapping *mapping = path->add_mapping(); \
-		mapping->set_rank(path->mapping_size()); \
-		Position *position = mapping->mutable_position(); \
-		position->set_node_id(graph.graph.get_id(n)); \
+    
+    // Add a mapping to node at index _id. Only the first mapping will be
+    // allowed to use offset. Also consults (and clears) ref_offset
+    #define _push_mapping(_id) ({ \
+        handle_t n = graph.order[(_id)]; \
+        Mapping *mapping = path->add_mapping(); \
+        size_t s = path->mapping_size(); \
+        mapping->set_rank(s); \
+        Position *position = mapping->mutable_position(); \
+        position->set_node_id(graph.graph.get_id(n)); \
         position->set_is_reverse(graph.graph.get_is_reverse(n)); \
-		position->set_offset(ref_offset); ref_offset = 0; \
-		mapping; \
-	})
+        if (s != 1 && ref_offset > 0) { mapping->add_edit()->set_from_length(ref_offset); } \
+        else { position->set_offset(ref_offset); } \
+        ref_offset = 0; \
+        mapping; \
+    })
 	#define _push_op(_m, _op, _len) { \
 		query_offset += push_edit(_m, (_op), &query[query_offset], (_len)); \
 	}

--- a/src/dozeu_interface.hpp
+++ b/src/dozeu_interface.hpp
@@ -226,6 +226,9 @@ protected:
      * can emit it as is. If it is false, the nodes were filled right to
      * left, and the internal traceback comes out in right to left order,
      * so we need to flip it.
+     *
+     * All Mappings in the Alignment other than the first will have a zero
+     * offset in their Positions.
      */
     void calculate_and_save_alignment(Alignment& alignment, const OrderedGraph& graph,
                                       const vector<graph_pos_s>& head_positions,


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` should no longer produce final mappings with nonzero offsets or other wrong answers when a read tail doubles back on itself.

## Description

This should fix the problem Zilan reported where a read couldn't be converted to GAF, because it had an offset on its last mapping, because when the flipped right tail was aligned right-anchored it doubled back onto the anchoring node and the extra cut-off part wasn't accounted for when translating back to the base graph.

I'm also adding more asserts, because we wouldn't have ever noticed this in GAM output mode, only GAF.