### PR TITLE
Drop insignificant rescue hits

### DIFF
--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -514,6 +514,10 @@ public:
     /// still break this!
     static constexpr size_t default_max_dozeu_cells = (size_t)(1.5 * 1024 * 1024);
     size_t max_dozeu_cells = default_max_dozeu_cells;
+
+    /// For rescure, how likely can an alignment be by chance to still accept it?
+    static constexpr double default_rescue_likelihood_limit = 0.05;
+    double rescue_likelihood_limit = default_rescue_likelihood_limit;
     
     ///What is the maximum fragment length that we accept as valid for paired-end reads?
     static constexpr size_t default_max_fragment_length = 2000;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` should no longer find and be very confident in obviously insignificant rescue alignments for paired reads

## Description
This should fix Kishwar's issue where we mapped an all-G read and got an all-C BAM alignment with about 4bp matched and MAPQ 60, since we were sure that the other read in the pair was mapped correctly and we knew we had the best placement for the read in pairing range.

Now we will drop any rescue alignments that don't look significant under a simple null model that accounts for read length and rescue graph size, and instead leave that read unmapped.