### PR TITLE
depth option -d now usable with edge filter -D

### DIFF
--- a/src/clip.hpp
+++ b/src/clip.hpp
@@ -85,6 +85,7 @@ void clip_contained_low_depth_nodes_and_edges(MutablePathMutableHandleGraph* gra
  * clip out deletion edges 
  */
 void clip_deletion_edges(MutablePathMutableHandleGraph* graph, int64_t max_deletion, int64_t context_steps,
+                         int64_t min_depth,
                          const vector<string>& ref_prefixes, int64_t min_fragment_len, bool verbose);
 
 /**

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -234,12 +234,6 @@ int main_clip(int argc, char** argv) {
         return 1;
     }
 
-    // to do: I think it could be a good idea to combine these options
-    if (min_depth >= 0 && max_deletion >= 0) {
-        cerr << "error:[vg-clip] -d cannot (yet?) be used with -D" << endl;
-        return 1;
-    }
-
     // ditto about combining
     if ((stub_clipping || stubbify_reference) && (min_depth >= 0 || max_deletion >= 0)) {
         cerr << "error:[vg-clip] -s and -S cannot (yet?) be used with -d or -D" << endl;
@@ -369,7 +363,7 @@ int main_clip(int argc, char** argv) {
         }
     }        
     
-    if (min_depth >= 0) {
+    if (min_depth >= 0 && max_deletion < 0) {
         // run the depth clipping       
         if (bed_regions.empty()) {            
             // do the whole graph
@@ -384,7 +378,7 @@ int main_clip(int argc, char** argv) {
         
     } else if (max_deletion >= 0) {
         // run the deletion edge clipping on the whole graph
-        clip_deletion_edges(graph.get(), max_deletion, context_steps, ref_prefixes, min_fragment_len, verbose);
+        clip_deletion_edges(graph.get(), max_deletion, context_steps, min_depth, ref_prefixes, min_fragment_len, verbose);
     } else if (stub_clipping || stubbify_reference) {
         // run the stub clipping
         if (bed_path.empty()) {            


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg clip -d`  and `-D` can now be used together (depth threshold applied to edge clipping)
 
## Description
