### PR TITLE
Fix documentation claiming that vg giraffe only supporting short reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ If you have more than one sequence, or you are working on a large graph, you wil
 
 There are multiple read mappers in `vg`:
 
-* `vg giraffe` is designed to be fast for highly accurate short reads, against graphs with haplotype information.
+* `vg giraffe` is designed to be fast for highly accurate short reads, against graphs with haplotype information. It also now has a chaining mode to use for long reads.
 * `vg map` is a general-purpose read mapper.
 * `vg mpmap` does "multi-path" mapping, to allow describing local alignment uncertainty. [This is useful for transcriptomics.](#Transcriptomic-analysis)
 

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1,5 +1,5 @@
 /**
- * \file giraffe_main.cpp: G(ir)AF (Graph Alignment Format) Fast Emitter: a fast short-read-to-haplotypes mapper
+ * \file giraffe_main.cpp: G(ir)AF (Graph Alignment Format) Fast Emitter: a fast read-to-haplotypes mapper
  */
 
 #include <omp.h>
@@ -704,7 +704,7 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
     << "  " << argv[0] << " giraffe -Z graph.gbz [-d graph.dist -m graph.min] <input options> [other options] > output.gam" << endl
     << "  " << argv[0] << " giraffe -Z graph.gbz --haplotype-name graph.hapl --kff-name sample.kff <input options> [other options] > output.gam" << endl
     << endl
-    << "Fast haplotype-aware short read mapper." << endl
+    << "Fast haplotype-aware read mapper." << endl
     << endl;
 
     cerr


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Change README and vg giraffe's helptext to indicate that it supports long reads as well as short reads

## Description

This was bothering me. I figure the minor documentation things just got forgotten when developing the big lr-giraffe branch.
