### PR TITLE
Allow cutting reads in `vg chunk`

### DIFF
--- a/src/algorithms/sorted_id_ranges.cpp
+++ b/src/algorithms/sorted_id_ranges.cpp
@@ -5,10 +5,10 @@ namespace algorithms {
 
 using namespace std;
 
-vector<pair<id_t, id_t>> sorted_id_ranges(const HandleGraph* graph) {
+std::vector<std::pair<nid_t, nid_t>> sorted_id_ranges(const HandleGraph* graph) {
 
     // Build the list of of all the node IDs to operate on
-    vector<id_t> graph_ids;
+    std::vector<nid_t> graph_ids;
     graph->for_each_handle([&](handle_t handle) {
         // Put all the ids in the list
         graph_ids.push_back(graph->get_id(handle));
@@ -18,7 +18,7 @@ vector<pair<id_t, id_t>> sorted_id_ranges(const HandleGraph* graph) {
     std::sort(graph_ids.begin(), graph_ids.end());
     
     // Coalesce them into ranges
-    vector<pair<id_t, id_t>> ranges;
+    std::vector<std::pair<nid_t, nid_t>> ranges;
     for (auto& id : graph_ids) {
         if (ranges.empty() || ranges.back().second + 1 != id) {
             // We can't glom on to the previous range, so start a new one of just us
@@ -30,6 +30,21 @@ vector<pair<id_t, id_t>> sorted_id_ranges(const HandleGraph* graph) {
     }
     
     return ranges;
+}
+
+bool is_in_sorted_id_ranges(const nid_t& value, const std::vector<std::pair<nid_t, nid_t>>& ranges) {
+    // Find the first interval starting after the value
+    auto it = std::upper_bound(ranges.begin(), ranges.end(), std::make_pair(value, value), [&](const std::pair<nid_t, nid_t>& a, const std::pair<nid_t, nid_t>& b) {
+        return a.first < b.first;
+    });
+    if (it == ranges.begin()) {
+        // All intervals start after the value, so none can cover it.
+        return false;
+    }
+    // Move back to the range covering the value, if there is one.
+    --it;
+    // Return whether that range contains the value.
+    return it->first <= value && it->second >= value;
 }
 
 

--- a/src/algorithms/sorted_id_ranges.hpp
+++ b/src/algorithms/sorted_id_ranges.hpp
@@ -18,7 +18,10 @@ namespace algorithms {
 using namespace std;
 
 /// Get a sorted list of inclusive ranges of IDs used in the given HandleGraph.
-vector<pair<id_t, id_t>> sorted_id_ranges(const HandleGraph* graph);
+std::vector<std::pair<nid_t, nid_t>> sorted_id_ranges(const HandleGraph* graph);
+
+/// Get whether an ID is in a sorted list of inclusive ID ranges
+bool is_in_sorted_id_ranges(const nid_t& value, const std::vector<std::pair<nid_t, nid_t>>& ranges);
 
 
 }

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1736,7 +1736,7 @@ std::vector<Alignment> alignment_pieces_within(const Alignment& aln, const std::
     if (pieces.size() == 0 && piece_path.mapping_size() == aln.path().mapping_size()) {
         // We never left the target region, so just emit the full input alignment wiht all its annotations.
         pieces.emplace_back(aln);
-    } else {
+    } else if (piece_path.mapping_size() > 0) {
         // Emit the last partial piece
         emit_piece();
     }

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -246,17 +246,22 @@ Alignment strip_from_start(const Alignment& aln, size_t drop);
 Alignment strip_from_end(const Alignment& aln, size_t drop);
 Alignment trim_alignment(const Alignment& aln, const Position& pos1, const Position& pos2);
 vector<Alignment> alignment_ends(const Alignment& aln, size_t len1, size_t len2);
+/// Get an Alignment corresponding to the middle len bases of the given alignment
 Alignment alignment_middle(const Alignment& aln, int len);
-// generate a digest of the alignmnet
+/// Cut the Alignment into contiguous pieces visiting nodes in the given node set, defined by a membership predicate.
+/// Will pass the original Alignment through if it is fully contained.
+/// Cut pieces will not have score or annotations set, but will keep mapping quality.
+std::vector<Alignment> alignment_pieces_within(const Alignment& aln, const std::function<bool(nid_t)>& node_in_set);
+// generate a digest of the alignment
 const string hash_alignment(const Alignment& aln);
 // Flip the alignment's sequence and is_reverse flag, and flip and re-order its
 // Mappings to match. A function to get node lengths is needed because the
 // Mappings in the alignment will need to give their positions from the opposite
 // ends of their nodes. Offsets will be updated to count unused bases from node
 // start when considering the node in its new orientation.
-Alignment reverse_complement_alignment(const Alignment& aln, const function<int64_t(id_t)>& node_length);
-void reverse_complement_alignment_in_place(Alignment* aln, const function<int64_t(id_t)>& node_length);
-vector<Alignment> reverse_complement_alignments(const vector<Alignment>& alns, const function<int64_t(int64_t)>& node_length);
+Alignment reverse_complement_alignment(const Alignment& aln, const function<int64_t(nid_t)>& node_length);
+void reverse_complement_alignment_in_place(Alignment* aln, const function<int64_t(nid_t)>& node_length);
+vector<Alignment> reverse_complement_alignments(const vector<Alignment>& alns, const function<int64_t(nid_t)>& node_length);
 int non_match_start(const Alignment& alignment);
 int non_match_end(const Alignment& alignment);
 int softclip_start(const Alignment& alignment);

--- a/src/stream_index.cpp
+++ b/src/stream_index.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <queue>
+#include "algorithms/sorted_id_ranges.hpp"
 
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/io/gzip_stream.h>
@@ -469,35 +470,7 @@ auto StreamIndexBase::scan_backward(const function<bool(int64_t, int64_t)> scan_
 /// Return true if the given ID is in any of the sorted, coalesced, inclusive ranges in the vector, and false otherwise.
 /// TODO: Is repeated binary search on the ranges going to be better than an unordered_set of all the individual IDs?
 auto StreamIndexBase::is_in_range(const vector<pair<id_t, id_t>>& ranges, id_t id) -> bool {
-    // Use a binary search
-    size_t left = 0;
-    size_t past_right = ranges.size();
-    
-    while (past_right >= left + 1) {
-        // We have a nonempty interval
-        
-        // Find the middle
-        size_t center = (left + past_right) / 2;
-        assert(center < ranges.size());
-        
-        // Look at the range there
-        auto& range = ranges[center];
-        
-        if (id < range.first) {
-            // If we're before it, go left
-            past_right = center;
-        } else if (id > range.second) {
-            // If we're after it, go right
-            left = center + 1;
-        } else {
-            // If we're in it, return true
-            return true;
-        }
-    }
-    
-    // If we get here, it wasn't in any range
-    return false;
-    
+   return vg::algorithms::is_in_sorted_id_ranges(id, ranges); 
 }
 
 auto StreamIndexBase::save(ostream& to) const -> void {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Added `-u`/`--cut-alignment` option to `vg chunk` to allow cutting long alignments down to the portion(s) actually in the chunk.
 * Renamed GAM-related `vg chunk` options to be about generic alignments (with fallback aliases of the old names).

## Description
To debug surject, I wanted to be able to cut out the interesting parts of alignments I don't think are surjecting right, to make small example surjection tasks that exhibit an issue. This adds that feature to `vg chunk`.