### PR TITLE
Add transcript paths to graph before saving in autoindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ There are multiple read mappers in `vg`:
 * `vg map` is a general-purpose read mapper.
 * `vg mpmap` does "multi-path" mapping, to allow describing local alignment uncertainty. [This is useful for transcriptomics.](#Transcriptomic-analysis)
 
+The graph alignment output format of these mappers (GAM/GAMP) may be [QC'ed by `vg filter --tsv-out`](https://github.com/vgteam/vg/wiki/Getting-alignment-statistics-with-%E2%80%90%E2%80%90tsv%E2%80%90out).
+
 #### Mapping with `vg giraffe`
 
 To use `vg giraffe` to map reads, you will first need to prepare indexes. This is best done using `vg autoindex`. In order to get `vg autoindex` to use haplotype information from a VCF file, you can give it the VCF and the associated linear reference directly.

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -2086,6 +2086,8 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                 auto dummy = unique_ptr<gbwt::GBWT>(new gbwt::GBWT());
                 size_t transcripts_added = transcriptome.add_reference_transcripts(vector<istream *>({&infile_tx}), dummy, false, false);
                 
+                transcriptome.embed_transcript_paths(true, false);
+
                 if (broadcasting_txs && !path_names.empty() && transcripts_added == 0
                     && transcript_file_nonempty(transcripts[idx])) {
                     cerr << "warning:[IndexRegistry] no matching paths from transcript file " << transcript_filename << " were found in graph chunk containing the following paths:" << endl;
@@ -3011,6 +3013,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             }
             
             // save the graph with the transcript paths added
+            transcriptome.embed_transcript_paths(true, making_hsts);
             transcriptome.write_graph(&tx_graph_outfile);
             
             tx_graph_names[i] = tx_graph_name;
@@ -3215,6 +3218,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         
         
         // save the graph with the transcript paths added
+        transcriptome.embed_transcript_paths(true, making_hsts);
         transcriptome.write_graph(&tx_graph_outfile);
         tx_graph_names.push_back(tx_graph_name);
         

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -51,6 +51,7 @@ void help_filter(char** argv) {
          << "    -v, --verbose              print out statistics on numbers of reads dropped by what." << endl
          << "    -V, --no-output            print out statistics (as above) but do not write out filtered GAM." << endl
          << "    -T, --tsv-out FIELD[;FIELD] do not write filtered gam but a tsv of the given fields" << endl
+         << "                                See \"Getting alignment statistics with ‐‐tsv‐out\" wiki page" << endl
          << "    -q, --min-mapq N           drop alignments with mapping quality < N" << endl
          << "    -E, --repeat-ends N        drop reads with tandem repeat (motif size <= 2N, spanning >= N bases) at either end" << endl
          << "    -D, --defray-ends N        clip back the ends of reads that are ambiguously aligned, up to N bases" << endl


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add transcript paths to spliced transcriptome graph before saving in autoindex

## Description

From debugging [#480](https://github.com/vgteam/sequenceTubeMap/issues/480): autoindex was successfully adding transcript paths to the spliced graph, but only to the Transcriptome's `._transcript_paths` private field. We were neglecting to embed those paths into the Transcriptome's graph. Thus when the graph was saved, it didn't have the paths in it, since the Transcriptome kept that knowledge separate from its graph.