### PR TITLE
Add options to annotate HTSlib with graph-space alignment

### DIFF
--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -106,6 +106,12 @@ Alignment bam_to_alignment(const bam1_t *b,
                            const PathPositionHandleGraph* graph);
 Alignment bam_to_alignment(const bam1_t *b, const map<string, string>& rg_sample, const map<int, path_handle_t>& tid_path_handle);
 
+// the CIGAR string of the graph alignment
+vector<pair<int, char>> graph_cigar(const Alignment& aln, bool rev_strand = false);
+// the CS-style (i.e. verbose) CIGAR difference string of the graph alignment
+string graph_CS_cigar(const Alignment& aln, const HandleGraph& graph, bool rev_strand = false);
+// the cs-style (i.e. compact) CIGAR difference string of the graph alignment
+string graph_cs_cigar(const Alignment& aln, const HandleGraph& graph, bool rev_stand = false);
 /**
  * Add a CIGAR operation to a vector representing the parsed CIGAR string.
  *

--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -60,7 +60,8 @@ unique_ptr<AlignmentEmitter> get_alignment_emitter(const string& filename, const
             }
             // Interpose a surjecting AlignmentEmitter
             emitter = make_unique<SurjectingAlignmentEmitter>(path_graph, target_paths, std::move(emitter),
-                flags & ALIGNMENT_EMITTER_FLAG_HTS_PRUNE_SUSPICIOUS_ANCHORS);
+                flags & ALIGNMENT_EMITTER_FLAG_HTS_PRUNE_SUSPICIOUS_ANCHORS,
+                flags & ALIGNMENT_EMITTER_FLAG_HTS_ADD_GRAPH_ALIGNMENT_TAG);
         }
     
     } else {

--- a/src/hts_alignment_emitter.hpp
+++ b/src/hts_alignment_emitter.hpp
@@ -44,7 +44,10 @@ enum alignment_emitter_flags_t {
     ALIGNMENT_EMITTER_FLAG_HTS_PRUNE_SUSPICIOUS_ANCHORS = 4,
     /// Emit graph alignments in named segment (i.e. GFA space) instead of
     /// numerical node ID space.
-    ALIGNMENT_EMITTER_FLAG_VG_USE_SEGMENT_NAMES = 8
+    ALIGNMENT_EMITTER_FLAG_VG_USE_SEGMENT_NAMES = 8,
+    /// When surjecting, annotate HTSlib records with a cs-style difference string that
+    /// expresses the alignment in graph space in the "GR" tag
+    ALIGNMENT_EMITTER_FLAG_HTS_ADD_GRAPH_ALIGNMENT_TAG = 16
 };
 
 /// Represents a path or subpath's sequence dictionary information. Holds

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -760,6 +760,7 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
     if (full_help) {
         cerr
         << "  -P, --prune-low-cplx          prune short and low complexity anchors during linear format realignment" << endl
+        << "  --add-graph-aln               annotate linear formats with the graph alignment in the GR tag as a cs-style difference string" << endl
         << "  -n, --discard                 discard all output alignments (for profiling)" << endl
         << "  --output-basename NAME        write output to a GAM file beginning with the given prefix for each setting combination" << endl
         << "  --report-name NAME            write a TSV of output file and mapping speed to the given file" << endl
@@ -807,11 +808,13 @@ int main_giraffe(int argc, char** argv) {
     constexpr int OPT_REF_NAME = 1009;
     constexpr int OPT_SHOW_WORK = 1010;
     constexpr int OPT_NAMED_COORDINATES = 1011;
+    constexpr int OPT_ADD_GRAPH_ALIGNMENT = 1012;
+    constexpr int OPT_COMMENTS_AS_TAGS = 1113;
     constexpr int OPT_HAPLOTYPE_NAME = 1100;
     constexpr int OPT_KFF_NAME = 1101;
     constexpr int OPT_INDEX_BASENAME = 1102;
     constexpr int OPT_SET_REFERENCE = 1103;
-    constexpr int OPT_COMMENTS_AS_TAGS = 1104;
+
 
     // initialize parameters with their default options
     
@@ -893,6 +896,9 @@ int main_giraffe(int argc, char** argv) {
     std::unordered_set<std::string> reference_assembly_names;
     // And should we drop low complexity anchors when surjectng?
     bool prune_anchors = false;
+    
+    // When surjecting, should we annotate the reads with the graph alignment?
+    bool add_graph_alignment = false;
     
     // For GAM format, should we report in named-segment space instead of node ID space?
     bool named_coordinates = false;
@@ -1167,6 +1173,7 @@ int main_giraffe(int argc, char** argv) {
         {"output-format", required_argument, 0, 'o'},
         {"ref-paths", required_argument, 0, OPT_REF_PATHS},
         {"prune-low-cplx", no_argument, 0, 'P'},
+        {"add-graph-aln", no_argument, 0, OPT_ADD_GRAPH_ALIGNMENT},
         {"named-coordinates", no_argument, 0, OPT_NAMED_COORDINATES},
         {"discard", no_argument, 0, 'n'},
         {"output-basename", required_argument, 0, OPT_OUTPUT_BASENAME},
@@ -1402,6 +1409,10 @@ int main_giraffe(int argc, char** argv) {
                 
             case OPT_NAMED_COORDINATES:
                 named_coordinates = true;
+                break;
+                
+            case OPT_ADD_GRAPH_ALIGNMENT:
+                add_graph_alignment = true;
                 break;
 
             case 'n':
@@ -1906,6 +1917,7 @@ int main_giraffe(int argc, char** argv) {
 
         report_flag("interleaved", interleaved);
         report_flag("prune-low-cplx", prune_anchors);
+        report_flag("add-graph-aln", add_graph_alignment);
         report_flag("set-refpos", set_refpos);
         minimizer_mapper.set_refpos = set_refpos;
         report_flag("track-provenance", track_provenance);
@@ -2025,6 +2037,10 @@ int main_giraffe(int argc, char** argv) {
                 if (named_coordinates) {
                     // When not surjecting, use named segments instead of node IDs.
                     flags |= ALIGNMENT_EMITTER_FLAG_VG_USE_SEGMENT_NAMES;
+                }
+                if (add_graph_alignment) {
+                    // When surjecting, add the graph alignment tag
+                    flags |= ALIGNMENT_EMITTER_FLAG_HTS_ADD_GRAPH_ALIGNMENT_TAG;
                 }
                 
                 // We send along the positional graph when we have it, and otherwise we send the GBWTGraph which is sufficient for GAF output.

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -62,6 +62,7 @@ void help_surject(char** argv) {
          << "  -R, --read-group NAME    set this read group for all reads" << endl
          << "  -f, --max-frag-len N     reads with fragment lengths greater than N will not be marked properly paired in SAM/BAM/CRAM" << endl
          << "  -L, --list-all-paths     annotate SAM records with a list of all attempted re-alignments to paths in SS tag" << endl
+         << "  -H, --graph-aln          annotate SAM records with cs-style difference string of the pre-surjected graph alignment in GR tag" << endl
          << "  -C, --compression N      level for compression [0-9]" << endl
          << "  -V, --no-validate        skip checking whether alignments plausibly are against the provided graph" << endl
          << "  -w, --watchdog-timeout N warn when reads take more than the given number of seconds to surject" << endl
@@ -138,6 +139,7 @@ int main_surject(int argc, char** argv) {
     int64_t max_slide = Surjector::DEFAULT_MAX_SLIDE;
     size_t max_anchors = std::numeric_limits<size_t>::max(); // As close to unlimited as makes no difference
     bool annotate_with_all_path_scores = false;
+    bool annotate_with_graph_alignment = false;
     bool multimap = false;
     bool validate = true;
     bool show_progress = false;
@@ -175,6 +177,7 @@ int main_surject(int argc, char** argv) {
             {"read-group", required_argument, 0, 'R'},
             {"max-frag-len", required_argument, 0, 'f'},
             {"list-all-paths", no_argument, 0, 'L'},
+            {"graph-aln", no_argument, 0, 'H'},
             {"compress", required_argument, 0, 'C'},
             {"no-validate", required_argument, 0, 'V'},
             {"watchdog-timeout", required_argument, 0, 'w'},
@@ -183,7 +186,7 @@ int main_surject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:p:F:n:lT:g:iGmcbsN:R:f:C:t:SPI:a:AE:LMVw:r",
+        c = getopt_long (argc, argv, "hx:p:F:n:lT:g:iGmcbsN:R:f:C:t:SPI:a:AE:LHMVw:r",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -309,6 +312,10 @@ int main_surject(int argc, char** argv) {
         case 'L':
             annotate_with_all_path_scores = true;
             break;
+            
+        case 'H':
+            annotate_with_graph_alignment = true;
+            break;
 
         case 'h':
         case '?':
@@ -403,6 +410,7 @@ int main_surject(int argc, char** argv) {
     }
     surjector.max_tail_length = max_tail_len;
     surjector.annotate_with_all_path_scores = annotate_with_all_path_scores;
+    surjector.annotate_with_graph_alignment = annotate_with_graph_alignment;
     if (max_graph_scale) {
         // We have an override
         surjector.max_subgraph_bases_per_read_base = *max_graph_scale;

--- a/src/surjecting_alignment_emitter.cpp
+++ b/src/surjecting_alignment_emitter.cpp
@@ -14,10 +14,11 @@ namespace vg {
 using namespace std;
 
 SurjectingAlignmentEmitter::SurjectingAlignmentEmitter(const PathPositionHandleGraph* graph, unordered_set<path_handle_t> paths,
-    unique_ptr<AlignmentEmitter>&& backing, bool prune_suspicious_anchors) : surjector(graph), paths(paths), backing(std::move(backing)) {
+    unique_ptr<AlignmentEmitter>&& backing, bool prune_suspicious_anchors, bool add_graph_alignment_tag) : surjector(graph), paths(paths), backing(std::move(backing)) {
     
     // Configure the surjector
     surjector.prune_suspicious_anchors = prune_suspicious_anchors;
+    surjector.annotate_with_graph_alignment = add_graph_alignment_tag;
     
 }
 

--- a/src/surjecting_alignment_emitter.hpp
+++ b/src/surjecting_alignment_emitter.hpp
@@ -35,7 +35,7 @@ public:
      */
     SurjectingAlignmentEmitter(const PathPositionHandleGraph* graph,
         unordered_set<path_handle_t> paths, unique_ptr<AlignmentEmitter>&& backing,
-        bool prune_suspicious_anchors = false);
+        bool prune_suspicious_anchors = false, bool add_graph_alignment_tag = false);
    
     ///  Force full length alignment in surjection resolution 
     bool surject_subpath_global = true;

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -182,6 +182,7 @@ using namespace std;
         size_t max_anchors = std::numeric_limits<size_t>::max();
         
         bool annotate_with_all_path_scores = false;
+        bool annotate_with_graph_alignment = false;
         
     protected:
 
@@ -318,13 +319,16 @@ using namespace std;
         static multipath_alignment_t make_null_mp_alignment(const string& src_sequence,
                                                             const string& src_quality);
         
+        void annotate_graph_cigar(vector<Alignment>& surjections, const Alignment& source, bool rev_strand) const;
+        
+        void annotate_graph_cigar(vector<multipath_alignment_t>& surjections, const multipath_alignment_t& source, bool rev_strand) const;
+        
         template<class AlnType>
         static int32_t get_score(const AlnType& aln);
         
         /// the graph we're surjecting onto
         const PathPositionHandleGraph* graph = nullptr;
     };
-
 
     template<class AlnType>
     string Surjector::path_score_annotations(const unordered_map<pair<path_handle_t, bool>, pair<AlnType, pair<step_handle_t, step_handle_t>>>& surjections) const {

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 55
+plan tests 56
 
 vg construct -r small/x.fa >j.vg
 vg index -x j.xg j.vg
@@ -176,6 +176,8 @@ vg surject -x j.sub.vg r.sub.gam -s --ref-paths path_info.tsv > r.sub.sam
 cat r.sam | sed -e 's/LN:1001/LN:2000/g' -e 's/161/661/g' -e 's/.M5:[a-zA-Z0-9]*//g' > r.manual.sam
 diff r.manual.sam r.sub.sam
 is "$?" 0 "vg surject correctly fetches base path length from input file"
+
+if "$(vg surject -x j.vg -b --graph-aln r.gam | samtools view | grep "GR:Z:" | sed 's/^[[:space:]]*//')" "1" "BAMs can be annotated with the graph-space alignment"
 
 rm -f h.vg h.gcsa r.gam r.sam x.sub.fa j.sub.vg j.sub.gcsa r.sub.gam r.sub.sam r.sub.sam
 

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -177,7 +177,7 @@ cat r.sam | sed -e 's/LN:1001/LN:2000/g' -e 's/161/661/g' -e 's/.M5:[a-zA-Z0-9]*
 diff r.manual.sam r.sub.sam
 is "$?" 0 "vg surject correctly fetches base path length from input file"
 
-if "$(vg surject -x j.vg -b --graph-aln r.gam | samtools view | grep "GR:Z:" | sed 's/^[[:space:]]*//')" "1" "BAMs can be annotated with the graph-space alignment"
+is "$(vg surject -x j.vg -b --graph-aln r.gam | samtools view | grep 'GR:Z:' | wc -l | sed 's/^[[:space:]]*//')" "1" "BAMs can be annotated with the graph-space alignment"
 
 rm -f h.vg h.gcsa r.gam r.sam x.sub.fa j.sub.vg j.sub.gcsa r.sub.gam r.sub.sam r.sub.sam
 
@@ -217,5 +217,5 @@ is "$(cat err.txt | grep 'cannot be interpreted' | wc -l)" "1" "Surjection of GA
 
 rm x.vg x.pathdup.vg x.xg x.gcsa x.gcsa.lcp x.gam mapped.gam mapped.gamp tiny.vg err.txt
 
-is "$(vg surject -p CHM13#0#chr8 -x surject/opposite_strands.gfa --prune-low-cplx --sam-output --gaf-input surject/opposite_strands.gaf | grep -v "^@" | cut -f3-12 | sort | uniq | wc -l)" "1" "vg surject low compelxity pruning gets the same alignment regardless of read orientation"
+is "$(vg surject -p CHM13#0#chr8 -x surject/opposite_strands.gfa --prune-low-cplx --sam-output --gaf-input surject/opposite_strands.gaf | grep -v "^@" | cut -f3-12 | sort | uniq | wc -l)" 1 "vg surject low compelxity pruning gets the same alignment regardless of read orientation"
 

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 64
+plan tests 65
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
@@ -77,6 +77,8 @@ rm -Rf grid-out
 vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.fq --full-l-bonus 0 > mapped-nobonus.gam
 is "$(vg view -aj  mapped-nobonus.gam | jq '.score')" "63" "Mapping without a full length bonus produces the correct score"
 rm -f mapped-nobonus.gam
+
+is "$(vg giraffe -Z x.giraffe.gbz -m x.shortread.withzip.min -z x.shortread.zipcodes -d x.dist -f reads/small.middle.ref.fq -o BAM --add-graph-aln | samtools view | grep "GR:Z:" | wc -l | sed 's/^[[:space:]]*//')" "1" "BAMs can be annotated with graph alignment"
 
 vg minimizer -k 29 -b -s 18 -d x.dist -g x.gbwt -o x.sync x.xg
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` and `vg surject` can annotate HTSlib output with graph-space alignment

## Description

Hi! This PR adds options to `vg giraffe` and `vg surject` that can add tags to HTSlib output with the alignment of the read in graph-space (minus the node IDs but allowing the graph sequence of the alignment to be reconstructed). The format is the same as the minimap2-style cs tag that we currently use for GAF output.