### PR TITLE
Standardize help caps

### DIFF
--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -34,40 +34,40 @@ void help_call(char** argv) {
        << "Call variants or genotype known variants" << endl
        << endl
        << "support calling options:" << endl
-       << "    -k, --pack FILE          Supports created from vg pack for given input graph" << endl
-       << "    -m, --min-support M,N    Minimum allele support (M) and minimum site support (N) for call [default = 2,4]" << endl
-       << "    -e, --baseline-error X,Y Baseline error rates for Poisson model for small (X) and large (Y) variants [default= 0.005,0.01]" << endl
-       << "    -B, --bias-mode          Use old ratio-based genotyping algorithm as opposed to probablistic model" << endl
-       << "    -b, --het-bias M,N       Homozygous alt/ref allele must have >= M/N times more support than the next best allele [default = 6,6]" << endl
+       << "    -k, --pack FILE          supports created from vg pack for given input graph" << endl
+       << "    -m, --min-support M,N    minimum allele support (M) and minimum site support (N) for call [default = 2,4]" << endl
+       << "    -e, --baseline-error X,Y baseline error rates for Poisson model for small (X) and large (Y) variants [default= 0.005,0.01]" << endl
+       << "    -B, --bias-mode          use old ratio-based genotyping algorithm as opposed to probablistic model" << endl
+       << "    -b, --het-bias M,N       homozygous alt/ref allele must have >= M/N times more support than the next best allele [default = 6,6]" << endl
        << "GAF options:" << endl
-       << "    -G, --gaf               Output GAF genotypes instead of VCF" << endl
-       << "    -T, --traversals        Output all candidate traversals in GAF without doing any genotyping" << endl
-       << "    -M, --trav-padding N    Extend each flank of traversals (from -T) with reference path by N bases if possible" << endl
+       << "    -G, --gaf               output GAF genotypes instead of VCF" << endl
+       << "    -T, --traversals        output all candidate traversals in GAF without doing any genotyping" << endl
+       << "    -M, --trav-padding N    extend each flank of traversals (from -T) with reference path by N bases if possible" << endl
        << "general options:" << endl
        << "    -v, --vcf FILE          VCF file to genotype (must have been used to construct input graph with -a)" << endl
-       << "    -a, --genotype-snarls   Genotype every snarl, including reference calls (use to compare multiple samples)" << endl
-       << "    -A, --all-snarls        Genotype all snarls, including nested child snarls (like deconstruct -a)" << endl
-       << "    -c, --min-length N      Genotype only snarls with at least one traversal of length >= N" << endl
-       << "    -C, --max-length N      Genotype only snarls where all traversals have length <= N" << endl
-       << "    -f, --ref-fasta FILE    Reference fasta (required if VCF contains symbolic deletions or inversions)" << endl
-       << "    -i, --ins-fasta FILE    Insertions fasta (required if VCF contains symbolic insertions)" << endl
-       << "    -s, --sample NAME       Sample name [default=SAMPLE]" << endl
-       << "    -r, --snarls FILE       Snarls (from vg snarls) to avoid recomputing." << endl
-       << "    -g, --gbwt FILE         Only call genotypes that are present in given GBWT index." << endl
-       << "    -z, --gbz               Only call genotypes that are present in GBZ index (applies only if input graph is GBZ)." << endl
-       << "    -N, --translation FILE  Node ID translation (as created by vg gbwt --translation) to apply to snarl names in output" << endl
-       << "    -O, --gbz-translation   Use the ID translation from the input gbz to apply snarl names to snarl names and AT fields in output" << endl
-       << "    -p, --ref-path NAME     Reference path to call on (multipile allowed. defaults to all paths)" << endl
-       << "    -S, --ref-sample NAME   Call on all paths with given sample name (cannot be used with -p)" << endl
-       << "    -o, --ref-offset N      Offset in reference path (multiple allowed, 1 per path)" << endl
-       << "    -l, --ref-length N      Override length of reference in the contig field of output VCF" << endl
-       << "    -d, --ploidy N          Ploidy of sample.  Only 1 and 2 supported. (default: 2)" << endl
+       << "    -a, --genotype-snarls   genotype every snarl, including reference calls (use to compare multiple samples)" << endl
+       << "    -A, --all-snarls        genotype all snarls, including nested child snarls (like deconstruct -a)" << endl
+       << "    -c, --min-length N      genotype only snarls with at least one traversal of length >= N" << endl
+       << "    -C, --max-length N      genotype only snarls where all traversals have length <= N" << endl
+       << "    -f, --ref-fasta FILE    reference fasta (required if VCF contains symbolic deletions or inversions)" << endl
+       << "    -i, --ins-fasta FILE    insertions fasta (required if VCF contains symbolic insertions)" << endl
+       << "    -s, --sample NAME       sample name [default=SAMPLE]" << endl
+       << "    -r, --snarls FILE       snarls (from vg snarls) to avoid recomputing." << endl
+       << "    -g, --gbwt FILE         only call genotypes that are present in given GBWT index." << endl
+       << "    -z, --gbz               only call genotypes that are present in GBZ index (applies only if input graph is GBZ)." << endl
+       << "    -N, --translation FILE  node ID translation (as created by vg gbwt --translation) to apply to snarl names in output" << endl
+       << "    -O, --gbz-translation   use the ID translation from the input gbz to apply snarl names to snarl names and AT fields in output" << endl
+       << "    -p, --ref-path NAME     reference path to call on (multipile allowed. defaults to all paths)" << endl
+       << "    -S, --ref-sample NAME   call on all paths with given sample name (cannot be used with -p)" << endl
+       << "    -o, --ref-offset N      offset in reference path (multiple allowed, 1 per path)" << endl
+       << "    -l, --ref-length N      override length of reference in the contig field of output VCF" << endl
+       << "    -d, --ploidy N          ploidy of sample.  Only 1 and 2 supported. (default: 2)" << endl
        << "    -R, --ploidy-regex RULES    use the given comma-separated list of colon-delimited REGEX:PLOIDY rules to assign" << endl
        << "                                ploidies to contigs not visited by the selected samples, or to all contigs simulated" << endl
        << "                                from if no samples are used. Unmatched contigs get ploidy 2 (or that from -d)." << endl
-       << "    -n, --nested            Activate nested calling mode (experimental)" << endl
-       << "    -I, --chains            Call chains instead of snarls (experimental)" << endl
-       << "        --progress          Show progress" << endl
+       << "    -n, --nested            activate nested calling mode (experimental)" << endl
+       << "    -I, --chains            call chains instead of snarls (experimental)" << endl
+       << "        --progress          show progress" << endl
        << "    -t, --threads N         number of threads to use" << endl;
 }    
 

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -79,9 +79,9 @@ void help_chunk(char** argv) {
          << "    -l, --context-length N   expand the context of the chunk by this many bp [0]" << endl
          << "    -T, --trace              trace haplotype threads in chunks (and only expand forward from input coordinates)." << endl
          << "                             Produces a .annotate.txt file with haplotype frequencies for each chunk." << endl
-         << "    --no-embedded-haplotypes Don't load haplotypes from the graph. It is possible to -T without any haplotypes available." << endl
+         << "    --no-embedded-haplotypes don't load haplotypes from the graph. It is possible to -T without any haplotypes available." << endl
          << "    -f, --fully-contained    only return GAM alignments that are fully contained within chunk" << endl
-         << "    -O, --output-fmt         Specify output format (vg, pg, hg, gfa).  [pg (vg with -T)]" << endl
+         << "    -O, --output-fmt         specify output format (vg, pg, hg, gfa).  [pg (vg with -T)]" << endl
          << "    -t, --threads N          for tasks that can be done in parallel, use this many threads [1]" << endl
          << "    -h, --help" << endl;
 }

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -22,30 +22,30 @@ void help_clip(char** argv) {
        << endl
        << "input options: " << endl
        << "    -b, --bed FILE            BED regions corresponding to path intervals of the graph to target" << endl
-       << "    -r, --snarls FILE         Snarls from vg snarls (recomputed if not given unless -d and -P used)." << endl
+       << "    -r, --snarls FILE         snarls from vg snarls (recomputed if not given unless -d and -P used)." << endl
        << "depth clipping options: " << endl
-       << "    -d, --depth N             Clip out nodes and edges with path depth below N" << endl
+       << "    -d, --depth N             clip out nodes and edges with path depth below N" << endl
        << "stub clipping options:" << endl
-       << "    -s, --stubs               Clip out all stubs (nodes with degree-0 sides that aren't on reference)" << endl
-       << "    -S, --stubbify-paths      Clip out all edges necessary to ensure selected reference paths have exactly two stubs" << endl
+       << "    -s, --stubs               clip out all stubs (nodes with degree-0 sides that aren't on reference)" << endl
+       << "    -S, --stubbify-paths      clip out all edges necessary to ensure selected reference paths have exactly two stubs" << endl
        << "snarl complexity clipping options: [default mode]" << endl
-       << "    -n, --max-nodes N         Only clip out snarls with > N nodes" << endl
-       << "    -e, --max-edges N         Only clip out snarls with > N edges" << endl
-       << "    -N  --max-nodes-shallow N Only clip out snarls with > N nodes not including nested snarls" << endl
-       << "    -E  --max-edges-shallow N Only clip out snarls with > N edges not including nested snarls" << endl
-       << "    -a, --max-avg-degree N    Only clip out snarls with average degree > N" << endl
-       << "    -l, --max-reflen-prop F   Ignore snarls whose reference traversal spans more than F (0<=F<=1) of the whole reference path" << endl
-       << "    -L, --max-reflen N        Ignore snarls whose reference traversal spans more than N bp" << endl
+       << "    -n, --max-nodes N         only clip out snarls with > N nodes" << endl
+       << "    -e, --max-edges N         only clip out snarls with > N edges" << endl
+       << "    -N  --max-nodes-shallow N only clip out snarls with > N nodes not including nested snarls" << endl
+       << "    -E  --max-edges-shallow N only clip out snarls with > N edges not including nested snarls" << endl
+       << "    -a, --max-avg-degree N    only clip out snarls with average degree > N" << endl
+       << "    -l, --max-reflen-prop F   ignore snarls whose reference traversal spans more than F (0<=F<=1) of the whole reference path" << endl
+       << "    -L, --max-reflen N        ignore snarls whose reference traversal spans more than N bp" << endl
        << "big deletion edge clipping options:" << endl
-       << "    -D, --max-deletion-edge N Clip out all edges whose endpoints have distance > N on a reference path" << endl
-       << "    -c, --context N           Search up to at most N steps from reference paths for candidate deletion edges [1]" << endl
+       << "    -D, --max-deletion-edge N clip out all edges whose endpoints have distance > N on a reference path" << endl
+       << "    -c, --context N           search up to at most N steps from reference paths for candidate deletion edges [1]" << endl
        << "general options: " << endl
-       << "    -P, --path-prefix STRING  Do not clip out alleles on paths beginning with given prefix (such references must be specified either with -P or -b). Multiple allowed" << endl
-       << "    -m, --min-fragment-len N  Don't write novel path fragment if it is less than N bp long" << endl
-       << "    -B, --output-bed          Write BED-style file of affected intervals instead of clipped graph. " << endl
-       << "                              Columns 4-9 are: snarl node-count edge-count shallow-node-count shallow-edge-count avg-degree" << endl
+       << "    -P, --path-prefix STRING  do not clip out alleles on paths beginning with given prefix (such references must be specified either with -P or -b). Multiple allowed" << endl
+       << "    -m, --min-fragment-len N  don't write novel path fragment if it is less than N bp long" << endl
+       << "    -B, --output-bed          write BED-style file of affected intervals instead of clipped graph. " << endl
+       << "                              columns 4-9 are: snarl node-count edge-count shallow-node-count shallow-edge-count avg-degree" << endl
        << "    -t, --threads N           number of threads to use [default: all available]" << endl
-       << "    -v, --verbose             Print some logging messages" << endl
+       << "    -v, --verbose             print some logging messages" << endl
        << endl;
 }    
 

--- a/src/subcommand/combine_main.cpp
+++ b/src/subcommand/combine_main.cpp
@@ -30,9 +30,9 @@ void help_combine(char** argv) {
          << "Node IDs will be modified as needed to resolve conflicts (in same manner as vg ids -j)." << endl
          << endl
          << "Options:" << endl
-         << "    -c, --cat-proto       Merge graphs by converting each to Protobuf (if not already) and catting the results."
-         << "                          Node IDs not modified [DEPRECATED]" << endl
-         << "    -p, --connect-paths   Add edges necessary to connect paths with the same name present in different graphs." << endl
+         << "    -c, --cat-proto       merge graphs by converting each to Protobuf (if not already) and catting the results."
+         << "                          node IDs not modified [DEPRECATED]" << endl
+         << "    -p, --connect-paths   add edges necessary to connect paths with the same name present in different graphs." << endl
          << "                          ex: If path x is present in graphs N-1 and N, then an edge connecting the last node of x in N-1 " << endl
          << "                          and the first node of x in N will be added." << endl;
 }

--- a/src/subcommand/concat_main.cpp
+++ b/src/subcommand/concat_main.cpp
@@ -30,7 +30,7 @@ void help_concat(char** argv) {
          << "between graphs, they will be resolved (as in vg ids -j)" << endl
          << endl
          << "Options:" << endl
-         << "    -p, --only-join-paths         Only add edges necessary to join up appended paths (as opposed between all heads/tails)" << endl
+         << "    -p, --only-join-paths         only add edges necessary to join up appended paths (as opposed between all heads/tails)" << endl
          << endl;
 }
 

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -47,7 +47,7 @@ void help_construct(char** argv) {
          << "shared construction options:" << endl
          << "    -m, --node-max N       limit the maximum allowable node sequence size (default: 32)" << endl
          << "                           nodes greater than this threshold will be divided" << endl
-         << "                           Note: nodes larger than ~1024 bp can't be GCSA2-indexed" << endl
+         << "                           note: nodes larger than ~1024 bp can't be GCSA2-indexed" << endl
          << "    -p, --progress         show progress" << endl;
 
 }

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -485,14 +485,14 @@ void help_convert(char** argv) {
          << "    -Q, --rgfa-prefix STR  write paths with given prefix as rGFA tags instead of lines" << endl
          << "                           (multiple allowed, only rank-0 supported)" << endl
          << "    -B, --rgfa-pline       paths written as rGFA tags also written as lines" << endl
-         << "    -W, --no-wline         Write all paths as GFA P-lines instead of W-lines." << endl
-         << "                           Allows handling multiple phase blocks and subranges used together." << endl
-         << "    --gbwtgraph-algorithm  Always use the GBWTGraph library GFA algorithm." << endl
-         << "                           Not compatible with other GFA output options or non-GBWT graphs." << endl
-         << "    --vg-algorithm         Always use the VG GFA algorithm. Works with all options and graph types," << endl
+         << "    -W, --no-wline         write all paths as GFA P-lines instead of W-lines." << endl
+         << "                           allows handling multiple phase blocks and subranges used together." << endl
+         << "    --gbwtgraph-algorithm  always use the GBWTGraph library GFA algorithm." << endl
+         << "                           not compatible with other GFA output options or non-GBWT graphs." << endl
+         << "    --vg-algorithm         always use the VG GFA algorithm. Works with all options and graph types," << endl
          << "                           but can't preserve original GFA coordinates." << endl
-         << "    --no-translation       When using the GBWTGraph algorithm, convert the graph directly to GFA." << endl
-         << "                           Do not use the translation to preserve original coordinates." << endl
+         << "    --no-translation       when using the GBWTGraph algorithm, convert the graph directly to GFA." << endl
+         << "                           do not use the translation to preserve original coordinates." << endl
          << "alignment options:" << endl
          << "    -G, --gam-to-gaf FILE  convert GAM FILE to GAF" << endl
          << "    -F, --gaf-to-gam FILE  convert GAF FILE to GAM" << endl

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -38,24 +38,24 @@ void help_deconstruct(char** argv){
     cerr << "usage: " << argv[0] << " deconstruct [options] [-p|-P] <PATH> <GRAPH>" << endl
          << "Outputs VCF records for Snarls present in a graph (relative to a chosen reference path)." << endl
          << "options: " << endl
-         << "    -p, --path NAME          A reference path to deconstruct against (multiple allowed)." << endl
-         << "    -P, --path-prefix NAME   All paths [excluding GBWT threads / non-reference GBZ paths] beginning with NAME used as reference (multiple allowed)." << endl
-         << "                             Other non-ref paths not considered as samples. " << endl
-         << "    -r, --snarls FILE        Snarls file (from vg snarls) to avoid recomputing." << endl
+         << "    -p, --path NAME          a reference path to deconstruct against (multiple allowed)." << endl
+         << "    -P, --path-prefix NAME   all paths [excluding GBWT threads / non-reference GBZ paths] beginning with NAME used as reference (multiple allowed)." << endl
+         << "                             other non-ref paths not considered as samples. " << endl
+         << "    -r, --snarls FILE        snarls file (from vg snarls) to avoid recomputing." << endl
          << "    -g, --gbwt FILE          consider alt traversals that correspond to GBWT haplotypes in FILE (not needed for GBZ graph input)." << endl
-         << "    -T, --translation FILE   Node ID translation (as created by vg gbwt --translation) to apply to snarl names and AT fields in output" << endl
-         << "    -O, --gbz-translation    Use the ID translation from the input gbz to apply snarl names to snarl names and AT fields in output" << endl
-         << "    -a, --all-snarls         Process all snarls, including nested snarls (by default only top-level snarls reported)." << endl
-         << "    -c, --context-jaccard N  Set context mapping size used to disambiguate alleles at sites with multiple reference traversals (default: 10000)." << endl
-         << "    -u, --untangle-travs     Use context mapping to determine the reference-relative positions of each step in allele traversals (AP INFO field)." << endl
-         << "    -K, --keep-conflicted    Retain conflicted genotypes in output." << endl
-         << "    -S, --strict-conflicts   Drop genotypes when we have more than one haplotype for any given phase (set by default when using GBWT input)." << endl
-         << "    -C, --contig-only-ref    Only use the CONTIG name (and not SAMPLE#CONTIG#HAPLOTYPE etc) for the reference if possible (ie there is only one reference sample)." << endl
-         << "    -L, --cluster F          Cluster traversals whose (handle) Jaccard coefficient is >= F together (default: 1.0) [experimental]" << endl
-         << "    -n, --nested             Write a nested VCF, including special tags. [experimental]" << endl
-         << "    -R, --star-allele        Use *-alleles to denote alleles that span but do not cross the site. Only works with -n" << endl
-         << "    -t, --threads N          Use N threads" << endl
-         << "    -v, --verbose            Print some status messages" << endl
+         << "    -T, --translation FILE   node ID translation (as created by vg gbwt --translation) to apply to snarl names and AT fields in output" << endl
+         << "    -O, --gbz-translation    use the ID translation from the input gbz to apply snarl names to snarl names and AT fields in output" << endl
+         << "    -a, --all-snarls         process all snarls, including nested snarls (by default only top-level snarls reported)." << endl
+         << "    -c, --context-jaccard N  set context mapping size used to disambiguate alleles at sites with multiple reference traversals (default: 10000)." << endl
+         << "    -u, --untangle-travs     use context mapping to determine the reference-relative positions of each step in allele traversals (AP INFO field)." << endl
+         << "    -K, --keep-conflicted    retain conflicted genotypes in output." << endl
+         << "    -S, --strict-conflicts   drop genotypes when we have more than one haplotype for any given phase (set by default when using GBWT input)." << endl
+         << "    -C, --contig-only-ref    only use the CONTIG name (and not SAMPLE#CONTIG#HAPLOTYPE etc) for the reference if possible (ie there is only one reference sample)." << endl
+         << "    -L, --cluster F          cluster traversals whose (handle) Jaccard coefficient is >= F together (default: 1.0) [experimental]" << endl
+         << "    -n, --nested             write a nested VCF, including special tags. [experimental]" << endl
+         << "    -R, --star-allele        use *-alleles to denote alleles that span but do not cross the site. Only works with -n" << endl
+         << "    -t, --threads N          use N threads" << endl
+         << "    -v, --verbose            print some status messages" << endl
          << endl;
 }
 

--- a/src/subcommand/gamsort_main.cpp
+++ b/src/subcommand/gamsort_main.cpp
@@ -191,4 +191,4 @@ int main_gamsort(int argc, char **argv)
     return 0;
 }
 
-static Subcommand vg_gamsort("gamsort", "Sort a GAM/GAF file or index a sorted GAM file.", main_gamsort);
+static Subcommand vg_gamsort("gamsort", "sort a GAM/GAF file or index a sorted GAM file.", main_gamsort);

--- a/src/subcommand/genotype_main.cpp
+++ b/src/subcommand/genotype_main.cpp
@@ -363,4 +363,4 @@ int main_genotype(int argc, char** argv) {
 }
 
 
-static Subcommand vg_genotype("genotype", "Genotype (or type) graphs, GAMS, and VCFs.", main_genotype);
+static Subcommand vg_genotype("genotype", "genotype (or type) graphs, GAMS, and VCFs.", main_genotype);

--- a/src/subcommand/mask_main.cpp
+++ b/src/subcommand/mask_main.cpp
@@ -174,4 +174,4 @@ int main_mask(int argc, char** argv) {
 
 
 // Register subcommand
-static Subcommand vg_mask("mask", "Mask out sequences in a graph with N's", main_mask);
+static Subcommand vg_mask("mask", "mask out sequences in a graph with N's", main_mask);

--- a/src/subcommand/mask_main.cpp
+++ b/src/subcommand/mask_main.cpp
@@ -51,8 +51,8 @@ void help_mask(char** argv) {
        << endl
        << "input options: " << endl
        << "    -b, --bed FILE       BED regions corresponding to path intervals of the graph to target (required)" << endl
-       << "    -g, --gbz-input      Input graph is in GBZ format" << endl
-       << "    -s, --snarls FILE    Snarls from vg snarls (computed directly if not provided)" << endl
+       << "    -g, --gbz-input      input graph is in GBZ format" << endl
+       << "    -s, --snarls FILE    snarls from vg snarls (computed directly if not provided)" << endl
     
        << endl;
 }    

--- a/src/subcommand/mcmc_main.cpp
+++ b/src/subcommand/mcmc_main.cpp
@@ -254,6 +254,6 @@ int main_mcmc(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_mcmc("mcmc", "Finds haplotypes based on reads using MCMC methods", DEVELOPMENT, main_mcmc);
+static Subcommand vg_mcmc("mcmc", "find haplotypes based on reads using MCMC methods", DEVELOPMENT, main_mcmc);
 
 

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -33,7 +33,7 @@ void help_paths(char** argv) {
          << "options:" << endl
          << "  input:" << endl
          << "    -x, --xg FILE            use the paths and haplotypes in this graph FILE. Supports GBZ haplotypes." <<endl
-         << "                             (Also accepts -v, --vg)" << endl
+         << "                             (also accepts -v, --vg)" << endl
          << "    -g, --gbwt FILE          use the threads in the GBWT index in FILE" << endl
          << "                             (graph also required for most output options; -g takes priority over -x)" << endl
          << "  output graph (.vg format)" << endl

--- a/src/subcommand/sift_main.cpp
+++ b/src/subcommand/sift_main.cpp
@@ -30,26 +30,26 @@ void help_sift(char** argv){
         << "General Options: " << endl
         << "    -t / --threads  <MTHRDS>    number of OMP threads (not all algorithms are parallelized)." << endl
         //<< "    -v / --inverse      return the inverse of a query (like grep -v)"   << endl
-        << "    -p / --paired       Input reads are paired-end" << endl
-        << "    -R / --remap        Remap (locally) any soft-clipped, split, or discordant read pairs." << endl
+        << "    -p / --paired       input reads are paired-end" << endl
+        << "    -R / --remap        remap (locally) any soft-clipped, split, or discordant read pairs." << endl
         << "    -o / --output <PREFIX>" << endl
         << "Paired-end options:" << endl
-        << "    -I / --insert-size <INSRTSZ>        Insert size mean. Flag reads where ((I - insrtsz) / W) > 2.95" << endl
-        << "    -W / --insert-size-sigma <SIGMA>    Standard deviation of insert size." << endl
-        << "    -O / --one-end-anchored             Flag reads where one read of the pair is mapped and the other is unmapped." << endl
-        << "    -C / --interchromosomal             Flag reads mapping to two distinct Paths" << endl
-        << "    -D / --discordant-orientation       Flag reads that do not have the expected --> <-- orientation." << endl
+        << "    -I / --insert-size <INSRTSZ>        insert size mean. Flag reads where ((I - insrtsz) / W) > 2.95" << endl
+        << "    -W / --insert-size-sigma <SIGMA>    standard deviation of insert size." << endl
+        << "    -O / --one-end-anchored             flag reads where one read of the pair is mapped and the other is unmapped." << endl
+        << "    -C / --interchromosomal             flag reads mapping to two distinct Paths" << endl
+        << "    -D / --discordant-orientation       flag reads that do not have the expected --> <-- orientation." << endl
         << "Single-end / individual read options:" << endl
-        << "    -c / --softclip <MAXCLIPLEN>        Flag reads with softclipped sections longer than MAXCLIPLEN" << endl
-        << "    -s / --split-read <SPLITLEN>        Flag reads with softclips that map independently of the anchored portion (requires -x, -g)." << endl
-        //<< "    -q / --quality <QUAL>               Flag reads with a single base quality below <QUAL>" << endl
-        //<< "    -d / --depth <DEPTH>                Flag reads which have a low-depth Pos+Edit combo." << endl
-        //<< "    -i / --percent-identity <PCTID>     Flag reads with percent identity to their primary path beliw <PCTID>" << endl
+        << "    -c / --softclip <MAXCLIPLEN>        flag reads with softclipped sections longer than MAXCLIPLEN" << endl
+        << "    -s / --split-read <SPLITLEN>        flag reads with softclips that map independently of the anchored portion (requires -x, -g)." << endl
+        //<< "    -q / --quality <QUAL>               flag reads with a single base quality below <QUAL>" << endl
+        //<< "    -d / --depth <DEPTH>                flag reads which have a low-depth Pos+Edit combo." << endl
+        //<< "    -i / --percent-identity <PCTID>     flag reads with percent identity to their primary path beliw <PCTID>" << endl
         //<< "    -a / --average" << endl
         //<< "    -w / --window <WINDOWLEN>" << endl
-        << "    -r / --reversing                    Flag reads with sections that reverse within the read, as with small inversions ( --->|<-|-->  or ---->||<-- )" << endl
+        << "    -r / --reversing                    flag reads with sections that reverse within the read, as with small inversions ( --->|<-|-->  or ---->||<-- )" << endl
         << "Helpful helpers: " << endl
-        << "    -1 / --calc-insert                  Calculate and print the insert size mean / sd every 1000 reads." << endl
+        << "    -1 / --calc-insert                  calculate and print the insert size mean / sd every 1000 reads." << endl
         << endl;
 }
 

--- a/src/subcommand/vectorize_main.cpp
+++ b/src/subcommand/vectorize_main.cpp
@@ -30,18 +30,18 @@ void help_vectorize(char** argv){
          << "Vectorize a set of alignments to a variety of vector formats." << endl
          << endl
          << "options: " << endl
-         << "  -x --xg FILE       An xg index or graph of interest" << endl
-         << "  -g --gcsa FILE     A gcsa2 index to use if generating MEM sketches" << endl
-         << "  -l --aln-label LABEL   Rename every alignment to LABEL when outputting alignment name." << endl
-         << "  -f --format        Tab-delimit output so it can be used in R." << endl
-         << "  -A --annotate      Create a header with each node/edge's name and a column with alignment names." << endl
-         << "  -a --a-hot         Instead of a 1-hot, output a vector of {0|1|2} for covered, reference, or alt." << endl
-         << "  -w --wabbit        Output a format that's friendly to vowpal wabbit" << endl
+         << "  -x --xg FILE       an xg index or graph of interest" << endl
+         << "  -g --gcsa FILE     a gcsa2 index to use if generating MEM sketches" << endl
+         << "  -l --aln-label LABEL   rename every alignment to LABEL when outputting alignment name." << endl
+         << "  -f --format        tab-delimit output so it can be used in R." << endl
+         << "  -A --annotate      create a header with each node/edge's name and a column with alignment names." << endl
+         << "  -a --a-hot         instead of a 1-hot, output a vector of {0|1|2} for covered, reference, or alt." << endl
+         << "  -w --wabbit        output a format that's friendly to vowpal wabbit" << endl
          << "  -M --wabbit-mapping <FILE> output the mappings used for vowpal wabbit classes (default: print to stderr)" << endl
-         << "  -m --mem-sketch    Generate a MEM sketch of a given read based on the GCSA" << endl
-         << "  -p --mem-positions Add the positions to the MEM sketch of a given read based on the GCSA" << endl
-         << "  -H --mem-hit-max N Ignore MEMs with this many hits when extracting poisitions" << endl
-         << "  -i --identity-hot  Output a score vector based on percent identity and coverage" << endl
+         << "  -m --mem-sketch    generate a MEM sketch of a given read based on the GCSA" << endl
+         << "  -p --mem-positions add the positions to the MEM sketch of a given read based on the GCSA" << endl
+         << "  -H --mem-hit-max N ignore MEMs with this many hits when extracting poisitions" << endl
+         << "  -i --identity-hot  output a score vector based on percent identity and coverage" << endl
          << endl;
 }
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Standardize capitalization in helptext

## Description

Most options' helptext start with a lowercase letter. This PR makes them all start with lowercase letters, except for uppercase abbreviations (VCF etc.) The first commit does so for just `vg help`, and the second does it for all commands' internal helptext.

Is this petty? Yes. But I can be very petty about orthography :)
