### PR TITLE
Avoid tail overflow

### DIFF
--- a/src/multipath_alignment_graph.hpp
+++ b/src/multipath_alignment_graph.hpp
@@ -326,8 +326,9 @@ namespace vg {
         /// null.
         ///
         /// If dp_aligner is different from scoring_aligner, it is used for
-        /// dynamic programming alignment operations, and the results are
-        /// rescored with scoring_aligner. Neither may be null.
+        /// dynamic programming alignment operations (where its scores do not
+        /// risk overflow), and the results are rescored with scoring_aligner.
+        /// Neither may be null.
         ///
         /// If a tail is longer than max_tail_length, produces an alignment
         /// softclipping it.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject` should no longer suffer from score overflows in tail alignment from the new higher gap open penalty.

## Description
This undoes part of #4585 by only using the new, larger scoring parameters when they won't overflow the 16-bit GSSW and Dozeu alignment scores. (BandedGlobalAligner for connecting between things already knows how to use wider score values when needed.) This will fix #4595.