### PR TITLE
Have autoindex add paths to spliced graph before saving

### DIFF
--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -3011,6 +3011,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
             }
             
             // save the graph with the transcript paths added
+            transcriptome.embed_transcript_paths(true, making_hsts);
             transcriptome.write_graph(&tx_graph_outfile);
             
             tx_graph_names[i] = tx_graph_name;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add transcript paths to spliced transcriptome graph before saving in autoindex

## Description

From debugging [SequenceTubeMap #480](https://github.com/vgteam/sequenceTubeMap/issues/480): autoindex was successfully adding transcript paths to the spliced graph, but only to the Transcriptome's `._transcript_paths` private field. We were neglecting to embed those paths into the Transcriptome's graph. Thus when the graph was saved, it didn't have the paths in it, since the Transcriptome kept that knowledge separate from its graph.