### PR TITLE
add --fastq-out option to vg sim

### DIFF
--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -343,8 +343,8 @@ int main_sim(int argc, char** argv) {
             break;
 
         case 'a':
-            if (align_out || fastq_out) {
-                cerr << "[vg sim] error: only one output format (-a, -q, -J) can be selected." << endl;
+            if (fastq_out) {
+                cerr << "[vg sim] error: only one output format (-a/-J or -q) can be selected." << endl;
                 exit(1);
             }
             align_out = true;
@@ -352,15 +352,15 @@ int main_sim(int argc, char** argv) {
 
         case 'q':
             if (align_out) {
-                cerr << "[vg sim] error: only one output format (-a, -q, -J) can be selected." << endl;
+                cerr << "[vg sim] error: only one output format (-a/-J or -q) can be selected." << endl;
                 exit(1);
             }
             fastq_out = true;
             break;
 
         case 'J':
-            if (align_out || fastq_out) {
-                cerr << "[vg sim] error: only one output format (-a, -q, -J) can be selected." << endl;
+            if (fastq_out) {
+                cerr << "[vg sim] error: only one output format (-a/-J or -q) can be selected." << endl;
                 exit(1);
             }
             json_out = true;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg sim` now can output in FASTQ format via `--fastq-out`

## Description

If I had a nickel for each time I recently wanted to generate some random reads in FASTQ format for a small test, I'd have two nickels, so I figured I might as well explicitly add that functionality to `vg sim` to avoid the extra step of a GAM --> FASTQ or read sequence --> FASTQ conversion.