### PR TITLE
Fix and test Giraffe Facts

### DIFF
--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -33,7 +33,8 @@ try:
     import histogram
     HISTOGRAMS_ENABLED = True
 except ImportError as e:
-    sys.stderr.write(f"Cannot make histograms because: {e}\n")
+    if __name__ == "__main__":
+        sys.stderr.write(f"Cannot make histograms because: {e}\n")
     HISTOGRAMS_ENABLED = False
 
 

--- a/src/subcommand/options.cpp
+++ b/src/subcommand/options.cpp
@@ -201,17 +201,22 @@ bool GroupedOptionGroup::query(BaseValuation& entry) const {
     return false;
 }
 
-void GroupedOptionGroup::print_options(ostream& out, OptionFormat format) const {
+bool GroupedOptionGroup::print_options(ostream& out, OptionFormat format) const {
+    bool to_return = false;
     bool first = true;
     for (auto& group : subgroups) {
         // Print options from all groups in order
         if (format == OptionFormat::JSON && !first) {
             // Add the separating comma
             out << ",";
+            to_return = true;
         }
-        group->print_options(out, format);
-        first = false;
+        bool printed_anything = group->print_options(out, format);
+        // If nothing was printed, stay in first mode.
+        first &= !printed_anything;
+        to_return |= printed_anything;
     }
+    return to_return;
 }
 
 std::vector<std::pair<std::string, std::string>> GroupedOptionGroup::get_help() const {

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -19,7 +19,7 @@ vg minimizer -k 29 -w 11 -d x.dist -g x.gbwt -o x.shortread.withzip.min -z x.sho
 
 # For later tests we expect this to make x.giraffe.gbz so we can't have an x.gbz around.
 rm -f x.gbz x.giraffe.gbz
-vg giraffe -x x.xg -H x.gbwt -m x.shortread.withzip.min -z x.shortread.zipcodes  -d x.dist -f reads/small.middle.ref.fq > mapped1.gam
+vg giraffe -x x.xg -H x.gbwt -m x.shortread.withzip.min -z x.shortread.zipcodes -d x.dist -f reads/small.middle.ref.fq > mapped1.gam
 is "${?}" "0" "a read can be mapped with xg + gbwt + min + zips + dist specified without crashing"
 rm -f x-haps.gbwt x-paths.gbwt x-merged.gbwt
 

--- a/test/t/99_scripts.t
+++ b/test/t/99_scripts.t
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+PATH=../bin:$PATH # for vg
+
+plan tests 2
+
+vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
+vg index -x x.xg x.vg
+vg gbwt -o x-haps.gbwt -x x.vg -v small/x.vcf.gz
+vg gbwt -o x-paths.gbwt -x x.vg --index-paths
+vg gbwt -o x-merged.gbwt -m x-haps.gbwt x-paths.gbwt
+vg gbwt -o x.gbwt --augment-gbwt -x x.vg x-merged.gbwt
+vg index -j x.dist x.vg
+vg minimizer -k 29 -w 11 -d x.dist -g x.gbwt -o x.shortread.withzip.min -z x.shortread.zipcodes x.xg
+vg giraffe --track-provenance -x x.xg -H x.gbwt -m x.shortread.withzip.min -z x.shortread.zipcodes -d x.dist -f reads/small.middle.ref.fq > mapped1.gam
+
+../scripts/giraffe-facts.py mapped1.gam facts-out >facts.txt
+
+is "$?" "0" "giraffe-facts.py processes Giraffe output successfully"
+is "$(grep cluster-coverage facts.txt | wc -l)" "1" "giraffe-facts.py lists filters used when provenance is tracked"
+rm -f x.vg x.xg x-haps.gbwt x-paths.gbwt x-merged.gbwt x.gbz x.giraffe.gbz x.dist x.shortread.withzip.min x.shortread.zipcodes facts.txt mapped1.gam
+rm -Rf facts-out
+
+
+


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `giraffe-facts.py` script works again (with backported changes from the long read Giraffe experiments repo) and is now under CI test

## Description
@faithokamoto noted that the Giraffe Facts script didn't work. I'd made changes to Giraffe and the corresponding changes to the script copy in the long read Giraffe experiments repo, but never copied the changes back.

This is why you shouldn't copy scripts around. This PR should synchronize the changes and prevent things from getting quite so badly out of sync with a test.