### PR TITLE
Better GBWT/GBWTGraph serialization error handling

### DIFF
--- a/src/gaf_sorter.cpp
+++ b/src/gaf_sorter.cpp
@@ -516,7 +516,7 @@ void merge_gaf_records(std::unique_ptr<std::vector<GAFSorterFile>> inputs, GAFSo
     std::priority_queue<std::pair<GAFSorterRecord, size_t>> queue;
     for (size_t i = 0; i < records.size(); i++) {
         if (!records[i].empty()) {
-            queue.emplace(records[i].front(), i);
+            queue.emplace(std::move(records[i].front()), i);
             records[i].pop_front();
         }
     }
@@ -541,7 +541,7 @@ void merge_gaf_records(std::unique_ptr<std::vector<GAFSorterFile>> inputs, GAFSo
             }
         }
         if (!records[source].empty()) {
-            queue.emplace(records[source].front(), source);
+            queue.emplace(std::move(records[source].front()), source);
             records[source].pop_front();
         }
     }

--- a/src/gaf_sorter.hpp
+++ b/src/gaf_sorter.hpp
@@ -7,6 +7,7 @@
  * TODO: This could be an independent utility.
  * TODO: Asynchronous I/O.
  * TODO: Option for automatic detection of merge width to guarantee <= 2 rounds.
+ * TODO: Option for giving approximate batch size in bytes.
  * TODO: Switch to std::string_view when we can.
  */
 

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -144,10 +144,15 @@ void save_r_index(const gbwt::FastLocate& index, const std::string& filename, bo
     if (show_progress) {
         std::cerr << "Saving r-index to " << filename << std::endl;
     }
-    if (!sdsl::store_to_file(index, filename)) {
-        std::cerr << "error: [save_r_index()] cannot write r-index to " << filename << std::endl;
-        std::exit(EXIT_FAILURE);
+
+    // This will mimic Simple-SDS serialization.
+    std::ofstream out(filename, std::ios_base::binary);
+    if (!out) {
+        throw sdsl::simple_sds::CannotOpenFile(filename, true);
     }
+    out.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+    index.serialize(out);
+    out.close();
 }
 
 //------------------------------------------------------------------------------

--- a/src/gbwt_helper.cpp
+++ b/src/gbwt_helper.cpp
@@ -168,7 +168,12 @@ void GBWTHandler::use_compressed() {
         this->dynamic = gbwt::DynamicGBWT();
         this->in_use = index_compressed;
     } else {
-        load_gbwt(this->compressed, this->filename, this->show_progress);
+        try {
+            load_gbwt(this->compressed, this->filename, this->show_progress);
+        } catch (const std::runtime_error& e) {
+            std::cerr << "error: [GBWTHandler] cannot load compressed GBWT from " << this->filename << ": " << e.what() << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
         this->in_use = index_compressed;
     }
 }
@@ -184,7 +189,12 @@ void GBWTHandler::use_dynamic() {
         this->compressed = gbwt::GBWT();
         this->in_use = index_dynamic;
     } else {
-        load_gbwt(this->dynamic, this->filename, this->show_progress);
+        try {
+            load_gbwt(this->dynamic, this->filename, this->show_progress);
+        } catch (const std::runtime_error& e) {
+            std::cerr << "error: [GBWTHandler] cannot load dynamic GBWT from " << this->filename << ": " << e.what() << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
         this->in_use = index_dynamic;
     }
 }
@@ -208,13 +218,18 @@ void GBWTHandler::unbacked() {
 }
 
 void GBWTHandler::serialize(const std::string& new_filename) {
-    if (this->in_use == index_none) {
-        std::cerr << "warning: [GBWTHandler] no GBWT to serialize" << std::endl;
-        return;
-    } else if (this->in_use == index_compressed) {
-        save_gbwt(this->compressed, new_filename, this->show_progress);
-    } else {
-        save_gbwt(this->dynamic, new_filename, this->show_progress);
+    try {
+        if (this->in_use == index_none) {
+            std::cerr << "warning: [GBWTHandler] no GBWT to serialize" << std::endl;
+            return;
+        } else if (this->in_use == index_compressed) {
+            save_gbwt(this->compressed, new_filename, this->show_progress);
+        } else {
+            save_gbwt(this->dynamic, new_filename, this->show_progress);
+        }
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [GBWTHandler] cannot save GBWT to " << new_filename << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
     }
     this->filename = new_filename;
 }

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -70,21 +70,11 @@ gbwt::size_type gbwt_node_width(const HandleGraph& graph);
 //------------------------------------------------------------------------------
 
 /*
-    These are the proper ways of saving and loading GBWT structures.
-    Loading them directly with `vg::io::VPKG::load_one` is also supported, but
-    exceptions must then be handled by the caller.
+    These are the proper ways of saving and loading GBWT structures. In case of
+    a failure, these will print an error message and exit the program.
 
-    In case of a failure, the loaders will:
-    * Throw an exception if sanity checks fail.
-    * Fail silently or throw an exception if reading the input fails (depends on libvgio).
-    * Print an error message and exit if the file does not exist or is not of the right type.
-    And then catch the exception, print it, and exit.
-
-    In case of a failure, the savers will:
-    * Throw an exception if writing to the output fails.
-    And then catch the exception, print it, and exit.
-
-    All exceptions are derived from std::runtime_error.
+    The vg::io::VPKG interface is effectively the same, but it does not handle
+    errors in a consistent way.
 */
 
 /// Load a compressed GBWT from the file.

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -71,7 +71,15 @@ gbwt::size_type gbwt_node_width(const HandleGraph& graph);
 
 /*
     These are the proper ways of saving and loading GBWT structures.
-    Loading with `vg::io::VPKG::load_one` is also supported.
+    Loading them directly with `vg::io::VPKG::load_one` is also supported.
+
+    In case of a failure, the savers will fail silently or exit with std::exit().
+
+    In case of a failure, the loaders will:
+    * Throw an exception if sanity checks fail.
+    * Throw an exception or fail silently if reading a Simple-SDS input fails.
+    * Exit with std::exit() or fail silently if reading an SDSL input fails.
+    The exceptions are derived from std::runtime_error.
 */
 
 /// Load a compressed GBWT from the file.

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -71,15 +71,18 @@ gbwt::size_type gbwt_node_width(const HandleGraph& graph);
 
 /*
     These are the proper ways of saving and loading GBWT structures.
-    Loading them directly with `vg::io::VPKG::load_one` is also supported.
+    Loading them directly with `vg::io::VPKG::load_one` is also supported, but
+    exceptions must then be handled by the caller.
 
     In case of a failure, the loaders will:
     * Throw an exception if sanity checks fail.
     * Fail silently or throw an exception if reading the input fails (depends on libvgio).
     * Print an error message and exit if the file does not exist or is not of the right type.
+    And then catch the exception, print it, and exit.
 
     In case of a failure, the savers will:
     * Throw an exception if writing to the output fails.
+    And then catch the exception, print it, and exit.
 
     All exceptions are derived from std::runtime_error.
 */

--- a/src/gbwt_helper.hpp
+++ b/src/gbwt_helper.hpp
@@ -73,13 +73,15 @@ gbwt::size_type gbwt_node_width(const HandleGraph& graph);
     These are the proper ways of saving and loading GBWT structures.
     Loading them directly with `vg::io::VPKG::load_one` is also supported.
 
-    In case of a failure, the savers will fail silently or exit with std::exit().
-
     In case of a failure, the loaders will:
     * Throw an exception if sanity checks fail.
-    * Throw an exception or fail silently if reading a Simple-SDS input fails.
-    * Exit with std::exit() or fail silently if reading an SDSL input fails.
-    The exceptions are derived from std::runtime_error.
+    * Fail silently or throw an exception if reading the input fails (depends on libvgio).
+    * Print an error message and exit if the file does not exist or is not of the right type.
+
+    In case of a failure, the savers will:
+    * Throw an exception if writing to the output fails.
+
+    All exceptions are derived from std::runtime_error.
 */
 
 /// Load a compressed GBWT from the file.

--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -153,11 +153,13 @@ void save_minimizer(const gbwtgraph::DefaultMinimizerIndex& index, const std::st
     if (show_progress) {
         std::cerr << "Saving MinimizerIndex to " << filename << std::endl;
     }
+
+    // This will mimic Simple-SDS serialization.
     std::ofstream out(filename, std::ios_base::binary);
     if (!out) {
-        std::cerr << "error: [save_minimizer()] cannot open file " << filename << " for writing" << std::endl;
-        std::exit(EXIT_FAILURE);
+        throw sdsl::simple_sds::CannotOpenFile(filename, true);
     }
+    out.exceptions(std::ofstream::badbit | std::ofstream::failbit);
     index.serialize(out);
     out.close();
 }

--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -64,7 +64,13 @@ void load_gbwtgraph(gbwtgraph::GBWTGraph& graph, const std::string& filename, bo
     if (show_progress) {
         std::cerr << "Loading GBWTGraph from " << filename << std::endl;
     }
-    std::unique_ptr<gbwtgraph::GBWTGraph> loaded = vg::io::VPKG::load_one<gbwtgraph::GBWTGraph>(filename);
+    std::unique_ptr<gbwtgraph::GBWTGraph> loaded;
+    try {
+        loaded = vg::io::VPKG::load_one<gbwtgraph::GBWTGraph>(filename);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [load_gbwtgraph()] cannot load GBWTGraph " << filename << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
     if (loaded.get() == nullptr) {
         std::cerr << "error: [load_gbwtgraph()] cannot load GBWTGraph " << filename << std::endl;
         std::exit(EXIT_FAILURE);
@@ -76,7 +82,13 @@ void load_gbz(gbwtgraph::GBZ& gbz, const std::string& filename, bool show_progre
     if (show_progress) {
         std::cerr << "Loading GBZ from " << filename << std::endl;
     }
-    std::unique_ptr<gbwtgraph::GBZ> loaded = vg::io::VPKG::load_one<gbwtgraph::GBZ>(filename);
+    std::unique_ptr<gbwtgraph::GBZ> loaded;
+    try {
+        loaded = vg::io::VPKG::load_one<gbwtgraph::GBZ>(filename);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [load_gbz()] cannot load GBZ " << filename << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
     if (loaded.get() == nullptr) {
         std::cerr << "error: [load_gbz()] cannot load GBZ " << filename << std::endl;
         std::exit(EXIT_FAILURE);
@@ -88,14 +100,20 @@ void load_gbz(gbwt::GBWT& index, gbwtgraph::GBWTGraph& graph, const std::string&
     if (show_progress) {
         std::cerr << "Loading GBWT and GBWTGraph from " << filename << std::endl;
     }
-    std::unique_ptr<gbwtgraph::GBZ> loaded = vg::io::VPKG::load_one<gbwtgraph::GBZ>(filename);
+    std::unique_ptr<gbwtgraph::GBZ> loaded;
+    try {
+        loaded = vg::io::VPKG::load_one<gbwtgraph::GBZ>(filename);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [load_gbz()] cannot load GBZ " << filename << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
     if (loaded.get() == nullptr) {
         std::cerr << "error: [load_gbz()] cannot load GBZ " << filename << std::endl;
         std::exit(EXIT_FAILURE);
     }
     index = std::move(loaded->index);
     graph = std::move(loaded->graph);
-    graph.set_gbwt(index); // We moved the GBWT out from the GBZ, so we have to update the pointer.
+    graph.set_gbwt_address(index); // We moved the GBWT out from the GBZ, so we have to update the pointer.
 }
 
 void load_gbz(gbwtgraph::GBZ& gbz, const std::string& gbwt_name, const std::string& graph_name, bool show_progress) {
@@ -109,7 +127,13 @@ void load_minimizer(gbwtgraph::DefaultMinimizerIndex& index, const std::string& 
     if (show_progress) {
         std::cerr << "Loading MinimizerIndex from " << filename << std::endl;
     }
-    std::unique_ptr<gbwtgraph::DefaultMinimizerIndex> loaded = vg::io::VPKG::load_one<gbwtgraph::DefaultMinimizerIndex>(filename);
+    std::unique_ptr<gbwtgraph::DefaultMinimizerIndex> loaded;
+    try {
+        loaded = vg::io::VPKG::load_one<gbwtgraph::DefaultMinimizerIndex>(filename);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [load_minimizer()] cannot load MinimizerIndex " << filename << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
     if (loaded.get() == nullptr) {
         std::cerr << "error: [load_minimizer()] cannot load MinimizerIndex " << filename << std::endl;
         std::exit(EXIT_FAILURE);
@@ -121,14 +145,24 @@ void save_gbwtgraph(const gbwtgraph::GBWTGraph& graph, const std::string& filena
     if (show_progress) {
         std::cerr << "Saving GBWTGraph to " << filename << std::endl;
     }
-    graph.serialize(filename);
+    try {
+        graph.serialize(filename);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [save_gbwtgraph()] cannot save GBWTGraph to " << filename << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
 }
 
 void save_gbz(const gbwtgraph::GBZ& gbz, const std::string& filename, bool show_progress) {
     if (show_progress) {
         std::cerr << "Saving GBZ to " << filename << std::endl;
     }
-    sdsl::simple_sds::serialize_to(gbz, filename);
+    try {
+        sdsl::simple_sds::serialize_to(gbz, filename);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [save_gbz()] cannot save GBZ to " << filename << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
 }
 
 void save_gbz(const gbwt::GBWT& index, gbwtgraph::GBWTGraph& graph, const std::string& filename, bool show_progress) {
@@ -140,7 +174,12 @@ void save_gbz(const gbwt::GBWT& index, gbwtgraph::GBWTGraph& graph, const std::s
         std::cerr << "error: [save_gbz()] cannot open file " << filename << " for writing" << std::endl;
         std::exit(EXIT_FAILURE);
     }
-    gbwtgraph::GBZ::simple_sds_serialize(index, graph, out);
+    try {
+        gbwtgraph::GBZ::simple_sds_serialize(index, graph, out);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [save_gbz()] cannot save GBWT and GBWTGraph to " << filename << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
     out.close();
 }
 
@@ -156,11 +195,16 @@ void save_minimizer(const gbwtgraph::DefaultMinimizerIndex& index, const std::st
 
     // This will mimic Simple-SDS serialization.
     std::ofstream out(filename, std::ios_base::binary);
-    if (!out) {
-        throw sdsl::simple_sds::CannotOpenFile(filename, true);
+    try {
+        if (!out) {
+            throw sdsl::simple_sds::CannotOpenFile(filename, true);
+        }
+        out.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+        index.serialize(out);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [save_minimizer()] cannot save MinimizerIndex to " << filename << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
     }
-    out.exceptions(std::ofstream::badbit | std::ofstream::failbit);
-    index.serialize(out);
     out.close();
 }
 

--- a/src/gbwtgraph_helper.hpp
+++ b/src/gbwtgraph_helper.hpp
@@ -26,13 +26,16 @@ gbwtgraph::GFAParsingParameters get_best_gbwtgraph_gfa_parsing_parameters();
     These are the proper ways of saving and loading GBWTGraph structures.
     Loading them directly with `vg::io::VPKG::load_one` is also supported.
 
-    In case of a failure, the savers will fail silently or exit with std::exit().
-
     In case of a failure, the loaders will:
     * Throw an exception if sanity checks fail.
-    * Throw an exception or fail silently if reading a Simple-SDS input fails.
-    * Exit with std::exit() or fail silently if reading an SDSL input fails.
-    The exceptions are derived from std::runtime_error.
+    * Fail silently or throw an exception if reading the input fails (depends on libvgio).
+    * Print an error message and exit if the file does not exist or is not of the right type.
+
+    In case of a failure, the savers will:
+    * Fail silently if writing GBWTGraph fails. (GBWTGraph files are deprecated anyway.)
+    * Throw an exception if writing any other object to the output fails.
+
+    All exceptions are derived from std::runtime_error.
 */
 
 /// Load GBWTGraph from the file.

--- a/src/gbwtgraph_helper.hpp
+++ b/src/gbwtgraph_helper.hpp
@@ -23,22 +23,11 @@ namespace vg {
 gbwtgraph::GFAParsingParameters get_best_gbwtgraph_gfa_parsing_parameters();
 
 /*
-    These are the proper ways of saving and loading GBWTGraph structures.
-    Loading them directly with `vg::io::VPKG::load_one` is also supported, but
-    exceptions must then be handled by the caller.
+    These are the proper ways of saving and loading GBWTGraph structures. In
+    case of a failure, these will print an error message and exit the program.
 
-    In case of a failure, the loaders will:
-    * Throw an exception if sanity checks fail.
-    * Fail silently or throw an exception if reading the input fails (depends on libvgio).
-    * Print an error message and exit if the file does not exist or is not of the right type.
-    And then catch the exception, print it, and exit.
-
-    In case of a failure, the savers will:
-    * Fail silently if writing GBWTGraph fails. (GBWTGraph files are deprecated anyway.)
-    * Throw an exception if writing any other object to the output fails.
-    And then catch the exception, print it, and exit.
-
-    All exceptions are derived from std::runtime_error.
+    The vg::io::VPKG interface is effectively the same, but it does not handle
+    errors in a consistent way.
 */
 
 /// Load GBWTGraph from the file.

--- a/src/gbwtgraph_helper.hpp
+++ b/src/gbwtgraph_helper.hpp
@@ -24,7 +24,15 @@ gbwtgraph::GFAParsingParameters get_best_gbwtgraph_gfa_parsing_parameters();
 
 /*
     These are the proper ways of saving and loading GBWTGraph structures.
-    Loading with `vg::io::VPKG::load_one` is also supported.
+    Loading them directly with `vg::io::VPKG::load_one` is also supported.
+
+    In case of a failure, the savers will fail silently or exit with std::exit().
+
+    In case of a failure, the loaders will:
+    * Throw an exception if sanity checks fail.
+    * Throw an exception or fail silently if reading a Simple-SDS input fails.
+    * Exit with std::exit() or fail silently if reading an SDSL input fails.
+    The exceptions are derived from std::runtime_error.
 */
 
 /// Load GBWTGraph from the file.

--- a/src/gbwtgraph_helper.hpp
+++ b/src/gbwtgraph_helper.hpp
@@ -24,16 +24,19 @@ gbwtgraph::GFAParsingParameters get_best_gbwtgraph_gfa_parsing_parameters();
 
 /*
     These are the proper ways of saving and loading GBWTGraph structures.
-    Loading them directly with `vg::io::VPKG::load_one` is also supported.
+    Loading them directly with `vg::io::VPKG::load_one` is also supported, but
+    exceptions must then be handled by the caller.
 
     In case of a failure, the loaders will:
     * Throw an exception if sanity checks fail.
     * Fail silently or throw an exception if reading the input fails (depends on libvgio).
     * Print an error message and exit if the file does not exist or is not of the right type.
+    And then catch the exception, print it, and exit.
 
     In case of a failure, the savers will:
     * Fail silently if writing GBWTGraph fails. (GBWTGraph files are deprecated anyway.)
     * Throw an exception if writing any other object to the output fails.
+    And then catch the exception, print it, and exit.
 
     All exceptions are derived from std::runtime_error.
 */

--- a/src/io/register_loader_saver_gbwt.cpp
+++ b/src/io/register_loader_saver_gbwt.cpp
@@ -24,8 +24,12 @@ void register_loader_saver_gbwt() {
     Registry::register_bare_loader_saver_with_magic<gbwt::GBWT>("GBWT", magic_string, [](istream& input) -> void* {
         // Allocate a GBWT
         gbwt::GBWT* index = new gbwt::GBWT();
-        
-        // Load it
+
+        // Load it. In case of a failure, this will:
+        // * Throw an exception if sanity checks fail.
+        // * Throw an exception or fail silently if reading a Simple-SDS input fails.
+        // * Exit with std::exit() or fail silently if reading an SDSL input fails.
+        // The exceptions are derived from std::runtime_error.
         index->load(input);
         
         // Return it so the caller owns it.
@@ -39,8 +43,12 @@ void register_loader_saver_gbwt() {
     Registry::register_bare_loader_saver_with_magic<gbwt::DynamicGBWT>("GBWT", magic_string, [](istream& input) -> void* {
         // Allocate a DynamicGBWT
         gbwt::DynamicGBWT* index = new gbwt::DynamicGBWT();
-        
-        // Load it
+
+        // Load it. In case of a failure, this will:
+        // * Throw an exception if sanity checks fail.
+        // * Throw an exception or fail silently if reading a Simple-SDS input fails.
+        // * Exit with std::exit() or fail silently if reading an SDSL input fails.
+        // The exceptions are derived from std::runtime_error.
         index->load(input);
         
         // Return it so the caller owns it.

--- a/src/io/register_loader_saver_gbwt.cpp
+++ b/src/io/register_loader_saver_gbwt.cpp
@@ -27,8 +27,7 @@ void register_loader_saver_gbwt() {
 
         // Load it. In case of a failure, this will:
         // * Throw an exception if sanity checks fail.
-        // * Throw an exception or fail silently if reading a Simple-SDS input fails.
-        // * Exit with std::exit() or fail silently if reading an SDSL input fails.
+        // * Fail silently if reading the input fails.
         // The exceptions are derived from std::runtime_error.
         index->load(input);
         
@@ -36,6 +35,7 @@ void register_loader_saver_gbwt() {
         return (void*) index;
     }, [](const void* index_void, ostream& output) {
         // Cast to GBWT and serialize to the stream.
+        // This will fail silently if writing to the output stream fails.
         assert(index_void != nullptr);
         ((const gbwt::GBWT*) index_void)->simple_sds_serialize(output);
     });
@@ -46,8 +46,7 @@ void register_loader_saver_gbwt() {
 
         // Load it. In case of a failure, this will:
         // * Throw an exception if sanity checks fail.
-        // * Throw an exception or fail silently if reading a Simple-SDS input fails.
-        // * Exit with std::exit() or fail silently if reading an SDSL input fails.
+        // * Fail silently if reading the input fails.
         // The exceptions are derived from std::runtime_error.
         index->load(input);
         
@@ -55,6 +54,7 @@ void register_loader_saver_gbwt() {
         return (void*) index;
     }, [](const void* index_void, ostream& output) {
         // Cast to DynamicGBWT and serialize to the stream.
+        // This will fail silently if writing to the output stream fails.
         assert(index_void != nullptr);
         ((const gbwt::DynamicGBWT*) index_void)->simple_sds_serialize(output);
     });

--- a/src/io/register_loader_saver_gbwtgraph.cpp
+++ b/src/io/register_loader_saver_gbwtgraph.cpp
@@ -29,8 +29,7 @@ void register_loader_saver_gbwtgraph() {
 
         // Load it. In case of a failure, this will:
         // * Throw an exception if sanity checks fail.
-        // * Throw an exception or fail silently if reading a Simple-SDS input fails.
-        // * Exit with std::exit() or fail silently if reading an SDSL input fails.
+        // * Fail silently if reading the input fails.
         // The exceptions are derived from std::runtime_error.
         graph->deserialize(input);
         
@@ -40,6 +39,7 @@ void register_loader_saver_gbwtgraph() {
         assert(graph_void != nullptr);
         // Serialize in the SDSL format, which is larger than the simple-sds format but faster to load.
         // If we want to use the simple-sds format, we can serialize GBZ instead.
+        // This will fail silently if writing to the output stream fails.
         static_cast<const gbwtgraph::GBWTGraph*>(graph_void)->serialize(output);
     });
 }

--- a/src/io/register_loader_saver_gbwtgraph.cpp
+++ b/src/io/register_loader_saver_gbwtgraph.cpp
@@ -26,6 +26,12 @@ void register_loader_saver_gbwtgraph() {
 
     Registry::register_bare_loader_saver_with_magic<gbwtgraph::GBWTGraph>("GBWTGraph", magic_string, [](istream& input) -> void* {
         gbwtgraph::GBWTGraph* graph = new gbwtgraph::GBWTGraph();
+
+        // Load it. In case of a failure, this will:
+        // * Throw an exception if sanity checks fail.
+        // * Throw an exception or fail silently if reading a Simple-SDS input fails.
+        // * Exit with std::exit() or fail silently if reading an SDSL input fails.
+        // The exceptions are derived from std::runtime_error.
         graph->deserialize(input);
         
         // Return the graph so the caller owns it.

--- a/src/io/register_loader_saver_gbz.cpp
+++ b/src/io/register_loader_saver_gbz.cpp
@@ -21,6 +21,10 @@ void register_loader_saver_gbz() {
 
     Registry::register_bare_loader_saver_with_magic<gbwtgraph::GBZ>("GBZ", magic_string, [](std::istream& input) -> void* {
         gbwtgraph::GBZ* result = new gbwtgraph::GBZ();
+        // Load it. In case of a failure, this will:
+        // * Throw an exception if sanity checks fail.
+        // * Throw an exception or fail silently if reading the input fails.
+        // The exceptions are derived from std::runtime_error.
         result->simple_sds_load(input);
         return reinterpret_cast<void*>(result);
     }, [](const void* gbz_void, std::ostream& output) {

--- a/src/io/register_loader_saver_gbz.cpp
+++ b/src/io/register_loader_saver_gbz.cpp
@@ -21,13 +21,16 @@ void register_loader_saver_gbz() {
 
     Registry::register_bare_loader_saver_with_magic<gbwtgraph::GBZ>("GBZ", magic_string, [](std::istream& input) -> void* {
         gbwtgraph::GBZ* result = new gbwtgraph::GBZ();
+
         // Load it. In case of a failure, this will:
         // * Throw an exception if sanity checks fail.
-        // * Throw an exception or fail silently if reading the input fails.
+        // * Fail silently if reading the input fails.
         // The exceptions are derived from std::runtime_error.
         result->simple_sds_load(input);
+
         return reinterpret_cast<void*>(result);
     }, [](const void* gbz_void, std::ostream& output) {
+        // This will fail silently if writing to the output stream fails.
         assert(gbz_void != nullptr);
         const gbwtgraph::GBZ* gbz = reinterpret_cast<const gbwtgraph::GBZ*>(gbz_void);
         gbz->simple_sds_serialize(output);

--- a/src/io/register_loader_saver_gbzgraph.cpp
+++ b/src/io/register_loader_saver_gbzgraph.cpp
@@ -22,13 +22,16 @@ void register_loader_saver_gbzgraph() {
 
     Registry::register_bare_loader_saver_with_magic<GBZGraph, PathHandleGraph, HandleGraph>("GBZ", magic_string, [](std::istream& input) -> void* {
         GBZGraph* result = new GBZGraph();
+
         // Load it. In case of a failure, this will:
         // * Throw an exception if sanity checks fail.
-        // * Throw an exception or fail silently if reading the input fails.
+        // * Fail silently if reading the input fails.
         // The exceptions are derived from std::runtime_error.
         result->gbz.simple_sds_load(input);
+
         return reinterpret_cast<void*>(result);
     }, [](const void* gbzgraph_void, std::ostream& output) {
+        // This will fail silently if writing to the output stream fails.
         assert(gbzgraph_void != nullptr);
         const GBZGraph* gbz_graph = reinterpret_cast<const GBZGraph*>(gbzgraph_void);
         gbz_graph->gbz.simple_sds_serialize(output);

--- a/src/io/register_loader_saver_gbzgraph.cpp
+++ b/src/io/register_loader_saver_gbzgraph.cpp
@@ -22,6 +22,10 @@ void register_loader_saver_gbzgraph() {
 
     Registry::register_bare_loader_saver_with_magic<GBZGraph, PathHandleGraph, HandleGraph>("GBZ", magic_string, [](std::istream& input) -> void* {
         GBZGraph* result = new GBZGraph();
+        // Load it. In case of a failure, this will:
+        // * Throw an exception if sanity checks fail.
+        // * Throw an exception or fail silently if reading the input fails.
+        // The exceptions are derived from std::runtime_error.
         result->gbz.simple_sds_load(input);
         return reinterpret_cast<void*>(result);
     }, [](const void* gbzgraph_void, std::ostream& output) {

--- a/src/io/register_loader_saver_gcsa.cpp
+++ b/src/io/register_loader_saver_gcsa.cpp
@@ -23,7 +23,10 @@ void register_loader_saver_gcsa() {
         // Allocate a GCSA
         gcsa::GCSA* index = new gcsa::GCSA();
         
-        // Load it
+        // Load it. In case of a failure, this will:
+        // * Print an error message if sanity checks fail.
+        // * Fail silently if reading the input fails.
+        // The exceptions are derived from std::runtime_error.
         index->load(input);
         
         // Return it so the caller owns it.

--- a/src/io/register_loader_saver_gcsa.cpp
+++ b/src/io/register_loader_saver_gcsa.cpp
@@ -24,15 +24,15 @@ void register_loader_saver_gcsa() {
         gcsa::GCSA* index = new gcsa::GCSA();
         
         // Load it. In case of a failure, this will:
-        // * Print an error message if sanity checks fail.
+        // * Throw std::runtime_error if sanity checks fail.
         // * Fail silently if reading the input fails.
-        // The exceptions are derived from std::runtime_error.
         index->load(input);
         
         // Return it so the caller owns it.
         return (void*) index;
     }, [](const void* index_void, ostream& output) {
         // Cast to GCSA and serialize to the stream.
+        // This will fail silently if writing to the output stream fails.
         assert(index_void != nullptr);
         ((const gcsa::GCSA*) index_void)->serialize(output);
     });

--- a/src/io/register_loader_saver_lcp.cpp
+++ b/src/io/register_loader_saver_lcp.cpp
@@ -24,15 +24,15 @@ void register_loader_saver_lcp() {
         gcsa::LCPArray* index = new gcsa::LCPArray();
         
         // Load it. In case of a failure, this will:
-        // * Print an error message if sanity checks fail.
+        // * Throw std::runtime_error if sanity checks fail.
         // * Fail silently if reading the input fails.
-        // The exceptions are derived from std::runtime_error.
         index->load(input);
         
         // Return it so the caller owns it.
         return (void*) index;
     }, [](const void* index_void, ostream& output) {
         // Cast to LCP and serialize to the stream.
+        // This will fail silently if writing to the output stream fails.
         ((const gcsa::LCPArray*) index_void)->serialize(output);
     });
 

--- a/src/io/register_loader_saver_lcp.cpp
+++ b/src/io/register_loader_saver_lcp.cpp
@@ -23,7 +23,10 @@ void register_loader_saver_lcp() {
         // Allocate an LCPArray
         gcsa::LCPArray* index = new gcsa::LCPArray();
         
-        // Load it
+        // Load it. In case of a failure, this will:
+        // * Print an error message if sanity checks fail.
+        // * Fail silently if reading the input fails.
+        // The exceptions are derived from std::runtime_error.
         index->load(input);
         
         // Return it so the caller owns it.

--- a/src/io/register_loader_saver_minimizer.cpp
+++ b/src/io/register_loader_saver_minimizer.cpp
@@ -21,6 +21,7 @@ void register_loader_saver_minimizer() {
 
     Registry::register_bare_loader_saver_with_magic<gbwtgraph::DefaultMinimizerIndex>("MinimizerIndex", magic_string, [](istream& input) -> void* {
         gbwtgraph::DefaultMinimizerIndex* index = new gbwtgraph::DefaultMinimizerIndex();
+        // Load it. In case of a failure, this will print an error message and return false.
         if (index->deserialize(input)) {
             // Return the index so the caller owns it.
             return static_cast<void*>(index);

--- a/src/io/register_loader_saver_minimizer.cpp
+++ b/src/io/register_loader_saver_minimizer.cpp
@@ -21,15 +21,16 @@ void register_loader_saver_minimizer() {
 
     Registry::register_bare_loader_saver_with_magic<gbwtgraph::DefaultMinimizerIndex>("MinimizerIndex", magic_string, [](istream& input) -> void* {
         gbwtgraph::DefaultMinimizerIndex* index = new gbwtgraph::DefaultMinimizerIndex();
-        // Load it. In case of a failure, this will print an error message and return false.
-        if (index->deserialize(input)) {
-            // Return the index so the caller owns it.
-            return static_cast<void*>(index);
-        } else {
-            //If deserializing failed
-            throw std::runtime_error("Failed to load minimizer index");
-        }
+
+        // Load it. In case of a failure, this will:
+        // * Throw an exception if sanity checks fail.
+        // * Fail silently if reading the input fails.
+        // The exceptions are derived from std::runtime_error.
+        index->deserialize(input);
+
+        return reinterpret_cast<void*>(index);
     }, [](const void* index_void, ostream& output) {
+        // This will fail silently if writing to the output stream fails.
         assert(index_void != nullptr);
         static_cast<const gbwtgraph::DefaultMinimizerIndex*>(index_void)->serialize(output);
     });

--- a/src/io/register_loader_saver_r_index.cpp
+++ b/src/io/register_loader_saver_r_index.cpp
@@ -33,6 +33,7 @@ void register_loader_saver_r_index() {
         return (void*) index;
     }, [](const void* index_void, ostream& output) {
         // Cast to r-index and serialize to the stream.
+        // This will fail silently if writing to the output stream fails.
         assert(index_void != nullptr);
         ((const gbwt::FastLocate*) index_void)->serialize(output);
     });

--- a/src/io/register_loader_saver_r_index.cpp
+++ b/src/io/register_loader_saver_r_index.cpp
@@ -23,7 +23,10 @@ void register_loader_saver_r_index() {
         // Allocate an r-index
         gbwt::FastLocate* index = new gbwt::FastLocate();
 
-        // Load it
+        // Load it. In case of a failure, this will:
+        // * Throw an exception if sanity checks fail.
+        // * Fail silently if reading the input fails.
+        // The exceptions are derived from std::runtime_error.
         index->load(input);
 
         // Return it so the caller owns it.

--- a/src/recombinator.cpp
+++ b/src/recombinator.cpp
@@ -351,6 +351,15 @@ void Haplotypes::simple_sds_serialize(std::ostream& out) const {
     }
 }
 
+void Haplotypes::serialize_to(const std::string& filename) const {
+    try {
+        sdsl::simple_sds::serialize_to(*this, filename);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [Haplotypes] Serialization to " << filename << " failed: " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+}
+
 void Haplotypes::simple_sds_load(std::istream& in) {
     this->header = sdsl::simple_sds::load_value<Header>(in);
     if (this->header.magic_number != Header::MAGIC_NUMBER) {
@@ -378,6 +387,15 @@ void Haplotypes::simple_sds_load(std::istream& in) {
 
     // Update to the current version.
     this->header.version = Header::VERSION;
+}
+
+void Haplotypes::load_from(const std::string& filename) {
+    try {
+        sdsl::simple_sds::load_from(*this, filename);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [Haplotypes] Loading from " << filename << " failed: " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
 }
 
 size_t Haplotypes::simple_sds_size() const {

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -33,6 +33,12 @@ namespace vg {
  * snarl, that snarl is broken into a suffix and a prefix, and those subchains
  * may share kmers.)
  *
+ * Serialization and loading will fail silently if the actual I/O fails.
+ * However, if `sdsl::simple_sds::serialize_to()` and `load_from()` are used, the
+ * functions will throw `std::ios_base::failure` if the I/O fails.
+ * Sanity checks after loading may throw `sdsl::simple_sds::InvalidData`.
+ * All exceptions are derived from `std::runtime_error`.
+ *
  * NOTE: This assumes that the top-level chains are linear, not cyclical.
  *
  * Versions:

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -33,12 +33,6 @@ namespace vg {
  * snarl, that snarl is broken into a suffix and a prefix, and those subchains
  * may share kmers.)
  *
- * Serialization and loading will fail silently if the actual I/O fails.
- * However, if `sdsl::simple_sds::serialize_to()` and `load_from()` are used, the
- * functions will throw `std::ios_base::failure` if the I/O fails.
- * Sanity checks after loading may throw `sdsl::simple_sds::InvalidData`.
- * All exceptions are derived from `std::runtime_error`.
- *
  * NOTE: This assumes that the top-level chains are linear, not cyclical.
  *
  * Versions:
@@ -186,13 +180,13 @@ public:
         /// * Information content of the kmers (disabled).
         double badness(const gbwtgraph::GBZ& gbz) const;
 
-        /// Serializes the object to a stream in the simple-sds format.
+        /// Serializes the object to a stream in the Simple-SDS format.
         void simple_sds_serialize(std::ostream& out) const;
 
         /// Loads a less space-efficient version 1 or 2 subchain.
         void load_v1(std::istream& in);
 
-        /// Loads the object from a stream in the simple-sds format.
+        /// Loads the object from a stream in the Simple-SDS format.
         void simple_sds_load(std::istream& in);
 
         /// Returns the size of the object in elements.
@@ -213,10 +207,10 @@ public:
         /// Subchains in the order they appear in.
         std::vector<Subchain> subchains;
 
-        /// Serializes the object to a stream in the simple-sds format.
+        /// Serializes the object to a stream in the Simple-SDS format.
         void simple_sds_serialize(std::ostream& out) const;
 
-        /// Loads the object from a stream in the simple-sds format.
+        /// Loads the object from a stream in the Simple-SDS format.
         void simple_sds_load(std::istream& in);
 
         /// Loads a version 1 chain without a contig name.
@@ -260,11 +254,22 @@ public:
      */
     hash_map<Subchain::kmer_type, size_t> kmer_counts(const std::string& kff_file, Verbosity verbosity) const;
 
-    /// Serializes the object to a stream in the simple-sds format.
+    /// Serializes the object to a stream in the Simple-SDS format.
+    /// I/O errors can be detected by checking the stream state.
     void simple_sds_serialize(std::ostream& out) const;
 
-    /// Loads the object from a stream in the simple-sds format.
+    /// Serializes the object to a file in the Simple-SDS format.
+    /// Prints an error message and exits the program on failure.
+    void serialize_to(const std::string& filename) const;
+
+    /// Loads the object from a stream in the Simple-SDS format.
+    /// I/O errors can be detected by checking the stream state.
+    /// Throws `sdsl::simple_sds::InvalidData` if sanity checks fail.
     void simple_sds_load(std::istream& in);
+
+    /// Loads the object from a file in the Simple-SDS format.
+    /// Prints an error message and exits the program on failure.
+    void load_from(const std::string& filename);
 
     /// Returns the size of the object in elements.
     size_t simple_sds_size() const;

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -1298,7 +1298,12 @@ void use_or_save(std::unique_ptr<gbwt::DynamicGBWT>& index, GBWTHandler& gbwts, 
                 std::cerr << "Job " << i << ": Saving the GBWT to " << temp << std::endl;
             }
         }
-        save_gbwt(*index, temp, false);
+        try {
+            save_gbwt(*index, temp, false);
+        } catch (const std::runtime_error& e) {
+            std::cerr << "error: [vg gbwt] failed to save the GBWT to a temporary file: " << e.what() << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
         filenames[i] = temp;
     }
 }
@@ -1608,10 +1613,15 @@ void step_5_gbwtgraph(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& conf
         }
         graph = gbwtgraph::GBWTGraph(gbwts.compressed, *(graphs.path_graph), vg::algorithms::find_translation(graphs.path_graph.get()));
     }
-    if (config.gbz_format) {
-        save_gbz(gbwts.compressed, graph, config.graph_output, config.show_progress);
-    } else {
-        save_gbwtgraph(graph, config.graph_output, config.show_progress);
+    try {
+        if (config.gbz_format) {
+            save_gbz(gbwts.compressed, graph, config.graph_output, config.show_progress);
+        } else {
+            save_gbwtgraph(graph, config.graph_output, config.show_progress);
+        }
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [vg gbwt] failed to save the GBWTGraph to " << config.graph_output << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
     }
 
     report_time_memory("GBWTGraph built", start, config);
@@ -1631,7 +1641,12 @@ void step_6_r_index(GBWTHandler& gbwts, GBWTConfig& config) {
         std::cerr << "Starting the construction" << std::endl;
     }
     gbwt::FastLocate r_index(gbwts.compressed);
-    save_r_index(r_index, config.r_index_name, config.show_progress);
+    try {
+        save_r_index(r_index, config.r_index_name, config.show_progress);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [vg gbwt] failed to save the r-index to " << config.r_index_name << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
 
     report_time_memory("R-index built", start, config);
 }
@@ -1790,7 +1805,12 @@ void GraphHandler::load_gbz(GBWTHandler& gbwts, GBWTConfig& config) {
     } else {
         this->clear();
         gbwtgraph::GBZ gbz;
-        vg::load_gbz(gbz, config.input_filenames.front(), config.show_progress);
+        try {
+            vg::load_gbz(gbz, config.input_filenames.front(), config.show_progress);
+        } catch (const std::runtime_error& e) {
+            std::cerr << "error: [vg gbwt] failed to load the GBZ from " << config.input_filenames.front() << ": " << e.what() << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
         gbwts.use(gbz.index);
         this->gbwt_graph = std::make_unique<gbwtgraph::GBWTGraph>(std::move(gbz.graph));
         this->gbwt_graph->set_gbwt(gbwts.compressed);
@@ -1805,12 +1825,22 @@ void GraphHandler::load_gbwtgraph(GBWTHandler& gbwts, GBWTConfig& config) {
         this->clear();
         // Load the GBWT
         gbwt::GBWT input_gbwt;
-        vg::load_gbwt(input_gbwt, config.input_filenames.front(), config.show_progress);
+        try {
+            load_gbwt(input_gbwt, config.input_filenames.front(), config.show_progress);
+        } catch (const std::runtime_error& e) {
+            std::cerr << "error: [vg gbwt] failed to load the GBWT from " << config.input_filenames.front() << ": " << e.what() << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
         gbwts.use(input_gbwt);
         
         // Then load the GBWTGraph
         this->gbwt_graph = std::make_unique<gbwtgraph::GBWTGraph>();
-        vg::load_gbwtgraph(*this->gbwt_graph, config.gbwtgraph_name, config.show_progress);
+        try {
+            vg::load_gbwtgraph(*this->gbwt_graph, config.gbwtgraph_name, config.show_progress);
+        } catch (const std::runtime_error& e) {
+            std::cerr << "error: [vg gbwt] failed to load the GBWTGraph from " << config.gbwtgraph_name << ": " << e.what() << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
         // And connect it
         this->gbwt_graph->set_gbwt(gbwts.compressed);
         this->in_use = graph_gbwtgraph;

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -1298,12 +1298,7 @@ void use_or_save(std::unique_ptr<gbwt::DynamicGBWT>& index, GBWTHandler& gbwts, 
                 std::cerr << "Job " << i << ": Saving the GBWT to " << temp << std::endl;
             }
         }
-        try {
-            save_gbwt(*index, temp, false);
-        } catch (const std::runtime_error& e) {
-            std::cerr << "error: [vg gbwt] failed to save the GBWT to a temporary file: " << e.what() << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
+        save_gbwt(*index, temp, false);
         filenames[i] = temp;
     }
 }
@@ -1613,15 +1608,10 @@ void step_5_gbwtgraph(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& conf
         }
         graph = gbwtgraph::GBWTGraph(gbwts.compressed, *(graphs.path_graph), vg::algorithms::find_translation(graphs.path_graph.get()));
     }
-    try {
-        if (config.gbz_format) {
-            save_gbz(gbwts.compressed, graph, config.graph_output, config.show_progress);
-        } else {
-            save_gbwtgraph(graph, config.graph_output, config.show_progress);
-        }
-    } catch (const std::runtime_error& e) {
-        std::cerr << "error: [vg gbwt] failed to save the GBWTGraph to " << config.graph_output << ": " << e.what() << std::endl;
-        std::exit(EXIT_FAILURE);
+    if (config.gbz_format) {
+        save_gbz(gbwts.compressed, graph, config.graph_output, config.show_progress);
+    } else {
+        save_gbwtgraph(graph, config.graph_output, config.show_progress);
     }
 
     report_time_memory("GBWTGraph built", start, config);
@@ -1641,12 +1631,7 @@ void step_6_r_index(GBWTHandler& gbwts, GBWTConfig& config) {
         std::cerr << "Starting the construction" << std::endl;
     }
     gbwt::FastLocate r_index(gbwts.compressed);
-    try {
-        save_r_index(r_index, config.r_index_name, config.show_progress);
-    } catch (const std::runtime_error& e) {
-        std::cerr << "error: [vg gbwt] failed to save the r-index to " << config.r_index_name << ": " << e.what() << std::endl;
-        std::exit(EXIT_FAILURE);
-    }
+    save_r_index(r_index, config.r_index_name, config.show_progress);
 
     report_time_memory("R-index built", start, config);
 }
@@ -1805,12 +1790,7 @@ void GraphHandler::load_gbz(GBWTHandler& gbwts, GBWTConfig& config) {
     } else {
         this->clear();
         gbwtgraph::GBZ gbz;
-        try {
-            vg::load_gbz(gbz, config.input_filenames.front(), config.show_progress);
-        } catch (const std::runtime_error& e) {
-            std::cerr << "error: [vg gbwt] failed to load the GBZ from " << config.input_filenames.front() << ": " << e.what() << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
+        vg::load_gbz(gbz, config.input_filenames.front(), config.show_progress);
         gbwts.use(gbz.index);
         this->gbwt_graph = std::make_unique<gbwtgraph::GBWTGraph>(std::move(gbz.graph));
         this->gbwt_graph->set_gbwt(gbwts.compressed);
@@ -1825,22 +1805,12 @@ void GraphHandler::load_gbwtgraph(GBWTHandler& gbwts, GBWTConfig& config) {
         this->clear();
         // Load the GBWT
         gbwt::GBWT input_gbwt;
-        try {
-            load_gbwt(input_gbwt, config.input_filenames.front(), config.show_progress);
-        } catch (const std::runtime_error& e) {
-            std::cerr << "error: [vg gbwt] failed to load the GBWT from " << config.input_filenames.front() << ": " << e.what() << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
+        load_gbwt(input_gbwt, config.input_filenames.front(), config.show_progress);
         gbwts.use(input_gbwt);
         
         // Then load the GBWTGraph
         this->gbwt_graph = std::make_unique<gbwtgraph::GBWTGraph>();
-        try {
-            vg::load_gbwtgraph(*this->gbwt_graph, config.gbwtgraph_name, config.show_progress);
-        } catch (const std::runtime_error& e) {
-            std::cerr << "error: [vg gbwt] failed to load the GBWTGraph from " << config.gbwtgraph_name << ": " << e.what() << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
+        vg::load_gbwtgraph(*this->gbwt_graph, config.gbwtgraph_name, config.show_progress);
         // And connect it
         this->gbwt_graph->set_gbwt(gbwts.compressed);
         this->in_use = graph_gbwtgraph;

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -2410,7 +2410,12 @@ std::string sample_haplotypes(
         std::cerr << "Loading haplotype information from " << haplotype_file << std::endl;
     }
     Haplotypes haplotypes;
-    sdsl::simple_sds::load_from(haplotypes, haplotype_file);
+    try {
+        sdsl::simple_sds::load_from(haplotypes, haplotype_file);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [vg giraffe] Cannot load haplotype information: " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
 
     // Sample haplotypes.
     Haplotypes::Verbosity verbosity = (progress ? Haplotypes::verbosity_basic : Haplotypes::verbosity_silent);

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -2410,12 +2410,7 @@ std::string sample_haplotypes(
         std::cerr << "Loading haplotype information from " << haplotype_file << std::endl;
     }
     Haplotypes haplotypes;
-    try {
-        sdsl::simple_sds::load_from(haplotypes, haplotype_file);
-    } catch (const std::runtime_error& e) {
-        std::cerr << "error: [vg giraffe] Cannot load haplotype information: " << e.what() << std::endl;
-        std::exit(EXIT_FAILURE);
-    }
+    haplotypes.load_from(haplotype_file);
 
     // Sample haplotypes.
     Haplotypes::Verbosity verbosity = (progress ? Haplotypes::verbosity_basic : Haplotypes::verbosity_silent);

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -149,12 +149,7 @@ int main_haplotypes(int argc, char** argv) {
         if (config.verbosity >= Haplotypes::verbosity_basic) {
             std::cerr << "Loading haplotype information from " << config.haplotype_input << std::endl;
         }
-        try {
-            sdsl::simple_sds::load_from(haplotypes, config.haplotype_input);
-        } catch (const std::runtime_error& e) {
-            std::cerr << "error: [vg haplotypes] " << e.what() << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
+        haplotypes.load_from(config.haplotype_input);
     }
 
     // Save haplotype information if necessary.
@@ -162,12 +157,7 @@ int main_haplotypes(int argc, char** argv) {
         if (config.verbosity >= Haplotypes::verbosity_basic) {
             std::cerr << "Writing haplotype information to " << config.haplotype_output << std::endl;
         }
-        try {
-            sdsl::simple_sds::serialize_to(haplotypes, config.haplotype_output);
-        } catch (const std::runtime_error& e) {
-            std::cerr << "error: [vg haplotypes] " << e.what() << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
+        haplotypes.serialize_to(config.haplotype_output);
     }
 
     // Sample the haplotypes.

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -162,7 +162,12 @@ int main_haplotypes(int argc, char** argv) {
         if (config.verbosity >= Haplotypes::verbosity_basic) {
             std::cerr << "Writing haplotype information to " << config.haplotype_output << std::endl;
         }
-        sdsl::simple_sds::serialize_to(haplotypes, config.haplotype_output);
+        try {
+            sdsl::simple_sds::serialize_to(haplotypes, config.haplotype_output);
+        } catch (const std::runtime_error& e) {
+            std::cerr << "error: [vg haplotypes] " << e.what() << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
     }
 
     // Sample the haplotypes.

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -240,7 +240,7 @@ int main_minimizer(int argc, char** argv) {
         }
     }
     if (output_name.empty()) {
-        std::cerr << "[vg minimizer] error: option --output-name is required" << std::endl;
+        std::cerr << "error: [vg minimizer] option --output-name is required" << std::endl;
         return 1;
     }
     if (optind + 1 != argc) {
@@ -249,7 +249,7 @@ int main_minimizer(int argc, char** argv) {
     }
     graph_name = argv[optind];
     if (require_distance_index && distance_name.empty()) {
-        std::cerr << "[vg minimizer] error: one of options --distance-index and --no-dist is required" << std::endl;
+        std::cerr << "error: [vg minimizer] one of options --distance-index and --no-dist is required" << std::endl;
         return 1;
     }
     if (!load_index.empty() || use_syncmers) {
@@ -277,7 +277,7 @@ int main_minimizer(int argc, char** argv) {
         gbz->graph = std::move(*get<1>(input));
         
         if (gbwt_name.empty()) {
-            std::cerr << "[vg minimizer] error: option --gbwt-name is required when using a GBWTGraph" << std::endl;
+            std::cerr << "error: [vg minimizer] option --gbwt-name is required when using a GBWTGraph" << std::endl;
             return 1;
         }
         
@@ -289,7 +289,7 @@ int main_minimizer(int argc, char** argv) {
         // We got a normal HandleGraph
         
         if (gbwt_name.empty()) {
-            std::cerr << "[vg minimizer] error: option --gbwt-name is required when using a HandleGraph" << std::endl;
+            std::cerr << "error: [vg minimizer] option --gbwt-name is required when using a HandleGraph" << std::endl;
             return 1;
         }
         
@@ -302,7 +302,7 @@ int main_minimizer(int argc, char** argv) {
         }
         gbz.reset(new gbwtgraph::GBZ(gbwt_index, *get<2>(input)));
     } else {
-        std::cerr << "[vg minimizer] error: input graph is not a GBZ, GBWTGraph, or HandleGraph." << std::endl;
+        std::cerr << "error: [vg minimizer] input graph is not a GBZ, GBWTGraph, or HandleGraph." << std::endl;
         return 1;
     }
 
@@ -339,7 +339,12 @@ int main_minimizer(int argc, char** argv) {
         if (progress) {
             std::cerr << "Loading MinimizerIndex from " << load_index << std::endl;
         }
-        index = vg::io::VPKG::load_one<gbwtgraph::DefaultMinimizerIndex>(load_index);
+        try {
+            index = vg::io::VPKG::load_one<gbwtgraph::DefaultMinimizerIndex>(load_index);
+        } catch (const std::runtime_error& e) {
+            std::cerr << "error: [vg minimizer] failed to load MinimizerIndex from " << load_index << ": " << e.what() << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
     }
 
     // Distance index.
@@ -440,7 +445,12 @@ int main_minimizer(int argc, char** argv) {
     }
 
     // Serialize the index.
-    save_minimizer(*index, output_name);
+    try {
+        save_minimizer(*index, output_name);
+    } catch (const std::runtime_error& e) {
+        std::cerr << "error: [vg minimizer] failed to save MinimizerIndex to " << output_name << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
 
     //If using it, write the larger zipcodes to a file
     if (!zipcode_name.empty()) { 

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -273,34 +273,30 @@ int main_minimizer(int argc, char** argv) {
         gbz = std::move(get<0>(input));
     } else if (get<1>(input)) {
         // We loaded a GBWTGraph and need to pair it with a GBWT
-        gbz.reset(new gbwtgraph::GBZ());
-        gbz->graph = std::move(*get<1>(input));
-        
         if (gbwt_name.empty()) {
             std::cerr << "error: [vg minimizer] option --gbwt-name is required when using a GBWTGraph" << std::endl;
             return 1;
         }
-        
+        gbz.reset(new gbwtgraph::GBZ());
+        gbz->graph = std::move(*get<1>(input));
+
         // Go get the GBWT
         load_gbwt(gbz->index, gbwt_name, progress);
         // And attach them together
         gbz->graph.set_gbwt(gbz->index);
     } else if (get<2>(input)) {
         // We got a normal HandleGraph
-        
         if (gbwt_name.empty()) {
             std::cerr << "error: [vg minimizer] option --gbwt-name is required when using a HandleGraph" << std::endl;
             return 1;
         }
+        gbz.reset(new gbwtgraph::GBZ());
         
-        if (progress) {
-            std::cerr << "Loading GBWT from " << gbwt_name << std::endl;
-        }
-        std::unique_ptr<gbwt::GBWT> gbwt_index(vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_name));
+        load_gbwt(gbz->index, gbwt_name, progress);
         if (progress) {
             std::cerr << "Building GBWTGraph" << std::endl;
         }
-        gbz.reset(new gbwtgraph::GBZ(gbwt_index, *get<2>(input)));
+        gbz->graph = gbwtgraph::GBWTGraph(gbz->index, *get<2>(input));
     } else {
         std::cerr << "error: [vg minimizer] input graph is not a GBZ, GBWTGraph, or HandleGraph." << std::endl;
         return 1;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

* (This does not concern the user.)

## Description

More consistent error handling when serializing and loading GCSA/GBWT/GBWTGraph data structures.

The `save_*` / `load_*` functions in `gbwt_helper.hpp` and `gbwtgraph_helper.hpp` now mimic Simple-SDS serialization. Both logical errors and stream errors result in exceptions. The exceptions are caught within the function, which then prints an error message and exists with `std::exit(EXIT_FAILURE)`. There are also equivalent `serialize_to()` / `load_from()` methods for `Haplotypes` (`.hapl` files).

Libvgio serialization `vg::io::VPKG::*` is also more consistent. Logical errors throw an exception (ultimately `std::runtime_error`). If not caught, vg will exit and print both the error message and an ugly stack trace. Stream errors will be ignored, as they should be handled within libvgio. If libvgio enables exceptions for the streams and catches them internally, the behavior should be equivalent to the `save_*` / `load_*` functions.