### PR TITLE
Always assign MAPQ 0 to unmapped reads in pairs

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -2647,6 +2647,13 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
             }
             read_mapq = max(min(capped_mapq, 120.0) / 2.0, 0.0);
             
+            // Unaligned reads always have MAPQ 0, even if they're the obvious
+            // right answer given pairing constraints.
+            bool is_aligned = (mappings[r].front().path().mapping_size() > 0);
+            if (!is_aligned) {
+                read_mapq = 0;
+            }
+            
             // Save the MAPQ
             mappings[r].front().set_mapping_quality(read_mapq);
             
@@ -2656,7 +2663,8 @@ pair<vector<Alignment>, vector<Alignment>> MinimizerMapper::map_paired(Alignment
                     cerr << log_name() << "MAPQ for read " << (r + 1) << " is " << read_mapq << ", was " << uncapped_mapq
                         << " capped by fragment cluster cap " << fragment_cluster_cap
                         << ", score group cap " << (mapq_score_groups[r] / 2.0)
-                        << ", combined explored cap " << ((mapq_explored_caps[0] + mapq_explored_caps[1]) / 2.0)  << endl;
+                        << ", combined explored cap " << ((mapq_explored_caps[0] + mapq_explored_caps[1]) / 2.0)
+                        << ", alignedness " << is_aligned << endl;
                 }
             }
         }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` will always assign MAPQ 0 to unmapped reads in pairs

## Description

Allowing rescue to produce unaligned rescue results was making it produce reads that were unmapped but with nonzero MAPQ, sometimes even MAPQ 60, in cases where we were sure about the placement of the pair partner but had to unmap an insignificant rescue result.

This doesn't address the case where reads can map well independently with high MAPQ but map paired with low MAPQ. We do, it turns out, support improperly-paired alignment results, but adding the pair constraint might make us prefer one of a few equally-good pairing-consistent placements, over the obvious unique best placement for each read but without pairing consistency.