### PR TITLE
Remove dead code for depth 1 which we can't have in S_SKIP_CHAIN

### DIFF
--- a/src/zip_code_tree.cpp
+++ b/src/zip_code_tree.cpp
@@ -2018,16 +2018,8 @@ auto ZipCodeTree::reverse_iterator::tick() -> bool {
             break;
         case CHAIN_START:
             if (top() == 0) {
-                // Parent snarl may be a top-level snarl.
-                if (depth() == 1) {
-                    // We have hit the start of a top-level snarl
-#ifdef debug_parse
-                    std::cerr << "Hit start of top-level snarl" << std::endl;
-#endif
-                    halt();
-                    // When we halt we have to return true to show the halting position.
-                    return true;
-                }
+                // Parent snarl may be a top-level snarl, but we don't need to
+                // do anything special in that case.
 
                 // This is the start of the chain we were wanting to skip.
                 pop();


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Zip code tree iterator no longer tries to handle a stack depth that can't occur in `S_SKIP_CHAIN`

## Description

When writing up the zip code tree iterator for the paper, I noticed that we can't ever actually have the stack depth we're checking for here, so I'm removing this code.

This fixes #4608.
