### PR TITLE
Fix subgraph extraction in Long Read Giraffe

### DIFF
--- a/src/algorithms/extract_connecting_graph.cpp
+++ b/src/algorithms/extract_connecting_graph.cpp
@@ -6,8 +6,9 @@
  
 #include "extract_connecting_graph.hpp"
 #include <structures/updateable_priority_queue.hpp>
+#include "../crash.hpp"
 
-//#define debug_vg_algorithms
+#define debug_vg_algorithms
 
 namespace vg {
 namespace algorithms {
@@ -220,9 +221,8 @@ unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source,
     auto duplicate_node = [&](const handle_t& handle, bool preserve_left_edges, bool preserve_right_edges) {
         unordered_set<edge_t> add_edges;
         
+        // Do the duplication and record the translation
         handle_t dup_handle = into->create_handle(into->get_sequence(into->forward(handle)));
-        
-        // record the translation
         id_trans[into->get_id(dup_handle)] = id_trans[into->get_id(handle)];
         
         if (preserve_right_edges) {
@@ -478,7 +478,9 @@ unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source,
     
     // if we did pruning, actually destroy the nodes
     for (const handle_t& handle : nodes_to_erase) {
+        nid_t id = into->get_id(handle);
         into->destroy_handle(handle);
+        id_trans.erase(id);
     }
     
     // and the edges
@@ -509,6 +511,7 @@ unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source,
     // TODO: it's not enough to return the translator because there's also the issue of the positions
     // on the first node being offset (however this information is fully contained in the arguments of
     // the function, which are obviously available in the environment that calls it)
+    crash_unless(id_trans.size() == into->get_node_count());
     return id_trans;
 }
 

--- a/src/algorithms/extract_connecting_graph.hpp
+++ b/src/algorithms/extract_connecting_graph.hpp
@@ -32,6 +32,10 @@ namespace algorithms {
     ///
     /// Node local forward orientations are not changed.
     ///
+    /// Unless strict_max_len is set, the graph may contain additional nodes
+    /// not actually on a connecting path under the given length, some of which
+    /// may be tips.
+    ///
     /// Args:
     ///  source                     graph to extract subgraph from
     ///  into                       graph to extract into

--- a/src/algorithms/extract_connecting_graph.hpp
+++ b/src/algorithms/extract_connecting_graph.hpp
@@ -28,7 +28,9 @@ namespace algorithms {
     /// portion of the node is produced in into. If they are on the same node
     /// but do not face each other, portions of the original node will exist as
     /// distinct nodes in into, and the one correspondign to pos_1 will have
-    /// the lower node ID. 
+    /// the lower node ID.
+    ///
+    /// Node local forward orientations are not changed.
     ///
     /// Args:
     ///  source                     graph to extract subgraph from
@@ -39,7 +41,9 @@ namespace algorithms {
     ///  strict_max_len             only extract nodes and edges if they fall on some walk between pos_1 and pos_2
     ///                             that is under the maximum length (implies only_walks = true)
     ///
-    /// Returns: a map from node ids in the extracted graph to the node ids in the original graph
+    /// Returns: a map from node ids in the extracted graph to the node ids in
+    /// the original graph. The map and the graph will have the same number of
+    /// entries.
     unordered_map<id_t, id_t> extract_connecting_graph(const HandleGraph* source,
                                                        DeletableHandleGraph* into,
                                                        int64_t max_len,

--- a/src/algorithms/extract_extending_graph.cpp
+++ b/src/algorithms/extract_extending_graph.cpp
@@ -6,6 +6,7 @@
  
 #include "extract_extending_graph.hpp"
 #include <structures/updateable_priority_queue.hpp>
+#include "../crash.hpp"
 
 //#define debug_vg_algorithms
 
@@ -175,10 +176,8 @@ unordered_map<id_t, id_t> extract_extending_graph(const HandleGraph* source, Del
         // choose an ID that hasn't been used yet
         id_t dup_id = max_id + 1;
         
-        // duplicate the node
+        // duplicate the node and record the ID translation
         handle_t dup_node = into->create_handle(source->get_sequence(search_origin), dup_id);
-        
-        // record the ID translation
         id_trans[dup_id] = id(pos);
         
         for (const edge_t& edge : src_edges) {
@@ -230,6 +229,7 @@ unordered_map<id_t, id_t> extract_extending_graph(const HandleGraph* source, Del
         id_trans[into->get_id(halves.first)] = id(pos);
     }
     
+    crash_unless(id_trans.size() == into->get_node_count());
     return id_trans;
 }
 

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -1035,17 +1035,20 @@ protected:
     void wfa_alignment_to_alignment(const WFAAlignment& wfa_alignment, Alignment& alignment) const;
    
     /**
-     * Clip out the part of the graph between the given positions, and dagify
-     * it from the perspective of the anchors. If a left anchor is set, all
-     * heads should correspond to the left anchor, and if a right anchor is
-     * set, all tails should correspond to the right anchor. At least one
-     * anchor must be set. Both anchors may be on the same node.
+     * Clip out the part of the graph between the given positions (left facing
+     * into the region to be extracted and right facing out), and dagify it
+     * from the perspective of the anchors. If a left anchor is set, all heads
+     * should correspond to the left anchor, and if a right anchor is set, all
+     * tails should correspond to the right anchor. At least one anchor must be
+     * set. Both anchors may be on the same node.
      *
-     * Calls the callback with an extracted, strand-split, dagified graph, and
-     * a function that translates from handle in the dagified graph to node ID
+     * Calls the callback with an extracted, strand-split, dagified graph, the
+     * handles for the anchoring copies of the left and right anchor nodes (if
+     * not empty), facing the same way as the anchoring positions, and a
+     * function that translates from handle in the dagified graph to node ID
      * and orientation in the base graph.
      */
-    static void with_dagified_local_graph(const pos_t& left_anchor, const pos_t& right_anchor, size_t max_path_length, const HandleGraph& graph, const std::function<void(DeletableHandleGraph&, const std::function<std::pair<nid_t, bool>(const handle_t&)>&)>& callback);
+    static void with_dagified_local_graph(const pos_t& left_anchor, const pos_t& right_anchor, size_t max_path_length, const HandleGraph& graph, const std::function<void(DeletableHandleGraph&, const handle_t&, const handle_t&, const std::function<std::pair<nid_t, bool>(const handle_t&)>&)>& callback);
     
     /**
      * Determine the gap limit to use when aligning the given range of sequence
@@ -1058,9 +1061,9 @@ protected:
     static size_t longest_detectable_gap_in_range(const Alignment& aln, const std::string::const_iterator& sequence_begin, const std::string::const_iterator& sequence_end, const GSSWAligner* aligner);
 
     /**
-     * Clip out the part of the graph between the given positions and
-     * global-align the sequence of the given Alignment to it. Populate the
-     * Alignment's path and score.
+     * Clip out the part of the graph between the given positions (left facing
+     * into the region and right facing out) and global-align the sequence of
+     * the given Alignment to it. Populate the Alignment's path and score.
      *
      * Finds an alignment against a graph path if it is <= max_path_length.
      *

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -3873,11 +3873,13 @@ std::pair<size_t, size_t> MinimizerMapper::align_sequence_between(const pos_t& l
                     }
                 }
             }
+#if defined(debug) || defined(dump_tips)
             if (!to_remove_handles.empty() && trim_count == 0) {
                 // We're going to trim, so dump the graph.
                 std::cerr << "warning[MinimizerMapper::align_sequence_between]: Going to trim, so dumping pre-trim.vg" << std::endl;
                 dynamic_cast<SerializableHandleGraph*>(&dagified_graph)->serialize("pre-trim.vg");
             }
+#endif
             for (auto& h : to_remove_handles) {
                 dagified_graph.destroy_handle(h);
                 trimmed = true;
@@ -3912,9 +3914,12 @@ std::pair<size_t, size_t> MinimizerMapper::align_sequence_between(const pos_t& l
                 if (alignment_name) {
                     std::cerr << " for read " << *alignment_name;
                 }
-                std::cerr << " to make post-trim.vg" << std::endl;
+#if defined(debug) || defined(dump_tips)
+                std::cerr << " to make post-trim.vg";
+                dynamic_cast<SerializableHandleGraph*>(&dagified_graph)->serialize("post-trim.vg");
+#endif
+                std::cerr << std::endl;
             }
-            dynamic_cast<SerializableHandleGraph*>(&dagified_graph)->serialize("post-trim.vg");
         }
         
         if (!is_empty(left_anchor) && !is_empty(right_anchor)) {

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -3537,6 +3537,21 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
             max_path_length,
             left_anchor, right_anchor
         );
+
+        if (local_to_base.empty()) {
+            // A possible result is that the one anchor is not reachable from
+            // the other within the length limit (at least without doubling
+            // back through one of the anchor nodes). In that case, we get an
+            // empty graph and an empty translation.
+
+            // Explain the problem but bail out on the chain connection safely,
+            // because we we expect this sometimes.
+            std::stringstream ss;
+            ss << "Cannot find an acceptable path from " << left_anchor;
+            ss << " to " << right_anchor;
+            ss << " with max path length of " << max_path_length;
+            throw ChainAlignmentFailedError(ss.str());
+        }
     } else if (!is_empty(left_anchor)) {
         // We only have the left anchor
         local_to_base = algorithms::extract_extending_graph(
@@ -3590,12 +3605,11 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
                     // nodes; there are too many copies of our shared node to
                     // work out which is which.
                     std::stringstream ss;
-                    ss << "Extracted graph from " << left_anchor;
-                    if (!is_empty(right_anchor)) {
-                        ss << " to " << right_anchor;
-                    }
+                    ss << "Extracted graph of " << local_graph.get_node_count() << " nodes";
+                    ss << " from " << left_anchor << " to " << right_anchor;
                     ss << " with max path length of " << max_path_length;
-                    ss << " but shared node appeared more than twice in the resulting translation";
+                    ss << " but shared node appeared more than twice in the resulting translation.";
+                    ss << " Graph dumped as crashdump.vg.";
                     local_graph.serialize("crashdump.vg");
                     throw std::runtime_error(ss.str());
                 }
@@ -3609,12 +3623,11 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
                 // We thought we already figured out the start node; there are
                 // too many copies of our start node to find it. 
                 std::stringstream ss;
-                ss << "Extracted graph from " << left_anchor;
-                if (!is_empty(right_anchor)) {
-                    ss << " to " << right_anchor;
-                }
+                ss << "Extracted graph of " << local_graph.get_node_count() << " nodes";
+                ss << " from " << left_anchor << " to " << right_anchor;
                 ss << " with max path length of " << max_path_length;
-                ss << " but start node appeared twice in the resulting translation";
+                ss << " but start node appeared twice in the resulting translation.";
+                ss << " Graph dumped as crashdump.vg.";
                 local_graph.serialize("crashdump.vg");
                 throw std::runtime_error(ss.str());
             }
@@ -3624,12 +3637,11 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
                 // We thought we already figured out the end node; there are
                 // too many copies of our end node to find it. 
                 std::stringstream ss;
-                ss << "Extracted graph from " << left_anchor;
-                if (!is_empty(right_anchor)) {
-                    ss << " to " << right_anchor;
-                }
+                ss << "Extracted graph of " << local_graph.get_node_count() << " nodes";
+                ss << " from " << left_anchor << " to " << right_anchor;
                 ss << " with max path length of " << max_path_length;
-                ss << " but end node appeared twice in the resulting translation";
+                ss << " but end node appeared twice in the resulting translation.";
+                ss << " Graph dumped as crashdump.vg.";
                 local_graph.serialize("crashdump.vg");
                 throw std::runtime_error(ss.str());
             }
@@ -3647,12 +3659,11 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
         }
         // Somehow the left anchor didn't come through. Complain.
         std::stringstream ss;
-        ss << "Extracted graph from " << left_anchor;
-        if (!is_empty(right_anchor)) {
-            ss << " to " << right_anchor;
-        }
+        ss << "Extracted graph of " << local_graph.get_node_count() << " nodes";
+        ss << " from " << left_anchor << " to " << right_anchor;
         ss << " with max path length of " << max_path_length;
-        ss << " but from node was not present in the resulting translation";
+        ss << " but from node was not present in the resulting translation.";
+        ss << " Graph dumped as crashdump.vg.";
         local_graph.serialize("crashdump.vg");
         throw std::runtime_error(ss.str());
     }
@@ -3660,13 +3671,11 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
     if (!is_empty(right_anchor) && local_right_anchor_id == 0) {
         // Somehow the right anchor didn't come through. Complain.
         std::stringstream ss;
-        ss << "Extracted graph";
-        if (!is_empty(left_anchor)) {
-            ss << " from " << left_anchor;
-        }
-        ss << " to " << right_anchor;
+        ss << "Extracted graph of " << local_graph.get_node_count() << " nodes";
+        ss << " from " << left_anchor << " to " << right_anchor;
         ss << " with max path length of " << max_path_length;
-        ss << " but to node was not present in the resulting translation";
+        ss << " but to node was not present in the resulting translation.";
+        ss << " Graph dumped as crashdump.vg.";
         local_graph.serialize("crashdump.vg");
         throw std::runtime_error(ss.str());
     }
@@ -3694,7 +3703,8 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
                 ss << " to " << right_anchor;
             }
             ss << " with max path length of " << max_path_length;
-            ss << " but from node local ID " << local_left_anchor_id << " was not present in the resulting graph";
+            ss << " but from node local ID " << local_left_anchor_id << " from translation was not present in the resulting graph.";
+            ss << " Graph dumped as crashdump.vg.";
             local_graph.serialize("crashdump.vg");
             throw std::runtime_error(ss.str());
         }
@@ -3718,7 +3728,8 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
             }
             ss << " to " << right_anchor;
             ss << " with max path length of " << max_path_length;
-            ss << " but to node local ID " << local_right_anchor_id << " was not present in the resulting graph";
+            ss << " but to node local ID " << local_right_anchor_id << " from translation was not present in the resulting graph.";
+            ss << " Graph dumped as crashdump.vg.";
             local_graph.serialize("crashdump.vg");
             throw std::runtime_error(ss.str());
         }
@@ -3862,6 +3873,11 @@ std::pair<size_t, size_t> MinimizerMapper::align_sequence_between(const pos_t& l
                     }
                 }
             }
+            if (!to_remove_handles.empty() && trim_count == 0) {
+                // We're going to trim, so dump the graph.
+                std::cerr << "warning[MinimizerMapper::align_sequence_between]: Going to trim, so dumping pre-trim.vg" << std::endl;
+                dynamic_cast<SerializableHandleGraph*>(&dagified_graph)->serialize("pre-trim.vg");
+            }
             for (auto& h : to_remove_handles) {
                 dagified_graph.destroy_handle(h);
                 trimmed = true;
@@ -3884,12 +3900,21 @@ std::pair<size_t, size_t> MinimizerMapper::align_sequence_between(const pos_t& l
         if (trim_count > 0) {
             #pragma omp critical (cerr)
             {
-                std::cerr << "warning[MinimizerMapper::align_sequence_between]: Trimmed back tips " << trim_count << " times on graph between " << left_anchor << " and " << right_anchor << " leaving " <<  dagified_graph.get_node_count() << " nodes and " << tip_handles.size() << " tips";
+                std::cerr << "warning[MinimizerMapper::align_sequence_between]: Trimmed back tips " << trim_count << " times on graph between " << left_anchor;
+                if (!is_empty(left_anchor)) {
+                    std::cerr << " as " << dagified_graph.get_id(left_anchor_handle) << (dagified_graph.get_is_reverse(left_anchor_handle) ? "-" : "+");
+                }
+                std::cerr << " and " << right_anchor;
+                if (!is_empty(right_anchor)) {
+                    std::cerr << " as " << dagified_graph.get_id(right_anchor_handle) << (dagified_graph.get_is_reverse(right_anchor_handle) ? "-" : "+");
+                }
+                std::cerr << " leaving " <<  dagified_graph.get_node_count() << " nodes and " << tip_handles.size() << " tips";
                 if (alignment_name) {
                     std::cerr << " for read " << *alignment_name;
                 }
-                std::cerr << std::endl;
+                std::cerr << " to make post-trim.vg" << std::endl;
             }
+            dynamic_cast<SerializableHandleGraph*>(&dagified_graph)->serialize("post-trim.vg");
         }
         
         if (!is_empty(left_anchor) && !is_empty(right_anchor)) {

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -3520,7 +3520,7 @@ void MinimizerMapper::wfa_alignment_to_alignment(const WFAAlignment& wfa_alignme
     }
 }
 
-void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const pos_t& right_anchor, size_t max_path_length, const HandleGraph& graph, const std::function<void(DeletableHandleGraph&, const std::function<std::pair<nid_t, bool>(const handle_t&)>&)>& callback) {
+void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const pos_t& right_anchor, size_t max_path_length, const HandleGraph& graph, const std::function<void(DeletableHandleGraph&, const handle_t&, const handle_t&, const std::function<std::pair<nid_t, bool>(const handle_t&)>&)>& callback) {
     
     if (is_empty(left_anchor) && is_empty(right_anchor)) {
         throw ChainAlignmentFailedError("Cannot align sequence between two unset positions");
@@ -3597,7 +3597,7 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
                     ss << " with max path length of " << max_path_length;
                     ss << " but shared node appeared more than twice in the resulting translation";
                     local_graph.serialize("crashdump.vg");
-                    throw ChainAlignmentFailedError(ss.str());
+                    throw std::runtime_error(ss.str());
                 }
                 // Whichever copy has the lower ID is the left one and
                 // whichever copy has the higher ID is the right one.
@@ -3605,8 +3605,34 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
                 local_right_anchor_id = std::max(local_right_anchor_id, kv.second);
             }
         } else if (kv.second == id(left_anchor)) {
+            if (local_left_anchor_id != 0) {
+                // We thought we already figured out the start node; there are
+                // too many copies of our start node to find it. 
+                std::stringstream ss;
+                ss << "Extracted graph from " << left_anchor;
+                if (!is_empty(right_anchor)) {
+                    ss << " to " << right_anchor;
+                }
+                ss << " with max path length of " << max_path_length;
+                ss << " but start node appeared twice in the resulting translation";
+                local_graph.serialize("crashdump.vg");
+                throw std::runtime_error(ss.str());
+            }
             local_left_anchor_id = kv.first;
         } else if (kv.second == id(right_anchor)) {
+            if (local_right_anchor_id != 0) {
+                // We thought we already figured out the end node; there are
+                // too many copies of our end node to find it. 
+                std::stringstream ss;
+                ss << "Extracted graph from " << left_anchor;
+                if (!is_empty(right_anchor)) {
+                    ss << " to " << right_anchor;
+                }
+                ss << " with max path length of " << max_path_length;
+                ss << " but end node appeared twice in the resulting translation";
+                local_graph.serialize("crashdump.vg");
+                throw std::runtime_error(ss.str());
+            }
             local_right_anchor_id = kv.first;
         }
         // TODO: Stop early when we found them all.
@@ -3628,7 +3654,7 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
         ss << " with max path length of " << max_path_length;
         ss << " but from node was not present in the resulting translation";
         local_graph.serialize("crashdump.vg");
-        throw ChainAlignmentFailedError(ss.str());
+        throw std::runtime_error(ss.str());
     }
 
     if (!is_empty(right_anchor) && local_right_anchor_id == 0) {
@@ -3642,7 +3668,7 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
         ss << " with max path length of " << max_path_length;
         ss << " but to node was not present in the resulting translation";
         local_graph.serialize("crashdump.vg");
-        throw ChainAlignmentFailedError(ss.str());
+        throw std::runtime_error(ss.str());
     }
     
     // And split by strand since we can only align to one strand
@@ -3670,7 +3696,7 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
             ss << " with max path length of " << max_path_length;
             ss << " but from node local ID " << local_left_anchor_id << " was not present in the resulting graph";
             local_graph.serialize("crashdump.vg");
-            throw ChainAlignmentFailedError(ss.str());
+            throw std::runtime_error(ss.str());
         }
         handle_t local_handle = local_graph.get_handle(local_left_anchor_id, is_rev(left_anchor));
         
@@ -3694,7 +3720,7 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
             ss << " with max path length of " << max_path_length;
             ss << " but to node local ID " << local_right_anchor_id << " was not present in the resulting graph";
             local_graph.serialize("crashdump.vg");
-            throw ChainAlignmentFailedError(ss.str());
+            throw std::runtime_error(ss.str());
         }
         handle_t local_handle = local_graph.get_handle(local_right_anchor_id, is_rev(right_anchor));
         
@@ -3706,7 +3732,21 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
         bounding_handles.push_back(overlay_handle);
     }
     
-    auto dagified_to_split = handlegraph::algorithms::dagify_from(&split_graph, bounding_handles, &dagified_graph, max_path_length);
+    // Do the dagification from those input handles.
+    auto dagification_result = handlegraph::algorithms::dagify_from(&split_graph, bounding_handles, &dagified_graph, max_path_length);
+    auto& dagified_to_split = dagification_result.first;
+    auto& anchor_handles = dagification_result.second;
+    
+    // Figure out which anchoring handle is which anchor.
+    handle_t left_anchor_handle = is_empty(left_anchor) ? handle_t() : anchor_handles.front();
+    // The right handle will be in facing-into-the-graph orientation, but we
+    // want to produce it in facing outwards orientation like the right anchor
+    // position was. 
+    handle_t right_anchor_handle = is_empty(right_anchor) ? handle_t() : dagified_graph.flip(anchor_handles.back());
+
+    // Note that in addition to cut nodes at these anchor handles, we can have
+    // strand-split version of the cut nodes' other strands.
+
     
 #ifdef debug
     std::cerr << "Dagified from " << bounding_handles.size() << " bounding handles in " << split_graph.get_node_count() << " node strand-split graph to " << dagified_graph.get_node_count() << " node DAG" << std::endl;
@@ -3718,7 +3758,7 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
         bool dagified_is_reverse = dagified_graph.get_is_reverse(h);
         auto found_in_split = dagified_to_split.find(dagified_id);
         if (found_in_split == dagified_to_split.end()) {
-            throw ChainAlignmentFailedError("ID " + std::to_string(dagified_id) + " from dagified graph not found in strand-split graph");
+            throw std::runtime_error("ID " + std::to_string(dagified_id) + " from dagified graph not found in strand-split graph");
         }
         nid_t split_id = found_in_split->second;
         handle_t split_handle = split_graph.get_handle(split_id, dagified_is_reverse);
@@ -3728,14 +3768,14 @@ void MinimizerMapper::with_dagified_local_graph(const pos_t& left_anchor, const 
         bool local_is_reverse = local_graph.get_is_reverse(local_handle);
         auto found_in_base = local_to_base.find(local_id);
         if (found_in_base == local_to_base.end()) {
-            throw ChainAlignmentFailedError("ID " + std::to_string(local_id) + " from local graph not found in full base graph");
+            throw std::runtime_error("ID " + std::to_string(local_id) + " from local graph not found in full base graph");
         }
         nid_t base_id = found_in_base->second;
         return std::make_pair(base_id, local_is_reverse);
     };
     
     // Show the graph we made and the translation function
-    callback(dagified_graph, dagified_handle_to_base);
+    callback(dagified_graph, left_anchor_handle, right_anchor_handle, dagified_handle_to_base);
 }
 
 size_t MinimizerMapper::longest_detectable_gap_in_range(const Alignment& aln, const std::string::const_iterator& sequence_begin, const std::string::const_iterator& sequence_end, const GSSWAligner* aligner) {
@@ -3770,7 +3810,10 @@ std::pair<size_t, size_t> MinimizerMapper::align_sequence_between(const pos_t& l
 
     // Get the dagified local graph, and the back translation
     MinimizerMapper::with_dagified_local_graph(left_anchor, right_anchor, max_path_length, *graph,
-        [&](DeletableHandleGraph& dagified_graph, const std::function<std::pair<nid_t, bool>(const handle_t&)>& dagified_handle_to_base) {
+        [&](DeletableHandleGraph& dagified_graph,
+            const handle_t& left_anchor_handle,
+            const handle_t& right_anchor_handle,
+            const std::function<std::pair<nid_t, bool>(const handle_t&)>& dagified_handle_to_base) {
 
 #ifdef debug
         dump_debug_graph(dagified_graph);
@@ -3784,60 +3827,30 @@ std::pair<size_t, size_t> MinimizerMapper::align_sequence_between(const pos_t& l
         std::vector<handle_t> tip_handles = handlegraph::algorithms::find_tips(&dagified_graph);
         bool trimmed;
         size_t trim_count = 0;
-        bool found_left_anchor_tip;
-        handle_t left_anchor_tip;
-        bool found_right_anchor_tip;
-        handle_t right_anchor_tip;
         do {
             trimmed = false;
-            found_left_anchor_tip = false;
-            found_right_anchor_tip = false;
             // We need to make sure to remove only one orientation of each handle
             // we remove.
             std::unordered_set<nid_t> to_remove_ids;
             std::vector<handle_t> to_remove_handles;
             for (auto& h : tip_handles) {
                 auto base_coords = dagified_handle_to_base(h);
-                if (!dagified_graph.get_is_reverse(h) && (is_empty(left_anchor) || base_coords.first == id(left_anchor))) {
+                if (!dagified_graph.get_is_reverse(h) && (is_empty(left_anchor) || h == left_anchor_handle)) {
                     // Tip is inward forward, so it's a source.
-                    // This is a head in the subgraph, and either matches a left
-                    // anchoring node or we don't have any, so keep it.
+                    // This is a head in the subgraph, and either matches the
+                    // left anchor or we don't have any, so keep it.
 #ifdef debug
                     std::cerr << "Dagified graph node " << dagified_graph.get_id(h) << " " << dagified_graph.get_is_reverse(h) << " is an acceptable source (" << base_coords.first << " " << base_coords.second << ")" << std::endl;
 #endif
-                    if (!is_empty(left_anchor)) {
-                        // If we somehow get multiple copies of the left anchor
-                        // node as tips, they need to have the same length or
-                        // our translation back to the base graph won't work.
-                        if (found_left_anchor_tip && dagified_graph.get_length(h) != dagified_graph.get_length(left_anchor_tip)) {
-                            std::stringstream ss;
-                            ss << "Different left anchor tip lengths of " << dagified_graph.get_length(h) << " and " << dagified_graph.get_length(left_anchor_tip) << " when extracting " << left_anchor << " to " << right_anchor;
-                            throw std::runtime_error(ss.str());
-                        }
-                        found_left_anchor_tip = true;
-                        left_anchor_tip = h;
-                    }
-                } else if (dagified_graph.get_is_reverse(h) && (is_empty(right_anchor) || base_coords.first == id(right_anchor))) {
+                } else if (dagified_graph.get_is_reverse(h) && (is_empty(right_anchor) || h == dagified_graph.flip(right_anchor_handle))) {
                     // Tip is inward reverse, so it's a sink.
-                    // This is a tail in the subgraph, and either matches a right
-                    // anchoring node or we don't have any, so keep it.
+                    // This is a tail in the subgraph, and either matches the right
+                    // anchor (which faces outwards) or we don't have any, so keep it.
 #ifdef debug
                     std::cerr << "Dagified graph node " << dagified_graph.get_id(h) << " " << dagified_graph.get_is_reverse(h) << " is an acceptable sink (" << base_coords.first << " " << base_coords.second << ")" << std::endl;
 #endif
-                    if (!is_empty(right_anchor)) {
-                        // If we somehow get multiple copies of the right anchor
-                        // node as tips, they need to have the same length or
-                        // our translation back to the base graph won't work.
-                        if (found_right_anchor_tip && dagified_graph.get_length(h) != dagified_graph.get_length(right_anchor_tip)) {
-                            std::stringstream ss;
-                            ss << "Different right anchor tip lengths of " << dagified_graph.get_length(h) << " and " << dagified_graph.get_length(right_anchor_tip) << " when extracting " << left_anchor << " to " << right_anchor;
-                            throw std::runtime_error(ss.str());
-                        }
-                        found_right_anchor_tip = true;
-                        right_anchor_tip = h;
-                    }
                 } else {
-                    // This is a wrong orientation of an anchoring node, or some other tip.
+                    // This is a wrong orientation or other copy of an anchoring node, or some other tip.
                     // We don't want to keep this handle
 #ifdef debug
                     std::cerr << "Dagified graph node " << dagified_graph.get_id(h) << " " << dagified_graph.get_is_reverse(h) << " is an unacceptable tip (" << base_coords.first << " " << base_coords.second << ")" << std::endl;
@@ -3951,48 +3964,27 @@ std::pair<size_t, size_t> MinimizerMapper::align_sequence_between(const pos_t& l
             auto base_coords = dagified_handle_to_base(dagified_handle);
            
             if (i == 0) {
-                // Make sure that, if the leftmost mapping is on an anchor
-                // node, it's on a copy with the correct length.
-                //
-                // Otherwise the changes we make to the offset of the leftmost
-                // mapping when it's on an anchor node won't make sense, because we
-                // won't know we were really on a cut copy.
-                // TODO: This should always be true.
-                if (!is_empty(left_anchor) && base_coords.first == id(left_anchor)) {
-                    crash_unless(dagified_graph.get_length(dagified_handle) == dagified_graph.get_length(left_anchor_tip));
-                }
-                if (!is_empty(right_anchor) && base_coords.first == id(right_anchor)) {
-                    crash_unless(dagified_graph.get_length(dagified_handle) == dagified_graph.get_length(right_anchor_tip));
+                if (!is_empty(left_anchor) && base_coords.first == id(left_anchor) && base_coords.second == is_rev(left_anchor)) {
+                    // The alignment starts on the left anchor's node. It may be on a cut copy.
+                    if (dagified_graph.get_length(dagified_handle) == dagified_graph.get_length(left_anchor_handle)) {
+                        // We're on a cut copy (the anchor itself or the strand-split version), or it was not cut.
+
+                        // Add on the offset for the cut-off outside piece of the left anchor node
+                        m->mutable_position()->set_offset(m->position().offset() + offset(left_anchor));
+                    }
+                } else if (!is_empty(right_anchor) && base_coords.first == id(right_anchor) && base_coords.second != is_rev(right_anchor)) {
+                    // The alignment starts on the right anchor's node, reading into the graph. It may be on a cut copy.
+                    if (dagified_graph.get_length(dagified_handle) == dagified_graph.get_length(right_anchor_handle)) {
+                        // We're on a cut copy (the anchor itself or the strand-split version), or it was not cut.
+
+                        // Add on the offset for the cut-off outside piece of the right anchor node
+                        m->mutable_position()->set_offset(m->position().offset() + graph->get_length(graph->get_handle(id(right_anchor))) - offset(right_anchor));
+                    }
                 }
             }
 
             m->mutable_position()->set_node_id(base_coords.first);
             m->mutable_position()->set_is_reverse(base_coords.second);
-        }
-
-        if (alignment.path().mapping_size() > 0) {
-            // If we anchored on the left, the leftmost mapping will be on a
-            // cut anchor node and its offset won't reflect the offset on the
-            // backing graph node.
-            //
-            // If we anchored on the right only, it's *still possible* for the
-            // alignment to turn around so the leftmost mapping is on the same
-            // cut anchor node we anchored the right end on, facing the other
-            // direction and offsetting from the cut point.
-            //
-            // Adjust the offset on the leftmost mapping so it counts from the
-            // edge of the entire node and not the cut-down part used for
-            // anchoring, if it's on one of the cut-down nodes.
-            Position* left_pos = alignment.mutable_path()->mutable_mapping(0)->mutable_position();
-
-            if (!is_empty(left_anchor) && left_pos->node_id() == id(left_anchor)) {
-                // If the alignment does start on the anchor node (even at 0 or at the past-end position)
-                // Add on the offset for the cut-off piece of the left anchor node
-                left_pos->set_offset(left_pos->offset() + offset(left_anchor));
-            } else if (!is_empty(right_anchor) && left_pos->node_id() == id(right_anchor)) {
-                // If the alignment starts on the right anchor, make sure to add the part that was cut off to the offset.
-                left_pos->set_offset(left_pos->offset() + graph->get_length(graph->get_handle(id(right_anchor))) - offset(right_anchor));
-            }
         }
 
         if (alignment.path().mapping_size() > 0) {
@@ -4058,7 +4050,7 @@ std::pair<size_t, size_t> MinimizerMapper::align_sequence_between_consistently(c
     // Flip and send the answer
     reverse_complement_alignment_in_place(&flipped_query, get_node_length);
     alignment = std::move(flipped_query);
-    
+
     // We shouldn't use any nonzero offsets after the first node. We're not
     // meant to be making a split alignment.
     for (size_t i = 0; i < alignment.path().mapping_size(); i++) {

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -37,7 +37,7 @@ void help_call(char** argv) {
        << "    -k, --pack FILE          Supports created from vg pack for given input graph" << endl
        << "    -m, --min-support M,N    Minimum allele support (M) and minimum site support (N) for call [default = 2,4]" << endl
        << "    -e, --baseline-error X,Y Baseline error rates for Poisson model for small (X) and large (Y) variants [default= 0.005,0.01]" << endl
-       << "    -B, --bias-mode          Use old ratio-based genotyping algorithm as opposed to porbablistic model" << endl
+       << "    -B, --bias-mode          Use old ratio-based genotyping algorithm as opposed to probablistic model" << endl
        << "    -b, --het-bias M,N       Homozygous alt/ref allele must have >= M/N times more support than the next best allele [default = 6,6]" << endl
        << "GAF options:" << endl
        << "    -G, --gaf               Output GAF genotypes instead of VCF" << endl

--- a/src/unittest/dagify.cpp
+++ b/src/unittest/dagify.cpp
@@ -453,7 +453,8 @@ namespace unittest {
         
         SECTION("dagify from n1") {
             // Dagify from n1
-            unordered_map<id_t, id_t> trans = handlealgs::dagify_from(&graph, {n1}, &dagified, 100);
+            auto result = handlealgs::dagify_from(&graph, {n1}, &dagified, 100);
+            unordered_map<id_t, id_t>& trans = result.first;
             
             // Must actually be a DAG
             REQUIRE(handlealgs::is_acyclic(&dagified));
@@ -473,11 +474,18 @@ namespace unittest {
                 REQUIRE(acceptable_tails.count(trans[dagified.get_id(tail)]));
                 REQUIRE(dagified.get_is_reverse(tail) == false);
             }
+            
+            // The dagified start version of our starting handle should be the head.
+            std::vector<handle_t> embedded_starts = result.second;
+            REQUIRE(embedded_starts.size() == 1);
+            REQUIRE(heads.count(embedded_starts.front()));
+
         }
 
         SECTION("dagify from n3 reverse") {
             // Dagify from n3 reverse
-            unordered_map<id_t, id_t> trans = handlealgs::dagify_from(&graph, {graph.flip(n3)}, &dagified, 100);
+            auto result = handlealgs::dagify_from(&graph, {graph.flip(n3)}, &dagified, 100);
+            unordered_map<id_t, id_t>& trans = result.first;
             
             // Must actually be a DAG
             REQUIRE(handlealgs::is_acyclic(&dagified));
@@ -496,6 +504,12 @@ namespace unittest {
                 REQUIRE(trans[dagified.get_id(head)] == graph.get_id(n1));
                 REQUIRE(dagified.get_is_reverse(head) == graph.get_is_reverse(n1));
             }
+
+            // The dagified start version of our starting handle should be the
+            // reverse of the tail.
+            std::vector<handle_t> embedded_starts = result.second;
+            REQUIRE(embedded_starts.size() == 1);
+            REQUIRE(tails.count(dagified.flip(embedded_starts.front())));
         }
     }
 }

--- a/src/unittest/vg_algorithms.cpp
+++ b/src/unittest/vg_algorithms.cpp
@@ -1085,6 +1085,40 @@ TEST_CASE( "Connecting graph extraction pruning options perform as expected", "[
     }
 }
         
+TEST_CASE( "Connecting graph extraction works on a cool loop without leaving extra tips in strict max length mode",
+           "[algorithms][extract_connecting_graph]" ) {
+                  
+    string graph_json = R"(
+    {"edge": [{"from": "185927720", "to": "185927722"}, {"from": "185927721", "from_start": true, "to": "185927722"}, {"from": "185927722", "to": "186681786", "to_end": true}, {"from": "185927722", "to": "185927723"}, {"from": "186681786", "to": "186683083"}, {"from": "186681786", "from_start": true, "to": "186681787", "to_end": true}, {"from": "186681787", "to": "186683069", "to_end": true}, {"from": "186681787", "from_start": true, "to": "186681789"}, {"from": "186681787", "from_start": true, "to": "186681788", "to_end": true}, {"from": "186681788", "from_start": true, "to": "186681790", "to_end": true}, {"from": "186681789", "to": "186681790", "to_end": true}, {"from": "186681790", "from_start": true, "to": "186681792", "to_end": true}, {"from": "186683069", "from_start": true, "to": "186683079", "to_end": true}, {"from": "186683079", "from_start": true, "to": "186683080", "to_end": true}, {"from": "186683080", "from_start": true, "to": "186683081", "to_end": true}, {"from": "186683081", "from_start": true, "to": "186683083", "to_end": true}], "node": [{"id": "185927720", "sequence": "G"}, {"id": "185927721", "sequence": "A"}, {"id": "185927722", "sequence": "ACCGGG"}, {"id": "185927723", "sequence": "AGTGGGGG"}, {"id": "186681786", "sequence": "C"}, {"id": "186681787", "sequence": "TGGGAGTCTAAGTCTCTTTTGATCACACTTTAAAGACCAAAAGGTAGAAGCGCAAAGACGTTATCTGTCCAATATTACAAACCTAGTAAGTGGTGGAATTTGGCCTTGAACCCAGATCTGTAACTCCAGAGCCGAAGTGCTTCACCCACCTCCCTGTGGTG"}, {"id": "186681788", "sequence": "G"}, {"id": "186681789", "sequence": "T"}, {"id": "186681790", "sequence": "TAT"}, {"id": "186681792", "sequence": "T"}, {"id": "186683069", "sequence": "G"}, {"id": "186683079", "sequence": "G"}, {"id": "186683080", "sequence": "TACCCCGGAATCCCTGCCGCGGCCCCTCGGGCCTGTCCACATCCCTCTGCCCCTCCCAGACCTCTGTCCTTCCACCAATCGCCTCCCGCAGCCCCGAGCCGCCACTCCCAGTCCCCCGAGTCCCTGCCGCGCGCCCTCGCGCCTGTCCACATCCCTCTGCCCATCCGAGACCTCTGTCCTTACACCACTAGCCACCCCACGTGGGACTTCCATGGCTTCTGAGTACAAGGCCAGCCCCCCGGCCCACCAGCTTTCGGAATGCCTGCTTACCTCTTTTTCTGTAGA"}, {"id": "186683081", "sequence": "CCGG"}, {"id": "186683083", "sequence": "C"}]}
+    )";
+            
+    Graph source;
+    json2pb(source, graph_json.c_str(), graph_json.size());
+            
+    VG vg;
+    vg.extend(source);
+            
+    bdsg::HashGraph extractor;
+            
+    auto max_dist = 9999;
+    pos_t src_pos = make_pos_t(186681787, false, 161);
+    pos_t dest_pos = make_pos_t(186681787, true, 131);
+
+    // If we have strict max length set to false, we may get extra tips.
+    unordered_map<id_t, id_t> connect_trans = algorithms::extract_connecting_graph(&vg, &extractor,  max_dist, src_pos, dest_pos, false);
+    std::vector<handle_t> tip_handles = handlegraph::algorithms::find_tips(&extractor);
+    // There ought to be at least the two tips
+    REQUIRE(tip_handles.size() >= 2);
+   
+    extractor.clear();
+
+    // If we have strict connecting-ness set to true, we won't get any extra tips.
+    connect_trans = algorithms::extract_connecting_graph(&vg, &extractor,  max_dist, src_pos, dest_pos, true);
+    tip_handles = handlegraph::algorithms::find_tips(&extractor);
+    // There ought to be just the two tips
+    REQUIRE(tip_handles.size() == 2);
+}
+
 TEST_CASE( "Connecting graph extraction works on a particular case without leaving dangling edges",
            "[algorithms][extract_connecting_graph]" ) {
                   


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe will no longer cut nodes wrong when anchoring an extracted subgraph's end on the reverse strand of the same node as its start
 * Giraffe will make fewer tips, by enforcing path length strictly for connecting subgraph extraction. Dagification will still produce tips that will still be trimmed.

## Description
This changes the way Giraffe extracts connecting subgraphs to fix some bugs, add some tests, and remove ways in which we could lose track of which nodes in the processed extracted subgraph are actually the anchoring ones.

I now think I know where tips in the graph are coming from, but I'm not currently ready to write a dagification algorithm that avoids generating them by construction. I've turned on strict path length checking in the connecting graph extraction, which cuts out a lot of tips that we didn't need to have.

I'm also replacing *more* `ChainAlignmentFailedError`s with actual fatal errors, for cases I really think should not happen. If we detect any of these, I don't understand what's going on and we shouldn't be shipping a paper until someone does.