### PR TITLE
Show zipcodes file in Giraffe usage example

### DIFF
--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -701,7 +701,7 @@ std::string sample_haplotypes(
 void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std::string, Preset>& presets, bool full_help) {
     cerr
     << "usage:" << endl
-    << "  " << argv[0] << " giraffe -Z graph.gbz [-d graph.dist -m graph.min] <input options> [other options] > output.gam" << endl
+    << "  " << argv[0] << " giraffe -Z graph.gbz [-d graph.dist [-m graph.withzip.min -z graph.zipcodes]] <input options> [other options] > output.gam" << endl
     << "  " << argv[0] << " giraffe -Z graph.gbz --haplotype-name graph.hapl --kff-name sample.kff <input options> [other options] > output.gam" << endl
     << endl
     << "Fast haplotype-aware read mapper." << endl


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` usage example now shows using a `.zipcodes` file and a `.withzip.min` file.

## Description

The Giraffe usage example now shows using a zipcodes file, and the `.withzip.min` name format for the minimizer index file, since that's now how we expect people to use it.
