### PR TITLE
Allow tracking either last correct or last possible alignment in giraffe-facts.py

### DIFF
--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -1440,7 +1440,15 @@ def main():
         # Make filter statistic histograms
         plot_filter_statistic_histograms(options.outdir, stats_total)
     
-if __name__ == "__main__" :
+def entrypoint():
+    """
+    0-argument entry point for setuptools to call.
+    """
+
+    # Provide main with its arguments and handle exit codes
     sys.exit(main())
+
+if __name__ == "__main__" :
+    entrypoint()
         
 

--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -90,10 +90,9 @@ FACTS = ["Giraffes are the tallest living terrestrial animal.",
          "Giraffes have never been observed swimming.",
          "Mozambique requires power lines to be 39 feet high so giraffes can safely pass underneath."]
 
-def parse_args(args):
+def parse_args():
     """
-    Takes in the command-line arguments list (args), and returns a nice argparse
-    result with fields for all the options.
+    Returns a nice argparse result with fields for all the options.
     
     Borrows heavily from the argparse documentation examples:
     <http://docs.python.org/library/argparse.html>
@@ -121,11 +120,7 @@ def parse_args(args):
     parser.add_argument("outdir",
                         help="directory to place output in")
     
-    # The command line arguments start with the program name, which we don't
-    # want to treat as an argument for argparse. So we remove it.
-    args = args[1:]
-        
-    return parser.parse_args(args)
+    return parser.parse_args()
     
 def sniff_params(read):
     """
@@ -1368,7 +1363,7 @@ def explain_filters_in(stats_total, vg):
 
     explain_filters(filters_and_stages, vg)
 
-def main(args):
+def main():
     """
     Parses command line arguments and do the work of the program.
     "args" specifies the program arguments, with args[0] being the executable
@@ -1377,7 +1372,7 @@ def main(args):
    
     print(random.choice(FACTS), file = sys.stderr)
     
-    options = parse_args(args) # This holds the nicely-parsed options object
+    options = parse_args() # This holds the nicely-parsed options object
     
     # Make the output directory if it doesn't exist
     os.makedirs(options.outdir, exist_ok=True)
@@ -1417,15 +1412,7 @@ def main(args):
         # Make filter statistic histograms
         plot_filter_statistic_histograms(options.outdir, stats_total)
     
-def entrypoint():
-    """
-    0-argument entry point for setuptools to call.
-    """
-    
-    # Provide main with its arguments and handle exit codes
-    sys.exit(main(sys.argv))
-    
 if __name__ == "__main__" :
-    entrypoint()
+    main()
         
 

--- a/scripts/giraffe-facts.py
+++ b/scripts/giraffe-facts.py
@@ -1441,6 +1441,6 @@ def main():
         plot_filter_statistic_histograms(options.outdir, stats_total)
     
 if __name__ == "__main__" :
-    main()
+    sys.exit(main())
         
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add new option `--track-last` to track either last correct alignment (current/default) or last existing alignment in `scripts/giraffe-facts.py`

## Description

I wanted to track where I was losing mappings without having to set correct positions for each read. Using `--track-last any` finds the first stage with `"passed": {"count_total": 0}` but `"failed": {"count_total": X}` (X > 0) for each read. This should be the stage at which that read lost all of its remaining alignment possibilities, if I'm understanding the JSON correctly. I had to make some annoying hacks to pass the necessary parameter into `make_stats()`, but it works.

Also, I rewrote the argument parsing to have argparse find the arguments itself, instead of pre-parsing `sys.argv` for it. 