### PR TITLE
Pomote generic-sense paths to haplotypes

### DIFF
--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -39,14 +39,14 @@ void help_convert(char** argv);
 void no_multiple_inputs(input_type input);
 // Generate an XG with nodes, edges, and paths from input.
 // Promote haplotype-sense paths for the samples in ref_samples to reference sense.
-// Promote generic-sense paths for the samples in hap_samples to haplotype sense.
+// Promote generic-sense path with the locus hap_locus to haplotype sense.
 // Copy across other haplotype-sense paths if unless drop_haplotypes is true.
-void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, const std::unordered_set<std::string>& ref_samples, const std::unordered_set<std::string>& hap_samples, bool drop_haplotypes);
+void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, const std::unordered_set<std::string>& ref_samples, const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes);
 // Copy paths from input to output.
 // Promote haplotype-sense paths for the samples in ref_samples to reference sense.
-// Promote generic-sense paths for the samples in hap_samples to haplotype sense.
+// Promote generic-sense paths with the locus hap_locus to haplotype sense.
 // Copy across other haplotype-sense paths if unless drop_haplotypes is true.
-void add_and_adjust_paths(const PathHandleGraph* input, MutablePathHandleGraph* output, const std::unordered_set<std::string>& ref_samples, const std::unordered_set<std::string>& hap_samples, bool drop_haplotypes);
+void add_and_adjust_paths(const PathHandleGraph* input, MutablePathHandleGraph* output, const std::unordered_set<std::string>& ref_samples, const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes);
 
 
 //------------------------------------------------------------------------------
@@ -60,7 +60,8 @@ int main_convert(int argc, char** argv) {
     string input_aln;
     string gbwt_name;
     unordered_set<string> ref_samples;
-    unordered_set<string> hap_samples;
+    string hap_locus;
+    string new_sample;
     bool drop_haplotypes = false;
     set<string> rgfa_paths;
     vector<string> rgfa_prefixes;
@@ -81,7 +82,8 @@ int main_convert(int argc, char** argv) {
     constexpr int OPT_GBWTGRAPH_ALGORITHM = 1001;
     constexpr int OPT_VG_ALGORITHM = 1002;
     constexpr int OPT_NO_TRANSLATION = 1003;
-    constexpr int OPT_HAP_SAMPLE = 1004;
+    constexpr int OPT_HAP_LOCUS = 1004;
+    constexpr int OPT_NEW_SAMPLE = 1005;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -93,7 +95,8 @@ int main_convert(int argc, char** argv) {
             {"in-rgfa-rank", required_argument, 0, 'r'},
             {"gbwt-in", required_argument, 0, 'b'},
             {"ref-sample", required_argument, 0, OPT_REF_SAMPLE},
-            {"hap-sample", required_argument, 0, OPT_HAP_SAMPLE},
+            {"hap-locus", required_argument, 0, OPT_HAP_LOCUS},
+            {"new-sample", required_argument, 0, OPT_NEW_SAMPLE},
             {"drop-haplotypes", no_argument, 0, 'H'},
             {"vg-out", no_argument, 0, 'v'},
             {"hash-out", no_argument, 0, 'a'},
@@ -144,8 +147,11 @@ int main_convert(int argc, char** argv) {
         case OPT_REF_SAMPLE:
             ref_samples.insert(optarg);
             break;
-        case OPT_HAP_SAMPLE:
-            hap_samples.insert(optarg);
+        case OPT_HAP_LOCUS:
+            hap_locus = optarg;
+            break;
+        case OPT_NEW_SAMPLE:
+            new_sample = optarg;
             break;
         case 'H':
             drop_haplotypes = true;
@@ -240,12 +246,16 @@ int main_convert(int argc, char** argv) {
         cerr << "error [vg convert]: paths cannot be converted to reference sense when writing GFA output" << endl;
         return 1;
     }
-    if (output_format == "gfa" && !hap_samples.empty()) {
+    if (output_format == "gfa" && !hap_locus.empty()) {
         cerr << "error [vg convert]: paths cannot be converted to haplotype sense when writing GFA output" << endl;
         return 1;
     }
-    if (!ref_samples.empty() && !hap_samples.empty()) {
+    if (!ref_samples.empty() && !hap_locus.empty()) {
         cerr << "error [vg convert]: cannot convert paths to haplotype and reference sense at the same time" << endl;
+        return 1;
+    }
+    if (new_sample.empty() != hap_locus.empty()) {
+        cerr << "error [vg convert]: to convert a generic-sense path to a haplotype, both --hap-locus and --new-sample are required" << endl;
         return 1;
     }
     if (output_format == "vg") {
@@ -320,7 +330,7 @@ int main_convert(int argc, char** argv) {
             cerr << "warning [vg convert]: currently cannot convert GFA directly to XG; converting through another format" << endl;
             algorithms::gfa_to_path_handle_graph(input_stream_name, &intermediate,
                                                  input_rgfa_rank, gfa_trans_path);
-            graph_to_xg_adjusting_paths(&intermediate, xg_graph, ref_samples, hap_samples, drop_haplotypes);
+            graph_to_xg_adjusting_paths(&intermediate, xg_graph, ref_samples, hap_locus, new_sample, drop_haplotypes);
         }
         else {
             // If the GFA doesn't have forward references, we can handle it
@@ -379,7 +389,7 @@ int main_convert(int argc, char** argv) {
                 xg::XG* xg_graph = dynamic_cast<xg::XG*>(output_graph.get());
                 if (input_path_graph != nullptr) {
                     // We can convert to XG with paths, which we might adjust
-                    graph_to_xg_adjusting_paths(input_path_graph, xg_graph, ref_samples, hap_samples, drop_haplotypes);
+                    graph_to_xg_adjusting_paths(input_path_graph, xg_graph, ref_samples, hap_locus, new_sample, drop_haplotypes);
                 } else {
                     // No paths, just convert to xg without paths
                     xg_graph->from_handle_graph(*input_graph);
@@ -394,7 +404,7 @@ int main_convert(int argc, char** argv) {
                 // Copy the graph as-is
                 handlealgs::copy_handle_graph(input_graph.get(), mutable_output_graph);
                 // Copy the paths across with possibly some rewriting
-                add_and_adjust_paths(input_path_graph, mutable_output_graph, ref_samples, hap_samples, drop_haplotypes);
+                add_and_adjust_paths(input_path_graph, mutable_output_graph, ref_samples, hap_locus, new_sample, drop_haplotypes);
             }
             // HandleGraph output.
             else {
@@ -485,7 +495,8 @@ void help_convert(char** argv) {
          << "    -r, --in-rgfa-rank N   import rgfa tags with rank <= N as paths [default=0]" << endl
          << "    -b, --gbwt-in FILE     input graph is a GBWTGraph using the GBWT in FILE" << endl
          << "        --ref-sample STR   change haplotypes for this sample to reference paths (may repeat)" << endl
-         << "        --hap-sample STR   change generic paths for this sample to haplotype paths (may repeat)" << endl
+         << "        --hap-locus STR    change generic paths with this locus to haplotype paths (must be used with --new-sample)" << endl
+         << "        --new-sample STR   when using --hap-locus, give the new haplotype this sample name (must be used with --hap-locus)" << endl
          << "gfa input options (use with -g):" << endl
          << "    -T, --gfa-trans FILE   write gfa id conversions to FILE" << endl
          << "output options:" << endl
@@ -573,7 +584,7 @@ std::unordered_map<std::string, std::unordered_set<int64_t>> check_duplicate_pat
     return sample_to_haplotypes;
 }
 
-void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, const std::unordered_set<std::string>& ref_samples, const std::unordered_set<std::string>& hap_samples, bool drop_haplotypes) {
+void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, const std::unordered_set<std::string>& ref_samples, const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes) {
     // Building an XG uses a slightly different interface, so we duplicate some
     // code from the normal MutablePathMutableHandleGraph build.
     // TODO: Find a way to unify the duplicated code?
@@ -616,7 +627,7 @@ void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, c
         
         // Copy over the existing generic paths, except ones that get promoted to haplotype paths
         input->for_each_path_matching({PathSense::GENERIC}, {}, {}, [&](const path_handle_t& path) {
-            if (hap_samples.empty() || hap_samples.count(input->get_locus_name(path)) == 0) {
+            if (hap_locus != input->get_locus_name(path)) {
                 copy_path(path, input->get_path_name(path));
             }
         });
@@ -652,18 +663,13 @@ void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, c
             });
         }
 
-        if (!hap_samples.empty()) {
-            // Copy all generic paths matching the hap samples as haplotypes
-            input->for_each_path_matching({PathSense::GENERIC}, {}, hap_samples, [&](const path_handle_t& path) {
+        if (!hap_locus.empty()) {
+            // Copy the generic paths matching the hap samples as haplotypes
+            input->for_each_path_matching({PathSense::GENERIC}, {}, {hap_locus}, [&](const path_handle_t& path) {
                 
                 // Compose the new haplotype-ified metadata
-                std::string sample = input->get_sample_name(path);
+                std::string sample = new_sample;
                 std::string locus = input->get_locus_name(path);
-                if (sample.empty()) {
-                    // If there is no sample, call it the locus and make locus 0
-                    sample = locus;
-                    locus = "0";
-                }
                 // We should always preserve the haplotype phase number; we
                 // will need it if we ever want to go back to haplotype sense.
                 int64_t haplotype = input->get_haplotype(path);
@@ -702,14 +708,14 @@ void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, c
     output->from_enumerators(for_each_sequence, for_each_edge, for_each_path_element, false);
 }
 
-void add_and_adjust_paths(const PathHandleGraph* input, MutablePathHandleGraph* output, const std::unordered_set<std::string>& ref_samples, const std::unordered_set<std::string>& hap_samples, bool drop_haplotypes) {
+void add_and_adjust_paths(const PathHandleGraph* input, MutablePathHandleGraph* output, const std::unordered_set<std::string>& ref_samples, const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes) {
     
     // Make sure we aren't working with fragmented haplotypes that can't convert to reference sense.
     auto sample_to_haplotypes = check_duplicate_path_names(input, ref_samples);
 
     // Copy over the existing generic paths, except ones that get promoted to haplotype paths
     input->for_each_path_matching({PathSense::GENERIC}, {}, {}, [&](const path_handle_t& path) {
-        if (hap_samples.empty() || hap_samples.count(input->get_locus_name(path)) == 0) {
+        if (hap_locus != input->get_locus_name(path)) {
         handlegraph::algorithms::copy_path(input, path, output);
         }
     });
@@ -746,17 +752,13 @@ void add_and_adjust_paths(const PathHandleGraph* input, MutablePathHandleGraph* 
             handlegraph::algorithms::copy_path(input, path, output, into_path);
         });
     }
-    if (!hap_samples.empty()) {
+    if (!hap_locus.empty()) {
         // Copy all generic paths matching the hap samples as haplotypes
-        input->for_each_path_matching({PathSense::GENERIC}, {}, hap_samples, [&](const path_handle_t& path) {
+        input->for_each_path_matching({PathSense::GENERIC}, {}, {hap_locus}, [&](const path_handle_t& path) {
             
             // Compose the new reference-ified metadata
-            std::string sample = input->get_sample_name(path);
+            std::string sample = new_sample;
             std::string locus = input->get_locus_name(path);
-            if (sample.empty()) {
-                sample = locus;
-                locus = "0";
-            }
             // We should always preserve the haplotype phase number; we
             // will need it if we ever want to go back to haplotype sense.
             int64_t haplotype = input->get_haplotype(path);


### PR DESCRIPTION


## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add option to `vg convert` to promote generic-sense paths to haplotype-sense paths

## Description
This adds option `vg convert --hap-sample` to convert generic-sense paths to haplotype-sense paths.
Since generic-sense paths only have a locus, the new haplotype-sense path will have that locus as its sample name and everything else defaults to 0.

I'm not sure if this makes sense to do, or if the way I formulated the new path is correct. I added it because I have a graph with only generic-sense paths and I want one of them to be the reference. I couldn't find another way to edit a path's metadata