### PR TITLE
fix wiki page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ There are multiple read mappers in `vg`:
 * `vg map` is a general-purpose read mapper.
 * `vg mpmap` does "multi-path" mapping, to allow describing local alignment uncertainty. [This is useful for transcriptomics.](#Transcriptomic-analysis)
 
-The graph alignment output format of these mappers (GAM/GAMP) may be [QC'ed by `vg filter --tsv-out`](https://github.com/vgteam/vg/wiki/Getting-alignment-statistics-with-%E2%80%90%E2%80%90tsv%E2%80%90out).
+The graph alignment output format of these mappers (GAM/GAMP) may be [QC'ed by `vg filter --tsv-out`](https://github.com/vgteam/vg/wiki/Getting-alignment-statistics-with-vg-filter).
 
 #### Mapping with `vg giraffe`
 


### PR DESCRIPTION


## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fix broken link in README due to wiki page rename

## Description

It's easier to put this in its own branch than add it to #4589 since that branch is a bunch of commits behind