### PR TITLE
More options in vg cluster + make it usuable with current giraffe

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -3523,7 +3523,7 @@ std::vector<MinimizerMapper::Minimizer> MinimizerMapper::find_minimizers(const s
     
     if (this->track_provenance) {
         // Record how many we found, as new lines.
-        // THey are going to be numbered in score order, not read order. Probably...
+        // They are going to be numbered in score order, not read order. Probably...
         funnel.introduce(result.size());
     }
 
@@ -3939,7 +3939,7 @@ std::vector<MinimizerMapper::Seed> MinimizerMapper::find_seeds(const std::vector
     // they would have to be created in the read no matter where we say it came
     // from, and because adding more of them should lower the MAPQ cap, whereas
     // locating more of the minimizers that are present and letting them pass
-    // to the enxt stage should raise the cap.
+    // to the next stage should raise the cap.
     for (size_t i = 0; i < minimizers.size(); i++) {
         if (this->track_provenance) {
             // Say we're working on it

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -53,6 +53,7 @@ void help_cluster(char** argv) {
     << "  -m, --minimizer-name FILE     use this minimizer index" << endl
     << "  -l, --long-reads              minimizer index is for long reads" << endl
     << "  -d, --dist-name FILE          cluster using this distance index (required)" << endl
+    << "  -p, --prefix PREFIX           prefix to find indexes at" << endl
     << "  -c, --hit-cap INT             use all minimizers with at most INT hits [10]" << endl
     << "  -C, --hard-hit-cap INT        ignore minimizers with more than this many locations [500]" << endl
     << "  -F, --score-fraction FLOAT    select minimizers between hit caps until score is FLOAT of total [0.9]" << endl
@@ -108,6 +109,7 @@ int main_cluster(int argc, char** argv) {
             {"minimizer-name", required_argument, 0, 'm'},
             {"long-reads", no_argument, 0, 'l'},
             {"dist-name", required_argument, 0, 'd'},
+            {"prefix", required_argument, 0, 'p'},
             {"hit-cap", required_argument, 0, 'c'},
             {"hard-hit-cap", required_argument, 0, 'C'},
             {"score-fraction", required_argument, 0, 'F'},
@@ -222,6 +224,14 @@ int main_cluster(int argc, char** argv) {
                     exit(1);
                 }
                 registry.provide("Giraffe Distance Index", optarg);
+                break;
+
+            case 'p':
+                if (!optarg || !*optarg) {
+                    cerr << "error:[vg cluster] Must provide prefix with -p." << endl;
+                    exit(1);
+                }
+                registry.set_prefix(optarg);
                 break;
             
             case 'c':

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -527,6 +527,13 @@ int main_cluster(int argc, char** argv) {
                     dag_non_dag_count.second += tree_count.second;
                 }
 
+                std::string cyclic_snarl_sizes_string;
+                for (const auto& zip_tree : zip_forest.trees) {
+                    for (const auto& size : zip_tree.cyclic_snarl_sizes(seeds, *distance_index)) {
+                        cyclic_snarl_sizes_string += std::to_string(size) + ",";
+                    }
+                }
+
                 // And with hit count clustered
                 set_annotation(aln, "seed_count", (double)seeds.size());
 
@@ -539,10 +546,13 @@ int main_cluster(int argc, char** argv) {
                 //The number of snarls that aren't dags
                 set_annotation(aln, "zip_tree_non_dag_count", dag_non_dag_count.second);
 
+                //CSV of the sizes of the cyclic snarls
+                set_annotation(aln, "zip_tree_cyclic_snarl_sizes", cyclic_snarl_sizes_string);
+
                 // TODO: parallelize this
                 #pragma omp critical (cout)
                 emitter.write(std::move(aln));
-                
+
             } else {
                 // Cluster the seeds. Get sets of input seed indexes that go together.
                 // Make sure to time it.

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -46,6 +46,7 @@ void help_cluster(char** argv) {
     << endl
     << "basic options:" << endl
     << "  -x, --xg-name FILE            use this xg index or graph (required)" << endl
+    << "  -f, --gbz-format              input graph is in GBZ format (contains both a graph and haplotypes)" << endl
     << "  -g, --gcsa-name FILE          use this GCSA2/LCP index pair (both FILE and FILE.lcp)" << endl
     << "  -G, --gbwt-name FILE          use this gbwt" << endl
     << "  -B, --gbwtgraph-name FILE     use this gbwtgraph" << endl
@@ -71,7 +72,8 @@ int main_cluster(int argc, char** argv) {
     }
 
     // initialize parameters with their default options
-    string xg_name;
+    string graph_name = "";
+    bool gbz_format = false;
     string gcsa_name;
     string zipcode_name;
     string distance_name;
@@ -96,6 +98,7 @@ int main_cluster(int argc, char** argv) {
         {
             {"help", no_argument, 0, 'h'},
             {"xg-name", required_argument, 0, 'x'},
+            {"gbz-format", no_argument, 0, 'f'},
             {"gcsa-name", required_argument, 0, 'g'},
             {"gbwt-name", required_argument, 0, 'G'},
             {"gbwtgraph-name", required_argument, 0, 'B'},
@@ -134,10 +137,11 @@ int main_cluster(int argc, char** argv) {
                     exit(1);
                 }
                 //Remember the string for MEMs
-                xg_name = optarg;
+                graph_name = optarg;
+                break;
 
-                //Give the file to the index registry for clustering minimizers
-                registry.provide("XG", optarg);
+            case 'f':
+                gbz_format = true;
                 break;
                 
             case 'g':
@@ -266,6 +270,17 @@ int main_cluster(int argc, char** argv) {
         }
     }
     
+    if (graph_name.empty()) {
+        cerr << "error:[vg cluster] Must provide a graph file with -x." << endl;
+        exit(1);
+    }
+
+    // Give the file to the index registry for clustering minimizers
+    if (gbz_format) {
+        registry.provide("GBZ", graph_name);
+    } else {
+        registry.provide("XG", graph_name);
+    }
 
     // We define a child class to expose protected stuff
     // This is copied from the minimizer mapper unit tests

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -159,7 +159,7 @@ int main_cluster(int argc, char** argv) {
                     cerr << "error:[vg cluster] Couldn't open GCSA file " << optarg << endl;
                     exit(1);
                 }
-                registry.provide("Giraffe GCSA", optarg);
+                registry.provide("GCSA", optarg);
                 break;
             
             case 'G':

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -341,11 +341,10 @@ int main_cluster(int argc, char** argv) {
     // we try in order of priority.
     unordered_map<string, vector<string>> indexes_and_extensions = {
         {"Giraffe GBZ", {"giraffe.gbz", "gbz"}},
-        {"XG", {"xg"}},
-        {"Giraffe GBWT", {"gbwt"}},
-        {"GBWTGraph", {"gg"}},
         {"Giraffe Distance Index", {"dist"}},
-        {minimizer_index_type, {long_reads ? "longread.withzip.min" : "shortread.withzip.min",}}
+        {minimizer_index_type, {long_reads ? "longread.withzip.min" : "shortread.withzip.min"}},
+        {long_reads ? "Long Read Zipcodes" : "Short Read Zipcodes", 
+            {long_reads ? "longread.zipcodes" : "shortread.zipcodes"}}
     };
     //Get minimizer indexes
     for (auto& completed : registry.completed_indexes()) {
@@ -373,7 +372,9 @@ int main_cluster(int argc, char** argv) {
     // TODO: add memory options like autoindex?
     registry.set_target_memory_usage(IndexRegistry::get_system_memory() / 2);
 
-    auto index_targets = VGIndexes::get_default_short_giraffe_indexes();
+    auto index_targets = long_reads 
+                         ? VGIndexes::get_default_long_giraffe_indexes() 
+                         : VGIndexes::get_default_short_giraffe_indexes();
 
     //Make sure we have all necessary indexes
     try {

--- a/src/zip_code_tree.hpp
+++ b/src/zip_code_tree.hpp
@@ -392,6 +392,11 @@ public:
     std::pair<size_t, size_t> dag_and_non_dag_snarl_count(const vector<Seed>& seeds, 
                                                     const SnarlDistanceIndex& distance_index) const;
 
+    /// Count the length of the zipcode tree for each cyclic snarl
+    /// Returns a vector of the lengths of each cyclic snarl
+    std::vector<size_t> cyclic_snarl_sizes(const vector<Seed>& seeds, 
+                                           const SnarlDistanceIndex& distance_index) const;
+
 protected:
 
     //Helper function to get the orientation of a snarl tree node at a given depth


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Bring `vg cluster` up-to-date: now accepts GBZ files, can do short-read or long-read giraffe, and allows `--prefix` for better compatibility with `vg autoindex`
 * Add some options to `vg cluster` to help with chaining issue diagnosis: print out cyclic snarl sizes, seeds with high hit amounts

## Description

I forgot to PR this some time back, but here it is. This resolves #4610 while also doing a bunch of other stuff.