### PR TITLE
Add --progress to vg filter

### DIFF
--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1788,7 +1788,7 @@ namespace vg {
         cerr << "building contig for chunk of reference " << reference_contig << " in interval " << leading_offset << " to " << reference_end << endl;
 #endif
 
-        // Set up a progress bar thhrough the chromosome
+        // Set up a progress bar through the chromosome
         create_progress("building graph for " + vcf_contig, reference_end - leading_offset);
 
         // Scan through variants until we find one that is on this contig and in this region.

--- a/src/progressive.cpp
+++ b/src/progressive.cpp
@@ -59,6 +59,14 @@ void Progressive::create_progress(long count) {
     }
 }
 
+void Progressive::ensure_progress(long count) {
+    if (show_progress) {
+        if (!progress || progress_count != count) {
+            create_progress(count);
+        }
+    }
+}
+
 void Progressive::preload_progress(const string& message) {
     if (show_progress && !progress) {
         // Set the message. We can't change it if a progress bar exists

--- a/src/progressive.hpp
+++ b/src/progressive.hpp
@@ -59,6 +59,13 @@ public:
      */
     void create_progress(long count);
     /**
+     * Ensure a progress bar is active with the given number of items to
+     * process. If no bar is active, one is created with a default message or
+     * the last message passed to preload_progress(). Does nothing if
+     * show_progress is false.
+     */
+    void ensure_progress(long count);
+    /**
      * Update the progress bar, noting that the given number of items have been
      * processed. Does nothing if no progress bar is displayed.
      */

--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -14,6 +14,7 @@
 #include "IntervalTree.h"
 #include "annotation.hpp"
 #include "multipath_alignment_emitter.hpp"
+#include "progressive.hpp"
 #include <vg/io/alignment_emitter.hpp>
 #include <vg/vg.pb.h>
 #include <vg/io/stream.hpp>
@@ -34,7 +35,7 @@ using namespace std;
 struct Counts;
 
 template<typename Read>
-class ReadFilter {
+class ReadFilter : public Progressive {
 public:
     
     // Filtering parameters
@@ -282,7 +283,7 @@ private:
     /** 
      * Does has the given annotation and does it match
      */
-     bool matches_annotation(const Read& read) const;
+    bool matches_annotation(const Read& read) const;
     
     /**
      * Check if the alignment is marked as being correctly mapped
@@ -488,11 +489,25 @@ void ReadFilter<Read>::filter_internal(istream* in) {
         }
     }
     
+    preload_progress("filter read file");
+
+    auto progress_function = [&](size_t offset, size_t length) {
+        if (length != std::numeric_limits<size_t>::max()) {
+            // We actually have progress data
+            // To avoid keeping state, we make the progress system keep state
+            ensure_progress(length);
+            // And then we do an update
+            update_progress(offset);
+        }
+    };
+
     if (interleaved) {
-        vg::io::for_each_interleaved_pair_parallel(*in, pair_lambda, batch_size);
+        vg::io::for_each_interleaved_pair_parallel(*in, pair_lambda, batch_size, progress_function);
     } else {
-        vg::io::for_each_parallel(*in, lambda, batch_size);
+        vg::io::for_each_parallel(*in, lambda, batch_size, progress_function);
     }
+
+    destroy_progress();
 
     if (write_tsv) {
         // Add a terminating newline

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -67,7 +67,8 @@ void help_filter(char** argv) {
          << "    -l, --first-alignment      keep only the first alignment for each read. Must be run with 1 thread" << endl
          << "    -U, --complement           apply the complement of the filter implied by the other arguments." << endl
          << "    -B, --batch-size           work in batches of the given number of reads [default=" << vg::io::DEFAULT_PARALLEL_BATCHSIZE << "]" << endl
-         << "    -t, --threads N            number of threads [1]" << endl;
+         << "    -t, --threads N            number of threads [1]" << endl
+         << "        --progress             show progress" << endl;
 }
 
 int main_filter(int argc, char** argv) {
@@ -122,11 +123,14 @@ int main_filter(int argc, char** argv) {
     string output_fields = "";
     bool correctly_mapped = false;
     bool first_alignment = false;
+    bool show_progress = false;
 
     size_t batch_size = vg::io::DEFAULT_PARALLEL_BATCHSIZE;
 
     // What XG index, if any, should we load to support the other options?
     string xg_name;
+
+    constexpr int OPT_PROGRESS = 1000;
 
     int c;
     optind = 2; // force optind past command positional arguments
@@ -171,6 +175,7 @@ int main_filter(int argc, char** argv) {
                 {"complement", no_argument, 0, 'U'},
                 {"batch-size", required_argument, 0, 'B'},
                 {"threads", required_argument, 0, 't'},
+                {"progress", no_argument, 0, OPT_PROGRESS},
                 {0, 0, 0, 0}
             };
 
@@ -366,6 +371,9 @@ int main_filter(int argc, char** argv) {
         case 't':
             omp_set_num_threads(parse<int>(optarg));
             break;
+        case OPT_PROGRESS:
+            show_progress = true;
+            break;
 
         case 'h':
         case '?':
@@ -487,6 +495,8 @@ int main_filter(int argc, char** argv) {
         filter.complement_filter = complement_filter;
         filter.batch_size = batch_size;
         filter.threads = get_thread_count();
+        filter.show_progress = show_progress;
+        
         filter.graph = xindex;
     };
     


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg filter --progress` now shows you the progress of reading through the input file.

## Description

I got tired of using `pv` with `vg filter` and am easily bored so I added a progress option.
