### PR TITLE
Deduplicate reads when querying indexed GAF

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -384,6 +384,113 @@ size_t fastq_paired_two_files_for_each(const string& file1, const string& file2,
 
 }
 
+void for_each_gaf_record_in_ranges(htsFile* gaf_fp, tbx_t* gaf_tbx, const vector<pair<vg::id_t, vg::id_t>>& ranges, const std::function<void(const std::string&)>& iteratee) {
+    // If we just query each range, we get duplicate reads when a read overlaps
+    // multiple ranges. We want to use an htslib multi-region iterator instead.
+    //
+    // According to
+    // <https://github.com/samtools/htslib/issues/785#issuecomment-433869384>,
+    // "If the target regions overlap, hts_itr_t visits the overlapping section
+    // twice, while hts_itr_multi_t removes this overlap.". And according to
+    // <https://github.com/samtools/htslib/issues/785#issuecomment-464135842>,
+    // "a read will only be output once even if it covers more than one
+    // region".
+    //
+    // But, htslib multi-region iterators don't support tabix files yet. See
+    // <https://github.com/samtools/htslib/issues/1913>. So we have to fake it
+    // with single-region iterators until that's fixed.
+    
+    // To hack around the duplicate entries from the query, we keep all the GAF
+    // records around as strings in memory.
+    std::unordered_set<std::string> seen_records;
+
+    // TODO: If this becomes a memory usage problem before htslib implements
+    // the multi-iterator, switch to keeping the records organized by their
+    // ending node ID in an ordered map of sets. Then we could throw out all
+    // earlier sets when we start a range that begins after their end point,
+    // and we can still check membership with a lookup on endpoint and then a
+    // lookup in the set. 
+
+    for (auto range : ranges) {
+        std::stringstream query_stream;
+        query_stream << "{node}:" << range.first << "-" << range.second;
+        std::string query_string(std::move(query_stream.str()));
+        hts_itr_t *itr = tbx_itr_querys(gaf_tbx, query_string.c_str());
+        if (!itr) {
+            // Can't visit this range. Nothing there?
+            // TODO: Is there an error to be handled here?
+            continue;
+        }
+        // We need a kstring_t to hold each result line from the tabix iterator.
+        kstring_t str;
+        ks_initialize(&str);
+        try {
+            while (tbx_itr_next(gaf_fp, gaf_tbx, itr, &str) >= 0) {
+                // The iterator will allocate/expand/overwrite the kstring_t
+                // storage, but we need to free it later.
+    
+                // Store the record as a C++ string.
+                std::string record_string(ks_str(&str));
+
+                // Parse the GAF record we got from the index
+                gafkluge::GafRecord record;
+                gafkluge::parse_gaf_record(record_string, record);
+
+                // We also have to account for how, even if a GAF record
+                // overlaps a tabix ID range, that just means it has a node ID
+                // before the range start and a node ID after the range end. It
+                // doesn't guarantee that those are ever the *same* ID; the GAF
+                // record might completely skip all the IDs in the range.
+                if (!gaf_record_intersects_range(record, range)) {
+                    // We don't actually intersect the range, so skip this record.
+                    continue;
+                }
+
+                auto found = seen_records.find(record_string);
+                if (found == seen_records.end()) {
+                    // This is a novel record.
+                    //
+                    // TODO: Handle GAF files that repeat the same record
+                    // multiple times, where we actually want to keep the
+                    // repeats.
+
+                    // Handle the record
+                    iteratee(record_string);
+
+                    // Mark it as handled and move it into the set.
+                    seen_records.emplace_hint(found, std::move(record_string));
+                }
+            }
+
+            // Make sure the iterator and kstring_t are cleaned up.
+            tbx_itr_destroy(itr);
+            // This is safe to do even if the kstring_t's buffer is not
+            // allocated.
+            ks_free(&str);
+        } catch(...) {
+            tbx_itr_destroy(itr);
+            ks_free(&str);
+            throw;
+        }
+    }
+}
+
+bool gaf_record_intersects_range(const gafkluge::GafRecord& record, const std::pair<nid_t, nid_t>& range) {
+    for (const gafkluge::GafStep& step : record.path) {
+        if (step.is_stable) {
+            // We can't parse the name field as a node ID, it's a path name.
+            throw std::runtime_error("Cannot parse GAF record with stable step on: " + step.name);
+        }
+        nid_t node_id = std::stol(step.name);
+        if (node_id >= range.first && node_id < range.second) {
+            // Found an intersection
+            return true;
+        }
+    }
+    // No intersection was ever found
+    return false;
+}
+
 void parse_rg_sample_map(char* hts_header, map<string, string>& rg_sample) {
     string header(hts_header);
     vector<string> header_lines = split_delims(header, "\n");

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -22,12 +22,16 @@ namespace vg {
 
 const char* const BAM_DNA_LOOKUP = "=ACMGRSVTWYHKDBN";
 
+// htslib-based alignment read functions
+
 int hts_for_each(string& filename, function<void(Alignment&)> lambda);
 int hts_for_each_parallel(string& filename, function<void(Alignment&)> lambda);
 int hts_for_each(string& filename, function<void(Alignment&)> lambda,
                  const PathPositionHandleGraph* graph);
 int hts_for_each_parallel(string& filename, function<void(Alignment&)> lambda,
                           const PathPositionHandleGraph* graph);
+
+// FASTQ-input functions
 
 // parsing a FASTQ record, optionally intepreting the comment as SAM-style tags
 bool get_next_alignment_from_fastq(gzFile fp, char* buffer, size_t len, Alignment& alignment, bool comment_as_tags);
@@ -65,6 +69,20 @@ size_t fastq_paired_two_files_for_each_parallel_after_wait(const string& file1, 
                                                            function<bool(void)> single_threaded_until_true,
                                                            bool comment_as_tags = false,
                                                            uint64_t batch_size = vg::io::DEFAULT_PARALLEL_BATCHSIZE);
+
+// Functions to read indexed GAF.
+// TODO: move to libvgio?
+
+/// Find each distinct GAF record intersecting any of the given sorted node ID ranges.
+/// Presents the GAF record as a string, even though it is parsed internally.
+/// If you need the gfakluge::GafRecord, refactor this function instead of parsing it again.
+void for_each_gaf_record_in_ranges(htsFile* gaf_fp, tbx_t* gaf_tbx, const vector<pair<vg::id_t, vg::id_t>>& ranges, const std::function<void(const std::string&)>& iteratee);
+
+/// Return True if the given parsed GAF record has any node IDs that occur in the given ID range.
+/// Raises an exception if any GAF path entries aren't ID visits.
+bool gaf_record_intersects_range(const gafkluge::GafRecord& record, const std::pair<nid_t, nid_t>& range);
+
+// More htslib-based functions
 
 bam_hdr_t* hts_file_header(string& filename, string& header);
 bam_hdr_t* hts_string_header(string& header,

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -518,18 +518,12 @@ int main_find(int argc, char** argv) {
               
             } else if (!sorted_gaf_name.empty()) {
                 // Find in sorted GAF
-                // loop over ranges and print GAF records
-                for (auto range : ranges) {
-                    string reg = "{node}:" + convert(range.first) + "-" + convert(range.second);
-                    hts_itr_t *itr = tbx_itr_querys(gaf_tbx, reg.c_str());
-                    kstring_t str = {0,0,0};
-                    if ( itr ) {
-                        while (tbx_itr_next(gaf_fp, gaf_tbx, itr, &str) >= 0) {
-                            puts(str.s);
-                        }
-                        tbx_itr_destroy(itr);
-                    }
-                }
+                for_each_gaf_record_in_ranges(gaf_fp, gaf_tbx, ranges, [&](const std::string& record_string) {
+                    // For each unique matching GAF record's unparsed string
+
+                    // Handle the record (by printing it).
+                    std::cout << record_string << std::endl;
+                }); 
             }
         } else {
             cerr << "error [vg find]: Cannot find alignments on graph without a sorted GAM" << endl;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Reads fetched from indexed GAF files are now deduplicated because one read might intersect multiple ID ranges
 * Reads fetched from indexed GAF files are now parsed and checked for actual intersection with the query range

## Description
This fixes a problem where `vg chunk` (and `vg find`, presumably) would report the same read multiple times (sometimes many, many times) when pulling reads from a tabix-indexed GAF file.

Because https://github.com/samtools/htslib/issues/1913 isn't implemented yet, this is keeping each decompressed matched GAF record in memory during the whole query, to check for duplicates. There are potential ways to figure out that we can throw some away sooner, but the real solution is multi-range query support for tabix in htslib, like it has for BAM and CRAM.

While looking here I also noticed that we needed to parse the records and make sure they actually touched the target range, and didn't just exist before and after it in the same read (and thus overlap it when looking at the min to max ID range), so I added that too.