### PR TITLE
Fix CRAM surjection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get -qq -y update && \
 RUN apt-get -qq -y update && apt-get -qq -y upgrade && apt-get -qq -y install \
     make git build-essential protobuf-compiler libprotoc-dev libjansson-dev libbz2-dev \
     libncurses5-dev automake gettext autopoint libtool jq bsdmainutils bc rs parallel npm \
-    samtools curl unzip redland-utils librdf-dev cmake pkg-config wget gtk-doc-tools \
+    samtools curl libcurl-dev unzip redland-utils librdf-dev cmake pkg-config wget gtk-doc-tools \
     raptor2-utils rasqal-utils bison flex gawk libgoogle-perftools-dev liblz4-dev liblzma-dev \
     libcairo2-dev libpixman-1-dev libffi-dev libcairo-dev libprotobuf-dev libboost-all-dev \
     tabix bcftools libzstd-dev pybind11-dev python3-pybind11 pandoc

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get -qq -y update && \
 RUN apt-get -qq -y update && apt-get -qq -y upgrade && apt-get -qq -y install \
     make git build-essential protobuf-compiler libprotoc-dev libjansson-dev libbz2-dev \
     libncurses5-dev automake gettext autopoint libtool jq bsdmainutils bc rs parallel npm \
-    samtools curl libcurl-dev unzip redland-utils librdf-dev cmake pkg-config wget gtk-doc-tools \
+    samtools curl libcurl4-openssl-dev unzip redland-utils librdf-dev cmake pkg-config wget gtk-doc-tools \
     raptor2-utils rasqal-utils bison flex gawk libgoogle-perftools-dev liblz4-dev liblzma-dev \
     libcairo2-dev libpixman-1-dev libffi-dev libcairo-dev libprotobuf-dev libboost-all-dev \
     tabix bcftools libzstd-dev pybind11-dev python3-pybind11 pandoc

--- a/Makefile
+++ b/Makefile
@@ -705,7 +705,7 @@ $(LIB_DIR)/libdeflate.a: $(LIBDEFLATE_DIR)/*.h $(LIBDEFLATE_DIR)/lib/*.h $(LIBDE
 $(LIB_DIR)/libhts%a $(LIB_DIR)/pkgconfig/htslib%pc $(LIB_DIR)/libhts%$(SHARED_SUFFIX): $(LIB_DIR)/libdeflate.a $(LIB_DIR)/libdeflate.$(SHARED_SUFFIX) $(HTSLIB_DIR)/*.c $(HTSLIB_DIR)/*.h $(HTSLIB_DIR)/htslib/*.h $(HTSLIB_DIR)/cram/*.c $(HTSLIB_DIR)/cram/*.h
 	+cd $(HTSLIB_DIR) && rm -Rf $(CWD)/$(INC_DIR)/htslib $(CWD)/$(LIB_DIR)/libhts* && autoreconf -i && autoheader && autoconf || true
 	+cd $(HTSLIB_DIR) && (./configure -n 2>&1 || true) | grep "build system type" | rev | cut -f1 -d' ' | rev >systype.txt
-	+cd $(HTSLIB_DIR) && CFLAGS="-I$(CWD)/$(HTSLIB_DIR) -isystem $(CWD)/$(HTSLIB_DIR) -I$(CWD)/$(INC_DIR) $(CFLAGS)" LDFLAGS="$(LDFLAGS) -L$(CWD)/$(LIB_DIR) $(LD_UTIL_RPATH_FLAGS)" ./configure --with-libdeflate --disable-s3 --disable-gcs --disable-libcurl --disable-plugins --prefix=$(CWD) --host=$$(cat systype.txt) $(FILTER) && $(MAKE) clean && $(MAKE) $(FILTER) && $(MAKE) install
+	+cd $(HTSLIB_DIR) && CFLAGS="-I$(CWD)/$(HTSLIB_DIR) -isystem $(CWD)/$(HTSLIB_DIR) -I$(CWD)/$(INC_DIR) $(CFLAGS)" LDFLAGS="$(LDFLAGS) -L$(CWD)/$(LIB_DIR) $(LD_UTIL_RPATH_FLAGS)" ./configure --with-libdeflate --disable-s3 --disable-gcs --enable-libcurl --disable-plugins --prefix=$(CWD) --host=$$(cat systype.txt) $(FILTER) && $(MAKE) clean && $(MAKE) $(FILTER) && $(MAKE) install
 
 # Build and install tabixpp for vcflib.
 $(LIB_DIR)/libtabixpp.a: $(LIB_DIR)/libhts.a $(TABIXPP_DIR)/*.cpp $(TABIXPP_DIR)/*.hpp

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ On other distros, or if you do not have root access, you will need to perform th
     sudo apt-get install build-essential git cmake pkg-config libncurses-dev libbz2-dev  \
                          protobuf-compiler libprotoc-dev libprotobuf-dev libjansson-dev \
                          automake gettext autopoint libtool jq bsdmainutils bc rs parallel \
-                         npm curl unzip redland-utils librdf-dev bison flex gawk lzma-dev \
+                         npm curl libcurl-dev unzip redland-utils librdf-dev bison flex gawk lzma-dev \
                          liblzma-dev liblz4-dev libffi-dev libcairo-dev libboost-all-dev \
                          libzstd-dev pybind11-dev python3-pybind11
                          

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ On other distros, or if you do not have root access, you will need to perform th
     sudo apt-get install build-essential git cmake pkg-config libncurses-dev libbz2-dev  \
                          protobuf-compiler libprotoc-dev libprotobuf-dev libjansson-dev \
                          automake gettext autopoint libtool jq bsdmainutils bc rs parallel \
-                         npm curl libcurl-dev unzip redland-utils librdf-dev bison flex gawk lzma-dev \
+                         npm curl libcurl4-openssl-dev unzip redland-utils librdf-dev bison flex gawk lzma-dev \
                          liblzma-dev liblz4-dev libffi-dev libcairo-dev libboost-all-dev \
                          libzstd-dev pybind11-dev python3-pybind11
                          

--- a/src/algorithms/md5_sum_path.cpp
+++ b/src/algorithms/md5_sum_path.cpp
@@ -1,0 +1,44 @@
+/**
+ * \file md5_sum_path.cpp
+ * Implementations of algorithms for MD5-summing paths
+ */
+
+#include "md5_sum_path.hpp"
+#include <htslib/hts.h>
+
+namespace vg {
+namespace algorithms {
+
+std::pair<std::string, size_t> md5_sum_path_with_length(const PathHandleGraph& graph, const path_handle_t& path) {
+    size_t length = 0;
+    hts_md5_context* context = hts_md5_init();
+    std::string digest_string;
+    try {
+        for (handle_t handle : graph.scan_path(path)) {
+            // Get the sequence of each visit along the path
+            std::string visit_sequence = graph.get_sequence(handle);
+            // Count its length
+            length += visit_sequence.size();
+            // And add it to the hash
+            hts_md5_update(context, (const void*)visit_sequence.c_str(), visit_sequence.size() * sizeof(char));
+        }
+        // Get a binary MD5 digest
+        unsigned char binary_digest[16];
+        hts_md5_final(binary_digest, context);
+        // Convert to a null-terminated hex string
+        char hex_digest[33];
+        hts_md5_hex(hex_digest, binary_digest);
+        // Copy to a C++ string
+        digest_string = std::string(hex_digest);
+    } catch (...) {
+        // Free alloated memory on exception
+        hts_md5_destroy(context);
+        throw;
+    }
+    // Free allocated memory when successful
+    hts_md5_destroy(context);
+    return std::make_pair(digest_string, length);
+}
+
+}
+}

--- a/src/algorithms/md5_sum_path.hpp
+++ b/src/algorithms/md5_sum_path.hpp
@@ -1,0 +1,23 @@
+#ifndef VG_ALGORITHMS_MD5_SUM_PATH_HPP_INCLUDED
+#define VG_ALGORITHMS_MD5_SUM_PATH_HPP_INCLUDED
+/**
+ * \file md5_sum_path.hpp
+ * Algorithms for MD5-summing paths
+ */
+
+#include "handle.hpp"
+#include <string>
+#include <utility>
+
+namespace vg {
+namespace algorithms {
+
+/// Get the Samtools-compatible hex MD5 sum and the length of a path in a graph, in one pass.
+std::pair<std::string, size_t> md5_sum_path_with_length(const PathHandleGraph& graph, const path_handle_t& path);
+
+}
+}
+
+#endif
+
+

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -16,6 +16,7 @@
 #include "handle.hpp"
 #include "vg/io/alignment_io.hpp"
 #include <vg/io/alignment_emitter.hpp>
+#include "hts_alignment_emitter.hpp"
 
 namespace vg {
 
@@ -67,10 +68,7 @@ size_t fastq_paired_two_files_for_each_parallel_after_wait(const string& file1, 
 
 bam_hdr_t* hts_file_header(string& filename, string& header);
 bam_hdr_t* hts_string_header(string& header,
-                             const map<string, int64_t>& path_length,
-                             const map<string, string>& rg_sample);
-bam_hdr_t* hts_string_header(string& header,
-                             const vector<pair<string, int64_t>>& path_order_and_length,
+                             const SequenceDictionary& sequence_dictionary,
                              const map<string, string>& rg_sample);
 void write_alignment_to_file(const Alignment& aln, const string& filename);
 

--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -461,11 +461,11 @@ HTSWriter::HTSWriter(const string& filename, const string& format,
     multiplexer(out_file.get() != nullptr ? *out_file : cout, max_threads),
     format(format), sequence_dictionary(sequence_dictionary), subpath_to_index(subpath_to_index),
     backing_files(max_threads, nullptr), sam_files(max_threads, nullptr),
-    atomic_header(nullptr), sam_header(), header_mutex(), output_is_bgzf(format != "SAM"),
+    atomic_header(nullptr), sam_header(), header_mutex(), output_is_bgzf(format == "BAM"),
     hts_mode() {
     
     // We can't work with no streams to multiplex, because we need to be able
-    // to write BGZF EOF blocks throught he multiplexer at destruction.
+    // to write BGZF EOF blocks through the multiplexer at destruction.
     assert(max_threads > 0);
     
     if (out_file.get() != nullptr && !*out_file) {

--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -561,8 +561,9 @@ void HTSWriter::save_records(bam_hdr_t* header, vector<bam1_t*>& records, size_t
     for (auto& b : records) {
         // Emit each record
         
-        if (sam_write1(sam_files[thread_number], header, b) == 0) {
-            cerr << "[vg::HTSWriter] error: writing to output file failed" << endl;
+        int sam_write_error = sam_write1(sam_files[thread_number], header, b);
+        if (sam_write_error < 0) {
+            cerr << "[vg::HTSWriter] error: writing to output file failed with sam_write1 error code " << sam_write_error << endl;
             exit(1);
         }
     }

--- a/src/hts_alignment_emitter.hpp
+++ b/src/hts_alignment_emitter.hpp
@@ -119,7 +119,7 @@ SequenceDictionary get_sequence_dictionary(const string& filename, const vector<
 std::unordered_map<std::string, size_t> index_sequence_dictionary(const SequenceDictionary& paths);
 
 /*
- * A class that can write SAM/BAM/CRAM files from parallel threads
+ * A class that can write SAM/BAM/CRAM files from parallel threads.
  */
 class HTSWriter {
 public:
@@ -144,6 +144,9 @@ protected:
     
     /// We hack about with htslib's BGZF EOF footers, so we need to know how long they are.
     static const size_t BGZF_FOOTER_LENGTH;
+
+    /// For CRAM output, we use a separate pool of compressor threads inside htslib.
+    static const size_t HTSLIB_CRAM_THREADS;
     
     /// If we are doing output to a file, this will hold the open file. Otherwise (for stdout) it will be empty.
     unique_ptr<ofstream> out_file;
@@ -152,6 +155,9 @@ protected:
     vg::io::StreamMultiplexer multiplexer;
     
     /// This holds our format name, for later error messages.
+    /// We also use it to decide if we're in magic serialized-writes CRAM mode,
+    /// where we use only one samFile* and one hFILE* and a one-thread
+    /// multiplexer that doesn't really multiplex.
     string format;
     
     /// Store the path names and lengths in the order to put them in the header.

--- a/src/multipath_alignment_emitter.cpp
+++ b/src/multipath_alignment_emitter.cpp
@@ -13,11 +13,11 @@ namespace vg {
 using namespace std;
 
 MultipathAlignmentEmitter::MultipathAlignmentEmitter(const string& filename, size_t num_threads, const string out_format,
-                                                     const PathPositionHandleGraph* graph, const vector<pair<string, int64_t>>* path_order_and_length) :
+                                                     const PathPositionHandleGraph* graph, const SequenceDictionary* sequence_dictionary) :
     HTSWriter(filename,
               out_format == "SAM" || out_format == "BAM" || out_format == "CRAM" ? out_format : "SAM", // just so the assert passes
-              path_order_and_length ? *path_order_and_length : vector<pair<string, int64_t>>(),
-              {},
+              sequence_dictionary ? *sequence_dictionary : SequenceDictionary(),
+              sequence_dictionary ? index_sequence_dictionary(*sequence_dictionary) : std::unordered_map<std::string, size_t>(),
               num_threads),
     graph(graph)
 {

--- a/src/multipath_alignment_emitter.hpp
+++ b/src/multipath_alignment_emitter.hpp
@@ -37,7 +37,7 @@ public:
     ///  already be surjected. If alignments have connections, requires a graph
     MultipathAlignmentEmitter(const string& filename, size_t num_threads, const string out_format = "GAMP",
                               const PathPositionHandleGraph* graph = nullptr,
-                              const vector<pair<string, int64_t>>* path_order_and_length = nullptr);
+                              const SequenceDictionary* sequence_dictionary = nullptr);
     ~MultipathAlignmentEmitter();
     
     /// Choose a read group to apply to all emitted alignments

--- a/src/primer_filter.cpp
+++ b/src/primer_filter.cpp
@@ -289,11 +289,11 @@ std::pair<string, size_t> PrimerFinder::get_graph_coordinates_from_sequence(cons
     string path_file;
     vector<string> path_names;
     std::unordered_set<std::string> reference_assembly_names;
-    vector<tuple<path_handle_t, size_t, size_t>> sequence_dictionary = get_sequence_dictionary(path_file, path_names, reference_assembly_names, *graph);
+    SequenceDictionary sequence_dictionary = get_sequence_dictionary(path_file, path_names, reference_assembly_names, *graph);
     unordered_set<path_handle_t> reference_paths;
     reference_paths.reserve(sequence_dictionary.size());
     for (auto& entry : sequence_dictionary) {
-        reference_paths.insert(get<0>(entry));
+        reference_paths.insert(entry.path_handle);
     }
 
     //Surject the alignment onto the reference paths

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -2002,7 +2002,7 @@ int main_giraffe(int argc, char** argv) {
         {
         
             // Look up all the paths we might need to surject to.
-            vector<tuple<path_handle_t, size_t, size_t>> paths;
+            SequenceDictionary paths;
             if (hts_output) {
                 // For htslib we need a non-empty list of paths.
                 assert(path_position_graph != nullptr);

--- a/src/subcommand/inject_main.cpp
+++ b/src/subcommand/inject_main.cpp
@@ -126,7 +126,7 @@ int main_inject(int argc, char** argv) {
     PathPositionHandleGraph* xgidx = overlay_helper.apply(path_handle_graph.get());
 
     // We don't do HTS output formats but we do need an empty paths collection to make an alignment emitter
-    vector<tuple<path_handle_t, size_t, size_t>> paths;
+    SequenceDictionary paths;
     unique_ptr<vg::io::AlignmentEmitter> alignment_emitter = get_alignment_emitter("-", output_format, paths, threads, xgidx);
 
     Aligner aligner;

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -766,7 +766,7 @@ int main_map(int argc, char** argv) {
     vector<Alignment> empty_alns;
    
     // Look up all the paths we might need to surject to.
-    vector<tuple<path_handle_t, size_t, size_t>> paths;
+    SequenceDictionary paths;
     if (hts_output) {
         paths = get_sequence_dictionary(ref_paths_name, {}, reference_assembly_names, *xgidx);
     }

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1861,7 +1861,7 @@ int main_mpmap(int argc, char** argv) {
     
     // Load structures that we need for HTS lib outputs
     unordered_set<path_handle_t> surjection_paths;
-    vector<pair<string, int64_t>> path_names_and_length;
+    SequenceDictionary paths;
     unique_ptr<Surjector> surjector(nullptr);
     if (hts_output) {
         // init the data structures
@@ -1880,13 +1880,11 @@ int main_mpmap(int argc, char** argv) {
         }
         
         // Load all the paths in the right order
-        vector<tuple<path_handle_t, size_t, size_t>> paths = get_sequence_dictionary(ref_paths_name, {}, reference_assembly_names, *path_position_handle_graph);
+        paths = get_sequence_dictionary(ref_paths_name, {}, reference_assembly_names, *path_position_handle_graph);
         // Make them into a set for directing surjection.
-        for (const auto& path_info : paths) {
-            surjection_paths.insert(get<0>(path_info));
+        for (const SequenceDictionaryEntry& path_info : paths) {
+            surjection_paths.insert(path_info.path_handle);
         }
-        // Copy out the metadata for making the emitter later
-        path_names_and_length = extract_path_metadata(paths, *path_position_handle_graph).first;
     }
     
     // barrier sync the background threads
@@ -2103,7 +2101,7 @@ int main_mpmap(int argc, char** argv) {
     // init a writer for the output
     MultipathAlignmentEmitter* emitter = new MultipathAlignmentEmitter("-", thread_count, out_format,
                                                                        path_position_handle_graph,
-                                                                       &path_names_and_length);
+                                                                       &paths);
     emitter->set_read_group(read_group);
     emitter->set_sample_name(sample_name);
     if (transcriptomic) {

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -355,7 +355,7 @@ int main_surject(int argc, char** argv) {
 
     // Get the paths to surject into and their length information, either from
     // the given file, or from the provided list, or from sniffing the graph.
-    vector<tuple<path_handle_t, size_t, size_t>> sequence_dictionary = get_sequence_dictionary(path_file, path_names, reference_assembly_names, *xgidx);
+    SequenceDictionary sequence_dictionary = get_sequence_dictionary(path_file, path_names, reference_assembly_names, *xgidx);
     // Clear out path_names so we don't accidentally use it
     path_names.clear();
 
@@ -363,7 +363,7 @@ int main_surject(int argc, char** argv) {
     unordered_set<path_handle_t> paths;
     paths.reserve(sequence_dictionary.size());
     for (auto& entry : sequence_dictionary) {
-        paths.insert(get<0>(entry));
+        paths.insert(entry.path_handle);
     }
 
     if (show_progress) {
@@ -595,8 +595,7 @@ int main_surject(int argc, char** argv) {
         }
     } else if (input_format == "GAMP") {
         // Working on multipath alignments. We need to set the emitter up ourselves.
-        auto path_order_and_length = extract_path_metadata(sequence_dictionary, *xgidx).first;
-        MultipathAlignmentEmitter mp_alignment_emitter("-", thread_count, output_format, xgidx, &path_order_and_length);
+        MultipathAlignmentEmitter mp_alignment_emitter("-", thread_count, output_format, xgidx, &sequence_dictionary);
         mp_alignment_emitter.set_read_group(read_group);
         mp_alignment_emitter.set_sample_name(sample_name);
         mp_alignment_emitter.set_min_splice_length(spliced ? min_splice_length : numeric_limits<int64_t>::max());

--- a/src/unittest/hts_alignment_emitter.cpp
+++ b/src/unittest/hts_alignment_emitter.cpp
@@ -1,0 +1,114 @@
+/// \file hts_alignment_emitter.cpp
+///  
+/// unit tests for alignment emitter creation
+
+#include <sys/stat.h>
+#include <iostream>
+#include "../handle.hpp"
+#include "../utility.hpp"
+#include <bdsg/hash_graph.hpp>
+#include <bdsg/overlays/overlay_helper.hpp>
+#include "catch.hpp"
+
+#include "../hts_alignment_emitter.hpp"
+
+namespace vg {
+namespace unittest {
+
+/// Make a graph and return a handle to a reference path
+static path_handle_t populate_test_graph(bdsg::HashGraph& graph) {
+    handle_t node_handle = graph.create_handle("GATTACA");
+    path_handle_t ref_path = graph.create_path(PathSense::REFERENCE, "RefSamp", "chr1", 0, PathMetadata::NO_PHASE_BLOCK, PathMetadata::NO_SUBRANGE, false);
+    graph.append_step(ref_path, node_handle);
+    return ref_path;
+}
+
+/// Make a sequence dictionary for the overlayed graph
+static vector<tuple<path_handle_t, size_t, size_t>> test_sequence_dictionary(const PathPositionHandleGraph* path_position_handle_graph, const bdsg::HashGraph& graph, const path_handle_t& ref_path) {
+    // There's 1 reference path, and its graph length is the same as its base path length.
+    path_handle_t overlayed_path = path_position_handle_graph->get_path_handle(graph.get_path_name(ref_path));
+    size_t ref_length = path_position_handle_graph->get_path_length(overlayed_path);
+    return {{overlayed_path, ref_length, ref_length}};
+}
+
+/// Get the size of a file
+static size_t get_file_size(const std::string& filename) {
+    struct stat buf;
+    if (stat(filename.c_str(), &buf) != 0) {
+        throw std::runtime_error("Could not stat " + filename);
+    }
+    return buf.st_size;
+}
+
+/// Get a test unmapped read.
+static Alignment get_unmapped_read() {
+    // Write a read.
+    Alignment unmapped;
+    unmapped.set_sequence("NNN");
+    unmapped.set_name("unmapped");
+    // To prove this is unmapped in a linear reference and not just not surjected, it has to have *a* refpos, even if it's completely empty.
+    unmapped.add_refpos();
+    return unmapped;
+}
+
+TEST_CASE("Can create and use a BAM alignment emitter", "[giraffe][alignment_emitter][hts_alignment_emitter]") {
+    // Set up the test fixtures
+    bdsg::HashGraph graph;
+    path_handle_t ph1 = populate_test_graph(graph);
+    bdsg::ReferencePathOverlayHelper overlay_helper;
+    PathPositionHandleGraph* overlay_graph = overlay_helper.apply(&graph);
+    auto sequence_dictionary = test_sequence_dictionary(overlay_graph, graph, ph1);
+
+    // Set up the temp file to write
+    std::string out_dir = vg::temp_file::create_directory();
+    std::string out_file = out_dir + "/test.bam";
+    
+    // Make the emitter
+    unique_ptr<AlignmentEmitter> alignment_emitter = get_alignment_emitter(out_file, "BAM", sequence_dictionary, 1, overlay_graph, ALIGNMENT_EMITTER_FLAG_HTS_RAW);
+
+    // We should get one
+    REQUIRE(alignment_emitter);
+    
+    // Write a read.
+    alignment_emitter->emit_single(get_unmapped_read());
+
+    // Delete it to shut it down
+    alignment_emitter.reset();
+
+    // We should see data on disk
+    REQUIRE(get_file_size(out_file) > 0);
+}
+
+TEST_CASE("Can create and use a CRAM alignment emitter", "[giraffe][alignment_emitter][hts_alignment_emitter]") {
+    // Set up the test fixtures
+    bdsg::HashGraph graph;
+    path_handle_t ph1 = populate_test_graph(graph);
+    bdsg::ReferencePathOverlayHelper overlay_helper;
+    PathPositionHandleGraph* overlay_graph = overlay_helper.apply(&graph);
+    auto sequence_dictionary = test_sequence_dictionary(overlay_graph, graph, ph1);
+
+    // Set up the temp file to write
+    std::string out_dir = vg::temp_file::create_directory();
+    std::string out_file = out_dir + "/test.cram";
+    
+    // Make the emitter
+    unique_ptr<AlignmentEmitter> alignment_emitter = get_alignment_emitter(out_file, "CRAM", sequence_dictionary, 1, overlay_graph, ALIGNMENT_EMITTER_FLAG_HTS_RAW);
+
+    // We should get one
+    REQUIRE(alignment_emitter);
+
+    // Write a read.
+    alignment_emitter->emit_single(get_unmapped_read());
+
+    // Delete it to shut it down
+    alignment_emitter.reset();
+
+    // We should see data on disk
+    REQUIRE(get_file_size(out_file) > 0);
+}
+
+
+
+}
+}
+    

--- a/src/unittest/hts_alignment_emitter.cpp
+++ b/src/unittest/hts_alignment_emitter.cpp
@@ -23,22 +23,6 @@ static path_handle_t populate_test_graph(bdsg::HashGraph& graph) {
     return ref_path;
 }
 
-/// Make a sequence dictionary for the overlayed graph
-static SequenceDictionary test_sequence_dictionary(const PathPositionHandleGraph* path_position_handle_graph, const bdsg::HashGraph& graph, const path_handle_t& ref_path) {
-    // There's 1 reference path, and its graph length is the same as its base path length.
-    path_handle_t overlayed_path = path_position_handle_graph->get_path_handle(graph.get_path_name(ref_path));
-    size_t ref_length = path_position_handle_graph->get_path_length(overlayed_path);
-    SequenceDictionary dict;
-    dict.emplace_back();
-    dict.back().path_handle = overlayed_path;
-    dict.back().path_name = graph.get_path_name(ref_path);
-    dict.back().path_length = ref_length;
-    dict.back().base_path_name = dict.back().path_name;
-    dict.back().base_path_length = dict.back().path_length;
-    // TODO: Just use get_sdequence_dictionary instead?
-    return dict;
-}
-
 /// Get the size of a file
 static size_t get_file_size(const std::string& filename) {
     struct stat buf;
@@ -65,7 +49,7 @@ TEST_CASE("Can create and use a BAM alignment emitter", "[giraffe][alignment_emi
     path_handle_t ph1 = populate_test_graph(graph);
     bdsg::ReferencePathOverlayHelper overlay_helper;
     PathPositionHandleGraph* overlay_graph = overlay_helper.apply(&graph);
-    auto sequence_dictionary = test_sequence_dictionary(overlay_graph, graph, ph1);
+    auto sequence_dictionary = get_sequence_dictionary("", {}, {}, *overlay_graph);
 
     // Set up the temp file to write
     std::string out_dir = vg::temp_file::create_directory();
@@ -93,7 +77,7 @@ TEST_CASE("Can create and use a CRAM alignment emitter", "[giraffe][alignment_em
     path_handle_t ph1 = populate_test_graph(graph);
     bdsg::ReferencePathOverlayHelper overlay_helper;
     PathPositionHandleGraph* overlay_graph = overlay_helper.apply(&graph);
-    auto sequence_dictionary = test_sequence_dictionary(overlay_graph, graph, ph1);
+    auto sequence_dictionary = get_sequence_dictionary("", {}, {}, *overlay_graph);
 
     // Set up the temp file to write
     std::string out_dir = vg::temp_file::create_directory();

--- a/src/unittest/hts_alignment_emitter.cpp
+++ b/src/unittest/hts_alignment_emitter.cpp
@@ -24,11 +24,19 @@ static path_handle_t populate_test_graph(bdsg::HashGraph& graph) {
 }
 
 /// Make a sequence dictionary for the overlayed graph
-static vector<tuple<path_handle_t, size_t, size_t>> test_sequence_dictionary(const PathPositionHandleGraph* path_position_handle_graph, const bdsg::HashGraph& graph, const path_handle_t& ref_path) {
+static SequenceDictionary test_sequence_dictionary(const PathPositionHandleGraph* path_position_handle_graph, const bdsg::HashGraph& graph, const path_handle_t& ref_path) {
     // There's 1 reference path, and its graph length is the same as its base path length.
     path_handle_t overlayed_path = path_position_handle_graph->get_path_handle(graph.get_path_name(ref_path));
     size_t ref_length = path_position_handle_graph->get_path_length(overlayed_path);
-    return {{overlayed_path, ref_length, ref_length}};
+    SequenceDictionary dict;
+    dict.emplace_back();
+    dict.back().path_handle = overlayed_path;
+    dict.back().path_name = graph.get_path_name(ref_path);
+    dict.back().path_length = ref_length;
+    dict.back().base_path_name = dict.back().path_name;
+    dict.back().base_path_length = dict.back().path_length;
+    // TODO: Just use get_sdequence_dictionary instead?
+    return dict;
 }
 
 /// Get the size of a file

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -97,11 +97,11 @@ is "$(vg surject -p x -x x.xg mapped.fwd.gam -s | cut -f1,3,4,5,6,7,8,9,10,11)" 
 
 rm -f fwd.fq rev.fq mapped.fwd.gam mapped.rev.gam
 
-is $(vg map -G <(vg sim -a -n 100 -x x.xg) -g x.gcsa -x x.xg | vg surject -p x -x x.xg -b - | samtools view - | wc -l) \
-    100 "vg surject produces valid BAM output"
+is "$(vg map -G <(vg sim -a -n 100 -x x.xg) -g x.gcsa -x x.xg | vg surject -p x -x x.xg -b - | samtools view - | wc -l)" \
+    "100" "vg surject produces valid BAM output"
 
-is $(vg map -G <(vg sim -a -n 100 -x x.vg) -g x.gcsa -x x.vg | vg surject -p x -x x.xg -c - | samtools view - | wc -l) \
-    100 "vg surject produces valid CRAM output"
+is "$(vg map -G <(vg sim -a -n 100 -x x.vg) -g x.gcsa -x x.vg | vg surject -p x -x x.xg -c - | samtools view - | wc -l)" \
+    "100" "vg surject produces valid CRAM output"
 
 echo '{"sequence": "CAAATAA", "path": {"mapping": [{"position": {"node_id": 1}, "edit": [{"from_length": 7, "to_length": 7}]}]}, "mapping_quality": 99}' | vg view -JGa - > read.gam
 is "$(vg surject -p x -x x.xg read.gam | vg view -aj - | jq '.mapping_quality')" "99" "mapping quality is preserved through surjection"
@@ -166,14 +166,14 @@ vg index j.sub.vg -g j.sub.gcsa
 vg map -x j.sub.vg -g j.sub.gcsa -s TGGAAAGAATACAAGATTTGGAGCCAGACAAATCTGGGTTCAAATCCTCACTTTGCCACATATTAGCCATGTGACTTTGA > r.sub.gam
 vg surject -x j.sub.vg r.sub.gam -s > r.sub.sam
 
-cat r.sam | sed -e 's/LN:1001/LN:1501/g' -e 's/161/661/g' > r.manual.sam
+cat r.sam | sed -e 's/LN:1001/LN:1501/g' -e 's/161/661/g' -e 's/.M5:[a-zA-Z0-9]*//g' > r.manual.sam
 diff r.manual.sam r.sub.sam
 is "$?" 0 "vg surject correctly handles subpath suffix in path name"
 
 printf "x\t2000\n" > path_info.tsv
 rm -f r.sub.sam r.manual.sam
 vg surject -x j.sub.vg r.sub.gam -s --ref-paths path_info.tsv > r.sub.sam
-cat r.sam | sed -e 's/LN:1001/LN:2000/g' -e 's/161/661/g' > r.manual.sam
+cat r.sam | sed -e 's/LN:1001/LN:2000/g' -e 's/161/661/g' -e 's/.M5:[a-zA-Z0-9]*//g' > r.manual.sam
 diff r.manual.sam r.sub.sam
 is "$?" 0 "vg surject correctly fetches base path length from input file"
 

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 54
+plan tests 55
 
 vg construct -r small/x.fa >j.vg
 vg index -x j.xg j.vg
@@ -100,8 +100,8 @@ rm -f fwd.fq rev.fq mapped.fwd.gam mapped.rev.gam
 is $(vg map -G <(vg sim -a -n 100 -x x.xg) -g x.gcsa -x x.xg | vg surject -p x -x x.xg -b - | samtools view - | wc -l) \
     100 "vg surject produces valid BAM output"
 
-#is $(vg map -G <(vg sim -a -n 100 x.vg) x.vg | vg surject -p x -g x.gcsa -x x.xg -c - | samtools view - | wc -l) \
-#    100 "vg surject produces valid CRAM output"
+is $(vg map -G <(vg sim -a -n 100 -x x.vg) -g x.gcsa -x x.vg | vg surject -p x -x x.xg -c - | samtools view - | wc -l) \
+    100 "vg surject produces valid CRAM output"
 
 echo '{"sequence": "CAAATAA", "path": {"mapping": [{"position": {"node_id": 1}, "edit": [{"from_length": 7, "to_length": 7}]}]}, "mapping_quality": 99}' | vg view -JGa - > read.gam
 is "$(vg surject -p x -x x.xg read.gam | vg view -aj - | jq '.mapping_quality')" "99" "mapping quality is preserved through surjection"

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -176,8 +176,8 @@ rm -f xy.vg xy.gbwt xy.xg xy.shortread.zipcodes xy.shortread.withzip.min xy.dist
 cp small/xy.fa .
 cp small/xy.vcf.gz .
 cp small/xy.vcf.gz.tbi .
-vg giraffe xy.fa xy.vcf.gz -f small/x.fa_1.fastq -o SAM --ref-paths small/yx.dict | grep -E "^@(SQ|HD)" > surjected-yx.dict
-vg giraffe xy.fa xy.vcf.gz -f small/x.fa_1.fastq -o SAM --ref-paths small/xy.dict | grep -E "^@(SQ|HD)" > surjected-xy.dict
+vg giraffe xy.fa xy.vcf.gz -f small/x.fa_1.fastq -o SAM --ref-paths small/yx.dict | sed 's/.M5:[a-zA-Z0-9]*//g' | grep -E "^@(SQ|HD)" > surjected-yx.dict
+vg giraffe xy.fa xy.vcf.gz -f small/x.fa_1.fastq -o SAM --ref-paths small/xy.dict | sed 's/.M5:[a-zA-Z0-9]*//g' | grep -E "^@(SQ|HD)" > surjected-xy.dict
 
 diff surjected-yx.dict small/yx.dict
 is "${?}" "0" "surjecting with a sequence dictionary in non-sorted order produces headers in non-sorted order"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg can now surject to CRAM. To use an external reference, you will need to pre-populate the reference cache (see `REF_PATH` and `REF_CACHE` documentation at https://www.htslib.org/workflow/cram.html).
 ~* vg will attempt to download CRAM references to the CRAM cache from the official CRAM reference archive server. This involves sending MD5 hashes of CRAM reference sequences to the server. Don't output CRAM against a secret reference without pre-populating the cache (see `REF_PATH` and `REF_CACHE` documentation at https://www.htslib.org/workflow/cram.html).~

## Description
This fixes CRAM output by not stopping if we have to go to no-reference mode, and also by tracking MD5 values through from dict files. It also checks the MD5 values against the actual graph paths and bails if they don't match.

To get CRAM checksums right, I had to turn off vg's custom multithreaded output multiplexing for CRAM, since that only applies to BGZF files, and CRAM isn't BGZF-compressed. Instead, we're now using htslib's multithreaded compression for CRAM files, with a static number of output threads.

vg is still not clever enough to dump your reference contigs to FASTA to use as the CRAM reference. I wanted to avoid creating a CRAM file against a reference that *only* exists in your graph and your local cache, since that file won't be interpretable on any other machine. If the reference isn't a standard one on the CRAM reference server, you will need to either make do with non-reference-based fallback CRAM files, or put it into a FASTA and then load that into your local CRAM reference cache with samtools's `seq_cache_populate.pl`.