### PR TITLE
Document that Giraffe supports FASTA input

### DIFF
--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -732,8 +732,8 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
     cerr
     << "input options:" << endl
     << "  -G, --gam-in FILE             read and realign GAM-format reads from FILE" << endl
-    << "  -f, --fastq-in FILE           read and align FASTQ-format reads from FILE (two are allowed, one for each mate)" << endl
-    << "  -i, --interleaved             GAM/FASTQ input is interleaved pairs, for paired-end alignment" << endl
+    << "  -f, --fastq-in FILE           read and align FASTQ- or FASTA-format reads from FILE (two are allowed, one for each mate)" << endl
+    << "  -i, --interleaved             GAM/FASTQ/FASTA input is interleaved pairs, for paired-end alignment" << endl
     << "  --comments-as-tags            intepret comments in name lines as SAM-style tags and annotate alignments with them" << endl;
 
     cerr


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` now admits to taking FASTA input with `-f`

## Description

The FASTQ reader also supports FASTA, but the Giraffe help doesn't mention this. This changes the help to tell you that it can read FASTA as well as FASTQ.
