### PR TITLE
Turn off extra surjection gap penalty by default

### DIFF
--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -57,6 +57,7 @@ void help_surject(char** argv) {
          << "  -a, --max-anchors N      use no more than N anchors per target path (default: unlimited)" << endl
          << "  -S, --spliced            interpret long deletions against paths as spliced alignments" << endl
          << "  -A, --qual-adj           adjust scoring for base qualities, if they are available" << endl
+         << "  -E, --extra-gap-cost N   for dynamic programming, add this to the gap open cost of the 10x-scaled scoring parameters" << endl 
          << "  -N, --sample NAME        set this sample name for all reads" << endl
          << "  -R, --read-group NAME    set this read group for all reads" << endl
          << "  -f, --max-frag-len N     reads with fragment lengths greater than N will not be marked properly paired in SAM/BAM/CRAM" << endl
@@ -132,6 +133,7 @@ int main_surject(int argc, char** argv) {
     // This needs to be nullable so that we can use the default for spliced if doing spliced mode.
     std::unique_ptr<double> max_graph_scale;
     bool qual_adj = false;
+    int8_t extra_gap_cost = 0;
     bool prune_anchors = false;
     int64_t max_slide = Surjector::DEFAULT_MAX_SLIDE;
     size_t max_anchors = std::numeric_limits<size_t>::max(); // As close to unlimited as makes no difference
@@ -168,6 +170,7 @@ int main_surject(int argc, char** argv) {
             {"max-slide", required_argument, 0, 'I'},
             {"max-anchors", required_argument, 0, 'a'},
             {"qual-adj", no_argument, 0, 'A'},
+            {"extra-gap-cost", required_argument, 0, 'E'},
             {"sample", required_argument, 0, 'N'},
             {"read-group", required_argument, 0, 'R'},
             {"max-frag-len", required_argument, 0, 'f'},
@@ -180,7 +183,7 @@ int main_surject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:p:F:n:lT:g:iGmcbsN:R:f:C:t:SPI:a:ALMVw:r",
+        c = getopt_long (argc, argv, "hx:p:F:n:lT:g:iGmcbsN:R:f:C:t:SPI:a:AE:LMVw:r",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -265,6 +268,10 @@ int main_surject(int argc, char** argv) {
             
         case 'A':
             qual_adj = true;
+            break;
+
+        case 'E':
+            extra_gap_cost = parse<int8_t>(optarg);
             break;
 
         case 'N':
@@ -376,6 +383,13 @@ int main_surject(int argc, char** argv) {
     // Make a single thread-safe Surjector.
     Surjector surjector(xgidx);
     surjector.adjust_alignments_for_base_quality = qual_adj;
+    if (extra_gap_cost != surjector.dp_gap_open_extra_cost) {
+        surjector.dp_gap_open_extra_cost = extra_gap_cost;
+        // Rebuild the scoring machinery for the parameter change
+        surjector.set_alignment_scores(default_score_matrix,
+                                       default_gap_open, default_gap_extension,
+                                       default_full_length_bonus); 
+    }
     surjector.prune_suspicious_anchors = prune_anchors;
     surjector.max_slide = max_slide;
     surjector.max_anchors = max_anchors;

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -70,42 +70,49 @@ using namespace std;
     }
 
     void Surjector::set_dp_alignment_scores(const int8_t* score_matrix, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus) {
-        // Scale up the matrix by the scale.
-        // We don't want to overflow the tiny score fields.
-        int8_t min_in_score = std::numeric_limits<int8_t>::min() / dp_score_scale;
-        int8_t max_in_score = std::numeric_limits<int8_t>::max() / dp_score_scale;
-        int8_t* scaled_matrix = (int8_t*) malloc(sizeof(int8_t) * 16);
-        crash_unless(scaled_matrix != nullptr);
-        for (int i = 0; i < 16; i++) {
-            if (score_matrix[i] > max_in_score || score_matrix[i] < min_in_score) {
-                free(scaled_matrix);
-                throw std::invalid_argument("Score value " + std::to_string(score_matrix[i]) + " is too large to scale; must be between" + std::to_string(min_in_score) + " and " + std::to_string(max_in_score));
-            }
-            if (i / 4 == i % 4 && score_matrix[i] < 0) {
-                // There's a negative value on the diagonal. Something is wrong.
-                free(scaled_matrix);
-                throw std::invalid_argument("Score value " + std::to_string(score_matrix[i]) + " is negative along scoring matrix diagonal");
-            }
-            scaled_matrix[i] = score_matrix[i] * dp_score_scale;
-        }
-        for (auto& score : {gap_open, gap_extend, full_length_bonus}) {
-            // Check each non-matrix score 
-            if (score > max_in_score || score < min_in_score) {
-                free(scaled_matrix);
-                throw std::invalid_argument("Score value " + std::to_string(score) + " is too large to scale; must be between" + std::to_string(min_in_score) + " and " + std::to_string(max_in_score));
-            }
-        }
-        if (gap_open * dp_score_scale > std::numeric_limits<int8_t>::max() - dp_gap_open_extra_cost) {
-            // We don't have room for the extra gap open penalty.
-            throw std::invalid_argument("Gap open score value " + std::to_string(gap_open) + " is too large after scaling; reduce by at least " + std::to_string(std::max<int8_t>(dp_gap_open_extra_cost / dp_score_scale, (int8_t)1)));
-        }
+        if (dp_gap_open_extra_cost != 0) {
+            // We actually want to do DP with different scores.
 
-        // Apply the scores
-        dp_aligner = std::unique_ptr<Aligner>(new Aligner(scaled_matrix, gap_open * dp_score_scale + dp_gap_open_extra_cost, gap_extend * dp_score_scale,
-                                                          full_length_bonus * dp_score_scale, this->gc_content_estimate));
-        
-        // Get rid of the scaled matrix
-        free(scaled_matrix);
+            // Scale up the matrix by the scale.
+            // We don't want to overflow the tiny score fields.
+            int8_t min_in_score = std::numeric_limits<int8_t>::min() / dp_score_scale;
+            int8_t max_in_score = std::numeric_limits<int8_t>::max() / dp_score_scale;
+            int8_t* scaled_matrix = (int8_t*) malloc(sizeof(int8_t) * 16);
+            crash_unless(scaled_matrix != nullptr);
+            for (int i = 0; i < 16; i++) {
+                if (score_matrix[i] > max_in_score || score_matrix[i] < min_in_score) {
+                    free(scaled_matrix);
+                    throw std::invalid_argument("Score value " + std::to_string(score_matrix[i]) + " is too large to scale; must be between" + std::to_string(min_in_score) + " and " + std::to_string(max_in_score));
+                }
+                if (i / 4 == i % 4 && score_matrix[i] < 0) {
+                    // There's a negative value on the diagonal. Something is wrong.
+                    free(scaled_matrix);
+                    throw std::invalid_argument("Score value " + std::to_string(score_matrix[i]) + " is negative along scoring matrix diagonal");
+                }
+                scaled_matrix[i] = score_matrix[i] * dp_score_scale;
+            }
+            for (auto& score : {gap_open, gap_extend, full_length_bonus}) {
+                // Check each non-matrix score 
+                if (score > max_in_score || score < min_in_score) {
+                    free(scaled_matrix);
+                    throw std::invalid_argument("Score value " + std::to_string(score) + " is too large to scale; must be between" + std::to_string(min_in_score) + " and " + std::to_string(max_in_score));
+                }
+            }
+            if (gap_open * dp_score_scale > std::numeric_limits<int8_t>::max() - dp_gap_open_extra_cost) {
+                // We don't have room for the extra gap open penalty.
+                throw std::invalid_argument("Gap open score value " + std::to_string(gap_open) + " is too large after scaling; reduce by at least " + std::to_string(std::max<int8_t>(dp_gap_open_extra_cost / dp_score_scale, (int8_t)1)));
+            }
+
+            // Apply the scores
+            dp_aligner = std::unique_ptr<Aligner>(new Aligner(scaled_matrix, gap_open * dp_score_scale + dp_gap_open_extra_cost, gap_extend * dp_score_scale,
+                                                              full_length_bonus * dp_score_scale, this->gc_content_estimate));
+            
+            // Get rid of the scaled matrix
+            free(scaled_matrix);
+        } else {
+            // Don't have a separate DP aligner.
+            dp_aligner.reset();
+        }
         
     }
 
@@ -3058,7 +3065,8 @@ using namespace std;
             
             // align the intervening segments and store the result in a multipath alignment
             multipath_alignment_t mp_aln;
-            mp_aln_graph.align(source, *aln_graph, get_aligner(), dp_aligner.get(),
+            auto normal_aligner = get_aligner();
+            mp_aln_graph.align(source, *aln_graph, normal_aligner, dp_aligner ? dp_aligner.get() : normal_aligner,
                                false,                                    // anchors as matches
                                1,                                        // max alt alns
                                false,                                    // dynamic alt alns

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -121,7 +121,7 @@ using namespace std;
         /// When doing DP alignments, we multiply scores by this factor before slightly increasing gap open. (Changes won't take effect until set_alignment_scores() is called.)
         int8_t dp_score_scale = 10;
         /// When doing DP alignment, we increase gap open score by this much. (Changes won't take effect until set_alignment_scores() is called.)
-        int8_t dp_gap_open_extra_cost = 1;
+        int8_t dp_gap_open_extra_cost = 0;
 
         
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject` no longer increases the gap open penalty by default, but allows it to be adjusted with `--extra-gap-cost`/`-E`.

## Description
My changes in 548d64..72afe1 actually made calling worse overall (more indel errors and more SNP errors) on my HG002 test case, so I'm turning off the extra surjection gap penalty by default and bringing it out to the command line.