### PR TITLE
Fix gaf path end

### DIFF
--- a/src/gaf_sorter.cpp
+++ b/src/gaf_sorter.cpp
@@ -163,6 +163,8 @@ gbwt::vector_type as_gbwt_path(const GAFSorterRecord& record, bool& ok) {
         return result;
     }
 
+    // FIXME: Flip orientation if the path is reversed. This should not happen with vg output.
+
     size_t start = 0;
     while (start < path.size) {
         bool is_reverse;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * GAF path end positions are calculated correctly in some edge cases.

## Description

GAF path end positions were calculated incorrectly when the alignment had a softclip assigned to an otherwise unused node. This PR updates libvgio to fix the issue.

See vgteam/libvgio#76.

Fixes #4249.