### PR TITLE
Tsv cigar

### DIFF
--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -1628,7 +1628,7 @@ inline void ReadFilter<Alignment>::emit_tsv(Alignment& read, std::ostream& out) 
                 }
             }
         } else {
-            cerr << endl << "Available fields: <https://github.com/vgteam/vg/wiki/Getting-alignment-statistics-with-%E2%80%90%E2%80%90tsv%E2%80%90out>" << endl;
+            cerr << endl << "Available fields: <https://github.com/vgteam/vg/wiki/Getting-alignment-statistics-with-vg-filter>" << endl;
             throw runtime_error("error: Writing non-existent field to tsv: " + field);
         }
         if (i != output_fields.size()-1) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add a CIGAR option to `--tsv-out`

## Description

I wanted to be able to output CIGARs to compare mappings against minimap2. The code here is patterned off of the [alignment logging](https://github.com/vgteam/vg/blob/61cfb60bb4963b9f378ebcf2babe240b1e0a6a33/src/minimizer_mapper.cpp#L100) in `minimizer_mapper.cpp`. Also I did minor tidying up to the `emit_tsv()` function in general (the later commits).
