### PR TITLE
fix call -v to use consistent ref traversals

### DIFF
--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -1201,9 +1201,11 @@ bool VCFGenotyper::call_snarl(const Snarl& snarl) {
                     if (j < trav_genotype.size() - 1) {
                         vcf_genotype += "/";
                     }
-                    vcf_alleles.push_back(vcf_allele);
-                    used_vcf_alleles.insert(vcf_allele);
-                    vcf_traversals[vcf_allele] = travs[trav_allele];
+                    if (!used_vcf_alleles.count(vcf_allele)) {                    
+                        vcf_alleles.push_back(vcf_allele);
+                        used_vcf_alleles.insert(vcf_allele);
+                        vcf_traversals[vcf_allele] = travs[trav_allele];
+                    }
                 }
                 // add traversals that correspond to vcf genotypes that are not
                 // present in the traversal_genotypes

--- a/src/subcommand/simplify_main.cpp
+++ b/src/subcommand/simplify_main.cpp
@@ -30,10 +30,8 @@ void help_simplify(char** argv) {
          << "    -b, --bed-in           read in the given BED file in the cordinates of the original paths" << endl
          << "    -B, --bed-out          output transformed features in the coordinates of the new paths" << endl
          << "path snarl simplifier options:" << endl
-         << "    -m, --min-size N       flatten sites (to reference) whose maximum traversal has < N bp (default: 10)" << endl
-
-         << "small snarl simplifier options:" << endl
          << "    -P, --path-prefix S    [NECESSARY TO SCALE PAST TINY GRAPHS] all paths whose names begins with S selected as reference paths (default: all reference-sense paths)" << endl
+         << "small snarl simplifier options:" << endl       
          << "    -m, --min-size N       remove leaf sites with fewer than N bases (with -P, uses max allele length) involved (default: 10)" << endl
          << "    -i, --max-iterations N perform up to N iterations of simplification (default: 10)" << endl
          << "    -L, --cluster F        cluster traversals whose (handle) Jaccard coefficient is >= F together (default: 1.0)" << endl

--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -686,7 +686,7 @@ void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const
     // both types of normalization selected. we're going to double the iterations
     // and alternate between them
     int64_t input_max_snarl_length = max_snarl_length;
-    int64_t input_min_jaccard = min_jaccard;
+    double input_min_jaccard = min_jaccard;
     int64_t empty_count = 0;
     bool alternate = max_snarl_length > 0 && min_jaccard < 1.0;
     if (alternate) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fix erroneous `INFO` tags (`AT`,`DP`,etc) in `vg call -v` output

## Description

this took a lot of digging through long-forgotten code, so some notes of what I (re)learned:

`vg call` genotypes snarls in the graph by finding the most likely pair of traversals (according the the pack file), and converting them into alleles. 

When running `vg call -v`, the variants are output with respect to an input VCF rather than the snarls in the graph.  Path fragments from `vg construct -a` are used to translate from graph back to VCF space.  In the case of overlapping variants, it's possible that there is a one-to-many relationship between graph snarls and VCF sites. 

The snarl genotyping itself is done with the normal `call` code and works about as well as that does.  But when outputting the (potentially many) VCF sites for the snarl, it recomputes local info tags for each, according to its own genotype.  And this seems to be where the bug was: Since many traversals in the graph could correspond to the same VCF allele, the same genotype could be represented many different ways (in graph space).  And there was a bug in the code where the allele chosen was determined somewhat arbitrarily according to how the whole snarl was genotyped.  This could lead to weird behaviour where, you could see higher AD for the reference allele on a filtered GAM - it's because the different genotype would trigger a different reference traversal being selected behind the scenes.  While equivalent for the genotype itself, the metadata is inconsistent. 

So this PR hacks the traversal->allele mapping logic to always use the first found in case of a tie.  This applies a canonical order and should be consistent between runs.  It also ensures that the reference path is always used when computing INFO for the 0 allele.  

Hopefully helps out with #4443 (but will wait until confirmation before merging)