### PR TITLE
add is_perfect option

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1892,6 +1892,24 @@ int softclip_trim(Alignment& alignment) {
     return cut_start + cut_end;
 }
 
+bool is_perfect(const Alignment& alignment) {
+    // Non-aligned paths can't be perfect (code from subcommand/stats_main.cpp)
+    bool has_alignment = alignment.score() > 0 || alignment.path().mapping_size() > 0;
+    if (!has_alignment) return false;
+
+    // Check that the path is perfect
+    for (size_t i = 0; i < alignment.path().mapping_size(); ++i) {
+        auto& mapping = alignment.path().mapping(i);
+        for (size_t j = 0; j < mapping.edit_size(); ++j) {
+            auto& edit = mapping.edit(j);
+            if (!edit_is_match(edit)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 int query_overlap(const Alignment& aln1, const Alignment& aln2) {
     if (!alignment_to_length(aln1) || !alignment_to_length(aln2)
         || !aln1.path().mapping_size() || !aln2.path().mapping_size()

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -272,6 +272,9 @@ string signature(const Alignment& aln);
 pair<string, string> signature(const Alignment& aln1, const Alignment& aln2);
 string middle_signature(const Alignment& aln, int len);
 pair<string, string> middle_signature(const Alignment& aln1, const Alignment& aln2, int len);
+// Return whether the path is a perfect match (i.e. contains no non-match edits)
+// and has no soft clips (e.g. like in vg stats -a)
+bool is_perfect(const Alignment& alignment);
 
 // project the alignment's path back into a different ID space
 void translate_nodes(Alignment& a, const unordered_map<id_t, pair<id_t, bool> >& ids, const std::function<size_t(int64_t)>& node_length);

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -1552,6 +1552,8 @@ inline void ReadFilter<Alignment>::emit_tsv(Alignment& read, std::ostream& out) 
             out << softclip_end(read);
         } else if (field == "identity") {
             out << read.identity();
+        } else if (field == "is_perfect") {
+            out << is_perfect(read);
         } else if (field == "mapping_quality") {
             out << get_mapq(read); 
         } else if (field == "sequence") {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add `is_perfect` option to `vg filter --tsv-out` to calculate whether a given alignment is perfect

## Description

`vg stats -a` has a statistic for whether an alignment is "perfect", defined as [having no non-match edits](https://github.com/vgteam/vg/blob/1d109aa7bec5034cc92cd8fdbec8644b352e1b35/src/subcommand/stats_main.cpp#L851). That is, it is aligned with no insertions (including soft clips), no deletions, and no substitutions. This PR simply copies the logic into a new function which takes an `Alignment` and spits out whether it is perfect. This allows easy granular investigation of specific reads which are or are not perfect. Perfection is calculated on-the-fly by `vg filter` whenever `is_perfect` is part of the fields requested by `--tsv-out`.